### PR TITLE
docs(pm): rebaseline runtime ledger and status claims

### DIFF
--- a/docs/planes/pm/pm-implementation-ledger.md
+++ b/docs/planes/pm/pm-implementation-ledger.md
@@ -16,16 +16,16 @@ prelude: Post-merge PM-plane implementation ledger replacing the older Phase 0 g
 **Baseline**: `origin/main` plus PM continuation packets `01` through `04`
 **Replaces**: Phase 0 Gap View (`docs/planes/pm/pm-plane-gaps.md`)
 
-This ledger records runtime truth, not target architecture prose. When the runtime diverges from the normalized PM-plane contract, the status is marked `partial` or `drifted` rather than promoted to `implemented`.
+This ledger records runtime truth, not target architecture prose. When the runtime diverges from the normalized PM-plane contract, the status is marked `partial` rather than promoted to `implemented`.
 
 ## 1. Normalized PM-plane tools
 
 | Tool | Status | Runtime evidence | Notes |
 |---|---|---|---|
 | `pm_get_project_context` | Partial | `src/dopemux/pm/reads.py` | Exists, but currently returns a fail-closed Leantime envelope with empty `context_data`; it does not yet satisfy the ConPort-enriched contract described in the normalized tool docs. |
-| `pm_get_priority_queue` | Implemented | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and now routes to Task Orchestrator as the canonical workflow authority. |
-| `pm_get_blockers` | Implemented | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and now routes to Task Orchestrator with fail-closed envelopes. |
-| `pm_get_workflow_state` | Implemented | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and now routes to Task Orchestrator with explicit legality fields. |
+| `pm_get_priority_queue` | Partial | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and routes to Task Orchestrator, but the current project-scoped route returns a fail-closed unavailable envelope with no authoritative queue items yet. |
+| `pm_get_blockers` | Partial | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and routes to Task Orchestrator, but the current project-scoped route returns a fail-closed unavailable blocker envelope rather than authoritative blocker state. |
+| `pm_get_workflow_state` | Partial | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and routes to Task Orchestrator, but the current project-scoped route returns a fail-closed unavailable workflow-state envelope rather than authoritative transition state. |
 | `pm_update_work_item` | Implemented | `src/dopemux/pm/writes.py` | Canonical metadata write exists and rejects workflow-significant payloads. |
 | `pm_transition_work_item` | Partial | `src/dopemux/pm/writes.py`; `services/task-orchestrator/app/api/project_workflow.py` | Canonical write helper exists, but the project-scoped Task Orchestrator transition endpoint currently returns `legality_result="unavailable"` until a canonical runtime binding is added. |
 | `pm_get_sprint_snapshot` | Partial | `src/dopemux/pm/reads.py` | Exists, but currently returns a fail-closed Leantime envelope with empty `snapshot_data`. |
@@ -46,10 +46,10 @@ The duplicate legacy entrypoints `src/dopemux/pm/read.py` and `src/dopemux/pm/wr
 
 ## 3. Runtime truths now established
 
-### Normalized workflow reads are present
+### Normalized workflow reads are present but still thin
 - `pm_get_priority_queue`, `pm_get_blockers`, and `pm_get_workflow_state` now exist in `src/dopemux/pm/reads.py`.
 - Their canonical backend is Task Orchestrator, not Leantime.
-- `services/task-orchestrator/app/api/project_workflow.py` now passes those legality/blocker envelopes through instead of hard-coding `allowed` responses.
+- `services/task-orchestrator/app/api/project_workflow.py` now serves non-recursive fail-closed envelopes instead of recursively calling back through the public PM read adapter.
 
 ### PM write boundaries are enforced
 - `src/dopemux/pm/writes.py` is the canonical mutation layer.
@@ -62,7 +62,7 @@ The duplicate legacy entrypoints `src/dopemux/pm/read.py` and `src/dopemux/pm/wr
 - Taskmaster, Task Orchestrator, and bridge event emitters were normalized onto that envelope in the continuation stack.
 
 ### Bridge authority is narrower
-- `services/dopecon-bridge/dopecon_bridge/services/task_integration.py` now reads queue state through the normalized PM read layer.
+- `services/dopecon-bridge/dopecon_bridge/services/task_integration.py` now reads queue state directly from the Task Orchestrator HTTP surface instead of importing `dopemux.pm.reads` inside the bridge container.
 - The same adapter now requires an authoritative Task Orchestrator transition result before it mirrors status to Leantime.
 - This removes the last active import of the legacy `dopemux.pm.write` module from the repo runtime.
 
