### PR TITLE
feat(pr-merge): add strategy-aware autopilot and scoped validation

### DIFF
--- a/config/pr_merge_specialist/policy.yaml
+++ b/config/pr_merge_specialist/policy.yaml
@@ -14,19 +14,24 @@ validation:
   require_local_validation_for_merge_ready: true
   steps:
     - name: pre-commit
-      command: [pre-commit, run, --all-files]
+      command: [pre-commit, run]
+      scope: changed_files
       run_in_dry_run: false
     - name: docs-frontmatter-fix
       command: [python, scripts/docs_frontmatter_guard.py, --fix]
+      scope: docs_frontmatter_files
       run_in_dry_run: false
     - name: docs-validator
       command: [python, scripts/docs_validator.py]
+      scope: docs_validator_files
       run_in_dry_run: false
     - name: docs-hygiene
-      command: [python, scripts/check_docs_hygiene.py, --check, --all-files]
+      command: [python, scripts/check_docs_hygiene.py, --check]
+      scope: docs_validator_files
       run_in_dry_run: false
     - name: docs-filename-hygiene
-      command: [python, scripts/check_docs_filename_hygiene.py, --check, --all-files]
+      command: [python, scripts/check_docs_filename_hygiene.py, --check]
+      scope: docs_validator_files
       run_in_dry_run: false
     - name: root-hygiene
       command: [python, scripts/check_root_hygiene.py]

--- a/src/dopemux_pr_merge_specialist/config/policy.example.yaml
+++ b/src/dopemux_pr_merge_specialist/config/policy.example.yaml
@@ -14,19 +14,24 @@ validation:
   require_local_validation_for_merge_ready: true
   steps:
     - name: pre-commit
-      command: [pre-commit, run, --all-files]
+      command: [pre-commit, run]
+      scope: changed_files
       run_in_dry_run: false
     - name: docs-frontmatter-fix
       command: [python, scripts/docs_frontmatter_guard.py, --fix]
+      scope: docs_frontmatter_files
       run_in_dry_run: false
     - name: docs-validator
       command: [python, scripts/docs_validator.py]
+      scope: docs_validator_files
       run_in_dry_run: false
     - name: docs-hygiene
-      command: [python, scripts/check_docs_hygiene.py, --check, --all-files]
+      command: [python, scripts/check_docs_hygiene.py, --check]
+      scope: docs_validator_files
       run_in_dry_run: false
     - name: docs-filename-hygiene
-      command: [python, scripts/check_docs_filename_hygiene.py, --check, --all-files]
+      command: [python, scripts/check_docs_filename_hygiene.py, --check]
+      scope: docs_validator_files
       run_in_dry_run: false
     - name: root-hygiene
       command: [python, scripts/check_root_hygiene.py]

--- a/src/dopemux_pr_merge_specialist/dashboard.py
+++ b/src/dopemux_pr_merge_specialist/dashboard.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import difflib
+import json
 import select
 import sys
 import termios
@@ -31,6 +32,7 @@ from .metrics import MetricsEngine
 from .plan_builder import build_plan_result
 from .preflight import preflight
 from .schema import PRMergeReport, PRResult, ValidationReport, ValidationStatus
+from .strategy_library import STRATEGY_LIBRARY
 from .thread_resolution import latest_comment
 from .ux_engine import RenderMode, RichTerminalRenderer
 from .conflict import apply_suggestion_to_file
@@ -48,6 +50,7 @@ from .queue_drain import (
     pr_merge,
     pr_ready,
     prepare_worktree,
+    queue_scan_internal,
     stage_and_push_if_needed,
 )
 
@@ -68,6 +71,8 @@ class QueueState:
     queue_plan: Dict[str, Any] = field(default_factory=dict)
     active_phase: str = "Monitor"
     train_progress: Dict[str, Any] = field(default_factory=dict)
+    autopilot_strategy: str = ""
+    autopilot_stall_counts: Dict[str, int] = field(default_factory=dict)
 
     @property
     def active_pr(self) -> Optional[Dict[str, Any]]:
@@ -120,6 +125,7 @@ class DopemuxDashboard:
             "layers": [{"layer": 0, "pr_ids": ordered_ids}],
             "edges": {},
             "cycle_detected": False,
+            "strategy": getattr(self.args, "strategy", "hybrid"),
         }
 
     def _restore_terminal_mode(self) -> None:
@@ -183,6 +189,288 @@ class DopemuxDashboard:
         if self.state is None or self.state.active_pr is None:
             return
         self.state.active_phase = dashboard_phase_for_snapshot(self.state.active_pr)
