### PR TITLE
fix(pr-merge): add live queue-drain run logging

### DIFF
--- a/docs/02-how-to/pr-merge-flight-dashboard.md
+++ b/docs/02-how-to/pr-merge-flight-dashboard.md
@@ -63,6 +63,7 @@ Important constraint:
 - bounded dry or execute runs respect `--max-prs`, so operator test runs can sample the queue without draining the whole backlog
 - explicitly mapped required checks can be reproduced locally before CI remediation runs; unmapped remote failures still fail closed
 - remote fingerprint harvesting is GitHub Actions-only in the first pass; non-Actions check URLs and ambiguous log output do not trigger shared remediation
+- headless queue runs append real-time progress to `proof/pr_merge/<run-id>/LIVE_LOG.txt`; this is the canonical artifact to tail while `queue-drain` is still running
 
 ### Optimistic Lifecycle
 The dashboard uses a state model that distinguishes local proof from GitHub lag:

--- a/docs/pr_merge/usage-patterns.md
+++ b/docs/pr_merge/usage-patterns.md
@@ -46,6 +46,14 @@ When queue-wide CI failures repeat across multiple PRs, `queue-drain` now falls 
 
 When `pr-apply` produces a passive `queued_for_merge` result after rebasing and validation, `queue-drain` now still executes the merge handoff step so GitHub receives the actual `gh pr merge` or auto-merge enqueue command for that PR.
 
+For headless `queue-drain` runs, the canonical real-time execution stream now lives in `proof/pr_merge/<run-id>/LIVE_LOG.txt`. Use that file to tail pass progress, tactic selection, shared global-fix activity, and final run summary lines while the queue is still active.
+
+`LIVE_LOG.txt` is additive:
+
+- `COMMANDS_RUN.txt` remains per-command evidence
+- `STATE.json` remains per-PR state authority
+- `RUN_SUMMARY.md` remains the final human rollup
+
 ## Common Workflows
 
 ### 1. Safe Review Cycle (Non-Mutating)

