### PR TITLE
🔒 Fix weak token hashing in SecureTokenManager

### DIFF
--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -9,7 +9,7 @@ import secrets
 
 
 class SecureTokenManager:
-    """Manages secure tokens for API authentication."""
+    """Manages secure tokens for API authentication using salted PBKDF2 hashing."""
 
     def __init__(self):
         self._tokens = {}
@@ -17,17 +17,34 @@ class SecureTokenManager:
     def generate_token(self, identifier: str) -> str:
         """Generate a secure token for an identifier."""
         token = secrets.token_urlsafe(32)
-        self._tokens[identifier] = token
+        # Store the hash of the token, not the plain token
+        self._tokens[identifier] = self.hash_token(token)
         return token
 
     def validate_token(self, identifier: str, token: str) -> bool:
         """Validate a token for an identifier."""
-        stored_token = self._tokens.get(identifier)
-        return stored_token == token
+        stored_hash = self._tokens.get(identifier)
+        if not stored_hash:
+            return False
+        return self.verify_token(token, stored_hash)
 
     def hash_token(self, token: str) -> str:
-        """Hash a token for secure storage."""
-        return hashlib.sha256(token.encode()).hexdigest()
+        """Hash a token securely using PBKDF2 with a random salt."""
+        salt = secrets.token_bytes(16)
+        key = hashlib.pbkdf2_hmac('sha256', token.encode('utf-8'), salt, 100000)
+        # Return format: salt$hash
+        return f"{salt.hex()}${key.hex()}"
+
+    def verify_token(self, token: str, stored_hash: str) -> bool:
+        """Verify a token against a stored hash."""
+        try:
+            salt_hex, key_hex = stored_hash.split('$')
+            salt = bytes.fromhex(salt_hex)
+            expected_key = bytes.fromhex(key_hex)
+            key = hashlib.pbkdf2_hmac('sha256', token.encode('utf-8'), salt, 100000)
+            return secrets.compare_digest(key, expected_key)
+        except (ValueError, TypeError):
+            return False
 
     def remove_token(self, identifier: str) -> bool:
         """Remove a token for an identifier."""

--- a/tests/unit/test_security.py
+++ b/tests/unit/test_security.py
@@ -1,0 +1,76 @@
+
+import pytest
+import hashlib
+from src.utils.security import SecureTokenManager
+
+class TestSecureTokenManager:
+
+    def test_generate_token_returns_string(self):
+        manager = SecureTokenManager()
+        token = manager.generate_token("user1")
+        assert isinstance(token, str)
+        assert len(token) > 0
+
+    def test_tokens_are_stored_securely(self):
+        manager = SecureTokenManager()
+        identifier = "user1"
+        token = manager.generate_token(identifier)
+
+        # Verify stored value is not the plain token
+        stored_value = manager._tokens[identifier]
+        assert stored_value != token
+
+        # Verify stored value has the correct format (salt$hash)
+        assert "$" in stored_value
+        parts = stored_value.split("$")
+        assert len(parts) == 2
+
+    def test_validate_token_success(self):
+        manager = SecureTokenManager()
+        identifier = "user1"
+        token = manager.generate_token(identifier)
+
+        assert manager.validate_token(identifier, token) is True
+
+    def test_validate_token_failure(self):
+        manager = SecureTokenManager()
+        identifier = "user1"
+        token = manager.generate_token(identifier)
+
+        assert manager.validate_token(identifier, "wrong_token") is False
+
+    def test_validate_token_unknown_identifier(self):
+        manager = SecureTokenManager()
+        assert manager.validate_token("unknown_user", "some_token") is False
+
+    def test_hash_token_is_salted(self):
+        manager = SecureTokenManager()
+        token = "test_token"
+
+        hash1 = manager.hash_token(token)
+        hash2 = manager.hash_token(token)
+
+        assert hash1 != hash2
+
+    def test_verify_token(self):
+        manager = SecureTokenManager()
+        token = "test_token"
+
+        # Manually hash
+        hashed = manager.hash_token(token)
+
+        # Verify correct token matches
+        assert manager.verify_token(token, hashed) is True
+
+        # Verify incorrect token fails
+        assert manager.verify_token("wrong_token", hashed) is False
+
+    def test_remove_token(self):
+        manager = SecureTokenManager()
+        identifier = "user1"
+        manager.generate_token(identifier)
+
+        assert identifier in manager._tokens
+        assert manager.remove_token(identifier) is True
+        assert identifier not in manager._tokens
+        assert manager.remove_token(identifier) is False


### PR DESCRIPTION
This PR addresses a security vulnerability in `src/utils/security.py` where tokens were hashed using a weak algorithm (unsalted SHA256) and potentially stored in plaintext (implied by the previous validation logic).

Changes:
- **`SecureTokenManager`**: 
    - `hash_token` now uses `hashlib.pbkdf2_hmac` with a random 16-byte salt and 100,000 iterations. It returns a string in `salt$hash` format.
    - `generate_token` now stores the hashed token in `_tokens` instead of the plaintext token. It still returns the plaintext token to the caller.
    - `validate_token` retrieves the stored hash and uses `verify_token` to validate the input.
    - Added `verify_token` helper method which safely extracts the salt and performs a constant-time comparison using `secrets.compare_digest`.
- **Tests**:
    - Added `tests/unit/test_security.py` to verify:
        - Token generation returns a string.
        - Internal storage contains hashed values (salt$hash), not plaintext.
        - Validation works correctly for valid and invalid tokens.
        - Hashing is salted (same input produces different outputs).
        - Token removal works as expected.

Risk Assessment:
- **Risk**: Low. The `SecureTokenManager` class appears to be primarily used in `LeantimeBridge` where it is instantiated but not yet heavily utilized for critical authentication flows that would be disrupted by this change (based on code analysis). The external API (`generate_token`, `validate_token`) remains compatible.
- **Testing**: Verified with new unit tests and a reproduction script.


---
*PR created automatically by Jules for task [10591492037449236668](https://jules.google.com/task/10591492037449236668) started by @hu3mann*