### PR TITLE
repo-truth-extractor: enforce spend caps and cost-abort semantics

### DIFF
--- a/docs/92-runbooks/repo-truth-extractor-v5-billing-verification-drill.md
+++ b/docs/92-runbooks/repo-truth-extractor-v5-billing-verification-drill.md
@@ -70,7 +70,9 @@ Observed runtime behavior:
 - unknown model ids use the recorded conservative fallback policy rather than optimistic zero-cost handling
 - batch submit and async submit reserve estimated spend at submit time
 - if a breach occurs after a provider response, the current partial output is retained and the run is marked `COST_ABORTED`
-- cost-aborted runs are not resumable
+- `If a run enters COST_ABORTED, resume is not allowed. Start a new run.`
+
+`Batch cost accounting is conservative reservation accounting and not authoritative provider billing truth.`
 
 ## Record the discrepancy
 

--- a/docs/92-runbooks/repo-truth-extractor-v5-billing-verification-drill.md
+++ b/docs/92-runbooks/repo-truth-extractor-v5-billing-verification-drill.md
@@ -26,6 +26,7 @@ Compare:
 
 - the v5 dry-run cost preview
 - the runtime spend ledger
+- the cost-abort artifact when the run stops on cap
 - the provider-side billing or usage export
 
 for a single controlled partition.
@@ -59,8 +60,17 @@ DPMX_LIVE_OK=1 python services/repo-truth-extractor/run_extraction_v5.py \
 ## Compare these artifacts
 
 - `runs/rte_billing_probe/spend_ledger.json`
+- `runs/rte_billing_probe/COST_ABORT.json` when the cap is hit
 - `runs/rte_billing_probe/A_repo_control_plane/inputs/COST_PREVIEW.json`
 - provider-side billing, usage export, or console view for the same time window
+
+Observed runtime behavior:
+
+- `--max-cost-usd` is enforced before projected submit/call work and after actual runtime accumulation
+- unknown model ids use the recorded conservative fallback policy rather than optimistic zero-cost handling
+- batch submit and async submit reserve estimated spend at submit time
+- if a breach occurs after a provider response, the current partial output is retained and the run is marked `COST_ABORTED`
+- cost-aborted runs are not resumable
 
 ## Record the discrepancy
 
@@ -100,6 +110,7 @@ Reasons for variance include:
 - fallback baseline pricing for unknown model ids
 - step-level route overrides
 - retries
