### PR TITLE
[codex] Harden PR-merge dashboard exit and metrics

### DIFF
--- a/src/dopemux_pr_merge_specialist/dashboard.py
+++ b/src/dopemux_pr_merge_specialist/dashboard.py
@@ -184,6 +184,23 @@ class DopemuxDashboard:
             return
         self.state.active_phase = dashboard_phase_for_snapshot(self.state.active_pr)
 
+    def _decode_input_choice(self, char: str) -> Optional[str]:
+        if char in {"\x03", "\x04"}:
+            return "Q"
+        if char == "\x1b":
+            if not self._input_fd:
+                return "Q"
+            rlist, _, _ = select.select([sys.stdin], [], [], 0.05)
+            if not rlist:
+                return "Q"
+            next_char = sys.stdin.read(2)
+            if next_char == "[A":
+                return "UP"
+            if next_char == "[B":
+                return "DOWN"
+            return "Q"
+        return char.upper()
+
     def _refresh_dashboard_result(self, pr_id: str) -> PRResult:
         repo_root = Path.cwd()
         policy = self.policy or load_effective_policy(
@@ -528,14 +545,7 @@ class DopemuxDashboard:
                     choice = None
                     if rlist:
                         char = sys.stdin.read(1)
-                        if char == "\x1b":
-                            next_char = sys.stdin.read(2)
-                            if next_char == "[A":
-                                choice = "UP"
-                            elif next_char == "[B":
-                                choice = "DOWN"
-                        else:
-                            choice = char.upper()
+                        choice = self._decode_input_choice(char)
                     elif self.state.auto_pilot:
                         ready_pr_ids = [
                             int(pr["pr_id"])

--- a/src/dopemux_pr_merge_specialist/metrics.py
+++ b/src/dopemux_pr_merge_specialist/metrics.py
@@ -3,6 +3,7 @@ import time
 from pathlib import Path
 from typing import Any, Dict
 
+from .action_model import enum_value
 from .schema import PRMergeReport
 
 
@@ -50,18 +51,26 @@ class MetricsEngine:
         resolved_threads: int = 0,
     ):
         """Log a merge event with expanded adoption and incident metadata."""
+        initial_state = report.initial_state
+        lifecycle_state = (
+            enum_value(getattr(initial_state, "lifecycle_state", ""))
+            if initial_state is not None
+            else ""
+        )
         event = {
             "timestamp": time.time(),
-            "run_id": report.run_id,
+            "run_id": str(report.telemetry.get("run_id", "")),
             "pr_id": report.pr_id,
             "status": report.status,
             "rollout_tier": rollout_tier,
             "mode": report.telemetry.get("mode", "advisory"),
             "duration_ms": duration_ms,
             "score": report.telemetry.get("score", 0.0),
-            "is_in_queue": report.initial_state.is_in_merge_queue,
-            "unresolved_threads": report.initial_state.unresolved_thread_count,
-            "ci_status": report.initial_state.ci_status,
+            "is_in_queue": lifecycle_state == "queued_for_merge",
+            "unresolved_threads": int(
+                getattr(initial_state, "unresolved_threads", 0) or 0
+            ),
+            "ci_status": getattr(initial_state, "ci_status", "UNKNOWN"),
             "conflict_class": report.telemetry.get("conflict_class", "UNKNOWN"),
             "blocker_count": len(report.blockers),
             "blocker_types": [b.type for b in report.blockers],

--- a/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
+++ b/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -8,8 +9,11 @@ from src.dopemux_pr_merge_specialist.action_model import (
 )
 from src.dopemux_pr_merge_specialist.conflict import apply_suggestion_to_file
 from src.dopemux_pr_merge_specialist.dashboard import DopemuxDashboard, QueueState
+from src.dopemux_pr_merge_specialist.metrics import MetricsEngine
 from src.dopemux_pr_merge_specialist.queue_drain import _ignite_speculative_train
 from src.dopemux_pr_merge_specialist.schema import (
+    PRMergeReport,
+    PRState,
     PRResult,
     PullRequestState,
     ReviewThread,
@@ -171,3 +175,51 @@ def test_dashboard_tactic_distinguishes_validation_ci_and_threads() -> None:
     assert dashboard_phase_for_snapshot(ci_failed) == "CI Remediation"
     assert dashboard_tactic_for_snapshot(thread_blocked) == "T"
     assert dashboard_phase_for_snapshot(thread_blocked) == "Thread Review"
+
+
+def test_metrics_log_event_accepts_dashboard_report_shape(tmp_path: Path) -> None:
+    engine = MetricsEngine(tmp_path)
+    pr = PullRequestState(
+        pr_id=7,
+        title="PR 7",
+        author="tester",
+        state="OPEN",
+        base_ref="main",
+        head_ref="feature-7",
+        ci_status="SUCCESS",
+        mergeable="MERGEABLE",
+        merge_state_status="CLEAN",
+        review_decision="APPROVED",
+        unresolved_threads=2,
+        lifecycle_state=PRState.QUEUED_FOR_MERGE,
+    )
+    report = PRMergeReport(
+        pr_id="7",
+        status="queued_for_merge",
+        initial_state=pr,
+        telemetry={"run_id": "run-7"},
+    )
+
+    engine.log_event(report=report, resolved_threads=3)
+
+    ledger = next(tmp_path.glob("events-*.jsonl"))
+    event = json.loads(ledger.read_text(encoding="utf-8").splitlines()[0])
+    assert event["run_id"] == "run-7"
+    assert event["is_in_queue"] is True
+    assert event["unresolved_threads"] == 2
+    assert event["resolved_threads_in_session"] == 3
+
+
+def test_dashboard_decode_input_choice_maps_exit_keys_to_quit(monkeypatch) -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+
+    assert dashboard._decode_input_choice("\x03") == "Q"
+    assert dashboard._decode_input_choice("\x04") == "Q"
+    assert dashboard._decode_input_choice("q") == "Q"
+
+    dashboard._input_fd = 1
+    monkeypatch.setattr(
+        "src.dopemux_pr_merge_specialist.dashboard.select.select",
+        lambda *_args, **_kwargs: ([], [], []),
+    )
+    assert dashboard._decode_input_choice("\x1b") == "Q"


### PR DESCRIPTION
## Summary
- fix the dashboard metrics logger so it accepts the actual `PRMergeReport` and `PullRequestState` shape produced by the flight dashboard
- add explicit live-loop exit handling for `q`, `Esc`, `Ctrl+C`, and `Ctrl+D`
- add focused regression coverage for the metrics logging path and the dashboard quit-key decoding

## Why
The follow-up merged dashboard change still had a runtime object mismatch in metrics logging, and the live dashboard needed a reliable explicit exit path when running in cbreak mode.

## Validation
- `ruff check src/dopemux_pr_merge_specialist/dashboard.py src/dopemux_pr_merge_specialist/metrics.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py`
- `pytest -q tests/unit/test_pr_merge_specialist_dashboard_and_train.py`
