### PR TITLE
chore(public): add governance docs and onboarding templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,18 @@
 # Global ownership
-* @DDD-Enterprises
+* @hu3mann
 
 # Core platform
-/src/ @DDD-Enterprises
-/services/ @DDD-Enterprises
-/docker/ @DDD-Enterprises
-/compose.yml @DDD-Enterprises
+/src/ @hu3mann
+/services/ @hu3mann
+/docker/ @hu3mann
+/compose.yml @hu3mann
 
 # CI/CD and governance
-/.github/ @DDD-Enterprises
-/config/repo_hygiene/ @DDD-Enterprises
+/.github/ @hu3mann
+/config/repo_hygiene/ @hu3mann
 
 # Docs
-/docs/ @DDD-Enterprises
-/README.md @DDD-Enterprises
-/INSTALL.md @DDD-Enterprises
-/QUICK_START.md @DDD-Enterprises
+/docs/ @hu3mann
+/README.md @hu3mann
+/INSTALL.md @hu3mann
+/QUICK_START.md @hu3mann

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Global ownership
+* @DDD-Enterprises
+
+# Core platform
+/src/ @DDD-Enterprises
+/services/ @DDD-Enterprises
+/docker/ @DDD-Enterprises
+/compose.yml @DDD-Enterprises
+
+# CI/CD and governance
+/.github/ @DDD-Enterprises
+/config/repo_hygiene/ @DDD-Enterprises
+
+# Docs
+/docs/ @DDD-Enterprises
+/README.md @DDD-Enterprises
+/INSTALL.md @DDD-Enterprises
+/QUICK_START.md @DDD-Enterprises

--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+## Our Standards
+
+Participants are expected to:
+
+- be respectful and constructive
+- assume good intent while reviewing technical work
+- focus criticism on ideas, code, and behavior, not people
+- avoid harassment, discrimination, and personal attacks
+
+Unacceptable behavior includes:
+
+- abusive language or personal insults
+- intimidation, threats, or stalking
+- publishing private information without consent
+- disruptive conduct that blocks collaboration
+
+## Enforcement
+
+Repository maintainers may remove comments, close threads, or restrict participation for violations.
+
+## Reporting
+
+If you experience or witness unacceptable behavior, report it to repository maintainers via GitHub private channels when possible.
+
+## Attribution
+
+This policy is informed by common open-source community conduct standards.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to Dopemux MVP
+
+Thanks for contributing to Dopemux.
+
+## Development Setup
+
+1. Fork and clone the repository.
+2. Install dependencies:
+
+```bash
+python -m pip install --upgrade pip
+pip install -e ".[dev]"
+pre-commit install --install-hooks
+```
+
+3. Start a local stack for validation:
+
+```bash
+docker compose -f docker-compose.smoke.yml up --build -d
+```
+
+## Branching and Pull Requests
+
+1. Create a feature branch from `main`.
+2. Keep changes scoped and auditable.
+3. Open a pull request with:
+   - clear problem statement
+   - summary of changes
+   - test evidence
+   - rollback notes for risky changes
+
+Use the repository PR template and complete all checklist items.
+
+## Required Checks Before PR
+
+Run these locally before opening or updating a PR:
+
+```bash
+python scripts/check_root_hygiene.py --all-files
+pytest tests/unit --maxfail=1 --disable-warnings --no-cov
+./test_installer_basic.sh
+```
+
+If you changed workflows, also run actionlint or equivalent workflow linting.
+
+## Documentation Requirements
+
+Update docs with code changes when behavior, interfaces, or operations change:
+
+- `README.md` for user-facing entrypoints
+- `INSTALL.md` and `QUICK_START.md` for onboarding/runtime changes
+- architecture docs under `docs/` for structural changes
+
+## Security
+
+Do not open public issues for vulnerabilities. Follow `SECURITY.md` for reporting.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug report
+description: Report a reproducible defect
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing a bug report. Please include enough detail for deterministic reproduction.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What happened and what did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Provide exact commands, inputs, and sequence.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and errors
+      description: Paste relevant logs/tracebacks (redact secrets).
+      render: shell
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, Docker version, and branch/commit.
+      placeholder: "Ubuntu 24.04, Python 3.11, Docker 28.x, main@<sha>"
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues first
+          required: true
+        - label: I removed secrets from logs and screenshots
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability report
+    url: https://github.com/DDD-Enterprises/dopemux-mvp/security/advisories/new
+    about: Report vulnerabilities privately via GitHub Security Advisories

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Propose an enhancement
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What user or developer problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the desired behavior, API, or UX.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What options have you ruled out and why?
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact and risks
+      description: Security, operational, migration, or compatibility impact.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues/discussions first
+          required: true

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the default branch (`main`).
+
+| Version | Supported |
+| ------- | --------- |
+| `main`  | Yes       |
+
+## Reporting a Vulnerability
+
+Use GitHub's private vulnerability reporting for this repository:
+
+1. Open the repository Security tab.
+2. Click **Report a vulnerability**.
+3. Provide reproduction steps, impact, and any proof-of-concept details.
+
+Do not disclose vulnerabilities in public issues, discussions, or pull requests.
+
+## Response Expectations
+
+- Initial triage target: within 3 business days
+- Status updates: as remediation progresses
+- Coordinated disclosure: after a fix is released
+
+## Scope Notes
+
+Please include:
+
+- affected files/services
+- exploit prerequisites
+- data impact (confidentiality, integrity, availability)
+- suggested mitigations if known

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -2,7 +2,7 @@
 
 ## Where to Get Help
 
