### PR TITLE
fix(pr-merge): keep arrow navigation inside dashboard

### DIFF
--- a/src/dopemux_pr_merge_specialist/dashboard.py
+++ b/src/dopemux_pr_merge_specialist/dashboard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import difflib
 import json
+import os
 import select
 import sys
 import termios
@@ -511,15 +512,22 @@ class DopemuxDashboard:
         if char in {"\x03", "\x04"}:
             return "Q"
         if char == "\x1b":
-            if not self._input_fd:
+            if self._input_fd is None:
                 return "Q"
-            rlist, _, _ = select.select([sys.stdin], [], [], 0.05)
+            rlist, _, _ = select.select([self._input_fd], [], [], 0.15)
             if not rlist:
                 return "Q"
-            next_char = sys.stdin.read(2)
-            if next_char == "[A":
+            suffix = ""
+            for _ in range(2):
+                rlist, _, _ = select.select([self._input_fd], [], [], 0.05)
+                if not rlist:
+                    break
+                suffix += os.read(self._input_fd, 1).decode("utf-8", errors="ignore")
+                if len(suffix) >= 2:
+                    break
+            if suffix == "[A":
                 return "UP"
-            if next_char == "[B":
+            if suffix == "[B":
                 return "DOWN"
             return "Q"
         return char.upper()

--- a/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
+++ b/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
@@ -225,6 +225,31 @@ def test_dashboard_decode_input_choice_maps_exit_keys_to_quit(monkeypatch) -> No
     assert dashboard._decode_input_choice("\x1b") == "Q"
 
 
+def test_dashboard_decode_input_choice_maps_down_arrow(monkeypatch) -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    dashboard._input_fd = 1
+
+    select_calls = iter(
+        [
+            ([1], [], []),
+            ([1], [], []),
+            ([1], [], []),
+        ]
+    )
+    reads = iter([b"[", b"B"])
+
+    monkeypatch.setattr(
+        "src.dopemux_pr_merge_specialist.dashboard.select.select",
+        lambda *_args, **_kwargs: next(select_calls),
+    )
+    monkeypatch.setattr(
+        "src.dopemux_pr_merge_specialist.dashboard.os.read",
+        lambda *_args, **_kwargs: next(reads),
+    )
+
+    assert dashboard._decode_input_choice("\x1b") == "DOWN"
+
+
 def test_choose_autopilot_strategy_prefers_simple_for_small_independent_queue() -> None:
     dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
     strategy, reason = dashboard._choose_autopilot_strategy(


### PR DESCRIPTION
## Summary
- fix dashboard arrow-key decoding so down-arrow moves between PRs instead of exiting
- make escape-sequence parsing read from the tty fd instead of falling through the bare-escape quit path
- add focused unit coverage for down-arrow decoding

## Validation
- `ruff check src/dopemux_pr_merge_specialist/dashboard.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py`
- `pytest -q tests/unit/test_pr_merge_specialist_dashboard_and_train.py`

@codex
@clauee
@copilot