### PR TITLE
land: bring post-wave-next fixes from docs-packs branch

### DIFF
--- a/docs/05-audit-reports/ACTIVE_DOCS_CONTRADICTION_MATRIX_2026-02-06.md
+++ b/docs/05-audit-reports/ACTIVE_DOCS_CONTRADICTION_MATRIX_2026-02-06.md
@@ -135,6 +135,51 @@ prelude: Active-doc claim parity matrix with severity, ownership, fix action, an
 - `verified_false` means the claim is contradicted by current code/config/tests.
 - `partially_true` means claim is directionally true but needs qualification.
 - `unverified` means no executable evidence exists yet; wording must be downgraded or tests added.
+- Resolved on 2026-02-08: previously tracked P0/P1 contradictions (`DPC0305`,
+  `DPC0302`, `DPC0303`, `DPC0304`) were closed by code-truth rewrites in
+  `docs/04-explanation/history/UNBUILT_FEATURES_AND_ROADMAP.md`.
+- `DPC0305` now has additional parity coverage in active docs and tests:
+  `docs/03-reference/services/task-orchestrator.md`,
+  `docs/02-how-to/operations/workflow-idea-epic-lifecycle.md`,
+  `tests/unit/test_task_orchestrator_workflow_api.py`.
+- Resolved on 2026-02-08 (link-drift batch, active docs):
+  `DPC0053`, `DPC0055`, `DPC0057`, `DPC0058`, `DPC0061`, `DPC0064`,
+  `DPC0070`, `DPC0071`, `DPC0072`, `DPC0073`, `DPC0083`, `DPC0084`,
+  `DPC0085`, `DPC0086`, `DPC0087`, `DPC0088`, `DPC0091`, `DPC0092`,
+  `DPC0093`, `DPC0099`, `DPC0122` through `DPC0136`, and `DPC0137`
+  through `DPC0155` via canonical path/case normalization in:
+  `docs/01-tutorials/quick-launch-commands.md`,
+  `docs/02-how-to/DEVELOPING_ZEN.md`,
+  `docs/02-how-to/DEVELOPMENT_SETUP.md`,
+  `docs/02-how-to/create-llm-archive.md`,
+  `docs/02-how-to/mobile-web-setup-guide.md`,
+  `docs/02-how-to/multi-instance-workflow.md`,
+  `docs/02-how-to/overview.md`,
+  `docs/03-reference/systems/adhd-intelligence/overview.md`,
+  `docs/03-reference/systems/dashboard/overview.md`,
+  `docs/03-reference/systems/dashboard/tmux-dashboard-readme.md`.
+- Resolved on 2026-02-08 (link-drift batch, reference/explanation/audit docs):
+  `DPC0105`, `DPC0107`, `DPC0110`, `DPC0111`, `DPC0118`, `DPC0119`,
+  `DPC0120`, `DPC0121`, `DPC0156`, `DPC0157`, `DPC0158`, `DPC0182`,
+  `DPC0184`, `DPC0187`, `DPC0188`, `DPC0189`, `DPC0190`, `DPC0191`,
+  `DPC0192`, and `DPC0193` via canonical path normalization and archive-link
+  retargeting in:
+  `docs/03-reference/overview.md`,
+  `docs/03-reference/systems/adhd-intelligence/adhd-engine-deep-dive.md`,
+  `docs/04-explanation/concepts/worktree-comprehensive-guide.md`,
+  `docs/05-audit-reports/audit-overview.md`.
+- Resolved on 2026-02-08 (link-drift batch, systems docs):
+  `DPC0207`, `DPC0208`, `DPC0209`, `DPC0210`, `DPC0213`, `DPC0216`,
+  `DPC0217`, `DPC0218`, `DPC0219`, `DPC0220`, `DPC0221`, `DPC0222`,
+  `DPC0223`, `DPC0224`, `DPC0225`, `DPC0226`, `DPC0227`, `DPC0228`,
+  and `DPC0229` via archive-link retargeting, active-path normalization, and
+  upstream-path de-linking in:
+  `docs/systems/adhd-engine/interruption-shield/quickstart.md`,
+  `docs/systems/adhd-features/README.md`,
+  `docs/systems/conport/release-notes.md`,
+  `docs/systems/dope-context/api-reference.md`,
+  `docs/systems/dope-context/deployment.md`,
+  `docs/systems/serena/multi-workspace-guide.md`.
 
 Artifacts generated in this wave:
 