+- submit-time reservation versus observed usage at finalize/watch
 - provider-side billing granularity differences
 - batch vs sync execution differences
 

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001/IMPLEMENTER_REPORT.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001/IMPLEMENTER_REPORT.md
@@ -1,0 +1,44 @@
+# TP-CODEX-RTE-PRELIVE-001 Implementer Report
+
+## Scope completed
+
+- upgraded `spend_ledger.py` to persist model-aware totals, provider totals, and fallback counters while remaining backward-compatible with older ledger files
+- added runtime helpers in `run_extraction_v5.py` for:
+  - projected pre-call cap checks
+  - runtime accumulation
+  - submit-time reservation for batch and async lanes
+  - persisted `cost_aborted` run state
+- instrumented verified billable paths in the v5 runtime and utility probe surfaces
+- added `services/repo-truth-extractor/tests/test_spend_ledger.py`
+- updated operator docs for `--max-cost-usd`, ledger location, reservation semantics, and abort behavior
+
+## Runtime behavior now enforced
+
+- every verified billable call path enters the spend ledger before additional billable work can continue
+- `--max-cost-usd` now blocks both:
+  - projected pre-call or pre-submit work
+  - post-response over-cap states after accumulation
+- live runs with a cost cap force single-worker partition execution so stop-on-breach remains deterministic
+- cost abort writes `COST_ABORT.json` and updates manifest, coverage, resume, proof, and dashboard artifacts
+
+## Validation summary
+
+- `pytest services/repo-truth-extractor/tests/ -v`
+  - `505 passed`
+- `pytest -k "spend or cost or breach" -v`
+  - `6 passed, 5 skipped`
+- `python services/repo-truth-extractor/extraction_hygiene.py scan`
+  - pass with one warning and zero errors
+- `python scripts/repo_truth_extractor_promptset_audit_v4.py`
+  - pass
+- `python services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+  - fails `NO_GO` for environment/readiness reasons outside this packet's code change:
+    - missing `XAI_API_KEY`
+    - PAL validation unavailable
+    - online preflight skipped
+
+## Remaining drift / uncertainty
+
+- `validate_pre_live_gate_v25.py` still reports pre-existing S-phase stale artifact-map findings and environment readiness blockers
+- S_INT now uses the cost-enforcement helpers, but its top-level flow still exits directly instead of writing the full v5 run-artifact bundle because that flow does not currently build the normal run directory contract before execution
+- provider-billing truth remains external; the ledger is still a conservative internal estimate, not authoritative billing

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001/PROOF.json
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001/PROOF.json
@@ -1,0 +1,116 @@
+{
+  "packet_id": "TP-CODEX-RTE-PRELIVE-001",
+  "head_sha": "cc20f95ba8d24e61126a90f21bb1cd31c3d7aa14",
+  "billable_paths": [
+    {
+      "path": "run_provider_doctor_probe",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "run_gemini_auth_probe",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "run_auth_doctor",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "run_comparison_lane",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "strict_contract_call",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "sync_partition_execution",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "audit_phase_sample",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "batch_submit",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "batch_watch",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "phase_r_async_submit",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "phase_r_async_finalize",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    },
+    {
+      "path": "s_int_sync",
+      "status": "instrumented",
+      "file": "services/repo-truth-extractor/run_extraction_v5.py"
+    }
+  ],
+  "pricing_strategy": {
+    "mode": "model-aware route registry with baseline_v1 rates",
+    "ledger_writer": "services/repo-truth-extractor/lib/spend_ledger.py",
+    "runtime_enforcement": "services/repo-truth-extractor/run_extraction_v5.py"
+  },
+  "fallback_policy": {
+    "name": "baseline_v1_fallback",
+    "behavior": "unknown model ids use the max-known registry rate and increment fallback_usage_count"
+  },
+  "tests_run": [
+    {
+      "command": "pytest services/repo-truth-extractor/tests/ -v",
+      "result": "PASS",
+      "details": "505 passed in 18.35s"
+    },
+    {
+      "command": "pytest -k \"spend or cost or breach\" -v",
+      "result": "PASS",
+      "details": "6 passed, 5 skipped, 2063 deselected in 5.56s"
+    },
+    {
+      "command": "python services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+      "result": "FAIL",
+      "details": "NO_GO: REQUIRED_API_KEY_MISSING (XAI_API_KEY), PAL_REQUIRED_UNAVAILABLE, ONLINE_PREFLIGHT_FAILURE"
+    },
+    {
+      "command": "python services/repo-truth-extractor/extraction_hygiene.py scan",
+      "result": "PASS",
+      "details": "warnings=1 errors=0"
+    },
+    {
+      "command": "python scripts/repo_truth_extractor_promptset_audit_v4.py",
+      "result": "PASS",
+      "details": "status=PASS global_issues_count=0"
+    }
+  ],
+  "abort_behavior": {
+    "run_status": "COST_ABORTED",
+    "reason": "MAX_COST_USD_EXCEEDED",
+    "partial_outputs_retained": true,
+    "resume_allowed": false,
+    "artifacts": [
+      "COST_ABORT.json",
+      "RUN_MANIFEST.json",
+      "COVERAGE_ROLLUP.json",
+      "RESUME_PROOF.json",
+      "PROOF_PACK.json"
+    ]
+  },
+  "verdict": "LOCAL_PASS_WITH_ENVIRONMENT_NO_GO"
+}

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001/billable_call_paths.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001/billable_call_paths.md
@@ -1,0 +1,52 @@
+# Billable call paths
+
+Repo truth inspected in `services/repo-truth-extractor/run_extraction_v5.py`.
+
+## Instrumented paths
+
+- `run_provider_doctor_probe`
+  - direct `call_llm(...)`
+  - now gated by `_check_projected_cost_limit(...)` and accumulated via `_accumulate_runtime_spend(...)`
+- `run_gemini_auth_probe`
+  - direct `call_llm(...)`
+  - now gated and accumulated
+- `run_auth_doctor`
+  - direct `call_llm(...)` across auth modes
+  - now gated and accumulated
+- `run_comparison_lane`
+  - comparison-only secondary lane
+  - now gated and accumulated; raises cost abort on breach
+- `_strict_contract_call`
+  - strict repair and sidefill path
+  - now gated and accumulated
+- sync partition execution inside `_execute_llm_call`
+  - canonical per-partition live path
+  - now gated and accumulated once; duplicate raw `ledger.accumulate(...)` block removed
+- `audit_phase_sample`
+  - judge-model lane
+  - now gated and accumulated
+- batch submit in `_execute_llm_call`
+  - projected pre-check retained
+  - submit now reserves spend via `_reserve_projected_spend(...)`
+- `run_batch_watch`
+  - accumulates only when submit did not already reserve spend
+  - stops after the first over-cap result
+- `run_phase_R_async_submit`
+  - projected pre-check retained
+  - submit now reserves spend
+- `run_phase_R_finalize`
+  - skips double-counting when submit already reserved spend
+  - otherwise accumulates and can abort
+- S_INT prompt executor
+  - now projected-gated and accumulated
+
+## Deterministic stop mechanics
+
+- when `--max-cost-usd` is active on a live run, `partition_workers` is clamped to `1`
+- sequential partition application writes the current partition output first, then raises `CostLimitExceededError`
+- top-level phase/batch/finalize handlers persist `COST_ABORT.json` plus manifest/proof updates and exit non-zero
+
+## Non-authoritative notes
+
+- `call_llm_with_ladder(...)` is a routing wrapper, not a provider call by itself
+- provider billing/export remains external and was not changed by this packet

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001/ledger_diff.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001/ledger_diff.md
@@ -1,0 +1,34 @@
+# Spend ledger diff
+
+## Previous observed shape
+
+- global `total_cost_usd`
+- per-phase totals
+- global `models`
+- legacy `unknown_model_events`
+- no public rate registry accessor
+- no provider totals
+- `accumulate(...)` had no `route` input
+
+## Current shape
+
+- public `MODEL_COST_RATES`
+- public `get_model_cost_rate(provider, model_id, route)`
+- `accumulate(phase, input_tokens, output_tokens, provider=None, model_id=None, route=None)`
+- persisted global totals:
+  - `total_cost_usd`
+  - `models`
+  - `providers`
+  - `fallback_usage_count`
+  - legacy `unknown_model_events`
+- persisted per-phase totals:
+  - `models`
+  - `providers`
+- backward-compatible load for older ledger files that do not contain provider maps or fallback counters
+
+## Runtime accounting changes
+
+- sync canonical path now records one accumulated spend record instead of a helper call plus an extra raw ledger increment
+- batch and async submit lanes reserve projected spend at submit time
+- batch watch and async finalize consume observed usage without double-counting previously reserved spend
+- cost-abort persistence now records the active ledger totals in `COST_ABORT.json` and linked run artifacts

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/IMPLEMENTER_REPORT.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/IMPLEMENTER_REPORT.md
@@ -1,0 +1,29 @@
+# TP-CODEX-RTE-PRELIVE-001A Implementer Report
+
+## Scope completed
+
+- added an exhaustive billable path census with `unknown = 0`
+- strengthened the forced-breach proof with an explicit post-breach call counter
+- made the recovery rule explicit in runtime abort artifacts and docs
+- made batch accounting semantics explicit as conservative reservation accounting
+
+## What changed
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+  - `cost_abort_recovery_rule` now persists in the cost-abort payload
+- `services/repo-truth-extractor/tests/test_spend_ledger.py`
+  - forced-breach test now proves no later batch-watch poll/fetch starts after breach
+- docs updated with exact recovery rule and exact batch-accounting wording
+
+## Result
+
+- billable path census now classifies all candidate surfaces
+- `unknown_paths_total = 0`
+- forced-breach proof now includes `post_breach_call_count = 0`
+
+## Out of scope kept out
+
+- validator wiring
+- validator drift repair
+- broader resilience changes
+- circuit breaker and UX work

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/PROOF.json
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/PROOF.json
@@ -1,0 +1,18 @@
+{
+  "packet_id": "TP-CODEX-RTE-PRELIVE-001A",
+  "head_sha": "014f285d71e53ee0e6b17f8da61d7861c8d8f4e0",
+  "candidate_call_paths_total": 14,
+  "billable_paths_total": 12,
+  "instrumented_billable_paths_total": 12,
+  "non_billable_paths_total": 2,
+  "unknown_paths_total": 0,
+  "forced_breach_test_name": "test_forced_breach_blocks_all_later_batch_watch_calls",
+  "post_breach_call_count": 0,
+  "cost_abort_recovery_rule": "If a run enters `COST_ABORTED`, resume is not allowed. Start a new run.",
+  "batch_accounting_mode": "conservative_reservation_accounting",
+  "docs_updated": [
+    "services/repo-truth-extractor/README.md",
+    "docs/92-runbooks/repo-truth-extractor-v5-billing-verification-drill.md"
+  ],
+  "verdict": "PASS"
+}

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/PROOF.json
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/PROOF.json
@@ -1,6 +1,6 @@
 {
   "packet_id": "TP-CODEX-RTE-PRELIVE-001A",
-  "head_sha": "014f285d71e53ee0e6b17f8da61d7861c8d8f4e0",
+  "code_under_test_sha": "014f285d71e53ee0e6b17f8da61d7861c8d8f4e0",
   "candidate_call_paths_total": 14,
   "billable_paths_total": 12,
   "instrumented_billable_paths_total": 12,

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/batch_accounting_contract.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/batch_accounting_contract.md
@@ -1,0 +1,14 @@
+# Batch accounting contract
+
+`Batch cost accounting is conservative reservation accounting and not authoritative provider billing truth.`
+
+## Current runtime contract
+
+- submit-time batch work reserves estimated spend through `_reserve_projected_spend(...)`
+- watch/finalize paths record observed usage when available
+- already-reserved submit work is not accumulated again at watch/finalize
+- the ledger is conservative for runtime cap enforcement, not a provider invoice source
+
+## Why this remains in scope
+
+TP-001A clarifies the contract. It does not redesign batch accounting into result-materialization billing truth.

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/billable_path_census.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/billable_path_census.md
@@ -1,0 +1,42 @@
+# Billable path census
+
+Method: inspect `services/repo-truth-extractor/run_extraction_v5.py` for all provider-call entry points and routing wrappers using:
+
+- `call_llm(`
+- `call_llm_with_ladder(`
+- batch submit/watch surfaces
+- async submit/finalize surfaces
+
+## Counts
+
+- candidate call paths total: **14**
+- billable paths total: **12**
+- instrumented billable paths total: **12**
+- non-billable paths total: **2**
+- unknown paths total: **0**
+
+## Census
+
+| # | Surface | File line | Classification | Instrumented |
+|---|---|---:|---|---|
+| 1 | `run_provider_doctor_probe` | `5854` | billable | yes |
+| 2 | `run_gemini_auth_probe` | `8895` | billable | yes |
+| 3 | `run_auth_doctor` | `9047` | billable | yes |
+| 4 | `run_comparison_lane` | `10546` | billable | yes |
+| 5 | `_strict_contract_call` | `11968` | billable | yes |
+| 6 | sync partition execution inside `_execute_llm_call` | `12808` | billable | yes |
+| 7 | canonical `call_llm_with_ladder` wrapper | `13047` | non-billable wrapper | n/a |
+| 8 | `audit_phase_sample` | `16294` | billable | yes |
+| 9 | `run_batch_watch` | `16517` | billable | yes |
+| 10 | `run_phase_R_async_submit` | `17371` | billable | yes |
+| 11 | `run_phase_R_finalize` | `17693` | billable | yes |
+| 12 | S_INT `_execute_attempt` | `18849` | billable | yes |
+| 13 | S_INT `call_llm_with_ladder` wrapper | `18912` | non-billable wrapper | n/a |
+| 14 | batch submit path inside `_execute_llm_call` | `12535` | billable | yes |
+
+## Notes
+
+- `call_llm_with_ladder(...)` routes attempts but is not itself a provider-billing surface.
+- batch submit is counted separately because it can incur provider-side cost without a direct `call_llm(...)` call.
+- async submit/finalize are counted separately for the same reason.
+- no candidate surface remains unclassified in this census.

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/forced_breach_evidence.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/forced_breach_evidence.md
@@ -1,0 +1,31 @@
+# Forced breach evidence
+
+## Test
+
+- name: `test_forced_breach_blocks_all_later_batch_watch_calls`
+- file: `services/repo-truth-extractor/tests/test_spend_ledger.py`
+
+## Scenario
+
+- cap: `0.00001`
+- mode: batch watch
+- job 1 result carries enough usage to breach the cap
+- job 2 is queued behind job 1 in the batch job index
+
+## Assertions proved
+
+- breach occurs
+- first partition output is written:
+  - `A1__A_P0001.json` exists
+- later billable work does not start:
+  - `A1__A_P0002.json` does not exist
+  - `fake_client.polled == ["job-1"]`
+  - `fake_client.fetched == ["job-1"]`
+  - `fake_client.post_breach_call_count == 0`
+
+## Interpretation
+
+This is the required no-post-breach-call proof for TP-001A:
+
+- the current allowed work completes cleanly enough to persist its output
+- the later queued billable call is never polled or fetched after the breach

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/verification_commands.txt
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001A/verification_commands.txt
@@ -1,0 +1,2 @@
+python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_spend_ledger.py
+pytest -q services/repo-truth-extractor/tests/test_spend_ledger.py -k forced_breach

--- a/services/repo-truth-extractor/README.md
+++ b/services/repo-truth-extractor/README.md
@@ -210,11 +210,13 @@ When a run breaches `--max-cost-usd`:
 - no further billable calls are started after the breach is detected
 - the run writes `COST_ABORT.json` under the run root
 - `RUN_MANIFEST.json`, `COVERAGE_ROLLUP.json`, `RESUME_PROOF.json`, and `PROOF_PACK.json` are updated with `run_status = COST_ABORTED`
-- resume is blocked for that run: `resume_allowed = false`
+- `If a run enters COST_ABORTED, resume is not allowed. Start a new run.`
 
 Abort artifact path:
 
 - `extraction/repo-truth-extractor/v5/runs/<RUN_ID>/COST_ABORT.json`
+
+`Batch cost accounting is conservative reservation accounting and not authoritative provider billing truth.`
 
 The ledger remains an internal estimate based on repo-local pricing authority. It is intended to be conservative and auditable, not a provider-billing source of truth.
 

--- a/services/repo-truth-extractor/README.md
+++ b/services/repo-truth-extractor/README.md
@@ -183,6 +183,41 @@ Notes:
 - step-level contract routes can override the top-level routing policy
 - comparison lane, retries, and unknown-model fallback pricing lower confidence
 
+### Runtime cost enforcement
+
+`--max-cost-usd` is a runtime gate, not a display-only preview.
+
+- Every billable v5 lane now records spend in `runs/<RUN_ID>/spend_ledger.json`
+- The ledger persists:
+  - `total_cost_usd`
+  - per-phase totals
+  - per-model totals
+  - per-provider totals
+  - fallback usage counts for unknown-model pricing
+- Unknown or unmapped model ids use the conservative fallback policy recorded in the ledger as `baseline_v1_fallback`
+- Batch submit and async submit reserve projected spend at submit time to avoid later under-counting
+- Batch watch and async finalize record observed usage when available and do not double-count already-reserved submit work
+
+Ledger path:
+
+- `extraction/repo-truth-extractor/v5/runs/<RUN_ID>/spend_ledger.json`
+
+### Cost-abort semantics
+
+When a run breaches `--max-cost-usd`:
+
+- the current partition or job output is retained when it has already been written
+- no further billable calls are started after the breach is detected
+- the run writes `COST_ABORT.json` under the run root
+- `RUN_MANIFEST.json`, `COVERAGE_ROLLUP.json`, `RESUME_PROOF.json`, and `PROOF_PACK.json` are updated with `run_status = COST_ABORTED`
+- resume is blocked for that run: `resume_allowed = false`
+
+Abort artifact path:
+
+- `extraction/repo-truth-extractor/v5/runs/<RUN_ID>/COST_ABORT.json`
+
+The ledger remains an internal estimate based on repo-local pricing authority. It is intended to be conservative and auditable, not a provider-billing source of truth.
+
 ### Prescan and batch wait guidance
 
 - Prescan is optional. It can help larger repos by reordering partition paths and adding context briefs.

--- a/services/repo-truth-extractor/lib/spend_ledger.py
+++ b/services/repo-truth-extractor/lib/spend_ledger.py
@@ -1,29 +1,58 @@
 import json
 import logging
+import threading
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-# Repo-local pricing authority is incomplete in this checkout. Until a canonical
-# config/pricing.yaml exists, keep a deterministic baseline registry and make
-# the fallback policy explicit in the ledger output instead of inventing rates.
+# Repo-local pricing authority is incomplete in this checkout. Keep the registry
+# explicit and deterministic, and make the fallback policy visible in the ledger
+# instead of inventing provider-billing truth.
 PRICING_VERSION = "baseline_v1"
 UNKNOWN_MODEL_POLICY = "baseline_v1_fallback"
 BASELINE_INPUT_COST_PER_1M_USD = 0.15
 BASELINE_OUTPUT_COST_PER_1M_USD = 0.60
 
-_KNOWN_MODEL_KEYS = {
-    "openai/gpt-5-nano",
-    "openai/gpt-5-mini",
-    "openai/gpt-5.2",
-    "gemini/gemini-2.5-flash",
-    "gemini/gemini-2.5-pro",
-    "xai/grok-code-fast-1",
-    "openrouter/openai/gpt-5-nano",
-    "openrouter/openai/gpt-5-mini",
+
+def _baseline_rate(pricing_source: str = "route_registry_baseline") -> Dict[str, Any]:
+    return {
+        "input_cost_per_1m_usd": BASELINE_INPUT_COST_PER_1M_USD,
+        "output_cost_per_1m_usd": BASELINE_OUTPUT_COST_PER_1M_USD,
+        "pricing_source": pricing_source,
+    }
+
+
+MODEL_COST_RATES: Dict[str, Dict[str, Any]] = {
+    "openai/gpt-5-nano": _baseline_rate(),
+    "openai/gpt-5-mini": _baseline_rate(),
+    "openai/gpt-5.2": _baseline_rate(),
+    "openai/gpt-5.3-codex": _baseline_rate(),
+    "openai/gpt-5.4": _baseline_rate(),
+    "gemini/gemini-2.5-flash": _baseline_rate(),
+    "gemini/gemini-2.5-pro": _baseline_rate(),
+    "gemini/gemini-3-flash-preview": _baseline_rate(),
+    "gemini/gemini-3.1-pro-preview": _baseline_rate(),
+    "xai/grok-code-fast-1": _baseline_rate(),
+    "xai/grok-4.20-beta": _baseline_rate(),
+    "xai/grok-4.20-beta-0309-reasoning": _baseline_rate(),
+    "openrouter/openai/gpt-5-nano": _baseline_rate(),
+    "openrouter/openai/gpt-5-mini": _baseline_rate(),
+    "openrouter/openai/gpt-5.2": _baseline_rate(),
+    "openrouter/openai/gpt-5.3-codex": _baseline_rate(),
+    "openrouter/openai/gpt-5.4": _baseline_rate(),
+    "openrouter/anthropic/claude-opus-4-6": _baseline_rate(),
 }
+
+
+@dataclass
+class ProviderSpend:
+    provider: str
+    usage_count: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    estimated_cost_usd: float = 0.0
 
 
 @dataclass
@@ -49,6 +78,7 @@ class PhaseSpend:
     output_tokens: int = 0
     estimated_cost_usd: float = 0.0
     models: Dict[str, ModelSpend] = field(default_factory=dict)
+    providers: Dict[str, ProviderSpend] = field(default_factory=dict)
 
 
 @dataclass
@@ -59,8 +89,10 @@ class SpendLedgerRecord:
     unknown_model_policy: str = UNKNOWN_MODEL_POLICY
     phases: Dict[str, PhaseSpend] = field(default_factory=dict)
     models: Dict[str, ModelSpend] = field(default_factory=dict)
+    providers: Dict[str, ProviderSpend] = field(default_factory=dict)
     total_cost_usd: float = 0.0
     unknown_model_events: int = 0
+    fallback_usage_count: int = 0
 
 
 def _safe_int(value: Any) -> int:
@@ -80,7 +112,14 @@ def _safe_float(value: Any) -> float:
 def _normalize_provider_model(
     provider: Optional[str],
     model_id: Optional[str],
+    route: Optional[str] = None,
 ) -> Tuple[str, str]:
+    route_token = str(route or "").strip()
+    if route_token and (not provider or not model_id):
+        if "/" in route_token:
+            route_provider, route_model_id = route_token.split("/", 1)
+            provider = provider or route_provider
+            model_id = model_id or route_model_id
     provider_token = str(provider or "").strip().lower()
     model_token = str(model_id or "").strip()
     if not provider_token and "/" in model_token:
@@ -111,35 +150,67 @@ def _pricing_candidates(provider: str, model_id: str) -> list[str]:
     return candidates
 
 
-def _resolve_pricing(provider: Optional[str], model_id: Optional[str]) -> Dict[str, Any]:
-    provider_token, model_token = _normalize_provider_model(provider, model_id)
-    lookup_key = ""
-    for candidate in _pricing_candidates(provider_token, model_token):
-        if candidate in _KNOWN_MODEL_KEYS:
-            lookup_key = candidate
-            break
-    if not lookup_key:
-        fallback_key = ""
-        if provider_token and model_token:
-            fallback_key = f"{provider_token}/{model_token}".lower()
-        elif model_token:
-            fallback_key = model_token.lower()
-        lookup_key = fallback_key or "unknown"
-    unknown_model = lookup_key not in _KNOWN_MODEL_KEYS
-    pricing_source = (
-        "known_route_baseline_registry"
-        if not unknown_model
-        else f"unknown_model:{UNKNOWN_MODEL_POLICY}"
+def _fallback_cost_rate() -> Dict[str, Any]:
+    max_input = max(
+        _safe_float(rate.get("input_cost_per_1m_usd"))
+        for rate in MODEL_COST_RATES.values()
+    )
+    max_output = max(
+        _safe_float(rate.get("output_cost_per_1m_usd"))
+        for rate in MODEL_COST_RATES.values()
+    )
+    return {
+        "input_cost_per_1m_usd": max_input,
+        "output_cost_per_1m_usd": max_output,
+        "pricing_source": f"unknown_model:{UNKNOWN_MODEL_POLICY}",
+    }
+
+
+def get_model_cost_rate(
+    provider: Optional[str] = None,
+    model_id: Optional[str] = None,
+    route: Optional[str] = None,
+) -> Dict[str, Any]:
+    provider_token, model_token = _normalize_provider_model(provider, model_id, route)
+    for index, candidate in enumerate(_pricing_candidates(provider_token, model_token)):
+        if candidate in MODEL_COST_RATES:
+            rate = MODEL_COST_RATES[candidate]
+            return {
+                "provider": provider_token,
+                "model_id": model_token,
+                "pricing_key": candidate,
+                "pricing_version": PRICING_VERSION,
+                "pricing_source": str(
+                    rate.get("pricing_source") or "route_registry_baseline"
+                ),
+                "match_type": "exact" if index == 0 else "fuzzy",
+                "unknown_model": False,
+                "input_cost_per_1m_usd": _safe_float(
+                    rate.get("input_cost_per_1m_usd", BASELINE_INPUT_COST_PER_1M_USD)
+                ),
+                "output_cost_per_1m_usd": _safe_float(
+                    rate.get(
+                        "output_cost_per_1m_usd", BASELINE_OUTPUT_COST_PER_1M_USD
+                    )
+                ),
+            }
+
+    fallback = _fallback_cost_rate()
+    fallback_key = (
+        f"{provider_token}/{model_token}".lower()
+        if provider_token and model_token
+        else (model_token.lower() if model_token else "unknown")
     )
     return {
         "provider": provider_token,
         "model_id": model_token,
-        "pricing_key": lookup_key,
-        "pricing_source": pricing_source,
+        "pricing_key": fallback_key,
         "pricing_version": PRICING_VERSION,
-        "unknown_model": unknown_model,
-        "input_cost_per_1m_usd": BASELINE_INPUT_COST_PER_1M_USD,
-        "output_cost_per_1m_usd": BASELINE_OUTPUT_COST_PER_1M_USD,
+        "pricing_source": str(fallback["pricing_source"]),
+        "match_type": "fallback",
+        "unknown_model": True,
+        "input_cost_per_1m_usd": _safe_float(fallback["input_cost_per_1m_usd"]),
+        "output_cost_per_1m_usd": _safe_float(fallback["output_cost_per_1m_usd"]),
     }
 
 
@@ -150,7 +221,17 @@ class SpendLedger:
             run_id=run_id,
             global_max_cost_usd=max_cost_usd,
         )
+        self._lock = threading.Lock()
         self._load()
+
+    def _provider_from_payload(self, provider_name: str, provider_data: Dict[str, Any]) -> ProviderSpend:
+        return ProviderSpend(
+            provider=provider_name,
+            usage_count=_safe_int(provider_data.get("usage_count", 0)),
+            input_tokens=_safe_int(provider_data.get("input_tokens", 0)),
+            output_tokens=_safe_int(provider_data.get("output_tokens", 0)),
+            estimated_cost_usd=_safe_float(provider_data.get("estimated_cost_usd", 0.0)),
+        )
 
     def _phase_from_payload(self, phase_name: str, phase_data: Dict[str, Any]) -> PhaseSpend:
         phase_spend = PhaseSpend(
@@ -190,6 +271,14 @@ class SpendLedger:
                         )
                     ),
                 )
+        providers = phase_data.get("providers")
+        if isinstance(providers, dict):
+            for provider_name, provider_data in providers.items():
+                if not isinstance(provider_data, dict):
+                    continue
+                phase_spend.providers[str(provider_name)] = self._provider_from_payload(
+                    str(provider_name), provider_data
+                )
         return phase_spend
 
     def _models_from_payload(self, payload: Dict[str, Any]) -> Dict[str, ModelSpend]:
@@ -223,6 +312,16 @@ class SpendLedger:
             )
         return loaded
 
+    def _providers_from_payload(self, payload: Dict[str, Any]) -> Dict[str, ProviderSpend]:
+        loaded: Dict[str, ProviderSpend] = {}
+        for provider_name, provider_data in payload.items():
+            if not isinstance(provider_data, dict):
+                continue
+            loaded[str(provider_name)] = self._provider_from_payload(
+                str(provider_name), provider_data
+            )
+        return loaded
+
     def _load(self) -> None:
         if not self.ledger_path.exists():
             return
@@ -238,6 +337,9 @@ class SpendLedger:
             self.record.unknown_model_events = _safe_int(
                 data.get("unknown_model_events", 0)
             )
+            self.record.fallback_usage_count = _safe_int(
+                data.get("fallback_usage_count", self.record.unknown_model_events)
+            )
             for phase_name, phase_data in data.get("phases", {}).items():
                 if not isinstance(phase_data, dict):
                     continue
@@ -247,6 +349,9 @@ class SpendLedger:
             models = data.get("models")
             if isinstance(models, dict):
                 self.record.models = self._models_from_payload(models)
+            providers = data.get("providers")
+            if isinstance(providers, dict):
+                self.record.providers = self._providers_from_payload(providers)
         except Exception as exc:
             logger.warning("Could not load existing spend ledger: %s", exc)
 
@@ -266,8 +371,9 @@ class SpendLedger:
         output_tokens: int,
         provider: Optional[str] = None,
         model_id: Optional[str] = None,
+        route: Optional[str] = None,
     ) -> Dict[str, Any]:
-        resolved = _resolve_pricing(provider, model_id)
+        resolved = get_model_cost_rate(provider=provider, model_id=model_id, route=route)
         input_tokens = _safe_int(input_tokens)
         output_tokens = _safe_int(output_tokens)
         estimated_cost_usd = (
@@ -288,63 +394,93 @@ class SpendLedger:
         output_tokens: int,
         provider: Optional[str] = None,
         model_id: Optional[str] = None,
+        route: Optional[str] = None,
     ) -> Dict[str, Any]:
-        priced = self.price_usage(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            provider=provider,
-            model_id=model_id,
-        )
-        if phase not in self.record.phases:
-            self.record.phases[phase] = PhaseSpend(phase=phase)
-        phase_spend = self.record.phases[phase]
-        phase_spend.input_tokens += priced["input_tokens"]
-        phase_spend.output_tokens += priced["output_tokens"]
-        phase_spend.estimated_cost_usd += priced["estimated_cost_usd"]
-
-        model_key = str(priced["pricing_key"])
-        phase_model = phase_spend.models.get(model_key)
-        if phase_model is None:
-            phase_model = ModelSpend(
-                provider=str(priced["provider"]),
-                model_id=str(priced["model_id"]),
-                pricing_key=model_key,
-                pricing_source=str(priced["pricing_source"]),
-                pricing_version=str(priced["pricing_version"]),
-                unknown_model=bool(priced["unknown_model"]),
-                input_cost_per_1m_usd=_safe_float(priced["input_cost_per_1m_usd"]),
-                output_cost_per_1m_usd=_safe_float(priced["output_cost_per_1m_usd"]),
+        with self._lock:
+            priced = self.price_usage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                provider=provider,
+                model_id=model_id,
+                route=route,
             )
-            phase_spend.models[model_key] = phase_model
-        phase_model.usage_count += 1
-        phase_model.input_tokens += priced["input_tokens"]
-        phase_model.output_tokens += priced["output_tokens"]
-        phase_model.estimated_cost_usd += priced["estimated_cost_usd"]
+            if phase not in self.record.phases:
+                self.record.phases[phase] = PhaseSpend(phase=phase)
+            phase_spend = self.record.phases[phase]
+            phase_spend.input_tokens += priced["input_tokens"]
+            phase_spend.output_tokens += priced["output_tokens"]
+            phase_spend.estimated_cost_usd += priced["estimated_cost_usd"]
 
-        global_model = self.record.models.get(model_key)
-        if global_model is None:
-            global_model = ModelSpend(
-                provider=str(priced["provider"]),
-                model_id=str(priced["model_id"]),
-                pricing_key=model_key,
-                pricing_source=str(priced["pricing_source"]),
-                pricing_version=str(priced["pricing_version"]),
-                unknown_model=bool(priced["unknown_model"]),
-                input_cost_per_1m_usd=_safe_float(priced["input_cost_per_1m_usd"]),
-                output_cost_per_1m_usd=_safe_float(priced["output_cost_per_1m_usd"]),
-            )
-            self.record.models[model_key] = global_model
-        global_model.usage_count += 1
-        global_model.input_tokens += priced["input_tokens"]
-        global_model.output_tokens += priced["output_tokens"]
-        global_model.estimated_cost_usd += priced["estimated_cost_usd"]
+            model_key = str(priced["pricing_key"])
+            phase_model = phase_spend.models.get(model_key)
+            if phase_model is None:
+                phase_model = ModelSpend(
+                    provider=str(priced["provider"]),
+                    model_id=str(priced["model_id"]),
+                    pricing_key=model_key,
+                    pricing_source=str(priced["pricing_source"]),
+                    pricing_version=str(priced["pricing_version"]),
+                    unknown_model=bool(priced["unknown_model"]),
+                    input_cost_per_1m_usd=_safe_float(priced["input_cost_per_1m_usd"]),
+                    output_cost_per_1m_usd=_safe_float(priced["output_cost_per_1m_usd"]),
+                )
+                phase_spend.models[model_key] = phase_model
+            phase_model.usage_count += 1
+            phase_model.input_tokens += priced["input_tokens"]
+            phase_model.output_tokens += priced["output_tokens"]
+            phase_model.estimated_cost_usd += priced["estimated_cost_usd"]
 
-        if priced["unknown_model"]:
-            self.record.unknown_model_events += 1
+            provider_key = str(priced["provider"] or "unknown")
+            phase_provider = phase_spend.providers.get(provider_key)
+            if phase_provider is None:
+                phase_provider = ProviderSpend(provider=provider_key)
+                phase_spend.providers[provider_key] = phase_provider
+            phase_provider.usage_count += 1
+            phase_provider.input_tokens += priced["input_tokens"]
+            phase_provider.output_tokens += priced["output_tokens"]
+            phase_provider.estimated_cost_usd += priced["estimated_cost_usd"]
 
-        self.record.total_cost_usd += priced["estimated_cost_usd"]
-        self._save()
-        return priced
+            global_model = self.record.models.get(model_key)
+            if global_model is None:
+                global_model = ModelSpend(
+                    provider=str(priced["provider"]),
+                    model_id=str(priced["model_id"]),
+                    pricing_key=model_key,
+                    pricing_source=str(priced["pricing_source"]),
+                    pricing_version=str(priced["pricing_version"]),
+                    unknown_model=bool(priced["unknown_model"]),
+                    input_cost_per_1m_usd=_safe_float(priced["input_cost_per_1m_usd"]),
+                    output_cost_per_1m_usd=_safe_float(priced["output_cost_per_1m_usd"]),
+                )
+                self.record.models[model_key] = global_model
+            global_model.usage_count += 1
+            global_model.input_tokens += priced["input_tokens"]
+            global_model.output_tokens += priced["output_tokens"]
+            global_model.estimated_cost_usd += priced["estimated_cost_usd"]
+
+            global_provider = self.record.providers.get(provider_key)
+            if global_provider is None:
+                global_provider = ProviderSpend(provider=provider_key)
+                self.record.providers[provider_key] = global_provider
+            global_provider.usage_count += 1
+            global_provider.input_tokens += priced["input_tokens"]
+            global_provider.output_tokens += priced["output_tokens"]
+            global_provider.estimated_cost_usd += priced["estimated_cost_usd"]
+
+            if priced["unknown_model"]:
+                self.record.unknown_model_events += 1
+                self.record.fallback_usage_count += 1
+                logger.warning(
+                    "SpendLedger using unknown-model fallback pricing provider=%s model=%s pricing_key=%s policy=%s",
+                    priced["provider"] or "unknown",
+                    priced["model_id"] or "unknown",
+                    model_key,
+                    self.record.unknown_model_policy,
+                )
+
+            self.record.total_cost_usd += priced["estimated_cost_usd"]
+            self._save()
+            return priced
 
     def check_limit(self, additional_cost_usd: float = 0.0) -> bool:
         if self.record.global_max_cost_usd is None:

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -258,6 +258,8 @@ TELEMETRY_DIRNAME = "telemetry"
 RUN_DASHBOARD_FILENAME = "RUN_DASHBOARD.json"
 STEP_METRICS_FILENAME = "STEP_METRICS.json"
 FAILURE_INDEX_FILENAME = "FAILURE_INDEX.json"
+COST_ABORT_FILENAME = "COST_ABORT.json"
+COST_ABORT_REASON = "MAX_COST_USD_EXCEEDED"
 RETRY_COST_REPORT_FILENAME = "RETRY_COST_REPORT.json"
 TERMINAL_TIMELINE_FILENAME = "TERMINAL_TIMELINE.jsonl"
 PROMPTSET_BLOCKED_REASON = "PROMPTSET_INVALID"
@@ -5832,6 +5834,23 @@ def run_provider_doctor_probe(
     endpoint_url = transport_endpoint_url(
         provider, model_id, cfg, api_key, effective_mode
     )
+    route_token = f"{provider}/{model_id}"
+    projected_input_tokens = _estimate_text_tokens(
+        "Return exactly OK.", "Return the single token OK."
+    )
+    projected_output_tokens = _project_output_tokens(projected_input_tokens)
+    _check_projected_cost_limit(
+        cfg,
+        phase="DOCTOR",
+        step_id="PROVIDER_PROBE",
+        partition_id=route_token,
+        provider=provider,
+        model_id=model_id,
+        input_tokens=projected_input_tokens,
+        output_tokens=projected_output_tokens,
+        execution_mode="doctor_probe",
+        route=route_token,
+    )
     result = call_llm(
         provider=provider,
         model_id=model_id,
@@ -5841,6 +5860,25 @@ def run_provider_doctor_probe(
         cfg=cfg,
     )
     meta = result.get("meta", {})
+    if meta.get("response_received") or result.get("ok"):
+        meta["spend_usage"] = _accumulate_runtime_spend(
+            cfg,
+            phase="DOCTOR",
+            step_id="PROVIDER_PROBE",
+            partition_id=route_token,
+            provider=provider,
+            model_id=model_id,
+            execution_mode="doctor_probe",
+            response_summary=(
+                meta.get("response_summary")
+                if isinstance(meta.get("response_summary"), dict)
+                else None
+            ),
+            response_text=str(result.get("text") or ""),
+            fallback_input_tokens=projected_input_tokens,
+            fallback_output_tokens=projected_output_tokens,
+            route=route_token,
+        )
     return {
         "provider": provider,
         "model_id": model_id,
@@ -7525,6 +7563,7 @@ def _pricing_preview(
     model_id: str,
     input_tokens: int,
     output_tokens: int,
+    route: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     if not cfg.ledger:
         return None
@@ -7533,7 +7572,187 @@ def _pricing_preview(
         output_tokens=output_tokens,
         provider=provider,
         model_id=model_id,
+        route=route,
     )
+
+
+class CostLimitExceededError(RuntimeError):
+    def __init__(self, message: str, details: Dict[str, Any]) -> None:
+        super().__init__(message)
+        self.details = dict(details)
+
+
+def _build_cost_abort_state(
+    cfg: RunnerConfig,
+    *,
+    phase: str,
+    step_id: str,
+    partition_id: str,
+    provider: str,
+    model_id: str,
+    execution_mode: str,
+    breach_stage: str,
+    pricing: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    ledger_record = getattr(cfg, "ledger", None)
+    spend_record = getattr(ledger_record, "record", None)
+    payload = {
+        "status": "cost_aborted",
+        "reason": COST_ABORT_REASON,
+        "phase": phase,
+        "step_id": step_id,
+        "partition_id": partition_id,
+        "provider": str(provider or "").strip().lower(),
+        "model_id": str(model_id or "").strip(),
+        "execution_mode": str(execution_mode or "").strip() or "unknown",
+        "breach_stage": str(breach_stage or "").strip() or "unknown",
+        "total_cost_usd": (
+            float(getattr(spend_record, "total_cost_usd", 0.0))
+            if spend_record is not None
+            else 0.0
+        ),
+        "limit_usd": (
+            float(cfg.max_cost_usd) if cfg.max_cost_usd is not None else None
+        ),
+        "fallback_usage_count": int(
+            getattr(spend_record, "fallback_usage_count", 0) or 0
+        )
+        if spend_record is not None
+        else 0,
+        "partial_outputs_retained": True,
+        "resume_allowed": False,
+    }
+    if isinstance(pricing, dict):
+        payload["pricing_key"] = pricing.get("pricing_key")
+        payload["pricing_source"] = pricing.get("pricing_source")
+        payload["pricing_version"] = pricing.get("pricing_version")
+        payload["unknown_model"] = bool(pricing.get("unknown_model", False))
+        payload["projected_additional_cost_usd"] = pricing.get("estimated_cost_usd")
+        payload["input_tokens"] = pricing.get("input_tokens")
+        payload["output_tokens"] = pricing.get("output_tokens")
+    return payload
+
+
+def _raise_cost_limit_exceeded(
+    cfg: RunnerConfig,
+    *,
+    phase: str,
+    step_id: str,
+    partition_id: str,
+    provider: str,
+    model_id: str,
+    execution_mode: str,
+    breach_stage: str,
+    pricing: Optional[Dict[str, Any]] = None,
+    message_prefix: str,
+) -> None:
+    abort_state = _build_cost_abort_state(
+        cfg,
+        phase=phase,
+        step_id=step_id,
+        partition_id=partition_id,
+        provider=provider,
+        model_id=model_id,
+        execution_mode=execution_mode,
+        breach_stage=breach_stage,
+        pricing=pricing,
+    )
+    raise CostLimitExceededError(
+        (
+            f"{message_prefix} "
+            f"(phase={phase} step={step_id} partition={partition_id} mode={execution_mode} "
+            f"provider={provider} model={model_id} total_usd={abort_state['total_cost_usd']:.4f} "
+            f"limit={abort_state['limit_usd']})"
+        ),
+        abort_state,
+    )
+
+
+def _persist_cost_abort(
+    *,
+    root: Path,
+    dirs: Dict[str, Path],
+    run_id: str,
+    phases: Iterable[str],
+    run_started_at: str,
+    exc: CostLimitExceededError,
+    ui: Optional["UI"] = None,
+    source: str = "cost_abort",
+) -> Dict[str, Any]:
+    cost_abort = {
+        **dict(exc.details),
+        "generated_at": now_iso(),
+        "run_id": run_id,
+        "run_started_at": run_started_at,
+        "active_phases": sorted({str(phase).upper() for phase in phases if str(phase).strip()}),
+    }
+    cost_abort_path = dirs["root"] / COST_ABORT_FILENAME
+    write_json(cost_abort_path, cost_abort)
+
+    manifest_path = dirs["root"] / "RUN_MANIFEST.json"
+    manifest = _load_json_object(manifest_path)
+    manifest["run_status"] = "COST_ABORTED"
+    manifest["phase_status"] = "cost_aborted"
+    manifest["blocked_reason"] = COST_ABORT_REASON
+    manifest["blocked_phase"] = cost_abort.get("phase")
+    manifest["resume_allowed"] = False
+    manifest["cost_abort"] = cost_abort
+    manifest["updated_at"] = now_iso()
+    write_json(manifest_path, manifest)
+
+    coverage_path = dirs["root"] / COVERAGE_ROLLUP_FILENAME
+    coverage = _load_json_object(coverage_path)
+    coverage["generated_at"] = now_iso()
+    coverage["run_id"] = run_id
+    coverage["run_status"] = "COST_ABORTED"
+    coverage["blocked_reason"] = COST_ABORT_REASON
+    coverage["resume_allowed"] = False
+    coverage["cost_abort"] = cost_abort
+    write_json(coverage_path, coverage)
+
+    resume_path = dirs["root"] / RESUME_PROOF_FILENAME
+    resume = _load_json_object(resume_path)
+    resume["generated_at"] = now_iso()
+    resume["run_id"] = run_id
+    resume["resume_status"] = "blocked"
+    resume["blocked_reason"] = COST_ABORT_REASON
+    resume["resume_allowed"] = False
+    resume["cost_abort"] = cost_abort
+    write_json(resume_path, resume)
+
+    proof_path = dirs["root"] / PROOF_PACK_FILENAME
+    proof = _load_json_object(proof_path)
+    linked_artifacts = (
+        dict(proof.get("linked_artifacts"))
+        if isinstance(proof.get("linked_artifacts"), dict)
+        else {}
+    )
+    linked_artifacts["cost_abort"] = str(cost_abort_path.resolve())
+    proof["run_id"] = run_id
+    proof["git_sha"] = proof.get("git_sha") or get_git_sha(root)
+    proof["runner_sha256"] = proof.get("runner_sha256") or sha256_text(RUNNER_SCRIPT)
+    proof["argv"] = proof.get("argv") or sys.argv
+    proof["python_version"] = proof.get("python_version") or platform.python_version()
+    proof["cwd"] = proof.get("cwd") or str(root.resolve())
+    proof["started_at"] = proof.get("started_at") or run_started_at
+    proof["finished_at"] = now_iso()
+    proof["updated_at"] = now_iso()
+    proof["run_status"] = "COST_ABORTED"
+    proof["blocked_reason"] = COST_ABORT_REASON
+    proof["resume_allowed"] = False
+    proof["cost_abort"] = cost_abort
+    proof["linked_artifacts"] = linked_artifacts
+    write_json(proof_path, proof)
+
+    dashboard_payload = phase_status_snapshot(run_id, dirs, PHASES)
+    dashboard_payload["run_status"] = "COST_ABORTED"
+    dashboard_payload["blocked_reason"] = COST_ABORT_REASON
+    dashboard_payload["resume_allowed"] = False
+    dashboard_payload["cost_abort"] = cost_abort
+    write_run_dashboard_snapshot(dirs["root"], dashboard_payload, source=source)
+    if ui is not None:
+        ui.run_dashboard_snapshot(dashboard_payload, source=source)
+    return cost_abort
 
 
 def _check_projected_cost_limit(
@@ -7547,6 +7766,7 @@ def _check_projected_cost_limit(
     input_tokens: int,
     output_tokens: int,
     execution_mode: str,
+    route: Optional[str] = None,
 ) -> None:
     pricing = _pricing_preview(
         cfg,
@@ -7554,16 +7774,23 @@ def _check_projected_cost_limit(
         model_id=model_id,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
+        route=route,
     )
     if pricing is None:
         return
     if cfg.ledger.check_limit(pricing["estimated_cost_usd"]):
         return
-    raise RuntimeError(
-        "Projected cost cap exceeded before provider call "
-        f"(phase={phase} step={step_id} partition={partition_id} mode={execution_mode} "
-        f"provider={provider} model={model_id} add_usd={pricing['estimated_cost_usd']:.4f} "
-        f"limit={cfg.max_cost_usd})"
+    _raise_cost_limit_exceeded(
+        cfg,
+        phase=phase,
+        step_id=step_id,
+        partition_id=partition_id,
+        provider=provider,
+        model_id=model_id,
+        execution_mode=execution_mode,
+        breach_stage="pre_model_execution",
+        pricing=pricing,
+        message_prefix="Projected cost cap exceeded before provider call",
     )
 
 
@@ -7613,6 +7840,8 @@ def _accumulate_runtime_spend(
     fallback_input_tokens: int = 0,
     fallback_output_tokens: Optional[int] = None,
     payload: Optional[Dict[str, Any]] = None,
+    route: Optional[str] = None,
+    raise_on_limit: bool = True,
 ) -> Optional[Dict[str, Any]]:
     if not cfg.ledger:
         return None
@@ -7629,6 +7858,7 @@ def _accumulate_runtime_spend(
         int(usage["output_tokens"]),
         provider=provider,
         model_id=model_id,
+        route=route,
     )
     combined = {
         **usage,
@@ -7636,11 +7866,97 @@ def _accumulate_runtime_spend(
         "execution_mode": execution_mode,
     }
     if not cfg.ledger.check_limit():
-        raise RuntimeError(
-            "Runtime cost cap exceeded after provider response "
-            f"(phase={phase} step={step_id} partition={partition_id} mode={execution_mode} "
-            f"provider={provider} model={model_id} total_usd={cfg.ledger.record.total_cost_usd:.4f} "
-            f"limit={cfg.max_cost_usd})"
+        cost_abort_state = _build_cost_abort_state(
+            cfg,
+            phase=phase,
+            step_id=step_id,
+            partition_id=partition_id,
+            provider=provider,
+            model_id=model_id,
+            execution_mode=execution_mode,
+            breach_stage="post_model_output",
+            pricing=pricing,
+        )
+        combined["cost_limit_exceeded"] = True
+        combined["cost_abort_state"] = cost_abort_state
+        if raise_on_limit:
+            raise CostLimitExceededError(
+                (
+                    "Runtime cost cap exceeded after provider response "
+                    f"(phase={phase} step={step_id} partition={partition_id} mode={execution_mode} "
+                    f"provider={provider} model={model_id} total_usd={cost_abort_state['total_cost_usd']:.4f} "
+                    f"limit={cost_abort_state['limit_usd']})"
+                ),
+                cost_abort_state,
+            )
+    else:
+        combined["cost_limit_exceeded"] = False
+    return combined
+
+
+def _reserve_projected_spend(
+    cfg: RunnerConfig,
+    *,
+    phase: str,
+    step_id: str,
+    partition_id: str,
+    provider: str,
+    model_id: str,
+    input_tokens: int,
+    output_tokens: int,
+    execution_mode: str,
+    route: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    if not cfg.ledger:
+        return None
+    _check_projected_cost_limit(
+        cfg,
+        phase=phase,
+        step_id=step_id,
+        partition_id=partition_id,
+        provider=provider,
+        model_id=model_id,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        execution_mode=execution_mode,
+        route=route,
+    )
+    reserved = cfg.ledger.accumulate(
+        phase,
+        input_tokens,
+        output_tokens,
+        provider=provider,
+        model_id=model_id,
+        route=route,
+    )
+    combined = {
+        **reserved,
+        "execution_mode": execution_mode,
+        "accounting_mode": "reserved_at_submit",
+        "cost_limit_exceeded": False,
+    }
+    if not cfg.ledger.check_limit():
+        cost_abort_state = _build_cost_abort_state(
+            cfg,
+            phase=phase,
+            step_id=step_id,
+            partition_id=partition_id,
+            provider=provider,
+            model_id=model_id,
+            execution_mode=execution_mode,
+            breach_stage="post_model_output",
+            pricing=reserved,
+        )
+        combined["cost_limit_exceeded"] = True
+        combined["cost_abort_state"] = cost_abort_state
+        raise CostLimitExceededError(
+            (
+                "Projected cost reservation exceeded limit after provider submit "
+                f"(phase={phase} step={step_id} partition={partition_id} mode={execution_mode} "
+                f"provider={provider} model={model_id} total_usd={cost_abort_state['total_cost_usd']:.4f} "
+                f"limit={cost_abort_state['limit_usd']})"
+            ),
+            cost_abort_state,
         )
     return combined
 
@@ -8561,6 +8877,21 @@ def run_gemini_auth_probe(
     probe_path = raw_dir / f"AUTH_PROBE__gemini__{step_id}.json"
     system_prompt = "Return exactly OK."
     user_content = "Return the single token OK."
+    route_token = f"{provider}/{model_id}"
+    projected_input_tokens = _estimate_text_tokens(system_prompt, user_content)
+    projected_output_tokens = _project_output_tokens(projected_input_tokens)
+    _check_projected_cost_limit(
+        cfg,
+        phase=phase,
+        step_id=step_id,
+        partition_id="AUTH_PROBE",
+        provider=provider,
+        model_id=model_id,
+        input_tokens=projected_input_tokens,
+        output_tokens=projected_output_tokens,
+        execution_mode="auth_probe",
+        route=route_token,
+    )
     result = call_llm(
         provider=provider,
         model_id=model_id,
@@ -8578,6 +8909,25 @@ def run_gemini_auth_probe(
         provider=provider,
         model_id=model_id,
     )
+    if meta.get("response_received") or result.get("ok"):
+        meta["spend_usage"] = _accumulate_runtime_spend(
+            cfg,
+            phase=phase,
+            step_id=step_id,
+            partition_id="AUTH_PROBE",
+            provider=provider,
+            model_id=model_id,
+            execution_mode="auth_probe",
+            response_summary=(
+                meta.get("response_summary")
+                if isinstance(meta.get("response_summary"), dict)
+                else None
+            ),
+            response_text=str(result.get("text") or ""),
+            fallback_input_tokens=projected_input_tokens,
+            fallback_output_tokens=projected_output_tokens,
+            route=route_token,
+        )
     payload = {
         "run_id": run_id,
         "phase": phase,
@@ -8677,6 +9027,23 @@ def run_auth_doctor(root: Path, args: argparse.Namespace, cfg: RunnerConfig) -> 
             if transport == "openai_compat_http"
             else sdk_auth_present_flags(provider, bool(api_key))
         )
+        route_token = f"{provider}/{model_id}"
+        projected_input_tokens = _estimate_text_tokens(
+            "Return exactly OK.", "Return the single token OK."
+        )
+        projected_output_tokens = _project_output_tokens(projected_input_tokens)
+        _check_projected_cost_limit(
+            probe_cfg,
+            phase="AUTH",
+            step_id="AUTH_DOCTOR",
+            partition_id=f"{provider}:{mode}",
+            provider=provider,
+            model_id=model_id,
+            input_tokens=projected_input_tokens,
+            output_tokens=projected_output_tokens,
+            execution_mode="auth_doctor",
+            route=route_token,
+        )
         result = call_llm(
             provider=provider,
             model_id=model_id,
@@ -8686,6 +9053,25 @@ def run_auth_doctor(root: Path, args: argparse.Namespace, cfg: RunnerConfig) -> 
             cfg=probe_cfg,
         )
         meta = result.get("meta", {})
+        if meta.get("response_received") or result.get("ok"):
+            meta["spend_usage"] = _accumulate_runtime_spend(
+                probe_cfg,
+                phase="AUTH",
+                step_id="AUTH_DOCTOR",
+                partition_id=f"{provider}:{mode}",
+                provider=provider,
+                model_id=model_id,
+                execution_mode="auth_doctor",
+                response_summary=(
+                    meta.get("response_summary")
+                    if isinstance(meta.get("response_summary"), dict)
+                    else None
+                ),
+                response_text=str(result.get("text") or ""),
+                fallback_input_tokens=projected_input_tokens,
+                fallback_output_tokens=projected_output_tokens,
+                route=route_token,
+            )
         failure_type = meta.get("failure_type")
         checks.append(
             {
@@ -10174,7 +10560,7 @@ def run_comparison_lane(
 
     Reuses the same prompt_text and partition inputs as the canonical lane.
     Stores results under raw/comparison/{provider}__{model}/.
-    Never raises — failures are captured in result dicts.
+    Raises CostLimitExceededError when the comparison lane breaches the active run cap.
 
     Returns:
         List of per-partition result dicts with keys:
@@ -10231,17 +10617,37 @@ def run_comparison_lane(
         try:
             context_text, _ctx_meta = build_partition_context_fn(
                 phase=phase,
-                step_id=step_id,
-                partition=partition,
+                partition_paths=list(partition.get("paths") or []),
+                file_truncate_chars=cfg.file_truncate_chars,
+                home_scan_mode=cfg.home_scan_mode,
+                max_files=max_files_for_phase(phase, cfg),
+                max_chars=cfg.max_chars,
+                router=cfg.router,
             )
-            full_prompt = f"{prompt_text}\n\n{context_text}"
+            route_token = f"{compare_provider}/{compare_model}"
+            projected_input_tokens = _estimate_text_tokens(prompt_text, context_text)
+            projected_output_tokens = _project_output_tokens(projected_input_tokens)
+            _check_projected_cost_limit(
+                cfg,
+                phase=phase,
+                step_id=step_id,
+                partition_id=partition_id,
+                provider=compare_provider,
+                model_id=compare_model,
+                input_tokens=projected_input_tokens,
+                output_tokens=projected_output_tokens,
+                execution_mode="comparison",
+                route=route_token,
+            )
             started = time.time()
             llm_result = call_llm_fn(
                 provider=compare_provider,
                 model_id=compare_model,
-                api_key=None,
-                prompt=full_prompt,
-                partition_id=partition_id,
+                api_key_env=PROVIDER_API_KEY_ENV.get(compare_provider, ""),
+                system_prompt=prompt_text,
+                user_content=context_text,
+                cfg=cfg,
+                force_json_output=True,
             )
             elapsed_ms = int((time.time() - started) * 1000)
 
@@ -10259,7 +10665,6 @@ def run_comparison_lane(
                     parsed, raw_text, output_artifacts
                 )
             )
-
             request_meta = {
                 "lane": "comparison",
                 "authoritative": False,
@@ -10271,6 +10676,29 @@ def run_comparison_lane(
                 "repair_invocations": 0,
                 "repair_successes": 0,
             }
+            if llm_meta.get("response_received") or llm_result.get("ok"):
+                spend_record = _accumulate_runtime_spend(
+                    cfg,
+                    phase=phase,
+                    step_id=step_id,
+                    partition_id=partition_id,
+                    provider=compare_provider,
+                    model_id=compare_model,
+                    execution_mode="comparison",
+                    response_summary=(
+                        llm_meta.get("response_summary")
+                        if isinstance(llm_meta.get("response_summary"), dict)
+                        else None
+                    ),
+                    response_text=raw_text,
+                    fallback_input_tokens=projected_input_tokens,
+                    fallback_output_tokens=projected_output_tokens,
+                    route=route_token,
+                    raise_on_limit=False,
+                )
+                if spend_record is not None:
+                    request_meta["spend_usage"] = spend_record
+
             payload = {
                 "phase": phase,
                 "step_id": step_id,
@@ -10282,6 +10710,16 @@ def run_comparison_lane(
                 json.dumps(payload, indent=2, sort_keys=True, default=str),
                 encoding="utf-8",
             )
+            if isinstance(request_meta.get("spend_usage"), dict) and isinstance(
+                request_meta["spend_usage"].get("cost_abort_state"), dict
+            ):
+                raise CostLimitExceededError(
+                    (
+                        "Runtime cost cap exceeded during comparison lane "
+                        f"(phase={phase} step={step_id} partition={partition_id})"
+                    ),
+                    request_meta["spend_usage"]["cost_abort_state"],
+                )
             logger.info(
                 "COMPARE_EXEC_DONE phase=%s step=%s partition=%s provider=%s model=%s elapsed_ms=%s",
                 phase, step_id, partition_id, compare_provider, compare_model, elapsed_ms,
@@ -10298,6 +10736,8 @@ def run_comparison_lane(
                 "artifacts": artifacts,
                 "failure_reason": None,
             })
+        except CostLimitExceededError:
+            raise
         except Exception as exc:
             failure_reason = str(exc)
             logger.warning(
@@ -10608,7 +11048,14 @@ def execute_step_for_partitions(
     batch_job_rows: List[Dict[str, Any]] = []
     batch_result_rows: List[Dict[str, Any]] = []
     started_at = time.time()
-    workers = max(1, min(16, int(cfg.partition_workers)))
+    requested_workers = max(1, min(16, int(cfg.partition_workers)))
+    workers = requested_workers
+    if cfg.max_cost_usd is not None and not cfg.dry_run and requested_workers > 1:
+        logger.warning(
+            "Cost cap active; clamping partition_workers from %s to 1 for deterministic stop-on-breach.",
+            requested_workers,
+        )
+        workers = 1
     ui_completed = 0
     ui_ok = 0
     ui_failed = 0
@@ -11501,6 +11948,23 @@ def execute_step_for_partitions(
                 if ui is not None
                 else None
             )
+            strict_route = f"{strict_provider}/{strict_model_id}"
+            projected_input_tokens = _estimate_text_tokens(
+                prompt_text, strict_user_content
+            )
+            projected_output_tokens = _project_output_tokens(projected_input_tokens)
+            _check_projected_cost_limit(
+                cfg,
+                phase=phase,
+                step_id=step_id,
+                partition_id=partition_id,
+                provider=strict_provider,
+                model_id=strict_model_id,
+                input_tokens=projected_input_tokens,
+                output_tokens=projected_output_tokens,
+                execution_mode=f"strict_{stage}",
+                route=strict_route,
+            )
             result = call_llm(
                 provider=strict_provider,
                 model_id=strict_model_id,
@@ -11532,6 +11996,46 @@ def execute_step_for_partitions(
                 provider=strict_provider,
                 model_id=strict_model_id,
             )
+            if request_meta_local.get("response_received") or result.get("ok"):
+                spend_record = _accumulate_runtime_spend(
+                    cfg,
+                    phase=phase,
+                    step_id=step_id,
+                    partition_id=partition_id,
+                    provider=strict_provider,
+                    model_id=strict_model_id,
+                    execution_mode=f"strict_{stage}",
+                    response_summary=(
+                        request_meta_local.get("response_summary")
+                        if isinstance(request_meta_local.get("response_summary"), dict)
+                        else None
+                    ),
+                    response_text=response_text_local,
+                    fallback_input_tokens=projected_input_tokens,
+                    fallback_output_tokens=projected_output_tokens,
+                    route=strict_route,
+                    raise_on_limit=False,
+                )
+                if spend_record is not None:
+                    request_meta_local["spend_usage"] = spend_record
+                    if "cost_abort_state" in spend_record:
+                        request_meta_local["cost_abort_state"] = spend_record["cost_abort_state"]
+                    if ui is not None:
+                        strict_trace = strict_trace_context or ui.make_trace_context(
+                            phase=phase,
+                            step_id=step_id,
+                            partition_id=partition_id,
+                        )
+                        ui.spend_ledger_event(
+                            phase=phase,
+                            step_id=step_id,
+                            partition_id=partition_id,
+                            trace_id=str(strict_trace.get("trace_id") or _new_trace_id()),
+                            span_id=_new_span_id(),
+                            parent_span_id=str(strict_trace.get("span_id") or "") or None,
+                            prompt_tokens=int(spend_record.get("input_tokens", 0) or 0),
+                            completion_tokens=int(spend_record.get("output_tokens", 0) or 0),
+                        )
             route_transport = transport_for_provider(strict_provider, cfg)
             strict_attestations = [
                 {
@@ -12023,32 +12527,39 @@ def execute_step_for_partitions(
                             input_tokens=projected_input_tokens,
                             output_tokens=projected_output_tokens,
                             execution_mode="batch_submit",
+                            route=f"{batch_provider}/{batch_model_id}",
                         )
                         batch_job_id = batch_client.submit(
                             batch_requests, BatchRoute(*selected_route), step_context
                         )
-
-                        if cfg.ledger:
-                            # Estimate tokens for batch requests
-                            in_toks = sum(len(req.user_content) // 4 for req in batch_requests)
-                            out_toks = 1000  # Arbitrary estimate for batch output
-                            cfg.ledger.accumulate(phase, in_toks, out_toks)
-                            if ui is not None:
-                                batch_trace = ui.make_trace_context(
-                                    phase=phase,
-                                    step_id=step_id,
-                                    partition_id=partition_id,
-                                )
-                                ui.spend_ledger_event(
-                                    phase=phase,
-                                    step_id=step_id,
-                                    partition_id=partition_id,
-                                    trace_id=batch_trace["trace_id"],
-                                    span_id=_new_span_id(),
-                                    parent_span_id=batch_trace.get("span_id"),
-                                    prompt_tokens=in_toks,
-                                    completion_tokens=out_toks,
-                                )
+                        reserved_spend = _reserve_projected_spend(
+                            cfg,
+                            phase=phase,
+                            step_id=step_id,
+                            partition_id=partition_id,
+                            provider=batch_provider,
+                            model_id=batch_model_id,
+                            input_tokens=projected_input_tokens,
+                            output_tokens=projected_output_tokens,
+                            execution_mode="batch_submit",
+                            route=f"{batch_provider}/{batch_model_id}",
+                        )
+                        if reserved_spend is not None and ui is not None:
+                            batch_trace = ui.make_trace_context(
+                                phase=phase,
+                                step_id=step_id,
+                                partition_id=partition_id,
+                            )
+                            ui.spend_ledger_event(
+                                phase=phase,
+                                step_id=step_id,
+                                partition_id=partition_id,
+                                trace_id=batch_trace["trace_id"],
+                                span_id=_new_span_id(),
+                                parent_span_id=batch_trace.get("span_id"),
+                                prompt_tokens=int(reserved_spend.get("input_tokens", 0) or 0),
+                                completion_tokens=int(reserved_spend.get("output_tokens", 0) or 0),
+                            )
 
                         job_row = {
                             "run_id": run_id,
@@ -12063,8 +12574,17 @@ def execute_step_for_partitions(
                             "submitted_at_utc": now_iso(),
                             "estimated_input_tokens": projected_input_tokens,
                             "estimated_output_tokens": projected_output_tokens,
+                            "cost_accounted_at_submit": bool(reserved_spend is not None),
+                            "cost_accounting_mode": (
+                                str(reserved_spend.get("accounting_mode"))
+                                if isinstance(reserved_spend, dict)
+                                else None
+                            ),
+                            "reserved_spend_usage": reserved_spend,
                         }
                         batch_job_rows.append(job_row)
+                    except CostLimitExceededError:
+                        raise
                     except Exception as exc:
                         failed_meta = {
                             "provider": batch_provider,
@@ -12114,6 +12634,9 @@ def execute_step_for_partitions(
                             "batch_pending": True,
                             "estimated_input_tokens": projected_input_tokens,
                             "estimated_output_tokens": projected_output_tokens,
+                            "reserved_spend_usage": (
+                                reserved_spend if "reserved_spend" in locals() else None
+                            ),
                         }
                         return json.dumps(
                             submit_payload, ensure_ascii=True, sort_keys=True
@@ -12268,7 +12791,20 @@ def execute_step_for_partitions(
                         partition_id=partition_id,
                         provider=batch_provider,
                         model_id=batch_model_id,
-                    )
+                )
+                route_token = f"{route_provider}/{route_model_id}"
+                _check_projected_cost_limit(
+                    cfg,
+                    phase=phase,
+                    step_id=step_id,
+                    partition_id=partition_id,
+                    provider=route_provider,
+                    model_id=route_model_id,
+                    input_tokens=projected_input_tokens,
+                    output_tokens=projected_output_tokens,
+                    execution_mode="sync",
+                    route=route_token,
+                )
                 llm_result = call_llm(
                     provider=route_provider,
                     model_id=route_model_id,
@@ -12347,9 +12883,25 @@ def execute_step_for_partitions(
                         fallback_input_tokens=_estimate_text_tokens(
                             prompt_text, effective_user_prompt
                         ),
+                        fallback_output_tokens=projected_output_tokens,
+                        route=route_token,
+                        raise_on_limit=False,
                 )
                     if spend_record is not None:
                         request_meta_local["spend_usage"] = spend_record
+                        if "cost_abort_state" in spend_record:
+                            request_meta_local["cost_abort_state"] = spend_record["cost_abort_state"]
+                        if ui is not None:
+                            ui.spend_ledger_event(
+                                phase=phase,
+                                step_id=step_id,
+                                partition_id=partition_id,
+                                trace_id=str(request_meta_local.get("trace_id") or _new_trace_id()),
+                                span_id=_new_span_id(),
+                                parent_span_id=str(request_meta_local.get("span_id") or "") or None,
+                                prompt_tokens=int(spend_record.get("input_tokens", 0) or 0),
+                                completion_tokens=int(spend_record.get("output_tokens", 0) or 0),
+                            )
                 request_meta_local.setdefault("request_payload_bytes", payload_bytes)
                 request_meta_local.setdefault(
                     "estimated_input_tokens", projected_input_tokens
@@ -12357,29 +12909,6 @@ def execute_step_for_partitions(
                 request_meta_local.setdefault(
                     "estimated_output_tokens", projected_output_tokens
                 )
-                if cfg.ledger:
-                    prompt_toks = int(
-                        request_meta_local.get("prompt_tokens")
-                        or request_meta_local.get("tokens_prompt")
-                        or ((len(effective_user_prompt) + len(prompt_text)) // 4)
-                    )
-                    completion_toks = int(
-                        request_meta_local.get("completion_tokens")
-                        or request_meta_local.get("tokens_completion")
-                        or (len(response_text_local) // 4)
-                    )
-                    cfg.ledger.accumulate(phase, prompt_toks, completion_toks)
-                    if ui is not None:
-                        ui.spend_ledger_event(
-                            phase=phase,
-                            step_id=step_id,
-                            partition_id=partition_id,
-                            trace_id=str(request_meta_local.get("trace_id") or _new_trace_id()),
-                            span_id=_new_span_id(),
-                            parent_span_id=str(request_meta_local.get("span_id") or "") or None,
-                            prompt_tokens=prompt_toks,
-                            completion_tokens=completion_toks,
-                        )
                 return response_text_local, request_meta_local
 
             parse_retry_attempted = False
@@ -13108,6 +13637,19 @@ def execute_step_for_partitions(
                 logger.error("%s", message)
             else:
                 logger.info("%s", message)
+        cost_abort_state = (
+            result.request_meta.get("cost_abort_state")
+            if isinstance(result.request_meta.get("cost_abort_state"), dict)
+            else None
+        )
+        if cost_abort_state is not None:
+            raise CostLimitExceededError(
+                (
+                    "Runtime cost cap exceeded after provider response "
+                    f"(phase={phase} step={step_id} partition={partition_id})"
+                ),
+                cost_abort_state,
+            )
 
         if result.success:
             valid_success, _validation_reason = validate_success_partition_output(
@@ -13341,6 +13883,8 @@ def execute_step_for_partitions(
                 compare_provider=str(getattr(cfg, "compare_provider", None) or "xai"),
                 compare_model=str(getattr(cfg, "compare_model", None) or "grok-4.20-beta"),
             )
+        except CostLimitExceededError:
+            raise
         except Exception as _cmp_exc:
             logger.warning(
                 "COMPARE_LANE_ERROR phase=%s step=%s error=%s (canonical result unaffected)",
@@ -15729,6 +16273,24 @@ def audit_phase_sample(
         artifact_repr = json.dumps(item, default=str)[:4000]
         user_content = f"Extraction artifact to audit:\n```json\n{artifact_repr}\n```"
         try:
+            phase_id = str(phase_dir.name or "").split("_", 1)[0].upper() or "UNKNOWN"
+            route_token = f"{judge_provider}/{judge_model}"
+            projected_input_tokens = _estimate_text_tokens(
+                _AUDIT_JUDGE_SYSTEM_PROMPT, user_content
+            )
+            projected_output_tokens = _project_output_tokens(projected_input_tokens)
+            _check_projected_cost_limit(
+                cfg,
+                phase=phase_id,
+                step_id="AUDIT",
+                partition_id=str(item.get("step_id", item.get("id", "unknown"))),
+                provider=judge_provider,
+                model_id=judge_model,
+                input_tokens=projected_input_tokens,
+                output_tokens=projected_output_tokens,
+                execution_mode="audit_judge",
+                route=route_token,
+            )
             llm_result = call_llm(
                 provider=judge_provider,
                 model_id=judge_model,
@@ -15738,6 +16300,25 @@ def audit_phase_sample(
                 cfg=cfg,
                 force_json_output=True,
             )
+            if llm_result.get("meta", {}).get("response_received") or llm_result.get("ok"):
+                _accumulate_runtime_spend(
+                    cfg,
+                    phase=phase_id,
+                    step_id="AUDIT",
+                    partition_id=str(item.get("step_id", item.get("id", "unknown"))),
+                    provider=judge_provider,
+                    model_id=judge_model,
+                    execution_mode="audit_judge",
+                    response_summary=(
+                        llm_result.get("meta", {}).get("response_summary")
+                        if isinstance(llm_result.get("meta", {}).get("response_summary"), dict)
+                        else None
+                    ),
+                    response_text=str(llm_result.get("content", llm_result.get("text", ""))),
+                    fallback_input_tokens=projected_input_tokens,
+                    fallback_output_tokens=projected_output_tokens,
+                    route=route_token,
+                )
             raw_text = llm_result.get("content", llm_result.get("text", "{}"))
             try:
                 scores = json.loads(raw_text) if isinstance(raw_text, str) else raw_text
@@ -15776,6 +16357,8 @@ def audit_phase_sample(
                     completeness_score,
                     composite,
                 )
+        except CostLimitExceededError:
+            raise
         except Exception as exc:
             logger.warning("audit_phase_sample: judge call failed for item: %s", exc)
             results.append({"item_id": "unknown", "error": str(exc)})
@@ -16176,36 +16759,83 @@ def run_batch_watch(
                         model_id=model_id,
                         salvage_meta=salvage_meta,
                     )
-                    spend_record = _accumulate_runtime_spend(
-                        cfg,
-                        phase=phase_id,
-                        step_id=step_id,
-                        partition_id=partition_id,
-                        provider=provider_id,
-                        model_id=model_id,
-                        execution_mode="batch_watch",
-                        response_summary=(
-                            request_meta.get("response_summary")
-                            if isinstance(request_meta.get("response_summary"), dict)
-                            else None
-                        ),
-                        response_text=response_text,
-                        fallback_input_tokens=int(
-                            row.get("estimated_input_tokens", 0) or 0
-                        ),
-                        fallback_output_tokens=int(
-                            row.get("estimated_output_tokens", 0) or 0
-                        ),
-                        payload=(
-                            result.meta.get("response", {}).get("body", {}).get("usage")
-                            if isinstance(result.meta, dict)
-                            and isinstance(result.meta.get("response"), dict)
-                            and isinstance(result.meta.get("response", {}).get("body"), dict)
-                            else None
-                        ),
-                    )
-                    if spend_record is not None:
-                        request_meta["spend_usage"] = spend_record
+                    route_token = f"{provider_id}/{model_id}"
+                    if bool(row.get("cost_accounted_at_submit", False)):
+                        request_meta["cost_accounted_at_submit"] = True
+                        request_meta["cost_accounting_mode"] = row.get("cost_accounting_mode")
+                        request_meta["reserved_spend_usage"] = row.get("reserved_spend_usage")
+                        request_meta["observed_spend_usage"] = _resolve_runtime_usage(
+                            response_summary=(
+                                request_meta.get("response_summary")
+                                if isinstance(request_meta.get("response_summary"), dict)
+                                else None
+                            ),
+                            response_text=response_text,
+                            fallback_input_tokens=int(
+                                row.get("estimated_input_tokens", 0) or 0
+                            ),
+                            fallback_output_tokens=int(
+                                row.get("estimated_output_tokens", 0) or 0
+                            ),
+                            payload=(
+                                result.meta.get("response", {}).get("body", {}).get("usage")
+                                if isinstance(result.meta, dict)
+                                and isinstance(result.meta.get("response"), dict)
+                                and isinstance(result.meta.get("response", {}).get("body"), dict)
+                                else None
+                            ),
+                        )
+                    else:
+                        spend_record = _accumulate_runtime_spend(
+                            cfg,
+                            phase=phase_id,
+                            step_id=step_id,
+                            partition_id=partition_id,
+                            provider=provider_id,
+                            model_id=model_id,
+                            execution_mode="batch_watch",
+                            response_summary=(
+                                request_meta.get("response_summary")
+                                if isinstance(request_meta.get("response_summary"), dict)
+                                else None
+                            ),
+                            response_text=response_text,
+                            fallback_input_tokens=int(
+                                row.get("estimated_input_tokens", 0) or 0
+                            ),
+                            fallback_output_tokens=int(
+                                row.get("estimated_output_tokens", 0) or 0
+                            ),
+                            payload=(
+                                result.meta.get("response", {}).get("body", {}).get("usage")
+                                if isinstance(result.meta, dict)
+                                and isinstance(result.meta.get("response"), dict)
+                                and isinstance(result.meta.get("response", {}).get("body"), dict)
+                                else None
+                            ),
+                            route=route_token,
+                            raise_on_limit=False,
+                        )
+                        if spend_record is not None:
+                            request_meta["spend_usage"] = spend_record
+                            if "cost_abort_state" in spend_record:
+                                request_meta["cost_abort_state"] = spend_record["cost_abort_state"]
+                            if ui is not None:
+                                batch_trace = ui.make_trace_context(
+                                    phase=phase_id,
+                                    step_id=step_id,
+                                    partition_id=partition_id,
+                                )
+                                ui.spend_ledger_event(
+                                    phase=phase_id,
+                                    step_id=step_id,
+                                    partition_id=partition_id,
+                                    trace_id=batch_trace["trace_id"],
+                                    span_id=_new_span_id(),
+                                    parent_span_id=batch_trace.get("span_id"),
+                                    prompt_tokens=int(spend_record.get("input_tokens", 0) or 0),
+                                    completion_tokens=int(spend_record.get("output_tokens", 0) or 0),
+                                )
                     write_json(
                         out_json,
                         {
@@ -16217,6 +16847,14 @@ def run_batch_watch(
                             "request_meta": request_meta,
                         },
                     )
+                    if isinstance(request_meta.get("cost_abort_state"), dict):
+                        raise CostLimitExceededError(
+                            (
+                                "Runtime cost cap exceeded during batch watch "
+                                f"(phase={phase_id} step={step_id} partition={partition_id})"
+                            ),
+                            request_meta["cost_abort_state"],
+                        )
                     if out_failed.exists():
                         out_failed.unlink()
                     if out_failed_json.exists():
@@ -16903,6 +17541,7 @@ def run_phase_R_async_submit(
                     input_tokens=projected_input_tokens,
                     output_tokens=projected_output_tokens,
                     execution_mode="async_submit",
+                    route=f"openai/{model_id}",
                 )
                 response = client.responses.create(
                     model=model_id,
@@ -16917,6 +17556,20 @@ def run_phase_R_async_submit(
                     partition_id,
                     external_job_id,
                 )
+                reserved_spend = _reserve_projected_spend(
+                    cfg,
+                    phase="R",
+                    step_id=step_id,
+                    partition_id=partition_id,
+                    provider="openai",
+                    model_id=model_id,
+                    input_tokens=projected_input_tokens,
+                    output_tokens=projected_output_tokens,
+                    execution_mode="async_submit",
+                    route=f"openai/{model_id}",
+                )
+            except CostLimitExceededError:
+                raise
             except Exception as exc:
                 logger.error(
                     "Async R submit failed step=%s partition=%s error=%s",
@@ -16990,6 +17643,13 @@ def run_phase_R_async_submit(
                         "external_job_id": external_job_id,
                         "estimated_input_tokens": projected_input_tokens,
                         "estimated_output_tokens": projected_output_tokens,
+                        "cost_accounted_at_submit": bool(reserved_spend is not None),
+                        "cost_accounting_mode": (
+                            str(reserved_spend.get("accounting_mode"))
+                            if isinstance(reserved_spend, dict)
+                            else None
+                        ),
+                        "reserved_spend_usage": reserved_spend,
                     },
                 },
             )
@@ -17204,31 +17864,64 @@ def run_phase_R_finalize(
                 model_id=model_id,
                 salvage_meta=salvage_meta,
             )
-            spend_record = _accumulate_runtime_spend(
-                cfg,
-                phase="R",
-                step_id=step_id,
-                partition_id=partition_id,
-                provider="openai",
-                model_id=model_id,
-                execution_mode="async_finalize",
-                response_text=response_text,
-                fallback_input_tokens=int(
-                    pending_meta.get("estimated_input_tokens", 0) or 0
-                ),
-                fallback_output_tokens=int(
-                    pending_meta.get("estimated_output_tokens", 0) or 0
-                ),
-                payload=(
-                    webhook_payload.get("data", {}).get("usage")
-                    if isinstance(webhook_payload.get("data"), dict)
-                    else None
-                ),
-            )
-            if spend_record is not None:
-                request_meta["spend_usage"] = spend_record
+            if bool(pending_meta.get("cost_accounted_at_submit", False)):
+                request_meta["cost_accounted_at_submit"] = True
+                request_meta["cost_accounting_mode"] = pending_meta.get("cost_accounting_mode")
+                request_meta["reserved_spend_usage"] = pending_meta.get("reserved_spend_usage")
+                request_meta["observed_spend_usage"] = _resolve_runtime_usage(
+                    response_text=response_text,
+                    fallback_input_tokens=int(
+                        pending_meta.get("estimated_input_tokens", 0) or 0
+                    ),
+                    fallback_output_tokens=int(
+                        pending_meta.get("estimated_output_tokens", 0) or 0
+                    ),
+                    payload=(
+                        webhook_payload.get("data", {}).get("usage")
+                        if isinstance(webhook_payload.get("data"), dict)
+                        else None
+                    ),
+                )
+            else:
+                spend_record = _accumulate_runtime_spend(
+                    cfg,
+                    phase="R",
+                    step_id=step_id,
+                    partition_id=partition_id,
+                    provider="openai",
+                    model_id=model_id,
+                    execution_mode="async_finalize",
+                    response_text=response_text,
+                    fallback_input_tokens=int(
+                        pending_meta.get("estimated_input_tokens", 0) or 0
+                    ),
+                    fallback_output_tokens=int(
+                        pending_meta.get("estimated_output_tokens", 0) or 0
+                    ),
+                    payload=(
+                        webhook_payload.get("data", {}).get("usage")
+                        if isinstance(webhook_payload.get("data"), dict)
+                        else None
+                    ),
+                    route=f"openai/{model_id}",
+                    raise_on_limit=False,
+                )
+                if spend_record is not None:
+                    request_meta["spend_usage"] = spend_record
+                    if "cost_abort_state" in spend_record:
+                        request_meta["cost_abort_state"] = spend_record["cost_abort_state"]
             persisted["request_meta"] = request_meta
             write_json(out_json, persisted)
+            if isinstance(request_meta.get("cost_abort_state"), dict):
+                raise CostLimitExceededError(
+                    (
+                        "Runtime cost cap exceeded during async finalize "
+                        f"(step={step_id} partition={partition_id})"
+                    ),
+                    request_meta["cost_abort_state"],
+                )
+        except CostLimitExceededError:
+            raise
         except Exception:
             pass
 
@@ -17914,6 +18607,15 @@ def main() -> None:
     if args.sync:
         run_sync_scopes()
     args.partition_workers = max(1, min(16, int(args.partition_workers)))
+    if (
+        getattr(args, "max_cost_usd", None) is not None
+        and not args.dry_run
+        and args.partition_workers > 1
+    ):
+        logger.warning(
+            "Cost cap active; forcing --partition-workers=1 for deterministic stop-on-breach."
+        )
+        args.partition_workers = 1
     if args.pretty and args.ui == "auto":
         args.ui = "rich"
     args.escalation_max_hops = max(0, int(args.escalation_max_hops))
@@ -18124,6 +18826,25 @@ def main() -> None:
 
             def _execute_attempt(route, _hop_index):  # type: ignore[no-untyped-def]
                 provider, model_id, api_key_env = route
+                route_token = f"{provider}/{model_id}"
+                projected_input_tokens = _estimate_text_tokens(
+                    "Return JSON only.", rendered_prompt
+                )
+                projected_output_tokens = _project_output_tokens(
+                    projected_input_tokens
+                )
+                _check_projected_cost_limit(
+                    cfg,
+                    phase=step.phase,
+                    step_id=step.step_id,
+                    partition_id=step.step_id,
+                    provider=provider,
+                    model_id=model_id,
+                    input_tokens=projected_input_tokens,
+                    output_tokens=projected_output_tokens,
+                    execution_mode="s_int_sync",
+                    route=route_token,
+                )
 
                 result = call_llm(
                     provider=provider,
@@ -18154,6 +18875,8 @@ def main() -> None:
                         fallback_input_tokens=_estimate_text_tokens(
                             "Return JSON only.", rendered_prompt
                         ),
+                        fallback_output_tokens=projected_output_tokens,
+                        route=route_token,
                     )
                     if spend_record is not None:
                         meta["spend_usage"] = spend_record
@@ -18227,6 +18950,9 @@ def main() -> None:
                 dry_run=bool(args.dry_run),
                 prompt_executor=None if args.dry_run else _prompt_executor,
             )
+        except CostLimitExceededError as exc:
+            logger.error("S_INT cost cap exceeded: %s", exc)
+            sys.exit(1)
         except Exception as exc:
             logger.error("S_INT failed: %s", exc)
             sys.exit(1)
@@ -18600,6 +19326,19 @@ def main() -> None:
             n = run_phase_R_async_submit(run_id=run_id, dirs=dirs, cfg=cfg)
             logger.info("Async R submit complete: submitted=%s run_id=%s", n, run_id)
             sys.exit(0)
+        except CostLimitExceededError as exc:
+            logger.error("Async R submit cost-aborted: %s", exc)
+            _persist_cost_abort(
+                root=root,
+                dirs=dirs,
+                run_id=run_id,
+                phases=phase_sequence or ["R"],
+                run_started_at=run_started_at,
+                exc=exc,
+                ui=ui,
+                source="async_submit:cost_abort",
+            )
+            sys.exit(1)
         except Exception as exc:
             logger.error("Async R submit failed: %s", exc)
             sys.exit(1)
@@ -18609,6 +19348,19 @@ def main() -> None:
             n = run_phase_R_finalize(run_id=run_id, dirs=dirs, cfg=cfg)
             logger.info("Finalize R complete: finalized=%s run_id=%s", n, run_id)
             sys.exit(0)
+        except CostLimitExceededError as exc:
+            logger.error("Finalize R cost-aborted: %s", exc)
+            _persist_cost_abort(
+                root=root,
+                dirs=dirs,
+                run_id=run_id,
+                phases=phase_sequence or ["R"],
+                run_started_at=run_started_at,
+                exc=exc,
+                ui=ui,
+                source="async_finalize:cost_abort",
+            )
+            sys.exit(1)
         except Exception as exc:
             logger.error("Finalize R failed: %s", exc)
             sys.exit(1)
@@ -18617,14 +19369,28 @@ def main() -> None:
         if not phase_sequence or len(phase_sequence) != 1:
             parser.error("--batch-watch requires exactly one phase via --phase.")
         watch_phase = phase_sequence[0]
-        watch_result = run_batch_watch(
-            root=root,
-            run_id=run_id,
-            phase=watch_phase,
-            dirs=dirs,
-            cfg=cfg,
-            ui=ui,
-        )
+        try:
+            watch_result = run_batch_watch(
+                root=root,
+                run_id=run_id,
+                phase=watch_phase,
+                dirs=dirs,
+                cfg=cfg,
+                ui=ui,
+            )
+        except CostLimitExceededError as exc:
+            logger.error("Batch watch cost-aborted: %s", exc)
+            _persist_cost_abort(
+                root=root,
+                dirs=dirs,
+                run_id=run_id,
+                phases=phase_sequence or [watch_phase],
+                run_started_at=run_started_at,
+                exc=exc,
+                ui=ui,
+                source="batch_watch:cost_abort",
+            )
+            sys.exit(1)
         if watch_result.exit_code != 0:
             sys.exit(watch_result.exit_code)
         if watch_result.next_phase:
@@ -18729,6 +19495,19 @@ def main() -> None:
         try:
             phase_cfg = prepare_phase_provider_preflight(root, run_id, phase, cfg)
             run_phase(dirs, phase_cfg, ui=ui)
+        except CostLimitExceededError as exc:
+            logger.error("Phase %s cost-aborted: %s", phase, exc)
+            _persist_cost_abort(
+                root=root,
+                dirs=dirs,
+                run_id=run_id,
+                phases=phases,
+                run_started_at=run_started_at,
+                exc=exc,
+                ui=ui,
+                source=f"phase:{phase}:cost_abort",
+            )
+            sys.exit(1)
         except Exception as exc:
             logger.error("Phase %s failed: %s", phase, exc)
             failed_counts = gather_phase_counts(dirs[phase])

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -7594,6 +7594,7 @@ def _build_cost_abort_state(
     breach_stage: str,
     pricing: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
+    recovery_rule = "If a run enters `COST_ABORTED`, resume is not allowed. Start a new run."
     ledger_record = getattr(cfg, "ledger", None)
     spend_record = getattr(ledger_record, "record", None)
     payload = {
@@ -7621,6 +7622,7 @@ def _build_cost_abort_state(
         else 0,
         "partial_outputs_retained": True,
         "resume_allowed": False,
+        "cost_abort_recovery_rule": recovery_rule,
     }
     if isinstance(pricing, dict):
         payload["pricing_key"] = pricing.get("pricing_key")

--- a/services/repo-truth-extractor/tests/test_spend_ledger.py
+++ b/services/repo-truth-extractor/tests/test_spend_ledger.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _runner_script() -> Path:
+    return _repo_root() / "services" / "repo-truth-extractor" / "run_extraction_v5.py"
+
+
+def _load_runner_module() -> types.ModuleType:
+    module_path = _runner_script()
+    spec = importlib.util.spec_from_file_location("run_extraction_v5_spend_tests", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_spend_ledger_module() -> types.ModuleType:
+    module_path = _repo_root() / "services" / "repo-truth-extractor" / "lib" / "spend_ledger.py"
+    spec = importlib.util.spec_from_file_location("spend_ledger_spend_tests", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_cfg(runner: types.ModuleType):
+    cfg = runner.RunnerConfig.__new__(runner.RunnerConfig)
+    defaults = {
+        "dry_run": False,
+        "max_files_docs": 10,
+        "max_files_code": 10,
+        "max_chars": 50000,
+        "max_request_bytes": 100000,
+        "file_truncate_chars": 10000,
+        "home_scan_mode": "safe",
+        "resume": False,
+        "fail_fast_auth": False,
+        "gemini_auth_mode": "auto",
+        "gemini_transport": "sdk",
+        "openai_transport": "openai_sdk",
+        "xai_transport": "openai_sdk",
+        "retry_policy": "none",
+        "retry_max_attempts": 1,
+        "retry_base_seconds": 0.0,
+        "retry_max_seconds": 0.0,
+        "phase_auth_fail_threshold": 5,
+        "partition_workers": 1,
+        "debug_phase_inputs": False,
+        "fail_fast_missing_inputs": False,
+        "executor": "thread",
+        "routing_policy": "cost",
+        "disable_escalation": False,
+        "escalation_max_hops": 2,
+        "batch_mode": False,
+        "batch_provider": "auto",
+        "batch_poll_seconds": 1,
+        "batch_wait_timeout_seconds": 60,
+        "batch_max_requests_per_job": 2000,
+        "batch_submit_only": False,
+        "webhook_url": "",
+        "webhook_secret": "",
+        "webhook_timeout_seconds": 5,
+        "webhook_required": False,
+        "webhook_auto_continue": False,
+        "live_ok": False,
+        "selected_s_steps": None,
+        "selected_execution_step": None,
+        "d0_max_files": None,
+        "d1_max_files": None,
+        "provider_denylist": (),
+        "compare_mode": None,
+        "compare_model": None,
+        "compare_provider": None,
+        "compare_steps": None,
+        "prescan_dir": None,
+        "router": None,
+        "max_cost_usd": None,
+        "ledger": None,
+        "fl_int_provider_timeout_seconds": 180,
+        "fl_int_f0_batch_timeout_seconds": 210,
+    }
+    for key, value in defaults.items():
+        object.__setattr__(cfg, key, value)
+    return cfg
+
+
+def test_model_cost_rate_exact_and_fuzzy_match() -> None:
+    spend_ledger = _load_spend_ledger_module()
+
+    exact = spend_ledger.get_model_cost_rate(
+        provider="openrouter",
+        model_id="openai/gpt-5-mini",
+    )
+    fuzzy = spend_ledger.get_model_cost_rate(model_id="gpt-5-mini", route="openai/gpt-5-mini")
+
+    assert exact["pricing_key"] == "openrouter/openai/gpt-5-mini"
+    assert exact["match_type"] == "exact"
+    assert fuzzy["pricing_key"] in {
+        "openai/gpt-5-mini",
+        "gpt-5-mini",
+    }
+    assert fuzzy["match_type"] in {"exact", "fuzzy"}
+    assert fuzzy["unknown_model"] is False
+
+
+def test_unknown_fallback_increments_legacy_and_new_counters(tmp_path: Path) -> None:
+    spend_ledger = _load_spend_ledger_module()
+    ledger = spend_ledger.SpendLedger(tmp_path, "fallback_run")
+
+    priced = ledger.accumulate(
+        "A",
+        1000,
+        500,
+        provider="mystery",
+        model_id="weird-model",
+        route="mystery/weird-model",
+    )
+
+    assert priced["unknown_model"] is True
+    assert ledger.record.fallback_usage_count == 1
+    assert ledger.record.unknown_model_events == 1
+
+
+def test_persistence_round_trip_preserves_model_provider_and_fallback_counts(
+    tmp_path: Path,
+) -> None:
+    spend_ledger = _load_spend_ledger_module()
+    ledger = spend_ledger.SpendLedger(tmp_path, "round_trip", max_cost_usd=3.5)
+    ledger.accumulate(
+        "R",
+        1200,
+        600,
+        provider="openrouter",
+        model_id="openai/gpt-5-mini",
+    )
+    ledger.accumulate(
+        "R",
+        300,
+        200,
+        provider="mystery",
+        model_id="weird-model",
+    )
+
+    reloaded = spend_ledger.SpendLedger(tmp_path, "round_trip")
+
+    assert reloaded.record.total_cost_usd == pytest.approx(ledger.record.total_cost_usd)
+    assert "openrouter/openai/gpt-5-mini" in reloaded.record.models
+    assert "openrouter" in reloaded.record.providers
+    assert reloaded.record.fallback_usage_count == 1
+    assert reloaded.record.unknown_model_events == 1
+
+
+def test_retries_and_escalations_count_as_additional_model_usage(tmp_path: Path) -> None:
+    spend_ledger = _load_spend_ledger_module()
+    ledger = spend_ledger.SpendLedger(tmp_path, "retry_counts")
+
+    ledger.accumulate(
+        "Q",
+        100,
+        50,
+        provider="openai",
+        model_id="gpt-5-mini",
+        route="openai/gpt-5-mini",
+    )
+    ledger.accumulate(
+        "Q",
+        100,
+        50,
+        provider="openai",
+        model_id="gpt-5-mini",
+        route="openai/gpt-5-mini",
+    )
+
+    model_row = ledger.record.models["openai/gpt-5-mini"]
+    provider_row = ledger.record.providers["openai"]
+    phase_row = ledger.record.phases["Q"]
+
+    assert model_row.usage_count == 2
+    assert provider_row.usage_count == 2
+    assert phase_row.models["openai/gpt-5-mini"].usage_count == 2
+
+
+def test_batch_watch_cost_breach_stops_after_first_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_runner_module()
+    spend_ledger = _load_spend_ledger_module()
+    cfg = _make_cfg(runner)
+    ledger = spend_ledger.SpendLedger(tmp_path, "batch_watch_breach", max_cost_usd=0.00001)
+    object.__setattr__(cfg, "ledger", ledger)
+    object.__setattr__(cfg, "max_cost_usd", 0.00001)
+
+    phase_dir = tmp_path / "A_repo_control_plane"
+    batch_dir = phase_dir / "batch"
+    raw_dir = phase_dir / "raw"
+    batch_dir.mkdir(parents=True, exist_ok=True)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    prompt_path = tmp_path / "PROMPT_A1.md"
+    prompt_path.write_text("Return OUT.json", encoding="utf-8")
+    (phase_dir / "inputs").mkdir(parents=True, exist_ok=True)
+
+    write_payload = {
+        "run_id": "batch_watch_breach",
+        "phase_id": "A",
+        "jobs": [
+            {
+                "run_id": "batch_watch_breach",
+                "phase_id": "A",
+                "step_id": "A1",
+                "partition_id": "A_P0001",
+                "provider_id": "openai",
+                "model_id": "gpt-5-mini",
+                "api_key_env": "OPENAI_API_KEY",
+                "job_id": "job-1",
+                "state": "submitted",
+                "estimated_input_tokens": 100,
+                "estimated_output_tokens": 100000,
+            },
+            {
+                "run_id": "batch_watch_breach",
+                "phase_id": "A",
+                "step_id": "A1",
+                "partition_id": "A_P0002",
+                "provider_id": "openai",
+                "model_id": "gpt-5-mini",
+                "api_key_env": "OPENAI_API_KEY",
+                "job_id": "job-2",
+                "state": "submitted",
+                "estimated_input_tokens": 10,
+                "estimated_output_tokens": 10,
+            },
+        ],
+    }
+    (batch_dir / "BATCH_JOB_INDEX.json").write_text(
+        json.dumps(write_payload), encoding="utf-8"
+    )
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(
+        runner,
+        "get_phase_prompts",
+        lambda phase: [
+            runner.PromptSpec(
+                step_id="A1",
+                prompt_path=prompt_path,
+                output_artifacts=("OUT.json",),
+            )
+        ],
+    )
+
+    class FakeBatchClient:
+        def __init__(self) -> None:
+            self.polled: list[str] = []
+            self.fetched: list[str] = []
+
+        def poll(self, job_id: str) -> str:
+            self.polled.append(job_id)
+            return "completed"
+
+        def fetch_results(self, job_id: str):
+            self.fetched.append(job_id)
+            if job_id == "job-1":
+                return [
+                    runner.BatchResult(
+                        custom_id="A_P0001",
+                        output_text=json.dumps(
+                            {
+                                "artifacts": [
+                                    {
+                                        "artifact_name": "OUT.json",
+                                        "payload": {"schema": "itemlist@v1", "items": []},
+                                    }
+                                ]
+                            }
+                        ),
+                        meta={
+                            "response": {
+                                "body": {
+                                    "usage": {
+                                        "prompt_tokens": 100,
+                                        "completion_tokens": 100000,
+                                    }
+                                }
+                            }
+                        },
+                    )
+                ]
+            return [
+                runner.BatchResult(
+                    custom_id="A_P0002",
+                    output_text=json.dumps(
+                        {
+                            "artifacts": [
+                                {
+                                    "artifact_name": "OUT.json",
+                                    "payload": {"schema": "itemlist@v1", "items": []},
+                                }
+                            ]
+                        }
+                    ),
+                )
+            ]
+
+        def cancel(self, job_id: str) -> None:
+            return None
+
+    fake_client = FakeBatchClient()
+    monkeypatch.setattr(runner, "build_batch_client", lambda provider, api_key, cfg: fake_client)
+
+    with pytest.raises(runner.CostLimitExceededError):
+        runner.run_batch_watch(
+            root=tmp_path,
+            run_id="batch_watch_breach",
+            phase="A",
+            dirs={"root": tmp_path, "A": phase_dir},
+            cfg=cfg,
+            ui=None,
+        )
+
+    assert (raw_dir / "A1__A_P0001.json").exists()
+    assert not (raw_dir / "A1__A_P0002.json").exists()
+    assert fake_client.fetched == ["job-1"]

--- a/services/repo-truth-extractor/tests/test_spend_ledger.py
+++ b/services/repo-truth-extractor/tests/test_spend_ledger.py
@@ -196,7 +196,7 @@ def test_retries_and_escalations_count_as_additional_model_usage(tmp_path: Path)
     assert phase_row.models["openai/gpt-5-mini"].usage_count == 2
 
 
-def test_batch_watch_cost_breach_stops_after_first_result(
+def test_forced_breach_blocks_all_later_batch_watch_calls(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -269,13 +269,18 @@ def test_batch_watch_cost_breach_stops_after_first_result(
         def __init__(self) -> None:
             self.polled: list[str] = []
             self.fetched: list[str] = []
+            self.post_breach_call_count = 0
 
         def poll(self, job_id: str) -> str:
             self.polled.append(job_id)
+            if job_id != "job-1":
+                self.post_breach_call_count += 1
             return "completed"
 
         def fetch_results(self, job_id: str):
             self.fetched.append(job_id)
+            if job_id != "job-1":
+                self.post_breach_call_count += 1
             if job_id == "job-1":
                 return [
                     runner.BatchResult(
@@ -336,4 +341,6 @@ def test_batch_watch_cost_breach_stops_after_first_result(
 
     assert (raw_dir / "A1__A_P0001.json").exists()
     assert not (raw_dir / "A1__A_P0002.json").exists()
+    assert fake_client.polled == ["job-1"]
     assert fake_client.fetched == ["job-1"]
+    assert fake_client.post_breach_call_count == 0


### PR DESCRIPTION
## Summary
- make spend tracking model-aware and provider-aware with conservative unknown-model fallback accounting
- enforce `--max-cost-usd` across verified billable runtime paths with deterministic cost-abort persistence
- add spend-ledger and breach-stop coverage plus operator docs and proof bundle

## Implementation
- upgraded `services/repo-truth-extractor/lib/spend_ledger.py`
- instrumented billable paths in `services/repo-truth-extractor/run_extraction_v5.py`
- added `services/repo-truth-extractor/tests/test_spend_ledger.py`
- updated README and billing verification runbook
- added `proof/repo-truth-extractor/TP-CODEX-RTE-PRELIVE-001/`

## Validation
- `pytest services/repo-truth-extractor/tests/ -v`
  - `505 passed`
- `pytest -k "spend or cost or breach" -v`
  - `6 passed, 5 skipped, 2063 deselected`
- `python services/repo-truth-extractor/extraction_hygiene.py scan`
  - pass with `warnings=1 errors=0`
- `python scripts/repo_truth_extractor_promptset_audit_v4.py`
  - pass
- `python services/repo-truth-extractor/validate_pre_live_gate_v25.py`
  - `NO_GO` due environment/readiness blockers: missing `XAI_API_KEY`, PAL validation unavailable, online preflight skipped

## Notes
- stacked on PR 384 head branch `codex/rte-v5-prelive-stack-pr-20260402`
- left generated `reports/repo-truth-extractor/` output out of git
- proof bundle verdict is `LOCAL_PASS_WITH_ENVIRONMENT_NO_GO`
