### PR TITLE
PM-INT-11 · PM Plane · remove Task Orchestrator workflow bypasses

### DIFF
--- a/services/task-orchestrator/app/models/workflow.py
+++ b/services/task-orchestrator/app/models/workflow.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field, root_validator, validator
 
@@ -44,6 +44,23 @@ class ADHDMetadata(BaseModel):
     can_work_parallel: bool = True
 
 
+class TransitionAuditRecord(BaseModel):
+    """Immutable audit record for a workflow state transition."""
+
+    id: str
+    entity_id: str
+    transition_type: str
+    from_state: str
+    to_state: str
+    actor: str = "system"
+    timestamp: str = Field(default_factory=utc_now_iso)
+    idempotency_key: Optional[str] = None
+    version_before: int
+    version_after: int
+    linked_ids_snapshot: Dict[str, Optional[str]] = Field(default_factory=dict)
+    receipt_id: Optional[str] = None
+
+
 class WorkflowIdea(BaseModel):
     """Stage-1 workflow idea persisted in ConPort custom_data."""
 
@@ -57,6 +74,8 @@ class WorkflowIdea(BaseModel):
     created_at: str = Field(default_factory=utc_now_iso)
     updated_at: str = Field(default_factory=utc_now_iso)
     promoted_to_epic_id: Optional[str] = None
+    version: int = Field(default=1)
+    idempotency_key: Optional[str] = None
 
     @validator("id")
     def validate_id(cls, value: str) -> str:
@@ -98,6 +117,8 @@ class WorkflowEpic(BaseModel):
     adhd_metadata: ADHDMetadata = Field(default_factory=ADHDMetadata)
     created_at: str = Field(default_factory=utc_now_iso)
     updated_at: str = Field(default_factory=utc_now_iso)
+    version: int = Field(default=1)
+    idempotency_key: Optional[str] = None
 
     @validator("id")
     def validate_id(cls, value: str) -> str:
@@ -137,6 +158,7 @@ class CreateIdeaRequest(BaseModel):
     source: IdeaSource = "other"
     creator: str = Field("system", min_length=1)
     tags: List[str] = Field(default_factory=list)
+    idempotency_key: Optional[str] = None
 
     _normalize_tags = validator("tags", pre=True, allow_reuse=True)(normalize_tags)
 
@@ -148,6 +170,8 @@ class UpdateIdeaRequest(BaseModel):
     description: Optional[str] = None
     status: Optional[IdeaStatus] = None
     tags: Optional[List[str]] = None
+    version: Optional[int] = None
+    idempotency_key: Optional[str] = None
 
     _normalize_tags = validator("tags", pre=True, allow_reuse=True)(normalize_tags)
 
@@ -170,6 +194,7 @@ class CreateEpicRequest(BaseModel):
     created_from_idea_id: Optional[str] = None
     tags: List[str] = Field(default_factory=list)
     adhd_metadata: ADHDMetadata = Field(default_factory=ADHDMetadata)
+    idempotency_key: Optional[str] = None
 
     @validator("acceptance_criteria", pre=True, always=True)
     def normalize_criteria(cls, value: Optional[List[str]]) -> List[str]:
@@ -192,6 +217,8 @@ class UpdateEpicRequest(BaseModel):
     tags: Optional[List[str]] = None
     leantime_project_id: Optional[int] = None
     adhd_metadata: Optional[ADHDMetadata] = None
+    version: Optional[int] = None
+    idempotency_key: Optional[str] = None
 
     @validator("acceptance_criteria", pre=True, always=False)
     def normalize_criteria(cls, value: Optional[List[str]]) -> Optional[List[str]]:
@@ -230,6 +257,7 @@ class PromoteIdeaRequest(BaseModel):
     priority: EpicPriority = "medium"
     tags: Optional[List[str]] = None
     adhd_metadata: ADHDMetadata = Field(default_factory=ADHDMetadata)