--- a/docs/systems/adhd-engine/interruption-shield/quickstart.md
+++ b/docs/systems/adhd-engine/interruption-shield/quickstart.md
@@ -293,7 +293,7 @@ pre-commit run --all-files
 ## Next Steps
 
 1. ✅ **Installation Complete** - You're running!
-2. **Week 1 Implementation** - See [`docs/PHASE1_SPRINT_PLAN.md`](docs/PHASE1_SPRINT_PLAN.md)
+2. **Week 1 Implementation** - See [`phase1-sprint-plan.md`](../../../archive/sessions/adhd-engine/phase1-sprint-plan.md)
 3. **Slack Integration** - Week 3 (see sprint plan)
 4. **Beta Testing** - Week 4 (recruit ADHD developers)
 
@@ -315,9 +315,9 @@ make ci             # Run all CI checks locally
 
 ## Documentation
 
-- **Technical Spec**: [`/docs/COMPONENT_7_ENVIRONMENTAL_INTERRUPTION_SHIELD.md`](../../docs/COMPONENT_7_ENVIRONMENTAL_INTERRUPTION_SHIELD.md)
-- **Sprint Plan**: [`docs/PHASE1_SPRINT_PLAN.md`](docs/PHASE1_SPRINT_PLAN.md)
-- **README**: [`README.md`](README.md)
+- **Technical Spec**: [`COMPONENT_7_ENVIRONMENTAL_INTERRUPTION_SHIELD.md`](../../../archive/component-implementations/COMPONENT_7_ENVIRONMENTAL_INTERRUPTION_SHIELD.md)
+- **Sprint Plan**: [`phase1-sprint-plan.md`](../../../archive/sessions/adhd-engine/phase1-sprint-plan.md)
+- **Guide Root**: [`quickstart.md`](quickstart.md)
 
 ## Support
 

--- a/docs/systems/adhd-features/README.md
+++ b/docs/systems/adhd-features/README.md
@@ -37,7 +37,7 @@ All 11 ADHD accommodation features with detailed technical documentation.
 - [Quick Reference Card](../../02-how-to/adhd-features-quick-reference.md)
 
 **API Documentation**:
-- [ADHD Engine API Reference](../adhd-engine-api.md)
+- [ADHD Engine API Reference](../../03-reference/adhd-engine-api.md)
 
 **Technical Documentation**:
 - [ADHD Engine README](../../../services/adhd_engine/README.md)

--- a/docs/systems/conport/release-notes.md
+++ b/docs/systems/conport/release-notes.md
@@ -36,7 +36,7 @@ and prefers dope-context/Serena retrieval for primary semantic flows.
 ### Fixes & Improvements
 
 - **Pydantic Validation Fix:** Corrected an issue where Pydantic's `ge=1` constraint was being applied before the `IntCoercionMixin` could convert string-based integers, causing validation errors. The fix ensures that string-to-integer coercion happens before validation, allowing for more flexible input.
-- Timezone-aware datetimes: replaced naive UTC usage with aware UTC across models and DB code, and registered SQLite adapters/converters for reliable UTC round-tripping. Files: [src/context_portal_mcp/db/models.py](src/context_portal_mcp/db/models.py), [src/context_portal_mcp/db/database.py](src/context_portal_mcp/db/database.py).
+- Timezone-aware datetimes: replaced naive UTC usage with aware UTC across models and DB code, and registered SQLite adapters/converters for reliable UTC round-tripping. Files: `src/context_portal_mcp/db/models.py`, `src/context_portal_mcp/db/database.py` (upstream Context Portal paths).
 - Integer-like string inputs: added lenient parsing that coerces digit-only strings to integers before validation in relevant argument models. Credit: @cipradu.
 - Dependency security: addressed Starlette advisory GHSA-2c2j-9gv5-cj73 by upgrading FastAPI to 0.116.2 and constraining Starlette to >=0.47.2,<0.49.0; verified via pip-audit: "No known vulnerabilities found."
 
@@ -243,8 +243,8 @@ This release focuses on enhancing deployment flexibility and improving the PyPI 
 ### Key Updates
 
 - **Official Docker Image:** Context Portal MCP is now available as an official Docker image on Docker Hub (`greatscottymac/context-portal-mcp`). This provides a streamlined way to deploy and run ConPort without needing to manage Python environments directly.
