### PR TITLE
feat(execution): add packet lease store and coordinator integration

### DIFF
--- a/services/task-orchestrator/app/services/task_coordinator.py
+++ b/services/task-orchestrator/app/services/task_coordinator.py
@@ -27,8 +27,10 @@ from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 from enum import Enum
+from uuid import UUID
 
 import asyncio
+import inspect
 import logging
 import os
 
@@ -47,6 +49,9 @@ from pal_client import TaskOrchestratorPALClient
 from dopemux.pm.store import InMemoryPMTaskStore
 from dopemux.pm.models import PMTask, PMTaskStatus, PMTransitionRequest, content_hash_task_id
 from dopemux.pm.mapping import ORCHESTRATOR_TO_CANONICAL, CANONICAL_TO_ORCHESTRATOR
+
+from dopemux.execution.store import get_execution_store, get_lease_store, PacketNotFoundError, PacketNotReadyError
+from dopemux.execution.models import ExecutionPacket, PacketState
 
 logger = logging.getLogger(__name__)
 
@@ -491,6 +496,10 @@ class TaskCoordinator:
             "context_switches": 0
         }
 
+        execution_store = get_execution_store()
+        lease_store = get_lease_store()
+        monitor_accepts_lease = "lease_id" in inspect.signature(self._monitor_execution).parameters
+
         for task_id in sequenced_tasks:
             # Execute task (placeholder - actual execution via agents)
             # Find the task object from internal storage
@@ -499,7 +508,22 @@ class TaskCoordinator:
                 logger.warning(f"⚠️ Task {task_id} not found in coordinator cache")
                 results["failed"].append(task_id)
                 continue
+            lease = None
             try:
+                # 1. Ensure ExecutionPacket exists in the Execution Plane
+                if not execution_store.get_packet(task_id):
+                    execution_store.create_packet(ExecutionPacket(
+                        packet_id=task_id,
+                        owner_id="orchestrator",
+                        state=PacketState.READY,
+                        metadata={"title": task.title}
+                    ))
+                
+                # 2. Acquire Lease
+                agent_id = task.assigned_agent.value if task.assigned_agent else "unassigned-agent"
+                lease = lease_store.checkout(task_id, agent_id, ttl_seconds=300)
+                logger.info(f"🔑 Leased packet {task_id} to {agent_id} (Lease ID: {lease.lease_id})")
+
                 # Sync status transition idempotently via Canonical Store
                 try:
                     pm_task = self.pm_store.get(task_id)
@@ -521,9 +545,11 @@ class TaskCoordinator:
                 
                 results["in_progress"].append(task_id)
 
-                # Simulate execution with monitoring
-                # We await this to maintain sequential execution order
-                await self._monitor_execution(task)
+                # Preserve compatibility with test/local monitor overrides that only accept `task`.
+                if monitor_accepts_lease:
+                    await self._monitor_execution(task, lease_id=lease.lease_id)
+                else:
+                    await self._monitor_execution(task)
 
                 # Mark task as completed after successful monitoring idempotently
                 try:
@@ -544,20 +570,36 @@ class TaskCoordinator:
                     logger.warning(f"Failed canonical transition to COMPLETED for {task_id}: {e}")
                     task.status = TaskStatus.COMPLETED
 
+                # 3. Release Lease
+                lease_store.release(lease.lease_id, final_state=PacketState.PROOF_GENERATED)
+                lease = None
+                logger.info(f"✅ Released lease for packet {task_id}")
+
                 results["completed"].append(task_id)
                 results["in_progress"].remove(task_id)
 
                 # Sync to ConPort
                 await self.conport_adapter.update_task_in_conport(task)
 
+            except (PacketNotReadyError, PacketNotFoundError) as e:
+                logger.warning(f"⚠️ Could not lease packet {task_id}: {e}")
+                results["failed"].append(task_id)
+                continue
             except Exception as e:
                 logger.error(f"❌ Task execution failed {task_id}: {e}")
-                task.status = TaskStatus.FAILED
+                task.status = TaskStatus.BLOCKED
                 # Remove from in_progress if it was added
                 if task_id in results["in_progress"]:
                     results["in_progress"].remove(task_id)
                 results["failed"].append(task_id)
                 break
