### PR TITLE
🔒 Fix command injection in Desktop Commander

### DIFF
--- a/docker/mcp-servers/desktop-commander/server.py
+++ b/docker/mcp-servers/desktop-commander/server.py
@@ -171,6 +171,7 @@ async def take_screenshot(filename: str) -> Dict[str, Any]:
         if IS_MACOS:
             # macOS: use screencapture
             # -x: no sound, -t: format (png default)
+            # screencapture doesn't consistently support -- for filenames
             result = subprocess.run(
                 ["screencapture", "-x", filename],
                 capture_output=True,
@@ -179,8 +180,9 @@ async def take_screenshot(filename: str) -> Dict[str, Any]:
             )
         else:
             # Linux: use scrot
+            # Use -- to prevent argument injection
             result = subprocess.run(
-                ["scrot", filename],
+                ["scrot", "--", filename],
                 capture_output=True,
                 text=True,
                 timeout=10
@@ -297,11 +299,11 @@ async def focus_window(title: str) -> Dict[str, Any]:
     try:
         if IS_MACOS:
             # macOS: use AppleScript to activate application
-            # Try treating 'title' as application name first
-            applescript = f'tell application "{title}" to activate'
+            # Use positional arguments to prevent command injection
+            applescript = 'on run {appName}\ntell application appName to activate\nend run'
 
             result = subprocess.run(
-                ["osascript", "-e", applescript],
+                ["osascript", "-e", applescript, title],
                 capture_output=True,
                 text=True,
                 timeout=5
@@ -315,13 +317,16 @@ async def focus_window(title: str) -> Dict[str, Any]:
                 }
             else:
                 # Try finding by window title if app name failed
-                applescript2 = f'''
-                tell application "System Events"
-                    set frontmost of first process whose name contains "{title}" to true
-                end tell
+                # Use positional arguments to prevent command injection
+                applescript2 = '''
+                on run {appName}
+                    tell application "System Events"
+                        set frontmost of first process whose name contains appName to true
+                    end tell
+                end run
                 '''
                 result2 = subprocess.run(
-                    ["osascript", "-e", applescript2],
+                    ["osascript", "-e", applescript2, title],
                     capture_output=True,
                     text=True,
                     timeout=5
@@ -341,6 +346,7 @@ async def focus_window(title: str) -> Dict[str, Any]:
                     }
         else:
             # Linux: use wmctrl
+            # wmctrl doesn't support -- before the title for -a
             result = subprocess.run(
                 ["wmctrl", "-a", title],
                 capture_output=True,
@@ -374,16 +380,17 @@ async def type_text(text: str) -> Dict[str, Any]:
     try:
         if IS_MACOS:
             # macOS: use AppleScript to type text
-            # Escape quotes in text
-            escaped_text = text.replace('"', '\\"')
-            applescript = f'''
-            tell application "System Events"
-                keystroke "{escaped_text}"
-            end tell
+            # Use positional arguments to prevent command injection
+            applescript = '''
+            on run {targetText}
+                tell application "System Events"
+                    keystroke targetText
+                end tell
+            end run
             '''
 
             result = subprocess.run(
-                ["osascript", "-e", applescript],
+                ["osascript", "-e", applescript, text],
                 capture_output=True,
                 text=True,
                 timeout=10
@@ -402,8 +409,9 @@ async def type_text(text: str) -> Dict[str, Any]:
                 }
         else:
             # Linux: use xdotool
+            # Use -- to prevent argument injection if text starts with -
             result = subprocess.run(
-                ["xdotool", "type", text],
+                ["xdotool", "type", "--", text],
                 capture_output=True,
                 text=True,
                 timeout=10

--- a/tests/unit/test_desktop_commander_security.py
+++ b/tests/unit/test_desktop_commander_security.py
@@ -1,0 +1,87 @@
+import sys
+import os
+from unittest.mock import MagicMock, patch
+import unittest
+import asyncio
+
+# Mock dependencies before importing server
+sys.modules["uvicorn"] = MagicMock()
+sys.modules["fastapi"] = MagicMock()
+sys.modules["pydantic"] = MagicMock()
+
+# Add the server directory to sys.path
+server_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../docker/mcp-servers/desktop-commander"))
+if server_dir not in sys.path:
+    sys.path.append(server_dir)
+
+# Mock platform.system() before importing server
+with patch("platform.system", return_value="Darwin"):
+    import server
+
+class TestDesktopCommanderSecurity(unittest.TestCase):
+    def run_async(self, coro):
+        return asyncio.run(coro)
+
+    def test_type_text_macos_security(self):
+        with patch("server.IS_MACOS", True), \
+             patch("server.subprocess.run") as mock_run:
+
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            malicious_input = '"; do shell script "rm -rf /"; --'
+            self.run_async(server.type_text(malicious_input))
+
+            args, _ = mock_run.call_args
+            cmd_list = args[0]
+
+            applescript = cmd_list[2]
+            self.assertNotIn(malicious_input, applescript)
+            self.assertEqual(cmd_list[3], malicious_input)
+
+    def test_focus_window_macos_security(self):
+        with patch("server.IS_MACOS", True), \
+             patch("server.subprocess.run") as mock_run:
+
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            malicious_input = 'Finder"; do shell script "rm -rf /"; --'
+            self.run_async(server.focus_window(malicious_input))
+
+            # The first call is Attempt 1
+            args, _ = mock_run.call_args_list[0]
+            cmd_list = args[0]
+
+            applescript = cmd_list[2]
+            self.assertNotIn(malicious_input, applescript)
+            self.assertEqual(cmd_list[3], malicious_input)
+
+    def test_type_text_linux_argument_injection(self):
+        with patch("server.IS_MACOS", False), \
+             patch("server.subprocess.run") as mock_run:
+
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            input_with_dash = "--help"
+            self.run_async(server.type_text(input_with_dash))
+
+            args, _ = mock_run.call_args
+            cmd_list = args[0]
+
+            self.assertEqual(cmd_list, ["xdotool", "type", "--", "--help"])
+
+    def test_take_screenshot_linux_argument_injection(self):
+        with patch("server.IS_MACOS", False), \
+             patch("server.subprocess.run") as mock_run:
+
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            input_with_dash = "-h"
+            self.run_async(server.take_screenshot(input_with_dash))
+
+            args, _ = mock_run.call_args
+            cmd_list = args[0]
+
+            self.assertEqual(cmd_list, ["scrot", "--", "-h"])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_desktop_commander_security.py
+++ b/tests/unit/test_desktop_commander_security.py
@@ -4,84 +4,99 @@ from unittest.mock import MagicMock, patch
 import unittest
 import asyncio
 
-# Mock dependencies before importing server
-sys.modules["uvicorn"] = MagicMock()
-sys.modules["fastapi"] = MagicMock()
-sys.modules["pydantic"] = MagicMock()
-
 # Add the server directory to sys.path
 server_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../docker/mcp-servers/desktop-commander"))
 if server_dir not in sys.path:
-    sys.path.append(server_dir)
-
-# Mock platform.system() before importing server
-with patch("platform.system", return_value="Darwin"):
-    import server
+    sys.path.insert(0, server_dir)
 
 class TestDesktopCommanderSecurity(unittest.TestCase):
     def run_async(self, coro):
         return asyncio.run(coro)
 
     def test_type_text_macos_security(self):
-        with patch("server.IS_MACOS", True), \
-             patch("server.subprocess.run") as mock_run:
+        with patch.dict(sys.modules, {
+            "uvicorn": MagicMock(),
+            "fastapi": MagicMock(),
+            "pydantic": MagicMock()
+        }):
+            import server
+            with patch.object(server, "IS_MACOS", True), \
+                 patch("server.subprocess.run") as mock_run:
 
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
+                mock_run.return_value = MagicMock(returncode=0, stdout="")
 
-            malicious_input = '"; do shell script "rm -rf /"; --'
-            self.run_async(server.type_text(malicious_input))
+                malicious_input = '"; do shell script "rm -rf /"; --'
+                self.run_async(server.type_text(malicious_input))
 
-            args, _ = mock_run.call_args
-            cmd_list = args[0]
+                args, _ = mock_run.call_args
+                cmd_list = args[0]
 
-            applescript = cmd_list[2]
-            self.assertNotIn(malicious_input, applescript)
-            self.assertEqual(cmd_list[3], malicious_input)
+                applescript = cmd_list[2]
+                self.assertNotIn(malicious_input, applescript)
+                self.assertEqual(cmd_list[3], malicious_input)
 
     def test_focus_window_macos_security(self):
-        with patch("server.IS_MACOS", True), \
-             patch("server.subprocess.run") as mock_run:
+        with patch.dict(sys.modules, {
+            "uvicorn": MagicMock(),
+            "fastapi": MagicMock(),
+            "pydantic": MagicMock()
+        }):
+            import server
+            with patch.object(server, "IS_MACOS", True), \
+                 patch("server.subprocess.run") as mock_run:
 
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
+                mock_run.return_value = MagicMock(returncode=0, stdout="")
 
-            malicious_input = 'Finder"; do shell script "rm -rf /"; --'
-            self.run_async(server.focus_window(malicious_input))
+                malicious_input = 'Finder"; do shell script "rm -rf /"; --'
+                self.run_async(server.focus_window(malicious_input))
 
-            # The first call is Attempt 1
-            args, _ = mock_run.call_args_list[0]
-            cmd_list = args[0]
+                # The first call is Attempt 1
+                args, _ = mock_run.call_args_list[0]
+                cmd_list = args[0]
 
-            applescript = cmd_list[2]
-            self.assertNotIn(malicious_input, applescript)
-            self.assertEqual(cmd_list[3], malicious_input)
+                applescript = cmd_list[2]
+                self.assertNotIn(malicious_input, applescript)
+                self.assertEqual(cmd_list[3], malicious_input)
 
     def test_type_text_linux_argument_injection(self):
-        with patch("server.IS_MACOS", False), \
-             patch("server.subprocess.run") as mock_run:
+        with patch.dict(sys.modules, {
+            "uvicorn": MagicMock(),
+            "fastapi": MagicMock(),
+            "pydantic": MagicMock()
+        }):
+            import server
+            with patch.object(server, "IS_MACOS", False), \
+                 patch("server.subprocess.run") as mock_run:
 
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
+                mock_run.return_value = MagicMock(returncode=0, stdout="")
 
-            input_with_dash = "--help"
-            self.run_async(server.type_text(input_with_dash))
+                input_with_dash = "--help"
+                self.run_async(server.type_text(input_with_dash))
 
-            args, _ = mock_run.call_args
-            cmd_list = args[0]
+                args, _ = mock_run.call_args
+                cmd_list = args[0]
 
-            self.assertEqual(cmd_list, ["xdotool", "type", "--", "--help"])
+                self.assertEqual(cmd_list, ["xdotool", "type", "--", "--help"])
 
     def test_take_screenshot_linux_argument_injection(self):
-        with patch("server.IS_MACOS", False), \
-             patch("server.subprocess.run") as mock_run:
+        with patch.dict(sys.modules, {
+            "uvicorn": MagicMock(),
+            "fastapi": MagicMock(),
+            "pydantic": MagicMock()
+        }):
+            import server
+            with patch.object(server, "IS_MACOS", False), \
+                 patch("server.subprocess.run") as mock_run:
 
-            mock_run.return_value = MagicMock(returncode=0, stdout="")
+                mock_run.return_value = MagicMock(returncode=0, stdout="")
 
-            input_with_dash = "-h"
-            self.run_async(server.take_screenshot(input_with_dash))
+                input_with_dash = "-h"
+                self.run_async(server.take_screenshot(input_with_dash))
 
-            args, _ = mock_run.call_args
-            cmd_list = args[0]
+                args, _ = mock_run.call_args
+                cmd_list = args[0]
 
-            self.assertEqual(cmd_list, ["scrot", "--", "-h"])
+                self.assertEqual(cmd_list, ["scrot", "--", "-h"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
🎯 **What:** Fixed command injection vulnerability in `docker/mcp-servers/desktop-commander/server.py`.

⚠️ **Risk:** Left unfixed, an attacker could execute arbitrary shell commands on the host (for macOS) or manipulate command arguments (for Linux) via the MCP tool interface by providing maliciously crafted window titles or text.

🛡️ **Solution:**
- Refactored macOS `osascript` calls to use `on run {arg}` or `on run argv` handlers, passing user input as separate positional arguments instead of using f-string interpolation.
- Hardened Linux CLI calls (`scrot`, `xdotool`) by adding the `--` argument separator to prevent argument injection from strings starting with a dash.
- Added a comprehensive unit test suite to verify that user input is never interpolated into script strings and is correctly passed as separate arguments.

---
*PR created automatically by Jules for task [11022608105041952641](https://jules.google.com/task/11022608105041952641) started by @hu3mann*