-  - Updated [`README.md`](README.md) with comprehensive instructions on how to pull and run the Docker image, including direct `docker run` commands and recommended MCP client configurations for seamless IDE integration.
-  - Added a new section to [`CONTRIBUTING.md`](CONTRIBUTING.md) detailing the process for building and publishing Docker images for contributors.
+  - Updated `README.md` with comprehensive instructions on how to pull and run the Docker image, including direct `docker run` commands and recommended MCP client configurations for seamless IDE integration.
+  - Added a new section to `CONTRIBUTING.md` detailing the process for building and publishing Docker images for contributors.
 
 - **PyPI Package Improvements:**
   - The `context-portal-mcp` PyPI package has been updated to version `0.2.5`.
@@ -304,11 +304,11 @@ This release focuses on improving the stability, reliability, and user experienc
   - Corrected Alembic `script_location` in `alembic.ini` and ensured all necessary Alembic configuration files are correctly bundled within the PyPI package. This significantly improves the robustness of database migrations for new installations and updates.
   - Verified successful data import and custom data handling after fresh database migrations.
 - **Updated and Clarified Documentation:**
-  - Revised [`README.md`](README.md) and [`v0.2.3_UPDATE_GUIDE.md`](v0.2.3_UPDATE_GUIDE.md) to provide the most accurate and up-to-date instructions.
+  - Revised `README.md` and `v0.2.3_UPDATE_GUIDE.md` to provide the most accurate and up-to-date instructions.
   - Updated `uv` commands in the documentation to `uv pip install` and `uv pip uninstall` for correct usage.
   - Clarified Alembic setup, `workspace_id` usage, and requirements for custom data values to be valid JSON.
 
-We recommend all users update to `v0.2.3` for these critical improvements. Please refer to the [v0.2.3_UPDATE_GUIDE.md](v0.2.3_UPDATE_GUIDE.md) for detailed update instructions.
+We recommend all users update to `v0.2.3` for these critical improvements. Please refer to `v0.2.3_UPDATE_GUIDE.md` for detailed update instructions.
 
 <br>
 

