### PR TITLE
feat(logging): add cross-system trace metadata

### DIFF
--- a/docker/mcp-servers-source/pal/pal-mcp-server/server.py
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/server.py
@@ -20,6 +20,7 @@ as defined by the MCP protocol.
 
 import asyncio
 import atexit
+import json
 import logging
 import os
 import sys
@@ -27,6 +28,7 @@ import time
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Any, Optional
+import uuid
 
 from mcp.server import Server  # noqa: E402
 from mcp.server.models import InitializationOptions  # noqa: E402
@@ -73,6 +75,9 @@ from utils.env import env_override_enabled, get_env  # noqa: E402
 # Configure logging for server operations
 # Can be controlled via LOG_LEVEL environment variable (DEBUG, INFO, WARNING, ERROR)
 log_level = (get_env("LOG_LEVEL", "DEBUG") or "DEBUG").upper()
+TRACE_HEADER_NAME = "X-Dopemux-Trace-Id"
+PAL_COMPONENT_NAME = "pal_mcp_server"
+PAL_STRUCTURED_ACTIVITY_ENV = "PAL_STRUCTURED_ACTIVITY_LOGGING"
 
 # MCP Token Budget Enforcement (10K hard limit)
 MCP_MAX_TOKENS = 10000
@@ -164,6 +169,142 @@ def enforce_token_budget_on_tool_output(result: list, tool_name: str, max_tokens
 
     return modified_result
 
+
+def _structured_activity_logging_enabled() -> bool:
+    value = str(get_env(PAL_STRUCTURED_ACTIVITY_ENV, "1") or "1").strip().lower()
+    return value not in {"0", "false", "no", "off"}
+
+
+def _new_trace_id() -> str:
+    return uuid.uuid4().hex
+
+
+def _new_span_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def _trace_id_from_continuation(continuation_id: str) -> str:
+    return uuid.uuid5(uuid.NAMESPACE_URL, f"dopemux-pal:{continuation_id}").hex
+
+
+def _safe_json_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {
+            str(key): _safe_json_value(subvalue)
+            for key, subvalue in value.items()
+            if subvalue is not None
+        }
+    if isinstance(value, (list, tuple)):
+        return [_safe_json_value(item) for item in value if item is not None]
+    return str(value)
+
+
+def _extract_trace_id(arguments: dict[str, Any]) -> str:
+    metadata = arguments.get("metadata")
+    if isinstance(metadata, dict):
+        trace_id = str(metadata.get("trace_id") or "").strip()
+        if trace_id:
+            return trace_id
+    for key in ("trace_id", "_dopemux_trace_id"):
+        value = str(arguments.get(key) or "").strip()
+        if value:
+            return value
+    continuation_id = str(arguments.get("continuation_id") or "").strip()
+    if continuation_id:
+        return _trace_id_from_continuation(continuation_id)
+    return _new_trace_id()
+
+
+def _activity_jsonl_path() -> Path:
+    return Path(__file__).parent / "logs" / "mcp_activity.jsonl"
+
+
+def _append_activity_jsonl(payload: dict[str, Any]) -> None:
+    if not _structured_activity_logging_enabled():
+        return
+    target = _activity_jsonl_path()
+    target.parent.mkdir(exist_ok=True)
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, ensure_ascii=True, sort_keys=True) + "\n")
+
+
+def _extract_tool_output_metadata(result: list[Any]) -> dict[str, Any]:
+    for item in result or []:
+        text = getattr(item, "text", None)
+        if not isinstance(text, str):
+            continue
+        try:
+            parsed = json.loads(text)
+        except Exception:
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        metadata = parsed.get("metadata")
+        if isinstance(metadata, dict):
+            return metadata
+    return {}
+
+
+def _log_activity_event(
+    *,
+    event_type: str,
+    trace_id: str,
+    span_id: str,
+    parent_span_id: Optional[str] = None,
+    tool_name: Optional[str] = None,
+    status: Optional[str] = None,
+    continuation_id: Optional[str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    latency_ms: Optional[int] = None,
+    status_code: Optional[int] = None,
+    finish_reason: Optional[str] = None,
+    prompt_tokens: Optional[int] = None,
+    completion_tokens: Optional[int] = None,
+    reasoning_tokens: Optional[int] = None,
+    cached_tokens: Optional[int] = None,
+    upstream_request_id: Optional[str] = None,
+    upstream_generation_id: Optional[str] = None,
+    argument_keys: Optional[list[str]] = None,
+    extra: Optional[dict[str, Any]] = None,
+) -> None:
+    payload = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + "Z",
+        "component": PAL_COMPONENT_NAME,
+        "event_type": event_type,
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "parent_span_id": parent_span_id,
+        "tool_name": tool_name,
+        "status": status,
+        "continuation_id": continuation_id,
+        "model": model,
+        "provider": provider,
+        "latency_ms": latency_ms,
+        "status_code": status_code,
+        "finish_reason": finish_reason,
+        "tokens_prompt": prompt_tokens,
+        "tokens_completion": completion_tokens,
+        "tokens_reasoning": reasoning_tokens,
+        "tokens_cached": cached_tokens,
+        "upstream_request_id": upstream_request_id,
+        "upstream_generation_id": upstream_generation_id,
+        "argument_keys": argument_keys,
+    }
+    if extra:
+        payload.update(_safe_json_value(extra))
+    sanitized = {key: value for key, value in payload.items() if value is not None}
+    try:
+        _append_activity_jsonl(sanitized)
+    except Exception:
+        logging.getLogger(__name__).debug("Failed to persist activity event", exc_info=True)
+
 # Create timezone-aware formatter
 
 
@@ -234,6 +375,7 @@ try:
 
     # Log setup info directly to root logger since logger isn't defined yet
     logging.info(f"Logging to: {log_dir / 'mcp_server.log'}")
+    logging.info(f"Structured activity logging to: {_activity_jsonl_path()}")
     logging.info(f"Process PID: {os.getpid()}")
 
 except Exception as e:
@@ -834,8 +976,20 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
         3. The CLI continues with codereview tool + continuation_id → full context preserved
         4. Multiple tools can collaborate using same thread ID
     """
+    trace_id = _extract_trace_id(arguments)
+    tool_call_span_id = _new_span_id()
+    argument_keys = sorted(str(key) for key in arguments.keys())
     logger.info(f"MCP tool call: {name}")
-    logger.debug(f"MCP tool arguments: {list(arguments.keys())}")
+    logger.debug(f"MCP tool arguments: {argument_keys}")
+    _log_activity_event(
+        event_type="tool_call_started",
+        trace_id=trace_id,
+        span_id=tool_call_span_id,
+        tool_name=name,
+        status="started",
+        continuation_id=str(arguments.get("continuation_id") or "").strip() or None,
+        argument_keys=argument_keys,
+    )
 
     # Log to activity file for monitoring
     try:
@@ -864,6 +1018,17 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
         logger.debug(f"[CONVERSATION_DEBUG] After thread reconstruction, arguments keys: {list(arguments.keys())}")
         if "_remaining_tokens" in arguments:
             logger.debug(f"[CONVERSATION_DEBUG] Remaining token budget: {arguments['_remaining_tokens']:,}")
+        _log_activity_event(
+            event_type="tool_context_resolved",
+            trace_id=trace_id,
+            span_id=_new_span_id(),
+            parent_span_id=tool_call_span_id,
+            tool_name=name,
+            status="continuation_resumed",
+            continuation_id=str(continuation_id),
+            argument_keys=sorted(str(key) for key in arguments.keys()),
+            extra={"remaining_tokens": arguments.get("_remaining_tokens")},
+        )
 
     # Route to AI-powered tools that require Gemini API calls
     if name in TOOLS:
@@ -895,7 +1060,56 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
         if not tool.requires_model():
             logger.debug(f"Tool {name} doesn't require model resolution - skipping model validation")
             # Execute tool directly without model context
-            return await tool.execute(arguments)
+            started_at = time.monotonic()
+            _log_activity_event(
+                event_type="tool_context_resolved",
+                trace_id=trace_id,
+                span_id=_new_span_id(),
+                parent_span_id=tool_call_span_id,
+                tool_name=name,
+                status="no_model_required",
+                continuation_id=str(arguments.get("continuation_id") or "").strip() or None,
+                argument_keys=sorted(str(key) for key in arguments.keys()),
+            )
+            try:
+                result = await tool.execute(arguments)
+            except Exception as exc:
+                _log_activity_event(
+                    event_type="tool_failed",
+                    trace_id=trace_id,
+                    span_id=_new_span_id(),
+                    parent_span_id=tool_call_span_id,
+                    tool_name=name,
+                    status="failed",
+                    continuation_id=str(arguments.get("continuation_id") or "").strip() or None,
+                    latency_ms=int((time.monotonic() - started_at) * 1000),
+                    argument_keys=sorted(str(key) for key in arguments.keys()),
+                    extra={
+                        "error_type": type(exc).__name__,
+                        "error_message_excerpt": str(exc)[:500],
+                    },
+                )
+                raise
+            tool_metadata = _extract_tool_output_metadata(result)
+            _log_activity_event(
+                event_type="tool_completed",
+                trace_id=trace_id,
+                span_id=_new_span_id(),
+                parent_span_id=tool_call_span_id,
+                tool_name=name,
+                status="completed",
+                continuation_id=str(arguments.get("continuation_id") or "").strip() or None,
+                latency_ms=int((time.monotonic() - started_at) * 1000),
+                finish_reason=str(tool_metadata.get("finish_reason") or "").strip() or None,
+                prompt_tokens=tool_metadata.get("input_tokens"),
+                completion_tokens=tool_metadata.get("output_tokens"),
+                reasoning_tokens=tool_metadata.get("reasoning_tokens"),
+                cached_tokens=tool_metadata.get("cached_tokens"),
+                upstream_request_id=str(tool_metadata.get("id") or tool_metadata.get("request_id") or "").strip() or None,
+                upstream_generation_id=str(tool_metadata.get("generation_id") or "").strip() or None,
+                argument_keys=sorted(str(key) for key in arguments.keys()),
+            )
+            return result
 
         # Handle auto mode at MCP boundary - resolve to specific model
         if model_name.lower() == "auto":
@@ -933,11 +1147,34 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
         model_context = ModelContext(model_name, model_option)
         arguments["_model_context"] = model_context
         arguments["_resolved_model_name"] = model_name
+        arguments["_dopemux_trace_id"] = trace_id
         logger.debug(
             f"Model context created for {model_name} with {model_context.capabilities.context_window} token capacity"
         )
         if model_option:
             logger.debug(f"Model option stored in context: '{model_option}'")
+        resolved_provider_name = getattr(provider, "get_provider_type", lambda: None)()
+        resolved_provider_value = (
+            getattr(resolved_provider_name, "value", None)
+            if resolved_provider_name is not None
+            else None
+        )
+        _log_activity_event(
+            event_type="tool_context_resolved",
+            trace_id=trace_id,
+            span_id=_new_span_id(),
+            parent_span_id=tool_call_span_id,
+            tool_name=name,
+            status="resolved",
+            continuation_id=str(arguments.get("continuation_id") or "").strip() or None,
+            model=model_name,
+            provider=resolved_provider_value,
+            argument_keys=sorted(str(key) for key in arguments.keys()),
+            extra={
+                "model_option": model_option,
+                "context_window": getattr(model_context.capabilities, "context_window", None),
+            },
+        )
 
         # EARLY FILE SIZE VALIDATION AT MCP BOUNDARY
         # Check file sizes before tool execution using resolved model
@@ -949,11 +1186,87 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
                 return [TextContent(type="text", text=ToolOutput(**file_size_check).model_dump_json())]
 
         # Execute tool with pre-resolved model context
-        result = await tool.execute(arguments)
+        provider_span_id = _new_span_id()
+        started_at = time.monotonic()
+        _log_activity_event(
+            event_type="provider_request_started",
+            trace_id=trace_id,
+            span_id=provider_span_id,
+            parent_span_id=tool_call_span_id,
+            tool_name=name,
+            status="started",
+            continuation_id=str(arguments.get("continuation_id") or "").strip() or None,
+            model=model_name,
+            provider=resolved_provider_value,
+            argument_keys=sorted(str(key) for key in arguments.keys()),
+        )
+        try:
+            result = await tool.execute(arguments)
+        except Exception as exc:
+            _log_activity_event(
+                event_type="tool_failed",
+                trace_id=trace_id,
+                span_id=_new_span_id(),
+                parent_span_id=tool_call_span_id,
+                tool_name=name,
+                status="failed",
+                continuation_id=str(arguments.get("continuation_id") or "").strip() or None,
+                model=model_name,
+                provider=resolved_provider_value,
+                latency_ms=int((time.monotonic() - started_at) * 1000),
+                argument_keys=sorted(str(key) for key in arguments.keys()),
+                extra={
+                    "error_type": type(exc).__name__,
+                    "error_message_excerpt": str(exc)[:500],
+                },
+            )
+            raise
         logger.info(f"Tool '{name}' execution completed")
 
         # Enforce MCP token budget at boundary (10K hard limit)
         result = enforce_token_budget_on_tool_output(result, name, max_tokens=SAFE_TOKEN_BUDGET)
+        tool_metadata = _extract_tool_output_metadata(result)
+        _log_activity_event(
+            event_type="provider_request_completed",
+            trace_id=trace_id,
+            span_id=provider_span_id,
+            parent_span_id=tool_call_span_id,
+            tool_name=name,
+            status="completed",
+            continuation_id=str(arguments.get("continuation_id") or "").strip() or None,
+            model=model_name,
+            provider=resolved_provider_value,
+            latency_ms=int((time.monotonic() - started_at) * 1000),
+            finish_reason=str(tool_metadata.get("finish_reason") or "").strip() or None,
+            prompt_tokens=tool_metadata.get("input_tokens"),
+            completion_tokens=tool_metadata.get("output_tokens"),
+            reasoning_tokens=tool_metadata.get("reasoning_tokens"),
+            cached_tokens=tool_metadata.get("cached_tokens"),
+            upstream_request_id=str(tool_metadata.get("id") or tool_metadata.get("request_id") or "").strip() or None,
+            upstream_generation_id=str(tool_metadata.get("generation_id") or "").strip() or None,
+            argument_keys=sorted(str(key) for key in arguments.keys()),
+        )
+        _log_activity_event(
+            event_type="tool_completed",
+            trace_id=trace_id,
+            span_id=_new_span_id(),
+            parent_span_id=tool_call_span_id,
+            tool_name=name,
+            status="completed",
+            continuation_id=str(arguments.get("continuation_id") or "").strip() or None,
+            model=model_name,
+            provider=resolved_provider_value,
+            latency_ms=int((time.monotonic() - started_at) * 1000),
+            finish_reason=str(tool_metadata.get("finish_reason") or "").strip() or None,
+            prompt_tokens=tool_metadata.get("input_tokens"),
+            completion_tokens=tool_metadata.get("output_tokens"),
+            reasoning_tokens=tool_metadata.get("reasoning_tokens"),
+            cached_tokens=tool_metadata.get("cached_tokens"),
+            upstream_request_id=str(tool_metadata.get("id") or tool_metadata.get("request_id") or "").strip() or None,
+            upstream_generation_id=str(tool_metadata.get("generation_id") or "").strip() or None,
+            argument_keys=sorted(str(key) for key in arguments.keys()),
+            extra={"token_budget_truncated": bool(tool_metadata.get("token_budget_truncated"))},
+        )
 
         # Log completion to activity file
         try:
@@ -965,6 +1278,15 @@ async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[TextCon
 
     # Handle unknown tool requests gracefully
     else:
+        _log_activity_event(
+            event_type="tool_failed",
+            trace_id=trace_id,
+            span_id=_new_span_id(),
+            parent_span_id=tool_call_span_id,
+            tool_name=name,
+            status="unknown_tool",
+            argument_keys=argument_keys,
+        )
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
 
 

--- a/docker/mcp-servers-source/pal/pal-mcp-server/tests/test_server.py
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/tests/test_server.py
@@ -2,8 +2,11 @@
 Tests for the main server functionality
 """
 
