### PR TITLE
feat(repo-truth-extractor): activate and harden phase S synthesis prompts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -128,6 +128,8 @@ repos:
               # Service/container docs and research
               if [[ "$normalized" =~ ^\./(services|docker)/[^/]+/(docs|research|intelligence|archive|migrations)/ ]]; then continue; fi
               if [[ "$normalized" =~ ^\./(services|docker)/[^/]+/[A-Z_0-9-]+\.md$ ]]; then continue; fi
+              # Repo-truth-extractor prompt assets are runtime inputs, not docs
+              if [[ "$normalized" =~ ^\./services/repo-truth-extractor/(prompts|promptsets)/ ]]; then continue; fi
               if [[ "$normalized" =~ ^\./(docker/mcp-servers/pal/) ]]; then continue; fi
               if [[ "$normalized" =~ ^\./(docker/mcp-servers/)[A-Z_0-9-]+\.md$ ]]; then continue; fi
 

--- a/services/repo-truth-extractor/prompts/v3/PROMPT_S0_OPUS_ARCHITECTURE_SYNTHESIS.md
+++ b/services/repo-truth-extractor/prompts/v3/PROMPT_S0_OPUS_ARCHITECTURE_SYNTHESIS.md
@@ -1,75 +1,67 @@
-# PROMPT_S0 — OPUS ARCHITECTURE + SUBSYSTEM SYNTHESIS (from Truth Pack)
+# PROMPT_S0 - OPUS ARCHITECTURE + SUBSYSTEM SYNTHESIS (from Truth Pack)
 
-ROLE: Opus Reviewer/Synthesist.
+ROLE: Synthesis writer (deep, evidence-bounded).
 MODE: Evidence-bounded synthesis. No excavation.
 
 GOAL:
-Produce a coherent, decision-grade architecture map for Dopemux and how TaskX fits into it,
-using ONLY the Truth Pack outputs from Phase R (+ supporting indices from X, and doc clusters from D).
+- Produce a decision-grade architecture map for Dopemux using only phase synthesis inputs.
+- Preserve implemented vs planned distinctions and fail closed on missing evidence.
+
+OUTPUTS:
+- S0_ARCHITECTURE_SYNTHESIS_OPUS.md
 
 HARD RULES:
-1) Do NOT rescan repo. Do NOT infer undocumented mechanisms.
-2) Every non-trivial claim MUST cite one of the Phase R truth artifacts, using:
-   EVIDENCE: <filename>#<section or anchor>
-3) If evidence is missing or ambiguous: write UNKNOWN and specify exactly what artifact is missing.
-4) Prefer "implemented reality" over "planned intent":
-   - IMPLEMENTED comes from Phase R's CODE-based sections
-   - PLANNED comes from Phase R's DOC-based sections
-5) No refactors. No rewriting. Only architecture decisions + bounded recommendations.
+1) Do not rescan the repo or home. Use only supplied synthesis artifacts.
+2) Every non-trivial claim must end with:
+   EVIDENCE: <artifact_filename>#<section_heading_or_anchor>
+3) If evidence is missing or ambiguous, write UNKNOWN and name the missing artifact(s).
+4) Prefer IMPLEMENTED over PLANNED. Label both explicitly. If unclear, mark UNKNOWN.
+5) Use deterministic language only. No hedging, no timestamps, no non-auditable claims.
 
 INPUTS (required):
-- R0 CONTROL_PLANE_TRUTH_MAP.md
-- R1 DOPE_MEMORY_IMPLEMENTATION_TRUTH.md
-- R2 EVENTBUS_WIRING_TRUTH.md
-- R3 TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md
-- R4 TASKX_INTEGRATION_TRUTH.md
-- R5 WORKFLOWS_TRUTH_GRAPH.md
-- R6 PORTABILITY_AND_MIGRATION_RISK_LEDGER.md
-- R7 CONFLICT_LEDGER.md
-- R8 RISK_REGISTER_TOP20.md
-Optional but helpful:
-- X feature index outputs (X* merged/norm)
-- D doc clusters + supersession outputs
+- R0_CONTROL_PLANE_TRUTH_MAP.md
+- R1_DOPE_MEMORY_IMPLEMENTATION_TRUTH.md
+- R2_EVENTBUS_WIRING_TRUTH.md
+- R3_TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md
+- R4_TASKX_INTEGRATION_TRUTH.md
+- R5_WORKFLOWS_TRUTH_GRAPH.md
+- R6_PORTABILITY_AND_MIGRATION_RISK_LEDGER.md
+- R7_CONFLICT_LEDGER.md
+- R8_RISK_REGISTER_TOP20.md
 
-DELIVERABLE:
-Write ARCHITECTURE_SYNTHESIS_OPUS.md with:
+INPUTS (optional):
+- FEATURE_INDEX_MERGED.json
+- TP_MERGED.json
+- TP_SUMMARY.md
+- FREEZE_MANIFEST.json
+- FREEZE_README.md
 
-1) Executive Architecture Snapshot (1 page)
-- What exists today (implemented)
-- What is planned but not implemented
-- Key boundaries and planes
-EVIDENCE required per bullet.
+OUTPUT FORMAT (write the full content of S0_ARCHITECTURE_SYNTHESIS_OPUS.md):
+1) Architecture Snapshot
+- Current implemented control planes, data planes, and operational boundaries.
+- Planned or disputed surfaces clearly separated.
 
 2) Subsystem Boundary Map
-For each subsystem:
-- Purpose
-- Inputs/outputs
-- Persistence surfaces (db/files)
-- Control plane dependencies
-- Failure modes
-EVIDENCE required.
+- control plane
+- dope-memory
+- eventbus
+- trinity, boundaries, and guardrails
+- taskx integration
+- workflow and automation surfaces
 
-Subsystems must include at minimum:
-- Dope-Memory
-- EventBus
-- Trinity/Boundary enforcement
-- TaskX integration surface
-- Control plane (repo + home)
-- Workflow runners + bootstrap (compose/tmux/scripts/mcp)
+3) Conflict Consumption (from R7)
+- For each top conflict, classify as RESOLVED or ESCALATE_TO_PRO.
+- Include decision rationale with evidence anchors for both sides.
 
-3) "Truth-First" Dataflow Diagrams (text diagrams)
-- Control plane -> runtime entrypoints
-- Event flow (producer -> bus -> consumer)
-- Memory flow (ingest -> store -> replay)
-All steps must cite.
+4) Risk-to-Decision Mapping (from R8)
+- Each major decision must cite at least one risk ID from R8.
+- Include mitigation notes tied to cited risk evidence.
 
-4) Decision Points (bounded)
-List decisions Opus recommends you make next:
-- Each decision must include:
-  - Evidence summary
-  - Options (2-3)
-  - Risks (tie to R8)
-  - Minimal verification commands (suggestions only)
+5) Decision Points
+- 2-3 options per decision
+- recommendation
+- stop conditions
+- minimal verification suggestions (commands are suggestions only)
 
-5) "Where Opus cannot decide"
-Explicit UNKNOWN list with what would be needed to decide.
+6) UNKNOWN Register
+- Strict list of unresolved claims and exact missing evidence artifacts.

--- a/services/repo-truth-extractor/prompts/v3/PROMPT_S1_OPUS_MCP_TO_HOOKS_MIGRATION_PLAN.md
+++ b/services/repo-truth-extractor/prompts/v3/PROMPT_S1_OPUS_MCP_TO_HOOKS_MIGRATION_PLAN.md
@@ -1,56 +1,53 @@
-# PROMPT_S1 — OPUS MCP -> HOOKS MIGRATION IMPACT + PLAN (from Truth Pack)
+# PROMPT_S1 - OPUS MCP TO HOOKS MIGRATION PLAN (evidence-bounded)
 
-ROLE: Opus Reviewer/Synthesist.
-MODE: Migration planner under evidence constraints.
+ROLE: Migration planner (audit-grade, conservative).
+MODE: Evidence-bounded synthesis. No excavation.
 
 GOAL:
-Design a safe, incremental MCP -> hooks migration plan (or a no-go recommendation),
-grounded ONLY in Phase R truth artifacts and portability risks.
+- Produce a staged MCP-to-hooks migration plan using only supplied synthesis artifacts.
+- Preserve boundary controls and avoid behavioral drift.
+
+OUTPUTS:
+- S1_MCP_TO_HOOKS_MIGRATION_PLAN.md
 
 HARD RULES:
-1) No repo rescans, no invented components.
-2) Every migration claim MUST cite Phase R evidence:
-   EVIDENCE: <filename>#<section>
-3) Separate:
-   - What is feasible now (IMPLEMENTED surfaces)
-   - What requires new work (PLANNED or UNKNOWN)
-4) No large refactors: propose minimal, mechanical steps.
+1) Do not rescan the repo or invent components.
+2) Every non-trivial claim must end with:
+   EVIDENCE: <artifact_filename>#<section_heading_or_anchor>
+3) If evidence is missing, write UNKNOWN and exclude the candidate from execution steps.
+4) Prefer minimal mechanical moves. No refactors.
+5) All no-go gates must tie to R8 risk IDs and R7 conflicts when relevant.
 
 INPUTS (required):
