### PR TITLE
PM-INT-20: Narrow dopecon-bridge to adapter-only role

### DIFF
--- a/services/dopecon-bridge/dopecon_bridge/routes.py
+++ b/services/dopecon-bridge/dopecon_bridge/routes.py
@@ -268,7 +268,10 @@ async def parse_prd(
     http_request: Request,
     x_source_plane: Optional[str] = Header(None)
 ):
-    """Parse PRD document into tasks across all systems with ADHD context preservation."""
+    """
+    Parse PRD document into tasks and route directly to canonical PM backend (Leantime).
+    This adapter endpoint ensures ADHD context preservation.
+    """
     from .services.task_integration import task_service
     
     # Enforce cognitive plane authority for writes
@@ -313,7 +316,10 @@ async def get_next_tasks(
     limit: int = Query(5, ge=1, le=20),
     x_source_plane: Optional[str] = Header(None)
 ):
-    """Get next actionable tasks for ADHD-friendly workflow."""
+    """
+    Route request to canonical PM backend (Leantime) to get next actionable tasks
+    for an ADHD-friendly workflow.
+    """
     if x_source_plane and x_source_plane not in ["pm_plane", "cognitive_plane"]:
         raise HTTPException(status_code=403, detail=f"Invalid source plane: {x_source_plane}")
 
@@ -349,7 +355,10 @@ async def update_task_status(
     current_user: dict = Depends(get_current_user),
     x_source_plane: Optional[str] = Header(None)
 ):
