### PR TITLE
fix(extractor): align line numbering and serena mounts

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -509,8 +509,8 @@ services:
       - HOST_PROJECT_RELATIVE_PATH=${HOST_PROJECT_RELATIVE_PATH}
     volumes:
       - ${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces
-      - ${HOME}/.serena:/root/.serena:rw
-      - ${HOME}/code:${HOME}/code:ro
+      - ${HOME:?HOME is required}/.serena:/root/.serena:rw
+      - ${HOME:?HOME is required}/code:${HOME:?HOME is required}/code:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:4006/health || exit 1"]
       timeout: 10s

--- a/compose.yml
+++ b/compose.yml
@@ -509,8 +509,8 @@ services:
       - HOST_PROJECT_RELATIVE_PATH=${HOST_PROJECT_RELATIVE_PATH}
     volumes:
       - ${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces
-      - /Users/hue/.serena:/root/.serena:rw
-      - /Users/hue/code:/Users/hue/code:ro
+      - ${HOME}/.serena:/root/.serena:rw
+      - ${HOME}/code:${HOME}/code:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:4006/health || exit 1"]
       timeout: 10s

--- a/services/repo-truth-extractor/run_extraction_v3.py
+++ b/services/repo-truth-extractor/run_extraction_v3.py
@@ -6344,15 +6344,15 @@ def _format_line_numbered_content(content: str, file_truncate_chars: int) -> str
     used_chars = 0
     truncated = False
     for line_no, line in enumerate(lines, start=1):
-        numbered = f"{line_no}: {line}"
+        line_prefix = f"{line_no:04d}: "
+        numbered = f"{line_prefix}{line}"
         additional = len(numbered) if not numbered_lines else len(numbered) + 1
         if numbered_lines and used_chars + additional > file_truncate_chars:
             truncated = True
             break
         if not numbered_lines and additional > file_truncate_chars:
-            prefix = f"{line_no}: "
-            available = max(0, file_truncate_chars - len(prefix) - len("...[TRUNCATED]..."))
-            numbered_lines.append(f"{prefix}{line[:available]}...[TRUNCATED]...")
+            available = max(0, file_truncate_chars - len(line_prefix) - len("...[TRUNCATED]..."))
+            numbered_lines.append(f"{line_prefix}{line[:available]}...[TRUNCATED]...")
             truncated = True
             break
         numbered_lines.append(numbered)


### PR DESCRIPTION
## What this changes
- switches Serena bind mounts in `compose.yml` from hardcoded `/Users/hue/...` paths to `${HOME}/...`
- aligns `run_extraction_v3.py` line numbering with the zero-padded `0001:` format already used by v5

## Why
- keeps the Serena service mounts portable across developer machines
- makes v3 evidence/context formatting consistent with the current extractor tests and v5 behavior

## Validation
- `python3 - <<...yaml.safe_load...>>` on `compose.yml`
- `python3 -m pytest -q services/repo-truth-extractor/tests/test_phase_d_line_range.py -k 'line_numbered or alpha or context'`
- direct formatter check prints `0001: alpha` / `0002: beta`

@codex
@clauee
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.
