### PR TITLE
feat(pr-merge): reproduce mapped remote required checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -980,6 +980,7 @@ uvicorn main:app --port 8095 --reload
 - **[Master Index](./docs/00-MASTER-INDEX.md)** - Canonical active docs navigation
 - **[PR Merge Flight Dashboard](./docs/02-how-to/pr-merge-flight-dashboard.md)** - Operator quickstart for the recovered PR merge cockpit
 - **[PR Merge Queue Orchestration](./docs/04-explanation/pr-merge-queue-orchestration.md)** - Queue-state and remediation design rationale
+- **[PR Merge Usage Patterns](./docs/pr_merge/usage-patterns.md)** - Live command patterns, bounded execute runs, and required-check reproduction behavior
 - **[ConPort Memory System](./docs/04-explanation/conport-technical-deep-dive.md)** - Knowledge graph and decision logging
 - **[Serena Code Intelligence](./docs/04-explanation/serena-v2-technical-deep-dive.md)** - LSP-based semantic navigation
 - **[System Architecture](./docs/94-architecture/system-bible.md)** - Two-plane architecture overview

--- a/config/pr_merge_specialist/policy.yaml
+++ b/config/pr_merge_specialist/policy.yaml
@@ -36,6 +36,19 @@ validation:
     - name: root-hygiene
       command: [python, scripts/check_root_hygiene.py]
       run_in_dry_run: false
+remote_check_repro:
+  steps:
+    - check_name: "🧪 Unit Tests"
+      command:
+        - pytest
+        - tests/
+        - --maxfail=1
+        - --disable-warnings
+        - --cov=src/dopemux
+        - --cov-report=term-missing
+        - --cov-report=xml:coverage.xml
+        - --cov-report=html:htmlcov
+      scope: repo
 gates:
   require_clean_worktree: true
   allow_dirty_override: true

--- a/docs/02-how-to/pr-merge-flight-dashboard.md
+++ b/docs/02-how-to/pr-merge-flight-dashboard.md
@@ -57,6 +57,7 @@ Important constraint:
 - branches with failing required GitHub checks remain blocked even when local validation passes
 - auto-merge-enabled PRs are still treated as blocked if the required remote checks are red
 - bounded dry or execute runs respect `--max-prs`, so operator test runs can sample the queue without draining the whole backlog
+- explicitly mapped required checks can be reproduced locally before CI remediation runs; unmapped remote failures still fail closed
 
 ### Optimistic Lifecycle
 The dashboard uses a state model that distinguishes local proof from GitHub lag:

--- a/docs/pr_merge/usage-patterns.md
+++ b/docs/pr_merge/usage-patterns.md
@@ -35,6 +35,8 @@ python -m dopemux_pr_merge_specialist.cli queue-drain --execute --max-prs 5
 
 `queue-drain` does not treat a PR as queued or merge-ready merely because local validation passed. Required GitHub check failures still block the PR until the remote checks clear.
 
+For explicitly mapped required checks, `pr-apply` and `queue-drain` can now attempt a fail-closed local reproduction before invoking automated CI remediation. These mappings live in `config/pr_merge_specialist/policy.yaml` under `remote_check_repro.steps`. Unmapped required-check failures remain blocked by design.
+
 When `pr-apply` produces a passive `queued_for_merge` result after rebasing and validation, `queue-drain` now still executes the merge handoff step so GitHub receives the actual `gh pr merge` or auto-merge enqueue command for that PR.
 
 ## Common Workflows

--- a/src/dopemux_pr_merge_specialist/config/policy.example.yaml
+++ b/src/dopemux_pr_merge_specialist/config/policy.example.yaml
@@ -36,6 +36,19 @@ validation:
     - name: root-hygiene
       command: [python, scripts/check_root_hygiene.py]
       run_in_dry_run: false
+remote_check_repro:
+  steps:
+    - check_name: "🧪 Unit Tests"
+      command:
+        - pytest
+        - tests/
+        - --maxfail=1
+        - --disable-warnings
+        - --cov=src/dopemux
+        - --cov-report=term-missing
+        - --cov-report=xml:coverage.xml
+        - --cov-report=html:htmlcov
+      scope: repo
 gates:
   require_clean_worktree: true
   allow_dirty_override: true

