### PR TITLE
docs: freeze PM-plane contract docs (PM-INT-01)

### DIFF
--- a/docs/03-reference/services/server-registry.md
+++ b/docs/03-reference/services/server-registry.md
@@ -148,7 +148,7 @@ docker-compose logs -f mas-sequential-thinking        # Tail logs
 **Integration Boundaries:**
 - **Hands off to**: Task-Orchestrator for dependency analysis and execution planning
 - **Coordinates with**: ConPort for decision logging, DopeconBridge for workflow orchestration
-- **Does NOT**: Manage task status (Leantime authority), handle code context (Serena authority)
+- **Does NOT**: Act as PM entity authority (Leantime authority), handle code context (Serena authority)
 
 ### Task Orchestrator - Dependency Analysis & Task Orchestration
 - **Container**: `mcp-task-orchestrator`
@@ -177,7 +177,7 @@ docker-compose logs -f mas-sequential-thinking        # Tail logs
 - **Hands off to**: Leantime Bridge for status management and team coordination
 - **Provides to**: Serena LSP for file and symbol context during development
 - **Coordinates with**: DopeconBridge for execution workflow, ConPort for dependency decisions
-- **Does NOT**: Create or modify tasks (Task-Master authority), manage status (Leantime authority)
+- **Does NOT**: Create or modify tasks (Task-Master authority), act as PM entity authority (Leantime authority)
 
 ### Serena - ADHD-Optimized Code Navigation & Project Memory
 - **Container**: `mcp-serena`
@@ -352,7 +352,7 @@ optimization: "min_query_length: 10, max_results: 3"
 project_management_plane:
   - task_master_ai: "PRD breakdown and analysis"
   - task_orchestrator: "Dependency analysis with 37 tools"
-  - leantime_bridge: "Status authority and team dashboards"
+  - leantime_bridge: "PM entity authority and team dashboards"
 
 cognitive_plane:
   - serena: "LSP server with ADHD code navigation"
@@ -361,12 +361,12 @@ cognitive_plane:
 coordination: "DopeconBridge manages data flow between planes"
 ```
 
-### Leantime Bridge - Status Authority
+### Leantime Bridge - PM Entity Authority
 - **Container**: `dopemux-mcp-leantime-bridge`
 - **Port**: `3015`
 - **Role**: `workflow`
 - **Package**: Custom Python MCP bridge
-- **Description**: Master authority for task status and team coordination
+- **Description**: Canonical PM operational system of record
 - **Health Check**: `http://localhost:3015/health`
 
 ### Plane Coordinator - Two-Plane API

--- a/docs/90-adr/adr-197-task-epic-workflow-system-2.md
+++ b/docs/90-adr/adr-197-task-epic-workflow-system-2.md
@@ -57,14 +57,14 @@ Dopemux currently lacks a comprehensive workflow system for tracking ideas from 
 
 **Architecture Context**:
 - Two-Plane Architecture (PM Plane + Cognitive Plane)
