### PR TITLE
feat(pm): implement dope-memory chronicle lane (Wave 1)

### DIFF
--- a/docs/archive/unclassified-top-level/plans/pm-metadata-vs-workflow-separation.md
+++ b/docs/archive/unclassified-top-level/plans/pm-metadata-vs-workflow-separation.md
@@ -1,0 +1,103 @@
+# Implementation Plan: PM Metadata vs. Workflow-Significant Writes
+
+## 1. Objective & Scope
+The objective is to operationalize the boundaries defined in `ADR-PM-001` (Canonical Task Object) and `ADR-PM-003` (Storage - Derived vs. Mirrored). The Dopemux PM Plane is the **Canonical Authority** for task lifecycle state, while integrations like Leantime act as **Mirrored/Projection Paths**. 
+
+This plan separates **Workflow-Significant Writes** (which mutate canonical state and require stale-write protection) from **PM Metadata Writes** (which passively update contextual fields without bumping task versions). It also implements the `LeantimeReflection` pattern to prevent webhook sync loops.
+
+---
+
+## 2. Phase 1: Canonical PM Store Updates (`src/dopemux/pm/`)
+
+We will update the core PM abstractions to natively support passive metadata patching and codify the boundary between workflow and metadata fields.
+
+### 2.1 Formalize Field Boundaries (`src/dopemux/pm/models.py`)
+Add explicit constants to define the field domains:
+```python
+# Fields requiring optimistic concurrency control (version bumps)
+WORKFLOW_SIGNIFICANT_FIELDS = frozenset({"status", "version", "blocked_reason", "dependencies"})
+
+# Fields supporting a last-write-wins update strategy
+METADATA_ONLY_FIELDS = frozenset({"title", "description", "assignee", "labels", "milestone", "meta"})
+```
+
+### 2.2 Modifications to `store.py`
+1.  **Update `PMTaskStore` Protocol:**
+    Add a new method signature:
+    ```python
+    def patch_metadata(self, task_id: str, patch: dict[str, Any]) -> PMTask:
+        """Apply passive metadata updates without bumping the canonical version."""
+        pass
+    ```
+
+2.  **Implement in `InMemoryPMTaskStore`:**
+    *   **Logic:** Retrieve the task by `task_id`. If not found, raise `TaskNotFoundError`.
+    *   Iterate through the `patch` dictionary.
+    *   **Crucial Rule:** Only apply updates to keys present in `METADATA_ONLY_FIELDS`. 
+    *   Silently ignore (or actively pop) any keys from `WORKFLOW_SIGNIFICANT_FIELDS` (especially `version` and `status`).
+    *   Update `updated_at_utc`.
+    *   Do **not** increment `version`. Do **not** check `expected_version` or `idempotency_key`.
+    *   Return a copy of the updated `PMTask`.
+
+### 2.3 Unit Tests (`tests/unit/pm/test_pm_store.py`)
+1.  **Test `patch_metadata` success:** Verify allowed fields (`title`, `description`) are updated correctly.
+2.  **Test version preservation:** Verify that calling `patch_metadata` does **not** increment `task.version`.
+3.  **Test restricted fields:** Verify that attempting to patch `status` or `version` via `patch_metadata` is completely ignored.
+4.  **Test missing task:** Verify `patch_metadata` raises `TaskNotFoundError` if the ID does not exist.
+
+---
+
+## 3. Phase 2: Orchestrator Integration & Reflection (`services/task-orchestrator/`)
+
+We will update the webhook handling logic to intelligently route incoming Leantime events based on whether they are echoes, metadata patches, or workflow overrides.
+
+### 3.1 Webhook Parsing Logic (`services/task-orchestrator/app/api/webhooks.py` or equivalent)
+When a Leantime webhook payload is received:
+
+1.  **Echo Check (Reflection Matching):**
+    *   Compare the incoming webhook state against the local `PMTask`'s most recent `LeantimeReflection`.
+    *   *If the incoming state exactly matches the `LeantimeReflection`*: **DROP** the event. This is an echo of an outbound sync. Log as `sync_echo_dropped`.
+
+2.  **State Classification & Mixed Payload Handling:**
+    If it's not an echo, diff the incoming payload against the local canonical task state:
+    *   *Did ANY `WORKFLOW_SIGNIFICANT_FIELDS` change?* 
+        *   **Action:** Treat the ENTIRE payload as a Workflow Override Attempt. 
+        *   **Rule:** Route to `store.transition()`. If the transition fails due to a stale `expected_version`, the entire payload (including metadata changes) is **REJECTED**. This prevents data divergence where a task gets a new title but an outdated status.
+    *   *Did ONLY `METADATA_ONLY_FIELDS` change?* 
+        *   **Action:** Treat as a pure Metadata Patch.
+        *   **Rule:** Route to `store.patch_metadata()`. The update succeeds on a last-write-wins basis without version checking.
+
+---
+
+## 4. Phase 3: Documentation Updates (`docs/planes/pm/`)
+
+Codify this contract in the PM architecture documentation.
+
+### 4.1 Create `docs/planes/pm/pm-metadata-vs-workflow.md`
+This document will serve as the definitive guide for field classification and sync behavior.
+
+**Structure:**
+*   **Header:** Title, Status (Active), Context.
+*   **Field Classification Boundary:**
+    *   *Workflow Authority (Strict):* `status`, `version`, `blocked_reason`, `dependencies`. Mutated ONLY via `PMTransitionRequest`.
+    *   *Metadata Authority (Passive):* `title`, `description`, `assignee`, `labels`. Mutated via `patch_metadata`.
+*   **The Reflection Pattern (Infinite Loop Prevention):**
+    *   Explain how `LeantimeReflection` records outbound syncs.
+    *   Include a flow chart explaining the Echo Drop sequence.
+*   **Stale Write Handling & Mixed Payloads:**
+    *   Explicitly define the atomic rule: "If a webhook contains workflow-significant changes, the entire update is subject to strict optimistic locking. If it fails, the entire update is rejected to prevent divergence. Pure metadata updates bypass version checks."
+
+### 4.2 Link from `pm-architecture.md`
+Add a reference and brief summary of this new document in the main `pm-architecture.md` file under the Storage/State section.
+
+---
+
+## 5. Rollout & Verification Strategy
+
+1.  **Implement Phase 1:** Add constants, add `patch_metadata`, and ensure all unit tests pass.
+2.  **Implement Phase 3:** Write the documentation to lock in the contract.
+3.  **Implement Phase 2:** Update the webhook routing logic.
+4.  **Integration Testing:** 
+    *   Simulate a Leantime webhook that only changes a title. Verify canonical version stays the same.
+    *   Simulate a mixed webhook (status + title change) against a stale version. Verify the entire update is rejected.
+    *   Simulate a standard outbound sync, then simulate the resulting inbound webhook. Verify the `LeantimeReflection` correctly drops the echo.