--- a/src/dopemux_pr_merge_specialist/github_api.py
+++ b/src/dopemux_pr_merge_specialist/github_api.py
@@ -26,6 +26,38 @@ BOT_AUTHORS = {
 }
 
 
+def _check_rollup_name(check: Dict[str, Any]) -> str:
+    name = str(check.get("name") or check.get("context") or "").strip()
+    return name
+
+
+def _required_check_names_by_state(
+    checks: List[Dict[str, Any]],
+    required_contexts: Sequence[str],
+    *,
+    failure_only: bool = False,
+    pending_only: bool = False,
+) -> List[str]:
+    required = {str(item).strip() for item in required_contexts if str(item).strip()}
+    names: List[str] = []
+    for check in checks:
+        name = _check_rollup_name(check)
+        if not name or name not in required:
+            continue
+        status = str(check.get("status") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        is_pending = bool(status and status != "COMPLETED") or (
+            not conclusion and status != "COMPLETED"
+        )
+        is_failure = conclusion in CHECK_FAILURE
+        if failure_only and not is_failure:
+            continue
+        if pending_only and not is_pending:
+            continue
+        names.append(name)
+    return sorted(dict.fromkeys(names))
+
+
 class GitHubClient:
     def __init__(
         self,
@@ -497,9 +529,16 @@ class GitHubClient:
         summary = summarize_checks(checks)
         review_decision = str(payload.get("reviewDecision") or "")
         protection = self.fetch_branch_protection(str(payload.get("baseRefName") or ""))
+        required_contexts = list(protection.get("required_status_checks") or [])
         approval_required = bool(protection.get("approval_required", False))
         blockers: List[str] = []
         warnings: List[str] = []
+        failed_required_checks = _required_check_names_by_state(
+            checks, required_contexts, failure_only=True
+        )
+        pending_required_checks = _required_check_names_by_state(
+            checks, required_contexts, pending_only=True
+        )
         if summary.required_failure > 0:
             blockers.append("required_check_failed")
         if summary.required_pending > 0:
@@ -522,6 +561,8 @@ class GitHubClient:
             "mergeable": payload.get("mergeable", ""),
             "merge_state_status": payload.get("mergeStateStatus", ""),
             "protection": protection,
+            "failed_required_checks": failed_required_checks,
+            "pending_required_checks": pending_required_checks,
             "approval_required": approval_required,
             "blocker_types": blockers,
             "warning_types": warnings,

--- a/src/dopemux_pr_merge_specialist/policy.py
+++ b/src/dopemux_pr_merge_specialist/policy.py
@@ -25,6 +25,7 @@ REQUIRED_TOP_LEVEL_KEYS = (
     "platform",
     "timeouts",
     "validation",
+    "remote_check_repro",
     "gates",
     "thread_rules",
     "check_rules",
@@ -98,6 +99,24 @@ DEFAULT_POLICY: Dict[str, Any] = {
                 "command": ["python", "scripts/check_root_hygiene.py"],
                 "run_in_dry_run": False,
             },
+        ],
+    },
+    "remote_check_repro": {
+        "steps": [
+            {
+                "check_name": "🧪 Unit Tests",
+                "command": [
+                    "pytest",
+                    "tests/",
+                    "--maxfail=1",
+                    "--disable-warnings",
+                    "--cov=src/dopemux",
+                    "--cov-report=term-missing",
+                    "--cov-report=xml:coverage.xml",
+                    "--cov-report=html:htmlcov",
+                ],
+                "scope": "repo",
+            }
         ],
     },
     "gates": {
@@ -248,7 +267,13 @@ def _validate_command_steps(steps: Iterable[Dict[str, Any]], *, section: str) ->
     for index, step in enumerate(steps):
         if not isinstance(step, dict):
             raise PolicyError(f"{section}.steps[{index}] must be a mapping.")
-        if not step.get("name"):
+        if section == "remote_check_repro":
+            check_name = step.get("check_name")
+            if not isinstance(check_name, str) or not check_name.strip():
+                raise PolicyError(
+                    f"{section}.steps[{index}] must define a non-empty 'check_name'."
+                )
+        elif not step.get("name"):
             raise PolicyError(f"{section}.steps[{index}] is missing 'name'.")
         command = step.get("command")
         if (
@@ -288,6 +313,12 @@ def validate_policy(policy: Dict[str, Any]) -> None:
     if not isinstance(validation, dict):
         raise PolicyError("validation must be a mapping.")
     _validate_command_steps(validation.get("steps", []), section="validation")
+    remote_check_repro = policy.get("remote_check_repro")
+    if not isinstance(remote_check_repro, dict):
+        raise PolicyError("remote_check_repro must be a mapping.")
+    _validate_command_steps(
+        remote_check_repro.get("steps", []), section="remote_check_repro"
+    )
     for section_name in (
         "gates",
         "thread_rules",

--- a/src/dopemux_pr_merge_specialist/queue_drain.py
+++ b/src/dopemux_pr_merge_specialist/queue_drain.py
@@ -19,7 +19,7 @@ from .action_model import allowed_actions_for_result
 from .github_api import BOT_AUTHORS, GitHubClient, ci_status, summarize_checks, thread_counters
 from .policy import PolicyError, load_effective_policy, policy_artifact_payload, policy_fingerprint
 from .runtime import CommandResult, append_command_log, execute_or_dry_run, fingerprint_payload, pid_is_running, run_command, run_id, shell_join, snapshot_environment, utc_now, write_json, write_text
-from .schema import ARTIFACT_VERSION, ArtifactMeta, BlockerType, FallbackReason, Finding, FindingSeverity, Fingerprint, MergeDecision, MergeActionType, OverrideRecord, PhaseRecord, PRResult, PRState, PRStateData, POLICY_SCHEMA_VERSION, PreflightCheck, PreflightResult, PullRequestState, QueueOrderingLayer, ReviewThread, RunManifest, ThreadComment, ThreadDisposition, ThreadDispositionType, TruthSource, ValidationReport, ValidationStatus, TOOL_VERSION
+from .schema import ARTIFACT_VERSION, ArtifactMeta, BlockerType, FallbackReason, Finding, FindingSeverity, Fingerprint, MergeDecision, MergeActionType, OverrideRecord, PhaseRecord, PRResult, PRState, PRStateData, POLICY_SCHEMA_VERSION, PreflightCheck, PreflightResult, PullRequestState, QueueOrderingLayer, ReviewThread, RunManifest, ThreadComment, ThreadDisposition, ThreadDispositionType, TruthSource, ValidationReport, ValidationStatus, ValidationStepResult, TOOL_VERSION
 from .validation import run_validation, validation_report_md
 from .strategy_library import STRATEGY_LIBRARY, select_strategy, StrategyAssignment, TRAIN_ELIGIBLE_STRATEGIES, STRATEGY_EXECUTION_ORDER
 
@@ -500,6 +500,96 @@ Identify the root cause, modify the necessary files, and ensure the command pass
     return True
 
 
+def reproduce_remote_required_check_failure(
+    *,
+    worktree_path: Path,
+    commands_log: Path,
+    policy: Dict[str, Any],
+    check_payload: Dict[str, Any],
+    log: Callable[[str, str], None],
+) -> Tuple[Optional[str], Optional[ValidationReport]]:
+    failed_required_checks = [
+        str(name).strip()
+        for name in check_payload.get("failed_required_checks", []) or []
+        if str(name).strip()
+    ]
+    if not failed_required_checks:
+        return None, None
+
+    mappings = list(policy.get("remote_check_repro", {}).get("steps", []))
+    if not mappings:
+        log(
+            "Required GitHub checks are failing, but no remote-check reproduction mappings are configured.",
+            "INFO",
+        )
+        return None, None
+
+    timeout_seconds = int(
+        policy.get("timeouts", {}).get("subprocess_seconds", 600) or 600
+    )
+    for step in mappings:
+        check_name = str(step.get("check_name") or "").strip()
+        if not check_name or check_name not in failed_required_checks:
+            continue
+        scope = str(step.get("scope", "repo"))
+        if scope != "repo":
+            log(
+                f"Skipping remote-check reproduction for '{check_name}': unsupported scope '{scope}'.",
+                "INFO",
+            )
+            return None, None
+        command = [str(part) for part in step.get("command", []) if str(part)]
+        if not command:
+            log(
+                f"Skipping remote-check reproduction for '{check_name}': empty command mapping.",
+                "INFO",
+            )
+            return None, None
+
+        log(f"Reproducing remote required check locally: {check_name}", "START")
+        result = execute_or_dry_run(
+            command,
+            execute=True,
+            cwd=worktree_path,
+            commands_log=commands_log,
+            timeout_seconds=timeout_seconds,
+        )
+        status = "passed" if result.returncode == 0 else "failed"
+        report = ValidationReport(
+            status=(
+                ValidationStatus.PASSED
+                if result.returncode == 0
+                else ValidationStatus.FAILED
+            ),
+            required_for_merge_ready=True,
+            steps=[
+                ValidationStepResult(
+                    name=check_name,
+                    command=shell_join(command),
+                    status=status,
+                    returncode=result.returncode,
+                    stdout=result.stdout,
+                    stderr=result.stderr,
+                )
+            ],
+            attempts=1,
+            remediation_applied=False,
+        )
+        if report.passed:
+            log(
+                f"Remote required check '{check_name}' passed locally; no local reproduction found.",
+                "INFO",
+            )
+        else:
+            log(f"Remote required check '{check_name}' reproduced locally.", "ERROR")
+        return check_name, report
+    log(
+        "Required GitHub checks are failing, but none of the failing check names have local reproduction mappings.",
+        "INFO",
+    )
+    return None, None
+
+
 def pr_apply(args: argparse.Namespace, progress_callback: Optional[Callable[[str, str], None]] = None) -> PRResult:
     def log(msg: str, s_type: str = "INFO"):
         if progress_callback:
@@ -728,7 +818,63 @@ def pr_apply(args: argparse.Namespace, progress_callback: Optional[Callable[[str
                         _refresh_client_state(client, pr.pr_id)        
         if validation.passed:
             log("Validation PASSED", "SUCCESS")
-            # Resolve threads only after validation passes
+        else:
+            log("Validation FAILED", "ERROR")
+
+        _refresh_client_state(client, pr.pr_id)
+        raw, threads, refreshed_pr, refreshed_checks = _load_pr_context(
+            client=client, pr_id=pr.pr_id
+        )
+        if validation.passed and execute:
+            reproduced_check, remote_validation = reproduce_remote_required_check_failure(
+                worktree_path=worktree_path,
+                commands_log=commands_log,
+                policy=policy,
+                check_payload=refreshed_checks,
+                log=log,
+            )
+            if remote_validation is not None and not remote_validation.passed:
+                log(
+                    f"Remote required check '{reproduced_check}' failed locally; attempting AI remediation..."
+                )
+                if remediate_ci_failure(worktree_path, remote_validation, log):
+                    reproduced_check, remote_validation = reproduce_remote_required_check_failure(
+                        worktree_path=worktree_path,
+                        commands_log=commands_log,
+                        policy=policy,
+                        check_payload=refreshed_checks,
+                        log=log,
+                    )
+                    if remote_validation is not None and remote_validation.passed:
+                        log("Remote-check remediation passed locally; re-running validation suite...", "START")
+                        validation = run_validation(
+                            repo_root=repo_root,
+                            worktree_path=worktree_path,
+                            policy=policy,
+                            execute=execute,
+                            commands_log=commands_log,
+                            pr_id=pr.pr_id,
+                            head_sha=pr.head_sha,
+                            base_sha=pr.base_sha,
+                            policy_fingerprint=policy_fingerprint(policy),
+                            lifecycle_state=(
+                                pr.lifecycle_state.value
+                                if hasattr(pr.lifecycle_state, "value")
+                                else str(pr.lifecycle_state)
+                            ),
+                            progress_callback=progress_callback
+                        )
+                        if validation.passed:
+                            log("Committing remote-check remediation fix...")
+                            if stage_and_push_if_needed(worktree_path=worktree_path, head_ref=pr.head_ref, active_run_id=active_run_id, pr_id=pr.pr_id, execute=execute, commands_log=commands_log, policy=policy, log=log):
+                                _refresh_client_state(client, pr.pr_id)
+                                raw, threads, refreshed_pr, refreshed_checks = _load_pr_context(
+                                    client=client, pr_id=pr.pr_id
+                                )
+                        else:
+                            log("Full validation still failed after remote-check remediation.", "ERROR")
+
+        if validation.passed:
             resolve_verified_threads(
                 dispositions=applied_threads,
                 execute=execute,
@@ -736,13 +882,7 @@ def pr_apply(args: argparse.Namespace, progress_callback: Optional[Callable[[str
                 repo_root=repo_root,
                 policy=policy
             )
-        else:
-            log("Validation FAILED", "ERROR")
-            
-        _refresh_client_state(client, pr.pr_id)
-        raw, threads, refreshed_pr, refreshed_checks = _load_pr_context(
-            client=client, pr_id=pr.pr_id
-        )
+
         result = build_plan_result(
             active_run_id=active_run_id,
             pr=refreshed_pr,

--- a/tests/pr_merge_specialist/test_policy_and_validation.py
+++ b/tests/pr_merge_specialist/test_policy_and_validation.py
@@ -19,6 +19,7 @@ def test_repo_policy_loads_and_has_fingerprint():
     assert payload["policy_schema_version"] == 1
     assert payload["policy_fingerprint"]
     assert payload["policy_source"] in {"repo", "bundled", "explicit"}
+    assert policy["remote_check_repro"]["steps"]
 
 
 def test_invalid_policy_fails_closed(tmp_path: Path):
@@ -28,6 +29,41 @@ def test_invalid_policy_fails_closed(tmp_path: Path):
         encoding="utf-8",
     )
     with pytest.raises(PolicyError):
+        load_effective_policy(REPO_ROOT, explicit_path=str(bad))
+
+
+def test_invalid_remote_check_repro_step_fails_closed(tmp_path: Path):
+    bad = tmp_path / "bad-policy.yaml"
+    bad.write_text(
+        """
+version: 1
+platform:
+  supported: [darwin]
+  unsupported: [windows]
+  shell: posix
+timeouts:
+  subprocess_seconds: 30
+  gh_seconds: 30
+  phase_seconds: 30
+validation:
+  require_local_validation_for_merge_ready: true
+  steps: []
+remote_check_repro:
+  steps:
+    - command: [pytest, tests/]
+      scope: repo
+gates: {}
+thread_rules: {}
+check_rules: {}
+conflict_rules: {}
+safety:
+  negative_allowlist: []
+retry: {}
+merge: {}
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(PolicyError, match="check_name"):
         load_effective_policy(REPO_ROOT, explicit_path=str(bad))
 
 

--- a/tests/pr_merge_specialist/test_queue_drain_integration.py
+++ b/tests/pr_merge_specialist/test_queue_drain_integration.py
@@ -7,9 +7,11 @@ from types import SimpleNamespace
 
 from dopemux_pr_merge_specialist import closed_loop_engine
 from dopemux_pr_merge_specialist import engine
+from dopemux_pr_merge_specialist.github_api import GitHubClient
 from dopemux_pr_merge_specialist import queue_drain as queue_drain_module
 from dopemux_pr_merge_specialist.plan_builder import build_plan_result, write_pr_state_artifact
 from dopemux_pr_merge_specialist.preflight import build_run_paths, pr_dir_for
+from dopemux_pr_merge_specialist.runtime import CommandResult
 from dopemux_pr_merge_specialist.schema import MergeActionType, MergeDecision, PRResult, PRState, PullRequestState, ValidationReport, ValidationStatus, ValidationStepResult
 from dopemux_pr_merge_specialist import cli as pr_merge_cli
 
@@ -631,6 +633,71 @@ def test_queue_drain_propagates_resolved_run_id_to_subcommands(
     assert rc == 0
     assert len(seen_run_ids) == 1
     assert seen_run_ids[0]
+
+
+def test_query_checks_reports_exact_failed_required_check_names(tmp_path: Path):
+    client = GitHubClient(
+        repo="DDD-Enterprises/dopemux-mvp",
+        repo_root=tmp_path,
+        policy={"retry": {}, "timeouts": {}},
+    )
+    client.fetch_branch_protection = lambda _branch: {  # type: ignore[method-assign]
+        "approval_required": False,
+        "required_status_checks": ["🧪 Unit Tests", "identity-check"],
+    }
+    payload = {
+        "baseRefName": "main",
+        "reviewDecision": "",
+        "mergeable": "MERGEABLE",
+        "mergeStateStatus": "BLOCKED",
+        "statusCheckRollup": [
+            {"name": "🧪 Unit Tests", "status": "COMPLETED", "conclusion": "FAILURE"},
+            {"name": "identity-check", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"name": "📚 Documentation Check", "status": "COMPLETED", "conclusion": "FAILURE"},
+        ],
+    }
+
+    result = client.query_checks(323, pr_payload=payload)
+
+    assert result["failed_required_checks"] == ["🧪 Unit Tests"]
+    assert result["pending_required_checks"] == []
+
+
+def test_reproduce_remote_required_check_failure_runs_mapped_command(monkeypatch, tmp_path: Path):
+    recorded_commands: list[list[str]] = []
+    messages: list[tuple[str, str]] = []
+
+    def fake_execute_or_dry_run(cmd, *, execute, cwd, commands_log, timeout_seconds=600):
+        recorded_commands.append(list(cmd))
+        return CommandResult(list(cmd), 1, "", "test failure")
+
+    monkeypatch.setattr(queue_drain_module, "execute_or_dry_run", fake_execute_or_dry_run)
+
+    check_name, report = queue_drain_module.reproduce_remote_required_check_failure(
+        worktree_path=tmp_path,
+        commands_log=tmp_path / "commands.txt",
+        policy={
+            "timeouts": {"subprocess_seconds": 30},
+            "remote_check_repro": {
+                "steps": [
+                    {
+                        "check_name": "🧪 Unit Tests",
+                        "command": ["pytest", "tests/", "--maxfail=1"],
+                        "scope": "repo",
+                    }
+                ]
+            },
+        },
+        check_payload={"failed_required_checks": ["🧪 Unit Tests"]},
+        log=lambda message, level="INFO": messages.append((message, level)),
+    )
+
+    assert check_name == "🧪 Unit Tests"
+    assert report is not None
+    assert report.status == ValidationStatus.FAILED
+    assert report.steps[0].name == "🧪 Unit Tests"
+    assert recorded_commands == [["pytest", "tests/", "--maxfail=1"]]
+    assert any("reproduced locally" in message for message, _level in messages)
 
 
 def test_handle_global_ci_blockers_ignores_failed_global_fix_creation(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary
- add a policy-backed `remote_check_repro` mapping for explicitly reproducible required GitHub checks
- extract exact failing required-check names from branch-protected check rollups
- teach `pr-apply` to reproduce mapped remote required checks locally before invoking CI remediation
- update PR merge docs and README to document the new fail-closed automation behavior

## Validation
- `python -m py_compile src/dopemux_pr_merge_specialist/policy.py src/dopemux_pr_merge_specialist/github_api.py src/dopemux_pr_merge_specialist/queue_drain.py`
- `pytest -q tests/pr_merge_specialist/test_policy_and_validation.py tests/pr_merge_specialist/test_queue_drain_integration.py -k 'repo_policy_loads_and_has_fingerprint or invalid_remote_check_repro_step_fails_closed or query_checks_reports_exact_failed_required_check_names or reproduce_remote_required_check_failure_runs_mapped_command'`
- `python -m dopemux_pr_merge_specialist.cli self-check --json --allow-dirty`
- live run: `python -m dopemux_pr_merge_specialist.cli pr-apply --id 323 --execute --allow-dirty`

## Notes
- this remains fail-closed for unmapped remote checks
- current mapping covers `🧪 Unit Tests` and mirrors the CI workflow command

@codex
@clauee
@copilot