--- a/src/dopemux_pr_merge_specialist/cli.py
+++ b/src/dopemux_pr_merge_specialist/cli.py
@@ -420,7 +420,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     queue_drain_parser = sub.add_parser(
         "queue-drain",
-        help="🌊 Automated Synchronization: Orchestrate scan, remediation, remote-fingerprint clustering, and merge across the queue.",
+        help="🌊 Automated Synchronization: Orchestrate scan, remediation, remote-fingerprint clustering, merge, and write LIVE_LOG.txt for headless tracking.",
     )
     add_common_arguments(queue_drain_parser)
     queue_drain_parser.add_argument(

--- a/src/dopemux_pr_merge_specialist/queue_drain.py
+++ b/src/dopemux_pr_merge_specialist/queue_drain.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Callabl
 from .action_model import allowed_actions_for_result
 from .github_api import BOT_AUTHORS, GitHubClient, RemoteCheckLogEvidence, ci_status, summarize_checks, thread_counters
 from .policy import PolicyError, load_effective_policy, policy_artifact_payload, policy_fingerprint
-from .runtime import CommandResult, append_command_log, execute_or_dry_run, fingerprint_payload, pid_is_running, run_command, run_id, shell_join, snapshot_environment, utc_now, write_json, write_text
+from .runtime import CommandResult, append_command_log, append_live_log, execute_or_dry_run, fingerprint_payload, pid_is_running, run_command, run_id, shell_join, snapshot_environment, utc_now, write_json, write_text
 from .schema import ARTIFACT_VERSION, ArtifactMeta, BlockerType, FallbackReason, Finding, FindingSeverity, Fingerprint, MergeDecision, MergeActionType, OverrideRecord, PhaseRecord, PRResult, PRState, PRStateData, POLICY_SCHEMA_VERSION, PreflightCheck, PreflightResult, PullRequestState, QueueOrderingLayer, ReviewThread, RunManifest, ThreadComment, ThreadDisposition, ThreadDispositionType, TruthSource, ValidationReport, ValidationStatus, ValidationStepResult, TOOL_VERSION
 from .validation import run_validation, validation_report_md
 from .strategy_library import STRATEGY_LIBRARY, select_strategy, StrategyAssignment, TRAIN_ELIGIBLE_STRATEGIES, STRATEGY_EXECUTION_ORDER
@@ -1217,14 +1217,44 @@ def _harvest_remote_failure_fingerprint(
             return fingerprint
     return None
 
-def _create_global_fix_pr(fingerprint: str, failed_step: ValidationStepResult, client: GitHubClient, repo_root: Path) -> int:
+def _emit_live_run_event(
+    live_log_path: Optional[Path],
+    *,
+    level: str,
+    scope: str,
+    message: str,
+    echo: bool = True,
+) -> None:
+    if live_log_path is not None:
+        append_live_log(live_log_path, level=level, scope=scope, message=message)
+    if echo:
+        print(message)
+
+
+def _create_global_fix_pr(
+    fingerprint: str,
+    failed_step: ValidationStepResult,
+    client: GitHubClient,
+    repo_root: Path,
+    logger: Optional[Callable[[str, str, str], None]] = None,
+) -> int:
     """Creates a global fix PR against the main branch."""
     import subprocess
     
     branch = f"global-ci-fix-{fingerprint[:8]}"
     path = Path("/tmp") / f"dopemux-global-fix-{fingerprint[:8]}"
+    scope = f"global-fix:{fingerprint[:8]}"
+
+    def _log(message: str, level: str = "INFO") -> None:
+        if logger:
+            logger(level, scope, message)
+        else:
+            print(message)
     
-    print(f"Creating global fix PR for fingerprint {fingerprint} on branch {branch}")
+    _log(
+        f"Creating global fix PR for fingerprint {fingerprint} on branch {branch} (worktree: {path})",
+        "START",
+    )
     
     # 1. Prepare worktree off main
     if path.exists():
@@ -1232,9 +1262,11 @@ def _create_global_fix_pr(fingerprint: str, failed_step: ValidationStepResult, c
     subprocess.run(["git", "branch", "-D", branch], cwd=repo_root, stderr=subprocess.DEVNULL)
     
     # Fetch latest main
+    _log("Fetching latest origin/main for shared CI remediation.")
     subprocess.run(["git", "fetch", "origin", "main"], cwd=repo_root, check=True)
     subprocess.run(["git", "branch", branch, "origin/main"], cwd=repo_root, check=True)
     subprocess.run(["git", "worktree", "add", str(path), branch], cwd=repo_root, check=True)
+    _log("Prepared global-fix worktree.", "SUCCESS")
     
     try:
         # 2. Invoke Gemini CLI to fix it
@@ -1259,7 +1291,7 @@ CRITICAL: You MUST follow the ci-remediation-specialist runbook:
 Identify the root cause, modify the necessary files, and verify your fix if possible.
 Your goal is to make the command `{failed_step.command}` pass.
 """
-        print("Launching Gemini CLI agent for GLOBAL FIX...")
+        _log("Launching Gemini CLI agent for GLOBAL FIX...", "START")
         cmd = _gemini_ci_remediation_command(prompt)
         
         process = subprocess.Popen(
@@ -1276,24 +1308,27 @@ Your goal is to make the command `{failed_step.command}` pass.
             for line in iter(process.stdout.readline, ""):
                 clean_line = line.strip()
                 if clean_line:
-                    print(f"  [gemini-global-fix] {clean_line}")
+                    _log(f"[gemini] {clean_line}")
                     if any(x in clean_line.lower() for x in ["quota", "rate limit", "429", "exhausted"]):
-                        print("CRITICAL: API QUOTA EXHAUSTED. GLOBAL FIX BLOCKED.")
+                        _log("CRITICAL: API QUOTA EXHAUSTED. GLOBAL FIX BLOCKED.", "ERROR")
         process.wait()
+        _log(f"Gemini global-fix process exited with code {process.returncode}.")
         
         if process.returncode != 0:
-            print("Global fix agent failed to complete successfully.")
+            _log("Global fix agent failed to complete successfully.", "ERROR")
             return -1
             
         # 3. Commit and push
         status = subprocess.run(["git", "status", "--porcelain"], cwd=path, capture_output=True, text=True)
         if not status.stdout.strip():
-            print("Global fix agent made no changes.")
+            _log("Global fix agent made no changes.", "WARNING")
             return -1
             
+        _log("Committing and pushing global CI remediation patch.", "START")
         subprocess.run(["git", "add", "-A"], cwd=path, check=True)
         subprocess.run(["git", "commit", "-m", f"fix: global CI remediation for {failed_step.name}\n\nAutomated fix generated by Dopemux."], cwd=path, check=True)
         subprocess.run(["git", "push", "-u", "origin", branch], cwd=path, check=True)
+        _log("Global fix branch pushed successfully.", "SUCCESS")
         
         # 4. Create PR
         pr_body = (
@@ -1314,30 +1349,42 @@ Your goal is to make the command `{failed_step.command}` pass.
         if client.repo:
             create_cmd.extend(["--repo", client.repo])
             
+        _log("Creating global fix PR on GitHub.", "START")
         pr_result = subprocess.run(create_cmd, cwd=path, capture_output=True, text=True)
         if pr_result.returncode != 0:
-            print(f"Failed to create PR: {pr_result.stderr}")
+            _log(f"Failed to create PR: {pr_result.stderr.strip()}", "ERROR")
             return -1
             
         # Extract PR number from URL returned by gh pr create
         url = pr_result.stdout.strip()
         pr_num = int(url.split("/")[-1])
-        print(f"Successfully created global fix PR #{pr_num}")
+        _log(f"Successfully created global fix PR #{pr_num}", "SUCCESS")
         return pr_num
         
     except Exception as e:
-        print(f"Error creating global fix: {e}")
+        _log(f"Error creating global fix: {e}", "ERROR")
         return -1
     finally:
         subprocess.run(["git", "worktree", "remove", "--force", str(path)], cwd=repo_root)
+        _log("Cleaned up global-fix worktree.")
 
-def _handle_global_ci_blockers(results: List[PRResult], client: GitHubClient, worktree_dir: Path) -> Dict[int, int]:
+def _handle_global_ci_blockers(
+    results: List[PRResult],
+    client: GitHubClient,
+    worktree_dir: Path,
+    logger: Optional[Callable[[str, str, str], None]] = None,
+) -> Dict[int, int]:
     """
     Identifies PRs blocked by the same CI failure and manages global fix PRs.
     Returns a dict mapping pr_id -> fix_pr_number for all PRs that should be
     blocked pending a global fix. Does NOT mutate any PRResult instances.
     """
     blocked_map: Dict[int, int] = {}
+    def _log(message: str, level: str = "INFO") -> None:
+        if logger:
+            logger(level, "queue", message)
+        else:
+            print(message)
 
     # 1. Find existing global fix PRs and map them by fingerprint
     existing_fix_prs = client.find_global_fix_prs()
@@ -1385,22 +1432,34 @@ def _handle_global_ci_blockers(results: List[PRResult], client: GitHubClient, wo
         if fingerprint in fingerprint_to_pr_map:
             # A global fix PR already exists. Record all grouped PRs as blocked.
             pr_number = fingerprint_to_pr_map[fingerprint]
-            print(f"Found existing global fix PR #{pr_number} for fingerprint {fingerprint}")
+            _log(
+                f"Found existing global fix PR #{pr_number} for fingerprint {fingerprint} affecting {len(blocked_prs)} PRs."
+            )
             for r, _failed_step in blocked_prs:
                 blocked_map[r.pr_state.pr_id] = pr_number
         else:
             # New global blocker. Create a global fix PR.
-            print(f"New global CI blocker detected for fingerprint: {fingerprint}. Triggering global fix.")
+            _log(
+                f"New global CI blocker detected for fingerprint {fingerprint}; triggering shared remediation for {len(blocked_prs)} PRs.",
+                "START",
+            )
             failed_step = blocked_prs[0][1]
             if failed_step:
-                new_pr_number = _create_global_fix_pr(fingerprint, failed_step, client, worktree_dir)
+                new_pr_number = _create_global_fix_pr(
+                    fingerprint,
+                    failed_step,
+                    client,
+                    worktree_dir,
+                    logger=logger,
+                )
                 if new_pr_number > 0:
                     for r, _failed_step in blocked_prs:
                         blocked_map[r.pr_state.pr_id] = new_pr_number
                 else:
-                    print(
+                    _log(
                         f"Global fix creation failed for fingerprint {fingerprint}; "
-                        "continuing with per-PR remediation."
+                        "continuing with per-PR remediation.",
+                        "WARNING",
                     )
 
     return blocked_map
@@ -1523,11 +1582,20 @@ def _ignite_speculative_train(
     return merged_ids, queued_ids
 
 
-def _queue_drain_progress(pr_id: int) -> Callable[[str, str], None]:
-    """Print-based progress callback for headless queue-drain mode."""
+def _queue_drain_progress(
+    pr_id: int, *, live_log_path: Optional[Path]
+) -> Callable[[str, str], None]:
+    """Print progress to stdout and persist it to the run live log."""
     def _cb(msg: str, step_type: str = "INFO") -> None:
         ts = datetime.now().strftime("%H:%M:%S")
         print(f"[{ts}] PR #{pr_id} [{step_type}] {msg}")
+        if live_log_path is not None:
+            append_live_log(
+                live_log_path,
+                level=step_type,
+                scope=f"pr:{pr_id}",
+                message=msg,
+            )
     return _cb
 
 
@@ -1537,19 +1605,30 @@ def queue_drain(args: argparse.Namespace) -> int:
     active_run_id = getattr(args, "run_id", None) or run_id()
     args.run_id = active_run_id
     run_dir, queue_dir, pr_root = build_run_paths(args.out_dir, active_run_id)
+    live_log_path = run_dir / "LIVE_LOG.txt"
     policy = load_effective_policy(repo_root, explicit_path=getattr(args, "policy", None))
     client = GitHubClient(repo=getattr(args, "repo", None), repo_root=repo_root, policy=policy)
     repo_slug = client.resolve_repo_slug()
     ops = _get_ops_engine(run_dir)
     closed_loop = ClosedLoopEngine(ops, STRATEGY_LIBRARY)
+
+    def log_queue(message: str, level: str = "INFO") -> None:
+        _emit_live_run_event(
+            live_log_path,
+            level=level,
+            scope="queue",
+            message=message,
+        )
     
     execute = getattr(args, "execute", False)
     lock_path: Optional[Path] = None
+    log_queue(f"Queue drain starting (run_id={active_run_id}, execute={execute}).", "START")
     if execute:
         ok, lock_path, err = acquire_queue_lock(repo_root=repo_root, active_run_id=active_run_id)
         if not ok:
-            print(f"Error: {err}")
+            log_queue(f"Unable to acquire queue lock: {err}", "ERROR")
             return 1
+        log_queue("Acquired queue lock.", "SUCCESS")
             
     try:
         max_passes = int(getattr(args, "max_passes", 3))
@@ -1563,14 +1642,30 @@ def queue_drain(args: argparse.Namespace) -> int:
         limit_reached = False
 
         for pass_idx in range(max_passes):
-            print(f"\n--- Queue Pass {pass_idx + 1}/{max_passes} ---")
+            log_queue(f"Starting queue pass {pass_idx + 1}/{max_passes}.")
             results = queue_scan_internal(args, client, policy, active_run_id)
             if not results:
-                print("No PRs found.")
+                log_queue("Queue scan returned no PRs.")
                 break
+            log_queue(f"Queue scan returned {len(results)} PRs.")
 
-            pass_blocked = _handle_global_ci_blockers(results, client, repo_root)
+            pass_blocked = _handle_global_ci_blockers(
+                results,
+                client,
+                repo_root,
+                logger=lambda level, scope, message: _emit_live_run_event(
+                    live_log_path,
+                    level=level,
+                    scope=scope,
+                    message=message,
+                ),
+            )
             global_fix_blocked.update(pass_blocked)
+            if pass_blocked:
+                log_queue(
+                    f"Global blockers active for PRs: {sorted(pass_blocked)}.",
+                    "WARNING",
+                )
 
             # Ignite speculative rebase train for READY PRs
             pass_commands_log = run_dir / f"PASS_{pass_idx + 1}_TRAIN_COMMANDS.txt"
@@ -1598,23 +1693,26 @@ def queue_drain(args: argparse.Namespace) -> int:
                 and r.pr_state.pr_id not in no_progress_ids
             ]
             if not active_results:
-                print("All PRs processed, merged, or queued.")
+                log_queue("All PRs processed, merged, or queued.", "SUCCESS")
                 break
             for result in active_results:
                 if max_prs > 0 and len(processed_ids) >= max_prs:
-                    print(f"Reached max PR limit ({max_prs}); stopping queue drain.")
+                    log_queue(f"Reached max PR limit ({max_prs}); stopping queue drain.")
                     limit_reached = True
                     break
                 pr_id = result.pr_state.pr_id
                 
                 fix_pr = global_fix_blocked.get(pr_id)
                 if fix_pr:
-                    print(f"PR #{pr_id}: Blocked pending global fix PR #{fix_pr}. Skipping remediation.")
+                    log_queue(
+                        f"PR #{pr_id}: blocked pending global fix PR #{fix_pr}; skipping remediation.",
+                        "WARNING",
+                    )
                     processed_ids.add(pr_id)
                     continue
                     
                 processed_ids.add(pr_id)
-                cb = _queue_drain_progress(pr_id)
+                cb = _queue_drain_progress(pr_id, live_log_path=live_log_path)
                 allowed = _derive_allowed_actions(result, policy)
                 report = result.to_dict()
                 report["allowed_actions"] = allowed
@@ -1622,7 +1720,10 @@ def queue_drain(args: argparse.Namespace) -> int:
                 closed_loop.emit_trace_artifacts(trace, pr_dir_for(pr_root, pr_id) / "traces")
                 tactic = trace.next_tactic
                 pr_strategy = select_strategy(result, policy)
-                print(f"PR #{pr_id}: {result.lifecycle_state} -> Tactic: {tactic} (Strategy: {pr_strategy.strategy_id})")
+                cb(
+                    f"{result.lifecycle_state} -> Tactic: {tactic} (Strategy: {pr_strategy.strategy_id})",
+                    "TACTIC",
+                )
                 if tactic == "MERGE" and execute:
                     try:
                         merge_result = pr_merge(
@@ -1640,7 +1741,7 @@ def queue_drain(args: argparse.Namespace) -> int:
                             else:
                                 queued_ids.add(pr_id)
                     except RuntimeError as e:
-                        print(f"Merge error for PR #{pr_id}: {e}")
+                        cb(f"Merge error: {e}", "ERROR")
                         failed_remediation_ids.add(pr_id)
                 elif tactic == "APPLY_FIX" and execute:
                     try:
@@ -1681,16 +1782,19 @@ def queue_drain(args: argparse.Namespace) -> int:
                         # If validation still failed after fix, we don't add to merged_ids,
                         # so it will be re-scanned in next pass.
                         if not apply_result.validation_report or not apply_result.validation_report.passed:
-                            print(f"PR #{pr_id}: Fix attempt completed but validation still failing.")
+                            cb("Fix attempt completed but validation still failing.", "WARNING")
                             failed_remediation_ids.add(pr_id)
                         elif pr_id not in merged_ids and pr_id not in queued_ids:
                             # Validation passed locally but PR wasn't handed off to merge;
                             # no point retrying in subsequent passes.
                             no_progress_ids.add(pr_id)
-                            print(f"PR #{pr_id}: Local validation passed but PR not merge-ready; skipping in future passes.")
+                            cb(
+                                "Local validation passed but PR not merge-ready; skipping in future passes.",
+                                "INFO",
+                            )
 
                     except RuntimeError as e:
-                        print(f"Apply error for PR #{pr_id}: {e}")
+                        cb(f"Apply error: {e}", "ERROR")
                         failed_remediation_ids.add(pr_id)
                 elif tactic == "READY" and execute:
                     try:
@@ -1700,7 +1804,7 @@ def queue_drain(args: argparse.Namespace) -> int:
                             ), progress_callback=cb
                         )
                     except RuntimeError as e:
-                        print(f"Ready error for PR #{pr_id}: {e}")
+                        cb(f"Ready error: {e}", "ERROR")
                 elif tactic == "APPROVE" and execute:
                     try:
                         pr_approve(
@@ -1709,24 +1813,28 @@ def queue_drain(args: argparse.Namespace) -> int:
                             ), progress_callback=cb
                         )
                     except RuntimeError as e:
-                        print(f"Approval error for PR #{pr_id}: {e}")
+                        cb(f"Approval error: {e}", "ERROR")
                 elif tactic in ("DEFER", "REQUEST_CHANGES", "REQUEST_REVIEW"):
                     no_progress_ids.add(pr_id)
                 elif not execute:
                     # Dry-run: tactic won't change state, skip in future passes
                     no_progress_ids.add(pr_id)
+            log_queue(
+                f"Completed queue pass {pass_idx + 1}/{max_passes} (processed={len(processed_ids)}, merged={len(merged_ids)}, queued={len(queued_ids)})."
+            )
             if limit_reached:
                 break
         
         # Write final run summary
         write_text(run_dir / "RUN_SUMMARY.md", render_operator_summary(results))
         
-        print(f"\nRun ID: {active_run_id}")
-        print(f"Processed PRs: {len(processed_ids)}")
-        print(f"Merged: {len(merged_ids)}")
-        print(f"Queued: {len(queued_ids)}")
-        print(f"Artifacts: {run_dir}")
+        log_queue(f"Run ID: {active_run_id}", "SUCCESS")
+        log_queue(f"Processed PRs: {len(processed_ids)}", "SUCCESS")
+        log_queue(f"Merged: {len(merged_ids)}", "SUCCESS")
+        log_queue(f"Queued: {len(queued_ids)}", "SUCCESS")
+        log_queue(f"Artifacts: {run_dir}", "SUCCESS")
         return 0
     finally:
         if execute:
             release_queue_lock(lock_path)
+            log_queue("Released queue lock.")

--- a/src/dopemux_pr_merge_specialist/runtime.py
+++ b/src/dopemux_pr_merge_specialist/runtime.py
@@ -112,6 +112,14 @@ def append_command_log(
         handle.write("\n")
 
 
+def append_live_log(path: Path, *, level: str, scope: str, message: str) -> None:
+    ensure_parent(path)
+    normalized = " ".join(str(message).replace("\r", "\n").splitlines()).strip()
+    line = f"{utc_now()} [{str(level).upper()}] {scope}: {normalized}\n"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
 def dry_run_result(cmd: Sequence[str]) -> CommandResult:
     return CommandResult(list(cmd), 0, "", "")
 

--- a/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/cli.py
+++ b/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/cli.py
@@ -65,7 +65,11 @@ def cmd_flight(args: argparse.Namespace) -> int:
 
     # 1. Perform initial scan to get prioritized PRs
     print(f"📡 Scanning subspace for PRs (Run: {active_run_id})...")
-    results = queue_scan_internal(args, client, policy, active_run_id)
+    try:
+        results = queue_scan_internal(args, client, policy, active_run_id)
+    except Exception as exc:
+        print(f"Flight scan failed: {exc}")
+        return 1
 
     if not results:
         print("📭 No PRs found in the current sector.")
@@ -219,7 +223,10 @@ def _self_check(args: argparse.Namespace) -> int:
         results["ok"] = False
 
     # Check 4: Policy loading
-    preflight_rc = preflight(args)
+    preflight_args = argparse.Namespace(**vars(args))
+    if getattr(args, "json", False):
+        preflight_args._suppress_output = True
+    preflight_rc = preflight(preflight_args)
     results["checks"].append(
         {"name": "preflight", "status": "PASS" if preflight_rc == 0 else "FAIL"}
     )
@@ -413,7 +420,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     queue_drain_parser = sub.add_parser(
         "queue-drain",
-        help="🌊 Automated Synchronization: Orchestrate scan, plan, apply, and merge across the entire queue.",
+        help="🌊 Automated Synchronization: Orchestrate scan, remediation, remote-fingerprint clustering, merge, and write LIVE_LOG.txt for headless tracking.",
     )
     add_common_arguments(queue_drain_parser)
     queue_drain_parser.add_argument(
@@ -508,7 +515,7 @@ def build_parser() -> argparse.ArgumentParser:
     flight_parser.set_defaults(func=cmd_flight)
 
     flight_deck_parser = sub.add_parser(
-        "flight-deck", help="🚀 Mission Control: Launch the Flight Deck operations center."
+        "flight-deck", help="🚀 Mission Control: Launch the Flight Deck operations center with shared CI blocker detection."
     )
     add_common_arguments(flight_deck_parser)
     flight_deck_parser.add_argument(

--- a/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/github_api.py
+++ b/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/github_api.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import json
+import re
 import textwrap
 import time
 from collections import defaultdict
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
@@ -24,6 +26,103 @@ BOT_AUTHORS = {
     "copilot-pull-request-reviewer",
     "codecov-commenter",
 }
+GITHUB_ACTIONS_DETAILS_URL_RE = re.compile(
+    r"^https://github\.com/[^/]+/[^/]+/actions/runs/(?P<run_id>\d+)(?:/job/(?P<job_id>\d+))?/?$"
+)
+
+
+@dataclass(frozen=True)
+class RemoteCheckLogEvidence:
+    check_name: str
+    details_url: str
+    run_id: Optional[str] = None
+    job_id: Optional[str] = None
+    log_text: str = ""
+    fetch_status: str = "unsupported"
+    error: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @property
+    def ok(self) -> bool:
+        return self.fetch_status == "ok"
+
+
+def _check_rollup_name(check: Dict[str, Any]) -> str:
+    name = str(check.get("name") or check.get("context") or "").strip()
+    return name
+
+
+def _check_rollup_details_url(check: Dict[str, Any]) -> str:
+    return str(check.get("detailsUrl") or check.get("targetUrl") or "").strip()
+
+
+def _required_check_entries_by_state(
+    checks: List[Dict[str, Any]],
+    required_contexts: Sequence[str],
+    *,
+    failure_only: bool = False,
+    pending_only: bool = False,
+) -> List[Dict[str, Any]]:
+    required = {str(item).strip() for item in required_contexts if str(item).strip()}
+    entries: List[Dict[str, Any]] = []
+    seen: set[Tuple[str, str]] = set()
+    for check in checks:
+        name = _check_rollup_name(check)
+        if not name or name not in required:
+            continue
+        status = str(check.get("status") or check.get("state") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        is_pending = bool(status and status != "COMPLETED") or (
+            not conclusion and status != "COMPLETED"
+        )
+        is_failure = conclusion in CHECK_FAILURE
+        if failure_only and not is_failure:
+            continue
+        if pending_only and not is_pending:
+            continue
+        details_url = _check_rollup_details_url(check)
+        dedupe_key = (name, details_url)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        entries.append(
+            {
+                "check_name": name,
+                "details_url": details_url,
+                "status": status,
+                "conclusion": conclusion,
+            }
+        )
+    return entries
+
+
+def _required_check_names_by_state(
+    checks: List[Dict[str, Any]],
+    required_contexts: Sequence[str],
+    *,
+    failure_only: bool = False,
+    pending_only: bool = False,
+) -> List[str]:
+    required = {str(item).strip() for item in required_contexts if str(item).strip()}
+    names: List[str] = []
+    for check in checks:
+        name = _check_rollup_name(check)
+        if not name or name not in required:
+            continue
+        status = str(check.get("status") or "").upper()
+        conclusion = str(check.get("conclusion") or "").upper()
+        is_pending = bool(status and status != "COMPLETED") or (
+            not conclusion and status != "COMPLETED"
+        )
+        is_failure = conclusion in CHECK_FAILURE
+        if failure_only and not is_failure:
+            continue
+        if pending_only and not is_pending:
+            continue
+        names.append(name)
+    return sorted(dict.fromkeys(names))
 
 
 class GitHubClient:
@@ -497,9 +596,19 @@ class GitHubClient:
         summary = summarize_checks(checks)
         review_decision = str(payload.get("reviewDecision") or "")
         protection = self.fetch_branch_protection(str(payload.get("baseRefName") or ""))
+        required_contexts = list(protection.get("required_status_checks") or [])
         approval_required = bool(protection.get("approval_required", False))
         blockers: List[str] = []
         warnings: List[str] = []
+        failed_required_checks = _required_check_names_by_state(
+            checks, required_contexts, failure_only=True
+        )
+        failed_required_check_entries = _required_check_entries_by_state(
+            checks, required_contexts, failure_only=True
+        )
+        pending_required_checks = _required_check_names_by_state(
+            checks, required_contexts, pending_only=True
+        )
         if summary.required_failure > 0:
             blockers.append("required_check_failed")
         if summary.required_pending > 0:
@@ -522,10 +631,71 @@ class GitHubClient:
             "mergeable": payload.get("mergeable", ""),
             "merge_state_status": payload.get("mergeStateStatus", ""),
             "protection": protection,
+            "failed_required_checks": failed_required_checks,
+            "failed_required_check_entries": failed_required_check_entries,
+            "pending_required_checks": pending_required_checks,
             "approval_required": approval_required,
             "blocker_types": blockers,
             "warning_types": warnings,
         }
+
+    def fetch_remote_check_log_evidence(
+        self, check_entry: Dict[str, Any]
+    ) -> RemoteCheckLogEvidence:
+        check_name = str(check_entry.get("check_name") or "").strip()
+        details_url = str(check_entry.get("details_url") or "").strip()
+        if not details_url:
+            return RemoteCheckLogEvidence(
+                check_name=check_name,
+                details_url=details_url,
+                fetch_status="missing_details_url",
+                error="Required check did not include a details URL.",
+            )
+        cache_key = f"remote_check_log:{check_name}:{details_url}"
+        cached = self._cache_get(cache_key)
+        if cached is not None:
+            return cached
+        match = GITHUB_ACTIONS_DETAILS_URL_RE.match(details_url)
+        if not match:
+            evidence = RemoteCheckLogEvidence(
+                check_name=check_name,
+                details_url=details_url,
+                fetch_status="unsupported",
+                error="Details URL is not a GitHub Actions run or job URL.",
+            )
+            self.cache[cache_key] = evidence
+            return evidence
+
+        run_id = match.group("run_id")
+        job_id = match.group("job_id")
+        cmd = ["gh", "run", "view", run_id]
+        if job_id:
+            cmd.extend(["--job", job_id])
+        cmd.append("--log")
+        if self.repo:
+            cmd.extend(["--repo", self.repo])
+        result = self._run(cmd)
+        if result.returncode != 0:
+            evidence = RemoteCheckLogEvidence(
+                check_name=check_name,
+                details_url=details_url,
+                run_id=run_id,
+                job_id=job_id,
+                fetch_status="error",
+                error=result.stderr.strip() or "Unable to fetch GitHub Actions log.",
+            )
+            self.cache[cache_key] = evidence
+            return evidence
+        evidence = RemoteCheckLogEvidence(
+            check_name=check_name,
+            details_url=details_url,
+            run_id=run_id,
+            job_id=job_id,
+            log_text=result.stdout or "",
+            fetch_status="ok",
+        )
+        self.cache[cache_key] = evidence
+        return evidence
 
     def rate_limit_snapshot(self) -> Dict[str, Any]:
         result = self._run(["gh", "api", "rate_limit"])

--- a/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/policy.py
+++ b/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/policy.py
@@ -25,6 +25,7 @@ REQUIRED_TOP_LEVEL_KEYS = (
     "platform",
     "timeouts",
     "validation",
+    "remote_check_repro",
     "gates",
     "thread_rules",
     "check_rules",
@@ -98,6 +99,24 @@ DEFAULT_POLICY: Dict[str, Any] = {
                 "command": ["python", "scripts/check_root_hygiene.py"],
                 "run_in_dry_run": False,
             },
+        ],
+    },
+    "remote_check_repro": {
+        "steps": [
+            {
+                "check_name": "🧪 Unit Tests",
+                "command": [
+                    "pytest",
+                    "tests/",
+                    "--maxfail=1",
+                    "--disable-warnings",
+                    "--cov=src/dopemux",
+                    "--cov-report=term-missing",
+                    "--cov-report=xml:coverage.xml",
+                    "--cov-report=html:htmlcov",
+                ],
+                "scope": "repo",
+            }
         ],
     },
     "gates": {
@@ -248,7 +267,13 @@ def _validate_command_steps(steps: Iterable[Dict[str, Any]], *, section: str) ->
     for index, step in enumerate(steps):
         if not isinstance(step, dict):
             raise PolicyError(f"{section}.steps[{index}] must be a mapping.")
-        if not step.get("name"):
+        if section == "remote_check_repro":
+            check_name = step.get("check_name")
+            if not isinstance(check_name, str) or not check_name.strip():
+                raise PolicyError(
+                    f"{section}.steps[{index}] must define a non-empty 'check_name'."
+                )
+        elif not step.get("name"):
             raise PolicyError(f"{section}.steps[{index}] is missing 'name'.")
         command = step.get("command")
         if (
@@ -288,6 +313,12 @@ def validate_policy(policy: Dict[str, Any]) -> None:
     if not isinstance(validation, dict):
         raise PolicyError("validation must be a mapping.")
     _validate_command_steps(validation.get("steps", []), section="validation")
+    remote_check_repro = policy.get("remote_check_repro")
+    if not isinstance(remote_check_repro, dict):
+        raise PolicyError("remote_check_repro must be a mapping.")
+    _validate_command_steps(
+        remote_check_repro.get("steps", []), section="remote_check_repro"
+    )
     for section_name in (
         "gates",
         "thread_rules",

--- a/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/runtime.py
+++ b/templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/runtime.py
@@ -112,6 +112,14 @@ def append_command_log(
         handle.write("\n")
 
 
+def append_live_log(path: Path, *, level: str, scope: str, message: str) -> None:
+    ensure_parent(path)
+    normalized = " ".join(str(message).replace("\r", "\n").splitlines()).strip()
+    line = f"{utc_now()} [{str(level).upper()}] {scope}: {normalized}\n"
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+
+
 def dry_run_result(cmd: Sequence[str]) -> CommandResult:
     return CommandResult(list(cmd), 0, "", "")
 

--- a/tests/pr_merge_specialist/test_policy_and_validation.py
+++ b/tests/pr_merge_specialist/test_policy_and_validation.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from dopemux_pr_merge_specialist.policy import PolicyError, load_effective_policy, policy_artifact_payload
-from dopemux_pr_merge_specialist.runtime import CommandResult
+from dopemux_pr_merge_specialist.runtime import CommandResult, append_live_log
 from dopemux_pr_merge_specialist.schema import ValidationStatus
 from dopemux_pr_merge_specialist.validation import run_validation
 
@@ -85,6 +85,28 @@ def test_validation_dry_run_is_not_executed(tmp_path: Path):
     assert report.passed is False
     assert report.steps
     assert all(step.status == "planned" for step in report.steps)
+
+
+def test_append_live_log_creates_append_only_stable_lines(tmp_path: Path):
+    log_path = tmp_path / "LIVE_LOG.txt"
+
+    append_live_log(
+        log_path,
+        level="info",
+        scope="queue",
+        message="first line\nwith newline",
+    )
+    append_live_log(
+        log_path,
+        level="warning",
+        scope="pr:42",
+        message="second line",
+    )
+
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert lines[0].endswith("[INFO] queue: first line with newline")
+    assert lines[1].endswith("[WARNING] pr:42: second line")
 
 
 def test_validation_scopes_commands_to_changed_pr_files(monkeypatch, tmp_path: Path):

--- a/tests/pr_merge_specialist/test_queue_drain_integration.py
+++ b/tests/pr_merge_specialist/test_queue_drain_integration.py
@@ -853,6 +853,72 @@ def test_extract_remote_failure_signature_returns_none_for_ambiguous_log():
     )
 
 
+def test_queue_drain_progress_writes_live_log(tmp_path: Path):
+    live_log_path = tmp_path / "LIVE_LOG.txt"
+
+    cb = queue_drain_module._queue_drain_progress(
+        42,
+        live_log_path=live_log_path,
+    )
+    cb("Running validation suite...", "START")
+
+    lines = live_log_path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert lines[0].endswith("[START] pr:42: Running validation suite...")
+
+
+def test_create_global_fix_pr_logs_no_changes_outcome(monkeypatch, tmp_path: Path):
+    log_events: list[tuple[str, str, str]] = []
+
+    def logger(level: str, scope: str, message: str) -> None:
+        log_events.append((level, scope, message))
+
+    class FakeStdout:
+        def __init__(self, lines: list[str]) -> None:
+            self._lines = iter(lines)
+
+        def readline(self) -> str:
+            return next(self._lines, "")
+
+    class FakePopen:
+        def __init__(self, cmd, stdout, stderr, text, cwd, bufsize, universal_newlines):
+            self.cmd = cmd
+            self.stdout = FakeStdout(["working\n"])
+            self.returncode = 0
+
+        def wait(self):
+            return 0
+
+    def fake_run(cmd, cwd=None, check=False, stderr=None, capture_output=False, text=False):
+        command = list(cmd)
+        if command[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("subprocess.Popen", FakePopen)
+
+    pr_num = queue_drain_module._create_global_fix_pr(
+        "abc12345deadbeef",
+        ValidationStepResult(
+            name="🧪 Unit Tests",
+            command="pytest tests/ --maxfail=1",
+            status="failed",
+            stderr="FAILED tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
+        ),
+        FakeGitHubClient(repo=None, repo_root=tmp_path, policy={}),
+        tmp_path,
+        logger=logger,
+    )
+
+    assert pr_num == -1
+    messages = [message for _level, _scope, message in log_events]
+    assert any("Creating global fix PR" in message for message in messages)
+    assert any("Launching Gemini CLI agent for GLOBAL FIX" in message for message in messages)
+    assert any("Gemini global-fix process exited with code 0" in message for message in messages)
+    assert any("Global fix agent made no changes." in message for message in messages)
+
+
 def test_handle_global_ci_blockers_groups_remote_fingerprints(monkeypatch, tmp_path: Path):
     monkeypatch.setattr(
         queue_drain_module,
@@ -862,7 +928,7 @@ def test_handle_global_ci_blockers_groups_remote_fingerprints(monkeypatch, tmp_p
 
     created: list[tuple[str, str]] = []
 
-    def fake_create_global_fix_pr(fingerprint, failed_step, client, repo_root):
+    def fake_create_global_fix_pr(fingerprint, failed_step, client, repo_root, logger=None):
         created.append((fingerprint, failed_step.command))
         return 777
 
@@ -972,7 +1038,7 @@ def test_global_fix_blocking_persists_across_passes(monkeypatch, tmp_path: Path)
 
     pass_counter = [0]
 
-    def fake_handle_global_ci_blockers(_results, _client, _worktree_dir):
+    def fake_handle_global_ci_blockers(_results, _client, _worktree_dir, logger=None):
         pass_counter[0] += 1
         if pass_counter[0] == 1:
             # Pass 1: both PRs are globally blocked by fix PR #999


### PR DESCRIPTION
## Summary
- add canonical append-only `LIVE_LOG.txt` artifacts for headless `queue-drain` runs
- route queue and shared global-fix remediation milestones into the live run log while preserving stdout progress
- sync template/runtime parity for the remote-check policy and logging helpers, and update operator docs/CLI help

## Validation
- `python -m py_compile src/dopemux_pr_merge_specialist/runtime.py src/dopemux_pr_merge_specialist/queue_drain.py src/dopemux_pr_merge_specialist/cli.py tests/pr_merge_specialist/test_policy_and_validation.py tests/pr_merge_specialist/test_queue_drain_integration.py`
- `pytest -q tests/pr_merge_specialist/test_policy_and_validation.py -k 'append_live_log or repo_policy_loads_and_has_fingerprint or invalid_remote_check_repro_step_fails_closed'`
- `pytest -q tests/pr_merge_specialist/test_queue_drain_integration.py -k 'queue_drain_progress_writes_live_log or create_global_fix_pr_logs_no_changes_outcome or handle_global_ci_blockers_groups_remote_fingerprints or global_fix_blocking_persists_across_passes'`
- `pytest -q tests/pr_merge_specialist/test_template_contracts.py -k 'template_runtime_parity_for_runtime_modules'`
- `python -m dopemux_pr_merge_specialist.cli self-check --json --allow-dirty`
- bounded live execute sample produced `proof/pr_merge/run_20260328_230126/LIVE_LOG.txt`

## Notes
- `LIVE_LOG.txt` is additive and does not replace `RUN_SUMMARY.md`, `STATE.json`, or `COMMANDS_RUN.txt`.
- The bounded live execute sample was stopped after confirming real-time logging; it was not left to complete a full remediation cycle.

@codex
@clauee
@copilot
