### PR TITLE
🎨 Palette: Add 'Total Remaining Duration' to TaskSequencer

### DIFF
--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -21,6 +21,7 @@ import {
   Pause,
   SkipForward,
   Timer,
+  Clock,
   Flame,
   Swords,
 } from 'lucide-react';
@@ -147,6 +148,11 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
   };
 
   const currentTask = tasks.find((task) => task.id === currentTaskId);
+
+  const totalRemainingMinutes = useMemo(() => {
+    const totalEstimatedMinutes = optimizedTasks.reduce((sum, task) => sum + task.estimatedMinutes, 0);
+    return Math.max(0, Math.ceil(totalEstimatedMinutes - (taskTimer / 60)));
+  }, [optimizedTasks, taskTimer]);
 
   const complexityColor = (complexity: number) => {
     if (complexity > 0.7) return brandTokens.colors.gremlinPink;
@@ -285,6 +291,16 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         <Typography variant="subtitle2">
           Optimized Sequence ({optimizedTasks.length} tasks)
         </Typography>
+        <Tooltip title={`Total remaining duration: ${totalRemainingMinutes} minutes`} arrow>
+          <Box
+            component="span"
+            tabIndex={0}
+            aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}
+            sx={{ display: 'flex', alignItems: 'center', outline: 'none', cursor: 'help' }}
+          >
+            <Clock size={16} color={brandTokens.colors.aftercareViolet} aria-hidden="true" />
+          </Box>
+        </Tooltip>
         <Tooltip title="Consent → Calibration → Chaos → Care" arrow>
           <Box component="span" tabIndex={0} sx={{ display: 'flex', alignItems: 'center' }}>
             <Flame size={16} color={brandTokens.colors.gremlinPink} aria-hidden="true" />

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -147,6 +147,11 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
     return `Time elapsed: ${secLabel}`;
   };
 
+  const getDurationAriaLabel = (minutes: number): string => {
+    const label = minutes === 1 ? '1 minute' : `${minutes} minutes`;
+    return `Total remaining duration: ${label}`;
+  };
+
   const currentTask = tasks.find((task) => task.id === currentTaskId);
 
   const totalRemainingMinutes = useMemo(() => {
@@ -291,11 +296,11 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         <Typography variant="subtitle2">
           Optimized Sequence ({optimizedTasks.length} tasks)
         </Typography>
-        <Tooltip title={`Total remaining duration: ${totalRemainingMinutes} minutes`} arrow>
+        <Tooltip title={getDurationAriaLabel(totalRemainingMinutes)} arrow>
           <Box
             component="span"
             tabIndex={0}
-            aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}
+            aria-label={getDurationAriaLabel(totalRemainingMinutes)}
             sx={{ display: 'flex', alignItems: 'center', outline: 'none', cursor: 'help' }}
           >
             <Clock size={16} color={brandTokens.colors.aftercareViolet} aria-hidden="true" />

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -75,6 +75,14 @@ test('TaskSequencer.tsx has accessible timer with pluralization', () => {
   expect(content).toContain('const getTimerAriaLabel = (seconds: number): string =>');
 });
 
+test('TaskSequencer.tsx displays total remaining duration with accessibility', () => {
+  const content = fs.readFileSync(path.join(componentsDir, 'TaskSequencer.tsx'), 'utf8');
+  expect(content).toContain('const totalRemainingMinutes = useMemo(() =>');
+  expect(content).toContain('aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}');
+  expect(content).toContain('tabIndex={0}');
+  expect(content).toMatch(/<Tooltip[^>]*title={`Total remaining duration: \${totalRemainingMinutes} minutes`}/);
+});
+
 test('App.tsx has accessible header chips and skip link', () => {
   const appContent = fs.readFileSync(path.resolve(__dirname, '../../App.tsx'), 'utf8');
   expect(appContent).toContain('href="#main-dashboard"');

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -78,9 +78,9 @@ test('TaskSequencer.tsx has accessible timer with pluralization', () => {
 test('TaskSequencer.tsx displays total remaining duration with accessibility', () => {
   const content = fs.readFileSync(path.join(componentsDir, 'TaskSequencer.tsx'), 'utf8');
   expect(content).toContain('const totalRemainingMinutes = useMemo(() =>');
-  expect(content).toContain('aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}');
+  expect(content).toContain('aria-label={getDurationAriaLabel(totalRemainingMinutes)}');
   expect(content).toContain('tabIndex={0}');
-  expect(content).toMatch(/<Tooltip[^>]*title={`Total remaining duration: \${totalRemainingMinutes} minutes`}/);
+  expect(content).toMatch(/<Tooltip[^>]*title=\{getDurationAriaLabel\(totalRemainingMinutes\)\}/);
 });
 
 test('App.tsx has accessible header chips and skip link', () => {


### PR DESCRIPTION
This PR adds a small but impactful UX improvement to the TaskSequencer component. By aggregating the estimated minutes of all pending tasks and adjusting for the current task's timer, it provides users with a clear "Total Remaining Duration" indicator. This is particularly helpful for users with ADHD to manage time blindness. The feature is fully accessible with ARIA labels, tooltips, and keyboard focus support.

---
*PR created automatically by Jules for task [12491915458240005406](https://jules.google.com/task/12491915458240005406) started by @hu3mann*