### PR TITLE
feat(pm): bind workflow transitions and normalize read surfaces

### DIFF
--- a/docs/planes/pm/pm-implementation-ledger.md
+++ b/docs/planes/pm/pm-implementation-ledger.md
@@ -5,7 +5,7 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-03-22'
-last_review: '2026-03-26'
+last_review: '2026-03-27'
 next_review: '2026-06-22'
 prelude: Post-merge PM-plane implementation ledger replacing the older Phase 0 gap view.
 ---
@@ -13,7 +13,7 @@ prelude: Post-merge PM-plane implementation ledger replacing the older Phase 0 g
 # PM Plane Implementation Ledger (Post-Merge)
 
 **Status**: Active Ledger
-**Baseline**: `origin/main` plus PM continuation packets `01` through `04`
+**Baseline**: `origin/main` plus PM continuation packets `01` through `08`
 **Replaces**: Phase 0 Gap View (`docs/planes/pm/pm-plane-gaps.md`)
 
 This ledger records runtime truth, not target architecture prose. When the runtime diverges from the normalized PM-plane contract, the status is marked `partial` rather than promoted to `implemented`.
@@ -22,18 +22,18 @@ This ledger records runtime truth, not target architecture prose. When the runti
 
 | Tool | Status | Runtime evidence | Notes |
 |---|---|---|---|
-| `pm_get_project_context` | Partial | `src/dopemux/pm/reads.py` | Exists, but currently returns a fail-closed Leantime envelope with empty `context_data`; it does not yet satisfy the ConPort-enriched contract described in the normalized tool docs. |
-| `pm_get_priority_queue` | Partial | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and routes to Task Orchestrator, but the current project-scoped route returns a fail-closed unavailable envelope with no authoritative queue items yet. |
-| `pm_get_blockers` | Partial | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and routes to Task Orchestrator, but the current project-scoped route returns a fail-closed unavailable blocker envelope rather than authoritative blocker state. |
-| `pm_get_workflow_state` | Partial | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read exists and routes to Task Orchestrator, but the current project-scoped route returns a fail-closed unavailable workflow-state envelope rather than authoritative transition state. |
+| `pm_get_project_context` | Partial | `src/dopemux/pm/reads.py`; `src/dopemux/tools/conport_client.py` | ConPort-backed project context now returns backend data plus linked IDs. It remains partial because supporting Leantime and dope-memory references are not yet attached. |
+| `pm_get_priority_queue` | Implemented | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read returns Task Orchestrator-backed queue data through the project-scoped workflow runtime. |
+| `pm_get_blockers` | Implemented | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read returns Task Orchestrator-backed blocker state through the project-scoped workflow runtime. |
+| `pm_get_workflow_state` | Implemented | `src/dopemux/pm/reads.py`; `services/task-orchestrator/app/api/project_workflow.py` | Normalized read returns Task Orchestrator-backed workflow legality and allowed transition data. |
 | `pm_update_work_item` | Implemented | `src/dopemux/pm/writes.py` | Canonical metadata write exists and rejects workflow-significant payloads. |
-| `pm_transition_work_item` | Partial | `src/dopemux/pm/writes.py`; `services/task-orchestrator/app/api/project_workflow.py` | Canonical write helper exists, but the project-scoped Task Orchestrator transition endpoint currently returns `legality_result="unavailable"` until a canonical runtime binding is added. |
-| `pm_get_sprint_snapshot` | Partial | `src/dopemux/pm/reads.py` | Exists, but currently returns a fail-closed Leantime envelope with empty `snapshot_data`. |
+| `pm_transition_work_item` | Implemented | `src/dopemux/pm/writes.py`; `services/task-orchestrator/app/api/project_workflow.py`; `src/dopemux/pm/adapters/orchestrator.py` | Canonical write now binds to the project-scoped Task Orchestrator transition route and returns real legality/result envelopes for supported transitions. |
+| `pm_get_sprint_snapshot` | Partial | `src/dopemux/pm/reads.py`; `src/integrations/leantime_jsonrpc_client.py` | Leantime-backed sprint snapshot now returns project and ticket data. It remains partial because optional ConPort context attachments are not yet included and non-numeric project IDs fail closed. |
 | `pm_get_decision_context` | Implemented | `src/dopemux/pm/reads.py` | Normalized ConPort-backed decision-context read exists. |
 | `pm_log_progress` | Implemented | `src/dopemux/pm/writes.py` | Canonical ConPort write exists with dope-memory mirror receipts. |
 | `pm_get_work_chronicle` | Implemented | `src/dopemux/pm/chronicle.py` | Normalized dope-memory chronicle read exists with fail-closed behavior. |
-| `pm_search_project_knowledge` | Missing | Not found under `src/dopemux/pm/` or service adapters | Target contract exists in docs only. |
-| `pm_get_technical_context` | Missing | Not found under `src/dopemux/pm/` or service adapters | Target contract exists in docs only. |
+| `pm_search_project_knowledge` | Partial | `src/dopemux/pm/reads.py`; `services/genetic_agent/shared/mcp/dope_context_client.py` | Normalized dope-context search now exists and returns evidence objects with ranking/confidence metadata. It remains partial because supporting source joins are envelope-only. |
+| `pm_get_technical_context` | Partial | `src/dopemux/pm/reads.py`; `services/genetic_agent/shared/mcp/serena_client.py` | Normalized Serena-backed technical context now exists and returns implementation findings. It remains partial because supporting ConPort/dope-context joins are envelope-only. |
 
 ## 2. Canonical runtime entrypoints
 
@@ -46,15 +46,16 @@ The duplicate legacy entrypoints `src/dopemux/pm/read.py` and `src/dopemux/pm/wr
 
 ## 3. Runtime truths now established
 
-### Normalized workflow reads are present but still thin
+### Normalized workflow reads are now authoritative
 - `pm_get_priority_queue`, `pm_get_blockers`, and `pm_get_workflow_state` now exist in `src/dopemux/pm/reads.py`.
 - Their canonical backend is Task Orchestrator, not Leantime.
-- `services/task-orchestrator/app/api/project_workflow.py` now serves non-recursive fail-closed envelopes instead of recursively calling back through the public PM read adapter.
+- `services/task-orchestrator/app/api/project_workflow.py` now serves runtime-backed queue, blocker, state, and transition envelopes instead of recursively calling back through the public PM read adapter.
 
-### PM write boundaries are enforced
+### PM write boundaries and transition binding are enforced
 - `src/dopemux/pm/writes.py` is the canonical mutation layer.
 - `pm_update_work_item` rejects workflow-significant payloads.
 - `pm_transition_work_item` and `pm_log_progress` return canonical receipts plus explicit mirror receipts and reconciliation state.
+- `pm_transition_work_item` now binds through the project-scoped Task Orchestrator workflow route instead of the deprecated bridge-local transition path.
 
 ### PM event taxonomy is normalized
 - `src/dopemux/events/types.py` defines the canonical `PMEvent` envelope.
@@ -68,17 +69,14 @@ The duplicate legacy entrypoints `src/dopemux/pm/read.py` and `src/dopemux/pm/wr
 
 ## 4. Remaining drift and gaps
 
-### Project-scoped transition binding is still missing
-The Task Orchestrator project workflow route exists, but `services/task-orchestrator/app/api/project_workflow.py` currently returns a fail-closed `legality_result="unavailable"` envelope for generic transitions. That is deliberate runtime truth, not a successful workflow transition implementation.
+### Project scoping is still thin inside Task Orchestrator runtime views
+The project-scoped Task Orchestrator route now returns real queue/blocker/state/transition data, but tasks without explicit project linkage are still treated as in-scope for the requested project. The route is authoritative for workflow state, but its project partitioning remains coarse.
 
-### Workflow reads are still fail-closed
-The queue, blockers, and workflow-state read surfaces no longer recurse, but the current project-scoped Task Orchestrator route still returns explicit unavailable envelopes with empty data. That makes these normalized read tools partial, not fully implemented.
+### Project context and sprint snapshot are backend-backed but not fully enriched
+`pm_get_project_context` now reads ConPort active context, and `pm_get_sprint_snapshot` now reads Leantime project/ticket data. Both remain partial because the richer supporting-source joins described in the PM docs are not yet populated.
 
-### Project context and sprint snapshot are still thin
-`pm_get_project_context` and `pm_get_sprint_snapshot` exist only as fail-closed Leantime-backed envelopes. They satisfy the naming contract, but not the full normalized data contract described in the PM-plane docs.
-
-### Search and technical context surfaces are still absent
-`pm_search_project_knowledge` and `pm_get_technical_context` remain documentation-level targets only.
+### Search and technical context now exist but are thin wrappers
+`pm_search_project_knowledge` and `pm_get_technical_context` now exist in runtime code and return normalized envelopes, but they currently expose only their canonical backend results plus provenance/supporting-source envelopes rather than richer cross-plane joins.
 
 ## 5. Practical interpretation
 
@@ -87,5 +85,5 @@ The PM continuation stack changed the repo from "normalized PM tools missing" to
 - PM read/write entrypoints exist in runtime code.
 - Workflow reads now route to Task Orchestrator.
 - Metadata writes resolve to Leantime; progress writes resolve to ConPort; chronicle reads resolve to dope-memory.
-- Project-scoped workflow transition still fails closed until a canonical Task Orchestrator runtime binding is implemented.
-- The PM plane is **in progress**, not yet a fully closed authority implementation.
+- Project-scoped workflow reads and transitions are now bound to Task Orchestrator runtime state.
+- The PM plane is **substantially implemented**, with remaining gaps concentrated in richer multi-source enrichment rather than missing canonical entrypoints.

--- a/docs/planes/pm/pm-plane-normalized-tool-surface.md
+++ b/docs/planes/pm/pm-plane-normalized-tool-surface.md
@@ -5,7 +5,7 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-03-12'
-last_review: '2026-03-26'
+last_review: '2026-03-27'
 next_review: '2026-06-10'
 prelude: Normalized PM-plane tool contract that routes agents through canonical backends instead of subsystem-native seams.
 ---
@@ -74,18 +74,18 @@ Whenever a tool pulls from more than one plane, the response must preserve:
 
 The current runtime now differs from the older March 22 ledger in a more specific way:
 
-- `pm_get_priority_queue`, `pm_get_blockers`, and `pm_get_workflow_state` are implemented in `src/dopemux/pm/reads.py` and route to Task Orchestrator-backed envelopes, but those envelopes are still fail-closed and currently carry unavailable/empty workflow data
+- `pm_get_priority_queue`, `pm_get_blockers`, and `pm_get_workflow_state` are implemented in `src/dopemux/pm/reads.py` and now route to Task Orchestrator-backed runtime data through `services/task-orchestrator/app/api/project_workflow.py`
 - `pm_update_work_item`, `pm_transition_work_item`, and `pm_log_progress` are implemented in `src/dopemux/pm/writes.py`
 - `pm_get_work_chronicle` is implemented in `src/dopemux/pm/chronicle.py`
-- `pm_get_project_context` and `pm_get_sprint_snapshot` exist only as fail-closed Leantime-backed envelopes, so they do not yet satisfy the richer target contract in the table above
-- `pm_transition_work_item` exists as a canonical helper, but the project-scoped Task Orchestrator transition route still returns an explicit unavailable result until a canonical runtime binding is added
-- `pm_search_project_knowledge` and `pm_get_technical_context` are still missing from runtime code
+- `pm_get_project_context` now reads ConPort active context and `pm_get_sprint_snapshot` now reads Leantime project/ticket data, but both remain thinner than the full multi-source enrichment target in the table above
+- `pm_transition_work_item` now binds to the project-scoped Task Orchestrator transition route and returns real legality/result envelopes for supported transitions
+- `pm_search_project_knowledge` and `pm_get_technical_context` now exist in runtime code, but currently expose canonical backend results without richer supporting-source joins
 
 Implications:
 
 - bridge implementations must fail closed or return an explicit unavailable/deferred result rather than invent local workflow truth
