### PR TITLE
Fix Serena Docker path mismatch

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -327,11 +327,15 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - QDRANT_URL=http://mcp-qdrant:6333
+      - HOST_CODE_PARENT_DIR=${HOST_CODE_PARENT_DIR}
+      - HOST_PROJECT_RELATIVE_PATH=${HOST_PROJECT_RELATIVE_PATH}
+      - DOPEMUX_WORKSPACE_ROOT=/workspaces/${HOST_PROJECT_RELATIVE_PATH}
     ports:
       - "3010:3010"
     volumes:
       - ./services/dope-context/data:/app/data
       - ./services/dope-context/logs:/app/logs
+      - ${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces
     depends_on:
       - mcp-qdrant
     healthcheck:
@@ -521,6 +525,10 @@ services:
       - MCP_SERVER_PORT=3006
       - HTTP_PORT=4006
       - WORKSPACE_ID=${WORKSPACE_ID:-/workspace}
+      - HOST_CODE_PARENT_DIR=${HOST_CODE_PARENT_DIR}
+      - HOST_PROJECT_RELATIVE_PATH=${HOST_PROJECT_RELATIVE_PATH}
+    volumes:
+      - ${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:4006/health || exit 1"]
       timeout: 10s

--- a/docker/mcp-servers/serena/start_with_info.sh
+++ b/docker/mcp-servers/serena/start_with_info.sh
@@ -3,6 +3,16 @@ set -e
 
 echo "Starting Serena with service discovery support..."
 
+# Symlink host path to internal mount if variables are set
+if [ -n "$HOST_CODE_PARENT_DIR" ]; then
+    echo "Creating symlink for host path compatibility..."
+    # Create parent directories
+    mkdir -p "$(dirname "$HOST_CODE_PARENT_DIR")"
+    # Link host path to /workspaces
+    ln -sfn /workspaces "$HOST_CODE_PARENT_DIR"
+    echo "Linked $HOST_CODE_PARENT_DIR -> /workspaces"
+fi
+
 # Start info server in background
 python info_server.py &
 INFO_PID=$!

--- a/services/dope-context/src/utils/workspace.py
+++ b/services/dope-context/src/utils/workspace.py
@@ -40,6 +40,17 @@ except ModuleNotFoundError:
     def _get_workspace_root(start_path: Optional[Path] = None) -> Path:
         current = Path(start_path or os.getcwd()).resolve()
 
+        # Check for dynamic relative path from Docker environment
+        host_relative_path = os.getenv("HOST_PROJECT_RELATIVE_PATH")
+        if host_relative_path:
+            # If we are in docker and have this var, we expect code at /workspaces/<name>
+            candidate = Path(f"/workspaces/{host_relative_path}")
+            if candidate.exists():
+                _logger.debug(
+                    "Workspace detected via HOST_PROJECT_RELATIVE_PATH: %s", candidate
+                )
+                return candidate
+
         env_workspace = os.getenv("DOPEMUX_WORKSPACE_ROOT")
         if env_workspace:
             workspace_path = Path(env_workspace).resolve()

--- a/src/dopemux/instance_manager.py
+++ b/src/dopemux/instance_manager.py
@@ -281,6 +281,10 @@ class InstanceManager:
             "DOPEMUX_MAIN_REPO": str(self.workspace_root),  # Main repo root for reference
             "DOPEMUX_PORT_BASE": str(port_base),
 
+            # Host path mapping for Docker containers (Serena/dope-context symlink fix)
+            "HOST_CODE_PARENT_DIR": str(actual_workspace.parent),
+            "HOST_PROJECT_RELATIVE_PATH": actual_workspace.name,
+
             # Service ports
             "TASK_MASTER_PORT": str(port_base + 5),
             "SERENA_PORT": str(port_base + 6),

--- a/tests/test_dope_context_workspace.py
+++ b/tests/test_dope_context_workspace.py
@@ -1,0 +1,37 @@
+
+import sys
+import os
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+import pytest
+
+# Add services/dope-context/src/utils to python path to import workspace directly
+sys.path.insert(0, str(Path.cwd() / "services/dope-context/src/utils"))
+
+def test_get_workspace_root_dynamic_fallback():
+    # Force ModuleNotFoundError for src.dopemux.workspace_detection
+    with patch.dict(sys.modules, {'src.dopemux.workspace_detection': None}):
+        # We need to import workspace module.
+        # Since we added utils to path, we can import it as 'workspace'
+        import workspace
+
+        # Now mock the environment and path existence
+        with patch("os.getenv") as mock_getenv, \
+             patch("pathlib.Path.exists") as mock_exists:
+
+            def getenv_side_effect(key, default=None):
+                if key == "HOST_PROJECT_RELATIVE_PATH":
+                    return "dopemux-mvp"
+                if key == "DOPEMUX_WORKSPACE_ROOT":
+                    return None
+                return default
+
+            mock_getenv.side_effect = getenv_side_effect
+            mock_exists.return_value = True
+
+            result = workspace._get_workspace_root()
+
+            assert str(result) == "/workspaces/dopemux-mvp"
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_instance_manager_env.py
+++ b/tests/test_instance_manager_env.py
@@ -1,0 +1,38 @@
+
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from src.dopemux.instance_manager import InstanceManager
+
+@patch("src.dopemux.instance_manager.InstanceManager._ensure_cache_dir")
+def test_get_instance_env_vars_host_paths(mock_ensure_cache):
+    """Verify that HOST_CODE_PARENT_DIR and HOST_PROJECT_RELATIVE_PATH are calculated correctly."""
+
+    # Setup mock workspace
+    # We use a path that looks like the user's setup
+    workspace_root = Path("/Users/hue/code/dopemux-mvp")
+
+    # Initialize manager (mock _ensure_cache_dir prevents fs access)
+    manager = InstanceManager(workspace_root)
+
+    # Test case 1: Main instance (A)
+    # instance_id='A', worktree_path=None
+    env_vars = manager.get_instance_env_vars('A', 3000, None)
+
+    assert "HOST_CODE_PARENT_DIR" in env_vars
+    assert "HOST_PROJECT_RELATIVE_PATH" in env_vars
+
+    # For main instance, actual_workspace is workspace_root
+    assert env_vars["HOST_CODE_PARENT_DIR"] == "/Users/hue/code"
+    assert env_vars["HOST_PROJECT_RELATIVE_PATH"] == "dopemux-mvp"
+
+    # Test case 2: Worktree instance (B)
+    # instance_id='B', worktree_path is inside worktrees dir
+    worktree_path = workspace_root / "worktrees" / "B"
+    env_vars_b = manager.get_instance_env_vars('B', 3030, worktree_path)
+
+    assert env_vars_b["HOST_CODE_PARENT_DIR"] == "/Users/hue/code/dopemux-mvp/worktrees"
+    assert env_vars_b["HOST_PROJECT_RELATIVE_PATH"] == "B"
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Fixes `ProjectNotFoundError` when running Serena MCP in Docker by synchronizing host and container paths via symlinks and volume mounts. Also updates `dope-context` for consistency.

---
*PR created automatically by Jules for task [10498554695922129330](https://jules.google.com/task/10498554695922129330) started by @hu3mann*