### PR TITLE
Migrate taskmaster to canonical PM-plane contract

### DIFF
--- a/services/taskmaster/README.md
+++ b/services/taskmaster/README.md
@@ -1,0 +1,25 @@
+# Taskmaster Service
+
+The Taskmaster service acts as an MCP wrapper for AI-driven task decomposition and PRD parsing with ADHD accommodations.
+
+## Architecture
+
+Taskmaster relies on the Dopemux PM plane to canonicalize tasks, enforce state boundaries, and maintain decision traceability. As a PM producer:
+- Task creations are normalized with stable `content_hash_task_id`.
+- Task statuses map exclusively to `PMTaskStatus` via `TASKMASTER_TO_CANONICAL`.
+- Canonical status updates are routed through `pm_transition_work_item`.
+- Linked IDs from synchronization are preserved canonically.
+- Comments and creation progress utilize `pm_log_progress` to push context explicitly to ConPort.
+
+## Wrapper Failure and Sync Behavior
+
+The wrapper (`TaskMasterWrapper`) wraps execution of the `task-master-ai` package and acts as a transparent stdio proxy. Event emission acts as a secondary mechanism to log completion and metrics.
+The `TaskMasterBridgeAdapter` routes sync and task modifications explicitly through PMPlane configurations (`PMWriteConfig`).
+
+If bridge actions fail, operations explicitly raise or return false per PM-plane "fail-closed" guarantees.
+
+## Run Tests
+
+```bash
+python3 -m pytest -q services/taskmaster tests
+```

--- a/services/taskmaster/bridge_adapter.py
+++ b/services/taskmaster/bridge_adapter.py
@@ -9,9 +9,10 @@ Task management via DopeconBridge for:
 
 from typing import Dict, Any, List, Optional
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 import sys
 import logging
+import httpx
 
 # Add shared modules
 SHARED_DIR = Path(__file__).parent.parent / "shared"
@@ -22,10 +23,85 @@ from dopecon_bridge_client import (
     DopeconBridgeConfig,
 )
 
-from dopemux.pm.models import PMTask, PMTaskStatus, PMTransitionRequest, content_hash_task_id
+from dopemux.pm.models import PMTask, PMTaskStatus, PMTransitionRequest, content_hash_task_id, PMLinkedIDUpdateRequest
 from dopemux.pm.store import InMemoryPMTaskStore
+from dopemux.pm.writes import PMWriteConfig, pm_update_work_item, pm_transition_work_item, pm_log_progress
+from dopemux.pm.mapping import TASKMASTER_TO_CANONICAL
 
 logger = logging.getLogger(__name__)