+import json
+
 import pytest
 
+import server
 from server import handle_call_tool
 
 
@@ -105,3 +108,53 @@ class TestServerTools:
         assert "## Server Information" in content
         assert "## Configuration" in content
         assert "Current Version" in content
+
+    @pytest.mark.asyncio
+    async def test_handle_call_tool_writes_structured_activity_events(self, monkeypatch, tmp_path):
+        class FakeTool:
+            name = "fake"
+
+            def requires_model(self):
+                return False
+
+            async def execute(self, arguments):
+                payload = {
+                    "status": "success",
+                    "content": "ok",
+                    "metadata": {
+                        "request_id": "req_123",
+                        "input_tokens": 11,
+                        "output_tokens": 7,
+                    },
+                }
+                return [server.TextContent(type="text", text=json.dumps(payload))]
+
+        activity_path = tmp_path / "mcp_activity.jsonl"
+        monkeypatch.setattr(server, "_activity_jsonl_path", lambda: activity_path)
+        monkeypatch.setitem(server.TOOLS, "fake", FakeTool())
+
+        result = await handle_call_tool(
+            "fake",
+            {"trace_id": "trace_abc", "prompt": "hello"},
+        )
+
+        assert len(result) == 1
+        rows = [
+            json.loads(line)
+            for line in activity_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        event_types = {row["event_type"] for row in rows}
+        assert "tool_call_started" in event_types
+        assert "tool_context_resolved" in event_types
+        assert "tool_completed" in event_types
+        for row in rows:
+            assert row["trace_id"] == "trace_abc"
+
+    def test_extract_trace_id_uses_continuation_id_when_not_provided(self):
+        trace_a = server._extract_trace_id({"continuation_id": "thread-42"})
+        trace_b = server._extract_trace_id({"continuation_id": "thread-42"})
+        trace_c = server._extract_trace_id({"continuation_id": "thread-43"})
+
+        assert trace_a == trace_b
+        assert trace_a != trace_c

--- a/docker/mcp-servers-source/pal/pal-mcp-server/tests/test_server.py
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/tests/test_server.py
@@ -7,7 +7,7 @@ import json
 import pytest
 
 import server
-from server import handle_call_tool
+
 
 
 class TestServerTools:
@@ -16,7 +16,7 @@ class TestServerTools:
     @pytest.mark.asyncio
     async def test_handle_call_tool_unknown(self):
         """Test calling an unknown tool"""
-        result = await handle_call_tool("unknown_tool", {})
+        result = await server.handle_call_tool("unknown_tool", {})
         assert len(result) == 1
         assert "Unknown tool: unknown_tool" in result[0].text
 
@@ -92,7 +92,7 @@ class TestServerTools:
     @pytest.mark.asyncio
     async def test_handle_version(self):
         """Test getting version info"""
-        result = await handle_call_tool("version", {})
+        result = await server.handle_call_tool("version", {})
         assert len(result) == 1
 
         response = result[0].text
@@ -133,7 +133,7 @@ class TestServerTools:
         monkeypatch.setattr(server, "_activity_jsonl_path", lambda: activity_path)
         monkeypatch.setitem(server.TOOLS, "fake", FakeTool())
 
-        result = await handle_call_tool(
+        result = await server.handle_call_tool(
             "fake",
             {"trace_id": "trace_abc", "prompt": "hello"},
         )

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -84,6 +84,22 @@ except ImportError:
     else:
         IntelligenceRouter = None
 try:
+    from lib.spend_ledger import SpendLedger
+except ImportError:
+    spend_ledger_path = RUNNER_SERVICE_DIR / "lib" / "spend_ledger.py"
+    if spend_ledger_path.exists():
+        spend_ledger_spec = importlib.util.spec_from_file_location(
+            "repo_truth_spend_ledger", spend_ledger_path
+        )
+        if spend_ledger_spec and spend_ledger_spec.loader:
+            spend_ledger_module = importlib.util.module_from_spec(spend_ledger_spec)
+            spend_ledger_spec.loader.exec_module(spend_ledger_module)
+            SpendLedger = spend_ledger_module.SpendLedger
+        else:
+            SpendLedger = None
+    else:
+        SpendLedger = None
+try:
     from lib.phase_contract_map import (
         CONTRACT_MAP_FILENAME as PHASE_CONTRACT_MAP_FILENAME,
         get_step_contract,
@@ -6277,6 +6293,10 @@ def resolve_api_key(
             )
             return "", api_key_env
         return key_value, api_key_env
+    if provider == "openrouter" and api_key_env == "OPENROUTER_API_KEY":
+        v5_override = os.getenv("V5_OPENROUTER_API_KEY", "")
+        if v5_override:
+            return v5_override, "V5_OPENROUTER_API_KEY"
     value = os.getenv(api_key_env, "")
     return value, api_key_env
 
@@ -15529,6 +15549,10 @@ def main() -> None:
         help="Extraction profile name (e.g., P09_INTEGRATION_SURFACE_V1). Filters phases and overrides budgets.",
     )
     args = parser.parse_args()
+    if not hasattr(args, "execute"):
+        # v5 runner currently models live execution as the inverse of --dry-run.
+        # Keep a concrete execute flag for downstream consent and batch gates.
+        args.execute = not bool(args.dry_run)
     # --promptset-root: wire into env var so prompt_root() picks it up
     if args.promptset_root:
         psr = Path(args.promptset_root).resolve()
@@ -15976,7 +16000,14 @@ def main() -> None:
     )
 
     if SpendLedger is not None:
-        cfg.ledger = SpendLedger(run_dir=dirs["root"], run_id=run_id, max_cost_usd=cfg.max_cost_usd)
+        cfg = replace(
+            cfg,
+            ledger=SpendLedger(
+                run_dir=dirs["root"],
+                run_id=run_id,
+                max_cost_usd=cfg.max_cost_usd,
+            ),
+        )
 
     # --profile: load extraction profile and apply phase filtering + budget overrides
     _active_profile = None

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -22,6 +22,7 @@ import threading
 import time
 import importlib.util
 import random
+import uuid
 from collections import Counter, defaultdict
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
@@ -1222,6 +1223,8 @@ class UI:
     def _emit_event(self, payload: Dict[str, Any]) -> None:
         row = dict(payload)
         row.setdefault("ts", now_iso())
+        row.setdefault("component", EXTRACTOR_COMPONENT_NAME)
+        row.setdefault("event_type", str(row.get("type") or "event"))
         row.setdefault("run_id", self.run_id)
         row.setdefault("run_root", str(self.run_root.resolve()))
         try:
@@ -1231,6 +1234,124 @@ class UI:
         except Exception:
             # UI event persistence must never alter execution flow.
             return
+
+    def make_trace_context(
+        self,
+        *,
+        phase: str,
+        step_id: str,
+        partition_id: Optional[str] = None,
+        parent_trace_id: Optional[str] = None,
+        parent_span_id: Optional[str] = None,
+    ) -> Dict[str, str]:
+        trace_id = str(parent_trace_id or "").strip() or _new_trace_id()
+        context = {
+            "trace_id": trace_id,
+            "span_id": _new_span_id(),
+        }
+        if parent_span_id:
+            context["parent_span_id"] = str(parent_span_id)
+        context["phase"] = phase
+        context["step_id"] = step_id
+        if partition_id:
+            context["partition_id"] = partition_id
+        return context
+
+    def llm_request_event(
+        self,
+        *,
+        phase: str,
+        step_id: str,
+        status: str,
+        trace_id: str,
+        span_id: str,
+        parent_span_id: Optional[str] = None,
+        partition_id: Optional[str] = None,
+        provider: Optional[str] = None,
+        model_id: Optional[str] = None,
+        route: Optional[str] = None,
+        routing_policy: Optional[str] = None,
+        attempt: Optional[int] = None,
+        hop: Optional[int] = None,
+        latency_ms: Optional[int] = None,
+        status_code: Optional[int] = None,
+        failure_type: Optional[str] = None,
+        finish_reason: Optional[str] = None,
+        request_payload_bytes: Optional[int] = None,
+        prompt_tokens: Optional[int] = None,
+        completion_tokens: Optional[int] = None,
+        reasoning_tokens: Optional[int] = None,
+        cached_tokens: Optional[int] = None,
+        estimated_cost_usd: Optional[float] = None,
+        actual_cost_usd: Optional[float] = None,
+        upstream_request_id: Optional[str] = None,
+        upstream_generation_id: Optional[str] = None,
+        batch_id: Optional[str] = None,
+        extra: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        payload: Dict[str, Any] = {
+            "type": f"llm_request_{status}",
+            "event_type": f"llm_request_{status}",
+            "phase": phase,
+            "step": step_id,
+            "partition_id": partition_id,
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "parent_span_id": parent_span_id,
+            "provider": provider,
+            "model_id": model_id,
+            "route": route,
+            "routing_policy": routing_policy,
+            "attempt": attempt,
+            "hop": hop,
+            "latency_ms": latency_ms,
+            "status": status,
+            "status_code": status_code,
+            "failure_type": failure_type,
+            "finish_reason": finish_reason,
+            "request_payload_bytes": request_payload_bytes,
+            "tokens_prompt": prompt_tokens,
+            "tokens_completion": completion_tokens,
+            "tokens_reasoning": reasoning_tokens,
+            "tokens_cached": cached_tokens,
+            "estimated_cost_usd": estimated_cost_usd,
+            "actual_cost_usd": actual_cost_usd,
+            "upstream_request_id": upstream_request_id,
+            "upstream_generation_id": upstream_generation_id,
+            "batch_id": batch_id,
+        }
+        if extra:
+            payload.update(_clean_event_value(extra))
+        self._emit_event({k: v for k, v in payload.items() if v is not None})
+
+    def spend_ledger_event(
+        self,
+        *,
+        phase: str,
+        trace_id: str,
+        span_id: str,
+        parent_span_id: Optional[str] = None,
+        prompt_tokens: int,
+        completion_tokens: int,
+        estimated_cost_usd: Optional[float] = None,
+        partition_id: Optional[str] = None,
+        step_id: Optional[str] = None,
+    ) -> None:
+        self._emit_event(
+            {
+                "type": "spend_ledger_accumulate",
+                "event_type": "spend_ledger_accumulate",
+                "phase": phase,
+                "step": step_id,
+                "partition_id": partition_id,
+                "trace_id": trace_id,
+                "span_id": span_id,
+                "parent_span_id": parent_span_id,
+                "tokens_prompt": int(prompt_tokens),
+                "tokens_completion": int(completion_tokens),
+                "estimated_cost_usd": estimated_cost_usd,
+            }
+        )
 
     def _print_plain(self, line: str) -> None:
         print(line, flush=True)
@@ -2285,6 +2406,34 @@ _TELEMETRY_SNAPSHOT_LOCK: threading.Lock = threading.Lock()
 
 _HTTP_SESSION: Optional[requests.Session] = None
 _HTTP_SESSION_LOCK: threading.Lock = threading.Lock()
+TRACE_HEADER_NAME = "X-Dopemux-Trace-Id"
+EXTRACTOR_COMPONENT_NAME = "repo_truth_extractor"
+
+
+def _new_trace_id() -> str:
+    return uuid.uuid4().hex
+
+
+def _new_span_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def _clean_event_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, dict):
+        return {
+            str(key): _clean_event_value(subvalue)
+            for key, subvalue in value.items()
+            if subvalue is not None
+        }
+    if isinstance(value, (list, tuple)):
+        return [_clean_event_value(item) for item in value if item is not None]
+    return str(value)
 
 
 def _get_http_session() -> requests.Session:
@@ -6440,18 +6589,39 @@ def summarize_llm_response(
     summary: Dict[str, Any] = {"text_length": len(response_text)}
     finish_reason = None
     candidate_count: Optional[int] = None
+    response_id: Optional[str] = None
+    prompt_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
 
     if provider == "gemini":
         candidates = getattr(response_obj, "candidates", None) or []
         candidate_count = len(candidates)
         if candidates:
             finish_reason = getattr(candidates[0], "finish_reason", None)
+        usage_metadata = getattr(response_obj, "usage_metadata", None)
+        if usage_metadata is not None:
+            prompt_tokens = getattr(usage_metadata, "prompt_token_count", None)
+            completion_tokens = getattr(usage_metadata, "candidates_token_count", None)
+            total_tokens = getattr(usage_metadata, "total_token_count", None)
     else:
         choices = None
         if isinstance(response_json, dict):
             choices = response_json.get("choices")
+            response_id = str(response_json.get("id") or "") or None
+            usage = response_json.get("usage")
+            if isinstance(usage, dict):
+                prompt_tokens = usage.get("prompt_tokens")
+                completion_tokens = usage.get("completion_tokens")
+                total_tokens = usage.get("total_tokens")
         else:
             choices = getattr(response_obj, "choices", None)
+            response_id = str(getattr(response_obj, "id", "") or "") or None
+            usage = getattr(response_obj, "usage", None)
+            if usage is not None:
+                prompt_tokens = getattr(usage, "prompt_tokens", None)
+                completion_tokens = getattr(usage, "completion_tokens", None)
+                total_tokens = getattr(usage, "total_tokens", None)
         if isinstance(choices, list):
             candidate_count = len(choices)
             if choices:
@@ -6461,6 +6631,14 @@ def summarize_llm_response(
         summary["candidate_count"] = candidate_count
     if finish_reason:
         summary["finish_reason"] = finish_reason
+    if response_id:
+        summary["response_id"] = response_id
+    if prompt_tokens is not None:
+        summary["prompt_tokens"] = int(prompt_tokens)
+    if completion_tokens is not None:
+        summary["completion_tokens"] = int(completion_tokens)
+    if total_tokens is not None:
+        summary["total_tokens"] = int(total_tokens)
     return summary
 
 
@@ -6618,6 +6796,8 @@ def call_llm(
     structured_output_override: Optional[Dict[str, Any]] = None,
     retry_callback: Optional[Callable] = None,
     timeout_seconds: Optional[int] = None,
+    trace_context: Optional[Dict[str, Any]] = None,
+    lifecycle_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
 ) -> Dict[str, Any]:
     if _live_llm_calls_blocked_for_tests():
         message = (
@@ -6765,6 +6945,8 @@ def call_llm(
                 "request_payload_bytes": request_payload_bytes,
                 "request_payload_bytes_mode": request_payload_bytes_mode,
                 "transport": transport,
+                "trace_id": trace_id,
+                "parent_span_id": request_parent_span_id,
                 "retry_trace": [],
                 "structured_output": structured_output,
             },
@@ -6808,6 +6990,28 @@ def call_llm(
         int(timeout_seconds if timeout_seconds is not None else 180),
     )
     started_monotonic = time.monotonic()
+    base_trace_context = dict(trace_context or {})
+    trace_id = str(base_trace_context.get("trace_id") or "").strip() or _new_trace_id()
+    request_parent_span_id = str(base_trace_context.get("parent_span_id") or "").strip() or None
+
+    def _emit_lifecycle(status: str, **fields: Any) -> None:
+        if lifecycle_callback is None:
+            return
+        payload = {
+            "phase": base_trace_context.get("phase"),
+            "step_id": base_trace_context.get("step_id"),
+            "partition_id": base_trace_context.get("partition_id"),
+            "trace_id": trace_id,
+            "parent_span_id": request_parent_span_id,
+            "provider": provider,
+            "model_id": model_id,
+            "route": base_trace_context.get("route"),
+            "routing_policy": base_trace_context.get("routing_policy"),
+            "hop": base_trace_context.get("hop"),
+            "status": status,
+        }
+        payload.update(fields)
+        lifecycle_callback({k: v for k, v in payload.items() if v is not None})
 
     def _remaining_timeout_seconds() -> int:
         elapsed = time.monotonic() - started_monotonic
@@ -6820,6 +7024,13 @@ def call_llm(
         response_body = ""
         failure_type = "unknown"
         provider_error_reason = None
+        attempt_span_id = _new_span_id()
+        _emit_lifecycle(
+            "started",
+            span_id=attempt_span_id,
+            attempt=attempt,
+            request_payload_bytes=request_payload_bytes,
+        )
         try:
             response_json: Optional[Dict[str, Any]] = None
             if transport == "openai_compat_http":
@@ -6903,6 +7114,18 @@ def call_llm(
                     "response_summary": response_summary,
                 }
             )
+            _emit_lifecycle(
+                "completed",
+                span_id=attempt_span_id,
+                attempt=attempt,
+                latency_ms=int((time.monotonic() - started_monotonic) * 1000),
+                status_code=status_code,
+                finish_reason=response_summary.get("finish_reason"),
+                prompt_tokens=response_summary.get("prompt_tokens"),
+                completion_tokens=response_summary.get("completion_tokens"),
+                upstream_request_id=response_summary.get("response_id"),
+                request_payload_bytes=request_payload_bytes,
+            )
             return {
                 "ok": True,
                 "text": response_text,
@@ -6936,6 +7159,9 @@ def call_llm(
                         auth_mode_sequence if provider == "gemini" else None
                     ),
                     "transport": transport,
+                    "trace_id": trace_id,
+                    "span_id": attempt_span_id,
+                    "parent_span_id": request_parent_span_id,
                     "retry_trace": retry_trace,
                     "response_received": True,
                     "response_summary": response_summary,
@@ -6995,10 +7221,27 @@ def call_llm(
                     auth_mode_sequence if provider == "gemini" else None
                 ),
                 "transport": transport,
+                "trace_id": trace_id,
+                "span_id": attempt_span_id,
+                "parent_span_id": request_parent_span_id,
                 "retry_trace": retry_trace,
                 "response_received": False,
                 "structured_output": structured_output,
             }
+            _emit_lifecycle(
+                "failed",
+                span_id=attempt_span_id,
+                attempt=attempt,
+                latency_ms=int((time.monotonic() - started_monotonic) * 1000),
+                status_code=status_code,
+                failure_type=failure_type,
+                upstream_request_id=exception_info.get("request_id"),
+                request_payload_bytes=request_payload_bytes,
+                extra={
+                    "provider_error_reason": provider_error_reason,
+                    "exception_type": exception_info.get("exception_type"),
+                },
+            )
             if response_body:
                 logger.warning(
                     "LLM call failed attempt %s/%s provider=%s model=%s status=%s failure_type=%s: %s | body=%s",
@@ -10234,6 +10477,15 @@ def execute_step_for_partitions(
                 "- If evidence cannot prove line ranges, emit payload.items as [] for that artifact.\n"
                 f"{existing_preview}"
             )
+            strict_trace_context = (
+                ui.make_trace_context(
+                    phase=phase,
+                    step_id=step_id,
+                    partition_id=partition_id,
+                )
+                if ui is not None
+                else None
+            )
             result = call_llm(
                 provider=strict_provider,
                 model_id=strict_model_id,
@@ -10244,6 +10496,16 @@ def execute_step_for_partitions(
                 force_json_output=False,
                 response_format_override=response_format,
                 structured_output_override=_strict_structured_meta(response_meta),
+                trace_context={
+                    **(strict_trace_context or {}),
+                    "route": f"{strict_provider}/{strict_model_id}",
+                    "routing_policy": cfg.routing_policy,
+                },
+                lifecycle_callback=(
+                    (lambda payload: ui.llm_request_event(**payload))
+                    if ui is not None
+                    else None
+                ),
             )
             response_text_local = str(result.get("text") or "")
             request_meta_local = enrich_request_meta(
@@ -10697,6 +10959,22 @@ def execute_step_for_partitions(
                             in_toks = sum(len(req.user_content) // 4 for req in batch_requests)
                             out_toks = 1000  # Arbitrary estimate for batch output
                             cfg.ledger.accumulate(phase, in_toks, out_toks)
+                            if ui is not None:
+                                batch_trace = ui.make_trace_context(
+                                    phase=phase,
+                                    step_id=step_id,
+                                    partition_id=partition_id,
+                                )
+                                ui.spend_ledger_event(
+                                    phase=phase,
+                                    step_id=step_id,
+                                    partition_id=partition_id,
+                                    trace_id=batch_trace["trace_id"],
+                                    span_id=_new_span_id(),
+                                    parent_span_id=batch_trace.get("span_id"),
+                                    prompt_tokens=in_toks,
+                                    completion_tokens=out_toks,
+                                )
                             
                         job_row = {
                             "run_id": run_id,
@@ -10935,6 +11213,24 @@ def execute_step_for_partitions(
                         ))
                         if ui is not None else None
                     ),
+                    trace_context=(
+                        {
+                            **ui.make_trace_context(
+                                phase=phase,
+                                step_id=step_id,
+                                partition_id=partition_id,
+                            ),
+                            "route": f"{route_provider}/{route_model_id}",
+                            "routing_policy": cfg.routing_policy,
+                        }
+                        if ui is not None
+                        else None
+                    ),
+                    lifecycle_callback=(
+                        (lambda payload: ui.llm_request_event(**payload))
+                        if ui is not None
+                        else None
+                    ),
                 )
                 response_text_local = str(llm_result.get("text", ""))
                 request_meta_local = enrich_request_meta(
@@ -10947,6 +11243,29 @@ def execute_step_for_partitions(
                     model_id=route_model_id,
                 )
                 request_meta_local.setdefault("request_payload_bytes", payload_bytes)
+                if cfg.ledger:
+                    prompt_toks = int(
+                        request_meta_local.get("prompt_tokens")
+                        or request_meta_local.get("tokens_prompt")
+                        or ((len(effective_user_prompt) + len(prompt_text)) // 4)
+                    )
+                    completion_toks = int(
+                        request_meta_local.get("completion_tokens")
+                        or request_meta_local.get("tokens_completion")
+                        or (len(response_text_local) // 4)
+                    )
+                    cfg.ledger.accumulate(phase, prompt_toks, completion_toks)
+                    if ui is not None:
+                        ui.spend_ledger_event(
+                            phase=phase,
+                            step_id=step_id,
+                            partition_id=partition_id,
+                            trace_id=str(request_meta_local.get("trace_id") or _new_trace_id()),
+                            span_id=_new_span_id(),
+                            parent_span_id=str(request_meta_local.get("span_id") or "") or None,
+                            prompt_tokens=prompt_toks,
+                            completion_tokens=completion_toks,
+                        )
                 return response_text_local, request_meta_local
 
             parse_retry_attempted = False

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_soft_gate_logging.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_soft_gate_logging.py
@@ -80,3 +80,63 @@ def test_soft_gate_events_include_denominator_math_and_states(tmp_path: Path) ->
     assert triggered["deterministic_input_skips"] == 3
     assert triggered["n_total"] == 32
     assert abs(float(triggered["fail_rate"]) - 0.21875) < 1e-9
+    assert triggered["component"] == "repo_truth_extractor"
+    assert triggered["event_type"] == "soft_gate_triggered"
+
+
+def test_llm_request_and_spend_events_include_trace_metadata(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    ui = runner.UI(
+        runner.UiConfig(mode="plain", quiet=True, jsonl_events=True),
+        run_root=tmp_path,
+        run_id="run_trace_logging",
+    )
+
+    trace = ui.make_trace_context(phase="D", step_id="D2", partition_id="part-001")
+    ui.llm_request_event(
+        phase="D",
+        step_id="D2",
+        status="completed",
+        trace_id=trace["trace_id"],
+        span_id=trace["span_id"],
+        partition_id="part-001",
+        provider="openrouter",
+        model_id="openai/gpt-5.3-codex",
+        route="openrouter/openai/gpt-5.3-codex",
+        routing_policy="balanced_openrouter",
+        attempt=1,
+        latency_ms=1250,
+        status_code=200,
+        finish_reason="stop",
+        prompt_tokens=123,
+        completion_tokens=45,
+        upstream_request_id="resp_123",
+    )
+    ui.spend_ledger_event(
+        phase="D",
+        step_id="D2",
+        partition_id="part-001",
+        trace_id=trace["trace_id"],
+        span_id="ledger-span-1",
+        parent_span_id=trace["span_id"],
+        prompt_tokens=123,
+        completion_tokens=45,
+        estimated_cost_usd=0.0123,
+    )
+
+    rows = _read_jsonl(tmp_path / "events.jsonl")
+    llm_event = next(row for row in rows if row.get("type") == "llm_request_completed")
+    spend_event = next(row for row in rows if row.get("type") == "spend_ledger_accumulate")
+
+    assert llm_event["trace_id"] == trace["trace_id"]
+    assert llm_event["span_id"] == trace["span_id"]
+    assert llm_event["event_type"] == "llm_request_completed"
+    assert llm_event["component"] == "repo_truth_extractor"
+    assert llm_event["upstream_request_id"] == "resp_123"
+    assert llm_event["tokens_prompt"] == 123
+    assert llm_event["tokens_completion"] == 45
+
+    assert spend_event["trace_id"] == trace["trace_id"]
+    assert spend_event["parent_span_id"] == trace["span_id"]
+    assert spend_event["event_type"] == "spend_ledger_accumulate"
+    assert abs(float(spend_event["estimated_cost_usd"]) - 0.0123) < 1e-9

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -4736,6 +4736,8 @@ _ROUTING_POLICY_CHOICES = [
     "balanced_grok_openrouter",
     "quality",
     "openrouter",
+    "gemini_primary",
+    "optimal",
 ]
 _LEGACY_DEFAULT_ROUTING_POLICY = "cost"
 _V5_DEFAULT_ROUTING_POLICY = "balanced_openrouter"

--- a/src/dopemux/litellm_manager.py
+++ b/src/dopemux/litellm_manager.py
@@ -20,7 +20,16 @@ from typing import Dict, List, Optional, Tuple, Any
 
 import yaml
 
+from dopemux.litellm_trace_logger import (
+    LOGGING_ENABLED_ENV,
+    LOG_PATH_ENV,
+    INSTANCE_ID_ENV,
+    TRACE_HEADER_NAME,
+    emit_startup_event,
+)
+
 logger = logging.getLogger(__name__)
+TRACE_CALLBACK_PATH = "dopemux.litellm_trace_logger.DopemuxLiteLLMTraceLogger"
 
 
 class LiteLLMManagerError(RuntimeError):
@@ -37,6 +46,7 @@ class LiteLLMProcessInfo:
         config_path: Path,
         config_data: Dict[str, Any],
         log_path: Path,
+        structured_log_path: Path,
         master_key: str,
         process: subprocess.Popen,
         db_enabled: bool = False,
@@ -47,6 +57,7 @@ class LiteLLMProcessInfo:
         self.config_path = config_path
         self.config_data = config_data
         self.log_path = log_path
+        self.structured_log_path = structured_log_path
         self.master_key = master_key
         self.process = process
         self.db_enabled = db_enabled
@@ -234,6 +245,7 @@ class LiteLLMManager:
             
             # Set up logging
             log_path = instance_dir / "litellm.log"
+            structured_log_path = instance_dir / "litellm.events.jsonl"
             
             # Check if port is available
             if self._is_port_in_use(port):
@@ -249,6 +261,7 @@ class LiteLLMManager:
                 config_path=config_path,
                 config_data=config_data,
                 log_path=log_path,
+                structured_log_path=structured_log_path,
                 master_key=master_key,
                 process=process,
                 db_enabled=db_enabled,
@@ -351,6 +364,8 @@ class LiteLLMManager:
                 "DOPEMUX_CLAUDE_VIA_LITELLM": "1",
                 "DOPEMUX_LITELLM_MASTER_KEY": process_info.master_key,
                 "DOPEMUX_LITELLM_PORT": str(process_info.port),
+                "DOPEMUX_LITELLM_TRACE_HEADER": TRACE_HEADER_NAME,
+                "DOPEMUX_LITELLM_JSONL_LOG_PATH": str(process_info.structured_log_path),
                 "LITELLM_PROXY_URL": process_info.base_url,
                 "LITELLM_MASTER_KEY": process_info.master_key,
             }
@@ -410,6 +425,19 @@ class LiteLLMManager:
         # Set master key
         general_settings = config_data.setdefault("general_settings", {})
         general_settings["master_key"] = master_key
+
+        litellm_settings = config_data.setdefault("litellm_settings", {})
+        callbacks = litellm_settings.get("callbacks")
+        if callbacks is None:
+            litellm_settings["callbacks"] = [TRACE_CALLBACK_PATH]
+        elif isinstance(callbacks, list):
+            if TRACE_CALLBACK_PATH not in callbacks:
+                callbacks.append(TRACE_CALLBACK_PATH)
+        else:
+            normalized_callbacks = [callbacks]
+            if TRACE_CALLBACK_PATH not in normalized_callbacks:
+                normalized_callbacks.append(TRACE_CALLBACK_PATH)
+            litellm_settings["callbacks"] = normalized_callbacks
         
         # Handle database configuration
         if db_enabled and db_url:
@@ -439,7 +467,17 @@ class LiteLLMManager:
         # Prepare environment
         env = os.environ.copy()
         env["LITELLM_MASTER_KEY"] = master_key
-        
+        env[LOGGING_ENABLED_ENV] = "1"
+        env[LOG_PATH_ENV] = str(log_path.with_suffix(".events.jsonl"))
+        env[INSTANCE_ID_ENV] = config_path.parent.name
+
+        src_path = self.project_root / "src"
+        existing_pythonpath = env.get("PYTHONPATH", "")
+        pythonpath_parts = [str(src_path)]
+        if existing_pythonpath:
+            pythonpath_parts.append(existing_pythonpath)
+        env["PYTHONPATH"] = os.pathsep.join(pythonpath_parts)
+
         if db_enabled and db_url:
             env["DATABASE_URL"] = db_url
         else:
@@ -458,6 +496,18 @@ class LiteLLMManager:
         log_file = open(log_path, "a", encoding="utf-8")
         
         try:
+            emit_startup_event(
+                log_path=env[LOG_PATH_ENV],
+                instance_id=config_path.parent.name,
+                config_path=str(config_path),
+                text_log_path=str(log_path),
+                structured_log_path=env[LOG_PATH_ENV],
+                port=port,
+                has_aliases=bool((yaml.safe_load(config_path.read_text()) or {}).get("router_settings", {}).get("model_group_alias")),
+                has_fallbacks=bool((yaml.safe_load(config_path.read_text()) or {}).get("router_settings", {}).get("fallbacks")),
+                db_enabled=db_enabled,
+                spend_logging_disabled=env.get("LITELLM_DISABLE_SPEND_LOGGING") == "true",
+            )
             process = subprocess.Popen(
                 cmd,
                 cwd=str(self.project_root),
@@ -513,6 +563,7 @@ class LiteLLMManager:
                     "last_health_check": process_info.last_health_check.isoformat(),
                     "start_time": process_info.start_time.isoformat(),
                     "db_enabled": process_info.db_enabled,
+                    "structured_log_path": str(process_info.structured_log_path),
                 }
         
         return status

--- a/src/dopemux/litellm_trace_logger.py
+++ b/src/dopemux/litellm_trace_logger.py
@@ -1,0 +1,218 @@
+"""Metadata-only structured logging callbacks for Dopemux-managed LiteLLM instances."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from litellm.integrations.custom_logger import CustomLogger
+
+TRACE_HEADER_NAME = "X-Dopemux-Trace-Id"
+LITELLM_COMPONENT_NAME = "dopemux_litellm_proxy"
+LOGGING_ENABLED_ENV = "DOPEMUX_LITELLM_STRUCTURED_LOGGING"
+LOG_PATH_ENV = "DOPEMUX_LITELLM_JSONL_LOG_PATH"
+INSTANCE_ID_ENV = "DOPEMUX_LITELLM_INSTANCE_ID"
+
+
+def _env_enabled(name: str, default: bool = True) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in {"0", "false", "no", "off"}
+
+
+def _new_span_id() -> str:
+    return uuid.uuid4().hex[:16]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _safe_value(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {
+            str(key): _safe_value(subvalue)
+            for key, subvalue in value.items()
+            if subvalue is not None
+        }
+    if isinstance(value, (list, tuple)):
+        return [_safe_value(item) for item in value if item is not None]
+    return str(value)
+
+
+def _log_path() -> Optional[Path]:
+    raw = str(os.getenv(LOG_PATH_ENV, "") or "").strip()
+    if not raw:
+        return None
+    return Path(raw)
+
+
+def _write_event(payload: Dict[str, Any]) -> None:
+    if not _env_enabled(LOGGING_ENABLED_ENV, default=True):
+        return
+    target = _log_path()
+    if target is None:
+        return
+    target.parent.mkdir(parents=True, exist_ok=True)
+    sanitized = {key: value for key, value in payload.items() if value is not None}
+    with target.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(sanitized, ensure_ascii=True, sort_keys=True) + "\n")
+
+
+def _get_metadata(kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    for key in ("metadata", "litellm_metadata"):
+        candidate = kwargs.get(key)
+        if isinstance(candidate, dict):
+            return candidate
+    return {}
+
+
+def _extract_trace_id(kwargs: Dict[str, Any]) -> str:
+    metadata = _get_metadata(kwargs)
+    trace_id = str(metadata.get("trace_id") or "").strip()
+    if trace_id:
+        return trace_id
+    extra_headers = kwargs.get("extra_headers")
+    if isinstance(extra_headers, dict):
+        trace_id = str(extra_headers.get(TRACE_HEADER_NAME) or "").strip()
+        if trace_id:
+            return trace_id
+    return uuid.uuid4().hex
+
+
+def _extract_usage(response_obj: Any) -> Dict[str, Optional[int]]:
+    usage = getattr(response_obj, "usage", None)
+    if usage is None:
+        return {}
+    return {
+        "tokens_prompt": getattr(usage, "prompt_tokens", None),
+        "tokens_completion": getattr(usage, "completion_tokens", None),
+        "tokens_total": getattr(usage, "total_tokens", None),
+        "tokens_reasoning": getattr(usage, "reasoning_tokens", None),
+        "tokens_cached": getattr(usage, "cached_tokens", None),
+    }
+
+
+def _base_event(event_type: str, trace_id: str, **fields: Any) -> Dict[str, Any]:
+    return {
+        "ts": _now_iso(),
+        "component": LITELLM_COMPONENT_NAME,
+        "event_type": event_type,
+        "trace_id": trace_id,
+        "span_id": fields.pop("span_id", None) or _new_span_id(),
+        "instance_id": os.getenv(INSTANCE_ID_ENV),
+        **_safe_value(fields),
+    }
+
+
+def emit_startup_event(*, log_path: Optional[str] = None, **fields: Any) -> None:
+    payload = _base_event("proxy_startup", trace_id=uuid.uuid4().hex, **fields)
+    if log_path:
+        target = Path(log_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        sanitized = {key: value for key, value in payload.items() if value is not None}
+        with target.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(sanitized, ensure_ascii=True, sort_keys=True) + "\n")
+        return
+    _write_event(payload)
+
+
+class DopemuxLiteLLMTraceLogger(CustomLogger):
+    """LiteLLM callback hook that records metadata-only request lifecycle events."""
+
+    def __init__(self) -> None:
+        super().__init__(turn_off_message_logging=True)
+
+    async def async_pre_call_deployment_hook(
+        self, kwargs: Dict[str, Any], call_type: Optional[Any]
+    ) -> Optional[Dict[str, Any]]:
+        metadata = dict(_get_metadata(kwargs))
+        trace_id = str(metadata.get("trace_id") or "").strip() or uuid.uuid4().hex
+        metadata["trace_id"] = trace_id
+        kwargs["metadata"] = metadata
+
+        extra_headers = dict(kwargs.get("extra_headers") or {})
+        extra_headers.setdefault(TRACE_HEADER_NAME, trace_id)
+        kwargs["extra_headers"] = extra_headers
+        return kwargs
+
+    def log_pre_api_call(self, model: str, messages: Any, kwargs: Dict[str, Any]) -> None:
+        trace_id = _extract_trace_id(kwargs)
+        metadata = _get_metadata(kwargs)
+        _write_event(
+            _base_event(
+                "proxy_request_started",
+                trace_id=trace_id,
+                model=model,
+                provider=str(kwargs.get("custom_llm_provider") or kwargs.get("provider") or ""),
+                parent_span_id=metadata.get("parent_span_id"),
+                route=metadata.get("model_group"),
+                status="started",
+                api_base=kwargs.get("api_base"),
+                request_id=metadata.get("request_id"),
+            )
+        )
+
+    def log_success_event(
+        self, kwargs: Dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
+    ) -> None:
+        trace_id = _extract_trace_id(kwargs)
+        metadata = _get_metadata(kwargs)
+        usage = _extract_usage(response_obj)
+        latency_ms = None
+        if start_time is not None and end_time is not None:
+            latency_ms = int((end_time - start_time).total_seconds() * 1000)
+        _write_event(
+            _base_event(
+                "proxy_request_completed",
+                trace_id=trace_id,
+                model=str(getattr(response_obj, "model", None) or kwargs.get("model") or ""),
+                provider=str(kwargs.get("custom_llm_provider") or kwargs.get("provider") or ""),
+                parent_span_id=metadata.get("parent_span_id"),
+                route=metadata.get("model_group"),
+                status="completed",
+                latency_ms=latency_ms,
+                finish_reason=getattr(getattr(response_obj, "choices", [None])[0], "finish_reason", None)
+                if getattr(response_obj, "choices", None)
+                else None,
+                upstream_request_id=str(getattr(response_obj, "id", "") or "") or None,
+                request_id=metadata.get("request_id"),
+                **usage,
+            )
+        )
+
+    def log_failure_event(
+        self, kwargs: Dict[str, Any], response_obj: Any, start_time: Any, end_time: Any
+    ) -> None:
+        trace_id = _extract_trace_id(kwargs)
+        metadata = _get_metadata(kwargs)
+        latency_ms = None
+        if start_time is not None and end_time is not None:
+            latency_ms = int((end_time - start_time).total_seconds() * 1000)
+        _write_event(
+            _base_event(
+                "proxy_request_failed",
+                trace_id=trace_id,
+                model=str(kwargs.get("model") or ""),
+                provider=str(kwargs.get("custom_llm_provider") or kwargs.get("provider") or ""),
+                parent_span_id=metadata.get("parent_span_id"),
+                route=metadata.get("model_group"),
+                status="failed",
+                latency_ms=latency_ms,
+                error_type=type(response_obj).__name__ if response_obj is not None else None,
+                error_message_excerpt=str(response_obj)[:500] if response_obj is not None else None,
+                request_id=metadata.get("request_id"),
+            )
+        )

--- a/src/dopemux/litellm_trace_logger.py
+++ b/src/dopemux/litellm_trace_logger.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import time
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path

--- a/tests/test_litellm_manager.py
+++ b/tests/test_litellm_manager.py
@@ -69,6 +69,7 @@ def test_start_instance_basic(tmp_path):
         assert process_info.port == 4000
         assert process_info.master_key.startswith("sk-")
         assert process_info.db_enabled == False
+        assert process_info.structured_log_path.name == "litellm.events.jsonl"
         assert len(manager._processes) == 1
         assert "test" in manager._processes
 
@@ -188,6 +189,8 @@ def test_build_client_environment(tmp_path):
         assert "OPENAI_API_BASE" in env_vars
         assert "ANTHROPIC_API_KEY" in env_vars
         assert "DOPEMUX_LITELLM_MASTER_KEY" in env_vars
+        assert "DOPEMUX_LITELLM_TRACE_HEADER" in env_vars
+        assert "DOPEMUX_LITELLM_JSONL_LOG_PATH" in env_vars
         assert env_vars["OPENAI_API_BASE"] == "http://127.0.0.1:4000"
 
 
@@ -289,6 +292,76 @@ def test_config_preparation(tmp_path):
     config_content = yaml.safe_load(config_path.read_text())
     assert config_content["general_settings"]["master_key"] == "test-key-123"
     assert "database_url" not in config_content["general_settings"]
+    assert "dopemux.litellm_trace_logger.DopemuxLiteLLMTraceLogger" in config_content["litellm_settings"]["callbacks"]
+
+
+def test_prepare_config_preserves_existing_callbacks(tmp_path):
+    manager = LiteLLMManager(tmp_path)
+    instance_dir = tmp_path / ".dopemux" / "litellm" / "test"
+    instance_dir.mkdir(parents=True, exist_ok=True)
+
+    config_data = {
+        "model_list": [{"model_name": "test-model", "litellm_params": {"model": "test/provider-model"}}],
+        "litellm_settings": {"callbacks": ["existing.callback.Hook"]},
+    }
+
+    config_path = manager._prepare_config(
+        instance_dir=instance_dir,
+        config_data=config_data,
+        master_key="test-key-123",
+        db_enabled=False,
+        db_url=None,
+    )
+
+    config_content = yaml.safe_load(config_path.read_text())
+    callbacks = config_content["litellm_settings"]["callbacks"]
+    assert "existing.callback.Hook" in callbacks
+    assert "dopemux.litellm_trace_logger.DopemuxLiteLLMTraceLogger" in callbacks
+
+
+def test_launch_process_sets_structured_logging_env(tmp_path):
+    manager = LiteLLMManager(tmp_path)
+    instance_dir = tmp_path / ".dopemux" / "litellm" / "A"
+    instance_dir.mkdir(parents=True, exist_ok=True)
+    config_path = instance_dir / "litellm.config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "model_list": [{"model_name": "test-model", "litellm_params": {"model": "test/provider-model"}}],
+                "router_settings": {"fallbacks": [{"test-model": ["backup-model"]}]},
+            },
+            sort_keys=False,
+        )
+    )
+    log_path = instance_dir / "litellm.log"
+
+    with patch("subprocess.Popen") as mock_popen:
+        mock_process = Mock()
+        mock_process.poll.return_value = None
+        mock_popen.return_value = mock_process
+
+        manager._launch_process(
+            config_path=config_path,
+            log_path=log_path,
+            port=4010,
+            master_key="sk-test",
+            db_enabled=False,
+            db_url=None,
+        )
+
+    _, kwargs = mock_popen.call_args
+    env = kwargs["env"]
+    assert env["DOPEMUX_LITELLM_STRUCTURED_LOGGING"] == "1"
+    assert env["DOPEMUX_LITELLM_JSONL_LOG_PATH"] == str(instance_dir / "litellm.events.jsonl")
+    assert env["DOPEMUX_LITELLM_INSTANCE_ID"] == "A"
+    assert str(tmp_path / "src") in env["PYTHONPATH"]
+    startup_rows = [
+        yaml.safe_load(line)
+        for line in (instance_dir / "litellm.events.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert startup_rows[0]["event_type"] == "proxy_startup"
+    assert startup_rows[0]["instance_id"] == "A"
 
 
 def test_get_health_status(tmp_path):


### PR DESCRIPTION
## Summary
- extend extractor events.jsonl with additive trace and request lifecycle metadata
- add PAL structured JSONL activity logging for tool and provider request phases
- wire LiteLLM managed instances to emit metadata-only structured logs and propagate a shared trace header

## Validation
- pytest services/repo-truth-extractor/tests/test_run_extraction_v5_soft_gate_logging.py -q
- pytest docker/mcp-servers-source/pal/pal-mcp-server/tests/test_server.py -q
- pytest tests/test_litellm_manager.py -q
- python -m py_compile src/dopemux/litellm_manager.py src/dopemux/litellm_trace_logger.py docker/mcp-servers-source/pal/pal-mcp-server/server.py

## Notes
- logging remains metadata-only; no prompt or completion bodies are persisted by the new structured events
- live extractor -> PAL -> LiteLLM smoke flow was not run in this change set