+    idempotency_key: Optional[str] = None
 
     @validator("acceptance_criteria", pre=True, always=True)
     def normalize_criteria(cls, value: Optional[List[str]]) -> List[str]:

--- a/services/task-orchestrator/app/services/workflow_service.py
+++ b/services/task-orchestrator/app/services/workflow_service.py
@@ -39,6 +39,7 @@ from ..models.workflow import (
     UpdateIdeaRequest,
     WorkflowEpic,
     WorkflowIdea,
+    TransitionAuditRecord,
     normalize_tags,
     utc_now_iso,
 )
@@ -112,6 +113,13 @@ class WorkflowService:
 
     async def create_idea(self, request: CreateIdeaRequest) -> WorkflowIdea:
         self._require_enabled()
+        idemp_key = getattr(request, "idempotency_key", None)
+        if idemp_key:
+            if hasattr(self.store, "get_idea_by_idempotency_key"):
+                existing = await self._call_store(self.store.get_idea_by_idempotency_key(idemp_key))
+                if existing:
+                    return WorkflowIdea(**existing)
+
         now = utc_now_iso()
         idea = WorkflowIdea(
             id=f"idea_{uuid4().hex}",
@@ -123,6 +131,8 @@ class WorkflowService:
             status="new",
             created_at=now,
             updated_at=now,
+            version=1,
+            idempotency_key=getattr(request, "idempotency_key", None),
         )
         await self._save_idea_or_raise(idea)
         self.metrics["workflow_ideas_created_total"] += 1
@@ -146,6 +156,10 @@ class WorkflowService:
         self._require_enabled()
         idea = await self.get_idea(idea_id)
 
+        idemp_key = getattr(request, "idempotency_key", None)
+        if idemp_key and idea.idempotency_key == idemp_key:
+            return idea
+
         if idea.status == "promoted" and request.status and request.status != "promoted":
             raise WorkflowConflictError("promoted ideas cannot be moved to a non-promoted state")
 
@@ -153,20 +167,32 @@ class WorkflowService:
             idea.title = request.title
         if request.description is not None:
             idea.description = request.description
-        if request.status is not None:
-            idea.status = request.status
+        if request.status is not None and request.status != idea.status:
+            raise WorkflowConflictError("direct status mutation blocked: use transition API")
         if request.tags is not None:
             idea.tags = request.tags
 
         if idea.status == "promoted" and not idea.promoted_to_epic_id:
             raise WorkflowConflictError("promoted ideas must include promoted_to_epic_id")
 
+        if getattr(request, "version", None) is not None and request.version != idea.version:
+            raise WorkflowConflictError("stale version update rejected")
+
         idea.updated_at = utc_now_iso()
+        idea.version += 1
+        idea.idempotency_key = getattr(request, "idempotency_key", None)
         await self._save_idea_or_raise(idea)
         return idea
 
     async def create_epic(self, request: CreateEpicRequest) -> WorkflowEpic:
         self._require_enabled()
+        idemp_key = getattr(request, "idempotency_key", None)
+        if idemp_key:
+            if hasattr(self.store, "get_epic_by_idempotency_key"):
+                existing = await self._call_store(self.store.get_epic_by_idempotency_key(idemp_key))
+                if existing:
+                    return WorkflowEpic(**existing)
+
         now = utc_now_iso()
         epic = WorkflowEpic(
             id=f"epic_{uuid4().hex}",
@@ -181,6 +207,8 @@ class WorkflowService:
             adhd_metadata=request.adhd_metadata,
             created_at=now,
             updated_at=now,
+            version=1,
+            idempotency_key=getattr(request, "idempotency_key", None),
         )
         await self._save_epic_or_raise(epic)
         self.metrics["workflow_epics_created_total"] += 1
@@ -210,6 +238,10 @@ class WorkflowService:
         self._require_enabled()
         epic = await self.get_epic(epic_id)
 
