### PR TITLE
fix(pr-merge): preserve remote blockers and bound queue drain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,9 @@
 name: docs
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ All notable changes to the PR Merge Specialist will be documented in this file.
 - Queue-wide CI remediation via failure fingerprinting, `global-ci-fix` PR detection, and the `ci-remediation-specialist` runbook.
 - Dashboard state distinctions for validation-pending, approval-required, and queued-for-merge PRs.
 - Targeted unit coverage for dashboard console rendering and speculative train continuation behavior.
+- Regression coverage for queue-wide required-check failures, prompt-only Gemini remediation, and bounded queue-drain execution.
 
 ### Changed
 - The speculative train now rebases each candidate against `origin/main` instead of chaining later PRs onto earlier speculative branches.
 - The flight dashboard passes its active `Console` into the renderer so viewport sizing reflects the live terminal instance.
 - `flight-deck` now delegates to the authoritative `flight` dashboard path so autopilot, remediation, and merge execution share the same runtime.
+- The docs workflow now runs on pull requests and `main` pushes only, preventing PR-branch push runs from re-failing on unrelated legacy docs debt.
 
 ### Fixed
 - Validation-only PRs are no longer shown as queued-for-merge before local verification is complete.
@@ -20,6 +22,8 @@ All notable changes to the PR Merge Specialist will be documented in this file.
 - Queue rescans now preserve prior executed local validation results for unchanged PR `head_sha`/`base_sha` pairs instead of resetting them to `not_executed`.
 - Queue-drain now treats already queued or merged PRs as processed state instead of re-entering patch loops on later passes.
 - Dashboard autopilot no longer treats monitor tactic `S` as queue navigation and no longer resets to the top PR after every reassessment.
+- Queue planning no longer downgrades failing required GitHub checks to warnings after a local validation pass; those PRs remain `apply_blocked` until the remote required checks actually clear.
+- `queue-drain --max-prs` now stops the execute loop at the requested bound instead of continuing through additional PRs in the same pass.
 
 ## [0.1.0] - 2026-03-14
 ### Added

--- a/docs/02-how-to/pr-merge-flight-dashboard.md
+++ b/docs/02-how-to/pr-merge-flight-dashboard.md
@@ -52,6 +52,12 @@ Important behavior:
 ### Global CI Remediation
 If multiple PRs fail CI with the same error, the orchestrator identifies a stable failure fingerprint from the failing validation step and error output. Instead of fixing each PR individually, it invokes the `ci-remediation-specialist` against `main` and opens or reuses a single `global-ci-fix` PR. Other failing PRs wait on that shared fix path instead of duplicating remediation.
 
+Important constraint:
+
+- branches with failing required GitHub checks remain blocked even when local validation passes
+- auto-merge-enabled PRs are still treated as blocked if the required remote checks are red
+- bounded dry or execute runs respect `--max-prs`, so operator test runs can sample the queue without draining the whole backlog
+
 ### Optimistic Lifecycle
 The dashboard uses a state model that distinguishes local proof from GitHub lag:
 
@@ -59,6 +65,8 @@ The dashboard uses a state model that distinguishes local proof from GitHub lag:
 - `🟣` approval required: reviewer consent is the remaining gate
 - `🔵` queued: local work is done and GitHub is handling the final queue/check path
 - `🟢` ready or merged: no local blocker remains
+
+Required-check failures are not treated as queue lag. If GitHub still reports failing required checks, the PR remains blocked even when local validation is green.
 
 ## Controls
 
@@ -86,6 +94,7 @@ After launching the dashboard:
 1. Confirm validation-only PRs appear as `🟡` rather than queued.
 1. Confirm approval-only PRs appear as `🟣`.
 1. Confirm already queued auto-merge PRs appear as `🔵`.
+1. Confirm PRs with failing required GitHub checks remain blocked instead of flipping to queued-for-merge after a local pass.
 1. Confirm Up/Down arrow navigation works in your terminal emulator, including Kitty.
 
 ## ADHD Optimization

--- a/docs/04-explanation/pr-merge-queue-orchestration.md
+++ b/docs/04-explanation/pr-merge-queue-orchestration.md
@@ -5,7 +5,7 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-03-20'
-last_review: '2026-03-20'
+last_review: '2026-03-27'
 next_review: '2026-06-20'
 prelude: Design rationale for speculative train handling, validation-first states, and global CI remediation in the PR Merge Specialist.
 ---
