### PR TITLE
feat(pm): enforce write classification boundaries

### DIFF
--- a/docs/planes/pm/write-boundaries.md
+++ b/docs/planes/pm/write-boundaries.md
@@ -1,0 +1,87 @@
+---
+id: pm-plane-write-boundaries
+title: PM Plane Write Boundaries
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-03-26'
+last_review: '2026-03-26'
+next_review: '2026-06-24'
+status: active
+prelude: Explicit write classification and Leantime reflection boundary for the normalized PM-plane write surface.
+---
+# PM Plane Write Boundaries
+
+## Objective
+
+Keep PM metadata writes, workflow-law transitions, and progress logging on distinct authority paths so the PM plane cannot silently invent shadow workflow truth.
+
+## Classification policy
+
+All payloads entering the normalized PM-plane write layer are classified before execution.
+
+### Metadata-only writes
+
+`pm_update_work_item` may carry only PM-record fields such as:
+
+- `title`, `headline`
+- `description`, `details`
+- `assignee`, `assigned_to`, `owner`
+- `labels`, `tags`
+- `due_date`, `start_date`, `end_date`
+- `priority`, `estimate`, `story_points`
+- `notes`, `comments`
+- `linked_ids`, `refs`, `meta`
+- `reflection_metadata`
+
+### Workflow-significant writes
+
+The generic PM update path must reject any field that could change workflow legality or next-action semantics, including:
+
+- `status`, `state`, `phase`, `stage`
+- `transition`
+- `blocked`, `blocker`, `blocked_reason`
+- `promote`, `demote`, `next_action`
+- `dependencies`
+- unknown field names that still look state-bearing, such as custom `*_status`, `*_state`, or `*_phase` keys
+
+Mixed payloads fail closed. The PM plane does not silently split metadata and workflow changes into separate backend calls.
+
+## Canonical routing
+
+- `pm_update_work_item`
+  - Canonical backend: `Leantime`
+  - Allowed only for metadata-only payloads
+  - Rejects workflow-significant fields
+
+- `pm_transition_work_item`
+  - Canonical backend: `Task Orchestrator`
+  - Only sanctioned path for workflow-significant changes
+  - `Leantime` mirrors the adjudicated outcome only
+
+- `pm_log_progress`
+  - Canonical backend: `ConPort`
+  - `dope-memory` receives the chronicle mirror
+
+## Reflection semantics
+
+Normalized PM-plane write receipts expose reflection state explicitly:
+
+- `succeeded`
+  - Canonical write succeeded and the configured mirror write also succeeded
+- `degraded`
+  - Canonical write succeeded, but the mirror write failed or the mirror client was unavailable
+
+Canonical write failure does not return a success receipt. It raises and must be surfaced as a failed operation by the caller.
+
+`reconciliation_state` stays authoritative for downstream handling:
+
+- `SYNCED` means the canonical and mirrored states are aligned
+- `PARTIAL` means the canonical write succeeded and reconciliation is still required for a mirror
+
+## Boundary consequences
+
+- Direct workflow-significant Leantime writes are not lawful workflow transitions.
+- Bridge and CLI callers must use `pm_transition_work_item` for workflow changes.
+- `dopemux.pm.writes` is the canonical PM write surface.
+- `dopemux.pm.write` may remain only as temporary compatibility glue while older callers are migrated.

--- a/docs/planes/pm/write-boundaries.md
+++ b/docs/planes/pm/write-boundaries.md
@@ -39,11 +39,12 @@ All payloads entering the normalized PM-plane write layer are classified before 
 The generic PM update path must reject any field that could change workflow legality or next-action semantics, including:
 
 - `status`, `state`, `phase`, `stage`
+- `version` (including optimistic-concurrency style workflow version fields)
 - `transition`
 - `blocked`, `blocker`, `blocked_reason`
 - `promote`, `demote`, `next_action`
 - `dependencies`
-- unknown field names that still look state-bearing, such as custom `*_status`, `*_state`, or `*_phase` keys
+- unknown field names that still match workflow-like key patterns, such as custom `*_status`, `*_state`, or `*_phase` keys
 
 Mixed payloads fail closed. The PM plane does not silently split metadata and workflow changes into separate backend calls.
 