-- Leantime = PM Plane presentation layer (status authority)
-- ConPort = Cognitive Plane knowledge graph (knowledge authority)
+- Leantime = PM Plane entity authority
+- ConPort = Cognitive Plane knowledge graph (decision and context authority)
 - DopeconBridge = Cross-plane coordination (PORT_BASE+16)
 
 **Critical Correction** (Decision #195):
 - Initial design incorrectly assumed Leantime deprecated
 - Leantime is ACTIVE component, required for two-plane architecture
-- Must integrate as status authority, not optional one-way sync
+- Must integrate as PM entity authority, not optional one-way sync
 
 ## Decision
 
@@ -126,8 +126,8 @@ WorkflowEpic = {
 ```
 
 **Leantime Sync**: ✅ Bidirectional (Epic ↔ Leantime Project)
-- **Status Authority**: Leantime (planned→active→done)
-- **Knowledge Authority**: ConPort (business value, acceptance criteria, relationships)
+- **PM Entity Authority**: Leantime (planned→active→done)
+- **Context Authority**: ConPort (business value, acceptance criteria, relationships)
 - **Sync Frequency**: 30 seconds (DopeconBridge webhook)
 - **Conflict Resolution**: Leantime status wins, ConPort knowledge wins
 
@@ -164,8 +164,8 @@ WorkflowTask = {
 ```
 
 **Leantime Sync**: ✅ Bidirectional (Task ↔ Leantime Task)
-- **Status Authority**: Leantime (TODO→In Progress→Done)
-- **Knowledge Authority**: ConPort (complexity, dependencies, file links)
+- **PM Entity Authority**: Leantime (TODO→In Progress→Done)
+- **Context Authority**: ConPort (complexity, dependencies, file links)
 - **Sync Frequency**: 30 seconds
 - **Dependency Visualization**: DopeconBridge provides dependency graph
 
@@ -230,8 +230,8 @@ Serena LSP Activation (start tracking files)
 - Manual retry for failed syncs
 
 **Conflict Resolution**:
-1. **Status Conflicts**: Leantime always wins (status authority)
-1. **Knowledge Conflicts**: ConPort always wins (knowledge authority)
+1. **Entity Conflicts**: Leantime always wins (PM entity authority)
+1. **Context Conflicts**: ConPort always wins (context authority)
 1. **Race Conditions**: Last-write-wins with audit trail
 1. **Sync Failures**: Queue for retry, show warning in UI
 

--- a/docs/90-adr/adr-pm-001-canonical-task-object-2.md
+++ b/docs/90-adr/adr-pm-001-canonical-task-object-2.md
@@ -60,7 +60,7 @@ Invariants:
 - Rejected: includes ADHD/session fields that are not universally valid lifecycle authority.
 
 1. Use dopecon-bridge `TaskRecord` as canonical PM model.
-- Rejected: integration service model is useful but not currently the PM-plane-wide contract.
+   - Rejected: mixes adapter telemetry fields into task schema; blurs adapter/plane boundary, and contradicts the rule that `dopecon-bridge` is explicitly an adapter/non-canonical.
   Evidence: `docs/planes/pm/_evidence/PM-ARCH-03.outputs/nl_top10_services_dopecon-bridge_dopecon_bridge_models.py.txt:L46-L65`.
 
 # Acceptance Tests

--- a/docs/planes/pm/pm-architecture.md
+++ b/docs/planes/pm/pm-architecture.md
@@ -35,6 +35,37 @@ Scope: architecture and ADR decisions only; no implementation or schema changes 
 - Leantime and taskmaster integration surfaces exist under `src/integrations/` and include bidirectional sync routines.
   Evidence: `docs/planes/pm/_evidence/PM-ARCH-03.outputs/10_conport_search.txt:L2-L20`; `docs/planes/pm/_evidence/PM-ARCH-03.outputs/10_conport_search.txt:L38-L110`.
 
+## PM Plane Authority Boundaries
+
+As defined in `adr-pm-plane-authority-boundaries.md`, the Dopemux PM plane uses the following canonical authority model to prevent split-brain state and clarify integration routing:
+
+1. **Leantime is the canonical PM operational system of record.**
+   - Authoritative for: projects, goals, milestones, tasks, user-facing PM state.
+   - Not authoritative for: workflow rules, durable memory.
+2. **Task Orchestrator is the canonical workflow authority.**
+   - Authoritative for: workflow rules, blockers, next-action computation, state progression policy.
+   - Not authoritative for: PM entity storage.
+3. **ConPort is the canonical authority for decisions, progress, and structured durable project context.**
+   - Authoritative for: decisions, progress records, context meant for reuse across systems.
+   - Not authoritative for: PM task lifecycle, workflow transitions.
+4. **dope-memory is the canonical authority for chronological work chronicle memory.**
+   - Authoritative for: work-log chronology, replay/reconstruction, trajectory state.
+   - Not authoritative for: PM task truth, workflow state, or the decisions themselves.
+5. **dopecon-bridge is an adapter/router/translator only.**
+   - Must not be treated as canonical for tasks, next-action, decisions, workflow state, or PM entities.
+   - Current mixed-authority behavior is architectural debt.
+
+Any tools or integration adapters must respect these boundaries and route reads/writes to the correct canonical backend.
+
+## Current Runtime Gaps (Downstream Packet Warning)
+
+The current implementation has drift from the authority model defined above. Downstream packets implementing PM features **must** honor the target architecture while working around or remediating these gaps:
+
+- `dopecon-bridge` currently maintains mixed-authority shadow state (e.g., local tasks/decisions) and unauthenticated write surfaces. These must be treated as non-canonical or removed.
+- `conport-kg` is currently blocked and non-canonical. Do not use it as a context authority until remediation is complete.
+- Explicit policy wrappers around PM-plane writes are missing. Tools should use JSON-RPC to Leantime and MCP/API to ConPort or Task Orchestrator rather than direct unvalidated DB writes.
+- Multiple task-creation entrypoints exist across the CLI and wrappers. They should all eventually converge to route through the Task Orchestrator workflow engine or write directly to Leantime.
+
 ## Canonical Task Object (Proposal)
 
 The PM plane defines one canonical task object used for deterministic lifecycle transitions.


### PR DESCRIPTION
Fixes PM-INT-01 packet to normalize and clarify PM-plane authority boundaries in architectural documentation.

---
*PR created automatically by Jules for task [3086613386649831115](https://jules.google.com/task/3086613386649831115) started by @hu3mann*