+
+    def _load_ordering_plan(self) -> Dict[str, Any]:
+        _, queue_dir, _ = build_run_paths(self.args.out_dir, self.state.run_id)
+        ordering_plan_path = queue_dir / "ORDERING_PLAN.json"
+        if ordering_plan_path.exists():
+            return json.loads(ordering_plan_path.read_text(encoding="utf-8"))
+        return self._default_queue_plan(self.state.prs)
+
+    def _candidate_tactics_for_snapshot(self, snapshot: Dict[str, Any]) -> List[str]:
+        blockers = {
+            str(item.get("type") or item.get("finding_type") or "")
+            for item in snapshot.get("blockers", [])
+            if isinstance(item, dict)
+        }
+        tactics: List[str] = []
+        if bool(snapshot.get("is_draft")):
+            tactics.append("R")
+        if "approval_missing" in blockers:
+            tactics.append("A")
+        if "validation_failed" in blockers:
+            tactics.append("F")
+        if "required_check_failed" in blockers or str(
+            snapshot.get("ci_status", "")
+        ).upper() == "FAILURE":
+            tactics.append("C")
+        if (
+            int(snapshot.get("unresolved_threads", 0) or 0) > 0
+            or "active_thread" in blockers
+        ):
+            tactics.append("T")
+        if (
+            "conflict_detected" in blockers
+            or str(snapshot.get("mergeable", "")).upper() == "CONFLICTING"
+            or str(snapshot.get("merge_state_status", "")).upper() in {"DIRTY", "HAS_HOOKS"}
+        ):
+            tactics.append("P")
+        if blockers & {"validation_not_executed", "required_check_pending"}:
+            tactics.append("V")
+        allowed = set(snapshot.get("allowed_actions", []) or [])
+        if "APPLY_FIX" in allowed:
+            tactics.append("P")
+        if "MERGE" in allowed:
+            tactics.append("I")
+        if "READY" in allowed:
+            tactics.append("R")
+        if "APPROVE" in allowed:
+            tactics.append("A")
+        seen = set()
+        ordered = []
+        for tactic in tactics:
+            if tactic not in seen:
+                ordered.append(tactic)
+                seen.add(tactic)
+        return ordered
+
+    def _select_advanced_strategy(
+        self, snapshot: Dict[str, Any], *, queue_plan: Optional[Dict[str, Any]] = None
+    ) -> tuple[str, str, List[str]]:
+        blockers = {
+            str(item.get("type") or item.get("finding_type") or "")
+            for item in snapshot.get("blockers", [])
+            if isinstance(item, dict)
+        }
+        unresolved_threads = int(snapshot.get("unresolved_threads", 0) or 0)
+        ci_status = str(snapshot.get("ci_status", "")).upper()
+        validation_status = str(
+            (snapshot.get("validation_report") or {}).get("status", "")
+        ).lower()
+        mergeable = str(snapshot.get("mergeable", "")).upper()
+        merge_state_status = str(snapshot.get("merge_state_status", "")).upper()
+        layer = None
+        pr_id = int(snapshot.get("pr_id", 0) or 0)
+        plan = queue_plan or {}
+        for item in plan.get("layers", []):
+            pr_ids = {int(pid) for pid in item.get("pr_ids", []) if str(pid).isdigit()}
+            if pr_id in pr_ids:
+                layer = int(item.get("layer", 0) or 0)
+                break
+
+        if mergeable == "CONFLICTING" or merge_state_status in {"DIRTY", "HAS_HOOKS"}:
+            return (
+                "STAGED_SEQUENCE_MERGE",
+                "Conflict or branch divergence detected; use staged remediation before merge.",
+                ["P", "T", "V", "A", "I"],
+            )
+        if ci_status == "FAILURE" or "required_check_failed" in blockers or validation_status == "failed":
+            return (
+                "PATCH_ISOLATION_PLAN",
+                "Broken validation or CI should be isolated and repaired before broader actions.",
+                ["F", "C", "P", "V", "A", "I"],
+            )
+        if unresolved_threads > 0 or "active_thread" in blockers:
+            return (
+                "OURS_THEN_PORT_SELECTIVE",
+                "Reviewer deltas can be ported onto the current branch before verification.",
+                ["T", "P", "V", "A", "I"],
+            )
+        if layer is not None and layer > 0:
+            return (
+                "STAGED_SEQUENCE_MERGE",
+                "Stacked PR position requires ordered integration through queue layers.",
+                ["V", "A", "I"],
+            )
+        return (
+            "PATCH_ISOLATION_PLAN",
+            "Default to the smallest safe change set and verify before merge.",
+            ["V", "A", "I"],
+        )
+
+    def _decorate_snapshots_with_strategy(
+        self, pr_queue: List[Dict[str, Any]], queue_plan: Dict[str, Any]
+    ) -> List[Dict[str, Any]]:
+        decorated = []
+        for snapshot in pr_queue:
+            strategy_id, rationale, steps = self._select_advanced_strategy(
+                snapshot, queue_plan=queue_plan
+            )
+            strategy = STRATEGY_LIBRARY.get(strategy_id)
+            enriched = dict(snapshot)
+            enriched["advanced_strategy_id"] = strategy_id
+            enriched["advanced_strategy_name"] = (
+                strategy.name if strategy is not None else strategy_id
+            )
+            enriched["advanced_strategy_reason"] = rationale
+            enriched["advanced_strategy_steps"] = steps
+            decorated.append(enriched)
+        return decorated
+
+    def _autopilot_tactic_for_snapshot(self, snapshot: Dict[str, Any]) -> str:
+        steps = snapshot.get("advanced_strategy_steps") or []
+        candidates = set(self._candidate_tactics_for_snapshot(snapshot))
+        for tactic in steps:
+            if tactic in candidates:
+                return tactic
+        return dashboard_tactic_for_snapshot(snapshot)
+
+    def _set_queue_state(
+        self,
+        pr_queue: List[Dict[str, Any]],
+        ordering_plan: Dict[str, Any],
+        *,
+        preserve_pr_id: Optional[int] = None,
+        prefer_top: bool = False,
+    ) -> None:
+        queue_plan = dict(ordering_plan or self._default_queue_plan(pr_queue))
+        if self.state.autopilot_strategy:
+            queue_plan["autopilot_strategy"] = self.state.autopilot_strategy
+        self.state.queue_plan = queue_plan
+        self.state.prs = self._decorate_snapshots_with_strategy(pr_queue, queue_plan)
+        if not pr_queue:
+            self.state.active_index = 0
+        elif prefer_top:
+            self.state.active_index = 0
+        elif preserve_pr_id is not None:
+            for index, snapshot in enumerate(pr_queue):
+                if int(snapshot.get("pr_id", 0) or 0) == preserve_pr_id:
+                    self.state.active_index = index
+                    break
+            else:
+                self.state.active_index = 0
+        else:
+            self.state.active_index = 0
+        self._sync_active_phase()
+
+    def _choose_autopilot_strategy(self, pr_queue: List[Dict[str, Any]]) -> tuple[str, str]:
+        head_refs = {
+            str(pr.get("head_ref") or "")
+            for pr in pr_queue
+            if pr.get("head_ref")
+        }
+        has_stack = any(
+            str(pr.get("base_ref") or "") in head_refs
+            for pr in pr_queue
+            if pr.get("base_ref")
+        )
+        if len(pr_queue) <= 3 and not has_stack:
+            return (
+                "simple",
+                "small independent queue detected; prioritize direct sequencing.",
+            )
+        return (
+            "hybrid",
+            "stacked or larger queue detected; use DAG/WSEMT prioritization.",
+        )
+
+    def _refresh_queue_state(
+        self, *, strategy_override: Optional[str] = None, prefer_top: bool = False
+    ) -> bool:
+        repo_root = Path.cwd()
+        policy = self.policy or load_effective_policy(
+            repo_root, explicit_path=getattr(self.args, "policy", None)
+        )
+        client = self.manager
+        if not isinstance(client, GitHubClient):
+            client = GitHubClient(
+                repo=getattr(self.args, "repo", None),
+                repo_root=repo_root,
+                policy=policy,
+            )
+        scan_args = argparse.Namespace(**vars(self.args))
+        if strategy_override:
+            scan_args.strategy = strategy_override
+        preserve_pr_id = (
+            None if prefer_top or self.state.active_pr is None else int(self.state.active_pr.get("pr_id", 0) or 0)
+        )
+        results = queue_scan_internal(scan_args, client, policy, self.state.run_id)
+        pr_queue = [result_to_dashboard_entry(result) for result in results]
+        ordering_plan = self._load_ordering_plan()
+        ordering_plan["strategy"] = getattr(scan_args, "strategy", getattr(self.args, "strategy", "hybrid"))
+        self._set_queue_state(
+            pr_queue,
+            ordering_plan,
+            preserve_pr_id=preserve_pr_id,
+            prefer_top=prefer_top,
+        )
+        return bool(pr_queue)
+
+    def _engage_autopilot(self) -> None:
+        strategy, reason = self._choose_autopilot_strategy(self.state.prs)
+        self.state.autopilot_strategy = strategy
+        self.state.auto_pilot = True
+        self.state.active_phase = "Assessment"
+        self.log_step(
+            f"AUTOPILOT ASSESSMENT: selecting {strategy.upper()} queue strategy; {reason}",
+            "START",
+        )
+        has_queue = self._refresh_queue_state(strategy_override=strategy, prefer_top=True)
+        ordered_ids = self.state.queue_plan.get("ordered_pr_ids", [])
+        if has_queue and ordered_ids:
+            sequence = " -> ".join(f"#{pr_id}" for pr_id in ordered_ids[:5])
+            self.log_step(f"Autopilot sequence: {sequence}", "INFO")
+            if self.state.active_pr:
+                self.log_step(
+                    f"Autopilot strategy for PR #{self.state.active_pr.get('pr_id')}: {self.state.active_pr.get('advanced_strategy_name')}."
+                    f" {self.state.active_pr.get('advanced_strategy_reason')}",
+                    "INFO",
+                )
+        self.state.status_message = f"AUTO-PILOT: ENGAGED ({strategy.upper()})"
+
+    def _reassess_autopilot_after_action(
+        self, *, target_pr_id: str, initial_state: Any, initial_tactic: str
+    ) -> None:
+        strategy = self.state.autopilot_strategy or getattr(
+            self.args, "strategy", "hybrid"
+        )
+        self._refresh_queue_state(strategy_override=strategy, prefer_top=True)
+        active = self.state.active_pr
+        if not active:
+            self.state.status_message = "Autopilot: queue exhausted after reassessment."
+            return
+        active_pr_id = str(active.get("pr_id"))
+        new_state = active.get("lifecycle_state")
+        new_tactic = dashboard_tactic_for_snapshot(active)
+        if (
+            active_pr_id == str(target_pr_id)
+            and self.state.last_action_result == "ERROR"
+        ) or (
+            active_pr_id == str(target_pr_id)
+            and new_state == initial_state
+            and new_tactic == initial_tactic
+        ):
+            self.state.autopilot_stall_counts[active_pr_id] = (
+                self.state.autopilot_stall_counts.get(active_pr_id, 0) + 1
+            )
+            if len(self.state.prs) > 1:
+                self.state.active_index = (self.state.active_index + 1) % len(
+                    self.state.prs
+                )
+                self._sync_active_phase()
+                next_pr_id = self.state.active_pr.get("pr_id")
+                self.state.status_message = (
+                    f"Autopilot: PR #{target_pr_id} stalled under {initial_tactic}; advancing to PR #{next_pr_id}."
+                )
+            else:
+                self.state.status_message = (
+                    f"Autopilot: PR #{target_pr_id} remains blocked under {initial_tactic}."
+                )
+            return
+        self.state.autopilot_stall_counts.pop(str(target_pr_id), None)
+        self.state.status_message = (
+            f"Autopilot: reassessed queue using {strategy.upper()} strategy."
+        )
 
     def _decode_input_choice(self, char: str) -> Optional[str]:
         if char in {"\x03", "\x04"}:
@@ -585,20 +873,30 @@ class DopemuxDashboard:
                                 self.state.status_message = (
                                     f"🚂 Train integration successful. {len(train_merged)+len(train_queued)} PRs moving."
                                 )
+                                self._refresh_queue_state(
+                                    strategy_override=self.state.autopilot_strategy
+                                    or getattr(self.args, "strategy", "hybrid"),
+                                    prefer_top=True,
+                                )
                                 time.sleep(2)
                                 continue
 
                         active = self.state.active_pr
                         if active:
                             self.state.active_phase = dashboard_phase_for_snapshot(active)
-                            choice = dashboard_tactic_for_snapshot(active)
+                            choice = self._autopilot_tactic_for_snapshot(active)
 
                     if choice == "Q":
                         self.state.status_message = "Mission aborted by operator."
                         break
                     elif choice == "X":
-                        self.state.auto_pilot = not self.state.auto_pilot
-                        self.state.status_message = f"AUTO-PILOT: {'ENGAGED' if self.state.auto_pilot else 'DISENGAGED'}"
+                        if self.state.auto_pilot:
+                            self.state.auto_pilot = False
+                            self.state.autopilot_strategy = ""
+                            self.state.train_progress = {}
+                            self.state.status_message = "AUTO-PILOT: DISENGAGED"
+                        else:
+                            self._engage_autopilot()
                     elif choice == "B":
                         self.state.status_message = "ENGAGING BULK APPROVAL..."
                         live.update(self.render())