--- a/docs/systems/dope-context/api-reference.md
+++ b/docs/systems/dope-context/api-reference.md
@@ -667,7 +667,7 @@ custom_profile = SearchProfile(
 
 ## Performance Metrics
 
-See [PERFORMANCE_TUNING.md](PERFORMANCE_TUNING.md) for detailed optimization guide.
+See [performance-tuning.md](performance-tuning.md) for detailed optimization guide.
 
 **Typical Performance:**
 

--- a/docs/systems/dope-context/deployment.md
+++ b/docs/systems/dope-context/deployment.md
@@ -768,4 +768,4 @@ After deployment:
 3. **Monitor performance**: Track latencies and costs
 4. **Tune parameters**: Adjust based on usage patterns
 
-For questions: See [README.md](README.md) and [API_REFERENCE.md](API_REFERENCE.md)
+For questions: See [architecture.md](architecture.md) and [api-reference.md](api-reference.md)

--- a/docs/systems/serena/multi-workspace-guide.md
+++ b/docs/systems/serena/multi-workspace-guide.md
@@ -547,10 +547,10 @@ workspace_paths=[os.path.abspath("../other-project")]
 
 ## See Also
 
-- [Serena F002 Multi-Session Guide](./docs/F002_USER_GUIDE.md)
-- [Multi-Workspace Wrapper Implementation](./multi_workspace_wrapper.py)
-- [Complexity Coordinator](../../services/shared/complexity_coordinator/)
-- [ADHD Engine Integration](./adhd_features.py)
+- [Serena F002 Multi-Session Guide](../../archive/sessions/serena/v2/f002-user-guide.md)
+- [Multi-Workspace Wrapper Implementation](../../../services/serena/multi_workspace_wrapper.py)
+- [Complexity Coordinator](../../../services/shared/complexity_coordinator/)
+- [ADHD Engine Integration](../../../services/serena/adhd_features.py)
 
 ---
 

--- a/scripts/utilities/serena_enrichment.py
+++ b/scripts/utilities/serena_enrichment.py
@@ -13,15 +13,16 @@ Usage:
     )
 """
 
+import ast
 import asyncio
-
 import logging
+import math
+import os
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
-
-import json
-import math
-from typing import Dict, List, Optional
 
 
 # ============================================================================
@@ -152,6 +153,186 @@ async def enrich_search_with_impact(
 # F-NEW-3: Unified Complexity Intelligence
 # ============================================================================
 
+def _repo_root() -> Path:
+    """Resolve repository root from this helper location."""
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve_file_path(file_path: str) -> Path:
+    """Resolve a path relative to CWD first, then repository root."""
+    candidate = Path(file_path)
+    if candidate.is_absolute():
+        return candidate
+
+    cwd_candidate = Path.cwd() / candidate
+    if cwd_candidate.exists():
+        return cwd_candidate
+
+    return _repo_root() / candidate
+
+
+def _ast_depth(node: ast.AST) -> int:
+    """Estimate maximum AST nesting depth."""
+    children = list(ast.iter_child_nodes(node))
+    if not children:
+        return 1
+    return 1 + max(_ast_depth(child) for child in children)
+
+
+def _find_symbol_node(tree: ast.AST, symbol: Optional[str]) -> Tuple[ast.AST, bool]:
+    """Find function/class node for symbol if available."""
+    if not symbol:
+        return tree, True
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) and node.name == symbol:
+            return node, True
+
+    return tree, False
+
+
+def _derive_python_scores(file_path: Path, symbol: Optional[str]) -> Tuple[float, float, float, str]:
+    """Derive AST and LSP-like complexity scores from Python source."""
+    source = file_path.read_text(encoding="utf-8", errors="ignore")
+    tree = ast.parse(source, filename=str(file_path))
+    target_node, symbol_found = _find_symbol_node(tree, symbol)
+
+    branch_nodes = (
+        ast.If,
+        ast.For,
+        ast.AsyncFor,
+        ast.While,
+        ast.Try,
+        ast.Match,
+        ast.With,
+        ast.AsyncWith,
+        ast.IfExp,
+        ast.BoolOp,
+        ast.ListComp,
+        ast.SetComp,
+        ast.DictComp,
+        ast.GeneratorExp,
+    )
+
+    walked = list(ast.walk(target_node))
+    branch_count = sum(1 for node in walked if isinstance(node, branch_nodes))
+    call_count = sum(1 for node in walked if isinstance(node, ast.Call))
+    node_count = len(walked)
+    depth = _ast_depth(target_node)
+
+    arg_count = 0
+    if isinstance(target_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        arg_count = (
+            len(target_node.args.posonlyargs)
+            + len(target_node.args.args)
+            + len(target_node.args.kwonlyargs)
+            + (1 if target_node.args.vararg else 0)
+            + (1 if target_node.args.kwarg else 0)
+        )
+
+    ast_score = min(1.0, (branch_count * 2.0 + node_count / 18.0 + depth) / 35.0)
+    lsp_score = min(1.0, (call_count + branch_count * 1.5 + depth + arg_count * 1.2) / 28.0)
+
+    if symbol and not symbol_found:
+        confidence = 0.55
+        source_tag = "python-ast(symbol-not-found)"
+    else:
+        confidence = 0.9
+        source_tag = "python-ast"
+
+    return round(ast_score, 3), round(lsp_score, 3), confidence, source_tag
+
+
+def _derive_text_scores(file_path: Path) -> Tuple[float, float, float, str]:
+    """Fallback complexity estimate for non-Python or parse failures."""
+    try:
+        source = file_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return 0.5, 0.5, 0.3, "fallback(file-unreadable)"
+
+    lines = [line for line in source.splitlines() if line.strip()]
+    if not lines:
+        return 0.05, 0.05, 0.5, "fallback(empty-file)"
+
+    branch_tokens = ("if ", "for ", "while ", "switch", "case ", "try", "catch", "elif ", "&&", "||")
+    branch_lines = sum(1 for line in lines if any(token in line for token in branch_tokens))
+    avg_line_len = sum(len(line) for line in lines) / len(lines)
+    max_indent = max(len(line) - len(line.lstrip(" \t")) for line in lines)
+
+    ast_score = min(1.0, (len(lines) / 500.0) + (branch_lines / 60.0) + (max_indent / 24.0))
+    lsp_score = min(1.0, (branch_lines / 40.0) + (avg_line_len / 240.0))
+    return round(ast_score, 3), round(lsp_score, 3), 0.45, "fallback(text-heuristic)"
+
+
+def _derive_structural_scores(file_path: Path, symbol: Optional[str]) -> Tuple[float, float, float, str]:
+    """Get structural complexity signals with graceful fallbacks."""
+    if not file_path.exists():
+        return 0.5, 0.5, 0.2, "fallback(file-missing)"
+
+    if file_path.suffix == ".py":
+        try:
+            return _derive_python_scores(file_path, symbol)
+        except (SyntaxError, ValueError):
+            logger.debug("AST parse failed for %s; using text heuristic fallback", file_path)
+            return _derive_text_scores(file_path)
+        except OSError:
+            return 0.5, 0.5, 0.3, "fallback(file-unreadable)"
+
+    return _derive_text_scores(file_path)
+
+
+def _derive_usage_score(symbol: Optional[str]) -> Tuple[float, float, str]:
+    """Estimate usage complexity by counting symbol references in code roots."""
+    if not symbol:
+        return 0.5, 0.3, "fallback(no-symbol)"
+
+    repo = _repo_root()
+    roots = [repo / "src", repo / "services", repo / "scripts", repo / "tests"]
+    pattern = re.compile(rf"\b{re.escape(symbol)}\b")
+
+    total_refs = 0
+    files_with_refs = 0
+
+    for root in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            try:
+                content = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            refs = len(pattern.findall(content))
+            if refs:
+                files_with_refs += 1
+                total_refs += refs
+
+    if total_refs == 0:
+        return 0.1, 0.4, "local-symbol-scan(no-matches)"
+
+    score = min(1.0, (math.log10(total_refs + 1) / 2.2) + (files_with_refs / 120.0))
+    return round(score, 3), 0.75, "local-symbol-scan"
+
+
+def _load_adhd_multiplier(user_id: str) -> Tuple[float, float, str]:
+    """Load optional ADHD multiplier from environment variables."""
+    normalized_user_id = re.sub(r"[^A-Z0-9]", "_", user_id.upper())
+    env_keys = [f"DOPMUX_ADHD_MULTIPLIER_{normalized_user_id}", "DOPMUX_ADHD_MULTIPLIER"]
+
+    for key in env_keys:
+        raw = os.getenv(key)
+        if raw is None:
+            continue
+        try:
+            multiplier = max(0.5, min(2.0, float(raw)))
+            return multiplier, 0.8, f"env:{key}"
+        except ValueError:
+            logger.warning("Ignoring invalid ADHD multiplier %s=%r", key, raw)
+
+    return 1.0, 0.4, "fallback(default)"
+
+
 async def get_unified_complexity(
     file_path: str,
     symbol: Optional[str] = None,
@@ -196,16 +377,17 @@ async def get_unified_complexity(
     LSP_WEIGHT = 0.3
     USAGE_WEIGHT = 0.3
 
-    # TODO: Call actual MCP tools
-    # ast_result = await mcp__dope-context__get_chunk_complexity(file_path, symbol)
-    # lsp_result = await mcp__serena-v2__analyze_complexity(file_path, symbol)
-    # refs_result = await mcp__serena-v2__find_references(file_path, line, 0)
-
-    # Placeholder scores
-    ast_score = 0.5
-    lsp_score = 0.5
-    usage_score = 0.5
-    adhd_mult = 1.0
+    resolved_path = _resolve_file_path(file_path)
+    ast_score, lsp_score, structural_confidence, structural_source = await asyncio.to_thread(
+        _derive_structural_scores,
+        resolved_path,
+        symbol,
+    )
+    usage_score, usage_confidence, usage_source = await asyncio.to_thread(
+        _derive_usage_score,
+        symbol,
+    )
+    adhd_mult, adhd_confidence, adhd_source = _load_adhd_multiplier(user_id)
 
     # Calculate unified score
     base_score = (ast_score * AST_WEIGHT + lsp_score * LSP_WEIGHT + usage_score * USAGE_WEIGHT)
@@ -225,8 +407,14 @@ async def get_unified_complexity(
         'usage_score': round(usage_score, 3),
         'adhd_multiplier': round(adhd_mult, 3),
         'unified_score': round(unified, 3),
-        'confidence': 0.5,
-        'interpretation': interpretation
+        'confidence': round((structural_confidence + usage_confidence + adhd_confidence) / 3.0, 3),
+        'interpretation': interpretation,
+        'sources': {
+            'structure': structural_source,
+            'usage': usage_source,
+            'adhd_multiplier': adhd_source,
+            'resolved_file': str(resolved_path),
+        },
     }
 
 

--- a/services/dope-query/tests/conftest.py
+++ b/services/dope-query/tests/conftest.py
@@ -5,13 +5,18 @@ Production-quality test fixtures and configuration for comprehensive testing.
 """
 
 import asyncio
