### PR TITLE
fix(webhooks): harden provider poller against legacy drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Repo Truth Extractor routing defaults now use `gpt-5.2` / `gpt-5.2-pro` model IDs for OpenAI ladders.
 - OpenAI GPT-5 requests omit custom temperature to avoid unsupported parameter errors.
+- Webhook poller now uses the shared EventStore ledger interface (instead of removed legacy DB helpers) and writes idempotent normalized poll events.
 - Webhook receiver and poller now accept `WEBHOOK_DB_URL` in compose, enabling explicit SQLite or Postgres ledger selection.
 - Repo Truth Extractor Phase R async finalize now applies webhook migrations with the resolved DB URL and script fallback.
 - Local runner fallback DB path for webhook ledger now avoids container-only `/data` defaults when running outside Docker.

--- a/services/webhook_receiver/README.md
+++ b/services/webhook_receiver/README.md
@@ -43,3 +43,4 @@ python /app/services/webhook_receiver/poller.py --providers xai,gemini --once
 ```
 
 The poller reads `async_jobs` in `submitted/running`, emits normalized completion/failure events idempotently, and updates job status.
+`--providers` is fail-closed: unsupported provider IDs exit with an error.

--- a/services/webhook_receiver/poller.py
+++ b/services/webhook_receiver/poller.py
@@ -2,65 +2,256 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import time
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Callable, Dict, List
 
+from ledger.interface import RunEventInsert, WebhookEventInsert
 from providers.gemini_poller import poll_status as poll_gemini_status
 from providers.xai_poller import poll_status as poll_xai_status
-from server import db_path_from_env, ingest_polled_job_event, init_db, list_pending_jobs
+from server import ensure_migrations
+from storage import build_event_store, resolve_webhook_db_url
+
+TERMINAL_STATUSES = {"completed", "failed"}
+SUPPORTED_PROVIDERS: Dict[str, Callable[[Dict[str, Any]], str]] = {
+    "xai": poll_xai_status,
+    "gemini": poll_gemini_status,
+}
 
 
-def _resolve_db_path(cli_db: str) -> Path:
-    raw = str(cli_db or "").strip()
-    if raw:
-        return Path(raw)
-    return db_path_from_env()
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
-def run_poll_cycle(db_path: Path, providers: list[str]) -> dict:
-    jobs = list_pending_jobs(db_path, providers)
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return int(default)
+
+
+def _parse_provider_list(raw: str) -> List[str]:
+    providers = [token.strip().lower() for token in str(raw or "").split(",") if token.strip()]
+    if not providers:
+        raise ValueError("At least one provider is required")
+    unsupported = sorted({provider for provider in providers if provider not in SUPPORTED_PROVIDERS})
+    if unsupported:
+        raise ValueError(f"Unsupported providers: {','.join(unsupported)}")
+    deduped: List[str] = []
+    for provider in providers:
+        if provider not in deduped:
+            deduped.append(provider)
+    return deduped
+
+
+def _resolve_db_url(cli_db_url: str, cli_db_path: str) -> str:
+    raw_url = str(cli_db_url or "").strip()
+    if raw_url:
+        return raw_url
+    raw_path = str(cli_db_path or "").strip()
+    if raw_path:
+        path = Path(raw_path).resolve()
+        return f"sqlite:///{path.as_posix()}"
+    return resolve_webhook_db_url()
+
+
+def _poll_delivery_id(provider: str, external_job_id: str, attempt: int, status: str) -> str:
+    payload = f"poll|{provider}|{external_job_id}|{attempt}|{status}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _poll_event_id(provider: str, external_job_id: str, attempt: int, status: str) -> str:
+    return f"poll:{provider}:{external_job_id}:{attempt}:{status}"
+
+
+def _run_event_dedupe_key(
+    provider: str,
+    run_id: str,
+    phase: str,
+    step_id: str,
+    partition_id: str,
+    attempt: int,
+    event_type: str,
+    external_job_id: str,
+    orphaned: bool,
+) -> str:
+    payload = "|".join(
+        [
+            "poll",
+            provider,
+            run_id,
+            phase,
+            step_id,
+            partition_id,
+            str(attempt),
+            event_type,
+            external_job_id,
+            "orphaned" if orphaned else "linked",
+        ]
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def run_poll_cycle(event_store: Any, providers: List[str]) -> Dict[str, Any]:
+    jobs: List[Dict[str, Any]] = []
+    for provider in providers:
+        jobs.extend(event_store.list_pending_jobs(provider=provider, run_id=None, phase=None))
+    jobs.sort(
+        key=lambda row: (
+            str(row.get("provider") or ""),
+            str(row.get("run_id") or ""),
+            str(row.get("phase") or ""),
+            str(row.get("step_id") or ""),
+            str(row.get("partition_id") or ""),
+            _as_int(row.get("attempt"), 0),
+            str(row.get("external_job_id") or ""),
+        )
+    )
+
     inserted = 0
     processed = 0
+    updated_running = 0
+
     for job in jobs:
-        provider = str(job.get("provider") or "").lower()
-        if provider == "xai":
-            status = poll_xai_status(job)
-        elif provider == "gemini":
-            status = poll_gemini_status(job)
-        else:
+        provider = str(job.get("provider") or "").lower().strip()
+        poll_fn = SUPPORTED_PROVIDERS.get(provider)
+        if poll_fn is None:
             continue
-        if status not in {"completed", "failed"}:
+
+        status = str(poll_fn(job) or "").strip().lower()
+        if status not in TERMINAL_STATUSES:
+            if status in {"running", "submitted"}:
+                attempt = _as_int(job.get("attempt"), 1)
+                event_store.update_async_job_status(
+                    provider=provider,
+                    external_job_id=str(job.get("external_job_id") or ""),
+                    attempt=attempt,
+                    status=status,
+                    last_error=None,
+                )
+                updated_running += 1
             continue
+
         processed += 1
-        if ingest_polled_job_event(db_path, job, status):
+        run_id = str(job.get("run_id") or "")
+        phase = str(job.get("phase") or "")
+        step_id = str(job.get("step_id") or "")
+        partition_id = str(job.get("partition_id") or "")
+        attempt = _as_int(job.get("attempt"), 1)
+        external_job_id = str(job.get("external_job_id") or "")
+
+        latest_attempt = event_store.latest_attempt_for_tuple(
+            run_id=run_id,
+            phase=phase,
+            step_id=step_id,
+            partition_id=partition_id,
+        )
+        orphaned = latest_attempt is not None and attempt < int(latest_attempt)
+
+        event_type = "job.completed" if status == "completed" else "job.failed"
+        delivery_id = _poll_delivery_id(provider, external_job_id, attempt, status)
+        event_id = _poll_event_id(provider, external_job_id, attempt, status)
+        payload = {
+            "source": "poller",
+            "provider": provider,
+            "status": status,
+            "run_id": run_id,
+            "phase": phase,
+            "step_id": step_id,
+            "partition_id": partition_id,
+            "attempt": attempt,
+            "external_job_id": external_job_id,
+            "latest_attempt": int(latest_attempt) if latest_attempt is not None else None,
+            "orphaned": bool(orphaned),
+            "polled_at_utc": now_iso(),
+        }
+
+        inserted_event = event_store.insert_webhook_event_if_absent(
+            WebhookEventInsert(
+                provider=provider,
+                idempotency_key=delivery_id,
+                event_type=event_type,
+                event_id=event_id,
+                received_at_utc=now_iso(),
+                payload_json=json.dumps(payload, ensure_ascii=True, sort_keys=True),
+                headers_json="{}",
+                signature_valid=True,
+            )
+        )
+
+        if inserted_event:
+            webhook_event_id = None
+            if hasattr(event_store, "fetch_webhook_event_id"):
+                webhook_event_id = event_store.fetch_webhook_event_id(provider, delivery_id)  # type: ignore[attr-defined]
+            event_store.append_run_event(
+                RunEventInsert(
+                    run_id=run_id,
+                    phase=phase,
+                    step_id=step_id,
+                    partition_id=partition_id,
+                    provider=provider,
+                    event_type=event_type,
+                    event_id=event_id,
+                    provider_ref=external_job_id,
+                    webhook_event_id=webhook_event_id,
+                    dedupe_key=_run_event_dedupe_key(
+                        provider,
+                        run_id,
+                        phase,
+                        step_id,
+                        partition_id,
+                        attempt,
+                        event_type,
+                        external_job_id,
+                        orphaned,
+                    ),
+                    orphaned=orphaned,
+                )
+            )
             inserted += 1
-    payload = {
-        "db_path": str(db_path.resolve()),
+
+        next_status = "orphaned" if orphaned else status
+        last_error = "stale_attempt" if orphaned else ("provider_failed" if status == "failed" else None)
+        event_store.update_async_job_status(
+            provider=provider,
+            external_job_id=external_job_id,
+            attempt=attempt,
+            status=next_status,
+            last_error=last_error,
+        )
+
+    return {
         "providers": providers,
         "jobs_seen": len(jobs),
         "jobs_processed": processed,
+        "jobs_marked_running": updated_running,
         "events_inserted": inserted,
     }
-    return payload
 
 
 def main() -> None:
     parser = argparse.ArgumentParser("webhook-receiver-poller")
+    parser.add_argument("--db-url", type=str, default="")
     parser.add_argument("--db-path", type=str, default="")
     parser.add_argument("--providers", type=str, default="xai,gemini")
     parser.add_argument("--interval-seconds", type=int, default=10)
     parser.add_argument("--once", action="store_true")
     args = parser.parse_args()
 
-    db_path = _resolve_db_path(args.db_path)
-    init_db(db_path)
-    providers = [token.strip().lower() for token in str(args.providers).split(",") if token.strip()]
+    db_url = _resolve_db_url(args.db_url, args.db_path)
+    ensure_migrations(db_url)
+    event_store = build_event_store(db_url)
+    providers = _parse_provider_list(args.providers)
+
     if args.once:
-        print(json.dumps(run_poll_cycle(db_path, providers), indent=2, sort_keys=True))
+        print(json.dumps(run_poll_cycle(event_store, providers), indent=2, sort_keys=True))
         return
+
     while True:
-        print(json.dumps(run_poll_cycle(db_path, providers), indent=2, sort_keys=True), flush=True)
+        print(json.dumps(run_poll_cycle(event_store, providers), indent=2, sort_keys=True), flush=True)
         time.sleep(max(1, int(args.interval_seconds)))
 
 

--- a/services/webhook_receiver/test_server.py
+++ b/services/webhook_receiver/test_server.py
@@ -70,6 +70,14 @@ def _load_ledger_interface_module():
     )
 
 
+def _load_poller_module():
+    root = Path(__file__).resolve().parents[2]
+    return _load_module(
+        "webhook_receiver_poller",
+        root / "services" / "webhook_receiver" / "poller.py",
+    )
+
+
 def _free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 0))
@@ -426,3 +434,84 @@ def test_latest_attempt_reconciliation_stale_event_orphaned(tmp_path: Path, monk
     orphaned_job = store.find_async_job(provider="openai", external_job_id="resp_1", attempt=1)
     assert orphaned_job is not None
     assert orphaned_job["status"] == "orphaned"
+
+
+def test_poller_cycle_idempotent_for_terminal_status(tmp_path: Path, monkeypatch) -> None:
+    interface_mod = _load_ledger_interface_module()
+    poller = _load_poller_module()
+    store = _build_store_with_migrations(tmp_path, monkeypatch, "poller.db")
+
+    store.register_async_job(
+        interface_mod.AsyncJobInsert(
+            provider="xai",
+            job_kind="responses_async",
+            external_job_id="job_xai_1",
+            run_id="run_poll",
+            phase="R",
+            step_id="R1",
+            partition_id="R_P0001",
+            attempt=1,
+            status="submitted",
+        )
+    )
+
+    first = poller.run_poll_cycle(store, ["xai"])
+    second = poller.run_poll_cycle(store, ["xai"])
+
+    assert first["jobs_seen"] == 1
+    assert first["jobs_processed"] == 1
+    assert first["events_inserted"] == 1
+    assert second["events_inserted"] == 0
+    assert store.count_webhook_events() == 1
+    assert store.count_run_events() == 1
+
+
+def test_poller_marks_stale_attempt_orphaned(tmp_path: Path, monkeypatch) -> None:
+    interface_mod = _load_ledger_interface_module()
+    poller = _load_poller_module()
+    store = _build_store_with_migrations(tmp_path, monkeypatch, "poller_orphaned.db")
+
+    # Two attempts for the same tuple: attempt=1 should be orphaned, attempt=2 should complete.
+    store.register_async_job(
+        interface_mod.AsyncJobInsert(
+            provider="xai",
+            job_kind="responses_async",
+            external_job_id="job_xai_stale",
+            run_id="run_orphan",
+            phase="R",
+            step_id="R1",
+            partition_id="R_P0001",
+            attempt=1,
+            status="submitted",
+        )
+    )
+    store.register_async_job(
+        interface_mod.AsyncJobInsert(
+            provider="xai",
+            job_kind="responses_async",
+            external_job_id="job_xai_latest",
+            run_id="run_orphan",
+            phase="R",
+            step_id="R1",
+            partition_id="R_P0001",
+            attempt=2,
+            status="submitted",
+        )
+    )
+
+    result = poller.run_poll_cycle(store, ["xai"])
+    assert result["events_inserted"] == 2
+
+    stale_job = store.find_async_job(provider="xai", external_job_id="job_xai_stale", attempt=1)
+    latest_job = store.find_async_job(provider="xai", external_job_id="job_xai_latest", attempt=2)
+    assert stale_job is not None and stale_job["status"] == "orphaned"
+    assert latest_job is not None and latest_job["status"] == "completed"
+
+
+def test_poller_rejects_unsupported_provider() -> None:
+    poller = _load_poller_module()
+    try:
+        poller._parse_provider_list("xai,unknown")
+        assert False, "Expected ValueError for unsupported provider"
+    except ValueError as exc:
+        assert "Unsupported providers" in str(exc)


### PR DESCRIPTION
## Summary
This packet hardens the provider polling path so it uses the same EventStore/ledger contract as webhook ingestion, with idempotent terminal event emission and latest-attempt reconciliation.

### What changed
- `services/webhook_receiver/poller.py`
  - Replaced removed legacy server-DB helper usage with EventStore-based flow.
  - Added `--db-url` support (with `--db-path` compatibility fallback).
  - Added fail-closed provider parsing (`xai`, `gemini` only unless expanded in code).
  - Emits normalized synthetic events into `webhook_events` + `run_events` via EventStore.
  - Enforces stale-attempt reconciliation: non-latest attempts become `orphaned`.
  - Uses deterministic dedupe keys for poll-delivered events.
- `services/webhook_receiver/test_server.py`
  - Added poller idempotency test for repeated cycles.
  - Added stale-attempt orphaning test for poller flow.
  - Added unsupported-provider rejection test.
- `services/webhook_receiver/README.md`
  - Documented fail-closed provider behavior for poller.
- `CHANGELOG.md`
  - Added Unreleased note for poller/EventStore hardening.

## Validation
- `pytest -q -c /dev/null services/webhook_receiver/test_server.py`
  - Result: `8 passed`
- `pytest -q -c /dev/null services/webhook_receiver/tests/test_admin_cli.py services/repo-truth-extractor/tests/test_run_extraction_v3_typer_cli.py`
  - Result: `10 passed`
- `python -m py_compile services/webhook_receiver/poller.py services/webhook_receiver/providers/xai_poller.py services/webhook_receiver/providers/gemini_poller.py`
  - Result: pass
- Smoke proof:
  - Seed async job in SQLite ledger
  - `python services/webhook_receiver/poller.py --db-url sqlite:////tmp/webhook_poller_accept.db --providers xai --once`
  - Result: inserted `job.completed` event

## Notes
This preserves the OpenAI-first webhook model while keeping non-webhook providers on poll adapters with identical ledger semantics.

@codex
@clauee
@copilot
