### PR TITLE
🎨 Palette: ADHD-aware temporal anchors and dashboard accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,11 @@
 ## 2026-03-11 - [Closing the Task Feedback Loop]
 **Learning:** In task-oriented interfaces, failing to provide a clear "success" or "empty" state after finishing a sequence can lead to user confusion or a sense of "unmet expectation." Providing a satisfying "Ritual Complete" visual (like a check icon and positive reinforcement text) creates a distinct sense of closure and progress.
 **Action:** Always implement explicit success and empty states for sequential task components to provide closure and guidance when a workflow is completed or empty.
+
+## 2026-03-12 - [ADHD-Aware Temporal Anchors ("End of the Tunnel")]
+**Learning:** For users with ADHD, "time blindness" can make a long list of tasks feel overwhelming or infinite. Providing a "Total Remaining Duration" that dynamically updates (subtracting elapsed time from the current task) creates a "light at the end of the tunnel" effect. Calculating this monotonically (capping current task contribution at zero) prevents demoralizing "jumps" in the total time estimate if a task takes longer than expected.
+**Action:** Implement aggregate duration displays for task sequences that update in real-time and use monotonic logic to ensure the estimate only ever decreases or stays the same.
+
+## 2026-03-13 - [Screen Reader Context for Shorthand Metrics]
+**Learning:** Shorthand metrics (like "Energy: 85%") or status chips ("[LIVE]") are visually efficient but can be ambiguous for screen reader users. Adding a descriptive `aria-label` that spells out the metric name and its value (e.g., `aria-label="Energy level: 85%"`) or the full meaning of a status chip ensures clarity for users relying on assistive technology.
+**Action:** Provide explicit, descriptive `aria-label` attributes for dashboard metric cards and status indicators to bridge the gap between visual brevity and semantic clarity.

--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -214,6 +214,7 @@ function App() {
                   />
                 }
                 label={`${brandTokens.chips.live} DØPEMÜX Ritual Daemon`}
+                aria-label={`System is actively monitoring ritual state: ${brandTokens.chips.live} DØPEMÜX Ritual Daemon`}
                 className="dopemux-chip"
                 color="primary"
                 tabIndex={0}
