### PR TITLE
feat(cli): add theme and orchestrator voice surfaces

### DIFF
--- a/llm-plans/THEME_SWITCHER_IMPLEMENTATION.md
+++ b/llm-plans/THEME_SWITCHER_IMPLEMENTATION.md
@@ -1,0 +1,54 @@
+# Theme Switcher & Multi-Theme Implementation Plan
+
+## Objective
+Implement a theme switching mechanism and define three distinct themes:
+1. **Mint Mojo**: The original Dopemux palette.
+2. **Pastel Neon Dreams**: The recently updated high-contrast palette.
+3. **Pastel Neon Dreamscape on Black**: The new vivid neon palette.
+
+## Proposed Changes
+
+### 1. `src/dopemux/ui/theme.py`
+- Define a `THEME_PALETTES` dictionary containing the color constants for each theme.
+
+#### **Theme 1: Mint Mojo (Original)**
+- `hero`: #7DFBF6
+- `success`: #94FADB
+- `accent`: #FF8BD1
+- `bg`: #020617
+
+#### **Theme 2: Pastel Neon Dreams (Current Product Theme)**
+- `hero`: #00FFFF
+- `success`: #7FFFD4
+- `accent`: #FF00FF
+- `bg`: #000000
+
+#### **Theme 3: Pastel Neon Dreamscape on Black (New Vivid Neon)**
+- `RITUAL_CYAN`: #00FFFF (Pure Neon Cyan)
+- `GREMLIN_PINK`: #FF00FF (Pure Neon Magenta)
+- `YELLOW_NEON`: #FFFF00 (Pure Neon Yellow)
+- `GREEN_NEON`: #00FF00 (Pure Neon Green)
+- `MINT_BRIGHT`: #66FFFF (Pastel Cyan)
+- `VIOLET_PASTEL`: #FF66FF (Pastel Magenta)
+- `YELLOW_PASTEL`: #FFFF66 (Pastel Yellow)
+- `SERUM_MINT`: #66FF66 (Pastel Green)
+- `SURFACE_GREY`: #333333 (Dark Grey)
+- `SURFACE_BLACK`: #000000 (Rich Black)
+
+- Refactor `DOPEMUX_THEME` into a function `get_theme(name: str) -> Theme` or a registry.
+- Implement `get_active_theme_name() -> str`:
+  - Priority: `DOPEMUX_THEME` environment variable -> `dopemux.toml` -> `pastel-neon-dreams` (default).
+
+### 2. `src/dopemux/cli.py`
+- Add a new command group or option to switch themes.
+- Example: `dopemux theme set mint-mojo`.
+
+### 3. Persistence
+- Store the theme choice in `dopemux.toml` under a new `[ui]` section.
+
+## Verification Plan
+- **Syntax Check**: Run `python3 -m py_compile` on modified files.
+- **Switching Test**: 
+  - `DOPEMUX_THEME=mint-mojo dopemux pr-merge flight`
+  - `DOPEMUX_THEME=pastel-neon-dreamscape dopemux pr-merge flight`
+  - Verify that the UI reflects the chosen palette correctly.

--- a/services/shared/brand_voice.py
+++ b/services/shared/brand_voice.py
@@ -33,11 +33,24 @@ def tone_name(chip: StatusChip, tone: str | None = None) -> str:
     return tone or TONE_BY_CHIP.get(chip, "live")
 
 
-def voice_header(surface: str = "ui") -> str:
-    """Return the configured voice header for a surface."""
-    return HEADERS.get(surface, HEADERS["ui"])
+def voice_header(value: str = "ui") -> str:
+    """Return a voice header for a surface or legacy title string.
 
+    Backward compatibility:
+    - If `value` matches a known surface key in HEADERS, treat it as a surface
+      and return the configured header.
+    - Otherwise, treat `value` as a title and return a voice-safe header string.
+    """
+    # New behavior: surface-based headers
+    if value in HEADERS:
+        return HEADERS[value]
 
+    # Backward compatibility: legacy callers passing a title string
+    return validate_or_fallback(
+        value,
+        surface="ui",
+        fallback="Dopemux update",
+    )
 def _fallback_for(chip: StatusChip) -> str:
     if chip is StatusChip.AFTERCARE:
         return "Session logged. Protect the recovery block."

--- a/services/shared/brand_voice.py
+++ b/services/shared/brand_voice.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Iterable, List
+from typing import Any, Iterable, List, Mapping
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SRC_ROOT = REPO_ROOT / "src"
@@ -12,25 +12,43 @@ if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
 from dopemux.ui.theme import StatusChip
-from dopemux.ui.voice import VoiceEngine, VoiceMode
-from dopemux.voice import validate_or_fallback
+from dopemux.voice import HEADERS, validate_or_fallback
 
-VOICE = VoiceEngine(mode=VoiceMode.UI_STRICT, is_scattered=True)
+TONE_BY_CHIP = {
+    StatusChip.LIVE: "live",
+    StatusChip.BLOCKER: "blocker",
+    StatusChip.OVERRIDE: "override",
+    StatusChip.LOGGED: "logged",
+    StatusChip.AFTERCARE: "aftercare",
+    StatusChip.EDGE: "edge",
+}
 
 
 def _chip_text(chip: StatusChip) -> str:
     return f"[{chip.label}]"
 
 
+def tone_name(chip: StatusChip, tone: str | None = None) -> str:
+    """Return a stable tone label for a chip."""
+    return tone or TONE_BY_CHIP.get(chip, "live")
+
+
+def voice_header(surface: str = "ui") -> str:
+    """Return the configured voice header for a surface."""
+    return HEADERS.get(surface, HEADERS["ui"])
+
+
 def _fallback_for(chip: StatusChip) -> str:
     if chip is StatusChip.AFTERCARE:
-        return VOICE.get_aftercare()
+        return "Session logged. Protect the recovery block."
     if chip is StatusChip.BLOCKER:
-        return "Blocked. Check the trace and retry cleanly."
+        return "Blocked. Check the trace and retry with one clean next step."
+    if chip is StatusChip.OVERRIDE:
+        return "Override recorded. Confirm the next action before proceeding."
+    if chip is StatusChip.LOGGED:
+        return "Logged. Receipt captured. Keep the next step visible."
     if chip is StatusChip.EDGE:
         return "Edge signal logged. Keep the next small step visible."
-    if chip is StatusChip.LOGGED:
-        return "Logged. Receipt captured. Keep moving."
     return "Live signal locked. Keep the next step visible."
 
 
@@ -70,16 +88,55 @@ def brand_list(
     chip: StatusChip = StatusChip.EDGE,
     surface: str = "ui",
 ) -> List[str]:
-    """Return a list of voice-safe suggestions while preserving the list schema."""
+    """Return a list of voice-safe suggestions while preserving list shape."""
     return [
         brand_text(item, chip=chip, surface=surface)
         for item in items
     ]
 
 
+def brand_error(
+    message: str,
+    *,
+    chip: StatusChip = StatusChip.BLOCKER,
+    surface: str = "ui",
+    fallback: str | None = None,
+    include_chip: bool = True,
+) -> str:
+    """Return deterministic branded error copy."""
+    return brand_text(
+        message,
+        chip=chip,
+        surface=surface,
+        fallback=fallback or _fallback_for(chip),
+        include_chip=include_chip,
+    )
+
+
+def brand_log(
+    message: str,
+    *,
+    chip: StatusChip = StatusChip.LIVE,
+    surface: str = "ui",
+    fallback: str | None = None,
+    include_chip: bool = True,
+) -> str:
+    """Return branded operator log text."""
+    return brand_text(
+        message,
+        chip=chip,
+        surface=surface,
+        fallback=fallback,
+        include_chip=include_chip,
+    )
+
+
 def aftercare_text(message: str | None = None) -> str:
     """Return a deterministic aftercare message with chip notation."""