+        idemp_key = getattr(request, "idempotency_key", None)
+        if idemp_key and epic.idempotency_key == idemp_key:
+            return epic
+
         if request.title is not None:
             epic.title = request.title
         if request.description is not None:
@@ -220,16 +252,23 @@ class WorkflowService:
             epic.acceptance_criteria = request.acceptance_criteria
         if request.priority is not None:
             epic.priority = request.priority
-        if request.status is not None:
-            epic.status = request.status
+        if request.status is not None and request.status != epic.status:
+            raise WorkflowConflictError("direct status mutation blocked: use transition API")
         if request.tags is not None:
             epic.tags = request.tags
         if request.leantime_project_id is not None:
+            if epic.leantime_project_id is not None and epic.leantime_project_id != request.leantime_project_id:
+                raise WorkflowConflictError("conflicting linked-ID overwrite fails closed")
             epic.leantime_project_id = request.leantime_project_id
         if request.adhd_metadata is not None:
             epic.adhd_metadata = request.adhd_metadata
 
+        if getattr(request, "version", None) is not None and request.version != epic.version:
+            raise WorkflowConflictError("stale version update rejected")
+
         epic.updated_at = utc_now_iso()
+        epic.version += 1
+        epic.idempotency_key = getattr(request, "idempotency_key", None)
         await self._save_epic_or_raise(epic)
         return epic
 
@@ -250,6 +289,40 @@ class WorkflowService:
                 "already_promoted": True,
                 "warning": None,
             }
