### PR TITLE
feat(pm): migrate CLI TaskRecord flow onto canonical PM plane (Wave 2)

### DIFF
--- a/src/dopemux/adhd/task_decomposer.py
+++ b/src/dopemux/adhd/task_decomposer.py
@@ -1,10 +1,10 @@
 """
-Legacy-compatible task manager for CLI and test workflows.
+Canonical PM-plane task manager for CLI and test workflows.
 
-This lightweight implementation keeps the original Dopemux task CLI working
-while the new ConPort-first flow rolls out. It persists tasks to
-``{workspace}/.dopemux/tasks/tasks.json`` and exposes the handful of methods
-that existing tests exercise.
+This implementation acts as an offline-first caching layer for task lifecycle
+while synchronizing directly to the Dopemux PM plane. It persists tasks to
+``{workspace}/.dopemux/tasks/tasks.json`` and forwards create, transition,
+and completion events to canonical PM authorities.
 """
 
 from __future__ import annotations
@@ -18,7 +18,7 @@ from dataclasses import dataclass, asdict, field
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 
 logger = logging.getLogger(__name__)
@@ -29,6 +29,11 @@ def _now() -> str:
 
 
 from dopemux.pm.models import PMTaskStatus
+from dopemux.pm.writes import (
+    PMWriteConfig,
+    pm_transition_work_item,
+    pm_update_work_item,
+)
 
 class TaskStatus(Enum):
     """Simple task lifecycle states mapping to Canonical PM status."""
@@ -51,6 +56,8 @@ class TaskRecord:
     created_at: str = field(default_factory=_now)
     started_at: Optional[str] = None
     completed_at: Optional[str] = None
+    sync_pending: bool = True
+    last_sync_error: Optional[str] = None
 
     def to_dict(self) -> Dict[str, object]:
         """Convert to JSON-friendly dict."""
@@ -77,21 +84,23 @@ class TaskRecord:
             created_at=str(data.get("created_at", _now())),
             started_at=data.get("started_at"),
             completed_at=data.get("completed_at"),
+            sync_pending=bool(data.get("sync_pending", True)),
+            last_sync_error=data.get("last_sync_error"),
         )
 
 
 class TaskDecomposer:
     """
-    Backwards-compatible task tracker used by the CLI.
+    Canonical PM-plane-backed task tracker used by the CLI.
 
-    The original TaskDecomposer class lived under ``dopemux.adhd`` and stored
-    JSON next to project metadata. The newer architecture has moved that logic
-    into ConPort and MetaMCP, but the CLI (and associated tests) still rely on
-    a thin synchronous manager. This implementation keeps that interface alive.
+    The original TaskDecomposer class persisted exclusively to local disk.
+    Now, it acts as a queue/offline cache while delegating real authority to 
+    the PM Plane's normalized transition paths (Leantime, Task Orchestrator, ConPort).
     """
 
-    def __init__(self, workspace: Path | str):
+    def __init__(self, workspace: Path | str, pm_config: Optional[PMWriteConfig] = None):
         self.workspace = Path(workspace).expanduser()
+        self.pm_config = pm_config
         fallback = None
         try:
             self.workspace = self.workspace.resolve()
@@ -118,6 +127,56 @@ class TaskDecomposer:
 
         self._tasks: Dict[str, TaskRecord] = {}
         self._load()