+            finally:
+                if lease is not None:
+                    try:
+                        lease_store.release(lease.lease_id, final_state=PacketState.READY)
+                        logger.info(f"↩️ Released failed lease for packet {task_id}")
+                    except Exception as release_error:
+                        logger.warning(f"Failed to release lease for {task_id}: {release_error}")
 
         # Check for context switching
         await self.context_recovery.detect_context_switch()
@@ -587,9 +629,9 @@ class TaskCoordinator:
         energy_cost = base_cost * energy_modifiers.get(adhd_state.get('energy'), 1.0)
         return min(1.0, energy_cost)  # Cap at 1.0
 
-    async def _monitor_execution(self, task: OrchestrationTask):
+    async def _monitor_execution(self, task: OrchestrationTask, lease_id: Optional[UUID] = None):
         """
-        Monitor task execution with ADHD-aware breaks.
+        Monitor task execution with ADHD-aware breaks and lease heartbeats.
         """
         # Simulate task duration (demo mode)
         # In a real system, this would monitor an actual agent's progress
@@ -598,8 +640,19 @@ class TaskCoordinator:
         if self.coordination_state.session_start_time is None:
             self.coordination_state.session_start_time = start_time
 
+        lease_store = get_lease_store()
+
         # Check energy decay over time
         while (datetime.now() - start_time).total_seconds() < simulated_duration:
+            # Pulse heartbeat if we have a lease
+            if lease_id:
+                try:
+                    lease_store.heartbeat(lease_id)
+                    logger.debug(f"💓 Heartbeat for lease {lease_id}")
+                except Exception as e:
+                    logger.error(f"💔 Heartbeat failed for lease {lease_id}: {e}")
+                    raise
+
             # Update global session timer based on elapsed time since session start
             elapsed = (datetime.now() - self.coordination_state.session_start_time).total_seconds()
             self.coordination_state.focus_session_timer = int(elapsed)

--- a/services/task-orchestrator/app/services/task_coordinator.py
+++ b/services/task-orchestrator/app/services/task_coordinator.py
@@ -50,7 +50,12 @@ from dopemux.pm.store import InMemoryPMTaskStore
 from dopemux.pm.models import PMTask, PMTaskStatus, PMTransitionRequest, content_hash_task_id
 from dopemux.pm.mapping import ORCHESTRATOR_TO_CANONICAL, CANONICAL_TO_ORCHESTRATOR
 
-from dopemux.execution.store import get_execution_store, get_lease_store, PacketNotFoundError, PacketNotReadyError
+from dopemux.execution.store import (
+    PacketNotFoundError,
+    PacketNotReadyError,
+    get_execution_store,
+    get_lease_store,
+)
 from dopemux.execution.models import ExecutionPacket, PacketState
 
 logger = logging.getLogger(__name__)

