### PR TITLE
feat(pm): normalize event taxonomy and provenance

### DIFF
--- a/services/dopecon-bridge/dopecon_bridge/event_bus.py
+++ b/services/dopecon-bridge/dopecon_bridge/event_bus.py
@@ -79,6 +79,12 @@ class EventBus:
         self.redis_client = await cache_manager.get_client()
 
     async def publish(self, stream: str, event: Event) -> str:
+        if event.type.startswith("pm."):
+            if "idempotency_key" not in event.data:
+                raise ValueError("PM events must include an idempotency_key")
+            if "source" not in event.data and not event.source:
+                raise ValueError("PM events must include a source")
+
         if not self.redis_client:
             await self.initialize()
         msg_id = await self.redis_client.xadd(stream, event.to_redis_fields())

--- a/services/dopecon-bridge/dopecon_bridge/routes.py
+++ b/services/dopecon-bridge/dopecon_bridge/routes.py
@@ -6,7 +6,7 @@ Extracted and organized from main.py ~1700-2915.
 
 import json
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
@@ -27,6 +27,10 @@ from .models import TaskPriority, TaskStatus
 
 
 logger = logging.getLogger(__name__)
+
+
+def _utc_now_z() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
 # ============================================================================
@@ -170,9 +174,13 @@ async def publish_event(request: PublishEventRequest):
                 source=source,
             )
         elif request.event_type.startswith("orchestrator."):
+            dialect_event_type = request.event_type.removeprefix("orchestrator.").replace(".", "_")
+            raw_data = dict(request.data)
+            raw_data.setdefault("original_event_type", request.event_type)
+            raw_data.setdefault("ts_utc", _utc_now_z())
             raw_event = {
-                "event_type": request.event_type,
-                "data": request.data,
+                "event_type": dialect_event_type,
+                "data": raw_data,
                 "source": source,
             }
             canonical_envelope = orchestrator_event_to_pm(
@@ -199,6 +207,9 @@ async def publish_event(request: PublishEventRequest):
             "stream": request.stream,
             "event_type": event.type
         }
