### PR TITLE
fix(pr-merge): harvest remote CI fingerprints for queue blockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ See [docs/03-reference/00-repo-map.md](docs/03-reference/00-repo-map.md) for a f
 - **Autonomous code/docs semantic search** (dope-context)
 - **Unified ConPort client and multi-session support**
 - **Mobile mode with Happy client**
-- **PR Merge Specialist flight deck** with validation-aware queue states, speculative train handling, and global CI remediation
+- **PR Merge Specialist flight deck** with validation-aware queue states, speculative train handling, and queue-wide CI fingerprint remediation for repeated required-check failures
 
 > **Screenshot/Diagram Placeholder:**
 > ![Dashboard Screenshot Placeholder](docs/SCREENSHOT_DASHBOARD_PLACEHOLDER.png)

--- a/docs/02-how-to/pr-merge-flight-dashboard.md
+++ b/docs/02-how-to/pr-merge-flight-dashboard.md
@@ -50,7 +50,11 @@ Important behavior:
 - GitHub remains the final merge authority when auto-merge or merge queue is enabled
 
 ### Global CI Remediation
-If multiple PRs fail CI with the same error, the orchestrator identifies a stable failure fingerprint from the failing validation step and error output. Instead of fixing each PR individually, it invokes the `ci-remediation-specialist` against `main` and opens or reuses a single `global-ci-fix` PR. Other failing PRs wait on that shared fix path instead of duplicating remediation.
+If multiple PRs fail CI with the same error, the orchestrator identifies a stable failure fingerprint and routes them through a shared remediation path instead of fixing each PR independently. The authority order is local-first:
+
+- if a PR already produced a failing local validation step, the global blocker fingerprint comes from that local validation output
+- otherwise, the queue can harvest GitHub Actions job logs for failed required checks and derive a remote fingerprint from the underlying failing test or error signature
+- when two or more PRs share that fingerprint and the failing required check has an explicit reproduction command, PRMS opens or reuses a single `global-ci-fix` PR against `main`
 
 Important constraint:
 
@@ -58,6 +62,7 @@ Important constraint:
 - auto-merge-enabled PRs are still treated as blocked if the required remote checks are red
 - bounded dry or execute runs respect `--max-prs`, so operator test runs can sample the queue without draining the whole backlog
 - explicitly mapped required checks can be reproduced locally before CI remediation runs; unmapped remote failures still fail closed
+- remote fingerprint harvesting is GitHub Actions-only in the first pass; non-Actions check URLs and ambiguous log output do not trigger shared remediation
 
 ### Optimistic Lifecycle
 The dashboard uses a state model that distinguishes local proof from GitHub lag:

--- a/docs/pr_merge/usage-patterns.md
+++ b/docs/pr_merge/usage-patterns.md
@@ -37,6 +37,13 @@ python -m dopemux_pr_merge_specialist.cli queue-drain --execute --max-prs 5
 
 For explicitly mapped required checks, `pr-apply` and `queue-drain` can now attempt a fail-closed local reproduction before invoking automated CI remediation. These mappings live in `config/pr_merge_specialist/policy.yaml` under `remote_check_repro.steps`. Unmapped required-check failures remain blocked by design.
 
+When queue-wide CI failures repeat across multiple PRs, `queue-drain` now falls back to remote fingerprint harvesting if a local validation fingerprint is not available. The first pass is intentionally narrow:
+
+- local validation fingerprints still win when a failing step was reproduced in the worktree
+- remote clustering only applies to GitHub Actions-backed required checks that expose a `detailsUrl`
+- the shared `global-ci-fix` PR path only engages when the failing required check has both a stable log-derived fingerprint and an explicit reproduction command in `remote_check_repro.steps`
+- unsupported providers, ambiguous logs, or unmapped checks remain fail-closed and continue down the existing per-PR path
+
 When `pr-apply` produces a passive `queued_for_merge` result after rebasing and validation, `queue-drain` now still executes the merge handoff step so GitHub receives the actual `gh pr merge` or auto-merge enqueue command for that PR.
 
 ## Common Workflows