@@ -26,6 +26,8 @@ The dashboard distinguishes `validation_pending`, `approval_required`, and `queu
 - `queued` means local work is done and the branch is waiting on GitHub's merge machinery.
 
 This separation prevents auto-merge branches from looking idle when they still require local verification, and it avoids showing validation-only work as if it were blocked by unrelated policy failures.
+
+The inverse also matters: a local validation pass must not erase a failing required GitHub check. Required remote check failures stay blocking until GitHub reports them green. Local proof and provider truth remain separate authorities.
 
 ## Why the Speculative Train Rebases onto `origin/main`
 
@@ -49,6 +51,8 @@ When multiple PRs fail on the same CI signature, per-branch remediation duplicat
 
 Blocked PRs remain branch-local records, but the actual systemic repair is centralized in one remediation branch and one PR.
 
+When the shared failure lives in `main` or in branch-protection workflows, the correct remediation target is still `main`; branch-local queue artifacts must remain blocked until the shared fix lands and the PR branch is updated onto that new base.
+
 ## Why the Specialist Uses a Strict Runbook
 
 The `ci-remediation-specialist` is intentionally constrained:
@@ -68,3 +72,4 @@ In this design:
 - local validation remains the readiness proof
 - the dashboard remains an operator surface, not a source of merge truth
 - the global remediation path exists only for failures that are demonstrably shared across multiple PRs
+- bounded execute runs (`--max-prs`, `--max-passes`) are operator safety rails and must be honored exactly

--- a/docs/pr_merge/usage-patterns.md
+++ b/docs/pr_merge/usage-patterns.md
@@ -5,7 +5,7 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-03-17'
-last_review: '2026-03-17'
+last_review: '2026-03-27'
 next_review: '2026-06-15'
 prelude: Usage Patterns (explanation) for dopemux documentation and developer workflows.
 ---
@@ -33,6 +33,8 @@ python -m dopemux_pr_merge_specialist.cli pr-merge --id 42 --execute
 python -m dopemux_pr_merge_specialist.cli queue-drain --execute --max-prs 5
 ```
 
+`queue-drain` does not treat a PR as queued or merge-ready merely because local validation passed. Required GitHub check failures still block the PR until the remote checks clear.
+
 ## Common Workflows
 
 ### 1. Safe Review Cycle (Non-Mutating)
@@ -55,6 +57,14 @@ python -m dopemux_pr_merge_specialist.cli queue-drain --execute --only 42,43,44
 # Prioritize specific PRs (process first, then others)
 python -m dopemux_pr_merge_specialist.cli queue-drain --execute --prioritize 42
 ```
+
+For bounded live runs, use `--max-prs` to stop the execute loop after a fixed number of PRs:
+
+```bash
+python -m dopemux_pr_merge_specialist.cli queue-drain --execute --max-prs 3 --max-passes 1
+```
+
+This is the safest way to validate queue behavior against live GitHub state without mutating the full backlog in one run.
 
 ### 3. Custom Policy
 ```bash

--- a/src/dopemux_pr_merge_specialist/action_model.py
+++ b/src/dopemux_pr_merge_specialist/action_model.py
@@ -46,6 +46,22 @@ QUEUED_OPERATOR_STATES = {
 }
 
 
+def is_passive_queued_state(snapshot: Mapping[str, Any]) -> bool:
+    lifecycle_state = enum_value(snapshot.get("lifecycle_state", ""))
+    operator_state = str(snapshot.get("operator_state") or "")
+    auto_merge_enabled = bool(snapshot.get("auto_merge_enabled", False))
+    blockers = blocker_types_from_snapshot(snapshot)
+    needs_validation = bool(blockers & VALIDATION_BLOCKERS)
+
+    if lifecycle_state == PRState.QUEUED_FOR_MERGE.value and not needs_validation:
+        return True
+    if operator_state in QUEUED_OPERATOR_STATES and not needs_validation:
+        return True
+    if auto_merge_enabled and not needs_validation and blockers <= AUTO_MERGE_PASSIVE_BLOCKERS:
+        return True
+    return False
+
+
 def enum_value(value: Any) -> str:
     return value.value if hasattr(value, "value") else str(value)
 
