### PR TITLE
[codex] Add codebase and Repo Truth Extractor explainer docs

### DIFF
--- a/docs/00-MASTER-INDEX.md
+++ b/docs/00-MASTER-INDEX.md
@@ -3,7 +3,7 @@ id: 00-MASTER-INDEX
 title: 00 Master Index
 type: explanation
 owner: '@hu3mann'
-last_review: '2026-03-30'
+last_review: '2026-04-12'
 next_review: '2026-06-30'
 author: '@hu3mann'
 date: '2026-02-05'
@@ -101,6 +101,7 @@ Status: [LOGGED] Topology Complete
 
 ### Core Architecture
 - [Architecture Overview](04-explanation/architecture/dopemux-architecture-overview.md) - Complete system architecture
+- [Full Codebase Explainer](04-explanation/architecture/dopemux-mvp-full-codebase-explainer.md) - Repo-truth explainer for the active Dopemux control surfaces, service boundaries, and authority split
 - [System Bible](04-explanation/architecture/system-bible.md) - Consolidated knowledge base
 - [Three-Layer Integration](90-adr/adr-207-architecture-3-0-three-layer-integration.md)
 - [Multi-Instance Implementation](04-explanation/architecture/multi-instance-implementation.md)
@@ -196,6 +197,7 @@ Status: [LOGGED] Topology Complete
 
 ### Technical Deep Dives
 - [Memory And Persistence Deep Dive](04-explanation/technical-deep-dives/memory-and-persistence-deep-dive.md)
+- [Repo Truth Extractor — Structure, Architecture & Optimal Design](04-explanation/technical-deep-dives/repo-truth-extractor-structure-architecture-and-optimal-design.md)
 - [Serena V2 Technical Deep Dive](04-explanation/technical-deep-dives/serena-v2-technical-deep-dive.md)
 - [ConPort Technical Deep Dive](04-explanation/technical-deep-dives/conport-technical-deep-dive.md)
 - [Dope-Memory Deep Dive](04-explanation/technical-deep-dives/dope-memory-deep-dive-2.md)

