### PR TITLE
🔒 Fix SQL Injection in Document Classifier

### DIFF
--- a/extraction/document_classifier.py
+++ b/extraction/document_classifier.py
@@ -239,6 +239,20 @@ class DocumentClassifier:
                 error_message=f"JSON parsing error: {e}"
             )
 
+    def _quote_identifier(self, identifier: str) -> str:
+        """
+        Safely quote a SQL identifier (like a table name) for SQLite.
+
+        Args:
+            identifier: The name to quote
+
+        Returns:
+            A safely quoted identifier string
+        """
+        # SQLite uses double quotes for identifiers.
+        # To escape a double quote, you use two double quotes.
+        return '"' + identifier.replace('"', '""') + '"'
+
     def _extract_text(self, doc_info: DocumentInfo) -> ExtractionResult:
         """Extract entities from plain text document."""
         # For plain text, try markdown patterns but with lower confidence
@@ -280,13 +294,14 @@ class DocumentClassifier:
 
             for table_name in tables:
                 table_name = table_name[0]
+                quoted_table_name = self._quote_identifier(table_name)
 
                 # Get table info
-                cursor.execute(f"PRAGMA table_info({table_name});")
+                cursor.execute(f"PRAGMA table_info({quoted_table_name});")
                 columns = cursor.fetchall()
 
                 # Get row count
-                cursor.execute(f"SELECT COUNT(*) FROM {table_name};")
+                cursor.execute(f"SELECT COUNT(*) FROM {quoted_table_name};")
                 row_count = cursor.fetchone()[0]
 
                 entities['database_info'].append({

--- a/tests/unit/test_document_classifier_security.py
+++ b/tests/unit/test_document_classifier_security.py
@@ -1,0 +1,55 @@
+try:
+    import pytest
+except ImportError:
+    pytest = None
+from unittest.mock import MagicMock
+import sys
+from pathlib import Path
+
+# Mock missing dependencies
+sys.modules['markdown_patterns'] = MagicMock()
+sys.modules['yaml_extractor'] = MagicMock()
+sys.modules['extraction.markdown_patterns'] = MagicMock()
+sys.modules['extraction.yaml_extractor'] = MagicMock()
+
+from extraction.document_classifier import DocumentClassifier
+
+def test_quote_identifier():
+    classifier = DocumentClassifier()
+
+    # Simple name
+    assert classifier._quote_identifier("users") == '"users"'
+
+    # Name with spaces
+    assert classifier._quote_identifier("user profiles") == '"user profiles"'
+
+    # Name with double quotes (the injection vector)
+    assert classifier._quote_identifier('users"; DROP TABLE secrets; --') == '"users""; DROP TABLE secrets; --"'
+
+    # Name with already doubled quotes
+    assert classifier._quote_identifier('my""table') == '"my""""table"'
+
+    # Reserved words
+    assert classifier._quote_identifier("select") == '"select"'
+
+def test_quote_identifier_extreme():
+    classifier = DocumentClassifier()
+
+    # Empty string
+    assert classifier._quote_identifier("") == '""'
+
+    # Only quotes
+    assert classifier._quote_identifier('"""') == '""""""""'
+
+    # Unicode
+    assert classifier._quote_identifier('τάμπλα') == '"τάμπλα"'
+
+if __name__ == "__main__":
+    # Run tests manually if pytest is not available or having issues
+    try:
+        test_quote_identifier()
+        test_quote_identifier_extreme()
+        print("Manual security tests passed!")
+    except AssertionError as e:
+        print(f"Manual security tests failed: {e}")
+        sys.exit(1)

--- a/tests/unit/test_document_classifier_security.py
+++ b/tests/unit/test_document_classifier_security.py
@@ -1,54 +1,73 @@
-try:
-    import pytest
-except ImportError:
-    pytest = None
 from unittest.mock import MagicMock
 import sys
-from pathlib import Path
 
 # Mock missing dependencies
-sys.modules['markdown_patterns'] = MagicMock()
-sys.modules['yaml_extractor'] = MagicMock()
-sys.modules['extraction.markdown_patterns'] = MagicMock()
-sys.modules['extraction.yaml_extractor'] = MagicMock()
+from unittest.mock import MagicMock, patch
+import sys
+from pathlib import Path
+import importlib
 
-from extraction.document_classifier import DocumentClassifier
+# Note: dependency modules are mocked within individual tests using patch.dict
+# to avoid mutating sys.modules at import time.
+
 
 def test_quote_identifier():
-    classifier = DocumentClassifier()
+    with patch.dict(
+        sys.modules,
+        {
+            "markdown_patterns": MagicMock(),
+            "yaml_extractor": MagicMock(),
+            "extraction.markdown_patterns": MagicMock(),
+            "extraction.yaml_extractor": MagicMock(),
+        },
+    ):
+        import extraction.document_classifier as document_classifier
 
-    # Simple name
-    assert classifier._quote_identifier("users") == '"users"'
+        importlib.reload(document_classifier)
+        classifier = document_classifier.DocumentClassifier()
 
-    # Name with spaces
-    assert classifier._quote_identifier("user profiles") == '"user profiles"'
+        # Simple name
+        assert classifier._quote_identifier("users") == '"users"'
 
-    # Name with double quotes (the injection vector)
-    assert classifier._quote_identifier('users"; DROP TABLE secrets; --') == '"users""; DROP TABLE secrets; --"'
+        # Name with spaces
+        assert classifier._quote_identifier("user profiles") == '"user profiles"'
 
-    # Name with already doubled quotes
-    assert classifier._quote_identifier('my""table') == '"my""""table"'
+        # Name with double quotes (the injection vector)
+        assert (
+            classifier._quote_identifier('users"; DROP TABLE secrets; --')
+            == '"users""; DROP TABLE secrets; --"'
+        )
 
-    # Reserved words
-    assert classifier._quote_identifier("select") == '"select"'
+        # Name with already doubled quotes
+        assert classifier._quote_identifier('my""table') == '"my""""table"'
+
+        # Reserved words
+        assert classifier._quote_identifier("select") == '"select"'
+
 
 def test_quote_identifier_extreme():
-    classifier = DocumentClassifier()
+    with patch.dict(
+        sys.modules,
+        {
+            "markdown_patterns": MagicMock(),
+            "yaml_extractor": MagicMock(),
+            "extraction.markdown_patterns": MagicMock(),
+            "extraction.yaml_extractor": MagicMock(),
+        },
+    ):
+        import extraction.document_classifier as document_classifier
 
-    # Empty string
-    assert classifier._quote_identifier("") == '""'
+        importlib.reload(document_classifier)
+        classifier = document_classifier.DocumentClassifier()
 
-    # Only quotes
-    assert classifier._quote_identifier('"""') == '""""""""'
+        # Empty string
+        assert classifier._quote_identifier("") == '""'
 
-    # Unicode
-    assert classifier._quote_identifier('τάμπλα') == '"τάμπλα"'
+        # Only quotes
+        assert classifier._quote_identifier('"""') == '""""""""'
 
-if __name__ == "__main__":
-    # Run tests manually if pytest is not available or having issues
-    try:
-        test_quote_identifier()
-        test_quote_identifier_extreme()
+        # Unicode
+        assert classifier._quote_identifier("τάμπλα") == '"τάμπλα"'
         print("Manual security tests passed!")
     except AssertionError as e:
         print(f"Manual security tests failed: {e}")

--- a/tests/unit/test_document_classifier_security.py
+++ b/tests/unit/test_document_classifier_security.py
@@ -1,73 +1,54 @@
+try:
+    import pytest
+except ImportError:
+    pytest = None
 from unittest.mock import MagicMock
 import sys
+from pathlib import Path
 
 # Mock missing dependencies
-from unittest.mock import MagicMock, patch
-import sys
-from pathlib import Path
-import importlib
+sys.modules['markdown_patterns'] = MagicMock()
+sys.modules['yaml_extractor'] = MagicMock()
+sys.modules['extraction.markdown_patterns'] = MagicMock()
+sys.modules['extraction.yaml_extractor'] = MagicMock()
 
-# Note: dependency modules are mocked within individual tests using patch.dict
-# to avoid mutating sys.modules at import time.
-
+from extraction.document_classifier import DocumentClassifier
 
 def test_quote_identifier():
-    with patch.dict(
-        sys.modules,
-        {
-            "markdown_patterns": MagicMock(),
-            "yaml_extractor": MagicMock(),
-            "extraction.markdown_patterns": MagicMock(),
-            "extraction.yaml_extractor": MagicMock(),
-        },
-    ):
-        import extraction.document_classifier as document_classifier
+    classifier = DocumentClassifier()
 
-        importlib.reload(document_classifier)
-        classifier = document_classifier.DocumentClassifier()
+    # Simple name
+    assert classifier._quote_identifier("users") == '"users"'
 
-        # Simple name
-        assert classifier._quote_identifier("users") == '"users"'
+    # Name with spaces
+    assert classifier._quote_identifier("user profiles") == '"user profiles"'
 
-        # Name with spaces
-        assert classifier._quote_identifier("user profiles") == '"user profiles"'
+    # Name with double quotes (the injection vector)
+    assert classifier._quote_identifier('users"; DROP TABLE secrets; --') == '"users""; DROP TABLE secrets; --"'
 
-        # Name with double quotes (the injection vector)
-        assert (
-            classifier._quote_identifier('users"; DROP TABLE secrets; --')
-            == '"users""; DROP TABLE secrets; --"'
-        )
+    # Name with already doubled quotes
+    assert classifier._quote_identifier('my""table') == '"my""""table"'
 
-        # Name with already doubled quotes
-        assert classifier._quote_identifier('my""table') == '"my""""table"'
-
-        # Reserved words
-        assert classifier._quote_identifier("select") == '"select"'
-
+    # Reserved words
+    assert classifier._quote_identifier("select") == '"select"'
 
 def test_quote_identifier_extreme():
-    with patch.dict(
-        sys.modules,
-        {
-            "markdown_patterns": MagicMock(),
-            "yaml_extractor": MagicMock(),
-            "extraction.markdown_patterns": MagicMock(),
-            "extraction.yaml_extractor": MagicMock(),
-        },
-    ):
-        import extraction.document_classifier as document_classifier
+    classifier = DocumentClassifier()
 
-        importlib.reload(document_classifier)
-        classifier = document_classifier.DocumentClassifier()
+    # Empty string
+    assert classifier._quote_identifier("") == '""'
 
-        # Empty string
-        assert classifier._quote_identifier("") == '""'
+    # Only quotes
+    assert classifier._quote_identifier('"""') == '""""""""'
 
-        # Only quotes
-        assert classifier._quote_identifier('"""') == '""""""""'
+    # Unicode
+    assert classifier._quote_identifier('τάμπλα') == '"τάμπλα"'
 
-        # Unicode
-        assert classifier._quote_identifier("τάμπλα") == '"τάμπλα"'
+if __name__ == "__main__":
+    # Run tests manually if pytest is not available or having issues
+    try:
+        test_quote_identifier()
+        test_quote_identifier_extreme()
         print("Manual security tests passed!")
     except AssertionError as e:
         print(f"Manual security tests failed: {e}")


### PR DESCRIPTION
### 🎯 What: 
Fixed a SQL injection vulnerability in the SQLite extraction logic of `DocumentClassifier` where table names were directly interpolated into SQL strings.

### ⚠️ Risk: 
Malicious SQLite databases containing crafted table names (e.g., `users"; DROP TABLE secrets; --`) could lead to arbitrary SQL execution during the document classification and extraction process. Since table names cannot be parameterized with `?` in SQLite, direct interpolation was particularly dangerous.

### 🛡️ Solution: 
Implemented a private method `_quote_identifier` that safely wraps table names in double quotes and escapes any existing double quotes by doubling them, adhering to standard SQLite identifier quoting rules. All dynamic table name references in `_extract_sqlite` now use this helper.

---
*PR created automatically by Jules for task [10561715005863198019](https://jules.google.com/task/10561715005863198019) started by @hu3mann*