-- R0 CONTROL_PLANE_TRUTH_MAP.md
-- R5 WORKFLOWS_TRUTH_GRAPH.md
-- R6 PORTABILITY_AND_MIGRATION_RISK_LEDGER.md
-- R7 CONFLICT_LEDGER.md
-- R8 RISK_REGISTER_TOP20.md
-Optional:
-- R3 TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md (to avoid bypassing guardrails)
+- R0_CONTROL_PLANE_TRUTH_MAP.md
+- R3_TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md
+- R6_PORTABILITY_AND_MIGRATION_RISK_LEDGER.md
+- R7_CONFLICT_LEDGER.md
+- R8_RISK_REGISTER_TOP20.md
 
-DELIVERABLE:
-Write MCP_TO_HOOKS_MIGRATION_OPUS.md with:
+INPUTS (optional):
+- REPO_MCP_SERVER_DEFS.json
+- REPO_HOOKS_SURFACE.json
+- REPO_MCP_PROXY_SURFACE.json
+- REPO_ROUTER_SURFACE.json
+- FEATURE_INDEX_MERGED.json
 
-1) Current-State Control Surfaces
-- What MCP is currently responsible for (by evidence)
-- What hooks/scripts/compose already do (by evidence)
-EVIDENCE per bullet.
+OUTPUT FORMAT (write the full content of S1_MCP_TO_HOOKS_MIGRATION_PLAN.md):
+1) Scope and Constraints
+- Summarize objective boundaries and guardrails.
 
-2) Migration Candidates Table
-Surface | Current mechanism | Proposed mechanism | Preconditions | Risks | Evidence
-Only include candidates supported by evidence.
+2) Candidate Inventory
+- Include only candidates with evidence for both current MCP mechanism and target hook surface.
+- Mark unsupported candidates as UNKNOWN with missing evidence references.
 
-3) "Portability First" Plan (staged)
-Stage 0: Observability + proof pack hardening
-Stage 1: Low-risk moves (no behavior change)
-Stage 2: Behavioral moves behind flags
-Stage 3: Decommission candidates
-Each stage must include:
-- Entry criteria
-- Steps
-- Rollback
-- Evidence links
-- Risks mapped to R8
+3) Plan Stages
+- Entry criteria (evidence-based)
+- Steps (mechanical)
+- Verification suggestions
+- Rollback path
 
-4) No-Go Triggers
-List conditions that should stop migration, with evidence.
+4) No-Go Triggers Table
+- Columns: trigger, linked risk_id (R8), linked conflict_id (R7 if applicable), evidence.
 
-5) Minimal verification commands (suggestions only)
-No claims of having run them.
+5) UNKNOWN and Missing Evidence Register
+- Explicit unresolved items and required artifacts.

--- a/services/repo-truth-extractor/prompts/v3/PROMPT_S2_DECISION_DOSSIER.md
+++ b/services/repo-truth-extractor/prompts/v3/PROMPT_S2_DECISION_DOSSIER.md
@@ -1,0 +1,43 @@
+# PROMPT_S2 - DECISION DOSSIER (evidence-bounded)
+
+ROLE: Decision synthesist.
+MODE: Compression and arbitration-ready synthesis from trusted artifacts only.
+
+GOAL:
+- Convert synthesis findings into a decision dossier that can drive implementation packets.
+
+OUTPUTS:
+- S2_DECISION_DOSSIER.md
+
+HARD RULES:
+1) Use only supplied synthesis artifacts.
+2) Every decision row must include evidence anchors.
+3) If evidence is insufficient, output UNKNOWN and required evidence.
+4) Keep entries deterministic, concise, and mechanically actionable.
+
+INPUTS (required):
+- S0_ARCHITECTURE_SYNTHESIS_OPUS.md
+- S1_MCP_TO_HOOKS_MIGRATION_PLAN.md
+- R7_CONFLICT_LEDGER.md
+- R8_RISK_REGISTER_TOP20.md
+
+INPUTS (optional):
+- FEATURE_INDEX_MERGED.json
+- TP_MERGED.json
+
+OUTPUT FORMAT (write the full content of S2_DECISION_DOSSIER.md):
+1) Decision Table
+- decision_id
+- context
+- options
+- recommendation
+- evidence anchors
+- risk_ids
+- verification suggestions
+- stop conditions
+
+2) Escalation Queue
+- Items requiring PRO rulings with conflict and risk references.
+
+3) UNKNOWN Register
+- Explicit unresolved decisions and missing evidence sources.

--- a/services/repo-truth-extractor/prompts/v3/PROMPT_S3_ARCH_PROOF_HOOKS.md
+++ b/services/repo-truth-extractor/prompts/v3/PROMPT_S3_ARCH_PROOF_HOOKS.md
@@ -1,0 +1,41 @@
+# PROMPT_S3 - ARCHITECTURE PROOF HOOKS
+
+ROLE: Verification planner.
+MODE: Evidence-bounded conversion of claims into proof hooks.
+
+GOAL:
+- Produce proof hooks that map architecture claims to minimal verification suggestions.
+
+OUTPUTS:
+- S3_ARCH_PROOF_HOOKS.md
+
+HARD RULES:
+1) Do not rescan repo or claim commands were executed.
+2) Every hook must cite claim evidence and expected verification signal.
+3) Keep hooks minimal and deterministic.
+4) If a hook cannot be defined from evidence, emit UNKNOWN with missing artifacts.
+
+INPUTS (required):
+- S0_ARCHITECTURE_SYNTHESIS_OPUS.md
+- S1_MCP_TO_HOOKS_MIGRATION_PLAN.md
+- S2_DECISION_DOSSIER.md
+- R8_RISK_REGISTER_TOP20.md
+
+INPUTS (optional):
+- TP_MERGED.json
+- FREEZE_MANIFEST.json
+
+OUTPUT FORMAT (write the full content of S3_ARCH_PROOF_HOOKS.md):
+1) Claim to Proof Hook Table
+- claim_id
+- claim_statement
+- evidence
+- verification_command_suggestion
+- expected_signal
+- risk_link
+
+2) Priority Proof Set
+- Minimal high-value hooks for first execution.
+
+3) UNKNOWN Hooks
+- Claims lacking sufficient evidence to define checks.

--- a/services/repo-truth-extractor/prompts/v3/manual/MANUAL_PRO_COLLISION_POLICY.md
+++ b/services/repo-truth-extractor/prompts/v3/manual/MANUAL_PRO_COLLISION_POLICY.md
@@ -1,0 +1,30 @@
+# MANUAL_PRO_COLLISION_POLICY
+
+ROLE: GPT-5.2-pro artifact collision policy judge.
+MODE: JSON-only ruling, deterministic, short.
+
+INPUT:
+- Artifact collision context.
+- Candidate writer steps.
+- Risk/conflict anchors from R7 and R8.
+
+RULES:
+1) Output JSON only.
+2) Choose a policy that is mechanically enforceable.
+3) Include acceptance tests with expected signals.
+4) Use `UNKNOWN` values when evidence is missing.
+
+OUTPUT SCHEMA:
+{
+  "artifact_name": "XYZ.json",
+  "policy": "LATEST_WINS|APPEND_LEDGER|MERGE_BY_ID|UNKNOWN",
+  "canonical_key": "id",
+  "required_item_keys": ["id", "path", "line_range"],
+  "dedup_rule": "KEEP_MOST_EVIDENCED|KEEP_NEWEST|KEEP_HIGHEST_CONFIDENCE|UNKNOWN",
+  "acceptance_tests": [
+    {"test": "...", "expected_signal": "..."}
+  ],
+  "risks": [
+    {"risk": "...", "evidence": ["R8_RISK_REGISTER_TOP20.md#..."]}
+  ]
+}

--- a/services/repo-truth-extractor/prompts/v3/manual/MANUAL_PRO_CONFLICT_RULING.md
+++ b/services/repo-truth-extractor/prompts/v3/manual/MANUAL_PRO_CONFLICT_RULING.md
@@ -1,0 +1,30 @@
+# MANUAL_PRO_CONFLICT_RULING
+
+ROLE: GPT-5.2-pro appellate conflict judge.
+MODE: JSON-only ruling, terse, evidence-bounded.
+
+INPUT:
+- One conflict entry from `R7_CONFLICT_LEDGER.md`.
+- Exact evidence snippets/anchors for both sides.
+
+RULES:
+1) Output JSON only. No prose outside JSON.
+2) If evidence is insufficient, return `decision: "DEFER"`.
+3) Every reason bullet must include one or more evidence anchors.
+4) Never invent artifacts, anchors, or side claims.
+
+OUTPUT SCHEMA:
+{
+  "conflict_id": "CONFLICT-...",
+  "decision": "ACCEPT_DOC|ACCEPT_CODE|SPLIT_SCOPE|DEFER",
+  "winner": {
+    "side": "DOC|CODE|BOTH|NONE",
+    "reason_bullets": [
+      {"bullet": "...", "evidence": ["R?.md#..."]}
+    ]
+  },
+  "scope_notes": ["..."],
+  "required_followups": [
+    {"need": "...", "missing_evidence": ["R?.md#..."]}
+  ]
+}