@@ -93,29 +109,14 @@ def allowed_actions_for_snapshot(snapshot: Mapping[str, Any]) -> List[str]:
     merge_strategy = enum_value(snapshot.get("merge_strategy", ""))
     pr_state = str(snapshot.get("state") or "").upper()
     is_draft = bool(snapshot.get("is_draft", False))
-    auto_merge_enabled = bool(snapshot.get("auto_merge_enabled", False))
     blockers = blocker_types_from_snapshot(snapshot)
 
     if pr_state == "MERGED" or lifecycle_state == PRState.MERGED.value:
         return []
-        
-    # If we need to run validation, we should never be purely passive, even if queued for merge.
-    needs_validation = bool(blockers & VALIDATION_BLOCKERS)
 
-    if lifecycle_state == PRState.QUEUED_FOR_MERGE.value and not needs_validation:
+    if is_passive_queued_state(snapshot):
         return []
-        
-    if auto_merge_enabled:
-        if needs_validation:
-            # We must run validation. Fall through to return APPLY_FIX.
-            pass
-        elif blockers <= AUTO_MERGE_PASSIVE_BLOCKERS:
-            # All validation is done, just waiting on GitHub CI
-            return []
-            
-    if str(snapshot.get("operator_state") or "") in QUEUED_OPERATOR_STATES and not needs_validation:
-        return []
-            
+
     if merge_strategy == MergeActionType.AUTO_MERGE_FALLBACK.value and not blockers:
         return []
     if is_draft:
@@ -141,6 +142,9 @@ def allowed_actions_for_result(result: PRResult) -> List[str]:
 
 
 def dashboard_tactic_for_snapshot(snapshot: Mapping[str, Any]) -> str:
+    if is_passive_queued_state(snapshot):
+        return "S"
+
     allowed = list(snapshot.get("allowed_actions") or allowed_actions_for_snapshot(snapshot))
     blockers = blocker_types_from_snapshot(snapshot)
     ci_status = str(snapshot.get("ci_status", "") or "").upper()

--- a/src/dopemux_pr_merge_specialist/classification.py
+++ b/src/dopemux_pr_merge_specialist/classification.py
@@ -151,10 +151,12 @@ def lifecycle_for_findings(
         if _severity_value(item.kind) == FindingSeverity.BLOCKER.value
     ]
     
-    # If the only blockers are validation related, we are APPLY_READY (Verification Pending)
+    # If the only blockers are strictly "validation not yet executed", we are APPLY_READY.
+    # Required GitHub checks still pending should remain blocked until validation or queueing
+    # logic explicitly clears them.
     non_val_blockers = [
         b for b in blockers 
-        if b.finding_type not in {"validation_not_executed", "required_check_pending"}
+        if b.finding_type != "validation_not_executed"
     ]
 
     if non_val_blockers:

--- a/src/dopemux_pr_merge_specialist/dashboard.py
+++ b/src/dopemux_pr_merge_specialist/dashboard.py
@@ -27,6 +27,7 @@ from dopemux.ui.theme import DOPEMUX_THEME
 from .action_model import (
     dashboard_phase_for_snapshot,
     dashboard_tactic_for_snapshot,
+    is_passive_queued_state,
     result_to_dashboard_entry,
 )
 from .metrics import MetricsEngine
@@ -234,6 +235,9 @@ class DopemuxDashboard:
         return self._default_queue_plan(self.state.prs)
 
     def _candidate_tactics_for_snapshot(self, snapshot: Dict[str, Any]) -> List[str]:
+        if is_passive_queued_state(snapshot):
+            return []
+
         blockers = {
             str(item.get("type") or item.get("finding_type") or "")
             for item in snapshot.get("blockers", [])

--- a/src/dopemux_pr_merge_specialist/plan_builder.py
+++ b/src/dopemux_pr_merge_specialist/plan_builder.py
@@ -230,28 +230,15 @@ def findings_from_pr_state(
             )
     summary = check_payload["summary"]
     if summary.required_failure > 0:
-        # OPTIMISTIC OVERRIDE: If local validation just passed, we suppress the CI failure blocker
-        # because we assume GitHub hasn't caught up to the new push yet.
-        if _status_value(validation_status) == ValidationStatus.PASSED.value:
-            findings.append(
-                Finding(
-                    kind=FindingSeverity.WARNING,
-                    finding_type="ci_failing_but_local_passed",
-                    message="GitHub CI is currently failing, but local validation passed. Assuming state transition in progress.",
-                    details=serialize_check_payload(check_payload),
-                    source="local_validation",
-                )
+        findings.append(
+            Finding(
+                kind=FindingSeverity.BLOCKER,
+                finding_type=BlockerType.REQUIRED_CHECK_FAILED.value,
+                message="Required checks are failing.",
+                details=serialize_check_payload(check_payload),
+                source="github_protection_review",
             )
-        else:
-            findings.append(
-                Finding(
-                    kind=FindingSeverity.BLOCKER,
-                    finding_type=BlockerType.REQUIRED_CHECK_FAILED.value,
-                    message="Required checks are failing.",
-                    details=serialize_check_payload(check_payload),
-                    source="github_protection_review",
-                )
-            )
+        )
     elif summary.required_pending > 0:
         # OPTIMISTIC OVERRIDE: If local validation passed, we assume it will eventually turn green on GH.
         if _status_value(validation_status) == ValidationStatus.PASSED.value:

--- a/src/dopemux_pr_merge_specialist/queue_drain.py
+++ b/src/dopemux_pr_merge_specialist/queue_drain.py
@@ -113,6 +113,12 @@ def _refresh_client_state(client: GitHubClient, pr_id: int) -> None:
     client.invalidate("open_prs:")
 
 
+def _gemini_ci_remediation_command(prompt: str) -> List[str]:
+    # Gemini CLI no longer accepts --skill in headless mode, so the runbook
+    # must live in the prompt and the invocation stays prompt-only.
+    return ["gemini", "--prompt", prompt, "--yolo"]
+
+
 def _inflate_result_from_state_path(state_path: Path) -> Optional[PRResult]:
     try:
         payload = json.loads(state_path.read_text(encoding="utf-8"))
@@ -430,8 +436,7 @@ Identify the root cause, modify the necessary files, and ensure the command pass
     log(f"Launching Gemini CLI agent in YOLO mode (worktree: {worktree_path.name})...")
     
     try:
-        # Use --debug for even more output if needed, but for now we stream everything
-        cmd = ["gemini", "-p", prompt, "--skill", "ci-remediation-specialist", "--yolo"]
+        cmd = _gemini_ci_remediation_command(prompt)
         
         process = subprocess.Popen(
             cmd,
@@ -467,9 +472,7 @@ Identify the root cause, modify the necessary files, and ensure the command pass
         
     if process.returncode != 0:
         log(f"Agent finished with non-zero exit code ({process.returncode}).", "WARNING")
-        # We still return True if the agent made changes, but how do we know?
-        # For now, we assume if it ran, we should try validating again.
-        return True
+        return False
         
     log("Agentic remediation cycle complete.")
     return True
@@ -930,11 +933,17 @@ Output/Error:
 ```
 
 Please diagnose the issue and FIX IT against the `main` branch. You are running in YOLO mode with full tool access. 
+CRITICAL: You MUST follow the ci-remediation-specialist runbook:
+1. REPRODUCE the failure locally first by running the command `{failed_step.command}`.
+2. USE AUTO-FIXERS if applicable (e.g., ruff check --fix).
+3. APPLY a minimal surgical fix if reproduction succeeds.
+4. VERIFY that your fix makes `{failed_step.command}` pass.
+
 Identify the root cause, modify the necessary files, and verify your fix if possible.
 Your goal is to make the command `{failed_step.command}` pass.
 """
         print("Launching Gemini CLI agent for GLOBAL FIX...")
-        cmd = ["gemini", "-p", prompt, "--skill", "ci-remediation-specialist", "--yolo"]
+        cmd = _gemini_ci_remediation_command(prompt)
         
         process = subprocess.Popen(
             cmd,
@@ -1053,8 +1062,14 @@ def _handle_global_ci_blockers(results: List[PRResult], client: GitHubClient, wo
             )
             if failed_step:
                 new_pr_number = _create_global_fix_pr(fingerprint, failed_step, client, worktree_dir)
-                for r in blocked_prs:
-                    object.__setattr__(r, "blocked_by_global_fix_pr", new_pr_number)
+                if new_pr_number > 0:
+                    for r in blocked_prs:
+                        object.__setattr__(r, "blocked_by_global_fix_pr", new_pr_number)
+                else:
+                    print(
+                        f"Global fix creation failed for fingerprint {fingerprint}; "
+                        "continuing with per-PR remediation."
+                    )
 
 
 def _ignite_speculative_train(
@@ -1170,10 +1185,12 @@ def queue_drain(args: argparse.Namespace) -> int:
             
     try:
         max_passes = int(getattr(args, "max_passes", 3))
+        max_prs = int(getattr(args, "max_prs", 0) or 0)
         processed_ids = set()
         merged_ids = set()
         queued_ids = set()
         failed_remediation_ids = set() # Track PRs that failed an attempt in THIS pass
+        limit_reached = False
         
         for pass_idx in range(max_passes):
             print(f"\n--- Queue Pass {pass_idx + 1}/{max_passes} ---")
@@ -1214,6 +1231,10 @@ def queue_drain(args: argparse.Namespace) -> int:
                 print("All PRs processed, merged, or queued.")
                 break
             for result in active_results:
+                if max_prs > 0 and len(processed_ids) >= max_prs:
+                    print(f"Reached max PR limit ({max_prs}); stopping queue drain.")
+                    limit_reached = True
+                    break
                 pr_id = result.pr_state.pr_id
                 
                 if result.blocked_by_global_fix_pr:
@@ -1310,6 +1331,8 @@ def queue_drain(args: argparse.Namespace) -> int:
                         )
                     except RuntimeError as e:
                         print(f"Approval error for PR #{pr_id}: {e}")
+            if limit_reached:
+                break
         print(f"\nRun ID: {active_run_id}")
         print(f"Processed PRs: {len(processed_ids)}")
         print(f"Merged: {len(merged_ids)}")

--- a/tests/pr_merge_specialist/test_ordering_and_classification.py
+++ b/tests/pr_merge_specialist/test_ordering_and_classification.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import pytest
 
 from dopemux_pr_merge_specialist import engine
-from dopemux_pr_merge_specialist.schema import Finding, FindingSeverity, PRState, PullRequestState, ValidationStatus
+from dopemux_pr_merge_specialist.plan_builder import findings_from_pr_state
+from dopemux_pr_merge_specialist.schema import CheckSummary, Finding, FindingSeverity, PRState, PullRequestState, ValidationStatus
 
 
 def _state(
@@ -149,3 +150,32 @@ def test_lifecycle_for_findings_blocks_on_blockers():
         )
     ]
     assert engine.lifecycle_for_findings(findings, validation_status=ValidationStatus.NOT_EXECUTED) == PRState.APPLY_BLOCKED
+
+
+def test_findings_from_pr_state_keeps_required_check_failures_blocking_after_local_pass() -> None:
+    pr = _state(
+        401,
+        base="main",
+        head="feature/failing-checks",
+        pr_class="CI_ONLY",
+        risk=5.0,
+        diff=10,
+    )
+    findings = findings_from_pr_state(
+        pr,
+        check_payload={
+            "summary": CheckSummary(required_failure=1, total=1, failure=1),
+            "review_decision": "APPROVED",
+            "approval_required": False,
+            "blocker_types": ["required_check_failed"],
+            "warning_types": [],
+        },
+        active_threads=0,
+        validation_status=ValidationStatus.PASSED,
+        local_validation_required=True,
+        policy={},
+    )
+
+    blocker_types = {finding.finding_type for finding in findings if finding.kind == FindingSeverity.BLOCKER}
+
+    assert "required_check_failed" in blocker_types

--- a/tests/pr_merge_specialist/test_queue_drain_integration.py
+++ b/tests/pr_merge_specialist/test_queue_drain_integration.py
@@ -9,7 +9,7 @@ from dopemux_pr_merge_specialist import engine
 from dopemux_pr_merge_specialist import queue_drain as queue_drain_module
 from dopemux_pr_merge_specialist.plan_builder import build_plan_result, write_pr_state_artifact
 from dopemux_pr_merge_specialist.preflight import build_run_paths, pr_dir_for
-from dopemux_pr_merge_specialist.schema import ValidationReport, ValidationStatus
+from dopemux_pr_merge_specialist.schema import ValidationReport, ValidationStatus, ValidationStepResult
 from dopemux_pr_merge_specialist import cli as pr_merge_cli
 
 
@@ -313,3 +313,105 @@ def test_cmd_flight_deck_routes_to_dashboard(monkeypatch):
     assert captured["auto_pilot"] is True
     assert captured["limit"] == 50
     assert captured["strategy"] == "hybrid"
+
+
+def test_remediate_ci_failure_uses_prompt_only_gemini_command(monkeypatch, tmp_path: Path):
+    captured: dict[str, object] = {}
+
+    class FakeStdout:
+        def __init__(self) -> None:
+            self._lines = iter(["gemini failed\n", ""])
+
+        def readline(self) -> str:
+            return next(self._lines)
+
+    class FakeProcess:
+        def __init__(self) -> None:
+            self.stdout = FakeStdout()
+            self.returncode = 2
+
+        def wait(self, timeout=None) -> None:
+            return None
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["cwd"] = kwargs.get("cwd")
+        return FakeProcess()
+
+    monkeypatch.setattr(queue_drain_module.subprocess, "Popen", fake_popen)
+
+    validation = ValidationReport(
+        status=ValidationStatus.FAILED,
+        required_for_merge_ready=True,
+        steps=[
+            ValidationStepResult(
+                name="pre-commit",
+                command="pre-commit run --all-files",
+                status="failed",
+                stderr="boom",
+            )
+        ],
+        attempts=1,
+        remediation_applied=False,
+    )
+    messages: list[str] = []
+
+    remediated = queue_drain_module.remediate_ci_failure(
+        tmp_path,
+        validation,
+        lambda message, *_: messages.append(message),
+    )
+
+    assert remediated is False
+    assert captured["cwd"] == tmp_path
+    assert captured["cmd"][0] == "gemini"
+    assert "--prompt" in captured["cmd"]
+    assert "--yolo" in captured["cmd"]
+    assert "--skill" not in captured["cmd"]
+    assert any("non-zero exit code" in message for message in messages)
+
+
+def test_handle_global_ci_blockers_ignores_failed_global_fix_creation(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        queue_drain_module,
+        "allowed_actions_for_result",
+        lambda _result: ["APPLY_FIX"],
+    )
+    monkeypatch.setattr(
+        queue_drain_module,
+        "_create_global_fix_pr",
+        lambda fingerprint, failed_step, client, repo_root: -1,
+    )
+
+    failed_validation = ValidationReport(
+        status=ValidationStatus.FAILED,
+        required_for_merge_ready=True,
+        steps=[
+            ValidationStepResult(
+                name="pre-commit",
+                command="pre-commit run --all-files",
+                status="failed",
+                stderr="boom",
+            )
+        ],
+        attempts=1,
+        remediation_applied=False,
+    )
+    results = [
+        SimpleNamespace(
+            validation_report=failed_validation,
+            blocked_by_global_fix_pr=None,
+        ),
+        SimpleNamespace(
+            validation_report=failed_validation,
+            blocked_by_global_fix_pr=None,
+        ),
+    ]
+
+    queue_drain_module._handle_global_ci_blockers(
+        results,
+        FakeGitHubClient(repo=None, repo_root=tmp_path, policy={}),
+        tmp_path,
+    )
+
+    assert all(result.blocked_by_global_fix_pr is None for result in results)

--- a/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
+++ b/tests/unit/test_pr_merge_specialist_dashboard_and_train.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from src.dopemux_pr_merge_specialist.action_model import (
     dashboard_phase_for_snapshot,
     dashboard_tactic_for_snapshot,
+    is_passive_queued_state,
 )
 from src.dopemux_pr_merge_specialist.conflict import apply_suggestion_to_file
 from src.dopemux_pr_merge_specialist.dashboard import DopemuxDashboard, QueueState
@@ -175,6 +176,23 @@ def test_dashboard_tactic_distinguishes_validation_ci_and_threads() -> None:
     assert dashboard_phase_for_snapshot(ci_failed) == "CI Remediation"
     assert dashboard_tactic_for_snapshot(thread_blocked) == "T"
     assert dashboard_phase_for_snapshot(thread_blocked) == "Thread Review"
+
+
+def test_dashboard_tactic_treats_queued_pending_ci_as_monitor_only() -> None:
+    queued_snapshot = {
+        "state": "OPEN",
+        "lifecycle_state": "queued_for_merge",
+        "operator_state": "queued_for_merge",
+        "auto_merge_enabled": True,
+        "ci_status": "PENDING",
+        "unresolved_threads": 0,
+        "validation_report": {"status": "passed"},
+        "blockers": [{"type": "required_check_pending"}],
+    }
+
+    assert is_passive_queued_state(queued_snapshot) is True
+    assert dashboard_tactic_for_snapshot(queued_snapshot) == "S"
+    assert dashboard_phase_for_snapshot(queued_snapshot) == "Monitor"
 
 
 def test_metrics_log_event_accepts_dashboard_report_shape(tmp_path: Path) -> None:
@@ -447,6 +465,25 @@ def test_autopilot_tactic_skips_patch_for_manual_conflict_blocker() -> None:
         "operator_state": "manual_conflict_required",
         "advanced_strategy_id": "SPLIT_DECISION_REQUIRED",
         "advanced_strategy_steps": ["S"],
+    }
+
+    assert dashboard._candidate_tactics_for_snapshot(snapshot) == []
+    assert dashboard._autopilot_tactic_for_snapshot(snapshot) == "S"
+
+
+def test_autopilot_tactic_skips_verification_for_queued_pr() -> None:
+    dashboard = DopemuxDashboard(manager=object(), args=Namespace(out_dir="reports"))
+    snapshot = {
+        "state": "OPEN",
+        "lifecycle_state": "queued_for_merge",
+        "operator_state": "queued_for_merge",
+        "auto_merge_enabled": True,
+        "ci_status": "PENDING",
+        "validation_report": {"status": "passed"},
+        "unresolved_threads": 0,
+        "blockers": [{"type": "required_check_pending"}],
+        "advanced_strategy_id": "PATCH_ISOLATION_PLAN",
+        "advanced_strategy_steps": ["V", "A", "I"],
     }
 
     assert dashboard._candidate_tactics_for_snapshot(snapshot) == []


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary
- keep required GitHub check failures blocking even after local validation passes
- honor `queue-drain --max-prs` during execute runs
- treat queued auto-merge PRs as passive monitor-only states in flight autopilot
- restrict the docs workflow to PRs and `main` pushes so PR-branch pushes do not re-fail on unrelated legacy docs debt
- document the updated queue and dashboard behavior

## Validation
- `pytest -q tests/pr_merge_specialist/test_ordering_and_classification.py tests/pr_merge_specialist/test_queue_drain_integration.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py`
- `python -m py_compile src/dopemux_pr_merge_specialist/action_model.py src/dopemux_pr_merge_specialist/classification.py src/dopemux_pr_merge_specialist/dashboard.py src/dopemux_pr_merge_specialist/plan_builder.py src/dopemux_pr_merge_specialist/queue_drain.py`
- `python scripts/docs_frontmatter_guard.py docs/02-how-to/pr-merge-flight-dashboard.md docs/pr_merge/usage-patterns.md docs/04-explanation/pr-merge-queue-orchestration.md docs/pr_merge/flight_deck/readme-2.md`
- `python scripts/docs_validator.py docs/02-how-to/pr-merge-flight-dashboard.md docs/pr_merge/usage-patterns.md docs/04-explanation/pr-merge-queue-orchestration.md docs/pr_merge/flight_deck/readme-2.md`
- `pre-commit run --files CHANGELOG.md .github/workflows/docs.yml docs/02-how-to/pr-merge-flight-dashboard.md docs/pr_merge/usage-patterns.md docs/04-explanation/pr-merge-queue-orchestration.md src/dopemux_pr_merge_specialist/action_model.py src/dopemux_pr_merge_specialist/classification.py src/dopemux_pr_merge_specialist/dashboard.py src/dopemux_pr_merge_specialist/plan_builder.py src/dopemux_pr_merge_specialist/queue_drain.py tests/pr_merge_specialist/test_ordering_and_classification.py tests/pr_merge_specialist/test_queue_drain_integration.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py`

## Runtime evidence
- bounded live execute run now stops at the requested PR limit
- queue artifacts remain `apply_blocked` with explicit `required_check_failed` blockers instead of falsely promoting failing PRs to queued state
- live backlog currently shows 15 open PRs, 14 with auto-merge enabled, 14 failing `checks`, and 15 failing `🧪 Unit Tests`
