### PR TITLE
fix(ci): handle rewritten before-sha in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
             pre-commit run --from-ref "origin/${{ github.base_ref }}" --to-ref HEAD
           else
             BEFORE="${{ github.event.before }}"
-            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            if [ -z "$BEFORE" ] || [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
               pre-commit run --all-files
             else
               pre-commit run --from-ref "$BEFORE" --to-ref "${{ github.sha }}"


### PR DESCRIPTION
## Summary
- guard docs pre-commit range logic for push events when github.event.before is not a valid local commit (history rewrite/force-push)
- fallback to pre-commit run --all-files in that case

## Why
After history rewrite, docs workflow failed with: fatal: Invalid revision range <before>..<sha>.

## Validation
- workflow syntax preserved
- one-line conditional guard, aligned with existing CI range-guard pattern