--- a/docs/04-explanation/architecture/dopemux-mvp-full-codebase-explainer.md
+++ b/docs/04-explanation/architecture/dopemux-mvp-full-codebase-explainer.md
@@ -1,0 +1,318 @@
+---
+id: dopemux-mvp-full-codebase-explainer
+title: Dopemux MVP - Full Codebase Explainer
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-04-12'
+last_review: '2026-04-12'
+next_review: '2026-07-12'
+prelude: Repo-truth explainer for the active Dopemux MVP checkout, including control surfaces, service boundaries, and known authority drift.
+---
+# Dopemux MVP - Full Codebase Explainer
+
+This explainer is grounded in active runtime code and config in this checkout, especially `pyproject.toml`, `compose.yml`, `services/registry.yaml`, `src/dopemux/pm/writes.py`, `scripts/taskx`, `scripts/dopetask`, `services/task-orchestrator/app/main.py`, `services/dopecon-bridge/dopecon_bridge/routes.py`, `services/working-memory-assistant/dope_memory_main.py`, `ui-dashboard/package.json`, and `ui-dashboard/src/App.tsx`.
+
+Older docs in this repo drift. Where authority is unresolved, this document keeps the ambiguity explicit instead of flattening the system into a single neat architecture.
+
+## What Is It?
+
+Dopemux is an ADHD-aware developer operations stack. Its core idea is that flow breaks when terminal state, project state, memory, AI tooling, and attention signals live in separate places. Dopemux tries to keep those surfaces coordinated.
+
+It is not one application. It is a composed workspace of cooperating systems with separate authority domains:
+
+- the `dopemux` CLI is the operator control surface
+- task execution is delegated to an external `dopetask` binary
+- workflow and PM writes are split across multiple systems
+- memory, context retrieval, routing, and UI each have their own runtime surfaces
+
+## Technology Stack
+
+| Layer | Technology |
+| --- | --- |
+| CLI / core library | Python 3.11+, Click, Rich |
+| Services | FastAPI-based Python services |
+| Dashboard UI | React, TypeScript, Vite, Material UI, `lucide-react` |
+| Structured graph / decision store | PostgreSQL with Apache AGE |
+| Vector search | Qdrant |
+| Event and cache layers | Redis (`redis-events` on `6379`, `redis-primary` on `6380`) |
+| AI proxy | LiteLLM |
+| PM surfaces | Leantime, task-orchestrator, ConPort, dope-memory mirror receipts |
+| Runtime orchestration | Docker Compose via canonical `compose.yml` |
+| Testing and quality | pytest, mypy, Black, isort, flake8 |
+| External task execution | `dopetask`, pinned in this repo at `0.5.1` via `.dopetask-pin` |
+
+## Repository Structure
+
+```text
+dopemux-mvp/
+├── src/dopemux/            # Core CLI, PM layer, ADHD modules, tmux/UI helpers
+├── services/               # Service apps, MCP servers, adapters, and related runtimes
+├── ui-dashboard/           # React/TypeScript dashboard
+├── ui-dashboard-backend/   # Dashboard backend support code
+├── docker/                 # Container build contexts and runtime support
+├── scripts/                # Operational wrappers and helper scripts
+├── tests/                  # Pytest suite for core package behavior
+├── docs/                   # Diataxis documentation tree
+├── compose.yml             # Canonical Docker Compose runtime
+└── services/registry.yaml  # Service ports, health endpoints, compose names
+```
+
+## The 9 Core Systems
+
+### 1. `dopemux` CLI (`src/dopemux/`)
+
+This is the operator-facing control plane. It is a Click CLI with Rich output and ADHD-oriented session helpers.
+
+Observed responsibilities in code include:
+
+- workspace and service startup through `dopemux start`
+- session/health/status surfaces such as `status`, `dashboard`, `doctor`, and `truth`
+- ADHD tracking through `src/dopemux/adhd/`
+- PM normalization through `src/dopemux/pm/`
+- MCP management through `src/dopemux/mcp/`
+- tmux integration through `src/dopemux/tmux/`
+- Claude and tool configuration through `src/dopemux/claude/` and `src/dopemux/claude_tools/`
+
+Important subpackages visible in this checkout:
+
+- `adhd/`
+- `pm/`
+- `mcp/`
+- `tmux/`
+- `ui/`
+- `claude/`
+- `roles/`
+- `worktree`-related helpers across `cli.py`, `cli_worktree_enhanced.py`, and related modules
+
+### 2. `dopetask` wrapper surface (`scripts/taskx`, `scripts/dopetask`)
+
+Task execution is not implemented directly in this repo. The runtime chain is:
+
+```text
+dopemux -> scripts/taskx -> scripts/dopetask -> external dopetask binary
+```
+
+Repo truth here:
+
+- `scripts/taskx` is a compatibility shim only
+- `scripts/dopetask` manages a dedicated virtualenv and installs the pinned binary
+- `.dopetask-pin` in this checkout pins `dopetask==0.5.1`
+
+### 3. task-orchestrator (`services/task-orchestrator/`, port `8000`)
+
+This is the workflow coordination surface. The intended FastAPI runtime entrypoint is `services/task-orchestrator/app/main.py`.
+
+Observed responsibilities include:
+
+- workflow/coordination APIs
+- idea and epic CRUD
+- workflow transition and audit surfaces
+- project workflow state routes
+- MCP tool exposure through its own server wiring
+
+Within the PM split, this is the intended authority for workflow-significant transitions. That matches `src/dopemux/pm/writes.py`, which routes transition writes to the orchestrator path.
+
+### 4. ConPort (`conport-http` on `3004`, `conport-mcp` on `3005`)
+
+ConPort is the structured context, decision, and progress surface. `services/registry.yaml` distinguishes:
+
+- HTTP API on `3004`
+- MCP/SSE surface on `3005`
+
+In practice it is used for:
+
+- decisions
+- progress records
+- custom data
+- structured project context
+
+Its backing infrastructure is PostgreSQL with AGE. In the PM plane, it is the canonical decision/progress logging target, not the workflow transition authority.
+
+### 5. Dope-Memory / working-memory-assistant naming surface (`services/working-memory-assistant/`, port `3020`)
+
+The active HTTP runtime for the chronicle service lives in `services/working-memory-assistant/dope_memory_main.py`, which exposes a FastAPI app on port `3020`.
+
+Observed responsibilities include:
+
+- temporal chronicle capture
+- canonical SQLite ledger management
+- work log and reflection storage
+- memory receipt and history surfaces
+- MCP server support in `services/working-memory-assistant/mcp/server.py`
+
+Important caveat: naming and directory authority drift here. This repo has both `services/working-memory-assistant/` and `services/dope-memory/`. The runtime and tests show a canonical SQLite chronicle ledger model, but the directory story is not perfectly unified.
+
+### 6. dope-context (`services/dope-context/`, port `3010`)
+
+Dope-context is the semantic code and document retrieval service.
+
+Observed responsibilities include:
+
+- code search and document search via MCP
+- Qdrant-backed retrieval and reranking
+- embeddings, contextual enrichment, and token-budgeted search responses
+- attention-aware result shaping tied to ADHD signals
+
+The active MCP surface in this checkout is visible in `services/dope-context/src/mcp/simple_server.py`, which defaults to port `3010`. It is a derived indexer and retrieval plane, not a source-of-truth owner.
+
+### 7. dopecon-bridge (`services/dopecon-bridge/`, port `3016`)
+
+Dopecon-bridge is an adapter and routing layer.
+
+The most important truth statement is in `services/dopecon-bridge/dopecon_bridge/routes.py` itself:
+
+- it is an adapter and proxy layer
+- it must not act as canonical task, workflow, decision, or progress authority
+
+Observed roles include:
+
+- PM route normalization
+- event publishing
+- ConPort proxying
+- compatibility routing for legacy callers
+
+It also has an alternate port entry in `services/registry.yaml` (`3000` -> `3016`), which reinforces that the bridge should be treated as plumbing, not authority.
+
+### 8. ADHD engine and Serena (`services/adhd_engine/`, `services/serena/`; ports `3025` and `3006`)
+
+These are the cognitive support surfaces.
+
+Observed ADHD-engine responsibilities include:
+
+- attention and energy state events
+- break recommendation signals
+- hyperfocus detection support
+- integration hooks for other services
+
+Observed Serena responsibilities include:
+
+- focus-state management
+- break reminders and hyperfocus protection
+- MCP-oriented developer assistance
+- navigation and code-intelligence support
+
+`services/registry.yaml` maps:
+
+- `adhd-engine` to port `3025`
+- `serena` to port `3006`
+
+### 9. repo-truth-extractor (`services/repo-truth-extractor/`)
+
+This is the audit and repo-truth extraction subsystem. The canonical runner named by repo instructions is:
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+
+It exists to generate evidence-backed reports about the current repo and to detect doc/runtime drift instead of hand-waving it away.
+
+## Infrastructure Services
+
+| Service | Port | Purpose |
+| --- | --- | --- |
+| PostgreSQL + AGE | `5432` | Decision graph / structured storage |
+| Redis Events | `6379` | Event streaming / PubSub |
+| Redis Primary | `6380` | Cache layer |
+| Qdrant | `6333` | Vector search backend |
+| LiteLLM | `4000` | Model proxy |
+| Leantime | `8080` | PM entity store / UI |
+
+## How The Systems Connect
+
+```mermaid
+flowchart TD
+    User["Developer"] --> CLI["dopemux CLI"]
+    CLI --> DT["scripts/taskx -> scripts/dopetask -> dopetask"]
+    CLI --> TO["task-orchestrator:8000"]
+    TO --> Bridge["dopecon-bridge:3016"]
+    Bridge --> Redis["redis-events:6379"]
+    Bridge --> ConPort["ConPort:3004 / 3005"]
+    Bridge --> Leantime["Leantime:8080"]
+    CLI --> Memory["Dope-Memory:3020"]
+    CLI --> Context["dope-context:3010"]
+    CLI --> ADHD["adhd-engine:3025"]
+    CLI --> LiteLLM["LiteLLM:4000"]
+    Dashboard["ui-dashboard"] --> ADHD
+    Dashboard --> DashboardState["/api/adhd-state and /ws/state"]
+```
+
+This is a coordination map, not a claim that every edge is canonical authority. Authority is split intentionally and, in a few places, imperfectly.
+
+## PM Plane: How Project Management Is Split
+
+The PM layer is divided by write type, not by a single backend. `src/dopemux/pm/writes.py` is the relevant code authority here.
+
+| Write type | Authority |
+| --- | --- |
+| Passive metadata such as title, description, assignee, labels | Leantime via `pm_update_work_item()` |
+| Workflow-significant transitions | task-orchestrator via `pm_transition_work_item()` |
+| Decisions and progress logging | ConPort via `pm_log_progress()` |
+| Historical receipts / chronicle mirror | dope-memory memory receipts |
+
+The routing logic is explicit:
+
+- `classify_pm_write()` separates metadata fields from workflow-significant fields
+- workflow-significant keys fail closed into the orchestrator path
+- mirror receipts are tracked explicitly instead of hidden
+
+## UX Surfaces
+
+### Terminal first
+
+The primary operator experience is still terminal-centric:
+
+- Rich-rendered status and health views
+- tmux-aware session handling
+- ADHD metrics via `AttentionMonitor`
+- task and context helpers via `TaskDecomposer` and `ContextManager`
+- CLI health, truth, dashboard, extraction, and diagnostic commands
+
+### Web dashboard
+
+The dashboard is a React/TypeScript Vite app in `ui-dashboard/`.
+
+Observed frontend facts:
+
+- dependencies include Material UI and `lucide-react`
+- `ui-dashboard/src/App.tsx` calls `.../api/adhd-state`
+- it opens a WebSocket to `.../ws/state`
+- it renders Energy Level, Attention Focus, Cognitive Load, and a 15-minute prediction
+- it includes a `Live Signal Feed`
+- layout behavior changes when cognitive load becomes critical
+
+### MCP and AI-assistant surface
+
+This repo exposes multiple MCP-facing systems that can be used by external coding assistants:
+
+- ConPort
+- dope-context
+- Serena
+- task-orchestrator MCP tools
+- additional MCP services listed in `services/registry.yaml`, including PAL
+
+The important boundary is that these tools expose retrieval, logging, or assistance surfaces. They do not collapse PM truth, workflow truth, and memory truth into one shared authority.
+
+## Known Fragmentation and Honest Caveats
+
+- `dopetask` is pinned at `0.5.1` in this checkout, so older `0.2.x` references are stale.
+- `scripts/taskx` is a compatibility shim, not a separate runtime.
+- task-orchestrator runtime authority is still not perfectly clean across code, packaging, and Docker wiring.
+- ConPort is exposed on both `3004` and `3005`, depending on whether callers want HTTP or MCP/SSE.
+- dope-memory naming and directory layout drift across `services/working-memory-assistant/` and `services/dope-memory/`.
+- agent-system authority remains unresolved across multiple families in this repo; there is no single verified agent architecture to document as canonical.
+- dopecon-bridge is broad and tempting to treat as a control plane, but its active routes explicitly mark it as adapter-only.
+- Older architecture prose in the repo should be treated as advisory until confirmed against code, config, and tests.
+
+## Bottom Line
+
+Dopemux is best understood as a terminal-first operator shell over a split system:
+
+- CLI control and developer ritual management in `src/dopemux/`
+- external task execution through `dopetask`
+- workflow coordination through task-orchestrator
+- decision/progress context through ConPort
+- temporal memory through dope-memory
+- semantic retrieval through dope-context
+- cognitive accommodations through ADHD engine and Serena
+- runtime composition through `compose.yml`
+
+That split is not a defect by itself. The risk is pretending the split does not exist. The safest mental model for this repo is a composed workspace with explicit authority boundaries, some intentional and some still drifting.