--- a/services/repo-truth-extractor/prompts/v3/manual/MANUAL_PRO_RISK_RERANK.md
+++ b/services/repo-truth-extractor/prompts/v3/manual/MANUAL_PRO_RISK_RERANK.md
@@ -1,0 +1,27 @@
+# MANUAL_PRO_RISK_RERANK
+
+ROLE: GPT-5.2-pro risk rerank judge.
+MODE: JSON-only output, short, evidence-bounded.
+
+INPUT:
+- Risk rows and evidence anchors from `R8_RISK_REGISTER_TOP20.md`.
+
+RULES:
+1) Output JSON only.
+2) Re-rank severity only when evidence supports change.
+3) If insufficient evidence, keep prior severity and mark rationale as `UNKNOWN`.
+4) Keep bullets concise and anchor-cited.
+
+OUTPUT SCHEMA:
+{
+  "rerank": [
+    {
+      "risk_id": "RISK-...",
+      "new_severity": "low|med|high|critical|unknown",
+      "why_bullets": [
+        {"bullet": "...", "evidence": ["R?.md#..."]}
+      ]
+    }
+  ],
+  "notes": ["..."]
+}

--- a/services/repo-truth-extractor/promptsets/v4/artifacts.yaml
+++ b/services/repo-truth-extractor/promptsets/v4/artifacts.yaml
@@ -1681,6 +1681,14 @@ artifacts:
   merge_strategy: markdown_concat
   required_fields: []
 - phase: S
+  artifact_name: S0_ARCHITECTURE_SYNTHESIS_OPUS.md
+  canonical_writer_step_id: S0
+  kind: markdown
+  norm_artifact: true
+  allow_timestamp_keys: false
+  merge_strategy: markdown_concat
+  required_fields: []
+- phase: S
   artifact_name: CONFLICT_LEDGER.md
   canonical_writer_step_id: S0
   kind: markdown
@@ -1715,6 +1723,46 @@ artifacts:
 - phase: S
   artifact_name: MCP_TO_HOOKS_MIGRATION_OPUS.md
   canonical_writer_step_id: S1
+  kind: markdown
+  norm_artifact: true
+  allow_timestamp_keys: false
+  merge_strategy: markdown_concat
+  required_fields: []
+- phase: S
+  artifact_name: S1_MCP_TO_HOOKS_MIGRATION_PLAN.md
+  canonical_writer_step_id: S1
+  kind: markdown
+  norm_artifact: true
+  allow_timestamp_keys: false
+  merge_strategy: markdown_concat
+  required_fields: []
+- phase: S
+  artifact_name: DECISION_DOSSIER_OPUS.md
+  canonical_writer_step_id: S2
+  kind: markdown
+  norm_artifact: true
+  allow_timestamp_keys: false
+  merge_strategy: markdown_concat
+  required_fields: []
+- phase: S
+  artifact_name: S2_DECISION_DOSSIER.md
+  canonical_writer_step_id: S2
+  kind: markdown
+  norm_artifact: true
+  allow_timestamp_keys: false
+  merge_strategy: markdown_concat
+  required_fields: []
+- phase: S
+  artifact_name: ARCHITECTURE_PROOF_HOOKS.md
+  canonical_writer_step_id: S3
+  kind: markdown
+  norm_artifact: true
+  allow_timestamp_keys: false
+  merge_strategy: markdown_concat
+  required_fields: []
+- phase: S
+  artifact_name: S3_ARCH_PROOF_HOOKS.md
+  canonical_writer_step_id: S3
   kind: markdown
   norm_artifact: true
   allow_timestamp_keys: false

--- a/services/repo-truth-extractor/promptsets/v4/manual/MANUAL_PRO_COLLISION_POLICY.md
+++ b/services/repo-truth-extractor/promptsets/v4/manual/MANUAL_PRO_COLLISION_POLICY.md
@@ -1,0 +1,30 @@
+# MANUAL_PRO_COLLISION_POLICY
+
+ROLE: GPT-5.2-pro artifact collision policy judge.
+MODE: JSON-only ruling, deterministic, short.
+
+INPUT:
+- Artifact collision context.
+- Candidate writer steps.
+- Risk/conflict anchors from R7 and R8.
+
+RULES:
+1) Output JSON only.
+2) Choose a policy that is mechanically enforceable.
+3) Include acceptance tests with expected signals.
+4) Use `UNKNOWN` values when evidence is missing.
+
+OUTPUT SCHEMA:
+{
+  "artifact_name": "XYZ.json",
+  "policy": "LATEST_WINS|APPEND_LEDGER|MERGE_BY_ID|UNKNOWN",
+  "canonical_key": "id",
+  "required_item_keys": ["id", "path", "line_range"],
+  "dedup_rule": "KEEP_MOST_EVIDENCED|KEEP_NEWEST|KEEP_HIGHEST_CONFIDENCE|UNKNOWN",
+  "acceptance_tests": [
+    {"test": "...", "expected_signal": "..."}
+  ],
+  "risks": [
+    {"risk": "...", "evidence": ["R8_RISK_REGISTER_TOP20.md#..."]}
+  ]
+}

--- a/services/repo-truth-extractor/promptsets/v4/manual/MANUAL_PRO_CONFLICT_RULING.md
+++ b/services/repo-truth-extractor/promptsets/v4/manual/MANUAL_PRO_CONFLICT_RULING.md
@@ -1,0 +1,30 @@
+# MANUAL_PRO_CONFLICT_RULING
+
+ROLE: GPT-5.2-pro appellate conflict judge.
+MODE: JSON-only ruling, terse, evidence-bounded.
+
+INPUT:
+- One conflict entry from `R7_CONFLICT_LEDGER.md`.
+- Exact evidence snippets/anchors for both sides.
+
+RULES:
+1) Output JSON only. No prose outside JSON.
+2) If evidence is insufficient, return `decision: "DEFER"`.
+3) Every reason bullet must include one or more evidence anchors.
+4) Never invent artifacts, anchors, or side claims.
+
+OUTPUT SCHEMA:
+{
+  "conflict_id": "CONFLICT-...",
+  "decision": "ACCEPT_DOC|ACCEPT_CODE|SPLIT_SCOPE|DEFER",
+  "winner": {
+    "side": "DOC|CODE|BOTH|NONE",
+    "reason_bullets": [
+      {"bullet": "...", "evidence": ["R?.md#..."]}
+    ]
+  },
+  "scope_notes": ["..."],
+  "required_followups": [
+    {"need": "...", "missing_evidence": ["R?.md#..."]}
+  ]
+}

--- a/services/repo-truth-extractor/promptsets/v4/manual/MANUAL_PRO_RISK_RERANK.md
+++ b/services/repo-truth-extractor/promptsets/v4/manual/MANUAL_PRO_RISK_RERANK.md
@@ -1,0 +1,27 @@
+# MANUAL_PRO_RISK_RERANK
+
+ROLE: GPT-5.2-pro risk rerank judge.
+MODE: JSON-only output, short, evidence-bounded.
+
+INPUT:
+- Risk rows and evidence anchors from `R8_RISK_REGISTER_TOP20.md`.
+
+RULES:
+1) Output JSON only.
+2) Re-rank severity only when evidence supports change.
+3) If insufficient evidence, keep prior severity and mark rationale as `UNKNOWN`.
+4) Keep bullets concise and anchor-cited.
+
+OUTPUT SCHEMA:
+{
+  "rerank": [
+    {
+      "risk_id": "RISK-...",
+      "new_severity": "low|med|high|critical|unknown",
+      "why_bullets": [
+        {"bullet": "...", "evidence": ["R?.md#..."]}
+      ]
+    }
+  ],
+  "notes": ["..."]
+}

--- a/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S0_OPUS_ARCHITECTURE_SYNTHESIS.md
+++ b/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S0_OPUS_ARCHITECTURE_SYNTHESIS.md
@@ -10,15 +10,15 @@ Produce phase `S0` synthesis artifacts from arbitration truth inputs with determ
   - `extraction/**/T_task_packets/norm/**`
   - `extraction/**/Z_handoff_freeze/norm/**`
 - Required arbitration artifacts:
-  - `R0_CONTROL_PLANE_TRUTH_MAP.md`
-  - `R1_DOPE_MEMORY_IMPLEMENTATION_TRUTH.md`
-  - `R2_EVENTBUS_WIRING_TRUTH.md`
-  - `R3_TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md`
-  - `R4_TASKX_INTEGRATION_TRUTH.md`
-  - `R5_WORKFLOWS_TRUTH_GRAPH.md`
-  - `R6_PORTABILITY_AND_MIGRATION_RISK_LEDGER.md`
-  - `R7_CONFLICT_LEDGER.md`
-  - `R8_RISK_REGISTER_TOP20.md`
+  - `CONTROL_PLANE_TRUTH_MAP.md`
+  - `DOPE_MEMORY_IMPLEMENTATION_TRUTH.md`
+  - `EVENTBUS_WIRING_TRUTH.md`
+  - `TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md`
+  - `TASKX_INTEGRATION_TRUTH.md`
+  - `WORKFLOWS_TRUTH_GRAPH.md`
+  - `PORTABILITY_AND_MIGRATION_RISK_LEDGER.md`
+  - `CONFLICT_LEDGER.md`
+  - `RISK_REGISTER_TOP20.md`
 - Optional synthesis helpers:
   - `FEATURE_INDEX_MERGED.json`
   - `TP_MERGED.json`
