### PR TITLE
repo-truth-extractor: bounded prelive runtime slice (A/A2 balanced_grok_openrouter) via clean replay

### DIFF
--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/IMPLEMENTER_REPORT.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/IMPLEMENTER_REPORT.md
@@ -25,3 +25,9 @@ This packet prepares and opens a reviewer-safe PR from the clean replay candidat
 ## Branching Note
 
 Local creation of `refs/heads/codex/rte-main-pr-001` was blocked by a ref-lock permission denial in this environment. Packet preparation therefore used the clean replay source branch as the local working state and is intended to publish the reviewed PR branch as remote `codex/rte-main-pr-001` via refspec.
+
+## PR Outcome
+
+- remote branch published: `codex/rte-main-pr-001`
+- PR opened: `#413`
+- PR URL: `https://github.com/DDD-Enterprises/dopemux-mvp/pull/413`

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/IMPLEMENTER_REPORT.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/IMPLEMENTER_REPORT.md
@@ -1,0 +1,27 @@
+# Implementer Report
+
+## Scope
+
+This packet prepares and opens a reviewer-safe PR from the clean replay candidate into `main` without changing runtime code.
+
+## Key Facts
+
+- source replay branch: `codex/rte-merge-exec-001`
+- target branch: `main`
+- replay execution verdict from prior packet: `READY_FOR_MAIN_PR`
+- bounded validation status carried into this packet:
+  - `py_compile`: pass
+  - targeted pytest slice: pass
+  - validator: `CONDITIONAL_GO`
+  - `operator_verdict = GO_NOW`
+
+## Reviewer Framing Constraints
+
+- validator is conditional, not flat `GO`
+- PAL validation was not provided
+- replay required bounded repair commit `c7250ecaf`
+- no claim is made about full extractor correctness or all phases/steps
+
+## Branching Note
+
+Local creation of `refs/heads/codex/rte-main-pr-001` was blocked by a ref-lock permission denial in this environment. Packet preparation therefore used the clean replay source branch as the local working state and is intended to publish the reviewed PR branch as remote `codex/rte-main-pr-001` via refspec.

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/PROOF.json
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/PROOF.json
@@ -1,0 +1,32 @@
+{
+  "packet_id": "TP-CODEX-RTE-MAIN-PR-001",
+  "branch": "codex/rte-main-pr-001",
+  "source_branch": "codex/rte-merge-exec-001",
+  "target_branch": "main",
+  "replay_commit_count": 8,
+  "files_changed": [
+    "proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/IMPLEMENTER_REPORT.md",
+    "proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/PROOF.json",
+    "proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/bounded_target_replay_readiness.md",
+    "proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/final_replay_exec_verdict.md",
+    "proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_branch_creation.md",
+    "proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_branch_validation.md",
+    "proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_conflict_resolution.md",
+    "proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replayed_commit_log.md",
+    "proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/verification_commands.txt",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/validate_pre_live_gate_v25.py"
+  ],
+  "bounded_target": {
+    "phase": "A",
+    "step": "A2",
+    "routing_policy": "balanced_grok_openrouter"
+  },
+  "validator_result": "CONDITIONAL_GO",
+  "operator_verdict": "GO_NOW",
+  "pal_required": true,
+  "bounded_repair_commit": "c7250ecaf",
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/413",
+  "final_pr_packet_verdict": "PR_OPENED",
+  "verdict": "PASS"
+}

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/final_pr_packet_verdict.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/final_pr_packet_verdict.md
@@ -1,0 +1,17 @@
+# Final PR Packet Verdict
+
+`PR_OPENED`
+
+## Why
+
+- diff vs `main` was computed and summarized
+- replay commit set was documented, including empty replays and bounded repair commit `c7250ecaf`
+- reviewer-facing PR description was written from proof, not inference
+- remote branch `codex/rte-main-pr-001` was published from the clean replay source branch
+- PR opened successfully:
+  - `#413`
+  - `https://github.com/DDD-Enterprises/dopemux-mvp/pull/413`
+
+## Known Constraint
+
+Local creation of branch `codex/rte-main-pr-001` remained blocked by ref-lock permission denial in this environment. The PR branch was therefore published as a remote ref via push refspec, and the PR opened from that remote branch.

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/pr_diff_summary.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/pr_diff_summary.md
@@ -1,0 +1,33 @@
+# PR Diff Summary
+
+- Packet: `TP-CODEX-RTE-MAIN-PR-001`
+- Source branch: `codex/rte-merge-exec-001`
+- Target branch: `main`
+- Source branch tip at inspection: `3749d3b2a8d1cb0746e6e98a1c4e36e0e746b9c5`
+- Target branch tip at inspection: `e4bf2d148886cee0883c2afda5bdfd0a9591f840`
+- Total commits ahead of `main`: `8`
+
+## Full Branch Diff vs `main`
+
+`git diff --stat main...codex/rte-merge-exec-001` shows 11 changed files:
+
+- `proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/IMPLEMENTER_REPORT.md`
+- `proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/PROOF.json`
+- `proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/bounded_target_replay_readiness.md`
+- `proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/final_replay_exec_verdict.md`
+- `proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_branch_creation.md`
+- `proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_branch_validation.md`
+- `proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_conflict_resolution.md`
+- `proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replayed_commit_log.md`
+- `proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/verification_commands.txt`
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+
+## Runtime Diff Scope
+
+The runtime code diff is limited to exactly two files:
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+
+The additional changed files are proof artifacts from `TP-CODEX-RTE-MERGE-EXEC-001`, not extra runtime surfaces.

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/pr_open_record.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/pr_open_record.md
@@ -1,0 +1,10 @@
+# PR Open Record
+
+- Status: opened
+- Local source state used for PR prep: `codex/rte-merge-exec-001`
+- Remote compare branch: `codex/rte-main-pr-001`
+- Base branch: `main`
+- Title:
+  - `repo-truth-extractor: bounded prelive runtime slice (A/A2 balanced_grok_openrouter) via clean replay`
+- PR number: `413`
+- PR URL: `https://github.com/DDD-Enterprises/dopemux-mvp/pull/413`

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/pull_request_description.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/pull_request_description.md
@@ -1,0 +1,67 @@
+## What this PR is
+
+Clean replay of the bounded prelive extractor runtime slice for:
+
+- phase `A`
+- step `A2`
+- routing policy `balanced_grok_openrouter`
+
+This PR is based on `codex/rte-merge-exec-001` and is intended to present the bounded merge candidate to reviewers without reusing the earlier contaminated local `main` integration path.
+
+## What was proven
+
+- bounded target validated for `A / A2 / balanced_grok_openrouter`
+- `python -m py_compile` passed for:
+  - `services/repo-truth-extractor/run_extraction_v5.py`
+  - `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+- targeted pytest slice passed:
+  - `cost_cap`
+  - `validator`
+  - `phase_execution_step_filter`
+  - `validator_repair_provenance`
+- validator result:
+  - `CONDITIONAL_GO`
+  - `operator_verdict = GO_NOW`
+
+## What changed
+
+Runtime code diff is limited to:
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+
+The branch also carries replay proof artifacts from `TP-CODEX-RTE-MERGE-EXEC-001`.
+
+## Replay notes
+
+- replay was not purely mechanical
+- five required source commits landed as replay commits
+- three required source commits replayed as empty because their behavior was already preserved after earlier conflict resolution
+- one bounded repair commit was required:
+  - `c7250ecaf`
+
+Reason for `c7250ecaf`:
+
+- restore validator step-scope correctness after replay conflict resolution
+- specifically restore missing `return scope` and selected-step contract-map filtering
+
+## What is NOT claimed
+
+- not full extractor correctness
+- not all phases or all steps
+- not production-wide readiness
+- not proof of correctness outside the bounded target described above
+
+## Remaining conditions
+
+- PAL validation was not provided
+- validator result remains `CONDITIONAL_GO`, not flat `GO`
+- reviewer should treat the current evidence as bounded-target validation only
+
+## Reviewer guidance
+
+- verify the runtime diff scope is limited to the two files above
+- verify the branch also includes the replay proof bundle and no unrelated runtime surfaces
+- verify replay integrity against the source replay slice and the empty-replay notes
+- verify `c7250ecaf` is bounded to validator step-scope repair and does not widen runtime scope
+- confirm the branch preserves the bounded `A / A2 / balanced_grok_openrouter` behavior without contamination from prior branch history

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/replay_commit_summary.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/replay_commit_summary.md
@@ -1,0 +1,40 @@
+# Replay Commit Summary
+
+## Source Replay Slice
+
+Planned runtime-critical source commits:
+
+1. `c660ab9df` `fix(repo-truth-extractor): recover deferred tp002-owned changes`
+2. `2144d4e36` `fix(repo-truth-extractor): recover TP001 spend-cap logic from mixed runner`
+3. `e14690d0d` `fix(repo-truth-extractor): recover TP003 bounded execution logic from mixed runner`
+4. `0db7b8528` `fix(repo-truth-extractor): recover missing TP001 usage summary logic`
+5. `91868d873` `feat(repo-truth-extractor): implement JSON repair provenance tracking and unify run status`
+6. `6bc14c7bd` `fix(repo-truth-extractor): correct narrow post-tp004 live defects`
+7. `d88a1bcc4` `fix(repo-truth-extractor): correct narrow bounded-live truth defect`
+8. `9317a169d` `fix(repo-truth-extractor): correct narrow post-tp006 artifact truth contradiction`
+
+## Replayed Commits
+
+- `d4fc167d7` from `c660ab9df`
+- `de544c137` from `2144d4e36`
+- `ff29dd457` from `e14690d0d`
+- `52d651b01` from `91868d873`
+- `1052feba2` from `6bc14c7bd`
+
+## Empty Replays
+
+These source commits replayed as empty because their behavior was already preserved on the replay branch after earlier resolutions:
+
+- `0db7b8528`
+- `d88a1bcc4`
+- `9317a169d`
+
+## Bounded Repair Commit
+
+- `c7250ecaf` `fix(repo-truth-extractor): restore selected-step validator replay integrity`
+
+Reason:
+
+- restore missing `return scope` in `validate_pre_live_gate_v25.py`
+- make selected-step contract-map observed keys respect `--step`
+- required so the replay branch would pass the packet validator command truthfully

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/verification_commands.txt
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MAIN-PR-001/verification_commands.txt
@@ -1,0 +1,27 @@
+git status --short
+[no output]
+
+git branch --show-current
+codex/rte-merge-exec-001
+
+git diff --stat main...codex/rte-merge-exec-001
+11 files changed
+runtime files:
+- services/repo-truth-extractor/run_extraction_v5.py
+- services/repo-truth-extractor/validate_pre_live_gate_v25.py
+
+git log --oneline main..codex/rte-merge-exec-001
+3749d3b2a docs(proof): record replay validation readiness assessment and final verdict
+18b8a1b31 docs(proof): record replay branch creation and required commit replay log
+c7250ecaf fix(repo-truth-extractor): restore selected-step validator replay integrity
+1052feba2 fix(repo-truth-extractor): correct narrow post-tp004 live defects
+52d651b01 feat(repo-truth-extractor): implement JSON repair provenance tracking and unify run status
+ff29dd457 fix(repo-truth-extractor): recover TP003 bounded execution logic from mixed runner
+de544c137 fix(repo-truth-extractor): recover TP001 spend-cap logic from mixed runner
+d4fc167d7 fix(repo-truth-extractor): recover deferred tp002-owned changes
+
+git status --short
+[no output before proof staging]
+
+git diff --stat
+[no runtime diff generated in this packet]

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/IMPLEMENTER_REPORT.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/IMPLEMENTER_REPORT.md
@@ -1,0 +1,40 @@
+# Implementer Report
+
+## Scope
+
+This packet created `codex/rte-merge-exec-001` from current `main`, replayed the required runtime-critical source slice from `TP-CODEX-RTE-MERGE-PREP-001`, validated the replay branch, and assessed whether it is the actual merge candidate.
+
+## Key Outcomes
+
+- Replay branch created from `main` at `e4bf2d148886cee0883c2afda5bdfd0a9591f840`
+- Required source slice attempted in exact planned order
+- Five source commits produced replay commits
+- Three source commits replayed as empty because their behavior was already preserved on the branch
+- One additional bounded replay-repair commit was required to restore validator step-scope correctness after conflict resolution
+- Final replay branch tip: `c7250ecaf5dd069dc324b5f538a9285dd03853d8`
+
+## Validation Summary
+
+- `python -m py_compile ...` passed
+- targeted pytest slice passed: `29 passed`
+- bounded validator command for `A/A2` and `balanced_grok_openrouter` finished `CONDITIONAL_GO`
+- online provider preflight passed
+- no run-scoped blockers remained in the final validator result
+
+## Branch Shape
+
+- `main..HEAD` contains:
+  - `d4fc167d7`
+  - `de544c137`
+  - `ff29dd457`
+  - `52d651b01`
+  - `1052feba2`
+  - `c7250ecaf`
+- bounded diff against `main` is now:
+  - `services/repo-truth-extractor/run_extraction_v5.py`
+  - `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+
+## Deviation From Packet Plan
+
+- The packet’s proof-only commit plan was insufficient because replay conflict resolution left a real validator defect uncommitted.
+- I added one bounded code commit, `c7250ecaf`, so the replay branch could become clean and validate truthfully.

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/PROOF.json
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/PROOF.json
@@ -1,0 +1,115 @@
+{
+  "packet_id": "TP-CODEX-RTE-MERGE-EXEC-001",
+  "branch": "codex/rte-merge-exec-001",
+  "base_branch": "main",
+  "base_commit": "e4bf2d148886cee0883c2afda5bdfd0a9591f840",
+  "replay_branch_created": true,
+  "required_commits_replayed": [
+    {
+      "source_sha": "c660ab9df36719e1a90acb1f23c53ea4215d45a9",
+      "replay_sha": "d4fc167d79e96b22f78109bd4e91f33ca3edf2af",
+      "result": "conflict_resolved"
+    },
+    {
+      "source_sha": "2144d4e369f097569f791c2407b2d87361b864f1",
+      "replay_sha": "de544c1379b2b259b9aab97bff0f7172e4f28366",
+      "result": "conflict_resolved"
+    },
+    {
+      "source_sha": "e14690d0d65a8a31fa6c0a6eeeec52d6b1e9cbed",
+      "replay_sha": "ff29dd457c78f2f63e51e3882a6310e4a7df5633",
+      "result": "conflict_resolved"
+    },
+    {
+      "source_sha": "0db7b85288bb90e540dc8659b53ab4d066c179f0",
+      "replay_sha": null,
+      "result": "empty_already_preserved"
+    },
+    {
+      "source_sha": "91868d873ac7e8e4b02eae31092677aa2ce1ef3d",
+      "replay_sha": "52d651b01033b889680f888c2bdb278e3297e77f",
+      "result": "conflict_resolved"
+    },
+    {
+      "source_sha": "6bc14c7bdb294efa8dace328f55c4ea378f1d1ac",
+      "replay_sha": "1052feba2d77d7ad14f008819ad073dfa61d9084",
+      "result": "conflict_resolved"
+    },
+    {
+      "source_sha": "d88a1bcc4994b4c6e6ecbc3a1cbe3dc1c70d50de",
+      "replay_sha": null,
+      "result": "empty_already_preserved"
+    },
+    {
+      "source_sha": "9317a169ddaed13cf120674049112304b28cb832",
+      "replay_sha": null,
+      "result": "empty_already_preserved"
+    }
+  ],
+  "recreated_from_proof": [
+    {
+      "replay_sha": "c7250ecaf5dd069dc324b5f538a9285dd03853d8",
+      "subject": "fix(repo-truth-extractor): restore selected-step validator replay integrity",
+      "reason": "restore missing return scope and selected-step observed contract-map filtering after replay conflict resolution"
+    }
+  ],
+  "replay_conflicts": [
+    {
+      "source_sha": "c660ab9df36719e1a90acb1f23c53ea4215d45a9",
+      "files": [
+        "services/repo-truth-extractor/validate_pre_live_gate_v25.py"
+      ]
+    },
+    {
+      "source_sha": "2144d4e369f097569f791c2407b2d87361b864f1",
+      "files": [
+        "services/repo-truth-extractor/run_extraction_v5.py"
+      ]
+    },
+    {
+      "source_sha": "e14690d0d65a8a31fa6c0a6eeeec52d6b1e9cbed",
+      "files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
+      ]
+    },
+    {
+      "source_sha": "91868d873ac7e8e4b02eae31092677aa2ce1ef3d",
+      "files": [
+        "services/repo-truth-extractor/run_extraction_v5.py"
+      ]
+    },
+    {
+      "source_sha": "6bc14c7bdb294efa8dace328f55c4ea378f1d1ac",
+      "files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/validate_pre_live_gate_v25.py"
+      ]
+    }
+  ],
+  "validation_commands_run": [
+    "git status --short",
+    "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+    "pytest -q services/repo-truth-extractor/tests/ -k \"cost_cap or validator or phase_execution_step_filter or validator_repair_provenance\"",
+    "env XAI_API_KEY=\"$XAI_API_KEY\" python services/repo-truth-extractor/validate_pre_live_gate_v25.py --target-policy balanced_grok_openrouter --target-phases A --step A2 --allow-online-preflight",
+    "git diff --stat main...HEAD"
+  ],
+  "bounded_target": {
+    "phase": "A",
+    "step": "A2",
+    "routing_policy": "balanced_grok_openrouter"
+  },
+  "bounded_target_replay_ready": true,
+  "missing_dependencies": [],
+  "excluded_commits_confirmed_unnecessary": [
+    "0db7b85288bb90e540dc8659b53ab4d066c179f0",
+    "d88a1bcc4994b4c6e6ecbc3a1cbe3dc1c70d50de",
+    "9317a169ddaed13cf120674049112304b28cb832"
+  ],
+  "final_replay_exec_verdict": "READY_FOR_MAIN_PR",
+  "residual_risks": [
+    "validator readiness is CONDITIONAL_GO because PAL validation file was not provided",
+    "branch required one bounded replay-repair commit beyond the original source slice"
+  ],
+  "verdict": "PASS"
+}

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/bounded_target_replay_readiness.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/bounded_target_replay_readiness.md
@@ -1,0 +1,34 @@
+# Bounded Target Replay Readiness
+
+## Target
+
+- phase: `A`
+- step: `A2`
+- routing policy: `balanced_grok_openrouter`
+
+## Assessment
+
+- The replay branch preserves bounded-target readiness for `A/A2`.
+- Validator behavior is consistent with the previously proven bounded target after the replay-repair commit.
+- No required runtime-critical behavior remains obviously missing for the packet’s required validation slice.
+- Excluded proof-only, stale, and unrelated commits were not needed for this replay branch.
+
+## Evidence
+
+- `pytest -q ... -k "cost_cap or validator or phase_execution_step_filter or validator_repair_provenance"` passed with `29 passed`
+- final validator command returned:
+  - `verdict = CONDITIONAL_GO`
+  - `operator_verdict = GO_NOW`
+  - `reason_codes = []`
+  - `contract_map_determinism = PASS`
+  - `online_provider_preflight = PASS`
+- `main...HEAD` diff is bounded to:
+  - `services/repo-truth-extractor/run_extraction_v5.py`
+  - `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+
+## Interpretation
+
+This replay branch is the actual bounded merge candidate, with one truthful caveat:
+
+- the branch is not a pure eight-commit mirror of the source plan
+- it required one bounded replay-repair commit, `c7250ecaf`, to restore validator step-scope correctness after replay conflict resolution

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/final_replay_exec_verdict.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/final_replay_exec_verdict.md
@@ -1,0 +1,26 @@
+# Final Replay Exec Verdict
+
+## Verdict
+
+`READY_FOR_MAIN_PR`
+
+## Why
+
+- Clean replay branch exists: `codex/rte-merge-exec-001`
+- Required runtime-critical replay slice was attempted in exact planned order
+- Replayed branch validates for bounded target `A/A2`
+- Final validator run returned `CONDITIONAL_GO` with no run-scoped blockers
+- Excluded proof-only, stale, and unrelated commits were not required
+
+## Required Caveat
+
+Readiness required one bounded replay-repair commit:
+
+- `c7250ecaf` `fix(repo-truth-extractor): restore selected-step validator replay integrity`
+
+That commit was necessary because replay conflict resolution left a missing `return scope` and a phase-wide observed-key comparison in the validator. Without it, the branch was not honest to call ready.
+
+## Recommended Next Step
+
+- Treat `codex/rte-merge-exec-001` as the actual merge-candidate branch
+- Open the bounded main-merge / PR packet from this branch

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_branch_creation.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_branch_creation.md
@@ -1,0 +1,19 @@
+# Replay Branch Creation
+
+- Packet: `TP-CODEX-RTE-MERGE-EXEC-001`
+- Replay branch: `codex/rte-merge-exec-001`
+- Base branch: `main`
+- Merge-prep base guard: `f9c29499a2a1179b2dd77d81528492f47fcd55c9`
+- Replay creation guard result: `BASE_OK`
+- Actual branch creation source: current `main` tip at replay time
+- Base commit: `e4bf2d148886cee0883c2afda5bdfd0a9591f840`
+- Starting HEAD SHA: `e4bf2d148886cee0883c2afda5bdfd0a9591f840`
+- Creation evidence: reflog entry `branch: Created from HEAD` at `2026-04-09 23:47:52 -0700`
+
+## Commands
+
+```bash
+git merge-base --is-ancestor f9c29499a2a1179b2dd77d81528492f47fcd55c9 main && echo BASE_OK
+git switch -c codex/rte-merge-exec-001
+git reflog show codex/rte-merge-exec-001 --date=iso --format='%H%x09%gs%x09%cd'
+```

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_branch_validation.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_branch_validation.md
@@ -1,0 +1,35 @@
+# Replay Branch Validation
+
+## Commands Run
+
+```bash
+git status --short
+python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py
+pytest -q services/repo-truth-extractor/tests/ -k "cost_cap or validator or phase_execution_step_filter or validator_repair_provenance"
+env XAI_API_KEY="$XAI_API_KEY" python services/repo-truth-extractor/validate_pre_live_gate_v25.py --target-policy balanced_grok_openrouter --target-phases A --step A2 --allow-online-preflight
+git diff --stat main...HEAD
+```
+
+## Results
+
+- `git status --short`: clean
+- `py_compile`: passed
+- targeted pytest slice: passed
+  - output: `29 passed`
+- validator command:
+  - first attempt failed because replay conflict resolution dropped validator step-scope integrity
+  - bounded repair applied and committed as `c7250ecaf`
+  - second attempt passed with:
+    - `verdict = CONDITIONAL_GO`
+    - `operator_verdict = GO_NOW`
+    - no run-scoped blockers
+    - only condition: `PAL_REQUIRED_UNAVAILABLE`
+- bounded diff versus `main`:
+  - `services/repo-truth-extractor/run_extraction_v5.py`
+  - `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+
+## Final Validation Status
+
+- replay branch integrity: `PASS`
+- bounded validator integrity for `A/A2`: `PASS`
+- replay branch clean after validation: `PASS`

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_conflict_resolution.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replay_conflict_resolution.md
@@ -1,0 +1,69 @@
+# Replay Conflict Resolution
+
+## Summary
+
+Conflicts occurred in the bounded runtime surface only:
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+- one add/add conflict in `services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py` was resolved by keeping the already-compatible staged content
+
+## Resolutions
+
+### `c660ab9df`
+
+- Conflicted file: `validate_pre_live_gate_v25.py`
+- Resolution: kept the richer current branch implementation:
+  - `Condition` plus `GateCondition = Condition`
+  - bounded target scope logic
+  - richer environment summary and sanitized JSON printing
+- Semantics preserved: validator slice required for bounded `A/A2` gating
+
+### `2144d4e36`
+
+- Conflicted file: `run_extraction_v5.py`
+- Resolution: restored pricing hash import / return behavior while preserving richer current spend-abort and resume-proof fields
+- Semantics preserved: TP001 spend-cap and pricing registry logic
+
+### `e14690d0d`
+
+- Conflicted files:
+  - `run_extraction_v5.py`
+  - `tests/test_run_extraction_v5_validator.py` (add/add)
+- Resolution: kept current bounded-execution and selected-step handling while preserving validator test coverage
+- Semantics preserved: TP003 bounded execution path
+
+### `0db7b8528`
+
+- Conflict in `run_extraction_v5.py` resolved to an empty replay
+- Reason: current branch already had the needed usage-summary extraction behavior
+
+### `91868d873`
+
+- Conflicted file: `run_extraction_v5.py`
+- Resolution: kept richer current parse-provenance, safe logging, and cost-abort status handling
+- Semantics preserved: repair provenance tracking and unified run-status behavior
+
+### `6bc14c7bd`
+
+- Conflicted files:
+  - `run_extraction_v5.py`
+  - `validate_pre_live_gate_v25.py`
+- Resolution:
+  - adopted the compact `collect_provider_routes(..., selected_step_ids_by_phase=...)` call shape
+  - preserved dict-safe request metadata extraction
+  - preserved richer validator scope/reporting fields while adding selected-step-aware route derivation and runtime call path
+- Semantics preserved: narrow post-TP004 live fixes
+
+## Replay-Repair Commit
+
+After the replayed commits landed, validator execution exposed one remaining bounded defect introduced by conflict resolution:
+
+- missing `return scope` in `derive_scope()`
+- phase-wide observed contract-map keys still compared against selected-step expectations
+
+This required bounded repair commit:
+
+- `c7250ecaf` `fix(repo-truth-extractor): restore selected-step validator replay integrity`
+
+Without that repair the replay branch failed the packet’s required validator command and could not be called ready.

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replayed_commit_log.md
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/replayed_commit_log.md
@@ -1,0 +1,24 @@
+# Replayed Commit Log
+
+## Required Source Slice
+
+Source authority came from `TP-CODEX-RTE-MERGE-PREP-001/clean_replay_plan.md` and `required_commit_source_map.md`.
+
+## Replay Results
+
+| Source SHA | Subject | Earliest source branch | Replay action | Result | Replay SHA / note |
+| --- | --- | --- | --- | --- | --- |
+| `c660ab9df` | `fix(repo-truth-extractor): recover deferred tp002-owned changes` | `feature/pm-jules-010-to-runtime-freeze-v2-clean` | `cherry-pick` | `conflict resolved` | `d4fc167d79e96b22f78109bd4e91f33ca3edf2af` |
+| `2144d4e36` | `fix(repo-truth-extractor): recover TP001 spend-cap logic from mixed runner` | `feature/pm-jules-010-to-runtime-freeze-v2-clean` | `cherry-pick` | `conflict resolved` | `de544c1379b2b259b9aab97bff0f7172e4f28366` |
+| `e14690d0d` | `fix(repo-truth-extractor): recover TP003 bounded execution logic from mixed runner` | `feature/pm-jules-010-to-runtime-freeze-v2-clean` | `cherry-pick` | `conflict resolved` | `ff29dd457c78f2f63e51e3882a6310e4a7df5633` |
+| `0db7b8528` | `fix(repo-truth-extractor): recover missing TP001 usage summary logic` | `feature/pm-jules-010-to-runtime-freeze-v2-clean` | `cherry-pick` | `already preserved / empty replay` | `git cherry-pick --skip` after empty delta |
+| `91868d873` | `feat(repo-truth-extractor): implement JSON repair provenance tracking and unify run status` | `feature/pm-jules-010-to-runtime-freeze-v2-clean` | `cherry-pick` | `conflict resolved` | `52d651b01033b889680f888c2bdb278e3297e77f` |
+| `6bc14c7bd` | `fix(repo-truth-extractor): correct narrow post-tp004 live defects` | `codex/rte-prelive-005-bounded-live-reattempt` | `cherry-pick` | `conflict resolved` | `1052feba2d77d7ad14f008819ad073dfa61d9084` |
+| `d88a1bcc4` | `fix(repo-truth-extractor): correct narrow bounded-live truth defect` | `codex/rte-prelive-006-coherent-bounded-live-reattempt` | `cherry-pick` | `already preserved / empty replay` | `git cherry-pick --skip` after empty delta |
+| `9317a169d` | `fix(repo-truth-extractor): correct narrow post-tp006 artifact truth contradiction` | `codex/rte-prelive-006-coherent-bounded-live-reattempt` | `cherry-pick` | `already preserved / empty replay` | `git cherry-pick --skip` after empty delta |
+
+## Replay-Repair Delta
+
+- Additional replay-repair commit created: `c7250ecaf5dd069dc324b5f538a9285dd03853d8`
+- Subject: `fix(repo-truth-extractor): restore selected-step validator replay integrity`
+- Reason: replay conflict resolution left `validate_pre_live_gate_v25.py` without `return scope` and without step-filtered observed contract-map keys. The branch did not validate until this bounded fix was applied.

