### PR TITLE
[codex] fix gemini dispatch workflow credential guards

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -67,6 +67,7 @@ jobs:
       command: '${{ steps.extract_command.outputs.command }}'
       request: '${{ steps.extract_command.outputs.request }}'
       additional_context: '${{ steps.extract_command.outputs.additional_context }}'
+      has_gemini_credentials: '${{ steps.detect_gemini_credentials.outputs.available }}'
       issue_number: '${{ github.event.pull_request.number || github.event.issue.number }}'
     steps:
       - name: 'Mint identity token'
@@ -113,6 +114,19 @@ jobs:
               core.setOutput('command', 'fallthrough');
             }
 
+      - name: 'Detect Gemini credentials'
+        id: 'detect_gemini_credentials'
+        env:
+          GEMINI_API_KEY: '${{ secrets.GEMINI_API_KEY }}'
+          GOOGLE_API_KEY: '${{ secrets.GOOGLE_API_KEY }}'
+          GCP_WIF_PROVIDER: '${{ vars.GCP_WIF_PROVIDER }}'
+        run: |-
+          if [[ -n "${GEMINI_API_KEY}" || -n "${GOOGLE_API_KEY}" || -n "${GCP_WIF_PROVIDER}" ]]; then
+            echo 'available=true' >> "${GITHUB_OUTPUT}"
+          else
+            echo 'available=false' >> "${GITHUB_OUTPUT}"
+          fi
+
       - name: 'Acknowledge request'
         env:
           GITHUB_TOKEN: '${{ steps.mint_identity_token.outputs.token || secrets.GITHUB_TOKEN || github.token }}'
@@ -128,7 +142,7 @@ jobs:
   review:
     needs: 'dispatch'
     if: |-
-      ${{ needs.dispatch.outputs.command == 'review' && (secrets.GEMINI_API_KEY != '' || secrets.GOOGLE_API_KEY != '' || vars.GCP_WIF_PROVIDER != '') }}
+      ${{ needs.dispatch.outputs.command == 'review' && needs.dispatch.outputs.has_gemini_credentials == 'true' }}
     uses: './.github/workflows/gemini-review.yml'
     permissions:
       contents: 'read'
@@ -142,7 +156,7 @@ jobs:
   triage:
     needs: 'dispatch'
     if: |-
-      ${{ needs.dispatch.outputs.command == 'triage' && (secrets.GEMINI_API_KEY != '' || secrets.GOOGLE_API_KEY != '' || vars.GCP_WIF_PROVIDER != '') }}
+      ${{ needs.dispatch.outputs.command == 'triage' && needs.dispatch.outputs.has_gemini_credentials == 'true' }}
     uses: './.github/workflows/gemini-triage.yml'
     permissions:
       contents: 'read'
@@ -156,7 +170,7 @@ jobs:
   invoke:
     needs: 'dispatch'
     if: |-
-      ${{ needs.dispatch.outputs.command == 'invoke' && (secrets.GEMINI_API_KEY != '' || secrets.GOOGLE_API_KEY != '' || vars.GCP_WIF_PROVIDER != '') }}
+      ${{ needs.dispatch.outputs.command == 'invoke' && needs.dispatch.outputs.has_gemini_credentials == 'true' }}
     uses: './.github/workflows/gemini-invoke.yml'
     permissions:
       contents: 'read'
@@ -170,7 +184,7 @@ jobs:
   plan-execute:
     needs: 'dispatch'
     if: |-
-      ${{ needs.dispatch.outputs.command == 'approve' && (secrets.GEMINI_API_KEY != '' || secrets.GOOGLE_API_KEY != '' || vars.GCP_WIF_PROVIDER != '') }}
+      ${{ needs.dispatch.outputs.command == 'approve' && needs.dispatch.outputs.has_gemini_credentials == 'true' }}
     uses: './.github/workflows/gemini-plan-execute.yml'
     permissions:
       contents: 'write'


### PR DESCRIPTION
# Summary
- Move Gemini credential detection into the `dispatch` job and expose it as `has_gemini_credentials`.
- Replace reusable-workflow job guards that referenced `secrets.*` directly with checks against `needs.dispatch.outputs.has_gemini_credentials`.

# Root cause
GitHub Actions rejected `.github/workflows/gemini-dispatch.yml` because `secrets` is not a valid context in those reusable-workflow job-level `if` expressions. The parser failure happened before the workflow could run.

# Impact
- Restores workflow validity for the Gemini dispatch entrypoint.
- Preserves the existing behavior of only running Gemini jobs when a credential source or WIF provider is configured.
- Leaves unrelated local documentation and extractor changes out of this PR.

# Validation
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color .github/workflows/gemini-dispatch.yml`
- Local commit hooks ran on the staged file set during commit and passed.

# Docs and release notes
- No documentation, changelog, or feature-list updates were required for this workflow-parse fix; I checked for repo references beyond the workflow files and command template.

@codex
@clauee
@copilot