+    except ValueError as e:
+        logger.warning(f"Event publish rejected: {e}")
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         logger.error(f"Event publish failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/services/dopecon-bridge/dopecon_bridge/routes.py
+++ b/services/dopecon-bridge/dopecon_bridge/routes.py
@@ -1,8 +1,8 @@
-\"\"\"
+"""
 DopeconBridge API Routes - FastAPI route definitions.
 
 Extracted and organized from main.py ~1700-2915.
-\"\"\"
+"""
 
 import json
 import logging
@@ -34,23 +34,23 @@ logger = logging.getLogger(__name__)
 # ============================================================================
 
 class PRDParseRequest(BaseModel):
-    \"\"\"Request to parse a PRD document.\"\"\"
-    content: str = Field(..., description=\"PRD content to parse\")
-    project_id: str = Field(..., description=\"Project ID for task creation\")
+    """Request to parse a PRD document."""
+    content: str = Field(..., description="PRD content to parse")
+    project_id: str = Field(..., description="Project ID for task creation")
 
 
 class PublishEventRequest(BaseModel):
-    \"\"\"Request to publish an event.\"\"\"
-    stream: str = Field(default=\"dopemux:events\", description=\"Redis Stream name\")
-    event_type: str = Field(..., description=\"Event type (e.g., tasks_imported)\")
-    data: Dict[str, Any] = Field(..., description=\"Event data payload\")
-    source: Optional[str] = Field(None, description=\"Event source identifier\")
+    """Request to publish an event."""
+    stream: str = Field(default="dopemux:events", description="Redis Stream name")
+    event_type: str = Field(..., description="Event type (e.g., tasks_imported)")
+    data: Dict[str, Any] = Field(..., description="Event data payload")
+    source: Optional[str] = Field(None, description="Event source identifier")
 
 
 class TaskUpdateRequest(BaseModel):
-    \"\"\"Request to update task status.\"\"\"
-    status: str = Field(..., description=\"New task status\")
-    assigned_to: Optional[str] = Field(None, description=\"User assignment\")
+    """Request to update task status."""
+    status: str = Field(..., description="New task status")
+    assigned_to: Optional[str] = Field(None, description="User assignment")
 
 
 # ============================================================================
@@ -58,87 +58,87 @@ class TaskUpdateRequest(BaseModel):
 # ============================================================================
 
 # Auth routes
-auth_router = APIRouter(prefix=\"/auth\", tags=[\"Authentication\"])
+auth_router = APIRouter(prefix="/auth", tags=["Authentication"])
 
 # Event routes
-events_router = APIRouter(prefix=\"/events\", tags=[\"EventBus\"])
+events_router = APIRouter(prefix="/events", tags=["EventBus"])
 
 # Task routes  
-tasks_router = APIRouter(prefix=\"/tasks\", tags=[\"Tasks\"])
+tasks_router = APIRouter(prefix="/tasks", tags=["Tasks"])
 
 # DDG routes (Dope Decision Graph)
-ddg_router = APIRouter(prefix=\"/ddg\", tags=[\"Decision Graph\"])
+ddg_router = APIRouter(prefix="/ddg", tags=["Decision Graph"])
 
 # Health routes
-health_router = APIRouter(tags=[\"Health\"])
+health_router = APIRouter(tags=["Health"])
 
 
 # ============================================================================
 # AUTH ENDPOINTS
 # ============================================================================
 
-@auth_router.post(\"/token\")
+@auth_router.post("/token")
 async def login(form_data: OAuth2PasswordRequestForm = Depends()):
-    \"\"\"Authenticate and return access token.\"\"\"
+    """Authenticate and return access token."""
     user = authenticate_user(form_data.username, form_data.password)
     if not user:
         raise HTTPException(
             status_code=401,
-            detail=\"Incorrect username or password\",
-            headers={\"WWW-Authenticate\": \"Bearer\"},
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Bearer"},
         )
     access_token = create_access_token(
-        data={\"sub\": user[\"username\"]},
+        data={"sub": user["username"]},
         expires_delta=timedelta(minutes=settings.access_token_expire_minutes)
     )
-    return {\"access_token\": access_token, \"token_type\": \"bearer\"}
+    return {"access_token": access_token, "token_type": "bearer"}
 
 
-@auth_router.post(\"/refresh\")
+@auth_router.post("/refresh")
 async def refresh_token(current_token: str = Depends(security)):
-    \"\"\"Refresh access token.\"\"\"
+    """Refresh access token."""
     # In production, validate the current token and issue a new one
     access_token = create_access_token(
-        data={\"sub\": \"admin\"},
+        data={"sub": "admin"},
         expires_delta=timedelta(minutes=settings.access_token_expire_minutes)
     )
-    return {\"access_token\": access_token, \"token_type\": \"bearer\"}
+    return {"access_token": access_token, "token_type": "bearer"}
 
 
 # ============================================================================
 # HEALTH ENDPOINTS
 # ============================================================================
 
-@health_router.get(\"/health\")
+@health_router.get("/health")
 async def health_check():
-    \"\"\"Health check with service status.\"\"\"
+    """Health check with service status."""
     try:
         services_health = await mcp_client.health_check_all()
         return {
-            \"status\": \"healthy\",
-            \"instance\": settings.instance_name,
-            \"port\": settings.port,
-            \"services\": services_health
+            "status": "healthy",
+            "instance": settings.instance_name,
+            "port": settings.port,
+            "services": services_health
         }
     except Exception as e:
-        logger.error(f\"Health check failed: {e}\")
+        logger.error(f"Health check failed: {e}")
         return {
-            \"status\": \"degraded\",
-            \"instance\": settings.instance_name,
-            \"error\": str(e)
+            "status": "degraded",
+            "instance": settings.instance_name,
+            "error": str(e)
         }
 
 
-@health_router.get(\"/\")
+@health_router.get("/")
 async def root():
-    \"\"\"Service information.\"\"\"
+    """Service information."""
     return {
-        \"service\": \"DopeconBridge\",
-        \"version\": \"2.0.0\",
-        \"instance\": settings.instance_name,
-        \"port\": settings.port,
-        \"architecture\": \"modular\",
-        \"docs\": f\"http://localhost:{settings.port}/docs\"
+        "service": "DopeconBridge",
+        "version": "2.0.0",
+        "instance": settings.instance_name,
+        "port": settings.port,
+        "architecture": "modular",
+        "docs": f"http://localhost:{settings.port}/docs"
     }
 
 
@@ -146,62 +146,92 @@ async def root():
 # EVENT BUS ENDPOINTS
 # ============================================================================
 
-@events_router.post(\"\")
+@events_router.post("")
 async def publish_event(request: PublishEventRequest):
-    \"\"\"Publish event to Redis Stream for cross-service coordination.\"\"\"
+    """Publish event to Redis Stream for cross-service coordination."""
     try:
         from .event_bus import EventBus, Event
-        
+        from dopemux.pm.adapters.core import orchestrator_event_to_pm, taskmaster_event_to_pm
+
         event_bus = EventBus()
         await event_bus.initialize()
-        
-        event = Event(
-            type=request.event_type,
-            data=request.data,
-            source=request.source or settings.service_name
-        )
+
+        source = request.source or settings.service_name
+
+        if request.event_type.startswith("taskmaster.task."):
+            canonical_envelope = taskmaster_event_to_pm(
+                event_type=request.event_type,
+                data=request.data,
+                source=source,
+            )
+            event = Event(
+                type=canonical_envelope["event_type"],
+                data=canonical_envelope,
+                source=source,
+            )
+        elif request.event_type.startswith("orchestrator."):
+            raw_event = {
+                "event_type": request.event_type,
+                "data": request.data,
+                "source": source,
+            }
+            canonical_envelope = orchestrator_event_to_pm(
+                raw_event,
+                source=source,
+            )
+            event = Event(
+                type=canonical_envelope["event_type"],
+                data=canonical_envelope,
+                source=source,
+            )
+        else:
+            event = Event(
+                type=request.event_type,
+                data=request.data,
+                source=source
+            )
         
         msg_id = await event_bus.publish(request.stream, event)
         
         return {
-            \"success\": True,
-            \"message_id\": msg_id,
-            \"stream\": request.stream,
-            \"event_type\": request.event_type
+            "success": True,
+            "message_id": msg_id,
+            "stream": request.stream,
+            "event_type": event.type
         }
     except Exception as e:
-        logger.error(f\"Event publish failed: {e}\")
+        logger.error(f"Event publish failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@events_router.get(\"/stream\")
+@events_router.get("/stream")
 async def subscribe_to_events(
-    stream: str = \"dopemux:events\",
-    consumer_group: str = \"dashboard\"
+    stream: str = "dopemux:events",
+    consumer_group: str = "dashboard"
 ):
-    \"\"\"Subscribe to event stream via Server-Sent Events (SSE).\"\"\"
+    """Subscribe to event stream via Server-Sent Events (SSE)."""
     from .event_bus import EventBus
     
     event_bus = EventBus()
     await event_bus.initialize()
     
     async def event_generator():
-        consumer = f\"sse-{settings.instance_name}\"
+        consumer = f"sse-{settings.instance_name}"
         async for msg_id, event in event_bus.subscribe(stream, consumer_group, consumer):
-            yield f\"data: {json.dumps({'id': msg_id, 'event': event.to_dict()})}\\n\\n\"
+            yield f"data: {json.dumps({'id': msg_id, 'event': event.to_dict()})}\\n\\n"
     
     return StreamingResponse(
         event_generator(),
-        media_type=\"text/event-stream\"
+        media_type="text/event-stream"
     )
 
 
-@events_router.get(\"/history\")
+@events_router.get("/history")
 async def get_event_history(
-    stream: str = \"dopemux:events\",
+    stream: str = "dopemux:events",
     count: int = Query(100, ge=1, le=1000)
 ):
-    \"\"\"Get event history from Redis Stream.\"\"\"
+    """Get event history from Redis Stream."""
     try:
         cache_client = await cache_manager.get_client()
         
@@ -210,50 +240,50 @@ async def get_event_history(
         events = []
         for msg_id, data in entries:
             events.append({
-                \"id\": msg_id,
-                \"type\": data.get(\"type\", \"unknown\"),
-                \"data\": json.loads(data.get(\"data\", \"{}\")) if data.get(\"data\") else {},
-                \"source\": data.get(\"source\"),
-                \"timestamp\": data.get(\"timestamp\")
+                "id": msg_id,
+                "type": data.get("type", "unknown"),
+                "data": json.loads(data.get("data", "{}")) if data.get("data") else {},
+                "source": data.get("source"),
+                "timestamp": data.get("timestamp")
             })
         
         return {
-            \"stream\": stream,
-            \"count\": len(events),
-            \"events\": events
+            "stream": stream,
+            "count": len(events),
+            "events": events
         }
     except Exception as e:
-        logger.error(f\"Event history retrieval failed: {e}\")
+        logger.error(f"Event history retrieval failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
 # Convenience event endpoints
-@events_router.post(\"/tasks-imported\")
+@events_router.post("/tasks-imported")
 async def publish_tasks_imported(task_count: int, sprint_id: str):
-    \"\"\"Publish tasks_imported event (convenience endpoint).\"\"\"
+    """Publish tasks_imported event (convenience endpoint)."""
     request = PublishEventRequest(
-        event_type=\"tasks_imported\",
-        data={\"task_count\": task_count, \"sprint_id\": sprint_id}
+        event_type="tasks_imported",
+        data={"task_count": task_count, "sprint_id": sprint_id}
     )
     return await publish_event(request)
 
 
-@events_router.post(\"/session-started\")
+@events_router.post("/session-started")
 async def publish_session_started(task_id: str, duration_minutes: int = 25):
-    \"\"\"Publish session_started event (convenience endpoint).\"\"\"
+    """Publish session_started event (convenience endpoint)."""
     request = PublishEventRequest(
-        event_type=\"session_started\",
-        data={\"task_id\": task_id, \"duration_minutes\": duration_minutes}
+        event_type="session_started",
+        data={"task_id": task_id, "duration_minutes": duration_minutes}
     )
     return await publish_event(request)
 
 
-@events_router.post(\"/progress-updated\")
+@events_router.post("/progress-updated")
 async def publish_progress_updated(task_id: str, status: str, progress: float):
-    \"\"\"Publish progress_updated event (convenience endpoint).\"\"\"
+    """Publish progress_updated event (convenience endpoint)."""
     request = PublishEventRequest(
-        event_type=\"progress_updated\",
-        data={\"task_id\": task_id, \"status\": status, \"progress\": progress}
+        event_type="progress_updated",
+        data={"task_id": task_id, "status": status, "progress": progress}
     )
     return await publish_event(request)
 
@@ -262,60 +292,60 @@ async def publish_progress_updated(task_id: str, status: str, progress: float):
 # TASK ENDPOINTS
 # ============================================================================
 
-@tasks_router.post(\"/parse-prd\")
+@tasks_router.post("/parse-prd")
 async def parse_prd(
     request: PRDParseRequest, 
     http_request: Request,
     x_source_plane: Optional[str] = Header(None)
 ):
-    \"\"\"Parse PRD document into tasks across all systems with ADHD context preservation.\"\"\"
+    """Parse PRD document into tasks across all systems with ADHD context preservation."""
     from .services.task_integration import task_service
     
     # Enforce cognitive plane authority for writes
-    if x_source_plane != \"cognitive_plane\":
+    if x_source_plane != "cognitive_plane":
         raise HTTPException(
             status_code=403,
-            detail=\"PRD parsing requires cognitive_plane authority\"
+            detail="PRD parsing requires cognitive_plane authority"
         )
 
     try:
         # Update context for ADHD tracking
         update_context_delta(
             http_request,
-            \"last_prd_parse\",
-            {\"project_id\": request.project_id, \"content_length\": len(request.content)}
+            "last_prd_parse",
+            {"project_id": request.project_id, "content_length": len(request.content)}
         )
         
         tasks = await task_service.parse_prd_to_tasks(request.content, request.project_id)
         
         return {
-            \"success\": True,
-            \"task_count\": len(tasks),
-            \"project_id\": request.project_id,
-            \"tasks\": [
+            "success": True,
+            "task_count": len(tasks),
+            "project_id": request.project_id,
+            "tasks": [
                 {
-                    \"id\": t.id,
-                    \"title\": t.title,
-                    \"status\": t.status.value,
-                    \"priority\": t.priority.value
+                    "id": t.id,
+                    "title": t.title,
+                    "status": t.status.value,
+                    "priority": t.priority.value
                 }
                 for t in tasks
             ]
         }
     except Exception as e:
-        logger.error(f\"PRD parsing failed: {e}\")
+        logger.error(f"PRD parsing failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@tasks_router.get(\"/next/{project_id}\")
+@tasks_router.get("/next/{project_id}")
 async def get_next_tasks(
     project_id: str, 
     limit: int = Query(5, ge=1, le=20),
     x_source_plane: Optional[str] = Header(None)
 ):
-    \"\"\"Get next actionable tasks for ADHD-friendly workflow via normalized PM-plane reads.\"\"\"
-    if x_source_plane and x_source_plane not in [\"pm_plane\", \"cognitive_plane\"]:
-        raise HTTPException(status_code=403, detail=f\"Invalid source plane: {x_source_plane}\")
+    """Get next actionable tasks for ADHD-friendly workflow via normalized PM-plane reads."""
+    if x_source_plane and x_source_plane not in ["pm_plane", "cognitive_plane"]:
+        raise HTTPException(status_code=403, detail=f"Invalid source plane: {x_source_plane}")
 
     from dopemux.pm.reads import pm_get_priority_queue
     
@@ -323,29 +353,29 @@ async def get_next_tasks(
         result = await pm_get_priority_queue(project_id)
         
         return {
-            \"success\": True,
-            \"project_id\": project_id,
-            \"count\": len(result.queue_items[:limit]),
-            \"tasks\": result.queue_items[:limit]
+            "success": True,
+            "project_id": project_id,
+            "count": len(result.queue_items[:limit]),
+            "tasks": result.queue_items[:limit]
         }
     except Exception as e:
-        logger.error(f\"Failed to get next tasks: {e}\")
+        logger.error(f"Failed to get next tasks: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@tasks_router.patch(\"/{task_id}/status\")
+@tasks_router.patch("/{task_id}/status")
 async def update_task_status(
     task_id: str,
     request: TaskUpdateRequest,
     current_user: dict = Depends(get_current_user),
     x_source_plane: Optional[str] = Header(None)
 ):
-    \"\"\"Update task status across all systems.\"\"\"
+    """Update task status across all systems."""
     # Enforce cognitive plane authority for writes
-    if x_source_plane != \"cognitive_plane\":
+    if x_source_plane != "cognitive_plane":
         raise HTTPException(
             status_code=403,
-            detail=\"Task status update requires cognitive_plane authority\"
+            detail="Task status update requires cognitive_plane authority"
         )
 
     from .services.task_integration import task_service
@@ -361,7 +391,7 @@ async def update_task_status(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
-        logger.error(f\"Task status update failed: {e}\")
+        logger.error(f"Task status update failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -369,15 +399,15 @@ async def update_task_status(
 # DDG ENDPOINTS (Dope Decision Graph)
 # ============================================================================
 
-@ddg_router.get(\"/decisions\")
+@ddg_router.get("/decisions")
 async def ddg_recent_decisions(
     workspace_id: Optional[str] = None,
     limit: int = Query(20, ge=1, le=100),
     x_source_plane: Optional[str] = Header(None)
 ):
-    \"\"\"Get recent decisions from the decision graph.\"\"\"
-    if x_source_plane and x_source_plane not in [\"pm_plane\", \"cognitive_plane\"]:
-        raise HTTPException(status_code=403, detail=f\"Invalid source plane: {x_source_plane}\")
+    """Get recent decisions from the decision graph."""
+    if x_source_plane and x_source_plane not in ["pm_plane", "cognitive_plane"]:
+        raise HTTPException(status_code=403, detail=f"Invalid source plane: {x_source_plane}")
 
     try:
         # Route to canonical backend via MCP client
@@ -385,30 +415,30 @@ async def ddg_recent_decisions(
         
         # We proxy to mcp_client.get_decisions which gets from Conport
         decisions = await mcp_client.call_tool(
-            \"conport\",
-            \"get_decisions\",
-            {\"workspace_id\": workspace_id, \"limit\": limit}
+            "conport",
+            "get_decisions",
+            {"workspace_id": workspace_id, "limit": limit}
         )
         
         return {
-            \"count\": len(decisions.get(\"decisions\", [])),
-            \"decisions\": decisions.get(\"decisions\", [])
+            "count": len(decisions.get("decisions", [])),
+            "decisions": decisions.get("decisions", [])
         }
     except Exception as e:
-        logger.error(f\"DDG decisions query failed: {e}\")
+        logger.error(f"DDG decisions query failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@ddg_router.get(\"/search\")
+@ddg_router.get("/search")
 async def ddg_search_decisions(
     q: str,
     workspace_id: Optional[str] = None,
     limit: int = Query(20, ge=1, le=100),
     x_source_plane: Optional[str] = Header(None)
 ):
-    \"\"\"Search decisions by text query.\"\"\"
-    if x_source_plane and x_source_plane not in [\"pm_plane\", \"cognitive_plane\"]:
-        raise HTTPException(status_code=403, detail=f\"Invalid source plane: {x_source_plane}\")
+    """Search decisions by text query."""
+    if x_source_plane and x_source_plane not in ["pm_plane", "cognitive_plane"]:
+        raise HTTPException(status_code=403, detail=f"Invalid source plane: {x_source_plane}")
 
     try:
         # Route to canonical backend via MCP client
@@ -416,18 +446,18 @@ async def ddg_search_decisions(
         
         # We proxy to mcp_client.query_knowledge_graph
         decisions = await mcp_client.call_tool(
-            \"conport\",
-            \"query_knowledge_graph\",
-            {\"query\": q, \"workspace_id\": workspace_id, \"limit\": limit}
+            "conport",
+            "query_knowledge_graph",
+            {"query": q, "workspace_id": workspace_id, "limit": limit}
         )
         
         return {
-            \"query\": q,
-            \"count\": len(decisions.get(\"decisions\", [])),
-            \"decisions\": decisions.get(\"decisions\", [])
+            "query": q,
+            "count": len(decisions.get("decisions", [])),
+            "decisions": decisions.get("decisions", [])
         }
     except Exception as e:
-        logger.error(f\"DDG search failed: {e}\")
+        logger.error(f"DDG search failed: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -436,7 +466,7 @@ async def ddg_search_decisions(
 # ============================================================================
 
 def get_all_routers() -> List[APIRouter]:
-    \"\"\"Return all API routers for inclusion in app.\"\"\"
+    """Return all API routers for inclusion in app."""
     return [
         health_router,
         auth_router,

--- a/services/dopecon-bridge/tests/test_route_endpoints_authority.py
+++ b/services/dopecon-bridge/tests/test_route_endpoints_authority.py
@@ -61,3 +61,27 @@ def test_publish_event_canonicalizes_taskmaster_events(monkeypatch):
     assert captured["event"].type == "pm.task.created"
     assert captured["event"].data["event_type"] == "pm.task.created"
     assert captured["event"].data["idempotency_key"]
+
+
+def test_publish_event_returns_400_for_invalid_pm_event(monkeypatch):
+    class DummyBus:
+        async def initialize(self):
+            return None
+
+        async def publish(self, stream, event):
+            raise ValueError("PM events must include a source")
+
+    monkeypatch.setattr("dopecon_bridge.event_bus.EventBus", DummyBus)
+
+    response = client.post(
+        "/events",
+        json={
+            "stream": "dopemux:events",
+            "event_type": "pm.task.created",
+            "data": {"idempotency_key": "idem-1"},
+            "source": None,
+        },
+    )
+
+    assert response.status_code == 400
+    assert "source" in response.json()["detail"]

--- a/services/dopecon-bridge/tests/test_route_endpoints_authority.py
+++ b/services/dopecon-bridge/tests/test_route_endpoints_authority.py
@@ -25,3 +25,39 @@ def test_ddg_search_enforces_plane():
     response = client.get("/ddg/search", params={"q": "test"}, headers={"X-Source-Plane": "invalid_plane"})
     assert response.status_code == 403
     assert "Invalid source plane" in response.json()["detail"]
+
+def test_publish_event_canonicalizes_taskmaster_events(monkeypatch):
+    captured = {}
+
+    class DummyBus:
+        async def initialize(self):
+            return None
+
+        async def publish(self, stream, event):
+            captured["stream"] = stream
+            captured["event"] = event
+            return "1-0"
+
+    monkeypatch.setattr("dopecon_bridge.event_bus.EventBus", DummyBus)
+
+    response = client.post(
+        "/events",
+        json={
+            "stream": "dopemux:events",
+            "event_type": "taskmaster.task.created",
+            "data": {
+                "source_task_id": "tm-1",
+                "title": "Canonical route event",
+                "description": "Bridge route canonicalization",
+                "ts_utc": "2026-03-26T12:00:00Z",
+            },
+            "source": "taskmaster",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["event_type"] == "pm.task.created"
+    assert captured["stream"] == "dopemux:events"
+    assert captured["event"].type == "pm.task.created"
+    assert captured["event"].data["event_type"] == "pm.task.created"
+    assert captured["event"].data["idempotency_key"]

--- a/services/task-orchestrator/app/adapters/bridge_adapter.py
+++ b/services/task-orchestrator/app/adapters/bridge_adapter.py
@@ -152,14 +152,25 @@ class TaskOrchestratorBridgeAdapter:
                 workspace_id=self.workspace_id,
             )
 
-            # Publish event
-            await self.client.publish_event(
-                event_type="orchestrator.task.synced",
-                data={
+            from dopemux.pm.adapters.core import orchestrator_event_to_pm
+            raw_event = {
+                "event_type": "orchestrator.task.synced",
+                "data": {
                     "task_id": task.task_id,
                     "conport_entry_id": result.get("id"),
                     "status": str(task.status),
                 },
+                "source": self.requester,
+            }
+            canonical_envelope = orchestrator_event_to_pm(
+                raw_event,
+                source=self.requester,
+            )
+
+            # Publish event
+            await self.client.publish_event(
+                event_type=canonical_envelope["event_type"],
+                data=canonical_envelope,
                 source=self.requester,
             )
 
@@ -246,9 +257,21 @@ class TaskOrchestratorBridgeAdapter:
             True if successful
         """
         try:
+            from dopemux.pm.adapters.core import orchestrator_event_to_pm
+
+            raw_event = {
+                "event_type": f"orchestrator.{event_type}",
+                "data": data,
+                "source": self.requester,
+            }
+            canonical_envelope = orchestrator_event_to_pm(
+                raw_event,
+                source=self.requester,
+            )
+
             await self.client.publish_event(
-                event_type=f"orchestrator.{event_type}",
-                data=data,
+                event_type=canonical_envelope["event_type"],
+                data=canonical_envelope,
                 source=self.requester,
             )
             return True

--- a/services/task-orchestrator/app/adapters/bridge_adapter.py
+++ b/services/task-orchestrator/app/adapters/bridge_adapter.py
@@ -38,6 +38,10 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _utc_now_z() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 class TaskOrchestratorBridgeAdapter:
     """
     DopeconBridge adapter for Task Orchestrator.
@@ -154,11 +158,13 @@ class TaskOrchestratorBridgeAdapter:
 
             from dopemux.pm.adapters.core import orchestrator_event_to_pm
             raw_event = {
-                "event_type": "orchestrator.task.synced",
+                "event_type": "task_updated",
                 "data": {
                     "task_id": task.task_id,
                     "conport_entry_id": result.get("id"),
                     "status": str(task.status),
+                    "original_event_type": "orchestrator.task.synced",
+                    "ts_utc": _utc_now_z(),
                 },
                 "source": self.requester,
             }
@@ -259,9 +265,12 @@ class TaskOrchestratorBridgeAdapter:
         try:
             from dopemux.pm.adapters.core import orchestrator_event_to_pm
 
+            raw_data = dict(data)
+            raw_data.setdefault("original_event_type", f"orchestrator.{event_type}")
+            raw_data.setdefault("ts_utc", _utc_now_z())
             raw_event = {
-                "event_type": f"orchestrator.{event_type}",
-                "data": data,
+                "event_type": event_type,
+                "data": raw_data,
                 "source": self.requester,
             }
             canonical_envelope = orchestrator_event_to_pm(

--- a/services/taskmaster/server.py
+++ b/services/taskmaster/server.py
@@ -18,7 +18,7 @@ import subprocess
 import logging
 from pathlib import Path
 from typing import Optional, Dict, Any
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Add dopemux to path for event bus integration
 project_root = Path(__file__).parent.parent.parent
@@ -39,6 +39,14 @@ logging.basicConfig(
     stream=sys.stderr
 )
 logger = logging.getLogger("task-master-wrapper")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _utc_now_z() -> str:
+    return _utc_now().isoformat().replace("+00:00", "Z")
 
 
 class TaskMasterWrapper:
@@ -139,10 +147,31 @@ class TaskMasterWrapper:
             from dopemux.pm.adapters.core import taskmaster_event_to_pm
             from dopemux.pm_publish import pm_envelope_to_dopemux_event
 
+            payload = dict(data)
+            tool_name = str(payload.get("tool") or "taskmaster")
+            source_task_id = str(
+                payload.get("source_task_id")
+                or payload.get("task_id")
+                or payload.get("request_id")
+                or payload.get("id")
+                or tool_name
+            )
+            payload.setdefault("source_task_id", source_task_id)
+            payload.setdefault("task_id", source_task_id)
+            payload.setdefault("title", tool_name.replace("_", " "))
+            if "description" not in payload:
+                params = payload.get("params")
+                payload["description"] = (
+                    json.dumps(params, sort_keys=True, default=str)
+                    if params is not None
+                    else tool_name
+                )
+            payload.setdefault("ts_utc", _utc_now_z())
+
             raw_event_type = f"taskmaster.task.{event_type}"
             canonical_envelope = taskmaster_event_to_pm(
                 event_type=raw_event_type,
-                data=data,
+                data=payload,
                 source=f"task-master-{self.instance_id}",
             )
             event = pm_envelope_to_dopemux_event(canonical_envelope)
@@ -182,7 +211,8 @@ class TaskMasterWrapper:
                         self.pending_calls[msg_id] = {
                             "tool": tool_name,
                             "params": params,
-                            "start_time": datetime.now()
+                            "request_id": str(msg_id),
+                            "start_time": _utc_now(),
                         }
 
                     # Emit event for task creation
@@ -190,7 +220,8 @@ class TaskMasterWrapper:
                         await self.emit_task_event("created", {
                             "tool": tool_name,
                             "params": params,
-                            "timestamp": datetime.now().isoformat()
+                            "source_task_id": str(msg_id) if msg_id is not None else tool_name,
+                            "ts_utc": _utc_now_z(),
                         })
 
                         # Show ADHD-friendly progress if enabled
@@ -227,14 +258,16 @@ class TaskMasterWrapper:
                 msg_id = resp_json.get("id")
                 if msg_id and msg_id in self.pending_calls:
                     call_info = self.pending_calls.pop(msg_id)
-                    duration = (datetime.now() - call_info["start_time"]).total_seconds()
+                    duration = (_utc_now() - call_info["start_time"]).total_seconds()
 
                     # Emit completion event
                     await self.emit_task_event("completed", {
                         "tool": call_info["tool"],
+                        "params": call_info["params"],
+                        "source_task_id": call_info.get("request_id") or str(msg_id),
                         "duration": duration,
                         "success": "error" not in resp_json,
-                        "timestamp": datetime.now().isoformat()
+                        "ts_utc": _utc_now_z(),
                     })
 
                     # Celebrate completion if enabled

--- a/services/taskmaster/server.py
+++ b/services/taskmaster/server.py
@@ -136,20 +136,23 @@ class TaskMasterWrapper:
             return
 
         try:
-            event = DopemuxEvent(
-                event_type=f"task.{event_type}",
-                source=f"task-master-{self.instance_id}",
-                instance_id=self.instance_id,
+            from dopemux.pm.adapters.core import taskmaster_event_to_pm
+            from dopemux.pm_publish import pm_envelope_to_dopemux_event
+
+            raw_event_type = f"taskmaster.task.{event_type}"
+            canonical_envelope = taskmaster_event_to_pm(
+                event_type=raw_event_type,
                 data=data,
-                priority=Priority.MEDIUM,
-                cognitive_load=CognitiveLoad.MEDIUM,
-                adhd_metadata=ADHDMetadata(
-                    interruption_allowed=event_type != "in_progress",
-                    focus_required=event_type == "in_progress",
-                    time_sensitive=False,
-                    can_batch=True
-                )
+                source=f"task-master-{self.instance_id}",
             )
+            event = pm_envelope_to_dopemux_event(canonical_envelope)
+            event.adhd_metadata = ADHDMetadata(
+                interruption_allowed=event_type != "in_progress",
+                focus_required=event_type == "in_progress",
+                time_sensitive=False,
+                can_batch=True
+            )
+            event.instance_id = self.instance_id
 
             await self.event_bus.publish(event)
             logger.debug(f"Emitted {event_type} event for task")

--- a/services/taskmaster/tests/test_server.py
+++ b/services/taskmaster/tests/test_server.py
@@ -21,6 +21,27 @@ async def test_emit_task_event_no_producer(wrapper):
     await wrapper.emit_task_event("test_event", {"data": "test"})
 
 @pytest.mark.asyncio
+async def test_emit_task_event_publishes_canonical_pm_envelope(wrapper):
+    wrapper.mcp_producer = MagicMock()
+    wrapper.event_bus = AsyncMock()
+
+    await wrapper.emit_task_event(
+        "created",
+        {
+            "source_task_id": "tm-1",
+            "title": "Canonical event",
+            "description": "Emit via PM envelope",
+            "ts_utc": "2026-03-26T12:00:00Z",
+        },
+    )
+
+    wrapper.event_bus.publish.assert_awaited_once()
+    published_event = wrapper.event_bus.publish.await_args.args[0]
+    assert published_event.envelope.namespace == "pm.task.created"
+    assert published_event.payload["envelope"]["idempotency_key"]
+    assert published_event.payload["envelope"]["source"].startswith("task-master-")
+
+@pytest.mark.asyncio
 async def test_handle_message_json_pass_through(wrapper):
     msg = b'{"jsonrpc": "2.0", "method": "test"}'
     with patch("services.taskmaster.server.sys") as mock_sys:

--- a/services/taskmaster/tests/test_server.py
+++ b/services/taskmaster/tests/test_server.py
@@ -40,6 +40,29 @@ async def test_emit_task_event_publishes_canonical_pm_envelope(wrapper):
     assert published_event.envelope.namespace == "pm.task.created"
     assert published_event.payload["envelope"]["idempotency_key"]
     assert published_event.payload["envelope"]["source"].startswith("task-master-")
+    assert published_event.payload["envelope"]["task_id"]
+
+
+@pytest.mark.asyncio
+async def test_emit_task_event_uses_request_identity_when_payload_is_wrapper_like(wrapper):
+    wrapper.mcp_producer = MagicMock()
+    wrapper.event_bus = AsyncMock()
+
+    await wrapper.emit_task_event(
+        "created",
+        {
+            "tool": "create_task",
+            "params": {"title": "Task A"},
+            "source_task_id": "rpc-42",
+        },
+    )
+
+    published_event = wrapper.event_bus.publish.await_args.args[0]
+    envelope = published_event.payload["envelope"]
+    assert envelope["payload"]["source_task_id"] == "rpc-42"
+    assert envelope["task_id"]
+    assert envelope["payload"]["title"] == "create task"
+    assert envelope["ts_utc"].endswith("Z")
 
 @pytest.mark.asyncio
 async def test_handle_message_json_pass_through(wrapper):

--- a/src/dopemux/event_bus.py
+++ b/src/dopemux/event_bus.py
@@ -85,6 +85,13 @@ class InMemoryAdapter(EventBus):
         self._patterns: Dict[str, str] = {} # sub_id -> pattern
 
     async def publish(self, event: DopemuxEvent) -> bool:
+        if event.envelope.namespace.startswith("pm."):
+            payload = event.payload.get("envelope", event.payload)
+            if "idempotency_key" not in payload:
+                raise ValueError("PM events must include an idempotency_key")
+            if "source" not in payload:
+                raise ValueError("PM events must include a source")
+
         # Dispatch to all subscribers
         # Use list() to allow subscribers to unsubscribe during iteration
         for sub_id, pattern in list(self._patterns.items()):
@@ -145,6 +152,13 @@ class RedisStreamsAdapter(EventBus):
         self.connected = False
 
     async def publish(self, event: DopemuxEvent) -> bool:
+        if event.envelope.namespace.startswith("pm."):
+            payload = event.payload.get("envelope", event.payload)
+            if "idempotency_key" not in payload:
+                raise ValueError("PM events must include an idempotency_key")
+            if "source" not in payload:
+                raise ValueError("PM events must include a source")
+
         if not self.connected:
             logger.warning("RedisStreamsAdapter.publish called while disconnected; using local fan-out fallback")
 

--- a/src/dopemux/events/__init__.py
+++ b/src/dopemux/events/__init__.py
@@ -12,6 +12,7 @@ from .types import (
     ADHDEvent,
     ThemeEvent,
     SessionEvent,
+    PMEvent,
 )
 __all__ = [
     "Event",
@@ -20,4 +21,5 @@ __all__ = [
     "ADHDEvent",
     "ThemeEvent",
     "SessionEvent",
+    "PMEvent",
 ]

--- a/src/dopemux/events/types.py
+++ b/src/dopemux/events/types.py
@@ -113,3 +113,17 @@ class SessionEvent(Event):
     action: Action = Field(..., description="Session action")
     session_id: str = Field(..., description="Tmux session ID")
     session_name: Optional[str] = Field(default=None)
+
+
+class PMEvent(Event):
+    """Canonical PM-plane envelope event."""
+
+    type: str = "pm"
+
+    event_id: str = Field(..., description="Deterministic event ID computed from envelope core")
+    event_type: str = Field(..., description="Canonical PM event type such as pm.task.created")
+    ts_utc: str = Field(..., description="Normalized UTC ISO8601 timestamp")
+    idempotency_key: str = Field(..., description="Idempotency key required for PM event processing")
+    source: str = Field(..., description="Component that emitted the PM event")
+    task_id: str = Field(..., description="Canonical task identifier")
+    payload: Dict[str, Any] = Field(default_factory=dict, description="Event payload data")

--- a/src/dopemux/events/types.py
+++ b/src/dopemux/events/types.py
@@ -115,11 +115,10 @@ class SessionEvent(Event):
     session_name: Optional[str] = Field(default=None)
 
 
-class PMEvent(Event):
+class PMEvent(BaseModel):
     """Canonical PM-plane envelope event."""
 
-    type: str = "pm"
-
+    type: str = Field(default="pm", description="Canonical PM event model kind")
     event_id: str = Field(..., description="Deterministic event ID computed from envelope core")
     event_type: str = Field(..., description="Canonical PM event type such as pm.task.created")
     ts_utc: str = Field(..., description="Normalized UTC ISO8601 timestamp")
@@ -127,3 +126,6 @@ class PMEvent(Event):
     source: str = Field(..., description="Component that emitted the PM event")
     task_id: str = Field(..., description="Canonical task identifier")
     payload: Dict[str, Any] = Field(default_factory=dict, description="Event payload data")
+
+    class Config:
+        frozen = True

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -121,6 +121,22 @@ class TestInMemoryAdapter:
 
         callback.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_publish_rejects_pm_event_without_idempotency_key(self):
+        adapter = InMemoryAdapter()
+        event = DopemuxEvent.create("pm", "pm.task.created", {"envelope": {"source": "taskmaster"}})
+
+        with pytest.raises(ValueError, match="idempotency_key"):
+            await adapter.publish(event)
+
+    @pytest.mark.asyncio
+    async def test_publish_rejects_pm_event_without_source(self):
+        adapter = InMemoryAdapter()
+        event = DopemuxEvent.create("pm", "pm.task.created", {"envelope": {"idempotency_key": "idem-1"}})
+
+        with pytest.raises(ValueError, match="source"):
+            await adapter.publish(event)
+
 class TestRedisStreamsAdapter:
     @pytest.mark.asyncio
     async def test_publish_local_dispatch_when_disconnected(self):
@@ -189,3 +205,11 @@ class TestRedisStreamsAdapter:
         await adapter.publish(event)
 
         callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_publish_rejects_pm_event_without_idempotency_key(self):
+        adapter = RedisStreamsAdapter(redis_url="redis://localhost")
+        event = DopemuxEvent.create("pm", "pm.task.created", {"envelope": {"source": "taskmaster"}})
+
+        with pytest.raises(ValueError, match="idempotency_key"):
+            await adapter.publish(event)

--- a/tests/unit/test_event_bus.py
+++ b/tests/unit/test_event_bus.py
@@ -213,3 +213,11 @@ class TestRedisStreamsAdapter:
 
         with pytest.raises(ValueError, match="idempotency_key"):
             await adapter.publish(event)
+
+    @pytest.mark.asyncio
+    async def test_publish_rejects_pm_event_without_source(self):
+        adapter = RedisStreamsAdapter(redis_url="redis://localhost")
+        event = DopemuxEvent.create("pm", "pm.task.created", {"envelope": {"idempotency_key": "idem-1"}})
+
+        with pytest.raises(ValueError, match="source"):
+            await adapter.publish(event)


### PR DESCRIPTION
## Summary
- add canonical `PMEvent` envelopes and provenance enforcement for `pm.*` events
- normalize Taskmaster, Task Orchestrator, and bridge event emission onto the PM taxonomy
- keep the bridge publish route returning the canonical event type actually emitted

## Validation
- `python3 -m py_compile src/dopemux/events/types.py src/dopemux/event_bus.py services/dopecon-bridge/dopecon_bridge/event_bus.py services/taskmaster/server.py services/task-orchestrator/app/adapters/bridge_adapter.py services/dopecon-bridge/dopecon_bridge/routes.py`
- `python3 -m pytest -q tests/unit/test_event_bus.py services/taskmaster/tests/test_server.py services/dopecon-bridge/tests/test_route_endpoints_authority.py tests/unit/pm/test_pm_events.py tests/unit/pm/test_pm_publish.py`

## Notes
- this PR is stacked on `codex/pm-continue-01-write-boundary`
- `services/dopecon-bridge/dopecon_bridge/routes.py` on the baseline branch contained literal escaped quotes and would not import; this packet normalizes that file as part of the event work