@@ -291,6 +292,7 @@ function App() {
                   <Tooltip title={metric.tooltip} arrow>
                     <Box
                       tabIndex={0}
+                      aria-label={`${metric.label}: ${metric.value !== null ? `${(metric.value * 100).toFixed(0)}%` : 'N/A'}`}
                       sx={{
                         display: 'flex',
                         alignItems: 'center',

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -23,6 +23,7 @@ import {
   Timer,
   Flame,
   Swords,
+  Clock,
 } from 'lucide-react';
 import { brandTokens } from '../theme';
 
@@ -148,6 +149,19 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
 
   const currentTask = tasks.find((task) => task.id === currentTaskId);
 
+  const totalRemainingMinutes = useMemo(() => {
+    const incompleteTasks = tasks.filter((t) => t.status !== 'completed');
+    const otherTasksTotal = incompleteTasks
+      .filter((t) => t.id !== currentTaskId)
+      .reduce((acc, t) => acc + t.estimatedMinutes, 0);
+
+    if (!currentTaskId || !currentTask) return otherTasksTotal;
+
+    const elapsedMinutes = taskTimer / 60;
+    const currentTaskRemaining = Math.max(0, currentTask.estimatedMinutes - elapsedMinutes);
+    return Math.ceil(otherTasksTotal + currentTaskRemaining);
+  }, [tasks, currentTaskId, currentTask, taskTimer]);
+
   const complexityColor = (complexity: number) => {
     if (complexity > 0.7) return brandTokens.colors.gremlinPink;
     if (complexity > 0.5) return brandTokens.colors.giltEdge;
@@ -161,13 +175,29 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         <Typography variant="h6" sx={{ letterSpacing: '0.16em' }}>
           Task Sequencer
         </Typography>
+        <Box
+          role="status"
+          aria-label={`Total remaining duration: ${totalRemainingMinutes} ${totalRemainingMinutes === 1 ? 'minute' : 'minutes'}`}
+          sx={{
+            ml: 'auto',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 0.5,
+            color: brandTokens.colors.ritualCyan,
+            fontSize: '0.875rem',
+            fontWeight: 'bold',
+          }}
+        >
+          <Clock size={16} aria-hidden="true" />
+          {totalRemainingMinutes}m
+        </Box>
         <Tooltip title="Real-time task synchronization active" arrow>
           <Chip
             size="small"
             label="[LIVE]"
             className="dopemux-chip"
             tabIndex={0}
-            sx={{ ml: 'auto', borderColor: 'rgba(125, 251, 246, 0.6)', color: brandTokens.colors.ritualCyan }}
+            sx={{ ml: 1, borderColor: 'rgba(125, 251, 246, 0.6)', color: brandTokens.colors.ritualCyan }}
           />
         </Tooltip>
       </Box>

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -43,6 +43,7 @@ test('App.tsx exposes metric card tooltips with focus indicators', () => {
   const appContent = fs.readFileSync(path.join(componentsDir, '..', 'App.tsx'), 'utf8');
   expect(appContent).toContain('<Tooltip title={metric.tooltip} arrow>');
   expect(appContent).toMatch(/<Tooltip title=\{metric\.tooltip\} arrow>[\s\S]*tabIndex=\{0\}/);
+  expect(appContent).toMatch(/aria-label=\{\`\$\{metric\.label\}: \$\{metric\.value !== null \? \`\$\{\(metric\.value \* 100\)\.toFixed\(0\)\}%\` : 'N\/A'\}\`\}/);
   expect(appContent).toContain('&:focus-visible');
 });
 
@@ -58,6 +59,9 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('aria-label={getTimerAriaLabel(taskTimer)}');
   expect(content).toMatch(/<Tooltip[^>]*title="Real-time task synchronization active"[^>]*arrow/);
   expect(content).toContain('aria-current={isCurrent ? \'step\' : undefined}');
+  // Total remaining duration
+  expect(content).toContain('role="status"');
+  expect(content).toContain('aria-label={`Total remaining duration: ${totalRemainingMinutes} ${totalRemainingMinutes === 1 ? \'minute\' : \'minutes\'}`}');
 });
 
 test('Components have aria-hidden="true" on decorative icons', () => {
@@ -82,4 +86,5 @@ test('App.tsx has accessible header chips and skip link', () => {
   expect(appContent).toContain('<Tooltip title="AI-generated recommendation based on current load" arrow>');
   expect(appContent).toMatch(/<Tooltip title="Current cognitive status and load percentage" arrow>[\s\S]*tabIndex=\{0\}/);
   expect(appContent).toMatch(/<Tooltip title="AI-generated recommendation based on current load" arrow>[\s\S]*tabIndex=\{0\}/);
+  expect(appContent).toContain('aria-label={`System is actively monitoring ritual state: ${brandTokens.chips.live} DØPEMÜX Ritual Daemon`}');
 });


### PR DESCRIPTION
### 🎨 Palette: ADHD-aware temporal anchors and dashboard accessibility

This PR introduces micro-UX and accessibility enhancements focused on temporal awareness and semantic clarity.

#### 💡 What
1.  **Temporal Anchors in `TaskSequencer`**: Added a "Total Remaining Duration" indicator that aggregates incomplete task estimates.
2.  **Monotonic Calculation**: The timer logic now subtracts elapsed time from the current task but caps the contribution at zero, ensuring the total estimate only ever decreases (avoiding demoralizing "jumps" if a task goes over time).
3.  **Semantic Metrics**: Added descriptive `aria-label` attributes to the Energy, Attention, and Load metric cards in `App.tsx`, as well as the `[LIVE]` status indicator.
4.  **Pluralization Logic**: Implemented pluralization for time-based ARIA labels (e.g., "1 minute" vs "2 minutes").

#### 🎯 Why
- **ADHD Support**: Users with ADHD often experience "time blindness." Providing a real-time, aggregate "light at the end of the tunnel" helps maintain focus and reduces overwhelm.
- **Accessibility**: Shorthand visual metrics (e.g., "Energy: 85%") are ambiguous for screen readers. Explicit labels provide necessary context.

#### ♿ Accessibility
- Added `role="status"` to the total duration indicator.
- Improved `aria-label` descriptiveness for all key dashboard metrics.
- Verified pluralization and ARIA attribute presence via unit tests.

#### 📸 Verification
- `pnpm test` passed (12/12 tests).
- Visual verification confirmed via Playwright screenshot.
- Reverted unintentional `pnpm-lock.yaml` changes to keep the PR clean.

---
*PR created automatically by Jules for task [6313945110396702763](https://jules.google.com/task/6313945110396702763) started by @hu3mann*