-- no Leantime or bridge-local surface may claim to replace the missing Task Orchestrator transition binding
-- workflow queue/blocker/state reads should be treated as partial until authoritative project-scoped data is returned
+- no Leantime or bridge-local surface may claim to replace the Task Orchestrator workflow authority
+- workflow queue/blocker/state reads are authoritative for workflow state, but project scoping remains coarse until all workflow items carry explicit project linkage
 - the implementation ledger should be used for current runtime status, while this document remains the contract target
 
 ## Never treat these as the long-term agent contract

--- a/services/task-orchestrator/app/api/pm_tools.py
+++ b/services/task-orchestrator/app/api/pm_tools.py
@@ -1,6 +1,7 @@
 import logging
 from fastapi import APIRouter, Depends, HTTPException, Request
 from typing import Dict, Any
+import httpx
 from src.dopemux.pm.writes import (
     pm_update_work_item,
     pm_transition_work_item,
@@ -12,6 +13,26 @@ from src.dopemux.pm.models import PMTaskStatus
 
 router = APIRouter(prefix="/api/pm", tags=["pm-plane"])
 logger = logging.getLogger(__name__)
+
+
+class _LocalTaskOrchestratorWriteClient:
+    """Bridge PM write calls into the local project-scoped workflow runtime."""
+
+    def transition(self, task_id: str, status: Any, reason: str, expected_version: int, idempotency_key: str):
+        transition_name = status.value.lower() if hasattr(status, "value") else str(status).lower()
+        project_id = "default"
+        payload = {
+            "workflow_id": task_id,
+            "transition": transition_name,
+            "actor": "task-orchestrator",
+            "idempotency_key": idempotency_key,
+            "expected_version": expected_version,
+            "reason": reason,
+        }
+        with httpx.Client(base_url="http://localhost:3014", timeout=10.0) as client:
+            response = client.post(f"/api/projects/{project_id}/workflow/transition", json=payload)
+            response.raise_for_status()
+            return response.json()
 
 def _record_metrics_and_log(request: Request, operation: str, receipt: CanonicalReceipt = None, failed: bool = False):
     """Log structured info and update Prometheus metrics on the coordinator."""
@@ -68,7 +89,7 @@ def get_pm_config(request: Request) -> PMWriteConfig:
     coordinator = getattr(request.app.state, "coordinator", None)
     
     leantime = getattr(coordinator, "leantime_client", None)
-    orchestrator = getattr(coordinator, "workflow_service", None)
+    orchestrator = _LocalTaskOrchestratorWriteClient()
     conport = getattr(coordinator, "conport_client", None)
     memory = getattr(coordinator, "memory_client", None)
     

--- a/services/task-orchestrator/app/api/project_workflow.py
+++ b/services/task-orchestrator/app/api/project_workflow.py
@@ -1,6 +1,16 @@
 """Project-scoped workflow endpoints for the Task Orchestrator PM-plane contract."""
 
-from fastapi import APIRouter, HTTPException
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+
+from dopemux.pm.mapping import CANONICAL_TO_ORCHESTRATOR
+from dopemux.pm.models import PMTaskStatus, PMTransitionRequest
+from dopemux.pm.store import IdempotencyMismatchError, StaleWriteError, TaskNotFoundError
 
 from app.models.workflow import (
     BlockersResult,
@@ -10,190 +20,460 @@ from app.models.workflow import (
     WorkflowStateResult,
 )
 
-# Use dynamic import to avoid circular dependencies or absolute path issues in service context
-async def _get_reads():
-    try:
-        from dopemux.pm.reads import pm_get_priority_queue, pm_get_blockers, pm_get_workflow_state
-        return pm_get_priority_queue, pm_get_blockers, pm_get_workflow_state
-    except ImportError:
-        return None, None, None
-
 router = APIRouter(prefix="/api/projects/{project_id}/workflow", tags=["project-workflow"])
 
 
-def _project_linked_ids(project_id: str) -> dict[str, str]:
-    return {"project": project_id}
+_ALLOWED_TRANSITIONS: dict[PMTaskStatus, dict[str, PMTaskStatus]] = {
+    PMTaskStatus.TODO: {
+        "start": PMTaskStatus.IN_PROGRESS,
+        "in_progress": PMTaskStatus.IN_PROGRESS,
+        "block": PMTaskStatus.BLOCKED,
+        "blocked": PMTaskStatus.BLOCKED,
+        "cancel": PMTaskStatus.CANCELED,
+        "cancelled": PMTaskStatus.CANCELED,
+        "canceled": PMTaskStatus.CANCELED,
+        "todo": PMTaskStatus.TODO,
+        "planned": PMTaskStatus.TODO,
+    },
+    PMTaskStatus.IN_PROGRESS: {
+        "done": PMTaskStatus.DONE,
+        "complete": PMTaskStatus.DONE,
+        "completed": PMTaskStatus.DONE,
+        "block": PMTaskStatus.BLOCKED,
+        "blocked": PMTaskStatus.BLOCKED,
+        "cancel": PMTaskStatus.CANCELED,
+        "cancelled": PMTaskStatus.CANCELED,
+        "canceled": PMTaskStatus.CANCELED,
+    },
+    PMTaskStatus.BLOCKED: {
+        "start": PMTaskStatus.IN_PROGRESS,
+        "resume": PMTaskStatus.IN_PROGRESS,
+        "in_progress": PMTaskStatus.IN_PROGRESS,
+        "cancel": PMTaskStatus.CANCELED,
+        "cancelled": PMTaskStatus.CANCELED,
+        "canceled": PMTaskStatus.CANCELED,
+    },
+    PMTaskStatus.DONE: {},
+    PMTaskStatus.CANCELED: {},
+}
 
 
-def _build_priority_queue_result(project_id: str) -> PriorityQueueResult:
+def _project_linked_ids(project_id: str, workflow_id: Optional[str] = None) -> dict[str, str]:
+    linked_ids = {"project": project_id}
+    if workflow_id:
+        linked_ids["workflow"] = workflow_id
+    return linked_ids
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coordinator_from_request(request: Optional[Request]) -> Any:
+    if request is not None:
+        coordinator = getattr(request.app.state, "coordinator", None)
+        if coordinator is not None:
+            return coordinator
+
+    from app.main import app
+    return getattr(app.state, "coordinator", None)
+
+
+def _task_runtime(request: Optional[Request]) -> Any:
+    coordinator = _coordinator_from_request(request)
+    return getattr(coordinator, "task_coordinator", None)
+
+
+def _coerce_task_dict(task: Any) -> dict[str, Any]:
+    if task is None:
+        return {}
+    if hasattr(task, "model_dump"):
+        return task.model_dump()
+    if is_dataclass(task):
+        return asdict(task)
+    if hasattr(task, "__dict__"):
+        return dict(task.__dict__)
+    return {}
+
+
+def _project_matches(project_id: str, task_data: dict[str, Any], pm_task: Any) -> bool:
+    scoped_project = (
+        task_data.get("project_id")
+        or pm_task.linked_ids.get("project")
+        or pm_task.refs.get("project_id")
+        or pm_task.meta.get("project_id")
+    )
+    if scoped_project is None:
+        return True
+    return str(scoped_project) == project_id
+
+
+def _runtime_entries(project_id: str, request: Optional[Request]) -> list[dict[str, Any]]:
+    runtime = _task_runtime(request)
+    if runtime is None:
+        return []
+
+    entries: list[dict[str, Any]] = []
+    task_ids: Iterable[str] = sorted(set(runtime.tasks.keys()))
+    for task_id in task_ids:
+        task = runtime.tasks.get(task_id)
+        pm_task = runtime.pm_store.get(task_id)
+        if pm_task is None:
+            continue
+
+        task_data = _coerce_task_dict(task)
+        if not _project_matches(project_id, task_data, pm_task):
+            continue
+
+        dependencies = list(task_data.get("dependencies") or pm_task.meta.get("dependencies") or [])
+        entry = {
+            "task_id": task_id,
+            "title": task_data.get("title") or pm_task.title,
+            "description": task_data.get("description") or pm_task.description or "",
+            "priority": task_data.get("priority", 0),
+            "dependencies": dependencies,
+            "canonical_status": pm_task.status,
+            "canonical_version": pm_task.version,
+            "linked_ids": {**_project_linked_ids(project_id, task_id), **pm_task.linked_ids},
+            "assignee": task_data.get("assigned_agent") or task_data.get("assigned_to"),
+        }
+        entries.append(entry)
+
+    return entries
+
+
+def _blocked_dependencies(entries_by_id: dict[str, dict[str, Any]], entry: dict[str, Any]) -> list[str]:
+    blocked: list[str] = []
+    for dependency_id in entry.get("dependencies", []):
+        dependency = entries_by_id.get(dependency_id)
+        if dependency is None or dependency["canonical_status"] != PMTaskStatus.DONE:
+            blocked.append(dependency_id)
+    return blocked
+
+
+def _sort_queue(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        entries,
+        key=lambda item: (
+            -(int(item.get("priority") or 0)),
+            str(item.get("title") or ""),
+            item["task_id"],
+        ),
+    )
+
+
+def _allowed_transitions_for_status(status: PMTaskStatus) -> list[str]:
+    return sorted(_ALLOWED_TRANSITIONS.get(status, {}).keys())
+
+
+def _build_priority_queue_result(project_id: str, request: Optional[Request] = None) -> PriorityQueueResult:
+    runtime = _task_runtime(request)
+    if runtime is None:
+        return PriorityQueueResult(
+            project_id=project_id,
+            linked_ids=_project_linked_ids(project_id),
+            legality_result="unavailable",
+            blockers=[],
+            next_action=None,
+            queue_items=[],
+        )
+
+    entries = _runtime_entries(project_id, request)
+    entries_by_id = {entry["task_id"]: entry for entry in entries}
+    queue_items = [
+        {
+            "id": entry["task_id"],
+            "title": entry["title"],
+            "description": entry["description"],
+            "priority": entry["priority"],
+            "linked_ids": entry["linked_ids"],
+            "version": entry["canonical_version"],
+        }
+        for entry in _sort_queue(entries)
+        if entry["canonical_status"] == PMTaskStatus.TODO and not _blocked_dependencies(entries_by_id, entry)
+    ]
+    blockers = [entry["task_id"] for entry in entries if _blocked_dependencies(entries_by_id, entry)]
+    next_action = queue_items[0] if queue_items else None
+
+    legality_result = "allowed" if queue_items or not blockers else "blocked"
     return PriorityQueueResult(
         project_id=project_id,
         linked_ids=_project_linked_ids(project_id),
-        legality_result="unavailable",
-        blockers=[],
-        next_action=None,
-        queue_items=[],
+        legality_result=legality_result,
+        blockers=blockers,
+        next_action=next_action,
+        queue_items=queue_items,
     )
 
 
-def _build_blockers_result(project_id: str) -> BlockersResult:
+def _build_blockers_result(project_id: str, request: Optional[Request] = None) -> BlockersResult:
+    runtime = _task_runtime(request)
+    if runtime is None:
+        return BlockersResult(
+            project_id=project_id,
+            linked_ids=_project_linked_ids(project_id),
+            legality_result="unavailable",
+            blockers=[],
+            next_action=None,
+            active_blockers=[],
+        )
+
+    entries = _runtime_entries(project_id, request)
+    entries_by_id = {entry["task_id"]: entry for entry in entries}
+    active_blockers = []
+    blocker_ids: list[str] = []
+    for entry in entries:
+        unresolved = _blocked_dependencies(entries_by_id, entry)
+        if entry["canonical_status"] == PMTaskStatus.BLOCKED or unresolved:
+            blocker_ids.append(entry["task_id"])
+            active_blockers.append(
+                {
+                    "id": entry["task_id"],
+                    "summary": entry["title"],
+                    "blocked_by": unresolved,
+                    "status": entry["canonical_status"].value,
+                    "linked_ids": entry["linked_ids"],
+                }
+            )
+
+    next_action = None
+    if active_blockers:
+        next_action = {"type": "resolve_blocker", "workflow_id": active_blockers[0]["id"]}
+
+    legality_result = "blocked" if active_blockers else "allowed"
     return BlockersResult(
         project_id=project_id,
         linked_ids=_project_linked_ids(project_id),
-        legality_result="unavailable",
-        blockers=[],
-        next_action=None,
-        active_blockers=[],
+        legality_result=legality_result,
+        blockers=blocker_ids,
+        next_action=next_action,
+        active_blockers=active_blockers,
     )
 
 
-def _build_workflow_state_result(project_id: str) -> WorkflowStateResult:
+def _build_workflow_state_result(project_id: str, request: Optional[Request] = None) -> WorkflowStateResult:
+    runtime = _task_runtime(request)
+    if runtime is None:
+        return WorkflowStateResult(
+            project_id=project_id,
+            linked_ids=_project_linked_ids(project_id),
+            legality_result="unavailable",
+            blockers=[],
+            next_action=None,
+            state={},
+            allowed_transitions=[],
+        )
+
+    queue_result = _build_priority_queue_result(project_id, request)
+    blockers_result = _build_blockers_result(project_id, request)
+    entries = _runtime_entries(project_id, request)
+    status_counts: dict[str, int] = {}
+    allowed_transitions = set()
+    for entry in entries:
+        status_key = entry["canonical_status"].value
+        status_counts[status_key] = status_counts.get(status_key, 0) + 1
+        allowed_transitions.update(_allowed_transitions_for_status(entry["canonical_status"]))
+
+    state = {
+        "task_count": len(entries),
+        "status_counts": status_counts,
+        "ready_count": len(queue_result.queue_items),
+        "blocked_count": len(blockers_result.active_blockers),
+    }
+
+    legality_result = "allowed"
+    if blockers_result.active_blockers and not queue_result.queue_items:
+        legality_result = "blocked"
+
     return WorkflowStateResult(
         project_id=project_id,
         linked_ids=_project_linked_ids(project_id),
-        legality_result="unavailable",
-        blockers=[],
-        next_action=None,
-        state={},
-        allowed_transitions=[],
+        legality_result=legality_result,
+        blockers=blockers_result.blockers,
+        next_action=queue_result.next_action,
+        state=state,
+        allowed_transitions=sorted(allowed_transitions),
     )
 
 
-def _priority_queue_response(result) -> PriorityQueueResult:
-    return PriorityQueueResult(
-        project_id=result.project_id,
-        linked_ids=result.linked_ids,
-        legality_result=result.legality_result,
-        blockers=result.blockers,
-        next_action=result.next_action,
-        queue_items=result.queue_items,
-    )
-
-
-def _blockers_response(result) -> BlockersResult:
-    return BlockersResult(
-        project_id=result.project_id,
-        linked_ids=result.linked_ids,
-        legality_result=result.legality_result,
-        blockers=result.blockers,
-        next_action=result.next_action,
-        active_blockers=result.active_blockers,
-    )
-
-
-def _workflow_state_response(result) -> WorkflowStateResult:
-    return WorkflowStateResult(
-        project_id=result.project_id,
-        linked_ids=result.linked_ids,
-        legality_result=result.legality_result,
-        blockers=result.blockers,
-        next_action=result.next_action,
-        state=result.state,
-        allowed_transitions=result.allowed_transitions,
-    )
-
-
-def _unavailable_transition_result(project_id: str, request: TransitionWorkflowRequest) -> TransitionResult:
+def _unavailable_transition_result(project_id: str, request: TransitionWorkflowRequest, reason: str) -> TransitionResult:
     return TransitionResult(
         project_id=project_id,
         workflow_id=request.workflow_id,
-        linked_ids={},
+        linked_ids=_project_linked_ids(project_id, request.workflow_id),
         legality_result="unavailable",
         blockers=[],
         next_action=None,
         transition_receipt={
             "transition": request.transition,
             "status": "unavailable",
-            "reason": "project-scoped workflow transition is not yet backed by a canonical runtime binding",
+            "reason": reason,
         },
         resulting_state={},
     )
 
 
-@router.get("/queue", response_model=PriorityQueueResult)
-async def get_project_workflow_queue(project_id: str):
-    """
-    Get the priority queue of next actions for a project.
+def _illegal_transition_result(
+    project_id: str,
+    request: TransitionWorkflowRequest,
+    *,
+    blockers: list[str],
+    allowed_transitions: list[str],
+    current_status: Optional[str],
+    reason: str,
+) -> TransitionResult:
+    return TransitionResult(
+        project_id=project_id,
+        workflow_id=request.workflow_id,
+        linked_ids=_project_linked_ids(project_id, request.workflow_id),
+        legality_result="illegal",
+        blockers=blockers,
+        next_action={"allowed_transitions": allowed_transitions} if allowed_transitions else None,
+        transition_receipt={
+            "transition": request.transition,
+            "status": "illegal",
+            "reason": reason,
+        },
+        resulting_state={
+            "workflow_id": request.workflow_id,
+            "current_status": current_status,
+            "allowed_transitions": allowed_transitions,
+        },
+    )
 
-    Returns prioritized next actions / queue items, blocker summary if queue
-    generation depends on blocker analysis, and next-action data.
-    """
+
+async def execute_transition_project_workflow(
+    project_id: str,
+    request: TransitionWorkflowRequest,
+    http_request: Optional[Request] = None,
+) -> TransitionResult:
+    runtime = _task_runtime(http_request)
+    if runtime is None:
+        return _unavailable_transition_result(
+            project_id,
+            request,
+            "project-scoped workflow transition runtime is unavailable",
+        )
+
+    pm_task = runtime.pm_store.get(request.workflow_id)
+    if pm_task is None:
+        raise HTTPException(status_code=404, detail="missing required workflow entity linkage")
+
+    normalized_transition = request.transition.strip().lower()
+    allowed_map = _ALLOWED_TRANSITIONS.get(pm_task.status, {})
+    target_status = allowed_map.get(normalized_transition)
+    blockers_result = _build_blockers_result(project_id, http_request)
+    blockers = []
+    for blocker in blockers_result.active_blockers:
+        if blocker["id"] == request.workflow_id:
+            blockers.extend(blocker.get("blocked_by", []))
+
+    if target_status is None:
+        return _illegal_transition_result(
+            project_id,
+            request,
+            blockers=blockers,
+            allowed_transitions=_allowed_transitions_for_status(pm_task.status),
+            current_status=pm_task.status.value,
+            reason="transition request references illegal or unresolved target",
+        )
+
+    if blockers and target_status == PMTaskStatus.IN_PROGRESS:
+        return _illegal_transition_result(
+            project_id,
+            request,
+            blockers=blockers,
+            allowed_transitions=_allowed_transitions_for_status(pm_task.status),
+            current_status=pm_task.status.value,
+            reason="workflow item is blocked by unresolved dependencies",
+        )
+
+    expected_version = request.expected_version or pm_task.version
+    try:
+        updated = runtime.pm_store.transition(
+            request.workflow_id,
+            PMTransitionRequest(
+                idempotency_key=request.idempotency_key or f"workflow-{project_id}-{request.workflow_id}-{normalized_transition}-{expected_version}",
+                expected_version=expected_version,
+                new_status=target_status,
+                ts_utc=_utc_now(),
+                source=request.actor or "task-orchestrator",
+                reason=request.reason,
+            ),
+        )
+    except StaleWriteError as exc:
+        return _illegal_transition_result(
+            project_id,
+            request,
+            blockers=[],
+            allowed_transitions=_allowed_transitions_for_status(pm_task.status),
+            current_status=pm_task.status.value,
+            reason=f"stale version rejected: expected {exc.expected_version}, actual {exc.actual_version}",
+        )
+    except IdempotencyMismatchError:
+        return _illegal_transition_result(
+            project_id,
+            request,
+            blockers=[],
+            allowed_transitions=_allowed_transitions_for_status(pm_task.status),
+            current_status=pm_task.status.value,
+            reason="idempotency key reused with a different transition payload",
+        )
+    except TaskNotFoundError:
+        raise HTTPException(status_code=404, detail="missing required workflow entity linkage")
+
+    task = runtime.tasks.get(request.workflow_id)
+    if task is not None:
+        task.status = task.status.__class__(CANONICAL_TO_ORCHESTRATOR[updated.status])
+
+    return TransitionResult(
+        project_id=project_id,
+        workflow_id=request.workflow_id,
+        linked_ids={**_project_linked_ids(project_id, request.workflow_id), **updated.linked_ids},
+        legality_result="allowed",
+        blockers=[],
+        next_action=None,
+        transition_receipt={
+            "transition": request.transition,
+            "status": "allowed",
+            "canonical_backend": "task-orchestrator",
+            "canonical_id": updated.task_id,
+            "version_before": expected_version,
+            "version_after": updated.version,
+            "idempotency_key": request.idempotency_key,
+            "actor": request.actor or "task-orchestrator",
+        },
+        resulting_state={
+            "workflow_id": updated.task_id,
+            "status": updated.status.value,
+            "version": updated.version,
+        },
+    )
+
+
+@router.get("/queue", response_model=PriorityQueueResult)
+async def get_project_workflow_queue(project_id: str, request: Request):
     if not project_id or project_id == "unknown":
         raise HTTPException(status_code=404, detail="project not found")
-        
-    if project_id == "no_state":
-        raise HTTPException(status_code=404, detail="workflow state unavailable")
-        
-    pm_get_priority_queue, _, _ = await _get_reads()
-    if pm_get_priority_queue:
-        result = await pm_get_priority_queue(project_id)
-        return _priority_queue_response(result)
-        
-    return _build_priority_queue_result(project_id)
+    return _build_priority_queue_result(project_id, request)
 
 
 @router.get("/blockers", response_model=BlockersResult)
-async def get_project_workflow_blockers(project_id: str):
-    """
-    Get active blockers for a project's workflow.
-
-    Returns active blockers, impacted workflow items, and legality/availability notes.
-    """
+async def get_project_workflow_blockers(project_id: str, request: Request):
     if not project_id or project_id == "unknown":
         raise HTTPException(status_code=404, detail="project not found")
-        
-    if project_id == "no_state":
-        raise HTTPException(status_code=404, detail="workflow state unavailable")
-        
-    _, pm_get_blockers, _ = await _get_reads()
-    if pm_get_blockers:
-        result = await pm_get_blockers(project_id)
-        return _blockers_response(result)
-        
-    return _build_blockers_result(project_id)
+    return _build_blockers_result(project_id, request)
 
 
 @router.get("/state", response_model=WorkflowStateResult)
-async def get_project_workflow_state(project_id: str):
-    """
-    Get a snapshot of the project's workflow state.
-
-    Returns project workflow snapshot, phases/stages, current legal next transitions,
-    and linked workflow IDs and PM IDs.
-    """
+async def get_project_workflow_state(project_id: str, request: Request):
     if not project_id or project_id == "unknown":
         raise HTTPException(status_code=404, detail="project not found")
-        
-    if project_id == "no_state":
-        raise HTTPException(status_code=404, detail="workflow state unavailable")
-        
-    _, _, pm_get_workflow_state = await _get_reads()
-    if pm_get_workflow_state:
-        result = await pm_get_workflow_state(project_id)
-        return _workflow_state_response(result)
-        
-    return _build_workflow_state_result(project_id)
+    return _build_workflow_state_result(project_id, request)
 
 
 @router.post("/transition", response_model=TransitionResult)
-async def transition_project_workflow(project_id: str, request: TransitionWorkflowRequest):
-    """
-    Transition a workflow item to a new state.
-
-    Returns transition legality result, resulting state, blockers if denied,
-    next_action if relevant, linked IDs, and canonical receipt / audit metadata.
-    """
+async def transition_project_workflow(project_id: str, request: TransitionWorkflowRequest, http_request: Request):
     if not project_id or project_id == "unknown":
         raise HTTPException(status_code=404, detail="project not found")
-        
-    if project_id == "no_state":
-        raise HTTPException(status_code=404, detail="workflow state unavailable")
-        
-    # Simulate missing required workflow entity linkage or illegal transition
-    if request.workflow_id == "missing_linkage":
-        raise HTTPException(status_code=404, detail="missing required workflow entity linkage")
-        
-    if request.transition == "illegal_target":
-        raise HTTPException(status_code=400, detail="transition request references illegal or unresolved target")
-
-    return _unavailable_transition_result(project_id, request)
+    return await execute_transition_project_workflow(project_id, request, http_request)

--- a/services/task-orchestrator/app/models/workflow.py
+++ b/services/task-orchestrator/app/models/workflow.py
@@ -224,6 +224,8 @@ class TransitionWorkflowRequest(BaseModel):
     transition: str
     actor: Optional[str] = None
     idempotency_key: Optional[str] = None
+    expected_version: Optional[int] = None
+    reason: Optional[str] = None
 
 
 class WorkflowEnvelopeBase(BaseModel):

--- a/services/task-orchestrator/tests/test_pm_tools.py
+++ b/services/task-orchestrator/tests/test_pm_tools.py
@@ -5,7 +5,6 @@ from app.main import app
 client = TestClient(app)
 
 def test_pm_update_work_item_emits_metric(monkeypatch):
-    import src.dopemux.pm.writes
     from src.dopemux.pm.writes import CanonicalReceipt
     
     def mock_pm_transition_work_item(*args, **kwargs):
@@ -17,7 +16,7 @@ def test_pm_update_work_item_emits_metric(monkeypatch):
             reconciliation_state="SYNCED"
         )
         
-    monkeypatch.setattr("src.dopemux.pm.writes.pm_transition_work_item", mock_pm_transition_work_item)
+    monkeypatch.setattr("app.api.pm_tools.pm_transition_work_item", mock_pm_transition_work_item)
     
     
     class MockClient:
@@ -41,7 +40,6 @@ def test_pm_update_work_item_emits_metric(monkeypatch):
 
 
 def test_pm_update_work_item_mirror_failure_emits_metric(monkeypatch):
-    import src.dopemux.pm.writes
     from src.dopemux.pm.writes import CanonicalReceipt, MirrorReceipt
     
     def mock_pm_transition_work_item(*args, **kwargs):
@@ -53,7 +51,7 @@ def test_pm_update_work_item_mirror_failure_emits_metric(monkeypatch):
             reconciliation_state="PARTIAL"
         )
         
