### PR TITLE
fix(pr-merge): sync skill template parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to the PR Merge Specialist will be documented in this file.
 - Dashboard autopilot no longer treats monitor tactic `S` as queue navigation and no longer resets to the top PR after every reassessment.
 - Queue planning no longer downgrades failing required GitHub checks to warnings after a local validation pass; those PRs remain `apply_blocked` until the remote required checks actually clear.
 - `queue-drain --max-prs` now stops the execute loop at the requested bound instead of continuing through additional PRs in the same pass.
+- Skill template parity is restored for the mirrored `cli.py`, `policy.py`, `runtime.py`, and `validation.py` modules so the full unit suite agrees with the runtime PR Merge specialist implementation.
 
 ## [0.1.0] - 2026-03-14
 ### Added

--- a/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/cli.py
+++ b/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/cli.py
@@ -6,7 +6,6 @@ import json
 import sys
 from pathlib import Path
 
-from . import engine
 from .action_model import result_to_dashboard_entry
 from .classification import classify_pr, risk_score
 from .conflict import build_conflict_analysis
@@ -51,7 +50,7 @@ def cmd_flight(args: argparse.Namespace) -> int:
     from .dashboard import DopemuxDashboard
     from .github_api import GitHubClient
     from .policy import load_effective_policy
-    from .preflight import run_id
+    from .preflight import build_run_paths, run_id
     from .queue_drain import queue_scan_internal
 
     repo_root = Path.cwd()
@@ -74,10 +73,15 @@ def cmd_flight(args: argparse.Namespace) -> int:
 
     # 2. Convert PR results to simple dicts for the dashboard
     pr_queue = [result_to_dashboard_entry(result) for result in results]
+    _, queue_dir, _ = build_run_paths(args.out_dir, active_run_id)
+    ordering_plan_path = queue_dir / "ORDERING_PLAN.json"
+    ordering_plan = {}
+    if ordering_plan_path.exists():
+        ordering_plan = json.loads(ordering_plan_path.read_text(encoding="utf-8"))
 
     # 3. Launch Dashboard
     dashboard = DopemuxDashboard(manager=client, args=args, policy=policy)
-    dashboard.run(pr_queue, active_run_id)
+    dashboard.run(pr_queue, active_run_id, ordering_plan=ordering_plan)
     return 0
 
 
@@ -148,13 +152,21 @@ def _self_check(args: argparse.Namespace) -> int:
 
     # Check 2: Schema completeness — consensus engine types exist
     try:
-        from .schema import (
-            ArbitrationRoleTrace,
-            AutonomyGateReport,
-            ConsensusDecision,
-            MergeExecutionPlan,
-            RequiredVerificationPlan,
-        )
+        schema_module = importlib.import_module("dopemux_pr_merge_specialist.schema")
+        required_schema_types = [
+            "ArbitrationRoleTrace",
+            "AutonomyGateReport",
+            "ConsensusDecision",
+            "MergeExecutionPlan",
+            "RequiredVerificationPlan",
+        ]
+        missing = [
+            name for name in required_schema_types if not hasattr(schema_module, name)
+        ]
+        if missing:
+            raise ImportError(
+                f"Missing schema consensus types: {', '.join(sorted(missing))}"
+            )
 
         results["checks"].append({"name": "schema:consensus_types", "status": "PASS"})
     except ImportError as exc:
@@ -282,36 +294,14 @@ def _health(args: argparse.Namespace) -> int:
 
 
 # Compatibility exports for existing callers/tests that import helpers from cli.
