### PR TITLE
🎨 Palette: Accessible Metric Tooltips & Keyboard Focus

### DIFF
--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -283,7 +283,22 @@ function App() {
               >
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
                   <Tooltip title={metric.tooltip} arrow>
-                    <Box tabIndex={0} sx={{ display: 'flex', alignItems: 'center', outline: 'none', '&:focus-visible': { borderRadius: 1, boxShadow: `0 0 0 2px ${brandTokens.colors.ritualCyan}` } }}>
+                    <Box
+                      tabIndex={0}
+                      sx={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        outline: 'none',
+                        '&:focus': {
+                          borderRadius: 1,
+                          boxShadow: `0 0 0 2px ${brandTokens.colors.ritualCyan}`,
+                        },
+                        '&:focus-visible': {
+                          borderRadius: 1,
+                          boxShadow: `0 0 0 2px ${brandTokens.colors.ritualCyan}`,
+                        },
+                      }}
+                    >
                       {metric.icon}
                     </Box>
                   </Tooltip>

--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -130,24 +130,28 @@ function App() {
       label: 'Energy Level',
       value: cognitiveState.energy,
       icon: <Zap color={brandTokens.colors.serumMint} size={24} aria-hidden="true" />,
+      tooltip: 'Current energy reserve based on biometric data',
       roast: "You're sipping ambition like it's lukewarm coffee.",
     },
     {
       label: 'Attention Focus',
       value: cognitiveState.attention,
       icon: <Eye color={brandTokens.colors.ritualCyan} size={24} aria-hidden="true" />,
+      tooltip: 'Real-time focus and attention span metrics',
       roast: "Focus is flirting with you; stop ghosting it.",
     },
     {
       label: 'Cognitive Load',
       value: cognitiveState.load,
       icon: <Brain color={brandTokens.colors.saintGold} size={24} aria-hidden="true" />,
+      tooltip: 'Average cognitive load across all team members',
       roast: "Load creeping up like a brat testing limits.",
     },
     {
       label: '15-min Prediction',
       value: cognitiveState.prediction ?? null,
       icon: <TrendingUp color={brandTokens.colors.giltEdge} size={24} aria-hidden="true" />,
+      tooltip: 'AI-driven prediction of cognitive state for the next 15 minutes',
       roast: "Future you is pacing. Hydrate before they mutiny.",
     },
   ];
@@ -278,7 +282,11 @@ function App() {
                 }}
               >
                 <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
-                  {metric.icon}
+                  <Tooltip title={metric.tooltip} arrow>
+                    <Box tabIndex={0} sx={{ display: 'flex', alignItems: 'center', outline: 'none', '&:focus-visible': { borderRadius: 1, boxShadow: `0 0 0 2px ${brandTokens.colors.ritualCyan}` } }}>
+                      {metric.icon}
+                    </Box>
+                  </Tooltip>
                   <Box>
                     <Typography variant="h6">{metric.value !== null ? `${(metric.value * 100).toFixed(0)}%` : 'N/A'}</Typography>
                     <Typography variant="body2" color="text.secondary">{metric.label}</Typography>

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -32,7 +32,10 @@ test('TeamDashboard.tsx has aria-labels for team and member progress bars and To
   expect(content).toContain('<Tooltip title="Aggregated cognitive load across all team members"');
   expect(content).toContain('<Tooltip title="Current energy reserve based on biometric data"');
   expect(content).toContain('<Tooltip title="Real-time focus and attention span metrics"');
-  expect(content).toContain('tabIndex={0}');
+  // Ensure the energy metric tooltip wraps a keyboard-focusable chip
+  expect(content).toMatch(/<Tooltip title="Current energy reserve based on biometric data"[\s\S]*tabIndex=\{0\}/);
+  // Ensure the attention metric tooltip wraps a keyboard-focusable chip
+  expect(content).toMatch(/<Tooltip title="Real-time focus and attention span metrics"[\s\S]*tabIndex=\{0\}/);
 });
 
 test('TaskSequencer.tsx has contextual aria-labels and current step indicator', () => {

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -33,9 +33,6 @@ test('TeamDashboard.tsx has aria-labels for team and member progress bars and To
   expect(content).toContain('<Tooltip title="Current energy reserve based on biometric data"');
   expect(content).toContain('<Tooltip title="Real-time focus and attention span metrics"');
   expect(content).toContain('tabIndex={0}');
-  expect(content).toContain('<Tooltip title="Average cognitive load across all team members" arrow>');
-  expect(content).toContain('<Tooltip title="Current energy level" arrow>');
-  expect(content).toContain('<Tooltip title="Current attention focus" arrow>');
 });
 
 test('TaskSequencer.tsx has contextual aria-labels and current step indicator', () => {


### PR DESCRIPTION
Identified a micro-UX opportunity in the `ui-dashboard` where high-density metric cards used icons without context or keyboard focus.

**Changes:**
- **App.tsx**: Enhanced the `metricCards` with descriptive tooltips. Wrapped icons in a focusable `Box` (`tabIndex={0}`) so keyboard users can trigger tooltips and screen readers receive context.
- **Accessibility.test.ts**: Updated the test suite to align with the new implementation, fixing pre-existing failures caused by label drift and missing assertions.
- **.Jules/palette.md**: Recorded the "Focusable Icon Tooltips" pattern to promote accessibility consistency across the project.

**Verification:**
- Ran `pnpm test` in `ui-dashboard`: All 6 accessibility tests passed.
- Ran `pnpm build`: Build succeeded.
- Visually verified via a Playwright-generated screenshot.

---
*PR created automatically by Jules for task [6747874921702673033](https://jules.google.com/task/6747874921702673033) started by @hu3mann*