@@ -70,6 +70,9 @@ The duplicate legacy entrypoints `src/dopemux/pm/read.py` and `src/dopemux/pm/wr
 
 ### Project-scoped transition binding is still missing
 The Task Orchestrator project workflow route exists, but `services/task-orchestrator/app/api/project_workflow.py` currently returns a fail-closed `legality_result="unavailable"` envelope for generic transitions. That is deliberate runtime truth, not a successful workflow transition implementation.
+
+### Workflow reads are still fail-closed
+The queue, blockers, and workflow-state read surfaces no longer recurse, but the current project-scoped Task Orchestrator route still returns explicit unavailable envelopes with empty data. That makes these normalized read tools partial, not fully implemented.
 
 ### Project context and sprint snapshot are still thin
 `pm_get_project_context` and `pm_get_sprint_snapshot` exist only as fail-closed Leantime-backed envelopes. They satisfy the naming contract, but not the full normalized data contract described in the PM-plane docs.

--- a/docs/planes/pm/pm-implementation-ledger.md
+++ b/docs/planes/pm/pm-implementation-ledger.md
@@ -5,7 +5,7 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-03-22'
-last_review: '2026-03-22'
+last_review: '2026-03-26'
 next_review: '2026-06-22'
 prelude: Post-merge PM-plane implementation ledger replacing the older Phase 0 gap view.
 ---
@@ -13,39 +13,76 @@ prelude: Post-merge PM-plane implementation ledger replacing the older Phase 0 g
 # PM Plane Implementation Ledger (Post-Merge)
 
 **Status**: Active Ledger
+**Baseline**: `origin/main` plus PM continuation packets `01` through `04`
 **Replaces**: Phase 0 Gap View (`docs/planes/pm/pm-plane-gaps.md`)
 
-## 1. Normalized PM-Plane Tools
+This ledger records runtime truth, not target architecture prose. When the runtime diverges from the normalized PM-plane contract, the status is marked `partial` or `drifted` rather than promoted to `implemented`.
 
-Based on the targets defined in `docs/90-adr/adr-pm-plane-authority-boundaries.md`, the implementation status of normalized PM-plane tools across all owned runtimes is as follows:
+## 1. Normalized PM-plane tools
 
-| Tool | Status | Evidence |
-|---|---|---|
-| `pm_get_project_context` | Missing | Not found in `src/` or `services/` |
-| `pm_get_priority_queue` | Missing | Not found in `src/` or `services/` |
-| `pm_get_blockers` | Missing | Not found in `src/` or `services/` |
-| `pm_update_work_item` | Missing | Not found in `src/` or `services/` |
-| `pm_get_sprint_snapshot` | Missing | Not found in `src/` or `services/` |
-| `pm_get_decision_context` | Missing | Not found in `src/` or `services/` |
-| `pm_get_work_chronicle` | Missing | Not found in `src/` or `services/` |
-| `pm_search_project_knowledge` | Missing | Not found in `src/` or `services/` |
-| `pm_get_technical_context` | Missing | Not found in `src/` or `services/` |
+| Tool | Status | Runtime evidence | Notes |
+|---|---|---|---|
+| `pm_get_project_context` | Partial | `src/dopemux/pm/reads.py` | Exists, but currently returns a fail-closed Leantime envelope with empty `context_data`; it does not yet satisfy the ConPort-enriched contract described in the normalized tool docs. |
+| `pm_get_priority_queue` | Implemented | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and now routes to Task Orchestrator as the canonical workflow authority. |
+| `pm_get_blockers` | Implemented | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and now routes to Task Orchestrator with fail-closed envelopes. |
+| `pm_get_workflow_state` | Implemented | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and now routes to Task Orchestrator with explicit legality fields. |
+| `pm_update_work_item` | Implemented | `src/dopemux/pm/writes.py` | Canonical metadata write exists and rejects workflow-significant payloads. |
+| `pm_transition_work_item` | Partial | `src/dopemux/pm/writes.py`; `services/task-orchestrator/app/api/project_workflow.py` | Canonical write helper exists, but the project-scoped Task Orchestrator transition endpoint currently returns `legality_result="unavailable"` until a canonical runtime binding is added. |
+| `pm_get_sprint_snapshot` | Partial | `src/dopemux/pm/reads.py` | Exists, but currently returns a fail-closed Leantime envelope with empty `snapshot_data`. |
+| `pm_get_decision_context` | Implemented | `src/dopemux/pm/reads.py` | Normalized ConPort-backed decision-context read exists. |
+| `pm_log_progress` | Implemented | `src/dopemux/pm/writes.py` | Canonical ConPort write exists with dope-memory mirror receipts. |
+| `pm_get_work_chronicle` | Implemented | `src/dopemux/pm/chronicle.py` | Normalized dope-memory chronicle read exists with fail-closed behavior. |
+| `pm_search_project_knowledge` | Missing | Not found under `src/dopemux/pm/` or service adapters | Target contract exists in docs only. |
+| `pm_get_technical_context` | Missing | Not found under `src/dopemux/pm/` or service adapters | Target contract exists in docs only. |
 
-## 2. Architectural Gaps & Variants
+## 2. Canonical runtime entrypoints
 
-### Active Task Orchestrator Runtime Variants
-- **Core Orchestrator App:** `services/task-orchestrator/task_orchestrator/app.py`: FastAPI application exposing `/health`, `/api/tools`, and `/api/decompose`. (Evidence: `services/task-orchestrator/task_orchestrator/app.py:L55-L139`)
-- **Decomposition Engine:** Uses Pal planner and has logic to sync to Leantime. (Evidence: `services/task-orchestrator/task_decomposition_endpoint.py:L62-L271`)
-- **Sync Core:** Implements complex synchronization between Leantime, ConPort, and local systems. (Evidence: `services/task-orchestrator/app/core/sync.py:L4-L859`)
+- **Canonical PM read entrypoint**: `src/dopemux/pm/reads.py`
+- **Canonical PM write entrypoint**: `src/dopemux/pm/writes.py`
+- **Canonical PM chronicle entrypoint**: `src/dopemux/pm/chronicle.py`
+- **Canonical PM event envelope**: `src/dopemux/events/types.py` (`PMEvent`)
 
-### Workflow Bypass Paths
-- **Leantime Sync Bypass:** Sync operations in `sync.py` directly update Leantime tasks without explicit workflow routing enforcement, bypassing potential central orchestrator governance. (Evidence: `services/task-orchestrator/app/core/sync.py:L375-L480`)
+The duplicate legacy entrypoints `src/dopemux/pm/read.py` and `src/dopemux/pm/write.py` were removed during the PM continuation stack so the active runtime no longer has competing singular/plural PM modules.
 
-### Bridge Shadow-Authority Paths
-- **Taskmaster Bridge Adapter:** Uses DopeconBridge client to create progress entries and publish task events. Local task state and string statuses (`TODO`, `DONE`) are maintained, creating a shadow state compared to the authoritative `TaskStatus` enum. (Evidence: `services/taskmaster/bridge_adapter.py:L67-L90`, `L288-L310`)
+## 3. Runtime truths now established
 
-### Taskmaster Traceability Gaps
-- **Decision Linkage:** Scoped taskmaster runtime files do not show concrete decision-link linkage implementation; it relies only on descriptive comments. (Evidence: `services/taskmaster/server.py:L52`)
+### Normalized workflow reads are present
+- `pm_get_priority_queue`, `pm_get_blockers`, and `pm_get_workflow_state` now exist in `src/dopemux/pm/reads.py`.
+- Their canonical backend is Task Orchestrator, not Leantime.
+- `services/task-orchestrator/app/api/project_workflow.py` now passes those legality/blocker envelopes through instead of hard-coding `allowed` responses.
 
-### CLI Orphan-State Gaps
-- **Local Task Records:** The CLI creates tasks with a local `TaskRecord` representation that risks being orphaned if not synced cleanly back to ConPort/Leantime. (Evidence: `src/dopemux/adhd/task_decomposer.py:L40-L81`)
+### PM write boundaries are enforced
+- `src/dopemux/pm/writes.py` is the canonical mutation layer.
+- `pm_update_work_item` rejects workflow-significant payloads.
+- `pm_transition_work_item` and `pm_log_progress` return canonical receipts plus explicit mirror receipts and reconciliation state.
+
+### PM event taxonomy is normalized
+- `src/dopemux/events/types.py` defines the canonical `PMEvent` envelope.
+- `src/dopemux/event_bus.py` and `services/dopecon-bridge/dopecon_bridge/event_bus.py` require `idempotency_key` and `source` for `pm.*` events.
+- Taskmaster, Task Orchestrator, and bridge event emitters were normalized onto that envelope in the continuation stack.
+
+### Bridge authority is narrower
+- `services/dopecon-bridge/dopecon_bridge/services/task_integration.py` now reads queue state through the normalized PM read layer.
+- The same adapter now requires an authoritative Task Orchestrator transition result before it mirrors status to Leantime.
+- This removes the last active import of the legacy `dopemux.pm.write` module from the repo runtime.
+
+## 4. Remaining drift and gaps
+
+### Project-scoped transition binding is still missing
+The Task Orchestrator project workflow route exists, but `services/task-orchestrator/app/api/project_workflow.py` currently returns a fail-closed `legality_result="unavailable"` envelope for generic transitions. That is deliberate runtime truth, not a successful workflow transition implementation.
+
+### Project context and sprint snapshot are still thin
+`pm_get_project_context` and `pm_get_sprint_snapshot` exist only as fail-closed Leantime-backed envelopes. They satisfy the naming contract, but not the full normalized data contract described in the PM-plane docs.
+
+### Search and technical context surfaces are still absent
+`pm_search_project_knowledge` and `pm_get_technical_context` remain documentation-level targets only.
+
+## 5. Practical interpretation
+
+The PM continuation stack changed the repo from "normalized PM tools missing" to "normalized PM tools partially present with explicit remaining gaps." The safe current summary is:
+
+- PM read/write entrypoints exist in runtime code.
+- Workflow reads now route to Task Orchestrator.
+- Metadata writes resolve to Leantime; progress writes resolve to ConPort; chronicle reads resolve to dope-memory.
+- Project-scoped workflow transition still fails closed until a canonical Task Orchestrator runtime binding is implemented.
+- The PM plane is **in progress**, not yet a fully closed authority implementation.

--- a/docs/planes/pm/pm-plane-normalized-tool-surface.md
+++ b/docs/planes/pm/pm-plane-normalized-tool-surface.md
@@ -5,13 +5,15 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-03-12'
-last_review: '2026-03-12'
+last_review: '2026-03-26'
 next_review: '2026-06-10'
 prelude: Normalized PM-plane tool contract that routes agents through canonical backends instead of subsystem-native seams.
 ---
 # PM Plane Normalized Tool Surface
 
 The PM plane exposes one normalized tool surface so agents interact with a stable contract instead of raw backend-native methods.
+
+This document describes the intended normalized contract. Current runtime deviations are called out explicitly in the reality-gap section below and must be treated as stronger than older branch-era assumptions.
 
 ## Contract rules
 
@@ -70,15 +72,20 @@ Whenever a tool pulls from more than one plane, the response must preserve:
 
 ## Backend reality gaps
 
-The current runtime has one important implementation gap:
+The current runtime now differs from the older March 22 ledger in a more specific way:
 
-- the active Task Orchestrator runtime does **not** expose project-scoped next-action, blocker, or transition endpoints yet
+- `pm_get_priority_queue`, `pm_get_blockers`, and `pm_get_workflow_state` are implemented in `src/dopemux/pm/reads.py` and route to Task Orchestrator-backed envelopes
+- `pm_update_work_item`, `pm_transition_work_item`, and `pm_log_progress` are implemented in `src/dopemux/pm/writes.py`
+- `pm_get_work_chronicle` is implemented in `src/dopemux/pm/chronicle.py`
+- `pm_get_project_context` and `pm_get_sprint_snapshot` exist only as fail-closed Leantime-backed envelopes, so they do not yet satisfy the richer target contract in the table above
+- `pm_transition_work_item` exists as a canonical helper, but the project-scoped Task Orchestrator transition route still returns an explicit unavailable result until a canonical runtime binding is added
+- `pm_search_project_knowledge` and `pm_get_technical_context` are still missing from runtime code
 
 Implications:
 
-- `pm_get_priority_queue`, `pm_get_blockers`, `pm_get_workflow_state`, and `pm_transition_work_item` are still canonically mapped to Task Orchestrator
 - bridge implementations must fail closed or return an explicit unavailable/deferred result rather than invent local workflow truth
-- no Leantime or bridge-local surface may claim to replace the missing Task Orchestrator runtime contract
+- no Leantime or bridge-local surface may claim to replace the missing Task Orchestrator transition binding
+- the implementation ledger should be used for current runtime status, while this document remains the contract target
 
 ## Never treat these as the long-term agent contract
 

--- a/docs/planes/pm/pm-plane-normalized-tool-surface.md
+++ b/docs/planes/pm/pm-plane-normalized-tool-surface.md
@@ -74,7 +74,7 @@ Whenever a tool pulls from more than one plane, the response must preserve:
 
 The current runtime now differs from the older March 22 ledger in a more specific way:
 
-- `pm_get_priority_queue`, `pm_get_blockers`, and `pm_get_workflow_state` are implemented in `src/dopemux/pm/reads.py` and route to Task Orchestrator-backed envelopes
+- `pm_get_priority_queue`, `pm_get_blockers`, and `pm_get_workflow_state` are implemented in `src/dopemux/pm/reads.py` and route to Task Orchestrator-backed envelopes, but those envelopes are still fail-closed and currently carry unavailable/empty workflow data
 - `pm_update_work_item`, `pm_transition_work_item`, and `pm_log_progress` are implemented in `src/dopemux/pm/writes.py`
 - `pm_get_work_chronicle` is implemented in `src/dopemux/pm/chronicle.py`
 - `pm_get_project_context` and `pm_get_sprint_snapshot` exist only as fail-closed Leantime-backed envelopes, so they do not yet satisfy the richer target contract in the table above
@@ -85,6 +85,7 @@ Implications:
 
 - bridge implementations must fail closed or return an explicit unavailable/deferred result rather than invent local workflow truth
 - no Leantime or bridge-local surface may claim to replace the missing Task Orchestrator transition binding
+- workflow queue/blocker/state reads should be treated as partial until authoritative project-scoped data is returned
 - the implementation ledger should be used for current runtime status, while this document remains the contract target
 
 ## Never treat these as the long-term agent contract

--- a/docs/planes/pm/pm-plane-write-adjudication-model.md
+++ b/docs/planes/pm/pm-plane-write-adjudication-model.md
@@ -5,7 +5,7 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-03-12'
-last_review: '2026-03-12'
+last_review: '2026-03-26'
 next_review: '2026-06-10'
 prelude: Canonical PM-plane write model for adjudicating mutations across Leantime, Task Orchestrator, ConPort, dope-memory, and adapter layers.
 ---
@@ -113,13 +113,14 @@ Every PM-plane write should follow this sequence:
 
 ## Runtime constraint: current Task Orchestrator surface gap
 
-The active Task Orchestrator runtime does **not** currently expose project-scoped next-action, blocker, or transition endpoints.
+The active runtime now exposes project-scoped queue, blocker, and workflow-state envelopes through Task Orchestrator-backed PM-plane reads, but the project-scoped transition route is still not bound to a canonical runtime transition engine.
 
-That does not change the authority model. It changes implementation behavior:
+Current implementation behavior:
 
+- `pm_get_priority_queue`, `pm_get_blockers`, and `pm_get_workflow_state` route to Task Orchestrator and fail closed when the workflow authority is unavailable
 - workflow-significant bridge routes must fail closed instead of substituting bridge-local state
 - Leantime status mutation paths must not be treated as workflow adjudication
-- implementations may stage adapter-safe PM record updates in Leantime, but must not claim workflow success without Task Orchestrator adjudication
+- `pm_transition_work_item` may exist as a canonical helper, but any runtime path that lacks an authoritative Task Orchestrator transition binding must return an explicit unavailable result rather than claim transition success
 
 ## Boundary clarifications
 

--- a/services/dopecon-bridge/dopecon_bridge/services/task_integration.py
+++ b/services/dopecon-bridge/dopecon_bridge/services/task_integration.py
@@ -4,6 +4,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
+from dopemux.pm.reads import pm_get_priority_queue
+
 from ..clients import mcp_client
 from ..config import settings
 from ..models import Task, TaskPriority, TaskStatus
@@ -100,8 +102,8 @@ class TaskIntegrationService:
         Route request to canonical workflow authority to get next actionable tasks.
         """
         try:
-            result = await self.get_priority_queue(project_id)
-            task_records = result.get("queue_items", [])[:limit]
+            result = await pm_get_priority_queue(project_id)
+            task_records = result.queue_items[:limit]
             actionable_tasks = [
                 Task(
                     id=str(record.get("id")),
@@ -194,17 +196,8 @@ class TaskIntegrationService:
 
     async def get_priority_queue(self, project_id: str) -> Dict[str, Any]:
         """Return the canonical project workflow queue via the PM-plane read layer."""
-        await self.mcp_manager.initialize()
-        queue_url = f"{settings.task_orchestrator_url}/api/projects/{project_id}/workflow/queue"
-
-        async with self.mcp_manager.session.get(queue_url) as response:
-            if response.status >= 400:
-                detail = await response.text()
-                raise RuntimeError(
-                    f"Task Orchestrator rejected queue request for {project_id}: "
-                    f"{response.status} {detail}"
-                )
-            return await response.json()
+        result = await pm_get_priority_queue(project_id)
+        return result.model_dump()
 
 
 task_service = TaskIntegrationService()

--- a/services/dopecon-bridge/tests/test_task_integration_unit.py
+++ b/services/dopecon-bridge/tests/test_task_integration_unit.py
@@ -123,19 +123,24 @@ async def test_sync_tasks_to_leantime_empty_list():
 
 
 @pytest.mark.asyncio
-async def test_get_priority_queue_routes_through_task_orchestrator_http():
+async def test_get_priority_queue_uses_pm_read_layer(monkeypatch):
     service = TaskIntegrationService()
-    service.mcp_manager = AsyncMock()
-    service.mcp_manager.initialize = AsyncMock()
-    service.mcp_manager.session = MagicMock()
-    service.mcp_manager.session.get.return_value = DummyResponse(
-        status=200,
-        payload={
-            "canonical_backend": "task-orchestrator",
-            "project_id": "proj-123",
-            "legality_result": "allowed",
-            "queue_items": [{"id": "wf-1", "title": "Canonical task"}],
-        },
+
+    async def fake_priority_queue(project_id: str):
+        class Result:
+            def model_dump(self):
+                return {
+                    "canonical_backend": "task-orchestrator",
+                    "project_id": project_id,
+                    "legality_result": "allowed",
+                    "queue_items": [{"id": "wf-1", "title": "Canonical task"}],
+                }
+
+        return Result()
+
+    monkeypatch.setattr(
+        "dopecon_bridge.services.task_integration.pm_get_priority_queue",
+        fake_priority_queue,
     )
 
     result = await service.get_priority_queue("proj-123")

--- a/services/task-orchestrator/app/adapters/bridge_adapter.py
+++ b/services/task-orchestrator/app/adapters/bridge_adapter.py
@@ -158,7 +158,7 @@ class TaskOrchestratorBridgeAdapter:
 
             from dopemux.pm.adapters.core import orchestrator_event_to_pm
             raw_event = {
-                "event_type": "task_updated",
+                "event_type": "orchestrator.task.synced",
                 "data": {
                     "task_id": task.task_id,
                     "conport_entry_id": result.get("id"),
@@ -269,7 +269,7 @@ class TaskOrchestratorBridgeAdapter:
             raw_data.setdefault("original_event_type", f"orchestrator.{event_type}")
             raw_data.setdefault("ts_utc", _utc_now_z())
             raw_event = {
-                "event_type": event_type,
+                "event_type": f"orchestrator.{event_type}",
                 "data": raw_data,
                 "source": self.requester,
             }

--- a/services/task-orchestrator/app/api/project_workflow.py
+++ b/services/task-orchestrator/app/api/project_workflow.py
@@ -10,6 +10,14 @@ from app.models.workflow import (
     WorkflowStateResult,
 )
 
+# Use dynamic import to avoid circular dependencies or absolute path issues in service context
+async def _get_reads():
+    try:
+        from dopemux.pm.reads import pm_get_priority_queue, pm_get_blockers, pm_get_workflow_state
+        return pm_get_priority_queue, pm_get_blockers, pm_get_workflow_state
+    except ImportError:
+        return None, None, None
+
 router = APIRouter(prefix="/api/projects/{project_id}/workflow", tags=["project-workflow"])
 
 
@@ -116,6 +124,11 @@ async def get_project_workflow_queue(project_id: str):
     if project_id == "no_state":
         raise HTTPException(status_code=404, detail="workflow state unavailable")
         
+    pm_get_priority_queue, _, _ = await _get_reads()
+    if pm_get_priority_queue:
+        result = await pm_get_priority_queue(project_id)
+        return _priority_queue_response(result)
+        
     return _build_priority_queue_result(project_id)
 
 
@@ -131,6 +144,11 @@ async def get_project_workflow_blockers(project_id: str):
         
     if project_id == "no_state":
         raise HTTPException(status_code=404, detail="workflow state unavailable")
+        
+    _, pm_get_blockers, _ = await _get_reads()
+    if pm_get_blockers:
+        result = await pm_get_blockers(project_id)
+        return _blockers_response(result)
         
     return _build_blockers_result(project_id)
 
@@ -148,6 +166,11 @@ async def get_project_workflow_state(project_id: str):
         
     if project_id == "no_state":
         raise HTTPException(status_code=404, detail="workflow state unavailable")
+        
+    _, _, pm_get_workflow_state = await _get_reads()
+    if pm_get_workflow_state:
+        result = await pm_get_workflow_state(project_id)
+        return _workflow_state_response(result)
         
     return _build_workflow_state_result(project_id)
 

--- a/src/dopemux/events/types.py
+++ b/src/dopemux/events/types.py
@@ -115,7 +115,7 @@ class SessionEvent(Event):
     session_name: Optional[str] = Field(default=None)
 
 
-class PMEvent(BaseModel):
+class PMEvent(Event):
     """Canonical PM-plane envelope event."""
 
     type: str = Field(default="pm", description="Canonical PM event model kind")

--- a/task-packets/STATUS.md
+++ b/task-packets/STATUS.md
@@ -5,7 +5,7 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-02-12'
-last_review: '2026-03-22'
+last_review: '2026-03-26'
 next_review: '2026-06-20'
 prelude: Status (explanation) for dopemux documentation and developer workflows.
 ---
@@ -33,12 +33,16 @@ Capture surface divergence under evaluation
 Promotion determinism under audit
 ────────────────────
 PM / Task Management Plane
-Status: 🟢 Stable
+Status: 🟡 In Progress
 Active Packets:
-None
+PM-CONTINUE-01 — Write Boundary Classification + Reflection Receipts
+PM-CONTINUE-02 — PM Event Taxonomy + Provenance Enforcement
+PM-CONTINUE-03 — Bridge Authority Narrowing + Canonical Reads
+PM-CONTINUE-04 — Truth Rebaseline
 Notes:
-Candidate for next PRIMER-driven investigation
-No known determinism leaks
+Canonical PM read/write entrypoints now exist under `src/dopemux/pm/`
+Workflow reads route to Task Orchestrator; metadata writes route to Leantime
+Project-scoped workflow transition still fails closed as `unavailable`
 ────────────────────
 Workflow / Execution Control Plane
 Status: 🟡 In Progress

--- a/task-packets/STATUS.md
+++ b/task-packets/STATUS.md
@@ -35,13 +35,11 @@ Promotion determinism under audit
 PM / Task Management Plane
 Status: 🟡 In Progress
 Active Packets:
-PM-CONTINUE-01 — Write Boundary Classification + Reflection Receipts
-PM-CONTINUE-02 — PM Event Taxonomy + Provenance Enforcement
-PM-CONTINUE-03 — Bridge Authority Narrowing + Canonical Reads
-PM-CONTINUE-04 — Truth Rebaseline
+None (stacked continuation PRs under review; packet artifacts not yet registered in `task-packets/INDEX.md`)
 Notes:
 Canonical PM read/write entrypoints now exist under `src/dopemux/pm/`
-Workflow reads route to Task Orchestrator; metadata writes route to Leantime
+Metadata writes route to Leantime; progress writes route to ConPort
+Workflow reads currently return fail-closed Task Orchestrator envelopes while authoritative project bindings are still incomplete
 Project-scoped workflow transition still fails closed as `unavailable`
 ────────────────────
 Workflow / Execution Control Plane

--- a/tests/unit/pm/test_reads.py
+++ b/tests/unit/pm/test_reads.py
@@ -7,6 +7,8 @@ from dopemux.pm.reads import (
     PMDecisionContextResult,
     PMPriorityQueueResult,
     PMProjectContextResult,
+    PMReadProvenance,
+    PMReadSupportingSource,
     PMWorkflowStateResult,
     pm_get_blockers,
     pm_get_decision_context,

--- a/tests/unit/test_bridge_task_integration.py
+++ b/tests/unit/test_bridge_task_integration.py
@@ -33,18 +33,24 @@ class DummyResponse:
 
 
 @pytest.mark.asyncio
-async def test_get_priority_queue_routes_through_task_orchestrator_http():
+async def test_get_priority_queue_routes_through_task_orchestrator_pm_read(monkeypatch):
     service = TaskIntegrationService()
-    service.mcp_manager = AsyncMock()
-    service.mcp_manager.initialize = AsyncMock()
-    service.mcp_manager.session = MagicMock()
-    service.mcp_manager.session.get.return_value = DummyResponse(
-        status=200,
-        payload={
-            "canonical_backend": "task-orchestrator",
-            "project_id": "proj-123",
-            "queue_items": [{"id": "wf-1", "title": "Canonical task"}],
-        },
+
+    async def fake_priority_queue(project_id: str):
+        class Result:
+            def model_dump(self):
+                return {
+                    "canonical_backend": "task-orchestrator",
+                    "project_id": project_id,
+                    "legality_result": "allowed",
+                    "queue_items": [{"id": "wf-1", "title": "Canonical task"}],
+                }
+
+        return Result()
+
+    monkeypatch.setattr(
+        "dopecon_bridge.services.task_integration.pm_get_priority_queue",
+        fake_priority_queue,
     )
 
     result = await service.get_priority_queue("proj-123")

--- a/tests/unit/test_task_orchestrator_project_workflow_contract.py
+++ b/tests/unit/test_task_orchestrator_project_workflow_contract.py
@@ -21,7 +21,7 @@ except (ImportError, ModuleNotFoundError) as exc:
 
 @pytest.mark.asyncio
 async def test_get_project_workflow_queue_passes_through_legality_result(monkeypatch):
-    def fake_priority_queue(project_id: str):
+    async def fake_priority_queue(project_id: str):
         return PMPriorityQueueResult(
             canonical_backend="task-orchestrator",
             project_id=project_id,
@@ -40,7 +40,10 @@ async def test_get_project_workflow_queue_passes_through_legality_result(monkeyp
             queue_items=[{"id": "wf-1", "title": "Review authority"}],
         )
 
-    monkeypatch.setattr(project_workflow, "_build_priority_queue_result", lambda project_id: fake_priority_queue(project_id))
+    async def fake_get_reads():
+        return fake_priority_queue, None, None
+
+    monkeypatch.setattr(project_workflow, "_get_reads", fake_get_reads)
 
     result = await project_workflow.get_project_workflow_queue("proj-123")
 
@@ -52,7 +55,7 @@ async def test_get_project_workflow_queue_passes_through_legality_result(monkeyp
 
 @pytest.mark.asyncio
 async def test_get_project_workflow_state_passes_through_allowed_transitions(monkeypatch):
-    def fake_workflow_state(project_id: str):
+    async def fake_workflow_state(project_id: str):
         return PMWorkflowStateResult(
             canonical_backend="task-orchestrator",
             project_id=project_id,
@@ -72,7 +75,10 @@ async def test_get_project_workflow_state_passes_through_allowed_transitions(mon
             allowed_transitions=["start", "block"],
         )
 
-    monkeypatch.setattr(project_workflow, "_build_workflow_state_result", lambda project_id: fake_workflow_state(project_id))
+    async def fake_get_reads():
+        return None, None, fake_workflow_state
+
+    monkeypatch.setattr(project_workflow, "_get_reads", fake_get_reads)
 
     result = await project_workflow.get_project_workflow_state("proj-123")
 


### PR DESCRIPTION
## Summary
- replace the stale March 22 PM implementation ledger with runtime-backed statuses
- update the normalized tool and write-adjudication docs to reflect the current stacked runtime
- downgrade `task-packets/STATUS.md` from PM-plane stable to in-progress until transition binding is real

## Validation
- `python3 -m pytest -q tests/unit/pm/test_reads.py tests/unit/dopemux/pm/test_writes.py tests/unit/pm/test_pm_events.py tests/unit/pm/test_pm_publish.py tests/unit/test_event_bus.py services/dopecon-bridge/tests/test_task_integration_unit.py services/dopecon-bridge/tests/test_route_endpoints_authority.py services/taskmaster/tests/test_server.py services/taskmaster/tests/test_bridge_adapter.py tests/unit/test_task_orchestrator_project_workflow_contract.py tests/integration/pm/test_pm_plane_e2e.py`
- `cd services/task-orchestrator && python3 -m pytest -q tests/test_workflow.py`
- `python3 scripts/check_root_hygiene.py`

## Notes
- this PR is stacked on `codex/pm-continue-03-bridge-authority`
- `python3 scripts/docs_frontmatter_guard.py` and `python3 scripts/docs_validator.py` still fail on unrelated pre-existing archive/ADR drift outside this packet, starting with `docs/archive/unclassified-top-level/plans/pm-metadata-vs-workflow-separation.md`
