### PR TITLE
fix(cli): unblock init regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to the PR Merge Specialist will be documented in this file.
 - `queue-drain` now performs merge handoff for post-apply `queued_for_merge` results instead of leaving rebased auto-merge PRs open with no `gh pr merge` execution step.
 - Skill template parity is restored for the mirrored `cli.py`, `policy.py`, `runtime.py`, and `validation.py` modules so the full unit suite agrees with the runtime PR Merge specialist implementation.
 - The top-level CLI help regression test now matches the current DØPEMÜX branding copy already emitted by `dopemux --help`, preventing rebased queue PRs from failing on a stale expectation.
+- The `dopemux init` already-initialized CLI regression test now uses the current `Path.exists` call pattern, preventing rebased queue PRs from failing on a broken mock instead of runtime behavior.
 - Docs template assets now use `template-*` filenames so the `docs-prohibited-patterns` hook no longer blocks active PRs on legacy template path names.
 
 ## [0.1.0] - 2026-03-14

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,11 +103,12 @@ class TestCLI:
     def test_init_command_already_initialized(self, mock_exists, mock_config):
         """Test init command when project is already initialized."""
 
-        # Mock that .dopemux directory exists
-        def side_effect(self):
-            if ".dopemux" in str(self):
-                return True
-            return False
+        # Click may probe the path type first; the command itself then checks the
+        # workspace path and the `.dopemux/` directory.
+        def side_effect(*args, **kwargs):
+            if not args:
+                return False
+            return ".dopemux" in str(args[0])
 
         mock_exists.side_effect = side_effect
 


### PR DESCRIPTION
## Summary
- fix the stale init already-initialized CLI regression test to match the current Path.exists call pattern
- document the shared queue unblocker in the changelog

## Validation
- pytest -q tests/test_cli.py -k 'init_command_already_initialized or cli_group_help'
- pre-commit run --files tests/test_cli.py CHANGELOG.md