### PR TITLE
feat(execution): consolidate canonical execution-plane branch

### DIFF
--- a/src/dopemux/adhd/task_decomposer.py
+++ b/src/dopemux/adhd/task_decomposer.py
@@ -34,6 +34,7 @@ from dopemux.pm.writes import (
     pm_transition_work_item,
     pm_update_work_item,
 )
+from dopemux.execution.models import ExecutionPacket, PacketState
 
 class TaskStatus(Enum):
     """Simple task lifecycle states mapping to Canonical PM status."""
@@ -64,6 +65,24 @@ class TaskRecord:
         data = asdict(self)
         data["status"] = self.status.value
         return data
+
+    def to_execution_packet(self, owner_id: str) -> ExecutionPacket:
+        """Wrap the local task mirror as an execution packet."""
+        state_map = {
+            TaskStatus.PENDING: PacketState.READY,
+            TaskStatus.IN_PROGRESS: PacketState.EXECUTING,
+            TaskStatus.COMPLETED: PacketState.PROOF_GENERATED,
+        }
+        return ExecutionPacket(
+            packet_id=self.id,
+            owner_id=owner_id,
+            state=state_map.get(self.status, PacketState.READY),
+            metadata={
+                "description": self.description,
+                "priority": self.priority,
+                "estimated_duration": self.estimated_duration,
+            },
+        )
 
     @classmethod
     def from_dict(cls, data: Dict[str, object]) -> "TaskRecord":

--- a/src/dopemux/execution/models.py
+++ b/src/dopemux/execution/models.py
@@ -7,7 +7,7 @@ Workflow / Execution Control Plane.
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -30,6 +30,27 @@ class LeaseState(str, Enum):
     ACTIVE = "ACTIVE"  # Lease is within TTL
     EXPIRED = "EXPIRED"  # Heartbeat missed; packet returned to READY
     RELEASED = "RELEASED"  # Graceful handoff or completion
+
+
+class ExecutionDisposition(str, Enum):
+    """Final outcome of an execution attempt."""
+
+    SUCCEEDED = "SUCCEEDED"
+    FAILED = "FAILED"
+    ABORTED = "ABORTED"
+
+
+class ExecutionResult(BaseModel):
+    """Immutable record of an execution attempt."""
+
+    packet_id: str
+    lease_id: UUID
+    agent_id: str
+    disposition: ExecutionDisposition
+    result_summary: str
+    artifacts: Dict[str, Any] = Field(default_factory=dict)
+    started_at_utc: datetime
+    completed_at_utc: datetime
 
 
 class ExecutionPacket(BaseModel):
@@ -59,5 +80,6 @@ class PacketLease(BaseModel):
     expires_at_utc: datetime = Field(..., description="Hard deadline for next heartbeat")
     ttl_seconds: int = Field(..., description="Original lease duration in seconds")
     state: LeaseState = Field(default=LeaseState.ACTIVE)
+    result: Optional[ExecutionResult] = None
 
     model_config = {"frozen": False}

--- a/src/dopemux/execution/store.py
+++ b/src/dopemux/execution/store.py
@@ -7,10 +7,18 @@ Workflow / Execution Control Plane.
 
 from abc import ABC, abstractmethod
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from threading import Lock
+from typing import Any, Dict, List, Optional
 from uuid import UUID, uuid4
 
-from .models import ExecutionPacket, PacketLease, PacketState, LeaseState
+from .models import (
+    ExecutionDisposition,
+    ExecutionPacket,
+    ExecutionResult,
+    LeaseState,
+    PacketLease,
+    PacketState,
+)
 
 
 class ExecutionError(Exception):
@@ -50,6 +58,17 @@ class LeaseExpiredError(ExecutionError):
     def __init__(self, lease_id: UUID) -> None:
         self.lease_id = lease_id
         super().__init__(f"Lease {lease_id} has expired")
