### PR TITLE
[codex] add explicit routing repair and refresh startup banner

### DIFF
--- a/docs/04-explanation/branding/brand-resource-pack.md
+++ b/docs/04-explanation/branding/brand-resource-pack.md
@@ -121,6 +121,47 @@ Run `python scripts/sync_brand_tokens.py` to verify all platforms match theme.py
 
 ### CLI Components (`src/dopemux/ui/theme.py`)
 
+### Startup Banner (`src/dopemux/ui/splash.py`)
+
+The Dopemux startup banner is a boxed operator-facing mark with a restrained drip accent. It must read as deterministic and legible first, styled second.
+
+**Palette mapping**
+
+| Element | Color |
+|---------|-------|
+| Frame | cyan |
+| Logo gradient | cyan → blue-cyan → violet |
+| `deterministic core` tag | magenta |
+| `memory mesh` tag | violet |
+| `operator` tag | cyan |
+
+**Canonical plain banner**
+
+```text
+╔══════════════════════════════════════════════════════════════════════════════╗
+║                                                                              ║
+║   ██████╗  ██████╗ ██████╗ ███████╗███╗   ███╗██╗   ██╗██╗  ██╗             ║
+║   ██╔══██╗██╔═══██╗██╔══██╗██╔════╝████╗ ████║██║   ██║╚██╗██╔╝             ║
+║   ██║  ██║██║   ██║██████╔╝█████╗  ██╔████╔██║██║   ██║ ╚███╔╝              ║
+║   ██║  ██║██║   ██║██╔═══╝ ██╔══╝  ██║╚██╔╝██║██║   ██║ ██╔██╗              ║
+║   ██████╔╝╚██████╔╝██║     ███████╗██║ ╚═╝ ██║╚██████╔╝██╔╝ ██╗             ║
+║   ╚═════╝  ╚═════╝ ╚═╝     ╚══════╝╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═╝             ║
+║        ║             ║                                ║                     ║
+║        '             '                                '                     ║
+║                                                                              ║
+║         [ deterministic core ]   [ memory mesh ]   [ operator ]            ║
+║                                                                              ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+```
+
+**Usage rules**
+
+- Render Rich hex colors only outside `PLAIN` mode.
+- Preserve the exact frame width and line order.
+- Keep the drip effect to the two minimal interior lines; do not add extra distortion.
+- Do not emit raw ANSI escape sequences from the Python startup path; use Rich styling.
+- If operators need shell-native export examples, store those in docs, not inline in runtime code.
+
 #### `styled_table(title, *columns, compact=False, **kw)`
 
 Branded Rich Table. All CLI table output must use this.

--- a/docs/04-explanation/branding/cli-branding.md
+++ b/docs/04-explanation/branding/cli-branding.md
@@ -30,11 +30,24 @@ This document explains how the Ritual Daemon voice surfaces inside `dopemux` CLI
 
 The console helper automatically handles color tags, so you can pass `message` as a preformatted string (e.g., `[dim]Hint[/dim]`) and it will still emit the chip in front.
 
-## 3. Printing without chips
+## 3. Startup Banner
+
+Startup branding is owned by [splash.py](/Users/hue/code/dopemux-mvp/src/dopemux/ui/splash.py).
+
+- The startup banner is a framed mark, not a scrolling gimmick.
+- Rich mode uses cyan-to-violet logo coloring plus magenta/violet/cyan lane tags.
+- Plain mode must print the same framed banner text with no ANSI escapes.
+- The drip accent is limited to the two short interior lines under the logo.
+- Startup copy that follows the banner should reinforce the same hierarchy:
+  - deterministic core
+  - memory mesh
+  - operator
+
+## 4. Printing without chips
 
 If a command needs to print a table, raw Markdown, or other layout-sensitive block, simply call `console.print(..., brand_chip="")`. This bypasses auto-tagging while leaving `RitualConsole` available for other adjacent lines.
 