-    """Update task status across all systems."""
+    """
+    Route task status update to canonical backend (Leantime) via adapter,
+    incorporating automatic next-action suggestions.
+    """
     # Enforce cognitive plane authority for writes
     if x_source_plane != "cognitive_plane":
         raise HTTPException(
@@ -384,7 +393,10 @@ async def ddg_recent_decisions(
     limit: int = Query(20, ge=1, le=100),
     x_source_plane: Optional[str] = Header(None)
 ):
-    """Get recent decisions from the decision graph."""
+    """
+    Adapter endpoint to get recent decisions from the canonical decision graph
+    backend (Conport).
+    """
     if x_source_plane and x_source_plane not in ["pm_plane", "cognitive_plane"]:
         raise HTTPException(status_code=403, detail=f"Invalid source plane: {x_source_plane}")
 
@@ -415,7 +427,10 @@ async def ddg_search_decisions(
     limit: int = Query(20, ge=1, le=100),
     x_source_plane: Optional[str] = Header(None)
 ):
-    """Search decisions by text query."""
+    """
+    Adapter endpoint to search decisions by text query from the canonical decision graph
+    backend (Conport).
+    """
     if x_source_plane and x_source_plane not in ["pm_plane", "cognitive_plane"]:
         raise HTTPException(status_code=403, detail=f"Invalid source plane: {x_source_plane}")
 

--- a/services/dopecon-bridge/dopecon_bridge/routes.py
+++ b/services/dopecon-bridge/dopecon_bridge/routes.py
@@ -9,7 +9,7 @@ import logging
 from datetime import timedelta
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, Field
@@ -263,10 +263,21 @@ async def publish_progress_updated(task_id: str, status: str, progress: float):
 # ============================================================================
 
 @tasks_router.post("/parse-prd")
-async def parse_prd(request: PRDParseRequest, http_request: Request):
+async def parse_prd(
+    request: PRDParseRequest,
+    http_request: Request,
+    x_source_plane: Optional[str] = Header(None)
+):
     """Parse PRD document into tasks across all systems with ADHD context preservation."""
     from .services.task_integration import task_service
     
+    # Enforce cognitive plane authority for writes
+    if x_source_plane != "cognitive_plane":
+        raise HTTPException(
+            status_code=403,
+            detail="PRD parsing requires cognitive_plane authority"
+        )
+
     try:
         # Update context for ADHD tracking
         update_context_delta(
@@ -297,8 +308,15 @@ async def parse_prd(request: PRDParseRequest, http_request: Request):
 
 
 @tasks_router.get("/next/{project_id}")
-async def get_next_tasks(project_id: str, limit: int = Query(5, ge=1, le=20)):
+async def get_next_tasks(
+    project_id: str,
+    limit: int = Query(5, ge=1, le=20),
+    x_source_plane: Optional[str] = Header(None)
+):
     """Get next actionable tasks for ADHD-friendly workflow."""
+    if x_source_plane and x_source_plane not in ["pm_plane", "cognitive_plane"]:
+        raise HTTPException(status_code=403, detail=f"Invalid source plane: {x_source_plane}")
+
     from .services.task_integration import task_service
     
     try:
@@ -328,9 +346,17 @@ async def get_next_tasks(project_id: str, limit: int = Query(5, ge=1, le=20)):
 async def update_task_status(
     task_id: str,
     request: TaskUpdateRequest,
-    current_user: dict = Depends(get_current_user)
+    current_user: dict = Depends(get_current_user),
+    x_source_plane: Optional[str] = Header(None)
 ):
     """Update task status across all systems."""
+    # Enforce cognitive plane authority for writes
+    if x_source_plane != "cognitive_plane":
+        raise HTTPException(
+            status_code=403,
+            detail="Task status update requires cognitive_plane authority"
+        )
+
     from .services.task_integration import task_service
     
     try:
@@ -355,34 +381,28 @@ async def update_task_status(
 @ddg_router.get("/decisions")
 async def ddg_recent_decisions(
     workspace_id: Optional[str] = None,
-    limit: int = Query(20, ge=1, le=100)
+    limit: int = Query(20, ge=1, le=100),
+    x_source_plane: Optional[str] = Header(None)
 ):
     """Get recent decisions from the decision graph."""
-    from sqlalchemy import select
-    from .models import DdgDecision
-    
+    if x_source_plane and x_source_plane not in ["pm_plane", "cognitive_plane"]:
+        raise HTTPException(status_code=403, detail=f"Invalid source plane: {x_source_plane}")
+
     try:
-        async with await db_manager.get_session() as session:
-            query = select(DdgDecision).order_by(DdgDecision.created_at.desc()).limit(limit)
-            if workspace_id:
-                query = query.where(DdgDecision.workspace_id == workspace_id)
-            
-            result = await session.execute(query)
-            decisions = result.scalars().all()
-            
-            return {
-                "count": len(decisions),
-                "decisions": [
-                    {
-                        "id": d.id,
-                        "summary": d.summary,
-                        "tags": d.tags or [],
-                        "workspace_id": d.workspace_id,
-                        "created_at": d.created_at.isoformat()
-                    }
-                    for d in decisions
-                ]
-            }
+        # Route to canonical backend via MCP client
+        from .clients import mcp_client
+
+        # We proxy to mcp_client.get_decisions which gets from Conport
+        decisions = await mcp_client.call_tool(
+            "conport",
+            "get_decisions",
+            {"workspace_id": workspace_id, "limit": limit}
+        )
+
+        return {
+            "count": len(decisions.get("decisions", [])),
+            "decisions": decisions.get("decisions", [])
+        }
     except Exception as e:
         logger.error(f"DDG decisions query failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
@@ -392,37 +412,29 @@ async def ddg_recent_decisions(
 async def ddg_search_decisions(
     q: str,
     workspace_id: Optional[str] = None,
-    limit: int = Query(20, ge=1, le=100)
+    limit: int = Query(20, ge=1, le=100),
+    x_source_plane: Optional[str] = Header(None)
 ):
     """Search decisions by text query."""
-    from sqlalchemy import select
-    from .models import DdgDecision
-    
+    if x_source_plane and x_source_plane not in ["pm_plane", "cognitive_plane"]:
+        raise HTTPException(status_code=403, detail=f"Invalid source plane: {x_source_plane}")
+
     try:
-        async with await db_manager.get_session() as session:
-            query = select(DdgDecision).where(
-                DdgDecision.summary.ilike(f"%{q}%")
-            ).order_by(DdgDecision.created_at.desc()).limit(limit)
-            
-            if workspace_id:
-                query = query.where(DdgDecision.workspace_id == workspace_id)
-            
-            result = await session.execute(query)
-            decisions = result.scalars().all()
-            
-            return {
-                "query": q,
-                "count": len(decisions),
-                "decisions": [
-                    {
-                        "id": d.id,
-                        "summary": d.summary,
-                        "tags": d.tags or [],
-                        "workspace_id": d.workspace_id
-                    }
-                    for d in decisions
-                ]
-            }
+        # Route to canonical backend via MCP client
+        from .clients import mcp_client
+
+        # We proxy to mcp_client.query_knowledge_graph
+        decisions = await mcp_client.call_tool(
+            "conport",
+            "query_knowledge_graph",
+            {"query": q, "workspace_id": workspace_id, "limit": limit}
+        )
+
+        return {
+            "query": q,
+            "count": len(decisions.get("decisions", [])),
+            "decisions": decisions.get("decisions", [])
+        }
     except Exception as e:
         logger.error(f"DDG search failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/services/dopecon-bridge/dopecon_bridge/services/task_integration.py
+++ b/services/dopecon-bridge/dopecon_bridge/services/task_integration.py
@@ -17,27 +17,24 @@ from sqlalchemy import bindparam
 
 from ..clients import mcp_client
 from ..config import settings
-from ..core import cache_manager, db_manager
-from ..models import Task, TaskPriority, TaskRecord, TaskStatus
+from ..models import Task, TaskPriority, TaskStatus
 
 
 logger = logging.getLogger(__name__)
 
 
 class TaskIntegrationService:
-    """Core task integration with multi-instance shared state."""
+    """Core task integration adapter to canonical backends."""
 
     def __init__(self):
-        self.db_manager = db_manager
-        self.cache_manager = cache_manager
         self.mcp_manager = mcp_client
 
     async def parse_prd_to_tasks(self, prd_content: str, project_id: str) -> List[Task]:
         """
-        Parse PRD using Task-Master-AI and create shared task structure.
-        ADHD-friendly: Clear progress indicators and manageable chunks.
+        Parse PRD using Task-Master-AI and route directly to canonical PM backend.
+        No local DB storage.
         """
-        logger.info(f"🔍 Parsing PRD for project {project_id} (instance: {settings.instance_name})")
+        logger.info(f"🔍 Parsing PRD for project {project_id} via adapter (instance: {settings.instance_name})")
 
         try:
             # Step 1: Use Task-Master-AI to parse PRD
@@ -47,41 +44,22 @@ class TaskIntegrationService:
                 {"content": prd_content, "project_id": project_id}
             )
 
-            # Step 2: Convert to unified task format and store in shared database
             tasks = []
-            async with await self.db_manager.get_session() as session:
-                for task_data in prd_result.get("tasks", []):
-                    task = Task(
-                        id=str(uuid.uuid4()),
-                        title=task_data.get("title", ""),
-                        description=task_data.get("description", ""),
-                        status=TaskStatus.PLANNED,
-                        priority=TaskPriority(task_data.get("priority", "medium")),
-                        project_id=project_id,
-                        instance_id=settings.instance_name,
-                        tags=task_data.get("tags", [])
-                    )
+            for task_data in prd_result.get("tasks", []):
+                task = Task(
+                    id=str(uuid.uuid4()),
+                    title=task_data.get("title", ""),
+                    description=task_data.get("description", ""),
+                    status=TaskStatus.PLANNED,
+                    priority=TaskPriority(task_data.get("priority", "medium")),
+                    project_id=project_id,
+                    instance_id=settings.instance_name,
+                    tags=task_data.get("tags", [])
+                )
+                tasks.append(task)
 
-                    # Store in shared database
-                    task_record = TaskRecord(**asdict(task))
-                    session.add(task_record)
-                    tasks.append(task)
-
-                await session.commit()
-
-            # Step 3: Use Task-Orchestrator to analyze dependencies
-            await self._analyze_task_dependencies(tasks)
-
-            # Step 4: Create tasks in Leantime for tracking
+            # Step 2: Directly route tasks to Leantime for tracking
             await self._sync_tasks_to_leantime(tasks)
-
-            # Step 5: Cache results for fast access
-            cache_client = await self.cache_manager.get_client()
-            await cache_client.setex(
-                f"project:{project_id}:tasks",
-                3600,  # 1 hour cache
-                json.dumps([asdict(task) for task in tasks], default=str)
-            )
 
             logger.info(f"✅ Successfully processed {len(tasks)} tasks from PRD")
             return tasks
@@ -90,67 +68,12 @@ class TaskIntegrationService:
             logger.error(f"❌ PRD parsing failed: {e}")
             raise
 
-    async def _analyze_task_dependencies(self, tasks: List[Task]):
-        """Use Task-Orchestrator to analyze and set dependencies."""
-        try:
-            task_descriptions = [
-                {"id": t.id, "title": t.title, "description": t.description}
-                for t in tasks
-            ]
-
-            dependency_result = await self.mcp_manager.call_tool(
-                "task-orchestrator",
-                "analyze_dependencies",
-                {"tasks": task_descriptions}
-            )
-
-            dependencies = dependency_result.get("dependencies", [])
-            if not dependencies:
-                return
-
-            # Map for efficient lookup
-            task_map = {t.id: t for t in tasks}
-            update_params = []
-            now = datetime.utcnow()
-
-            for dep in dependencies:
-                task_id = dep.get("task_id")
-                depends_on = dep.get("depends_on", [])
-
-                # Collect for bulk update
-                update_params.append({
-                    "b_id": task_id,
-                    "b_dependencies": depends_on,
-                    "b_updated_at": now
-                })
-
-                # Update in-memory objects
-                if task_id in task_map:
-                    task_map[task_id].dependencies = depends_on
-
-            # Perform bulk update in shared database
-            async with await self.db_manager.get_session() as session:
-                await session.execute(
-                    TaskRecord.__table__.update()
-                    .where(TaskRecord.id == bindparam("b_id"))
-                    .values(
-                        dependencies=bindparam("b_dependencies"),
-                        updated_at=bindparam("b_updated_at")
-                    ),
-                    update_params
-                )
-                await session.commit()
-
-        except Exception as e:
-            logger.warning(f"⚠️ Dependency analysis failed: {e}")
-
     async def _sync_tasks_to_leantime(self, tasks: List[Task]):
         """Sync tasks to Leantime for project management tracking."""
         if not tasks:
             return
 
         try:
-            # Step 1: Prepare parallel tool calls
             coros = [
                 self.mcp_manager.call_tool(
                     "leantime-bridge",
@@ -166,11 +89,8 @@ class TaskIntegrationService:
                 for task in tasks
             ]
 
-            # Step 2: Execute in parallel to avoid N+1 sequential waits
             results = await asyncio.gather(*coros, return_exceptions=True)
 
-            update_params = []
-            now = datetime.utcnow()
             for task, leantime_result in zip(tasks, results):
                 if isinstance(leantime_result, Exception):
                     logger.error(f"❌ Failed to sync task {task.id} to Leantime: {leantime_result}")
@@ -178,25 +98,6 @@ class TaskIntegrationService:
 
                 if leantime_result and "id" in leantime_result:
                     task.tags.append(f"leantime_id:{leantime_result['id']}")
-                    update_params.append({
-                        "b_id": task.id,
-                        "b_tags": task.tags,
-                        "b_updated_at": now
-                    })
-
-            # Step 3: Perform bulk update for all successful syncs
-            if update_params:
-                async with await self.db_manager.get_session() as session:
-                    await session.execute(
-                        TaskRecord.__table__.update()
-                        .where(TaskRecord.id == bindparam("b_id"))
-                        .values(
-                            tags=bindparam("b_tags"),
-                            updated_at=bindparam("b_updated_at")
-                        ),
-                        update_params
-                    )
-                    await session.commit()
 
         except Exception as e:
             logger.warning(f"⚠️ Leantime sync failed: {e}")
@@ -213,85 +114,31 @@ class TaskIntegrationService:
 
     async def get_next_actionable_tasks(self, project_id: str, limit: int = 5) -> List[Task]:
         """
-        Get next actionable tasks for ADHD-friendly workflow.
-        Checks shared database for cross-instance task coordination.
+        Route request to canonical PM backend to get next actionable tasks.
         """
         try:
-            cache_client = await self.cache_manager.get_client()
-            cache_key = f"project:{project_id}:actionable_tasks"
-            cached_result = await cache_client.get(cache_key)
+            # Query canonical backend for actionable tasks
+            result = await self.mcp_manager.call_tool(
+                "leantime-bridge",
+                "search_tickets",
+                {"project_id": project_id, "status": "planned", "limit": limit}
+            )
 
-            if cached_result:
-                logger.debug("📋 Returning cached actionable tasks")
-                task_dicts = json.loads(cached_result)
-                return [
-                    Task(
-                        id=t["id"],
-                        title=t["title"],
-                        description=t["description"],
-                        status=TaskStatus(t["status"]),
-                        priority=TaskPriority(t["priority"]),
-                        instance_id=t.get("instance_id", "default"),
-                        project_id=t.get("project_id"),
-                        dependencies=t.get("dependencies", []),
-                        tags=t.get("tags", [])
-                    )
-                    for t in task_dicts
-                ]
-
-            # Query database for actionable tasks (no blocking dependencies)
-            async with await self.db_manager.get_session() as session:
-                from sqlalchemy import text
-                
-                result = await session.execute(
-                    text("""
-                    SELECT t.* FROM tasks t
-                    WHERE t.project_id = :project_id
-                    AND t.status = 'planned'
-                    AND (
-                        t.dependencies IS NULL
-                        OR t.dependencies = '[]'::json
-                    )
-                    ORDER BY
-                        CASE t.priority
-                            WHEN 'critical' THEN 1
-                            WHEN 'high' THEN 2
-                            WHEN 'medium' THEN 3
-                            WHEN 'low' THEN 4
-                        END,
-                        t.created_at
-                    LIMIT :limit
-                    """),
-                    {"project_id": project_id, "limit": limit}
+            task_records = result.get("tickets", [])
+            actionable_tasks = [
+                Task(
+                    id=str(record.get("id")),
+                    title=record.get("headline", ""),
+                    description=record.get("description", ""),
+                    status=TaskStatus.PLANNED,
+                    priority=TaskPriority.MEDIUM,
+                    project_id=project_id,
                 )
+                for record in task_records
+            ][:limit]
 
-                task_records = result.fetchall()
-                actionable_tasks = [
-                    Task(
-                        id=record.id,
-                        title=record.title,
-                        description=record.description or "",
-                        status=TaskStatus(record.status),
-                        priority=TaskPriority(record.priority),
-                        instance_id=record.instance_id,
-                        project_id=record.project_id,
-                        dependencies=record.dependencies or [],
-                        tags=record.tags or [],
-                        assigned_to=record.assigned_to,
-                        estimated_hours=record.estimated_hours
-                    )
-                    for record in task_records
-                ]
-
-                # Cache result for 5 minutes
-                await cache_client.setex(
-                    cache_key,
-                    300,
-                    json.dumps([asdict(task) for task in actionable_tasks], default=str)
-                )
-
-                logger.info(f"📋 Found {len(actionable_tasks)} actionable tasks for project {project_id}")
-                return actionable_tasks
+            logger.info(f"📋 Found {len(actionable_tasks)} actionable tasks for project {project_id} via adapter")
+            return actionable_tasks
 
         except Exception as e:
             logger.error(f"❌ Failed to get actionable tasks: {e}")
@@ -304,61 +151,52 @@ class TaskIntegrationService:
         assigned_to: str = None
     ) -> Dict[str, Any]:
         """
-        Update task status across all systems with dependency resolution.
-        ADHD-friendly: Clear progress feedback and automatic next-action suggestions.
+        Route task status update to canonical backend.
         """
-        logger.info(f"🔄 Updating task {task_id} to status {new_status.value}")
+        logger.info(f"🔄 Routing task {task_id} status update to {new_status.value} via adapter")
 
         try:
-            async with await self.db_manager.get_session() as session:
-                result = await session.execute(
-                    TaskRecord.__table__.select().where(TaskRecord.id == task_id)
+            # Map unified status to canonical Leantime status logic or similar
+            # Assuming task_id is a Leantime ID here.
+            await self.mcp_manager.call_tool(
+                "leantime-bridge",
+                "update_ticket",
+                {"ticket_id": task_id, "status": new_status.value, "assigned_to": assigned_to}
+            )
+
+            # We need the project ID to get next actionable tasks.
+            # We can fetch the ticket details from leantime-bridge to get it.
+            try:
+                ticket = await self.mcp_manager.call_tool(
+                    "leantime-bridge",
+                    "get_ticket",
+                    {"ticket_id": task_id}
                 )
-                task_record = result.fetchone()
+                project_id = str(ticket.get("projectId", "1"))
+            except Exception as get_err:
+                logger.warning(f"⚠️ Failed to get ticket details for {task_id}, defaulting project to 1: {get_err}")
+                project_id = "1"
 
-                if not task_record:
-                    raise ValueError(f"Task {task_id} not found")
+            # Get next suggested actions for ADHD accommodation
+            # using canonical backend
+            next_actions = await self.get_next_actionable_tasks(project_id, 3)
 
-                old_status = task_record.status
+            response = {
+                "success": True,
+                "task_id": task_id,
+                "new_status": new_status.value,
+                "instance": settings.instance_name,
+                "timestamp": datetime.utcnow().isoformat(),
+                "suggested_next_actions": [
+                    {"id": t.id, "title": t.title, "priority": t.priority.value}
+                    for t in next_actions
+                ]
+            }
 
-                update_data = {
-                    "status": new_status.value,
-                    "updated_at": datetime.utcnow()
-                }
-                if assigned_to:
-                    update_data["assigned_to"] = assigned_to
+            if new_status == TaskStatus.COMPLETED:
+                logger.info(f"✅ Task {task_id} completed!")
 
-                await session.execute(
-                    TaskRecord.__table__.update()
-                    .where(TaskRecord.id == task_id)
-                    .values(**update_data)
-                )
-                await session.commit()
-
-                # Invalidate cache
-                cache_client = await self.cache_manager.get_client()
-                await cache_client.delete(f"project:{task_record.project_id}:actionable_tasks")
-
-                # Get next suggested actions for ADHD accommodation
-                next_actions = await self.get_next_actionable_tasks(task_record.project_id, 3)
-
-                response = {
-                    "success": True,
-                    "task_id": task_id,
-                    "old_status": old_status,
-                    "new_status": new_status.value,
-                    "instance": settings.instance_name,
-                    "timestamp": datetime.utcnow().isoformat(),
-                    "suggested_next_actions": [
-                        {"id": t.id, "title": t.title, "priority": t.priority.value}
-                        for t in next_actions
-                    ]
-                }
-
-                if new_status == TaskStatus.COMPLETED:
-                    logger.info(f"✅ Task {task_id} completed!")
-
-                return response
+            return response
 
         except Exception as e:
             logger.error(f"❌ Task status update failed: {e}")

--- a/services/dopecon-bridge/dopecon_bridge/services/task_integration.py
+++ b/services/dopecon-bridge/dopecon_bridge/services/task_integration.py
@@ -13,8 +13,6 @@ from dataclasses import asdict
 from datetime import datetime
 from typing import Any, Dict, List
 
-from sqlalchemy import bindparam
-
 from ..clients import mcp_client
 from ..config import settings
 from ..models import Task, TaskPriority, TaskStatus

--- a/services/dopecon-bridge/tests/test_route_endpoints_authority.py
+++ b/services/dopecon-bridge/tests/test_route_endpoints_authority.py
@@ -1,0 +1,27 @@
+import pytest
+from fastapi.testclient import TestClient
+import sys
+
+from dopecon_bridge.app import app
+
+client = TestClient(app)
+
+def test_parse_prd_requires_cognitive_plane():
+    response = client.post("/tasks/parse-prd", json={"content": "test prd", "project_id": "1"})
+    assert response.status_code == 403
+    assert "cognitive_plane authority" in response.json()["detail"]
+
+def test_get_next_tasks_enforces_plane():
+    response = client.get("/tasks/next/project-123", headers={"X-Source-Plane": "invalid_plane"})
+    assert response.status_code == 403
+    assert "Invalid source plane" in response.json()["detail"]
+
+def test_ddg_decisions_enforces_plane():
+    response = client.get("/ddg/decisions", headers={"X-Source-Plane": "invalid_plane"})
+    assert response.status_code == 403
+    assert "Invalid source plane" in response.json()["detail"]
+
+def test_ddg_search_enforces_plane():
+    response = client.get("/ddg/search", params={"q": "test"}, headers={"X-Source-Plane": "invalid_plane"})
+    assert response.status_code == 403
+    assert "Invalid source plane" in response.json()["detail"]

--- a/services/dopecon-bridge/tests/test_route_endpoints_coverage.py
+++ b/services/dopecon-bridge/tests/test_route_endpoints_coverage.py
@@ -1,0 +1,245 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+from dopecon_bridge.app import app
+from dopecon_bridge.models import Task, TaskStatus, TaskPriority
+
+client = TestClient(app)
+
+# Helper to get valid token
+def get_token():
+    return "dummy-token"
+
+# Test Task Routes Proxying
+@patch('dopecon_bridge.services.task_integration.task_service')
+def test_parse_prd_success(mock_task_service):
+    mock_task_service.parse_prd_to_tasks = AsyncMock(return_value=[
+        Task(id="1", title="Test", description="Test", status=TaskStatus.PLANNED, priority=TaskPriority.MEDIUM)
+    ])
+    response = client.post(
+        "/tasks/parse-prd",
+        json={"content": "dummy", "project_id": "1"},
+        headers={"X-Source-Plane": "cognitive_plane"}
+    )
+    assert response.status_code == 200
+    assert response.json()["success"] == True
+
+@patch('dopecon_bridge.services.task_integration.task_service')
+def test_get_next_tasks_success(mock_task_service):
+    mock_task_service.get_next_actionable_tasks = AsyncMock(return_value=[
+        Task(id="1", title="Test", description="Test", status=TaskStatus.PLANNED, priority=TaskPriority.MEDIUM)
+    ])
+    response = client.get(
+        "/tasks/next/1",
+        headers={"X-Source-Plane": "pm_plane"}
+    )
+    assert response.status_code == 200
+
+@patch('dopecon_bridge.services.task_integration.task_service')
+def test_update_task_status_success(mock_task_service):
+    # Mock authentication by patching DEPENDS or mocking get_current_user
+    app.dependency_overrides = {}  # Clear overrides just in case
+    # Mocking task service response
+    mock_task_service.update_task_status = AsyncMock(return_value={"success": True})
+
+    # Needs auth mocking, we'll patch Depends via app dependency overrides
+    from dopecon_bridge.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: {"username": "admin"}
+
+    response = client.patch(
+        "/tasks/task-123/status",
+        json={"status": "in_progress"},
+        headers={"X-Source-Plane": "cognitive_plane"}
+    )
+    assert response.status_code == 200
+
+# Test DDG Routes Proxying
+@patch('dopecon_bridge.routes.mcp_client', new_callable=AsyncMock)
+def test_ddg_recent_decisions_success(mock_mcp_client):
+    mock_mcp_client.call_tool = AsyncMock(return_value={"decisions": []})
+
+    # Note: `routes.py` dynamically imports `mcp_client` inside the function,
+    # so we mock `dopecon_bridge.clients.mcp_client` instead
+    pass
+
+@patch('dopecon_bridge.clients.mcp_client.call_tool')
+def test_ddg_recent_decisions_success_proper(mock_call_tool):
+    mock_call_tool.return_value = {"decisions": [{"id": "1", "summary": "test decision"}]}
+    response = client.get(
+        "/ddg/decisions",
+        headers={"X-Source-Plane": "pm_plane"}
+    )
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+@patch('dopecon_bridge.clients.mcp_client.call_tool')
+def test_ddg_search_decisions_success_proper(mock_call_tool):
+    mock_call_tool.return_value = {"decisions": [{"id": "2", "summary": "arch decision"}]}
+    response = client.get(
+        "/ddg/search",
+        params={"q": "arch"},
+        headers={"X-Source-Plane": "cognitive_plane"}
+    )
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+from dopecon_bridge.services.task_integration import TaskIntegrationService
+
+@pytest.mark.asyncio
+async def test_parse_prd_to_tasks():
+    service = TaskIntegrationService()
+    mock_mcp = AsyncMock()
+    mock_mcp.call_tool.return_value = {"tasks": [{"title": "t1", "description": "d1", "priority": "high", "tags": []}]}
+    service.mcp_manager = mock_mcp
+
+    # Test PRD parse
+    # Leantime expects project ID to be an integer (e.g. "1")
+    tasks = await service.parse_prd_to_tasks("prd content", "1")
+    assert len(tasks) == 1
+    assert tasks[0].title == "t1"
+    assert tasks[0].project_id == "1"
+
+    # Verify sync was called
+    # _sync_tasks_to_leantime calls mcp_manager.call_tool with create_ticket
+    call_args = mock_mcp.call_tool.call_args_list
+    assert len(call_args) == 2  # parse_prd + create_ticket
+    assert call_args[1][0][0] == "leantime-bridge"
+    assert call_args[1][0][1] == "create_ticket"
+
+@pytest.mark.asyncio
+async def test_get_next_actionable_tasks():
+    service = TaskIntegrationService()
+    mock_mcp = AsyncMock()
+    mock_mcp.call_tool.return_value = {
+        "tickets": [{"id": 123, "headline": "h1", "description": "d1"}]
+    }
+    service.mcp_manager = mock_mcp
+
+    tasks = await service.get_next_actionable_tasks("proj-1", 5)
+    assert len(tasks) == 1
+    assert tasks[0].id == "123"
+    assert tasks[0].title == "h1"
+
+@pytest.mark.asyncio
+async def test_update_task_status():
+    service = TaskIntegrationService()
+    mock_mcp = AsyncMock()
+
+    # Mocking different calls for update_ticket and get_ticket and search_tickets
+    async def mock_call_tool(server, method, params):
+        if method == "update_ticket":
+            return {}
+        elif method == "get_ticket":
+            return {"projectId": "proj-1"}
+        elif method == "search_tickets":
+            return {"tickets": [{"id": 456, "headline": "h2"}]}
+        return {}
+
+    mock_mcp.call_tool.side_effect = mock_call_tool
+    service.mcp_manager = mock_mcp
+
+    resp = await service.update_task_status("123", TaskStatus.IN_PROGRESS, "user1")
+    assert resp["success"] == True
+    assert resp["task_id"] == "123"
+    assert resp["new_status"] == "in_progress"
+    assert len(resp["suggested_next_actions"]) == 1
+    assert resp["suggested_next_actions"][0]["id"] == "456"
+
+
+from dopecon_bridge.routes import *
+
+# Error handling in routes
+@patch('dopecon_bridge.services.task_integration.task_service')
+def test_parse_prd_error(mock_task_service):
+    mock_task_service.parse_prd_to_tasks = AsyncMock(side_effect=Exception("parse error"))
+    response = client.post("/tasks/parse-prd", json={"content": "dummy", "project_id": "1"}, headers={"X-Source-Plane": "cognitive_plane"})
+    assert response.status_code == 500
+
+@patch('dopecon_bridge.services.task_integration.task_service')
+def test_get_next_tasks_error(mock_task_service):
+    mock_task_service.get_next_actionable_tasks = AsyncMock(side_effect=Exception("next error"))
+    response = client.get("/tasks/next/1", headers={"X-Source-Plane": "pm_plane"})
+    assert response.status_code == 500
+
+@patch('dopecon_bridge.services.task_integration.task_service')
+def test_update_task_status_value_error(mock_task_service):
+    mock_task_service.update_task_status = AsyncMock(side_effect=ValueError("bad value"))
+    from dopecon_bridge.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: {"username": "admin"}
+    response = client.patch("/tasks/task-123/status", json={"status": "in_progress"}, headers={"X-Source-Plane": "cognitive_plane"})
+    assert response.status_code == 400
+
+@patch('dopecon_bridge.services.task_integration.task_service')
+def test_update_task_status_exception(mock_task_service):
+    mock_task_service.update_task_status = AsyncMock(side_effect=Exception("generic error"))
+    from dopecon_bridge.auth import get_current_user
+    app.dependency_overrides[get_current_user] = lambda: {"username": "admin"}
+    response = client.patch("/tasks/task-123/status", json={"status": "in_progress"}, headers={"X-Source-Plane": "cognitive_plane"})
+    assert response.status_code == 500
+
+@patch('dopecon_bridge.clients.mcp_client.call_tool')
+def test_ddg_decisions_error(mock_call_tool):
+    mock_call_tool.side_effect = Exception("ddg err")
+    response = client.get("/ddg/decisions", headers={"X-Source-Plane": "pm_plane"})
+    assert response.status_code == 500
+
+@patch('dopecon_bridge.clients.mcp_client.call_tool')
+def test_ddg_search_error(mock_call_tool):
+    mock_call_tool.side_effect = Exception("search err")
+    response = client.get("/ddg/search", params={"q": "arch"}, headers={"X-Source-Plane": "cognitive_plane"})
+    assert response.status_code == 500
+
+
+# Add test for convenience endpoints in routes
+@patch('dopecon_bridge.routes.publish_event')
+def test_publish_tasks_imported(mock_publish):
+    mock_publish.return_value = {"success": True}
+    response = client.post("/events/tasks-imported?task_count=10&sprint_id=1")
+    assert response.status_code == 200
+
+@patch('dopecon_bridge.routes.publish_event')
+def test_publish_session_started(mock_publish):
+    mock_publish.return_value = {"success": True}
+    response = client.post("/events/session-started?task_id=123")
+    assert response.status_code == 200
+
+@patch('dopecon_bridge.routes.publish_event')
+def test_publish_progress_updated(mock_publish):
+    mock_publish.return_value = {"success": True}
+    response = client.post("/events/progress-updated?task_id=123&status=DONE&progress=1.0")
+    assert response.status_code == 200
+
+
+# Add test for get_event_history
+@patch('dopecon_bridge.routes.cache_manager.get_client', new_callable=AsyncMock)
+def test_get_event_history(mock_get_client):
+    mock_redis = AsyncMock()
+    mock_redis.xrevrange.return_value = [("msg-1", {"type": "t1", "data": '{"k":"v"}'})]
+    mock_get_client.return_value = mock_redis
+
+    response = client.get("/events/history")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+
+@patch('dopecon_bridge.routes.cache_manager.get_client', new_callable=AsyncMock)
+def test_get_event_history_error(mock_get_client):
+    mock_get_client.side_effect = Exception("redis err")
+    response = client.get("/events/history")
+    assert response.status_code == 500
+
+
+# Test publish_event directly
+@patch('dopecon_bridge.event_bus.EventBus.publish', new_callable=AsyncMock)
+@patch('dopecon_bridge.event_bus.EventBus.initialize', new_callable=AsyncMock)
+def test_publish_event_endpoint(mock_init, mock_publish):
+    mock_publish.return_value = "msg-2"
+    response = client.post("/events", json={"event_type": "foo", "data": {}})
+    assert response.status_code == 200
+    assert response.json()["message_id"] == "msg-2"
+
+@patch('dopecon_bridge.event_bus.EventBus.initialize', new_callable=AsyncMock)
+def test_publish_event_endpoint_error(mock_init):
+    mock_init.side_effect = Exception("init err")
+    response = client.post("/events", json={"event_type": "foo", "data": {}})
+    assert response.status_code == 500

--- a/services/dopecon-bridge/tests/test_task_integration_unit.py
+++ b/services/dopecon-bridge/tests/test_task_integration_unit.py
@@ -52,9 +52,9 @@ async def test_sync_tasks_to_leantime_parallel_execution():
     assert tasks[1].tags == ["leantime_id:leantime_Task 1"]
     assert tasks[2].tags == ["leantime_id:leantime_Task 2"]
 
-    # Verify DB update was called
-    assert mock_session.execute.called
-    assert mock_session.commit.called
+    # DB update was removed
+    assert not mock_session.execute.called
+    assert not mock_session.commit.called
 
 @pytest.mark.asyncio
 async def test_sync_tasks_to_leantime_handles_partial_failure():
@@ -91,14 +91,8 @@ async def test_sync_tasks_to_leantime_handles_partial_failure():
     assert tasks[1].tags == []
     assert tasks[2].tags == ["leantime_id:leantime_Task 2"]
 
-    # DB update should still be called for successful ones
-    assert mock_session.execute.called
-    # Check that only 2 update params were sent
-    args, kwargs = mock_session.execute.call_args
-    update_params = args[1]
-    assert len(update_params) == 2
-    assert update_params[0]["b_id"] == "0"
-    assert update_params[1]["b_id"] == "2"
+    # DB update was removed
+    assert not mock_session.execute.called
 
 @pytest.mark.asyncio
 async def test_sync_tasks_to_leantime_empty_list():


### PR DESCRIPTION
Removes bridge-local task, next-action, and DDG authority behavior from `dopecon-bridge` and routes operations directly to canonical backends, adding mandatory authority policy wrapping for side-effectful writes.

---
*PR created automatically by Jules for task [7089940311464071007](https://jules.google.com/task/7089940311464071007) started by @hu3mann*