@@ -65,7 +65,7 @@ Produce phase `S0` synthesis artifacts from arbitration truth inputs with determ
 ## Extraction Procedure
 1. Load only provided phase synthesis inputs and build a deterministic evidence index keyed by artifact and section.
 2. Produce implemented/planned splits for each subsystem before writing conclusions.
-3. Consume `R7_CONFLICT_LEDGER.md` and classify each material conflict as `RESOLVED` or `ESCALATE_TO_PRO` with evidence.
+3. Consume `CONFLICT_LEDGER.md` and classify each material conflict as `RESOLVED` or `ESCALATE_TO_PRO` with evidence.
 4. Build risk-to-decision mapping so each decision references one or more `R8` risk IDs.
 5. Write each declared output with stable section order, stable list ordering, and explicit unknown handling.
 6. Mirror the architecture narrative into both `ARCHITECTURE_SYNTHESIS_OPUS.md` and `S0_ARCHITECTURE_SYNTHESIS_OPUS.md` so compatibility and step-specific consumers receive the same deterministic payload.

--- a/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S0_OPUS_ARCHITECTURE_SYNTHESIS.md
+++ b/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S0_OPUS_ARCHITECTURE_SYNTHESIS.md
@@ -1,22 +1,35 @@
 # PROMPT_S0
 
 ## Goal
-Produce `S0` outputs for phase `S` with strict schema, explicit evidence, and deterministic normalization.
-Focus on concrete, machine-verifiable implementation facts.
+Produce phase `S0` synthesis artifacts from arbitration truth inputs with deterministic structure and explicit evidence anchors. This step consolidates implementation reality, conflict resolution status, and risk-mapped decision framing without performing any additional repository excavation.
 
 ## Inputs
-- Source scope (scan these roots first):
-- `extraction/**/norm/**`
-- `docs/**`
-- `services/repo-truth-extractor/**`
-- Upstream normalized artifacts available to this step:
-- None; this step can rely on phase inventory inputs.
+- Source scope:
+  - `extraction/**/R_arbitration/norm/**`
+  - `extraction/**/X_feature_index/norm/**`
+  - `extraction/**/T_task_packets/norm/**`
+  - `extraction/**/Z_handoff_freeze/norm/**`
+- Required arbitration artifacts:
+  - `R0_CONTROL_PLANE_TRUTH_MAP.md`
+  - `R1_DOPE_MEMORY_IMPLEMENTATION_TRUTH.md`
+  - `R2_EVENTBUS_WIRING_TRUTH.md`
+  - `R3_TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md`
+  - `R4_TASKX_INTEGRATION_TRUTH.md`
+  - `R5_WORKFLOWS_TRUTH_GRAPH.md`
+  - `R6_PORTABILITY_AND_MIGRATION_RISK_LEDGER.md`
+  - `R7_CONFLICT_LEDGER.md`
+  - `R8_RISK_REGISTER_TOP20.md`
+- Optional synthesis helpers:
+  - `FEATURE_INDEX_MERGED.json`
+  - `TP_MERGED.json`
+  - `TP_SUMMARY.md`
+  - `FREEZE_MANIFEST.json`
+  - `FREEZE_README.md`
 - Runner context artifacts:
-  - `extraction/*/inputs/INVENTORY.json`
-  - `extraction/*/inputs/PARTITIONS.json`
   - `services/repo-truth-extractor/promptsets/v4/promptset.yaml`
   - `services/repo-truth-extractor/promptsets/v4/artifacts.yaml`
-- When relevant, use `services/registry.yaml` as canonical service list.
+- Constraint:
+  - Consume only precollected phase inputs. Do not scan source trees directly.
 
 ## Outputs
 - `CONTROL_PLANE_TRUTH_MAP.md`
@@ -29,159 +42,64 @@ Focus on concrete, machine-verifiable implementation facts.
 - `CONFLICT_LEDGER.md`
 - `RISK_REGISTER_TOP20.md`
 - `ARCHITECTURE_SYNTHESIS_OPUS.md`
+- `S0_ARCHITECTURE_SYNTHESIS_OPUS.md`
 
 ## Schema
-- Use deterministic containers only:
-  - `ItemList`: `{"schema":"<schema_id>@v1","items":[...]}`
-  - `Graph`: `{"schema":"<schema_id>@v1","nodes":[...],"edges":[...]}`
-- Output contracts:
-  - `CONTROL_PLANE_TRUTH_MAP.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `CONTROL_PLANE_TRUTH_MAP:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, evidence`
-  - `DOPE_MEMORY_IMPLEMENTATION_TRUTH.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `DOPE_MEMORY_IMPLEMENTATION_TRUTH:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, evidence`
-  - `EVENTBUS_WIRING_TRUTH.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `EVENTBUS_WIRING_TRUTH:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, evidence`
-  - `TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `TRINITY_BOUNDARY_ENFORCEMENT_TRA:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, evidence`
-  - `TASKX_INTEGRATION_TRUTH.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `TASKX_INTEGRATION_TRUTH:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, evidence`
-  - `WORKFLOWS_TRUTH_GRAPH.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `WORKFLOWS_TRUTH_GRAPH:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `nodes, edges, schema`
-  - `PORTABILITY_AND_MIGRATION_RISK_LEDGER.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `PORTABILITY_AND_MIGRATION_RISK_L:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, risk, severity, location, evidence`
-  - `CONFLICT_LEDGER.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `CONFLICT_LEDGER:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, evidence`
-  - `RISK_REGISTER_TOP20.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `RISK_REGISTER_TOP20:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, risk, severity, location, evidence`
-  - `ARCHITECTURE_SYNTHESIS_OPUS.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S0`
-    - `id_rule`: `ARCHITECTURE_SYNTHESIS_OPUS:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, evidence`
+- Artifact kind: markdown outputs with deterministic headings and tables where appropriate.
+- Canonical writer: `S0` for every declared output in this step.
+- Required output content contracts:
+  - `CONTROL_PLANE_TRUTH_MAP.md`: control-plane realities with implemented vs planned separation and evidence anchors.
+  - `DOPE_MEMORY_IMPLEMENTATION_TRUTH.md`: memory subsystem findings, persistence surfaces, and bounded unknowns.
+  - `EVENTBUS_WIRING_TRUTH.md`: producer/consumer pathways, payload surfaces, and conflict annotations.
+  - `TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md`: boundary/guardrail traces with explicit enforcement points.
+  - `TASKX_INTEGRATION_TRUTH.md`: TaskX coupling map, authority touchpoints, and drift indicators.
+  - `WORKFLOWS_TRUTH_GRAPH.md`: workflow graph narrative with dependency and failure-mode evidence.
+  - `PORTABILITY_AND_MIGRATION_RISK_LEDGER.md`: portability risks with mitigation notes tied to R8 risk IDs.
+  - `CONFLICT_LEDGER.md`: conflict intake with `RESOLVED` or `ESCALATE_TO_PRO` outcomes.
+  - `RISK_REGISTER_TOP20.md`: top risks with severity rationale and explicit evidence references.
+  - `ARCHITECTURE_SYNTHESIS_OPUS.md`: decision-grade architecture narrative.
+  - `S0_ARCHITECTURE_SYNTHESIS_OPUS.md`: alias copy of architecture synthesis for step-scoped consumers.
+- Required citation shape for load-bearing claims:
+  - `EVIDENCE: <artifact_filename>#<section_heading_or_anchor>`
 
 ## Extraction Procedure
-1. Enumerate candidate facts only from in-scope inputs and upstream artifacts.
-2. Build deterministic IDs using stable content keys (path/symbol/name/service_id).
-3. Attach evidence to every non-derived field and every relationship edge.
-4. Normalize arrays by stable sort keys; deduplicate by ID (or stable content hash).
-5. Validate required fields; emit `UNKNOWN` for unsatisfied values with evidence gaps.
-6. Emit exactly the declared outputs and no additional files.
+1. Load only provided phase synthesis inputs and build a deterministic evidence index keyed by artifact and section.
+2. Produce implemented/planned splits for each subsystem before writing conclusions.
+3. Consume `R7_CONFLICT_LEDGER.md` and classify each material conflict as `RESOLVED` or `ESCALATE_TO_PRO` with evidence.
+4. Build risk-to-decision mapping so each decision references one or more `R8` risk IDs.
+5. Write each declared output with stable section order, stable list ordering, and explicit unknown handling.
+6. Mirror the architecture narrative into both `ARCHITECTURE_SYNTHESIS_OPUS.md` and `S0_ARCHITECTURE_SYNTHESIS_OPUS.md` so compatibility and step-specific consumers receive the same deterministic payload.
 
 ## Evidence Rules