-def _classify_pr(*args, **kwargs):
-    return classify_pr(*args, **kwargs)
-
-
-def _risk_score(*args, **kwargs):
-    return risk_score(*args, **kwargs)
-
-
-def _sort_states(*args, **kwargs):
-    return sort_states(*args, **kwargs)
-
-
-def _decide_thread_disposition(*args, **kwargs):
-    return decide_thread_disposition(*args, **kwargs)
-
-
-def _build_conflict_analysis(*args, **kwargs):
-    return build_conflict_analysis(*args, **kwargs)
-
-
-def _run_merge_with_fallback(*args, **kwargs):
-    return run_merge_with_fallback(*args, **kwargs)
-
-
-def _queue_scan(*args, **kwargs):
-    return queue_scan(*args, **kwargs)
-
-
-def _queue_drain(*args, **kwargs):
-    return queue_drain(*args, **kwargs)
+_classify_pr = classify_pr
+_risk_score = risk_score
+_sort_states = sort_states
+_decide_thread_disposition = decide_thread_disposition
+_build_conflict_analysis = build_conflict_analysis
+_run_merge_with_fallback = run_merge_with_fallback
+_queue_scan = queue_scan
+_queue_drain = queue_drain
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -557,65 +547,22 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def cmd_flight_deck(args: argparse.Namespace) -> int:
-    """🚀 Launch Flight Deck operations center with closed-loop automation."""
-    from .closed_loop_engine import ClosedLoopEngine
-    from .github_api import GitHubClient
-    from .interactive import InteractiveMergeWizard
-    from .ops_engine import FlightDeckOpsEngine
-    from .policy import load_effective_policy
-    from .strategy_library import STRATEGY_LIBRARY
-
-    repo_root = Path.cwd()
-    policy = load_effective_policy(
-        repo_root, explicit_path=getattr(args, "policy", None)
-    )
-    client = GitHubClient(
-        repo=getattr(args, "repo", None), repo_root=repo_root, policy=policy
-    )
-
-    # Initialize Flight Deck engines
-    ops_engine = FlightDeckOpsEngine(Path("proof/pr_merge/flight_deck/ops"))
-    closed_loop = ClosedLoopEngine(ops_engine, STRATEGY_LIBRARY)
-
-    # Configure wizard with Flight Deck enhancements
-    class FlightDeckWizard(InteractiveMergeWizard):
-        def __init__(self, manager, ops_engine, closed_loop):
-            super().__init__(manager=manager)
-            self.ops_engine = ops_engine
-            self.closed_loop = closed_loop
-            self.auto_pilot = getattr(args, "auto_pilot", False)
-            self.focus_pr_id = getattr(args, "pr_id", None)
-
-    wizard = FlightDeckWizard(client, ops_engine, closed_loop)
-    print(
-        f"🚀 Flight Deck launched in {'AUTO-PILOT' if wizard.auto_pilot else 'MANUAL'} mode"
-    )
-    if wizard.focus_pr_id:
-        print(f"🎯 Focused on PR #{wizard.focus_pr_id}")
-    wizard.run()
-    return 0
+    """🚀 Launch Flight Deck via the authoritative merge dashboard."""
+    flight_args = argparse.Namespace(**vars(args))
+    flight_args.limit = getattr(args, "limit", 50)
+    flight_args.strategy = getattr(args, "strategy", "hybrid")
+    flight_args.prioritize = list(getattr(args, "prioritize", []) or [])
+    flight_args.only = []
+    if getattr(args, "pr_id", None):
+        flight_args.only = [str(args.pr_id)]
+    return cmd_flight(flight_args)
 
 
 def cmd_fusion(args: argparse.Namespace) -> int:
     """🔥 Launch Fusion Engine for advanced conflict resolution."""
-    from .fusion_engine import FusionEngine
-    from .github_api import GitHubClient
     from .ops_engine import FlightDeckOpsEngine
-    from .patch_engine import PatchEngine
-    from .policy import load_effective_policy
 
-    repo_root = Path.cwd()
-    policy = load_effective_policy(
-        repo_root, explicit_path=getattr(args, "policy", None)
-    )
-    client = GitHubClient(
-        repo=getattr(args, "repo", None), repo_root=repo_root, policy=policy
-    )
-    ops_engine = FlightDeckOpsEngine(Path("proof/pr_merge/flight_deck/fusion"))
-
-    # Initialize engines
-    patch_engine = PatchEngine(ops_engine, posture="GO_SUPERVISED_ONLY")
-    fusion_engine = FusionEngine(patch_engine, ops_engine)
+    FlightDeckOpsEngine(Path("proof/pr_merge/flight_deck/fusion"))
 
     pr_id = args.pr_id
     strategy = args.strategy
@@ -631,13 +578,16 @@ def cmd_fusion(args: argparse.Namespace) -> int:
     # 5. Emit fusion artifacts
 
     print(f"✅ Fusion analysis complete for PR #{pr_id}")
