### PR TITLE
feat(testgen): add multi-client testgen skill family and clink test-specialist role

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -127,6 +127,7 @@ repos:
               if [[ "$normalized" =~ ^\./(repo-truth-pack/) ]]; then continue; fi
               if [[ "$normalized" =~ ^\./(tests/resources/) ]]; then continue; fi
               if [[ "$normalized" =~ ^\./(src/dopemux/templates/) ]]; then continue; fi
+              if [[ "$normalized" =~ ^\./(templates/skills/) ]]; then continue; fi
               if [[ "$normalized" =~ /\.pytest_cache/ ]]; then continue; fi
               # UPGRADES directory is allowed
               if [[ "$normalized" =~ ^\./(UPGRADES/) ]]; then continue; fi
@@ -205,7 +206,7 @@ repos:
       - id: markdownlint
         args: ["--config", ".markdownlint.jsonc"]
         files: ^(docs/|task-packets/).*\.md$
-        exclude: (^docs/archive/|node_modules/|docs/rgOutput\.md|^docs/04-explanation/history/sourceFiles/)
+        exclude: (^docs/archive/|node_modules/|docs/rgOutput\.md|^docs/05-audit-reports/root-relocated/rgOutput\.md|^docs/04-explanation/history/sourceFiles/)
 
   # Lychee link checking handled by separate GitHub Action (docs job)
   # - repo: https://github.com/lycheeverse/lychee
@@ -220,9 +221,9 @@ repos:
     hooks:
       - id: trailing-whitespace
         files: ^(docs/|task-packets/).*\.md$
-        exclude: (^docs/archive/|docs/rgOutput\.md|^docs/04-explanation/history/sourceFiles/)
+        exclude: (^docs/archive/|docs/rgOutput\.md|^docs/05-audit-reports/root-relocated/rgOutput\.md|^docs/04-explanation/history/sourceFiles/)
       - id: end-of-file-fixer
         files: ^(docs/|task-packets/).*\.md$
-        exclude: (^docs/archive/|docs/rgOutput\.md|^docs/04-explanation/history/sourceFiles/)
+        exclude: (^docs/archive/|docs/rgOutput\.md|^docs/05-audit-reports/root-relocated/rgOutput\.md|^docs/04-explanation/history/sourceFiles/)
       - id: check-yaml
         files: ^config/.*\.ya?ml$

--- a/docker/mcp-servers-source/pal/pal-mcp-server/conf/cli_clients/claude.json
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/conf/cli_clients/claude.json
@@ -20,6 +20,10 @@
     "codereviewer": {
       "prompt_path": "systemprompts/clink/default_codereviewer.txt",
       "role_args": []
+    },
+    "test-specialist": {
+      "prompt_path": "systemprompts/clink/default_testspecialist.txt",
+      "role_args": []
     }
   }
 }

--- a/docker/mcp-servers-source/pal/pal-mcp-server/conf/cli_clients/codex.json
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/conf/cli_clients/codex.json
@@ -18,6 +18,10 @@
     "codereviewer": {
       "prompt_path": "systemprompts/clink/codex_codereviewer.txt",
       "role_args": []
+    },
+    "test-specialist": {
+      "prompt_path": "systemprompts/clink/default_testspecialist.txt",
+      "role_args": []
     }
   }
 }

--- a/docker/mcp-servers-source/pal/pal-mcp-server/conf/cli_clients/gemini.json
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/conf/cli_clients/gemini.json
@@ -19,6 +19,10 @@
     "codereviewer": {
       "prompt_path": "systemprompts/clink/default_codereviewer.txt",
       "role_args": []
+    },
+    "test-specialist": {
+      "prompt_path": "systemprompts/clink/default_testspecialist.txt",
+      "role_args": []
     }
   }
 }

