### PR TITLE
ci: re-enable docs-graph-validator check

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -75,7 +75,6 @@ jobs:
             fi
           fi
         env:
-          SKIP: docs-graph-validator  # Temporarily skip graph validator (pre-existing validation issues)
 
       - name: 🎯 ADHD-Friendly Summary
         if: always()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,7 +28,6 @@ jobs:
             fi
           fi
         env:
-          SKIP: docs-graph-validator  # Temporarily skip graph validator (pre-existing validation issues)
       - name: Broken-link check (lychee)
         uses: lycheeverse/lychee-action@v2  # Security: Fixed code injection vulnerability in v1
         with:


### PR DESCRIPTION
Removes the redundant `SKIP: docs-graph-validator` environment variable from CI workflows. Documentation hygiene is now stable and legacy files are correctly excluded via pre-commit configuration.