### PR TITLE
fix(pr-merge): skip stale shared CI fingerprints

### DIFF
--- a/src/dopemux_pr_merge_specialist/queue_drain.py
+++ b/src/dopemux_pr_merge_specialist/queue_drain.py
@@ -1304,8 +1304,27 @@ def _create_global_fix_pr(
     
     # 1. Prepare worktree off main
     if path.exists():
-        subprocess.run(["git", "worktree", "remove", "--force", str(path)], cwd=repo_root)
-    subprocess.run(["git", "branch", "-D", branch], cwd=repo_root, stderr=subprocess.DEVNULL)
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(path)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if path.exists():
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
+            _log(
+                f"Removed stale global-fix path that was not an active git worktree: {path}",
+                "WARNING",
+            )
+    subprocess.run(
+        ["git", "branch", "-D", branch],
+        cwd=repo_root,
+        stderr=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+    )
     
     # Fetch latest main
     _log("Fetching latest origin/main for shared CI remediation.")
@@ -1315,13 +1334,52 @@ def _create_global_fix_pr(
     _log("Prepared global-fix worktree.", "SUCCESS")
     
     try:
-        # 2. Invoke Gemini CLI to fix it
-        error_output = (failed_step.stderr or failed_step.stdout or "No output available")[-6000:]
         targeted_repro_command = failed_step.command
         full_verification_command = verification_command or failed_step.command
         lane_verification_command = _pytest_lane_verification_command(targeted_nodeid)
         if targeted_nodeid:
             targeted_repro_command = f"pytest {targeted_nodeid} -q"
+
+        def _run_verification(command_text: str) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                shlex.split(command_text),
+                cwd=path,
+                capture_output=True,
+                text=True,
+                timeout=900,
+            )
+
+        # 2. Re-check the current main-based worktree before launching Gemini.
+        # If the focused fingerprint already passes locally, the remote signal is stale.
+        _log(
+            f"Pre-checking focused remediation command before launching Gemini: {targeted_repro_command}",
+            "START",
+        )
+        precheck_focused = _run_verification(targeted_repro_command)
+        if precheck_focused.returncode == 0:
+            _log("Focused remediation command already passes on current main.", "SUCCESS")
+            if lane_verification_command and lane_verification_command != targeted_repro_command:
+                _log(
+                    f"Pre-checking fingerprint lane command before launching Gemini: {lane_verification_command}",
+                    "START",
+                )
+                precheck_lane = _run_verification(lane_verification_command)
+                if precheck_lane.returncode == 0:
+                    _log(
+                        "Focused remediation and lane verification already pass on current main; "
+                        "treating the remote fingerprint as stale and skipping shared remediation.",
+                        "WARNING",
+                    )
+                    return -1
+                _log(
+                    "Focused remediation passes, but the fingerprint lane still fails; continuing with shared remediation.",
+                    "INFO",
+                )
+        else:
+            _log("Focused remediation command still fails on current main; launching shared remediation.", "INFO")
+
+        # 3. Invoke Gemini CLI to fix it
+        error_output = (failed_step.stderr or failed_step.stdout or "No output available")[-6000:]
         targeted_instruction = ""
         if targeted_nodeid:
             targeted_instruction = (
@@ -1383,13 +1441,7 @@ Only edit files required for the original failure you reproduced.
             return -1
 
         _log(f"Verifying focused remediation command: {targeted_repro_command}", "START")
-        focused_verify_result = subprocess.run(
-            shlex.split(targeted_repro_command),
-            cwd=path,
-            capture_output=True,
-            text=True,
-            timeout=900,
-        )
+        focused_verify_result = _run_verification(targeted_repro_command)
         if focused_verify_result.returncode != 0:
             verify_tail = (focused_verify_result.stderr or focused_verify_result.stdout or "No output available")[-1200:]
             _log(
@@ -1402,13 +1454,7 @@ Only edit files required for the original failure you reproduced.
 
         if lane_verification_command and lane_verification_command != targeted_repro_command:
             _log(f"Verifying fingerprint lane command: {lane_verification_command}", "START")
-            verify_result = subprocess.run(
-                shlex.split(lane_verification_command),
-                cwd=path,
-                capture_output=True,
-                text=True,
-                timeout=900,
-            )
+            verify_result = _run_verification(lane_verification_command)
             if verify_result.returncode != 0:
                 verify_tail = (verify_result.stderr or verify_result.stdout or "No output available")[-1200:]
                 _log(
@@ -1477,7 +1523,17 @@ Only edit files required for the original failure you reproduced.
         _log(f"Error creating global fix: {e}", "ERROR")
         return -1
     finally:
-        subprocess.run(["git", "worktree", "remove", "--force", str(path)], cwd=repo_root)
+        subprocess.run(
+            ["git", "worktree", "remove", "--force", str(path)],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+        )
+        if path.exists():
+            if path.is_dir():
+                shutil.rmtree(path)
+            else:
+                path.unlink()
         _log("Cleaned up global-fix worktree.")
 
 def _handle_global_ci_blockers(

--- a/tests/pr_merge_specialist/test_queue_drain_integration.py
+++ b/tests/pr_merge_specialist/test_queue_drain_integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 from argparse import Namespace
 from pathlib import Path
 from types import SimpleNamespace
@@ -892,10 +893,17 @@ def test_create_global_fix_pr_logs_no_changes_outcome(monkeypatch, tmp_path: Pat
             return 0
 
     seen_commands: list[list[str]] = []
+    focused_precheck_calls = 0
 
-    def fake_run(cmd, cwd=None, check=False, stderr=None, capture_output=False, text=False, timeout=None):
+    def fake_run(cmd, cwd=None, check=False, stderr=None, stdout=None, capture_output=False, text=False, timeout=None):
+        nonlocal focused_precheck_calls
         command = list(cmd)
         seen_commands.append(command)
+        if command[:4] == ["pytest", "tests/test_cli.py::TestCLI::test_start_command_role_dry_run", "-q"]:
+            focused_precheck_calls += 1
+            if focused_precheck_calls == 1:
+                return SimpleNamespace(returncode=1, stdout="", stderr="FAILED tests/test_cli.py::TestCLI::test_start_command_role_dry_run")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
         if command and command[0] == "pytest":
             return SimpleNamespace(returncode=0, stdout="", stderr="")
         if command[:3] == ["git", "status", "--porcelain"]:
@@ -932,6 +940,128 @@ def test_create_global_fix_pr_logs_no_changes_outcome(monkeypatch, tmp_path: Pat
     assert popen_env["XDG_CONFIG_HOME"].endswith("/.config")
 
 
+def test_create_global_fix_pr_skips_stale_remote_fingerprint_when_precheck_is_green(
+    monkeypatch, tmp_path: Path
+):
+    log_events: list[tuple[str, str, str]] = []
+
+    def logger(level: str, scope: str, message: str) -> None:
+        log_events.append((level, scope, message))
+
+    def fake_popen(*args, **kwargs):
+        raise AssertionError("Gemini should not launch when precheck is already green")
+
+    def fake_run(
+        cmd,
+        cwd=None,
+        check=False,
+        stderr=None,
+        stdout=None,
+        capture_output=False,
+        text=False,
+        timeout=None,
+    ):
+        command = list(cmd)
+        if command[:2] == ["git", "fetch"] or command[:2] == ["git", "branch"] or command[:2] == ["git", "worktree"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[:4] == ["pytest", "tests/test_cli.py::TestCLI::test_start_command_role_dry_run", "-q"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[:3] == ["pytest", "tests/test_cli.py", "-q"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    pr_num = queue_drain_module._create_global_fix_pr(
+        "abc12345deadbeef",
+        ValidationStepResult(
+            name="🧪 Unit Tests",
+            command="pytest tests/ --maxfail=1",
+            status="failed",
+            stderr="FAILED tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
+        ),
+        FakeGitHubClient(repo=None, repo_root=tmp_path, policy={}),
+        tmp_path,
+        logger=logger,
+        verification_command="pytest tests/ --maxfail=1",
+        targeted_nodeid="tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
+    )
+
+    assert pr_num == -1
+    messages = [message for _level, _scope, message in log_events]
+    assert any("Pre-checking focused remediation command before launching Gemini" in message for message in messages)
+    assert any("Focused remediation command already passes on current main." in message for message in messages)
+    assert any("Pre-checking fingerprint lane command before launching Gemini" in message for message in messages)
+    assert any("treating the remote fingerprint as stale and skipping shared remediation" in message for message in messages)
+    assert not any("Launching Gemini CLI agent for GLOBAL FIX" in message for message in messages)
+
+
+def test_create_global_fix_pr_removes_stale_non_worktree_path(monkeypatch, tmp_path: Path):
+    log_events: list[tuple[str, str, str]] = []
+    stale_path = Path("/tmp") / "dopemux-global-fix-deadbeef"
+    if stale_path.exists():
+        if stale_path.is_dir():
+            shutil.rmtree(stale_path)
+        else:
+            stale_path.unlink()
+    stale_path.mkdir(parents=True)
+    (stale_path / "leftover.txt").write_text("stale", encoding="utf-8")
+
+    def logger(level: str, scope: str, message: str) -> None:
+        log_events.append((level, scope, message))
+
+    def fake_popen(*args, **kwargs):
+        raise AssertionError("Gemini should not launch for a stale-green fingerprint")
+
+    def fake_run(
+        cmd,
+        cwd=None,
+        check=False,
+        stderr=None,
+        stdout=None,
+        capture_output=False,
+        text=False,
+        timeout=None,
+    ):
+        command = list(cmd)
+        if command[:4] == ["git", "worktree", "remove", "--force"]:
+            return SimpleNamespace(returncode=128, stdout="", stderr="fatal: not a working tree")
+        if command[:2] == ["git", "fetch"] or command[:2] == ["git", "branch"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[:3] == ["git", "worktree", "add"]:
+            assert not stale_path.exists()
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[:4] == ["pytest", "tests/test_cli.py::TestCLI::test_start_command_role_dry_run", "-q"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if command[:3] == ["pytest", "tests/test_cli.py", "-q"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    pr_num = queue_drain_module._create_global_fix_pr(
+        "deadbeefcafebabe",
+        ValidationStepResult(
+            name="🧪 Unit Tests",
+            command="pytest tests/ --maxfail=1",
+            status="failed",
+            stderr="FAILED tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
+        ),
+        FakeGitHubClient(repo=None, repo_root=tmp_path, policy={}),
+        tmp_path,
+        logger=logger,
+        verification_command="pytest tests/ --maxfail=1",
+        targeted_nodeid="tests/test_cli.py::TestCLI::test_start_command_role_dry_run",
+    )
+
+    assert pr_num == -1
+    assert not stale_path.exists()
+    messages = [message for _level, _scope, message in log_events]
+    assert any("Removed stale global-fix path that was not an active git worktree" in message for message in messages)
+
+
 def test_create_global_fix_pr_aborts_when_post_verify_fails(monkeypatch, tmp_path: Path):
     log_events: list[tuple[str, str, str]] = []
 
@@ -953,7 +1083,7 @@ def test_create_global_fix_pr_aborts_when_post_verify_fails(monkeypatch, tmp_pat
         def wait(self, timeout=None):
             return 0
 
-    def fake_run(cmd, cwd=None, check=False, stderr=None, capture_output=False, text=False, timeout=None):
+    def fake_run(cmd, cwd=None, check=False, stderr=None, stdout=None, capture_output=False, text=False, timeout=None):
         command = list(cmd)
         if command[:3] == ["git", "status", "--porcelain"]:
             return SimpleNamespace(returncode=0, stdout=" M changed.py\n", stderr="")


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary
- pre-check focused and lane verification in shared remediation before launching Gemini
- skip shared remediation when the remote fingerprint is already green on current `main`
- remove stale `/tmp/dopemux-global-fix-*` paths even when they are no longer registered git worktrees
- keep queue-drain moving to the next blocker instead of crashing on stale worktree paths

## Validation
- `python -m py_compile src/dopemux_pr_merge_specialist/queue_drain.py tests/pr_merge_specialist/test_queue_drain_integration.py`
- `pytest -q tests/pr_merge_specialist/test_queue_drain_integration.py -k 'create_global_fix_pr_skips_stale_remote_fingerprint_when_precheck_is_green or create_global_fix_pr_removes_stale_non_worktree_path or create_global_fix_pr_logs_no_changes_outcome or create_global_fix_pr_aborts_when_post_verify_fails or handle_global_ci_blockers_groups_remote_fingerprints'`
- bounded live run: `python -m dopemux_pr_merge_specialist.cli queue-drain --execute --max-prs 1 --max-passes 1 --allow-dirty`

## Live evidence
- fingerprint `193f81a2...` was skipped as stale after focused and lane prechecks passed on current `main`
- the next fingerprint `e16e849b...` no longer crashed on stale `/tmp/dopemux-global-fix-e16e849b`