--- a/src/dopemux/pm/writes.py
+++ b/src/dopemux/pm/writes.py
@@ -4,11 +4,85 @@ Normalized PM-plane writes.
 Implements ADR-PM-001 boundary enforcement and canonical receipts.
 """
 
-from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 from pydantic import BaseModel, Field
 
 from .models import PMTaskStatus, WORKFLOW_SIGNIFICANT_FIELDS
+
+ALLOWED_METADATA_FIELDS = frozenset(
+    {
+        "title",
+        "headline",
+        "description",
+        "details",
+        "assignee",
+        "assigned_to",
+        "owner",
+        "labels",
+        "tags",
+        "due_date",
+        "start_date",
+        "end_date",
+        "priority",
+        "estimate",
+        "story_points",
+        "notes",
+        "comments",
+        "reflection_metadata",
+        "linked_ids",
+        "refs",
+        "meta",
+        "source_task_id",
+        "milestone",
+    }
+)
+
+EXPLICIT_WORKFLOW_FIELDS = frozenset(
+    {field.lower() for field in WORKFLOW_SIGNIFICANT_FIELDS}
+    | {
+        "state",
+        "phase",
+        "stage",
+        "transition",
+        "blocked",
+        "blocker",
+        "promote",
+        "demote",
+        "next_action",
+    }
+)
+
+
+def classify_pm_write(payload: Dict[str, Any]) -> Tuple[List[str], List[str]]:
+    """Classify payload keys into metadata and workflow-significant fields.
+
+    Unknown fields default to metadata unless they look state-bearing, in which
+    case they fail closed into the workflow bucket.
+    """
+
+    metadata_fields: List[str] = []
+    workflow_fields: List[str] = []
+
+    for key in payload.keys():
+        key_lower = key.lower()
+        if key_lower in EXPLICIT_WORKFLOW_FIELDS:
+            workflow_fields.append(key)
+        elif key_lower in ALLOWED_METADATA_FIELDS:
+            metadata_fields.append(key)
+        elif any(token in key_lower for token in ("status", "state", "phase")):
+            workflow_fields.append(key)
+        else:
+            metadata_fields.append(key)
+
+    return metadata_fields, workflow_fields
+
+
+def is_workflow_significant_payload(payload: Dict[str, Any]) -> bool:
+    """Return True when a payload contains workflow-significant fields."""
+
+    _, workflow_fields = classify_pm_write(payload)
+    return bool(workflow_fields)
+
 
 class MirrorReceipt(BaseModel):
     """Result of a best-effort mirror write."""
@@ -23,6 +97,8 @@ class CanonicalReceipt(BaseModel):
     canonical_id: str
     success: bool
     version: Optional[int] = None
+    operation_type: Optional[str] = None
+    reflection_state: str = "succeeded"
     mirror_receipts: List[MirrorReceipt] = Field(default_factory=list)
     reconciliation_state: str = "SYNCED"
 
@@ -47,13 +123,16 @@ def pm_update_work_item(
     Rejects any fields in WORKFLOW_SIGNIFICANT_FIELDS. Those must be 
     routed through pm_transition_work_item.
     """
-    # Enforce workflow authority boundary
-    illegal_fields = set(updates.keys()) & WORKFLOW_SIGNIFICANT_FIELDS
-    if illegal_fields:
+    metadata_fields, workflow_fields = classify_pm_write(updates)
+
+    if workflow_fields:
         raise ValueError(
-            f"Cannot update workflow-significant fields {illegal_fields} via pm_update_work_item. "
+            f"Cannot update workflow-significant fields {workflow_fields} via pm_update_work_item. "
             "Use pm_transition_work_item instead."
         )
+
+    if not metadata_fields:
+        raise ValueError("No metadata fields provided for pm_update_work_item.")
 
     # Fail closed if authority client is missing
     if config.leantime_client is None:
@@ -69,6 +148,8 @@ def pm_update_work_item(
         canonical_system="leantime",
         canonical_id=task_id,
         success=True,
+        operation_type="metadata_update",
+        reflection_state="succeeded",
         reconciliation_state="SYNCED"
     )
 
