### PR TITLE
🎨 Palette: Add contextual Tooltips to shorthand status chips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -14,6 +14,6 @@
 **Learning:** For ADHD-focused dashboards, timers are critical components that require accurate screen reader feedback. Using pluralization logic in ARIA labels (e.g., '1 minute' vs '2 minutes') ensures the UI is accessible and professional for users relying on assistive technology.
 **Action:** Always implement a helper like `getTimerAriaLabel` for any duration-based displays and apply it to components with `role="timer"`.
 
-## 2025-05-16 - [Contextual Status Indicators]
-**Learning:** High-density dashboards often use shorthand status chips (like "[LIVE]"). While visually efficient, they lack context for new users or when multiple systems are integrated. Adding a descriptive Tooltip to these chips explains *what* is live (e.g., "Real-time connection to ADHD Engine active"), bridging the gap between shorthand brevity and clarity.
-**Action:** Always wrap status indicators in descriptive Tooltips to provide context without cluttering the main UI.
+## 2025-05-17 - [Contextual Shorthand Indicators]
+**Learning:** High-density dashboards often use shorthand status chips (like "[LIVE]" or "[EDGE]") to save space. While visually efficient, they lack context for new users and are inaccessible to keyboard users if they are not focusable. Adding a descriptive Tooltip and `tabIndex={0}` bridges the gap between shorthand brevity and clarity while ensuring accessibility.
+**Action:** Always wrap shorthand status indicators in descriptive Tooltips and ensure they have `tabIndex={0}` to be keyboard focusable.

--- a/ui-dashboard/src/components/PredictionPanel.tsx
+++ b/ui-dashboard/src/components/PredictionPanel.tsx
@@ -6,7 +6,8 @@ import {
   LinearProgress,
   Chip,
   Divider,
-  Alert
+  Alert,
+  Tooltip
 } from '@mui/material';
 import { TrendingUp, Clock, AlertCircle, Sparkles } from 'lucide-react';
 import { brandTokens } from '../theme';
@@ -61,12 +62,15 @@ const PredictionPanel: React.FC<PredictionPanelProps> = ({ prediction }) => {
       <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, gap: 1.5 }}>
         <TrendingUp size={24} aria-hidden="true" />
         <Typography variant="h6" sx={{ letterSpacing: '0.12em' }}>15-Minute Prediction</Typography>
-        <Chip
-          size="small"
-          label="[EDGE]"
-          className="dopemux-chip"
-          sx={{ ml: 'auto', borderColor: 'rgba(255, 139, 209, 0.7)', color: brandTokens.colors.gremlinPink }}
-        />
+        <Tooltip title="Predictive LSTM model running on edge device" arrow>
+          <Chip
+            size="small"
+            label="[EDGE]"
+            className="dopemux-chip"
+            tabIndex={0}
+            sx={{ ml: 'auto', borderColor: 'rgba(255, 139, 209, 0.7)', color: brandTokens.colors.gremlinPink }}
+          />
+        </Tooltip>
       </Box>
       <Typography className="dopemux-roast" sx={{ mb: 2 }}>
         I edge your curiosity until the model finally spills percentages.

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -168,12 +168,15 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         <Typography variant="h6" sx={{ letterSpacing: '0.16em' }}>
           Task Sequencer
         </Typography>
-        <Chip
-          size="small"
-          label="[LIVE]"
-          className="dopemux-chip"
-          sx={{ ml: 'auto', borderColor: 'rgba(125, 251, 246, 0.6)', color: brandTokens.colors.ritualCyan }}
-        />
+        <Tooltip title="Real-time task synchronization active" arrow>
+          <Chip
+            size="small"
+            label="[LIVE]"
+            className="dopemux-chip"
+            tabIndex={0}
+            sx={{ ml: 'auto', borderColor: 'rgba(125, 251, 246, 0.6)', color: brandTokens.colors.ritualCyan }}
+          />
+        </Tooltip>
       </Box>
       <Typography className="dopemux-roast" sx={{ mb: 2 }}>
         Your backlog is feral. I muzzle it with ritual order and velvet threats.

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -18,6 +18,7 @@ test('PredictionPanel.tsx has aria-label for LinearProgress and loading state', 
   expect(content).toContain('Prediction Loading...');
   // Indeterminate LinearProgress in loading state
   expect(content).toContain('aria-label="Loading prediction data"');
+  expect(content).toContain('<Tooltip title="Predictive LSTM model running on edge device"');
 });
 
 test('TeamDashboard.tsx has aria-labels for team and member progress bars', () => {
@@ -35,7 +36,8 @@ test('TaskSequencer.tsx has contextual aria-labels for buttons', () => {
   // New LinearProgress for task progress
   expect(content).toContain('aria-label="Current task progress"');
   // Timer accessibility
-  expect(content).toContain('aria-label={`Time elapsed: ${Math.floor(taskTimer / 60)} ${Math.floor(taskTimer / 60) === 1 ? \'minute\' : \'minutes\'} and ${taskTimer % 60} ${taskTimer % 60 === 1 ? \'second\' : \'seconds\'}`}');
+  expect(content).toContain('aria-label={getTimerAriaLabel(taskTimer)}');
+  expect(content).toContain('<Tooltip title="Real-time task synchronization active"');
 });
 
 test('Components have aria-hidden="true" on decorative icons', () => {


### PR DESCRIPTION
🎨 Palette: Add contextual Tooltips to shorthand status chips

This change adds descriptive tooltips and keyboard focusability (tabIndex={0}) to the [LIVE] and [EDGE] status chips in TaskSequencer and PredictionPanel.

💡 What:
- Added Tooltip to [LIVE] chip in TaskSequencer.tsx.
- Added Tooltip to [EDGE] chip in PredictionPanel.tsx.
- Added tabIndex={0} to these chips to ensure they are keyboard focusable.
- Fixed a stale accessibility test in Accessibility.test.ts and added checks for the new tooltips.
- Updated .Jules/palette.md with the latest learning.

🎯 Why:
- Shorthand terms like [LIVE] and [EDGE] are not immediately intuitive for all users.
- These chips were previously inaccessible via keyboard as they were not focusable.

♿ Accessibility:
- Keyboard focusable status indicators.
- Contextual information provided via ARIA-compliant tooltips.
- Fixed broken accessibility test coverage for the task timer.

---
*PR created automatically by Jules for task [10983644197848336661](https://jules.google.com/task/10983644197848336661) started by @hu3mann*