### PR TITLE
🔒 Fix Command Injection Vulnerability in AppleScript Notification

### DIFF
--- a/services/adhd_engine/cli/break_guide.py
+++ b/services/adhd_engine/cli/break_guide.py
@@ -87,8 +87,8 @@ def _notify(title, message):
     """Send system notification via osascript."""
     import subprocess
     try:
-        script = f'display notification "{message}" with title "{title}" sound name "Glass"'
-        subprocess.run(["osascript", "-e", script], check=False)
+        script = 'on run argv\n  display notification (item 1 of argv) with title (item 2 of argv) sound name "Glass"\nend run'
+        subprocess.run(["osascript", "-e", script, message, title], check=False)
     except Exception:
         pass
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The string interpolation `f'display notification "{message}" with title "{title}"...'` does not escape double quotes, so an attacker could break out of the string if they control `title` or `message` in `services/adhd_engine/cli/break_guide.py`.

⚠️ **Risk:** The potential impact if left unfixed
Command injection via `osascript`, enabling arbitrary AppleScript execution (e.g. `do shell script`).

🛡️ **Solution:** How the fix addresses the vulnerability
Refactored the `osascript` script snippet to use an `on run argv` handler, passing `message` and `title` variables securely as command-line arguments to `subprocess.run(["osascript", "-e", script, message, title], check=False)` instead of concatenating them into the script string. This effectively prevents the injection.

---
*PR created automatically by Jules for task [14438019287325469182](https://jules.google.com/task/14438019287325469182) started by @hu3mann*