@@ -99,21 +180,26 @@ def pm_transition_work_item(
     # Mirror to Leantime (Partial Failure Handling)
     mirror_success = True
     mirror_error = None
+    reflection_state = "succeeded"
     try:
         if config.leantime_client is not None:
             config.leantime_client.update_status(task_id, new_status.value, idempotency_key=idempotency_key)
         else:
             mirror_success = False
             mirror_error = "Leantime client missing"
+            reflection_state = "degraded"
     except Exception as e:
         mirror_success = False
         mirror_error = str(e)
+        reflection_state = "degraded"
     
     return CanonicalReceipt(
         canonical_system="task-orchestrator",
         canonical_id=task_id,
         success=True,
         version=expected_version + 1,
+        operation_type="transition",
+        reflection_state=reflection_state,
         mirror_receipts=[
             MirrorReceipt(system="leantime", success=mirror_success, persisted_id=task_id if mirror_success else None, error=mirror_error)
         ],
@@ -147,20 +233,25 @@ def pm_log_progress(
     # Mirror to dope-memory chronicle (Partial Failure Handling)
     mirror_success = True
     mirror_error = None
+    reflection_state = "succeeded"
     try:
         if config.memory_client is not None:
             config.memory_client.append_chronicle(task_id, progress_notes, is_decision, idempotency_key=idempotency_key)
         else:
             mirror_success = False
             mirror_error = "Memory client missing"
+            reflection_state = "degraded"
     except Exception as e:
         mirror_success = False
         mirror_error = str(e)
+        reflection_state = "degraded"
 
     return CanonicalReceipt(
         canonical_system="conport",
         canonical_id=task_id,
         success=True,
+        operation_type="log_progress",
+        reflection_state=reflection_state,
         mirror_receipts=[
             MirrorReceipt(system="dope-memory", success=mirror_success, error=mirror_error)
         ],

--- a/src/dopemux/pm/writes.py
+++ b/src/dopemux/pm/writes.py
@@ -52,12 +52,20 @@ EXPLICIT_WORKFLOW_FIELDS = frozenset(
     }
 )
 
+WORKFLOW_FIELD_SUFFIXES = ("_status", "_state", "_phase", "_stage")
+
+
+def _looks_workflow_significant_key(key_lower: str) -> bool:
+    """Fail closed for likely workflow keys without substring collisions."""
+
+    return key_lower.endswith(WORKFLOW_FIELD_SUFFIXES)
+
 
 def classify_pm_write(payload: Dict[str, Any]) -> Tuple[List[str], List[str]]:
     """Classify payload keys into metadata and workflow-significant fields.
 
-    Unknown fields default to metadata unless they look state-bearing, in which
-    case they fail closed into the workflow bucket.
+    Unknown fields default to metadata unless they match a workflow-like key
+    pattern, in which case they fail closed into the workflow bucket.
     """
 
     metadata_fields: List[str] = []
@@ -69,7 +77,7 @@ def classify_pm_write(payload: Dict[str, Any]) -> Tuple[List[str], List[str]]:
             workflow_fields.append(key)
         elif key_lower in ALLOWED_METADATA_FIELDS:
             metadata_fields.append(key)
-        elif any(token in key_lower for token in ("status", "state", "phase")):
+        elif _looks_workflow_significant_key(key_lower):
             workflow_fields.append(key)
         else:
             metadata_fields.append(key)
@@ -120,8 +128,9 @@ def pm_update_work_item(
     
     Canonical Authority: Leantime (PM Entity Store)
     
-    Rejects any fields in WORKFLOW_SIGNIFICANT_FIELDS. Those must be 
-    routed through pm_transition_work_item.
+    Rejects any workflow-significant payload as determined by PM write
+    classification. Those changes must be routed through
+    pm_transition_work_item instead.
     """
     metadata_fields, workflow_fields = classify_pm_write(updates)
 

--- a/tests/unit/dopemux/pm/test_writes.py
+++ b/tests/unit/dopemux/pm/test_writes.py
@@ -1,5 +1,5 @@
 import pytest
-from src.dopemux.pm.writes import (
+from dopemux.pm.writes import (
     classify_pm_write,
     is_workflow_significant_payload,
     pm_update_work_item,
@@ -8,7 +8,7 @@ from src.dopemux.pm.writes import (
     PMWriteConfig,
     CanonicalReceipt
 )
-from src.dopemux.pm.models import PMTaskStatus
+from dopemux.pm.models import PMTaskStatus
 
 class MockLeantimeClient:
     def __init__(self):
@@ -52,17 +52,29 @@ def test_classify_pm_write_splits_metadata_and_workflow_fields():
 def test_classify_pm_write_fails_closed_for_unknown_state_like_fields():
     metadata_fields, workflow_fields = classify_pm_write(
         {
-            "custom_state_projection": "pending",
+            "custom_state": "pending",
             "other_field": "value",
         }
     )
 
     assert metadata_fields == ["other_field"]
-    assert workflow_fields == ["custom_state_projection"]
+    assert workflow_fields == ["custom_state"]
+
+
+def test_classify_pm_write_does_not_trip_on_substring_collisions():
+    metadata_fields, workflow_fields = classify_pm_write(
+        {
+            "statement": "status report",
+            "phase_notes": "operator notes",
+        }
+    )
+
+    assert metadata_fields == ["statement", "phase_notes"]
+    assert workflow_fields == []
 
 def test_is_workflow_significant_payload_detects_status_like_fields():
     assert is_workflow_significant_payload({"status": PMTaskStatus.DONE.value}) is True
-    assert is_workflow_significant_payload({"workflow_state_hint": "blocked"}) is True
+    assert is_workflow_significant_payload({"workflow_state": "blocked"}) is True
     assert is_workflow_significant_payload({"title": "hello"}) is False
 
 def test_pm_update_work_item_rejects_significant_fields():
@@ -84,8 +96,8 @@ def test_pm_update_work_item_rejects_unknown_state_like_fields():
         memory_client=None,
     )
     with pytest.raises(ValueError) as exc:
-        pm_update_work_item(config, "task-1", {"my_state_projection": "done"}, "key-1")
-    assert "my_state_projection" in str(exc.value)
+        pm_update_work_item(config, "task-1", {"my_state": "done"}, "key-1")
+    assert "my_state" in str(exc.value)
 
 def test_pm_update_work_item_rejects_empty_payload():
     config = PMWriteConfig(

--- a/tests/unit/dopemux/pm/test_writes.py
+++ b/tests/unit/dopemux/pm/test_writes.py
@@ -1,5 +1,7 @@
 import pytest
 from src.dopemux.pm.writes import (
+    classify_pm_write,
+    is_workflow_significant_payload,
     pm_update_work_item,
     pm_transition_work_item,
     pm_log_progress,
@@ -34,6 +36,35 @@ class MockMemoryClient:
     def append_chronicle(self, task_id, progress_notes, is_decision, idempotency_key):
         self.calls.append(("append_chronicle", task_id, progress_notes, is_decision, idempotency_key))
 
+def test_classify_pm_write_splits_metadata_and_workflow_fields():
+    metadata_fields, workflow_fields = classify_pm_write(
+        {
+            "title": "new title",
+            "status": PMTaskStatus.IN_PROGRESS.value,
+            "priority": "high",
+            "promote": True,
+        }
+    )
+
+    assert metadata_fields == ["title", "priority"]
+    assert workflow_fields == ["status", "promote"]
+
+def test_classify_pm_write_fails_closed_for_unknown_state_like_fields():
+    metadata_fields, workflow_fields = classify_pm_write(
+        {
+            "custom_state_projection": "pending",
+            "other_field": "value",
+        }
+    )
+
+    assert metadata_fields == ["other_field"]
+    assert workflow_fields == ["custom_state_projection"]
+
+def test_is_workflow_significant_payload_detects_status_like_fields():
+    assert is_workflow_significant_payload({"status": PMTaskStatus.DONE.value}) is True
+    assert is_workflow_significant_payload({"workflow_state_hint": "blocked"}) is True
+    assert is_workflow_significant_payload({"title": "hello"}) is False
+
 def test_pm_update_work_item_rejects_significant_fields():
     config = PMWriteConfig(
         leantime_client=MockLeantimeClient(), 
@@ -44,6 +75,28 @@ def test_pm_update_work_item_rejects_significant_fields():
     with pytest.raises(ValueError) as exc:
         pm_update_work_item(config, "task-1", {"status": PMTaskStatus.DONE.value}, "key-1")
     assert "status" in str(exc.value)
+
+def test_pm_update_work_item_rejects_unknown_state_like_fields():
+    config = PMWriteConfig(
+        leantime_client=MockLeantimeClient(),
+        orchestrator_client=None,
+        conport_client=None,
+        memory_client=None,
+    )
+    with pytest.raises(ValueError) as exc:
+        pm_update_work_item(config, "task-1", {"my_state_projection": "done"}, "key-1")
+    assert "my_state_projection" in str(exc.value)
+
+def test_pm_update_work_item_rejects_empty_payload():
+    config = PMWriteConfig(
+        leantime_client=MockLeantimeClient(),
+        orchestrator_client=None,
+        conport_client=None,
+        memory_client=None,
+    )
+    with pytest.raises(ValueError) as exc:
+        pm_update_work_item(config, "task-1", {}, "key-1")
+    assert "No metadata fields provided" in str(exc.value)
 
 def test_pm_update_work_item_fail_closed_missing_client():
     config = PMWriteConfig(leantime_client=None, orchestrator_client=None, conport_client=None, memory_client=None)
@@ -59,6 +112,8 @@ def test_pm_update_work_item_success():
     assert receipt.success
     assert receipt.canonical_system == "leantime"
     assert receipt.canonical_id == "task-1"
+    assert receipt.operation_type == "metadata_update"
+    assert receipt.reflection_state == "succeeded"
     assert len(client.calls) == 1
     assert client.calls[0] == ("update_task", "task-1", {"title": "new title"}, "key-idem-1")
 
@@ -100,6 +155,8 @@ def test_pm_transition_work_item_partial_failure():
     # Canonical should succeed, mirror should fail
     assert receipt.success
     assert receipt.canonical_system == "task-orchestrator"
+    assert receipt.operation_type == "transition"
+    assert receipt.reflection_state == "degraded"
     assert receipt.reconciliation_state == "PARTIAL"
     assert len(orch_client.calls) == 1
     
@@ -107,6 +164,30 @@ def test_pm_transition_work_item_partial_failure():
     assert mirror.system == "leantime"
     assert not mirror.success
     assert "Leantime is down" in mirror.error
+
+def test_pm_transition_work_item_successful_reflection():
+    orch_client = MockOrchestratorClient()
+    leantime_client = MockLeantimeClient()
+    config = PMWriteConfig(
+        leantime_client=leantime_client,
+        orchestrator_client=orch_client,
+        conport_client=None,
+        memory_client=None,
+    )
+
+    receipt = pm_transition_work_item(
+        config=config,
+        task_id="task-1",
+        new_status=PMTaskStatus.IN_PROGRESS,
+        reason="starting work",
+        idempotency_key="key-2",
+        expected_version=3,
+    )
+
+    assert receipt.success
+    assert receipt.reflection_state == "succeeded"
+    assert receipt.reconciliation_state == "SYNCED"
+    assert leantime_client.calls[-1] == ("update_status", "task-1", PMTaskStatus.IN_PROGRESS.value, "key-2")
 
 def test_pm_log_progress_fail_closed():
     config = PMWriteConfig(leantime_client=None, orchestrator_client=None, conport_client=None, memory_client=None)
@@ -127,6 +208,8 @@ def test_pm_log_progress_success_with_missing_mirror():
     
     assert receipt.success
     assert receipt.canonical_system == "conport"
+    assert receipt.operation_type == "log_progress"
+    assert receipt.reflection_state == "degraded"
     assert receipt.reconciliation_state == "PARTIAL"
     assert len(conport_client.calls) == 1
     
@@ -134,4 +217,3 @@ def test_pm_log_progress_success_with_missing_mirror():
     assert mirror.system == "dope-memory"
     assert not mirror.success
     assert mirror.error == "Memory client missing"
-


### PR DESCRIPTION
## Summary
- add explicit PM metadata vs workflow write classification in the canonical `dopemux.pm.writes` surface
- surface deterministic reflection state in canonical receipts
- document the write-boundary contract in the PM docs

## Validation
- `python3 -m py_compile src/dopemux/pm/writes.py tests/unit/dopemux/pm/test_writes.py services/task-orchestrator/app/api/pm_tools.py`
- `python3 -m pytest -q tests/unit/dopemux/pm/test_writes.py services/taskmaster/tests/test_bridge_adapter.py tests/unit/test_task_decomposer_pm.py tests/integration/pm/test_pm_plane_e2e.py`

## Notes
- `docs_frontmatter_guard.py` still fails on unrelated pre-existing archive drift in `docs/archive/unclassified-top-level/plans/pm-metadata-vs-workflow-separation.md`.