-    print(f"📁 Artifacts: proof/pr_merge/flight_deck/fusion/")
-    print(f"🎯 Next: Review VERIFICATION_GATE_REPORT.json")
+    print("📁 Artifacts: proof/pr_merge/flight_deck/fusion/")
+    print("🎯 Next: Review VERIFICATION_GATE_REPORT.json")
     return 0
 
 
 def cmd_ops(args: argparse.Namespace) -> int:
     """📊 Show Flight Deck operational metrics and health."""
+    import json
+    from pathlib import Path
+
     ops_dir = Path("proof/pr_merge/flight_deck/ops")
 
     print("📊 Flight Deck Operational Metrics")
@@ -661,7 +611,7 @@ def cmd_ops(args: argparse.Namespace) -> int:
             manifest_path = ops_dir / "OPERATIONALIZATION_MANIFEST.json"
             if manifest_path.exists():
                 manifest = json.loads(manifest_path.read_text())
-                print(f"\n📋 Manifest:")
+                print("\n📋 Manifest:")
                 print(f"   Version: {manifest.get('version', '1.0.0')}")
                 print(
                     f"   Artifacts: {', '.join(manifest.get('artifacts', {}).keys())}"
@@ -672,14 +622,14 @@ def cmd_ops(args: argparse.Namespace) -> int:
             print(f"⚠️ Error reading ops report: {e}")
 
     # Fallback: Show basic Flight Deck info
-    print(f"\n📈 Current Status: STANDBY")
-    print(f"🎛️ Posture: GO_SUPERVISED_ONLY")
-    print(f"📝 Flight Deck Sessions: 0")
-    print(f"✍️ Formal Signoffs: 0")
-    print(f"🛡️ Auto-Apply Safety: CLEAN")
-    print(f"📊 Runtime Stability: 1.0")
+    print("\n📈 Current Status: STANDBY")
+    print("🎛️ Posture: GO_SUPERVISED_ONLY")
+    print("📝 Flight Deck Sessions: 0")
+    print("✍️ Formal Signoffs: 0")
+    print("🛡️ Auto-Apply Safety: CLEAN")
+    print("📊 Runtime Stability: 1.0")
 
-    print(f"\n💡 Tip: Run 'flight-deck' or 'fusion' commands to generate metrics")
+    print("\n💡 Tip: Run 'flight-deck' or 'fusion' commands to generate metrics")
 
     return 0
 

--- a/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/policy.py
+++ b/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/policy.py
@@ -33,6 +33,12 @@ REQUIRED_TOP_LEVEL_KEYS = (
     "retry",
     "merge",
 )
+VALID_VALIDATION_SCOPES = {
+    "repo",
+    "changed_files",
+    "docs_frontmatter_files",
+    "docs_validator_files",
+}
 
 DEFAULT_POLICY: Dict[str, Any] = {
     "version": POLICY_SCHEMA_VERSION,
@@ -51,17 +57,20 @@ DEFAULT_POLICY: Dict[str, Any] = {
         "steps": [
             {
                 "name": "pre-commit",
-                "command": ["pre-commit", "run", "--all-files"],
+                "command": ["pre-commit", "run"],
+                "scope": "changed_files",
                 "run_in_dry_run": False,
             },
             {
                 "name": "docs-frontmatter-fix",
                 "command": ["python", "scripts/docs_frontmatter_guard.py", "--fix"],
+                "scope": "docs_frontmatter_files",
                 "run_in_dry_run": False,
             },
             {
                 "name": "docs-validator",
                 "command": ["python", "scripts/docs_validator.py"],
+                "scope": "docs_validator_files",
                 "run_in_dry_run": False,
             },
             {
@@ -70,8 +79,8 @@ DEFAULT_POLICY: Dict[str, Any] = {
                     "python",
                     "scripts/check_docs_hygiene.py",
                     "--check",
-                    "--all-files",
                 ],
+                "scope": "docs_validator_files",
                 "run_in_dry_run": False,
             },
             {
@@ -80,8 +89,8 @@ DEFAULT_POLICY: Dict[str, Any] = {
                     "python",
                     "scripts/check_docs_filename_hygiene.py",
                     "--check",
-                    "--all-files",
                 ],
+                "scope": "docs_validator_files",
                 "run_in_dry_run": False,
             },
             {
@@ -249,6 +258,12 @@ def _validate_command_steps(steps: Iterable[Dict[str, Any]], *, section: str) ->
         ):
             raise PolicyError(
                 f"{section}.steps[{index}] must define a non-empty string command list."
+            )
+        scope = step.get("scope", "repo")
+        if not isinstance(scope, str) or scope not in VALID_VALIDATION_SCOPES:
+            raise PolicyError(
+                f"{section}.steps[{index}] has invalid scope {scope!r}; "
+                f"expected one of {sorted(VALID_VALIDATION_SCOPES)}."
             )
 
 

--- a/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/runtime.py
+++ b/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/runtime.py
@@ -32,6 +32,11 @@ def shell_join(cmd: Sequence[str]) -> str:
     return " ".join(shlex.quote(part) for part in cmd)
 
 
+def contains_marker(text: str, markers: Sequence[str]) -> bool:
+    lowered = text.lower()
+    return any(marker.lower() in lowered for marker in markers)
+
+
 def run_command(
     cmd: Sequence[str],
     *,

--- a/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/validation.py
+++ b/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/validation.py
@@ -1,15 +1,97 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Sequence
 
-from .runtime import execute_or_dry_run, fingerprint_payload, shell_join
+from .runtime import (
+    append_command_log,
+    execute_or_dry_run,
+    fingerprint_payload,
+    run_command,
+    shell_join,
+)
 from .schema import (
     Fingerprint,
     ValidationReport,
     ValidationStatus,
     ValidationStepResult,
 )
+
+SCOPED_VALIDATION_SCOPES = {
+    "changed_files",
+    "docs_frontmatter_files",
+    "docs_validator_files",
+}
+
+
+def _unique_paths(paths: Sequence[str]) -> List[str]:
+    unique: Dict[str, None] = {}
+    for path in paths:
+        normalized = str(path).strip()
+        if normalized:
+            unique[normalized] = None
+    return sorted(unique)
+
+
+def _is_docs_frontmatter_candidate(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    if not normalized.endswith(".md"):
+        return False
+    if normalized.startswith(("docs/", "task-packets/", "UPGRADES/")):
+        return True
+    parts = normalized.split("/")
+    if len(parts) >= 3 and parts[0] in {"services", "docker"} and parts[2] == "docs":
+        return True
+    return False
+
+
+def _is_docs_validator_candidate(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    return normalized.endswith(".md") and normalized.startswith(
+        ("docs/", "task-packets/")
+    )
+
+
+def _resolve_step_files(scope: str, changed_files: Sequence[str]) -> Optional[List[str]]:
+    if scope == "changed_files":
+        return list(changed_files)
+    if scope == "docs_frontmatter_files":
+        return [path for path in changed_files if _is_docs_frontmatter_candidate(path)]
+    if scope == "docs_validator_files":
+        return [path for path in changed_files if _is_docs_validator_candidate(path)]
+    return None
+
+
+def _build_scoped_command(command: Sequence[str], scope_files: Sequence[str]) -> List[str]:
+    scoped = [str(part) for part in command]
+    if scoped[:2] == ["pre-commit", "run"] and "--files" not in scoped:
+        return [*scoped, "--files", *scope_files]
+    return [*scoped, *scope_files]
+
+
+def _collect_changed_files(
+    *,
+    cwd: Path,
+    base_sha: str,
+    commands_log: Path,
+    timeout_seconds: int,
+) -> List[str]:
+    collected: List[str] = []
+    commands = [
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", f"{base_sha}...HEAD"],
+        ["git", "diff", "--name-only", "--diff-filter=ACMR", "HEAD"],
+        ["git", "ls-files", "--others", "--exclude-standard"],
+    ]
+    for command in commands:
+        result = run_command(command, cwd=cwd, timeout_seconds=timeout_seconds)
+        append_command_log(commands_log, result)
+        if result.returncode != 0:
+            raise RuntimeError(
+                result.stderr.strip()
+                or f"Unable to resolve changed files for validation via {shell_join(command)}"
+            )
+        collected.extend(line.strip() for line in result.stdout.splitlines())
+    return _unique_paths(collected)
 
 
 def validation_fingerprint(
@@ -57,6 +139,9 @@ def run_validation(
 ) -> ValidationReport:
     target_cwd = worktree_path or repo_root
     steps_cfg = list(policy.get("validation", {}).get("steps", []))
+    timeout_seconds = int(
+        policy.get("timeouts", {}).get("subprocess_seconds", 600) or 600
+    )
     fingerprint = validation_fingerprint(
         pr_id=pr_id,
         head_sha=head_sha,
@@ -88,9 +173,60 @@ def run_validation(
 
     step_results: List[ValidationStepResult] = []
     remediation_applied = False
+    changed_files: Optional[List[str]] = None
+    if any(str(step.get("scope", "repo")) in SCOPED_VALIDATION_SCOPES for step in steps_cfg):
+        if progress_callback:
+            progress_callback("Resolving changed files for scoped validation", "INFO")
+        try:
+            changed_files = _collect_changed_files(
+                cwd=target_cwd,
+                base_sha=base_sha,
+                commands_log=commands_log,
+                timeout_seconds=timeout_seconds,
+            )
+        except RuntimeError as exc:
+            return ValidationReport(
+                status=ValidationStatus.FAILED,
+                required_for_merge_ready=bool(
+                    policy.get("validation", {}).get(
+                        "require_local_validation_for_merge_ready", True
+                    )
+                ),
+                steps=[
+                    ValidationStepResult(
+                        name="validation-scope-resolution",
+                        command="git diff --name-only",
+                        status="failed",
+                        returncode=1,
+                        stderr=str(exc),
+                    )
+                ],
+                attempts=1,
+                remediation_applied=False,
+                fingerprint=fingerprint,
+            )
+
     for step in steps_cfg:
         command = [str(part) for part in step.get("command", [])]
         name = str(step.get("name", "unnamed-step"))
+        scope = str(step.get("scope", "repo"))
+        if scope in SCOPED_VALIDATION_SCOPES:
+            scoped_files = _resolve_step_files(scope, changed_files or [])
+            if not scoped_files:
+                if progress_callback:
+                    progress_callback(
+                        f"Skipping step: {name} (no files matched scope {scope})",
+                        "INFO",
+                    )
+                step_results.append(
+                    ValidationStepResult(
+                        name=name,
+                        command=shell_join(command),
+                        status="skipped",
+                    )
+                )
+                continue
+            command = _build_scoped_command(command, scoped_files)
 
         if progress_callback:
             progress_callback(f"Running step: {name}", "INFO")
@@ -100,9 +236,7 @@ def run_validation(
             execute=True,
             cwd=target_cwd,
             commands_log=commands_log,
-            timeout_seconds=int(
-                policy.get("timeouts", {}).get("subprocess_seconds", 600) or 600
-            ),
+            timeout_seconds=timeout_seconds,
         )
         status = "passed" if result.returncode == 0 else "failed"
 
@@ -110,9 +244,7 @@ def run_validation(
             if status == "passed":
                 progress_callback(f"Step '{name}' PASSED", "SUCCESS")
             else:
-                progress_callback(
-                    f"Step '{name}' FAILED (Exit {result.returncode})", "ERROR"
-                )
+                progress_callback(f"Step '{name}' FAILED (Exit {result.returncode})", "ERROR")
 
         step_results.append(
             ValidationStepResult(


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary
- sync the skill-template mirrors for `cli.py`, `policy.py`, `runtime.py`, and `validation.py` with the authoritative runtime modules
- restore the `test_template_runtime_parity_for_runtime_modules` contract that was breaking queue PR unit-test runs after rebases onto `main`
- record the parity repair in the changelog

## Validation
- `pytest -q tests/pr_merge_specialist/test_template_contracts.py tests/pr_merge_specialist/test_ordering_and_classification.py tests/pr_merge_specialist/test_queue_drain_integration.py tests/unit/test_pr_merge_specialist_dashboard_and_train.py`
- `python -m py_compile templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/cli.py templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/policy.py templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/runtime.py templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/validation.py`
- `pre-commit run --files CHANGELOG.md templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/cli.py templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/policy.py templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/runtime.py templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/validation.py`

## Why this matters for queue-drain
The rebased queue PRs cleared the shared `checks` failure after PR #334, but they still failed `🧪 Unit Tests` because the template-parity test compared runtime modules against stale template copies on `main`. This patch removes that shared unit-test blocker.
