### PR TITLE
feat: implement dope-memory as the PM-plane chronicle backend

### DIFF
--- a/src/dopemux/pm/adapters/dope_memory.py
+++ b/src/dopemux/pm/adapters/dope_memory.py
@@ -1,0 +1,116 @@
+"""Dope-Memory backend adapter for PM-plane chronicle integration."""
+
+import logging
+import os
+from typing import Any, Dict, List, Optional
+import httpx
+
+logger = logging.getLogger(__name__)
+
+class DopeMemoryAdapter:
+    """Adapter for communicating with the dope-memory HTTP API."""
+
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = (base_url or os.getenv("DOPE_MEMORY_URL", "http://localhost:3020")).rstrip("/")
+
+    async def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
+        """Helper to make an HTTP request."""
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.request(method, f"{self.base_url}{path}", **kwargs)
+            return response
+
+    async def search_chronicle(
+        self,
+        workspace_id: str,
+        session_id: Optional[str] = None,
+        category: Optional[str] = None,
+        entry_type: Optional[str] = None,
+        workflow_phase: Optional[str] = None,
+        tags_any: Optional[List[str]] = None,
+        time_range: str = "week",
+        top_k: int = 3,
+        cursor: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Call the memory_search endpoint."""
+        payload = {
+            "workspace_id": workspace_id,
+            "session_id": session_id,
+            "category": category,
+            "entry_type": entry_type,
+            "workflow_phase": workflow_phase,
+            "tags_any": tags_any,
+            "time_range": time_range,
+            "top_k": top_k,
+            "cursor": cursor,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        try:
+            response = await self._request("POST", "/tools/memory_search", json=payload)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            logger.error(f"Failed to search dope-memory chronicle: {e}")
+            raise
+
+    async def append_chronicle(
+        self,
+        workspace_id: str,
+        entry_type: str,
+        summary: str,
+        category: str,
+        details: Optional[Dict[str, Any]] = None,
+        tags: Optional[List[str]] = None,
+        links: Optional[Dict[str, Any]] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Call the memory_store endpoint to append a record."""
+        payload = {
+            "workspace_id": workspace_id,
+            "entry_type": entry_type,
+            "category": category,
+            "summary": summary,
+            "details": details,
+            "tags": tags,
+            "links": links,
+            "idempotency_key": idempotency_key,
+        }
+
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        try:
+            response = await self._request("POST", "/tools/memory_store", json=payload)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            logger.error(f"Failed to append to dope-memory chronicle: {e}")
+            raise
+
+    async def correct_chronicle(
+        self,
+        workspace_id: str,
+        entry_id: str,
+        correction_type: str,
+        corrected_summary: Optional[str] = None,
+        corrected_tags: Optional[List[str]] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Call the memory_correct endpoint to correct/supersede a record."""
+        payload = {
+            "workspace_id": workspace_id,
+            "entry_id": entry_id,
+            "correction_type": correction_type,
+            "corrected_summary": corrected_summary,
+            "corrected_tags": corrected_tags,
+            "idempotency_key": idempotency_key,
+        }
+        payload = {k: v for k, v in payload.items() if v is not None}
+
+        try:
+            response = await self._request("POST", "/tools/memory_correct", json=payload)
+            response.raise_for_status()
+            return response.json()
+        except Exception as e:
+            # Re-raise so callers can catch HTTPError to do a fallback
+            logger.error(f"Failed to correct dope-memory chronicle: {e}")
+            raise

--- a/src/dopemux/pm/chronicle.py
+++ b/src/dopemux/pm/chronicle.py
@@ -1,0 +1,242 @@
+"""Normalized PM-plane chronicle read/write contracts."""
+
+import logging
+from typing import Any, Dict, List, Optional
+from dopemux.pm.chronicle_models import (
+    PMChronicleReadResult,
+    PMChronicleProvenance,
+    PMChronicleSupportingSource,
+    PMChronicleWriteReceipt,
+)
+from dopemux.pm.adapters.dope_memory import DopeMemoryAdapter
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Single instance of the adapter to use
+_adapter = DopeMemoryAdapter()
+
+async def pm_get_work_chronicle(
+    *,
+    workspace_id: str,
+    canonical_id: Optional[str] = None,
+    linked_ids: Optional[Dict[str, str]] = None,
+    session_id: Optional[str] = None,
+    category: Optional[str] = None,
+    entry_type: Optional[str] = None,
+    tags_any: Optional[List[str]] = None,
+    time_range: str = "week",
+    top_k: int = 3,
+    next_token: Optional[str] = None,
+) -> PMChronicleReadResult:
+    """Read normalized PM-plane chronicle from dope-memory authority.
+
+    Returns fail-closed empty result if backend is down.
+    """
+    try:
+        raw_result = await _adapter.search_chronicle(
+            workspace_id=workspace_id,
+            session_id=session_id,
+            category=category,
+            entry_type=entry_type,
+            tags_any=tags_any,
+            time_range=time_range,
+            top_k=top_k,
+            cursor=next_token,
+        )
+    except httpx.HTTPError:
+        logger.warning("dope-memory backend unavailable. Returning fail-closed empty result.")
+        raw_result = {"items": [], "more_count": 0, "next_token": None}
+    except Exception as e:
+        logger.error(f"Unexpected error calling dope-memory: {e}")
+        raw_result = {"items": [], "more_count": 0, "next_token": None}
+
+    items = raw_result.get("items", [])
+    entry_ids = [str(item.get("id")) for item in items if "id" in item]
+
+    provenance = PMChronicleProvenance(
+        source="dope-memory",
+        query_mode="work_chronicle",
+        workspace_id=workspace_id,
+        time_range=time_range,
+    )
+
+    supporting_source = PMChronicleSupportingSource(
+        kind="canonical",
+        backend="dope-memory",
+        entry_ids=entry_ids,
+    )
+
+    return PMChronicleReadResult(
+        canonical_backend="dope-memory",
+        canonical_id=canonical_id,
+        linked_ids=linked_ids or {},
+        provenance=provenance,
+        supporting_sources=[supporting_source],
+        items=items,
+        more_count=raw_result.get("more_count", 0),
+        next_token=raw_result.get("next_token"),
+    )
+
+
+async def pm_append_work_chronicle(
+    *,
+    workspace_id: str,
+    canonical_id: str,
+    linked_ids: Dict[str, str],
+    entry_type: str,
+    summary: str,
+    details: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[str]] = None,
+    actor: Optional[str] = None,
+    source_system: str = "pm-plane",
+    idempotency_key: str,
+    category: str = "work_chronicle",
+) -> PMChronicleWriteReceipt:
+    """Append a normalized PM-plane chronicle entry to dope-memory authority.
+
+    Includes canonical_id and linked_ids in the metadata/details payload.
+    """
+    # Merge PM linkage into details or links
+    augmented_details = details.copy() if details else {}
+    augmented_details.update({
+        "canonical_id": canonical_id,
+        "actor": actor,
+        "source_system": source_system,
+    })
+
+    # Put linked_ids into links
+    links = linked_ids.copy()
+    if canonical_id:
+        links["pm_canonical"] = canonical_id
+
+    try:
+        result = await _adapter.append_chronicle(
+            workspace_id=workspace_id,
+            entry_type=entry_type,
+            summary=summary,
+            category=category,
+            details=augmented_details,
+            tags=tags,
+            links=links,
+            idempotency_key=idempotency_key,
+        )
+
+        success = result.get("success", False) or "entry_id" in result
+        entry_id = result.get("entry_id", "unknown")
+
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id=entry_id,
+            linked_ids=linked_ids,
+            success=success,
+            error=result.get("error"),
+        )
+    except httpx.HTTPError as e:
+        logger.warning(f"dope-memory backend unavailable during append: {e}")
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id="unknown",
+            linked_ids=linked_ids,
+            success=False,
+            error="Backend unavailable",
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error calling dope-memory append: {e}")
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id="unknown",
+            linked_ids=linked_ids,
+            success=False,
+            error=str(e),
+        )
+
+
+async def pm_correct_work_chronicle(
+    *,
+    workspace_id: str,
+    canonical_id: str,
+    chronicle_entry_id: str,
+    correction_reason: str,
+    corrected_summary: Optional[str] = None,
+    corrected_details: Optional[Dict[str, Any]] = None,
+    actor: Optional[str] = None,
+    source_system: str = "pm-plane",
+    idempotency_key: str,
+) -> PMChronicleWriteReceipt:
+    """Correct/supersede a normalized PM-plane chronicle entry in dope-memory authority.
+
+    Uses memory_correct (correction_type="summary") if available, otherwise appends.
+    """
+    correction_type = "summary" if corrected_summary else "retraction"
+
+    try:
+        result = await _adapter.correct_chronicle(
+            workspace_id=workspace_id,
+            entry_id=chronicle_entry_id,
+            correction_type=correction_type,
+            corrected_summary=corrected_summary or correction_reason,
+            corrected_tags=None,
+            idempotency_key=idempotency_key,
+        )
+
+        success = result.get("success", False)
+        entry_id = result.get("entry_id", "unknown")
+
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id=entry_id,
+            linked_ids={},
+            success=success,
+            error=result.get("error"),
+        )
+    except httpx.HTTPStatusError as e:
+        # If the endpoint doesn't exist or returns 404, we fall back to append.
+        if e.response.status_code == 404:
+            logger.info("memory_correct endpoint returned 404, falling back to append-only correction.")
+            # Fall back to append
+            return await pm_append_work_chronicle(
+                workspace_id=workspace_id,
+                canonical_id=canonical_id,
+                linked_ids={},
+                entry_type="correction",
+                summary=f"Correction for {chronicle_entry_id}: {corrected_summary or correction_reason}",
+                details={"superseded_entry_id": chronicle_entry_id, "reason": correction_reason},
+                actor=actor,
+                source_system=source_system,
+                idempotency_key=idempotency_key,
+            )
+        else:
+            logger.warning(f"dope-memory backend HTTP error during correct: {e}")
+            return PMChronicleWriteReceipt(
+                canonical_backend="dope-memory",
+                canonical_id=canonical_id,
+                entry_id="unknown",
+                linked_ids={},
+                success=False,
+                error="Backend unavailable",
+            )
+    except httpx.HTTPError as e:
+        logger.warning(f"dope-memory backend unavailable during correct: {e}")
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id="unknown",
+            linked_ids={},
+            success=False,
+            error="Backend unavailable",
+        )
+    except Exception as e:
+        logger.error(f"Unexpected error calling dope-memory correct: {e}")
+        return PMChronicleWriteReceipt(
+            canonical_backend="dope-memory",
+            canonical_id=canonical_id,
+            entry_id="unknown",
+            linked_ids={},
+            success=False,
+            error=str(e),
+        )

--- a/src/dopemux/pm/chronicle_models.py
+++ b/src/dopemux/pm/chronicle_models.py
@@ -1,0 +1,33 @@
+"""Normalized PM-plane models for chronicle reads and writes."""
+
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+class PMChronicleProvenance(BaseModel):
+    source: str = "dope-memory"
+    query_mode: str
+    workspace_id: str
+    time_range: Optional[str] = None
+
+class PMChronicleSupportingSource(BaseModel):
+    kind: str = "canonical"
+    backend: str = "dope-memory"
+    entry_ids: List[str] = Field(default_factory=list)
+
+class PMChronicleReadResult(BaseModel):
+    canonical_backend: str = "dope-memory"
+    canonical_id: Optional[str] = None
+    linked_ids: Dict[str, str] = Field(default_factory=dict)
+    provenance: PMChronicleProvenance
+    supporting_sources: List[PMChronicleSupportingSource] = Field(default_factory=list)
+    items: List[Dict[str, Any]] = Field(default_factory=list)
+    more_count: int = 0
+    next_token: Optional[str] = None
+
+class PMChronicleWriteReceipt(BaseModel):
+    canonical_backend: str = "dope-memory"
+    canonical_id: str
+    entry_id: str
+    linked_ids: Dict[str, str] = Field(default_factory=dict)
+    success: bool
+    error: Optional[str] = None

--- a/tests/unit/pm/test_chronicle.py
+++ b/tests/unit/pm/test_chronicle.py
@@ -1,0 +1,187 @@
+"""Tests for normalized PM-plane chronicle contract."""
+
+import pytest
+import httpx
+from unittest.mock import AsyncMock, MagicMock
+
+from dopemux.pm.chronicle import (
+    pm_get_work_chronicle,
+    pm_append_work_chronicle,
+    pm_correct_work_chronicle,
+    _adapter
+)
+from dopemux.pm.chronicle_models import PMChronicleReadResult, PMChronicleWriteReceipt
+
+@pytest.fixture
+def mock_adapter(monkeypatch):
+    adapter_mock = AsyncMock()
+    monkeypatch.setattr("dopemux.pm.chronicle._adapter", adapter_mock)
+    return adapter_mock
+
+@pytest.mark.asyncio
+async def test_pm_get_work_chronicle_success(mock_adapter):
+    """Test successful chronicle read resolves to dope-memory and preserves shape."""
+    mock_adapter.search_chronicle.return_value = {
+        "items": [
+            {"id": "entry-1", "summary": "test1"},
+            {"id": "entry-2", "summary": "test2"}
+        ],
+        "more_count": 5,
+        "next_token": "token123"
+    }
+
+    result = await pm_get_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        linked_ids={"leantime": "lt-1"}
+    )
+
+    assert isinstance(result, PMChronicleReadResult)
+    assert result.canonical_backend == "dope-memory"
+    assert result.canonical_id == "task-1"
+    assert result.linked_ids == {"leantime": "lt-1"}
+    assert result.more_count == 5
+    assert result.next_token == "token123"
+    assert len(result.items) == 2
+
+    # Provenance
+    assert result.provenance.source == "dope-memory"
+    assert result.provenance.query_mode == "work_chronicle"
+    assert result.provenance.workspace_id == "ws-1"
+
+    # Supporting sources
+    assert len(result.supporting_sources) == 1
+    assert result.supporting_sources[0].backend == "dope-memory"
+    assert result.supporting_sources[0].entry_ids == ["entry-1", "entry-2"]
+
+    mock_adapter.search_chronicle.assert_called_once_with(
+        workspace_id="ws-1",
+        session_id=None,
+        category=None,
+        entry_type=None,
+        tags_any=None,
+        time_range="week",
+        top_k=3,
+        cursor=None
+    )
+
+@pytest.mark.asyncio
+async def test_pm_get_work_chronicle_fail_closed(mock_adapter):
+    """Test read fails closed when backend is unavailable."""
+    mock_adapter.search_chronicle.side_effect = httpx.HTTPError("Backend down")
+
+    result = await pm_get_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1"
+    )
+
+    assert isinstance(result, PMChronicleReadResult)
+    assert len(result.items) == 0
+    assert result.more_count == 0
+    assert result.canonical_backend == "dope-memory"
+    assert result.supporting_sources[0].entry_ids == []
+
+@pytest.mark.asyncio
+async def test_pm_append_work_chronicle_success(mock_adapter):
+    """Test successful append."""
+    mock_adapter.append_chronicle.return_value = {
+        "success": True,
+        "entry_id": "new-entry-1"
+    }
+
+    result = await pm_append_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        linked_ids={"leantime": "lt-1"},
+        entry_type="task.completed",
+        summary="Task was done",
+        idempotency_key="idemp-1"
+    )
+
+    assert isinstance(result, PMChronicleWriteReceipt)
+    assert result.success is True
+    assert result.canonical_backend == "dope-memory"
+    assert result.entry_id == "new-entry-1"
+
+    mock_adapter.append_chronicle.assert_called_once()
+    kwargs = mock_adapter.append_chronicle.call_args.kwargs
+    assert kwargs["workspace_id"] == "ws-1"
+    assert kwargs["entry_type"] == "task.completed"
+    assert kwargs["summary"] == "Task was done"
+    assert kwargs["idempotency_key"] == "idemp-1"
+    assert kwargs["links"]["pm_canonical"] == "task-1"
+    assert kwargs["links"]["leantime"] == "lt-1"
+
+@pytest.mark.asyncio
+async def test_pm_append_work_chronicle_fail_closed(mock_adapter):
+    """Test append fails gracefully."""
+    mock_adapter.append_chronicle.side_effect = httpx.HTTPError("Backend down")
+
+    result = await pm_append_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        linked_ids={},
+        entry_type="task.completed",
+        summary="Task was done",
+        idempotency_key="idemp-1"
+    )
+
+    assert result.success is False
+    assert result.entry_id == "unknown"
+
+@pytest.mark.asyncio
+async def test_pm_correct_work_chronicle_success(mock_adapter):
+    """Test successful correct."""
+    mock_adapter.correct_chronicle.return_value = {
+        "success": True,
+        "entry_id": "new-corrected-entry"
+    }
+
+    result = await pm_correct_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        chronicle_entry_id="old-entry",
+        correction_reason="Typo",
+        corrected_summary="Fixed typo",
+        idempotency_key="idemp-2"
+    )
+
+    assert isinstance(result, PMChronicleWriteReceipt)
+    assert result.success is True
+    assert result.entry_id == "new-corrected-entry"
+
+    mock_adapter.correct_chronicle.assert_called_once_with(
+        workspace_id="ws-1",
+        entry_id="old-entry",
+        correction_type="summary",
+        corrected_summary="Fixed typo",
+        corrected_tags=None,
+        idempotency_key="idemp-2"
+    )
+
+@pytest.mark.asyncio
+async def test_pm_correct_work_chronicle_fallback(mock_adapter, monkeypatch):
+    """Test fallback to append when correct returns 404."""
+    # We need to simulate HTTPStatusError with status 404
+    mock_response = MagicMock(status_code=404)
+    mock_adapter.correct_chronicle.side_effect = httpx.HTTPStatusError("Not found", request=MagicMock(), response=mock_response)
+    mock_adapter.append_chronicle.return_value = {
+        "success": True,
+        "entry_id": "fallback-entry"
+    }
+
+    result = await pm_correct_work_chronicle(
+        workspace_id="ws-1",
+        canonical_id="task-1",
+        chronicle_entry_id="old-entry",
+        correction_reason="Typo",
+        corrected_summary="Fixed typo",
+        idempotency_key="idemp-3"
+    )
+
+    assert result.success is True
+    assert result.entry_id == "fallback-entry"
+    mock_adapter.append_chronicle.assert_called_once()
+    kwargs = mock_adapter.append_chronicle.call_args.kwargs
+    assert kwargs["entry_type"] == "correction"
+    assert kwargs["details"]["superseded_entry_id"] == "old-entry"


### PR DESCRIPTION
This change implements PM-INT-16, adding dope-memory as the PM-plane chronicle backend. It establishes a normalized set of PM-plane interfaces (`pm_get_work_chronicle`, `pm_append_work_chronicle`, and `pm_correct_work_chronicle`) and maps them down to the raw dope-memory tools using a new `DopeMemoryAdapter`.

It ensures proper handling of canonical IDs and linked IDs, properly routes and sets provenance mapping back to dope-memory, and provides fail-closed defaults when the backend is unavailable or un-reachable. We deliberately segregate chronicle writes to this new module, keeping them distinct from `pm_log_progress` which is owned by ConPort, matching the PM-plane authority boundaries.

---
*PR created automatically by Jules for task [10115339073497197586](https://jules.google.com/task/10115339073497197586) started by @hu3mann*