--- a/src/dopemux_pr_merge_specialist/cli.py
+++ b/src/dopemux_pr_merge_specialist/cli.py
@@ -420,7 +420,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     queue_drain_parser = sub.add_parser(
         "queue-drain",
-        help="🌊 Automated Synchronization: Orchestrate scan, plan, apply, and merge across the entire queue.",
+        help="🌊 Automated Synchronization: Orchestrate scan, remediation, remote-fingerprint clustering, and merge across the queue.",
     )
     add_common_arguments(queue_drain_parser)
     queue_drain_parser.add_argument(
@@ -515,7 +515,7 @@ def build_parser() -> argparse.ArgumentParser:
     flight_parser.set_defaults(func=cmd_flight)
 
     flight_deck_parser = sub.add_parser(
-        "flight-deck", help="🚀 Mission Control: Launch the Flight Deck operations center."
+        "flight-deck", help="🚀 Mission Control: Launch the Flight Deck operations center with shared CI blocker detection."
     )
     add_common_arguments(flight_deck_parser)
     flight_deck_parser.add_argument(

--- a/src/dopemux_pr_merge_specialist/github_api.py
+++ b/src/dopemux_pr_merge_specialist/github_api.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import re
 import textwrap
 import time
 from collections import defaultdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -24,11 +26,76 @@ BOT_AUTHORS = {
     "copilot-pull-request-reviewer",
     "codecov-commenter",
 }
+GITHUB_ACTIONS_DETAILS_URL_RE = re.compile(
+    r"^https://github\.com/[^/]+/[^/]+/actions/runs/(?P<run_id>\d+)(?:/job/(?P<job_id>\d+))?/?$"
+)
+
+
+@dataclass(frozen=True)
+class RemoteCheckLogEvidence:
+    check_name: str
+    details_url: str
+    run_id: Optional[str] = None
+    job_id: Optional[str] = None
+    log_text: str = ""
+    fetch_status: str = "unsupported"
+    error: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @property
+    def ok(self) -> bool:
+        return self.fetch_status == "ok"
 
 
 def _check_rollup_name(check: Dict[str, Any]) -> str:
     name = str(check.get("name") or check.get("context") or "").strip()
     return name
+
+
+def _check_rollup_details_url(check: Dict[str, Any]) -> str:
+    return str(check.get("detailsUrl") or check.get("targetUrl") or "").strip()
+
+
+def _required_check_entries_by_state(
+    checks: List[Dict[str, Any]],
+    required_contexts: Sequence[str],
+    *,
+    failure_only: bool = False,
+    pending_only: bool = False,
+) -> List[Dict[str, Any]]:
+    required = {str(item).strip() for item in required_contexts if str(item).strip()}
+    entries: List[Dict[str, Any]] = []
+    seen: set[Tuple[str, str]] = set()
+    for check in checks:
+        name = _check_rollup_name(check)
+        if not name or name not in required:
+            continue
+        status = str(check.get("status") or check.get("state") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        is_pending = bool(status and status != "COMPLETED") or (
+            not conclusion and status != "COMPLETED"
+        )
+        is_failure = conclusion in CHECK_FAILURE
+        if failure_only and not is_failure:
+            continue
+        if pending_only and not is_pending:
+            continue
+        details_url = _check_rollup_details_url(check)
+        dedupe_key = (name, details_url)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        entries.append(
+            {
+                "check_name": name,
+                "details_url": details_url,
+                "status": status,
+                "conclusion": conclusion,
+            }
+        )
+    return entries
 
 
 def _required_check_names_by_state(
@@ -536,6 +603,9 @@ class GitHubClient:
         failed_required_checks = _required_check_names_by_state(
             checks, required_contexts, failure_only=True
         )
+        failed_required_check_entries = _required_check_entries_by_state(
+            checks, required_contexts, failure_only=True
+        )
         pending_required_checks = _required_check_names_by_state(
             checks, required_contexts, pending_only=True
         )
@@ -562,11 +632,70 @@ class GitHubClient:
             "merge_state_status": payload.get("mergeStateStatus", ""),
             "protection": protection,
             "failed_required_checks": failed_required_checks,
+            "failed_required_check_entries": failed_required_check_entries,
             "pending_required_checks": pending_required_checks,
             "approval_required": approval_required,
             "blocker_types": blockers,
             "warning_types": warnings,
         }
+
+    def fetch_remote_check_log_evidence(
+        self, check_entry: Dict[str, Any]
+    ) -> RemoteCheckLogEvidence:
+        check_name = str(check_entry.get("check_name") or "").strip()
+        details_url = str(check_entry.get("details_url") or "").strip()
+        if not details_url:
+            return RemoteCheckLogEvidence(
+                check_name=check_name,
+                details_url=details_url,
+                fetch_status="missing_details_url",
+                error="Required check did not include a details URL.",
+            )
+        cache_key = f"remote_check_log:{check_name}:{details_url}"
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+        match = GITHUB_ACTIONS_DETAILS_URL_RE.match(details_url)
+        if not match:
+            evidence = RemoteCheckLogEvidence(
+                check_name=check_name,
+                details_url=details_url,
+                fetch_status="unsupported",
+                error="Details URL is not a GitHub Actions run or job URL.",
+            )
+            self.cache[cache_key] = evidence
+            return evidence
+
+        run_id = match.group("run_id")
+        job_id = match.group("job_id")
+        cmd = ["gh", "run", "view", run_id]
+        if job_id:
+            cmd.extend(["--job", job_id])
+        cmd.append("--log")
+        if self.repo:
+            cmd.extend(["--repo", self.repo])
+        result = self._run(cmd)
+        if result.returncode != 0:
+            evidence = RemoteCheckLogEvidence(
+                check_name=check_name,
+                details_url=details_url,
+                run_id=run_id,
+                job_id=job_id,
+                fetch_status="error",
+                error=result.stderr.strip() or "Unable to fetch GitHub Actions log.",
+            )
+            self.cache[cache_key] = evidence
+            return evidence
+        evidence = RemoteCheckLogEvidence(
+            check_name=check_name,
+            details_url=details_url,
+            run_id=run_id,
+            job_id=job_id,
+            log_text=result.stdout or "",
+            fetch_status="ok",
+        )
+        self.cache[cache_key] = evidence
+        return evidence
 
     def rate_limit_snapshot(self) -> Dict[str, Any]:
         result = self._run(["gh", "api", "rate_limit"])

--- a/src/dopemux_pr_merge_specialist/merge.py
+++ b/src/dopemux_pr_merge_specialist/merge.py
@@ -388,6 +388,11 @@ def serialize_check_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
         "mergeable": payload.get("mergeable", ""),
         "merge_state_status": payload.get("merge_state_status", ""),
         "protection": payload.get("protection", {}),
+        "failed_required_checks": payload.get("failed_required_checks", []),
+        "failed_required_check_entries": payload.get(
+            "failed_required_check_entries", []
+        ),
+        "pending_required_checks": payload.get("pending_required_checks", []),
         "blocker_types": payload.get("blocker_types", []),
         "warning_types": payload.get("warning_types", []),
     }

--- a/src/dopemux_pr_merge_specialist/queue_drain.py
+++ b/src/dopemux_pr_merge_specialist/queue_drain.py
@@ -10,13 +10,13 @@ import subprocess
 import tempfile
 import time
 from collections import defaultdict, deque
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Callable
 
 from .action_model import allowed_actions_for_result
-from .github_api import BOT_AUTHORS, GitHubClient, ci_status, summarize_checks, thread_counters
+from .github_api import BOT_AUTHORS, GitHubClient, RemoteCheckLogEvidence, ci_status, summarize_checks, thread_counters
 from .policy import PolicyError, load_effective_policy, policy_artifact_payload, policy_fingerprint
 from .runtime import CommandResult, append_command_log, execute_or_dry_run, fingerprint_payload, pid_is_running, run_command, run_id, shell_join, snapshot_environment, utc_now, write_json, write_text
 from .schema import ARTIFACT_VERSION, ArtifactMeta, BlockerType, FallbackReason, Finding, FindingSeverity, Fingerprint, MergeDecision, MergeActionType, OverrideRecord, PhaseRecord, PRResult, PRState, PRStateData, POLICY_SCHEMA_VERSION, PreflightCheck, PreflightResult, PullRequestState, QueueOrderingLayer, ReviewThread, RunManifest, ThreadComment, ThreadDisposition, ThreadDispositionType, TruthSource, ValidationReport, ValidationStatus, ValidationStepResult, TOOL_VERSION
@@ -516,8 +516,7 @@ def reproduce_remote_required_check_failure(
     if not failed_required_checks:
         return None, None
 
-    mappings = list(policy.get("remote_check_repro", {}).get("steps", []))
-    if not mappings:
+    if not list(policy.get("remote_check_repro", {}).get("steps", [])):
         log(
             "Required GitHub checks are failing, but no remote-check reproduction mappings are configured.",
             "INFO",
@@ -527,9 +526,9 @@ def reproduce_remote_required_check_failure(
     timeout_seconds = int(
         policy.get("timeouts", {}).get("subprocess_seconds", 600) or 600
     )
-    for step in mappings:
-        check_name = str(step.get("check_name") or "").strip()
-        if not check_name or check_name not in failed_required_checks:
+    for check_name in failed_required_checks:
+        step = _remote_check_repro_mapping(policy, check_name)
+        if step is None:
             continue
         scope = str(step.get("scope", "repo"))
         if scope != "repo":
@@ -1068,6 +1067,20 @@ def _should_handoff_prepared_result(result: PRResult, policy: Dict[str, Any]) ->
 
 
 FINGERPRINT_MARKER = "<!-- bot:failure_fingerprint:"
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+PYTEST_NODE_ID_RE = re.compile(r"\b(?:FAILED|ERROR)\s+((?:tests|src|services|ui-dashboard)/\S+::\S+)")
+EXCEPTION_HEADER_RE = re.compile(
+    r"^(AssertionError|[A-Za-z_][A-Za-z0-9_]*(?:Error|Exception|Failure|Warning))(?:\s*:\s*.*)?$"
+)
+
+
+@dataclass(frozen=True)
+class RemoteFailureFingerprint:
+    fingerprint: str
+    check_name: str
+    command: str
+    evidence_summary: str
+    evidence: RemoteCheckLogEvidence
 
 def _parse_fingerprint_from_body(body: str) -> Optional[str]:
     """Extracts the failure fingerprint from a PR body."""
@@ -1078,6 +1091,130 @@ def _parse_fingerprint_from_body(body: str) -> Optional[str]:
             parts = line.split(FINGERPRINT_MARKER)
             if len(parts) > 1:
                 return parts[1].split("-->")[0].strip()
+    return None
+
+
+def _remote_check_repro_mapping(
+    policy: Dict[str, Any], check_name: str
+) -> Optional[Dict[str, Any]]:
+    for step in policy.get("remote_check_repro", {}).get("steps", []) or []:
+        if str(step.get("check_name") or "").strip() == check_name:
+            return step
+    return None
+
+
+def _normalize_remote_failure_line(line: str) -> str:
+    normalized = ANSI_ESCAPE_RE.sub("", line or "").strip()
+    normalized = re.sub(r"\s+", " ", normalized)
+    normalized = re.sub(r"\b\d+\.\d+s\b", "<duration>", normalized)
+    normalized = re.sub(r"\bline \d+\b", "line <n>", normalized)
+    normalized = re.sub(r":\d+:", ":<n>:", normalized)
+    normalized = re.sub(r"\b0x[0-9a-fA-F]+\b", "0xADDR", normalized)
+    return normalized.strip("[] ")
+
+
+def _extract_remote_failure_signature(log_text: str) -> Optional[Tuple[str, str, str]]:
+    for raw_line in (log_text or "").splitlines():
+        clean_line = ANSI_ESCAPE_RE.sub("", raw_line or "").strip()
+        match = PYTEST_NODE_ID_RE.search(clean_line)
+        if match:
+            node_id = match.group(1)
+            return (
+                "pytest_node",
+                node_id,
+                f"pytest failure {node_id}",
+            )
+
+    for raw_line in (log_text or "").splitlines():
+        clean_line = _normalize_remote_failure_line(raw_line)
+        if not clean_line:
+            continue
+        candidate = clean_line[2:].strip() if clean_line.startswith("E ") else clean_line
+        if EXCEPTION_HEADER_RE.match(candidate):
+            return (
+                "exception_header",
+                candidate,
+                f"failure header {candidate[:160]}",
+            )
+
+    for raw_line in (log_text or "").splitlines():
+        clean_line = _normalize_remote_failure_line(raw_line)
+        if not clean_line:
+            continue
+        lowered = clean_line.lower()
+        if (
+            clean_line.startswith("FAILED ")
+            or clean_line.startswith("ERROR ")
+            or "assertionerror" in lowered
+            or "exception" in lowered
+            or "error:" in lowered
+        ):
+            return (
+                "stable_line",
+                clean_line[:200],
+                f"failure line {clean_line[:160]}",
+            )
+    return None
+
+
+def _extract_result_check_payload(result: PRResult) -> Dict[str, Any]:
+    for finding in result.findings:
+        if finding.finding_type == BlockerType.REQUIRED_CHECK_FAILED.value:
+            return dict(finding.details or {})
+    return {}
+
+
+def _build_remote_failure_fingerprint(
+    *,
+    policy: Dict[str, Any],
+    evidence: RemoteCheckLogEvidence,
+) -> Optional[RemoteFailureFingerprint]:
+    if not evidence.ok:
+        return None
+    mapping = _remote_check_repro_mapping(policy, evidence.check_name)
+    if mapping is None:
+        return None
+    scope = str(mapping.get("scope", "repo") or "repo")
+    command = [str(part) for part in mapping.get("command", []) if str(part)]
+    if scope != "repo" or not command:
+        return None
+    signature = _extract_remote_failure_signature(evidence.log_text)
+    if signature is None:
+        return None
+    signature_kind, signature_value, summary = signature
+    fingerprint = fingerprint_payload(
+        {
+            "source": "remote_required_check",
+            "check_name": evidence.check_name,
+            "signature_kind": signature_kind,
+            "signature_value": signature_value,
+        }
+    )
+    return RemoteFailureFingerprint(
+        fingerprint=fingerprint,
+        check_name=evidence.check_name,
+        command=shell_join(command),
+        evidence_summary=summary,
+        evidence=evidence,
+    )
+
+
+def _harvest_remote_failure_fingerprint(
+    result: PRResult, client: GitHubClient
+) -> Optional[RemoteFailureFingerprint]:
+    check_payload = _extract_result_check_payload(result)
+    blocker_types = [str(item) for item in check_payload.get("blocker_types", []) or []]
+    if "required_check_failed" not in blocker_types:
+        return None
+    failed_entries = list(check_payload.get("failed_required_check_entries", []) or [])
+    for check_entry in failed_entries:
+        evidence = client.fetch_remote_check_log_evidence(check_entry)
+        fingerprint = _build_remote_failure_fingerprint(
+            policy=client.policy,
+            evidence=evidence,
+        )
+        if fingerprint is not None:
+            return fingerprint
     return None
 
 def _create_global_fix_pr(fingerprint: str, failed_step: ValidationStepResult, client: GitHubClient, repo_root: Path) -> int:
@@ -1210,12 +1347,35 @@ def _handle_global_ci_blockers(results: List[PRResult], client: GitHubClient, wo
         if fingerprint:
             fingerprint_to_pr_map[fingerprint] = pr["number"]
 
-    # 2. Group failing PRs by their failure fingerprint
-    failing_prs_by_fingerprint = defaultdict(list)
+    # 2. Group failing PRs by either a local validation fingerprint or a harvested
+    # remote required-check fingerprint. Local evidence remains authoritative.
+    failing_prs_by_fingerprint: Dict[str, List[Tuple[PRResult, ValidationStepResult]]] = defaultdict(list)
     for r in results:
         allowed = allowed_actions_for_result(r)
-        if "APPLY_FIX" in allowed and r.validation_report and r.validation_report.failure_fingerprint:
-            failing_prs_by_fingerprint[r.validation_report.failure_fingerprint].append(r)
+        if "APPLY_FIX" not in allowed:
+            continue
+        if r.validation_report and r.validation_report.failure_fingerprint:
+            failed_step = r.validation_report.failing_step
+            if failed_step is not None:
+                failing_prs_by_fingerprint[
+                    r.validation_report.failure_fingerprint
+                ].append((r, failed_step))
+            continue
+        remote_failure = _harvest_remote_failure_fingerprint(r, client)
+        if remote_failure is None:
+            continue
+        failed_step = ValidationStepResult(
+            name=remote_failure.check_name,
+            command=remote_failure.command,
+            status="failed",
+            returncode=1,
+            stdout="",
+            stderr=(
+                f"{remote_failure.evidence_summary}\n\n"
+                + (remote_failure.evidence.log_text or "")[-6000:]
+            ).strip(),
+        )
+        failing_prs_by_fingerprint[remote_failure.fingerprint].append((r, failed_step))
 
     # 3. Process groups to identify and act on global blockers
     for fingerprint, blocked_prs in failing_prs_by_fingerprint.items():
@@ -1226,23 +1386,16 @@ def _handle_global_ci_blockers(results: List[PRResult], client: GitHubClient, wo
             # A global fix PR already exists. Record all grouped PRs as blocked.
             pr_number = fingerprint_to_pr_map[fingerprint]
             print(f"Found existing global fix PR #{pr_number} for fingerprint {fingerprint}")
-            for r in blocked_prs:
+            for r, _failed_step in blocked_prs:
                 blocked_map[r.pr_state.pr_id] = pr_number
         else:
             # New global blocker. Create a global fix PR.
             print(f"New global CI blocker detected for fingerprint: {fingerprint}. Triggering global fix.")
-            failed_step = next(
-                (
-                    s
-                    for s in blocked_prs[0].validation_report.steps
-                    if s.status == "failed"
-                ),
-                None,
-            )
+            failed_step = blocked_prs[0][1]
             if failed_step:
                 new_pr_number = _create_global_fix_pr(fingerprint, failed_step, client, worktree_dir)
                 if new_pr_number > 0:
-                    for r in blocked_prs:
+                    for r, _failed_step in blocked_prs:
                         blocked_map[r.pr_state.pr_id] = new_pr_number
                 else:
                     print(

--- a/tests/pr_merge_specialist/test_queue_drain_integration.py
+++ b/tests/pr_merge_specialist/test_queue_drain_integration.py
@@ -7,12 +7,12 @@ from types import SimpleNamespace
 
 from dopemux_pr_merge_specialist import closed_loop_engine
 from dopemux_pr_merge_specialist import engine
-from dopemux_pr_merge_specialist.github_api import GitHubClient
+from dopemux_pr_merge_specialist.github_api import GitHubClient, RemoteCheckLogEvidence
 from dopemux_pr_merge_specialist import queue_drain as queue_drain_module
 from dopemux_pr_merge_specialist.plan_builder import build_plan_result, write_pr_state_artifact
 from dopemux_pr_merge_specialist.preflight import build_run_paths, pr_dir_for
 from dopemux_pr_merge_specialist.runtime import CommandResult
-from dopemux_pr_merge_specialist.schema import MergeActionType, MergeDecision, PRResult, PRState, PullRequestState, ValidationReport, ValidationStatus, ValidationStepResult
+from dopemux_pr_merge_specialist.schema import BlockerType, Finding, FindingSeverity, MergeActionType, MergeDecision, PRResult, PRState, PullRequestState, ValidationReport, ValidationStatus, ValidationStepResult
 from dopemux_pr_merge_specialist import cli as pr_merge_cli
 
 
@@ -82,6 +82,14 @@ class FakeGitHubClient:
     def find_global_fix_prs(self) -> list[dict]:
         return []
 
+    def fetch_remote_check_log_evidence(self, check_entry: dict) -> RemoteCheckLogEvidence:
+        return RemoteCheckLogEvidence(
+            check_name=str(check_entry.get("check_name") or ""),
+            details_url=str(check_entry.get("details_url") or ""),
+            fetch_status="unsupported",
+            error="not configured in FakeGitHubClient",
+        )
+
 
 def _make_result(
     *,
@@ -92,6 +100,7 @@ def _make_result(
     auto_merge_enabled: bool = False,
     artifacts: dict[str, str] | None = None,
     validation_status: ValidationStatus = ValidationStatus.PASSED,
+    findings: list[Finding] | None = None,
 ) -> PRResult:
     return PRResult(
         run_id="testrun",
@@ -117,7 +126,7 @@ def _make_result(
         lifecycle_state=lifecycle_state,
         apply_actions=[],
         merge_decision=merge_decision,
-        findings=[],
+        findings=findings or [],
         truth_sources=[],
         precedence_order=[],
         decision_basis={},
@@ -745,6 +754,191 @@ def test_handle_global_ci_blockers_ignores_failed_global_fix_creation(monkeypatc
 
     # Creation failed (-1), so no PRs should be in the blocked map
     assert blocked_map == {}
+
+
+def test_fetch_remote_check_log_evidence_parses_github_actions_job_url(tmp_path: Path):
+    client = GitHubClient(
+        repo="DDD-Enterprises/dopemux-mvp",
+        repo_root=tmp_path,
+        policy={"retry": {}, "timeouts": {}},
+    )
+    seen_commands: list[list[str]] = []
+
+    def fake_run(cmd):
+        seen_commands.append(list(cmd))
+        return CommandResult(list(cmd), 0, "pytest log output", "")
+
+    client._run = fake_run  # type: ignore[method-assign]
+    evidence = client.fetch_remote_check_log_evidence(
+        {
+            "check_name": "🧪 Unit Tests",
+            "details_url": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/23701466608/job/69045799064",
+        }
+    )
+
+    assert evidence.fetch_status == "ok"
+    assert evidence.run_id == "23701466608"
+    assert evidence.job_id == "69045799064"
+    assert evidence.log_text == "pytest log output"
+    assert seen_commands == [
+        [
+            "gh",
+            "run",
+            "view",
+            "23701466608",
+            "--job",
+            "69045799064",
+            "--log",
+            "--repo",
+            "DDD-Enterprises/dopemux-mvp",
+        ]
+    ]
+
+
+def test_fetch_remote_check_log_evidence_rejects_non_actions_url(tmp_path: Path):
+    client = GitHubClient(
+        repo="DDD-Enterprises/dopemux-mvp",
+        repo_root=tmp_path,
+        policy={"retry": {}, "timeouts": {}},
+    )
+
+    evidence = client.fetch_remote_check_log_evidence(
+        {
+            "check_name": "🔍 Docker Scout",
+            "details_url": "https://scout.docker.com/v/CVE-123",
+        }
+    )
+
+    assert evidence.fetch_status == "unsupported"
+    assert evidence.run_id is None
+    assert evidence.job_id is None
+
+
+def test_extract_remote_failure_signature_prefers_pytest_node_id():
+    signature = queue_drain_module._extract_remote_failure_signature(
+        """
+=========================== short test summary info ============================
+FAILED tests/test_cli.py::TestCLI::test_start_command_role_dry_run - UnboundLocalError: cannot access local variable 'project_path'
+        """.strip()
+    )
+
+    assert signature == (
+        "pytest_node",
+        "tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
+        "pytest failure tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
+    )
+
+
+def test_extract_remote_failure_signature_falls_back_to_exception_header():
+    signature = queue_drain_module._extract_remote_failure_signature(
+        """
+Traceback (most recent call last):
+E   AssertionError: template/runtime parity mismatch
+        """.strip()
+    )
+
+    assert signature == (
+        "exception_header",
+        "AssertionError: template/runtime parity mismatch",
+        "failure header AssertionError: template/runtime parity mismatch",
+    )
+
+
+def test_extract_remote_failure_signature_returns_none_for_ambiguous_log():
+    assert (
+        queue_drain_module._extract_remote_failure_signature(
+            "Build failed after 12.3s with no test summary available."
+        )
+        is None
+    )
+
+
+def test_handle_global_ci_blockers_groups_remote_fingerprints(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(
+        queue_drain_module,
+        "allowed_actions_for_result",
+        lambda _result: ["APPLY_FIX"],
+    )
+
+    created: list[tuple[str, str]] = []
+
+    def fake_create_global_fix_pr(fingerprint, failed_step, client, repo_root):
+        created.append((fingerprint, failed_step.command))
+        return 777
+
+    monkeypatch.setattr(
+        queue_drain_module,
+        "_create_global_fix_pr",
+        fake_create_global_fix_pr,
+    )
+
+    remote_details = {
+        "blocker_types": ["required_check_failed"],
+        "failed_required_checks": ["🧪 Unit Tests"],
+        "failed_required_check_entries": [
+            {
+                "check_name": "🧪 Unit Tests",
+                "details_url": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/23701466608/job/69045799064",
+            }
+        ],
+    }
+    findings = [
+        Finding(
+            kind=FindingSeverity.BLOCKER,
+            finding_type=BlockerType.REQUIRED_CHECK_FAILED.value,
+            message="Required checks are failing.",
+            details=remote_details,
+            source="github_protection_review",
+        )
+    ]
+    results = [
+        _make_result(
+            pr_id=401,
+            lifecycle_state=PRState.APPLY_BLOCKED.value,
+            ci_status="FAILURE",
+            findings=findings,
+        ),
+        _make_result(
+            pr_id=402,
+            lifecycle_state=PRState.APPLY_BLOCKED.value,
+            ci_status="FAILURE",
+            findings=findings,
+        ),
+    ]
+
+    client = FakeGitHubClient(
+        repo=None,
+        repo_root=tmp_path,
+        policy={
+            "remote_check_repro": {
+                "steps": [
+                    {
+                        "check_name": "🧪 Unit Tests",
+                        "command": ["pytest", "tests/", "--maxfail=1"],
+                        "scope": "repo",
+                    }
+                ]
+            }
+        },
+    )
+    client.fetch_remote_check_log_evidence = lambda _entry: RemoteCheckLogEvidence(  # type: ignore[method-assign]
+        check_name="🧪 Unit Tests",
+        details_url="https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/23701466608/job/69045799064",
+        run_id="23701466608",
+        job_id="69045799064",
+        log_text="FAILED tests/test_cli.py::TestCLI::test_start_command_role_dry_run - UnboundLocalError",
+        fetch_status="ok",
+    )
+
+    blocked_map = queue_drain_module._handle_global_ci_blockers(
+        results,
+        client,
+        tmp_path,
+    )
+
+    assert blocked_map == {401: 777, 402: 777}
+    assert len(created) == 1
+    assert created[0][1] == "pytest tests/ --maxfail=1"
 
 
 def test_global_fix_blocking_persists_across_passes(monkeypatch, tmp_path: Path):


### PR DESCRIPTION
## Summary
- harvest GitHub Actions job logs for failed required checks
- derive stable remote fingerprints and cluster queue-wide blockers
- reuse the existing global-ci-fix path only when a mapped reproduction command exists
- update CLI help and operator docs for the new fail-closed behavior

## Validation
- python -m py_compile src/dopemux_pr_merge_specialist/github_api.py src/dopemux_pr_merge_specialist/merge.py src/dopemux_pr_merge_specialist/queue_drain.py tests/pr_merge_specialist/test_queue_drain_integration.py
- pytest -q tests/pr_merge_specialist/test_queue_drain_integration.py -k "query_checks_reports_exact_failed_required_check_names or reproduce_remote_required_check_failure_runs_mapped_command or fetch_remote_check_log_evidence or extract_remote_failure_signature or handle_global_ci_blockers_groups_remote_fingerprints or handle_global_ci_blockers_ignores_failed_global_fix_creation"
- pytest -q tests/pr_merge_specialist/test_queue_drain_integration.py -k "global_fix_blocking_persists_across_passes or handle_global_ci_blockers_ignores_failed_global_fix_creation or handle_global_ci_blockers_groups_remote_fingerprints"
- pytest -q tests/pr_merge_specialist/test_policy_and_validation.py -k "repo_policy_loads_and_has_fingerprint or invalid_remote_check_repro_step_fails_closed"
- python -m dopemux_pr_merge_specialist.cli self-check --json --allow-dirty

@codex 
@clauee
@copilot