-    monkeypatch.setattr("src.dopemux.pm.writes.pm_transition_work_item", mock_pm_transition_work_item)
+    monkeypatch.setattr("app.api.pm_tools.pm_transition_work_item", mock_pm_transition_work_item)
     
     class MockClient:
         def update_task(self, *args, **kwargs):
@@ -75,4 +73,3 @@ def test_pm_update_work_item_mirror_failure_emits_metric(monkeypatch):
     assert metrics.get("pm_mirror_failures_total", 0) == 1
     assert metrics.get("pm_reconciliation_pending_total", 0) == 1
     assert metrics.get("pm_degraded_results_total", 0) == 1
-

--- a/services/taskmaster/bridge_adapter.py
+++ b/services/taskmaster/bridge_adapter.py
@@ -27,6 +27,7 @@ from dopemux.pm.models import PMTask, PMTaskStatus, PMTransitionRequest, content
 from dopemux.pm.store import InMemoryPMTaskStore
 from dopemux.pm.writes import PMWriteConfig, pm_update_work_item, pm_transition_work_item, pm_log_progress
 from dopemux.pm.mapping import TASKMASTER_TO_CANONICAL
+from dopemux.pm.adapters.orchestrator import SyncTaskOrchestratorAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -61,21 +62,22 @@ class SyncLeantimeBridgeClient(SyncBridgeAdapterClientStub):
         resp.raise_for_status()
 
 class SyncOrchestratorBridgeClient(SyncBridgeAdapterClientStub):
+    def __init__(self, config: DopeconBridgeConfig, project_id: str = "default"):
+        super().__init__(config)
+        self.project_id = project_id
+        self.task_orchestrator = SyncTaskOrchestratorAdapter(default_project_id=project_id)
+
     def transition(self, task_id: str, status: Any, reason: str, expected_version: int, idempotency_key: str):
-        payload = {
-            "source": "cognitive",
-            "operation": "orchestrator.transition",
-            "data": {
-                "task_id": task_id, 
-                "status": status.value if hasattr(status, 'value') else status, 
-                "reason": reason, 
-                "expected_version": expected_version,
-                "idempotency_key": idempotency_key
-            },
-            "requester": "taskmaster"
-        }
-        resp = self.client.post("/route/pm", json=payload)
-        resp.raise_for_status()
+        transition_name = status.value.lower() if hasattr(status, "value") else str(status).lower()
+        return self.task_orchestrator.transition(
+            project_id=self.project_id,
+            workflow_id=task_id,
+            transition_name=transition_name,
+            actor="taskmaster",
+            idempotency_key=idempotency_key,
+            expected_version=expected_version,
+            reason=reason,
+        )
 
 class SyncConportBridgeClient(SyncBridgeAdapterClientStub):
     def record_progress(self, task_id: str, progress_notes: str, is_decision: bool, idempotency_key: str):
@@ -130,7 +132,7 @@ class TaskMasterBridgeAdapter:
         # Configure PM writes using the synchronous blocking clients
         self.pm_config = PMWriteConfig(
             leantime_client=SyncLeantimeBridgeClient(config),
-            orchestrator_client=SyncOrchestratorBridgeClient(config),
+            orchestrator_client=SyncOrchestratorBridgeClient(config, project_id=workspace_id),
             conport_client=SyncConportBridgeClient(config),
             memory_client=SyncMemoryBridgeClient(config)
         )
@@ -144,6 +146,7 @@ class TaskMasterBridgeAdapter:
         # Clean up HTTPX sync clients
         self.pm_config.leantime_client.client.close()
         self.pm_config.orchestrator_client.client.close()
+        self.pm_config.orchestrator_client.task_orchestrator.close()
         self.pm_config.conport_client.client.close()
         self.pm_config.memory_client.client.close()
     

--- a/src/dopemux/pm/adapters/orchestrator.py
+++ b/src/dopemux/pm/adapters/orchestrator.py
@@ -1,93 +1,152 @@
-"""Task Orchestrator backend adapter for PM-plane workflow integration."""
+"""Task Orchestrator backend adapters for PM-plane workflow integration."""
+
+from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
+
 import httpx
 
 logger = logging.getLogger(__name__)
 
-class TaskOrchestratorAdapter:
-    """Adapter for communicating with the task-orchestrator HTTP API."""
 
+class _BaseTaskOrchestratorAdapter:
     def __init__(self, base_url: Optional[str] = None):
-        # Default to PORT_BASE+14 (3014)
         self.base_url = (base_url or os.getenv("TASK_ORCHESTRATOR_URL", "http://localhost:3014")).rstrip("/")
 
+    @staticmethod
+    def _transition_payload(
+        workflow_id: str,
+        transition_name: str,
+        *,
+        actor: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+        expected_version: Optional[int] = None,
+        reason: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "workflow_id": workflow_id,
+            "transition": transition_name,
+        }
+        if actor is not None:
+            payload["actor"] = actor
+        if idempotency_key is not None:
+            payload["idempotency_key"] = idempotency_key
+        if expected_version is not None:
+            payload["expected_version"] = expected_version
+        if reason is not None:
+            payload["reason"] = reason
+        return payload
+
+
+class TaskOrchestratorAdapter(_BaseTaskOrchestratorAdapter):
+    """Async adapter for communicating with the task-orchestrator HTTP API."""
+
     async def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
-        """Helper to make an HTTP request."""
         async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.request(method, f"{self.base_url}{path}", **kwargs)
-            return response
+            return await client.request(method, f"{self.base_url}{path}", **kwargs)
 
     async def get_queue(self, project_id: str) -> Dict[str, Any]:
-        """Get project priority queue."""
         try:
             response = await self._request("GET", f"/api/projects/{project_id}/workflow/queue")
             response.raise_for_status()
             return response.json()
-        except Exception as e:
-            logger.error(f"Failed to get queue from task-orchestrator: {e}")
+        except Exception as exc:
+            logger.error("Failed to get queue from task-orchestrator: %s", exc)
             raise
 
     async def get_blockers(self, project_id: str) -> Dict[str, Any]:
-        """Get project blockers."""
         try:
             response = await self._request("GET", f"/api/projects/{project_id}/workflow/blockers")
             response.raise_for_status()
             return response.json()
-        except Exception as e:
-            logger.error(f"Failed to get blockers from task-orchestrator: {e}")
+        except Exception as exc:
+            logger.error("Failed to get blockers from task-orchestrator: %s", exc)
             raise
 
     async def get_state(self, project_id: str) -> Dict[str, Any]:
-        """Get project workflow state."""
         try:
             response = await self._request("GET", f"/api/projects/{project_id}/workflow/state")
             response.raise_for_status()
             return response.json()
-        except Exception as e:
-            logger.error(f"Failed to get state from task-orchestrator: {e}")
+        except Exception as exc:
+            logger.error("Failed to get state from task-orchestrator: %s", exc)
             raise
 
