### PR TITLE
fix(pr-merge): report dashboard mission exits truthfully

### DIFF
--- a/src/dopemux_pr_merge_specialist/dashboard.py
+++ b/src/dopemux_pr_merge_specialist/dashboard.py
@@ -73,6 +73,8 @@ class QueueState:
     train_progress: Dict[str, Any] = field(default_factory=dict)
     autopilot_strategy: str = ""
     autopilot_stall_counts: Dict[str, int] = field(default_factory=dict)
+    exit_outcome: str = "running"
+    exit_reason: str = ""
 
     @property
     def active_pr(self) -> Optional[Dict[str, Any]]:
@@ -117,6 +119,39 @@ class DopemuxDashboard:
         })
         if self._live:
             self._live.update(self.render())
+
+    def _set_exit_state(self, outcome: str, reason: str) -> None:
+        if not self.state:
+            return
+        self.state.exit_outcome = outcome
+        self.state.exit_reason = reason
+        self.state.status_message = reason
+
+    def _mission_banner(self) -> tuple[str, str]:
+        if not self.state:
+            return ("MISSION ENDED. NO DASHBOARD STATE AVAILABLE.", "yellow")
+
+        outcome = str(self.state.exit_outcome or "running")
+        reason = str(self.state.exit_reason or self.state.status_message or "").strip()
+        if outcome == "complete":
+            return (
+                "MISSION COMPLETE. FLIGHT DATA SAVED TO PROOF BUNDLE.",
+                "green",
+            )
+        if outcome == "aborted":
+            return (
+                f"MISSION ABORTED. {reason or 'Operator ended the session.'} FLIGHT DATA SAVED TO PROOF BUNDLE.",
+                "yellow",
+            )
+        if outcome == "detached":
+            return (
+                f"MISSION ENDED EARLY. {reason or 'Interactive input was unavailable.'} FLIGHT DATA SAVED TO PROOF BUNDLE.",
+                "yellow",
+            )
+        return (
+            f"MISSION ENDED WITHOUT COMPLETION. {reason or 'Queue processing stopped before merge completion.'} FLIGHT DATA SAVED TO PROOF BUNDLE.",
+            "yellow",
+        )
 
     def _default_queue_plan(self, pr_queue: List[Dict[str, Any]]) -> Dict[str, Any]:
         ordered_ids = [int(pr.get("pr_id")) for pr in pr_queue if pr.get("pr_id") is not None]
@@ -825,6 +860,10 @@ class DopemuxDashboard:
                 while True:
                     live.update(self.render())
                     if self._terminal_settings is None:
+                        self._set_exit_state(
+                            "detached",
+                            "Interactive input is unavailable; dashboard exited before queue completion.",
+                        )
                         break
 
                     timeout = 0.5 if not self.state.auto_pilot else 2.5
@@ -887,7 +926,7 @@ class DopemuxDashboard:
                             choice = self._autopilot_tactic_for_snapshot(active)
 
                     if choice == "Q":
-                        self.state.status_message = "Mission aborted by operator."
+                        self._set_exit_state("aborted", "Mission aborted by operator.")
                         break
                     elif choice == "X":
                         if self.state.auto_pilot:
@@ -937,4 +976,5 @@ class DopemuxDashboard:
         finally:
             self._restore_terminal_mode()
 
-        self.console.print("\n[bold green]MISSION COMPLETE. FLIGHT DATA SAVED TO PROOF BUNDLE. 🛰️[/bold green]")
+        banner, color = self._mission_banner()
+        self.console.print(f"\n[bold {color}]{banner}[/bold {color}]")

--- a/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
+++ b/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
@@ -335,3 +335,30 @@ def test_autopilot_tactic_prefers_strategy_order_over_generic_choice() -> None:
     }
 
     assert dashboard._autopilot_tactic_for_snapshot(snapshot) == "F"
+
+
+def test_mission_banner_reports_abort_truthfully() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    dashboard.state = QueueState(run_id="run", prs=[])
+    dashboard._set_exit_state("aborted", "Mission aborted by operator.")
+
+    banner, color = dashboard._mission_banner()
+
+    assert "MISSION ABORTED" in banner
+    assert "Mission aborted by operator." in banner
+    assert color == "yellow"
+
+
+def test_mission_banner_reports_detached_exit_truthfully() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    dashboard.state = QueueState(run_id="run", prs=[])
+    dashboard._set_exit_state(
+        "detached",
+        "Interactive input is unavailable; dashboard exited before queue completion.",
+    )
+
+    banner, color = dashboard._mission_banner()
+
+    assert "MISSION ENDED EARLY" in banner
+    assert "Interactive input is unavailable" in banner
+    assert color == "yellow"


### PR DESCRIPTION
## Summary
- report dashboard exits truthfully instead of always printing a false mission-complete banner
- mark the non-interactive exit path as an early end instead of a successful queue completion
- add focused unit coverage for truthful exit banners

## Validation
- `ruff check src/dopemux_pr_merge_specialist/dashboard.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py`
- `pytest -q tests/unit/test_pr_merge_specialist_dashboard_and_train.py`

@codex
@clauee
@copilot