### PR TITLE
[codex] Improve PR-merge flight dashboard visibility

### DIFF
--- a/src/dopemux_pr_merge_specialist/action_model.py
+++ b/src/dopemux_pr_merge_specialist/action_model.py
@@ -2,7 +2,15 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Mapping, Sequence, Set
 
-from .schema import BlockerType, Finding, FindingSeverity, MergeActionType, PRResult, PRState
+from .schema import (
+    BlockerType,
+    Finding,
+    FindingSeverity,
+    MergeActionType,
+    PRResult,
+    PRState,
+    ValidationStatus,
+)
 
 
 VALIDATION_BLOCKERS = {
@@ -26,6 +34,12 @@ AUTO_MERGE_PASSIVE_BLOCKERS = {
 NON_AUTOMATABLE_BLOCKERS = {
     "manual_conflict_required",
     "semantic_conflict_blocked",
+}
+CI_FAILURE_BLOCKERS = {
+    BlockerType.REQUIRED_CHECK_FAILED.value,
+}
+THREAD_BLOCKERS = {
+    BlockerType.ACTIVE_THREAD.value,
 }
 QUEUED_OPERATOR_STATES = {
     "queued_for_merge",
@@ -63,6 +77,15 @@ def blocker_types_from_snapshot(snapshot: Mapping[str, Any]) -> Set[str]:
         for item in blockers
         if isinstance(item, Mapping)
     }
+
+
+def validation_status_from_snapshot(snapshot: Mapping[str, Any]) -> str:
+    report = snapshot.get("validation_report") or {}
+    if isinstance(report, Mapping):
+        return str(
+            report.get("status", ValidationStatus.NOT_EXECUTED.value)
+        ).lower()
+    return ValidationStatus.NOT_EXECUTED.value
 
 
 def allowed_actions_for_snapshot(snapshot: Mapping[str, Any]) -> List[str]:
@@ -120,6 +143,9 @@ def allowed_actions_for_result(result: PRResult) -> List[str]:
 def dashboard_tactic_for_snapshot(snapshot: Mapping[str, Any]) -> str:
     allowed = list(snapshot.get("allowed_actions") or allowed_actions_for_snapshot(snapshot))
     blockers = blocker_types_from_snapshot(snapshot)
+    ci_status = str(snapshot.get("ci_status", "") or "").upper()
+    validation_status = validation_status_from_snapshot(snapshot)
+    unresolved_threads = int(snapshot.get("unresolved_threads", 0) or 0)
 
     if "READY" in allowed:
         return "R"
@@ -128,10 +154,33 @@ def dashboard_tactic_for_snapshot(snapshot: Mapping[str, Any]) -> str:
     if "APPROVE" in allowed:
         return "A"
     if "APPLY_FIX" in allowed:
+        if validation_status == ValidationStatus.FAILED.value:
+            return "F"
+        if ci_status == "FAILURE" or bool(blockers & CI_FAILURE_BLOCKERS):
+            return "C"
+        if unresolved_threads > 0 or bool(blockers & THREAD_BLOCKERS):
+            return "T"
         if blockers and blockers <= {*VALIDATION_BLOCKERS, BlockerType.REQUIRED_CHECK_PENDING.value}:
             return "V"
         return "P"
+    if unresolved_threads > 0:
+        return "T"
     return "S"
+
+
+def dashboard_phase_for_snapshot(snapshot: Mapping[str, Any]) -> str:
+    tactic = dashboard_tactic_for_snapshot(snapshot)
+    return {
+        "R": "Ready For Review",
+        "A": "Approval",
+        "C": "CI Remediation",
+        "F": "Validation Remediation",
+        "I": "Merge",
+        "P": "Patch",
+        "S": "Monitor",
+        "T": "Thread Review",
+        "V": "Verification",
+    }.get(tactic, "Monitor")
 
 
 def result_to_dashboard_entry(result: PRResult) -> Dict[str, Any]:

--- a/src/dopemux_pr_merge_specialist/cli.py
+++ b/src/dopemux_pr_merge_specialist/cli.py
@@ -6,7 +6,6 @@ import json
 import sys
 from pathlib import Path
 
-from . import engine
 from .action_model import result_to_dashboard_entry
 from .classification import classify_pr, risk_score
 from .conflict import build_conflict_analysis
@@ -51,7 +50,7 @@ def cmd_flight(args: argparse.Namespace) -> int:
     from .dashboard import DopemuxDashboard
     from .github_api import GitHubClient
     from .policy import load_effective_policy
-    from .preflight import run_id
+    from .preflight import build_run_paths, run_id
     from .queue_drain import queue_scan_internal
 
     repo_root = Path.cwd()
@@ -74,10 +73,15 @@ def cmd_flight(args: argparse.Namespace) -> int:
 
     # 2. Convert PR results to simple dicts for the dashboard
     pr_queue = [result_to_dashboard_entry(result) for result in results]
+    _, queue_dir, _ = build_run_paths(args.out_dir, active_run_id)
+    ordering_plan_path = queue_dir / "ORDERING_PLAN.json"
+    ordering_plan = {}
+    if ordering_plan_path.exists():
+        ordering_plan = json.loads(ordering_plan_path.read_text(encoding="utf-8"))
 
     # 3. Launch Dashboard
     dashboard = DopemuxDashboard(manager=client, args=args, policy=policy)
-    dashboard.run(pr_queue, active_run_id)
+    dashboard.run(pr_queue, active_run_id, ordering_plan=ordering_plan)
     return 0
 
 
@@ -148,13 +152,21 @@ def _self_check(args: argparse.Namespace) -> int:
 
     # Check 2: Schema completeness — consensus engine types exist
     try:
-        from .schema import (
-            ArbitrationRoleTrace,
-            AutonomyGateReport,
-            ConsensusDecision,
-            MergeExecutionPlan,
-            RequiredVerificationPlan,
-        )
+        schema_module = importlib.import_module("dopemux_pr_merge_specialist.schema")
+        required_schema_types = [
+            "ArbitrationRoleTrace",
+            "AutonomyGateReport",
+            "ConsensusDecision",
+            "MergeExecutionPlan",
+            "RequiredVerificationPlan",
+        ]
+        missing = [
+            name for name in required_schema_types if not hasattr(schema_module, name)
+        ]
+        if missing:
+            raise ImportError(
+                f"Missing schema consensus types: {', '.join(sorted(missing))}"
+            )
 
         results["checks"].append({"name": "schema:consensus_types", "status": "PASS"})
     except ImportError as exc:
@@ -576,24 +588,9 @@ def cmd_flight_deck(args: argparse.Namespace) -> int:
 
 def cmd_fusion(args: argparse.Namespace) -> int:
     """🔥 Launch Fusion Engine for advanced conflict resolution."""
-    from .fusion_engine import FusionEngine
-    from .github_api import GitHubClient
     from .ops_engine import FlightDeckOpsEngine
-    from .patch_engine import PatchEngine
-    from .policy import load_effective_policy
 
-    repo_root = Path.cwd()
-    policy = load_effective_policy(
-        repo_root, explicit_path=getattr(args, "policy", None)
-    )
-    client = GitHubClient(
-        repo=getattr(args, "repo", None), repo_root=repo_root, policy=policy
-    )
-    ops_engine = FlightDeckOpsEngine(Path("proof/pr_merge/flight_deck/fusion"))
-
-    # Initialize engines
-    patch_engine = PatchEngine(ops_engine, posture="GO_SUPERVISED_ONLY")
-    fusion_engine = FusionEngine(patch_engine, ops_engine)
+    FlightDeckOpsEngine(Path("proof/pr_merge/flight_deck/fusion"))
 
     pr_id = args.pr_id
     strategy = args.strategy
@@ -609,8 +606,8 @@ def cmd_fusion(args: argparse.Namespace) -> int:
     # 5. Emit fusion artifacts
 
     print(f"✅ Fusion analysis complete for PR #{pr_id}")
-    print(f"📁 Artifacts: proof/pr_merge/flight_deck/fusion/")
-    print(f"🎯 Next: Review VERIFICATION_GATE_REPORT.json")
+    print("📁 Artifacts: proof/pr_merge/flight_deck/fusion/")
+    print("🎯 Next: Review VERIFICATION_GATE_REPORT.json")
     return 0
 
 
@@ -642,7 +639,7 @@ def cmd_ops(args: argparse.Namespace) -> int:
             manifest_path = ops_dir / "OPERATIONALIZATION_MANIFEST.json"
             if manifest_path.exists():
                 manifest = json.loads(manifest_path.read_text())
-                print(f"\n📋 Manifest:")
+                print("\n📋 Manifest:")
                 print(f"   Version: {manifest.get('version', '1.0.0')}")
                 print(
                     f"   Artifacts: {', '.join(manifest.get('artifacts', {}).keys())}"
@@ -653,14 +650,14 @@ def cmd_ops(args: argparse.Namespace) -> int:
             print(f"⚠️ Error reading ops report: {e}")
 
     # Fallback: Show basic Flight Deck info
-    print(f"\n📈 Current Status: STANDBY")
-    print(f"🎛️ Posture: GO_SUPERVISED_ONLY")
-    print(f"📝 Flight Deck Sessions: 0")
-    print(f"✍️ Formal Signoffs: 0")
-    print(f"🛡️ Auto-Apply Safety: CLEAN")
-    print(f"📊 Runtime Stability: 1.0")
+    print("\n📈 Current Status: STANDBY")
+    print("🎛️ Posture: GO_SUPERVISED_ONLY")
+    print("📝 Flight Deck Sessions: 0")
+    print("✍️ Formal Signoffs: 0")
+    print("🛡️ Auto-Apply Safety: CLEAN")
+    print("📊 Runtime Stability: 1.0")
 
-    print(f"\n💡 Tip: Run 'flight-deck' or 'fusion' commands to generate metrics")
+    print("\n💡 Tip: Run 'flight-deck' or 'fusion' commands to generate metrics")
 
     return 0
 

--- a/src/dopemux_pr_merge_specialist/conflict.py
+++ b/src/dopemux_pr_merge_specialist/conflict.py
@@ -1,76 +1,21 @@
 from __future__ import annotations
 
-import argparse
 import html
-import json
-import os
 import re
-import tempfile
-import time
-from collections import defaultdict, deque
-from dataclasses import replace
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-from .github_api import (
-    BOT_AUTHORS,
-    GitHubClient,
-    ci_status,
-    summarize_checks,
-    thread_counters,
-)
-from .policy import (
-    PolicyError,
-    load_effective_policy,
-    policy_artifact_payload,
-    policy_fingerprint,
-)
 from .runtime import (
-    CommandResult,
     append_command_log,
-    execute_or_dry_run,
-    fingerprint_payload,
-    pid_is_running,
     run_command,
-    run_id,
-    shell_join,
-    snapshot_environment,
-    utc_now,
-    write_json,
-    write_text,
+    contains_marker,
 )
 from .schema import (
-    ARTIFACT_VERSION,
-    POLICY_SCHEMA_VERSION,
-    TOOL_VERSION,
-    ArtifactMeta,
-    BlockerType,
-    FallbackReason,
-    Finding,
-    FindingSeverity,
-    Fingerprint,
-    MergeActionType,
-    MergeDecision,
-    OverrideRecord,
-    PhaseRecord,
-    PreflightCheck,
-    PreflightResult,
-    PRResult,
-    PRState,
-    PRStateData,
     PullRequestState,
-    QueueOrderingLayer,
     ReviewThread,
-    RunManifest,
     ThreadComment,
-    ThreadDisposition,
-    ThreadDispositionType,
-    TruthSource,
-    ValidationReport,
-    ValidationStatus,
 )
 from .strategy_library import STRATEGY_LIBRARY
-from .validation import run_validation, validation_report_md
 
 __all__ = [
     "read_file_at_ref",
@@ -271,13 +216,14 @@ def apply_suggestion_to_file(
     comment: ThreadComment,
     base_ref: str,
     policy: Dict[str, Any],
-) -> Tuple[bool, str]:
+    dry_run: bool = False,
+) -> Tuple[bool, str, Optional[str]]:
     target = comment.path or thread.path
     if not target:
-        return False, "No path on thread/comment."
+        return False, "No path on thread/comment.", None
     file_path = worktree_path / target
     if not file_path.exists() or not file_path.is_file():
-        return False, f"Target file missing: {target}"
+        return False, f"Target file missing: {target}", None
     original = file_path.read_text(encoding="utf-8")
     text = original
     preferred_conflict_side = comment_prefers_conflict_side(comment.body)
@@ -286,7 +232,7 @@ def apply_suggestion_to_file(
             text, prefer=preferred_conflict_side
         )
         if not changed:
-            return False, resolved
+            return False, resolved, None
         resolved, canonical_note = maybe_sync_canonical_file(
             worktree_path=worktree_path,
             base_ref=base_ref,
@@ -298,18 +244,20 @@ def apply_suggestion_to_file(
             policy=policy,
         )
         if resolved == original:
-            return False, "Conflict-marker resolution produced no file changes."
-        file_path.write_text(resolved, encoding="utf-8")
+            return False, "Conflict-marker resolution produced no file changes.", None
+        if not dry_run:
+            file_path.write_text(resolved, encoding="utf-8")
         return (
             True,
             f"Resolved conflict markers in {target} using {preferred_conflict_side} side{canonical_note}.",
+            resolved,
         )
     suggestion = extract_suggestion_block(comment.body)
     if suggestion is not None:
         start = thread.original_start_line or thread.original_line or thread.line
         end = thread.original_line or thread.line or start
         if start is None or end is None:
-            return False, "Suggestion block missing line anchors."
+            return False, "Suggestion block missing line anchors.", None
         lines = text.splitlines()
         start_idx = max(start - 1, 0)
         end_idx = max(end, start_idx + 1)
@@ -327,7 +275,11 @@ def apply_suggestion_to_file(
             old = html.unescape(replace_match.group(1)).strip()
             new = html.unescape(replace_match.group(2)).strip()
             if old not in text:
-                return False, "Could not locate replacement source fragment in file."
+                return (
+                    False,
+                    "Could not locate replacement source fragment in file.",
+                    None,
+                )
             text = text.replace(old, new, 1)
         else:
             delete_match = re.search(
@@ -336,7 +288,7 @@ def apply_suggestion_to_file(
                 re.IGNORECASE | re.DOTALL,
             )
             if not delete_match:
-                return False, "No known machine-applicable suggestion pattern."
+                return False, "No known machine-applicable suggestion pattern.", None
             snippet = html.unescape(delete_match.group(1)).strip()
             removed = False
             new_lines: List[str] = []
@@ -346,12 +298,13 @@ def apply_suggestion_to_file(
                     continue
                 new_lines.append(line)
             if not removed:
-                return False, "Could not find deletion snippet in file."
+                return False, "Could not find deletion snippet in file.", None
             text = "\n".join(new_lines) + ("\n" if original.endswith("\n") else "")
     if text == original:
-        return False, "No file changes produced."
-    file_path.write_text(text, encoding="utf-8")
-    return True, f"Applied suggestion to {target}."
+        return False, "No file changes produced.", None
+    if not dry_run:
+        file_path.write_text(text, encoding="utf-8")
+    return True, f"Applied suggestion to {target}.", text
 
 
 def conflict_files(worktree_path: Path, policy: Dict[str, Any]) -> List[str]:

--- a/src/dopemux_pr_merge_specialist/dashboard.py
+++ b/src/dopemux_pr_merge_specialist/dashboard.py
@@ -1,32 +1,54 @@
 from __future__ import annotations
 
 import argparse
+import difflib
 import select
 import sys
 import termios
 import time
 import tty
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Callable
+from pathlib import Path
+from typing import Any, Dict, List, Optional
 
 from rich.console import Console
 from rich.layout import Layout
 from rich.live import Live
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.text import Text
 
 from dopemux.ui.theme import DOPEMUX_THEME
 
-from .action_model import dashboard_tactic_for_snapshot, result_to_dashboard_entry
+from .action_model import (
+    dashboard_phase_for_snapshot,
+    dashboard_tactic_for_snapshot,
+    result_to_dashboard_entry,
+)
+from .metrics import MetricsEngine
+from .plan_builder import build_plan_result
 from .preflight import preflight
+from .schema import PRMergeReport, PRResult, ValidationReport, ValidationStatus
+from .thread_resolution import latest_comment
 from .ux_engine import RenderMode, RichTerminalRenderer
+from .conflict import apply_suggestion_to_file
 from .queue_drain import (
-    pr_apply, 
-    pr_merge, 
-    pr_approve, 
-    pr_ready, 
-    _inflate_pr_result, 
+    GitHubClient,
     _ignite_speculative_train,
-    build_run_paths
+    _inflate_pr_result,
+    _load_pr_context,
+    _refresh_client_state,
+    build_run_paths,
+    cleanup_worktree,
+    load_effective_policy,
+    pr_apply,
+    pr_approve,
+    pr_merge,
+    pr_ready,
+    prepare_worktree,
+    stage_and_push_if_needed,
 )
 
 
@@ -42,6 +64,10 @@ class QueueState:
     auto_pilot: bool = False
     execution_log: List[Dict[str, str]] = field(default_factory=list)
     last_action_result: Optional[str] = None
+    resolved_threads_in_session: int = 0
+    queue_plan: Dict[str, Any] = field(default_factory=dict)
+    active_phase: str = "Monitor"
+    train_progress: Dict[str, Any] = field(default_factory=dict)
 
     @property
     def active_pr(self) -> Optional[Dict[str, Any]]:
@@ -64,8 +90,11 @@ class DopemuxDashboard:
         self.policy = policy
         self.ux = RichTerminalRenderer(mode=RenderMode.RICH)
         self.console = Console(theme=DOPEMUX_THEME)
+        self.metrics = MetricsEngine(Path("proof/pr_merge/metrics"))
         self.state: Optional[QueueState] = None
         self._live: Optional[Live] = None
+        self._input_fd: Optional[int] = None
+        self._terminal_settings: Optional[List[Any]] = None
 
     def render(self) -> Any:
         """Assemble the entire Grand Dashboard layout."""
@@ -84,6 +113,279 @@ class DopemuxDashboard:
         if self._live:
             self._live.update(self.render())
 
+    def _default_queue_plan(self, pr_queue: List[Dict[str, Any]]) -> Dict[str, Any]:
+        ordered_ids = [int(pr.get("pr_id")) for pr in pr_queue if pr.get("pr_id") is not None]
+        return {
+            "ordered_pr_ids": ordered_ids,
+            "layers": [{"layer": 0, "pr_ids": ordered_ids}],
+            "edges": {},
+            "cycle_detected": False,
+        }
+
+    def _restore_terminal_mode(self) -> None:
+        if self._input_fd is not None and self._terminal_settings is not None:
+            termios.tcsetattr(
+                self._input_fd, termios.TCSADRAIN, self._terminal_settings
+            )
+
+    def _enter_cbreak_mode(self) -> None:
+        if self._input_fd is not None and self._terminal_settings is not None:
+            tty.setcbreak(self._input_fd)
+
+    @contextmanager
+    def _paused_live_prompt(self):
+        if self._live:
+            self._live.stop()
+        self._restore_terminal_mode()
+        try:
+            yield
+        finally:
+            self._enter_cbreak_mode()
+            if self._live:
+                self._live.start()
+                self._live.update(self.render())
+
+    def _validation_report_from_snapshot(
+        self, snapshot: Optional[Dict[str, Any]]
+    ) -> ValidationReport:
+        report = snapshot.get("validation_report") if snapshot else {}
+        if not isinstance(report, dict):
+            report = {}
+        raw_status = str(
+            report.get("status", ValidationStatus.NOT_EXECUTED.value)
+        ).lower()
+        status = ValidationStatus(raw_status)
+        steps = [
+            {
+                "name": str(item.get("name", "")),
+                "command": str(item.get("command", "")),
+                "status": str(item.get("status", "")),
+                "returncode": item.get("returncode"),
+                "stdout": str(item.get("stdout", "")),
+                "stderr": str(item.get("stderr", "")),
+            }
+            for item in report.get("steps", [])
+            if isinstance(item, dict)
+        ]
+        from .schema import ValidationStepResult
+
+        return ValidationReport(
+            status=status,
+            required_for_merge_ready=bool(
+                report.get("required_for_merge_ready", True)
+            ),
+            steps=[ValidationStepResult(**step) for step in steps],
+            attempts=int(report.get("attempts", 0) or 0),
+            remediation_applied=bool(report.get("remediation_applied", False)),
+        )
+
+    def _sync_active_phase(self) -> None:
+        if self.state is None or self.state.active_pr is None:
+            return
+        self.state.active_phase = dashboard_phase_for_snapshot(self.state.active_pr)
+
+    def _refresh_dashboard_result(self, pr_id: str) -> PRResult:
+        repo_root = Path.cwd()
+        policy = self.policy or load_effective_policy(
+            repo_root, explicit_path=getattr(self.args, "policy", None)
+        )
+        client = self.manager
+        if not isinstance(client, GitHubClient):
+            client = GitHubClient(
+                repo=getattr(self.args, "repo", None),
+                repo_root=repo_root,
+                policy=policy,
+            )
+        _raw, threads, pr, check_payload = _load_pr_context(
+            client=client, pr_id=int(pr_id)
+        )
+        current_snapshot = self.state.active_pr if self.state else None
+        validation_report = self._validation_report_from_snapshot(current_snapshot)
+        return build_plan_result(
+            active_run_id=self.state.run_id,
+            pr=pr,
+            threads=threads,
+            check_payload=check_payload,
+            validation_report=validation_report,
+            policy=policy,
+        )
+
+    def _review_threads_interactively(self, pr_id: str) -> bool:
+        """Interactively review and apply thread suggestions."""
+        self.log_step(f"Starting interactive thread review for PR #{pr_id}...", "START")
+
+        repo_root = Path.cwd()
+        active_run_id = self.state.run_id
+        policy = self.policy or load_effective_policy(
+            repo_root, explicit_path=getattr(self.args, "policy", None)
+        )
+        client = self.manager
+        if not isinstance(client, GitHubClient):
+            client = GitHubClient(
+                repo=getattr(self.args, "repo", None),
+                repo_root=repo_root,
+                policy=policy,
+            )
+
+        _, _, pr_root = build_run_paths(self.args.out_dir, active_run_id)
+        pr_dir = pr_root / f"PR-{pr_id}"
+        commands_log = pr_dir / "COMMANDS_RUN.txt"
+
+        _raw, threads, pr, _ = _load_pr_context(client=client, pr_id=int(pr_id))
+        unresolved = [t for t in threads if not t.is_resolved]
+        if not unresolved:
+            self.log_step("No unresolved threads found.", "SUCCESS")
+            return False
+
+        worktree_path, branch, err = prepare_worktree(
+            repo_root=repo_root,
+            pr_id=int(pr_id),
+            active_run_id=active_run_id,
+            commands_log=commands_log,
+            policy=policy,
+        )
+        if err:
+            self.log_step(f"Error preparing worktree: {err}", "ERROR")
+            return False
+
+        threads_resolved_count = 0
+        try:
+            for thread in unresolved:
+                comment = latest_comment(thread)
+                if not comment:
+                    self.log_step(
+                        f"Skipping thread {thread.id[:8]}: no latest comment payload.",
+                        "INFO",
+                    )
+                    continue
+                target = comment.path or thread.path or "<unknown>"
+                preview = " ".join(comment.body.split())
+                self.log_step(
+                    f"Reviewing thread {thread.id[:8]} on {target}: {preview[:120]}",
+                    "INFO",
+                )
+
+                ok, reason, new_text = apply_suggestion_to_file(
+                    worktree_path=worktree_path,
+                    thread=thread,
+                    comment=comment,
+                    base_ref=pr.base_ref,
+                    policy=policy,
+                    dry_run=True
+                )
+
+                if not ok or new_text is None:
+                    self.log_step(f"Skipping thread {thread.id[:8]}: {reason}", "INFO")
+                    continue
+
+                orig_text = (worktree_path / target).read_text(encoding="utf-8")
+
+                diff = "".join(difflib.unified_diff(
+                    orig_text.splitlines(keepends=True),
+                    new_text.splitlines(keepends=True),
+                    fromfile=f"a/{target}",
+                    tofile=f"b/{target}"
+                ))
+
+                info_panel = Panel(
+                    Text.assemble(
+                        ("COMMENT: ", "bold cyan"), f"{comment.body}\n",
+                        ("AUTHOR : ", "bold"), f"{comment.author}\n",
+                        ("FILE   : ", "bold"), f"{target}"
+                    ),
+                    title=f"THREAD {thread.id[:8]}",
+                    border_style="magenta"
+                )
+                diff_syntax = Syntax(diff, "diff", theme="monokai", line_numbers=True)
+
+                with self._paused_live_prompt():
+                    self.console.print(info_panel)
+                    self.console.print(
+                        Panel(
+                            diff_syntax,
+                            title="PROPOSED CHANGE",
+                            border_style="green",
+                        )
+                    )
+
+                    try:
+                        choice = input(
+                            "\nApply this fix? [y]es, [n]o, [q]uit: "
+                        ).strip().lower()
+                    except (EOFError, KeyboardInterrupt):
+                        choice = "q"
+                        self.log_step(
+                            "Interactive prompt interrupted; aborting thread review.",
+                            "WARNING",
+                        )
+
+                if choice == "y":
+                    applied, apply_reason, _ = apply_suggestion_to_file(
+                        worktree_path=worktree_path,
+                        thread=thread,
+                        comment=comment,
+                        base_ref=pr.base_ref,
+                        policy=policy,
+                        dry_run=False
+                    )
+                    if not applied:
+                        self.log_step(
+                            f"Failed to apply fix for thread {thread.id[:8]}: {apply_reason}",
+                            "ERROR",
+                        )
+                        continue
+                    threads_resolved_count += 1
+                    self.log_step(
+                        f"Applied fix for thread {thread.id[:8]}: {apply_reason}",
+                        "SUCCESS",
+                    )
+                elif choice == "q":
+                    self.log_step("Operator ended the thread review session.", "INFO")
+                    break
+                else:
+                    self.log_step(f"Skipped thread {thread.id[:8]}", "INFO")
+
+            if threads_resolved_count > 0:
+                self.log_step(f"Pushing {threads_resolved_count} thread fixes...", "INFO")
+                pushed = stage_and_push_if_needed(
+                    worktree_path=worktree_path,
+                    head_ref=pr.head_ref,
+                    active_run_id=active_run_id,
+                    pr_id=int(pr_id),
+                    execute=True,
+                    commands_log=commands_log,
+                    policy=policy,
+                )
+                if pushed:
+                    _refresh_client_state(client, int(pr_id))
+                    self.state.resolved_threads_in_session += threads_resolved_count
+                    return True
+                self.log_step("Thread fixes were not pushed successfully.", "ERROR")
+        finally:
+            cleanup_worktree(
+                repo_root=repo_root,
+                worktree_path=worktree_path,
+                branch=branch,
+                commands_log=commands_log,
+                policy=policy,
+            )
+
+        return False
+
+    def _log_metrics(self, result: PRResult):
+        """Translate PRResult to PRMergeReport and log to MetricsEngine."""
+        report = PRMergeReport(
+            pr_id=str(result.pr_state.pr_id),
+            status=result.lifecycle_state,
+            initial_state=result.pr_state,
+            blockers=[b.as_blocker() for b in result.findings if hasattr(b, "as_blocker")],
+            telemetry=result.decision_basis
+        )
+        self.metrics.log_event(
+            report=report,
+            resolved_threads=self.state.resolved_threads_in_session
+        )
+
     def _execute_tactic(self, tactic: str, pr_id: str) -> Optional[Dict[str, Any]]:
         """Execute the actual logic for a tactic and return updated data."""
         if not self.args:
@@ -99,11 +401,50 @@ class DopemuxDashboard:
         
         try:
             result = None
-            if tactic == "P" or tactic == "T":
-                self.log_step(f"ENGAGING REMEDIATION ENGINE: PR #{pr_id}", "START")
+            self.state.active_phase = {
+                "A": "Approval",
+                "C": "CI Remediation",
+                "F": "Validation Remediation",
+                "I": "Merge",
+                "P": "Patch",
+                "R": "Ready For Review",
+                "T": "Thread Review",
+                "V": "Verification",
+            }.get(tactic, "Monitor")
+            if tactic == "P":
+                self.log_step(f"ENGAGING PATCH ENGINE: PR #{pr_id}", "START")
                 result = pr_apply(cmd_args, progress_callback=self.log_step)
                 self.log_step("Patch Engine finished.", "SUCCESS")
-                self.state.status_message = f"Remediation complete for PR #{pr_id}."
+                self.state.status_message = f"Patch applied for PR #{pr_id}."
+            
+            elif tactic == "T":
+                self.log_step(f"ENGAGING THREAD RESOLUTION: PR #{pr_id}", "START")
+                changed = self._review_threads_interactively(pr_id)
+                if changed:
+                    self.log_step("Refreshing PR state from GitHub...", "INFO")
+                    result = self._refresh_dashboard_result(pr_id)
+                    self.log_step("Thread resolution sequence complete and pushed.", "SUCCESS")
+                    self.state.status_message = f"Threads resolved for PR #{pr_id}."
+                else:
+                    self.log_step("No threads were modified.", "INFO")
+                    self.state.status_message = f"Thread review finished for PR #{pr_id}."
+                    result = self._refresh_dashboard_result(pr_id)
+
+            elif tactic == "C":
+                self.log_step(f"ENGAGING CI REMEDIATION: PR #{pr_id}", "START")
+                self.log_step(
+                    "Routing through pr-apply so CI remediation uses the specialist-backed validation path.",
+                    "INFO",
+                )
+                result = pr_apply(cmd_args, progress_callback=self.log_step)
+                self.log_step("CI Remediation agent cycle complete.", "SUCCESS")
+                self.state.status_message = f"CI Remediation attempt finished for PR #{pr_id}."
+
+            elif tactic == "F":
+                self.log_step(f"ENGAGING VALIDATION FIX: PR #{pr_id}", "START")
+                result = pr_apply(cmd_args, progress_callback=self.log_step)
+                self.log_step("Validation fix attempt complete.", "SUCCESS")
+                self.state.status_message = f"Validation remediation complete for PR #{pr_id}."
                     
             elif tactic == "I":
                 self.log_step(f"ENGAGING MERGE ENGINE: PR #{pr_id}", "START")
@@ -133,39 +474,53 @@ class DopemuxDashboard:
                 time.sleep(1)
                 
             if result:
+                self._log_metrics(result)
                 self.state.last_action_result = result.lifecycle_state
                 # Preserve history if it exists
                 history = self.state.active_pr.get("history", [])
                 entry = result_to_dashboard_entry(result)
                 entry["history"] = history
+                self.state.active_phase = dashboard_phase_for_snapshot(entry)
                 return entry
         except Exception as e:
-            self.log_step(f"CRITICAL EXECUTION ERROR", "ERROR")
+            self.log_step("CRITICAL EXECUTION ERROR", "ERROR")
             self.log_step(f"REASON: {str(e)[:150]}", "ERROR")
             self.state.status_message = f"Error executing {tactic}."
             self.state.last_action_result = "ERROR"
             time.sleep(2)
         return None
 
-    def run(self, pr_queue: List[Dict[str, Any]], run_id: str):
+    def run(
+        self,
+        pr_queue: List[Dict[str, Any]],
+        run_id: str,
+        ordering_plan: Optional[Dict[str, Any]] = None,
+    ):
         """Run the persistent dashboard loop."""
-        self.state = QueueState(run_id=run_id, prs=pr_queue)
+        self.state = QueueState(
+            run_id=run_id,
+            prs=pr_queue,
+            queue_plan=ordering_plan or self._default_queue_plan(pr_queue),
+        )
+        self._sync_active_phase()
 
         if sys.stdin.isatty():
-            fd = sys.stdin.fileno()
-            old_settings = termios.tcgetattr(fd)
+            self._input_fd = sys.stdin.fileno()
+            self._terminal_settings = termios.tcgetattr(self._input_fd)
         else:
-            old_settings = None
+            self._input_fd = None
+            self._terminal_settings = None
 
         try:
-            if old_settings:
-                tty.setcbreak(fd)
+            if self._terminal_settings is not None:
+                self._enter_cbreak_mode()
 
             with Live(self.render(), console=self.console, screen=False, auto_refresh=True) as live:
                 self._live = live
                 while True:
                     live.update(self.render())
-                    if not old_settings: break
+                    if self._terminal_settings is None:
+                        break
 
                     timeout = 0.5 if not self.state.auto_pilot else 2.5
                     rlist, _, _ = select.select([sys.stdin], [], [], timeout)
@@ -173,38 +528,59 @@ class DopemuxDashboard:
                     choice = None
                     if rlist:
                         char = sys.stdin.read(1)
-                        if char == '\x1b':
+                        if char == "\x1b":
                             next_char = sys.stdin.read(2)
-                            if next_char == "[A": choice = "UP"
-                            elif next_char == "[B": choice = "DOWN"
+                            if next_char == "[A":
+                                choice = "UP"
+                            elif next_char == "[B":
+                                choice = "DOWN"
                         else:
                             choice = char.upper()
                     elif self.state.auto_pilot:
-                        # 1. Periodically check for 'Train' opportunities in Bulk
-                        ready_count = sum(1 for pr in self.state.prs if dashboard_tactic_for_snapshot(pr) in ("I", "R"))
+                        ready_pr_ids = [
+                            int(pr["pr_id"])
+                            for pr in self.state.prs
+                            if pr.get("pr_id") is not None
+                            and dashboard_tactic_for_snapshot(pr) in ("I", "R")
+                        ]
+                        ready_count = len(ready_pr_ids)
                         if ready_count >= 2:
-                            self.state.status_message = f"🚂 Autopilot: Train opportunity detected ({ready_count} PRs)..."
+                            self.state.active_phase = "Train Planning"
+                            self.state.train_progress = {
+                                "status": "planning",
+                                "candidate_pr_ids": ready_pr_ids,
+                            }
+                            self.state.status_message = (
+                                f"🚂 Autopilot: Train opportunity detected ({ready_count} PRs)..."
+                            )
                             live.update(self.render())
-                            
-                            # Reconstruct PRResult objects from snapshots
+
                             results_to_train = [_inflate_pr_result(pr) for pr in self.state.prs]
                             repo_root = Path.cwd()
                             _, _, pr_root = build_run_paths(self.args.out_dir, self.state.run_id)
                             commands_log = pr_root / "AUTOPILOT_TRAIN_COMMANDS.txt"
-                            
+
                             train_merged, train_queued = _ignite_speculative_train(
                                 results_to_train, self.manager, repo_root, self.state.run_id, commands_log, self.policy, True
                             )
-                            
+
                             if train_merged or train_queued:
-                                self.state.status_message = f"🚂 Train integration successful. {len(train_merged)+len(train_queued)} PRs moving."
-                                # We'll let the next individual cycle refresh the PR states from GitHub
+                                self.state.train_progress = {
+                                    "status": "active",
+                                    "candidate_pr_ids": ready_pr_ids,
+                                    "merged_pr_ids": train_merged,
+                                    "queued_pr_ids": train_queued,
+                                    "current_pr_id": self.state.active_pr.get("pr_id"),
+                                }
+                                self.state.status_message = (
+                                    f"🚂 Train integration successful. {len(train_merged)+len(train_queued)} PRs moving."
+                                )
                                 time.sleep(2)
                                 continue
 
-                        # 2. Otherwise, fall back to individual tactic selection
                         active = self.state.active_pr
                         if active:
+                            self.state.active_phase = dashboard_phase_for_snapshot(active)
                             choice = dashboard_tactic_for_snapshot(active)
 
                     if choice == "Q":
@@ -231,7 +607,8 @@ class DopemuxDashboard:
                         self.state.status_message = f"Cycled to PR #{self.state.active_pr.get('pr_id')}"
                         self.state.execution_log = []
                         self.state.last_action_result = None
-                    elif choice in ("A", "P", "I", "T", "V", "R"):
+                        self._sync_active_phase()
+                    elif choice in ("A", "P", "I", "T", "V", "R", "C", "F"):
                         active_pr_id = str(self.state.active_pr.get('pr_id'))
                         initial_state = self.state.active_pr.get("lifecycle_state")
                         
@@ -252,7 +629,6 @@ class DopemuxDashboard:
                                 self.state.active_index = (self.state.active_index + 1) % len(self.state.prs)
                                 self.state.status_message = f"PR #{active_pr_id} stalled. Advancing."
         finally:
-            if old_settings:
-                termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+            self._restore_terminal_mode()
 
         self.console.print("\n[bold green]MISSION COMPLETE. FLIGHT DATA SAVED TO PROOF BUNDLE. 🛰️[/bold green]")

--- a/src/dopemux_pr_merge_specialist/metrics.py
+++ b/src/dopemux_pr_merge_specialist/metrics.py
@@ -1,7 +1,7 @@
 import json
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
 from .schema import PRMergeReport
 
@@ -35,6 +35,7 @@ class MetricsEngine:
                 "ci_rerun_count": "int",
                 "incident": "bool",
                 "rollback_event": "bool",
+                "resolved_threads_in_session": "int",
             }
         }
         (self.metrics_path / "METRICS_SCHEMA.json").write_text(
@@ -42,7 +43,11 @@ class MetricsEngine:
         )
 
     def log_event(
-        self, report: PRMergeReport, duration_ms: float = 0.0, rollout_tier: str = "0"
+        self,
+        report: PRMergeReport,
+        duration_ms: float = 0.0,
+        rollout_tier: str = "0",
+        resolved_threads: int = 0,
     ):
         """Log a merge event with expanded adoption and incident metadata."""
         event = {
@@ -64,6 +69,7 @@ class MetricsEngine:
             "ci_rerun_count": report.telemetry.get("ci_rerun_count", 0),
             "incident": report.telemetry.get("incident", False),
             "rollback_event": report.telemetry.get("rollback_event", False),
+            "resolved_threads_in_session": resolved_threads,
         }
 
         date_str = time.strftime("%Y-%m-%d")
@@ -105,6 +111,9 @@ class MetricsEngine:
         total_retries = sum(e.get("retry_count", 0) for e in events)
         total_ci_reruns = sum(e.get("ci_rerun_count", 0) for e in events)
         total_incidents = len([e for e in events if e.get("incident")])
+        total_resolved_threads = sum(
+            e.get("resolved_threads_in_session", 0) for e in events
+        )
 
         blocker_dist = {}
         conflict_dist = {}
@@ -123,6 +132,7 @@ class MetricsEngine:
             "total_retries": total_retries,
             "total_ci_reruns": total_ci_reruns,
             "total_incidents": total_incidents,
+            "total_resolved_threads": total_resolved_threads,
             "blocker_distribution": blocker_dist,
             "conflict_class_frequency": conflict_dist,
             "queue_admission_rate": round(

--- a/src/dopemux_pr_merge_specialist/runtime.py
+++ b/src/dopemux_pr_merge_specialist/runtime.py
@@ -32,6 +32,11 @@ def shell_join(cmd: Sequence[str]) -> str:
     return " ".join(shlex.quote(part) for part in cmd)
 
 
+def contains_marker(text: str, markers: Sequence[str]) -> bool:
+    lowered = text.lower()
+    return any(marker.lower() in lowered for marker in markers)
+
+
 def run_command(
     cmd: Sequence[str],
     *,

--- a/src/dopemux_pr_merge_specialist/thread_resolution.py
+++ b/src/dopemux_pr_merge_specialist/thread_resolution.py
@@ -1,89 +1,28 @@
 from __future__ import annotations
 
-import argparse
-import html
 import json
-import os
 import re
-import tempfile
 import time
-from collections import defaultdict, deque
-from dataclasses import replace
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional
 from .conflict import (
     apply_suggestion_to_file,
-    build_conflict_analysis,
     comment_prefers_conflict_side,
-    conflict_excerpt,
-    conflict_files,
-    maybe_sync_canonical_file,
-    pr_changed_files,
-    read_file_at_ref,
-    recent_file_history,
-    recommend_conflict_strategy,
-    resolve_conflict_markers,
-    scan_files_for_conflict_markers,
 )
 from .github_api import (
     BOT_AUTHORS,
-    GitHubClient,
-    ci_status,
-    summarize_checks,
-    thread_counters,
-)
-from .policy import (
-    PolicyError,
-    load_effective_policy,
-    policy_artifact_payload,
-    policy_fingerprint,
 )
 from .runtime import (
     CommandResult,
     append_command_log,
-    execute_or_dry_run,
-    fingerprint_payload,
-    pid_is_running,
     run_command,
-    run_id,
-    shell_join,
-    snapshot_environment,
-    utc_now,
-    write_json,
-    write_text,
+    contains_marker,
 )
 from .schema import (
-    ARTIFACT_VERSION,
-    POLICY_SCHEMA_VERSION,
-    TOOL_VERSION,
-    ArtifactMeta,
-    BlockerType,
-    FallbackReason,
-    Finding,
-    FindingSeverity,
-    Fingerprint,
-    MergeActionType,
-    MergeDecision,
-    OverrideRecord,
-    PhaseRecord,
-    PreflightCheck,
-    PreflightResult,
-    PRResult,
-    PRState,
-    PRStateData,
-    PullRequestState,
-    QueueOrderingLayer,
     ReviewThread,
-    RunManifest,
     ThreadComment,
     ThreadDisposition,
-    ThreadDispositionType,
-    TruthSource,
-    ValidationReport,
-    ValidationStatus,
 )
-from .strategy_library import STRATEGY_LIBRARY
-from .validation import run_validation, validation_report_md
 
 __all__ = [
     "latest_comment",
@@ -106,11 +45,6 @@ def latest_comment(thread: ReviewThread) -> Optional[ThreadComment]:
     if not thread.comments:
         return None
     return sorted(thread.comments, key=lambda comment: comment.created_at or "")[-1]
-
-
-def contains_marker(text: str, markers: Sequence[str]) -> bool:
-    lowered = text.lower()
-    return any(marker.lower() in lowered for marker in markers)
 
 
 def has_newer_objection(thread: ReviewThread, policy: Dict[str, Any]) -> bool:
@@ -303,7 +237,7 @@ def apply_thread_dispositions(
                 comment=comment,
                 base_ref=base_ref,
                 policy=policy,
-            )
+            )[:2]
             if not ok:
                 applied.append(
                     ThreadDisposition(

--- a/src/dopemux_pr_merge_specialist/ux_engine.py
+++ b/src/dopemux_pr_merge_specialist/ux_engine.py
@@ -1,6 +1,6 @@
 import sys
 from enum import Enum, auto
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Mapping, Optional
 
 from rich.console import Console
 from dopemux.ui.theme import DOPEMUX_THEME
@@ -16,6 +16,14 @@ class RenderMode(Enum):
 def detect_render_mode() -> RenderMode:
     """Determine the best rendering mode based on terminal capabilities."""
     if not sys.stdout.isatty():
+        return RenderMode.PLAIN
+    # Check for Rich support
+    try:
+        console = Console()
+        if console.width < 80:
+            return RenderMode.COMPACT
+        return RenderMode.RICH
+    except ImportError:
         return RenderMode.PLAIN
 
 
@@ -66,16 +74,6 @@ def dashboard_status_icon(snapshot: Mapping[str, Any]) -> str:
         "pending": "⏳",
     }.get(status, "⏳")
 
-    # Check for Rich support
-    try:
-
-        console = Console()
-        if console.width < 80:
-            return RenderMode.COMPACT
-        return RenderMode.RICH
-    except ImportError:
-        return RenderMode.PLAIN
-
 
 class TerminalRenderer:
     """Base class for all terminal output."""
@@ -104,12 +102,10 @@ class RichTerminalRenderer(TerminalRenderer):
 
     def __init__(self, mode: Optional[RenderMode] = None):
         super().__init__(mode)
-
         self.console = Console(theme=DOPEMUX_THEME)
 
     def print_header(self, text: str):
         from rich.panel import Panel
-
         self.console.print(Panel(text, style="bold cyan", border_style="cyan"))
 
     def print_success(self, text: str):
@@ -123,24 +119,6 @@ class RichTerminalRenderer(TerminalRenderer):
 
     def print_info(self, text: str):
         self.console.print(f"[blue]ℹ️ {text}[/blue]")
-
-    def next_action_card(self, command: str, reason: str, severity: str):
-        """Render the next recommended action."""
-        from rich.panel import Panel
-        from rich.text import Text
-
-        color = (
-            "red"
-            if severity == "HIGH"
-            else "yellow" if severity == "MEDIUM" else "green"
-        )
-        content = Text.assemble(
-            ("COMMAND : ", "bold cyan"),
-            f"{command}\n",
-            ("REASON  : ", "bold cyan"),
-            reason,
-        )
-        print(Panel(content, title="NEXT ACTION", border_style=color))
 
     def render_dashboard_layout(self, state: Any, console: Optional[Console] = None) -> Any:
         """Assemble the entire Grand Dashboard layout using rich.layout.Layout."""
@@ -190,9 +168,7 @@ class RichTerminalRenderer(TerminalRenderer):
         table.add_column("Title", ratio=1, no_wrap=True, overflow="ellipsis")
         table.add_column("Status", justify="center")
 
-        # Deduct space for header (3), footer (3), panel borders (2), and some padding
         max_visible = max(5, term_height - 12)
-
         total_prs = len(state.prs)
         
         start_idx = 0
@@ -207,7 +183,6 @@ class RichTerminalRenderer(TerminalRenderer):
             pr = state.prs[i]
             is_active = i == state.active_index
             row_style = "row.active" if is_active else "text.dim"
-            
             status_icon = dashboard_status_icon(pr)
             
             table.add_row(
@@ -239,16 +214,80 @@ class RichTerminalRenderer(TerminalRenderer):
             
             # Intel
             intel_text = Text()
+            queue_plan = getattr(state, "queue_plan", {}) or {}
+            ordered_ids = [
+                int(pr_id)
+                for pr_id in queue_plan.get("ordered_pr_ids", [])
+                if str(pr_id).isdigit()
+            ]
+            active_id = int(active.get("pr_id", 0) or 0)
+            if not ordered_ids:
+                ordered_ids = [
+                    int(pr.get("pr_id", 0) or 0)
+                    for pr in state.prs
+                    if pr.get("pr_id") is not None
+                ]
+            queue_position = (
+                ordered_ids.index(active_id) + 1
+                if active_id in ordered_ids
+                else state.active_index + 1
+            )
+            active_layer = None
+            for layer in queue_plan.get("layers", []):
+                pr_ids = {
+                    int(pr_id) for pr_id in layer.get("pr_ids", []) if str(pr_id).isdigit()
+                }
+                if active_id in pr_ids:
+                    active_layer = layer.get("layer")
+                    break
+            next_ids = ordered_ids[queue_position:queue_position + 3]
+            active_phase = getattr(state, "active_phase", "Monitor")
+            train_progress = getattr(state, "train_progress", {}) or {}
             intel_text.append(f"#{active.get('pr_id')} | ", style="mint")
             intel_text.append(f"{active.get('title', 'Unknown')[:60]}...\n", style="text")
+            intel_text.append(f"PHASE    : {active_phase}\n", style="info")
+            intel_text.append(
+                f"QUEUE    : {queue_position}/{max(len(ordered_ids), len(state.prs))}",
+                style="text",
+            )
+            if active_layer is not None:
+                intel_text.append(f" | LAYER {active_layer}", style="mint")
+            if queue_plan.get("cycle_detected"):
+                intel_text.append(" | CYCLE DETECTED", style="warning")
+            intel_text.append("\n")
+            if next_ids:
+                intel_text.append(
+                    f"NEXT     : {' -> '.join(f'#{pr_id}' for pr_id in next_ids)}\n",
+                    style="text.dim",
+                )
             intel_text.append(f"STRATEGY : {active.get('merge_strategy', 'MECHANICAL')}\n", style="magenta")
             intel_text.append(f"RATIONALE: {active.get('rationale', 'Standard rebase.')[:150]}...", style="text.dim")
+            if train_progress:
+                train_status = str(train_progress.get("status", "active")).upper()
+                intel_text.append(f"\nTRAIN    : {train_status}\n", style="warning")
+                candidate_ids = train_progress.get("candidate_pr_ids", [])[:5]
+                if candidate_ids:
+                    intel_text.append(
+                        f"CANDIDATES: {' '.join(f'#{pr_id}' for pr_id in candidate_ids)}\n",
+                        style="text.dim",
+                    )
+                merged_ids = train_progress.get("merged_pr_ids", [])
+                if merged_ids:
+                    intel_text.append(
+                        f"MERGED   : {' '.join(f'#{pr_id}' for pr_id in merged_ids)}\n",
+                        style="success",
+                    )
+                queued_ids = train_progress.get("queued_pr_ids", [])
+                if queued_ids:
+                    intel_text.append(
+                        f"QUEUED   : {' '.join(f'#{pr_id}' for pr_id in queued_ids)}\n",
+                        style="info",
+                    )
             cockpit["top"]["intel"].update(Panel(intel_text, title="MISSION INTEL", border_style="magenta"))
             
             # Blockers & Warnings -> Tactical Checklist
             blocker_text = Text()
             blockers = active.get("blockers", [])
-            warnings = active.get("warnings", [])
             history = active.get("history", [])
             blocker_types = {
                 str(item.get("type") or item.get("finding_type") or "")
@@ -262,7 +301,6 @@ class RichTerminalRenderer(TerminalRenderer):
                 or str(active.get("lifecycle_state", "")).upper() == "QUEUED_FOR_MERGE"
             )
             
-            # 1. CI Status
             ci = active.get("ci_status", "UNKNOWN")
             if ci == "SUCCESS":
                 blocker_text.append("✅ CI Checks Passed\n", style="success")
@@ -271,7 +309,6 @@ class RichTerminalRenderer(TerminalRenderer):
             else:
                 blocker_text.append("❌ CI Checks Failed\n", style="error")
 
-            # 1.5 Approval status
             review_decision = str(active.get("review_decision", "") or "")
             if approval_blocked:
                 blocker_text.append("🟣 Approval Required\n", style="magenta")
@@ -280,7 +317,6 @@ class RichTerminalRenderer(TerminalRenderer):
             elif review_decision == "CHANGES_REQUESTED":
                 blocker_text.append("❌ Changes Requested\n", style="error")
                 
-            # 2. Local Validation
             v_report = active.get("validation_report", {})
             v_status = v_report.get("status", "NOT_EXECUTED").upper() if isinstance(v_report, dict) else "NOT_EXECUTED"
             if "PASSED" in v_status:
@@ -293,7 +329,6 @@ class RichTerminalRenderer(TerminalRenderer):
             if queued_for_merge:
                 blocker_text.append("🔵 Auto-merge Queued\n", style="info")
                 
-            # 3. Conflicts
             mergeable = str(active.get("mergeable", "")).upper()
             state_status = str(active.get("merge_state_status", "")).upper()
             if mergeable == "CONFLICTING" or state_status in ("DIRTY", "HAS_HOOKS"):
@@ -301,18 +336,15 @@ class RichTerminalRenderer(TerminalRenderer):
             else:
                 blocker_text.append("✅ No Merge Conflicts\n", style="success")
                 
-            # 4. Threads
-            threads = active.get("unresolved_threads", 0)
-            if threads == 0:
+            threads_count = active.get("unresolved_threads", 0)
+            if threads_count == 0:
                 blocker_text.append("✅ All Threads Resolved\n", style="success")
             else:
-                blocker_text.append(f"❌ {threads} Unresolved Threads\n", style="error")
+                blocker_text.append(f"❌ {threads_count} Unresolved Threads\n", style="error")
                 
-            # 5. Draft Status
             if active.get("is_draft"):
                 blocker_text.append("❌ PR is Draft\n", style="warning")
                 
-            # Other blockers
             other_blockers = [b for b in blockers if b.get("type") not in ("validation_not_executed", "required_check_pending", "required_check_failed", "active_thread", "conflict_detected", "draft_pr")]
             if other_blockers:
                 blocker_text.append("\n⚠️ Other Blockers:\n", style="warning")
@@ -343,6 +375,9 @@ class RichTerminalRenderer(TerminalRenderer):
             v_text = Text.assemble(("VERIFY: ", "bold"), (v_status, "success" if "PASSED" in v_status else "error" if "FAILED" in v_status else "text.dim"))
             
             threads_text = Text.assemble(("THREADS: ", "bold"), (f"{active.get('unresolved_threads', 0)}", "info"))
+            resolved_session = state.resolved_threads_in_session if hasattr(state, "resolved_threads_in_session") else 0
+            if resolved_session > 0:
+                threads_text.append(f" (+{resolved_session})", style="success")
             
             is_draft = bool(active.get("is_draft", False))
             draft_text = Text.assemble(("DRAFT: ", "bold"), ("YES" if is_draft else "NO", "warning" if is_draft else "text.dim"))
@@ -366,8 +401,15 @@ class RichTerminalRenderer(TerminalRenderer):
                     obj_text.append("🎯 OBJECTIVE: Satisfy the missing approval gate.\n", style="bold magenta")
                     obj_text.append("NEXT STEP: Press [A] to approve. Auto-merge should proceed after approval if all other gates stay green.", style="text")
                 elif validation_only_blocked:
-                    obj_text.append("🎯 OBJECTIVE: Run local verification before merge readiness.\n", style="bold warning")
-                    obj_text.append("NEXT STEP: Press [V] to execute validation. Merge follows only after validation passes.", style="text")
+                    if v_status == "FAILED":
+                        obj_text.append("🎯 OBJECTIVE: Resolve local validation failures.\n", style="bold error")
+                        obj_text.append("NEXT STEP: Press [F] to attempt auto-fix for validation failures.", style="text")
+                    else:
+                        obj_text.append("🎯 OBJECTIVE: Run local verification before merge readiness.\n", style="bold warning")
+                        obj_text.append("NEXT STEP: Press [V] to execute validation. Merge follows only after validation passes.", style="text")
+                elif ci == "FAILURE":
+                    obj_text.append("🎯 OBJECTIVE: Remediate broken CI checks.\n", style="bold error")
+                    obj_text.append("NEXT STEP: Press [C] to invoke CI Remediation via specialist agent.", style="text")
                 elif "READY" in lc_state:
                     obj_text.append("🎯 OBJECTIVE: Final sign-off and integration.\n", style="bold success")
                     obj_text.append("NEXT STEP: Press [A] to Approve or [I] to Implement Merge.", style="text")
@@ -386,6 +428,10 @@ class RichTerminalRenderer(TerminalRenderer):
                 
                 cockpit["bottom"].update(Panel(obj_text, title="MISSION OBJECTIVE", border_style="info"))
             else:
+                log_text.append(
+                    f"[{getattr(state, 'active_phase', 'Monitor')}] current phase\n",
+                    style="bold info",
+                )
                 for step in execution_log[-5:]:
                     s_type = step.get("type", "INFO")
                     s_msg = step.get("message", "")
@@ -405,6 +451,8 @@ class RichTerminalRenderer(TerminalRenderer):
         controls = Text.assemble(
             ("[A] ", "bold info"), "Approve  ",
             ("[B] ", "bold info"), "Bulk Approve  ",
+            ("[C] ", "bold warning"), "Remediate  ",
+            ("[F] ", "bold error"), "Fix  ",
             ("[R] ", "bold success"), "Ready  ",
             ("[P] ", "bold magenta"), "Patch  ",
             ("[I] ", "bold warning"), "Implement  ",

--- a/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
+++ b/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
@@ -2,9 +2,19 @@ from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
 
+from src.dopemux_pr_merge_specialist.action_model import (
+    dashboard_phase_for_snapshot,
+    dashboard_tactic_for_snapshot,
+)
+from src.dopemux_pr_merge_specialist.conflict import apply_suggestion_to_file
 from src.dopemux_pr_merge_specialist.dashboard import DopemuxDashboard, QueueState
 from src.dopemux_pr_merge_specialist.queue_drain import _ignite_speculative_train
-from src.dopemux_pr_merge_specialist.schema import PullRequestState, PRResult
+from src.dopemux_pr_merge_specialist.schema import (
+    PRResult,
+    PullRequestState,
+    ReviewThread,
+    ThreadComment,
+)
 
 
 def _pr_result(pr_id: int, *, lifecycle_state: str = "merge_ready") -> PRResult:
@@ -90,3 +100,74 @@ def test_speculative_train_rebases_against_origin_main_and_continues(monkeypatch
         ("wt-101", "branch-101"),
         ("wt-102", "branch-102"),
     ]
+
+
+def test_apply_suggestion_to_file_dry_run_returns_preview(tmp_path: Path) -> None:
+    target = tmp_path / "demo.py"
+    target.write_text("alpha\nbeta\n", encoding="utf-8")
+    thread = ReviewThread(
+        id="thread-1",
+        is_resolved=False,
+        is_outdated=False,
+        viewer_can_resolve=True,
+        path="demo.py",
+        line=2,
+        original_line=2,
+        comments=[],
+    )
+    comment = ThreadComment(
+        id="comment-1",
+        author="reviewer",
+        body="```suggestion\nbeta_updated\n```",
+        created_at="2024-01-01T00:00:00Z",
+        path="demo.py",
+        line=2,
+        original_line=2,
+    )
+
+    ok, reason, proposed_text = apply_suggestion_to_file(
+        worktree_path=tmp_path,
+        thread=thread,
+        comment=comment,
+        base_ref="main",
+        policy={},
+        dry_run=True,
+    )
+
+    assert ok is True
+    assert "Applied suggestion" in reason
+    assert proposed_text == "alpha\nbeta_updated\n"
+    assert target.read_text(encoding="utf-8") == "alpha\nbeta\n"
+
+
+def test_dashboard_tactic_distinguishes_validation_ci_and_threads() -> None:
+    base_snapshot = {
+        "allowed_actions": ["APPLY_FIX"],
+        "ci_status": "SUCCESS",
+        "unresolved_threads": 0,
+        "validation_report": {"status": "not_executed"},
+        "blockers": [],
+    }
+
+    validation_failed = dict(
+        base_snapshot,
+        validation_report={"status": "failed"},
+        blockers=[{"type": "validation_failed"}],
+    )
+    ci_failed = dict(
+        base_snapshot,
+        ci_status="FAILURE",
+        blockers=[{"type": "required_check_failed"}],
+    )
+    thread_blocked = dict(
+        base_snapshot,
+        unresolved_threads=2,
+        blockers=[{"type": "active_thread"}],
+    )
+
+    assert dashboard_tactic_for_snapshot(validation_failed) == "F"
+    assert dashboard_phase_for_snapshot(validation_failed) == "Validation Remediation"
+    assert dashboard_tactic_for_snapshot(ci_failed) == "C"
+    assert dashboard_phase_for_snapshot(ci_failed) == "CI Remediation"
+    assert dashboard_tactic_for_snapshot(thread_blocked) == "T"
+    assert dashboard_phase_for_snapshot(thread_blocked) == "Thread Review"


### PR DESCRIPTION
## Summary
- improve the PR-merge flight dashboard so thread review shows the comment plus proposed diff before approval
- distinguish thread review, CI remediation, validation remediation, and verification tactics in the dashboard
- surface queue ordering, active phase, and train progress in the cockpit while keeping queue ordering sourced from the existing ordering artifact
- restore the shared `contains_marker` helper and add focused unit coverage for dashboard/train behavior

## Why
The dashboard had visibility gaps around review comments, remediation progress, and autopilot state. This change makes operator actions and queue progress visible without inventing a new backend contract.

## Validation
- `ruff check src/dopemux_pr_merge_specialist/dashboard.py src/dopemux_pr_merge_specialist/ux_engine.py src/dopemux_pr_merge_specialist/conflict.py src/dopemux_pr_merge_specialist/metrics.py src/dopemux_pr_merge_specialist/cli.py src/dopemux_pr_merge_specialist/runtime.py src/dopemux_pr_merge_specialist/thread_resolution.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py`
- Python import smoke test for `runtime`, `thread_resolution`, `conflict`, `queue_drain`, and `dashboard`
- `pytest -q tests/unit/test_pr_merge_specialist_dashboard_and_train.py`

@codex 
@clauee
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated
