### PR TITLE
fix(dopecon-bridge): normalize workflow ideas empty state

### DIFF
--- a/proof/bridge-workflow-ideas-empty-state-fix.proof.json
+++ b/proof/bridge-workflow-ideas-empty-state-fix.proof.json
@@ -43,7 +43,7 @@
         "slice": 2,
         "status": "completed",
         "result": "Patched bridge ConPortClient.get_custom_data to normalize upstream /api/custom_data 404 into empty-state payload {count: 0, items: []} while preserving non-404 failures as HTTP 502.",
-        "commit_sha": null,
+        "commit_sha": "5d3411340c48d2b298248c969767e15b8b76977b",
         "verification": [
           "services/dopecon-bridge/tests/test_conport_custom_data_client.py",
           "services/dopecon-bridge/tests/test_leantime_route_contract.py",
@@ -66,12 +66,13 @@
       {
         "slice": 4,
         "status": "completed_with_limits",
-        "result": "Completed internal PAL codereview and precommit; proof artifact written. Git branch/worktree finalization steps remain blocked by sandboxed .git writes.",
+        "result": "Completed internal PAL codereview and precommit; proof artifact written; branch pushed and draft PR opened. Worktree cleanup remains pending because the packet is not VERIFIED.",
         "commit_sha": null,
         "verification": [
           "PAL codereview internal run reported 0 issues",
           "PAL precommit internal run reported commit-ready validation",
-          "Final challenge confirmed remaining gap is live integrated rerun, not a code-local defect"
+          "Final challenge confirmed remaining gap is live integrated rerun, not a code-local defect",
+          "Draft PR opened at https://github.com/DDD-Enterprises/dopemux-mvp/pull/409"
         ]
       }
     ],
@@ -107,7 +108,7 @@
       "The packet fix is proven live only at the bridge custom-data boundary in this session; the full task-orchestrator route remains blocked by separate startup drift.",
       "Bridge custom-data reads now treat upstream 404 as empty-state on this endpoint; if the downstream custom-data service later uses 404 for a non-empty-state read failure on the same endpoint, the adapter contract would need tightening."
     ],
-    "pr_url": null,
+    "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/409",
     "merge_readiness": "not_ready_due_to_task_orchestrator_startup_blocking_full_live_rerun",
     "worktree_cleanup_status": "pending_until_git_finalization"
   }