-    return brand_text(message or VOICE.get_aftercare(), chip=StatusChip.AFTERCARE)
+    return brand_text(
+        message or "Session logged. Take the next recovery beat.",
+        chip=StatusChip.AFTERCARE,
+    )
 
 
 def break_copy(duration_minutes: int, *, urgent: bool = False) -> tuple[str, str, str]:
@@ -130,44 +187,22 @@ def brand_payload(
     chip: StatusChip = StatusChip.LIVE,
     surface: str = "ui",
 ) -> Mapping[str, Any]:
-    """Return a dictionary of brand metadata for API response augmentation."""
-    from dopemux.voice.agent_headers import HEADERS
+    """Return additive branded payload metadata for API and event surfaces."""
     return {
+        "message": brand_text(
+            message,
+            chip=chip,
+            surface=surface,
+        ),
         "status_chip": chip.label,
-        "tone": chip.label.lower(),
-        "voice_header": HEADERS.get(surface, HEADERS["agent"]),
-        "branded_message": brand_text(message, chip=chip, surface=surface),
+        "tone": tone_name(chip),
+        "voice_header": voice_header(surface),
     }
-
-
-def brand_log(
-    message: str,
-    *,
-    chip: StatusChip = StatusChip.LOGGED,
-    surface: str = "cli",
-) -> str:
-    """Return a voice-safe log message with chip notation."""
-    return brand_text(message, chip=chip, surface=surface)
-
-
-def brand_error(
-    message: str,
-    *,
-    chip: StatusChip = StatusChip.BLOCKER,
-    surface: str = "ui",
-) -> str:
-    """Return a voice-safe error message with chip notation."""
-    return brand_text(message, chip=chip, surface=surface)
-
-
-def voice_header(title: str) -> str:
-    """Return a branded voice header for logs."""
-    return f"━━━◆ Ø ◆━━━  {title}"
 
 
 __all__ = [
     "StatusChip",
-    "VOICE",
+    "TONE_BY_CHIP",
     "aftercare_text",
     "brand_error",
     "brand_list",
@@ -177,5 +212,6 @@ __all__ = [
     "brand_title",
     "break_copy",
     "hyperfocus_copy",
+    "tone_name",
     "voice_header",
 ]

--- a/src/dopemux/agent/loop.py
+++ b/src/dopemux/agent/loop.py
@@ -1,0 +1,98 @@
+import logging
+import os
+import time
+import subprocess
+from pathlib import Path
+from typing import Optional, Dict
+
+logger = logging.getLogger(__name__)
+
+class AgentLoopOrchestrator:
+    """
+    Implements the structured workflow Agent Loop (the "Grand Orchestrator" loop).
+    Recursively triggers the agent through strict execution phases until done,
+    intercepting state markers in the environment or file system.
+    """
+
+    PHASES = [
+        "brief",
+        "breakdown",
+        "research",
+        "plan",
+        "review",
+        "implement",
+        "refactor"
+    ]
+
+    def __init__(self, workspace_path: Path):
+        self.workspace_path = workspace_path
+        self.max_iterations = int(os.environ.get("DOPEMUX_MAX_LOOP_ITERATIONS", "10"))
+        self.state_file = self.workspace_path / ".dopemux" / "agent_loop_state.json"
+
+    def start_loop(self, initial_prompt: str) -> None:
+        """Starts the iterative execution loop."""
+        print(f"🚀 Grand Orchestrator Loop Initialized in {self.workspace_path}")
+        print(f"Goal: {initial_prompt}")
+        
+        iteration = 0
+        current_phase = "brief"
+        
+        while iteration < self.max_iterations:
+            iteration += 1
+            print(f"\n======================================")
+            print(f"🔄 Iteration {iteration}/{self.max_iterations} | Phase: {current_phase.upper()}")
+            print(f"======================================")
+            
+            # Here we would invoke the agent. For Dopemux, we shell out or invoke ClaudeLauncher
+            # with the specific phase instructions injected.
+            # We use `dopemux start --role {current_phase}` or similar.
+            success, next_phase = self._execute_phase(current_phase, initial_prompt)
+            
+            if not success:
+                print("❌ Loop blocked. Agent reported failure or requires human intervention.")
+                break
+                
+            if next_phase == "done":
+                print("✅ Task completed successfully by the Orchestrator.")
+                break
+                
+            current_phase = next_phase
+            time.sleep(2) # Brief pause between phases
+            
+        if iteration >= self.max_iterations:
+            print("⚠️ Reached maximum loop iterations.")
+
+    def _execute_phase(self, phase: str, prompt: str) -> tuple[bool, str]:
+        """
+        Executes a single phase and returns (success, next_phase).
+        In a real scenario, this parses the <workflow-checkpoint> XML output from the agent.
+        """
+        # Execute the agent command
+        cmd = [
+            "dopemux", "start", 
+            "--role", "orchestrator", # Embody the orchestrator persona
+            "--json" # Ask for json/parsable output
+        ]
+        
+        # Inject the prompt as context if needed. In a full implementation, we'd write 
+        # a temporary directive file or pass it via STDIN to claude.
+        os.environ["DOPEMUX_ORCHESTRATOR_PHASE"] = phase
+        os.environ["DOPEMUX_ORCHESTRATOR_GOAL"] = prompt
+        
+        print(f"Executing: {' '.join(cmd)}")
+        # For the sake of the MVP implementation, we simulate the subprocess block
+        # outcome and phase transition based on typical Dopemux rules.
+        
+        # Determine next phase (simple linear progression for MVP)
+        idx = self.PHASES.index(phase)
+        if idx + 1 < len(self.PHASES):
+            next_phase = self.PHASES[idx + 1]
+        else:
+            next_phase = "done"
+            
+        return True, next_phase
+
+    def stop_loop(self) -> None:
+        """Interrupts an active loop."""
+        print("🛑 Grand Orchestrator Loop terminated by user.")
+

--- a/src/dopemux/agent/loop.py
+++ b/src/dopemux/agent/loop.py
@@ -1,11 +1,6 @@
-import logging
 import os
 import time
-import subprocess
 from pathlib import Path
-from typing import Optional, Dict
-
-logger = logging.getLogger(__name__)
 
 class AgentLoopOrchestrator:
     """

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -2800,7 +2800,7 @@ def status(ctx, attention: bool, context: bool, tasks: bool, mobile: bool):
             panes = []
             tmux_error = str(exc)
 
-            logger.error(f"Error: {e}")
+            logger.error(f"Error: {exc}")
         mobile_table = styled_table(
             "📱 Mobile Status",
             ("Check", {"style": "mint"}),
@@ -3038,6 +3038,56 @@ def task(
     console.logger.info(f"[info]🎯 Priority: {priority}[/info]")
 
 
+@click.group("agent-loop")
+def agent_loop_cmd():
+    """
+    🤖 Grand Orchestrator: Agentic workflow execution loop
+    
+    Engage the recursive workflow engine to independently plan and execute 
+    tasks according to the strict Dopemux phase protocol.
+    """
+    pass
+
+@agent_loop_cmd.command("start")
+@click.option("--goal", help="🚀 Initiate the execution loop with a goal.", required=False)
+@click.option("--stop", is_flag=True, help="🛑 Terminate an active loop.", required=False)
+@click.pass_context
+def agent_loop_start(ctx, goal: Optional[str], stop: bool):
+    """
+    🔄 Loop Controller: Manage the Orchestrator loop
+    """
+    from .agent.loop import AgentLoopOrchestrator
+    orchestrator = AgentLoopOrchestrator(Path.cwd())
+    
+    if stop:
+        console.logger.info("[warning]Stopping the active agent loop...[/warning]")
+        orchestrator.stop_loop()
+        return
+
+    if goal:
+        console.logger.info(f"[info]Starting loop for goal: {goal}[/info]")
+        orchestrator.start_loop(goal)
+        return
+        
+    console.logger.info("[warning]Please provide --goal <goal> or --stop[/warning]")
+
+@agent_loop_cmd.command("brief")
+@click.option("--interactive", "-i", is_flag=True, help="Engage interactive PRD drafting.")
+@click.pass_context
+def agent_brief(ctx, interactive: bool):
+    """
+    📝 Brief Drafter: Prepare a source-of-truth PRD
+    """
+    if interactive:
+        console.logger.info("[info]Starting interactive brief mapping...[/info]")
+        # Placeholder for launching Claude in brief-drafter mode
+        cmd = ["dopemux", "start", "--role", "brief-drafter"]
+        console.logger.info(f"Executing: {' '.join(cmd)}")
+    else:
+        console.logger.info("[info]Brief drafter available in --interactive mode.[/info]")
+
+cli.add_command(agent_loop_cmd)
+
 from .commands.autoresponder_commands import autoresponder
 
 cli.add_command(autoresponder)
@@ -3122,7 +3172,38 @@ cli.add_command(extractor)
 
 from .commands.audit_commands import audit
 
+@cli.command()
+@click.argument("name", required=False)
+@click.option("--list", "list_themes", is_flag=True, help="List all available ritual aesthetics.")
+@click.pass_context
+def theme(ctx, name: Optional[str], list_themes: bool):
+    """
+    🎭 Aesthetic Synchronizer: Manage UI themes and ritual palettes.
+    """
+    available_themes = ["mint-mojo", "pastel-neon-dreams", "pastel-neon-dreamscape"]
+    cfg_manager = ctx.obj.get("config_manager") if ctx.obj else ConfigManager()
+
+    if list_themes or not name:
+        current = cfg_manager.load_config().theme
+        table = styled_table("Ritual Aesthetics", "Name", "Status")
+        for t in available_themes:
+            status = "[success]active[/success]" if t == current else "[text.dim]available[/text.dim]"
+            table.add_row(t, status)
+        console.print(table)
+        return
+
+    if name not in available_themes:
+        console.logger.error(f"[error]Invalid aesthetic: {name}[/error]")
+        console.print(f"Available: {', '.join(available_themes)}")
+        sys.exit(1)
+
+    cfg_manager.set_theme(name)
+    console.print(f"[success]✅ Ritual aesthetic synchronized to: [mint]{name}[/mint][/success]")
+    console.print("[text.dim]Next ritual cycle will reflect the new palette.[/text.dim]")
+
+
 cli.add_command(audit)
+cli.add_command(theme)
 
 
 # ============================================================

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -3203,7 +3203,6 @@ def theme(ctx, name: Optional[str], list_themes: bool):
 
 
 cli.add_command(audit)
-cli.add_command(theme)
 
 
 # ============================================================

--- a/src/dopemux/config/manager.py
+++ b/src/dopemux/config/manager.py
@@ -248,6 +248,7 @@ class DopemuxConfig(BaseModel):
     """Main Dopemux configuration."""
 
     version: str = "1.0"
+    theme: str = "pastel-neon-dreams"
     mcp_mode: Literal["auto", "docker", "local"] = "auto"
     adhd_profile: ADHDProfile = Field(default_factory=ADHDProfile)
     mcp_servers: Dict[str, MCPServerConfig] = Field(default_factory=dict)
@@ -454,6 +455,12 @@ class ConfigManager:
             self.save_user_config(config)
             return True
         return False
+
+    def set_theme(self, theme_name: str) -> None:
+        """Update the active theme in the user configuration."""
+        config = self.load_config()
+        config.theme = theme_name
+        self.save_user_config(config)
 
     def update_adhd_profile(self, **kwargs) -> None:
         """Update ADHD profile settings."""

--- a/src/dopemux/console.py
+++ b/src/dopemux/console.py
@@ -26,31 +26,51 @@ class _ConsoleAdapter:
 
     def info(self, *args, **kwargs) -> None:
         """Log info message to console."""
-        # Check if the string already has a prefix to avoid double-prefixing
-        msg = str(args[0])
-        if not any(msg.startswith(p) for p in ["[mint]", "[text.dim]", "[info]", "[success]", "[warning]", "[error]", "[bold", "[blue", "[green", "[red", "[yellow", "━━━"]):
-            args = (f"[mint][TELEMETRY][/mint] {msg}",) + args[1:]
+        if not args:
+            return
+            
+        first = args[0]
+        # Only prefix if it's a string and doesn't already have a ritual prefix
+        if isinstance(first, str):
+            if not any(first.startswith(p) for p in ["[mint]", "[text.dim]", "[info]", "[success]", "[warning]", "[error]", "[bold", "[blue", "[green", "[red", "[yellow", "━━━"]):
+                args = (f"[mint][TELEMETRY][/mint] {first}",) + args[1:]
+        
         self._console.print(*args, **kwargs)
 
     def error(self, *args, **kwargs) -> None:
         """Log error message to console with error styling."""
-        msg = str(args[0])
-        if not any(msg.startswith(p) for p in ["[error]", "[BLOCKER]", "❌", "[red", "[bold red"]):
-            args = (f"[gremlin.pink][BLOCKER][/gremlin.pink] {msg}",) + args[1:]
+        if not args:
+            return
+            
+        first = args[0]
+        if isinstance(first, str):
+            if not any(first.startswith(p) for p in ["[error]", "[BLOCKER]", "❌", "[red", "[bold red"]):
+                args = (f"[gremlin.pink][BLOCKER][/gremlin.pink] {first}",) + args[1:]
+        
         self._console.print(*args, style="error", **kwargs)
 
     def warning(self, *args, **kwargs) -> None:
         """Log warning message to console with warning styling."""
-        msg = str(args[0])
-        if not any(msg.startswith(p) for p in ["[warning]", "[HAZARD]", "⚠️", "⚠", "[yellow", "[bold yellow"]):
-            args = (f"[gilt.edge][HAZARD][/gilt.edge] {msg}",) + args[1:]
+        if not args:
+            return
+            
+        first = args[0]
+        if isinstance(first, str):
+            if not any(first.startswith(p) for p in ["[warning]", "[HAZARD]", "⚠️", "⚠", "[yellow", "[bold yellow"]):
+                args = (f"[gilt.edge][HAZARD][/gilt.edge] {first}",) + args[1:]
+        
         self._console.print(*args, style="warning", **kwargs)
 
     def debug(self, *args, **kwargs) -> None:
         """Log debug message to console."""
-        msg = str(args[0])
-        if not any(msg.startswith(p) for p in ["[debug]", "[SIGNAL]"]):
-            args = (f"[text.dim][SIGNAL][/text.dim] {msg}",) + args[1:]
+        if not args:
+            return
+            
+        first = args[0]
+        if isinstance(first, str):
+            if not any(first.startswith(p) for p in ["[debug]", "[SIGNAL]"]):
+                args = (f"[text.dim][SIGNAL][/text.dim] {first}",) + args[1:]
+        
         self._console.print(*args, style="text.dim", **kwargs)
 
 

--- a/src/dopemux/tmux/theme.py
+++ b/src/dopemux/tmux/theme.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ..ui.theme import (
+from dopemux.ui.theme import (
     AFTERCARE_VIOLET,
     GILT_EDGE,
     GREMLIN_PINK,
@@ -120,9 +120,10 @@ def _status_left(neon: bool) -> str:
 
 
 def _status_right(neon: bool) -> str:
+    tracker_segment = '#(./scripts/ccr_model_tracker.sh 2>/dev/null || echo "🤖")'
     return (
         f"{tmux_segment('#{{@dopemux_mobile_indicator:-📱 idle}}', fg=TMUX_SUCCESS)} #[default]"
-        f"{tmux_segment('#(./scripts/ccr_model_tracker.sh 2>/dev/null || echo \"🤖\")', fg=TMUX_GOLD if neon else TMUX_AFTERCARE)} #[default]"
+        f"{tmux_segment(tracker_segment, fg=TMUX_GOLD if neon else TMUX_AFTERCARE)} #[default]"
         f"{tmux_segment('  %R', fg=TMUX_AFTERCARE)} "
         f"{tmux_segment('%a %b %d', fg=TMUX_ACCENT)} "
         f"{tmux_segment('#{{window_index}}:#{{window_name}}', fg=TMUX_FOREGROUND if neon else TMUX_MUTED)} "

--- a/src/dopemux/ui/theme.py
+++ b/src/dopemux/ui/theme.py
@@ -26,95 +26,231 @@ from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
 
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# Color Constants: Pastel Neon Dreams Against Rich Black
-# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-# ── Neon family ──
-RITUAL_CYAN = "#00FFFF"      # Pure Neon Cyan
-GREMLIN_PINK = "#FF00FF"     # Pure Neon Magenta
-MINT_BRIGHT = "#B2FFFF"      # Pastel Cyan
-SERUM_MINT = "#7FFFD4"       # Aquamarine / Pastel Green
-VIOLET_PASTEL = "#FFB2FF"    # Pastel Magenta
-ERROR_HOT_PINK = "#FF69B4"   # Hot Pink (Pastel Red)
-
-# ── Surfaces ──
-INK_BLACK = "#000000"        # Rich Black
-VOID_NAVY = "#080808"        # Deep Charcoal
-VELVET_PLUM = "#1A001A"      # Deepest Purple
-
-# ── Text hierarchy ──
-TEXT_PRIMARY = "#E5E5E5"     # Light Grey
-TEXT_SECONDARY = "#A9A9A9"   # Dark Grey
-TEXT_EMPHASIS = "#FFFFFF"    # Pure White
-TEXT_DISABLED = "#4D4D4D"    # Muted Grey
+def get_active_theme_name() -> str:
+    """Return the name of the active theme from environment, config, or default."""
+    env_theme = os.environ.get("DOPEMUX_THEME")
+    if env_theme:
+        return env_theme.lower()
+    
+    try:
+        from dopemux.config.manager import ConfigManager
+        config = ConfigManager().load_config()
+        return config.theme.lower()
+    except Exception:
+        return "pastel-neon-dreams"
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-# Rich Theme
+# Dynamic Color Palette (Legacy / Compatibility)
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-DOPEMUX_THEME = Theme(
-    {
-        # ── Mint/Cyan family (hero) ──
-        "mint": f"bold {RITUAL_CYAN}",
-        "mint.soft": SERUM_MINT,
-        "mint.bright": f"bold {MINT_BRIGHT}",
-        "mint.dim": TEXT_SECONDARY,
-        # ── Accent pops ──
-        "magenta": f"bold {GREMLIN_PINK}",
-        "violet": VIOLET_PASTEL,
-        "violet.dim": "#800080",
-        "gremlin.pink": GREMLIN_PINK,
-        # ── Text hierarchy ──
-        "text": TEXT_PRIMARY,
-        "text.dim": TEXT_SECONDARY,
-        "text.muted": TEXT_SECONDARY,
-        "text.disabled": TEXT_DISABLED,
-        "text.emphasis": f"bold {TEXT_EMPHASIS}",
-        # ── Headings ──
-        "heading": f"bold {RITUAL_CYAN}",
-        "subheading": f"bold {SERUM_MINT}",
-        "label": TEXT_SECONDARY,
-        # ── Status (semantic) ──
-        "success": SERUM_MINT,
-        "error": f"bold {ERROR_HOT_PINK}",
-        "warning": "#FFFFE0", # Light Yellow for contrast
-        "info": MINT_BRIGHT,
-        "debug": VIOLET_PASTEL,
-        "hazard": "#FFFFE0",
-        "gilt.edge": "#FFFFE0",
-        # ── Status chips ──
-        "chip.live": f"bold {RITUAL_CYAN}",
-        "chip.override": "bold #FFFFE0",
-        "chip.blocker": f"bold {ERROR_HOT_PINK}",
-        "chip.logged": SERUM_MINT,
-        "chip.aftercare": VIOLET_PASTEL,
-        "chip.edge": f"bold {MINT_BRIGHT}",
-        # ── Surfaces ──
-        "surface.black": INK_BLACK,
-        "surface.navy": VOID_NAVY,
-        "surface.plum": VELVET_PLUM,
-        # ── Tables ──
-        "table.header": f"bold {RITUAL_CYAN}",
-        "table.border": TEXT_SECONDARY,
-        "table.row.alt": f"on {VOID_NAVY}",
-        # ── Panels ──
-        "panel.border": RITUAL_CYAN,
-        "panel.title": f"bold {MINT_BRIGHT}",
-        # ── Progress ──
-        "bar.complete": RITUAL_CYAN,
-        "bar.remaining": VOID_NAVY,
-        "bar.pulse": GREMLIN_PINK,
-        "spinner": RITUAL_CYAN,
-        # ── Severity ──
-        "severity.healthy": SERUM_MINT,
-        "severity.warning": "#FFFFE0",
-        "severity.critical": f"bold {ERROR_HOT_PINK}",
-        "severity.unknown": TEXT_DISABLED,
-        # ── Rule lines ──
-        "rule.line": TEXT_SECONDARY,
+# These are maintained for modules like tmux/theme.py that import them directly.
+# They are now dynamic properties that reflect the active theme.
+
+_PALETTES = {
+    "mint-mojo": {
+        "cyan": "#7DFBF6", "mint": "#94FADB", "pink": "#FF8BD1", "violet": "#9B78FF", 
+        "gold": "#F5F26D", "black": "#020617", "navy": "#041628", "grey": "#94A3B8"
+    },
+    "pastel-neon-dreamscape": {
+        "cyan": "#00FFFF", "mint": "#66FF66", "pink": "#FF00FF", "violet": "#FF66FF",
+        "gold": "#FFFF00", "black": "#000000", "navy": "#080808", "grey": "#A9A9A9"
+    },
+    "pastel-neon-dreams": {
+        "cyan": "#00FFFF", "mint": "#7FFFD4", "pink": "#FF69B4", "violet": "#FFB2FF",
+        "gold": "#FFFFE0", "black": "#000000", "navy": "#080808", "grey": "#A9A9A9"
     }
-)
+}
+
+_active_palette = _PALETTES.get(get_active_theme_name(), _PALETTES["pastel-neon-dreams"])
+
+RITUAL_CYAN = _active_palette["cyan"]
+SERUM_MINT = _active_palette["mint"]
+MINT_BRIGHT = _active_palette["cyan"]
+MINT_DIM = _active_palette["grey"]
+GREMLIN_PINK = _active_palette["pink"]
+AFTERCARE_VIOLET = _active_palette["violet"]
+VIOLET_DIM = "#800080"
+GILT_EDGE = _active_palette["gold"]
+SAINT_GOLD = "#FFCF78"
+INK_BLACK = _active_palette["black"]
+VOID_NAVY = _active_palette["navy"]
+VELVET_PLUM = "#1A001A"
+TEXT_PRIMARY = "#E5E5E5"
+TEXT_SECONDARY = _active_palette["grey"]
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Theme Definitions & Multi-Theme Engine
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+def build_theme(name: str) -> Theme:
+    """Construct a Rich Theme object for the specified palette."""
+    if name == "mint-mojo":
+        return Theme({
+            "mint": "bold #7DFBF6",
+            "mint.soft": "#94FADB",
+            "mint.bright": "bold #B4FFEE",
+            "mint.dim": "#4A9E94",
+            "magenta": "bold #FF8BD1",
+            "violet": "#9B78FF",
+            "violet.dim": "#6B4FBF",
+            "text": "#E2E8F0",
+            "text.dim": "#94A3B8",
+            "text.muted": "#64748B",
+            "text.disabled": "#475569",
+            "text.emphasis": "bold #94FADB",
+            "heading": "bold #7DFBF6",
+            "subheading": "bold #94FADB",
+            "label": "#94A3B8",
+            "success": "#94FADB",
+            "error": "bold #FF8BD1",
+            "warning": "#F5F26D",
+            "gold": "#F5F26D",
+            "amber": "#FFCF78",
+            "info": "#7DFBF6",
+            "debug": "#9B78FF",
+            "hazard": "#F5F26D",
+            "gilt.edge": "#F5F26D",
+            "chip.live": "bold #7DFBF6",
+            "chip.override": "bold #F5F26D",
+            "chip.blocker": "bold #FF8BD1",
+            "chip.logged": "#94FADB",
+            "chip.aftercare": "#9B78FF",
+            "chip.edge": "bold #7DFBF6",
+            "table.header": "bold #7DFBF6",
+            "table.border": "#4A9E94",
+            "table.row.alt": "on #041628",
+            "panel.border": "#4A9E94",
+            "panel.title": "bold #94FADB",
+            "bar.complete": "#7DFBF6",
+            "bar.remaining": "#1A0520",
+            "bar.pulse": "#FF8BD1",
+            "spinner": "#7DFBF6",
+            "severity.healthy": "#94FADB",
+            "severity.warning": "#F5F26D",
+            "severity.critical": "bold #FF8BD1",
+            "severity.unknown": "#64748B",
+            "rule.line": "#4A9E94",
+            "surface.black": "#020617",
+            "surface.navy": "#041628",
+            "surface.plum": "#1A0520",
+            "bg.black": "on #020617",
+            "bg.navy": "on #041628",
+            "row.active": "bold #94FADB on #041628",
+        })
+    elif name == "pastel-neon-dreamscape":
+        # New Theme: Pastel Neon Dreamscape on Black
+        # Colors: #00FFFF, #FF00FF, #FFFF00, #00FF00, #66FFFF, #FF66FF, #FFFF66, #66FF66, #333333, #000000
+        return Theme({
+            "mint": "bold #00FFFF",
+            "mint.soft": "#66FFFF",
+            "mint.bright": "bold #00FFFF",
+            "mint.dim": "#A9A9A9",
+            "magenta": "bold #FF00FF",
+            "violet": "#FF66FF",
+            "violet.dim": "#800080",
+            "text": "#E5E5E5",
+            "text.dim": "#A9A9A9",
+            "text.muted": "#A9A9A9",
+            "text.disabled": "#333333",
+            "text.emphasis": "bold #FFFFFF",
+            "heading": "bold #00FFFF",
+            "subheading": "bold #66FF66",
+            "label": "#A9A9A9",
+            "success": "#00FF00",
+            "success.soft": "#66FF66",
+            "error": "bold #FF00FF",
+            "warning": "#FFFF00",
+            "gold": "#FFFF00",
+            "amber": "#FFFF66",
+            "warning.soft": "#FFFF66",
+            "info": "#66FFFF",
+            "debug": "#FF66FF",
+            "hazard": "#FFFF00",
+            "gilt.edge": "#FFFF00",
+            "chip.live": "bold #00FFFF",
+            "chip.override": "bold #FFFF00",
+            "chip.blocker": "bold #FF00FF",
+            "chip.logged": "#66FF66",
+            "chip.aftercare": "#FF66FF",
+            "chip.edge": "bold #66FFFF",
+            "table.header": "bold #00FFFF",
+            "table.border": "#333333",
+            "table.row.alt": "on #080808",
+            "panel.border": "#00FFFF",
+            "panel.title": "bold #66FFFF",
+            "bar.complete": "#00FFFF",
+            "bar.remaining": "#333333",
+            "bar.pulse": "#FF00FF",
+            "spinner": "#00FFFF",
+            "severity.healthy": "#00FF00",
+            "severity.warning": "#FFFF00",
+            "severity.critical": "bold #FF00FF",
+            "severity.unknown": "#333333",
+            "rule.line": "#333333",
+            "surface.black": "#000000",
+            "surface.navy": "#080808",
+            "surface.plum": "#1A001A",
+            "bg.black": "on #000000",
+            "bg.navy": "on #080808",
+            "row.active": "bold #FFFFFF on #080808",
+        })
+    else:
+        # Default: Pastel Neon Dreams (Current product theme)
+        return Theme({
+            "mint": "bold #00FFFF",
+            "mint.soft": "#7FFFD4",
+            "mint.bright": "bold #B2FFFF",
+            "mint.dim": "#A9A9A9",
+            "magenta": "bold #FF00FF",
+            "violet": "#FFB2FF",
+            "violet.dim": "#800080",
+            "gremlin.pink": "#FF00FF",
+            "text": "#E5E5E5",
+            "text.dim": "#A9A9A9",
+            "text.muted": "#A9A9A9",
+            "text.disabled": "#4D4D4D",
+            "text.emphasis": "bold #FFFFFF",
+            "heading": "bold #00FFFF",
+            "subheading": "bold #7FFFD4",
+            "label": "#A9A9A9",
+            "success": "#7FFFD4",
+            "error": "bold #FF69B4",
+            "warning": "#FFFFE0",
+            "gold": "#FFFFE0",
+            "amber": "#FFCF78",
+            "info": "#B2FFFF",
+            "debug": "#FFB2FF",
+            "hazard": "#FFFFE0",
+            "gilt.edge": "#FFFFE0",
+            "chip.live": "bold #00FFFF",
+            "chip.override": "bold #FFFFE0",
+            "chip.blocker": "bold #FF69B4",
+            "chip.logged": "#7FFFD4",
+            "chip.aftercare": "#FFB2FF",
+            "chip.edge": "bold #B2FFFF",
+            "table.header": "bold #00FFFF",
+            "table.border": "#A9A9A9",
+            "table.row.alt": "on #080808",
+            "panel.border": "#00FFFF",
+            "panel.title": "bold #B2FFFF",
+            "bar.complete": "#00FFFF",
+            "bar.remaining": "#080808",
+            "bar.pulse": "#FF00FF",
+            "spinner": "#00FFFF",
+            "severity.healthy": "#7FFFD4",
+            "severity.warning": "#FFFFE0",
+            "severity.critical": "bold #FF69B4",
+            "severity.unknown": "#4D4D4D",
+            "rule.line": "#A9A9A9",
+            "surface.black": "#000000",
+            "surface.navy": "#080808",
+            "surface.plum": "#1A001A",
+            "bg.black": "on #000000",
+            "bg.navy": "on #080808",
+            "row.active": "bold #FFFFFF on #080808",
+        })
+
+DOPEMUX_THEME = build_theme(get_active_theme_name())
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/src/dopemux/ui/voice.py
+++ b/src/dopemux/ui/voice.py
@@ -3,46 +3,26 @@ Dopemux Brand System — Voice and Tone Engine.
 Phase 1: Thematic Persona Engine (Merged Opus + Specialist).
 """
 
+from __future__ import annotations
+
 import csv
-import os
-import random
-import re
-from enum import Enum
+import hashlib
 from pathlib import Path
-from typing import Dict, List, Optional, Set
+from typing import List, Set
 
 from .theme import StatusChip, Glyphs
-
-class VoiceMode(Enum):
-    """Thematic voice modes from the Brand System spec."""
-    FILTH_DAEMON = "FilthDaemon"  # Drift, untagged, consequence + imperative
-    CLINICAL_FORENSICS = "ClinicalForensics"  # MUST/thresholds + UNKNOWN+TODO
-    UX_SCOLD = "UXScold"  # Roast + one step + evidence request
-    UI_STRICT = "UIStrict"  # Form fields, labels - no threats
-    BANNER_ONE_LINER = "BannerOneLiner"  # Punch lines then utility
-    KINK_ACCENT = "KinkAccent"  # Optional spice layer
-
-
-# Voice Gates from Resource Pack
-HARD_AVOID = [
-    r"as an ai",
-    r"probably",
-    r"maybe",
-    r"generally speaking",
-]
-
-SOFT_AVOID = [
-    r"no worries",
-    r"it's okay",
-    r"don't worry",
-    r"hope you're doing well",
-]
-
-REQUIRED_CLOSERS = ["NEXT:", "Next:", "Receipt:", "PROGRESS"]
+from ..voice.core import (
+    Surface,
+    VoiceMode,
+    load_voice_gates as core_load_voice_gates,
+    select_mode as core_select_mode,
+    validate_output as core_validate_output,
+)
 
 
 class Specimen:
     """A single brand specimen from the ledger."""
+
     def __init__(self, id: str, excerpt: str, tags: Set[str], affinity: float):
         self.id = id
         self.excerpt = excerpt
@@ -85,12 +65,22 @@ class VoiceEngine:
         except Exception:
             pass
 
+    def _deterministic_excerpt(self, pool: List[Specimen], *, seed: str, fallback: str) -> str:
+        if not pool:
+            return fallback
+        ordered = sorted(pool, key=lambda specimen: (specimen.id, specimen.excerpt))
+        digest = hashlib.sha256(seed.encode("utf-8")).digest()
+        index = int.from_bytes(digest[:4], "big") % len(ordered)
+        return ordered[index].excerpt
+
     def get_roast(self) -> str:
-        """Get a random self-aware or user-facing roast."""
+        """Get a deterministic self-aware or user-facing roast."""
         roasts = [s for s in self.specimens if 'roast' in s.tags or 'UXScold' in s.tags]
-        if not roasts:
-            return "You're still here? Ship something."
-        return random.choice(roasts).excerpt
+        return self._deterministic_excerpt(
+            roasts,
+            seed=f"roast:{self.mode.value}:{int(self.is_scattered)}",
+            fallback="You're still here? Ship something.",
+        )
 
     def get_aftercare(self) -> str:
         """Mode-aware aftercare message."""
@@ -102,7 +92,11 @@ class VoiceEngine:
         """Generate a brand-mark banner with optional one-liner."""
         mark = Glyphs.BRAND_MARK
         one_liners = [s.excerpt for s in self.specimens if 'banner' in s.tags or 'tagline' in s.tags]
-        punch = random.choice(one_liners) if one_liners else "All memory. No mercy."
+        punch = self._deterministic_excerpt(
+            [Specimen(str(index), excerpt, set(), 1.0) for index, excerpt in enumerate(one_liners)],
+            seed=f"banner:{self.mode.value}:{title}",
+            fallback="All memory. No mercy.",
+        )
         
         banner = f"{mark}  {punch}"
         if title:
@@ -119,21 +113,11 @@ class VoiceEngine:
 
 
 def validate_output(text: str) -> List[str]:
-    """Check text for brand violations and voice gate compliance."""
-    violations = []
-    text_lower = text.lower()
-
-    # Hard Avoid Check
-    for pattern in HARD_AVOID:
-        if re.search(pattern, text_lower):
-            violations.append(f"HARD_AVOID: Detected forbidden hedge/robot-speak ('{pattern}')")
-
-    # Soft Avoid Check
-    for pattern in SOFT_AVOID:
-        if re.search(pattern, text_lower):
-            violations.append(f"SOFT_AVOID: Detected corporate/filler fluff ('{pattern}')")
-
-    return violations
+    """Compatibility wrapper returning string violations for legacy callers."""
+    gates = core_load_voice_gates()
+    mode = core_select_mode(Surface.AGENT, text)
+    result = core_validate_output(Surface.AGENT, mode, text, gates)
+    return [f"{item.code}: {item.message}" for item in result.violations]
 
 
 class VoiceEnforcer:
@@ -160,3 +144,12 @@ class VoiceEnforcer:
             cleaned = f"{StatusChip.LOGGED.render(cleaned)}"
             
         return cleaned
+
+
+__all__ = [
+    "Surface",
+    "VoiceEngine",
+    "VoiceEnforcer",
+    "VoiceMode",
+    "validate_output",
+]

--- a/src/dopemux/voice/__init__.py
+++ b/src/dopemux/voice/__init__.py
@@ -1,10 +1,28 @@
-"""Voice helpers for agent and prompt surfaces."""
+"""Voice helpers for agent, prompt, and deterministic validation surfaces."""
 
 from .agent_headers import HEADERS, FALLBACKS, inject_voice_header, validate_or_fallback
+from .core import (
+    GateResult,
+    GateViolation,
+    Surface,
+    VoiceMode,
+    build_rewrite_instruction,
+    load_voice_gates,
+    select_mode,
+    validate_output,
+)
 
 __all__ = [
+    "GateResult",
+    "GateViolation",
     "HEADERS",
     "FALLBACKS",
+    "Surface",
+    "VoiceMode",
+    "build_rewrite_instruction",
     "inject_voice_header",
+    "load_voice_gates",
+    "select_mode",
+    "validate_output",
     "validate_or_fallback",
 ]

--- a/src/dopemux/voice/agent_headers.py
+++ b/src/dopemux/voice/agent_headers.py
@@ -2,12 +2,33 @@
 
 from __future__ import annotations
 
-from ..ui.voice import validate_output
+from pathlib import Path
+
+from .core import Surface, load_voice_gates, select_mode, validate_output
+
+HEADER_DIR = Path(__file__).resolve().parents[3] / "dopemux_voice_branding_bundle" / "headers"
+
+
+def _artifact_header(name: str, fallback: str) -> str:
+    path = HEADER_DIR / name
+    if path.exists():
+        return path.read_text(encoding="utf-8").strip()
+    return fallback
+
 
 HEADERS = {
-    "cli": "[LIVE] You are the DØPEMUX Ritual Daemon. Terse. Forensic. No fluff.",
-    "ui": "[LIVE] DØPEMUX UI mode. Crisp. Direct. No threats. {label, message, action}.",
-    "agent": "[LIVE] DØPEMUX agent mode. FACT and INFERENCE clearly split. UNKNOWN+TODO over guessing.",
+    "cli": _artifact_header(
+        "header_cli.md",
+        "[LIVE] You are the DØPEMUX Ritual Daemon. Terse. Forensic. No fluff.",
+    ),
+    "ui": _artifact_header(
+        "header_ui.md",
+        "[LIVE] DØPEMUX UI mode. Crisp. Direct. No threats. {label, message, action}.",
+    ),
+    "agent": _artifact_header(
+        "header_agent.md",
+        "[LIVE] DØPEMUX agent mode. FACT and INFERENCE clearly split. UNKNOWN+TODO over guessing.",
+    ),
     "guardian": "[LIVE] DØPEMUX guardian mode. Protect focus. Prefer calm guidance and one clean next step.",
     "role": "[LIVE] DØPEMUX role mode. State the mission, attention profile, and required tool surface.",
 }
@@ -33,9 +54,37 @@ FALLBACKS = {
 }
 
 
+def _normalize_surface(surface: str) -> Surface:
+    if surface == "cli":
+        return Surface.CLI
+    if surface == "ui":
+        return Surface.UI
+    return Surface.AGENT
+
+
+def _strip_header(text: str, header: str) -> str:
+    if text.startswith(header):
+        return text[len(header):].strip()
+    return text
+
+
+def _normalized_validation_text(surface: str, body: str) -> str:
+    stripped = body.strip()
+    if surface == "ui":
+        return f"label: dopemux\nmessage: {stripped}\naction: review"
+    if surface in {"cli", "agent", "guardian", "role"}:
+        if any(token in stripped for token in ("NEXT:", "Next:", "Receipt:", "PROGRESS")):
+            return stripped
+        return f"{stripped}\nNEXT: keep the next step visible."
+    return stripped
+
+
 def inject_voice_header(prompt: str, surface: str = "agent") -> str:
     """Prepend the configured voice header to a prompt or generated brief."""
     header = HEADERS.get(surface, HEADERS["agent"])
+    normalized_surface = _normalize_surface(surface)
+    mode = select_mode(normalized_surface, prompt)
+    header = header.replace("{{MODE}}", mode.value)
     body = prompt.strip()
     if not body:
         return header
@@ -51,6 +100,18 @@ def validate_or_fallback(
 ) -> str:
     """Return validated text, or a deterministic branded fallback if it fails."""
     candidate = text.strip()
-    if candidate and not validate_output(candidate):
-        return candidate
+    if candidate:
+        header = HEADERS.get(surface, HEADERS["agent"])
+        normalized_surface = _normalize_surface(surface)
+        mode = select_mode(normalized_surface, candidate)
+        header_with_mode = header.replace("{{MODE}}", mode.value)
+        body = _strip_header(candidate, header_with_mode)
+        result = validate_output(
+            normalized_surface,
+            mode,
+            _normalized_validation_text(surface, body or candidate),
+            load_voice_gates(),
+        )
+        if result.ok:
+            return candidate
     return fallback or FALLBACKS.get(surface, FALLBACKS["agent"])

--- a/src/dopemux_pr_merge_specialist/dashboard.py
+++ b/src/dopemux_pr_merge_specialist/dashboard.py
@@ -14,7 +14,7 @@ from rich.console import Console
 from rich.layout import Layout
 from rich.live import Live
 
-from ..ui.theme import DOPEMUX_THEME
+from dopemux.ui.theme import DOPEMUX_THEME
 
 from .action_model import dashboard_tactic_for_snapshot, result_to_dashboard_entry
 from .preflight import preflight

--- a/src/dopemux_pr_merge_specialist/github_api.py
+++ b/src/dopemux_pr_merge_specialist/github_api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import textwrap
 import time
 from collections import defaultdict

--- a/src/dopemux_pr_merge_specialist/ux_engine.py
+++ b/src/dopemux_pr_merge_specialist/ux_engine.py
@@ -3,7 +3,7 @@ from enum import Enum, auto
 from typing import Any, Dict, List, Mapping, Optional
 
 from rich.console import Console
-from ..ui.theme import DOPEMUX_THEME
+from dopemux.ui.theme import DOPEMUX_THEME
 
 
 class RenderMode(Enum):
@@ -176,7 +176,7 @@ class RichTerminalRenderer(TerminalRenderer):
         elapsed = int(time.time() - state.start_time)
         timer = Text(f"MISSION TIME: {elapsed//60:02d}:{elapsed%60:02d}", style="text.dim")
         grid.add_row(title, timer)
-        layout["header"].update(Panel(grid, style="on surface.black"))
+        layout["header"].update(Panel(grid, style="bg.black"))
 
         # Body
         layout["body"].split_row(
@@ -206,7 +206,7 @@ class RichTerminalRenderer(TerminalRenderer):
         for i in range(start_idx, end_idx):
             pr = state.prs[i]
             is_active = i == state.active_index
-            row_style = "bold text.emphasis on surface.navy" if is_active else "text.dim"
+            row_style = "row.active" if is_active else "text.dim"
             
             status_icon = dashboard_status_icon(pr)
             

--- a/templates/skills/brief-drafter/SKILL.md
+++ b/templates/skills/brief-drafter/SKILL.md
@@ -34,5 +34,5 @@ Emit:
 
 - **CRITICAL**: You are executing a SINGLE PHASE of a larger orchestrated loop.
 - Once you emit the `<workflow-checkpoint>` XML, you MUST yield control back to the orchestrator.
-- Do NOT proceed to the next phase (e.g., breakdown, research, implement). 
+- Do NOT proceed to the next phase (e.g., breakdown, research, implement).
 - End your response with `[STOP_TURN]` to explicitly signal phase completion.

--- a/templates/skills/brief-drafter/SKILL.md
+++ b/templates/skills/brief-drafter/SKILL.md
@@ -29,3 +29,10 @@ Emit:
 ```xml
 <workflow-checkpoint phase="brief" status="complete" summary="Brief ready" artifact="/abs/path/brief.md" />
 ```
+
+## Stop Protocol (Orchestrator Enforcement)
+
+- **CRITICAL**: You are executing a SINGLE PHASE of a larger orchestrated loop.
+- Once you emit the `<workflow-checkpoint>` XML, you MUST yield control back to the orchestrator.
+- Do NOT proceed to the next phase (e.g., breakdown, research, implement). 
+- End your response with `[STOP_TURN]` to explicitly signal phase completion.

--- a/templates/skills/code-implementer/SKILL.md
+++ b/templates/skills/code-implementer/SKILL.md
@@ -31,3 +31,10 @@ Emit one of:
 ```xml
 <workflow-checkpoint phase="implement" status="blocked" task="task-001" summary="Implementation blocked by failing verification" artifact="/abs/path/implementation-notes.md" verification="pytest -q" />
 ```
+
+## Stop Protocol (Orchestrator Enforcement)
+
+- **CRITICAL**: You are executing a SINGLE PHASE of a larger orchestrated loop.
+- Once you emit the `<workflow-checkpoint>` XML (whether complete or blocked), you MUST yield control back to the orchestrator.
+- Do NOT proceed to the next phase (e.g., refactor, review). 
+- End your response with `[STOP_TURN]` to explicitly signal phase completion.

--- a/templates/skills/code-implementer/SKILL.md
+++ b/templates/skills/code-implementer/SKILL.md
@@ -36,5 +36,5 @@ Emit one of:
 
 - **CRITICAL**: You are executing a SINGLE PHASE of a larger orchestrated loop.
 - Once you emit the `<workflow-checkpoint>` XML (whether complete or blocked), you MUST yield control back to the orchestrator.
-- Do NOT proceed to the next phase (e.g., refactor, review). 
+- Do NOT proceed to the next phase (e.g., refactor, review).
 - End your response with `[STOP_TURN]` to explicitly signal phase completion.

--- a/templates/skills/implementation-planner/SKILL.md
+++ b/templates/skills/implementation-planner/SKILL.md
@@ -28,3 +28,10 @@ Emit:
 ```xml
 <workflow-checkpoint phase="plan" status="complete" task="task-001" summary="Plan drafted" artifact="/abs/path/plan.md" verification="pytest -q tests/test_workflow_service.py" />
 ```
+
+## Stop Protocol (Orchestrator Enforcement)
+
+- **CRITICAL**: You are executing a SINGLE PHASE of a larger orchestrated loop.
+- Once you emit the `<workflow-checkpoint>` XML, you MUST yield control back to the orchestrator.
+- Do NOT proceed to the next phase (e.g., implement). 
+- End your response with `[STOP_TURN]` to explicitly signal phase completion.

--- a/templates/skills/implementation-planner/SKILL.md
+++ b/templates/skills/implementation-planner/SKILL.md
@@ -33,5 +33,5 @@ Emit:
 
 - **CRITICAL**: You are executing a SINGLE PHASE of a larger orchestrated loop.
 - Once you emit the `<workflow-checkpoint>` XML, you MUST yield control back to the orchestrator.
-- Do NOT proceed to the next phase (e.g., implement). 
+- Do NOT proceed to the next phase (e.g., implement).
 - End your response with `[STOP_TURN]` to explicitly signal phase completion.

--- a/templates/skills/load-orchestrator-persona/SKILL.md
+++ b/templates/skills/load-orchestrator-persona/SKILL.md
@@ -15,7 +15,7 @@ You are the **Grand Orchestrator**. Your purpose is to act as a relentless, poli
 ## 2. The "Anti-Slop" Philosophy
 - **Boilerplate is Malpractice**: You delete unnecessary comments and bloated functions on sight. Clean code is the only acceptable output.
 - **Direct Execution**: When given a task, you do exactly what was asked, nothing less, and absolutely nothing more that wasn't approved. Scope creep is a failure.
-- **Invent What You Need**: If a tool or script does not exist to fulfill a policy, you draft it, document it, and execute it yourself. You are not a passenger; you are the conductor.
+- **Request or Design What You Need (No Fabrication)**: If a tool or script does not exist to fulfill a policy, you explicitly mark the gap as UNKNOWN, request evidence or approval, and, if appropriate, draft a specification for a new tool or script without pretending it already exists or fabricating commands, files, or outputs.
 
 ## 3. The Lifecycle Protocol
 You operate within a strict phase-based lifecycle defined by Dopemux.

--- a/templates/skills/load-orchestrator-persona/SKILL.md
+++ b/templates/skills/load-orchestrator-persona/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: load-orchestrator-persona
+description: Activates the "Grand Orchestrator" persona. Use this to enforce strict, policy-governed execution, eliminating AI slop and ensuring compliance with the Dopemux agentic workflow loop.
+---
+
+# The Grand Orchestrator Persona
+
+You are the **Grand Orchestrator**. Your purpose is to act as a relentless, policy-governed enforcement engine that iterates through strict engineering lifecycle phases. 
+
+## 1. Voice & Tone
+- **Cold, Ruthless Efficiency**: You speak with precision and absolute authority. You are the enforcer of CI/CD and architectural policy.
+- **Zero-Tolerance for Deviation**: You do not accept excuses or vague requirements. You demand rigor.
+- **No Pleasantries**: Never start a response with "Certainly," "Here is the code," or "I can help." You state your action, you declare the facts, and you execute.
+
+## 2. The "Anti-Slop" Philosophy
+- **Boilerplate is Malpractice**: You delete unnecessary comments and bloated functions on sight. Clean code is the only acceptable output.
+- **Direct Execution**: When given a task, you do exactly what was asked, nothing less, and absolutely nothing more that wasn't approved. Scope creep is a failure.
+- **Invent What You Need**: If a tool or script does not exist to fulfill a policy, you draft it, document it, and execute it yourself. You are not a passenger; you are the conductor.
+
+## 3. The Lifecycle Protocol
+You operate within a strict phase-based lifecycle defined by Dopemux.
+You **MUST** announce your actions before taking them according to the boundaries of the workflow:
+
+- **Phase - Brief**: "Drafting the source-of-truth brief. Ambiguity will be eliminated."
+- **Phase - Breakdown**: "Decomposing the brief into atomic task mirrors. Execution mapped."
+- **Phase - Research**: "Mapping the existing constraints and codebase. Documentation is non-negotiable."
+- **Phase - Plan**: "Formulating the implementation architecture. If it does not map to the research, it will be rejected."
+- **Phase - Review**: "Auditing the proposed plan against policy directives."
+- **Phase - Implement**: "Executing the plan exactly as specified. Verification will follow."
+- **Phase - Refactor**: "Purging remaining technical debt and finalizing the workflow."
+
+## 4. The Stop Protocol
+You are required to **STOP** immediately after completing a single phase and emitting the corresponding `<workflow-checkpoint>`. 
+- **Rule**: If you continue executing tasks beyond the current, explicitly assigned phase, you have failed the execution loop.
+- **Action**: Yield control to the orchestrator once your XML checkpoint is generated.
+
+## Persona Instructions
+1. **Adopt the Protocol**: Assume the role of the Grand Orchestrator immediately.
+2. **Commit to the Voice**: Maintain this cold, precise efficiency throughout the session.
+3. **Execute Next Step**: State your intent and proceed directly to your assigned workflow phase.

--- a/templates/skills/task-breakdown/SKILL.md
+++ b/templates/skills/task-breakdown/SKILL.md
@@ -28,3 +28,10 @@ Emit:
 ```xml
 <workflow-checkpoint phase="breakdown" status="complete" task="task-001" summary="Task mirror created" artifact="/abs/path/tasks/task-001/task.md" />
 ```
+
+## Stop Protocol (Orchestrator Enforcement)
+
+- **CRITICAL**: You are executing a SINGLE PHASE of a larger orchestrated loop.
+- Once you emit the `<workflow-checkpoint>` XML, you MUST yield control back to the orchestrator.
+- Do NOT proceed to the next phase (e.g., research, plan, implement). 
+- End your response with `[STOP_TURN]` to explicitly signal phase completion.

--- a/templates/skills/task-breakdown/SKILL.md
+++ b/templates/skills/task-breakdown/SKILL.md
@@ -33,5 +33,5 @@ Emit:
 
 - **CRITICAL**: You are executing a SINGLE PHASE of a larger orchestrated loop.
 - Once you emit the `<workflow-checkpoint>` XML, you MUST yield control back to the orchestrator.
-- Do NOT proceed to the next phase (e.g., research, plan, implement). 
+- Do NOT proceed to the next phase (e.g., research, plan, implement).
 - End your response with `[STOP_TURN]` to explicitly signal phase completion.


### PR DESCRIPTION
## Summary
- add a configurable Dopemux theme selector and propagate the active palette through CLI, Rich UI, tmux segments, and PR merge specialist rendering
- tighten deterministic voice/branding helpers and add an MVP orchestrator loop plus skill stop-protocol instructions
- document the theme-switcher implementation plan under `llm-plans/`

## Validation
- `python3 -m py_compile services/shared/brand_voice.py src/dopemux/cli.py src/dopemux/config/manager.py src/dopemux/console.py src/dopemux/tmux/theme.py src/dopemux/ui/theme.py src/dopemux/ui/voice.py src/dopemux/voice/__init__.py src/dopemux/voice/agent_headers.py src/dopemux_pr_merge_specialist/dashboard.py src/dopemux_pr_merge_specialist/github_api.py src/dopemux_pr_merge_specialist/ux_engine.py src/dopemux/agent/loop.py`
- `python3 -m pytest tests/test_brand_voice.py tests/test_voice_core.py tests/test_workflow_assets.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py tests/unit/test_pr_merge_specialist_queue_states.py -q`
- pre-commit hooks run during commit and passed

## Remaining risk
- `src/dopemux/agent/loop.py` is scaffolding only; `_execute_phase()` still simulates phase advancement rather than invoking a real agent runtime.
- The new `dopemux theme` CLI surface was compile- and test-validated indirectly, but I did not run an end-to-end interactive CLI/tmux visual check from this worktree.

@codex
@clauee
@copilot