--- a/docs/04-explanation/overview.md
+++ b/docs/04-explanation/overview.md
@@ -5,7 +5,7 @@ type: explanation
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-03-19'
-last_review: '2026-03-30'
+last_review: '2026-04-12'
 next_review: '2026-06-30'
 prelude: Understanding-oriented explanation index for architecture, design rationale, and system behavior.
 ---
@@ -23,6 +23,8 @@ Explanation docs provide architecture and design context for why the system work
 
 ## Highlighted Active Topics
 
+- [Dopemux MVP - Full Codebase Explainer](architecture/dopemux-mvp-full-codebase-explainer.md)
+- [Repo Truth Extractor — Structure, Architecture & Optimal Design](technical-deep-dives/repo-truth-extractor-structure-architecture-and-optimal-design.md)
 - [Memory And Persistence Deep Dive](technical-deep-dives/memory-and-persistence-deep-dive.md)
 - [Workflow Kit Architecture](workflow-kit-architecture.md)
 - [PR Merge Queue Orchestration](pr-merge-queue-orchestration.md)

--- a/docs/04-explanation/technical-deep-dives/repo-truth-extractor-structure-architecture-and-optimal-design.md
+++ b/docs/04-explanation/technical-deep-dives/repo-truth-extractor-structure-architecture-and-optimal-design.md
@@ -1,0 +1,400 @@
+---
+id: repo-truth-extractor-structure-architecture-and-optimal-design
+title: 'Deep Analysis: Repo Truth Extractor (RTE) — Structure, Architecture & Optimal Design'
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-04-12'
+last_review: '2026-04-12'
+next_review: '2026-07-12'
+prelude: Deep analysis of Repo Truth Extractor structure, current architecture, critical findings, optimal target design, and migration plan.
+---
+# Deep Analysis: Repo Truth Extractor (RTE) — Structure, Architecture & Optimal Design
+
+## Part I: Current Architecture Map
+
+### 1. System Overview
+
+The Repo Truth Extractor (RTE) is a multi-phase, multi-provider LLM-powered codebase analysis engine that extracts structured truth from arbitrary repositories. It is the most complex subsystem in dopemux, spanning 55K+ lines of Python across 164 files, 138 promptset files, 82 test files, and 14 extraction phases.
+
+### 2. Component Architecture (As-Is)
+
+```text
+┌────────────────────────────────────────────────────────────────────────┐
+│                      CLI / UX LAYER                                    │
+│                                                                        │
+│  dopemux audit wizard ──────── 8-stage interactive wizard              │
+│  dopemux audit prescan ─────── corpus pre-scan (no LLM)               │
+│  dopemux upgrades run ──────── v4 runner facade                        │
+│  dopemux extract docs ──────── document entity extraction              │
+│  dopemux extractor [LEGACY] ── redirects to upgrades                   │
+│                                                                        │
+│  src/dopemux/ux/wizard/  (11 files, ~1,700 LOC)                       │
+│    runner.py → preflight → corpus → prompts → cost_profiles            │
+│    → partitions → extraction → summary + display + stages              │
+└─────────────┬──────────────────────────────────────────────────────────┘
+              │ delegates via subprocess
+              ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│               EXTRACTION ENGINE (services/repo-truth-extractor/)       │
+│                                                                        │
+│  ┌─────────────┐  ┌─────────────┐  ┌──────────────────────────────┐   │
+│  │ run_v3.py   │  │ run_v4.py   │  │ run_v5.py [CANONICAL]        │   │
+│  │ 12K lines   │  │ 1.1K lines  │  │ 20.7K lines                  │   │
+│  │ LEGACY      │  │ BRIDGE      │  │ 13 classes, 368 functions    │   │
+│  └─────────────┘  └─────────────┘  │ 442 exception handlers       │   │
+│                                     │ 396 JSON parsing ops         │   │
+│                                     └──────────────────────────────┘   │
+│                                                                        │
+│  14-Phase Pipeline: A → H → D → C → E → W → B → G → X → Q → R       │
+│                     → T → Z → S                                        │
+│                                                                        │
+│  Post-Processing:  FL_INT (design claims)  │  S_INT (synthesis)        │
+│  Comparison Lane:  Side-by-side model validation                       │
+└─────────────┬──────────────────────────────────────────────────────────┘
+              │ depends on
+              ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                    LIBRARY LAYER (lib/)                                 │
+│                                                                        │
+│  ┌─────────────────┐  ┌─────────────────┐  ┌──────────────────┐       │
+│  │ prescan/         │  │ promptgen/       │  │ Core Modules     │       │
+│  │ (19 files)       │  │ (19 files)       │  │                  │       │
+│  │ engine.py        │  │ sync_engine.py   │  │ intelligence_    │       │
+│  │ code_prescan.py  │  │ fingerprint.py   │  │  router.py (iR_l)│       │
+│  │ grok_passes.py   │  │ feature_detector │  │ spend_ledger.py  │       │
+│  │ classifier.py    │  │ contract_gen.py  │  │ batch_clients.py │       │
+│  │ models.py        │  │ template_render  │  │ batch_retriever  │       │
+│  └─────────────────┘  │ integrity_valid  │  │ struct_output_   │       │
+│                        └─────────────────┘  │  contracts.py    │       │
+│                                              └──────────────────┘       │
+└─────────────┬──────────────────────────────────────────────────────────┘
+              │ reads/writes
+              ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                    PROMPT ASSETS LAYER                                  │
+│                                                                        │
+│  promptsets/v4/ (138 files)       │  base_prompts/ (5 templates)       │
+│    promptset.yaml (1076 lines)    │  prompts/v3/ (500+ files)          │
+│    artifacts.yaml (2113 lines)    │  prompts/phase_fl_int/ (8 files)   │
+│    model_map.yaml (3831 lines)    │  prompts/phase_s_int/ (5 files)    │
+│    prompts/ (500+ step files)     │  prompts/phase_s/ (standalone)     │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### 3. Key Subsystems Deep Dive
+
+#### 3.1 Intelligence Router (iR_l)
+
+**What it is:** A prescan-to-extraction adapter that optimizes the extraction pipeline using pre-computed intelligence about the repository.
+
+**Current implementation:** `lib/intelligence_router.py` — single class, ~80 lines
+
+**API surface:**
+
+- `should_skip(path)` → skip duplicate/noise files
+- `should_skip_code(path)` → skip orphan code/test stubs
+- `get_compression_hint(path)` → version chain summaries
+- `get_phase_routing_override(path)` → reroute files to different phases
+- `get_model_tier(path)` → premium/standard/economy model selection
+- `get_bundling_group(path)` → partition co-location hints
+- `reorder_partition(files)` → priority-based file ordering
+
+**Problem:** iR_l is well-designed but minimally integrated. Only 2 unit tests exist. No integration tests prove that routing hints actually change extraction behavior.
+
+#### 3.2 Prescan Pipeline
+
+**Architecture:** 4-stage intelligence gathering → `prescan_intelligence.json`
+
+- Corpus Walking — File inventory, size/type classification, authority labeling
+- Code Intelligence — AST analysis, PageRank processing order, hotspot detection, orphan finding
+- Duplicate Detection — Version chain identification, compression candidates
+- Grok Passes (4 LLM-powered passes, optional):
+  - DEDUP: Near-duplicate compression summaries
+  - DISCOVER: Hidden feature/drift/ghost assessment
+  - FEASIBILITY: Planned feature effort/risk analysis
+  - OPTIMIZE: Routing hints, cost optimization, model tier suggestions
+
+**Output artifacts:** 6 JSON files feeding iR_l and extraction phases
+
+**Strength:** Well-architected, modular, optional, cost-tracked separately
+**Gap:** Grok passes not well integrated with wizard UX; code intelligence stage partially wired
+
+#### 3.3 Extraction Pipeline (v5)
+
+**14-phase dependency graph:**
+
+```text
+Independent (parallel-safe):  A  H  D  C  E  W  B  G  X
+Dependent:                    Q (requires all above)
+                              R (requires A,H,D,C; optional B,E,G,W,Q,X)
+                              T (requires R,X)
+                              Z (requires R,X,T)
+                              S (requires R; optional X,T,Z)
+```
+
+**Per-phase universal model:**
+
+- X0: Inventory (mechanical indexing)
+- X1-X2: Discovery (claims, boundaries)
+- X3-X8: Synthesis (merge, normalize, QA)
+- X9: Finalization (canonical merge)
+
+**Contract enforcement:** Primary route → Repair route → Sidefill route per step
+
+**Three routing policies:** cost / balanced / quality (8 named profiles)
+
+#### 3.4 Promptgen System
+
+**Pipeline:** fingerprint → archetype → feature_detect → phase_plan → interactive_discovery → scope_resolve → template_render → contract_gen → integrity_validate
+
+**Key innovation:** Adaptive PromptPack V2 — 5 dynamic adjustment rules based on QA feedback from prior runs (split, shrink, reduce, strict, reorder)
+
+**Contract trilogy:** `promptset.yaml` + `artifacts.yaml` + `model_map.yaml` — defines the complete extraction behavior
+
+#### 3.5 Post-Processing
+
+- FL_INT (Feature Ledger Intelligence): Design claims synthesis (F0→F4, L0→L4)
+- S_INT (System Intelligence): MCP validation, hook mapping, contract coverage, gradecard, release plan (S16→S20)
+- Comparison Lane: Run same prompts with different models, compare side-by-side without impacting canonical run
+
+### 4. UX/UI Architecture
+
+**Interactive Wizard (8 stages):**
+
+- Stage 0: Welcome + system checks (Python, git, deps)
+- Stage 1: Repo health (git status, branch, cleanliness)
+- Stage 2: Corpus audit (prescan subprocess, authority classification)
+- Stage 3: Prompt setup (promptset validation/generation)
+- Stage 4: Cost profile (8 routing policies, cost estimation, API key check)
+- Stage 5: Partition preview (file→phase mapping)
+- Stage 6: Extraction (per-phase delegation with Run/Skip/Abort)
+- Stage 7: Summary (telemetry, proof pack, next steps)
+
+**Design patterns:**
+
+- Rich terminal UI (tables, panels, progress bars, emojis)
+- Two-mode execution (preview default, `--execute` for real)
+- Educational panels (opt-in explanations)
+- Phase-by-phase confirmation
+- Subprocess delegation to `dopemux extract truth-run`
+
+### 5. Dependencies & Integration
+
+**CLI entry points (4 command groups):**
+
+- `dopemux audit` — wizard + prescan + status [NEW, canonical]
+- `dopemux upgrades` — v4 runner facade [NEW]
+- `dopemux extract` — document/code extraction [ACTIVE]
+- `dopemux extractor` — legacy, redirects to upgrades [DEPRECATED]
+
+**External dependencies:** OpenRouter, OpenAI, Anthropic, xAI/Grok, Google Gemini, GitHub Models
+**Internal dependencies:** LiteLLM proxy, Qdrant, PostgreSQL/AGE (optional), Redis (optional)
+
+## Part II: Critical Findings
+
+### 6. Architecture Pain Points
+
+| # | Issue | Severity | Evidence |
+| --- | --- | --- | --- |
+| 1 | v5 monolith — 20.7K lines, 368 functions, 13 classes in ONE file | 🔴 CRITICAL | `run_extraction_v5.py` |
+| 2 | Version duplication — v3 (12K) + v4 (1.1K) + v5 (20.7K) = 33.9K redundant lines | 🔴 CRITICAL | Three runner files |
+| 3 | 82 tests excluded from CI — `pytest.ini` excludes `services/` | 🔴 CRITICAL | `pytest.ini`, `ci-complete.yml` |
+| 4 | 84.5% functions undocumented — 311/368 functions lack docstrings | 🔴 CRITICAL | `run_extraction_v5.py` |
+| 5 | iR_l under-integrated — Only 2 unit tests, no integration proof | ⚠️ HIGH | `tests/extractor/conftest.py` |
+| 6 | Stringly-typed phases — No enum, string comparisons everywhere | ⚠️ HIGH | 16+ phase dispatcher functions |
+| 7 | 442 scattered exception handlers — No centralized error strategy | ⚠️ HIGH | `run_extraction_v5.py` |
+| 8 | Global state mutation — 20+ module-level constants mutated at runtime | ⚠️ MEDIUM | Module globals |
+| 9 | Circular import risk — `lib/prescan/provider_catalog.py` imports v5 at runtime | ⚠️ MEDIUM | Line 33 |
+| 10 | CLI command sprawl — 4 overlapping command groups (`audit`/`extract`/`extractor`/`upgrades`) | ⚠️ MEDIUM | CLI registration |
+
+### 7. Strengths to Preserve
+
+| # | Strength | Evidence |
+| --- | --- | --- |
+| 1 | Comprehensive 14-phase model — Well-thought dependency graph | Phase specs + v5 implementation |
+| 2 | Contract trilogy — promptset/artifacts/model_map is a strong abstraction | `promptsets/v4/` |
+| 3 | Prescan intelligence — Modular, optional, cost-tracked | `lib/prescan/` (19 files) |
+| 4 | Adaptive PromptPack V2 — QA-driven feedback loop (5 rules) | `lib/promptgen/promptpack_v2.py` |
+| 5 | Cost management — SpendLedger with per-phase, per-model tracking + hard limits | `lib/spend_ledger.py` |
+| 6 | Comparison Lane — Validate without impact | `v5 --compare-mode` |
+| 7 | Interactive wizard — 8-stage progressive disclosure UX | `src/dopemux/ux/wizard/` |
+| 8 | Output safety — Secret redaction on all outputs | `output_safety.py` |
+| 9 | 82 test files — Good coverage foundation | `services/repo-truth-extractor/tests/` |
+| 10 | Feature detection — 99 built-in rules + interactive enrichment | `lib/promptgen/feature_detector.py` |
+
+## Part III: Optimal Target Design
+
+### 8. Proposed Architecture
+
+```text
+┌────────────────────────────────────────────────────────────────────────┐
+│                      CLI LAYER (unified)                               │
+│                                                                        │
+│  dopemux extract                                                       │
+│    ├── prescan       # corpus intelligence audit                       │
+│    ├── wizard        # interactive guided workflow                     │
+│    ├── run           # direct phase execution                          │
+│    ├── status        # run status/dashboard                            │
+│    ├── validate      # pre-live gate + promptset integrity             │
+│    └── compare       # comparison lane                                 │
+│                                                                        │
+│  (Retire: dopemux audit, dopemux extractor, dopemux upgrades)          │
+└─────────────┬──────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                  ORCHESTRATION LAYER (NEW)                             │
+│                                                                        │
+│  extractor/                                                            │
+│    orchestrator.py ──── Phase graph execution, dependency resolution   │
+│    config.py ─────────── RunnerConfig + Phase enum + routing enums     │
+│    cost_engine.py ────── Cost estimation, ledger integration           │
+│    manifest.py ──────── Run manifest, proof pack, coverage rollup      │
+│    resume.py ─────────── Resume state management                       │
+│    comparison.py ────── Comparison lane orchestration                  │
+└─────────────┬──────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│                  PHASE EXECUTION LAYER (NEW)                           │
+│                                                                        │
+│  extractor/phases/                                                     │
+│    base.py ─────────── Abstract PhaseRunner + step dispatcher          │
+│    repo_control.py ── Phase A: Repo Control Plane                      │
+│    home_control.py ── Phase H: Home Control Plane                      │
+│    docs.py ──────────── Phase D: Documentation Pipeline                │
+│    code_surfaces.py ── Phase C: Code Surfaces                          │
+│    execution.py ─────── Phase E: Execution Plane                       │
+│    workflows.py ─────── Phase W: Workflow Plane                        │
+│    boundaries.py ────── Phase B: Boundary Contracts                    │
+│    governance.py ────── Phase G: Governance Plane                      │
+│    features.py ──────── Phase X: Feature Index                         │
+│    qa.py ─────────────── Phase Q: Quality Assurance                    │
+│    arbitration.py ──── Phase R: Arbitration                            │
+│    tasks.py ──────────── Phase T: Task Packets                         │
+│    handoff.py ────────── Phase Z: Handoff Freeze                       │
+│    synthesis.py ─────── Phase S: System Truths                         │
+└─────────────┬──────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│              LLM INTERFACE LAYER (NEW)                                 │
+│                                                                        │
+│  extractor/llm/                                                        │
+│    client.py ──────── Unified LLM call interface (call_llm)            │
+│    routing.py ─────── Provider selection, escalation ladder            │
+│    batch.py ──────── Batch API management                              │
+│    contracts.py ──── Structured output schema enforcement              │
+│    retry.py ──────── Retry + escalation + cost-aware fallback          │
+└─────────────┬──────────────────────────────────────────────────────────┘
+              │
+              ▼
+┌────────────────────────────────────────────────────────────────────────┐
+│           INTELLIGENCE LAYER (prescan + iR_l + promptgen)              │
+│           (Mostly preserved, minor refactoring)                        │
+│                                                                        │
+│  lib/prescan/    ─── Keep as-is (well-architected)                     │
+│  lib/promptgen/  ─── Keep as-is (mature pipeline)                      │
+│  lib/intelligence_router.py ─── Enhance integration                    │
+│  lib/spend_ledger.py ────────── Keep as-is                             │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+### 9. Key Design Decisions
+
+| Decision | Rationale |
+| --- | --- |
+| Decompose v5 into ~15 phase modules | 20.7K monolith → ~1.5K per phase file; testable, reviewable, ownable |
+| Introduce Phase enum | Replace all string comparisons; compile-time validation; IDE support |
+| Create LLM interface layer | Extract `call_llm()`, retry logic, batch management; single responsibility |
+| Unify CLI under `dopemux extract` | 4 overlapping groups → 1 coherent group; progressive disclosure preserved |
+| Preserve `lib/prescan` & `lib/promptgen` | Already well-structured; don't fix what works |
+| Enhance iR_l integration | Wire routing hints into orchestrator; add integration tests |
+| Enable RTE tests in CI | 82 test files running = instant regression safety net |
+| Retire v3 and v4 | Remove 13K lines of duplication; v5 is canonical |
+
+## Part IV: Migration Plan (Current Reality → Optimal Design)
+
+### Phase 0: Foundation & Safety Net (Week 1-2)
+
+- Enable RTE tests in CI — Add `services/repo-truth-extractor/tests/` to CI pipeline (new workflow job or `pytest` config adjustment)
+- Run full test suite manually — Identify failures, environment deps, API key requirements
+- Document all 14 phase runner functions — Add docstrings to the 16 `run_phase_*()` functions in v5
+- Create Phase enum — `extractor/config.py` with `Phase`, `RoutingPolicy`, `LaneClass` enums
+- Add integration test for iR_l → extraction — Prove routing hints actually change extraction behavior
+
+### Phase 1: Extract LLM Interface (Week 3-4)
+
+- Extract `call_llm()` and retry logic — Move from v5 into `extractor/llm/client.py`
+- Extract batch management — Move `batch_watch`, `batch_submit` into `extractor/llm/batch.py`
+- Extract routing ladder — Move escalation logic into `extractor/llm/routing.py`
+- Extract structured output contracts — Consolidate with `lib/structured_output_contracts.py`
+- Create unified LLM test suite — Unit tests for `call_llm`, retry, escalation, batch
+
+### Phase 2: Decompose Phase Runners (Week 5-8)
+
+- Create PhaseRunner base class — Abstract interface: `configure()`, `execute()`, `validate_outputs()`, `get_dependencies()`
+- Extract Phase A (Repo Control Plane) as first reference implementation
+- Extract Phases H, D, C — Primary phases (most tested)
+- Extract Phases E, W, B, G — Secondary phases
+- Extract Phases X, Q, R, T, Z, S — Dependent/meta phases
+- Wire phases into orchestrator — Phase graph resolution, dependency checking, parallel-safe execution
+
+### Phase 3: Orchestration Layer (Week 7-9)
+
+- Create Orchestrator class — Replaces v5's `main()` (388 lines)
+- Extract config management — `RunnerConfig` into `extractor/config.py` with validation
+- Extract manifest/proof — Run manifest, proof pack, coverage rollup into `extractor/manifest.py`
+- Extract resume logic — Resume state management into `extractor/resume.py`
+- Extract comparison lane — Into `extractor/comparison.py`
+- Wire iR_l into orchestrator — Apply routing hints at partition/phase/model selection points
+
+### Phase 4: CLI Unification (Week 9-10)
+
+- Create unified `dopemux extract` command group — `prescan`, `wizard`, `run`, `status`, `validate`, `compare`
+- Deprecate `dopemux audit` — Redirect to `dopemux extract wizard`/`prescan`
+- Deprecate `dopemux extractor` — Already marked legacy
+- Deprecate `dopemux upgrades` — Merge into `dopemux extract run`
+- Update wizard — Point Stage 6 at new orchestrator API instead of subprocess
+
+### Phase 5: Cleanup & Retirement (Week 10-12)
+
+- Retire `run_extraction_v3.py` — Remove 12K lines; redirect any remaining references
+- Retire `run_extraction_v4.py` — Remove 1.1K lines
+- Retire deprecated code in v5 — Remove legacy prompt mode, deprecated iR_l parameter
+- Remove dead imports and globals — 20+ module-level constants → config
+- Update documentation — ADR for migration decision; update all reference docs; update README
+- Full regression test — Run all 82 tests + wizard smoke test + extraction dry-run
+
+### Phase 6: Enhancement (Post-Migration, Week 12+)
+
+- Add Pydantic models — Replace 396 manual `json.loads()` with validated schemas
+- Add async LLM calls — Replace synchronous `call_llm` with `async`/`await`
+- Add dependency injection — Remove global state; enable isolated testing
+- Add centralized error hierarchy — Replace 442 scattered exception handlers
+- Add cross-phase artifact validation tests — Phase A output → Phase R input compatibility
+- Wire code intelligence into wizard — Fully integrate `prescan_stages.py` into `WizardRunner`
+- Add observability — OpenTelemetry spans for phase execution, LLM calls, cost tracking
+
+### Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Breaking extraction during refactor | HIGH | CRITICAL | Enable CI tests first (Phase 0); extract one phase at a time; preserve v5 as fallback |
+| Prompt regression | MEDIUM | HIGH | Contract trilogy (`promptset`/`artifacts`/`model_map`) stays unchanged; tests validate output schemas |
+| Cost model divergence | LOW | MEDIUM | SpendLedger preserved as-is; cost tests cover pricing edge cases |
+| Wizard UX disruption | LOW | MEDIUM | Wizard delegates via subprocess — can point at old or new orchestrator |
+| iR_l integration regression | LOW | LOW | Add integration tests before wiring changes |
+| Version upgrade stall | MEDIUM | MEDIUM | Clear deprecation schedule; v3/v4 retained until v5 extraction passes all tests |
+
+### Success Criteria
+
+- No file > 2,000 lines in the extraction engine
+- All 82 tests passing in CI on every PR
+- Single CLI entry point (`dopemux extract`) with 6 subcommands
+- Phase enum eliminates all string-typed phase routing
+- v3 and v4 retired — 13K lines removed
+- iR_l integration tested — Routing hints provably change extraction behavior
+- Function documentation > 80% — Up from 15.5%
+- Zero deprecated code in active paths