--- a/proof/bridge-workflow-ideas-empty-state-fix.proof.json
+++ b/proof/bridge-workflow-ideas-empty-state-fix.proof.json
@@ -1,0 +1,114 @@
+{
+  "packet": {
+    "name": "bridge-workflow-ideas-empty-state-fix",
+    "title": "Dopecon-Bridge Workflow Ideas Empty-State Contract Fix",
+    "objective": "Fix bridge-backed workflow ideas reads so missing workflow custom-data is treated as empty-state while real downstream failures still surface as failure, without expanding bridge authority."
+  },
+  "commit_plan": {
+    "planned_slices": [
+      {
+        "slice": 1,
+        "objective": "Reproduce and trace the live empty-state failure path"
+      },
+      {
+        "slice": 2,
+        "objective": "Implement the narrowest empty-state normalization fix"
+      },
+      {
+        "slice": 3,
+        "objective": "Rerun live container-path proof"
+      },
+      {
+        "slice": 4,
+        "objective": "Close review, precommit, and proof artifacts"
+      }
+    ],
+    "completed_slices": [
+      {
+        "slice": 1,
+        "status": "completed",
+        "result": "Traced GET /api/workflow/ideas through WorkflowService.list_ideas -> WorkflowStore.get_custom_data -> AsyncDopeconBridgeClient.get_custom_data -> bridge /kg/custom_data -> bridge ConPortClient.get_custom_data. Confirmed task-orchestrator and workflow store only propagate upstream errors.",
+        "commit_sha": null,
+        "verification": [
+          "Inspected services/task-orchestrator/app/main.py",
+          "Inspected services/task-orchestrator/app/services/workflow_service.py",
+          "Inspected services/task-orchestrator/app/services/workflow_store.py",
+          "Inspected services/shared/dopecon_bridge_client/client.py",
+          "Inspected services/dopecon-bridge/dopecon_bridge/routes.py",
+          "Inspected services/dopecon-bridge/dopecon_bridge/clients.py",
+          "Inspected prior live proof in .codex-worktrees/task-orchestrator-container-router-parity/proof/proof.json"
+        ]
+      },
+      {
+        "slice": 2,
+        "status": "completed",
+        "result": "Patched bridge ConPortClient.get_custom_data to normalize upstream /api/custom_data 404 into empty-state payload {count: 0, items: []} while preserving non-404 failures as HTTP 502.",
+        "commit_sha": null,
+        "verification": [
+          "services/dopecon-bridge/tests/test_conport_custom_data_client.py",
+          "services/dopecon-bridge/tests/test_leantime_route_contract.py",
+          "tests/shared/test_dopecon_bridge_client.py",
+          "tests/unit/test_task_orchestrator_workflow_api.py",
+          "tests/unit/test_task_orchestrator_workflow_store.py"
+        ]
+      },
+      {
+        "slice": 3,
+        "status": "completed_with_blocker",
+        "result": "Ran the patched bridge live from this worktree and verified authenticated GET /kg/custom_data returns 200 empty-state for workflow_ideas. Full /api/workflow/ideas parity rerun remained blocked because task-orchestrator app.main on main fails during startup with NameError before the route can serve.",
+        "commit_sha": null,
+        "verification": [
+          "Prior recorded live failure proof from .codex-worktrees/task-orchestrator-container-router-parity/proof/proof.json",
+          "Patched bridge container on localhost:3017 returned 200 with {\"success\":true,\"count\":0,\"data\":[],\"source\":\"conport\"} for authenticated GET /kg/custom_data?category=workflow_ideas",
+          "Task-orchestrator app.main container on localhost:3014 exited during startup with NameError: absolute_import_error"
+        ]
+      },
+      {
+        "slice": 4,
+        "status": "completed_with_limits",
+        "result": "Completed internal PAL codereview and precommit; proof artifact written. Git branch/worktree finalization steps remain blocked by sandboxed .git writes.",
+        "commit_sha": null,
+        "verification": [
+          "PAL codereview internal run reported 0 issues",
+          "PAL precommit internal run reported commit-ready validation",
+          "Final challenge confirmed remaining gap is live integrated rerun, not a code-local defect"
+        ]
+      }
+    ],
+    "replan_events": [
+      {
+        "event": "Authority correction",
+        "reason": "Prior live parity proof in .codex-worktrees/task-orchestrator-container-router-parity/proof/proof.json established the residual blocker was bridge 404 on /kg/custom_data reads, so the fix layer was corrected from shared bridge client speculation to bridge ConPort client normalization."
+      },
+      {
+        "event": "Worktree block",
+        "reason": "Requested git worktree creation off main initially failed because sandboxed writes to .git refs were denied in the first session; a dedicated worktree was created once full git permissions were available."
+      },
+      {
+        "event": "Live rerun split",
+        "reason": "Bridge runtime was rerun successfully from the packet worktree, but task-orchestrator app.main startup on main is currently blocked by an unrelated NameError outside this packet scope, preventing a fresh end-to-end /api/workflow/ideas rerun."
+      }
+    ],
+    "skipped_abandoned_merged_slices": [
+      {
+        "slice": 3,
+        "status": "partially_blocked",
+        "rationale": "The bridge side of the live path was rerun successfully. The full /api/workflow/ideas path could not be rerun because task-orchestrator app.main currently fails during startup on this main baseline before serving traffic."
+      }
+    ]
+  },
+  "finalization": {
+    "codereview_status": "complete_internal_clean",
+    "precommit_status": "complete_internal_clean",
+    "evidence_ledger_completeness": "complete_with_live_rerun_gap",
+    "final_confidence": "HIGH",
+    "residual_risks": [
+      "Live integrated container-path validation for GET /api/workflow/ideas is still not rerun successfully in this session because task-orchestrator app.main currently fails startup on main with NameError: absolute_import_error.",
+      "The packet fix is proven live only at the bridge custom-data boundary in this session; the full task-orchestrator route remains blocked by separate startup drift.",
+      "Bridge custom-data reads now treat upstream 404 as empty-state on this endpoint; if the downstream custom-data service later uses 404 for a non-empty-state read failure on the same endpoint, the adapter contract would need tightening."
+    ],
+    "pr_url": null,
+    "merge_readiness": "not_ready_due_to_task_orchestrator_startup_blocking_full_live_rerun",
+    "worktree_cleanup_status": "pending_until_git_finalization"
+  }
+}