-## 4. Future contribution tips
+## 5. Future contribution tips
 
 1. Start with `brand_status(...)` whenever you want a chip; add new chip constants to the brand system if needed.
 1. Avoid sprinkling literal `console.print("[color]...")` lines unless you're printing multiline tables or help text that relies on precise spacing.

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -4472,7 +4472,10 @@ def resolve_effective_step_route(
                 f"JSON-managed step {phase}:{step_id} missing primary_routes in model_map.yaml."
             )
         if strict_required:
-            strict_ladder: List[Tuple[str, str, str]] = []
+            # For strict-required stages, we deliberately track only provider and model_id in
+            # strict_ladder to avoid persisting authentication-related environment identifiers
+            # (such as api_key_env names) in any logged or serialized strict-route metadata.
+            strict_ladder: List[Tuple[str, str]] = []
             strict_attempts: List[Dict[str, Any]] = []
             for route in primary_routes:
                 selected_route, attempts = resolve_stage_route(
@@ -4491,7 +4494,6 @@ def resolve_effective_step_route(
                         (
                             str(selected_route["provider"]),
                             str(selected_route["model_id"]),
-                            str(selected_route["api_key_env"]),
                         )
                     )
             if not strict_ladder:
@@ -4502,7 +4504,7 @@ def resolve_effective_step_route(
                     "Strict-required stage has no strict-capable route before token spend: "
                     f"{phase}:{step_id} attempts={attempt_json}"
                 )
-            provider, model_id, api_key_env = strict_ladder[0]
+            provider, model_id = strict_ladder[0]
             logger.info(
                 "STRICT_ROUTE_CHOSEN phase=%s step=%s provider=%s model=%s",
                 phase,
@@ -4516,7 +4518,9 @@ def resolve_effective_step_route(
                 "ladder": strict_ladder,
                 "provider": provider,
                 "model_id": model_id,
-                "api_key_env": api_key_env,
+                # Intentionally omit api_key_env from the returned strict metadata; callers
+                # that need the environment-variable name should derive it from the original
+                # contract routes rather than from strict_ladder.
                 "reason": "contract_lane_primary_strict",
                 "contract_lane": resolve_contract_lane(contract),
                 "strict_required": True,

--- a/src/dopemux/routing_cli.py
+++ b/src/dopemux/routing_cli.py
@@ -5,6 +5,7 @@ import logging
 from pathlib import Path
 
 from dopemux.launchd_services import LaunchdServiceManager
+from dopemux.routing_config import RoutingConfigError
 
 logger = logging.getLogger(__name__)
 
@@ -266,6 +267,97 @@ def config():
         
     except Exception as e:
         logger.error(f"Failed to load routing config: {e}")
+        click.echo(f"❌ Error: {e}", err=True)
+        raise
+
+
+@routing.command()
+def doctor():
+    """Audit repo-owned routing alias contract drift in routing.yaml."""
+    try:
+        manager = LaunchdServiceManager.get_instance()
+        audit = manager.routing_config.audit_alias_contract()
+
+        click.echo("🩺 Routing Alias Contract Doctor")
+        click.echo("=" * 50)
+        click.echo(f"Config:   {audit['config_path']}")
+        click.echo(f"Template: {audit['template_path']}")
+
+        if not audit["stale"]:
+            click.echo("\n✅ Alias contract matches the repo-owned template.")
+            return
+
+        click.echo("\n❌ Stale routing alias contract detected.")
+
+        missing = audit["missing_aliases"]
+        if missing:
+            click.echo("\nMissing aliases:")
+            for alias, target in missing.items():
+                click.echo(f"  - {alias}: expected {target}")
+
+        mismatched = audit["mismatched_aliases"]
+        if mismatched:
+            click.echo("\nMismatched aliases:")
+            for alias, values in mismatched.items():
+                click.echo(
+                    f"  - {alias}: expected {values['expected']}, found {values['actual']}"
+                )
+
+        click.echo("\nNext steps:")
+        click.echo("  • Preview repair: dopemux routing repair-aliases")
+        click.echo("  • Apply repair: dopemux routing repair-aliases --apply")
+        click.echo("  • Inspect config: dopemux routing config")
+        raise SystemExit(1)
+    except RoutingConfigError as e:
+        click.echo(f"❌ Error: {e}", err=True)
+        raise SystemExit(2)
+    except Exception as e:
+        logger.error(f"Failed to audit routing alias contract: {e}")
+        click.echo(f"❌ Error: {e}", err=True)
+        raise
+
+
+@routing.command("repair-aliases")
+@click.option(
+    "--apply",
+    is_flag=True,
+    help="Write the repo-owned alias contract into ~/.dopemux/routing.yaml.",
+)
+def repair_aliases(apply: bool):
+    """Preview or repair stale repo-owned alias mappings explicitly."""
+    try:
+        manager = LaunchdServiceManager.get_instance()
+        audit = manager.routing_config.audit_alias_contract()
+
+        click.echo("🔧 Routing Alias Contract Repair")
+        click.echo("=" * 50)
+
+        if not audit["stale"]:
+            click.echo("✅ No alias repair needed.")
+            return
+
+        click.echo("Planned alias updates:")
+        for alias, target in audit["missing_aliases"].items():
+            click.echo(f"  - add {alias}: {target}")
+        for alias, values in audit["mismatched_aliases"].items():
+            click.echo(
+                f"  - set {alias}: {values['actual']} -> {values['expected']}"
+            )
+
+        if not apply:
+            click.echo("\nDry run only. No files changed.")
+            click.echo("Run `dopemux routing repair-aliases --apply` to write the repair.")
+            return
+
+        result = manager.routing_config.repair_alias_contract()
+        click.echo("\n✅ Alias contract repaired.")
+        click.echo(f"Backup: {result['backup_path']}")
+        click.echo(f"Updated: {manager.routing_config.config_path}")
+    except RoutingConfigError as e:
+        click.echo(f"❌ Error: {e}", err=True)
+        raise SystemExit(2)
+    except Exception as e:
+        logger.error(f"Failed to repair routing alias contract: {e}")
         click.echo(f"❌ Error: {e}", err=True)
         raise
 

--- a/src/dopemux/routing_config.py
+++ b/src/dopemux/routing_config.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 import logging
 from pathlib import Path
+import shutil
 from typing import Any, Dict, Optional
 
 import yaml
@@ -76,6 +78,115 @@ class RoutingConfig:
             )
         except Exception as e:
             raise RoutingConfigError(f"Failed to copy template: {e}") from e
+
+    def load_template(self) -> Dict[str, Any]:
+        """Load the repo-owned routing template."""
+        if not self.TEMPLATE_PATH.exists():
+            raise RoutingConfigError(
+                f"Routing template not found at {self.TEMPLATE_PATH}"
+            )
+
+        try:
+            with open(self.TEMPLATE_PATH, "r", encoding="utf-8") as f:
+                return yaml.safe_load(f) or {}
+        except yaml.YAMLError as e:
+            raise RoutingConfigError(f"Invalid YAML in routing template: {e}") from e
+        except Exception as e:
+            raise RoutingConfigError(f"Failed to load routing template: {e}") from e
+
+    def audit_alias_contract(
+        self, config: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Compare current alias mappings against the repo-owned template."""
+        current = config if config is not None else self.load()
+        template = self.load_template()
+
+        template_aliases = template.get("aliases", {})
+        current_aliases = current.get("aliases", {})
+
+        if not isinstance(template_aliases, dict):
+            raise RoutingConfigError("Template aliases must be a dictionary")
+        if not isinstance(current_aliases, dict):
+            raise RoutingConfigError("Config aliases must be a dictionary")
+
+        missing = {
+            alias: target
+            for alias, target in template_aliases.items()
+            if alias not in current_aliases
+        }
+        mismatched = {
+            alias: {"expected": target, "actual": current_aliases[alias]}
+            for alias, target in template_aliases.items()
+            if alias in current_aliases and current_aliases[alias] != target
+        }
+
+        return {
+            "config_path": str(self.config_path),
+            "template_path": str(self.TEMPLATE_PATH),
+            "template_aliases": template_aliases,
+            "missing_aliases": missing,
+            "mismatched_aliases": mismatched,
+            "stale": bool(missing or mismatched),
+        }
+
+    def repair_alias_contract(self) -> Dict[str, Any]:
+        """Repair repo-owned alias drift without overwriting unrelated config."""
+        current = self.load()
+        audit = self.audit_alias_contract(current)
+        if not audit["stale"]:
+            return {
+                "changed": False,
+                "backup_path": None,
+                "audit": audit,
+            }
+
+        merged_aliases = dict(current.get("aliases", {}))
+        merged_aliases.update(audit["template_aliases"])
+
+        backup_path = self.config_path.with_name(
+            f"{self.config_path.name}.bak.{datetime.now().strftime('%Y%m%d%H%M%S')}"
+        )
+        shutil.copy2(self.config_path, backup_path)
+
+        self._write_alias_block(merged_aliases)
+        self._loaded = False
+        repaired = self.load()
+
+        return {
+            "changed": True,
+            "backup_path": str(backup_path),
+            "audit": self.audit_alias_contract(repaired),
+        }
+
+    def _write_alias_block(self, aliases: Dict[str, str]) -> None:
+        """Rewrite only the top-level aliases block in routing.yaml."""
+        text = self.config_path.read_text(encoding="utf-8")
+        lines = text.splitlines(keepends=True)
+
+        start = None
+        end = len(lines)
+        for index, line in enumerate(lines):
+            if line.strip() == "aliases:" and line[: len(line) - len(line.lstrip())] == "":
+                start = index
+                break
+
+        if start is None:
+            raise RoutingConfigError("routing.yaml missing top-level aliases section")
+
+        for index in range(start + 1, len(lines)):
+            stripped = lines[index].strip()
+            if not stripped:
+                continue
+            if lines[index][: len(lines[index]) - len(lines[index].lstrip())] == "":
+                end = index
+                break
+
+        alias_lines = ["aliases:\n"]
+        for alias, target in aliases.items():
+            alias_lines.append(f"  {alias}: {target}\n")
+
+        updated = "".join(lines[:start] + alias_lines + lines[end:])
+        self.config_path.write_text(updated, encoding="utf-8")
 
     def validate(self) -> None:
         """Validate the loaded configuration.
@@ -371,4 +482,3 @@ class RoutingConfig:
         if not self._loaded:
             self.load()
         return self.config.get("ports", {})
-

--- a/src/dopemux/ui/splash.py
+++ b/src/dopemux/ui/splash.py
@@ -1,24 +1,138 @@
+"""
+Dopemux boot sequence and startup banner rendering.
+"""
+
+from __future__ import annotations
+
 import time
+
 from rich.live import Live
 from rich.text import Text
-from .theme import Glyphs
 
-def boot_sequence():
-    """Display a cyber-themed boot sequence."""
-    messages = [
-        ("INITIALIZING CORE SENSORS", "READY", "mint"),
-        ("SYNCHRONIZING ATTENTION MAP", "ALIGNED", "info"),
-        ("LOADING WORKTREE ISOLATION", "ENGAGED", "warning"),
-        ("PRIMING RITUAL CHAMBER", "STABLE", "violet"),
+from .theme import Glyphs, RenderMode, get_render_mode
+
+DOPEMUX_STARTUP_BANNER = """\
+╔══════════════════════════════════════════════════════════════════════════════╗
+║                                                                              ║
+║   ██████╗  ██████╗ ██████╗ ███████╗███╗   ███╗██╗   ██╗██╗  ██╗             ║
+║   ██╔══██╗██╔═══██╗██╔══██╗██╔════╝████╗ ████║██║   ██║╚██╗██╔╝             ║
+║   ██║  ██║██║   ██║██████╔╝█████╗  ██╔████╔██║██║   ██║ ╚███╔╝              ║
+║   ██║  ██║██║   ██║██╔═══╝ ██╔══╝  ██║╚██╔╝██║██║   ██║ ██╔██╗              ║
+║   ██████╔╝╚██████╔╝██║     ███████╗██║ ╚═╝ ██║╚██████╔╝██╔╝ ██╗             ║
+║   ╚═════╝  ╚═════╝ ╚═╝     ╚══════╝╚═╝     ╚═╝ ╚═════╝ ╚═╝  ╚═╝             ║
+║        ║             ║                                ║                     ║
+║        '             '                                '                     ║
+║                                                                              ║
+║         [ deterministic core ]   [ memory mesh ]   [ operator ]            ║
+║                                                                              ║
+╚══════════════════════════════════════════════════════════════════════════════╝
+"""
+
+
+def _banner_markup() -> str:
+    """Return Rich markup for the branded startup banner."""
+    frame = "#00ffff"
+    logo = [
+        "#00ffff",
+        "#00f0ff",
+        "#00e1ff",
+        "#00d2ff",
+        "#5aaaff",
+        "#8c82ff",
+        "#b478ff",
     ]
-    
-    current_text = Text()
-    current_text.append(f"\n{Glyphs.INFO} [bold]DØPEMÜX CORE SYSTEM IGNITION[/bold]\n", style="heading")
-    
-    with Live(current_text, refresh_per_second=10, transient=True) as live:
+    drip_bar = "#78b4ff"
+    drip_tick = "#b478ff"
+    tag_core = "#ff50dc"
+    tag_mesh = "#b478ff"
+    tag_operator = "#00ffff"
+
+    return "\n".join(
+        [
+            f"[{frame}]╔══════════════════════════════════════════════════════════════════════════════╗[/]",
+            f"[{frame}]║[/]                                                                              [{frame}]║[/]",
+            (
+                f"[{frame}]║   [/]"
+                f"[{logo[0]}]██████╗[/][{logo[1]}]  ██████╗[/][{logo[2]}] ██████╗[/]"
+                f"[{logo[3]}] ███████╗[/][{logo[4]}]███╗   ███╗[/][{logo[5]}]██╗   ██╗[/]"
+                f"[{logo[6]}]██╗  ██╗[/]"
+                f"[{frame}]             ║[/]"
+            ),
+            (
+                f"[{frame}]║   [/]"
+                f"[{logo[0]}]██╔══██╗[/][{logo[1]}]██╔═══██╗[/][{logo[2]}]██╔══██╗[/]"
+                f"[{logo[3]}]██╔════╝[/][{logo[4]}]████╗ ████║[/][{logo[5]}]██║   ██║[/]"
+                f"[{logo[6]}]╚██╗██╔╝[/]"
+                f"[{frame}]             ║[/]"
+            ),
+            (
+                f"[{frame}]║   [/]"
+                f"[{logo[0]}]██║  ██║[/][{logo[1]}]██║   ██║[/][{logo[2]}]██████╔╝[/]"
+                f"[{logo[3]}]█████╗  [/][{logo[4]}]██╔████╔██║[/][{logo[5]}]██║   ██║[/]"
+                f"[{logo[6]}] ╚███╔╝[/]"
+                f"[{frame}]              ║[/]"
+            ),
+            (
+                f"[{frame}]║   [/]"
+                f"[{logo[0]}]██║  ██║[/][{logo[1]}]██║   ██║[/][{logo[2]}]██╔═══╝ [/]"
+                f"[{logo[3]}]██╔══╝  [/][{logo[4]}]██║╚██╔╝██║[/][{logo[5]}]██║   ██║[/]"
+                f"[{logo[6]}] ██╔██╗[/]"
+                f"[{frame}]              ║[/]"
+            ),
+            (
+                f"[{frame}]║   [/]"
+                f"[{logo[0]}]██████╔╝[/][{logo[1]}]╚██████╔╝[/][{logo[2]}]██║     [/]"
+                f"[{logo[3]}]███████╗[/][{logo[4]}]██║ ╚═╝ ██║[/][{logo[5]}]╚██████╔╝[/]"
+                f"[{logo[6]}]██╔╝ ██╗[/]"
+                f"[{frame}]             ║[/]"
+            ),
+            (
+                f"[{frame}]║   [/]"
+                f"[{logo[0]}]╚═════╝ [/][{logo[1]}] ╚═════╝ [/][{logo[2]}]╚═╝     [/]"
+                f"[{logo[3]}]╚══════╝[/][{logo[4]}]╚═╝     ╚═╝[/][{logo[5]}] ╚═════╝ [/]"
+                f"[{logo[6]}]╚═╝  ╚═╝[/]"
+                f"[{frame}]             ║[/]"
+            ),
+            f"[{frame}]║        [/{frame}][{drip_bar}]║[/][{frame}]             [{drip_bar}]║[/][{frame}]                                [{drip_bar}]║[/][{frame}]                     ║[/]",
+            f"[{frame}]║        [/{frame}][{drip_tick}]'[/][{frame}]             [{drip_tick}]'[/][{frame}]                                [{drip_tick}]'[/][{frame}]                     ║[/]",
+            f"[{frame}]║[/]                                                                              [{frame}]║[/]",
+            (
+                f"[{frame}]║         [/]"
+                f"[{tag_core}][ deterministic core ][/]"
+                f"[{frame}]   [/]"
+                f"[{tag_mesh}][ memory mesh ][/]"
+                f"[{frame}]   [/]"
+                f"[{tag_operator}][ operator ][/]"
+                f"[{frame}]            ║[/]"
+            ),
+            f"[{frame}]║[/]                                                                              [{frame}]║[/]",
+            f"[{frame}]╚══════════════════════════════════════════════════════════════════════════════╝[/]",
+        ]
+    )
+
+
+def render_startup_banner(mode: RenderMode | None = None) -> Text:
+    """Render the startup banner for the active render mode."""
+    active_mode = mode or get_render_mode()
+    if active_mode == RenderMode.PLAIN:
+        return Text(DOPEMUX_STARTUP_BANNER.rstrip("\n"))
+    return Text.from_markup(_banner_markup())
+
+
+def boot_sequence() -> None:
+    """Display the startup banner and boot-status sequence."""
+    messages = [
+        ("Initializing flight-deck telemetry...", "OK", "mint"),
+        ("Mounting memory mesh...", "ACTIVE", "violet"),
+        ("Synchronizing deterministic core...", "OK", "magenta"),
+        ("Confirming operator surface...", "READY", "info"),
+    ]
+
+    with Live(Text("", justify="center"), refresh_per_second=15, transient=True) as live:
+        current_text = render_startup_banner()
         live.update(current_text)
         time.sleep(0.4)
-        
+
         for msg, status, color in messages:
             current_text.append("\n")
             current_text.append(f"{Glyphs.SUCCESS} {msg} ", style="text.dim")
@@ -26,9 +140,6 @@ def boot_sequence():
             time.sleep(0.3)
             current_text.append(f"[{status}]", style=f"bold {color}")
             live.update(current_text)
-            time.sleep(0.2)
-            
-        current_text.append("\n\n" + "="*40 + "\n", style="text.dim")
-        current_text.append(f"{Glyphs.RUNNING} [bold]SYSTEM LIVE - RITUAL COMMENCING[/bold]\n", style="mint")
-        live.update(current_text)
-        time.sleep(0.8)
+            time.sleep(0.1)
+
+        time.sleep(0.5)

--- a/templates/routing.yaml
+++ b/templates/routing.yaml
@@ -173,6 +173,7 @@ aliases:
   claude-sonnet-4: sonnet
   claude-haiku: haiku
   claude-opus: opus
+  claude-opus-4-6: opus
   claude-opus-4-1-20250805: opus
   claude-opus-4-20250514: opus
   claude-opus-4: opus

--- a/tests/test_routing_config.py
+++ b/tests/test_routing_config.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+from pathlib import Path
+
+import yaml
+from click.testing import CliRunner
+
+import dopemux.routing_cli as routing_cli
+from dopemux.routing_config import RoutingConfig
+
+
+def _write_yaml(path, data):
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def _make_config(tmp_path, monkeypatch):
+    template_path = tmp_path / "routing-template.yaml"
+    config_path = tmp_path / "routing.yaml"
+
+    template = {
+        "version": 1,
+        "mode": "api",
+        "ports": {"litellm": 4000, "ccr": 4010},
+        "providers": [{"name": "openai", "api_key_env": "OPENAI_API_KEY"}],
+        "models": [{"name": "gpt-5.4-mini", "provider": "openai", "model_id": "openai/gpt-5.4-mini"}],
+        "slots": {"default": "gpt-5.4-mini", "opus": "gpt-5.4-mini"},
+        "fallbacks": {"gpt-5.4-mini": []},
+        "default_fallbacks": ["gpt-5.4-mini"],
+        "aliases": {"grok": "default", "claude-opus-4-6": "opus"},
+    }
+    _write_yaml(template_path, template)
+    monkeypatch.setattr(RoutingConfig, "TEMPLATE_PATH", template_path)
+    return template, config_path
+
+
+def test_audit_alias_contract_reports_missing_and_mismatched_aliases(tmp_path, monkeypatch):
+    template, config_path = _make_config(tmp_path, monkeypatch)
+    current = dict(template)
+    current["aliases"] = {"grok": "opus", "custom": "default"}
+    _write_yaml(config_path, current)
+
+    config = RoutingConfig(config_path=config_path)
+    audit = config.audit_alias_contract()
+
+    assert audit["stale"] is True
+    assert audit["missing_aliases"] == {"claude-opus-4-6": "opus"}
+    assert audit["mismatched_aliases"] == {
+        "grok": {"expected": "default", "actual": "opus"}
+    }
+
+
+def test_repair_alias_contract_updates_template_aliases_only_and_creates_backup(
+    tmp_path, monkeypatch
+):
+    template, config_path = _make_config(tmp_path, monkeypatch)
+    current = dict(template)
+    current["aliases"] = {"grok": "opus", "custom": "default"}
+    _write_yaml(config_path, current)
+
+    config = RoutingConfig(config_path=config_path)
+    result = config.repair_alias_contract()
+    repaired = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert result["changed"] is True
+    assert result["audit"]["stale"] is False
+    assert result["backup_path"] is not None
+    assert Path(result["backup_path"]).exists()
+    assert repaired["aliases"]["grok"] == "default"
+    assert repaired["aliases"]["claude-opus-4-6"] == "opus"
+    assert repaired["aliases"]["custom"] == "default"
+
+
+def test_routing_doctor_reports_stale_alias_contract(tmp_path, monkeypatch):
+    template, config_path = _make_config(tmp_path, monkeypatch)
+    current = dict(template)
+    current["aliases"] = {"grok": "default"}
+    _write_yaml(config_path, current)
+
+    config = RoutingConfig(config_path=config_path)
+    fake_manager = SimpleNamespace(routing_config=config)
+    monkeypatch.setattr(
+        routing_cli.LaunchdServiceManager,
+        "get_instance",
+        staticmethod(lambda: fake_manager),
+    )
+
+    result = CliRunner().invoke(routing_cli.routing, ["doctor"])
+
+    assert result.exit_code == 1
+    assert "Stale routing alias contract detected" in result.output
+    assert "claude-opus-4-6: expected opus" in result.output
+    assert "dopemux routing repair-aliases --apply" in result.output
+
+
+def test_routing_repair_aliases_apply_repairs_file(tmp_path, monkeypatch):
+    template, config_path = _make_config(tmp_path, monkeypatch)
+    current = dict(template)
+    current["aliases"] = {"grok": "opus", "custom": "default"}
+    _write_yaml(config_path, current)
+
+    config = RoutingConfig(config_path=config_path)
+    fake_manager = SimpleNamespace(routing_config=config)
+    monkeypatch.setattr(
+        routing_cli.LaunchdServiceManager,
+        "get_instance",
+        staticmethod(lambda: fake_manager),
+    )
+
+    result = CliRunner().invoke(routing_cli.routing, ["repair-aliases", "--apply"])
+    repaired = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert result.exit_code == 0
+    assert "Alias contract repaired" in result.output
+    assert "Backup:" in result.output
+    assert repaired["aliases"]["grok"] == "default"
+    assert repaired["aliases"]["claude-opus-4-6"] == "opus"
+    assert repaired["aliases"]["custom"] == "default"

--- a/tests/test_ui_splash.py
+++ b/tests/test_ui_splash.py
@@ -1,0 +1,17 @@
+from dopemux.ui.splash import DOPEMUX_STARTUP_BANNER, render_startup_banner
+from dopemux.ui.theme import RenderMode
+
+
+def test_render_startup_banner_plain_mode_emits_plain_banner_text() -> None:
+    banner = render_startup_banner(RenderMode.PLAIN)
+
+    assert banner.plain == DOPEMUX_STARTUP_BANNER.rstrip("\n")
+
+
+def test_render_startup_banner_rich_mode_preserves_banner_text() -> None:
+    banner = render_startup_banner(RenderMode.RICH)
+
+    assert banner.plain == DOPEMUX_STARTUP_BANNER.rstrip("\n")
+    assert "[ deterministic core ]" in banner.plain
+    assert "[ memory mesh ]" in banner.plain
+    assert "[ operator ]" in banner.plain


### PR DESCRIPTION
## What changed

This branch combines two bounded changes:

- adds an explicit, operator-invoked routing alias doctor/repair path for stale `~/.dopemux/routing.yaml` api-mode alias drift
- refreshes the startup banner and branding docs with the new framed startup mark and render-mode-safe startup presentation

## Why

The routing alias contract was fixed in repo-owned code, but operators with stale user-global routing config still needed a safe, explicit repair path. Separately, startup branding needed to move to the new boxed banner style without breaking plain/no-color rendering.

## User and developer impact

- operators can run `dopemux routing doctor` to see exact missing or mismatched aliases
- operators can run `dopemux routing repair-aliases` for a dry run, then `--apply` to merge repo-owned aliases into `~/.dopemux/routing.yaml` with a backup
- startup now renders the new banner in Rich mode and preserves the same text in plain mode
- branding docs now record the canonical startup banner contract and palette mapping

## Root cause

- stale home routing config could drift behind the repo-owned alias contract and there was no explicit config-level doctor/repair path
- startup banner implementation was still using the older mark and did not encode the new branded hierarchy

## Validation

- `pytest -q tests/test_routing_config.py`
- `pytest -q tests/test_ui_splash.py tests/test_routing_config.py`
- `python -m compileall src/dopemux/routing_config.py src/dopemux/routing_cli.py`
- `python -m compileall src/dopemux/ui/splash.py`
- internal PAL codereview completed with no issues found
- internal PAL precommit completed with no blocking issues found

## Notes

- the routing repair path is explicit only; there is no silent mutation on startup
- the repair path rewrites only the top-level `aliases:` block and creates a timestamped backup first
- local branch push succeeded, but local upstream tracking could not be written in this checkout due to `.git/config` lock permissions; this did not affect the remote branch or PR creation