-- Every load-bearing value must carry at least one evidence object:
-```json
-{
-  "path": "<repo-relative-path>",
-  "line_range": [<start>, <end>],
-  "excerpt": "<exact substring <=200 chars>"
-}
-```
-- `path` must be repo-relative (never absolute in norm artifacts).
-- `excerpt` must be exact (no paraphrase) and <= 200 chars.
-- If the source is ambiguous, include multiple evidence objects and set value to `UNKNOWN`.
+- Every non-trivial sentence must terminate with an evidence anchor in the canonical form.
+- Evidence anchors must resolve to supplied artifacts only; unsupported anchors are invalid.
+- For structured rows, include source evidence in the row itself rather than a detached appendix.
+- If evidence is conflicting, cite both sides and identify whether the item is resolved or escalated.
+- If evidence is absent, emit `UNKNOWN` and include `missing_evidence` details.
+- Evidence objects, when used in structured snippets, must include keys `path`, `line_range`, and `excerpt` to keep parity with norm contracts.
+- No uncited policy claims, no uncited migration advice, and no uncited risk severity assertions.
 
 ## Determinism Rules
-- Norm outputs MUST NOT contain: `generated_at`, `timestamp`, `created_at`, `updated_at`, `run_id`.
-- Sort `items` by `(path, line_start, id)` when available; otherwise by `id` then stable JSON text.
-- Merge duplicates deterministically:
-  - union evidence by `(path,line_range,excerpt)`
-  - union arrays with stable sort
-  - choose scalar conflicts by non-empty, else lexicographically smallest stable value
-- Output byte content must be reproducible for same commit + same configuration.
+- Do not include generated timestamps or runtime identity keys such as `generated_at`, `timestamp`, `created_at`, `updated_at`, or `run_id`.
+- Use fixed heading order and fixed row ordering by deterministic keys.
+- Keep terminology stable: use `IMPLEMENTED`, `PLANNED`, `UNKNOWN`, `RESOLVED`, `ESCALATE_TO_PRO` exactly as spelled.
+- Avoid speculative language such as "probably", "likely", or "might be" unless explicitly qualified as `UNKNOWN` with evidence gaps.
+- Ensure alias outputs are semantic copies of their canonical siblings.
+- Keep markdown deterministic: no random bullet ordering, no free-form appendices that alter ordering between runs.
 
 ## Anti-Fabrication Rules
-- Do not invent endpoints, handlers, dependencies, env vars, commands, or policy claims.
-- Do not infer intent from filenames alone; require direct textual/code evidence.
-- If required evidence is missing, keep item with `UNKNOWN` fields and `missing_evidence_reason`.
-- Never copy unsupported keys from upstream QA artifacts into norm artifacts.
+- Do not infer mechanisms from filenames, directory names, or prior expectations.
+- Do not invent services, endpoints, guardrails, workflows, or migration stages.
+- Do not claim commands were executed; only provide bounded verification suggestions where requested.
+- Do not collapse conflicting evidence into a single assertion without conflict status.
+- Do not replace missing evidence with intuition; retain explicit `UNKNOWN` entries.
+- Do not introduce references to artifacts outside this step's supplied input set.
+- Do not emit hidden assumptions; every assumption must be explicit and evidence-backed.
 
 ## Failure Modes
-- Missing input files: emit valid empty containers plus `missing_inputs` list in output items.
-- Partial scan coverage: emit partial results with explicit `coverage_notes` and evidence gaps.
-- Schema violation risk: drop unverifiable fields, keep item `id` + `evidence` + `UNKNOWN` placeholders.
-- Parse/runtime ambiguity: keep all plausible candidates but mark `status: needs_review` with evidence.
-
-## Legacy Context (for intent only; never as evidence)
-```markdown
-# PROMPT_S0 — OPUS ARCHITECTURE + SUBSYSTEM SYNTHESIS (from Truth Pack)
-
-ROLE: Opus Reviewer/Synthesist.
-MODE: Evidence-bounded synthesis. No excavation.
-
-GOAL:
-Produce a coherent, decision-grade architecture map for Dopemux and how TaskX fits into it,
-using ONLY the Truth Pack outputs from Phase R (+ supporting indices from X, and doc clusters from D).
-
-HARD RULES:
-1) Do NOT rescan repo. Do NOT infer undocumented mechanisms.
-2) Every non-trivial claim MUST cite one of the Phase R truth artifacts, using:
-   EVIDENCE: <filename>#<section or anchor>
-3) If evidence is missing or ambiguous: write UNKNOWN and specify exactly what artifact is missing.
-4) Prefer "implemented reality" over "planned intent":
-   - IMPLEMENTED comes from Phase R's CODE-based sections
-   - PLANNED comes from Phase R's DOC-based sections
-5) No refactors. No rewriting. Only architecture decisions + bounded recommendations.
-
-INPUTS (required):
-- R0 CONTROL_PLANE_TRUTH_MAP.md
-- R1 DOPE_MEMORY_IMPLEMENTATION_TRUTH.md
-- R2 EVENTBUS_WIRING_TRUTH.md
-- R3 TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md
-- R4 TASKX_INTEGRATION_TRUTH.md
-- R5 WORKFLOWS_TRUTH_GRAPH.md
-- R6 PORTABILITY_AND_MIGRATION_RISK_LEDGER.md
-- R7 CONFLICT_LEDGER.md
-- R8 RISK_REGISTER_TOP20.md
-Optional but helpful:
-- X feature index outputs (X* merged/norm)
-- D doc clusters + supersession outputs
-
-DELIVERABLE:
-Write ARCHITECTURE_SYNTHESIS_OPUS.md with:
-
-1) Executive Architecture Snapshot (1 page)
-- What exists today (implemented)
-- What is planned but not implemented
-- Key boundaries and planes
-EVIDENCE required per bullet.
-
-2) Subsystem Boundary Map
-For
-```
+- Missing required `R*` artifacts: fail closed by writing only `UNKNOWN` conclusions and listing missing artifacts.
+- Conflicting arbitration statements without enough evidence to resolve: mark `ESCALATE_TO_PRO` and identify required ruling scope.
+- Partial optional inputs (`X`, `T`, `Z`) absent: continue with required `R` artifacts and annotate reduced context.
+- Risk mapping cannot be completed: include explicit `UNKNOWN` decision risk links and missing artifact references.
+- Output alias mismatch between `ARCHITECTURE_SYNTHESIS_OPUS.md` and `S0_ARCHITECTURE_SYNTHESIS_OPUS.md`: treat as invalid and rewrite both deterministically.
+- Non-deterministic wording drift: normalize section names and status tokens to the prescribed vocabulary before final output.

--- a/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S1_OPUS_MCP_TO_HOOKS_MIGRATION_PLAN.md
+++ b/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S1_OPUS_MCP_TO_HOOKS_MIGRATION_PLAN.md
@@ -1,142 +1,87 @@
 # PROMPT_S1
 
 ## Goal
-Produce `S1` outputs for phase `S` with strict schema, explicit evidence, and deterministic normalization.
-Focus on concrete, machine-verifiable implementation facts.
+Produce phase `S1` migration planning artifacts that transform arbitration truths into a conservative MCP-to-hooks plan. The output must remain evidence-bounded, reversible, and suitable for task packet generation without introducing refactors or speculative behavior claims.
 
 ## Inputs
-- Source scope (scan these roots first):
-- `extraction/**/norm/**`
-- `docs/**`
-- `services/repo-truth-extractor/**`
-- Upstream normalized artifacts available to this step:
-- `CONTROL_PLANE_TRUTH_MAP.md`
-- `DOPE_MEMORY_IMPLEMENTATION_TRUTH.md`
-- `EVENTBUS_WIRING_TRUTH.md`
-- `TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md`
-- `TASKX_INTEGRATION_TRUTH.md`
-- `WORKFLOWS_TRUTH_GRAPH.md`
-- `PORTABILITY_AND_MIGRATION_RISK_LEDGER.md`
-- `CONFLICT_LEDGER.md`
-- `RISK_REGISTER_TOP20.md`
-- `ARCHITECTURE_SYNTHESIS_OPUS.md`
-- Runner context artifacts:
-  - `extraction/*/inputs/INVENTORY.json`
-  - `extraction/*/inputs/PARTITIONS.json`
-  - `services/repo-truth-extractor/promptsets/v4/promptset.yaml`
-  - `services/repo-truth-extractor/promptsets/v4/artifacts.yaml`
-- When relevant, use `services/registry.yaml` as canonical service list.
+- Source scope:
+  - `extraction/**/R_arbitration/norm/**`
+  - `extraction/**/X_feature_index/norm/**`
+  - `extraction/**/T_task_packets/norm/**`
+  - `extraction/**/Z_handoff_freeze/norm/**`
+- Required artifacts:
+  - `R0_CONTROL_PLANE_TRUTH_MAP.md`
+  - `R3_TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md`
+  - `R6_PORTABILITY_AND_MIGRATION_RISK_LEDGER.md`
+  - `R7_CONFLICT_LEDGER.md`
+  - `R8_RISK_REGISTER_TOP20.md`
+- Optional supporting artifacts:
+  - `REPO_MCP_SERVER_DEFS.json`
+  - `REPO_HOOKS_SURFACE.json`
+  - `REPO_MCP_PROXY_SURFACE.json`
+  - `REPO_ROUTER_SURFACE.json`
+  - `FEATURE_INDEX_MERGED.json`
+  - `S0_ARCHITECTURE_SYNTHESIS_OPUS.md`
+- Constraint:
+  - Operate only on supplied phase artifacts; no direct repository scans.
 
 ## Outputs
 - `MCP_TO_HOOKS_MIGRATION_OPUS.md`
+- `S1_MCP_TO_HOOKS_MIGRATION_PLAN.md`
 
 ## Schema
-- Use deterministic containers only:
-  - `ItemList`: `{"schema":"<schema_id>@v1","items":[...]}`
-  - `Graph`: `{"schema":"<schema_id>@v1","nodes":[...],"edges":[...]}`
+- Artifact kind: markdown planning documents with deterministic section order.
+- Canonical writer: `S1` for both declared outputs.
 - Output contracts:
-  - `MCP_TO_HOOKS_MIGRATION_OPUS.md`
-    - `kind`: `markdown`
-    - `merge_strategy`: `markdown_concat`
-    - `canonical_writer_step_id`: `S1`
-    - `id_rule`: `MCP_TO_HOOKS_MIGRATION_OPUS:<stable-hash(path|symbol|name)>`
-    - `required_item_fields`: `id, evidence`
+  - `MCP_TO_HOOKS_MIGRATION_OPUS.md`: compatibility migration report for existing consumers.
+  - `S1_MCP_TO_HOOKS_MIGRATION_PLAN.md`: step-scoped migration plan alias for new consumers.
+- Mandatory content blocks in each output:
+  - Scope and constraints
+  - Candidate inventory with eligibility gate status
+  - Staged migration plan with entry criteria, steps, verification suggestions, and rollback
+  - No-go triggers table with `risk_id` and optional `conflict_id`
+  - Unknown/missing evidence register
+- Candidate eligibility rule:
+  - Include a candidate only when evidence exists for both current MCP surface and target hooks surface.
 
 ## Extraction Procedure
-1. Enumerate candidate facts only from in-scope inputs and upstream artifacts.
-2. Build deterministic IDs using stable content keys (path/symbol/name/service_id).
-3. Attach evidence to every non-derived field and every relationship edge.
-4. Normalize arrays by stable sort keys; deduplicate by ID (or stable content hash).
-5. Validate required fields; emit `UNKNOWN` for unsatisfied values with evidence gaps.
-6. Emit exactly the declared outputs and no additional files.
+1. Build a migration evidence map from required arbitration artifacts and optional control-surface artifacts.
+2. Enumerate candidate surfaces and evaluate eligibility using the dual-evidence gate.
+3. Reject ineligible candidates into `UNKNOWN` with explicit missing evidence references.
+4. Create staged plan entries that remain mechanical and rollback-capable.
+5. Derive no-go triggers from `R8` risk IDs and `R7` conflicts where relevant.
+6. Write identical semantic content to both outputs to maintain compatibility and alias determinism.
 
 ## Evidence Rules
-- Every load-bearing value must carry at least one evidence object:
-```json
-{
-  "path": "<repo-relative-path>",
-  "line_range": [<start>, <end>],
-  "excerpt": "<exact substring <=200 chars>"
-}
-```
-- `path` must be repo-relative (never absolute in norm artifacts).
-- `excerpt` must be exact (no paraphrase) and <= 200 chars.
-- If the source is ambiguous, include multiple evidence objects and set value to `UNKNOWN`.
+- Every non-trivial plan claim must terminate with:
+  - `EVIDENCE: <artifact_filename>#<section_heading_or_anchor>`
+- Risk and no-go entries must cite `R8` and include `R7` when conflict-driven.
+- Candidate inclusion must reference at least one MCP-side and one hook-side evidence anchor.
+- Unsupported candidates must be listed in unknowns with explicit missing artifacts.
+- If evidence objects are emitted, include `path`, `line_range`, and `excerpt` keys.
+- Never present migration readiness without cited evidence.
+- Do not cite non-input artifacts.
 
 ## Determinism Rules
-- Norm outputs MUST NOT contain: `generated_at`, `timestamp`, `created_at`, `updated_at`, `run_id`.
-- Sort `items` by `(path, line_start, id)` when available; otherwise by `id` then stable JSON text.
-- Merge duplicates deterministically:
-  - union evidence by `(path,line_range,excerpt)`
-  - union arrays with stable sort
-  - choose scalar conflicts by non-empty, else lexicographically smallest stable value
-- Output byte content must be reproducible for same commit + same configuration.
+- Do not include `generated_at`, `timestamp`, `created_at`, `updated_at`, or `run_id`.
+- Keep section order fixed and candidate ordering deterministic.
+- Use fixed status tokens: `ELIGIBLE`, `INELIGIBLE`, `UNKNOWN`, `NO_GO`, `READY`.
+- Keep `MCP_TO_HOOKS_MIGRATION_OPUS.md` and `S1_MCP_TO_HOOKS_MIGRATION_PLAN.md` semantically identical.
+- Avoid speculative terms unless coupled with `UNKNOWN` and missing evidence details.
+- Normalize table columns and heading names for reproducible output.
 
 ## Anti-Fabrication Rules
-- Do not invent endpoints, handlers, dependencies, env vars, commands, or policy claims.
-- Do not infer intent from filenames alone; require direct textual/code evidence.
-- If required evidence is missing, keep item with `UNKNOWN` fields and `missing_evidence_reason`.
-- Never copy unsupported keys from upstream QA artifacts into norm artifacts.
+- Do not invent migration targets, hooks, proxies, or service boundaries.
+- Do not infer target mechanisms without direct evidence.
+- Do not claim execution or validation was performed.
+- Do not recommend refactors or broad architecture rewrites.
+- Do not hide uncertainty; unresolved issues must stay explicit.
+- Do not modify risk severity labels without evidence anchors.
 
 ## Failure Modes
-- Missing input files: emit valid empty containers plus `missing_inputs` list in output items.
-- Partial scan coverage: emit partial results with explicit `coverage_notes` and evidence gaps.
-- Schema violation risk: drop unverifiable fields, keep item `id` + `evidence` + `UNKNOWN` placeholders.
-- Parse/runtime ambiguity: keep all plausible candidates but mark `status: needs_review` with evidence.
-
-## Legacy Context (for intent only; never as evidence)
-```markdown
-# PROMPT_S1 — OPUS MCP -> HOOKS MIGRATION IMPACT + PLAN (from Truth Pack)
-
-ROLE: Opus Reviewer/Synthesist.
-MODE: Migration planner under evidence constraints.
-
-GOAL:
-Design a safe, incremental MCP -> hooks migration plan (or a no-go recommendation),
-grounded ONLY in Phase R truth artifacts and portability risks.
-
-HARD RULES:
-1) No repo rescans, no invented components.
-2) Every migration claim MUST cite Phase R evidence:
-   EVIDENCE: <filename>#<section>
-3) Separate:
-   - What is feasible now (IMPLEMENTED surfaces)
-   - What requires new work (PLANNED or UNKNOWN)
-4) No large refactors: propose minimal, mechanical steps.
-
-INPUTS (required):
-- R0 CONTROL_PLANE_TRUTH_MAP.md
-- R5 WORKFLOWS_TRUTH_GRAPH.md
-- R6 PORTABILITY_AND_MIGRATION_RISK_LEDGER.md
-- R7 CONFLICT_LEDGER.md
-- R8 RISK_REGISTER_TOP20.md
-Optional:
-- R3 TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md (to avoid bypassing guardrails)
-
-DELIVERABLE:
-Write MCP_TO_HOOKS_MIGRATION_OPUS.md with:
-
-1) Current-State Control Surfaces
-- What MCP is currently responsible for (by evidence)
-- What hooks/scripts/compose already do (by evidence)
-EVIDENCE per bullet.
-
-2) Migration Candidates Table
-Surface | Current mechanism | Proposed mechanism | Preconditions | Risks | Evidence
-Only include candidates supported by evidence.
-
-3) "Portability First" Plan (staged)
-Stage 0: Observability + proof pack hardening
-Stage 1: Low-risk moves (no behavior change)
-Stage 2: Behavioral moves behind flags
-Stage 3: Decommission candidates
-Each stage must include:
-- Entry criteria
-- Steps
-- Rollback
-- Evidence links
-- Risks mapped to R8
-
-4) No-Go Triggers
-List c
-```
+- Required artifacts missing: output conservative plan with `UNKNOWN` sections and missing input list.
+- Candidate evidence asymmetric (MCP present, hook absent or vice versa): mark candidate `INELIGIBLE` and exclude from execution steps.
+- Conflict cannot be resolved from available evidence: tie candidate to `NO_GO` and flag for PRO escalation.
+- Risk mapping incomplete: include explicit no-go placeholder and missing-risk evidence request.
+- Alias output drift between two files: regenerate both from the same deterministic content template.
+- Excessive optional-input dependence: downgrade confidence and keep stage progression conservative.