--- a/src/dopemux/execution/models.py
+++ b/src/dopemux/execution/models.py
@@ -1,0 +1,63 @@
+"""
+Canonical Execution Domain Models.
+
+Implements TP-SIA-EXEC-0001: core data models and locking primitives for the
+Workflow / Execution Control Plane.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+
+class PacketState(str, Enum):
+    """Execution lifecycle state for a Task Packet."""
+
+    READY = "READY"  # Available for lease
+    LEASED = "LEASED"  # Checked out by an agent
+    EXECUTING = "EXECUTING"  # Agent is actively processing (heartbeat active)
+    PROOF_GENERATED = "PROOF_GENERATED"  # Work complete, verification artifacts present
+    AUDITED = "AUDITED"  # Human or Supervisor has verified the proof
+    COMMITTED = "COMMITTED"  # Changes merged to target branch
+
+
+class LeaseState(str, Enum):
+    """State of a packet lease."""
+
+    ACTIVE = "ACTIVE"  # Lease is within TTL
+    EXPIRED = "EXPIRED"  # Heartbeat missed; packet returned to READY
+    RELEASED = "RELEASED"  # Graceful handoff or completion
+
+
+class ExecutionPacket(BaseModel):
+    """Authoritative state container for an executable packet."""
+
+    packet_id: str = Field(..., description="Unique string (e.g., 'TP-SIA-EXEC-0001')")
+    owner_id: str = Field(..., description="Primary author/operator")
+    depends_on: List[str] = Field(default_factory=list, description="Prerequisite packet IDs")
+    state: PacketState = Field(default=PacketState.READY)
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict, description="Branch names, initial commit SHAs, requirements"
+    )
+    proof_bundle: Dict[str, Any] = Field(
+        default_factory=dict, description="Links to logs, diffs, and test results"
+    )
+
+    model_config = {"frozen": False}
+
+
+class PacketLease(BaseModel):
+    """Locking primitive for exclusive packet access."""
+
+    lease_id: UUID = Field(..., description="UUID4 unique lease identifier")
+    packet_id: str = Field(..., description="Targeted packet ID")
+    agent_id: str = Field(..., description="Identifier of the leasing entity (e.g., 'gemini-2.5-pro')")
+    leased_at_utc: datetime = Field(..., description="Timestamp of checkout")
+    expires_at_utc: datetime = Field(..., description="Hard deadline for next heartbeat")
+    ttl_seconds: int = Field(..., description="Original lease duration in seconds")
+    state: LeaseState = Field(default=LeaseState.ACTIVE)
+
+    model_config = {"frozen": False}

--- a/src/dopemux/execution/store.py
+++ b/src/dopemux/execution/store.py
@@ -1,0 +1,238 @@
+"""
+Execution store and lease management implementation.
+
+Implements TP-SIA-EXEC-0001: core data models and locking primitives for the
+Workflow / Execution Control Plane.
+"""
+
+from abc import ABC, abstractmethod
+from datetime import datetime, timedelta, timezone
+from typing import Dict, List, Optional
+from uuid import UUID, uuid4
+
+from .models import ExecutionPacket, PacketLease, PacketState, LeaseState
+
+
+class ExecutionError(Exception):
+    """Base class for execution-related errors."""
+
+    pass
+
+
+class PacketNotFoundError(ExecutionError):
+    """Raised when a packet_id does not exist."""
+
+    def __init__(self, packet_id: str) -> None:
+        self.packet_id = packet_id
+        super().__init__(f"Packet not found: {packet_id}")
+
+
+class PacketNotReadyError(ExecutionError):
+    """Raised when attempting to checkout a packet that is not in READY state."""
+
+    def __init__(self, packet_id: str, state: PacketState) -> None:
+        self.packet_id = packet_id
+        self.state = state
+        super().__init__(f"Packet {packet_id} is not READY (current state: {state})")
+
+
+class LeaseNotFoundError(ExecutionError):
+    """Raised when a lease_id does not exist."""
+
+    def __init__(self, lease_id: UUID) -> None:
+        self.lease_id = lease_id
+        super().__init__(f"Lease not found: {lease_id}")
+
+
+class LeaseExpiredError(ExecutionError):
+    """Raised when an operation is attempted on an expired lease."""
+
+    def __init__(self, lease_id: UUID) -> None:
+        self.lease_id = lease_id
+        super().__init__(f"Lease {lease_id} has expired")
+
+
+class ExecutionStore(ABC):
+    """Abstract base class for ExecutionPacket persistence."""
+
+    @abstractmethod
+    def create_packet(self, packet: ExecutionPacket) -> ExecutionPacket:
+        """Store a new packet. If packet_id exists, return existing."""
+        pass
+
+    @abstractmethod
+    def get_packet(self, packet_id: str) -> Optional[ExecutionPacket]:
+        """Retrieve packet by ID."""
+        pass
+
+    @abstractmethod
+    def list_ready_packets(self) -> List[ExecutionPacket]:
+        """List all packets in READY state."""
+        pass
+
+    @abstractmethod
+    def update_packet_state(self, packet_id: str, state: PacketState) -> ExecutionPacket:
+        """Update the state of a packet."""
+        pass
+
+
+class LeaseStore(ABC):
+    """Abstract base class for PacketLease management."""
+
+    @abstractmethod
+    def checkout(self, packet_id: str, agent_id: str, ttl_seconds: int) -> PacketLease:
+        """
+        Atomically transition packet to LEASED and create a lease.
+
+        Raises:
+            PacketNotFoundError: packet_id does not exist.
+            PacketNotReadyError: packet is not in READY state.
+        """
+        pass
+
+    @abstractmethod
+    def heartbeat(self, lease_id: UUID) -> PacketLease:
+        """
+        Extend the expiry of an active lease.
+
+        Raises:
+            LeaseNotFoundError: lease_id does not exist.
+            LeaseExpiredError: lease has already expired.
+        """
+        pass
+
+    @abstractmethod
+    def release(self, lease_id: UUID, final_state: PacketState) -> PacketLease:
+        """
+        Transition packet to final_state and mark lease as RELEASED.
+
+        Raises:
+            LeaseNotFoundError: lease_id does not exist.
+        """
+        pass
+
+
+class InMemoryExecutionStore(ExecutionStore):
+    """In-memory implementation of ExecutionStore."""
+
+    def __init__(self) -> None:
+        self._packets: Dict[str, ExecutionPacket] = {}
+
+    def create_packet(self, packet: ExecutionPacket) -> ExecutionPacket:
+        if packet.packet_id in self._packets:
+            return self._packets[packet.packet_id].model_copy()
+        self._packets[packet.packet_id] = packet.model_copy()
+        return self._packets[packet.packet_id].model_copy()
+
+    def get_packet(self, packet_id: str) -> Optional[ExecutionPacket]:
+        packet = self._packets.get(packet_id)
+        return packet.model_copy() if packet else None
+
+    def list_ready_packets(self) -> List[ExecutionPacket]:
+        return [p.model_copy() for p in self._packets.values() if p.state == PacketState.READY]
+
+    def update_packet_state(self, packet_id: str, state: PacketState) -> ExecutionPacket:
+        if packet_id not in self._packets:
+            raise PacketNotFoundError(packet_id)
+        self._packets[packet_id].state = state
+        return self._packets[packet_id].model_copy()
+
+
+class InMemoryLeaseStore(LeaseStore):
+    """In-memory implementation of LeaseStore."""
+
+    def __init__(self, execution_store: ExecutionStore) -> None:
+        self._execution_store = execution_store
+        self._leases: Dict[UUID, PacketLease] = {}
+        # Track active lease per packet_id
+        self._packet_to_lease: Dict[str, UUID] = {}
+
+    def checkout(self, packet_id: str, agent_id: str, ttl_seconds: int) -> PacketLease:
+        now = datetime.now(timezone.utc)
+        packet = self._execution_store.get_packet(packet_id)
+        if not packet:
+            raise PacketNotFoundError(packet_id)
+        if packet.state != PacketState.READY:
+            active_lease_id = self._packet_to_lease.get(packet_id)
+            if active_lease_id is None or packet.state not in {PacketState.LEASED, PacketState.EXECUTING}:
+                raise PacketNotReadyError(packet_id, packet.state)
+
+            lease = self._leases.get(active_lease_id)
+            if lease is None or lease.state != LeaseState.ACTIVE:
+                raise PacketNotReadyError(packet_id, packet.state)
+
+            if lease.expires_at_utc > now:
+                raise PacketNotReadyError(packet_id, packet.state)
+
+            lease.state = LeaseState.EXPIRED
+            del self._packet_to_lease[packet_id]
+
+        expires_at = now + timedelta(seconds=ttl_seconds)
+        lease = PacketLease(
+            lease_id=uuid4(),
+            packet_id=packet_id,
+            agent_id=agent_id,
+            leased_at_utc=now,
+            expires_at_utc=expires_at,
+            ttl_seconds=ttl_seconds,
+            state=LeaseState.ACTIVE
+        )
+
+        self._execution_store.update_packet_state(packet_id, PacketState.LEASED)
+        self._leases[lease.lease_id] = lease
+        self._packet_to_lease[packet_id] = lease.lease_id
+        return lease.model_copy()
+
+    def heartbeat(self, lease_id: UUID) -> PacketLease:
+        lease = self._leases.get(lease_id)
+        if not lease:
+            raise LeaseNotFoundError(lease_id)
+
+        now = datetime.now(timezone.utc)
+        if lease.expires_at_utc < now:
+            lease.state = LeaseState.EXPIRED
+            if self._packet_to_lease.get(lease.packet_id) == lease_id:
+                del self._packet_to_lease[lease.packet_id]
+            packet = self._execution_store.get_packet(lease.packet_id)
+            if packet and packet.state in {PacketState.LEASED, PacketState.EXECUTING}:
+                self._execution_store.update_packet_state(lease.packet_id, PacketState.READY)
+            raise LeaseExpiredError(lease_id)
+
+        lease.expires_at_utc = now + timedelta(seconds=lease.ttl_seconds)
+        # Ensure packet state is EXECUTING if it was LEASED
+        packet = self._execution_store.get_packet(lease.packet_id)
+        if packet and packet.state == PacketState.LEASED:
+            self._execution_store.update_packet_state(lease.packet_id, PacketState.EXECUTING)
+
+        return lease.model_copy()
+
+    def release(self, lease_id: UUID, final_state: PacketState) -> PacketLease:
+        lease = self._leases.get(lease_id)
+        if not lease:
+            raise LeaseNotFoundError(lease_id)
+
+        current_lease_id = self._packet_to_lease.get(lease.packet_id)
+        if lease.state != LeaseState.ACTIVE or current_lease_id != lease_id:
+            raise LeaseExpiredError(lease_id)
+
+        lease.state = LeaseState.RELEASED
+        self._execution_store.update_packet_state(lease.packet_id, final_state)
+        del self._packet_to_lease[lease.packet_id]
+
+        return lease.model_copy()
+
+
+_execution_store: Optional[ExecutionStore] = None
+_lease_store: Optional[LeaseStore] = None
+
+def get_execution_store() -> ExecutionStore:
+    global _execution_store
+    if _execution_store is None:
+        _execution_store = InMemoryExecutionStore()
+    return _execution_store
+
+def get_lease_store() -> LeaseStore:
+    global _lease_store
+    if _lease_store is None:
+        _lease_store = InMemoryLeaseStore(get_execution_store())
+    return _lease_store

--- a/src/dopemux/execution/store.py
+++ b/src/dopemux/execution/store.py
@@ -58,22 +58,22 @@ class ExecutionStore(ABC):
     @abstractmethod
     def create_packet(self, packet: ExecutionPacket) -> ExecutionPacket:
         """Store a new packet. If packet_id exists, return existing."""
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def get_packet(self, packet_id: str) -> Optional[ExecutionPacket]:
         """Retrieve packet by ID."""
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def list_ready_packets(self) -> List[ExecutionPacket]:
         """List all packets in READY state."""
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def update_packet_state(self, packet_id: str, state: PacketState) -> ExecutionPacket:
         """Update the state of a packet."""
-        pass
+        raise NotImplementedError
 
 
 class LeaseStore(ABC):
@@ -88,7 +88,7 @@ class LeaseStore(ABC):
             PacketNotFoundError: packet_id does not exist.
             PacketNotReadyError: packet is not in READY state.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def heartbeat(self, lease_id: UUID) -> PacketLease:
@@ -99,7 +99,7 @@ class LeaseStore(ABC):
             LeaseNotFoundError: lease_id does not exist.
             LeaseExpiredError: lease has already expired.
         """
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def release(self, lease_id: UUID, final_state: PacketState) -> PacketLease:
@@ -109,7 +109,7 @@ class LeaseStore(ABC):
         Raises:
             LeaseNotFoundError: lease_id does not exist.
         """
-        pass
+        raise NotImplementedError
 
 
 class InMemoryExecutionStore(ExecutionStore):
@@ -175,7 +175,7 @@ class InMemoryLeaseStore(LeaseStore):
             leased_at_utc=now,
             expires_at_utc=expires_at,
             ttl_seconds=ttl_seconds,
-            state=LeaseState.ACTIVE
+            state=LeaseState.ACTIVE,
         )
 
         self._execution_store.update_packet_state(packet_id, PacketState.LEASED)
@@ -189,13 +189,14 @@ class InMemoryLeaseStore(LeaseStore):
             raise LeaseNotFoundError(lease_id)
 
         now = datetime.now(timezone.utc)
-        if lease.expires_at_utc < now:
+        if lease.expires_at_utc <= now:
             lease.state = LeaseState.EXPIRED
-            if self._packet_to_lease.get(lease.packet_id) == lease_id:
+            is_active_lease = self._packet_to_lease.get(lease.packet_id) == lease_id
+            if is_active_lease:
                 del self._packet_to_lease[lease.packet_id]
-            packet = self._execution_store.get_packet(lease.packet_id)
-            if packet and packet.state in {PacketState.LEASED, PacketState.EXECUTING}:
-                self._execution_store.update_packet_state(lease.packet_id, PacketState.READY)
+                packet = self._execution_store.get_packet(lease.packet_id)
+                if packet and packet.state in {PacketState.LEASED, PacketState.EXECUTING}:
+                    self._execution_store.update_packet_state(lease.packet_id, PacketState.READY)
             raise LeaseExpiredError(lease_id)
 
         lease.expires_at_utc = now + timedelta(seconds=lease.ttl_seconds)
@@ -225,11 +226,13 @@ class InMemoryLeaseStore(LeaseStore):
 _execution_store: Optional[ExecutionStore] = None
 _lease_store: Optional[LeaseStore] = None
 
+
 def get_execution_store() -> ExecutionStore:
     global _execution_store
     if _execution_store is None:
         _execution_store = InMemoryExecutionStore()
     return _execution_store
+
 
 def get_lease_store() -> LeaseStore:
     global _lease_store

--- a/tests/test_execution_store.py
+++ b/tests/test_execution_store.py
@@ -13,9 +13,11 @@ from dopemux.execution.store import (
 def execution_store():
     return InMemoryExecutionStore()
 
+
 @pytest.fixture
 def lease_store(execution_store):
     return InMemoryLeaseStore(execution_store)
+
 
 def test_packet_creation(execution_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
@@ -23,51 +25,57 @@ def test_packet_creation(execution_store):
     assert created.packet_id == "TP-1"
     assert created.state == PacketState.READY
 
+
 def test_checkout_success(execution_store, lease_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
     execution_store.create_packet(packet)
-    
+
     lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
     assert lease.packet_id == "TP-1"
     assert lease.agent_id == "agent-1"
     assert lease.state == LeaseState.ACTIVE
-    
+
     # Verify packet state updated
     updated_packet = execution_store.get_packet("TP-1")
     assert updated_packet.state == PacketState.LEASED
+
 
 def test_checkout_non_existent_packet(lease_store):
     with pytest.raises(PacketNotFoundError):
         lease_store.checkout("NON-EXISTENT", "agent-1", ttl_seconds=60)
 
+
 def test_checkout_already_leased(execution_store, lease_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
     execution_store.create_packet(packet)
     lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
-    
+
     with pytest.raises(PacketNotReadyError):
         lease_store.checkout("TP-1", "agent-2", ttl_seconds=60)
+
 
 def test_heartbeat_extends_expiry(execution_store, lease_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
     execution_store.create_packet(packet)
     lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
-    
+
     original_expiry = lease.expires_at_utc
     updated_lease = lease_store.heartbeat(lease.lease_id)
-    
+
     assert updated_lease.expires_at_utc > original_expiry
     assert execution_store.get_packet("TP-1").state == PacketState.EXECUTING
+
 
 def test_heartbeat_expired_lease(execution_store, lease_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
     execution_store.create_packet(packet)
-    
-    # Create lease with 0 TTL (instantly expired)
+
+    # Create lease with negative TTL (instantly expired)
     lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=-1)
-    
+
     with pytest.raises(LeaseExpiredError):
         lease_store.heartbeat(lease.lease_id)
+
 
 def test_release_packet(execution_store, lease_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
@@ -79,13 +87,14 @@ def test_release_packet(execution_store, lease_store):
     assert execution_store.get_packet("TP-1").state == PacketState.PROOF_GENERATED
     assert released_lease.state == LeaseState.RELEASED
 
+
 def test_reclaim_expired_lease(execution_store, lease_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
     execution_store.create_packet(packet)
-    
+
     # Agent 1 takes lease and it expires
     lease_store.checkout("TP-1", "agent-1", ttl_seconds=-1)
-    
+
     # Agent 2 should be able to checkout now
     lease2 = lease_store.checkout("TP-1", "agent-2", ttl_seconds=60)
     assert lease2.agent_id == "agent-2"
@@ -114,6 +123,21 @@ def test_heartbeat_expiry_returns_packet_to_ready(execution_store, lease_store):
 
     assert execution_store.get_packet("TP-1").state == PacketState.READY
     assert "TP-1" not in lease_store._packet_to_lease
+
+
+def test_stale_heartbeat_cannot_clobber_newer_lease(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    stale_lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=-1)
+    fresh_lease = lease_store.checkout("TP-1", "agent-2", ttl_seconds=60)
+
+    with pytest.raises(LeaseExpiredError):
+        lease_store.heartbeat(stale_lease.lease_id)
+
+    assert execution_store.get_packet("TP-1").state == PacketState.LEASED
+    active_lease = lease_store.heartbeat(fresh_lease.lease_id)
+    assert active_lease.state == LeaseState.ACTIVE
+    assert execution_store.get_packet("TP-1").state == PacketState.EXECUTING
 
 
 def test_stale_release_cannot_overwrite_packet_state(execution_store, lease_store):

--- a/tests/test_execution_store.py
+++ b/tests/test_execution_store.py
@@ -1,0 +1,128 @@
+import pytest
+
+from dopemux.execution.models import ExecutionPacket, LeaseState, PacketState
+from dopemux.execution.store import (
+    InMemoryExecutionStore,
+    InMemoryLeaseStore,
+    LeaseExpiredError,
+    PacketNotFoundError,
+    PacketNotReadyError,
+)
+
+@pytest.fixture
+def execution_store():
+    return InMemoryExecutionStore()
+
+@pytest.fixture
+def lease_store(execution_store):
+    return InMemoryLeaseStore(execution_store)
+
+def test_packet_creation(execution_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    created = execution_store.create_packet(packet)
+    assert created.packet_id == "TP-1"
+    assert created.state == PacketState.READY
+
+def test_checkout_success(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+    assert lease.packet_id == "TP-1"
+    assert lease.agent_id == "agent-1"
+    assert lease.state == LeaseState.ACTIVE
+    
+    # Verify packet state updated
+    updated_packet = execution_store.get_packet("TP-1")
+    assert updated_packet.state == PacketState.LEASED
+
+def test_checkout_non_existent_packet(lease_store):
+    with pytest.raises(PacketNotFoundError):
+        lease_store.checkout("NON-EXISTENT", "agent-1", ttl_seconds=60)
+
+def test_checkout_already_leased(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+    
+    with pytest.raises(PacketNotReadyError):
+        lease_store.checkout("TP-1", "agent-2", ttl_seconds=60)
+
+def test_heartbeat_extends_expiry(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+    
+    original_expiry = lease.expires_at_utc
+    updated_lease = lease_store.heartbeat(lease.lease_id)
+    
+    assert updated_lease.expires_at_utc > original_expiry
+    assert execution_store.get_packet("TP-1").state == PacketState.EXECUTING
+
+def test_heartbeat_expired_lease(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    
+    # Create lease with 0 TTL (instantly expired)
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=-1)
+    
+    with pytest.raises(LeaseExpiredError):
+        lease_store.heartbeat(lease.lease_id)
+
+def test_release_packet(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+
+    released_lease = lease_store.release(lease.lease_id, final_state=PacketState.PROOF_GENERATED)
+
+    assert execution_store.get_packet("TP-1").state == PacketState.PROOF_GENERATED
+    assert released_lease.state == LeaseState.RELEASED
+
+def test_reclaim_expired_lease(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    
+    # Agent 1 takes lease and it expires
+    lease_store.checkout("TP-1", "agent-1", ttl_seconds=-1)
+    
+    # Agent 2 should be able to checkout now
+    lease2 = lease_store.checkout("TP-1", "agent-2", ttl_seconds=60)
+    assert lease2.agent_id == "agent-2"
+    assert execution_store.get_packet("TP-1").state == PacketState.LEASED
+
+
+def test_checkout_rejects_non_ready_terminal_state(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1", state=PacketState.PROOF_GENERATED)
+    execution_store.create_packet(packet)
+
+    with pytest.raises(PacketNotReadyError):
+        lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+
+
+def test_heartbeat_expiry_returns_packet_to_ready(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=1)
+
+    lease_store._leases[lease.lease_id].expires_at_utc = lease_store._leases[lease.lease_id].expires_at_utc.replace(
+        year=2000
+    )
+
+    with pytest.raises(LeaseExpiredError):
+        lease_store.heartbeat(lease.lease_id)
+
+    assert execution_store.get_packet("TP-1").state == PacketState.READY
+    assert "TP-1" not in lease_store._packet_to_lease
+
+
+def test_stale_release_cannot_overwrite_packet_state(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
+    execution_store.create_packet(packet)
+    lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+    lease_store.release(lease.lease_id, final_state=PacketState.PROOF_GENERATED)
+
+    with pytest.raises(LeaseExpiredError):
+        lease_store.release(lease.lease_id, final_state=PacketState.READY)
+
+    assert execution_store.get_packet("TP-1").state == PacketState.PROOF_GENERATED

--- a/tests/unit/test_task_coordinator_execution_leases.py
+++ b/tests/unit/test_task_coordinator_execution_leases.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+SERVICE_ROOT = Path(__file__).resolve().parents[2] / "services" / "task-orchestrator"
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from app.services.task_coordinator import TaskCoordinator
+from dopemux.execution.models import PacketState
+from dopemux.execution.store import InMemoryExecutionStore, InMemoryLeaseStore
+from task_orchestrator.models import AgentType, OrchestrationTask, TaskStatus
+
+
+@pytest.mark.asyncio
+async def test_execute_batch_uses_leases_for_monitoring(monkeypatch: pytest.MonkeyPatch):
+    execution_store = InMemoryExecutionStore()
+    lease_store = InMemoryLeaseStore(execution_store)
+
+    monkeypatch.setattr(
+        "app.services.task_coordinator.get_execution_store",
+        lambda: execution_store,
+    )
+    monkeypatch.setattr(
+        "app.services.task_coordinator.get_lease_store",
+        lambda: lease_store,
+    )
+
+    coordinator = TaskCoordinator(workspace_id="/tmp/test-workspace")
+
+    async def _noop(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def _monitor(task: OrchestrationTask, lease_id=None) -> None:
+        assert lease_id is not None
+        lease_store.heartbeat(lease_id)
+
+    async def _recovery_statistics() -> dict[str, int]:
+        return {"total_switches": 0}
+
+    monkeypatch.setattr(coordinator.conport_adapter, "update_task_in_conport", _noop)
+    monkeypatch.setattr(coordinator.context_recovery, "detect_context_switch", _noop)
+    monkeypatch.setattr(
+        coordinator.context_recovery,
+        "get_recovery_statistics",
+        _recovery_statistics,
+    )
+    monkeypatch.setattr(coordinator, "_monitor_execution", _monitor)
+
+    task = OrchestrationTask(
+        id="task-lease-1",
+        leantime_id=101,
+        title="Lease-backed execution",
+        description="Verify coordinator heartbeat and release flow",
+        status=TaskStatus.PENDING,
+        priority=3,
+        complexity_score=0.4,
+        estimated_minutes=15,
+        assigned_agent=AgentType.SERENA,
+        energy_required="medium",
+        dependencies=[],
+        context_switches_allowed=2,
+        break_frequency_minutes=25,
+    )
+    coordinator.tasks[task.id] = task
+
+    results = await coordinator._execute_batch([task.id])
+
+    assert results["completed"] == [task.id]
+    assert results["failed"] == []
+    packet = execution_store.get_packet(task.id)
+    assert packet is not None
+    assert packet.state == PacketState.PROOF_GENERATED


### PR DESCRIPTION
## Summary
- add execution-plane packet and lease models on top of current main
- wire task coordinator batch execution through packet leasing with safer expiry, heartbeat, and release handling
- add regression coverage for expired heartbeat recovery, stale heartbeat isolation, stale release rejection, and coordinator lease execution through the repo-root test lane
- replace the drifted dev-targeting delivery lane with a clean main PR

## Validation
- pytest tests/test_execution_store.py tests/unit/test_task_coordinator_execution_leases.py
- pytest services/task-orchestrator/tests/test_task_coordinator_monitoring.py
- python3 -m py_compile src/dopemux/execution/models.py src/dopemux/execution/store.py

Supersedes the unstable delivery lane around #288 for main delivery.

@codex
@clauee
@copilot
