### PR TITLE
feat(taskx): integrate submodule-backed kernel lifecycle in dopemux

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -21,6 +21,9 @@ jobs:
       - name: 📥 Checkout code
         uses: actions/checkout@v5
         with:
+          submodules: recursive
+          fetch-depth: 0
+        with:
           fetch-depth: 0
 
       - name: 🐍 Setup Python
@@ -161,23 +164,28 @@ jobs:
           pip install -r requirements.txt
           pip install -e .[dev]
 
-      - name: 📦 Setup TaskX venv
+      - name: 📦 Setup TaskX venv from submodule
         run: |
           if [ ! -d .taskx_venv ]; then
-            source .taskx-pin
             python -m venv .taskx_venv
-            .taskx_venv/bin/pip install "git+$repo@$ref" pyyaml
-          else
-            .taskx_venv/bin/pip install pyyaml
           fi
+          .taskx_venv/bin/pip install --upgrade pip
+          .taskx_venv/bin/pip install --upgrade -e ./vendor/taskx
 
       - name: ✅ Verify TaskX wiring
         run: |
-          test -f .taskx-pin
-          grep -q '^commit=' .taskx-pin
+          test -f .gitmodules
+          test -d vendor/taskx
+          test -f vendor/taskx/pyproject.toml
+          SUBMODULE_STATUS="$(git submodule status -- vendor/taskx)"
+          echo "$SUBMODULE_STATUS"
+          if [[ "$SUBMODULE_STATUS" == -* || "$SUBMODULE_STATUS" == +* ]]; then
+            echo "TaskX submodule is not in the pinned clean state."
+            exit 1
+          fi
           test -f .taskxroot
           test -d .taskx_venv
-          test -x .taskx_venv/bin/taskx
+          test -x scripts/taskx
 
       - name: 🧠 TaskX doctor
         run: |

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -23,8 +23,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-        with:
-          fetch-depth: 0
 
       - name: 🐍 Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -150,6 +150,9 @@ jobs:
     steps:
       - name: 📥 Checkout code
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
+          fetch-depth: 0
 
       - name: 🐍 Setup Python
         uses: actions/setup-python@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/taskx"]
+	path = vendor/taskx
+	url = https://github.com/hu3mann/taskX.git

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -60,6 +60,25 @@ That's it! The installer handles everything automatically.
 - Verifies all services are running
 - Shows status of each component
 
+## TaskX Kernel Integration (Submodule-First)
+
+Dopemux now consumes TaskX from `vendor/taskx` and executes through `scripts/taskx`.
+
+```bash
+git submodule update --init --recursive vendor/taskx
+scripts/taskx --version
+scripts/taskx doctor --timestamp-mode deterministic
+```
+
+Kernel lifecycle commands are available through Dopemux:
+
+```bash
+dopemux kernel --help
+```
+
+`.taskx-pin` is deprecated for runtime and CI behavior.
+See `docs/TASKX_KERNEL_INTEGRATION.md` for contract details, update procedure, and rollback.
+
 ## 🧱 Service Bundles
 
 | Mode | Compose File | Services Included |

--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -43,6 +43,17 @@ export ANTHROPIC_API_KEY='<REDACTED_LITELLM_MASTER_KEY>'
 dopemux start
 ```
 
+### Step 4: Verify TaskX Kernel Wiring
+
+```bash
+git submodule update --init --recursive vendor/taskx
+scripts/taskx --version
+dopemux kernel doctor --timestamp-mode deterministic
+```
+
+Use `dopemux kernel --help` for full lifecycle commands (`compile`, `run`, `collect`, `gate`, `promote`, `feedback`, `loop`).
+`.taskx-pin` is deprecated for runtime and CI behavior.
+
 ## Verify It's Working
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Why Dopemux?](#why-dopemux)
 - [Project Name and Description](#project-name-and-description)
 - [Quick Start](#quick-start)
+- [TaskX Kernel Integration](#taskx-kernel-integration)
 - [Technology Stack](#technology-stack)
 - [Project Architecture](#project-architecture)
 - [Project Structure](#project-structure)
@@ -76,6 +77,24 @@ dopemux --help
 ```
 
 See [docs/04-installation.md](docs/04-installation.md), [INSTALL.md](INSTALL.md), and [QUICK_START.md](QUICK_START.md) for more.
