### PR TITLE
chore(reports): publish extraction gate validation bundle

### DIFF
--- a/reports/extraction/gate/2026-03-11/VALIDATION_FINDINGS.json
+++ b/reports/extraction/gate/2026-03-11/VALIDATION_FINDINGS.json
@@ -1,0 +1,82 @@
+{
+  "findings": [
+    {
+      "layer": 1,
+      "message": "Runner and library modules loaded.",
+      "name": "import_smoke",
+      "status": "PASS"
+    },
+    {
+      "layer": 2,
+      "message": "promptset.yaml exists.",
+      "name": "contract_promptset.yaml",
+      "status": "PASS"
+    },
+    {
+      "layer": 2,
+      "message": "artifacts.yaml exists.",
+      "name": "contract_artifacts.yaml",
+      "status": "PASS"
+    },
+    {
+      "layer": 2,
+      "message": "model_map.yaml exists.",
+      "name": "contract_model_map.yaml",
+      "status": "PASS"
+    },
+    {
+      "layer": 3,
+      "message": "All prompts exist and match hashes.",
+      "name": "prompt_integrity",
+      "status": "PASS"
+    },
+    {
+      "layer": 4,
+      "message": "PHASE_CONTRACT_MAP.json generated.",
+      "name": "contract_map_gen",
+      "status": "PASS"
+    },
+    {
+      "layer": 5,
+      "message": "test_live_llm_guard.py exists.",
+      "name": "test_test_live_llm_guard.py",
+      "status": "PASS"
+    },
+    {
+      "layer": 5,
+      "message": "test_promptset_v4_lint.py exists.",
+      "name": "test_test_promptset_v4_lint.py",
+      "status": "PASS"
+    },
+    {
+      "layer": 5,
+      "message": "test_audit_tp008_drift.py exists.",
+      "name": "test_test_audit_tp008_drift.py",
+      "status": "PASS"
+    },
+    {
+      "layer": 6,
+      "message": "Preflight exists (generated 2026-02-20T11:29:42.485023+00:00).",
+      "name": "provider_preflight",
+      "status": "PASS"
+    },
+    {
+      "layer": 8,
+      "message": "test_v5_golden_fixture_smoke.py exists.",
+      "name": "smoke_test_v5_golden_fixture_smoke.py",
+      "status": "PASS"
+    },
+    {
+      "layer": 8,
+      "message": "test_v5_resume_smoke.py exists.",
+      "name": "smoke_test_v5_resume_smoke.py",
+      "status": "PASS"
+    },
+    {
+      "layer": 8,
+      "message": "test_v5_verify_phase_output_smoke.py exists.",
+      "name": "smoke_test_v5_verify_phase_output_smoke.py",
+      "status": "PASS"
+    }
+  ]
+}

--- a/reports/extraction/gate/2026-03-11/VALIDATION_MANIFEST.json
+++ b/reports/extraction/gate/2026-03-11/VALIDATION_MANIFEST.json
@@ -1,0 +1,9 @@
+{
+  "generated_at": "2026-03-11T23:56:03.827742+00:00",
+  "run_id": "gate_test_run",
+  "runner": "/Users/hue/code/dopemux-mvp/services/repo-truth-extractor/run_extraction_v5.py",
+  "target_phases": [
+    "A"
+  ],
+  "target_policy": "cost"
+}

--- a/reports/extraction/gate/2026-03-11/VALIDATION_MANIFEST.json
+++ b/reports/extraction/gate/2026-03-11/VALIDATION_MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "2026-03-11T23:56:03.827742+00:00",
   "run_id": "gate_test_run",
-  "runner": "/Users/hue/code/dopemux-mvp/services/repo-truth-extractor/run_extraction_v5.py",
+"runner": "services/repo-truth-extractor/run_extraction_v5.py",
   "target_phases": [
     "A"
   ],

--- a/reports/extraction/gate/2026-03-11/VALIDATION_SUMMARY.md
+++ b/reports/extraction/gate/2026-03-11/VALIDATION_SUMMARY.md
@@ -1,0 +1,19 @@
+# VALIDATION SUMMARY
+
+Verdict: **GO**
+
+
+## Findings
+- [Layer 1] import_smoke: PASS - Runner and library modules loaded.
+- [Layer 2] contract_promptset.yaml: PASS - promptset.yaml exists.
+- [Layer 2] contract_artifacts.yaml: PASS - artifacts.yaml exists.
+- [Layer 2] contract_model_map.yaml: PASS - model_map.yaml exists.
+- [Layer 3] prompt_integrity: PASS - All prompts exist and match hashes.
+- [Layer 4] contract_map_gen: PASS - PHASE_CONTRACT_MAP.json generated.
+- [Layer 5] test_test_live_llm_guard.py: PASS - test_live_llm_guard.py exists.
+- [Layer 5] test_test_promptset_v4_lint.py: PASS - test_promptset_v4_lint.py exists.
+- [Layer 5] test_test_audit_tp008_drift.py: PASS - test_audit_tp008_drift.py exists.
+- [Layer 6] provider_preflight: PASS - Preflight exists (generated 2026-02-20T11:29:42.485023+00:00).
+- [Layer 8] smoke_test_v5_golden_fixture_smoke.py: PASS - test_v5_golden_fixture_smoke.py exists.
+- [Layer 8] smoke_test_v5_resume_smoke.py: PASS - test_v5_resume_smoke.py exists.
+- [Layer 8] smoke_test_v5_verify_phase_output_smoke.py: PASS - test_v5_verify_phase_output_smoke.py exists.

--- a/reports/extraction/gate/2026-03-11/VALIDATION_VERDICT.json
+++ b/reports/extraction/gate/2026-03-11/VALIDATION_VERDICT.json
@@ -1,0 +1,5 @@
+{
+  "blocker_count": 0,
+  "blockers": [],
+  "verdict": "GO"
+}


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary
- publish the unpublished extraction gate validation bundle under `reports/extraction/gate/2026-03-11/`
- move the generated artifacts out of the untracked top-level `extraction/` scratch area into a repo-hygiene-compliant location

## Included artifacts
- `VALIDATION_FINDINGS.json`
- `VALIDATION_MANIFEST.json`
- `VALIDATION_SUMMARY.md`
- `VALIDATION_VERDICT.json`

## Audit note
- I inspected all live worktrees for unpublished changes.
- The only other dirty worktree was a stale superseded `#193` rescue branch that would regress current repo policy, so it was intentionally not published in this PR.

## Validation
- `python3 scripts/check_root_hygiene.py`