+
+
+class StaleLeaseError(ExecutionError):
+    """Raised when an operation uses a non-authoritative lease."""
+
+    def __init__(self, lease_id: UUID, packet_id: str) -> None:
+        self.lease_id = lease_id
+        self.packet_id = packet_id
+        super().__init__(
+            f"Lease {lease_id} for packet {packet_id} is stale (no longer authoritative)"
+        )
 
 
 class ExecutionStore(ABC):
@@ -98,16 +117,25 @@ class LeaseStore(ABC):
         Raises:
             LeaseNotFoundError: lease_id does not exist.
             LeaseExpiredError: lease has already expired.
+            StaleLeaseError: lease is no longer authoritative.
         """
         pass
 
     @abstractmethod
-    def release(self, lease_id: UUID, final_state: PacketState) -> PacketLease:
+    def release(
+        self,
+        lease_id: UUID,
+        final_state: PacketState,
+        disposition: ExecutionDisposition = ExecutionDisposition.SUCCEEDED,
+        result_summary: str = "",
+        artifacts: Optional[Dict[str, Any]] = None,
+    ) -> PacketLease:
         """
         Transition packet to final_state and mark lease as RELEASED.
 
         Raises:
             LeaseNotFoundError: lease_id does not exist.
+            StaleLeaseError: lease is no longer authoritative.
         """
         pass
 
@@ -117,25 +145,30 @@ class InMemoryExecutionStore(ExecutionStore):
 
     def __init__(self) -> None:
         self._packets: Dict[str, ExecutionPacket] = {}
+        self._lock = Lock()
 
     def create_packet(self, packet: ExecutionPacket) -> ExecutionPacket:
-        if packet.packet_id in self._packets:
+        with self._lock:
+            if packet.packet_id in self._packets:
+                return self._packets[packet.packet_id].model_copy()
+            self._packets[packet.packet_id] = packet.model_copy()
             return self._packets[packet.packet_id].model_copy()
-        self._packets[packet.packet_id] = packet.model_copy()
-        return self._packets[packet.packet_id].model_copy()
 
     def get_packet(self, packet_id: str) -> Optional[ExecutionPacket]:
-        packet = self._packets.get(packet_id)
-        return packet.model_copy() if packet else None
+        with self._lock:
+            packet = self._packets.get(packet_id)
+            return packet.model_copy() if packet else None
 
     def list_ready_packets(self) -> List[ExecutionPacket]:
-        return [p.model_copy() for p in self._packets.values() if p.state == PacketState.READY]
+        with self._lock:
+            return [p.model_copy() for p in self._packets.values() if p.state == PacketState.READY]
 
     def update_packet_state(self, packet_id: str, state: PacketState) -> ExecutionPacket:
-        if packet_id not in self._packets:
-            raise PacketNotFoundError(packet_id)
-        self._packets[packet_id].state = state
-        return self._packets[packet_id].model_copy()
+        with self._lock:
+            if packet_id not in self._packets:
+                raise PacketNotFoundError(packet_id)
+            self._packets[packet_id].state = state
+            return self._packets[packet_id].model_copy()
 
 
 class InMemoryLeaseStore(LeaseStore):
@@ -146,72 +179,101 @@ class InMemoryLeaseStore(LeaseStore):
         self._leases: Dict[UUID, PacketLease] = {}
         # Track active lease per packet_id
         self._packet_to_lease: Dict[str, UUID] = {}
+        self._lock = Lock()
 
     def checkout(self, packet_id: str, agent_id: str, ttl_seconds: int) -> PacketLease:
-        now = datetime.now(timezone.utc)
-        packet = self._execution_store.get_packet(packet_id)
-        if not packet:
-            raise PacketNotFoundError(packet_id)
-        if packet.state != PacketState.READY:
-            active_lease_id = self._packet_to_lease.get(packet_id)
-            if active_lease_id is None or packet.state not in {PacketState.LEASED, PacketState.EXECUTING}:
-                raise PacketNotReadyError(packet_id, packet.state)
+        with self._lock:
+            now = datetime.now(timezone.utc)
+            packet = self._execution_store.get_packet(packet_id)
+            if not packet:
+                raise PacketNotFoundError(packet_id)
+            if packet.state != PacketState.READY:
+                active_lease_id = self._packet_to_lease.get(packet_id)
+                if active_lease_id is None or packet.state not in {PacketState.LEASED, PacketState.EXECUTING}:
+                    raise PacketNotReadyError(packet_id, packet.state)
 
-            lease = self._leases.get(active_lease_id)
-            if lease is None or lease.state != LeaseState.ACTIVE:
-                raise PacketNotReadyError(packet_id, packet.state)
+                lease = self._leases.get(active_lease_id)
+                if lease is None or lease.state != LeaseState.ACTIVE:
+                    raise PacketNotReadyError(packet_id, packet.state)
 
-            if lease.expires_at_utc > now:
-                raise PacketNotReadyError(packet_id, packet.state)
+                if lease.expires_at_utc > now:
+                    raise PacketNotReadyError(packet_id, packet.state)
 
-            lease.state = LeaseState.EXPIRED
-            del self._packet_to_lease[packet_id]
+                lease.state = LeaseState.EXPIRED
+                del self._packet_to_lease[packet_id]
 
-        expires_at = now + timedelta(seconds=ttl_seconds)
-        lease = PacketLease(
-            lease_id=uuid4(),
-            packet_id=packet_id,
-            agent_id=agent_id,
-            leased_at_utc=now,
-            expires_at_utc=expires_at,
-            ttl_seconds=ttl_seconds,
-            state=LeaseState.ACTIVE
-        )
+            expires_at = now + timedelta(seconds=ttl_seconds)
+            lease = PacketLease(
+                lease_id=uuid4(),
+                packet_id=packet_id,
+                agent_id=agent_id,
+                leased_at_utc=now,
+                expires_at_utc=expires_at,
+                ttl_seconds=ttl_seconds,
+                state=LeaseState.ACTIVE,
+            )
 
-        self._execution_store.update_packet_state(packet_id, PacketState.LEASED)
-        self._leases[lease.lease_id] = lease
-        self._packet_to_lease[packet_id] = lease.lease_id
-        return lease.model_copy()
+            self._execution_store.update_packet_state(packet_id, PacketState.LEASED)
+            self._leases[lease.lease_id] = lease
+            self._packet_to_lease[packet_id] = lease.lease_id
+            return lease.model_copy()
 
     def heartbeat(self, lease_id: UUID) -> PacketLease:
-        lease = self._leases.get(lease_id)
-        if not lease:
-            raise LeaseNotFoundError(lease_id)
+        with self._lock:
+            lease = self._leases.get(lease_id)
+            if not lease:
+                raise LeaseNotFoundError(lease_id)
 
-        now = datetime.now(timezone.utc)
-        if lease.expires_at_utc < now:
-            lease.state = LeaseState.EXPIRED
-            raise LeaseExpiredError(lease_id)
+            if self._packet_to_lease.get(lease.packet_id) != lease_id:
+                raise StaleLeaseError(lease_id, lease.packet_id)
 
-        lease.expires_at_utc = now + timedelta(seconds=lease.ttl_seconds)
-        # Ensure packet state is EXECUTING if it was LEASED
-        packet = self._execution_store.get_packet(lease.packet_id)
-        if packet and packet.state == PacketState.LEASED:
-            self._execution_store.update_packet_state(lease.packet_id, PacketState.EXECUTING)
+            now = datetime.now(timezone.utc)
+            if lease.expires_at_utc < now:
+                lease.state = LeaseState.EXPIRED
+                if self._packet_to_lease.get(lease.packet_id) == lease_id:
+                    del self._packet_to_lease[lease.packet_id]
+                raise LeaseExpiredError(lease_id)
 
-        return lease.model_copy()
+            lease.expires_at_utc = now + timedelta(seconds=lease.ttl_seconds)
+            packet = self._execution_store.get_packet(lease.packet_id)
+            if packet and packet.state == PacketState.LEASED:
+                self._execution_store.update_packet_state(lease.packet_id, PacketState.EXECUTING)
 
-    def release(self, lease_id: UUID, final_state: PacketState) -> PacketLease:
-        lease = self._leases.get(lease_id)
-        if not lease:
-            raise LeaseNotFoundError(lease_id)
+            return lease.model_copy()
 
-        lease.state = LeaseState.RELEASED
-        self._execution_store.update_packet_state(lease.packet_id, final_state)
-        if self._packet_to_lease.get(lease.packet_id) == lease_id:
-            del self._packet_to_lease[lease.packet_id]
+    def release(
+        self,
+        lease_id: UUID,
+        final_state: PacketState,
+        disposition: ExecutionDisposition = ExecutionDisposition.SUCCEEDED,
+        result_summary: str = "",
+        artifacts: Optional[Dict[str, Any]] = None,
+    ) -> PacketLease:
+        with self._lock:
+            lease = self._leases.get(lease_id)
+            if not lease:
+                raise LeaseNotFoundError(lease_id)
 
-        return lease.model_copy()
+            if self._packet_to_lease.get(lease.packet_id) != lease_id:
+                raise StaleLeaseError(lease_id, lease.packet_id)
+
+            now = datetime.now(timezone.utc)
+            lease.state = LeaseState.RELEASED
+            lease.result = ExecutionResult(
+                packet_id=lease.packet_id,
+                lease_id=lease_id,
+                agent_id=lease.agent_id,
+                disposition=disposition,
+                result_summary=result_summary,
+                artifacts=artifacts or {},
+                started_at_utc=lease.leased_at_utc,
+                completed_at_utc=now,
+            )
+            self._execution_store.update_packet_state(lease.packet_id, final_state)
+            if self._packet_to_lease.get(lease.packet_id) == lease_id:
+                del self._packet_to_lease[lease.packet_id]
+
+            return lease.model_copy()
 
 
 _execution_store: Optional[ExecutionStore] = None

--- a/src/dopemux/workflow/store.py
+++ b/src/dopemux/workflow/store.py
@@ -1,0 +1,200 @@
+"""Workspace-local workflow state persistence helpers."""
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from ..workspace_detection import get_workspace_root
+from .models import WorkflowState, WorkflowStatus
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-")
+    return slug or "workflow"
+
+
+def _atomic_json_write(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        json.dump(payload, handle, indent=2, sort_keys=False)
+        handle.write("\n")
+        temp_path = Path(handle.name)
+    temp_path.replace(path)
+
+
+class WorkflowStore:
+    """Canonical writer for workspace-local workflow state."""
+
+    INDEX_VERSION = 1
+
+    def __init__(self, workspace_root: Path):
+        self.workspace_root = workspace_root.expanduser().resolve()
+        self.workflows_dir = self.workspace_root / ".dopemux" / "workflows"
+        self.index_path = self.workflows_dir / "index.json"
+
+    @classmethod
+    def for_path(cls, start_path: Optional[Path] = None) -> "WorkflowStore":
+        if start_path is None:
+            return cls(get_workspace_root(None))
+        return cls(cls._resolve_explicit_workspace_root(start_path))
+
+    @staticmethod
+    def _resolve_explicit_workspace_root(start_path: Path) -> Path:
+        current = start_path.expanduser().resolve()
+        if current.is_file():
+            current = current.parent
+        for candidate in (current, *current.parents):
+            if (candidate / ".dopemux" / "workflows").exists():
+                return candidate
+            if (candidate / ".dopetaskroot").exists():
+                return candidate
+            if (candidate / "pyproject.toml").exists():
+                return candidate
+            if (candidate / ".git").exists():
+                return candidate
+        return current
+
+    def _state_path(self, workflow_id: str) -> Path:
+        return self.workflows_dir / workflow_id / "state.json"
+
+    def _load_index(self) -> Dict[str, Any]:
+        if not self.index_path.exists():
+            return {
+                "version": self.INDEX_VERSION,
+                "updated_at": None,
+                "workflows_by_instance": {},
+            }
+        with self.index_path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        if not isinstance(data, dict):
+            raise ValueError(f"Invalid workflow index at {self.index_path}")
+        data.setdefault("version", self.INDEX_VERSION)
+        data.setdefault("workflows_by_instance", {})
+        return data
+
+    def _save_index(self, index: Dict[str, Any]) -> None:
+        _atomic_json_write(self.index_path, index)
+
+    def save(self, state: WorkflowState) -> WorkflowState:
+        path = self._state_path(state.workflow_id)
+        _atomic_json_write(path, state.to_dict())
+        index = self._load_index()
+        mapping = dict(index.get("workflows_by_instance") or {})
+        if state.status == WorkflowStatus.ACTIVE:
+            mapping[state.instance_id] = state.workflow_id
+        elif mapping.get(state.instance_id) == state.workflow_id:
+            mapping.pop(state.instance_id, None)
+        index["workflows_by_instance"] = mapping
+        index["updated_at"] = state.updated_at
+        self._save_index(index)
+        return state
+
+    def load(self, workflow_id: str) -> WorkflowState:
+        path = self._state_path(workflow_id)
+        if not path.exists():
+            raise FileNotFoundError(f"Workflow state not found: {workflow_id}")
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        return WorkflowState.from_dict(payload)
+
+    def list_states(self) -> Iterable[WorkflowState]:
+        if not self.workflows_dir.exists():
+            return []
+        states = []
+        for state_path in sorted(self.workflows_dir.glob("*/state.json")):
+            try:
+                with state_path.open("r", encoding="utf-8") as handle:
+                    states.append(WorkflowState.from_dict(json.load(handle)))
+            except (OSError, ValueError, json.JSONDecodeError):
+                continue
+        return states
+
+    def resolve_active(self, instance_id: str) -> Optional[WorkflowState]:
+        index = self._load_index()
+        workflow_id = (index.get("workflows_by_instance") or {}).get(instance_id)
+        if workflow_id:
+            return self.load(str(workflow_id))
+        candidates = [
+            state
+            for state in self.list_states()
+            if state.instance_id == instance_id and state.status == WorkflowStatus.ACTIVE
+        ]
+        if not candidates and instance_id != "main":
+            candidates = [
+                state for state in self.list_states() if state.status == WorkflowStatus.ACTIVE
+            ]
+        return candidates[0] if len(candidates) == 1 else None
+
+    def create_or_resume(
+        self,
+        *,
+        workflow_id: Optional[str],
+        instance_id: str,
+        mode: str,
+        max_iterations: int,
+        max_minutes: int,
+        completion_token: str,
+    ) -> WorkflowState:
+        existing = self.resolve_active(instance_id)
+        if existing is not None:
+            return existing
+
+        resolved_id = workflow_id or _slugify(f"{self.workspace_root.name}-{instance_id}")
+        path = self._state_path(resolved_id)
+        if path.exists():
+            state = self.load(resolved_id)
+        else:
+            state = WorkflowState.new(
+                workflow_id=resolved_id,
+                workspace_root=self.workspace_root,
+                instance_id=instance_id,
+                mode=mode,
+                max_iterations=max_iterations,
+                max_minutes=max_minutes,
+                completion_token=completion_token,
+            )
+        return self.save(state)
+
+    def cancel(self, state: WorkflowState, reason: str) -> WorkflowState:
+        state.status = WorkflowStatus.CANCELLED
+        state.record_history(event="workflow_cancelled", message=reason or "Workflow cancelled")
+        return self.save(state)
+
+    def inspect(self, state: WorkflowState) -> Dict[str, Any]:
+        checkpoints: Dict[str, Optional[bool]] = {}
+        for checkpoint in ("brief", "research_review", "plan_review", state.phase.value):
+            latest = None
+            for entry in reversed(state.history):
+                if entry.get("event") == "checkpoint":
+                    details = entry.get("details") or {}
+                    if details.get("phase") == checkpoint:
+                        latest = details.get("status")
+                        break
+            checkpoints[checkpoint] = latest == "approved"
+        return {
+            "workflow_id": state.workflow_id,
+            "workspace_root": state.workspace_root,
+            "instance_id": state.instance_id,
+            "mode": state.mode,
+            "status": state.status.value,
+            "phase": state.phase.value,
+            "current_task_id": state.current_task_id,
+            "iteration": state.iteration,
+            "max_iterations": state.max_iterations,
+            "max_minutes": state.max_minutes,
+            "completion_token": state.completion_token,
+            "checkpoints": checkpoints,
+            "validation": state.gate_failures_for(state.phase),
+            "history_count": len(state.history),
+        }

--- a/tests/test_execution_store.py
+++ b/tests/test_execution_store.py
@@ -1,12 +1,18 @@
 import pytest
 
-from dopemux.execution.models import ExecutionPacket, LeaseState, PacketState
+from dopemux.execution.models import (
+    ExecutionDisposition,
+    ExecutionPacket,
+    LeaseState,
+    PacketState,
+)
 from dopemux.execution.store import (
     InMemoryExecutionStore,
     InMemoryLeaseStore,
     LeaseExpiredError,
     PacketNotFoundError,
     PacketNotReadyError,
+    StaleLeaseError,
 )
 
 @pytest.fixture
@@ -74,10 +80,20 @@ def test_release_packet(execution_store, lease_store):
     execution_store.create_packet(packet)
     lease = lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
 
-    released_lease = lease_store.release(lease.lease_id, final_state=PacketState.PROOF_GENERATED)
+    released_lease = lease_store.release(
+        lease.lease_id,
+        final_state=PacketState.PROOF_GENERATED,
+        disposition=ExecutionDisposition.SUCCEEDED,
+        result_summary="Completed successfully",
+        artifacts={"test": "data"},
+    )
 
     assert execution_store.get_packet("TP-1").state == PacketState.PROOF_GENERATED
     assert released_lease.state == LeaseState.RELEASED
+    assert released_lease.result is not None
+    assert released_lease.result.disposition == ExecutionDisposition.SUCCEEDED
+    assert released_lease.result.result_summary == "Completed successfully"
+    assert released_lease.result.artifacts == {"test": "data"}
 
 def test_reclaim_expired_lease(execution_store, lease_store):
     packet = ExecutionPacket(packet_id="TP-1", owner_id="user1")
@@ -98,3 +114,15 @@ def test_checkout_rejects_non_ready_terminal_state(execution_store, lease_store)
 
     with pytest.raises(PacketNotReadyError):
         lease_store.checkout("TP-1", "agent-1", ttl_seconds=60)
+
+
+def test_stale_lease_cannot_release_after_reclaim(execution_store, lease_store):
+    packet = ExecutionPacket(packet_id="TP-STALE", owner_id="user1")
+    execution_store.create_packet(packet)
+
+    lease_a = lease_store.checkout("TP-STALE", "agent-a", ttl_seconds=-1)
+    lease_b = lease_store.checkout("TP-STALE", "agent-b", ttl_seconds=60)
+
+    assert lease_b.lease_id != lease_a.lease_id
+    with pytest.raises(StaleLeaseError):
+        lease_store.release(lease_a.lease_id, final_state=PacketState.PROOF_GENERATED)

--- a/tests/unit/test_execution_plane_concurrency.py
+++ b/tests/unit/test_execution_plane_concurrency.py
@@ -1,0 +1,84 @@
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from dopemux.execution.models import ExecutionPacket, PacketState
+from dopemux.execution.store import (
+    InMemoryExecutionStore,
+    InMemoryLeaseStore,
+    StaleLeaseError,
+)
+
+
+@pytest.fixture
+def execution_store():
+    return InMemoryExecutionStore()
+
+
+@pytest.fixture
+def lease_store(execution_store):
+    return InMemoryLeaseStore(execution_store)
+
+
+def test_atomic_checkout_contention(execution_store, lease_store):
+    packet_id = "TP-RACE"
+    execution_store.create_packet(ExecutionPacket(packet_id=packet_id, owner_id="test"))
+
+    results = []
+
+    def checkout_task(agent_id):
+        try:
+            lease = lease_store.checkout(packet_id, agent_id, ttl_seconds=60)
+            results.append(("success", agent_id, lease))
+        except Exception as exc:  # pragma: no cover - assertion inspects aggregate results
+            results.append(("fail", agent_id, exc))
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        for i in range(10):
+            executor.submit(checkout_task, f"agent-{i}")
+
+    successes = [r for r in results if r[0] == "success"]
+    assert len(successes) == 1, f"Expected 1 success, got {len(successes)}"
+
+
+def test_stale_holder_protection(execution_store, lease_store):
+    packet_id = "TP-STALE"
+    execution_store.create_packet(ExecutionPacket(packet_id=packet_id, owner_id="test"))
+
+    lease_a = lease_store.checkout(packet_id, "agent-a", ttl_seconds=-1)
+    lease_b = lease_store.checkout(packet_id, "agent-b", ttl_seconds=60)
+    assert lease_b.lease_id != lease_a.lease_id
+
+    with pytest.raises(StaleLeaseError):
+        lease_store.heartbeat(lease_a.lease_id)
+
+    with pytest.raises(StaleLeaseError):
+        lease_store.release(lease_a.lease_id, final_state=PacketState.PROOF_GENERATED)
+
+    packet = execution_store.get_packet(packet_id)
+    assert packet is not None
+    assert packet.state == PacketState.LEASED
+
+
+def test_task_decomposer_to_execution_packet():
+    from dopemux.adhd.task_decomposer import TaskRecord, TaskStatus
+
+    record = TaskRecord(
+        id="task-123",
+        description="Test task",
+        estimated_duration=30,
+        priority="high",
+        status=TaskStatus.PENDING,
+    )
+
+    packet = record.to_execution_packet(owner_id="user-1")
+
+    assert packet.packet_id == "task-123"
+    assert packet.owner_id == "user-1"
+    assert packet.state == PacketState.READY
+    assert packet.metadata["description"] == "Test task"
+    assert packet.metadata["priority"] == "high"
+    assert packet.metadata["estimated_duration"] == 30
+
+    record.status = TaskStatus.COMPLETED
+    assert record.to_execution_packet(owner_id="user-1").state == PacketState.PROOF_GENERATED


### PR DESCRIPTION
@codex 
@clauee
@copilot

## Summary
- replace the overlapping execution-plane branches with one canonical main-targeting PR
- port thread-safe lease handling and stale-holder protection
- add task-to-execution packet bridging and a workspace-local workflow state store
- exclude uv.lock churn and the non-essential llm-plans design note

## Validation
- python3 -m py_compile src/dopemux/execution/models.py src/dopemux/execution/store.py src/dopemux/adhd/task_decomposer.py src/dopemux/workflow/store.py tests/test_execution_store.py tests/unit/test_execution_plane_concurrency.py
- python3 -m pytest tests/test_execution_store.py tests/unit/test_execution_plane_concurrency.py tests/unit/test_task_coordinator_execution_leases.py tests/unit/test_task_decomposer.py tests/test_workflow_orchestration.py -q

## Supersedes
- #310
- #314

## Notes
- current main classifier semantics are preserved
- workflow/store.py is a trimmed canonical store port only; it does not replace existing workflow orchestration APIs
