### PR TITLE
fix(webhooks): harden DB URL migration wiring for async Phase R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Repo Truth Extractor routing defaults now use `gpt-5.2` / `gpt-5.2-pro` model IDs for OpenAI ladders.
 - OpenAI GPT-5 requests omit custom temperature to avoid unsupported parameter errors.
+- Webhook receiver and poller now accept `WEBHOOK_DB_URL` in compose, enabling explicit SQLite or Postgres ledger selection.
+- Repo Truth Extractor Phase R async finalize now applies webhook migrations with the resolved DB URL and script fallback.
+- Local runner fallback DB path for webhook ledger now avoids container-only `/data` defaults when running outside Docker.
 
 ### Planned
 - Windows support (chocolatey package)

--- a/compose.yml
+++ b/compose.yml
@@ -621,6 +621,7 @@ services:
       - WEBHOOK_RECEIVER_PORT=8790
       # Default to SQLite at WEBHOOK_DB_PATH; set WEBHOOK_DB_URL to use PostgreSQL instead.
       - WEBHOOK_DB_PATH=/data/webhook_receiver.db
+      - WEBHOOK_DB_URL=${WEBHOOK_DB_URL:-}
       - DPMX_ENV=${DPMX_ENV:-development}
       - OPENAI_WEBHOOK_SECRET=${OPENAI_WEBHOOK_SECRET}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
@@ -646,6 +647,7 @@ services:
       - dopemux-network
     environment:
       - WEBHOOK_DB_PATH=/data/webhook_receiver.db
+      - WEBHOOK_DB_URL=${WEBHOOK_DB_URL:-}
     volumes:
       - ./.dopemux/webhook_receiver:/data
     command: ["python", "/app/services/webhook_receiver/poller.py", "--providers", "xai,gemini", "--interval-seconds", "10"]

--- a/services/repo-truth-extractor/run_extraction_v3.py
+++ b/services/repo-truth-extractor/run_extraction_v3.py
@@ -9076,6 +9076,7 @@ def _build_event_store_for_runner() -> Any:
     webhook event store have been applied before constructing the EventStore, mirroring
     the migration behavior used by the main server where possible.
     """
+    repo_root = RUNNER_SERVICE_DIR.parents[1]
     webhook_receiver_dir = RUNNER_SERVICE_DIR.parent / "webhook_receiver"
     if str(webhook_receiver_dir) not in sys.path:
         sys.path.insert(0, str(webhook_receiver_dir))
@@ -9095,18 +9096,18 @@ def _build_event_store_for_runner() -> Any:
 
         if server is not None and hasattr(server, "ensure_migrations"):
             try:
-                server.ensure_migrations()  # type: ignore[call-arg]
+                server.ensure_migrations(db_url)  # type: ignore[call-arg]
             except Exception:
                 logging.exception(
                     "Failed to apply webhook event store migrations via server.ensure_migrations(); proceeding without them."
                 )
 
         if not (server is not None and hasattr(server, "ensure_migrations")):
-            migrate_script = webhook_receiver_dir / "webhook_migrate.py"
+            migrate_script = repo_root / "scripts" / "webhook_migrate.py"
             if migrate_script.is_file():
                 try:
                     subprocess.run(
-                        [sys.executable, str(migrate_script)],
+                        [sys.executable, str(migrate_script), "--db", db_url],
                         check=True,
                     )
                 except Exception:
@@ -9119,6 +9120,8 @@ def _build_event_store_for_runner() -> Any:
         logging.debug("Migrations not available or failed in runner context; continuing without them.")
 
     return storage.build_event_store(db_url)
+
+
 def _extract_openai_response_text(payload: Dict[str, Any]) -> str:
     """Extract plain text content from an OpenAI response.completed webhook payload."""
     data = payload.get("data")

--- a/services/webhook_receiver/README.md
+++ b/services/webhook_receiver/README.md
@@ -13,7 +13,8 @@ OpenAI-first webhook sidecar with provider-agnostic event ledger and poller adap
 - `OPENAI_API_KEY` (required by OpenAI SDK init)
 - `WEBHOOK_RECEIVER_HOST` (default `0.0.0.0`)
 - `WEBHOOK_RECEIVER_PORT` (default `8790`)
-- `WEBHOOK_DB_PATH` (default `/data/webhook_receiver.db`)
+- `WEBHOOK_DB_URL` (`sqlite:////...` or `postgresql://...`; preferred)
+- `WEBHOOK_DB_PATH` (legacy SQLite fallback, default `/data/webhook_receiver.db`)
 
 ## Ledger Tables
 

--- a/services/webhook_receiver/requirements.txt
+++ b/services/webhook_receiver/requirements.txt
@@ -1,1 +1,2 @@
 openai==2.20.0
+psycopg2-binary==2.9.10

--- a/services/webhook_receiver/storage.py
+++ b/services/webhook_receiver/storage.py
@@ -17,7 +17,12 @@ def resolve_webhook_db_url() -> str:
     if legacy:
         path = Path(legacy).resolve()
         return f"sqlite:///{path.as_posix()}"
-    return "sqlite:////data/webhook_receiver.db"
+    default_container = Path("/data/webhook_receiver.db")
+    parent = default_container.parent
+    if parent.exists() and os.access(parent, os.W_OK):
+        return "sqlite:////data/webhook_receiver.db"
+    local_default = (Path.cwd() / ".dopemux" / "webhook_receiver" / "webhook_receiver.db").resolve()
+    return f"sqlite:///{local_default.as_posix()}"
 
 
 def build_event_store(db_url: Optional[str] = None) -> EventStore:


### PR DESCRIPTION
## Summary
This PR hardens OpenAI-first webhook/ledger integration for local and dual-DB execution paths.

### What changed
- Pass resolved DB URL into runner-side migration bootstrap for Phase R async finalize flow.
- Fix migration script fallback path in runner (`/Users/hue/code/dopemux-mvp/scripts/webhook_migrate.py`) and include `--db` argument.
- Improve default webhook DB resolution outside containers to avoid writing to `/data` when not writable.
- Add `WEBHOOK_DB_URL` wiring for `webhook-receiver` and `webhook-poller` in compose.
- Add `psycopg2-binary` for Postgres-backed webhook ledger support.
- Update service README and `CHANGELOG.md` (`Unreleased` section).

## Why
Without these fixes, local finalize flows could fail due to missing/incorrect migration invocation and container-only DB defaults.

## Validation
- `pytest -q -c /dev/null services/webhook_receiver/test_server.py services/repo-truth-extractor/tests/test_run_extraction_v3_typer_cli.py`
  - Result: `12 passed`
- `python services/repo-truth-extractor/run_extraction_v3.py --finalize --phase R --run-id test_async_finalize_smoke`
  - Result: exits cleanly with no pending jobs when none exist.

## Release notes
- Webhook receiver/poller now honor `WEBHOOK_DB_URL` in compose for explicit SQLite/Postgres selection.
- Phase R async finalize migration bootstrap is deterministic and DB-URL aware.
- Local non-container webhook DB fallback no longer uses container-only `/data` path.

@codex
@clauee
@copilot