--- a/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/verification_commands.txt
+++ b/proof/repo-truth-extractor/TP-CODEX-RTE-MERGE-EXEC-001/verification_commands.txt
@@ -1,0 +1,48 @@
+git merge-base --is-ancestor f9c29499a2a1179b2dd77d81528492f47fcd55c9 main && echo BASE_OK
+BASE_OK
+
+git status --short
+[no output]
+
+git branch --show-current
+codex/rte-merge-exec-001
+
+git log --oneline --decorate --graph --max-count=40
+* c7250ecaf (HEAD -> codex/rte-merge-exec-001) fix(repo-truth-extractor): restore selected-step validator replay integrity
+* 1052feba2 fix(repo-truth-extractor): correct narrow post-tp004 live defects
+* 52d651b01 feat(repo-truth-extractor): implement JSON repair provenance tracking and unify run status
+* ff29dd457 fix(repo-truth-extractor): recover TP003 bounded execution logic from mixed runner
+* de544c137 fix(repo-truth-extractor): recover TP001 spend-cap logic from mixed runner
+* d4fc167d7 fix(repo-truth-extractor): recover deferred tp002-owned changes
+* e4bf2d148 (origin/main, origin/HEAD, main) fix(cli): move ALL_PASSES to module level, clarify --passes help text
+
+python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py
+[exit 0]
+
+pytest -q services/repo-truth-extractor/tests/ -k "cost_cap or validator or phase_execution_step_filter or validator_repair_provenance"
+.............................                                            [100%]
+
+env XAI_API_KEY="$XAI_API_KEY" python services/repo-truth-extractor/validate_pre_live_gate_v25.py --target-policy balanced_grok_openrouter --target-phases A --step A2 --allow-online-preflight
+First attempt:
+- warning: model_map.yaml steps outside repo_truth_map JSON scope
+- HTTP 200 preflight calls to x.ai succeeded
+- failed before verdict due replay defect:
+  - `TypeError: 'NoneType' object is not subscriptable`
+  - cause: `derive_scope()` lost `return scope`
+
+Second attempt after bounded replay repair:
+- warning: model_map.yaml steps outside repo_truth_map JSON scope
+- HTTP 200 preflight calls to x.ai succeeded
+- verdict JSON:
+  - `verdict`: `CONDITIONAL_GO`
+  - `operator_verdict`: `GO_NOW`
+  - `reason_codes`: `[]`
+  - `contract_map_determinism`: `PASS`
+  - `online_provider_preflight`: `PASS`
+  - `critical_tests`: `PASS`
+  - only condition: `PAL_REQUIRED_UNAVAILABLE`
+
+git diff --stat main...HEAD
+ services/repo-truth-extractor/run_extraction_v5.py | 32 +++++++---------------
+ .../validate_pre_live_gate_v25.py                  | 26 +++++++++++++++---
+ 2 files changed, 32 insertions(+), 26 deletions(-)

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -3055,11 +3055,8 @@ def load_pricing_registry(path: Path = PRICING_CONFIG_PATH) -> Tuple[Dict[str, D
             "input_cost_per_m": input_cost,
             "output_cost_per_m": output_cost,
         }
-<<<<<<< HEAD
-=======
     from lib.promptgen.hashing import sha256_text
     return registry, sha256_text(path.read_text(encoding="utf-8"))
->>>>>>> 4d91d39bf (fix(repo-truth-extractor): correct narrow post-tp004 live defects)
 
 
 def extract_usage_summary(provider: str, response_obj: Any, response_json: Optional[Dict[str, Any]]) -> Optional[Dict[str, int]]:
@@ -16838,11 +16835,8 @@ def write_resume_proof(
                 missing = c_payload.get("missing_required_artifacts", [])
                 missing_total += len(missing)
                 phase_statuses[phase] = c_payload.get("status", "UNKNOWN")
-<<<<<<< HEAD
-=======
             except Exception:
                 pass
->>>>>>> 4d91d39bf (fix(repo-truth-extractor): correct narrow post-tp004 live defects)
 
     run_status = compute_run_status(
         blocked_promptset=blocked_promptset,
@@ -16856,8 +16850,6 @@ def write_resume_proof(
         "run_id": run_id,
         "active_phases": active_phases,
         "resume_status": "ready" if run_status == "OK" else "blocked",
-<<<<<<< HEAD
-=======
         "run_status": run_status,
         "cost_abort_triggered": cost_abort_triggered,
         "totals": {
@@ -16865,7 +16857,6 @@ def write_resume_proof(
             "recomputed_partitions": total_recomputed,
         },
         "phases": per_phase,
->>>>>>> 4d91d39bf (fix(repo-truth-extractor): correct narrow post-tp004 live defects)
         "prompt_hash_mode": promptset["prompt_hash_mode"],
         "promptset_sha256": promptset["promptset_sha256"],
         "prompt_hashes": promptset["prompt_hashes"],

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -6316,6 +6316,7 @@ def derive_route_readiness_summary(
                     for step_id in raw_selected
                     if str(step_id).strip()
                 }
+                }
         for prompt in prompts:
             if selected_ids is not None and prompt.step_id not in selected_ids:
                 continue

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -6538,17 +6538,11 @@ def run_provider_preflight(
         if (selected_ids := _selected_execution_step_ids_for_phase(cfg, phase))
         is not None
     }
-    if selected_step_ids_by_phase:
-        provider_routes = collect_provider_routes(
-            phases=phases,
-            routing_policy=cfg.routing_policy,
-            selected_step_ids_by_phase=selected_step_ids_by_phase,
-        )
-    else:
-        provider_routes = collect_provider_routes(
-            phases=phases,
-            routing_policy=cfg.routing_policy,
-        )
+    provider_routes = collect_provider_routes(
+        phases=phases,
+        routing_policy=cfg.routing_policy,
+        selected_step_ids_by_phase=selected_step_ids_by_phase or None,
+    )
     provider_probes = [
         run_provider_doctor_probe(
             provider=route["provider"],

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -6316,7 +6316,6 @@ def derive_route_readiness_summary(
                     for step_id in raw_selected
                     if str(step_id).strip()
                 }
-                }
         for prompt in prompts:
             if selected_ids is not None and prompt.step_id not in selected_ids:
                 continue
@@ -10247,6 +10246,11 @@ def log_response_parse_repair(finalized: Dict[str, Any]) -> None:
     safe = _sanitize_provenance_for_logging(finalized)
     logger.warning(
         "RESPONSE_PARSE_REPAIRED: phase=%s step=%s partition=%s strategy=%s delta=%d",
+        _safe_log_value(safe.get("phase")),
+        _safe_log_value(safe.get("step_id")),
+        _safe_log_value(safe.get("partition_id")),
+        _safe_log_value(safe.get("repair_type")),
+        int(safe.get("chars_delta", 0) or 0),
     )
 
 
@@ -12897,7 +12901,6 @@ def execute_step_for_partitions(
             ]
             request_meta_local["strict_route_attempts"] = strict_attempts
             request_meta_local["strict_route_attestations"] = strict_attestations
-            parse_json_from_response(response_text_local)
             parsed, provenance = parse_json_from_response_with_provenance(
                 response_text_local
             )
@@ -13788,7 +13791,6 @@ def execute_step_for_partitions(
                     strict_error is not None
                     and _is_semantic_eof_eligible(strict_error, strict_candidate)
                 )
-                parse_json_from_response(response_text_local)
                 parsed, provenance = parse_json_from_response_with_provenance(
                     response_text_local
                 )

--- a/services/repo-truth-extractor/validate_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/validate_pre_live_gate_v25.py
@@ -1304,7 +1304,7 @@ def run_gate(
     all_blockers.extend(blockers)
     all_conditions.extend(conditions)
 
-    online_preflight, blockers, conditions = evaluate_online_preflight(runner, config, args)
+    online_preflight, blockers, conditions = evaluate_online_preflight(runner, config)
     layer_payloads["online_provider_preflight"] = online_preflight
     write_json(config.output_dir / "ONLINE_PREFLIGHT_RESULTS.json", online_preflight)
     all_blockers.extend(blockers)

--- a/services/repo-truth-extractor/validate_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/validate_pre_live_gate_v25.py
@@ -147,7 +147,6 @@ class Condition:
 
 
 GateCondition = Condition
-
 CODE_BLOCKER = "CODE_BLOCKER"
 ARTIFACT_OR_STATE_BLOCKER = "ARTIFACT_OR_STATE_BLOCKER"
 ENVIRONMENT_BLOCKER = "ENVIRONMENT_BLOCKER"
@@ -1317,9 +1316,9 @@ def run_gate(
         "run_id": config.run_id,
         "output_dir": str(config.output_dir.resolve()),
         "reason_codes": reason_codes,
+        "conditions": condition_rows,
         "run_scoped_blockers": active_blockers,
         "blocker_classification": blocker_classification,
-        "conditions": condition_rows,
         "repo_wide_findings": repo_wide_findings,
         "waivers": waived,
         "layers": summarize_layers(layer_payloads),

--- a/services/repo-truth-extractor/validate_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/validate_pre_live_gate_v25.py
@@ -492,9 +492,10 @@ def evaluate_contract_map(
     observed_target_keys = sorted(
         key
         for key in map_steps.keys()
-        if str(key).split(":")[0] in set(config.target_phases)
         and (
             not target_step
+            or (":" in str(key) and str(key).split(":", 1)[1].strip().upper() == target_step)
+        )
             or str(key).split(":", 1)[1].strip().upper() == target_step
         )
     )

--- a/services/repo-truth-extractor/validate_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/validate_pre_live_gate_v25.py
@@ -339,7 +339,7 @@ def expected_contract_map_target_keys(contract_module: Any, config: GateConfig) 
         if str(key).split(":", 1)[0] in target_phases
         and (
             not target_step
-            or str(key).split(":", 1)[1].strip().upper() == target_step
+            or (":" in str(key) and str(key).split(":", 1)[1].strip().upper() == target_step)
         )
     )
 

--- a/services/repo-truth-extractor/validate_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/validate_pre_live_gate_v25.py
@@ -408,6 +408,7 @@ def derive_scope(runner: Any, contract_module: Any, config: GateConfig) -> Dict[
             volatile_keys=CONTRACT_MAP_VOLATILE_KEYS,
         ),
     }
+    return scope
 
 
 def evaluate_import_cli_smoke(config: GateConfig) -> Tuple[Dict[str, Any], List[Blocker]]:
@@ -487,10 +488,15 @@ def evaluate_contract_map(
 
     expected_target_keys = expected_contract_map_target_keys(contract_module, config)
     map_steps = payload_one.get("steps", {})
+    target_step = str(config.target_step or "").strip().upper()
     observed_target_keys = sorted(
         key
         for key in map_steps.keys()
         if str(key).split(":")[0] in set(config.target_phases)
+        and (
+            not target_step
+            or str(key).split(":", 1)[1].strip().upper() == target_step
+        )
     )
     if hash_one != hash_two or expected_target_keys != observed_target_keys:
         blockers.append(

--- a/services/repo-truth-extractor/validate_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/validate_pre_live_gate_v25.py
@@ -332,17 +332,29 @@ def expected_contract_map_target_keys(contract_module: Any, config: GateConfig) 
     if not isinstance(steps, dict):
         return []
     target_phases = set(config.target_phases)
+    target_step = str(config.target_step or "").strip().upper()
     return sorted(
         key
         for key in steps.keys()
         if str(key).split(":", 1)[0] in target_phases
+        and (
+            not target_step
+            or str(key).split(":", 1)[1].strip().upper() == target_step
+        )
     )
 
 
 def derive_scope(runner: Any, contract_module: Any, config: GateConfig) -> Dict[str, Any]:
+    selected_step_ids_by_phase: Optional[Dict[str, Sequence[str]]] = None
+    if config.target_step:
+        target_step = str(config.target_step).strip().upper()
+        target_phase = target_step[:1]
+        if target_phase in set(config.target_phases):
+            selected_step_ids_by_phase = {target_phase: [target_step]}
     readiness = runner.derive_route_readiness_summary(  # type: ignore[attr-defined]
         phases=list(config.target_phases),
         routing_policy=config.target_policy,
+        selected_step_ids_by_phase=selected_step_ids_by_phase,
     )
     enriched_routes = []
     for row in readiness["routes"]:
@@ -371,6 +383,7 @@ def derive_scope(runner: Any, contract_module: Any, config: GateConfig) -> Dict[
         "target_step": config.target_step,
         "target_mode": config.target_mode,
         "target_runner_path": str(RUNNER_PATH.resolve()),
+        "target_contract_map_path": str(CONTRACT_MAP_PATH.resolve()),
         "target_runner_sha256": sha256_file(RUNNER_PATH),
         "promptset_sha256": sha256_file(PROMPTSET_PATH),
         "artifacts_sha256": sha256_file(ARTIFACTS_PATH),
@@ -395,7 +408,6 @@ def derive_scope(runner: Any, contract_module: Any, config: GateConfig) -> Dict[
             volatile_keys=CONTRACT_MAP_VOLATILE_KEYS,
         ),
     }
-    return scope
 
 
 def evaluate_import_cli_smoke(config: GateConfig) -> Tuple[Dict[str, Any], List[Blocker]]:
@@ -775,6 +787,7 @@ def evaluate_pal_validation(
 def evaluate_online_preflight(
     runner: Any,
     config: GateConfig,
+    args: Optional[argparse.Namespace] = None,
 ) -> Tuple[Dict[str, Any], List[Blocker], List[Condition]]:
     blockers: List[Blocker] = []
     conditions: List[Condition] = []
@@ -1285,7 +1298,7 @@ def run_gate(
     all_blockers.extend(blockers)
     all_conditions.extend(conditions)
 
-    online_preflight, blockers, conditions = evaluate_online_preflight(runner, config)
+    online_preflight, blockers, conditions = evaluate_online_preflight(runner, config, args)
     layer_payloads["online_provider_preflight"] = online_preflight
     write_json(config.output_dir / "ONLINE_PREFLIGHT_RESULTS.json", online_preflight)
     all_blockers.extend(blockers)
@@ -1340,7 +1353,7 @@ def main() -> int:
     parser = build_arg_parser()
     args = parser.parse_args()
     config = build_config(args)
-    result = run_gate(config)
+    result = run_gate(config, args)
     print(sanitized_json_text(result["verdict"], indent=2, sort_keys=True, ensure_ascii=True))
     return 0 if result["verdict"]["verdict"] in {"GO", "CONDITIONAL_GO"} else 1
 


### PR DESCRIPTION
## What this PR is

Clean replay of the bounded prelive extractor runtime slice for:

- phase `A`
- step `A2`
- routing policy `balanced_grok_openrouter`

This PR is based on `codex/rte-merge-exec-001` and is intended to present the bounded merge candidate to reviewers without reusing the earlier contaminated local `main` integration path.

## What was proven

- bounded target validated for `A / A2 / balanced_grok_openrouter`
- `python -m py_compile` passed for:
  - `services/repo-truth-extractor/run_extraction_v5.py`
  - `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
- targeted pytest slice passed:
  - `cost_cap`
  - `validator`
  - `phase_execution_step_filter`
  - `validator_repair_provenance`
- validator result:
  - `CONDITIONAL_GO`
  - `operator_verdict = GO_NOW`

## What changed

Runtime code diff is limited to:

- `services/repo-truth-extractor/run_extraction_v5.py`
- `services/repo-truth-extractor/validate_pre_live_gate_v25.py`

The branch also carries replay proof artifacts from `TP-CODEX-RTE-MERGE-EXEC-001`.

## Replay notes

- replay was not purely mechanical
- five required source commits landed as replay commits
- three required source commits replayed as empty because their behavior was already preserved after earlier conflict resolution
- one bounded repair commit was required:
  - `c7250ecaf`

Reason for `c7250ecaf`:

- restore validator step-scope correctness after replay conflict resolution
- specifically restore missing `return scope` and selected-step contract-map filtering

## What is NOT claimed

- not full extractor correctness
- not all phases or all steps
- not production-wide readiness
- not proof of correctness outside the bounded target described above

## Remaining conditions

- PAL validation was not provided
- validator result remains `CONDITIONAL_GO`, not flat `GO`
- reviewer should treat the current evidence as bounded-target validation only

## Reviewer guidance

- verify the runtime diff scope is limited to the two files above
- verify the branch also includes the replay proof bundle and no unrelated runtime surfaces
- verify replay integrity against the source replay slice and the empty-replay notes
- verify `c7250ecaf` is bounded to validator step-scope repair and does not widen runtime scope
- confirm the branch preserves the bounded `A / A2 / balanced_grok_openrouter` behavior without contamination from prior branch history