### PR TITLE
fix(pr-merge): stop looping blocked conflicts

### DIFF
--- a/src/dopemux_pr_merge_specialist/dashboard.py
+++ b/src/dopemux_pr_merge_specialist/dashboard.py
@@ -239,6 +239,11 @@ class DopemuxDashboard:
             for item in snapshot.get("blockers", [])
             if isinstance(item, dict)
         }
+        operator_state = str(snapshot.get("operator_state", "") or "")
+        conflict_blocked = (
+            bool(blockers & {"manual_conflict_required", "semantic_conflict_blocked"})
+            or operator_state in {"manual_conflict_required", "semantic_conflict_blocked"}
+        )
         tactics: List[str] = []
         if bool(snapshot.get("is_draft")):
             tactics.append("R")
@@ -259,7 +264,7 @@ class DopemuxDashboard:
             "conflict_detected" in blockers
             or str(snapshot.get("mergeable", "")).upper() == "CONFLICTING"
             or str(snapshot.get("merge_state_status", "")).upper() in {"DIRTY", "HAS_HOOKS"}
-        ):
+        ) and not conflict_blocked:
             tactics.append("P")
         if blockers & {"validation_not_executed", "required_check_pending"}:
             tactics.append("V")
@@ -295,6 +300,7 @@ class DopemuxDashboard:
         ).lower()
         mergeable = str(snapshot.get("mergeable", "")).upper()
         merge_state_status = str(snapshot.get("merge_state_status", "")).upper()
+        operator_state = str(snapshot.get("operator_state", "") or "")
         layer = None
         pr_id = int(snapshot.get("pr_id", 0) or 0)
         plan = queue_plan or {}
@@ -304,6 +310,24 @@ class DopemuxDashboard:
                 layer = int(item.get("layer", 0) or 0)
                 break
 
