### PR TITLE
feat(adhd): add RTE adapter and conport smoke test

### DIFF
--- a/smoke_test_integration.py
+++ b/smoke_test_integration.py
@@ -1,0 +1,48 @@
+import asyncio
+import json
+from pathlib import Path
+from src.dopemux.adhd.rte_adapter import RTEAdapter
+
+async def run_smoke_test():
+    print("🚀 Starting Phase 5 Smoke Test: RTE -> ConPort KG")
+    
+    adapter = RTEAdapter(Path("."))
+    
+    try:
+        # 1. Read RTE Truth
+        print("📥 Step 1: Reading RTE Truth artifact...")
+        truth = adapter.get_latest_truth()
+        print(f"✅ Truth artifact loaded (Generated at: {truth.get('generated_at')})")
+        
+        # 2. Map to Decision Payload
+        print("🗺️ Step 2: Mapping to ConPort Decision payload...")
+        payload = {
+            "title": "RTE Integration Verified",
+            "summary": f"Automated verification of RTE truth flow into ConPort KG.",
+            "rationale": "Verify that the 2026 RTE architecture can successfully communicate with restored 2025 services.",
+            "context": {
+                "generated_at": truth.get("generated_at"),
+                "phases": truth.get("phases", []),
+                "source": "RTE_SMOKE_TEST"
+            },
+            "workspace_id": "dopemux-mvp-smoke-test"
+        }
+        
+        # 3. Write to ConPort
+        print("📤 Step 3: Writing to ConPort (localhost:3004/api/decisions)...")
+        result = await adapter.write_decision_to_conport(payload)
+        
+        if result.get("status") in ["success", "logged"]:
+            decision_id = result.get("decision_id") or result.get("decision", {}).get("id")
+            print(f"✅ Successfully logged decision to ConPort! (ID: {decision_id})")
+            print("🏆 Integration Verified: Truth flowed from 2026 RTE to 2025 ConPort KG.")
+        else:
+            print(f"❌ ConPort returned unexpected response: {result}")
+        
+    except Exception as e:
+        print(f"❌ Smoke Test Failed: {e}")
+        import traceback
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    asyncio.run(run_smoke_test())

--- a/src/dopemux/adhd/rte_adapter.py
+++ b/src/dopemux/adhd/rte_adapter.py
@@ -1,0 +1,36 @@
+import json
+import os
+import httpx
+from pathlib import Path
+from typing import Dict, Any, List, Optional
+
+class RTEAdapter:
+    """Boundary adapter between 2025 Cognitive Plane and 2026 RTE architecture."""
+    
+    def __init__(self, workspace_root: Path):
+        self.workspace_root = workspace_root
+        self.rte_output_dir = self.workspace_root / "extraction"
+        # Connect directly to ConPort for decision logging
+        self.conport_url = os.getenv("CONPORT_URL", "http://localhost:3004")
+        
+    def get_latest_truth(self, artifact_type: str = "doctor/DOCTOR_FULL") -> Dict[str, Any]:
+        """Read the latest specified JSON artifact from RTE output."""
+        path = self.rte_output_dir / f"{artifact_type}.json"
+        if not path.exists():
+            raise FileNotFoundError(f"RTE Artifact not found at: {path}")
+            
+        with open(path, 'r') as f:
+            return json.load(f)
+
+    async def write_decision_to_conport(self, decision_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Write truth artifacts as 'decisions' into ConPort KG."""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"{self.conport_url}/api/decisions",
+                json=decision_data,
+                timeout=10.0
+            )
+            response.raise_for_status()
+            # httpx .json() is NOT a coroutine
+            return response.json()
+


### PR DESCRIPTION
## Summary
- add RTEAdapter for reading truth artifacts and writing ConPort decisions
- add smoke_test_integration.py to exercise RTE -> ConPort flow

## Testing
- not run (manual smoke script)