+
+        idemp_key = getattr(request, "idempotency_key", None)
+        if idemp_key and hasattr(self.store, "get_epic_by_idempotency_key"):
+            existing_epic = await self._call_store(self.store.get_epic_by_idempotency_key(idemp_key))
+            if existing_epic and existing_epic.get("created_from_idea_id") == idea.id:
+                audit_record = TransitionAuditRecord(
+                    id=f"audit_{uuid4().hex}",
+                    entity_id=idea.id,
+                    transition_type="promote_idea",
+                    from_state=idea.status,
+                    to_state="promoted",
+                    actor="system",
+                    timestamp=utc_now_iso(),
+                    idempotency_key=idemp_key,
+                    version_before=idea.version,
+                    version_after=idea.version + 1,
+                    linked_ids_snapshot={"promoted_to_epic_id": existing_epic["id"]},
+                )
+
+                saved_audit = await self._call_store(self.store.save_audit_record(audit_record.dict()))
+                if not saved_audit:
+                    raise WorkflowUnavailableError("failed to persist workflow transition audit")
+
+                idea.status = "promoted"
+                idea.promoted_to_epic_id = existing_epic["id"]
+                idea.updated_at = utc_now_iso()
+                idea.version += 1
+                await self._save_idea_or_raise(idea)
+                return {
+                    "idea": idea,
+                    "epic": WorkflowEpic(**existing_epic),
+                    "already_promoted": True,
+                    "warning": None,
+                }
 
         now = utc_now_iso()
         epic = WorkflowEpic(
@@ -278,9 +351,28 @@ class WorkflowService:
 
         await self._save_epic_or_raise(epic)
 
+        audit_record = TransitionAuditRecord(
+            id=f"audit_{uuid4().hex}",
+            entity_id=idea.id,
+            transition_type="promote_idea",
+            from_state=idea.status,
+            to_state="promoted",
+            actor="system",
+            timestamp=utc_now_iso(),
+            idempotency_key=getattr(request, "idempotency_key", None),
+            version_before=idea.version,
+            version_after=idea.version + 1,
+            linked_ids_snapshot={"promoted_to_epic_id": epic.id},
+        )
+
+        saved_audit = await self._call_store(self.store.save_audit_record(audit_record.dict()))
+        if not saved_audit:
+            raise WorkflowUnavailableError("failed to persist workflow transition audit")
+
         idea.status = "promoted"
         idea.promoted_to_epic_id = epic.id
         idea.updated_at = utc_now_iso()
+        idea.version += 1
         await self._save_idea_or_raise(idea)
 
         self.metrics["workflow_epics_created_total"] += 1

--- a/services/task-orchestrator/app/services/workflow_store.py
+++ b/services/task-orchestrator/app/services/workflow_store.py
@@ -44,6 +44,7 @@ class WorkflowStore:
 
     IDEAS_CATEGORY = "workflow_ideas"
     EPICS_CATEGORY = "workflow_epics"
+    AUDIT_CATEGORY = "workflow_audit"
 
     def __init__(
         self,
@@ -128,6 +129,38 @@ class WorkflowStore:
             key=epic_id,
             value=epic,
         )
+
+    async def save_audit_record(self, record: Mapping[str, Any]) -> bool:
+        audit_id = str(record.get("id", ""))
+        if not audit_id:
+            raise WorkflowStoreError("audit id is required")
+        return await self.upsert_custom_data(
+            category=self.AUDIT_CATEGORY,
+            key=audit_id,
+            value=record,
+        )
+
+    async def get_idea_by_idempotency_key(self, key: str) -> Optional[Dict[str, Any]]:
+        rows = await self.get_custom_data(
+            category=self.IDEAS_CATEGORY,
+            limit=1000,
+        )
+        for row in rows:
+            payload = self._payload_from_row(row)
+            if payload.get("idempotency_key") == key:
+                return payload
+        return None
+
+    async def get_epic_by_idempotency_key(self, key: str) -> Optional[Dict[str, Any]]:
+        rows = await self.get_custom_data(
+            category=self.EPICS_CATEGORY,
+            limit=1000,
+        )
+        for row in rows:
+            payload = self._payload_from_row(row)
+            if payload.get("idempotency_key") == key:
+                return payload
+        return None
 
     async def get_idea(self, idea_id: str) -> Optional[Dict[str, Any]]:
         rows = await self.get_custom_data(

--- a/services/task-orchestrator/tests/test_workflow.py
+++ b/services/task-orchestrator/tests/test_workflow.py
@@ -1,0 +1,125 @@
+import pytest
+from app.models.workflow import CreateIdeaRequest, UpdateIdeaRequest, PromoteIdeaRequest, CreateEpicRequest, UpdateEpicRequest, WorkflowIdea
+from app.services.workflow_service import WorkflowService, WorkflowConflictError, WorkflowUnavailableError
+
+class MockStore:
+    def __init__(self):
+        self.ideas = {}
+        self.epics = {}
+        self.audits = {}
+        self.fail_audit = False
+
+    async def get_idea(self, idea_id):
+        return self.ideas.get(idea_id)
+
+    async def get_epic(self, epic_id):
+        return self.epics.get(epic_id)
+
+    async def get_idea_by_idempotency_key(self, key):
+        for val in self.ideas.values():
+            if val.get("idempotency_key") == key:
+                return val
+        return None
+
+    async def get_epic_by_idempotency_key(self, key):
+        for val in self.epics.values():
+            if val.get("idempotency_key") == key:
+                return val
+        return None
+
+    async def save_idea(self, idea_data):
+        self.ideas[idea_data["id"]] = idea_data
+        return True
+
+    async def save_epic(self, epic_data):
+        self.epics[epic_data["id"]] = epic_data
+        return True
+
+    async def save_audit_record(self, record):
+        if self.fail_audit:
+            return False
+        self.audits[record["id"]] = record
+        return True
+
+    async def close(self):
+        pass
+
+@pytest.fixture
+def mock_store():
+    return MockStore()
+
+@pytest.fixture
+def service(mock_store):
+    svc = WorkflowService(workspace_id="test", store=mock_store)
+    return svc
+
+@pytest.mark.asyncio
+async def test_direct_status_mutation_blocked_idea(service):
+    idea = await service.create_idea(CreateIdeaRequest(title="T", description="D"))
+    with pytest.raises(WorkflowConflictError, match="direct status mutation blocked"):
+        await service.update_idea(idea.id, UpdateIdeaRequest(status="promoted"))
+
+@pytest.mark.asyncio
+async def test_duplicate_create(service):
+    req1 = CreateIdeaRequest(title="T1", description="D1", idempotency_key="create_key")
+    idea1 = await service.create_idea(req1)
+
+    req2 = CreateIdeaRequest(title="T2", description="D2", idempotency_key="create_key")
+    idea2 = await service.create_idea(req2)
+
+    # Should return the same idea and not duplicate mutation
+    assert idea1.id == idea2.id
+    assert idea2.title == "T1"
+
+@pytest.mark.asyncio
+async def test_stale_version_rejected(service):
+    idea = await service.create_idea(CreateIdeaRequest(title="T", description="D"))
+    req = UpdateIdeaRequest(title="T2")
+    req.version = idea.version - 1
+    with pytest.raises(WorkflowConflictError, match="stale version update rejected"):
+        await service.update_idea(idea.id, req)
+
+@pytest.mark.asyncio
+async def test_idempotent_idea_update(service):
+    idea = await service.create_idea(CreateIdeaRequest(title="T", description="D"))
+
+    req1 = UpdateIdeaRequest(title="T2", idempotency_key="update_key")
+    idea1 = await service.update_idea(idea.id, req1)
+
+    # Same update idempotency key
+    req2 = UpdateIdeaRequest(title="T3", idempotency_key="update_key")
+    idea2 = await service.update_idea(idea.id, req2)
+
+    assert idea1.title == "T2"
+    assert idea2.title == "T2"
+    assert idea1.version == idea2.version
+
+@pytest.mark.asyncio
+async def test_conflicting_linked_id_overwrite(service):
+    epic = await service.create_epic(CreateEpicRequest(title="E1", description="D1", business_value="BV"))
+
+    # First update sets leantime_project_id
+    req1 = UpdateEpicRequest(leantime_project_id=10)
+    epic = await service.update_epic(epic.id, req1)
+
+    # Second update conflicts
+    req2 = UpdateEpicRequest(leantime_project_id=20)
+    with pytest.raises(WorkflowConflictError, match="conflicting linked-ID overwrite fails closed"):
+        await service.update_epic(epic.id, req2)
+
+    # Second update matches (should succeed)
+    req3 = UpdateEpicRequest(leantime_project_id=10)
+    epic = await service.update_epic(epic.id, req3)
+    assert epic.leantime_project_id == 10
+
+@pytest.mark.asyncio
+async def test_promote_idea_audit_failure(service, mock_store):
+    idea = await service.create_idea(CreateIdeaRequest(title="T", description="D"))
+    mock_store.fail_audit = True
+
+    with pytest.raises(WorkflowUnavailableError, match="failed to persist workflow transition audit"):
+        await service.promote_idea(idea.id, PromoteIdeaRequest(business_value="test value"))
+
+    # Check that idea was not promoted
+    stored_idea = await service.get_idea(idea.id)
+    assert stored_idea.status == "new"


### PR DESCRIPTION
- Identified direct status mutations occurring via `update_idea` and `update_epic` in `services/task-orchestrator/app/services/workflow_service.py`
- Blocked those direct status mutations by checking for state mismatches during generic updates, forcing callers to use explicitly sanctioned transition APIs.
- Established strict invariants for PM task modifications: idempotency handling (via `idempotency_key` lookups), stale version rejection (via `version` checks), and linked-ID protections (preventing arbitrary overwrite of `leantime_project_id`).
- Modified `promote_idea` to mandate the creation and persistence of a `TransitionAuditRecord`. A state transition will not be reported as successful unless this audit record is safely durably persisted (failing closed).
- Added robust, functional tests to `services/task-orchestrator/tests/test_workflow.py` to assert idempotency, version controls, ID conflicts, and audit persistence failures.

---
*PR created automatically by Jules for task [8348954787056667770](https://jules.google.com/task/8348954787056667770) started by @hu3mann*