+
+class SyncBridgeAdapterClientStub:
+    """Uses a synchronous HTTPX client to implement proxy clients for PMWriteConfig.
+    This guarantees block execution and explicit fail-closed exceptions.
+    """
+    def __init__(self, config: DopeconBridgeConfig):
+        self.base_url = config.base_url
+        self.headers = {"Authorization": f"Bearer {config.token}", "x-source-plane": config.source_plane}
+        self.client = httpx.Client(base_url=self.base_url, headers=self.headers, timeout=config.timeout)
+
+class SyncLeantimeBridgeClient(SyncBridgeAdapterClientStub):
+    def update_task(self, task_id: str, updates: Dict[str, Any], idempotency_key: str):
+        payload = {
+            "source": "cognitive",
+            "operation": "leantime.update_task",
+            "data": {"task_id": task_id, "updates": updates, "idempotency_key": idempotency_key},
+            "requester": "taskmaster"
+        }
+        resp = self.client.post("/route/pm", json=payload)
+        resp.raise_for_status()
+
+    def update_status(self, task_id: str, status: str, idempotency_key: str):
+        payload = {
+            "source": "cognitive",
+            "operation": "leantime.update_status",
+            "data": {"task_id": task_id, "status": status, "idempotency_key": idempotency_key},
+            "requester": "taskmaster"
+        }
+        resp = self.client.post("/route/pm", json=payload)
+        resp.raise_for_status()
+
+class SyncOrchestratorBridgeClient(SyncBridgeAdapterClientStub):
+    def transition(self, task_id: str, status: Any, reason: str, expected_version: int, idempotency_key: str):
+        payload = {
+            "source": "cognitive",
+            "operation": "orchestrator.transition",
+            "data": {
+                "task_id": task_id,
+                "status": status.value if hasattr(status, 'value') else status,
+                "reason": reason,
+                "expected_version": expected_version,
+                "idempotency_key": idempotency_key
+            },
+            "requester": "taskmaster"
+        }
+        resp = self.client.post("/route/pm", json=payload)
+        resp.raise_for_status()
+
+class SyncConportBridgeClient(SyncBridgeAdapterClientStub):
+    def record_progress(self, task_id: str, progress_notes: str, is_decision: bool, idempotency_key: str):
+        payload = {
+            "description": progress_notes,
+            "status": "DONE" if is_decision else "IN_PROGRESS",
+            "metadata": {"taskmaster_task": True, "idempotency_key": idempotency_key, "task_id": task_id}
+        }
+        resp = self.client.post("/kg/progress", json=payload)
+        resp.raise_for_status()
+
+class SyncMemoryBridgeClient(SyncBridgeAdapterClientStub):
+    def append_chronicle(self, task_id: str, progress_notes: str, is_decision: bool, idempotency_key: str):
+        payload = {
+            "source": "cognitive",
+            "operation": "memory.append_chronicle",
+            "data": {
+                "task_id": task_id,
+                "progress_notes": progress_notes,
+                "is_decision": is_decision,
+                "idempotency_key": idempotency_key
+            },
+            "requester": "taskmaster"
+        }
+        resp = self.client.post("/route/pm", json=payload)
+        resp.raise_for_status()
 
 
 class TaskMasterBridgeAdapter:
@@ -50,6 +126,14 @@ class TaskMasterBridgeAdapter:
         
         self.client = AsyncDopeconBridgeClient(config=config)
         self.pm_store = InMemoryPMTaskStore()
+
+        # Configure PM writes using the synchronous blocking clients
+        self.pm_config = PMWriteConfig(
+            leantime_client=SyncLeantimeBridgeClient(config),
+            orchestrator_client=SyncOrchestratorBridgeClient(config),
+            conport_client=SyncConportBridgeClient(config),
+            memory_client=SyncMemoryBridgeClient(config)
+        )
         logger.info(f"✅ TaskMaster DopeconBridge adapter initialized (workspace: {workspace_id})")
     
     async def __aenter__(self):
@@ -57,6 +141,11 @@ class TaskMasterBridgeAdapter:
     
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.client.aclose()
+        # Clean up HTTPX sync clients
+        self.pm_config.leantime_client.client.close()
+        self.pm_config.orchestrator_client.client.close()
+        self.pm_config.conport_client.client.close()
+        self.pm_config.memory_client.client.close()
     
     async def create_task(
         self,
@@ -76,48 +165,44 @@ class TaskMasterBridgeAdapter:
                 description=description,
                 status=PMTaskStatus.TODO,
                 source="taskmaster",
-                created_at_utc=datetime.utcnow(),
-                updated_at_utc=datetime.utcnow(),
+                created_at_utc=datetime.now(timezone.utc),
+                updated_at_utc=datetime.now(timezone.utc),
             )
             pm_task = self.pm_store.create(pm_task)
             
