### PR TITLE
feat(execution): add packet lease store and coordinator integration

### DIFF
--- a/services/task-orchestrator/app/services/task_coordinator.py
+++ b/services/task-orchestrator/app/services/task_coordinator.py
@@ -27,8 +27,10 @@ from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 from enum import Enum
+from uuid import UUID
 
 import asyncio
+import inspect
 import logging
 import os
 
@@ -43,6 +45,13 @@ from ..adapters.conport_adapter import ConPortEventAdapter
 from intelligence.cognitive_load_balancer import CognitiveLoadBalancer
 from intelligence.context_switch_recovery import ContextSwitchRecovery
 from pal_client import TaskOrchestratorPALClient
+
+from dopemux.pm.store import InMemoryPMTaskStore
+from dopemux.pm.models import PMTask, PMTaskStatus, PMTransitionRequest, content_hash_task_id
+from dopemux.pm.mapping import ORCHESTRATOR_TO_CANONICAL, CANONICAL_TO_ORCHESTRATOR
+
+from dopemux.execution.store import get_execution_store, get_lease_store, PacketNotFoundError, PacketNotReadyError
+from dopemux.execution.models import ExecutionPacket, PacketState
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +105,8 @@ class TaskCoordinator:
         self.break_duration = 300  # 5 minute breaks
         self.max_context_switches = 2
         
+        # Canonical PM Task Store
+        self.pm_store = InMemoryPMTaskStore()
         # Task storage (in-memory for now, will sync to ConPort)
         self.tasks: Dict[str, OrchestrationTask] = {}
 
@@ -273,7 +284,7 @@ class TaskCoordinator:
     
     async def store_task(self, task: OrchestrationTask) -> bool:
         """
-        Store task in memory and optionally sync to ConPort.
+        Store task canonically and in memory, then optionally sync to ConPort.
         
         Args:
             task: OrchestrationTask to store
@@ -282,11 +293,24 @@ class TaskCoordinator:
             True if stored successfully
         """
         try:
+            # Enforce canonical store invariant for task creation
+            canonical_status = ORCHESTRATOR_TO_CANONICAL.get(task.status.value, PMTaskStatus.TODO)
+            pm_task = PMTask(
+                task_id=task.id,
+                title=task.title,
+                description=task.description or "",
+                status=canonical_status,
+                source="orchestrator",
+                created_at_utc=datetime.now(timezone.utc),
+                updated_at_utc=datetime.now(timezone.utc),
+            )
+            self.pm_store.create(pm_task)
+            
+            # Update local memory representation with canonical metadata if needed
             self.tasks[task.id] = task
-            logger.debug(f"Stored task {task.id} in memory cache")
+            logger.debug(f"Stored task {task.id} in memory cache & canonical PM store")
             
             # Optionally sync to ConPort in background
-            # (Don't await to avoid blocking)
             asyncio.create_task(self._sync_task_to_conport(task))
             
             return True
@@ -472,6 +496,9 @@ class TaskCoordinator:
             "context_switches": 0
         }
 
+        execution_store = get_execution_store()
+        lease_store = get_lease_store()
+
         for task_id in sequenced_tasks:
             # Execute task (placeholder - actual execution via agents)
             # Find the task object from internal storage
@@ -481,25 +508,84 @@ class TaskCoordinator:
                 results["failed"].append(task_id)
                 continue
             try:
-                # Update status
-                task.status = TaskStatus.IN_PROGRESS
+                # 1. Ensure ExecutionPacket exists in the Execution Plane
+                if not execution_store.get_packet(task_id):
+                    execution_store.create_packet(ExecutionPacket(
+                        packet_id=task_id,
+                        owner_id="orchestrator",
+                        state=PacketState.READY,
+                        metadata={"title": task.title}
+                    ))
+                
+                # 2. Acquire Lease
+                agent_id = task.assigned_agent.value if task.assigned_agent else "unassigned-agent"
+                lease = lease_store.checkout(task_id, agent_id, ttl_seconds=300)
+                logger.info(f"🔑 Leased packet {task_id} to {agent_id} (Lease ID: {lease.lease_id})")
+
+                # Sync status transition idempotently via Canonical Store
+                try:
+                    pm_task = self.pm_store.get(task_id)
+                    expected_version = pm_task.version if pm_task else 1
+                    pm_task = self.pm_store.transition(
+                        task_id,
+                        PMTransitionRequest(
+                            idempotency_key=f"start-{task_id}",
+                            expected_version=expected_version,
+                            new_status=PMTaskStatus.IN_PROGRESS,
+                            ts_utc=datetime.now(timezone.utc),
+                            source="orchestrator"
+                        )
+                    )
+                    task.status = TaskStatus(CANONICAL_TO_ORCHESTRATOR[pm_task.status])
+                except Exception as e:
+                    logger.warning(f"Failed canonical transition to IN_PROGRESS for {task_id}: {e}")
+                    task.status = TaskStatus.IN_PROGRESS
+                
                 results["in_progress"].append(task_id)
 
-                # Simulate execution with monitoring
-                # We await this to maintain sequential execution order
-                await self._monitor_execution(task)
+                # Preserve compatibility with test/local monitor overrides that only accept `task`.
+                monitor_params = inspect.signature(self._monitor_execution).parameters
+                if "lease_id" in monitor_params:
+                    await self._monitor_execution(task, lease_id=lease.lease_id)
+                else:
+                    await self._monitor_execution(task)
 
-                # Mark task as completed after successful monitoring
-                task.status = TaskStatus.COMPLETED
+                # Mark task as completed after successful monitoring idempotently
+                try:
+                    pm_task = self.pm_store.get(task_id)
+                    expected_version = pm_task.version if pm_task else 1
+                    pm_task = self.pm_store.transition(
+                        task_id,
+                        PMTransitionRequest(
+                            idempotency_key=f"complete-{task_id}",
+                            expected_version=expected_version,
+                            new_status=PMTaskStatus.DONE,
+                            ts_utc=datetime.now(timezone.utc),
+                            source="orchestrator"
+                        )
+                    )
+                    task.status = TaskStatus(CANONICAL_TO_ORCHESTRATOR[pm_task.status])
+                except Exception as e:
+                    logger.warning(f"Failed canonical transition to COMPLETED for {task_id}: {e}")
+                    task.status = TaskStatus.COMPLETED
+
+                # 3. Release Lease
+                lease_store.release(lease.lease_id, final_state=PacketState.PROOF_GENERATED)
+                logger.info(f"✅ Released lease for packet {task_id}")
+
                 results["completed"].append(task_id)
                 results["in_progress"].remove(task_id)
 
                 # Sync to ConPort
                 await self.conport_adapter.update_task_in_conport(task)
 
+            except (PacketNotReadyError, PacketNotFoundError) as e:
+                logger.warning(f"⚠️ Could not lease packet {task_id}: {e}")
+                results["failed"].append(task_id)
+                continue
             except Exception as e:
                 logger.error(f"❌ Task execution failed {task_id}: {e}")
-                task.status = TaskStatus.FAILED
+                task.status = TaskStatus.BLOCKED
                 # Remove from in_progress if it was added
                 if task_id in results["in_progress"]:
                     results["in_progress"].remove(task_id)
@@ -534,9 +620,9 @@ class TaskCoordinator:
         energy_cost = base_cost * energy_modifiers.get(adhd_state.get('energy'), 1.0)
         return min(1.0, energy_cost)  # Cap at 1.0
 
-    async def _monitor_execution(self, task: OrchestrationTask):
+    async def _monitor_execution(self, task: OrchestrationTask, lease_id: Optional[UUID] = None):
         """
-        Monitor task execution with ADHD-aware breaks.
+        Monitor task execution with ADHD-aware breaks and lease heartbeats.
         """
         # Simulate task duration (demo mode)
         # In a real system, this would monitor an actual agent's progress
@@ -545,8 +631,19 @@ class TaskCoordinator:
         if self.coordination_state.session_start_time is None:
             self.coordination_state.session_start_time = start_time
 
+        lease_store = get_lease_store()
+
         # Check energy decay over time
         while (datetime.now() - start_time).total_seconds() < simulated_duration:
