### PR TITLE
fix(pr-merge): support kitty arrow navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to the PR Merge Specialist will be documented in this file.
 ### Fixed
 - Validation-only PRs are no longer shown as queued-for-merge before local verification is complete.
 - A single failed speculative rebase or push no longer aborts the rest of the train pass.
+- Flight dashboard arrow-key navigation now accepts Kitty/application-cursor escape sequences instead of treating Down Arrow as an exit.
+- Flight dashboard arrow-key navigation now accepts Kitty/application-cursor escape sequences instead of treating Down Arrow as an exit.
 
 ## [0.1.0] - 2026-03-14
 ### Added

--- a/docs/02-how-to/pr-merge-flight-dashboard.md
+++ b/docs/02-how-to/pr-merge-flight-dashboard.md
@@ -5,8 +5,8 @@ type: how-to
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-03-18'
-last_review: '2026-03-18'
-next_review: '2026-06-18'
+last_review: '2026-03-27'
+next_review: '2026-06-27'
 prelude: PR Merge Flight Dashboard (how-to) for dopemux documentation and developer workflows.
 ---
 # PR Merge Flight Dashboard Quickstart
@@ -64,6 +64,12 @@ The dashboard features non-blocking input handling. Simply press the correspondi
 - **[S] Skip**: Skip to the next PR in the queue.
 - **[Q] Quit**: Gracefully exit the dashboard and restore terminal state.
 
+Navigation behavior:
+
+- **Up / Down Arrow**: Move between PRs in the queue without exiting the dashboard.
+- **Kitty and other application-cursor terminals**: Arrow-key navigation accepts both CSI (`Esc [ A/B`) and SS3 (`Esc O A/B`) cursor sequences.
+- **Bare `Esc`**: Quit only when no cursor-key suffix arrives. Unrecognized escape suffixes are ignored instead of forcing a quit.
+
 ## Verification
 
 After launching the dashboard:
@@ -72,6 +78,7 @@ After launching the dashboard:
 1. Confirm validation-only PRs appear as `🟡` rather than queued.
 1. Confirm approval-only PRs appear as `🟣`.
 1. Confirm already queued auto-merge PRs appear as `🔵`.
+1. Confirm Up/Down arrow navigation works in your terminal emulator, including Kitty.
 
 ## ADHD Optimization
 

--- a/src/dopemux_pr_merge_specialist/dashboard.py
+++ b/src/dopemux_pr_merge_specialist/dashboard.py
@@ -538,22 +538,30 @@ class DopemuxDashboard:
         if char == "\x1b":
             if self._input_fd is None:
                 return "Q"
-            rlist, _, _ = select.select([self._input_fd], [], [], 0.15)
-            if not rlist:
-                return "Q"
             suffix = ""
-            for _ in range(2):
-                rlist, _, _ = select.select([self._input_fd], [], [], 0.05)
+            deadline = time.monotonic() + 0.2
+            while len(suffix) < 8 and time.monotonic() < deadline:
+                timeout = max(0.0, min(0.05, deadline - time.monotonic()))
+                rlist, _, _ = select.select([self._input_fd], [], [], timeout)
                 if not rlist:
                     break
-                suffix += os.read(self._input_fd, 1).decode("utf-8", errors="ignore")
-                if len(suffix) >= 2:
+                suffix += os.read(self._input_fd, 1).decode(
+                    "utf-8", errors="ignore"
+                )
+                if suffix.startswith("O") and len(suffix) >= 2 and suffix[-1:].isalpha():
                     break
-            if suffix == "[A":
-                return "UP"
-            if suffix == "[B":
-                return "DOWN"
-            return "Q"
+                if suffix.startswith("[") and len(suffix) >= 2 and (
+                    suffix[-1:].isalpha() or suffix.endswith("~")
+                ):
+                    break
+            if not suffix:
+                return "Q"
+            if suffix[0] in {"[", "O"}:
+                if suffix.endswith("A"):
+                    return "UP"
+                if suffix.endswith("B"):
+                    return "DOWN"
+            return None
         return char.upper()
 
     def _refresh_dashboard_result(self, pr_id: str) -> PRResult:

--- a/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
+++ b/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
@@ -250,6 +250,31 @@ def test_dashboard_decode_input_choice_maps_down_arrow(monkeypatch) -> None:
     assert dashboard._decode_input_choice("\x1b") == "DOWN"
 
 
+def test_dashboard_decode_input_choice_maps_kitty_down_arrow(monkeypatch) -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    dashboard._input_fd = 1
+
+    select_calls = iter(
+        [
+            ([1], [], []),
+            ([1], [], []),
+            ([], [], []),
+        ]
+    )
+    reads = iter([b"O", b"B"])
+
+    monkeypatch.setattr(
+        "src.dopemux_pr_merge_specialist.dashboard.select.select",
+        lambda *_args, **_kwargs: next(select_calls),
+    )
+    monkeypatch.setattr(
+        "src.dopemux_pr_merge_specialist.dashboard.os.read",
+        lambda *_args, **_kwargs: next(reads),
+    )
+
+    assert dashboard._decode_input_choice("\x1b") == "DOWN"
+
+
 def test_choose_autopilot_strategy_prefers_simple_for_small_independent_queue() -> None:
     dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
     strategy, reason = dashboard._choose_autopilot_strategy(


### PR DESCRIPTION
@codex 
@clauee
@copilot

## Summary
- accept Kitty/application-cursor arrow escape sequences in the PR merge dashboard input decoder
- stop treating unrecognized escape suffixes as an immediate quit
- document arrow-key behavior in the PR Merge Flight Dashboard quickstart and record the fix in the changelog

## Validation
- `ruff check src/dopemux_pr_merge_specialist/dashboard.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py`
- `pytest -q tests/unit/test_pr_merge_specialist_dashboard_and_train.py`
- `python scripts/docs_frontmatter_guard.py docs/02-how-to/pr-merge-flight-dashboard.md`
- `python scripts/docs_validator.py docs/02-how-to/pr-merge-flight-dashboard.md`
- `python scripts/check_root_hygiene.py`
- `pre-commit run --files src/dopemux_pr_merge_specialist/dashboard.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py docs/02-how-to/pr-merge-flight-dashboard.md CHANGELOG.md`

## Release Notes
- Fixed PR Merge Flight Dashboard navigation so Kitty Down Arrow moves between PRs instead of exiting the dashboard.
- Documented supported terminal cursor-sequence behavior in the flight dashboard quickstart.