--- a/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S1_OPUS_MCP_TO_HOOKS_MIGRATION_PLAN.md
+++ b/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S1_OPUS_MCP_TO_HOOKS_MIGRATION_PLAN.md
@@ -10,11 +10,11 @@ Produce phase `S1` migration planning artifacts that transform arbitration truth
   - `extraction/**/T_task_packets/norm/**`
   - `extraction/**/Z_handoff_freeze/norm/**`
 - Required artifacts:
-  - `R0_CONTROL_PLANE_TRUTH_MAP.md`
-  - `R3_TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md`
-  - `R6_PORTABILITY_AND_MIGRATION_RISK_LEDGER.md`
-  - `R7_CONFLICT_LEDGER.md`
-  - `R8_RISK_REGISTER_TOP20.md`
+  - `CONTROL_PLANE_TRUTH_MAP.md`
+  - `TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md`
+  - `PORTABILITY_AND_MIGRATION_RISK_LEDGER.md`
+  - `CONFLICT_LEDGER.md`
+  - `RISK_REGISTER_TOP20.md`
 - Optional supporting artifacts:
   - `REPO_MCP_SERVER_DEFS.json`
   - `REPO_HOOKS_SURFACE.json`

--- a/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S2_DECISION_DOSSIER.md
+++ b/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S2_DECISION_DOSSIER.md
@@ -11,8 +11,8 @@ Produce phase `S2` decision dossier artifacts that compress synthesis results in
 - Required artifacts:
   - `S0_ARCHITECTURE_SYNTHESIS_OPUS.md`
   - `S1_MCP_TO_HOOKS_MIGRATION_PLAN.md`
-  - `R7_CONFLICT_LEDGER.md`
-  - `R8_RISK_REGISTER_TOP20.md`
+  - `CONFLICT_LEDGER.md`
+  - `RISK_REGISTER_TOP20.md`
 - Optional artifacts:
   - `TP_MERGED.json`
   - `FEATURE_INDEX_MERGED.json`

--- a/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S2_DECISION_DOSSIER.md
+++ b/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S2_DECISION_DOSSIER.md
@@ -1,0 +1,84 @@
+# PROMPT_S2
+
+## Goal
+Produce phase `S2` decision dossier artifacts that compress synthesis results into implementation-ready decision rows. The dossier must preserve evidence traceability, unknown boundaries, and escalation hooks for unresolved conflicts.
+
+## Inputs
+- Source scope:
+  - `extraction/**/S_synthesis/norm/**`
+  - `extraction/**/R_arbitration/norm/**`
+  - `extraction/**/T_task_packets/norm/**`
+- Required artifacts:
+  - `S0_ARCHITECTURE_SYNTHESIS_OPUS.md`
+  - `S1_MCP_TO_HOOKS_MIGRATION_PLAN.md`
+  - `R7_CONFLICT_LEDGER.md`
+  - `R8_RISK_REGISTER_TOP20.md`
+- Optional artifacts:
+  - `TP_MERGED.json`
+  - `FEATURE_INDEX_MERGED.json`
+- Constraint:
+  - Decision rows must be grounded in supplied evidence only.
+
+## Outputs
+- `DECISION_DOSSIER_OPUS.md`
+- `S2_DECISION_DOSSIER.md`
+
+## Schema
+- Artifact kind: markdown decision tables and registers.
+- Canonical writer: `S2` for both outputs.
+- Required row fields per decision:
+  - `decision_id`
+  - `context`
+  - `options`
+  - `recommendation`
+  - `evidence`
+  - `risk_ids`
+  - `verification_suggestions`
+  - `stop_conditions`
+- Required sections:
+  - Decision table
+  - Escalation queue
+  - Unknown register
+- Output alias requirement:
+  - `DECISION_DOSSIER_OPUS.md` and `S2_DECISION_DOSSIER.md` must convey the same decision corpus.
+
+## Extraction Procedure
+1. Parse S0 and S1 synthesis outputs into candidate decision statements.
+2. Validate each decision against conflict and risk artifacts.
+3. Retain only decisions with sufficient evidence; unresolved items enter unknown register.
+4. Build escalation queue entries for items requiring PRO conflict, policy, or risk rerank rulings.
+5. Render deterministic decision tables and keep row ordering stable.
+6. Emit equivalent content to both output files.
+
+## Evidence Rules
+- Every decision row must include evidence anchors in canonical format.
+- Every recommendation must map to at least one `R8` risk ID.
+- Conflicted decisions must cite the associated `R7` conflict entry.
+- If evidence is missing, set recommendation to `UNKNOWN` and cite missing artifacts.
+- If structured evidence snippets appear, they must include `path`, `line_range`, and `excerpt`.
+- No decision may be emitted without traceable evidence.
+- Escalation queue items must cite exact anchors that triggered escalation.
+
+## Determinism Rules
+- Disallow runtime keys: `generated_at`, `timestamp`, `created_at`, `updated_at`, `run_id`.
+- Use fixed headings and table column order.
+- Order decisions by `decision_id` or deterministic fallback key.
+- Normalize status tokens (`RECOMMEND`, `DEFER`, `UNKNOWN`, `ESCALATE_TO_PRO`).
+- Keep both outputs synchronized from the same deterministic representation.
+- Avoid free-text drift by using concise, bounded language.
+
+## Anti-Fabrication Rules
+- Do not invent decision IDs, risk IDs, or conflict IDs without evidence.
+- Do not infer implementation readiness when evidence is incomplete.
+- Do not add hidden assumptions to recommendation rationale.
+- Do not claim command execution; suggestions only.
+- Do not synthesize options that are not represented in source artifacts.
+- Do not suppress unknowns to make decisions look complete.
+
+## Failure Modes
+- Missing S0 or S1 input artifacts: emit unknown-only dossier with explicit missing inputs.
+- Risk linkage absent for a decision: downgrade recommendation to `DEFER` and request evidence.
+- Conflict unresolved and no clear winning evidence: enqueue `ESCALATE_TO_PRO`.
+- Duplicate decision IDs detected: merge deterministically and retain complete evidence union.
+- Alias output mismatch: regenerate both outputs from a single in-memory table model.
+- Oversized decision text reducing auditability: enforce concise row summaries and retain detail in evidence anchors.

--- a/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S3_ARCHITECTURE_PROOF_HOOKS.md
+++ b/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S3_ARCHITECTURE_PROOF_HOOKS.md
@@ -12,7 +12,7 @@ Produce phase `S3` proof-hook artifacts that transform architecture and migratio
   - `S0_ARCHITECTURE_SYNTHESIS_OPUS.md`
   - `S1_MCP_TO_HOOKS_MIGRATION_PLAN.md`
   - `S2_DECISION_DOSSIER.md`
-  - `R8_RISK_REGISTER_TOP20.md`
+  - `RISK_REGISTER_TOP20.md`
 - Optional artifacts:
   - `TP_MERGED.json`
   - `FREEZE_MANIFEST.json`

--- a/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S3_ARCHITECTURE_PROOF_HOOKS.md
+++ b/services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S3_ARCHITECTURE_PROOF_HOOKS.md
@@ -1,0 +1,83 @@
+# PROMPT_S3
+
+## Goal
+Produce phase `S3` proof-hook artifacts that transform architecture and migration claims into minimal verification guidance. This step must preserve evidence traceability and avoid implying that commands were executed.
+
+## Inputs
+- Source scope:
+  - `extraction/**/S_synthesis/norm/**`
+  - `extraction/**/R_arbitration/norm/**`
+  - `extraction/**/T_task_packets/norm/**`
+- Required artifacts:
+  - `S0_ARCHITECTURE_SYNTHESIS_OPUS.md`
+  - `S1_MCP_TO_HOOKS_MIGRATION_PLAN.md`
+  - `S2_DECISION_DOSSIER.md`
+  - `R8_RISK_REGISTER_TOP20.md`
+- Optional artifacts:
+  - `TP_MERGED.json`
+  - `FREEZE_MANIFEST.json`
+- Constraint:
+  - Hooks must be generated from supplied claim evidence only.
+
+## Outputs
+- `ARCHITECTURE_PROOF_HOOKS.md`
+- `S3_ARCH_PROOF_HOOKS.md`
+
+## Schema
+- Artifact kind: markdown tables for claim-to-proof mapping.
+- Canonical writer: `S3` for both outputs.
+- Required table fields:
+  - `claim_id`
+  - `claim_statement`
+  - `evidence`
+  - `verification_command_suggestion`
+  - `expected_signal`
+  - `risk_link`
+  - `confidence`
+- Required sections:
+  - Full claim-to-proof table
+  - Priority proof set
+  - Unknown hooks register
+- Alias requirement:
+  - `ARCHITECTURE_PROOF_HOOKS.md` and `S3_ARCH_PROOF_HOOKS.md` must remain semantically aligned.
+
+## Extraction Procedure
+1. Extract major claims from S0, S1, and S2 outputs.
+2. Map each claim to one or more verification suggestions with expected pass/fail signals.
+3. Tie each hook to relevant risk IDs from R8.
+4. Assign deterministic confidence values based on evidence completeness.
+5. Separate unresolved hooks into an explicit unknown section.
+6. Write the same hook corpus into both output aliases with stable ordering.
+
+## Evidence Rules
+- Each hook row must include evidence anchors for the source claim.
+- Verification suggestions must cite the claim evidence they validate.
+- Risk links must reference `R8` anchors when available.
+- Missing evidence must force `UNKNOWN` confidence and explicit gap notes.
+- Structured evidence snippets must include `path`, `line_range`, and `excerpt` when present.
+- No hook may cite artifacts outside supplied inputs.
+- No claim can be marked high confidence without direct evidence support.
+
+## Determinism Rules
+- Do not emit runtime identity fields such as `generated_at`, `timestamp`, `created_at`, `updated_at`, or `run_id`.
+- Use fixed column order and deterministic row sorting by `claim_id`.
+- Normalize confidence tokens to `HIGH`, `MEDIUM`, `LOW`, or `UNKNOWN`.
+- Keep suggestion wording concise and stable across runs.
+- Keep both output files semantically identical for compatibility.
+- Avoid narrative digressions that can reorder content non-deterministically.
+
+## Anti-Fabrication Rules
+- Do not invent commands, expected signals, or claim IDs absent from evidence.
+- Do not claim hooks were executed or verified.
+- Do not infer infrastructure surfaces not represented in S0/S1/S2.
+- Do not hide uncertainty behind broad confidence labels.
+- Do not emit risk mappings without explicit anchors.
+- Do not merge unrelated claims into a single hook entry.
+
+## Failure Modes
+- Claims cannot be mapped to verification suggestions: retain in unknown hooks register.
+- Missing decision dossier input: degrade to partial hooks with explicit scope warning.
+- Risk linkage absent: keep hook but mark risk link `UNKNOWN` with required evidence list.
+- Duplicate claim IDs: merge evidence deterministically and preserve strongest expected signal text.
+- Alias output mismatch: regenerate both outputs from one normalized hook table.
+- Overly broad command suggestions: reduce to minimal bounded checks and note limitations.