+        if (
+            "semantic_conflict_blocked" in blockers
+            or operator_state == "semantic_conflict_blocked"
+        ):
+            return (
+                "SPLIT_DECISION_REQUIRED",
+                "Conflict surface is explicitly marked semantic; skip autopilot patching and require human resolution.",
+                ["S"],
+            )
+        if (
+            "manual_conflict_required" in blockers
+            or operator_state == "manual_conflict_required"
+        ):
+            return (
+                "SPLIT_DECISION_REQUIRED",
+                "Conflict auto-recovery requires explicit opt-in before patching can run safely.",
+                ["S"],
+            )
         if mergeable == "CONFLICTING" or merge_state_status in {"DIRTY", "HAS_HOOKS"}:
             return (
                 "STAGED_SEQUENCE_MERGE",
@@ -477,7 +501,7 @@ class DopemuxDashboard:
             return
         active_pr_id = str(active.get("pr_id"))
         new_state = active.get("lifecycle_state")
-        new_tactic = dashboard_tactic_for_snapshot(active)
+        new_tactic = self._autopilot_tactic_for_snapshot(active)
         if (
             active_pr_id == str(target_pr_id)
             and self.state.last_action_result == "ERROR"

--- a/src/dopemux_pr_merge_specialist/queue.py
+++ b/src/dopemux_pr_merge_specialist/queue.py
@@ -25,6 +25,7 @@ from .classification import (
     lifecycle_for_findings,
     risk_score,
 )
+from .conflict import conflict_recovery_state
 from .github_api import (
     BOT_AUTHORS,
     GitHubClient,
@@ -156,13 +157,28 @@ def release_queue_lock(lock_path: Optional[Path]) -> None:
         lock_path.unlink()
 
 
-def priority_key(pr: PullRequestState, policy: Optional[Dict[str, Any]] = None) -> Tuple[int, float, int, str, int]:
+def priority_key(
+    pr: PullRequestState, policy: Optional[Dict[str, Any]] = None
+) -> Tuple[int, int, float, int, str, int]:
     from .scoring import AdvancedQueueScorer
     scorer = AdvancedQueueScorer(policy=policy)
-    
+
     wsemt_score = scorer.calculate_wsemt_score(pr)
-    
+    automation_tier = 1
+    if has_conflicts(pr.mergeable, pr.merge_state_status):
+        recovery_state = conflict_recovery_state(pr, policy or {})
+        if recovery_state == "eligible":
+            automation_tier = 0
+            wsemt_score += 25.0
+        elif recovery_state in {
+            "manual_conflict_required",
+            "semantic_conflict_blocked",
+        }:
+            automation_tier = 2
+            wsemt_score -= 250.0
+
     return (
+        automation_tier,
         CLASS_PRIORITY.get(pr.pr_class, 99),
         -wsemt_score, # Higher score = better priority
         pr.diff_size,

--- a/src/dopemux_pr_merge_specialist/ux_engine.py
+++ b/src/dopemux_pr_merge_specialist/ux_engine.py
@@ -321,10 +321,11 @@ class RichTerminalRenderer(TerminalRenderer):
                 for item in blockers
                 if isinstance(item, dict)
             }
+            operator_state = str(active.get("operator_state", "") or "")
             approval_blocked = blocker_types == {"approval_missing"}
             validation_only_blocked = bool(blocker_types) and blocker_types <= VALIDATION_BLOCKER_TYPES
             queued_for_merge = (
-                str(active.get("operator_state", "")) == "queued_for_merge"
+                operator_state == "queued_for_merge"
                 or str(active.get("lifecycle_state", "")).upper() == "QUEUED_FOR_MERGE"
             )
             
@@ -376,8 +377,12 @@ class RichTerminalRenderer(TerminalRenderer):
             if other_blockers:
                 blocker_text.append("\n⚠️ Other Blockers:\n", style="warning")
                 for b in other_blockers[:2]:
-                    b_name = b.get('name', b.get('type', 'Blocker'))
-                    blocker_text.append(f"  • {b_name[:40]}\n", style="error")
+                    label = (
+                        str(b.get("message") or "")
+                        or str(b.get("name") or "")
+                        or str(b.get("type") or "Blocker")
+                    )
+                    blocker_text.append(f"  • {label}\n", style="error")
 
             if history:
                 blocker_text.append("\n📜 MISSION HISTORY:\n", style="bold info")
@@ -418,12 +423,35 @@ class RichTerminalRenderer(TerminalRenderer):
             if not execution_log:
                 lc_state = str(active.get("lifecycle_state", "discovered")).upper()
                 obj_text = Text()
+                conflict_blocked = (
+                    operator_state == "manual_conflict_required"
+                    or "manual_conflict_required" in blocker_types
+                )
+                semantic_conflict = (
+                    operator_state == "semantic_conflict_blocked"
+                    or "semantic_conflict_blocked" in blocker_types
+                )
+                conflict_eligible = (
+                    not conflict_blocked
+                    and not semantic_conflict
+                    and (
+                        "conflict_detected" in blocker_types
+                        or mergeable == "CONFLICTING"
+                        or state_status in ("DIRTY", "HAS_HOOKS")
+                    )
+                )
                 if is_draft:
                     obj_text.append("🎯 OBJECTIVE: Transition PR out of DRAFT mode.\n", style="bold warning")
                     obj_text.append("NEXT STEP: Press [R] to mark as READY FOR REVIEW.", style="text")
                 elif queued_for_merge:
                     obj_text.append("🎯 OBJECTIVE: Wait for GitHub to complete queued auto-merge.\n", style="bold info")
                     obj_text.append("NEXT STEP: No local verification needed here; monitor checks/queue state.", style="text")
+                elif semantic_conflict:
+                    obj_text.append("🎯 OBJECTIVE: Defer semantic conflict to human review.\n", style="bold error")
+                    obj_text.append("NEXT STEP: Resolve manually or remove the `conflict:semantic` label only after confirming the conflict is mechanically safe.", style="text")
+                elif conflict_blocked:
+                    obj_text.append("🎯 OBJECTIVE: Decide whether conflict recovery is safe.\n", style="bold error")
+                    obj_text.append("NEXT STEP: Add `conflict:mechanical` only for safe docs/tests/lockfile conflicts, otherwise resolve manually.", style="text")
                 elif approval_blocked:
                     obj_text.append("🎯 OBJECTIVE: Satisfy the missing approval gate.\n", style="bold magenta")
                     obj_text.append("NEXT STEP: Press [A] to approve. Auto-merge should proceed after approval if all other gates stay green.", style="text")
@@ -437,6 +465,9 @@ class RichTerminalRenderer(TerminalRenderer):
                 elif ci == "FAILURE":
                     obj_text.append("🎯 OBJECTIVE: Remediate broken CI checks.\n", style="bold error")
                     obj_text.append("NEXT STEP: Press [C] to invoke CI Remediation via specialist agent.", style="text")
+                elif conflict_eligible:
+                    obj_text.append("🎯 OBJECTIVE: Attempt mechanical conflict recovery.\n", style="bold error")
+                    obj_text.append("NEXT STEP: Press [P] to try the safe conflict-recovery path, then re-verify queue state.", style="text")
                 elif "READY" in lc_state:
                     obj_text.append("🎯 OBJECTIVE: Final sign-off and integration.\n", style="bold success")
                     obj_text.append("NEXT STEP: Press [A] to Approve or [I] to Implement Merge.", style="text")

--- a/tests/pr_merge_specialist/test_ordering_and_classification.py
+++ b/tests/pr_merge_specialist/test_ordering_and_classification.py
@@ -6,7 +6,18 @@ from dopemux_pr_merge_specialist import engine
 from dopemux_pr_merge_specialist.schema import Finding, FindingSeverity, PRState, PullRequestState, ValidationStatus
 
 
-def _state(pr_id: int, *, base: str, head: str, pr_class: str, risk: float, diff: int) -> PullRequestState:
+def _state(
+    pr_id: int,
+    *,
+    base: str,
+    head: str,
+    pr_class: str,
+    risk: float,
+    diff: int,
+    labels: list[str] | None = None,
+    mergeable: str = "MERGEABLE",
+    merge_state_status: str = "CLEAN",
+) -> PullRequestState:
     return PullRequestState(
         pr_id=pr_id,
         title=f"PR {pr_id}",
@@ -15,8 +26,8 @@ def _state(pr_id: int, *, base: str, head: str, pr_class: str, risk: float, diff
         base_ref=base,
         head_ref=head,
         ci_status="SUCCESS",
-        mergeable="MERGEABLE",
-        merge_state_status="CLEAN",
+        mergeable=mergeable,
+        merge_state_status=merge_state_status,
         review_decision="APPROVED",
         updated_at="2026-03-12T00:00:00Z",
         additions=diff,
@@ -30,6 +41,7 @@ def _state(pr_id: int, *, base: str, head: str, pr_class: str, risk: float, diff
         lifecycle_state=PRState.DISCOVERED,
         head_sha=f"head-{pr_id}",
         base_sha="base-main",
+        labels=labels or [],
     )
 
 
@@ -66,6 +78,36 @@ def test_simple_ordering_for_small_queues():
     assert len(layers) == 1
     assert edges == {}
     assert cycle is False
+
+
+def test_sort_states_prioritizes_eligible_conflicts_over_manual_conflict_blocks():
+    eligible = _state(
+        301,
+        base="main",
+        head="feature/eligible",
+        pr_class="CONFLICTS_ONLY",
+        risk=10.0,
+        diff=15,
+        labels=["conflict:mechanical"],
+        mergeable="CONFLICTING",
+        merge_state_status="DIRTY",
+    )
+    blocked = _state(
+        302,
+        base="main",
+        head="feature/blocked",
+        pr_class="CONFLICTS_ONLY",
+        risk=1.0,
+        diff=5,
+        mergeable="CONFLICTING",
+        merge_state_status="DIRTY",
+    )
+
+    ordered, _layers, _edges, _cycle = engine.sort_states(
+        [blocked, eligible], strategy="simple"
+    )
+
+    assert [item.pr_id for item in ordered] == [301, 302]
 
 
 def test_risk_score_penalizes_active_threads_and_failures():

--- a/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
+++ b/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
@@ -387,3 +387,42 @@ def test_mission_banner_reports_detached_exit_truthfully() -> None:
     assert "MISSION ENDED EARLY" in banner
     assert "Interactive input is unavailable" in banner
     assert color == "yellow"
+
+
+def test_select_advanced_strategy_blocks_manual_conflict_recovery_without_opt_in() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    strategy_id, rationale, steps = dashboard._select_advanced_strategy(
+        {
+            "pr_id": 203,
+            "ci_status": "SUCCESS",
+            "validation_report": {"status": "passed"},
+            "blockers": [{"type": "manual_conflict_required"}],
+            "mergeable": "CONFLICTING",
+            "merge_state_status": "DIRTY",
+            "operator_state": "manual_conflict_required",
+            "unresolved_threads": 0,
+        }
+    )
+
+    assert strategy_id == "SPLIT_DECISION_REQUIRED"
+    assert "opt-in" in rationale
+    assert steps == ["S"]
+
+
+def test_autopilot_tactic_skips_patch_for_manual_conflict_blocker() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    snapshot = {
+        "allowed_actions": [],
+        "ci_status": "SUCCESS",
+        "validation_report": {"status": "passed"},
+        "unresolved_threads": 0,
+        "blockers": [{"type": "manual_conflict_required"}],
+        "mergeable": "CONFLICTING",
+        "merge_state_status": "DIRTY",
+        "operator_state": "manual_conflict_required",
+        "advanced_strategy_id": "SPLIT_DECISION_REQUIRED",
+        "advanced_strategy_steps": ["S"],
+    }
+
+    assert dashboard._candidate_tactics_for_snapshot(snapshot) == []
+    assert dashboard._autopilot_tactic_for_snapshot(snapshot) == "S"


### PR DESCRIPTION
@codex 
@clauee
@copilot

## Summary
- stop autopilot from selecting patch/apply for `manual_conflict_required` and `semantic_conflict_blocked`
- prioritize mechanically eligible conflicts ahead of blocked/manual conflicts in queue ordering
- show full conflict blocker guidance and explicit conflict objectives in the dashboard

## Validation
- `ruff check src/dopemux_pr_merge_specialist/dashboard.py src/dopemux_pr_merge_specialist/ux_engine.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py tests/pr_merge_specialist/test_ordering_and_classification.py`
- `pytest -q tests/unit/test_pr_merge_specialist_dashboard_and_train.py -k 'manual_conflict or mission_banner or autopilot_tactic or choose_autopilot_strategy or select_advanced_strategy or stalled_pr'`
- `pytest -q tests/pr_merge_specialist/test_ordering_and_classification.py -k 'prioritizes_eligible_conflicts_over_manual_conflict_blocks or simple_ordering_for_small_queues or hybrid_ordering_respects_dependency_edges'`
- runtime probe: blocked manual conflict snapshot resolves to autopilot tactic `S`

## Notes
- `src/dopemux_pr_merge_specialist/queue.py` still has pre-existing unused-import lint debt, so this PR keeps validation scoped to the touched conflict loop surfaces.
- broader baseline drift remains in `tests/pr_merge_specialist/test_ordering_and_classification.py::test_lifecycle_for_findings_blocks_on_blockers`, which was not changed here.