-            result = await self.client.create_progress_entry(
-                description=f"{title}: {description}",
-                status=PMTaskStatus.TODO.value,
-                metadata={
-                    "taskmaster_task": True,
-                    "priority": priority,
-                    "tags": tags or [],
-                    "title": title,
-                    "canonical_id": pm_task.task_id,
-                    "canonical_version": pm_task.version,
-                    **(metadata or {}),
-                },
-                workspace_id=self.workspace_id,
+            # Canonical progress logging
+            idempotency_key = f"create-{task_id}-{pm_task.version}"
+            pm_log_progress(
+                config=self.pm_config,
+                task_id=task_id,
+                progress_notes=f"Task created: {title}\nDescription: {description}",
+                idempotency_key=idempotency_key,
+                is_decision=True
             )
-            
-            # Fallback update client ID if returned by Dopecon bridge differently
-            canonical_task_id = pm_task.task_id
             
             # Publish event
             await self.client.publish_event(
                 event_type="taskmaster.task.created",
                 data={
-                    "task_id": canonical_task_id,
-                    "bridge_id": result.get("id"),
+                    "task_id": task_id,
                     "title": title,
                     "priority": priority,
                     "workspace_id": self.workspace_id,
+                    "source": "taskmaster",
+                    "idempotency_key": idempotency_key
                 },
                 source="taskmaster",
             )
             
             logger.info(f"Created task: {title} (priority: {priority})")
             
-            # Add canonical fields to return
-            result["canonical_id"] = pm_task.task_id
-            result["canonical_version"] = pm_task.version
-            return result
+            return {
+                "canonical_id": pm_task.task_id,
+                "canonical_version": pm_task.version,
+                "title": title,
+                "priority": priority,
+                "status": "TODO"
+            }
         except Exception as e:
             logger.error(f"Failed to create task: {e}")
             return {}
@@ -158,17 +243,17 @@ class TaskMasterBridgeAdapter:
                 logger.error(f"Task {task_id} not found in store")
                 return False
 
-            from dopemux.pm.mapping import TASKMASTER_TO_CANONICAL
             canonical_status = TASKMASTER_TO_CANONICAL.get(new_status, PMTaskStatus.TODO)
+            idempotency_key = f"status-{task_id}-{canonical_status.value}-{task.version}"
             
             try:
                 task = self.pm_store.transition(
                     task_id=task_id,
                     req=PMTransitionRequest(
-                        idempotency_key=f"status-{task_id}-{canonical_status.value}",
+                        idempotency_key=idempotency_key,
                         expected_version=task.version,
                         new_status=canonical_status,
-                        ts_utc=datetime.utcnow(),
+                        ts_utc=datetime.now(timezone.utc),
                         source="taskmaster",
                     )
                 )
@@ -176,16 +261,27 @@ class TaskMasterBridgeAdapter:
                 logger.error(f"Store transition failed: {e}")
                 return False
                 
-            # Create a new progress entry with updated status
-            # (In real implementation, would update existing entry)
+            # Perform canonical PM-plane write synchronously and fail closed
+            pm_transition_work_item(
+                config=self.pm_config,
+                task_id=task_id,
+                new_status=canonical_status,
+                reason=f"Status update to {new_status} via taskmaster",
+                idempotency_key=idempotency_key,
+                expected_version=task.version - 1  # Before the transition was recorded
+            )
+
             await self.client.publish_event(
                 event_type="taskmaster.task.status_updated",
                 data={
                     "task_id": task_id,
                     "new_status": new_status,
+                    "canonical_status": canonical_status.value,
                     "canonical_version": task.version,
-                    "updated_at": datetime.utcnow().isoformat(),
+                    "updated_at": datetime.now(timezone.utc).isoformat(),
                     "workspace_id": self.workspace_id,
+                    "source": "taskmaster",
+                    "idempotency_key": idempotency_key
                 },
                 source="taskmaster",
             )
@@ -200,16 +296,14 @@ class TaskMasterBridgeAdapter:
         self,
         task_id: str,
     ) -> bool:
-        """Sync task to PM plane with canonical linked IDs validation"""
-        from dopemux.pm.models import PMLinkedIDUpdateRequest
-
+        """Sync task to PM plane using canonical writes"""
         try:
             pm_task = self.pm_store.get(task_id)
             if not pm_task:
                 logger.error(f"Task {task_id} not found in store")
                 return False
 