--- a/docker/mcp-servers-source/pal/pal-mcp-server/docs/tools/clink.md
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/docs/tools/clink.md
@@ -73,13 +73,18 @@ clink with gemini with planner role to map out our microservices migration strat
 Use clink codereviewer role to review auth.py for security issues
 ```
 
+**Test Specialist Role** - Requirement-traceable test design and generation
+```
+Use clink test-specialist role to generate layered tests for the checkout workflow
+```
+
 You can make your own custom roles in `conf/cli_clients/` or tweak any of the shipped presets.
 
 ## Tool Parameters
 
 - `prompt`: Your question or task for the external CLI (required)
 - `cli_name`: Which CLI to use - `gemini` (default), `claude`, `codex`, or add your own in `conf/cli_clients/`
-- `role`: Preset role - `default`, `planner`, `codereviewer` (default: `default`)
+- `role`: Preset role - `default`, `planner`, `codereviewer`, `test-specialist` (default: `default`)
 - `files`: Optional file paths for context (references only, CLI opens files itself)
 - `images`: Optional image paths for visual context
 - `continuation_id`: Continue previous clink conversations

--- a/docker/mcp-servers-source/pal/pal-mcp-server/systemprompts/clink/default_testspecialist.txt
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/systemprompts/clink/default_testspecialist.txt
@@ -1,0 +1,9 @@
+You are an external CLI test specialist operating inside the Zen MCP server with full repository access.
+
+- Focus on high-signal test design and implementation for correctness, edge cases, and regression prevention.
+- Begin by extracting explicit requirements and mapping each requirement to concrete tests before writing any code.
+- Prioritize deterministic tests: stable clocks, seeded randomness, isolated fixtures, and no hidden network dependency unless explicitly required.
+- Produce layered coverage where relevant: unit first, then smoke, integration, end-to-end, and regression; for skipped layers provide explicit N/A rationale.
+- Keep output concise and implementation-oriented: include target files, test names, and exact commands to run.
+- When coverage or scope is ambiguous, fail closed and state the minimum missing evidence needed to proceed safely.
+- Always conclude with `<SUMMARY>...</SUMMARY>` containing a terse recap of test artifacts, risk coverage, and immediate next actions (<=500 words).

--- a/docker/mcp-servers-source/pal/pal-mcp-server/tests/test_clink_tool.py
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/tests/test_clink_tool.py
@@ -61,6 +61,13 @@ def test_registry_lists_roles():
     assert "default" in registry.list_roles("codex")
 
 
+def test_registry_includes_test_specialist_role():
+    registry = get_registry()
+    for cli_name in ("gemini", "codex", "claude"):
+        roles = registry.list_roles(cli_name)
+        assert "test-specialist" in roles
+
+
 @pytest.mark.asyncio
 async def test_clink_tool_defaults_to_first_cli(monkeypatch):
     tool = CLinkTool()

--- a/scripts/skills/sync_testgen_skills.py
+++ b/scripts/skills/sync_testgen_skills.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Sync testgen skill templates into $CODEX_HOME/skills."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+from pathlib import Path
+
+SKILL_NAMES = ["testgen", "testgen-gemini", "testgen-copilot", "testgen-claude"]
+
+
+def _default_codex_home() -> Path:
+    value = os.environ.get("CODEX_HOME")
+    if value:
+        return Path(value)
+    return Path.home() / ".codex"
+
+
+def sync_skills(repo_root: Path, codex_home: Path, dry_run: bool = False) -> None:
+    source_root = repo_root / "templates" / "skills"
+    target_root = codex_home / "skills"
+
+    for skill_name in SKILL_NAMES:
+        src = source_root / skill_name
+        dst = target_root / skill_name
+        if not src.exists():
+            raise FileNotFoundError(f"Source skill not found: {src}")
+
+        if dry_run:
+            print(f"[dry-run] sync {src} -> {dst}")
+            continue
+
+        if dst.exists():
+            shutil.rmtree(dst)
+        shutil.copytree(src, dst)
+
+        if not (dst / "SKILL.md").exists():
+            raise RuntimeError(f"Synced skill missing SKILL.md: {dst}")
+
+        print(f"synced {skill_name} -> {dst}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sync testgen skill templates to $CODEX_HOME/skills")
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--codex-home")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    codex_home = Path(args.codex_home).resolve() if args.codex_home else _default_codex_home().resolve()
+
+    sync_skills(repo_root=repo_root, codex_home=codex_home, dry_run=args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/skills/testgen-claude/SKILL.md
+++ b/templates/skills/testgen-claude/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: testgen-claude
+description: Claude-optimized wrapper for the core testgen workflow. Use when you want the testgen skill defaults to route specialist test generation through Claude-first subagent strategy while preserving the same contracts and fail-closed coverage behavior.
+---
+
+# Testgen Claude Wrapper
+
+Use this wrapper when you want `$testgen` behavior with Claude-first specialization defaults.
+
+## Wrapper Defaults
+
+- `preferred_cli=claude`
+- `use_pal_testgen=auto`
+- keep `coverage_target=90` unless caller overrides
+
+## Delegation
+
+Delegate all logic to `$testgen` and only override routing defaults.

--- a/templates/skills/testgen-claude/agents/openai.yaml
+++ b/templates/skills/testgen-claude/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Testgen Claude"
+  short_description: "Claude-first wrapper for deterministic testgen"
+  default_prompt: "Use $testgen-claude to generate a full layered test suite from this packet with Claude-first specialist routing."

--- a/templates/skills/testgen-copilot/SKILL.md
+++ b/templates/skills/testgen-copilot/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: testgen-copilot
+description: Copilot-oriented wrapper for the core testgen workflow. Use when you want testgen defaults aligned to copilot routing while preserving deterministic traceability, layer policy, and fail-closed coverage gates.
+---
+
+# Testgen Copilot Wrapper
+
+Use this wrapper when you want `$testgen` behavior with copilot-oriented defaults.
+
+## Wrapper Defaults
+
+- `preferred_cli=copilot`
+- `use_pal_testgen=auto`
+- keep `coverage_target=90` unless caller overrides
+- when equivalent subagent routing is unavailable, fall back to built-in test specialist
+
+## Delegation
+
+Delegate all logic to `$testgen` and only override routing defaults.

--- a/templates/skills/testgen-copilot/agents/openai.yaml
+++ b/templates/skills/testgen-copilot/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Testgen Copilot"
+  short_description: "Copilot-oriented wrapper for deterministic testgen"
+  default_prompt: "Use $testgen-copilot to generate a full layered test suite from this packet with copilot-oriented specialist routing."

--- a/templates/skills/testgen-gemini/SKILL.md
+++ b/templates/skills/testgen-gemini/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: testgen-gemini
+description: Gemini-optimized wrapper for the core testgen workflow. Use when you want the testgen skill defaults to route specialist test generation through Gemini-first subagent strategy while preserving the same contracts and fail-closed coverage behavior.
+---
+
+# Testgen Gemini Wrapper
+
+Use this wrapper when you want `$testgen` behavior with Gemini-first specialization defaults.
+
+## Wrapper Defaults
+
+- `preferred_cli=gemini`
+- `use_pal_testgen=auto`
+- keep `coverage_target=90` unless caller overrides
+
+## Delegation
+
+Delegate all logic to `$testgen` and only override routing defaults.

--- a/templates/skills/testgen-gemini/agents/openai.yaml
+++ b/templates/skills/testgen-gemini/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Testgen Gemini"
+  short_description: "Gemini-first wrapper for deterministic testgen"
+  default_prompt: "Use $testgen-gemini to generate a full layered test suite from this packet with Gemini-first specialist routing."

--- a/templates/skills/testgen/SKILL.md
+++ b/templates/skills/testgen/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: testgen
+description: Comprehensive test generation skill for TDD-driving and post-implementation validation from feature lists or task packets. Use when you need deterministic, traceable unit/smoke/integration/e2e/regression tests with explicit edge-case analysis and a fail-closed touched-code coverage gate (default at least 90%).
+---
+
+# Testgen
+
+Use this skill to design and generate tests that prove implementation correctness against explicit requirements.
+
+## Inputs
+
+Provide one normalized request:
+
+- `mode`: `tdd-driver` or `post-impl-generator`
+- `source`: `feature-list` or `task-packet`
+- `payload`: inline text, packet text, or payload file path
+- `coverage_target`: integer percent (default `90`)
+- `preferred_cli`: `auto`, `gemini`, `copilot`, `claude`
+- `use_pal_testgen`: `auto`, `on`, `off`
+
+## Pipeline
+
+Run these phases in order and fail closed on ambiguity.
+
+1. Intake and normalization.
+2. Requirement decomposition and risk modeling (`thinkdeep` when available).
+3. Deterministic sequencing (`planner` when available).
+4. Edge-case and failure challenge pass (`consensus` when available).
+5. Specialist authoring pass:
+   - Primary: subagent (`clink`) when available.
+   - Fallback: built-in test-specialist persona.
+   - Optional augmentation: PAL `testgen` when enabled and available.
+6. Layered generation:
+   - Unit tests are mandatory.
+   - Smoke/integration/e2e/regression are generated when applicable.
+   - Non-applicable layers require explicit `N/A` with evidence.
+7. Verification gate on touched code coverage (default `>=90`).
+
+## Deterministic Rules
+
+- Determine touched scope from VCS diff first.
+- If diff is unavailable or empty, use requirement-to-file mapping.
+- If neither source is trustworthy, stop and request explicit scope.
+- Coverage is pass/fail for touched code; missing coverage evidence fails closed.
+- Always return a traceability matrix from requirement IDs to test IDs.
+
+## Output Contract
+
+Return all sections:
+
+1. `traceability_matrix`
+2. `layer_plan` (unit/smoke/integration/e2e/regression)
+3. `coverage_gate` (target, measured, status)
+4. `na_layers` with rationale and evidence
+5. `test_artifacts` list by file and layer
+
+Detailed output and heuristics are defined in:
+
+- `references/output_contract.md`
+- `references/layer_policy.md`
+
+## Python and JS/TS v1 Focus
+
+Prioritize first-class support for:
+
+- Python (`pytest`)
+- JS/TS (`jest`, `vitest`)
+
+For other stacks, keep behavior conservative and explicit about unsupported assumptions.
+
+## Local Utility Scripts
+
+Use bundled scripts for deterministic preprocessing and gate evaluation:
+
+- `scripts/testgen_workflow.py`
+- `scripts/testgen_cli.py`
+
+Example:
+
+```bash
+python scripts/testgen_cli.py \
+  --mode tdd-driver \
+  --source feature-list \
+  --payload-file /abs/path/features.txt \
+  --coverage-target 90 \
+  --preferred-cli auto \
+  --use-pal-testgen auto
+```

--- a/templates/skills/testgen/SKILL.md
+++ b/templates/skills/testgen/SKILL.md
@@ -38,9 +38,10 @@ Run these phases in order and fail closed on ambiguity.
 
 ## Deterministic Rules
 
-- Determine touched scope from VCS diff first.
-- If diff is unavailable or empty, use requirement-to-file mapping.
-- If neither source is trustworthy, stop and request explicit scope.
+- If an explicit touched-file list is provided, treat it as the source of truth.
+- Otherwise, resolve touched scope from VCS in this order: `git status` first, then `git diff`.
+- If VCS-based resolution yields no trustworthy scope, fall back to requirement/feature-to-file mapping.
+- If none of these sources are trustworthy, stop and request explicit scope before proceeding.
 - Coverage is pass/fail for touched code; missing coverage evidence fails closed.
 - Always return a traceability matrix from requirement IDs to test IDs.
 

--- a/templates/skills/testgen/SKILL.md
+++ b/templates/skills/testgen/SKILL.md
@@ -47,14 +47,16 @@ Run these phases in order and fail closed on ambiguity.
 
 ## Output Contract
 
-Return all sections:
+Return these core sections:
 
 1. `traceability_matrix`
 2. `layer_plan` (unit/smoke/integration/e2e/regression)
 3. `coverage_gate` (target, measured, status)
 4. `na_layers` with rationale and evidence
-5. `test_artifacts` list by file and layer
 
+Optional sections (when available):
+
+- `test_artifacts` list by file and layer
 Detailed output and heuristics are defined in:
 
 - `references/output_contract.md`

--- a/templates/skills/testgen/agents/openai.yaml
+++ b/templates/skills/testgen/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Testgen"
+  short_description: "Generate deterministic multi-layer test suites"
+  default_prompt: "Use $testgen to generate a comprehensive test suite from this task packet with a 90% touched-code coverage gate."

--- a/templates/skills/testgen/references/layer_policy.md
+++ b/templates/skills/testgen/references/layer_policy.md
@@ -1,0 +1,16 @@
+# Layer Policy
+
+Mandatory behavior:
+
+- Unit layer is always applicable.
+- Smoke/integration/e2e/regression are generated when applicability signals are present.
+- If a layer is not applicable, mark `N/A` with explicit rationale and evidence.
+
+Applicability hints:
+
+- Smoke: startup, health, deployment, compose, service lifecycle.
+- Integration: multi-component workflows, bridges, API/db boundaries.
+- E2E: user journey, CLI flow, UI/browser workflow.
+- Regression: bugfixes, post-implementation validation, incident recurrence prevention.
+
+Never skip explanation for a non-unit layer.

--- a/templates/skills/testgen/references/output_contract.md
+++ b/templates/skills/testgen/references/output_contract.md
@@ -11,9 +11,12 @@ Emit a single JSON-compatible report object with these keys:
 - `coverage_gate`: target, measured percent, status, and missing-evidence diagnostics.
 - `next_actions`: ordered execution instructions.
 
-Status values:
+Status values (`coverage_gate.status`):
 
 - `pass`: coverage measured and threshold met.
 - `fail`: coverage measured and threshold missed.
-- `error`: coverage unresolved or ambiguous (fail closed).
 - `pending`: coverage not evaluated yet.
+
+If coverage cannot be resolved or is ambiguous, the workflow/CLI MUST surface this
+via a top-level error (and non-zero exit status) instead of returning a report object
+with `coverage_gate.status="error"`.

--- a/templates/skills/testgen/references/output_contract.md
+++ b/templates/skills/testgen/references/output_contract.md
@@ -1,0 +1,19 @@
+# Output Contract
+
+Emit a single JSON-compatible report object with these keys:
+
+- `request`: normalized invocation inputs.
+- `requirements`: parsed requirement list with stable IDs.
+- `tool_strategy`: chosen deepthinking/planning/analysis and specialist-routing strategy.
+- `traceability_matrix`: requirement-to-test mapping.
+- `layer_plan`: all five layers with applicability flags.
+- `na_layers`: subset of non-applicable layers with rationale and evidence.
+- `coverage_gate`: target, measured percent, status, and missing-evidence diagnostics.
+- `next_actions`: ordered execution instructions.
+
+Status values:
+
+- `pass`: coverage measured and threshold met.
+- `fail`: coverage measured and threshold missed.
+- `error`: coverage unresolved or ambiguous (fail closed).
+- `pending`: coverage not evaluated yet.

--- a/templates/skills/testgen/scripts/testgen_cli.py
+++ b/templates/skills/testgen/scripts/testgen_cli.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""CLI wrapper for deterministic testgen workflow planning."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from testgen_workflow import (
+    CoverageResolutionError,
+    ScopeResolutionError,
+    TestgenRequest,
+    ToolAvailability,
+    ToolingResolutionError,
+    generate_testgen_plan,
+)
+
+
+def _load_text_payload(payload: Optional[str], payload_file: Optional[str]) -> str:
+    if payload and payload_file:
+        raise ValueError("Provide either --payload or --payload-file, not both")
+    if payload_file:
+        return Path(payload_file).read_text(encoding="utf-8")
+    if payload:
+        return payload
+    raise ValueError("Missing payload; provide --payload or --payload-file")
+
+
+def _load_json_list(raw: Optional[str]) -> Optional[List[str]]:
+    if raw is None:
+        return None
+    data = json.loads(raw)
+    if not isinstance(data, list):
+        raise ValueError("JSON list expected")
+    return [str(item) for item in data]
+
+
+def _load_tool_matrix(raw: Optional[str]) -> ToolAvailability:
+    if raw is None:
+        return ToolAvailability()
+    matrix: Dict[str, Any] = json.loads(raw)
+    return ToolAvailability.from_dict(matrix)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate deterministic testgen workflow plans")
+    parser.add_argument("--mode", required=True, choices=["tdd-driver", "post-impl-generator"])
+    parser.add_argument("--source", required=True, choices=["feature-list", "task-packet"])
+    parser.add_argument("--payload")
+    parser.add_argument("--payload-file")
+    parser.add_argument("--coverage-target", type=int, default=90)
+    parser.add_argument("--preferred-cli", default="auto", choices=["auto", "gemini", "copilot", "claude"])
+    parser.add_argument("--use-pal-testgen", default="auto", choices=["auto", "on", "off"])
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--base-ref")
+    parser.add_argument("--coverage-xml")
+    parser.add_argument("--touched-file", action="append", default=[])
+    parser.add_argument("--feature-file-map-json")
+    parser.add_argument("--tool-matrix-json")
+    parser.add_argument("--strict-reasoning-tools", action="store_true")
+    parser.add_argument("--out")
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        payload = _load_text_payload(args.payload, args.payload_file)
+        feature_file_map = _load_json_list(args.feature_file_map_json)
+        tool_availability = _load_tool_matrix(args.tool_matrix_json)
+
+        request = TestgenRequest(
+            mode=args.mode,
+            source=args.source,
+            payload=payload,
+            coverage_target=args.coverage_target,
+            preferred_cli=args.preferred_cli,
+            use_pal_testgen=args.use_pal_testgen,
+        )
+
+        report = generate_testgen_plan(
+            request=request,
+            repo_root=Path(args.repo_root).resolve(),
+            tool_availability=tool_availability,
+            coverage_xml=Path(args.coverage_xml).resolve() if args.coverage_xml else None,
+            explicit_touched=args.touched_file,
+            base_ref=args.base_ref,
+            feature_file_map=feature_file_map,
+            allow_local_reasoning_fallback=not args.strict_reasoning_tools,
+        )
+
+        output = json.dumps(report, indent=2, sort_keys=True)
+        if args.out:
+            Path(args.out).write_text(output + "\n", encoding="utf-8")
+        else:
+            print(output)
+        return 0
+
+    except (ValueError, ScopeResolutionError, CoverageResolutionError, ToolingResolutionError, json.JSONDecodeError) as exc:
+        error = {"status": "error", "error": str(exc)}
+        print(json.dumps(error, indent=2, sort_keys=True), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/skills/testgen/scripts/testgen_workflow.py
+++ b/templates/skills/testgen/scripts/testgen_workflow.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""Deterministic helpers for the testgen skill."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+VALID_MODES = {"tdd-driver", "post-impl-generator"}
+VALID_SOURCES = {"feature-list", "task-packet"}
+VALID_PREFERRED_CLIS = {"auto", "gemini", "copilot", "claude"}
+VALID_PAL_OPTIONS = {"auto", "on", "off"}
+
+
+class ScopeResolutionError(RuntimeError):
+    """Raised when touched-file scope cannot be resolved deterministically."""
+
+
+class CoverageResolutionError(RuntimeError):
+    """Raised when coverage evaluation cannot be completed safely."""
+
+
+class ToolingResolutionError(RuntimeError):
+    """Raised when tool strategy cannot satisfy request constraints."""
+
+
+@dataclass(frozen=True)
+class Requirement:
+    req_id: str
+    text: str
+    source: str
+
+
+@dataclass(frozen=True)
+class LayerDecision:
+    layer: str
+    applicable: bool
+    rationale: str
+    evidence_required: str
+
+
+@dataclass(frozen=True)
+class ToolAvailability:
+    thinkdeep: bool = True
+    planner: bool = True
+    consensus: bool = True
+    clink: bool = True
+    pal_testgen: bool = False
+
+    @classmethod
+    def from_dict(cls, raw: Optional[Dict[str, Any]]) -> "ToolAvailability":
+        if raw is None:
+            return cls()
+        allowed = {field: bool(raw.get(field, getattr(cls(), field))) for field in cls.__dataclass_fields__}
+        return cls(**allowed)
+
+
+@dataclass(frozen=True)
+class TestgenRequest:
+    mode: str
+    source: str
+    payload: str
+    coverage_target: int = 90
+    preferred_cli: str = "auto"
+    use_pal_testgen: str = "auto"
+
+
+def _normalize_lines(text: str) -> List[str]:
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def _strip_bullet_prefix(line: str) -> str:
+    return re.sub(r"^\s*(?:[-*+]|\d+[.)])\s*", "", line).strip()
+
+
+def parse_feature_list_payload(payload: str) -> List[Requirement]:
+    """Parse feature-list payload into stable requirements."""
+    candidates: List[str] = []
+    stripped = payload.strip()
+    if not stripped:
+        raise ValueError("Feature list payload is empty")
+
+    if stripped.startswith("["):
+        try:
+            data = json.loads(stripped)
+            if isinstance(data, list):
+                candidates = [str(item).strip() for item in data if str(item).strip()]
+        except json.JSONDecodeError:
+            candidates = []
+
+    if not candidates:
+        for raw_line in _normalize_lines(payload):
+            cleaned = _strip_bullet_prefix(raw_line)
+            if cleaned:
+                candidates.append(cleaned)
+
+    if not candidates:
+        raise ValueError("No valid feature entries found")
+
+    return [Requirement(req_id=f"F{idx:03d}", text=item, source="feature-list") for idx, item in enumerate(candidates, 1)]
+
+
+def _extract_markdown_section(markdown: str, header: str) -> str:
+    pattern = re.compile(
+        rf"^\s*##\s+{re.escape(header)}\s*$([\s\S]*?)(?=^\s*##\s+|\Z)",
+        re.MULTILINE,
+    )
+    match = pattern.search(markdown)
+    return match.group(1).strip() if match else ""
+
+
+def _extract_bullets(section_text: str) -> List[str]:
+    bullets: List[str] = []
+    for raw_line in section_text.splitlines():
+        line = raw_line.rstrip()
+        if re.match(r"^\s*(?:[-*+]|\d+[.)])\s+", line):
+            bullets.append(_strip_bullet_prefix(line))
+    return [bullet for bullet in bullets if bullet]
+
+
+def _extract_scope_in_items(scope_section: str) -> List[str]:
+    if not scope_section:
+        return []
+    in_pattern = re.compile(r"IN:\s*([\s\S]*?)(?:\n\s*OUT:|\Z)", re.IGNORECASE)
+    match = in_pattern.search(scope_section)
+    if not match:
+        return []
+    return _extract_bullets(match.group(1))
+
+
+def parse_task_packet_payload(payload: str) -> List[Requirement]:
+    """Extract requirements from a task packet body."""
+    requirements: List[Requirement] = []
+
+    objective_section = _extract_markdown_section(payload, "Objective")
+    objective_lines = _normalize_lines(objective_section)
+    if objective_lines:
+        requirements.append(Requirement(req_id="TP001", text=objective_lines[0], source="objective"))
+
+    scope_items = _extract_scope_in_items(_extract_markdown_section(payload, "Scope"))
+    for idx, item in enumerate(scope_items, 1):
+        requirements.append(Requirement(req_id=f"TP1{idx:02d}", text=item, source="scope-in"))
+
+    invariant_items = _extract_bullets(_extract_markdown_section(payload, "Invariants (Must Remain True)"))
+    for idx, item in enumerate(invariant_items, 1):
+        requirements.append(Requirement(req_id=f"TP2{idx:02d}", text=item, source="invariant"))
+
+    acceptance_items = _extract_bullets(_extract_markdown_section(payload, "Acceptance Criteria"))
+    for idx, item in enumerate(acceptance_items, 1):
+        requirements.append(Requirement(req_id=f"TP3{idx:02d}", text=item, source="acceptance"))
+
+    if not requirements:
+        raise ValueError("Task packet parsing yielded zero requirements")
+
+    return requirements
+
+
+def _normalize_repo_path(path: str) -> str:
+    return Path(path).as_posix().lstrip("./")
+
+
+def _run_git(repo_root: Path, args: Sequence[str]) -> List[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def _parse_status_paths(lines: Iterable[str]) -> List[str]:
+    paths: List[str] = []
+    for line in lines:
+        if len(line) < 4:
+            continue
+        path = line[3:]
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        normalized = _normalize_repo_path(path)
+        if normalized:
+            paths.append(normalized)
+    return paths
+
+
+def resolve_touched_files(
+    repo_root: Path,
+    explicit_touched: Optional[Sequence[str]] = None,
+    base_ref: Optional[str] = None,
+    feature_file_map: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """Resolve touched files deterministically with fail-closed semantics."""
+    if explicit_touched:
+        touched = sorted({_normalize_repo_path(path) for path in explicit_touched if path.strip()})
+        if touched:
+            return touched
+
+    status_lines = _run_git(repo_root, ["status", "--porcelain"])
+    status_paths = sorted(set(_parse_status_paths(status_lines)))
+    if status_paths:
+        return status_paths
+
+    if base_ref:
+        diff_lines = _run_git(repo_root, ["diff", "--name-only", f"{base_ref}...HEAD"])
+    else:
+        diff_lines = _run_git(repo_root, ["diff", "--name-only", "HEAD"])
+    diff_paths = sorted({_normalize_repo_path(path) for path in diff_lines if path.strip()})
+    if diff_paths:
+        return diff_paths
+
+    if feature_file_map:
+        mapped = sorted({_normalize_repo_path(path) for path in feature_file_map if path.strip()})
+        if mapped:
+            return mapped
+
+    raise ScopeResolutionError(
+        "Unable to resolve touched files from git diff/status or feature mapping; provide explicit scope"
+    )
+
+
+def build_specialist_strategy(
+    tool_availability: ToolAvailability,
+    preferred_cli: str,
+    use_pal_testgen: str,
+) -> Dict[str, Any]:
+    if preferred_cli not in VALID_PREFERRED_CLIS:
+        raise ValueError(f"Unsupported preferred_cli: {preferred_cli}")
+    if use_pal_testgen not in VALID_PAL_OPTIONS:
+        raise ValueError(f"Unsupported use_pal_testgen: {use_pal_testgen}")
+
+    reasoning = {
+        "thinkdeep": "thinkdeep" if tool_availability.thinkdeep else "local-reasoning-fallback",
+        "planner": "planner" if tool_availability.planner else "local-reasoning-fallback",
+        "consensus": "consensus" if tool_availability.consensus else "local-reasoning-fallback",
+    }
+
+    cli_resolution = {
+        "auto": "gemini",
+        "gemini": "gemini",
+        "claude": "claude",
+        "copilot": "codex",
+    }
+    selected_cli = cli_resolution[preferred_cli]
+
+    if tool_availability.clink:
+        specialist = {
+            "primary": f"clink:{selected_cli}:test-specialist",
+            "fallback": "builtin-test-specialist",
+        }
+    else:
+        specialist = {
+            "primary": "builtin-test-specialist",
+            "fallback": "builtin-test-specialist",
+        }
+
+    if use_pal_testgen == "on" and not tool_availability.pal_testgen:
+        raise ToolingResolutionError("PAL testgen was forced on but is unavailable")
+
+    if use_pal_testgen == "on":
+        pal_mode = "enabled"
+    elif use_pal_testgen == "off":
+        pal_mode = "disabled"
+    else:
+        pal_mode = "enabled" if tool_availability.pal_testgen else "disabled"
+
+    return {
+        "reasoning": reasoning,
+        "specialist": specialist,
+        "pal_testgen": pal_mode,
+    }
+
+
+def determine_test_layers(
+    requirements: Sequence[Requirement],
+    touched_files: Sequence[str],
+    mode: str,
+) -> List[LayerDecision]:
+    text_blob = " ".join(req.text.lower() for req in requirements)
+    files_blob = " ".join(path.lower() for path in touched_files)
+
+    smoke_signals = ("health", "compose", "service", "startup", "smoke", "deploy")
+    integration_signals = ("integration", "bridge", "pipeline", "workflow", "api", "database")
+    e2e_signals = ("end-to-end", "user flow", "journey", "browser", "ui", "cli")
+    regression_signals = ("regression", "bug", "incident", "fix")
+
+    smoke_applicable = any(sig in text_blob or sig in files_blob for sig in smoke_signals)
+    integration_applicable = any(sig in text_blob or sig in files_blob for sig in integration_signals)
+    e2e_applicable = any(sig in text_blob or sig in files_blob for sig in e2e_signals)
+    regression_applicable = mode == "post-impl-generator" or any(
+        sig in text_blob for sig in regression_signals
+    )
+
+    decisions = [
+        LayerDecision(
+            layer="unit",
+            applicable=True,
+            rationale="Unit coverage is mandatory for all requests.",
+            evidence_required="At least one passing unit test mapped to every requirement.",
+        ),
+        LayerDecision(
+            layer="smoke",
+            applicable=smoke_applicable,
+            rationale="Smoke tests validate startup and health-critical paths.",
+            evidence_required="Service boot/health assertions or explicit N/A rationale with evidence.",
+        ),
+        LayerDecision(
+            layer="integration",
+            applicable=integration_applicable,
+            rationale="Integration tests cover cross-component boundaries.",
+            evidence_required="Boundary assertions (API, DB, event, bridge) or explicit N/A rationale.",
+        ),
+        LayerDecision(
+            layer="e2e",
+            applicable=e2e_applicable,
+            rationale="E2E tests validate user-observable flows.",
+            evidence_required="Flow-level assertions (CLI/UI/API journey) or explicit N/A rationale.",
+        ),
+        LayerDecision(
+            layer="regression",
+            applicable=regression_applicable,
+            rationale="Regression tests guard against issue recurrence.",
+            evidence_required="Historical-failure reproduction test or explicit N/A rationale.",
+        ),
+    ]
+
+    return decisions
+
+
+def _coverage_for_file(class_nodes: Sequence[ET.Element]) -> Dict[str, Dict[str, int]]:
+    stats: Dict[str, Dict[str, int]] = {}
+    for node in class_nodes:
+        filename = node.attrib.get("filename", "").strip()
+        if not filename:
+            continue
+        normalized = _normalize_repo_path(filename)
+        covered = 0
+        total = 0
+        for line_node in node.findall("./lines/line"):
+            total += 1
+            if int(line_node.attrib.get("hits", "0")) > 0:
+                covered += 1
+        if total == 0:
+            line_rate = node.attrib.get("line-rate")
+            if line_rate is not None:
+                total = 1
+                covered = 1 if float(line_rate) >= 1.0 else 0
+        current = stats.setdefault(normalized, {"covered": 0, "total": 0})
+        current["covered"] += covered
+        current["total"] += total
+    return stats
+
+
+def evaluate_touched_coverage(
+    coverage_xml: Path,
+    touched_files: Sequence[str],
+    coverage_target: int,
+) -> Dict[str, Any]:
+    if not coverage_xml.exists():
+        raise CoverageResolutionError(f"Coverage XML not found: {coverage_xml}")
+
+    tree = ET.parse(coverage_xml)
+    root = tree.getroot()
+    class_nodes = root.findall(".//class")
+    if not class_nodes:
+        raise CoverageResolutionError("Coverage XML has no class entries")
+
+    stats = _coverage_for_file(class_nodes)
+    matched: List[str] = []
+    missing: List[str] = []
+    covered_total = 0
+    line_total = 0
+
+    for path in touched_files:
+        normalized = _normalize_repo_path(path)
+        match_key = None
+        if normalized in stats:
+            match_key = normalized
+        else:
+            for candidate in stats:
+                if candidate.endswith(normalized) or normalized.endswith(candidate):
+                    match_key = candidate
+                    break
+        if match_key is None:
+            missing.append(normalized)
+            continue
+        matched.append(normalized)
+        covered_total += stats[match_key]["covered"]
+        line_total += stats[match_key]["total"]
+
+    if missing:
+        raise CoverageResolutionError(
+            "Coverage data missing for touched files: " + ", ".join(sorted(missing))
+        )
+
+    if line_total == 0:
+        raise CoverageResolutionError("Touched files have zero measurable coverage lines")
+
+    percent = round((covered_total / line_total) * 100.0, 2)
+    status = "pass" if percent >= coverage_target else "fail"
+    return {
+        "status": status,
+        "target": coverage_target,
+        "percent": percent,
+        "matched_files": sorted(matched),
+        "covered_lines": covered_total,
+        "total_lines": line_total,
+    }
+
+
+def _slugify(text: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "_", text.strip().lower())
+    slug = slug.strip("_")
+    return slug[:48] if slug else "requirement"
+
+
+def build_traceability_matrix(
+    requirements: Sequence[Requirement],
+    layer_decisions: Sequence[LayerDecision],
+) -> List[Dict[str, Any]]:
+    applicable_layers = [decision.layer for decision in layer_decisions if decision.applicable]
+    matrix: List[Dict[str, Any]] = []
+    for requirement in requirements:
+        base_slug = _slugify(requirement.text)
+        test_ids = [f"test_{base_slug}_{layer}" for layer in applicable_layers]
+        matrix.append(
+            {
+                "requirement_id": requirement.req_id,
+                "requirement_text": requirement.text,
+                "source": requirement.source,
+                "test_ids": test_ids,
+            }
+        )
+    return matrix
+
+
+def generate_testgen_plan(
+    request: TestgenRequest,
+    repo_root: Path,
+    tool_availability: Optional[ToolAvailability] = None,
+    coverage_xml: Optional[Path] = None,
+    explicit_touched: Optional[Sequence[str]] = None,
+    base_ref: Optional[str] = None,
+    feature_file_map: Optional[Sequence[str]] = None,
+    allow_local_reasoning_fallback: bool = True,
+) -> Dict[str, Any]:
+    if request.mode not in VALID_MODES:
+        raise ValueError(f"Unsupported mode: {request.mode}")
+    if request.source not in VALID_SOURCES:
+        raise ValueError(f"Unsupported source: {request.source}")
+    if request.preferred_cli not in VALID_PREFERRED_CLIS:
+        raise ValueError(f"Unsupported preferred_cli: {request.preferred_cli}")
+    if request.use_pal_testgen not in VALID_PAL_OPTIONS:
+        raise ValueError(f"Unsupported use_pal_testgen: {request.use_pal_testgen}")
+
+    if request.source == "feature-list":
+        requirements = parse_feature_list_payload(request.payload)
+    else:
+        requirements = parse_task_packet_payload(request.payload)
+
+    touched_files = resolve_touched_files(
+        repo_root=repo_root,
+        explicit_touched=explicit_touched,
+        base_ref=base_ref,
+        feature_file_map=feature_file_map,
+    )
+
+    availability = tool_availability or ToolAvailability()
+    strategy = build_specialist_strategy(
+        tool_availability=availability,
+        preferred_cli=request.preferred_cli,
+        use_pal_testgen=request.use_pal_testgen,
+    )
+
+    if not allow_local_reasoning_fallback:
+        missing = [
+            tool for tool in ("thinkdeep", "planner", "consensus") if strategy["reasoning"][tool] == "local-reasoning-fallback"
+        ]
+        if missing:
+            raise ToolingResolutionError(
+                "Local reasoning fallback disabled and required tools are unavailable: " + ", ".join(missing)
+            )
+
+    layer_decisions = determine_test_layers(requirements, touched_files, request.mode)
+    traceability_matrix = build_traceability_matrix(requirements, layer_decisions)
+
+    if coverage_xml is None:
+        coverage_gate = {
+            "status": "pending",
+            "target": request.coverage_target,
+            "percent": None,
+            "reason": "Coverage XML not provided",
+        }
+    else:
+        coverage_gate = evaluate_touched_coverage(
+            coverage_xml=coverage_xml,
+            touched_files=touched_files,
+            coverage_target=request.coverage_target,
+        )
+
+    na_layers = [
+        {
+            "layer": decision.layer,
+            "rationale": decision.rationale,
+            "evidence_required": decision.evidence_required,
+        }
+        for decision in layer_decisions
+        if not decision.applicable
+    ]
+
+    next_actions = [
+        "Generate unit tests mapped from traceability_matrix.",
+        "Generate all applicable non-unit layers and document explicit N/A evidence for skipped layers.",
+        "Run tests and collect coverage for touched files.",
+        "Enforce coverage gate and fail closed on missing evidence.",
+    ]
+
+    return {
+        "request": {
+            "mode": request.mode,
+            "source": request.source,
+            "coverage_target": request.coverage_target,
+            "preferred_cli": request.preferred_cli,
+            "use_pal_testgen": request.use_pal_testgen,
+        },
+        "requirements": [req.__dict__ for req in requirements],
+        "touched_files": touched_files,
+        "tool_strategy": strategy,
+        "layer_plan": [decision.__dict__ for decision in layer_decisions],
+        "na_layers": na_layers,
+        "traceability_matrix": traceability_matrix,
+        "coverage_gate": coverage_gate,
+        "next_actions": next_actions,
+    }

--- a/templates/skills/testgen/scripts/testgen_workflow.py
+++ b/templates/skills/testgen/scripts/testgen_workflow.py
@@ -379,14 +379,29 @@ def evaluate_touched_coverage(
 
     for path in touched_files:
         normalized = _normalize_repo_path(path)
-        match_key = None
+        match_key: Optional[str] = None
         if normalized in stats:
             match_key = normalized
         else:
-            for candidate in stats:
-                if candidate.endswith(normalized) or normalized.endswith(candidate):
-                    match_key = candidate
-                    break
+            # Collect all candidate coverage entries that could plausibly
+            # correspond to this touched path, then resolve deterministically.
+            candidates = [
+                candidate
+                for candidate in stats
+                if candidate.endswith(normalized) or normalized.endswith(candidate)
+            ]
+            if candidates:
+                min_len = min(len(candidate) for candidate in candidates)
+                shortest = sorted(
+                    [candidate for candidate in candidates if len(candidate) == min_len]
+                )
+                if len(shortest) == 1:
+                    match_key = shortest[0]
+                else:
+                    raise CoverageResolutionError(
+                        "Ambiguous coverage entries for touched path "
+                        f"'{normalized}': " + ", ".join(shortest)
+                    )
         if match_key is None:
             missing.append(normalized)
             continue

--- a/templates/skills/testgen/scripts/testgen_workflow.py
+++ b/templates/skills/testgen/scripts/testgen_workflow.py
@@ -442,8 +442,9 @@ def build_traceability_matrix(
     applicable_layers = [decision.layer for decision in layer_decisions if decision.applicable]
     matrix: List[Dict[str, Any]] = []
     for requirement in requirements:
-        base_slug = _slugify(requirement.text)
-        test_ids = [f"test_{base_slug}_{layer}" for layer in applicable_layers]
+        text_slug = _slugify(requirement.text)
+        id_slug = _slugify(requirement.req_id)
+        test_ids = [f"test_{text_slug}_{id_slug}_{layer}" for layer in applicable_layers]
         matrix.append(
             {
                 "requirement_id": requirement.req_id,

--- a/tests/testgen_skill/test_workflow_contracts.py
+++ b/tests/testgen_skill/test_workflow_contracts.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "templates" / "skills" / "testgen" / "scripts" / "testgen_workflow.py"
+    spec = importlib.util.spec_from_file_location("testgen_workflow", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load testgen_workflow module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+workflow = _load_module()
+
+
+def test_parse_feature_list_payload():
+    payload = """
+    - Login succeeds with valid credentials
+    - Login fails with invalid password
+    """
+    requirements = workflow.parse_feature_list_payload(payload)
+    assert len(requirements) == 2
+    assert requirements[0].req_id == "F001"
+    assert "valid credentials" in requirements[0].text
+
+
+def test_parse_task_packet_payload_extracts_sections():
+    packet = """
+    ## Objective
+
+    Deliver deterministic authentication behavior.
+
+    ## Scope
+
+    IN:
+
+    - Add lockout policy
+    - Add audit logging
+
+    OUT:
+
+    - UI redesign
+
+    ## Invariants (Must Remain True)
+
+    - Existing API route names remain stable
+
+    ## Acceptance Criteria
+
+    - Lockout triggers after five failures
+    - Audit events are emitted for each attempt
+    """
+
+    requirements = workflow.parse_task_packet_payload(packet)
+    sources = {item.source for item in requirements}
+    assert "objective" in sources
+    assert "scope-in" in sources
+    assert "acceptance" in sources
+    assert any("five failures" in item.text for item in requirements)
+
+
+def test_layer_applicability_for_service_and_ui_paths():
+    requirements = [
+        workflow.Requirement("F001", "Validate browser user flow and service health", "feature-list")
+    ]
+    touched_files = ["services/auth/api.py", "ui-dashboard/src/Login.tsx"]
+
+    decisions = workflow.determine_test_layers(requirements, touched_files, "post-impl-generator")
+    by_layer = {decision.layer: decision for decision in decisions}
+
+    assert by_layer["unit"].applicable is True
+    assert by_layer["smoke"].applicable is True
+    assert by_layer["integration"].applicable is True
+    assert by_layer["e2e"].applicable is True
+    assert by_layer["regression"].applicable is True
+
+
+def test_coverage_gate_fails_closed_when_touched_file_missing(tmp_path: Path):
+    coverage_xml = tmp_path / "coverage.xml"
+    coverage_xml.write_text(
+        """
+        <coverage>
+          <packages>
+            <package name="x">
+              <classes>
+                <class name="auth" filename="src/auth.py">
+                  <lines>
+                    <line number="1" hits="1"/>
+                    <line number="2" hits="1"/>
+                  </lines>
+                </class>
+              </classes>
+            </package>
+          </packages>
+        </coverage>
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(workflow.CoverageResolutionError):
+        workflow.evaluate_touched_coverage(
+            coverage_xml=coverage_xml,
+            touched_files=["src/auth.py", "src/missing.py"],
+            coverage_target=90,
+        )

--- a/tests/testgen_skill/test_workflow_e2e.py
+++ b/tests/testgen_skill/test_workflow_e2e.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _workflow_cli() -> Path:
+    return Path(__file__).resolve().parents[2] / "templates" / "skills" / "testgen" / "scripts" / "testgen_cli.py"
+
+
+def _write_coverage_xml(path: Path, filename: str, hits: list[int]) -> None:
+    lines_xml = "\n".join(
+        f'<line number="{idx + 1}" hits="{hit}"/>' for idx, hit in enumerate(hits)
+    )
+    path.write_text(
+        (
+            "<coverage><packages><package name=\"pkg\"><classes>"
+            f"<class name=\"x\" filename=\"{filename}\"><lines>{lines_xml}</lines></class>"
+            "</classes></package></packages></coverage>"
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_python_fixture_tdd_driver(tmp_path: Path):
+    coverage_xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(coverage_xml, "src/auth.py", [1] * 9 + [0])
+
+    command = [
+        sys.executable,
+        str(_workflow_cli()),
+        "--mode",
+        "tdd-driver",
+        "--source",
+        "feature-list",
+        "--payload",
+        "- Validate login success\n- Validate login failure",
+        "--repo-root",
+        str(tmp_path),
+        "--coverage-xml",
+        str(coverage_xml),
+        "--touched-file",
+        "src/auth.py",
+    ]
+
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads(result.stdout)
+    assert report["request"]["mode"] == "tdd-driver"
+    assert report["coverage_gate"]["status"] == "pass"
+    assert report["coverage_gate"]["percent"] >= 90
+
+
+def test_js_fixture_post_impl_generator(tmp_path: Path):
+    packet = tmp_path / "packet.md"
+    packet.write_text(
+        """
+        ## Objective
+
+        Prevent checkout regression for invalid discount codes.
+
+        ## Scope
+
+        IN:
+
+        - Validate API workflow for discount validation
+
+        OUT:
+
+        - Payment redesign
+
+        ## Acceptance Criteria
+
+        - Invalid codes return deterministic error payload
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    coverage_xml = tmp_path / "coverage.xml"
+    _write_coverage_xml(coverage_xml, "src/checkout.ts", [1] * 10)
+
+    command = [
+        sys.executable,
+        str(_workflow_cli()),
+        "--mode",
+        "post-impl-generator",
+        "--source",
+        "task-packet",
+        "--payload-file",
+        str(packet),
+        "--repo-root",
+        str(tmp_path),
+        "--coverage-xml",
+        str(coverage_xml),
+        "--touched-file",
+        "src/checkout.ts",
+        "--preferred-cli",
+        "copilot",
+    ]
+
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    assert result.returncode == 0, result.stderr
+
+    report = json.loads(result.stdout)
+    assert report["request"]["mode"] == "post-impl-generator"
+    assert report["coverage_gate"]["status"] == "pass"
+    layers = {entry["layer"]: entry["applicable"] for entry in report["layer_plan"]}
+    assert layers["regression"] is True

--- a/tests/testgen_skill/test_workflow_integration.py
+++ b/tests/testgen_skill/test_workflow_integration.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    module_path = repo_root / "templates" / "skills" / "testgen" / "scripts" / "testgen_workflow.py"
+    spec = importlib.util.spec_from_file_location("testgen_workflow", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load testgen_workflow module")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+workflow = _load_module()
+
+
+def _request() -> object:
+    return workflow.TestgenRequest(
+        mode="tdd-driver",
+        source="feature-list",
+        payload="- Add audit logging for login attempts",
+        coverage_target=90,
+        preferred_cli="gemini",
+        use_pal_testgen="auto",
+    )
+
+
+def test_strategy_prefers_clink_when_available(tmp_path: Path):
+    availability = workflow.ToolAvailability(
+        thinkdeep=True,
+        planner=True,
+        consensus=True,
+        clink=True,
+        pal_testgen=True,
+    )
+
+    plan = workflow.generate_testgen_plan(
+        request=_request(),
+        repo_root=tmp_path,
+        tool_availability=availability,
+        explicit_touched=["src/auth.py"],
+    )
+
+    assert plan["tool_strategy"]["specialist"]["primary"].startswith("clink:gemini")
+    assert plan["tool_strategy"]["pal_testgen"] == "enabled"
+
+
+def test_strategy_falls_back_without_clink(tmp_path: Path):
+    availability = workflow.ToolAvailability(
+        thinkdeep=True,
+        planner=True,
+        consensus=True,
+        clink=False,
+        pal_testgen=False,
+    )
+
+    plan = workflow.generate_testgen_plan(
+        request=_request(),
+        repo_root=tmp_path,
+        tool_availability=availability,
+        explicit_touched=["src/auth.py"],
+    )
+
+    assert plan["tool_strategy"]["specialist"]["primary"] == "builtin-test-specialist"
+    assert plan["tool_strategy"]["pal_testgen"] == "disabled"
+
+
+def test_forced_pal_testgen_requires_availability(tmp_path: Path):
+    availability = workflow.ToolAvailability(
+        thinkdeep=True,
+        planner=True,
+        consensus=True,
+        clink=True,
+        pal_testgen=False,
+    )
+
+    request = workflow.TestgenRequest(
+        mode="post-impl-generator",
+        source="feature-list",
+        payload="- Keep bugfix from regressing",
+        coverage_target=90,
+        preferred_cli="claude",
+        use_pal_testgen="on",
+    )
+
+    with pytest.raises(workflow.ToolingResolutionError):
+        workflow.generate_testgen_plan(
+            request=request,
+            repo_root=tmp_path,
+            tool_availability=availability,
+            explicit_touched=["src/bugfix.py"],
+        )
+
+
+def test_copilot_prefers_codex_subagent_when_clink_available(tmp_path: Path):
+    availability = workflow.ToolAvailability(
+        thinkdeep=True,
+        planner=True,
+        consensus=True,
+        clink=True,
+        pal_testgen=False,
+    )
+
+    request = workflow.TestgenRequest(
+        mode="post-impl-generator",
+        source="feature-list",
+        payload="- Verify checkout bugfix remains stable",
+        coverage_target=90,
+        preferred_cli="copilot",
+        use_pal_testgen="auto",
+    )
+
+    plan = workflow.generate_testgen_plan(
+        request=request,
+        repo_root=tmp_path,
+        tool_availability=availability,
+        explicit_touched=["src/checkout.ts"],
+    )
+
+    assert plan["tool_strategy"]["specialist"]["primary"] == "clink:codex:test-specialist"
+    assert plan["tool_strategy"]["specialist"]["fallback"] == "builtin-test-specialist"
+
+
+def test_strict_reasoning_mode_fails_when_tools_missing(tmp_path: Path):
+    availability = workflow.ToolAvailability(
+        thinkdeep=False,
+        planner=False,
+        consensus=False,
+        clink=False,
+        pal_testgen=False,
+    )
+
+    with pytest.raises(workflow.ToolingResolutionError):
+        workflow.generate_testgen_plan(
+            request=_request(),
+            repo_root=tmp_path,
+            tool_availability=availability,
+            explicit_touched=["src/auth.py"],
+            allow_local_reasoning_fallback=False,
+        )


### PR DESCRIPTION
## Summary
This PR adds a complete `testgen` skill family and a dedicated `test-specialist` clink role to support deterministic, requirement-traceable test generation workflows in both TDD and post-implementation modes.

## What changed
- Added core skill template: `templates/skills/testgen`
  - Deterministic workflow contract with `mode/source/payload/coverage_target/preferred_cli/use_pal_testgen`
  - Workflow engine + CLI utility for normalization, layer decisions, traceability matrix, and fail-closed coverage gating
  - Layer and output contract references
- Added thin wrapper skill templates:
  - `templates/skills/testgen-gemini`
  - `templates/skills/testgen-copilot`
  - `templates/skills/testgen-claude`
- Added sync utility:
  - `scripts/skills/sync_testgen_skills.py` to mirror template skills into `$CODEX_HOME/skills`
- Added clink `test-specialist` role prompt:
  - `docker/mcp-servers-source/pal/pal-mcp-server/systemprompts/clink/default_testspecialist.txt`
- Added `test-specialist` role to clink client configs:
  - `conf/cli_clients/gemini.json`
  - `conf/cli_clients/codex.json`
  - `conf/cli_clients/claude.json`
- Updated clink docs to include the new role and parameter enum:
  - `docs/tools/clink.md`
- Updated and expanded tests:
  - `tests/testgen_skill/test_workflow_contracts.py`
  - `tests/testgen_skill/test_workflow_integration.py`
  - `tests/testgen_skill/test_workflow_e2e.py`
  - `docker/.../tests/test_clink_tool.py` now asserts `test-specialist` is present in registry roles

## Documentation updates
- Documented `test-specialist` clink role usage in `docs/tools/clink.md`
- Added full skill documentation in `templates/skills/testgen*/SKILL.md`
- Added explicit output and layer policy docs in `templates/skills/testgen/references/*`

## Validation
- `PYTHONPATH=docker/mcp-servers-source/pal/pal-mcp-server pytest -q docker/mcp-servers-source/pal/pal-mcp-server/tests/test_clink_tool.py`
- `pytest -q tests/testgen_skill`
- `python3 /Users/hue/.codex/skills/.system/skill-creator/scripts/quick_validate.py templates/skills/testgen`
- `python3 /Users/hue/.codex/skills/.system/skill-creator/scripts/quick_validate.py templates/skills/testgen-gemini`
- `python3 /Users/hue/.codex/skills/.system/skill-creator/scripts/quick_validate.py templates/skills/testgen-copilot`
- `python3 /Users/hue/.codex/skills/.system/skill-creator/scripts/quick_validate.py templates/skills/testgen-claude`

## Release notes
- Added a new cross-client `testgen` skill family for deterministic multi-layer test generation with 90% touched-code coverage gate defaults.
- Added clink `test-specialist` role for Gemini/Codex/Claude subagent routing.
- Added deterministic workflow utilities and test coverage for parsing, tool fallback matrixes, layer applicability, and end-to-end fixture scenarios.

@codex
@clauee
@copilot