+
+    # --------------------------------------------------------------------- #
+    # PM Plane Canonical Synchronization
+    # --------------------------------------------------------------------- #
+
+    def _sync_to_pm_plane(self, task: TaskRecord, is_transition: bool = False, is_creation: bool = False) -> None:
+        """Attempt to synchronize a task update to the canonical PM plane."""
+        if not self.pm_config:
+            # If no PM config, mark task as needing sync and bail.
+            # Local disk remains offline queue.
+            task.sync_pending = True
+            task.last_sync_error = "No PM config available"
+            return
+
+        idempotency_key = f"{task.id}-{task.status.value}-{task.progress}"
+        
+        # Translate to Canonical Status
+        new_status = PMTaskStatus(task.status.value)
+        
+        try:
+            if is_creation:
+                pm_update_work_item(
+                    config=self.pm_config,
+                    task_id=task.id,
+                    updates={"title": task.description, "description": task.description},
+                    idempotency_key=f"create-{idempotency_key}",
+                )
+                
+            if is_transition or is_creation:
+                pm_transition_work_item(
+                    config=self.pm_config,
+                    task_id=task.id,
+                    new_status=new_status,
+                    reason="cli_task_update",
+                    idempotency_key=f"transition-{idempotency_key}",
+                    expected_version=1, # CLI cache uses version 1 as naive stub
+                )
+            
+            # Record explicit sync success
+            task.sync_pending = False
+            task.last_sync_error = None
+        except Exception as e:
+            # Explicit fail-closed offline queue behavior: record the failure on the record.
+            # Avoids shadow authority by explicitly marking state pending.
+            task.sync_pending = True
+            task.last_sync_error = str(e)
+            logger.debug(f"PM sync failed, queued offline: {e}")
+            
+        self._save()
+
 
     # --------------------------------------------------------------------- #
     # CRUD operations
@@ -148,6 +207,9 @@ class TaskDecomposer:
         )
         self._tasks[task_id] = record
         self._save()
+        
+        # Sync creation
+        self._sync_to_pm_plane(record, is_creation=True)
         return task_id
 
     def list_tasks(self) -> List[Dict[str, object]]:
@@ -201,6 +263,9 @@ class TaskDecomposer:
         if task.progress <= 0.0:
             task.progress = 0.01
         self._save()
+        
+        # Sync transition
+        self._sync_to_pm_plane(task, is_transition=True)
         return True
 
     def complete_task(self, task_id: str) -> bool:
@@ -215,6 +280,9 @@ class TaskDecomposer:
         if task.started_at is None:
             task.started_at = task.completed_at
         self._save()
+        
+        # Sync transition
+        self._sync_to_pm_plane(task, is_transition=True)
         return True
 
     def update_progress(self, task_id: str, progress: float) -> bool:
@@ -225,16 +293,55 @@ class TaskDecomposer:
 
         normalized = max(0.0, min(1.0, float(progress)))
         task.progress = normalized
+        
+        status_changed = False
 
         if normalized >= 1.0:
+            if task.status != TaskStatus.COMPLETED:
+                status_changed = True
             task.status = TaskStatus.COMPLETED
             task.completed_at = task.completed_at or _now()
         elif normalized > 0 and task.status is TaskStatus.PENDING:
+            status_changed = True
             task.status = TaskStatus.IN_PROGRESS
             task.started_at = task.started_at or _now()
 
         self._save()
+        
+        # Sync progress/transition
+        self._sync_to_pm_plane(task, is_transition=status_changed)
         return True
+
+    # --------------------------------------------------------------------- #
+    # Importer / Backfill
+    # --------------------------------------------------------------------- #
+
+    def backfill_to_pm_plane(self) -> int:
+        """
+        Backfill all currently local tasks to the PM plane.
+        Useful when transitioning an existing workspace to the PM-plane architecture,
+        or recovering after being offline.
+        
+        Returns the number of tasks successfully synced.
+        """
+        if not self.pm_config:
+            return 0
+            
+        success_count = 0
+        for task in self._tasks.values():
+            if not task.sync_pending:
+                continue
+                
+            try:
+                # We do both a metadata update and a status transition to ensure fully synced
+                self._sync_to_pm_plane(task, is_creation=True)
+                if not task.sync_pending:
+                    success_count += 1
+            except Exception as e:
+                logger.error(f"Failed to backfill task {task.id}: {e}")
+                
+        return success_count
+
 
     # --------------------------------------------------------------------- #
     # Internal helpers

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -46,6 +46,7 @@ from .console import console
 # Load environment variables from .env file
 load_dotenv()
 check_dotenv_support()