+            # Pulse heartbeat if we have a lease
+            if lease_id:
+                try:
+                    lease_store.heartbeat(lease_id)
+                    logger.debug(f"💓 Heartbeat for lease {lease_id}")
+                except Exception as e:
+                    logger.error(f"💔 Heartbeat failed for lease {lease_id}: {e}")
+                    raise
+
             # Update global session timer based on elapsed time since session start
             elapsed = (datetime.now() - self.coordination_state.session_start_time).total_seconds()
             self.coordination_state.focus_session_timer = int(elapsed)

--- a/services/task-orchestrator/app/services/task_coordinator.py
+++ b/services/task-orchestrator/app/services/task_coordinator.py
@@ -498,6 +498,7 @@ class TaskCoordinator:
 
         execution_store = get_execution_store()
         lease_store = get_lease_store()
+        monitor_accepts_lease = "lease_id" in inspect.signature(self._monitor_execution).parameters
 
         for task_id in sequenced_tasks:
             # Execute task (placeholder - actual execution via agents)
@@ -507,6 +508,7 @@ class TaskCoordinator:
                 logger.warning(f"⚠️ Task {task_id} not found in coordinator cache")
                 results["failed"].append(task_id)
                 continue
+            lease = None
             try:
                 # 1. Ensure ExecutionPacket exists in the Execution Plane
                 if not execution_store.get_packet(task_id):
@@ -544,8 +546,7 @@ class TaskCoordinator:
                 results["in_progress"].append(task_id)
 
                 # Preserve compatibility with test/local monitor overrides that only accept `task`.
-                monitor_params = inspect.signature(self._monitor_execution).parameters
-                if "lease_id" in monitor_params:
+                if monitor_accepts_lease:
                     await self._monitor_execution(task, lease_id=lease.lease_id)
                 else:
                     await self._monitor_execution(task)
@@ -571,6 +572,7 @@ class TaskCoordinator:
 
                 # 3. Release Lease
                 lease_store.release(lease.lease_id, final_state=PacketState.PROOF_GENERATED)
+                lease = None
                 logger.info(f"✅ Released lease for packet {task_id}")
 
                 results["completed"].append(task_id)
@@ -591,6 +593,13 @@ class TaskCoordinator:
                     results["in_progress"].remove(task_id)
                 results["failed"].append(task_id)
                 break
+            finally:
+                if lease is not None:
+                    try:
+                        lease_store.release(lease.lease_id, final_state=PacketState.READY)
+                        logger.info(f"↩️ Released failed lease for packet {task_id}")
+                    except Exception as release_error:
+                        logger.warning(f"Failed to release lease for {task_id}: {release_error}")
 
         # Check for context switching
         await self.context_recovery.detect_context_switch()