@@ -621,6 +919,7 @@ class DopemuxDashboard:
                     elif choice in ("A", "P", "I", "T", "V", "R", "C", "F"):
                         active_pr_id = str(self.state.active_pr.get('pr_id'))
                         initial_state = self.state.active_pr.get("lifecycle_state")
+                        initial_tactic = choice
                         
                         updated_pr = self._execute_tactic(choice, active_pr_id)
                         
@@ -630,14 +929,11 @@ class DopemuxDashboard:
                         
                         if self.state.auto_pilot:
                             time.sleep(3.0)
-                            
-                            new_state = updated_pr.get("lifecycle_state") if updated_pr else None
-                            if new_state and "MERGED" in str(new_state).upper():
-                                self.state.active_index = (self.state.active_index + 1) % len(self.state.prs)
-                                self.state.status_message = f"Integrated PR #{active_pr_id}. Advancing."
-                            elif self.state.last_action_result == "ERROR" or new_state == initial_state:
-                                self.state.active_index = (self.state.active_index + 1) % len(self.state.prs)
-                                self.state.status_message = f"PR #{active_pr_id} stalled. Advancing."
+                            self._reassess_autopilot_after_action(
+                                target_pr_id=active_pr_id,
+                                initial_state=initial_state,
+                                initial_tactic=initial_tactic,
+                            )
         finally:
             self._restore_terminal_mode()
 

--- a/src/dopemux_pr_merge_specialist/policy.py
+++ b/src/dopemux_pr_merge_specialist/policy.py
@@ -33,6 +33,12 @@ REQUIRED_TOP_LEVEL_KEYS = (
     "retry",
     "merge",
 )
