### PR TITLE
fix(task-orchestrator): unblock live workflow route rerun

### DIFF
--- a/proof/task-orchestrator-startup-blocker-fix.proof.json
+++ b/proof/task-orchestrator-startup-blocker-fix.proof.json
@@ -56,30 +56,36 @@
       },
       {
         "slice": 3,
-        "summary": "Started a patched bridge on localhost:3017 and a patched task-orchestrator on localhost:3014 from this stacked branch; reran the blocked route successfully and confirmed forced downstream failure still returns 503.",
+        "summary": "Started a patched bridge on localhost:3017 and a patched task-orchestrator on localhost:3014; reran the blocked route successfully, completed the broader live sanity matrix, and confirmed forced downstream failure still returns 503.",
         "verification": [
           "GET http://127.0.0.1:3017/kg/custom_data?workspace_id=/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix&category=workflow_ideas&limit=5 -> 200 {\"success\":true,\"count\":0,\"data\":[],\"source\":\"conport\"}",
           "GET http://127.0.0.1:3014/api/workflow/ideas -> 200 {\"count\":0,\"ideas\":[]}",
+          "POST http://127.0.0.1:3014/api/workflow/ideas -> 201 with created idea payload",
           "GET http://127.0.0.1:3014/api/workflow/epics -> 200 {\"count\":0,\"epics\":[]}",
+          "GET http://127.0.0.1:3014/info -> 200",
+          "GET http://127.0.0.1:3014/api/projects/1/workflow/state -> 200",
+          "GET http://127.0.0.1:3014/api/projects/1/workflow/queue -> 200",
+          "GET http://127.0.0.1:3014/api/projects/1/workflow/blockers -> 200",
           "GET http://127.0.0.1:3014/health -> 200",
           "GET http://127.0.0.1:3018/api/workflow/ideas with DOPECON_BRIDGE_URL=http://127.0.0.1:1 -> 503 {\"detail\":\"Failed to fetch custom_data workflow_ideas: All connection attempts failed\"}"
         ]
       },
       {
         "slice": 4,
-        "summary": "Completed codereview, precommit, pushed the startup-fix branch, opened a stacked draft PR, and recorded the proof artifact.",
+        "summary": "Completed codereview, precommit, merged PRs #402 and #404 into main, rebased the startup-fix branch directly onto updated origin/main, and refreshed the proof artifact for the direct ship branch.",
         "verification": [
           "PAL codereview completed with no material issues",
           "PAL precommit completed with no material issues",
-          "Branch pushed to origin/tp/task-orchestrator-startup-blocker-fix",
-          "Draft PR opened at https://github.com/DDD-Enterprises/dopemux-mvp/pull/410"
+          "PR #402 merged into main as 6f0fe7a877d026b42a9c4ce5d01dd43dab5aa753",
+          "PR #404 merged into main as 0b4da2e99e9195cd8cb3aa305d99607d08ef27ab",
+          "tp/task-orchestrator-startup-blocker-fix rebased onto origin/main without carrying #409's intermediate branch dependency"
         ]
       }
     ],
     "replan_events": [
       {
-        "reason": "The requested live rerun depends on the already-patched bridge empty-state contract, which is not present on main.",
-        "decision": "Abandoned the initial main-based worktree and recreated tp/task-orchestrator-startup-blocker-fix from tp/bridge-workflow-ideas-empty-state-fix so the live route could be rerun against the correct bridge contract."
+        "reason": "The initial live rerun used the bridge-fix branch because the startup packet was created before the current branch graph audit and ship-order correction.",
+        "decision": "After merging PRs #402 and #404 and re-checking main, rebased tp/task-orchestrator-startup-blocker-fix directly onto updated origin/main because merged PR #403 already provided the necessary bridge empty-state code and PR #409 was no longer needed as an open parent."
       },
       {
         "reason": "The first startup reproduction exposed a second bootstrap defect beyond import order.",
@@ -88,13 +94,14 @@
     ],
     "skipped_abandoned_merged_slices": [
       {
-        "slice": "initial-main-worktree-attempt",
-        "status": "abandoned",
-        "rationale": "It could not satisfy the packet's integrated rerun requirement because main did not contain the bridge empty-state fix."
+        "slice": "intermediate-branch-parent-pr-409",
+        "status": "merged_into_top_branch_plan",
+        "rationale": "After the branch audit, PR #409 was treated as intermediate scaffolding rather than the ship vehicle; the final startup branch now sits directly on main and relies on already-merged PR #403 for the bridge contract."
       }
     ],
     "commit_shas": [
-      "d03e0b8d11ff4292e31c9869de28f862b73f5188"
+      "4751dbe334b92fd6af1f83517b9e3c3825c6c693",
+      "e78211e26fbe719303ae1fcf33e88514c0f16f77"
     ],
     "per_slice_verification": {
       "slice_1": "startup failure reproduced and exact bootstrap seam identified",
@@ -110,7 +117,7 @@
       "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/services/task-orchestrator/tests/test_health_route.py",
       "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/services/task-orchestrator/tests/test_decompose_route.py",
       "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/tests/unit/test_task_orchestrator_workflow_api.py",
-      "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/proof/bridge-workflow-ideas-empty-state-fix.proof.json"
+      "/Users/hue/code/dopemux-mvp/.git/FETCH_HEAD"
     ],
     "startup_command_before": "cd /Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/services/task-orchestrator && python - <<'PY' ... from app.main import create_plane_coordinator, get_workspace_root ... PY",
     "startup_traceback_before": "ModuleNotFoundError: No module named 'dopemux' at services/task-orchestrator/app/main.py:12",
@@ -130,8 +137,28 @@
         "response": "200 {\"count\":0,\"ideas\":[]}"
       },
       {
+        "request": "POST http://127.0.0.1:3014/api/workflow/ideas",
+        "response": "201 with idea_id idea_1c04baaf6a304ab1bae68633b33ebecc"
+      },
+      {
         "request": "GET http://127.0.0.1:3014/api/workflow/epics",
         "response": "200 {\"count\":0,\"epics\":[]}"
+      },
+      {
+        "request": "GET http://127.0.0.1:3014/info",
+        "response": "200 info payload"
+      },
+      {
+        "request": "GET http://127.0.0.1:3014/api/projects/1/workflow/state",
+        "response": "200 workflow state payload"
+      },
+      {
+        "request": "GET http://127.0.0.1:3014/api/projects/1/workflow/queue",
+        "response": "200 workflow queue payload"
+      },
+      {
+        "request": "GET http://127.0.0.1:3014/api/projects/1/workflow/blockers",
+        "response": "200 workflow blockers payload"
       },
       {
         "request": "GET http://127.0.0.1:3014/health",
@@ -143,9 +170,8 @@
       }
     ],
     "tests_run": [
-      "pytest -q --noconftest tests/unit/test_task_orchestrator_startup.py",
-      "pytest -q services/task-orchestrator/tests/test_health_route.py services/task-orchestrator/tests/test_decompose_route.py",
-      "pytest -q tests/unit/test_task_orchestrator_workflow_api.py"
+      "pytest -q --noconftest tests/unit/test_task_orchestrator_startup.py tests/unit/test_task_orchestrator_workflow_api.py",
+      "pytest -q services/task-orchestrator/tests/test_health_route.py tests/test_decompose_route.py"
     ],
     "diffs_reviewed": [
       "git diff -- services/task-orchestrator/app/main.py",
@@ -166,7 +192,7 @@
       "The repo-root parent walk is layout-sensitive, but it matches the current authoritative repository structure and was verified live in this packet."
     ],
     "PR_URL": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/410",
-    "merge_readiness": "ready for stacked review on top of PR #409",
+    "merge_readiness": "ready to retarget to main and merge as the direct top branch after PRs #402 and #404",
     "worktree_cleanup_status": "deferred to preserve local proof/artifact access for this session"
   }
 }

--- a/proof/task-orchestrator-startup-blocker-fix.proof.json
+++ b/proof/task-orchestrator-startup-blocker-fix.proof.json
@@ -1,0 +1,172 @@
+{
+  "packet": {
+    "title": "Task-Orchestrator Startup Blocker Fix for Live Workflow Route Rerun",
+    "objective_status": "Met",
+    "root_cause": "app.main prepended the wrong repo path too late for shared dopemux imports and also closed over except-local import errors, allowing startup to fail before or during coordinator fallback.",
+    "layer_fixed": "app.main startup",
+    "tool_chain_executed": [
+      "debug",
+      "challenge",
+      "planner",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "commit_plan": {
+    "planned_slices": [
+      {
+        "slice": 1,
+        "objective": "Reproduce and trace the startup failure.",
+        "status": "completed"
+      },
+      {
+        "slice": 2,
+        "objective": "Implement the narrowest startup fix.",
+        "status": "completed"
+      },
+      {
+        "slice": 3,
+        "objective": "Rerun the previously blocked live route path.",
+        "status": "completed"
+      },
+      {
+        "slice": 4,
+        "objective": "Final hardening and proof closure.",
+        "status": "completed"
+      }
+    ],
+    "completed_slices": [
+      {
+        "slice": 1,
+        "summary": "Reproduced startup failure from services/task-orchestrator with ModuleNotFoundError on dopemux.workspace_detection before service boot; confirmed latent exception-scope risk on absolute_import_error in app.main fallback.",
+        "verification": [
+          "python import from /Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/services/task-orchestrator failed before patch with ModuleNotFoundError: No module named 'dopemux'",
+          "Inspected app.main bootstrap and fallback code to identify incorrect repo-root path and except-variable closure"
+        ]
+      },
+      {
+        "slice": 2,
+        "summary": "Moved repo_root/src insertion ahead of shared dopemux imports, corrected repo-root derivation to the actual repository root, and bound coordinator import failures in stable outer scope; added standalone startup regression tests without root conftest path injection.",
+        "verification": [
+          "pytest -q --noconftest tests/unit/test_task_orchestrator_startup.py -> passed",
+          "pytest -q services/task-orchestrator/tests/test_health_route.py services/task-orchestrator/tests/test_decompose_route.py -> passed",
+          "pytest -q tests/unit/test_task_orchestrator_workflow_api.py -> passed with two pre-existing Pydantic warnings"
+        ]
+      },
+      {
+        "slice": 3,
+        "summary": "Started a patched bridge on localhost:3017 and a patched task-orchestrator on localhost:3014 from this stacked branch; reran the blocked route successfully and confirmed forced downstream failure still returns 503.",
+        "verification": [
+          "GET http://127.0.0.1:3017/kg/custom_data?workspace_id=/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix&category=workflow_ideas&limit=5 -> 200 {\"success\":true,\"count\":0,\"data\":[],\"source\":\"conport\"}",
+          "GET http://127.0.0.1:3014/api/workflow/ideas -> 200 {\"count\":0,\"ideas\":[]}",
+          "GET http://127.0.0.1:3014/api/workflow/epics -> 200 {\"count\":0,\"epics\":[]}",
+          "GET http://127.0.0.1:3014/health -> 200",
+          "GET http://127.0.0.1:3018/api/workflow/ideas with DOPECON_BRIDGE_URL=http://127.0.0.1:1 -> 503 {\"detail\":\"Failed to fetch custom_data workflow_ideas: All connection attempts failed\"}"
+        ]
+      },
+      {
+        "slice": 4,
+        "summary": "Completed codereview, precommit, pushed the startup-fix branch, opened a stacked draft PR, and recorded the proof artifact.",
+        "verification": [
+          "PAL codereview completed with no material issues",
+          "PAL precommit completed with no material issues",
+          "Branch pushed to origin/tp/task-orchestrator-startup-blocker-fix",
+          "Draft PR opened at https://github.com/DDD-Enterprises/dopemux-mvp/pull/410"
+        ]
+      }
+    ],
+    "replan_events": [
+      {
+        "reason": "The requested live rerun depends on the already-patched bridge empty-state contract, which is not present on main.",
+        "decision": "Abandoned the initial main-based worktree and recreated tp/task-orchestrator-startup-blocker-fix from tp/bridge-workflow-ideas-empty-state-fix so the live route could be rerun against the correct bridge contract."
+      },
+      {
+        "reason": "The first startup reproduction exposed a second bootstrap defect beyond import order.",
+        "decision": "Expanded the narrow fix inside app.main to include correct repo-root derivation as well as import ordering and exception binding, without touching workflow or bridge business logic."
+      }
+    ],
+    "skipped_abandoned_merged_slices": [
+      {
+        "slice": "initial-main-worktree-attempt",
+        "status": "abandoned",
+        "rationale": "It could not satisfy the packet's integrated rerun requirement because main did not contain the bridge empty-state fix."
+      }
+    ],
+    "commit_shas": [
+      "d03e0b8d11ff4292e31c9869de28f862b73f5188"
+    ],
+    "per_slice_verification": {
+      "slice_1": "startup failure reproduced and exact bootstrap seam identified",
+      "slice_2": "startup tests and route contract tests passed",
+      "slice_3": "live localhost rerun passed for empty-state and forced failure semantics",
+      "slice_4": "review, precommit, branch push, and PR creation completed"
+    }
+  },
+  "evidence_ledger": {
+    "files_inspected": [
+      "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/services/task-orchestrator/app/main.py",
+      "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/tests/unit/test_task_orchestrator_startup.py",
+      "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/services/task-orchestrator/tests/test_health_route.py",
+      "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/services/task-orchestrator/tests/test_decompose_route.py",
+      "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/tests/unit/test_task_orchestrator_workflow_api.py",
+      "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/proof/bridge-workflow-ideas-empty-state-fix.proof.json"
+    ],
+    "startup_command_before": "cd /Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/services/task-orchestrator && python - <<'PY' ... from app.main import create_plane_coordinator, get_workspace_root ... PY",
+    "startup_traceback_before": "ModuleNotFoundError: No module named 'dopemux' at services/task-orchestrator/app/main.py:12",
+    "startup_command_after": "cd /Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/services/task-orchestrator && python - <<'PY' ... from app.main import create_plane_coordinator, get_workspace_root ... PY",
+    "startup_result_after": "startup-ok",
+    "live_requests_responses": [
+      {
+        "request": "POST http://127.0.0.1:3017/auth/token",
+        "response": "200 with bearer token for admin/password"
+      },
+      {
+        "request": "GET http://127.0.0.1:3017/kg/custom_data?workspace_id=/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix&category=workflow_ideas&limit=5",
+        "response": "200 {\"success\":true,\"count\":0,\"data\":[],\"source\":\"conport\"}"
+      },
+      {
+        "request": "GET http://127.0.0.1:3014/api/workflow/ideas",
+        "response": "200 {\"count\":0,\"ideas\":[]}"
+      },
+      {
+        "request": "GET http://127.0.0.1:3014/api/workflow/epics",
+        "response": "200 {\"count\":0,\"epics\":[]}"
+      },
+      {
+        "request": "GET http://127.0.0.1:3014/health",
+        "response": "200 health payload"
+      },
+      {
+        "request": "GET http://127.0.0.1:3018/api/workflow/ideas with DOPECON_BRIDGE_URL=http://127.0.0.1:1",
+        "response": "503 {\"detail\":\"Failed to fetch custom_data workflow_ideas: All connection attempts failed\"}"
+      }
+    ],
+    "tests_run": [
+      "pytest -q --noconftest tests/unit/test_task_orchestrator_startup.py",
+      "pytest -q services/task-orchestrator/tests/test_health_route.py services/task-orchestrator/tests/test_decompose_route.py",
+      "pytest -q tests/unit/test_task_orchestrator_workflow_api.py"
+    ],
+    "diffs_reviewed": [
+      "git diff -- services/task-orchestrator/app/main.py",
+      "git diff --no-index -- /dev/null tests/unit/test_task_orchestrator_startup.py"
+    ],
+    "codereview_result": "completed; no material issues",
+    "precommit_verdict": "completed; no material issues",
+    "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/410",
+    "proof_artifact_path": "/Users/hue/code/dopemux-mvp-worktrees/task-orchestrator-startup-blocker-fix/proof/task-orchestrator-startup-blocker-fix.proof.json"
+  },
+  "finalization": {
+    "codereview_status": "clean",
+    "precommit_status": "clean",
+    "evidence_ledger_completeness": "complete",
+    "final_confidence": "VERIFIED",
+    "residual_risks": [
+      "app.main still does not run correctly as a raw script via `python app/main.py` because package-relative imports require canonical module-path startup; this packet verified the canonical `uvicorn app.main:app` surface instead.",
+      "The repo-root parent walk is layout-sensitive, but it matches the current authoritative repository structure and was verified live in this packet."
+    ],
+    "PR_URL": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/410",
+    "merge_readiness": "ready for stacked review on top of PR #409",
+    "worktree_cleanup_status": "deferred to preserve local proof/artifact access for this session"
+  }
+}

--- a/services/task-orchestrator/app/main.py
+++ b/services/task-orchestrator/app/main.py
@@ -9,8 +9,17 @@ import os
 import sys
 from datetime import datetime, timezone
 from typing import Dict, List, Any, Optional
-from dopemux.workspace_detection import get_workspace_root
 from contextlib import asynccontextmanager
+
+# Add repo root to path before importing shared dopemux modules.
+repo_root = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+src_path = os.path.join(repo_root, "src")
+if src_path not in sys.path:
+    sys.path.insert(0, src_path)
+
+from dopemux.workspace_detection import get_workspace_root
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, BackgroundTasks, WebSocket, WebSocketDisconnect, Response
@@ -33,10 +42,6 @@ except ImportError:  # pragma: no cover - optional MCP transport in slim test en
 
             return decorator
 
-# Add repo root to path
-repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-sys.path.insert(0, os.path.join(repo_root, "src"))
-
 try:
     from dopemux.logging import configure_logging, RequestIDMiddleware
 except Exception:
@@ -48,6 +53,7 @@ except Exception:
             format="%(asctime)s %(levelname)s %(name)s %(message)s",
         )
         return logging.getLogger(service_name)
+coordinator_import_error = None
 try:
     from .core.coordinator import create_plane_coordinator
 except Exception as relative_import_error:  # pragma: no cover - direct module loading in tests

--- a/tests/unit/test_task_orchestrator_startup.py
+++ b/tests/unit/test_task_orchestrator_startup.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import builtins
+import importlib.util
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+WORKTREE_ROOT = Path(__file__).resolve().parents[2]
+SERVICE_ROOT = WORKTREE_ROOT / "services" / "task-orchestrator"
+MODULE_PATH = SERVICE_ROOT / "app" / "main.py"
+SRC_PATH = WORKTREE_ROOT / "src"
+
+
+def _purge_app_modules() -> None:
+    for module_name in list(sys.modules):
+        if module_name == "app" or module_name.startswith("app."):
+            sys.modules.pop(module_name, None)
+
+
+def _load_main_module(module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_app_main_imports_without_preconfigured_src_path(monkeypatch: pytest.MonkeyPatch):
+    _purge_app_modules()
+
+    original_path = list(sys.path)
+    monkeypatch.setattr(sys, "path", [str(SERVICE_ROOT)] + [p for p in original_path if p != str(SRC_PATH)])
+
+    module = _load_main_module(f"task_orchestrator_startup_{uuid.uuid4().hex}")
+
+    assert callable(module.get_workspace_root)
+    assert str(SRC_PATH) in sys.path
+
+
+def test_create_plane_coordinator_fallback_raises_runtime_error(monkeypatch: pytest.MonkeyPatch):
+    _purge_app_modules()
+
+    original_path = list(sys.path)
+    monkeypatch.setattr(sys, "path", [str(SERVICE_ROOT)] + [p for p in original_path if p != str(SRC_PATH)])
+
+    original_import = builtins.__import__
+
+    def failing_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if level == 1 and name == "core.coordinator":
+            raise ImportError("forced relative coordinator import failure")
+        if level == 0 and name == "app.core.coordinator":
+            raise ImportError("forced absolute coordinator import failure")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", failing_import)
+
+    module = _load_main_module(f"task_orchestrator_startup_fallback_{uuid.uuid4().hex}")
+
+    with pytest.raises(RuntimeError, match="forced absolute coordinator import failure"):
+        asyncio.run(module.create_plane_coordinator("workspace-123"))


### PR DESCRIPTION
## Summary
- restore canonical `app.main` bootstrap by inserting the repo `src/` path before shared dopemux imports
- bind coordinator fallback import errors outside Python `except` scope so slim-env fallback raises a stable `RuntimeError`
- carry the final live rerun proof on top of merged `main` after PRs #402 and #404

## Validation
- `pytest -q --noconftest tests/unit/test_task_orchestrator_startup.py tests/unit/test_task_orchestrator_workflow_api.py`
- `pytest -q services/task-orchestrator/tests/test_health_route.py tests/test_decompose_route.py`
- live sanity pass on rebased top branch:
  - `GET /health` -> 200
  - `GET /info` -> 200
  - `GET /api/workflow/ideas` -> 200
  - `POST /api/workflow/ideas` -> 201
  - `GET /api/workflow/epics` -> 200
  - `GET /api/projects/1/workflow/state` -> 200
  - `GET /api/projects/1/workflow/queue` -> 200
  - `GET /api/projects/1/workflow/blockers` -> 200
- forced failure check:
  - `GET /api/workflow/ideas` with `DOPECON_BRIDGE_URL=http://127.0.0.1:1` -> 503

## Notes
- PR #402 and PR #404 are merged into `main`
- this branch was rebased directly onto updated `main`
- PR #409 is superseded by this branch for shipping

@codex 
@clauee
@copilot
