### PR TITLE
fix(pr-merge): narrow shared CI remediation verification

### DIFF
--- a/config/repo_hygiene/root_hygiene_policy.json
+++ b/config/repo_hygiene/root_hygiene_policy.json
@@ -50,7 +50,9 @@
     "llm-plans",
     "dopemux_voice_branding_bundle",
     "proof_bundle",
-    "llm-docs"
+    "llm-docs",
+    "dopemux",
+    "dopemux_pr_merge_specialist"
   ],
   "allowed_root_files": [
     "SPECIMEN_LEDGER_REGEN_BIG.csv",

--- a/dopemux/__init__.py
+++ b/dopemux/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pathlib import Path
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+
+_SRC_PACKAGE = Path(__file__).resolve().parent.parent / "src" / __name__
+if _SRC_PACKAGE.is_dir():
+    __path__.append(str(_SRC_PACKAGE))

--- a/dopemux_pr_merge_specialist/__init__.py
+++ b/dopemux_pr_merge_specialist/__init__.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from pathlib import Path
+from pkgutil import extend_path
+
+__path__ = extend_path(__path__, __name__)
+
+_SRC_PACKAGE = Path(__file__).resolve().parent.parent / "src" / __name__
+if _SRC_PACKAGE.is_dir():
+    __path__.append(str(_SRC_PACKAGE))

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -1678,6 +1678,26 @@ def start(
     else:
         pending_profile_name = None
 
+    cwd_path = Path.cwd()
+    project_path = cwd_path
+
+    try:
+        dopemux_exists = Path.exists(project_path / ".dopemux")
+    except TypeError:
+        dopemux_exists = False
+
+    if not dopemux_exists:
+        project_path_candidate = get_workspace_root()
+        if hasattr(project_path_candidate, "__truediv__"):
+            project_path = project_path_candidate
+        else:
+            project_path = Path(project_path_candidate)
+
+        try:
+            dopemux_exists = Path.exists(project_path / ".dopemux")
+        except TypeError:
+            dopemux_exists = False
+
     if dry_run:
         console.logger.info(
             "[info]Dry run: no tmux or Claude Code processes will be started.[/info]"
@@ -1767,25 +1787,6 @@ def start(
         pass
 
         logger.error(f"Error: {e}")
-    cwd_path = Path.cwd()
-    project_path = cwd_path
-
-    try:
-        dopemux_exists = Path.exists(project_path / ".dopemux")
-    except TypeError:
-        dopemux_exists = False
-
-    if not dopemux_exists:
-        project_path_candidate = get_workspace_root()
-        if hasattr(project_path_candidate, "__truediv__"):
-            project_path = project_path_candidate
-        else:
-            project_path = Path(project_path_candidate)
-
-        try:
-            dopemux_exists = Path.exists(project_path / ".dopemux")
-        except TypeError:
-            dopemux_exists = False
 
     # Check if project is initialized
     if not dopemux_exists:

--- a/src/dopemux_pr_merge_specialist/queue_drain.py
+++ b/src/dopemux_pr_merge_specialist/queue_drain.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import argparse
+import contextlib
 import html
 import json
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import tempfile
 import time
@@ -139,6 +141,29 @@ def _gemini_ci_remediation_command(prompt: str) -> List[str]:
     # Gemini CLI no longer accepts --skill in headless mode, so the runbook
     # must live in the prompt and the invocation stays prompt-only.
     return ["gemini", "--prompt", prompt, "--yolo"]
+
+
+@contextlib.contextmanager
+def _isolated_gemini_home_env() -> Iterable[Dict[str, str]]:
+    """
+    Run Gemini in a minimal temporary HOME so it does not inherit the user's
+    desktop MCP registry and stall on unrelated server discovery.
+    """
+    with tempfile.TemporaryDirectory(prefix="dopemux-gemini-home-") as temp_home:
+        temp_home_path = Path(temp_home)
+        gemini_dir = temp_home_path / ".gemini"
+        gemini_dir.mkdir(parents=True, exist_ok=True)
+
+        source_gemini_dir = Path.home() / ".gemini"
+        for name in ("oauth_creds.json", "google_accounts.json", "installation_id"):
+            source = source_gemini_dir / name
+            if source.exists():
+                shutil.copy2(source, gemini_dir / name)
+
+        env = os.environ.copy()
+        env["HOME"] = str(temp_home_path)
+        env["XDG_CONFIG_HOME"] = str(temp_home_path / ".config")
+        yield env
 
 
 def _inflate_result_from_state_path(state_path: Path) -> Optional[PRResult]:
@@ -459,30 +484,31 @@ Identify the root cause, modify the necessary files, and ensure the command pass
     
     try:
         cmd = _gemini_ci_remediation_command(prompt)
-        
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            cwd=worktree_path,
-            bufsize=1, # Line buffered
-            universal_newlines=True,
-        )
-        
-        # Stream output to log in real-time
-        if process.stdout:
-            for line in iter(process.stdout.readline, ""):
-                clean_line = line.strip()
-                if clean_line:
-                    log(f"[gemini] {clean_line}")
+        with _isolated_gemini_home_env() as gemini_env:
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                cwd=worktree_path,
+                env=gemini_env,
+                bufsize=1, # Line buffered
+                universal_newlines=True,
+            )
+            
+            # Stream output to log in real-time
+            if process.stdout:
+                for line in iter(process.stdout.readline, ""):
+                    clean_line = line.strip()
+                    if clean_line:
+                        log(f"[gemini] {clean_line}")
+                        
+                        # Proactive quota detection
+                        lowered = clean_line.lower()
+                        if any(x in lowered for x in ["quota", "rate limit", "429", "exhausted"]):
+                            log("CRITICAL: API QUOTA EXHAUSTED. GEMINI REMEDIATION BLOCKED.", "ERROR")
                     
-                    # Proactive quota detection
-                    lowered = clean_line.lower()
-                    if any(x in lowered for x in ["quota", "rate limit", "429", "exhausted"]):
-                        log("CRITICAL: API QUOTA EXHAUSTED. GEMINI REMEDIATION BLOCKED.", "ERROR")
-                
-        process.wait(timeout=timeout_seconds)
+            process.wait(timeout=timeout_seconds)
         
     except subprocess.TimeoutExpired:
         process.kill()
@@ -1081,6 +1107,23 @@ class RemoteFailureFingerprint:
     command: str
     evidence_summary: str
     evidence: RemoteCheckLogEvidence
+    targeted_nodeid: Optional[str]
+
+
+def _extract_pytest_nodeid(text: str) -> Optional[str]:
+    match = re.search(r"FAILED\s+((?:tests|test)[^\s]+::[^\s]+)", text or "")
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def _pytest_lane_verification_command(targeted_nodeid: Optional[str]) -> Optional[str]:
+    if not targeted_nodeid:
+        return None
+    file_path = targeted_nodeid.split("::", 1)[0].strip()
+    if not file_path:
+        return None
+    return f"pytest {file_path} -q"
 
 def _parse_fingerprint_from_body(body: str) -> Optional[str]:
     """Extracts the failure fingerprint from a PR body."""
@@ -1196,6 +1239,7 @@ def _build_remote_failure_fingerprint(
         command=shell_join(command),
         evidence_summary=summary,
         evidence=evidence,
+        targeted_nodeid=_extract_pytest_nodeid(evidence.log_text),
     )
 
 
@@ -1237,6 +1281,8 @@ def _create_global_fix_pr(
     client: GitHubClient,
     repo_root: Path,
     logger: Optional[Callable[[str, str, str], None]] = None,
+    verification_command: Optional[str] = None,
+    targeted_nodeid: Optional[str] = None,
 ) -> int:
     """Creates a global fix PR against the main branch."""
     import subprocess
@@ -1271,10 +1317,24 @@ def _create_global_fix_pr(
     try:
         # 2. Invoke Gemini CLI to fix it
         error_output = (failed_step.stderr or failed_step.stdout or "No output available")[-6000:]
+        targeted_repro_command = failed_step.command
+        full_verification_command = verification_command or failed_step.command
+        lane_verification_command = _pytest_lane_verification_command(targeted_nodeid)
+        if targeted_nodeid:
+            targeted_repro_command = f"pytest {targeted_nodeid} -q"
+        targeted_instruction = ""
+        if targeted_nodeid:
+            targeted_instruction = (
+                f"\nTARGETED FAILURE CONTRACT:\n"
+                f"- The first authoritative failing test is `{targeted_nodeid}`.\n"
+                f"- Reproduce and fix that exact failure first with `{targeted_repro_command}`.\n"
+                f"- Do not run the full test suite or broaden scope to unrelated failures until `{targeted_nodeid}` passes.\n"
+            )
         prompt = f"""
 You are an expert developer fixing a widespread CI failure in the dopemux-mvp workspace.
 This failure is blocking multiple PRs.
-The following command failed: {failed_step.command}
+The original blocking command failed: {full_verification_command}
+For this remediation attempt, your ONLY reproduction command is: {targeted_repro_command}
 
 Output/Error:
 ```
@@ -1283,40 +1343,89 @@ Output/Error:
 
 Please diagnose the issue and FIX IT against the `main` branch. You are running in YOLO mode with full tool access. 
 CRITICAL: You MUST follow the ci-remediation-specialist runbook:
-1. REPRODUCE the failure locally first by running the command `{failed_step.command}`.
+1. REPRODUCE the failure locally first by running the command `{targeted_repro_command}`.
 2. USE AUTO-FIXERS if applicable (e.g., ruff check --fix).
 3. APPLY a minimal surgical fix if reproduction succeeds.
-4. VERIFY that your fix makes `{failed_step.command}` pass.
+4. VERIFY that your fix makes `{targeted_repro_command}` pass.
+5. STOP after one focused remediation attempt. Do not keep exploring unrelated failures.
 
 Identify the root cause, modify the necessary files, and verify your fix if possible.
-Your goal is to make the command `{failed_step.command}` pass.
+Your goal for this agent run is to make `{targeted_repro_command}` pass.
+Only edit files required for the original failure you reproduced.
+{targeted_instruction}
 """
         _log("Launching Gemini CLI agent for GLOBAL FIX...", "START")
         cmd = _gemini_ci_remediation_command(prompt)
-        
-        process = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            cwd=path,
-            bufsize=1,
-            universal_newlines=True,
-        )
-        
-        if process.stdout:
-            for line in iter(process.stdout.readline, ""):
-                clean_line = line.strip()
-                if clean_line:
-                    _log(f"[gemini] {clean_line}")
-                    if any(x in clean_line.lower() for x in ["quota", "rate limit", "429", "exhausted"]):
-                        _log("CRITICAL: API QUOTA EXHAUSTED. GLOBAL FIX BLOCKED.", "ERROR")
-        process.wait()
+        with _isolated_gemini_home_env() as gemini_env:
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                cwd=path,
+                env=gemini_env,
+                bufsize=1,
+                universal_newlines=True,
+            )
+            
+            if process.stdout:
+                for line in iter(process.stdout.readline, ""):
+                    clean_line = line.strip()
+                    if clean_line:
+                        _log(f"[gemini] {clean_line}")
+                        if any(x in clean_line.lower() for x in ["quota", "rate limit", "429", "exhausted"]):
+                            _log("CRITICAL: API QUOTA EXHAUSTED. GLOBAL FIX BLOCKED.", "ERROR")
+            process.wait(timeout=900)
         _log(f"Gemini global-fix process exited with code {process.returncode}.")
         
         if process.returncode != 0:
             _log("Global fix agent failed to complete successfully.", "ERROR")
             return -1
+
+        _log(f"Verifying focused remediation command: {targeted_repro_command}", "START")
+        focused_verify_result = subprocess.run(
+            shlex.split(targeted_repro_command),
+            cwd=path,
+            capture_output=True,
+            text=True,
+            timeout=900,
+        )
+        if focused_verify_result.returncode != 0:
+            verify_tail = (focused_verify_result.stderr or focused_verify_result.stdout or "No output available")[-1200:]
+            _log(
+                "Focused global fix verification failed; aborting shared remediation without commit. "
+                f"Verification command: {targeted_repro_command}\n{verify_tail}",
+                "ERROR",
+            )
+            return -1
+        _log("Focused global fix verification passed.", "SUCCESS")
+
+        if lane_verification_command and lane_verification_command != targeted_repro_command:
+            _log(f"Verifying fingerprint lane command: {lane_verification_command}", "START")
+            verify_result = subprocess.run(
+                shlex.split(lane_verification_command),
+                cwd=path,
+                capture_output=True,
+                text=True,
+                timeout=900,
+            )
+            if verify_result.returncode != 0:
+                verify_tail = (verify_result.stderr or verify_result.stdout or "No output available")[-1200:]
+                _log(
+                    "Lane verification failed; aborting shared remediation without commit. "
+                    f"Verification command: {lane_verification_command}\n{verify_tail}",
+                    "ERROR",
+                )
+                return -1
+            _log("Lane verification passed for the fingerprinted failure family.", "SUCCESS")
+        else:
+            _log("Focused remediation command is already the narrowest fingerprint lane.", "SUCCESS")
+
+        if full_verification_command != targeted_repro_command:
+            _log(
+                f"Deferring broad command verification to downstream CI after shared-fix PR creation: {full_verification_command}",
+                "INFO",
+            )
             
         # 3. Commit and push
         status = subprocess.run(["git", "status", "--porcelain"], cwd=path, capture_output=True, text=True)
@@ -1361,6 +1470,9 @@ Your goal is to make the command `{failed_step.command}` pass.
         _log(f"Successfully created global fix PR #{pr_num}", "SUCCESS")
         return pr_num
         
+    except subprocess.TimeoutExpired:
+        _log("Global fix agent timed out before producing a verified fix.", "ERROR")
+        return -1
     except Exception as e:
         _log(f"Error creating global fix: {e}", "ERROR")
         return -1
@@ -1397,6 +1509,7 @@ def _handle_global_ci_blockers(
     # 2. Group failing PRs by either a local validation fingerprint or a harvested
     # remote required-check fingerprint. Local evidence remains authoritative.
     failing_prs_by_fingerprint: Dict[str, List[Tuple[PRResult, ValidationStepResult]]] = defaultdict(list)
+    remote_group_metadata: Dict[str, RemoteFailureFingerprint] = {}
     for r in results:
         allowed = allowed_actions_for_result(r)
         if "APPLY_FIX" not in allowed:
@@ -1423,6 +1536,7 @@ def _handle_global_ci_blockers(
             ).strip(),
         )
         failing_prs_by_fingerprint[remote_failure.fingerprint].append((r, failed_step))
+        remote_group_metadata.setdefault(remote_failure.fingerprint, remote_failure)
 
     # 3. Process groups to identify and act on global blockers
     for fingerprint, blocked_prs in failing_prs_by_fingerprint.items():
@@ -1445,12 +1559,19 @@ def _handle_global_ci_blockers(
             )
             failed_step = blocked_prs[0][1]
             if failed_step:
+                remote_metadata = remote_group_metadata.get(fingerprint)
                 new_pr_number = _create_global_fix_pr(
                     fingerprint,
                     failed_step,
                     client,
                     worktree_dir,
                     logger=logger,
+                    verification_command=(
+                        remote_metadata.command if remote_metadata is not None else None
+                    ),
+                    targeted_nodeid=(
+                        remote_metadata.targeted_nodeid if remote_metadata is not None else None
+                    ),
                 )
                 if new_pr_number > 0:
                     for r, _failed_step in blocked_prs:

--- a/tests/pr_merge_specialist/test_policy_and_validation.py
+++ b/tests/pr_merge_specialist/test_policy_and_validation.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -107,6 +110,28 @@ def test_append_live_log_creates_append_only_stable_lines(tmp_path: Path):
     assert len(lines) == 2
     assert lines[0].endswith("[INFO] queue: first line with newline")
     assert lines[1].endswith("[WARNING] pr:42: second line")
+
+
+def test_module_entrypoint_works_without_pythonpath():
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "dopemux_pr_merge_specialist.cli",
+            "self-check",
+            "--json",
+            "--allow-dirty",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert '"ok": true' in result.stdout
 
 
 def test_validation_scopes_commands_to_changed_pr_files(monkeypatch, tmp_path: Path):

--- a/tests/pr_merge_specialist/test_queue_drain_integration.py
+++ b/tests/pr_merge_specialist/test_queue_drain_integration.py
@@ -869,6 +869,7 @@ def test_queue_drain_progress_writes_live_log(tmp_path: Path):
 
 def test_create_global_fix_pr_logs_no_changes_outcome(monkeypatch, tmp_path: Path):
     log_events: list[tuple[str, str, str]] = []
+    popen_env: dict[str, str] = {}
 
     def logger(level: str, scope: str, message: str) -> None:
         log_events.append((level, scope, message))
@@ -881,16 +882,22 @@ def test_create_global_fix_pr_logs_no_changes_outcome(monkeypatch, tmp_path: Pat
             return next(self._lines, "")
 
     class FakePopen:
-        def __init__(self, cmd, stdout, stderr, text, cwd, bufsize, universal_newlines):
+        def __init__(self, cmd, stdout, stderr, text, cwd, env, bufsize, universal_newlines):
             self.cmd = cmd
+            popen_env.update(env)
             self.stdout = FakeStdout(["working\n"])
             self.returncode = 0
 
-        def wait(self):
+        def wait(self, timeout=None):
             return 0
 
-    def fake_run(cmd, cwd=None, check=False, stderr=None, capture_output=False, text=False):
+    seen_commands: list[list[str]] = []
+
+    def fake_run(cmd, cwd=None, check=False, stderr=None, capture_output=False, text=False, timeout=None):
         command = list(cmd)
+        seen_commands.append(command)
+        if command and command[0] == "pytest":
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
         if command[:3] == ["git", "status", "--porcelain"]:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         return SimpleNamespace(returncode=0, stdout="", stderr="")
@@ -909,6 +916,8 @@ def test_create_global_fix_pr_logs_no_changes_outcome(monkeypatch, tmp_path: Pat
         FakeGitHubClient(repo=None, repo_root=tmp_path, policy={}),
         tmp_path,
         logger=logger,
+        verification_command="pytest tests/ --maxfail=1",
+        targeted_nodeid="tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
     )
 
     assert pr_num == -1
@@ -917,6 +926,89 @@ def test_create_global_fix_pr_logs_no_changes_outcome(monkeypatch, tmp_path: Pat
     assert any("Launching Gemini CLI agent for GLOBAL FIX" in message for message in messages)
     assert any("Gemini global-fix process exited with code 0" in message for message in messages)
     assert any("Global fix agent made no changes." in message for message in messages)
+    assert ["pytest", "tests/test_cli.py::TestCLI::test_start_command_role_dry_run", "-q"] in seen_commands
+    assert ["pytest", "tests/test_cli.py", "-q"] in seen_commands
+    assert popen_env["HOME"] != str(Path.home())
+    assert popen_env["XDG_CONFIG_HOME"].endswith("/.config")
+
+
+def test_create_global_fix_pr_aborts_when_post_verify_fails(monkeypatch, tmp_path: Path):
+    log_events: list[tuple[str, str, str]] = []
+
+    def logger(level: str, scope: str, message: str) -> None:
+        log_events.append((level, scope, message))
+
+    class FakeStdout:
+        def __init__(self, lines: list[str]) -> None:
+            self._lines = iter(lines)
+
+        def readline(self) -> str:
+            return next(self._lines, "")
+
+    class FakePopen:
+        def __init__(self, cmd, stdout, stderr, text, cwd, env, bufsize, universal_newlines):
+            self.stdout = FakeStdout(["working\n"])
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return 0
+
+    def fake_run(cmd, cwd=None, check=False, stderr=None, capture_output=False, text=False, timeout=None):
+        command = list(cmd)
+        if command[:3] == ["git", "status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout=" M changed.py\n", stderr="")
+        if command[:2] == ["git", "fetch"] or command[:2] == ["git", "branch"] or command[:2] == ["git", "worktree"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[:4] == ["pytest", "tests/test_cli.py::TestCLI::test_start_command_role_dry_run", "-q"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[:3] == ["pytest", "tests/test_cli.py", "-q"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr="FAILED tests/test_cli.py::TestCLI::test_start_command_role_dry_run")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("subprocess.Popen", FakePopen)
+
+    pr_num = queue_drain_module._create_global_fix_pr(
+        "abc12345deadbeef",
+        ValidationStepResult(
+            name="🧪 Unit Tests",
+            command="pytest tests/ --maxfail=1",
+            status="failed",
+            stderr="FAILED tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
+        ),
+        FakeGitHubClient(repo=None, repo_root=tmp_path, policy={}),
+        tmp_path,
+        logger=logger,
+        verification_command="pytest tests/ --maxfail=1",
+        targeted_nodeid="tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
+    )
+
+    assert pr_num == -1
+    messages = [message for _level, _scope, message in log_events]
+    assert any("Verifying focused remediation command" in message for message in messages)
+    assert any("Verifying fingerprint lane command" in message for message in messages)
+    assert any("aborting shared remediation without commit." in message for message in messages)
+    assert not any("Creating global fix PR on GitHub." in message for message in messages)
+
+
+def test_isolated_gemini_home_env_copies_auth_without_settings(monkeypatch, tmp_path: Path):
+    source_home = tmp_path / "source-home"
+    source_gemini = source_home / ".gemini"
+    source_gemini.mkdir(parents=True)
+    (source_gemini / "oauth_creds.json").write_text('{"token":"abc"}', encoding="utf-8")
+    (source_gemini / "google_accounts.json").write_text('{"accounts":[]}', encoding="utf-8")
+    (source_gemini / "settings.json").write_text('{"mcpServers":{"desktop-commander":{}}}', encoding="utf-8")
+
+    monkeypatch.setattr(queue_drain_module.Path, "home", lambda: source_home)
+
+    with queue_drain_module._isolated_gemini_home_env() as env:
+        isolated_home = Path(env["HOME"])
+        isolated_gemini = isolated_home / ".gemini"
+        assert isolated_gemini.exists()
+        assert (isolated_gemini / "oauth_creds.json").read_text(encoding="utf-8") == '{"token":"abc"}'
+        assert (isolated_gemini / "google_accounts.json").read_text(encoding="utf-8") == '{"accounts":[]}'
+        assert not (isolated_gemini / "settings.json").exists()
+        assert env["XDG_CONFIG_HOME"] == str(isolated_home / ".config")
 
 
 def test_handle_global_ci_blockers_groups_remote_fingerprints(monkeypatch, tmp_path: Path):
@@ -928,8 +1020,18 @@ def test_handle_global_ci_blockers_groups_remote_fingerprints(monkeypatch, tmp_p
 
     created: list[tuple[str, str]] = []
 
-    def fake_create_global_fix_pr(fingerprint, failed_step, client, repo_root, logger=None):
+    def fake_create_global_fix_pr(
+        fingerprint,
+        failed_step,
+        client,
+        repo_root,
+        logger=None,
+        verification_command=None,
+        targeted_nodeid=None,
+    ):
         created.append((fingerprint, failed_step.command))
+        assert verification_command == "pytest tests/ --maxfail=1"
+        assert targeted_nodeid == "tests/test_cli.py::TestCLI::test_start_command_role_dry_run"
         return 777
 
     monkeypatch.setattr(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -600,7 +600,7 @@ class TestCLI:
             assert exc_info.value.code == 1
             # Code uses console.logger.info
             mock_console.logger.info.assert_called_with(
-                "\n[yellow]⏸️ Interrupted by user[/yellow]"
+                "\n[warning]⏸️ Interrupted by user[/warning]"
             )
 
     @patch("dopemux.cli.console")


### PR DESCRIPTION
@codex 
@clauee
@copilot

## Summary
- narrow shared PRMS remediation to fingerprint-scoped repro and lane verification instead of broad full-suite gating before PR creation
- isolate Gemini remediation HOME so it no longer inherits MCP registry noise
- fix the underlying CLI dry-run `project_path` bug exposed by the shared CI fingerprint
- make `python -m dopemux_pr_merge_specialist.cli ...` work from the repo root without `PYTHONPATH=src`
- explicitly allow the new repo-root package shim directories in root hygiene policy

## Validation
- `pytest -q tests/test_cli.py -k 'test_start_command_role_dry_run or test_main_function_keyboard_interrupt'`
- `pytest -q tests/pr_merge_specialist/test_policy_and_validation.py -k 'module_entrypoint_works_without_pythonpath'`
- `pytest -q tests/pr_merge_specialist/test_queue_drain_integration.py -k 'create_global_fix_pr_logs_no_changes_outcome or create_global_fix_pr_aborts_when_post_verify_fails or isolated_gemini_home_env or queue_drain_progress_writes_live_log or handle_global_ci_blockers_groups_remote_fingerprints'`

## Notes
- unrelated untracked research docs were intentionally left out of this PR
- next step after merge is a bounded live `queue-drain --execute --max-prs 1 --max-passes 1 --allow-dirty` on `main`
