### PR TITLE
🧪 Improve test coverage for detect_level and fix regex bug

### DIFF
--- a/src/dopemux/core_logging/packet.py
+++ b/src/dopemux/core_logging/packet.py
@@ -12,7 +12,7 @@ LEVEL_PATTERNS: List[Tuple[str, re.Pattern[str]]] = [
     (
         "error",
         re.compile(
-            r"\b(error|exception|traceback|failed?|failure|panic)\b|[A-Za-z]+Error\b",
+            r"\b(error|exception|traceback|fail(ed)?|failure|panic)\b|[A-Za-z]+Error\b",
             re.IGNORECASE,
         ),
     ),

--- a/tests/dopemux/test_logging_packet.py
+++ b/tests/dopemux/test_logging_packet.py
@@ -105,17 +105,17 @@ def test_metrics_exports_include_packet_and_service_dimensions():
         ("it failed", "error"),
         ("ConnectionError", "error"),
         # New test cases below
-        ("Critical Error: Database down", "critical"), # Priority: Critical > Error
-        ("Error: Critical failure", "critical"), # Priority: Critical > Error (regex order)
-        ("Warning: This is an error", "error"), # Priority: Error > Warning
-        ("Info: but there was a warning", "warning"), # Priority: Warning > Info
-        ("Debug info", "info"), # Priority: Info > Debug
-        ("erroring", "unknown"), # Word boundary check
-        ("failures", "unknown"), # Word boundary check
-        ("warned", "unknown"), # Word boundary check
-        ("fail", "error"), # "fail" should match
-        ("failed", "error"), # "failed" should match
-        ("failure", "error"), # "failure" should match
+        ("Critical Error: Database down", "critical"),  # Priority: Critical > Error
+        ("Error: Critical failure", "critical"),  # Priority: Critical > Error (regex order)
+        ("Warning: This is an error", "error"),  # Priority: Error > Warning
+        ("Info: but there was a warning", "warning"),  # Priority: Warning > Info
+        ("Debug info", "info"),  # Priority: Info > Debug
+        ("erroring", "unknown"),  # Word boundary check
+        ("failures", "unknown"),  # Word boundary check
+        ("warned", "unknown"),  # Word boundary check
+        ("fail", "error"),  # "fail" should match
+        ("failed", "error"),  # "failed" should match
+        ("failure", "error"),  # "failure" should match
     ],
 )
 def test_detect_level(line: str, expected: str):

--- a/tests/dopemux/test_logging_packet.py
+++ b/tests/dopemux/test_logging_packet.py
@@ -104,6 +104,18 @@ def test_metrics_exports_include_packet_and_service_dimensions():
         ("information is power", "unknown"),
         ("it failed", "error"),
         ("ConnectionError", "error"),
+        # New test cases below
+        ("Critical Error: Database down", "critical"), # Priority: Critical > Error
+        ("Error: Critical failure", "critical"), # Priority: Critical > Error (regex order)
+        ("Warning: This is an error", "error"), # Priority: Error > Warning
+        ("Info: but there was a warning", "warning"), # Priority: Warning > Info
+        ("Debug info", "info"), # Priority: Info > Debug
+        ("erroring", "unknown"), # Word boundary check
+        ("failures", "unknown"), # Word boundary check
+        ("warned", "unknown"), # Word boundary check
+        ("fail", "error"), # "fail" should match
+        ("failed", "error"), # "failed" should match
+        ("failure", "error"), # "failure" should match
     ],
 )
 def test_detect_level(line: str, expected: str):


### PR DESCRIPTION
This PR improves the test coverage for the `detect_level` function in `src/dopemux/core_logging/packet.py` (tested via `src/dopemux/logging/packet.py`). It adds test cases for various log level scenarios including priority handling, case insensitivity, and word boundaries.

During the process, a bug was identified where the regex `failed?` matched "failed" and "faile" but missed the standalone word "fail". This has been corrected to `fail(ed)?` to properly match both "fail" and "failed".

**Changes:**
- Modified `tests/dopemux/test_logging_packet.py` to include a parameterized test `test_detect_level` with extensive cases.
- Modified `src/dopemux/core_logging/packet.py` to fix the error detection regex.

---
*PR created automatically by Jules for task [871565348418608467](https://jules.google.com/task/871565348418608467) started by @hu3mann*