--- a/docs/planes/pm/pm-architecture.md
+++ b/docs/planes/pm/pm-architecture.md
@@ -143,6 +143,8 @@ Evidence basis for current multi-surface lifecycle operations: `docs/planes/pm/_
 
 ## Storage, Derived, Mirrored
 
+For a detailed breakdown of how task fields are classified and how bidirectional sync loops are prevented using the reflection pattern, see [PM Metadata vs Workflow Authority](pm-metadata-vs-workflow.md).
+
 | Classification | Owner | Content | Write Contract |
 |---|---|---|---|
 | Stored (Canonical PM) | PM plane | Canonical task object fields and lifecycle version | Single canonical write per accepted transition; idempotent by key. |

--- a/docs/planes/pm/pm-metadata-vs-workflow.md
+++ b/docs/planes/pm/pm-metadata-vs-workflow.md
@@ -1,0 +1,55 @@
+---
+id: pm-metadata-vs-workflow
+title: PM Metadata vs Workflow Authority
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-03-22'
+last_review: '2026-03-22'
+next_review: '2026-06-22'
+prelude: Field classification boundary and Stale Write Handling rules defining PM Metadata vs Workflow Authority.
+---
+
+# PM Metadata vs Workflow Authority
+
+This document operationalizes the boundaries defined in `ADR-PM-001` (Canonical Task Object) and `ADR-PM-003` (Storage - Derived vs. Mirrored).
+
+The Dopemux PM Plane acts as the **Canonical Authority** for task lifecycle state, while external integrations (like Leantime) act as **Mirrored/Projection Paths**. To enforce this, we strictly separate **Workflow-Significant Writes** from **PM Metadata Writes**.
+
+## Field Classification Boundary
+
+The task schema is divided into two distinct domains of authority:
+
+1. **Workflow Authority (Strict Transitions)**
+   - **Fields:** `status`, `version`, `blocked_reason`, `dependencies`.
+   - **Contract:** These fields mutate the canonical state machine. They **MUST** be processed via a `PMTransitionRequest` utilizing optimistic concurrency control (`expected_version`) and idempotency (`idempotency_key`).
+   - **Resolution:** If a mirror (e.g., Leantime webhook) attempts to override these fields and the local canonical version has advanced past the mirror's known state, the workflow override is **REJECTED** as a stale write.
+
+2. **Metadata Authority (Passive Patches)**
+   - **Fields:** `title`, `description`, `assignee`, `labels`, `milestone`, `meta`, `linked_ids`, `refs`, `source_task_id`.
+   - **Contract:** These fields provide context but do not alter the workflow state machine. They are updated via passive patches (`patch_metadata`).
+   - **Resolution:** Metadata patches do **not** increment the canonical `version` and do **not** require strict stale-write protection. They are accepted on a last-write-wins basis.
+
+## The Reflection Pattern (Infinite Loop Prevention)
+
+Bidirectional sync introduces the risk of infinite echo loops (e.g., Dopemux updates Leantime -> Leantime fires a webhook back to Dopemux -> Dopemux updates Leantime).
+
+To prevent this, the Task Orchestrator implements the **Reflection Pattern** using a `LeantimeReflection` object on the task.
+
+1. **Outbound Sync:** When Dopemux pushes a state change to Leantime, it records the exact state it pushed as a `LeantimeReflection`. It emits a `pm.sync.succeeded` event.
+2. **Inbound Webhook:** When a webhook arrives from Leantime, the Orchestrator compares the incoming state to the `LeantimeReflection`.
+3. **Echo Drop:** If the webhook state exactly matches the reflection, the event is recognized as an echo of our own outbound sync and is **DROPPED**.
+
+## Stale Write Handling & Mixed Payloads
+
+When a non-echo webhook arrives from a mirrored system, its payload is diffed against the current local canonical state.
+
+Handling follows an atomic, fail-closed rule for mixed payloads:
+
+*   **Scenario A: Pure Metadata Patch**
+    *   *Condition:* The diff shows changes ONLY to `METADATA_ONLY_FIELDS`.
+    *   *Action:* The update is processed as a passive patch. It succeeds regardless of the mirror's version awareness.
+*   **Scenario B: Workflow Override (Mixed or Pure)**
+    *   *Condition:* The diff shows changes to ANY `WORKFLOW_SIGNIFICANT_FIELDS` (e.g., `status` changed).
+    *   *Action:* The **ENTIRE payload** is treated as a workflow transition and subjected to strict optimistic locking (`expected_version` check).
+    *   *Resolution:* If the local canonical version has advanced, the **ENTIRE update is REJECTED**, including any metadata changes bundled within it. This prevents split-brain divergence where a task receives a new title from the mirror but retains an outdated status locally.

--- a/src/dopemux/pm/adapters/__init__.py
+++ b/src/dopemux/pm/adapters/__init__.py
@@ -1,0 +1,5 @@
+from .core import (
+    orchestrator_event_to_pm,
+    taskmaster_event_to_pm,
+    pm_to_bus_event,
+)

--- a/src/dopemux/pm/adapters/core.py
+++ b/src/dopemux/pm/adapters/core.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from .events import PMEventType, canonical_json, create_pm_event, sha256_hex
-from .models import content_hash_task_id, normalize_text as _normalize_text
+from ..events import PMEventType, canonical_json, create_pm_event, sha256_hex
+from ..models import content_hash_task_id, normalize_text as _normalize_text
 
 
 _DEFAULT_TS_UTC = "1970-01-01T00:00:00Z"

--- a/src/dopemux/pm/adapters/dope_memory.py
+++ b/src/dopemux/pm/adapters/dope_memory.py
@@ -1,0 +1,116 @@
+"""Dope-Memory backend adapter for PM-plane chronicle integration."""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+import httpx
+
+logger = logging.getLogger(__name__)
+
+class DopeMemoryAdapter:
+    """Adapter for communicating with the dope-memory HTTP API."""
+
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = (base_url or os.getenv("DOPE_MEMORY_URL", "http://localhost:3020")).rstrip("/")
+
+    async def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
+        """Helper to make an HTTP request."""
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.request(method, f"{self.base_url}{path}", **kwargs)
+            return response
+
+    async def search_chronicle(
+        self,
+        workspace_id: str,
+        session_id: Optional[str] = None,
+        category: Optional[str] = None,
+        entry_type: Optional[str] = None,
+        workflow_phase: Optional[str] = None,
+        tags_any: Optional[List[str]] = None,
+        time_range: str = "week",
+        top_k: int = 3,
+        cursor: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Call the memory_search endpoint."""
+        payload = {
+            "workspace_id": workspace_id,
+            "session_id": session_id,
+            "category": category,
+            "entry_type": entry_type,
+            "workflow_phase": workflow_phase,
+            "tags_any": tags_any,
+            "time_range": time_range,
+            "top_k": top_k,
+            "cursor": cursor,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+        
+        try:
+            response = await self._request("POST", "/tools/memory_search", json=payload)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            logger.error(f"Failed to search dope-memory chronicle: {e}")
+            raise
+
+    async def append_chronicle(
+        self,
+        workspace_id: str,
+        entry_type: str,
+        summary: str,
+        category: str,
+        details: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+        links: Optional[Dict[str, Any]] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Call the memory_store endpoint to append a record."""
+        payload = {
+            "workspace_id": workspace_id,
+            "entry_type": entry_type,
+            "category": category,
+            "summary": summary,
+            "details": details,
+            "tags": tags,
+            "links": links,
+            "idempotency_key": idempotency_key,
+        }
+        
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        try:
+            response = await self._request("POST", "/tools/memory_store", json=payload)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            logger.error(f"Failed to append to dope-memory chronicle: {e}")
+            raise
+
+    async def correct_chronicle(
+        self,
+        workspace_id: str,
+        entry_id: str,
+        correction_type: str,
+        corrected_summary: Optional[str] = None,
+        corrected_tags: Optional[List[str]] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Call the memory_correct endpoint to correct/supersede a record."""
+        payload = {
+            "workspace_id": workspace_id,
+            "entry_id": entry_id,
+            "correction_type": correction_type,
+            "corrected_summary": corrected_summary,
+            "corrected_tags": corrected_tags,
+            "idempotency_key": idempotency_key,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        try:
+            response = await self._request("POST", "/tools/memory_correct", json=payload)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            # Re-raise so callers can catch HTTPError to do a fallback
+            logger.error(f"Failed to correct dope-memory chronicle: {e}")
+            raise

--- a/src/dopemux/pm/chronicle.py
+++ b/src/dopemux/pm/chronicle.py
@@ -1,0 +1,242 @@
+"""Normalized PM-plane chronicle read/write contracts."""
+
+import logging
+from typing import Any, Dict, List, Optional
+from dopemux.pm.chronicle_models import (
+    PMChronicleReadResult,
+    PMChronicleProvenance,
+    PMChronicleSupportingSource,
+    PMChronicleWriteReceipt,
+)
+from dopemux.pm.adapters.dope_memory import DopeMemoryAdapter
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Single instance of the adapter to use
+_adapter = DopeMemoryAdapter()
+
+async def pm_get_work_chronicle(
+    *,
+    workspace_id: str,
+    canonical_id: Optional[str] = None,
+    linked_ids: Optional[Dict[str, str]] = None,
+    session_id: Optional[str] = None,
+    category: Optional[str] = None,
+    entry_type: Optional[str] = None,
+    tags_any: Optional[List[str]] = None,
+    time_range: str = "week",
+    top_k: int = 3,
+    next_token: Optional[str] = None,
+) -> PMChronicleReadResult:
+    """Read normalized PM-plane chronicle from dope-memory authority.
+    
+    Returns fail-closed empty result if backend is down.
+    """
+    try:
+        raw_result = await _adapter.search_chronicle(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            category=category,
+            entry_type=entry_type,
+            tags_any=tags_any,
+            time_range=time_range,
+            top_k=top_k,
+            cursor=next_token,
+        )
+    except httpx.HTTPError:
+        logger.warning("dope-memory backend unavailable. Returning fail-closed empty result.")
+        raw_result = {"items": [], "more_count": 0, "next_token": None}
+    except Exception as e:
+        logger.error(f"Unexpected error calling dope-memory: {e}")
+        raw_result = {"items": [], "more_count": 0, "next_token": None}
+
+    items = raw_result.get("items", [])
+    entry_ids = [str(item.get("id")) for item in items if "id" in item]
+
+    provenance = PMChronicleProvenance(
+        source="dope-memory",
+        query_mode="work_chronicle",
+        workspace_id=workspace_id,
+        time_range=time_range,
+    )
+
+    supporting_source = PMChronicleSupportingSource(
+        kind="canonical",
+        backend="dope-memory",
+        entry_ids=entry_ids,
+    )
+
+    return PMChronicleReadResult(
+        canonical_backend="dope-memory",
+        canonical_id=canonical_id,
+        linked_ids=linked_ids or {},
+        provenance=provenance,
+        supporting_sources=[supporting_source],
+        items=items,
+        more_count=raw_result.get("more_count", 0),
+        next_token=raw_result.get("next_token"),
+    )
+
+
+async def pm_append_work_chronicle(
+    *,
+    workspace_id: str,
+    canonical_id: str,
+    linked_ids: Dict[str, str],
+    entry_type: str,
+    summary: str,
+    details: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[str]] = None,
+    actor: Optional[str] = None,
+    source_system: str = "pm-plane",
+    idempotency_key: str,
+    category: str = "work_chronicle",
+) -> PMChronicleWriteReceipt:
+    """Append a normalized PM-plane chronicle entry to dope-memory authority.
+    
+    Includes canonical_id and linked_ids in the metadata/details payload.
+    """
+    # Merge PM linkage into details or links
+    augmented_details = details.copy() if details else {}
+    augmented_details.update({
+        "canonical_id": canonical_id,
+        "actor": actor,
+        "source_system": source_system,
+    })
+
+    # Put linked_ids into links
+    links = linked_ids.copy()
+    if canonical_id:
+        links["pm_canonical"] = canonical_id
+
+    try:
+        result = await _adapter.append_chronicle(
+            workspace_id=workspace_id,
+            entry_type=entry_type,
+            summary=summary,
+            category=category,
+            details=augmented_details,
+            tags=tags,
+            links=links,
+            idempotency_key=idempotency_key,
+        )
+        
+        success = result.get("success", False) or "entry_id" in result
+        entry_id = result.get("entry_id", "unknown")
+
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id=entry_id,
+            linked_ids=linked_ids,
+            success=success,
+            error=result.get("error"),
+        )
+    except httpx.HTTPError as e:
+        logger.warning(f"dope-memory backend unavailable during append: {e}")
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id="unknown",
+            linked_ids=linked_ids,
+            success=False,
+            error="Backend unavailable",
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error calling dope-memory append: {e}")
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id="unknown",
+            linked_ids=linked_ids,
+            success=False,
+            error=str(e),
+        )
+
+
+async def pm_correct_work_chronicle(
+    *,
+    workspace_id: str,
+    canonical_id: str,
+    chronicle_entry_id: str,
+    correction_reason: str,
+    corrected_summary: Optional[str] = None,
+    corrected_details: Optional[Dict[str, Any]] = None,
+    actor: Optional[str] = None,
+    source_system: str = "pm-plane",
+    idempotency_key: str,
+) -> PMChronicleWriteReceipt:
+    """Correct/supersede a normalized PM-plane chronicle entry in dope-memory authority.
+    
+    Uses memory_correct (correction_type="summary") if available, otherwise appends.
+    """
+    correction_type = "summary" if corrected_summary else "retraction"
+    
+    try:
+        result = await _adapter.correct_chronicle(
+            workspace_id=workspace_id,
+            entry_id=chronicle_entry_id,
+            correction_type=correction_type,
+            corrected_summary=corrected_summary or correction_reason,
+            corrected_tags=None,
+            idempotency_key=idempotency_key,
+        )
+
+        success = result.get("success", False)
+        entry_id = result.get("entry_id", "unknown")
+
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id=entry_id,
+            linked_ids={},
+            success=success,
+            error=result.get("error"),
+        )
+    except httpx.HTTPStatusError as e:
+        # If the endpoint doesn't exist or returns 404, we fall back to append.
+        if e.response.status_code == 404:
+            logger.info("memory_correct endpoint returned 404, falling back to append-only correction.")
+            # Fall back to append
+            return await pm_append_work_chronicle(
+                workspace_id=workspace_id,
+                canonical_id=canonical_id,
+                linked_ids={},
+                entry_type="correction",
+                summary=f"Correction for {chronicle_entry_id}: {corrected_summary or correction_reason}",
+                details={"superseded_entry_id": chronicle_entry_id, "reason": correction_reason},
+                actor=actor,
+                source_system=source_system,
+                idempotency_key=idempotency_key,
+            )
+        else:
+            logger.warning(f"dope-memory backend HTTP error during correct: {e}")
+            return PMChronicleWriteReceipt(
+                canonical_backend="dope-memory",
+                canonical_id=canonical_id,
+                entry_id="unknown",
+                linked_ids={},
+                success=False,
+                error="Backend unavailable",
+            )
+    except httpx.HTTPError as e:
+        logger.warning(f"dope-memory backend unavailable during correct: {e}")
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id="unknown",
+            linked_ids={},
+            success=False,
+            error="Backend unavailable",
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error calling dope-memory correct: {e}")
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id="unknown",
+            linked_ids={},
+            success=False,
+            error=str(e),
+        )

--- a/src/dopemux/pm/chronicle_models.py
+++ b/src/dopemux/pm/chronicle_models.py
@@ -1,0 +1,33 @@
+"""Normalized PM-plane models for chronicle reads and writes."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+class PMChronicleProvenance(BaseModel):
+    source: str = "dope-memory"
+    query_mode: str
+    workspace_id: str
+    time_range: Optional[str] = None
+
+class PMChronicleSupportingSource(BaseModel):
+    kind: str = "canonical"
+    backend: str = "dope-memory"
+    entry_ids: List[str] = Field(default_factory=list)
+
+class PMChronicleReadResult(BaseModel):
+    canonical_backend: str = "dope-memory"
+    canonical_id: Optional[str] = None
+    linked_ids: Dict[str, str] = Field(default_factory=dict)
+    provenance: PMChronicleProvenance
+    supporting_sources: List[PMChronicleSupportingSource] = Field(default_factory=list)
+    items: List[Dict[str, Any]] = Field(default_factory=list)
+    more_count: int = 0
+    next_token: Optional[str] = None
+
+class PMChronicleWriteReceipt(BaseModel):
+    canonical_backend: str = "dope-memory"
+    canonical_id: str
+    entry_id: str
+    linked_ids: Dict[str, str] = Field(default_factory=dict)
+    success: bool
+    error: Optional[str] = None

--- a/src/dopemux/pm/models.py
+++ b/src/dopemux/pm/models.py
@@ -33,6 +33,13 @@ class PMTaskStatus(str, Enum):
     CANCELED = "CANCELED"
 
 
+# Fields requiring optimistic concurrency control (version bumps)
+WORKFLOW_SIGNIFICANT_FIELDS = frozenset({"status", "version", "blocked_reason", "dependencies"})
+
+# Fields supporting a last-write-wins update strategy
+METADATA_ONLY_FIELDS = frozenset({"title", "description", "assignee", "labels", "milestone", "meta", "linked_ids", "refs", "source_task_id"})
+
+
 class PMTask(BaseModel):
     """Canonical PM task — single source of lifecycle truth.
 
@@ -52,6 +59,9 @@ class PMTask(BaseModel):
 
     description: Optional[str] = None
     source_task_id: Optional[str] = None
+    assignee: Optional[str] = None
+    labels: list[str] = Field(default_factory=list)
+    milestone: Optional[str] = None
     linked_ids: Dict[str, str] = Field(default_factory=dict)
     refs: Dict[str, Any] = Field(default_factory=dict)
     meta: Dict[str, Any] = Field(default_factory=dict)

--- a/src/dopemux/pm/store.py
+++ b/src/dopemux/pm/store.py
@@ -7,8 +7,9 @@ per ADR-PM-001 invariants.
 
 from abc import ABC, abstractmethod
 from typing import Dict, Optional, Tuple, Any
+from datetime import datetime, timezone
 
-from .models import PMTask, PMTransitionRequest, PMLinkedIDUpdateRequest
+from .models import PMTask, PMTransitionRequest, PMLinkedIDUpdateRequest, METADATA_ONLY_FIELDS
 
 
 class TaskNotFoundError(Exception):
@@ -81,6 +82,18 @@ class PMTaskStore(ABC):
 
         Idempotency: duplicate (task_id, idempotency_key) returns
         the previously produced result without mutation.
+        """
+        ...
+
+    @abstractmethod
+    def patch_metadata(self, task_id: str, patch: dict[str, Any]) -> PMTask:
+        """Apply passive metadata updates without bumping the canonical version.
+        
+        Only fields in METADATA_ONLY_FIELDS will be updated.
+        Fields in WORKFLOW_SIGNIFICANT_FIELDS will be silently ignored.
+        
+        Raises:
+            TaskNotFoundError: task_id does not exist.
         """
         ...
 
@@ -187,4 +200,25 @@ class InMemoryPMTaskStore(PMTaskStore):
         task.updated_at_utc = req.ts_utc
         self._replay_log[replay_key] = (task.version, req_hash)
         
+        return task.model_copy()
+
+    def patch_metadata(self, task_id: str, patch: dict[str, Any]) -> PMTask:
+        """Apply passive metadata updates without bumping the canonical version."""
+        task = self._tasks.get(task_id)
+        if task is None:
+            raise TaskNotFoundError(task_id)
+
+        changed = False
+        for key, value in patch.items():
+            if key in METADATA_ONLY_FIELDS:
+                if hasattr(task, key) or key in task.model_fields:
+                    setattr(task, key, value)
+                    changed = True
+                elif key in ["meta", "refs", "linked_ids"] and isinstance(value, dict):
+                    getattr(task, key).update(value)
+                    changed = True
+
+        if changed:
+            task.updated_at_utc = datetime.now(timezone.utc)
+
         return task.model_copy()

--- a/tests/unit/pm/test_chronicle.py
+++ b/tests/unit/pm/test_chronicle.py
@@ -4,7 +4,7 @@ import pytest
 import httpx
 from unittest.mock import AsyncMock, MagicMock
 
-import dopemux.pm.chronicle
+from dopemux.pm import chronicle
 from dopemux.pm.chronicle import (
     pm_get_work_chronicle,
     pm_append_work_chronicle,
@@ -16,7 +16,7 @@ from dopemux.pm.chronicle_models import PMChronicleReadResult, PMChronicleWriteR
 @pytest.fixture
 def mock_adapter(monkeypatch):
     adapter_mock = AsyncMock()
-    monkeypatch.setattr(dopemux.pm.chronicle, "_adapter", adapter_mock)
+    monkeypatch.setattr(chronicle, "_adapter", adapter_mock)
     return adapter_mock
 
 @pytest.mark.asyncio

--- a/tests/unit/pm/test_chronicle.py
+++ b/tests/unit/pm/test_chronicle.py
@@ -1,0 +1,187 @@
+"""Tests for normalized PM-plane chronicle contract."""
+
+import pytest
+import httpx
+from unittest.mock import AsyncMock, MagicMock
+
+from dopemux.pm.chronicle import (
+    pm_get_work_chronicle,
+    pm_append_work_chronicle,
+    pm_correct_work_chronicle,
+    _adapter
+)
+from dopemux.pm.chronicle_models import PMChronicleReadResult, PMChronicleWriteReceipt
+
+@pytest.fixture
+def mock_adapter(monkeypatch):
+    adapter_mock = AsyncMock()
+    monkeypatch.setattr("dopemux.pm.chronicle._adapter", adapter_mock)
+    return adapter_mock
+
+@pytest.mark.asyncio
+async def test_pm_get_work_chronicle_success(mock_adapter):
+    """Test successful chronicle read resolves to dope-memory and preserves shape."""
+    mock_adapter.search_chronicle.return_value = {
+        "items": [
+            {"id": "entry-1", "summary": "test1"},
+            {"id": "entry-2", "summary": "test2"}
+        ],
+        "more_count": 5,
+        "next_token": "token123"
+    }
+
+    result = await pm_get_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        linked_ids={"leantime": "lt-1"}
+    )
+
+    assert isinstance(result, PMChronicleReadResult)
+    assert result.canonical_backend == "dope-memory"
+    assert result.canonical_id == "task-1"
+    assert result.linked_ids == {"leantime": "lt-1"}
+    assert result.more_count == 5
+    assert result.next_token == "token123"
+    assert len(result.items) == 2
+    
+    # Provenance
+    assert result.provenance.source == "dope-memory"
+    assert result.provenance.query_mode == "work_chronicle"
+    assert result.provenance.workspace_id == "ws-1"
+    
+    # Supporting sources
+    assert len(result.supporting_sources) == 1
+    assert result.supporting_sources[0].backend == "dope-memory"
+    assert result.supporting_sources[0].entry_ids == ["entry-1", "entry-2"]
+    
+    mock_adapter.search_chronicle.assert_called_once_with(
+        workspace_id="ws-1",
+        session_id=None,
+        category=None,
+        entry_type=None,
+        tags_any=None,
+        time_range="week",
+        top_k=3,
+        cursor=None
+    )
+
+@pytest.mark.asyncio
+async def test_pm_get_work_chronicle_fail_closed(mock_adapter):
+    """Test read fails closed when backend is unavailable."""
+    mock_adapter.search_chronicle.side_effect = httpx.HTTPError("Backend down")
+    
+    result = await pm_get_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1"
+    )
+    
+    assert isinstance(result, PMChronicleReadResult)
+    assert len(result.items) == 0
+    assert result.more_count == 0
+    assert result.canonical_backend == "dope-memory"
+    assert result.supporting_sources[0].entry_ids == []
+
+@pytest.mark.asyncio
+async def test_pm_append_work_chronicle_success(mock_adapter):
+    """Test successful append."""
+    mock_adapter.append_chronicle.return_value = {
+        "success": True,
+        "entry_id": "new-entry-1"
+    }
+    
+    result = await pm_append_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        linked_ids={"leantime": "lt-1"},
+        entry_type="task.completed",
+        summary="Task was done",
+        idempotency_key="idemp-1"
+    )
+    
+    assert isinstance(result, PMChronicleWriteReceipt)
+    assert result.success is True
+    assert result.canonical_backend == "dope-memory"
+    assert result.entry_id == "new-entry-1"
+    
+    mock_adapter.append_chronicle.assert_called_once()
+    kwargs = mock_adapter.append_chronicle.call_args.kwargs
+    assert kwargs["workspace_id"] == "ws-1"
+    assert kwargs["entry_type"] == "task.completed"
+    assert kwargs["summary"] == "Task was done"
+    assert kwargs["idempotency_key"] == "idemp-1"
+    assert kwargs["links"]["pm_canonical"] == "task-1"
+    assert kwargs["links"]["leantime"] == "lt-1"
+
+@pytest.mark.asyncio
+async def test_pm_append_work_chronicle_fail_closed(mock_adapter):
+    """Test append fails gracefully."""
+    mock_adapter.append_chronicle.side_effect = httpx.HTTPError("Backend down")
+    
+    result = await pm_append_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        linked_ids={},
+        entry_type="task.completed",
+        summary="Task was done",
+        idempotency_key="idemp-1"
+    )
+    
+    assert result.success is False
+    assert result.entry_id == "unknown"
+
+@pytest.mark.asyncio
+async def test_pm_correct_work_chronicle_success(mock_adapter):
+    """Test successful correct."""
+    mock_adapter.correct_chronicle.return_value = {
+        "success": True,
+        "entry_id": "new-corrected-entry"
+    }
+    
+    result = await pm_correct_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        chronicle_entry_id="old-entry",
+        correction_reason="Typo",
+        corrected_summary="Fixed typo",
+        idempotency_key="idemp-2"
+    )
+    
+    assert isinstance(result, PMChronicleWriteReceipt)
+    assert result.success is True
+    assert result.entry_id == "new-corrected-entry"
+    
+    mock_adapter.correct_chronicle.assert_called_once_with(
+        workspace_id="ws-1",
+        entry_id="old-entry",
+        correction_type="summary",
+        corrected_summary="Fixed typo",
+        corrected_tags=None,
+        idempotency_key="idemp-2"
+    )
+
+@pytest.mark.asyncio
+async def test_pm_correct_work_chronicle_fallback(mock_adapter, monkeypatch):
+    """Test fallback to append when correct returns 404."""
+    # We need to simulate HTTPStatusError with status 404
+    mock_response = MagicMock(status_code=404)
+    mock_adapter.correct_chronicle.side_effect = httpx.HTTPStatusError("Not found", request=MagicMock(), response=mock_response)
+    mock_adapter.append_chronicle.return_value = {
+        "success": True,
+        "entry_id": "fallback-entry"
+    }
+
+    result = await pm_correct_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        chronicle_entry_id="old-entry",
+        correction_reason="Typo",
+        corrected_summary="Fixed typo",
+        idempotency_key="idemp-3"
+    )
+
+    assert result.success is True
+    assert result.entry_id == "fallback-entry"
+    mock_adapter.append_chronicle.assert_called_once()
+    kwargs = mock_adapter.append_chronicle.call_args.kwargs
+    assert kwargs["entry_type"] == "correction"
+    assert kwargs["details"]["superseded_entry_id"] == "old-entry"

--- a/tests/unit/pm/test_chronicle.py
+++ b/tests/unit/pm/test_chronicle.py
@@ -4,6 +4,7 @@ import pytest
 import httpx
 from unittest.mock import AsyncMock, MagicMock
 
+import dopemux.pm.chronicle
 from dopemux.pm.chronicle import (
     pm_get_work_chronicle,
     pm_append_work_chronicle,
@@ -15,7 +16,7 @@ from dopemux.pm.chronicle_models import PMChronicleReadResult, PMChronicleWriteR
 @pytest.fixture
 def mock_adapter(monkeypatch):
     adapter_mock = AsyncMock()
-    monkeypatch.setattr("dopemux.pm.chronicle._adapter", adapter_mock)
+    monkeypatch.setattr(dopemux.pm.chronicle, "_adapter", adapter_mock)
     return adapter_mock
 
 @pytest.mark.asyncio

--- a/tests/unit/pm/test_pm_store.py
+++ b/tests/unit/pm/test_pm_store.py
@@ -191,3 +191,72 @@ class TestTransition:
         result.title = "mutated"
         stored = store.get("task-001")
         assert stored.title == "Test task"
+
+
+class TestPatchMetadata:
+    """patch_metadata() updates specific fields without touching version/status."""
+
+    def test_successful_metadata_patch(self, store, sample_task):
+        store.create(sample_task)
+        initial_version = sample_task.version
+        initial_updated_at = sample_task.updated_at_utc
+        
+        patch = {
+            "title": "Updated Title",
+            "description": "Updated Description",
+            "labels": ["urgent"]
+        }
+        
+        # Ensure some time passes for timestamp check
+        # (Though InMemoryPMTaskStore uses datetime.now which is fine)
+        result = store.patch_metadata("task-001", patch)
+        
+        assert result.title == "Updated Title"
+        assert result.description == "Updated Description"
+        assert result.labels == ["urgent"]
+        # Version should NOT increment for a metadata patch
+        assert result.version == initial_version
+        assert result.updated_at_utc > initial_updated_at
+        
+        stored = store.get("task-001")
+        assert stored.title == "Updated Title"
+
+    def test_patch_merges_dictionary_fields(self, store, sample_task):
+        """Verify that patching dict fields merges rather than replaces."""
+        sample_task.meta = {"existing_key": "old_value"}
+        store.create(sample_task)
+        
+        patch = {
+            "meta": {
+                "new_key": "new_value",
+                "existing_key": "updated_value"
+            }
+        }
+        
+        result = store.patch_metadata("task-001", patch)
+        
+        assert result.meta["existing_key"] == "updated_value"
+        assert result.meta["new_key"] == "new_value"
+
+    def test_workflow_fields_are_ignored(self, store, sample_task):
+        store.create(sample_task)
+        initial_version = sample_task.version
+        initial_status = sample_task.status
+        
+        patch = {
+            "title": "Title Update",
+            "status": "DONE",  # Workflow field
+            "version": 99,     # Workflow field
+        }
+        
+        result = store.patch_metadata("task-001", patch)
+        
+        # Valid metadata updated
+        assert result.title == "Title Update"
+        # Workflow fields silently ignored
+        assert result.status == initial_status
+        assert result.version == initial_version
+
+    def test_missing_task_raises(self, store):
+        with pytest.raises(TaskNotFoundError):
+            store.patch_metadata("ghost", {"title": "Update"})


### PR DESCRIPTION
This PR implements the normalized PM-plane chronicle read/write contracts over the dope-memory backend (PM-INT-16).