--- a/services/dopecon-bridge/dopecon_bridge/clients.py
+++ b/services/dopecon-bridge/dopecon_bridge/clients.py
@@ -250,7 +250,24 @@ class ConPortClient:
         return await self._request("POST", "/api/custom_data", json_body=payload)
 
     async def get_custom_data(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        return await self._request("GET", "/api/custom_data", params=params)
+        """Read custom data, preserving empty-state as an empty payload."""
+        if not self.session:
+            await self.initialize()
+
+        url = f"{self.base_url}/api/custom_data"
+        async with self.session.request("GET", url, params=params) as response:
+            raw_text = await response.text()
+            if response.status == 404:
+                return {"count": 0, "items": []}
+            if response.status >= 400:
+                detail = raw_text or f"ConPort request failed with status {response.status}"
+                raise HTTPException(status_code=502, detail=detail[:500])
+            if not raw_text:
+                return {}
+            try:
+                return json.loads(raw_text)
+            except json.JSONDecodeError as exc:
+                raise HTTPException(status_code=502, detail="ConPort returned invalid JSON") from exc
 
     @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, max=10))
     async def get_context(self, context_token: str) -> Dict[str, Any]:

--- a/services/dopecon-bridge/tests/test_conport_custom_data_client.py
+++ b/services/dopecon-bridge/tests/test_conport_custom_data_client.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+from aiohttp import web
+from fastapi import HTTPException
+
+from dopecon_bridge.clients import ConPortClient
+
+
+async def _start_test_server(handler, port: int):
+    app = web.Application()
+    app.router.add_get("/api/custom_data", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", port)
+    await site.start()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_get_custom_data_normalizes_upstream_404_to_empty(unused_tcp_port):
+    async def handler(_request):
+        raise web.HTTPNotFound(text="category missing")
+
+    runner = await _start_test_server(handler, unused_tcp_port)
+
+    client = ConPortClient()
+    client.base_url = f"http://127.0.0.1:{unused_tcp_port}"
+
+    try:
+        payload = await client.get_custom_data(
+            {"workspace_id": "/workspace", "category": "workflow_ideas", "limit": 5}
+        )
+    finally:
+        await client.close()
+        await runner.cleanup()
+
+    assert payload == {"count": 0, "items": []}
+
+
+@pytest.mark.asyncio
+async def test_get_custom_data_preserves_non_404_failures(unused_tcp_port):
+    async def handler(_request):
+        raise web.HTTPServiceUnavailable(text="conport unavailable")
+
+    runner = await _start_test_server(handler, unused_tcp_port)
+
+    client = ConPortClient()
+    client.base_url = f"http://127.0.0.1:{unused_tcp_port}"
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await client.get_custom_data(
+                {"workspace_id": "/workspace", "category": "workflow_ideas", "limit": 5}
+            )
+    finally:
+        await client.close()
+        await runner.cleanup()
+
+    assert exc_info.value.status_code == 502
+    assert "conport unavailable" in exc_info.value.detail

--- a/tests/shared/test_dopecon_bridge_client.py
+++ b/tests/shared/test_dopecon_bridge_client.py
@@ -101,6 +101,21 @@ def test_error_response_raises_bridge_error() -> None:
     client.close()
 
 
+def test_bridge_client_preserves_unrelated_404_as_error() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="missing stream")
+
+    client = DopeconBridgeClient(
+        base_url="http://bridge",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(DopeconBridgeError, match="404"):
+        client.get_stream_info("missing")
+
+    client.close()
+
+
 def test_save_and_get_custom_data() -> None:
     """Saving custom data should set headers and return success."""
 

--- a/tests/unit/test_task_orchestrator_workflow_api.py
+++ b/tests/unit/test_task_orchestrator_workflow_api.py
@@ -163,6 +163,18 @@ def test_list_workflow_ideas_passes_filters():
     }
 
 