-    async def transition(self, project_id: str, workflow_id: str, transition_name: str) -> Dict[str, Any]:
-        """Execute a workflow transition."""
-        payload = {
-            "workflow_id": workflow_id,
-            "transition": transition_name
-        }
+    async def transition(
+        self,
+        project_id: str,
+        workflow_id: str,
+        transition_name: str,
+        *,
+        actor: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+        expected_version: Optional[int] = None,
+        reason: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload = self._transition_payload(
+            workflow_id,
+            transition_name,
+            actor=actor,
+            idempotency_key=idempotency_key,
+            expected_version=expected_version,
+            reason=reason,
+        )
         try:
             response = await self._request("POST", f"/api/projects/{project_id}/workflow/transition", json=payload)
             response.raise_for_status()
             return response.json()
-        except Exception as e:
-            logger.error(f"Failed to execute transition on task-orchestrator: {e}")
-            raise
-
-    async def get_project_context(self, project_id: str) -> Dict[str, Any]:
-        """Get project context from the orchestrator."""
-        try:
-            response = await self._request("GET", f"/api/projects/{project_id}/context")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Failed to get project context from task-orchestrator: {e}")
-            raise
-
-    async def get_sprint_snapshot(self, project_id: str) -> Dict[str, Any]:
-        """Get sprint snapshot from the orchestrator."""
-        try:
-            response = await self._request("GET", f"/api/projects/{project_id}/sprint/snapshot")
-            response.raise_for_status()
-            return response.json()
-        except Exception as e:
-            logger.error(f"Failed to get sprint snapshot from task-orchestrator: {e}")
+        except Exception as exc:
+            logger.error("Failed to execute transition on task-orchestrator: %s", exc)
             raise
 
     async def health(self) -> bool:
-        """Check health of task-orchestrator."""
         try:
             response = await self._request("GET", "/health")
             return response.status_code == 200
         except Exception:
             return False
+
+
+class SyncTaskOrchestratorAdapter(_BaseTaskOrchestratorAdapter):
+    """Synchronous adapter for PM write callers that need direct HTTP transitions."""
+
+    def __init__(self, base_url: Optional[str] = None, *, default_project_id: str = "default"):
+        super().__init__(base_url)
+        self.default_project_id = default_project_id
+        self._client = httpx.Client(timeout=10.0)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def transition(
+        self,
+        *,
+        project_id: Optional[str] = None,
+        workflow_id: str,
+        transition_name: str,
+        actor: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+        expected_version: Optional[int] = None,
+        reason: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        payload = self._transition_payload(
+            workflow_id,
+            transition_name,
+            actor=actor,
+            idempotency_key=idempotency_key,
+            expected_version=expected_version,
+            reason=reason,
+        )
+        resolved_project_id = project_id or self.default_project_id
+        try:
+            response = self._client.post(
+                f"{self.base_url}/api/projects/{resolved_project_id}/workflow/transition",
+                json=payload,
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception as exc:
+            logger.error("Failed to execute sync transition on task-orchestrator: %s", exc)
+            raise

--- a/src/dopemux/pm/reads.py
+++ b/src/dopemux/pm/reads.py
@@ -1,13 +1,20 @@
 """Normalized PM-plane read tools."""
 
-from typing import Any, Dict, List, Optional
+from __future__ import annotations
+
 import logging
+import os
+from importlib import import_module
+from typing import Any, Dict, List, Optional
+
 import httpx
 from pydantic import BaseModel, Field
 
+from core.config import Config
 from dopemux.pm.adapters.conport import ConPortAdapter
 from dopemux.pm.adapters.orchestrator import TaskOrchestratorAdapter
-
+from dopemux.tools.conport_client import ConPortClient
+from integrations.leantime_jsonrpc_client import LeantimeJSONRPCClient
 logger = logging.getLogger(__name__)
 
 
@@ -66,16 +73,74 @@ class PMDecisionContextResult(PMReadEnvelope):
     decisions: List[Dict[str, Any]] = Field(default_factory=list)
 
 
+class PMProjectKnowledgeResult(PMReadEnvelope):
+    query: str
+    evidence: List[Dict[str, Any]] = Field(default_factory=list)
+
+
+class PMTechnicalContextResult(PMReadEnvelope):
+    query: str
+    technical_findings: List[Dict[str, Any]] = Field(default_factory=list)
+
+
 _orchestrator = TaskOrchestratorAdapter()
 _conport = ConPortAdapter()
+
+
+class _PMMCPConfig:
+    def __init__(self, timeout: int = 30, health_check_interval: int = 300):
+        self.timeout = timeout
+        self.health_check_interval = health_check_interval
 
 
 def _project_provenance(source: str, query_mode: str, project_id: str) -> PMReadProvenance:
     return PMReadProvenance(source=source, query_mode=query_mode, project_id=project_id)
 
 
-def _supporting_source(kind: str, backend: str, project_id: str) -> List[PMReadSupportingSource]:
-    return [PMReadSupportingSource(kind=kind, backend=backend, entity_ids=[project_id])]
+def _linked_ids(project_id: str, payload: Optional[Dict[str, Any]] = None) -> Dict[str, str]:
+    merged = {"project": project_id}
+    if payload:
+        merged.update(payload.get("linked_ids", {}))
+    return merged
+
+
+def _supporting_sources(*sources: tuple[str, str, List[str]]) -> List[PMReadSupportingSource]:
+    return [
+        PMReadSupportingSource(kind=kind, backend=backend, entity_ids=entity_ids)
+        for kind, backend, entity_ids in sources
+    ]
+
+
+def _mcp_config() -> _PMMCPConfig:
+    return _PMMCPConfig()
+
+
+def _conport_context_client() -> ConPortClient:
+    return ConPortClient(base_url=os.getenv("CONPORT_CONTEXT_URL", "http://localhost:3005"))
+
+
+def _leantime_client() -> LeantimeJSONRPCClient:
+    api_url = os.getenv("LEANTIME_API_URL") or os.getenv("LEANTIME_URL") or "http://localhost:8080"
+    api_token = os.getenv("LEANTIME_API_TOKEN") or os.getenv("LEANTIME_TOKEN")
+    if not api_token:
+        raise RuntimeError("LEANTIME_API_TOKEN is not configured")
+    return LeantimeJSONRPCClient(Config({"leantime": {"api_url": api_url, "api_token": api_token}}))
+
+
+def _dope_context_client():
+    client_cls = import_module("services.genetic_agent.shared.mcp.dope_context_client").DopeContextClient
+    return client_cls(
+        os.getenv("GENETIC_AGENT_DOPE_CONTEXT_URL", "http://localhost:3002"),
+        _mcp_config(),
+    )
+
+
+def _serena_client():
+    client_cls = import_module("services.genetic_agent.shared.mcp.serena_client").SerenaClient
+    return client_cls(
+        os.getenv("GENETIC_AGENT_SERENA_URL", "http://localhost:3001"),
+        _mcp_config(),
+    )
 
 
 def _project_context_result(
@@ -86,11 +151,14 @@ def _project_context_result(
 ) -> PMProjectContextResult:
     payload = payload or {}
     return PMProjectContextResult(
-        canonical_backend="orchestrator",
+        canonical_backend="conport",
         project_id=project_id,
-        linked_ids=payload.get("linked_ids", {}),
-        provenance=_project_provenance("leantime", "project_context", project_id),
-        supporting_sources=_supporting_source("canonical", "leantime", project_id),
+        linked_ids=_linked_ids(project_id, payload),
+        provenance=_project_provenance("conport", "project_context", project_id),
+        supporting_sources=_supporting_sources(
+            ("canonical", "conport", [project_id]),
+            ("supporting", "leantime", [project_id]),
+        ),
         context_data=payload.get("context_data", {}),
         error=error,
     )
@@ -106,9 +174,12 @@ def _priority_queue_result(
     return PMPriorityQueueResult(
         canonical_backend="task-orchestrator",
         project_id=project_id,
-        linked_ids=payload.get("linked_ids", {}),
+        linked_ids=_linked_ids(project_id, payload),
         provenance=_project_provenance("task-orchestrator", "priority_queue", project_id),
-        supporting_sources=_supporting_source("canonical", "task-orchestrator", project_id),
+        supporting_sources=_supporting_sources(
+            ("canonical", "task-orchestrator", [project_id]),
+            ("supporting", "leantime", [project_id]),
+        ),
         legality_result=payload.get("legality_result", "unavailable"),
         blockers=payload.get("blockers", []),
         queue_items=payload.get("queue_items", []),
@@ -127,9 +198,12 @@ def _blockers_result(
     return PMBlockersResult(
         canonical_backend="task-orchestrator",
         project_id=project_id,
-        linked_ids=payload.get("linked_ids", {}),
+        linked_ids=_linked_ids(project_id, payload),
         provenance=_project_provenance("task-orchestrator", "blockers", project_id),
-        supporting_sources=_supporting_source("canonical", "task-orchestrator", project_id),
+        supporting_sources=_supporting_sources(
+            ("canonical", "task-orchestrator", [project_id]),
+            ("supporting", "conport", [project_id]),
+        ),
         legality_result=payload.get("legality_result", "unavailable"),
         blockers=payload.get("blockers", []),
         next_action=payload.get("next_action"),
@@ -148,9 +222,12 @@ def _workflow_state_result(
     return PMWorkflowStateResult(
         canonical_backend="task-orchestrator",
         project_id=project_id,
-        linked_ids=payload.get("linked_ids", {}),
+        linked_ids=_linked_ids(project_id, payload),
         provenance=_project_provenance("task-orchestrator", "workflow_state", project_id),
-        supporting_sources=_supporting_source("canonical", "task-orchestrator", project_id),
+        supporting_sources=_supporting_sources(
+            ("canonical", "task-orchestrator", [project_id]),
+            ("supporting", "leantime", [project_id]),
+        ),
         legality_result=payload.get("legality_result", "unavailable"),
         blockers=payload.get("blockers", []),
         next_action=payload.get("next_action"),
@@ -168,11 +245,14 @@ def _sprint_snapshot_result(
 ) -> PMSprintSnapshotResult:
     payload = payload or {}
     return PMSprintSnapshotResult(
-        canonical_backend="orchestrator",
+        canonical_backend="leantime",
         project_id=project_id,
-        linked_ids=payload.get("linked_ids", {}),
+        linked_ids=_linked_ids(project_id, payload),
         provenance=_project_provenance("leantime", "sprint_snapshot", project_id),
-        supporting_sources=_supporting_source("canonical", "leantime", project_id),
+        supporting_sources=_supporting_sources(
+            ("canonical", "leantime", [project_id]),
+            ("supporting", "conport", [project_id]),
+        ),
         snapshot_data=payload.get("snapshot_data", {}),
         error=error,
     )
@@ -188,22 +268,143 @@ def _decision_context_result(
     return PMDecisionContextResult(
         canonical_backend="conport",
         project_id=project_id,
-        linked_ids=payload.get("linked_ids", {}),
+        linked_ids=_linked_ids(project_id, payload),
         provenance=_project_provenance("conport", "decision_context", project_id),
-        supporting_sources=_supporting_source("canonical", "conport", project_id),
+        supporting_sources=_supporting_sources(
+            ("canonical", "conport", [project_id]),
+            ("supporting", "dope-memory", [project_id]),
+        ),
         decisions=payload.get("decisions", []),
         error=error,
     )
 
 
+def _project_knowledge_result(
+    project_id: str,
+    query: str,
+    *,
+    error: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> PMProjectKnowledgeResult:
+    payload = payload or {}
+    return PMProjectKnowledgeResult(
+        canonical_backend="dope-context",
+        project_id=project_id,
+        linked_ids=_linked_ids(project_id, payload),
+        provenance=_project_provenance("dope-context", "project_knowledge", project_id),
+        supporting_sources=_supporting_sources(
+            ("canonical", "dope-context", [project_id]),
+            ("supporting", "conport", [project_id]),
+            ("supporting", "dope-memory", [project_id]),
+            ("supporting", "leantime", [project_id]),
+        ),
+        query=query,
+        evidence=payload.get("evidence", []),
+        error=error,
+    )
+
+
+def _technical_context_result(
+    project_id: str,
+    query: str,
+    *,
+    error: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> PMTechnicalContextResult:
+    payload = payload or {}
+    return PMTechnicalContextResult(
+        canonical_backend="serena",
+        project_id=project_id,
+        linked_ids=_linked_ids(project_id, payload),
+        provenance=_project_provenance("serena", "technical_context", project_id),
+        supporting_sources=_supporting_sources(
+            ("canonical", "serena", [project_id]),
+            ("supporting", "conport", [project_id]),
+            ("supporting", "dope-context", [project_id]),
+        ),
+        query=query,
+        technical_findings=payload.get("technical_findings", []),
+        error=error,
+    )
+
+
+def _normalize_knowledge_hits(raw_payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw_hits = raw_payload.get("results") or raw_payload.get("result") or raw_payload.get("hits") or []
+    evidence: List[Dict[str, Any]] = []
+    for index, item in enumerate(raw_hits, start=1):
+        if not isinstance(item, dict):
+            evidence.append(
+                {
+                    "rank": index,
+                    "confidence": None,
+                    "summary": str(item),
+                    "source_plane": "dope-context",
+                    "source_ref": None,
+                }
+            )
+            continue
+        evidence.append(
+            {
+                "rank": item.get("rank", index),
+                "confidence": item.get("score", item.get("similarity")),
+                "summary": item.get("summary") or item.get("snippet") or item.get("content") or item.get("title") or item.get("path") or "",
+                "source_plane": "dope-context",
+                "source_ref": item.get("source_path") or item.get("file_path") or item.get("path") or item.get("id") or item.get("url"),
+                "source_kind": item.get("kind") or item.get("type"),
+            }
+        )
+    return evidence
+
+
+def _normalize_serena_findings(raw_payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw_findings = raw_payload.get("symbols") or raw_payload.get("results") or raw_payload.get("definitions") or []
+    findings: List[Dict[str, Any]] = []
+    for index, item in enumerate(raw_findings, start=1):
+        if not isinstance(item, dict):
+            findings.append(
+                {
+                    "rank": index,
+                    "summary": str(item),
+                    "source_plane": "serena",
+                    "file_path": None,
+                    "symbol": None,
+                }
+            )
+            continue
+        findings.append(
+            {
+                "rank": item.get("rank", index),
+                "summary": item.get("summary") or item.get("name") or item.get("symbol") or item.get("file_path") or "",
+                "source_plane": "serena",
+                "file_path": item.get("file_path") or item.get("path"),
+                "symbol": item.get("symbol") or item.get("name"),
+                "symbol_type": item.get("symbol_type") or item.get("kind"),
+                "line": item.get("line"),
+                "column": item.get("column"),
+            }
+        )
+    return findings
+
+
 async def pm_get_project_context(project_id: str) -> PMProjectContextResult:
     """Read normalized project context from the PM record authority."""
+    client = _conport_context_client()
     try:
-        context_data: Dict[str, Any] = {}
-        return _project_context_result(project_id, payload={"context_data": context_data})
+        payload = await client.get_active_context(project_id)
+        if payload.get("error"):
+            raise RuntimeError(payload["error"])
+        return _project_context_result(
+            project_id,
+            payload={
+                "linked_ids": payload.get("linked_ids", {}),
+                "context_data": payload,
+            },
+        )
     except Exception as exc:
-        logger.warning("Leantime backend unavailable for pm_get_project_context: %s", exc)
+        logger.warning("ConPort backend unavailable for pm_get_project_context: %s", exc)
         return _project_context_result(project_id, error=str(exc))
+    finally:
+        await client.close()
 
 
 async def pm_get_priority_queue(project_id: str) -> PMPriorityQueueResult:
@@ -248,11 +449,35 @@ async def pm_get_workflow_state(project_id: str) -> PMWorkflowStateResult:
 async def pm_get_sprint_snapshot(project_id: str) -> PMSprintSnapshotResult:
     """Read normalized sprint snapshot from the PM record authority."""
     try:
-        snapshot_data: Dict[str, Any] = {}
-        return _sprint_snapshot_result(project_id, payload={"snapshot_data": snapshot_data})
+        numeric_project_id = int(project_id)
+    except ValueError as exc:
+        logger.warning("Leantime requires numeric project ids for pm_get_sprint_snapshot: %s", project_id)
+        return _sprint_snapshot_result(project_id, error=f"invalid Leantime project id: {project_id}")
+
+    client = _leantime_client()
+    try:
+        await client.connect()
+        project_response = await client.get_project(numeric_project_id)
+        tickets_response = await client.get_tickets(project_id=numeric_project_id, limit=100)
+        if not project_response.success:
+            raise RuntimeError(project_response.error or "Leantime project lookup failed")
+        if not tickets_response.success:
+            raise RuntimeError(tickets_response.error or "Leantime ticket lookup failed")
+        tickets = tickets_response.data or []
+        payload = {
+            "linked_ids": {"leantime_project": str(numeric_project_id)},
+            "snapshot_data": {
+                "project": project_response.data,
+                "tickets": tickets,
+                "ticket_count": len(tickets),
+            },
+        }
+        return _sprint_snapshot_result(project_id, payload=payload)
     except Exception as exc:
         logger.warning("Leantime backend unavailable for pm_get_sprint_snapshot: %s", exc)
         return _sprint_snapshot_result(project_id, error=str(exc))
+    finally:
+        await client.disconnect()
 
 
 async def pm_get_decision_context(project_id: str) -> PMDecisionContextResult:
@@ -266,3 +491,39 @@ async def pm_get_decision_context(project_id: str) -> PMDecisionContextResult:
     except Exception as exc:
         logger.error("Unexpected error in pm_get_decision_context: %s", exc)
         return _decision_context_result(project_id, error=str(exc))
+
+
+async def pm_search_project_knowledge(project_id: str, query: str, top_k: int = 5) -> PMProjectKnowledgeResult:
+    """Read normalized project knowledge from dope-context."""
+    client = _dope_context_client()
+    try:
+        async with client:
+            payload = await client.search_all(query, top_k=top_k)
+        return _project_knowledge_result(
+            project_id,
+            query,
+            payload={
+                "evidence": _normalize_knowledge_hits(payload),
+            },
+        )
+    except Exception as exc:
+        logger.warning("dope-context backend unavailable for pm_search_project_knowledge: %s", exc)
+        return _project_knowledge_result(project_id, query, error=str(exc))
+
+
+async def pm_get_technical_context(project_id: str, query: str) -> PMTechnicalContextResult:
+    """Read normalized technical context from Serena."""
+    client = _serena_client()
+    try:
+        async with client:
+            payload = await client.find_symbol(query)
+        return _technical_context_result(
+            project_id,
+            query,
+            payload={
+                "technical_findings": _normalize_serena_findings(payload),
+            },
+        )
+    except Exception as exc:
+        logger.warning("Serena backend unavailable for pm_get_technical_context: %s", exc)
+        return _technical_context_result(project_id, query, error=str(exc))

--- a/src/dopemux/pm/writes.py
+++ b/src/dopemux/pm/writes.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from pydantic import BaseModel, Field
 
 from .models import PMTaskStatus, WORKFLOW_SIGNIFICANT_FIELDS
+from .mapping import CANONICAL_TO_ORCHESTRATOR
 
 ALLOWED_METADATA_FIELDS = frozenset(
     {
@@ -117,6 +118,10 @@ class PMWriteConfig(BaseModel):
     conport_client: Any
     memory_client: Any
 
+
+def _transition_name_for_status(status: PMTaskStatus) -> str:
+    return CANONICAL_TO_ORCHESTRATOR.get(status, status.value).lower()
+
 def pm_update_work_item(
     config: PMWriteConfig,
     task_id: str,
@@ -169,6 +174,10 @@ def pm_transition_work_item(
     reason: str,
     idempotency_key: str,
     expected_version: int,
+    *,
+    project_id: str = "default",
+    workflow_id: Optional[str] = None,
+    actor: str = "dopemux",
 ) -> CanonicalReceipt:
     """
     Transition the workflow state of a work item.
@@ -180,9 +189,42 @@ def pm_transition_work_item(
     if config.orchestrator_client is None:
         raise RuntimeError("Task Orchestrator client (Workflow Authority) is not configured.")
 
+    version_after = expected_version + 1
     try:
-        # Client implementations are responsible for enforcing idempotency
-        config.orchestrator_client.transition(task_id, new_status, reason, expected_version, idempotency_key=idempotency_key)
+        transition_response = None
+        transition_name = _transition_name_for_status(new_status)
+        target_workflow_id = workflow_id or task_id
+        try:
+            transition_response = config.orchestrator_client.transition(
+                project_id=project_id,
+                workflow_id=target_workflow_id,
+                transition_name=transition_name,
+                actor=actor,
+                idempotency_key=idempotency_key,
+                expected_version=expected_version,
+                reason=reason,
+            )
+        except TypeError:
+            # Compatibility path for older sync bridge clients that still expose
+            # the task-centric transition signature.
+            transition_response = config.orchestrator_client.transition(
+                task_id,
+                new_status,
+                reason,
+                expected_version,
+                idempotency_key=idempotency_key,
+            )
+        if isinstance(transition_response, dict):
+            legality_result = transition_response.get("legality_result")
+            if legality_result and legality_result != "allowed":
+                raise RuntimeError(
+                    f"Task Orchestrator rejected transition with legality_result={legality_result}"
+                )
+            version_after = (
+                transition_response.get("resulting_state", {}).get("version")
+                or transition_response.get("transition_receipt", {}).get("version_after")
+                or version_after
+            )
     except Exception as e:
         raise RuntimeError(f"Canonical write failed: {e}") from e
 
@@ -206,7 +248,7 @@ def pm_transition_work_item(
         canonical_system="task-orchestrator",
         canonical_id=task_id,
         success=True,
-        version=expected_version + 1,
+        version=version_after,
         operation_type="transition",
         reflection_state=reflection_state,
         mirror_receipts=[

--- a/task-packets/STATUS.md
+++ b/task-packets/STATUS.md
@@ -5,7 +5,7 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-02-12'
-last_review: '2026-03-26'
+last_review: '2026-03-27'
 next_review: '2026-06-20'
 prelude: Status (explanation) for dopemux documentation and developer workflows.
 ---
@@ -35,12 +35,16 @@ Promotion determinism under audit
 PM / Task Management Plane
 Status: 🟡 In Progress
 Active Packets:
-None (stacked continuation PRs under review; packet artifacts not yet registered in `task-packets/INDEX.md`)
+PM-CONTINUE-05 — Transition Binding
+PM-CONTINUE-06 — Project Context + Sprint Snapshot
+PM-CONTINUE-07 — Knowledge + Technical Context
+PM-CONTINUE-08 — Truth Rebaseline
 Notes:
 Canonical PM read/write entrypoints now exist under `src/dopemux/pm/`
 Metadata writes route to Leantime; progress writes route to ConPort
-Workflow reads currently return fail-closed Task Orchestrator envelopes while authoritative project bindings are still incomplete
-Project-scoped workflow transition still fails closed as `unavailable`
+Workflow reads and project-scoped transitions now route through Task Orchestrator runtime state
+Project context routes through ConPort; sprint snapshot routes through Leantime; knowledge and technical reads now exist as normalized canonical-backend wrappers
+Remaining risk: project-scoped workflow views still treat unscoped runtime tasks as in-scope, and the newer PM reads are backend-thin rather than richly multi-source
 ────────────────────
 Workflow / Execution Control Plane
 Status: 🟡 In Progress

--- a/tests/integration/pm/test_pm_plane_e2e.py
+++ b/tests/integration/pm/test_pm_plane_e2e.py
@@ -98,11 +98,34 @@ async def test_taskmaster_to_pm_e2e_flow(mock_httpx):
     for call in mock_httpx.sync_client.post.call_args_list:
         args, kwargs = call
         url = args[0] if args else kwargs.get("url", "")
-        if "/route/pm" in str(url):
+        if "/api/projects/test-ws/workflow/transition" in str(url):
             payload = kwargs.get("json", {})
-            if payload.get("operation") == "orchestrator.transition":
+            if payload.get("workflow_id") == task_id:
                 transition_called = True
-                
+
+    assert transition_called is True
+
+
+@pytest.mark.asyncio
+async def test_taskmaster_transition_uses_project_scoped_workflow_endpoint(mock_httpx):
+    adapter = TaskMasterBridgeAdapter(workspace_id="test-ws")
+    created = await adapter.create_task(
+        title="Scoped transition task",
+        description="Ensure project-scoped transition path is used",
+    )
+    task_id = created["canonical_id"]
+
+    await adapter.update_task_status(task_id, "IN_PROGRESS")
+
+    transition_called = False
+    for call in mock_httpx.sync_client.post.call_args_list:
+        args, kwargs = call
+        url = args[0] if args else kwargs.get("url", "")
+        if "/api/projects/test-ws/workflow/transition" in str(url):
+            payload = kwargs.get("json", {})
+            if payload.get("workflow_id") == task_id:
+                transition_called = True
+
     assert transition_called is True
 
 
@@ -136,9 +159,9 @@ async def test_cli_to_pm_e2e_flow(mock_httpx, tmp_path):
     for call in mock_httpx.sync_client.post.call_args_list:
         args, kwargs = call
         url = args[0] if args else kwargs.get("url", "")
-        if "/route/pm" in str(url):
+        if "/api/projects/default/workflow/transition" in str(url):
             payload = kwargs.get("json", {})
-            if payload.get("operation") == "orchestrator.transition":
+            if payload.get("workflow_id") == task_id:
                 transition_called = True
-                
+
     assert transition_called is True

--- a/tests/unit/dopemux/pm/test_writes.py
+++ b/tests/unit/dopemux/pm/test_writes.py
@@ -21,8 +21,34 @@ class MockLeantimeClient:
 class MockOrchestratorClient:
     def __init__(self):
         self.calls = []
-    def transition(self, task_id, new_status, reason, expected_version, idempotency_key):
-        self.calls.append(("transition", task_id, new_status, reason, expected_version, idempotency_key))
+    def transition(
+        self,
+        *,
+        project_id,
+        workflow_id,
+        transition_name,
+        actor,
+        idempotency_key,
+        expected_version,
+        reason,
+    ):
+        self.calls.append(
+            (
+                "transition",
+                project_id,
+                workflow_id,
+                transition_name,
+                actor,
+                reason,
+                expected_version,
+                idempotency_key,
+            )
+        )
+        return {
+            "legality_result": "allowed",
+            "transition_receipt": {"version_after": expected_version + 1},
+            "resulting_state": {"version": expected_version + 1},
+        }
 
 class MockConportClient:
     def __init__(self):
@@ -171,6 +197,16 @@ def test_pm_transition_work_item_partial_failure():
     assert receipt.reflection_state == "degraded"
     assert receipt.reconciliation_state == "PARTIAL"
     assert len(orch_client.calls) == 1
+    assert orch_client.calls[0] == (
+        "transition",
+        "default",
+        "task-1",
+        "in_progress",
+        "dopemux",
+        "starting work",
+        1,
+        "key-2",
+    )
     
     mirror = receipt.mirror_receipts[0]
     assert mirror.system == "leantime"
@@ -199,6 +235,16 @@ def test_pm_transition_work_item_successful_reflection():
     assert receipt.success
     assert receipt.reflection_state == "succeeded"
     assert receipt.reconciliation_state == "SYNCED"
+    assert orch_client.calls[-1] == (
+        "transition",
+        "default",
+        "task-1",
+        "in_progress",
+        "dopemux",
+        "starting work",
+        3,
+        "key-2",
+    )
     assert leantime_client.calls[-1] == ("update_status", "task-1", PMTaskStatus.IN_PROGRESS.value, "key-2")
 
 def test_pm_log_progress_fail_closed():

--- a/tests/unit/pm/test_reads.py
+++ b/tests/unit/pm/test_reads.py
@@ -7,28 +7,111 @@ from dopemux.pm.reads import (
     PMDecisionContextResult,
     PMPriorityQueueResult,
     PMProjectContextResult,
-    PMReadProvenance,
-    PMReadSupportingSource,
+    PMProjectKnowledgeResult,
+    PMSprintSnapshotResult,
+    PMTechnicalContextResult,
     PMWorkflowStateResult,
     pm_get_blockers,
     pm_get_decision_context,
     pm_get_priority_queue,
     pm_get_project_context,
     pm_get_sprint_snapshot,
+    pm_get_technical_context,
     pm_get_workflow_state,
+    pm_search_project_knowledge,
 )
 
 
+class FakeConPortContextClient:
+    def __init__(self, payload):
+        self.payload = payload
+        self.closed = False
+
+    async def get_active_context(self, workspace_id: str):
+        assert workspace_id == "proj-123"
+        return self.payload
+
+    async def close(self):
+        self.closed = True
+
+
+class FakeLeantimeResponse:
+    def __init__(self, success=True, data=None, error=None):
+        self.success = success
+        self.data = data
+        self.error = error
+
+
+class FakeLeantimeClient:
+    def __init__(self, project_payload, tickets_payload):
+        self.project_payload = project_payload
+        self.tickets_payload = tickets_payload
+        self.connected = False
+        self.disconnected = False
+
+    async def connect(self):
+        self.connected = True
+        return True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+    async def get_project(self, project_id: int):
+        assert project_id == 123
+        return self.project_payload
+
+    async def get_tickets(self, project_id: int, limit: int = 100):
+        assert project_id == 123
+        assert limit == 100
+        return self.tickets_payload
+
+
+class FakeAsyncSearchClient:
+    def __init__(self, payload, method_name):
+        self.payload = payload
+        self.method_name = method_name
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def search_all(self, query: str, top_k: int = 5):
+        assert self.method_name == "search_all"
+        assert query == "release notes"
+        assert top_k == 3
+        return self.payload
+
+    async def find_symbol(self, query: str):
+        assert self.method_name == "find_symbol"
+        assert query == "TaskCoordinator"
+        return self.payload
+
+
 @pytest.mark.asyncio
-async def test_pm_get_project_context():
+async def test_pm_get_project_context_routes_to_conport(monkeypatch):
+    fake_client = FakeConPortContextClient(
+        {
+            "active_context": "Packet 06 planning",
+            "decision_ids": ["dec-1"],
+            "linked_ids": {"conport_context": "ctx-123"},
+        }
+    )
+    monkeypatch.setattr(pm_reads, "_conport_context_client", lambda: fake_client)
+
     result = await pm_get_project_context("proj-123")
+
     assert isinstance(result, PMProjectContextResult)
     assert result.project_id == "proj-123"
-    assert result.canonical_backend == "orchestrator"
-    assert result.provenance.source == "leantime"
+    assert result.canonical_backend == "conport"
+    assert result.provenance.source == "conport"
     assert result.provenance.query_mode == "project_context"
-    assert result.supporting_sources[0].backend == "leantime"
-    assert result.context_data == {}
+    assert result.supporting_sources[0].backend == "conport"
+    assert result.context_data["active_context"] == "Packet 06 planning"
+    assert result.linked_ids["project"] == "proj-123"
+    assert result.linked_ids["conport_context"] == "ctx-123"
+    assert fake_client.closed is True
 
 
 @pytest.mark.asyncio
@@ -114,12 +197,36 @@ async def test_pm_get_workflow_state_routes_to_task_orchestrator(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_pm_get_sprint_snapshot():
-    result = await pm_get_sprint_snapshot("proj-123")
-    assert result.project_id == "proj-123"
-    assert result.canonical_backend == "orchestrator"
+async def test_pm_get_sprint_snapshot_routes_to_leantime(monkeypatch):
+    fake_client = FakeLeantimeClient(
+        project_payload=FakeLeantimeResponse(success=True, data={"id": 123, "name": "PM Sprint"}),
+        tickets_payload=FakeLeantimeResponse(
+            success=True,
+            data=[{"id": 1, "headline": "Boundary"}, {"id": 2, "headline": "Reads"}],
+        ),
+    )
+    monkeypatch.setattr(pm_reads, "_leantime_client", lambda: fake_client)
+
+    result = await pm_get_sprint_snapshot("123")
+
+    assert isinstance(result, PMSprintSnapshotResult)
+    assert result.project_id == "123"
+    assert result.canonical_backend == "leantime"
     assert result.provenance.source == "leantime"
+    assert result.snapshot_data["project"]["name"] == "PM Sprint"
+    assert result.snapshot_data["ticket_count"] == 2
+    assert result.linked_ids["leantime_project"] == "123"
+    assert fake_client.connected is True
+    assert fake_client.disconnected is True
+
+
+@pytest.mark.asyncio
+async def test_pm_get_sprint_snapshot_fails_closed_for_non_numeric_project_id():
+    result = await pm_get_sprint_snapshot("proj-123")
+
+    assert result.canonical_backend == "leantime"
     assert result.snapshot_data == {}
+    assert result.error == "invalid Leantime project id: proj-123"
 
 
 @pytest.mark.asyncio
@@ -136,3 +243,39 @@ async def test_pm_get_decision_context_routes_to_conport(monkeypatch):
     assert result.canonical_backend == "conport"
     assert result.provenance.source == "conport"
     assert result.decisions[0]["id"] == "d-1"
+
+
+@pytest.mark.asyncio
+async def test_pm_search_project_knowledge_routes_to_dope_context(monkeypatch):
+    fake_client = FakeAsyncSearchClient(
+        {"results": [{"path": "docs/pm.md", "summary": "PM contract", "score": 0.91}]},
+        "search_all",
+    )
+    monkeypatch.setattr(pm_reads, "_dope_context_client", lambda: fake_client)
+
+    result = await pm_search_project_knowledge("proj-123", "release notes", top_k=3)
+
+    assert isinstance(result, PMProjectKnowledgeResult)
+    assert result.canonical_backend == "dope-context"
+    assert result.provenance.source == "dope-context"
+    assert result.query == "release notes"
+    assert result.evidence[0]["source_ref"] == "docs/pm.md"
+    assert result.evidence[0]["confidence"] == 0.91
+
+
+@pytest.mark.asyncio
+async def test_pm_get_technical_context_routes_to_serena(monkeypatch):
+    fake_client = FakeAsyncSearchClient(
+        {"symbols": [{"name": "TaskCoordinator", "file_path": "task_coordinator.py", "line": 42}]},
+        "find_symbol",
+    )
+    monkeypatch.setattr(pm_reads, "_serena_client", lambda: fake_client)
+
+    result = await pm_get_technical_context("proj-123", "TaskCoordinator")
+
+    assert isinstance(result, PMTechnicalContextResult)
+    assert result.canonical_backend == "serena"
+    assert result.provenance.source == "serena"
+    assert result.query == "TaskCoordinator"
+    assert result.technical_findings[0]["symbol"] == "TaskCoordinator"
+    assert result.technical_findings[0]["file_path"] == "task_coordinator.py"

--- a/tests/unit/test_task_orchestrator_project_workflow_contract.py
+++ b/tests/unit/test_task_orchestrator_project_workflow_contract.py
@@ -1,7 +1,12 @@
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 import sys
 
 import pytest
+
+from dopemux.pm.models import PMTask, PMTaskStatus
+from dopemux.pm.store import InMemoryPMTaskStore
 
 SERVICE_ROOT = Path(__file__).resolve().parents[2] / "services" / "task-orchestrator"
 if str(SERVICE_ROOT) not in sys.path:
@@ -9,93 +14,143 @@ if str(SERVICE_ROOT) not in sys.path:
 
 try:
     from app.api import project_workflow  # noqa: E402
-    from dopemux.pm.reads import (  # noqa: E402
-        PMPriorityQueueResult,
-        PMReadProvenance,
-        PMReadSupportingSource,
-        PMWorkflowStateResult,
-    )
+    from task_orchestrator.models import TaskStatus  # noqa: E402
 except (ImportError, ModuleNotFoundError) as exc:
     pytest.skip(f"task-orchestrator service deps not available: {exc}", allow_module_level=True)
 
 
-@pytest.mark.asyncio
-async def test_get_project_workflow_queue_passes_through_legality_result(monkeypatch):
-    async def fake_priority_queue(project_id: str):
-        return PMPriorityQueueResult(
-            canonical_backend="task-orchestrator",
-            project_id=project_id,
-            linked_ids={"workflow": "wf-1"},
-            provenance=PMReadProvenance(
-                source="task-orchestrator",
-                query_mode="priority_queue",
-                project_id=project_id,
+@dataclass
+class RuntimeTask:
+    id: str
+    title: str
+    description: str = ""
+    status: TaskStatus = TaskStatus.PENDING
+    priority: int = 1
+    dependencies: list[str] = field(default_factory=list)
+    assigned_agent: object = None
+
+
+@dataclass
+class RuntimeStub:
+    tasks: dict[str, RuntimeTask]
+    pm_store: InMemoryPMTaskStore
+
+
+@pytest.fixture
+def runtime_stub():
+    store = InMemoryPMTaskStore()
+    now = datetime.now(timezone.utc)
+    ready_pm = PMTask(
+        task_id="wf-ready",
+        title="Ready task",
+        description="Can start now",
+        source="test",
+        status=PMTaskStatus.TODO,
+        created_at_utc=now,
+        updated_at_utc=now,
+    )
+    blocked_pm = PMTask(
+        task_id="wf-blocked",
+        title="Blocked task",
+        description="Waiting on dependency",
+        source="test",
+        status=PMTaskStatus.TODO,
+        created_at_utc=now,
+        updated_at_utc=now,
+    )
+    done_pm = PMTask(
+        task_id="wf-done",
+        title="Done task",
+        description="Already finished",
+        source="test",
+        status=PMTaskStatus.DONE,
+        created_at_utc=now,
+        updated_at_utc=now,
+    )
+    store.create(ready_pm)
+    store.create(blocked_pm)
+    store.create(done_pm)
+
+    return RuntimeStub(
+        tasks={
+            "wf-ready": RuntimeTask(id="wf-ready", title="Ready task", priority=5),
+            "wf-blocked": RuntimeTask(
+                id="wf-blocked",
+                title="Blocked task",
+                priority=3,
+                dependencies=["wf-done", "wf-missing"],
             ),
-            supporting_sources=[
-                PMReadSupportingSource(kind="canonical", backend="task-orchestrator", entity_ids=[project_id])
-            ],
-            legality_result="blocked",
-            blockers=["needs-review"],
-            next_action={"workflow_id": "wf-1"},
-            queue_items=[{"id": "wf-1", "title": "Review authority"}],
-        )
-
-    async def fake_get_reads():
-        return fake_priority_queue, None, None
-
-    monkeypatch.setattr(project_workflow, "_get_reads", fake_get_reads)
-
-    result = await project_workflow.get_project_workflow_queue("proj-123")
-
-    assert result.project_id == "proj-123"
-    assert result.legality_result == "blocked"
-    assert result.blockers == ["needs-review"]
-    assert result.queue_items[0]["id"] == "wf-1"
+            "wf-done": RuntimeTask(id="wf-done", title="Done task", status=TaskStatus.COMPLETED, priority=1),
+        },
+        pm_store=store,
+    )
 
 
 @pytest.mark.asyncio
-async def test_get_project_workflow_state_passes_through_allowed_transitions(monkeypatch):
-    async def fake_workflow_state(project_id: str):
-        return PMWorkflowStateResult(
-            canonical_backend="task-orchestrator",
-            project_id=project_id,
-            linked_ids={"workflow": "wf-2"},
-            provenance=PMReadProvenance(
-                source="task-orchestrator",
-                query_mode="workflow_state",
-                project_id=project_id,
-            ),
-            supporting_sources=[
-                PMReadSupportingSource(kind="canonical", backend="task-orchestrator", entity_ids=[project_id])
-            ],
-            legality_result="allowed",
-            blockers=[],
-            next_action=None,
-            state={"status": "ready"},
-            allowed_transitions=["start", "block"],
-        )
+async def test_get_project_workflow_queue_uses_runtime_state(monkeypatch, runtime_stub):
+    monkeypatch.setattr(project_workflow, "_task_runtime", lambda request=None: runtime_stub)
 
-    async def fake_get_reads():
-        return None, None, fake_workflow_state
-
-    monkeypatch.setattr(project_workflow, "_get_reads", fake_get_reads)
-
-    result = await project_workflow.get_project_workflow_state("proj-123")
+    result = await project_workflow.get_project_workflow_queue("proj-123", request=None)
 
     assert result.project_id == "proj-123"
     assert result.legality_result == "allowed"
-    assert result.state == {"status": "ready"}
-    assert result.allowed_transitions == ["start", "block"]
+    assert result.queue_items[0]["id"] == "wf-ready"
+    assert result.blockers == ["wf-blocked"]
 
 
 @pytest.mark.asyncio
-async def test_transition_project_workflow_fails_closed_when_runtime_binding_missing():
-    request = project_workflow.TransitionWorkflowRequest(workflow_id="wf-3", transition="start")
+async def test_get_project_workflow_state_reports_allowed_transitions(monkeypatch, runtime_stub):
+    monkeypatch.setattr(project_workflow, "_task_runtime", lambda request=None: runtime_stub)
 
-    result = await project_workflow.transition_project_workflow("proj-123", request)
+    result = await project_workflow.get_project_workflow_state("proj-123", request=None)
 
     assert result.project_id == "proj-123"
-    assert result.workflow_id == "wf-3"
-    assert result.legality_result == "unavailable"
-    assert result.transition_receipt["status"] == "unavailable"
-    assert result.resulting_state == {}
+    assert result.legality_result == "allowed"
+    assert result.state["task_count"] == 3
+    assert result.state["ready_count"] == 1
+    assert "start" in result.allowed_transitions
+    assert "block" in result.allowed_transitions
+    assert "done" not in result.allowed_transitions
+
+
+@pytest.mark.asyncio
+async def test_transition_project_workflow_returns_real_receipt(monkeypatch, runtime_stub):
+    monkeypatch.setattr(project_workflow, "_task_runtime", lambda request=None: runtime_stub)
+    request = project_workflow.TransitionWorkflowRequest(
+        workflow_id="wf-ready",
+        transition="start",
+        actor="tester",
+        idempotency_key="idem-1",
+        expected_version=1,
+        reason="begin work",
+    )
+
+    result = await project_workflow.execute_transition_project_workflow("proj-123", request)
+
+    assert result.project_id == "proj-123"
+    assert result.workflow_id == "wf-ready"
+    assert result.legality_result == "allowed"
+    assert result.transition_receipt["canonical_backend"] == "task-orchestrator"
+    assert result.transition_receipt["version_after"] == 2
+    assert result.resulting_state == {"workflow_id": "wf-ready", "status": "IN_PROGRESS", "version": 2}
+    assert runtime_stub.tasks["wf-ready"].status == TaskStatus.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_transition_project_workflow_rejects_illegal_target(monkeypatch, runtime_stub):
+    monkeypatch.setattr(project_workflow, "_task_runtime", lambda request=None: runtime_stub)
+    request = project_workflow.TransitionWorkflowRequest(
+        workflow_id="wf-done",
+        transition="start",
+        actor="tester",
+        idempotency_key="idem-2",
+        expected_version=1,
+    )
+
+    result = await project_workflow.execute_transition_project_workflow("proj-123", request)
+
+    assert result.project_id == "proj-123"
+    assert result.workflow_id == "wf-done"
+    assert result.legality_result == "illegal"
+    assert result.transition_receipt["status"] == "illegal"
+    assert result.resulting_state["current_status"] == "DONE"


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary
- bind `pm_transition_work_item` to the project-scoped Task Orchestrator workflow route
- implement backend-backed normalized PM reads for project context, sprint snapshot, project knowledge, and technical context
- rebaseline the PM ledger and status docs to match runtime truth

## What changed
- replaced the placeholder Task Orchestrator project workflow transition path with a runtime-backed legality/result envelope
- updated PM write adapters and TaskMaster sync clients to call the project-scoped workflow endpoint directly
- implemented normalized PM read surfaces in `src/dopemux/pm/reads.py` for ConPort, Leantime, dope-context, and Serena-backed reads
- updated unit and integration tests around workflow transitions, PM writes, PM reads, and bridge/task flows
- updated PM implementation docs and `task-packets/STATUS.md` to reflect the new runtime state

## Validation
- `python3 -m py_compile services/task-orchestrator/app/api/project_workflow.py services/task-orchestrator/app/models/workflow.py src/dopemux/pm/adapters/orchestrator.py src/dopemux/pm/writes.py services/taskmaster/bridge_adapter.py services/task-orchestrator/app/api/pm_tools.py src/dopemux/pm/reads.py`
- `python3 -m pytest -q tests/unit/test_task_orchestrator_project_workflow_contract.py tests/unit/dopemux/pm/test_writes.py`
- `python3 -m pytest -q tests/integration/pm/test_pm_plane_e2e.py services/taskmaster/tests/test_bridge_adapter.py services/dopecon-bridge/tests/test_task_integration_unit.py tests/unit/test_bridge_task_integration.py`
- `cd services/task-orchestrator && python3 -m pytest -q tests/test_workflow.py tests/test_pm_tools.py tests/test_pm_metrics.py`
- `python3 -m pytest -q tests/unit/pm/test_reads.py tests/unit/test_task_decomposer_pm_coverage.py`
- `python3 -m pytest -q tests/unit/pm/test_reads.py tests/unit/dopemux/pm/test_writes.py tests/unit/pm/test_pm_events.py tests/unit/pm/test_pm_publish.py tests/unit/test_event_bus.py tests/unit/test_task_orchestrator_project_workflow_contract.py tests/integration/pm/test_pm_plane_e2e.py services/dopecon-bridge/tests/test_task_integration_unit.py tests/unit/test_bridge_task_integration.py services/taskmaster/tests/test_bridge_adapter.py && cd services/task-orchestrator && python3 -m pytest -q tests/test_workflow.py tests/test_pm_tools.py tests/test_pm_metrics.py`
- `python3 scripts/check_root_hygiene.py`

## Known drift
- `python3 scripts/docs_frontmatter_guard.py` still fails on unrelated pre-existing doc drift in `docs/archive/unclassified-top-level/plans/pr-drainage-plan.md`
- `services/dopecon-bridge/tests/test_route_endpoints_authority.py` still fails in this worktree with auth/plane-gating expectations that were not changed by this PR

## Notes
- this branch now includes the packet-05 transition binding plus the packet-06/07/08 normalized read and truth-rebaseline work because the runtime, tests, and docs had already become integrated around the same PM contract surface before commit time
- remaining PM risk is concentrated in coarse project scoping for unlinked workflow items and thinner-than-target multi-source enrichment for the new read surfaces