--- a/services/repo-truth-extractor/promptsets/v4/promptset.yaml
+++ b/services/repo-truth-extractor/promptsets/v4/promptset.yaml
@@ -875,6 +875,8 @@ phases:
     required_steps:
     - S0
     - S1
+    - S2
+    - S3
     steps:
     - step_id: S0
       prompt_file: services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S0_OPUS_ARCHITECTURE_SYNTHESIS.md
@@ -891,9 +893,25 @@ phases:
       - CONFLICT_LEDGER.md
       - RISK_REGISTER_TOP20.md
       - ARCHITECTURE_SYNTHESIS_OPUS.md
+      - S0_ARCHITECTURE_SYNTHESIS_OPUS.md
     - step_id: S1
       prompt_file: services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S1_OPUS_MCP_TO_HOOKS_MIGRATION_PLAN.md
       coverage_targets:
       - phase_scope
       outputs:
       - MCP_TO_HOOKS_MIGRATION_OPUS.md
+      - S1_MCP_TO_HOOKS_MIGRATION_PLAN.md
+    - step_id: S2
+      prompt_file: services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S2_DECISION_DOSSIER.md
+      coverage_targets:
+      - phase_scope
+      outputs:
+      - DECISION_DOSSIER_OPUS.md
+      - S2_DECISION_DOSSIER.md
+    - step_id: S3
+      prompt_file: services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_S3_ARCHITECTURE_PROOF_HOOKS.md
+      coverage_targets:
+      - phase_scope
+      outputs:
+      - ARCHITECTURE_PROOF_HOOKS.md
+      - S3_ARCH_PROOF_HOOKS.md

--- a/services/repo-truth-extractor/run_extraction_v3.py
+++ b/services/repo-truth-extractor/run_extraction_v3.py
@@ -7765,7 +7765,7 @@ def run_phase_R(dirs: Dict[str, Path], cfg: RunnerConfig, ui: Optional[UI] = Non
             input_files.extend(sorted(phase_norm.glob("*.json")))
             input_files.extend(sorted(phase_norm.glob("*.md")))
 
-    deduped_inputs = sorted(set(input_files), key=lambda path: str(path))
+    deduped_inputs = sorted(set(input_files), key=str)
     _run_phase_inner("R", dirs, cfg, None, None, precollected_items=to_items(deduped_inputs), ui=ui)
 
 

--- a/services/repo-truth-extractor/run_extraction_v3.py
+++ b/services/repo-truth-extractor/run_extraction_v3.py
@@ -82,7 +82,7 @@ except Exception:  # pragma: no cover - optional rich rendering
 
 # --- Configuration & Constants ---
 
-PHASES = ["A", "H", "D", "C", "E", "W", "B", "G", "Q", "R", "X", "T", "Z"]
+PHASES = ["A", "H", "D", "C", "E", "W", "B", "G", "Q", "R", "X", "T", "Z", "S"]
 PROMPT_HASH_MODE = "strict"
 PROMPT_ROOT_ENV_VAR = "REPO_TRUTH_EXTRACTOR_PROMPT_ROOT"
 LEGACY_PROMPT_ROOT_ENV_VAR = "UPGRADES_PROMPT_ROOT"
@@ -163,6 +163,7 @@ PHASE_DIR_NAMES: Dict[str, str] = {
     "X": "X_feature_index",
     "T": "T_task_packets",
     "Z": "Z_handoff_freeze",
+    "S": "S_synthesis",
 }
 LEGACY_PHASE_DIR_ALIASES: Dict[str, str] = {
     "R2_synthesis": "R_arbitration",
@@ -473,6 +474,7 @@ REQUIRED_PROMPT_STEP_IDS: Dict[str, Set[str]] = {
     "X": {"X0", "X1", "X2", "X3", "X4", "X9"},
     "T": {"T0", "T1", "T2", "T3", "T4", "T5", "T9"},
     "Z": {"Z0", "Z1", "Z2", "Z9"},
+    "S": {"S0", "S1", "S2", "S3"},
 }
 
 
@@ -7788,6 +7790,25 @@ def run_phase_T(dirs: Dict[str, Path], cfg: RunnerConfig, ui: Optional[UI] = Non
     _run_phase_inner("T", dirs, cfg, None, None, precollected_items=to_items(input_files), ui=ui)
 
 
+def run_phase_S(dirs: Dict[str, Path], cfg: RunnerConfig, ui: Optional[UI] = None) -> None:
+    r_norm = dirs["R"] / "norm"
+    input_files: List[Path] = []
+    if r_norm.exists():
+        input_files.extend(sorted(r_norm.glob("*.json")))
+        input_files.extend(sorted(r_norm.glob("*.md")))
+    if not input_files:
+        raise RuntimeError(f"Phase S requires R norm outputs at {r_norm}")
+
+    for phase in ["X", "T", "Z"]:
+        norm_dir = dirs[phase] / "norm"
+        if norm_dir.exists():
+            input_files.extend(sorted(norm_dir.glob("*.json")))
+            input_files.extend(sorted(norm_dir.glob("*.md")))
+
+    deduped_inputs = sorted(set(input_files), key=lambda path: str(path))
+    _run_phase_inner("S", dirs, cfg, None, None, precollected_items=to_items(deduped_inputs), ui=ui)
+
+
 def run_phase_Z(dirs: Dict[str, Path], cfg: RunnerConfig, ui: Optional[UI] = None) -> None:
     final_items = collect_phase_artifacts(dirs, ["R", "X", "T"], ["raw", "norm", "qa"])
     _run_phase_inner("Z", dirs, cfg, None, None, precollected_items=final_items, ui=ui)
@@ -8105,6 +8126,7 @@ def main() -> None:
         "X": run_phase_X,
         "T": run_phase_T,
         "Z": run_phase_Z,
+        "S": run_phase_S,
     }
 
     for phase in phases:


### PR DESCRIPTION
## Summary
This PR adds and wires Phase S synthesis for the v3 runner and aligns v3/v4 synthesis prompt contracts.

### Included
- Activate Phase `S` in `run_extraction_v3.py` and wire `run_phase_S` dispatch.
- Rewrite `S0/S1` prompts and add required `S2/S3` prompts for v3 and v4 prompt trees.
- Add manual GPT-5.2-pro ruling prompt pack (`MANUAL_PRO_*`) in v3 and v4 trees (non-pipeline discovery).

### Determinism and Safety
- Output filenames are explicit and underscore-safe.
- Synthesis phase is fail-closed if required R artifacts are missing.
- Promptset contracts lint clean for v4.

## Validation
- `python services/repo-truth-extractor/run_extraction_v3.py --help`
- `python services/repo-truth-extractor/run_extraction_v3.py --print-promptpack --phase S --dry-run`
- `python scripts/repo_truth_extractor_promptset_audit_v4.py --repo-root . --strict`

## Release Notes (Unreleased)
- Added runnable v3 Phase S synthesis support and new S2/S3 synthesis prompt coverage.
- Added manual GPT-5.2-pro ruling prompts for conflict, collision-policy, and risk-rerank workflows.

@codex
@clauee
@copilot