-- Usage questions: open a GitHub Discussion (if enabled) or Issue using the support template path.
+- Usage questions: open a GitHub Discussion (if enabled) or a GitHub Issue using the most appropriate issue template.
 - Bug reports: open a GitHub Issue with reproduction details.
 - Security issues: follow `SECURITY.md` and use private reporting.
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,0 +1,21 @@
+# Support
+
+## Where to Get Help
+
+- Usage questions: open a GitHub Discussion (if enabled) or Issue using the support template path.
+- Bug reports: open a GitHub Issue with reproduction details.
+- Security issues: follow `SECURITY.md` and use private reporting.
+
+## What to Include
+
+For faster triage, include:
+
+- environment (OS, Python version, Docker version)
+- exact command(s) run
+- expected vs actual behavior
+- relevant logs and stack traces
+- minimal reproduction steps
+
+## Not for Public Issues
+
+Do not post secrets, tokens, credentials, or private infrastructure details in public threads.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+Describe the problem and what this PR changes.
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] CI/CD
+- [ ] Security hardening
+
+## Validation
+
+- [ ] `python scripts/check_root_hygiene.py --all-files`
+- [ ] `pytest tests/unit --maxfail=1 --disable-warnings --no-cov`
+- [ ] `./test_installer_basic.sh` (when install/runtime paths changed)
+- [ ] Added/updated tests for behavior changes
+
+## Risk and Rollback
+
+- [ ] Risk level documented (low/medium/high)
+- [ ] Rollback plan provided for risky changes
+
+## Security and Docs
+
+- [ ] No secrets/credentials added
+- [ ] Security implications reviewed
+- [ ] Docs updated (README/INSTALL/QUICK_START/docs) as needed

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DDD-Enterprises
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ See [docs/engineering/refactor_gates.md](docs/engineering/refactor_gates.md) for
 - No cross-layer imports; respect boundaries enforced by `tests/arch/`
 - Run `pre-commit run --all-files` before PRs
 
-See [copilot-instructions.md](.github/copilot/copilot-instructions.md) for more.
+See [copilot-instructions.md](.github/copilot-instructions.md) for more.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 - [Coding Standards](#coding-standards)
 - [Testing](#testing)
 - [Contributing](#contributing)
+- [Security](#security)
 - [Community & Support](#community--support)
 - [License](#license)
 - [FAQ & Troubleshooting](#faq--troubleshooting)
@@ -234,15 +235,31 @@ See [docs/03-reference/03-testing.md](docs/03-reference/03-testing.md) for full 
 
 ## Contributing
 
-Contributions are welcome! Focus areas include ADHD accommodations, statusline, energy/attention tracking, and context preservation. Follow code exemplars in `src/dopemux/`, `services/`, and `tests/`. See [copilot-instructions.md](.github/copilot/copilot-instructions.md) for project-specific rules.
+Contributions are welcome. Start with the repository contribution guide:
+
+- [Contributing Guide](.github/CONTRIBUTING.md)
+- [Pull Request Template](.github/pull_request_template.md)
+- [Code Owners](.github/CODEOWNERS)
+
+Follow code exemplars in `src/dopemux/`, `services/`, and `tests/`. For repository-specific AI/automation instructions, see [copilot-instructions.md](.github/copilot-instructions.md).
+
+---
+
+## Security
+
+Use private disclosure for vulnerabilities:
+
+- [Security Policy](.github/SECURITY.md)
+- [Report a Vulnerability](https://github.com/DDD-Enterprises/dopemux-mvp/security/advisories/new)
 
 ---
 
 ## Community & Support
 
-- [GitHub Issues](https://github.com/DDD-Enterprises/dopemux-mvp/issues) — Bug reports & feature requests
-- [Issues](https://github.com/DDD-Enterprises/dopemux-mvp/issues) — Community Q&A
-- [Contact](mailto:support@dopemux.dev) — Direct support
+- [Support Guide](.github/SUPPORT.md)
+- [GitHub Issues](https://github.com/DDD-Enterprises/dopemux-mvp/issues) — Bug reports and feature requests
+- [Issue Templates](.github/ISSUE_TEMPLATE/) — Standardized bug/feature intake
+- [Code of Conduct](.github/CODE_OF_CONDUCT.md)
 
 ---
 

--- a/config/repo_hygiene/root_hygiene_policy.json
+++ b/config/repo_hygiene/root_hygiene_policy.json
@@ -73,6 +73,7 @@
     "Makefile",
     "QUICK_START.md",
     "README.md",
+    "LICENSE",
     "AG-master_plan.md",
     "CHECKLIST.md",
     "DOCKER_SETUP.md",


### PR DESCRIPTION
## Summary\n- add public-facing governance docs in .github (contributing, security, conduct, support)\n- add issue + PR templates and CODEOWNERS\n- add root LICENSE (MIT) and allowlist it in root hygiene policy\n- update README links for contribution/security/support discovery\n\n## Validation\n- python scripts/check_root_hygiene.py <changed_paths>\n- actionlint on .github/workflows/*.yml\n\n## Notes\n- intentionally leaves existing local change in docker/mcp-servers/docker-compose.yml untouched