-            # Route to PM plane
+            # Fetch actual remote canonical ID properly via route_pm
             response = await self.client.route_pm(
                 operation="taskmaster.sync_task",
                 data={
@@ -227,13 +321,14 @@ class TaskMasterBridgeAdapter:
                 
                 # Update linked IDs canonically
                 try:
+                    idempotency_key = f"sync-{task_id}-{pm_task_id}"
                     self.pm_store.update_linked_ids(
                         task_id=task_id,
                         req=PMLinkedIDUpdateRequest(
-                            idempotency_key=f"sync-{task_id}-{pm_task_id}",
+                            idempotency_key=idempotency_key,
                             expected_version=pm_task.version,
                             linked_ids={"leantime": pm_task_id},
-                            ts_utc=datetime.utcnow(),
+                            ts_utc=datetime.now(timezone.utc),
                             source="taskmaster",
                         )
                     )
@@ -241,21 +336,23 @@ class TaskMasterBridgeAdapter:
                     logger.error(f"Failed to update linked IDs: {e}")
                     return False
                 
-                # Save sync record (legacy)
-                await self.client.save_custom_data(
-                    workspace_id=self.workspace_id,
-                    category="taskmaster_pm_sync",
-                    key=task_id,
-                    value={
-                        "task_id": task_id,
-                        "pm_task_id": pm_task_id,
-                        "synced_at": datetime.utcnow().isoformat(),
-                    },
-                )
+                # Use pm_update_work_item to record the sync passively
+                try:
+                    pm_update_work_item(
+                        config=self.pm_config,
+                        task_id=task_id,
+                        updates={"linked_ids": {"leantime": pm_task_id}},
+                        idempotency_key=idempotency_key
+                    )
+                except Exception as e:
+                    logger.error(f"Failed canonical sync to PM plane: {e}")
+                    return False
                 
-                logger.info(f"Synced task {task_id} to PM plane")
-            
-            return response.success
+                logger.info(f"Synced task {task_id} to PM plane (canonical_id: {pm_task_id})")
+                return True
+            else:
+                logger.error(f"Failed to route taskmaster.sync_task: {response.error}")
+                return False
         except Exception as e:
             logger.error(f"Failed to sync task to PM plane: {e}")
             return False
@@ -267,13 +364,29 @@ class TaskMasterBridgeAdapter:
     ) -> bool:
         """Assign task to a user"""
         try:
+            task = self.pm_store.get(task_id)
+            if not task:
+                logger.error(f"Task {task_id} not found in store")
+                return False
+
+            idempotency_key = f"assign-{task_id}-{assignee}-{datetime.now(timezone.utc).timestamp()}"
+
+            pm_update_work_item(
+                config=self.pm_config,
+                task_id=task_id,
+                updates={"assignee": assignee},
+                idempotency_key=idempotency_key
+            )
+
             await self.client.publish_event(
                 event_type="taskmaster.task.assigned",
                 data={
                     "task_id": task_id,
                     "assignee": assignee,
-                    "assigned_at": datetime.utcnow().isoformat(),
+                    "assigned_at": datetime.now(timezone.utc).isoformat(),
                     "workspace_id": self.workspace_id,
+                    "source": "taskmaster",
+                    "idempotency_key": idempotency_key
                 },
                 source="taskmaster",
             )
@@ -292,15 +405,30 @@ class TaskMasterBridgeAdapter:
     ) -> bool:
         """Add comment to task"""
         try:
+            task = self.pm_store.get(task_id)
+            if not task:
+                logger.error(f"Task {task_id} not found in store")
+                return False
+
+            idempotency_key = f"comment-{task_id}-{author}-{datetime.now(timezone.utc).timestamp()}"
+
+            pm_log_progress(
+                config=self.pm_config,
+                task_id=task_id,
+                progress_notes=f"[{author}]: {comment}",
+                idempotency_key=idempotency_key,
+                is_decision=False
+            )
+
             await self.client.save_custom_data(
                 workspace_id=self.workspace_id,
                 category="task_comments",
-                key=f"{task_id}_{datetime.utcnow().isoformat()}",
+                key=f"{task_id}_{datetime.now(timezone.utc).isoformat()}",
                 value={
                     "task_id": task_id,
                     "comment": comment,
                     "author": author,
-                    "created_at": datetime.utcnow().isoformat(),
+                    "created_at": datetime.now(timezone.utc).isoformat(),
                 },
             )
             
@@ -310,6 +438,8 @@ class TaskMasterBridgeAdapter:
                     "task_id": task_id,
                     "author": author,
                     "workspace_id": self.workspace_id,
+                    "source": "taskmaster",
+                    "idempotency_key": idempotency_key
                 },
                 source="taskmaster",
             )
@@ -319,7 +449,7 @@ class TaskMasterBridgeAdapter:
         except Exception as e:
             logger.error(f"Failed to add task comment: {e}")
             return False
-    
+
     async def get_task_comments(
         self,
         task_id: str,
@@ -353,19 +483,19 @@ class TaskMasterBridgeAdapter:
         """Mark task as completed"""
         try:
             # Update status
-            await self.update_task_status(task_id, "DONE")
+            success = await self.update_task_status(task_id, "DONE")
+            if not success:
+                return False
             
-            # Save completion data
-            await self.client.save_custom_data(
-                workspace_id=self.workspace_id,
-                category="task_completions",
-                key=task_id,
-                value={
-                    "task_id": task_id,
-                    "completed_at": datetime.utcnow().isoformat(),
-                    "notes": completion_notes,
-                },
-            )
+            if completion_notes:
+                idempotency_key = f"complete-notes-{task_id}-{datetime.now(timezone.utc).timestamp()}"
+                pm_log_progress(
+                    config=self.pm_config,
+                    task_id=task_id,
+                    progress_notes=f"Completion notes: {completion_notes}",
+                    idempotency_key=idempotency_key,
+                    is_decision=True
+                )
             
             # Publish event
             await self.client.publish_event(
@@ -373,6 +503,7 @@ class TaskMasterBridgeAdapter:
                 data={
                     "task_id": task_id,
                     "workspace_id": self.workspace_id,
+                    "source": "taskmaster"
                 },
                 source="taskmaster",
             )

--- a/services/taskmaster/tests/test_bridge_adapter.py
+++ b/services/taskmaster/tests/test_bridge_adapter.py
@@ -1,0 +1,82 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from services.taskmaster.bridge_adapter import TaskMasterBridgeAdapter
+
+@pytest.fixture
+def mock_pm_config():
+    with patch("services.taskmaster.bridge_adapter.PMWriteConfig") as MockConfig:
+        config_instance = MockConfig.return_value
+        yield config_instance
+
+@pytest.fixture
+def mock_client():
+    with patch("services.taskmaster.bridge_adapter.AsyncDopeconBridgeClient") as MockClient:
+        client_instance = AsyncMock()
+        MockClient.return_value = client_instance
+        yield client_instance
+
+@pytest.fixture
+async def adapter(mock_pm_config, mock_client):
+    with patch("services.taskmaster.bridge_adapter.SyncLeantimeBridgeClient"), \
+         patch("services.taskmaster.bridge_adapter.SyncOrchestratorBridgeClient"), \
+         patch("services.taskmaster.bridge_adapter.SyncConportBridgeClient"), \
+         patch("services.taskmaster.bridge_adapter.SyncMemoryBridgeClient"):
+         async with TaskMasterBridgeAdapter(workspace_id="test_workspace") as ad:
+            yield ad
+
+@pytest.mark.asyncio
+async def test_create_task(adapter):
+    with patch("services.taskmaster.bridge_adapter.pm_log_progress") as mock_log_progress:
+        result = await adapter.create_task(title="Test Task", description="Test Description")
+
+        assert "canonical_id" in result
+        assert result["title"] == "Test Task"
+        assert result["status"] == "TODO"
+
+        mock_log_progress.assert_called_once()
+        adapter.client.publish_event.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_update_task_status(adapter):
+    # First create a task
+    result = await adapter.create_task(title="Test Task", description="Test Description")
+    task_id = result["canonical_id"]
+
+    with patch("services.taskmaster.bridge_adapter.pm_transition_work_item") as mock_transition:
+        success = await adapter.update_task_status(task_id, "DONE")
+
+        assert success is True
+        mock_transition.assert_called_once()
+        # Verify status is correctly mapped
+        call_args = mock_transition.call_args[1]
+        assert call_args["new_status"].value == "DONE"
+
+@pytest.mark.asyncio
+async def test_sync_to_pm_plane(adapter):
+    # Create a task first
+    result = await adapter.create_task(title="Test Sync Task", description="Sync Description")
+    task_id = result["canonical_id"]
+
+    # Mock route_pm response
+    adapter.client.route_pm.return_value = MagicMock(success=True, data={"pm_task_id": "real-leantime-id-123"})
+
+    with patch("services.taskmaster.bridge_adapter.pm_update_work_item") as mock_update:
+        success = await adapter.sync_to_pm_plane(task_id)
+
+        assert success is True
+        mock_update.assert_called_once()
+        call_args = mock_update.call_args[1]
+        assert call_args["updates"]["linked_ids"]["leantime"] == "real-leantime-id-123"
+
+@pytest.mark.asyncio
+async def test_add_task_comment(adapter):
+    # Create a task first
+    result = await adapter.create_task(title="Test Task", description="Test Description")
+    task_id = result["canonical_id"]
+
+    with patch("services.taskmaster.bridge_adapter.pm_log_progress") as mock_log:
+        success = await adapter.add_task_comment(task_id, "This is a comment", "Hue")
+
+        assert success is True
+        mock_log.assert_called_once()
+        adapter.client.publish_event.assert_called()

--- a/services/taskmaster/tests/test_server.py
+++ b/services/taskmaster/tests/test_server.py
@@ -1,0 +1,57 @@
+import pytest
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
+from services.taskmaster.server import TaskMasterWrapper
+
+@pytest.fixture
+def wrapper():
+    return TaskMasterWrapper()
+
+@pytest.mark.asyncio
+async def test_wrapper_initialization(wrapper):
+    assert wrapper.instance_id is not None
+    assert wrapper.workspace_id is not None
+    assert wrapper.adhd_config["focus_duration"] > 0
+
+@pytest.mark.asyncio
+async def test_emit_task_event_no_producer(wrapper):
+    # Tests that emit gracefully fails/no-ops when producer is none
+    wrapper.mcp_producer = None
+    # Should not raise
+    await wrapper.emit_task_event("test_event", {"data": "test"})
+
+@pytest.mark.asyncio
+async def test_handle_message_json_pass_through(wrapper):
+    msg = b'{"jsonrpc": "2.0", "method": "test"}'
+    with patch("services.taskmaster.server.sys") as mock_sys:
+        wrapper.process = MagicMock()
+        wrapper.process.stdin = MagicMock()
+
+        await wrapper.handle_message(msg)
+
+        wrapper.process.stdin.write.assert_called_once_with(msg)
+        wrapper.process.stdin.flush.assert_called_once()
+
+@pytest.mark.asyncio
+async def test_handle_response_tracked_call(wrapper):
+    # Setup pending call
+    wrapper.pending_calls["1"] = {
+        "tool": "create_task",
+        "params": {},
+        "start_time": MagicMock()
+    }
+    wrapper.pending_calls["1"]["start_time"].timestamp.return_value = 0
+
+    resp = b'{"jsonrpc": "2.0", "id": "1", "result": {}}'
+
+    with patch("services.taskmaster.server.sys") as mock_sys:
+        # Prevent actually calling sys.stdout/stderr things
+        wrapper.mcp_producer = MagicMock()
+
+        with patch.object(wrapper, "emit_task_event", new_callable=AsyncMock) as mock_emit:
+            await wrapper.handle_response(resp)
+            mock_emit.assert_called_once()
+
+            call_args = mock_emit.call_args[0]
+            assert call_args[0] == "completed"
+            assert call_args[1]["tool"] == "create_task"


### PR DESCRIPTION
Migrates the `taskmaster` service adapter onto the canonical PM-plane APIs enforcing strict fail-closed boundary controls. It introduces stable ID traceability and synchronous `httpx` proxy adapters to adhere strictly to the workflow tracking constraints established in ADR-PM-001. Comprehensive wrapper tests were added.

---
*PR created automatically by Jules for task [10231600626141035080](https://jules.google.com/task/10231600626141035080) started by @hu3mann*