+VALID_VALIDATION_SCOPES = {
+    "repo",
+    "changed_files",
+    "docs_frontmatter_files",
+    "docs_validator_files",
+}
 
 DEFAULT_POLICY: Dict[str, Any] = {
     "version": POLICY_SCHEMA_VERSION,
@@ -51,17 +57,20 @@ DEFAULT_POLICY: Dict[str, Any] = {
         "steps": [
             {
                 "name": "pre-commit",
-                "command": ["pre-commit", "run", "--all-files"],
+                "command": ["pre-commit", "run"],
+                "scope": "changed_files",
                 "run_in_dry_run": False,
             },
             {
                 "name": "docs-frontmatter-fix",
                 "command": ["python", "scripts/docs_frontmatter_guard.py", "--fix"],
+                "scope": "docs_frontmatter_files",
                 "run_in_dry_run": False,
             },
             {
                 "name": "docs-validator",
                 "command": ["python", "scripts/docs_validator.py"],
+                "scope": "docs_validator_files",
                 "run_in_dry_run": False,
             },
             {
@@ -70,8 +79,8 @@ DEFAULT_POLICY: Dict[str, Any] = {
                     "python",
                     "scripts/check_docs_hygiene.py",
                     "--check",
-                    "--all-files",
                 ],
+                "scope": "docs_validator_files",
                 "run_in_dry_run": False,
             },
             {
@@ -80,8 +89,8 @@ DEFAULT_POLICY: Dict[str, Any] = {
                     "python",
                     "scripts/check_docs_filename_hygiene.py",
                     "--check",
-                    "--all-files",
                 ],
+                "scope": "docs_validator_files",
                 "run_in_dry_run": False,
             },
             {
@@ -249,6 +258,12 @@ def _validate_command_steps(steps: Iterable[Dict[str, Any]], *, section: str) ->
         ):
             raise PolicyError(
                 f"{section}.steps[{index}] must define a non-empty string command list."
+            )
+        scope = step.get("scope", "repo")
+        if not isinstance(scope, str) or scope not in VALID_VALIDATION_SCOPES:
+            raise PolicyError(
+                f"{section}.steps[{index}] has invalid scope {scope!r}; "
+                f"expected one of {sorted(VALID_VALIDATION_SCOPES)}."
             )
 
 

--- a/src/dopemux_pr_merge_specialist/ux_engine.py
+++ b/src/dopemux_pr_merge_specialist/ux_engine.py
@@ -243,9 +243,26 @@ class RichTerminalRenderer(TerminalRenderer):
             next_ids = ordered_ids[queue_position:queue_position + 3]
             active_phase = getattr(state, "active_phase", "Monitor")
             train_progress = getattr(state, "train_progress", {}) or {}
+            ordering_strategy = (
+                queue_plan.get("autopilot_strategy")
+                or queue_plan.get("strategy")
+                or "hybrid"
+            )
+            advanced_strategy = str(
+                active.get("advanced_strategy_name")
+                or active.get("advanced_strategy_id")
+                or "UNSPECIFIED"
+            )
+            advanced_reason = str(active.get("advanced_strategy_reason") or "")
+            advanced_steps = list(active.get("advanced_strategy_steps") or [])
             intel_text.append(f"#{active.get('pr_id')} | ", style="mint")
             intel_text.append(f"{active.get('title', 'Unknown')[:60]}...\n", style="text")
             intel_text.append(f"PHASE    : {active_phase}\n", style="info")
+            intel_text.append(
+                f"ORDERING : {str(ordering_strategy).upper()}\n",
+                style="magenta",
+            )
+            intel_text.append(f"ADVANCED : {advanced_strategy}\n", style="magenta")
             intel_text.append(
                 f"QUEUE    : {queue_position}/{max(len(ordered_ids), len(state.prs))}",
                 style="text",
@@ -259,6 +276,16 @@ class RichTerminalRenderer(TerminalRenderer):
                 intel_text.append(
                     f"NEXT     : {' -> '.join(f'#{pr_id}' for pr_id in next_ids)}\n",
                     style="text.dim",
+                )
+            if advanced_reason:
+                intel_text.append(
+                    f"WHY      : {advanced_reason[:150]}\n",
+                    style="text.dim",
+                )
+            if advanced_steps:
+                intel_text.append(
+                    f"STEPS    : {' -> '.join(advanced_steps)}\n",
+                    style="info",
                 )
             intel_text.append(f"STRATEGY : {active.get('merge_strategy', 'MECHANICAL')}\n", style="magenta")
             intel_text.append(f"RATIONALE: {active.get('rationale', 'Standard rebase.')[:150]}...", style="text.dim")

--- a/src/dopemux_pr_merge_specialist/validation.py
+++ b/src/dopemux_pr_merge_specialist/validation.py
@@ -1,15 +1,97 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
-from .runtime import execute_or_dry_run, fingerprint_payload, shell_join
+from .runtime import (
+    append_command_log,
+    execute_or_dry_run,
+    fingerprint_payload,
+    run_command,
+    shell_join,
+)
 from .schema import (
     Fingerprint,
     ValidationReport,
     ValidationStatus,
     ValidationStepResult,
 )
+
+SCOPED_VALIDATION_SCOPES = {
+    "changed_files",
+    "docs_frontmatter_files",
+    "docs_validator_files",
+}
+
+
+def _unique_paths(paths: Sequence[str]) -> List[str]:
+    unique: Dict[str, None] = {}
+    for path in paths:
+        normalized = str(path).strip()
+        if normalized:
+            unique[normalized] = None
+    return sorted(unique)
+
+
+def _is_docs_frontmatter_candidate(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    if not normalized.endswith(".md"):
+        return False
+    if normalized.startswith(("docs/", "task-packets/", "UPGRADES/")):
+        return True
+    parts = normalized.split("/")
+    if len(parts) >= 3 and parts[0] in {"services", "docker"} and parts[2] == "docs":
+        return True
+    return False
+
+
+def _is_docs_validator_candidate(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    return normalized.endswith(".md") and normalized.startswith(
+        ("docs/", "task-packets/")
+    )
+
+
+def _resolve_step_files(scope: str, changed_files: Sequence[str]) -> Optional[List[str]]:
+    if scope == "changed_files":
+        return list(changed_files)
+    if scope == "docs_frontmatter_files":
+        return [path for path in changed_files if _is_docs_frontmatter_candidate(path)]
+    if scope == "docs_validator_files":
+        return [path for path in changed_files if _is_docs_validator_candidate(path)]
+    return None
+
+
+def _build_scoped_command(command: Sequence[str], scope_files: Sequence[str]) -> List[str]:
+    scoped = [str(part) for part in command]
+    if scoped[:2] == ["pre-commit", "run"] and "--files" not in scoped:
+        return [*scoped, "--files", *scope_files]
+    return [*scoped, *scope_files]
+
+
+def _collect_changed_files(
+    *,
+    cwd: Path,
+    base_sha: str,
+    commands_log: Path,
+    timeout_seconds: int,
+) -> List[str]:
+    collected: List[str] = []
+    commands = [
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_sha}...HEAD"],
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", "HEAD"],
+        ["git", "ls-files", "--others", "--exclude-standard"],
+    ]
+    for command in commands:
+        result = run_command(command, cwd=cwd, timeout_seconds=timeout_seconds)
+        append_command_log(commands_log, result)
+        if result.returncode != 0:
+            raise RuntimeError(
+                result.stderr.strip()
+                or f"Unable to resolve changed files for validation via {shell_join(command)}"
+            )
+        collected.extend(line.strip() for line in result.stdout.splitlines())
+    return _unique_paths(collected)
 
 
 def validation_fingerprint(
@@ -57,6 +139,9 @@ def run_validation(
 ) -> ValidationReport:
     target_cwd = worktree_path or repo_root
     steps_cfg = list(policy.get("validation", {}).get("steps", []))
+    timeout_seconds = int(
+        policy.get("timeouts", {}).get("subprocess_seconds", 600) or 600
+    )
     fingerprint = validation_fingerprint(
         pr_id=pr_id,
         head_sha=head_sha,
@@ -88,24 +173,73 @@ def run_validation(
 
     step_results: List[ValidationStepResult] = []
     remediation_applied = False
+    changed_files: Optional[List[str]] = None
+    if any(str(step.get("scope", "repo")) in SCOPED_VALIDATION_SCOPES for step in steps_cfg):
+        if progress_callback:
+            progress_callback("Resolving changed files for scoped validation", "INFO")
+        try:
+            changed_files = _collect_changed_files(
+                cwd=target_cwd,
+                base_sha=base_sha,
+                commands_log=commands_log,
+                timeout_seconds=timeout_seconds,
+            )
+        except RuntimeError as exc:
+            return ValidationReport(
+                status=ValidationStatus.FAILED,
+                required_for_merge_ready=bool(
+                    policy.get("validation", {}).get(
+                        "require_local_validation_for_merge_ready", True
+                    )
+                ),
+                steps=[
+                    ValidationStepResult(
+                        name="validation-scope-resolution",
+                        command="git diff --name-only",
+                        status="failed",
+                        returncode=1,
+                        stderr=str(exc),
+                    )
+                ],
+                attempts=1,
+                remediation_applied=False,
+                fingerprint=fingerprint,
+            )
+
     for step in steps_cfg:
         command = [str(part) for part in step.get("command", [])]
         name = str(step.get("name", "unnamed-step"))
-        
+        scope = str(step.get("scope", "repo"))
+        if scope in SCOPED_VALIDATION_SCOPES:
+            scoped_files = _resolve_step_files(scope, changed_files or [])
+            if not scoped_files:
+                if progress_callback:
+                    progress_callback(
+                        f"Skipping step: {name} (no files matched scope {scope})",
+                        "INFO",
+                    )
+                step_results.append(
+                    ValidationStepResult(
+                        name=name,
+                        command=shell_join(command),
+                        status="skipped",
+                    )
+                )
+                continue
+            command = _build_scoped_command(command, scoped_files)
+
         if progress_callback:
             progress_callback(f"Running step: {name}", "INFO")
-            
+
         result = execute_or_dry_run(
             command,
             execute=True,
             cwd=target_cwd,
             commands_log=commands_log,
-            timeout_seconds=int(
-                policy.get("timeouts", {}).get("subprocess_seconds", 600) or 600
-            ),
+            timeout_seconds=timeout_seconds,
         )
         status = "passed" if result.returncode == 0 else "failed"
-        
+
         if progress_callback:
             if status == "passed":
                 progress_callback(f"Step '{name}' PASSED", "SUCCESS")

--- a/tests/pr_merge_specialist/test_policy_and_validation.py
+++ b/tests/pr_merge_specialist/test_policy_and_validation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from dopemux_pr_merge_specialist.policy import PolicyError, load_effective_policy, policy_artifact_payload
+from dopemux_pr_merge_specialist.runtime import CommandResult
 from dopemux_pr_merge_specialist.schema import ValidationStatus
 from dopemux_pr_merge_specialist.validation import run_validation
 
@@ -48,3 +49,154 @@ def test_validation_dry_run_is_not_executed(tmp_path: Path):
     assert report.passed is False
     assert report.steps
     assert all(step.status == "planned" for step in report.steps)
+
+
+def test_validation_scopes_commands_to_changed_pr_files(monkeypatch, tmp_path: Path):
+    recorded_commands = []
+
+    def fake_run_command(cmd, *, cwd=None, env=None, timeout_seconds=600):
+        command = list(cmd)
+        if command[:4] == ["git", "diff", "--name-only", "--diff-filter=ACMR"]:
+            if command[-1].endswith("...HEAD"):
+                return CommandResult(
+                    command,
+                    0,
+                    "src/app.py\ndocs/02-how-to/guide.md\ntask-packets/packet.md\n",
+                    "",
+                )
+            return CommandResult(command, 0, "src/local-only.py\n", "")
+        if command[:4] == ["git", "ls-files", "--others", "--exclude-standard"]:
+            return CommandResult(command, 0, "notes.tmp\n", "")
+        raise AssertionError(f"Unexpected helper command: {command}")
+
+    def fake_execute_or_dry_run(
+        cmd, *, execute, cwd, commands_log, timeout_seconds=600
+    ):
+        recorded_commands.append(list(cmd))
+        return CommandResult(list(cmd), 0, "", "")
+
+    monkeypatch.setattr(
+        "dopemux_pr_merge_specialist.validation.run_command", fake_run_command
+    )
+    monkeypatch.setattr(
+        "dopemux_pr_merge_specialist.validation.execute_or_dry_run",
+        fake_execute_or_dry_run,
+    )
+
+    policy = {
+        "timeouts": {"subprocess_seconds": 30},
+        "validation": {
+            "require_local_validation_for_merge_ready": True,
+            "steps": [
+                {"name": "pre-commit", "command": ["pre-commit", "run"], "scope": "changed_files"},
+                {
+                    "name": "docs-frontmatter-fix",
+                    "command": ["python", "scripts/docs_frontmatter_guard.py", "--fix"],
+                    "scope": "docs_frontmatter_files",
+                },
+                {
+                    "name": "docs-validator",
+                    "command": ["python", "scripts/docs_validator.py"],
+                    "scope": "docs_validator_files",
+                },
+            ],
+        },
+    }
+
+    report = run_validation(
+        repo_root=REPO_ROOT,
+        worktree_path=tmp_path,
+        policy=policy,
+        execute=True,
+        commands_log=tmp_path / "commands.txt",
+        pr_id=1,
+        head_sha="headsha",
+        base_sha="basesha",
+        policy_fingerprint="fingerprint",
+        lifecycle_state="planned",
+    )
+
+    assert report.status == ValidationStatus.PASSED
+    assert recorded_commands == [
+        [
+            "pre-commit",
+            "run",
+            "--files",
+            "docs/02-how-to/guide.md",
+            "notes.tmp",
+            "src/app.py",
+            "src/local-only.py",
+            "task-packets/packet.md",
+        ],
+        [
+            "python",
+            "scripts/docs_frontmatter_guard.py",
+            "--fix",
+            "docs/02-how-to/guide.md",
+            "task-packets/packet.md",
+        ],
+        [
+            "python",
+            "scripts/docs_validator.py",
+            "docs/02-how-to/guide.md",
+            "task-packets/packet.md",
+        ],
+    ]
+
+
+def test_validation_skips_docs_steps_when_no_docs_changed(monkeypatch, tmp_path: Path):
+    recorded_commands = []
+
+    def fake_run_command(cmd, *, cwd=None, env=None, timeout_seconds=600):
+        command = list(cmd)
+        if command[:4] == ["git", "diff", "--name-only", "--diff-filter=ACMR"]:
+            return CommandResult(command, 0, "src/app.py\n", "")
+        if command[:4] == ["git", "ls-files", "--others", "--exclude-standard"]:
+            return CommandResult(command, 0, "", "")
+        raise AssertionError(f"Unexpected helper command: {command}")
+
+    def fake_execute_or_dry_run(
+        cmd, *, execute, cwd, commands_log, timeout_seconds=600
+    ):
+        recorded_commands.append(list(cmd))
+        return CommandResult(list(cmd), 0, "", "")
+
+    monkeypatch.setattr(
+        "dopemux_pr_merge_specialist.validation.run_command", fake_run_command
+    )
+    monkeypatch.setattr(
+        "dopemux_pr_merge_specialist.validation.execute_or_dry_run",
+        fake_execute_or_dry_run,
+    )
+
+    policy = {
+        "timeouts": {"subprocess_seconds": 30},
+        "validation": {
+            "require_local_validation_for_merge_ready": True,
+            "steps": [
+                {"name": "pre-commit", "command": ["pre-commit", "run"], "scope": "changed_files"},
+                {
+                    "name": "docs-validator",
+                    "command": ["python", "scripts/docs_validator.py"],
+                    "scope": "docs_validator_files",
+                },
+            ],
+        },
+    }
+
+    report = run_validation(
+        repo_root=REPO_ROOT,
+        worktree_path=tmp_path,
+        policy=policy,
+        execute=True,
+        commands_log=tmp_path / "commands.txt",
+        pr_id=1,
+        head_sha="headsha",
+        base_sha="basesha",
+        policy_fingerprint="fingerprint",
+        lifecycle_state="planned",
+    )
+
+    assert report.status == ValidationStatus.PASSED
+    assert recorded_commands == [["pre-commit", "run", "--files", "src/app.py"]]
+    assert [step.status for step in report.steps] == ["passed", "skipped"]

--- a/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
+++ b/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
@@ -223,3 +223,115 @@ def test_dashboard_decode_input_choice_maps_exit_keys_to_quit(monkeypatch) -> No
         lambda *_args, **_kwargs: ([], [], []),
     )
     assert dashboard._decode_input_choice("\x1b") == "Q"
+
+
+def test_choose_autopilot_strategy_prefers_simple_for_small_independent_queue() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    strategy, reason = dashboard._choose_autopilot_strategy(
+        [
+            {"pr_id": 1, "head_ref": "feature-1", "base_ref": "main"},
+            {"pr_id": 2, "head_ref": "feature-2", "base_ref": "main"},
+        ]
+    )
+
+    assert strategy == "simple"
+    assert "small independent queue" in reason
+
+
+def test_choose_autopilot_strategy_prefers_hybrid_for_stack() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    strategy, reason = dashboard._choose_autopilot_strategy(
+        [
+            {"pr_id": 1, "head_ref": "feature-1", "base_ref": "main"},
+            {"pr_id": 2, "head_ref": "feature-2", "base_ref": "feature-1"},
+        ]
+    )
+
+    assert strategy == "hybrid"
+    assert "stacked or larger queue" in reason
+
+
+def test_autopilot_reassess_advances_after_stalled_pr(monkeypatch) -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    dashboard.state = QueueState(
+        run_id="run",
+        prs=[
+            {"pr_id": 101, "lifecycle_state": "apply_ready", "allowed_actions": ["APPLY_FIX"], "validation_report": {"status": "not_executed"}, "ci_status": "SUCCESS", "unresolved_threads": 0, "blockers": []},
+            {"pr_id": 102, "lifecycle_state": "merge_ready", "allowed_actions": ["MERGE"], "validation_report": {"status": "passed"}, "ci_status": "SUCCESS", "unresolved_threads": 0, "blockers": []},
+        ],
+        autopilot_strategy="hybrid",
+    )
+
+    def fake_refresh_queue_state(*, strategy_override=None, prefer_top=False):
+        assert strategy_override == "hybrid"
+        assert prefer_top is True
+        return True
+
+    monkeypatch.setattr(dashboard, "_refresh_queue_state", fake_refresh_queue_state)
+    dashboard.state.last_action_result = "apply_ready"
+
+    dashboard._reassess_autopilot_after_action(
+        target_pr_id="101",
+        initial_state="apply_ready",
+        initial_tactic="P",
+    )
+
+    assert dashboard.state.active_index == 1
+    assert "stalled" in dashboard.state.status_message
+
+
+def test_select_advanced_strategy_prefers_patch_isolation_for_failed_ci() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    strategy_id, rationale, steps = dashboard._select_advanced_strategy(
+        {
+            "pr_id": 201,
+            "ci_status": "FAILURE",
+            "validation_report": {"status": "passed"},
+            "blockers": [{"type": "required_check_failed"}],
+            "mergeable": "MERGEABLE",
+            "merge_state_status": "CLEAN",
+            "unresolved_threads": 0,
+        }
+    )
+
+    assert strategy_id == "PATCH_ISOLATION_PLAN"
+    assert "Broken validation or CI" in rationale
+    assert steps[0] in {"F", "C"}
+
+
+def test_select_advanced_strategy_prefers_ours_then_port_for_threads() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    strategy_id, rationale, steps = dashboard._select_advanced_strategy(
+        {
+            "pr_id": 202,
+            "ci_status": "SUCCESS",
+            "validation_report": {"status": "not_executed"},
+            "blockers": [{"type": "active_thread"}],
+            "mergeable": "MERGEABLE",
+            "merge_state_status": "CLEAN",
+            "unresolved_threads": 2,
+        }
+    )
+
+    assert strategy_id == "OURS_THEN_PORT_SELECTIVE"
+    assert "Reviewer deltas" in rationale
+    assert steps[0] == "T"
+
+
+def test_autopilot_tactic_prefers_strategy_order_over_generic_choice() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    snapshot = {
+        "allowed_actions": ["APPLY_FIX"],
+        "ci_status": "FAILURE",
+        "validation_report": {"status": "failed"},
+        "unresolved_threads": 2,
+        "blockers": [
+            {"type": "validation_failed"},
+            {"type": "required_check_failed"},
+            {"type": "active_thread"},
+        ],
+        "advanced_strategy_id": "PATCH_ISOLATION_PLAN",
+        "advanced_strategy_steps": ["F", "C", "T", "V", "I"],
+    }
+
+    assert dashboard._autopilot_tactic_for_snapshot(snapshot) == "F"


### PR DESCRIPTION
## Summary
- reassess and reorder the queue when autopilot engages and after each action
- surface advanced merge strategy, rationale, and planned step sequence in the flight dashboard
- scope PR-merge validation to the active PR/worktree file set instead of running repo-wide pre-commit and docs checks

## Validation
- `ruff check src/dopemux_pr_merge_specialist/dashboard.py src/dopemux_pr_merge_specialist/ux_engine.py src/dopemux_pr_merge_specialist/validation.py src/dopemux_pr_merge_specialist/policy.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py tests/pr_merge_specialist/test_policy_and_validation.py`
- `pytest -q tests/unit/test_pr_merge_specialist_dashboard_and_train.py tests/pr_merge_specialist/test_policy_and_validation.py`
- `pre-commit run --files $(git diff --name-only ...)`

## Notes
- docs-facing validation policy and bundled example policy were both updated to match the new scoped validation contract
- no broad repo-wide pre-commit run was used for this PR because the change is specifically to stop unrelated whole-repo docs debt from blocking PR-merge remediation

@codex
@clauee
@copilot