+def test_list_workflow_ideas_empty_state_returns_200():
+    module = _load_task_orchestrator_module()
+    workflow_service = _build_workflow_service()
+    workflow_service.list_ideas = AsyncMock(return_value=[])
+
+    with _build_client(module, workflow_service) as client:
+        response = client.get("/api/workflow/ideas")
+
+    assert response.status_code == 200
+    assert response.json() == {"count": 0, "ideas": []}
+
+
 def test_promote_workflow_idea_contract():
     module = _load_task_orchestrator_module()
     workflow_service = _build_workflow_service()

--- a/tests/unit/test_task_orchestrator_workflow_store.py
+++ b/tests/unit/test_task_orchestrator_workflow_store.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+
+import httpx
+import pytest
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[2] / "services" / "task-orchestrator"
+MODULE_PATH = SERVICE_ROOT / "app" / "services" / "workflow_store.py"
+
+
+def _load_workflow_store_module():
+    service_root_str = str(SERVICE_ROOT)
+    if service_root_str in sys.path:
+        sys.path.remove(service_root_str)
+    sys.path.insert(0, service_root_str)
+
+    for module_name in list(sys.modules):
+        if module_name == "app" or module_name.startswith("app."):
+            sys.modules.pop(module_name, None)
+
+    module_name = f"task_orchestrator_workflow_store_test_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.asyncio
+async def test_workflow_store_list_ideas_returns_empty_for_empty_bridge_payload():
+    module = _load_workflow_store_module()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/kg/custom_data"
+        assert request.url.params["category"] == "workflow_ideas"
+        return httpx.Response(200, json={"success": True, "count": 0, "data": []})
+
+    store = module.WorkflowStore(workspace_id="/workspace")
+    await store._client.aclose()
+    store._client = module.AsyncDopeconBridgeClient(
+        base_url="http://bridge",
+        transport=httpx.MockTransport(handler),
+    )
+
+    try:
+        ideas = await store.list_ideas(limit=5)
+    finally:
+        await store.close()
+
+    assert ideas == []
+
+
+@pytest.mark.asyncio
+async def test_workflow_store_list_ideas_raises_on_bridge_failure():
+    module = _load_workflow_store_module()
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="bridge unavailable")
+
+    store = module.WorkflowStore(workspace_id="/workspace")
+    await store._client.aclose()
+    store._client = module.AsyncDopeconBridgeClient(
+        base_url="http://bridge",
+        transport=httpx.MockTransport(handler),
+    )
+
+    try:
+        with pytest.raises(module.WorkflowStoreError, match="503"):
+            await store.list_ideas(limit=5)
+    finally:
+        await store.close()


### PR DESCRIPTION
## Summary
- normalize bridge custom-data read 404s into empty-state for workflow idea reads
- add regression coverage for bridge, workflow store, and workflow API empty-state vs failure semantics
- include a proof artifact capturing live bridge validation and the remaining task-orchestrator startup blocker

## Validation
- `pytest -q --confcutdir=/Users/hue/code/dopemux-mvp-worktrees/bridge-workflow-ideas-empty-state-fix/services/dopecon-bridge/tests /Users/hue/code/dopemux-mvp-worktrees/bridge-workflow-ideas-empty-state-fix/services/dopecon-bridge/tests/test_conport_custom_data_client.py /Users/hue/code/dopemux-mvp-worktrees/bridge-workflow-ideas-empty-state-fix/services/dopecon-bridge/tests/test_leantime_route_contract.py`
- `PYTHONPATH=/Users/hue/code/dopemux-mvp-worktrees/bridge-workflow-ideas-empty-state-fix pytest -q --noconftest /Users/hue/code/dopemux-mvp-worktrees/bridge-workflow-ideas-empty-state-fix/tests/shared/test_dopecon_bridge_client.py /Users/hue/code/dopemux-mvp-worktrees/bridge-workflow-ideas-empty-state-fix/tests/unit/test_task_orchestrator_workflow_api.py /Users/hue/code/dopemux-mvp-worktrees/bridge-workflow-ideas-empty-state-fix/tests/unit/test_task_orchestrator_workflow_store.py`
- live authenticated bridge probe: `GET http://localhost:3017/kg/custom_data?...category=workflow_ideas...` -> `200 {"success":true,"count":0,"data":[],"source":"conport"}`

## Remaining blocker
- full live `GET /api/workflow/ideas` parity rerun is still blocked on this `main` baseline because `app.main` startup currently fails with `NameError: absolute_import_error` before serving traffic.

@codex 
@clauee
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated
