### PR TITLE
🎨 Palette: Add total remaining duration to Task Sequencer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-03-11 - [Closing the Task Feedback Loop]
 **Learning:** In task-oriented interfaces, failing to provide a clear "success" or "empty" state after finishing a sequence can lead to user confusion or a sense of "unmet expectation." Providing a satisfying "Ritual Complete" visual (like a check icon and positive reinforcement text) creates a distinct sense of closure and progress.
 **Action:** Always implement explicit success and empty states for sequential task components to provide closure and guidance when a workflow is completed or empty.
+
+## 2025-05-20 - [Combatting Time Blindness]
+**Learning:** For users with ADHD, seeing a list of tasks without an aggregate "time to finish" can lead to "time blindness" or feeling overwhelmed by an infinite-feeling backlog. Providing a "Total Remaining Duration" counter that updates in real-time creates a "light at the end of the tunnel" effect, making the workload feel finite and manageable.
+**Action:** Aggregate and display total remaining estimated duration in sequential task managers to help users maintain perspective on their progress.

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -23,6 +23,7 @@ import {
   Timer,
   Flame,
   Swords,
+  Clock,
 } from 'lucide-react';
 import { brandTokens } from '../theme';
 
@@ -147,6 +148,14 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
   };
 
   const currentTask = tasks.find((task) => task.id === currentTaskId);
+
+  const totalRemainingMinutes = useMemo(() => {
+    const totalEstimatedMinutes = tasks
+      .filter((task) => task.status !== 'completed')
+      .reduce((sum, task) => sum + task.estimatedMinutes, 0);
+
+    return Math.max(0, Math.ceil(totalEstimatedMinutes - (taskTimer / 60)));
+  }, [tasks, taskTimer]);
 
   const complexityColor = (complexity: number) => {
     if (complexity > 0.7) return brandTokens.colors.gremlinPink;
@@ -285,6 +294,27 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         <Typography variant="subtitle2">
           Optimized Sequence ({optimizedTasks.length} tasks)
         </Typography>
+        <Tooltip title={`Total remaining duration: ${totalRemainingMinutes} minutes`} arrow>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 0.5,
+              ml: 'auto',
+              color: brandTokens.colors.ritualCyan,
+              cursor: 'help',
+              '&:focus': { outline: 'none', borderRadius: 1, boxShadow: `0 0 0 2px ${brandTokens.colors.ritualCyan}` }
+            }}
+            tabIndex={0}
+            role="status"
+            aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}
+          >
+            <Clock size={14} aria-hidden="true" />
+            <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
+              {totalRemainingMinutes}m
+            </Typography>
+          </Box>
+        </Tooltip>
         <Tooltip title="Consent → Calibration → Chaos → Care" arrow>
           <Box component="span" tabIndex={0} sx={{ display: 'flex', alignItems: 'center' }}>
             <Flame size={16} color={brandTokens.colors.gremlinPink} aria-hidden="true" />

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -58,6 +58,10 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('aria-label={getTimerAriaLabel(taskTimer)}');
   expect(content).toMatch(/<Tooltip[^>]*title="Real-time task synchronization active"[^>]*arrow/);
   expect(content).toContain('aria-current={isCurrent ? \'step\' : undefined}');
+  // Total remaining duration accessibility
+  expect(content).toContain('role="status"');
+  expect(content).toContain('aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}');
+  expect(content).toMatch(/<Tooltip title=\{`Total remaining duration: \$\{totalRemainingMinutes\} minutes`\} arrow>/);
 });
 
 test('Components have aria-hidden="true" on decorative icons', () => {


### PR DESCRIPTION
💡 What: Added a 'Total remaining duration' indicator to the Task Sequencer component.
🎯 Why: Helps users with ADHD combat 'time blindness' by showing a finite end to the current task sequence.
♿ Accessibility: Added role='status', dynamic aria-label, and keyboard focusable container for the tooltip.

---
*PR created automatically by Jules for task [9048409209723803455](https://jules.google.com/task/9048409209723803455) started by @hu3mann*