+import logging
 import os
-import pytest
-import pytest_asyncio
-from typing import AsyncGenerator, Generator, Dict, Any
-from unittest.mock import AsyncMock, MagicMock
 import tempfile
 import shutil
+from pathlib import Path
+from typing import AsyncGenerator, Generator, Dict, Any, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+
+logger = logging.getLogger(__name__)
 
 # Test database configuration
 TEST_DATABASE_URL = os.getenv(
@@ -27,6 +32,77 @@ TEST_SETTINGS = {
     "debug": True,
     "testing": True
 }
+
+
+def _runtime_test_database_url() -> str:
+    """Read the current test DB URL (supports runtime override by fixtures)."""
+    return os.getenv("TEST_DATABASE_URL", TEST_DATABASE_URL)
+
+
+def _to_asyncpg_url(database_url: str) -> str:
+    """Normalize database URL for SQLAlchemy async engine."""
+    if database_url.startswith("postgresql+asyncpg://"):
+        return database_url
+    return database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+
+def _to_sync_pg_url(database_url: str) -> str:
+    """Normalize database URL for Alembic migrations."""
+    return database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def _find_alembic_ini(service_root: Path) -> Optional[Path]:
+    """Locate Alembic config file if present."""
+    candidates = (
+        service_root / "alembic.ini",
+        service_root.parent / "alembic.ini",
+        service_root.parent.parent / "alembic.ini",
+    )
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _find_migration_dir(service_root: Path) -> Optional[Path]:
+    """Locate migration script directory if present."""
+    candidates = (
+        service_root / "migrations",
+        service_root / "alembic",
+        service_root / "db" / "migrations",
+    )
+    for candidate in candidates:
+        if (candidate / "env.py").exists():
+            return candidate
+    return None
+
+
+async def _run_alembic_migrations_if_available(database_url: str) -> None:
+    """
+    Run Alembic upgrades for tests when migration assets exist.
+
+    No-op when Alembic config/scripts are absent.
+    """
+    service_root = Path(__file__).resolve().parents[1]
+    alembic_ini = _find_alembic_ini(service_root)
+    migration_dir = _find_migration_dir(service_root)
+
+    if alembic_ini is None and migration_dir is None:
+        return
+
+    try:
+        from alembic import command
+        from alembic.config import Config
+    except ImportError:
+        logger.warning("Alembic is not installed; skipping migration execution in test fixture")
+        return
+
+    config = Config(str(alembic_ini)) if alembic_ini else Config()
+    if migration_dir is not None:
+        config.set_main_option("script_location", str(migration_dir))
+    config.set_main_option("sqlalchemy.url", _to_sync_pg_url(database_url))
+
+    await asyncio.to_thread(command.upgrade, config, "head")
 
 @pytest.fixture(scope="session")
 def event_loop():
@@ -84,8 +160,9 @@ async def db_session(database_container):
     from sqlalchemy.orm import sessionmaker
 
     # Create async engine for testing
+    database_url = _runtime_test_database_url()
     engine = create_async_engine(
-        TEST_DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://"),
+        _to_asyncpg_url(database_url),
         echo=False,
         pool_pre_ping=True
     )
@@ -120,8 +197,7 @@ async def clean_db(db_session):
         await conn.run_sync(Base.metadata.drop_all)
         await conn.run_sync(Base.metadata.create_all)
 
-    # Run migrations if needed
-    # TODO: Add alembic migration execution here
+    await _run_alembic_migrations_if_available(str(db_session.bind.url))
 
     yield db_session
 
@@ -134,6 +210,7 @@ def mock_user_data() -> Dict[str, Any]:
         "id": 1,
         "email": "test@example.com",
         "username": "testuser",
+        "password": "SecurePass123!",
         "password_hash": "hashed_password",
         "is_active": True,
         "created_at": "2024-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary
This PR lands the remaining effective work from `codex/docs-packs-1-2-memory-pass` onto `main`, after `Codex/wave next (#21)` already landed.

Included commits:
- `a22a4340` docs(parity): repair systems-doc link drift and archive references
- `a5558de4` fix(testing): replace placeholder complexity helper and harden dope-query fixtures

## Explicit decisions from batch
- Dropped pair: `34038596` + `d6d536aa` (`docs(memory)` + revert)
- PR-based landing (this PR)
- Deferred report/payload cleanup to follow-up

## Note on skipped commit
`28ba9d6f` was not applied because its target file (`reports/next_batch_fix_audit_2026-02-08.json`) is deleted on current `main`. We kept `main`’s deletion and deferred report cleanup/reintroduction decisions to the planned cleanup follow-up.

## Validation
- `python -m compileall -q src services scripts`
- `ruff check --select F821 src services scripts`
- `pytest -q services/dope-query/tests/test_infrastructure.py --no-cov`
- `pytest -q tests/unit/test_unified_complexity_coordinator.py --no-cov`

cc @codex @clauee @copilot
