### PR TITLE
ci: support merge queue triggers

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -3,6 +3,7 @@ name: 🚀 Complete CI Pipeline (ADHD-Optimized)
 on:
   push:
     branches: [main]
+  merge_group: {}
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  merge_group: {}
   pull_request:
 jobs:
   checks:


### PR DESCRIPTION
Adds `merge_group: {}` to the main CI and Docs workflows. This is required for GitHub's merge queue to correctly run and report checks on its temporary merge branches.