### PR TITLE
🎨 Palette: ADHD-aware task sequencer duration & accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2026-03-11 - [Closing the Task Feedback Loop]
 **Learning:** In task-oriented interfaces, failing to provide a clear "success" or "empty" state after finishing a sequence can lead to user confusion or a sense of "unmet expectation." Providing a satisfying "Ritual Complete" visual (like a check icon and positive reinforcement text) creates a distinct sense of closure and progress.
 **Action:** Always implement explicit success and empty states for sequential task components to provide closure and guidance when a workflow is completed or empty.
+
+## 2026-03-12 - [Non-Jumping Dynamic Durations]
+**Learning:** For users with "time blindness" (ADHD), showing the total remaining time is a critical "end of the tunnel" signal. However, if the time "jumps" back up when completing an overdue task, it can be demoralizing. Calculating totals as `otherMinutes + Math.max(0, currentTaskEstimate - elapsed)` ensures the estimate only ever decreases or stays flat during the ritual.
+**Action:** When aggregating dynamic remaining time, always use `Math.max(0, ...)` for the active task's contribution to ensure the total is monotonically decreasing and psychologically consistent.

--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -291,6 +291,7 @@ function App() {
                   <Tooltip title={metric.tooltip} arrow>
                     <Box
                       tabIndex={0}
+                      aria-label={metric.label}
                       sx={{
                         display: 'flex',
                         alignItems: 'center',

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -23,6 +23,7 @@ import {
   Timer,
   Flame,
   Swords,
+  Clock,
 } from 'lucide-react';
 import { brandTokens } from '../theme';
 
@@ -147,6 +148,18 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
   };
 
   const currentTask = tasks.find((task) => task.id === currentTaskId);
+
+  const totalRemainingMinutes = useMemo(() => {
+    const otherTasks = optimizedTasks.filter((task) => task.id !== currentTaskId);
+    const otherMinutes = otherTasks.reduce((sum, task) => sum + task.estimatedMinutes, 0);
+
+    const currentTaskObj = tasks.find((task) => task.id === currentTaskId);
+    const remainingCurrent = currentTaskObj
+      ? Math.max(0, currentTaskObj.estimatedMinutes - taskTimer / 60)
+      : 0;
+
+    return Math.ceil(otherMinutes + remainingCurrent);
+  }, [optimizedTasks, tasks, currentTaskId, taskTimer]);
 
   const complexityColor = (complexity: number) => {
     if (complexity > 0.7) return brandTokens.colors.gremlinPink;
@@ -285,6 +298,35 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         <Typography variant="subtitle2">
           Optimized Sequence ({optimizedTasks.length} tasks)
         </Typography>
+        {optimizedTasks.length > 0 && (
+          <Tooltip title="Total remaining duration for all tasks" arrow>
+            <Box
+              role="status"
+              aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}
+              tabIndex={0}
+              sx={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 0.5,
+                ml: 'auto',
+                px: 1,
+                py: 0.25,
+                borderRadius: 1,
+                bgcolor: 'rgba(255, 255, 255, 0.05)',
+                color: brandTokens.colors.ritualCyan,
+                border: '1px solid rgba(125, 251, 246, 0.2)',
+                '&:focus-visible': {
+                  outline: `2px solid ${brandTokens.colors.ritualCyan}`,
+                },
+              }}
+            >
+              <Clock size={14} aria-hidden="true" />
+              <Typography variant="caption" sx={{ fontWeight: 'bold', fontFamily: '"Space Grotesk", sans-serif' }}>
+                {totalRemainingMinutes}m
+              </Typography>
+            </Box>
+          </Tooltip>
+        )}
         <Tooltip title="Consent → Calibration → Chaos → Care" arrow>
           <Box component="span" tabIndex={0} sx={{ display: 'flex', alignItems: 'center' }}>
             <Flame size={16} color={brandTokens.colors.gremlinPink} aria-hidden="true" />

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -39,10 +39,11 @@ test('TeamDashboard.tsx has aria-labels for team and member progress bars and To
   expect(content).toMatch(/<Tooltip[^>]*title="AI-generated team coordination insights"[^>]*arrow/);
 });
 
-test('App.tsx exposes metric card tooltips with focus indicators', () => {
+test('App.tsx exposes metric card tooltips with focus indicators and labels', () => {
   const appContent = fs.readFileSync(path.join(componentsDir, '..', 'App.tsx'), 'utf8');
   expect(appContent).toContain('<Tooltip title={metric.tooltip} arrow>');
   expect(appContent).toMatch(/<Tooltip title=\{metric\.tooltip\} arrow>[\s\S]*tabIndex=\{0\}/);
+  expect(appContent).toContain('aria-label={metric.label}');
   expect(appContent).toContain('&:focus-visible');
 });
 
@@ -56,6 +57,9 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('aria-label="Current task progress"');
   // Timer accessibility
   expect(content).toContain('aria-label={getTimerAriaLabel(taskTimer)}');
+  // Total remaining duration status
+  expect(content).toContain('role="status"');
+  expect(content).toContain('aria-label={`Total remaining duration: ${totalRemainingMinutes} minutes`}');
   expect(content).toMatch(/<Tooltip[^>]*title="Real-time task synchronization active"[^>]*arrow/);
   expect(content).toContain('aria-current={isCurrent ? \'step\' : undefined}');
 });


### PR DESCRIPTION
### 💡 What
Implemented a micro-UX enhancement for the `TaskSequencer` component that displays the total estimated time remaining for all pending tasks. Additionally, improved dashboard accessibility by adding missing `aria-label` attributes to focusable metric containers.

### 🎯 Why
For users with ADHD, "time blindness" can make a long list of tasks feel overwhelming. Providing an aggregate "end of the tunnel" duration helps with cognitive grounding. The calculation logic specifically ensures the total time only ever decreases or stays flat (even if a task goes over its estimate) to maintain psychological momentum.

### ♿ Accessibility
- Added `role="status"` and dynamic `aria-label` to the total duration display.
- Added `aria-label` to dashboard metric cards (Energy, Attention, Load) so screen reader users can identify the focusable cards' purpose.
- Ensured keyboard focusability (`tabIndex={0}`) for new informative elements.

### ✅ Verification
- Ran `pnpm test` (all tests passed).
- Ran `pnpm lint` (no errors).
- Verified visually with a Playwright script and captured a screenshot showing the correctly updated 135m duration after completing the first task.
- Documented the "Non-Jumping Dynamic Durations" principle in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [12700409259532471563](https://jules.google.com/task/12700409259532471563) started by @hu3mann*