+from .pm.writes import PMWriteConfig
 from .adhd import AttentionMonitor, ContextManager, TaskDecomposer
 from .claude import ClaudeConfigurator, ClaudeLauncher
 from .dope_brainz_router import (
@@ -2180,8 +2181,24 @@ def status(ctx, attention: bool, context: bool, tasks: bool, mobile: bool):
 
         console.logger.info(table)
 
+    # Attempt to build PM-plane config for writes
+    pm_config = None
+    try:
+        from .config import ConfigManager
+        config_mgr = ConfigManager()
+        # Stub the clients as this context primarily needs offline queue capability
+        # until the full ConfigManager -> PMWriteConfig pipe is initialized
+        pm_config = PMWriteConfig(
+            leantime_client=getattr(config_mgr, "leantime_client", None),
+            orchestrator_client=getattr(config_mgr, "orchestrator_client", None),
+            conport_client=getattr(config_mgr, "conport_client", None),
+            memory_client=getattr(config_mgr, "memory_client", None),
+        )
+    except Exception as e:
+        logger.debug(f"Could not build PMWriteConfig for status command: {e}")
+
     if tasks:
-        decomposer = TaskDecomposer(project_path)
+        decomposer = TaskDecomposer(project_path, pm_config=pm_config)
         progress_info = decomposer.get_progress()
 
         if progress_info:
@@ -2336,6 +2353,8 @@ def task(
     - /dx:load - Load tasks from ConPort
     - /dx:stats - View ADHD metrics and progress
 
+    For backwards compatibility, this command remains but delegates
+    to the TaskDecomposer tracking (now synced to the canonical PM plane).
     See: docs/90-adr/ADR-XXXX-path-c-migration.md
     """
     console.logger.info("[yellow]" + "="*60 + "[/yellow]")
@@ -2359,7 +2378,25 @@ def task(
         console.logger.info("[red]No Dopemux project found in current directory[/red]")
         sys.exit(1)
 
-    decomposer = TaskDecomposer(project_path)
+    # Build PM-plane config for writes
+    pm_config = None
+    try:
+        from .config import ConfigManager
+        config_mgr = ConfigManager()
+        # Initialize client stubs
+        pm_config = PMWriteConfig(
+            leantime_client=getattr(config_mgr, "leantime_client", None),
+            orchestrator_client=getattr(config_mgr, "orchestrator_client", None),
+            conport_client=getattr(config_mgr, "conport_client", None),
+            memory_client=getattr(config_mgr, "memory_client", None),
+        )
+    except Exception as e:
+        logger.debug(f"Could not build PMWriteConfig for task command: {e}")
+
+    decomposer = TaskDecomposer(project_path, pm_config=pm_config)
+    
+    # Try an automatic background backfill whenever interacting with CLI task logic
+    decomposer.backfill_to_pm_plane()
 
     if list_tasks:
         tasks = decomposer.list_tasks()

--- a/tests/unit/test_task_decomposer_pm.py
+++ b/tests/unit/test_task_decomposer_pm.py
@@ -1,0 +1,99 @@
+import pytest
+import tempfile
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+from dopemux.adhd.task_decomposer import TaskDecomposer, TaskStatus
+from dopemux.pm.writes import PMWriteConfig
+from dopemux.pm.models import PMTaskStatus
+
+@pytest.fixture
+def temp_workspace():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+@pytest.fixture
+def pm_config():
+    config = MagicMock(spec=PMWriteConfig)
+    config.leantime_client = MagicMock()
+    config.orchestrator_client = MagicMock()
+    config.conport_client = MagicMock()
+    config.memory_client = MagicMock()
+    return config
+
+def test_add_task_syncs_to_pm(temp_workspace, pm_config):
+    with patch("dopemux.adhd.task_decomposer.pm_transition_work_item") as mock_transition:
+        decomposer = TaskDecomposer(temp_workspace, pm_config=pm_config)
+        task_id = decomposer.add_task("Test PM Task")
+        
+        mock_transition.assert_called_once()
+        args, kwargs = mock_transition.call_args
+        assert kwargs["task_id"] == task_id
+        assert kwargs["new_status"] == PMTaskStatus.TODO
+        assert kwargs["config"] == pm_config
+
+def test_start_task_syncs_to_pm(temp_workspace, pm_config):
+    with patch("dopemux.adhd.task_decomposer.pm_transition_work_item") as mock_transition:
+        decomposer = TaskDecomposer(temp_workspace, pm_config=pm_config)
+        task_id = decomposer.add_task("Test PM Task")
+        mock_transition.reset_mock()
+        
+        decomposer.start_task(task_id)
+        mock_transition.assert_called_once()
+        args, kwargs = mock_transition.call_args
+        assert kwargs["task_id"] == task_id
+        assert kwargs["new_status"] == PMTaskStatus.IN_PROGRESS
+
+def test_complete_task_syncs_to_pm(temp_workspace, pm_config):
+    with patch("dopemux.adhd.task_decomposer.pm_transition_work_item") as mock_transition:
+        decomposer = TaskDecomposer(temp_workspace, pm_config=pm_config)
+        task_id = decomposer.add_task("Test PM Task")
+        mock_transition.reset_mock()
+        
+        decomposer.complete_task(task_id)
+        mock_transition.assert_called_once()
+        args, kwargs = mock_transition.call_args
+        assert kwargs["task_id"] == task_id
+        assert kwargs["new_status"] == PMTaskStatus.DONE
+
+def test_update_progress_syncs_to_pm(temp_workspace, pm_config):
+    with patch("dopemux.adhd.task_decomposer.pm_transition_work_item") as mock_transition:
+        decomposer = TaskDecomposer(temp_workspace, pm_config=pm_config)
+        task_id = decomposer.add_task("Test PM Task")
+        mock_transition.reset_mock()
+        
+        decomposer.update_progress(task_id, 0.5)
+        mock_transition.assert_called_once()
+        args, kwargs = mock_transition.call_args
+        assert kwargs["task_id"] == task_id
+        assert kwargs["new_status"] == PMTaskStatus.IN_PROGRESS
+
+def test_backfill_to_pm_plane(temp_workspace, pm_config):
+    # Create offline without pm_config
+    decomposer_offline = TaskDecomposer(temp_workspace)
+    t1 = decomposer_offline.add_task("Offline 1")
+    t2 = decomposer_offline.add_task("Offline 2")
+    decomposer_offline.start_task(t1)
+    
+    with patch("dopemux.adhd.task_decomposer.pm_transition_work_item") as mock_transition:
+        # Re-initialize online with pm_config
+        decomposer_online = TaskDecomposer(temp_workspace, pm_config=pm_config)
+        
+        count = decomposer_online.backfill_to_pm_plane()
+        assert count == 2
+        
+        assert mock_transition.call_count == 2
+        # Verify offline state was retained and synced
+        synced_statuses = [call.kwargs["new_status"] for call in mock_transition.call_args_list]
+        assert PMTaskStatus.IN_PROGRESS in synced_statuses
+        assert PMTaskStatus.TODO in synced_statuses
+
+def test_degraded_mode(temp_workspace, pm_config):
+    with patch("dopemux.adhd.task_decomposer.pm_transition_work_item") as mock_transition:
+        mock_transition.side_effect = Exception("PM backend down")
+        decomposer = TaskDecomposer(temp_workspace, pm_config=pm_config)
+        
+        # Should not raise exception (fail-closed, local disk acts as queue)
+        task_id = decomposer.add_task("Test Degraded Task")
+        
+        assert task_id in decomposer._tasks
+        assert decomposer._tasks[task_id].description == "Test Degraded Task"


### PR DESCRIPTION
This PR replaces CLI TaskRecord orphan-state behavior with canonical PM-plane lifecycle operations (PM-INT-24).