### PR TITLE
🎨 Palette: Add total remaining duration to Task Sequencer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-03-11 - [Closing the Task Feedback Loop]
 **Learning:** In task-oriented interfaces, failing to provide a clear "success" or "empty" state after finishing a sequence can lead to user confusion or a sense of "unmet expectation." Providing a satisfying "Ritual Complete" visual (like a check icon and positive reinforcement text) creates a distinct sense of closure and progress.
 **Action:** Always implement explicit success and empty states for sequential task components to provide closure and guidance when a workflow is completed or empty.
+
+## 2026-03-12 - [Mitigating Time Blindness with Aggregate Durations]
+**Learning:** For users with ADHD, individual task estimates can feel disconnected from the overall workload, leading to "time blindness." Aggregating the total remaining duration for all incomplete tasks into a single, high-visibility metric provides a holistic sense of the remaining effort, helping users plan their energy and breaks more effectively.
+**Action:** In task-oriented interfaces, always provide a "Total Remaining Duration" summary that updates in real-time to bridge the gap between individual task progress and the overall workflow completion.

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -23,6 +23,7 @@ import {
   Timer,
   Flame,
   Swords,
+  Hourglass,
 } from 'lucide-react';
 import { brandTokens } from '../theme';
 
@@ -153,6 +154,13 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
     if (complexity > 0.5) return brandTokens.colors.giltEdge;
     return brandTokens.colors.serumMint;
   };
+
+  const totalRemainingMinutes = useMemo(() => {
+    const totalEstimatedMinutes = tasks
+      .filter((task) => task.status !== 'completed')
+      .reduce((sum, task) => sum + task.estimatedMinutes, 0);
+    return Math.max(0, Math.round(totalEstimatedMinutes - taskTimer / 60));
+  }, [tasks, taskTimer]);
 
   return (
     <Paper sx={{ p: 3, height: '100%', borderRadius: 4 }} className="dopemux-panel">
@@ -285,6 +293,24 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         <Typography variant="subtitle2">
           Optimized Sequence ({optimizedTasks.length} tasks)
         </Typography>
+        <Tooltip title="Aggregate estimated time remaining for all incomplete tasks" arrow>
+          <Chip
+            size="small"
+            icon={<Hourglass size={12} color={brandTokens.colors.giltEdge} />}
+            label={`${totalRemainingMinutes}m left`}
+            tabIndex={0}
+            aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}
+            sx={{
+              ml: 1,
+              height: 20,
+              fontSize: '0.7rem',
+              bgcolor: 'rgba(255, 207, 120, 0.1)',
+              color: brandTokens.colors.giltEdge,
+              border: `1px solid ${alpha(brandTokens.colors.giltEdge, 0.4)}`,
+              '& .MuiChip-icon': { ml: 0.5, mr: -0.5 }
+            }}
+          />
+        </Tooltip>
         <Tooltip title="Consent → Calibration → Chaos → Care" arrow>
           <Box component="span" tabIndex={0} sx={{ display: 'flex', alignItems: 'center' }}>
             <Flame size={16} color={brandTokens.colors.gremlinPink} aria-hidden="true" />

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -304,7 +304,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               ml: 1,
               height: 20,
               fontSize: '0.7rem',
-              bgcolor: 'rgba(255, 207, 120, 0.1)',
+              bgcolor: alpha(brandTokens.colors.saintGold, 0.1),
               color: brandTokens.colors.giltEdge,
               border: `1px solid ${alpha(brandTokens.colors.giltEdge, 0.4)}`,
               '& .MuiChip-icon': { ml: 0.5, mr: -0.5 }

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -58,6 +58,8 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('aria-label={getTimerAriaLabel(taskTimer)}');
   expect(content).toMatch(/<Tooltip[^>]*title="Real-time task synchronization active"[^>]*arrow/);
   expect(content).toContain('aria-current={isCurrent ? \'step\' : undefined}');
+  expect(content).toMatch(/<Tooltip title="Aggregate estimated time remaining for all incomplete tasks" arrow>/);
+  expect(content).toContain('aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}');
 });
 
 test('Components have aria-hidden="true" on decorative icons', () => {


### PR DESCRIPTION
Implemented a micro-UX improvement in the Task Sequencer component to display the total remaining duration of all incomplete tasks. This helps users with ADHD manage time blindness by providing an aggregate view of the remaining workload. The change includes a new UI element (MUI Chip), real-time calculation logic, accessibility enhancements (ARIA labels, keyboard focus), and corresponding unit tests.

---
*PR created automatically by Jules for task [8701576098574772613](https://jules.google.com/task/8701576098574772613) started by @hu3mann*