### PR TITLE
feat(repo-truth-extractor): enrich extractor CLI introspection payloads

### DIFF
--- a/services/repo-truth-extractor/run_extraction_v3.py
+++ b/services/repo-truth-extractor/run_extraction_v3.py
@@ -7688,15 +7688,21 @@ def print_run_order(phases: List[str]) -> int:
     payload = {
         "generated_at": now_iso(),
         "runner_script_path": str(RUNNER_SCRIPT.resolve()),
+        "phase_count": len(phases),
         "phase_order": [
             {
                 "phase_id": phase,
                 "phase_dir": PHASE_DIR_NAMES.get(phase, phase),
+                "required_steps": sorted(
+                    list(REQUIRED_PROMPT_STEP_IDS.get(phase, set())),
+                    key=step_sort_key,
+                ),
+                "prompt_count": len(get_phase_prompts(phase)),
             }
             for phase in phases
         ],
     }
-    print(json.dumps(payload, indent=2))
+    print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 
@@ -7705,9 +7711,18 @@ def print_phase_routing(phases: List[str], cfg: RunnerConfig) -> int:
         "generated_at": now_iso(),
         "runner_script_path": str(RUNNER_SCRIPT.resolve()),
         "routing_policy": cfg.routing_policy,
+        "routing_policy_version": ROUTING_POLICY_VERSION,
+        "phase_defaults": {},
         "phases": {},
     }
     for phase in phases:
+        provider, model_id, api_key_env = MODEL_ROUTING.get(phase, ("", "", ""))
+        payload["phase_defaults"][phase] = {
+            "provider": provider,
+            "model_id": model_id,
+            "model": f"{provider}/{model_id}" if provider and model_id else "",
+            "api_key_env": api_key_env,
+        }
         entries: List[Dict[str, Any]] = []
         for spec in get_phase_prompts(phase):
             route = resolve_effective_step_route(phase, spec.step_id, cfg)
@@ -7732,7 +7747,7 @@ def print_phase_routing(phases: List[str], cfg: RunnerConfig) -> int:
             )
         entries.sort(key=lambda row: step_sort_key(str(row.get("step_id", ""))))
         payload["phases"][phase] = entries
-    print(json.dumps(payload, indent=2))
+    print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 
@@ -7740,6 +7755,7 @@ def print_phase_prompts(phases: List[str]) -> int:
     payload: Dict[str, Any] = {
         "generated_at": now_iso(),
         "runner_script_path": str(RUNNER_SCRIPT.resolve()),
+        "phase_count": len(phases),
         "phases": {},
     }
     for phase in phases:
@@ -7753,7 +7769,7 @@ def print_phase_prompts(phases: List[str]) -> int:
             }
             for spec in specs
         ]
-    print(json.dumps(payload, indent=2))
+    print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
 
 


### PR DESCRIPTION
## Summary
- enrich `--print-run-order` output with required step IDs and per-phase prompt counts
- enrich `--print-phase-routing` output with phase default routes and routing policy version
- keep deterministic JSON output by using sorted keys for introspection payloads
- enrich `--print-phase-prompts` payload with explicit phase_count and sorted-key output

## Why
The extractor already had introspection flags. This makes them immediately actionable for ops/debugging without manual cross-referencing.

## Validation
- `python services/repo-truth-extractor/run_extraction_v3.py --print-run-order`
- `python services/repo-truth-extractor/run_extraction_v3.py --print-phase-routing`
- `python -m py_compile services/repo-truth-extractor/run_extraction_v3.py`

## Notes
- No execution semantics changed.
- No normalization/QA behavior changed.
- No provider calls added.

@codex  
@clauee  
@copilot