--- a/src/dopemux/execution/models.py
+++ b/src/dopemux/execution/models.py
@@ -1,0 +1,62 @@
+"""
+Canonical Execution Domain Models.
+
+Implements TP-SIA-EXEC-0001: core data models and locking primitives for the
+Workflow / Execution Control Plane.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class PacketState(str, Enum):
+    """Execution lifecycle state for a Task Packet."""
+
+    READY = "READY"  # Available for lease
+    LEASED = "LEASED"  # Checked out by an agent
+    EXECUTING = "EXECUTING"  # Agent is actively processing (heartbeat active)
+    PROOF_GENERATED = "PROOF_GENERATED"  # Work complete, verification artifacts present
+    AUDITED = "AUDITED"  # Human or Supervisor has verified the proof
+    COMMITTED = "COMMITTED"  # Changes merged to target branch
+
+
+class LeaseState(str, Enum):
+    """State of a packet lease."""
+
+    ACTIVE = "ACTIVE"  # Lease is within TTL
+    EXPIRED = "EXPIRED"  # Heartbeat missed; packet returned to READY
+    RELEASED = "RELEASED"  # Graceful handoff or completion
+
+
+class ExecutionPacket(BaseModel):
+    """Authoritative state container for an executable packet."""
+
+    packet_id: str = Field(..., description="Unique string (e.g., 'TP-SIA-EXEC-0001')")
+    owner_id: str = Field(..., description="Primary author/operator")
+    depends_on: List[str] = Field(default_factory=list, description="Prerequisite packet IDs")
+    state: PacketState = Field(default=PacketState.READY)
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict, description="Branch names, initial commit SHAs, requirements"
+    )
+    proof_bundle: Dict[str, Any] = Field(
+        default_factory=dict, description="Links to logs, diffs, and test results"
+    )
+
+    model_config = {"frozen": False}
+
+
+class PacketLease(BaseModel):
+    """Locking primitive for exclusive packet access."""
+
+    lease_id: UUID = Field(..., description="UUID4 unique lease identifier")
+    packet_id: str = Field(..., description="Targeted packet ID")
+    agent_id: str = Field(..., description="Identifier of the leasing entity (e.g., 'gemini-2.5-pro')")
+    leased_at_utc: datetime = Field(..., description="Timestamp of checkout")
+    expires_at_utc: datetime = Field(..., description="Hard deadline for next heartbeat")
+    state: LeaseState = Field(default=LeaseState.ACTIVE)
+
+    model_config = {"frozen": False}

--- a/src/dopemux/execution/models.py
+++ b/src/dopemux/execution/models.py
@@ -7,7 +7,7 @@ Workflow / Execution Control Plane.
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -57,6 +57,7 @@ class PacketLease(BaseModel):
     agent_id: str = Field(..., description="Identifier of the leasing entity (e.g., 'gemini-2.5-pro')")
     leased_at_utc: datetime = Field(..., description="Timestamp of checkout")
     expires_at_utc: datetime = Field(..., description="Hard deadline for next heartbeat")
+    ttl_seconds: int = Field(..., description="Original lease duration in seconds")
     state: LeaseState = Field(default=LeaseState.ACTIVE)
 
     model_config = {"frozen": False}

--- a/src/dopemux/execution/store.py
+++ b/src/dopemux/execution/store.py
@@ -1,0 +1,220 @@
+"""
+Execution store and lease management implementation.
+
+Implements TP-SIA-EXEC-0001: core data models and locking primitives for the
+Workflow / Execution Control Plane.
+"""
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+from uuid import UUID, uuid4
+
+from .models import ExecutionPacket, PacketLease, PacketState, LeaseState
+
+
+class ExecutionError(Exception):
+    """Base class for execution-related errors."""
+    pass
+
+
+class PacketNotFoundError(ExecutionError):
+    """Raised when a packet_id does not exist."""
+    def __init__(self, packet_id: str) -> None:
+        self.packet_id = packet_id
+        super().__init__(f"Packet not found: {packet_id}")
+
+
+class PacketNotReadyError(ExecutionError):
+    """Raised when attempting to checkout a packet that is not in READY state."""
+    def __init__(self, packet_id: str, state: PacketState) -> None:
+        self.packet_id = packet_id
+        self.state = state
+        super().__init__(f"Packet {packet_id} is not READY (current state: {state})")
+
+
+class LeaseNotFoundError(ExecutionError):
+    """Raised when a lease_id does not exist."""
+    def __init__(self, lease_id: UUID) -> None:
+        self.lease_id = lease_id
+        super().__init__(f"Lease not found: {lease_id}")
+
+
+class LeaseExpiredError(ExecutionError):
+    """Raised when an operation is attempted on an expired lease."""
+    def __init__(self, lease_id: UUID) -> None:
+        self.lease_id = lease_id
+        super().__init__(f"Lease {lease_id} has expired")
+
+
+class ExecutionStore(ABC):
+    """Abstract base class for ExecutionPacket persistence."""
+
+    @abstractmethod
+    def create_packet(self, packet: ExecutionPacket) -> ExecutionPacket:
+        """Store a new packet. If packet_id exists, return existing."""
+        ...
+
+    @abstractmethod
+    def get_packet(self, packet_id: str) -> Optional[ExecutionPacket]:
+        """Retrieve packet by ID."""
+        ...
+
+    @abstractmethod
+    def list_ready_packets(self) -> List[ExecutionPacket]:
+        """List all packets in READY state."""
+        ...
+
+    @abstractmethod
+    def update_packet_state(self, packet_id: str, state: PacketState) -> ExecutionPacket:
+        """Update the state of a packet."""
+        ...
+
+
+class LeaseStore(ABC):
+    """Abstract base class for PacketLease management."""
+
+    @abstractmethod
+    def checkout(self, packet_id: str, agent_id: str, ttl_seconds: int) -> PacketLease:
+        """
+        Atomically transition packet to LEASED and create a lease.
+
+        Raises:
+            PacketNotFoundError: packet_id does not exist.
+            PacketNotReadyError: packet is not in READY state.
+        """
+        ...
+
+    @abstractmethod
+    def heartbeat(self, lease_id: UUID) -> PacketLease:
+        """
+        Extend the expiry of an active lease.
+
+        Raises:
+            LeaseNotFoundError: lease_id does not exist.
+            LeaseExpiredError: lease has already expired.
+        """
+        ...
+
+    @abstractmethod
+    def release(self, lease_id: UUID, final_state: PacketState) -> PacketLease:
+        """
+        Transition packet to final_state and mark lease as RELEASED.
+
+        Raises:
+            LeaseNotFoundError: lease_id does not exist.
+        """
+        ...
+
+
+class InMemoryExecutionStore(ExecutionStore):
+    """In-memory implementation of ExecutionStore."""
+
+    def __init__(self) -> None:
+        self._packets: Dict[str, ExecutionPacket] = {}
+
+    def create_packet(self, packet: ExecutionPacket) -> ExecutionPacket:
+        if packet.packet_id in self._packets:
+            return self._packets[packet.packet_id].model_copy()
+        self._packets[packet.packet_id] = packet.model_copy()
+        return self._packets[packet.packet_id].model_copy()
+
+    def get_packet(self, packet_id: str) -> Optional[ExecutionPacket]:
+        packet = self._packets.get(packet_id)
+        return packet.model_copy() if packet else None
+
+    def list_ready_packets(self) -> List[ExecutionPacket]:
+        return [p.model_copy() for p in self._packets.values() if p.state == PacketState.READY]
+
+    def update_packet_state(self, packet_id: str, state: PacketState) -> ExecutionPacket:
+        if packet_id not in self._packets:
+            raise PacketNotFoundError(packet_id)
+        self._packets[packet_id].state = state
+        return self._packets[packet_id].model_copy()
+
+
+class InMemoryLeaseStore(LeaseStore):
+    """In-memory implementation of LeaseStore."""
+
+    def __init__(self, execution_store: ExecutionStore) -> None:
+        self._execution_store = execution_store
+        self._leases: Dict[UUID, PacketLease] = {}
+        # Track active lease per packet_id
+        self._packet_to_lease: Dict[str, UUID] = {}
+
+    def checkout(self, packet_id: str, agent_id: str, ttl_seconds: int) -> PacketLease:
+        packet = self._execution_store.get_packet(packet_id)
+        if not packet:
+            raise PacketNotFoundError(packet_id)
+        if packet.state != PacketState.READY:
+            # Check if there's an expired lease we can reclaim
+            active_lease_id = self._packet_to_lease.get(packet_id)
+            if active_lease_id:
+                lease = self._leases[active_lease_id]
+                if lease.expires_at_utc > datetime.now(timezone.utc):
+                    raise PacketNotReadyError(packet_id, packet.state)
+                # Reclaim expired lease
+                lease.state = LeaseState.EXPIRED
+
+        now = datetime.now(timezone.utc)
+        expires_at = now + timedelta(seconds=ttl_seconds)
+        lease = PacketLease(
+            lease_id=uuid4(),
+            packet_id=packet_id,
+            agent_id=agent_id,
+            leased_at_utc=now,
+            expires_at_utc=expires_at,
+            state=LeaseState.ACTIVE
+        )
+
+        self._execution_store.update_packet_state(packet_id, PacketState.LEASED)
+        self._leases[lease.lease_id] = lease
+        self._packet_to_lease[packet_id] = lease.lease_id
+        return lease.model_copy()
+
+    def heartbeat(self, lease_id: UUID) -> PacketLease:
+        lease = self._leases.get(lease_id)
+        if not lease:
+            raise LeaseNotFoundError(lease_id)
+
+        now = datetime.now(timezone.utc)
+        if lease.expires_at_utc < now:
+            lease.state = LeaseState.EXPIRED
+            raise LeaseExpiredError(lease_id)
+
+        # Extend lease by another 5 minutes (default heartbeat)
+        lease.expires_at_utc = now + timedelta(minutes=5)
+        # Ensure packet state is EXECUTING if it was LEASED
+        packet = self._execution_store.get_packet(lease.packet_id)
+        if packet and packet.state == PacketState.LEASED:
+            self._execution_store.update_packet_state(lease.packet_id, PacketState.EXECUTING)
+
+        return lease.model_copy()
+
+    def release(self, lease_id: UUID, final_state: PacketState) -> PacketLease:
+        lease = self._leases.get(lease_id)
+        if not lease:
+            raise LeaseNotFoundError(lease_id)
+
+        lease.state = LeaseState.RELEASED
+        self._execution_store.update_packet_state(lease.packet_id, final_state)
+        if self._packet_to_lease.get(lease.packet_id) == lease_id:
+            del self._packet_to_lease[lease.packet_id]
+
+        return lease.model_copy()
+
+
+_execution_store: Optional[ExecutionStore] = None
+_lease_store: Optional[LeaseStore] = None
+
+def get_execution_store() -> ExecutionStore:
+    global _execution_store
+    if _execution_store is None:
+        _execution_store = InMemoryExecutionStore()
+    return _execution_store
+
+def get_lease_store() -> LeaseStore:
+    global _lease_store
+    if _lease_store is None:
+        _lease_store = InMemoryLeaseStore(get_execution_store())
+    return _lease_store

--- a/src/dopemux/execution/store.py
+++ b/src/dopemux/execution/store.py
@@ -15,11 +15,13 @@ from .models import ExecutionPacket, PacketLease, PacketState, LeaseState
 
 class ExecutionError(Exception):
     """Base class for execution-related errors."""
+
     pass
 
 
 class PacketNotFoundError(ExecutionError):
     """Raised when a packet_id does not exist."""
+
     def __init__(self, packet_id: str) -> None:
         self.packet_id = packet_id
         super().__init__(f"Packet not found: {packet_id}")
@@ -27,6 +29,7 @@ class PacketNotFoundError(ExecutionError):
 
 class PacketNotReadyError(ExecutionError):
     """Raised when attempting to checkout a packet that is not in READY state."""
+
     def __init__(self, packet_id: str, state: PacketState) -> None:
         self.packet_id = packet_id
         self.state = state
@@ -35,6 +38,7 @@ class PacketNotReadyError(ExecutionError):
 
 class LeaseNotFoundError(ExecutionError):
     """Raised when a lease_id does not exist."""
+
     def __init__(self, lease_id: UUID) -> None:
         self.lease_id = lease_id
         super().__init__(f"Lease not found: {lease_id}")
@@ -42,6 +46,7 @@ class LeaseNotFoundError(ExecutionError):
 
 class LeaseExpiredError(ExecutionError):
     """Raised when an operation is attempted on an expired lease."""
+
     def __init__(self, lease_id: UUID) -> None:
         self.lease_id = lease_id
         super().__init__(f"Lease {lease_id} has expired")
@@ -53,22 +58,22 @@ class ExecutionStore(ABC):
     @abstractmethod
     def create_packet(self, packet: ExecutionPacket) -> ExecutionPacket:
         """Store a new packet. If packet_id exists, return existing."""
-        ...
+        pass
 
     @abstractmethod
     def get_packet(self, packet_id: str) -> Optional[ExecutionPacket]:
         """Retrieve packet by ID."""
-        ...
+        pass
 
     @abstractmethod
     def list_ready_packets(self) -> List[ExecutionPacket]:
         """List all packets in READY state."""
-        ...
+        pass
 
     @abstractmethod
     def update_packet_state(self, packet_id: str, state: PacketState) -> ExecutionPacket:
         """Update the state of a packet."""
-        ...
+        pass
 
 
 class LeaseStore(ABC):
@@ -83,7 +88,7 @@ class LeaseStore(ABC):
             PacketNotFoundError: packet_id does not exist.
             PacketNotReadyError: packet is not in READY state.
         """
-        ...
+        pass
 
     @abstractmethod
     def heartbeat(self, lease_id: UUID) -> PacketLease:
@@ -94,7 +99,7 @@ class LeaseStore(ABC):
             LeaseNotFoundError: lease_id does not exist.
             LeaseExpiredError: lease has already expired.
         """
-        ...
+        pass
 
     @abstractmethod
     def release(self, lease_id: UUID, final_state: PacketState) -> PacketLease:
@@ -104,7 +109,7 @@ class LeaseStore(ABC):
         Raises:
             LeaseNotFoundError: lease_id does not exist.
         """
-        ...
+        pass
 
 
 class InMemoryExecutionStore(ExecutionStore):
@@ -143,20 +148,25 @@ class InMemoryLeaseStore(LeaseStore):
         self._packet_to_lease: Dict[str, UUID] = {}
 
     def checkout(self, packet_id: str, agent_id: str, ttl_seconds: int) -> PacketLease:
+        now = datetime.now(timezone.utc)
         packet = self._execution_store.get_packet(packet_id)
         if not packet:
             raise PacketNotFoundError(packet_id)
         if packet.state != PacketState.READY:
-            # Check if there's an expired lease we can reclaim
             active_lease_id = self._packet_to_lease.get(packet_id)
-            if active_lease_id:
-                lease = self._leases[active_lease_id]
-                if lease.expires_at_utc > datetime.now(timezone.utc):
-                    raise PacketNotReadyError(packet_id, packet.state)
-                # Reclaim expired lease
-                lease.state = LeaseState.EXPIRED
+            if active_lease_id is None or packet.state not in {PacketState.LEASED, PacketState.EXECUTING}:
+                raise PacketNotReadyError(packet_id, packet.state)
 
-        now = datetime.now(timezone.utc)
+            lease = self._leases.get(active_lease_id)
+            if lease is None or lease.state != LeaseState.ACTIVE:
+                raise PacketNotReadyError(packet_id, packet.state)
+
+            if lease.expires_at_utc > now:
+                raise PacketNotReadyError(packet_id, packet.state)
+
+            lease.state = LeaseState.EXPIRED
+            del self._packet_to_lease[packet_id]
+
         expires_at = now + timedelta(seconds=ttl_seconds)
         lease = PacketLease(
             lease_id=uuid4(),
@@ -164,6 +174,7 @@ class InMemoryLeaseStore(LeaseStore):
             agent_id=agent_id,
             leased_at_utc=now,
             expires_at_utc=expires_at,
+            ttl_seconds=ttl_seconds,
             state=LeaseState.ACTIVE
         )
 
@@ -182,8 +193,7 @@ class InMemoryLeaseStore(LeaseStore):
             lease.state = LeaseState.EXPIRED
             raise LeaseExpiredError(lease_id)
 
-        # Extend lease by another 5 minutes (default heartbeat)
-        lease.expires_at_utc = now + timedelta(minutes=5)
+        lease.expires_at_utc = now + timedelta(seconds=lease.ttl_seconds)
         # Ensure packet state is EXECUTING if it was LEASED
         packet = self._execution_store.get_packet(lease.packet_id)
         if packet and packet.state == PacketState.LEASED:

--- a/tests/test_execution_store.py
+++ b/tests/test_execution_store.py
@@ -1,15 +1,12 @@
 import pytest
-from datetime import datetime, timedelta, timezone
-from uuid import UUID
 
-from src.dopemux.execution.models import ExecutionPacket, PacketState, LeaseState
-from src.dopemux.execution.store import (
+from dopemux.execution.models import ExecutionPacket, LeaseState, PacketState
+from dopemux.execution.store import (
     InMemoryExecutionStore,
     InMemoryLeaseStore,
+    LeaseExpiredError,
     PacketNotFoundError,
     PacketNotReadyError,
-    LeaseNotFoundError,
-    LeaseExpiredError,
 )
 
 @pytest.fixture
@@ -76,11 +73,11 @@ def test_release_packet(execution_store, lease_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
     execution_store.create_packet(packet)
     lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
-    
-    lease_store.release(lease.lease_id, final_state=PacketState.PROOF_GENERATED)
-    
+
+    released_lease = lease_store.release(lease.lease_id, final_state=PacketState.PROOF_GENERATED)
+
     assert execution_store.get_packet("TP-1").state == PacketState.PROOF_GENERATED
-    assert lease_store._leases[lease.lease_id].state == LeaseState.RELEASED
+    assert released_lease.state == LeaseState.RELEASED
 
 def test_reclaim_expired_lease(execution_store, lease_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
@@ -93,3 +90,11 @@ def test_reclaim_expired_lease(execution_store, lease_store):
     lease2 = lease_store.checkout("TP-1", "agent-2", ttl_seconds=60)
     assert lease2.agent_id == "agent-2"
     assert execution_store.get_packet("TP-1").state == PacketState.LEASED
+
+
+def test_checkout_rejects_non_ready_terminal_state(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1", state=PacketState.PROOF_GENERATED)
+    execution_store.create_packet(packet)
+
+    with pytest.raises(PacketNotReadyError):
+        lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)

--- a/tests/test_execution_store.py
+++ b/tests/test_execution_store.py
@@ -1,0 +1,95 @@
+import pytest
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from src.dopemux.execution.models import ExecutionPacket, PacketState, LeaseState
+from src.dopemux.execution.store import (
+    InMemoryExecutionStore,
+    InMemoryLeaseStore,
+    PacketNotFoundError,
+    PacketNotReadyError,
+    LeaseNotFoundError,
+    LeaseExpiredError,
+)
+
+@pytest.fixture
+def execution_store():
+    return InMemoryExecutionStore()
+
+@pytest.fixture
+def lease_store(execution_store):
+    return InMemoryLeaseStore(execution_store)
+
+def test_packet_creation(execution_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    created = execution_store.create_packet(packet)
+    assert created.packet_id == "TP-1"
+    assert created.state == PacketState.READY
+
+def test_checkout_success(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+    assert lease.packet_id == "TP-1"
+    assert lease.agent_id == "agent-1"
+    assert lease.state == LeaseState.ACTIVE
+    
+    # Verify packet state updated
+    updated_packet = execution_store.get_packet("TP-1")
+    assert updated_packet.state == PacketState.LEASED
+
+def test_checkout_non_existent_packet(lease_store):
+    with pytest.raises(PacketNotFoundError):
+        lease_store.checkout("NON-EXISTENT", "agent-1", ttl_seconds=60)
+
+def test_checkout_already_leased(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+    
+    with pytest.raises(PacketNotReadyError):
+        lease_store.checkout("TP-1", "agent-2", ttl_seconds=60)
+
+def test_heartbeat_extends_expiry(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+    
+    original_expiry = lease.expires_at_utc
+    updated_lease = lease_store.heartbeat(lease.lease_id)
+    
+    assert updated_lease.expires_at_utc > original_expiry
+    assert execution_store.get_packet("TP-1").state == PacketState.EXECUTING
+
+def test_heartbeat_expired_lease(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    
+    # Create lease with 0 TTL (instantly expired)
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=-1)
+    
+    with pytest.raises(LeaseExpiredError):
+        lease_store.heartbeat(lease.lease_id)
+
+def test_release_packet(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+    
+    lease_store.release(lease.lease_id, final_state=PacketState.PROOF_GENERATED)
+    
+    assert execution_store.get_packet("TP-1").state == PacketState.PROOF_GENERATED
+    assert lease_store._leases[lease.lease_id].state == LeaseState.RELEASED
+
+def test_reclaim_expired_lease(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    
+    # Agent 1 takes lease and it expires
+    lease_store.checkout("TP-1", "agent-1", ttl_seconds=-1)
+    
+    # Agent 2 should be able to checkout now
+    lease2 = lease_store.checkout("TP-1", "agent-2", ttl_seconds=60)
+    assert lease2.agent_id == "agent-2"
+    assert execution_store.get_packet("TP-1").state == PacketState.LEASED


### PR DESCRIPTION
## Summary
- add execution-plane packet and lease models
- add in-memory execution and lease stores
- wire task coordinator execution batches through packet leasing and heartbeats
- add targeted execution-store coverage

## Validation
- pytest tests/test_execution_store.py
- pytest tests/test_task_coordinator_monitoring.py
- python3 -m py_compile src/dopemux/execution/models.py src/dopemux/execution/store.py