--- a/docs/docs_index.yaml
+++ b/docs/docs_index.yaml
@@ -1,5 +1,5 @@
 version: '1.0'
-last_updated: '2026-04-06'
+last_updated: '2026-04-12'
 description: Machine-readable index of dopemux-mvp documentation for AI/tool consumption
 entry_points:
   quickstart: QUICK_START.md
@@ -53,6 +53,7 @@ services:
     claudedocs_dir: services/conport_kg_ui/src/
 architecture:
   overview: docs/04-explanation/architecture/dopemux-architecture-overview.md
+  full_codebase_explainer: docs/04-explanation/architecture/dopemux-mvp-full-codebase-explainer.md
   system_bible: docs/04-explanation/architecture/system-bible.md
   multi_instance: docs/04-explanation/architecture/multi-instance-implementation.md
   pipeline_readme: services/repo-truth-extractor/README.md
@@ -118,6 +119,7 @@ reference:
   dope_context_architecture_and_boundaries: docs/03-reference/dope-context/dope-context-architecture-and-boundaries-v1.md
 explanation:
   directory: docs/04-explanation/
+  repo_truth_extractor_deep_analysis: docs/04-explanation/technical-deep-dives/repo-truth-extractor-structure-architecture-and-optimal-design.md
   serena_v2: docs/04-explanation/technical-deep-dives/serena-v2-technical-deep-dive.md
   conport: docs/04-explanation/technical-deep-dives/conport-technical-deep-dive.md
   dope_memory: docs/04-explanation/technical-deep-dives/dope-memory-deep-dive-2.md


### PR DESCRIPTION
## Summary

- Add a new full-codebase explainer for the active Dopemux MVP checkout.
- Add a new deep analysis / target-design explainer for Repo Truth Extractor.
- Link both docs from the explanation indexes and machine docs index so they are discoverable.

## Why

- The codebase already had fragmented architecture prose, but it did not have a single operator-facing explainer for the current Dopemux stack.
- Repo Truth Extractor also lacked a clean deep-dive document that combined current-state mapping, critical findings, and proposed target design in one place.

## Validation

- `python scripts/docs_frontmatter_guard.py docs/04-explanation/architecture/dopemux-mvp-full-codebase-explainer.md docs/04-explanation/technical-deep-dives/repo-truth-extractor-structure-architecture-and-optimal-design.md docs/00-MASTER-INDEX.md docs/04-explanation/overview.md`
- `python scripts/docs_validator.py docs/04-explanation/architecture/dopemux-mvp-full-codebase-explainer.md docs/04-explanation/technical-deep-dives/repo-truth-extractor-structure-architecture-and-optimal-design.md docs/00-MASTER-INDEX.md docs/04-explanation/overview.md`
- Parsed `docs/docs_index.yaml` with `yaml.safe_load(...)` successfully.
