### PR TITLE
fix(cli): align help test with current copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to the PR Merge Specialist will be documented in this file.
 - `queue-drain --max-prs` now stops the execute loop at the requested bound instead of continuing through additional PRs in the same pass.
 - `queue-drain` now performs merge handoff for post-apply `queued_for_merge` results instead of leaving rebased auto-merge PRs open with no `gh pr merge` execution step.
 - Skill template parity is restored for the mirrored `cli.py`, `policy.py`, `runtime.py`, and `validation.py` modules so the full unit suite agrees with the runtime PR Merge specialist implementation.
+- The top-level CLI help regression test now matches the current DØPEMÜX branding copy already emitted by `dopemux --help`, preventing rebased queue PRs from failing on a stale expectation.
 
 ## [0.1.0] - 2026-03-14
 ### Added

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,8 @@ class TestCLI:
         result = runner.invoke(cli, ["--help"])
 
         assert result.exit_code == 0
-        assert "ADHD-optimized development platform" in result.output
+        assert "Ritual Daemon of Focused Development" in result.output
+        assert "flight-deck for neurodivergent developers" in result.output
         assert "init" in result.output
         assert "start" in result.output
         assert "save" in result.output


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary
- update `tests/test_cli.py` to assert the current DØPEMÜX help copy instead of stale pre-branding text
- note the test-contract correction in `CHANGELOG.md`

## Why
Queue-drain is now successfully rebasing and enqueueing PRs, but rebased heads were still failing `tests/test_cli.py::TestCLI::test_cli_group_help` because the test expected old help text that no longer matches `dopemux --help` on `main`.

## Validation
- `pytest -q tests/test_cli.py -k 'cli_group_help or cli_group_help_includes_kernel'`
- `pre-commit run --files CHANGELOG.md tests/test_cli.py`
