### PR TITLE
🎨 Palette: Mitigate time blindness in TaskSequencer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-03-11 - [Closing the Task Feedback Loop]
 **Learning:** In task-oriented interfaces, failing to provide a clear "success" or "empty" state after finishing a sequence can lead to user confusion or a sense of "unmet expectation." Providing a satisfying "Ritual Complete" visual (like a check icon and positive reinforcement text) creates a distinct sense of closure and progress.
 **Action:** Always implement explicit success and empty states for sequential task components to provide closure and guidance when a workflow is completed or empty.
+
+## 2026-03-12 - [Mitigating Time Blindness with Aggregated Metrics]
+**Learning:** For users with ADHD, "time blindness" makes it difficult to estimate the total duration of a backlog from individual task estimates. Aggregating these into a single "Total Remaining Duration" metric provides a high-level reality check that is more cognitively accessible than a list of numbers.
+**Action:** In task-oriented dashboards, always provide an aggregated "total time remaining" metric that updates in real-time to support executive function and time management.

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -23,6 +23,7 @@ import {
   Timer,
   Flame,
   Swords,
+  Info,
 } from 'lucide-react';
 import { brandTokens } from '../theme';
 
@@ -108,6 +109,12 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
     return sortedTasks.sort((a, b) => a.complexity - b.complexity);
   }, [tasks, cognitiveState.status]);
 
+  const totalRemainingMinutes = useMemo(() => {
+    const totalEstimated = optimizedTasks.reduce((acc, task) => acc + task.estimatedMinutes, 0);
+    const elapsedMinutes = taskTimer / 60;
+    return Math.max(0, Math.round(totalEstimated - elapsedMinutes));
+  }, [optimizedTasks, taskTimer]);
+
   const startTask = (taskId: string) => {
     setTasks((prev) =>
       prev.map((task) => (task.id === taskId ? { ...task, status: 'in_progress' } : task))
@@ -161,13 +168,35 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         <Typography variant="h6" sx={{ letterSpacing: '0.16em' }}>
           Task Sequencer
         </Typography>
+        <Tooltip title="Total remaining time for all incomplete tasks - mitigates time blindness" arrow>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              ml: 'auto',
+              color: brandTokens.colors.ritualCyan,
+              bgcolor: alpha(brandTokens.colors.ritualCyan, 0.1),
+              px: 1.5,
+              py: 0.5,
+              borderRadius: 2,
+              border: `1px solid ${alpha(brandTokens.colors.ritualCyan, 0.3)}`,
+            }}
+            tabIndex={0}
+          >
+            <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+              {totalRemainingMinutes}m
+            </Typography>
+            <Info size={14} aria-hidden="true" />
+          </Box>
+        </Tooltip>
         <Tooltip title="Real-time task synchronization active" arrow>
           <Chip
             size="small"
             label="[LIVE]"
             className="dopemux-chip"
             tabIndex={0}
-            sx={{ ml: 'auto', borderColor: 'rgba(125, 251, 246, 0.6)', color: brandTokens.colors.ritualCyan }}
+            sx={{ borderColor: 'rgba(125, 251, 246, 0.6)', color: brandTokens.colors.ritualCyan }}
           />
         </Tooltip>
       </Box>
@@ -265,6 +294,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
       ) : (
         <Box
           role="status"
+          aria-label="Ritual Complete: All tasks in your backlog are finished"
           sx={{
             mb: 3, p: 2.5, borderRadius: 3, textAlign: 'center',
             border: `1px solid ${brandTokens.colors.serumMint}`,

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -58,6 +58,10 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('aria-label={getTimerAriaLabel(taskTimer)}');
   expect(content).toMatch(/<Tooltip[^>]*title="Real-time task synchronization active"[^>]*arrow/);
   expect(content).toContain('aria-current={isCurrent ? \'step\' : undefined}');
+  // Total Remaining Duration
+  expect(content).toMatch(/<Tooltip[^>]*title="Total remaining time for all incomplete tasks - mitigates time blindness"[^>]*arrow/);
+  expect(content).toContain('{totalRemainingMinutes}m');
+  expect(content).toContain('aria-label="Ritual Complete: All tasks in your backlog are finished"');
 });
 
 test('Components have aria-hidden="true" on decorative icons', () => {


### PR DESCRIPTION
This PR introduces a micro-UX improvement to the `TaskSequencer` component in the `ui-dashboard`. 

Key changes:
1.  **Total Remaining Duration**: Added a real-time counter in the header that aggregates the estimated time for all pending and in-progress tasks. This is specifically designed to help users with ADHD manage "time blindness" by providing a high-level overview of the remaining workload.
2.  **Accessibility Improvements**: 
    - Added an `aria-label` to the "Ritual Complete" (empty) state to provide clear context for screen reader users when all tasks are finished.
    - Wrapped the new duration display in a Tooltip with `tabIndex={0}` for keyboard accessibility.
3.  **Testing**: Updated the static accessibility tests in `Accessibility.test.ts` to ensure these new elements and attributes are present in the source code.
4.  **Documentation**: Added a new entry to the Palette journal (.Jules/palette.md) documenting the learning about mitigating time blindness with aggregated metrics.

The changes are localized to the frontend and do not affect any backend logic or performance. Visual consistency is maintained using existing design system tokens.

---
*PR created automatically by Jules for task [11559017549983090508](https://jules.google.com/task/11559017549983090508) started by @hu3mann*

# 🚀 Summary
- [ ] Pending detail...

--- 

# 🧪 Verification
- [ ] Pending detail...

--- 

# ⚠️ Risks
- [ ] Pending detail...

--- 

# ↩️ Rollback
- [ ] Pending detail...