+
+---
+
+## TaskX Kernel Integration
+
+Dopemux consumes TaskX via a vendored submodule (`vendor/taskx`) and wrapper (`scripts/taskx`).
+
+```bash
+git submodule update --init --recursive vendor/taskx
+scripts/taskx --version
+dopemux kernel doctor --timestamp-mode deterministic
+```
+
+- Runtime and CI are submodule-first.
+- `.taskx-pin` is deprecated for runtime/CI behavior.
+- Use `dopemux kernel <lifecycle-command>` for kernel lifecycle operations.
+
+See [docs/TASKX_KERNEL_INTEGRATION.md](docs/TASKX_KERNEL_INTEGRATION.md) for the full contract and update/rollback process.
 
 ---
 

--- a/config/repo_hygiene/root_hygiene_policy.json
+++ b/config/repo_hygiene/root_hygiene_policy.json
@@ -33,10 +33,12 @@
     "tools",
     "ui-dashboard",
     "ui-dashboard-backend",
+    "vendor",
     "UPGRADES",
     "_audit_out"
   ],
   "allowed_root_files": [
+    ".gitmodules",
     ".taskxroot",
     ".taskx-pin",
     ".repo_id",

--- a/docs/TASKX_KERNEL_INTEGRATION.md
+++ b/docs/TASKX_KERNEL_INTEGRATION.md
@@ -1,0 +1,72 @@
+# TaskX Kernel Integration (Submodule-First)
+
+## Purpose
+
+Dopemux consumes TaskX as an external deterministic kernel.
+
+- Dopemux orchestrates workflows and context.
+- TaskX executes task-packet lifecycle commands and writes artifacts.
+- Decision logic in Dopemux must use TaskX artifacts, not stdout/stderr parsing.
+
+## Contract
+
+1. Call direction is strictly `Dopemux -> TaskX`.
+2. TaskX never calls back into Dopemux APIs.
+3. TaskX results are consumed from filesystem artifacts.
+4. Runtime and CI use `vendor/taskx` as the source of truth.
+
+## Repository Model
+
+- TaskX is vendored as a git submodule at `vendor/taskx`.
+- Wrapper entrypoint is `scripts/taskx`.
+- `.taskx-pin` is deprecated for runtime and CI behavior.
+
+## Local Setup
+
+```bash
+git submodule update --init --recursive vendor/taskx
+scripts/taskx --version
+scripts/taskx doctor --timestamp-mode deterministic
+```
+
+## Dopemux CLI Surface
+
+Use the kernel lifecycle group:
+
+```bash
+dopemux kernel doctor --timestamp-mode deterministic
+dopemux kernel compile -- --mode mvp
+dopemux kernel run -- --task-id T001
+dopemux kernel collect
+dopemux kernel gate
+dopemux kernel promote
+dopemux kernel feedback
+dopemux kernel loop
+```
+
+Subcommands delegate directly to `scripts/taskx` and pass through trailing arguments unchanged.
+
+## Updating TaskX
+
+```bash
+git submodule update --remote vendor/taskx
+cd vendor/taskx
+git checkout <taskx-commit-or-tag>
+cd ../..
+git add vendor/taskx .gitmodules
+```
+
+Then run:
+
+```bash
+scripts/taskx --version
+scripts/taskx doctor --timestamp-mode deterministic
+```
+
+## Rollback
+
+To roll back TaskX integration state:
+
+1. Checkout a previous Dopemux commit that points `vendor/taskx` to a known-good submodule revision.
+2. Run `git submodule update --init --recursive vendor/taskx`.
+3. Re-run `scripts/taskx doctor --timestamp-mode deterministic`.

--- a/docs/TASKX_KERNEL_INTEGRATION.md
+++ b/docs/TASKX_KERNEL_INTEGRATION.md
@@ -1,3 +1,15 @@
+---
+id: TASKX_KERNEL_INTEGRATION
+title: Taskx Kernel Integration
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-02-20'
+last_review: '2026-02-20'
+next_review: '2026-05-21'
+prelude: Taskx Kernel Integration (explanation) for dopemux documentation and developer
+  workflows.
+---
 # TaskX Kernel Integration (Submodule-First)
 
 ## Purpose

--- a/scripts/taskx
+++ b/scripts/taskx
@@ -45,74 +45,45 @@ if [[ "$TASKX_PROJECT_ID" != "$EXPECTED_PROJECT_ID" ]]; then
   exit 2
 fi
 
-if [[ ! -f "$REPO_ROOT/.taskx-pin" ]]; then
-  echo "Refusing: .taskx-pin missing in repo root." >&2
+TASKX_SOURCE_DIR="$REPO_ROOT/vendor/taskx"
+if [[ ! -d "$TASKX_SOURCE_DIR" ]]; then
+  echo "Refusing: TaskX submodule missing at $TASKX_SOURCE_DIR" >&2
+  echo "Run: git submodule update --init --recursive vendor/taskx" >&2
+  exit 2
+fi
+if [[ ! -f "$TASKX_SOURCE_DIR/pyproject.toml" ]]; then
+  echo "Refusing: invalid TaskX submodule; pyproject.toml missing at $TASKX_SOURCE_DIR" >&2
   exit 2
 fi
 
-PIN_INSTALL="$(sed -n 's/^install=//p' "$REPO_ROOT/.taskx-pin" | head -n 1)"
-PIN_REPO="$(sed -n 's/^repo=//p' "$REPO_ROOT/.taskx-pin" | head -n 1)"
-PIN_REF="$(sed -n 's/^ref=//p' "$REPO_ROOT/.taskx-pin" | head -n 1)"
-PIN_COMMIT="$(sed -n 's/^commit=//p' "$REPO_ROOT/.taskx-pin" | head -n 1)"
-
-if [[ "$PIN_INSTALL" != "git" || -z "$PIN_REPO" || -z "$PIN_REF" || -z "$PIN_COMMIT" ]]; then
-  echo "Refusing: .taskx-pin must include install=git, repo, ref, and commit fields." >&2
+TASKX_COMMIT="$(git -C "$TASKX_SOURCE_DIR" rev-parse HEAD 2>/dev/null || true)"
+if [[ -z "$TASKX_COMMIT" ]]; then
+  echo "Refusing: unable to resolve TaskX submodule commit at $TASKX_SOURCE_DIR" >&2
   exit 2
 fi
 
 VENV="$REPO_ROOT/.taskx_venv"
 if [[ ! -d "$VENV" ]]; then
-  echo "Refusing: TaskX venv missing ($VENV)." >&2
-  exit 2
+  python3 -m venv "$VENV"
 fi
 
-DIRECT_URL_FILE="$(ls "$VENV"/lib/python*/site-packages/taskx-*.dist-info/direct_url.json 2>/dev/null | head -n 1 || true)"
-if [[ -z "$DIRECT_URL_FILE" || ! -f "$DIRECT_URL_FILE" ]]; then
-  echo "Refusing: cannot verify installed TaskX source (direct_url.json missing)." >&2
-  exit 2
+TASKX_COMMIT_FILE="$VENV/.taskx_submodule_commit"
+INSTALLED_COMMIT=""
+if [[ -f "$TASKX_COMMIT_FILE" ]]; then
+  INSTALLED_COMMIT="$(cat "$TASKX_COMMIT_FILE" 2>/dev/null || true)"
 fi
 
-readarray -t INSTALLED_META < <(python3 - "$DIRECT_URL_FILE" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
-    payload = json.load(fh)
-
-vcs = payload.get("vcs_info", {})
-print(str(payload.get("url", "")).strip())
-print(str(vcs.get("requested_revision", "")).strip())
-print(str(vcs.get("commit_id", "")).strip())
-PY
-)
-
-INSTALLED_URL="${INSTALLED_META[0]:-}"
-INSTALLED_REF="${INSTALLED_META[1]:-}"
-INSTALLED_COMMIT="${INSTALLED_META[2]:-}"
-
-normalize_git_url() {
-  local raw="${1:-}"
-  raw="${raw%.git}"
-  raw="${raw%/}"
-  printf '%s\n' "$raw"
+ensure_taskx_installed() {
+  source "$VENV/bin/activate"
+  pip install --quiet --upgrade pip
+  pip install --quiet --upgrade -e "$TASKX_SOURCE_DIR[dopemux]"
+  printf '%s\n' "$TASKX_COMMIT" > "$TASKX_COMMIT_FILE"
 }
 
-if [[ "$(normalize_git_url "$INSTALLED_URL")" != "$(normalize_git_url "$PIN_REPO")" ]]; then
-  echo "Refusing: installed TaskX repo mismatch. expected=$PIN_REPO got=${INSTALLED_URL:-<missing>}" >&2
-  exit 2
+if [[ ! -x "$VENV/bin/taskx" || "$INSTALLED_COMMIT" != "$TASKX_COMMIT" ]]; then
+  ensure_taskx_installed
+else
+  source "$VENV/bin/activate"
 fi
 
-if [[ "$INSTALLED_REF" != "$PIN_REF" ]]; then
-  echo "Refusing: installed TaskX ref mismatch. expected=$PIN_REF got=${INSTALLED_REF:-<missing>}" >&2
-  exit 2
-fi
-
-if [[ "$INSTALLED_COMMIT" != "$PIN_COMMIT" ]]; then
-  echo "Refusing: installed TaskX commit mismatch. expected=$PIN_COMMIT got=${INSTALLED_COMMIT:-<missing>}" >&2
-  exit 2
-fi
-
-source "$VENV/bin/activate"
-# Ensure dependencies required by TaskX are present in the venv
-python3 -c "import yaml" 2>/dev/null || pip install PyYAML >/dev/null 2>&1 || true
-exec taskx "$@"
+exec "$VENV/bin/taskx" "$@"

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -2404,6 +2404,81 @@ def run_build(ctx, command: Sequence[str], cwd: Optional[str], label: str):
     update_tmux_mobile_indicator(cfg_manager)
 
 
+def _run_taskx_kernel(base_args: Sequence[str], taskx_args: Sequence[str]) -> None:
+    """Delegate kernel lifecycle commands to scripts/taskx."""
+    repo_root = Path(__file__).resolve().parents[2]
+    wrapper = repo_root / "scripts" / "taskx"
+    if not wrapper.exists():
+        console.logger.error(f"[red]TaskX wrapper missing: {wrapper}[/red]")
+        sys.exit(1)
+
+    cmd = [str(wrapper), *base_args, *taskx_args]
+    result = subprocess.run(cmd, cwd=repo_root, check=False)
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+
+@cli.group("kernel")
+def kernel() -> None:
+    """TaskX kernel lifecycle commands delegated through scripts/taskx."""
+
+
+@kernel.command("doctor", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("taskx_args", nargs=-1, type=click.UNPROCESSED)
+def kernel_doctor(taskx_args: Sequence[str]) -> None:
+    """Run TaskX doctor."""
+    _run_taskx_kernel(["doctor"], taskx_args)
+
+
+@kernel.command("compile", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("taskx_args", nargs=-1, type=click.UNPROCESSED)
+def kernel_compile(taskx_args: Sequence[str]) -> None:
+    """Run TaskX Dopemux compile lifecycle step."""
+    _run_taskx_kernel(["dopemux", "compile"], taskx_args)
+
+
+@kernel.command("run", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("taskx_args", nargs=-1, type=click.UNPROCESSED)
+def kernel_run(taskx_args: Sequence[str]) -> None:
+    """Run TaskX Dopemux run lifecycle step."""
+    _run_taskx_kernel(["dopemux", "run"], taskx_args)
+
+
+@kernel.command("collect", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("taskx_args", nargs=-1, type=click.UNPROCESSED)
+def kernel_collect(taskx_args: Sequence[str]) -> None:
+    """Run TaskX Dopemux collect lifecycle step."""
+    _run_taskx_kernel(["dopemux", "collect"], taskx_args)
+
+
+@kernel.command("gate", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("taskx_args", nargs=-1, type=click.UNPROCESSED)
+def kernel_gate(taskx_args: Sequence[str]) -> None:
+    """Run TaskX Dopemux gate lifecycle step."""
+    _run_taskx_kernel(["dopemux", "gate"], taskx_args)
+
+
+@kernel.command("promote", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("taskx_args", nargs=-1, type=click.UNPROCESSED)
+def kernel_promote(taskx_args: Sequence[str]) -> None:
+    """Run TaskX Dopemux promote lifecycle step."""
+    _run_taskx_kernel(["dopemux", "promote"], taskx_args)
+
+
+@kernel.command("feedback", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("taskx_args", nargs=-1, type=click.UNPROCESSED)
+def kernel_feedback(taskx_args: Sequence[str]) -> None:
+    """Run TaskX Dopemux feedback lifecycle step."""
+    _run_taskx_kernel(["dopemux", "feedback"], taskx_args)
+
+
+@kernel.command("loop", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.argument("taskx_args", nargs=-1, type=click.UNPROCESSED)
+def kernel_loop(taskx_args: Sequence[str]) -> None:
+    """Run TaskX Dopemux loop lifecycle step."""
+    _run_taskx_kernel(["dopemux", "loop"], taskx_args)
+
+
 @cli.command()
 @click.argument("description", required=False)
 @click.option("--duration", "-d", type=int, default=25, help="Task duration in minutes")

--- a/tests/arch/test_taskx_submodule_contract.py
+++ b/tests/arch/test_taskx_submodule_contract.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_gitmodules_declares_taskx_submodule() -> None:
+    gitmodules = (REPO_ROOT / ".gitmodules").read_text(encoding="utf-8")
+    assert '[submodule "vendor/taskx"]' in gitmodules
+    assert "path = vendor/taskx" in gitmodules
+    assert "url = https://github.com/hu3mann/taskX.git" in gitmodules
+
+
+def test_ci_workflow_uses_submodule_not_taskx_pin() -> None:
+    workflow = (REPO_ROOT / ".github" / "workflows" / "ci-complete.yml").read_text(encoding="utf-8")
+    assert "submodules: recursive" in workflow
+    assert "vendor/taskx" in workflow
+    assert ".taskx-pin" not in workflow
+
+
+def test_taskx_wrapper_requires_vendor_submodule() -> None:
+    wrapper = (REPO_ROOT / "scripts" / "taskx").read_text(encoding="utf-8")
+    assert "TASKX_SOURCE_DIR=\"$REPO_ROOT/vendor/taskx\"" in wrapper
+    assert ".taskx-pin" not in wrapper

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,14 @@ class TestCLI:
         assert "status" in result.output
         assert "task" in result.output
 
+    def test_cli_group_help_includes_kernel(self):
+        """Kernel command group should be exposed in top-level help."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0
+        assert "kernel" in result.output
+
     def test_cli_verbose_flag(self):
         """Test verbose flag is passed to context."""
         runner = CliRunner()

--- a/tests/unit/test_cli_kernel_commands.py
+++ b/tests/unit/test_cli_kernel_commands.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from click.testing import CliRunner
+
+from dopemux.cli import cli
+
+
+@pytest.mark.parametrize(
+    ("command", "extra_args", "expected"),
+    [
+        ("doctor", ["--timestamp-mode", "deterministic"], ["doctor", "--timestamp-mode", "deterministic"]),
+        ("compile", ["--", "--mode", "mvp"], ["dopemux", "compile", "--mode", "mvp"]),
+        ("run", ["--", "--task-id", "T001"], ["dopemux", "run", "--task-id", "T001"]),
+        ("collect", [], ["dopemux", "collect"]),
+        ("gate", [], ["dopemux", "gate"]),
+        ("promote", [], ["dopemux", "promote"]),
+        ("feedback", [], ["dopemux", "feedback"]),
+        ("loop", [], ["dopemux", "loop"]),
+    ],
+)
+def test_kernel_commands_delegate_to_taskx(monkeypatch, command: str, extra_args: list[str], expected: list[str]) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(cmd, cwd=None, check=False):
+        captured["cmd"] = cmd
+        captured["cwd"] = cwd
+        captured["check"] = check
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("dopemux.cli.subprocess.run", _fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kernel", command, *extra_args])
+
+    assert result.exit_code == 0, result.output
+    cmd = captured["cmd"]
+    assert isinstance(cmd, list)
+    assert cmd[1:] == expected
+
+
+def test_kernel_group_help_includes_lifecycle_commands() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kernel", "--help"])
+    assert result.exit_code == 0, result.output
+    for command_name in ["doctor", "compile", "run", "collect", "gate", "promote", "feedback", "loop"]:
+        assert command_name in result.output
+
+
+def test_kernel_command_propagates_nonzero_exit(monkeypatch) -> None:
+    def _fake_run(cmd, cwd=None, check=False):
+        return SimpleNamespace(returncode=23)
+
+    monkeypatch.setattr("dopemux.cli.subprocess.run", _fake_run)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["kernel", "gate"])
+    assert result.exit_code == 23

--- a/tests/unit/test_taskx_wrapper_submodule.py
+++ b/tests/unit/test_taskx_wrapper_submodule.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WRAPPER_SOURCE = REPO_ROOT / "scripts" / "taskx"
+
+
+def _write_wrapper(repo_root: Path) -> Path:
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    wrapper_path = scripts_dir / "taskx"
+    wrapper_path.write_text(WRAPPER_SOURCE.read_text(encoding="utf-8"), encoding="utf-8")
+    wrapper_path.chmod(0o755)
+    return wrapper_path
+
+
+def _write_identity_rails(repo_root: Path, *, project_id: str = "dopemux-mvp") -> None:
+    (repo_root / ".taskxroot").write_text("", encoding="utf-8")
+    (repo_root / ".repo_id").write_text(f"project={project_id}\n", encoding="utf-8")
+    taskx_dir = repo_root / ".taskx"
+    taskx_dir.mkdir(parents=True, exist_ok=True)
+    (taskx_dir / "project.json").write_text(json.dumps({"project_id": project_id}), encoding="utf-8")
+
+
+def _run_wrapper(repo_root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    wrapper = repo_root / "scripts" / "taskx"
+    return subprocess.run(
+        [str(wrapper), *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_wrapper_refuses_when_submodule_missing(tmp_path: Path) -> None:
+    _write_identity_rails(tmp_path)
+    _write_wrapper(tmp_path)
+
+    result = _run_wrapper(tmp_path, "--version")
+    assert result.returncode == 2
+    assert "TaskX submodule missing" in result.stderr
+
+
+def test_wrapper_refuses_when_identity_is_invalid(tmp_path: Path) -> None:
+    _write_wrapper(tmp_path)
+    (tmp_path / ".taskxroot").write_text("", encoding="utf-8")
+
+    result = _run_wrapper(tmp_path, "--version")
+    assert result.returncode == 2
+    assert ".repo_id missing" in result.stderr
+
+
+def test_wrapper_executes_when_submodule_and_venv_are_ready(tmp_path: Path) -> None:
+    _write_identity_rails(tmp_path)
+    _write_wrapper(tmp_path)
+
+    vendor_taskx = tmp_path / "vendor" / "taskx"
+    vendor_taskx.mkdir(parents=True, exist_ok=True)
+    (vendor_taskx / "pyproject.toml").write_text("[project]\nname='taskx-kernel'\nversion='0.0.0'\n", encoding="utf-8")
+
+    subprocess.run(["git", "init"], cwd=vendor_taskx, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=vendor_taskx, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=vendor_taskx, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "add", "."], cwd=vendor_taskx, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=vendor_taskx, check=True, capture_output=True, text=True)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=vendor_taskx,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    venv_bin = tmp_path / ".taskx_venv" / "bin"
+    venv_bin.mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".taskx_venv" / ".taskx_submodule_commit").write_text(f"{commit}\n", encoding="utf-8")
+    (venv_bin / "activate").write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+    stub_taskx = venv_bin / "taskx"
+    stub_taskx.write_text("#!/usr/bin/env bash\necho STUB_TASKX_OK\n", encoding="utf-8")
+    stub_taskx.chmod(0o755)
+
+    result = _run_wrapper(tmp_path, "--version")
+    assert result.returncode == 0
+    assert "STUB_TASKX_OK" in result.stdout


### PR DESCRIPTION
## Summary
This PR implements the Dopemux MVP submodule-first TaskX kernel lifecycle integration end-to-end.

- Replaces `.taskx-pin` runtime/CI bootstrap with vendored TaskX submodule (`vendor/taskx`)
- Adds first-class `dopemux kernel` lifecycle command surface
- Migrates CI to submodule-backed kernel setup and validation
- Documents integration contract, migration path, update flow, and rollback
- Adds tests for CLI delegation, wrapper behavior, and submodule/CI architecture contract

cc: @codex @clauee @copilot

## Migration Rationale
The previous model depended on runtime git-pin installs from `.taskx-pin` and direct-url metadata checks.
This PR switches Dopemux to a deterministic, repository-managed dependency model where TaskX is vendored as a git submodule pinned to a known commit.

Benefits:
- deterministic local + CI kernel source
- simpler bootstrap and fewer runtime network assumptions
- clearer upgrade/rollback semantics via submodule pinning

## Interface Changes
New CLI group in `src/dopemux/cli.py`:
- `dopemux kernel doctor [-- ...]`
- `dopemux kernel compile [-- ...]`
- `dopemux kernel run [-- ...]`
- `dopemux kernel collect [-- ...]`
- `dopemux kernel gate [-- ...]`
- `dopemux kernel promote [-- ...]`
- `dopemux kernel feedback [-- ...]`
- `dopemux kernel loop [-- ...]`

Delegation mapping:
- `kernel doctor` -> `scripts/taskx doctor`
- `kernel compile` -> `scripts/taskx dopemux compile`
- `kernel run` -> `scripts/taskx dopemux run`
- `kernel collect` -> `scripts/taskx dopemux collect`
- `kernel gate` -> `scripts/taskx dopemux gate`
- `kernel promote` -> `scripts/taskx dopemux promote`
- `kernel feedback` -> `scripts/taskx dopemux feedback`
- `kernel loop` -> `scripts/taskx dopemux loop`

## Deprecation Note
`.taskx-pin` is deprecated for runtime and CI behavior in this PR.
TaskX kernel source of truth is now `vendor/taskx` submodule.

## TaskX Submodule Pin
- submodule URL: `https://github.com/hu3mann/taskX.git`
- path: `vendor/taskx`
- pinned commit: `479df1a9ffb33f3ee34836d301a395ef32ca5412`

## Files Changed
- `.github/workflows/ci-complete.yml`
- `.gitmodules`
- `INSTALL.md`
- `QUICK_START.md`
- `README.md`
- `config/repo_hygiene/root_hygiene_policy.json`
- `docs/TASKX_KERNEL_INTEGRATION.md`
- `scripts/taskx`
- `src/dopemux/cli.py`
- `tests/arch/test_taskx_submodule_contract.py`
- `tests/test_cli.py`
- `tests/unit/test_cli_kernel_commands.py`
- `tests/unit/test_taskx_wrapper_submodule.py`
- `vendor/taskx` (gitlink)

## Proof Bundle
All commands executed in `/Users/hue/code/dopemux-mvp/.worktrees/codex-dopemux-kernel-mvp`.

1) `git status --porcelain`
```text
<empty>
```

2) `git submodule status`
```text
479df1a9ffb33f3ee34836d301a395ef32ca5412 vendor/taskx (v0.1.2-246-g479df1a)
```

3) `PYTEST_ADDOPTS='--cov-fail-under=0' python -m pytest tests/unit/test_cli_kernel_commands.py tests/unit/test_taskx_wrapper_submodule.py tests/arch/test_taskx_submodule_contract.py`
```text
16 passed in 6.89s
```

4) `PYTEST_ADDOPTS='--cov-fail-under=0' python -m pytest tests/test_cli.py -k kernel`
```text
1 passed, 31 deselected in 6.25s
```

5) `scripts/taskx --version`
```text
0.1.3
```

6) `scripts/taskx doctor --timestamp-mode deterministic`
```text
TaskX Doctor Report
Status: PASSED

Checks:
  Passed: 6
  Failed: 0
  Warnings: 0
```

7) `PYTHONPATH=src python -m dopemux.cli --help`
```text
... includes command group: kernel ...
```

8) `PYTHONPATH=src python -m dopemux.cli kernel --help`
```text
Commands:
  collect
  compile
  doctor
  feedback
  gate
  loop
  promote
  run
```

## Notes
- Targeted pytest proofs are run with `PYTEST_ADDOPTS='--cov-fail-under=0'` to avoid repo-global coverage threshold failure on narrow test subsets.
- Full suite behavior is unchanged.
