### PR TITLE
refactor(prompts): normalize filenames and add SP template rendering (phases 0-2)

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -3,7 +3,7 @@
 **Project**: Python-based ADHD-optimized development platform
 **Architecture**: Simplified (ConPort + SuperClaude + Python ADHD Engine)
 **Mode**: PLAN/ACT-aware with modular authority boundaries
-**Workspace**: `/Users/hue/code/dopemux-mvp`
+**Workspace**: `<workspace_root>`
 
 ## 🧠 Core ADHD Principles
 
@@ -52,7 +52,7 @@
 ### ConPort Memory Management (AUTOMATIC)
 ```bash
 # Workspace ID for ALL ConPort calls
-WORKSPACE_ID="/Users/hue/code/dopemux-mvp"
+WORKSPACE_ID="<workspace_root>"
 
 # Mandatory session initialization
 mcp__conport__get_active_context --workspace_id "$WORKSPACE_ID"

--- a/.conport/CONPORT_LOCAL_GUIDE.md
+++ b/.conport/CONPORT_LOCAL_GUIDE.md
@@ -27,15 +27,15 @@
 ./scripts/conport/restart.sh
 ```
 
-### 📊 Current Installation Details
+### 📊 Installation Details
 
-**Service Endpoint**: `http://127.0.0.1:3007/mcp`
-**Health Check**: `http://127.0.0.1:3007/`
-**Process ID**: 50757
-**Status**: ✅ FULLY OPERATIONAL
+**Service Endpoint**: `http://127.0.0.1:<port>/mcp` (port auto-detected; check `./scripts/conport/status.sh`)
+**Health Check**: `http://127.0.0.1:<port>/`
+**Process ID**: Run `./scripts/conport/status.sh` to retrieve the current PID
+**Status**: Run `./scripts/conport/status.sh --quick` for current status
 
 **Data Locations**:
-- Database: `context_portal/context.db` (112K)
+- Database: `context_portal/context.db`
 - Vector Data: `context_portal/conport_vector_data/`
 - Session Files: `.conport/sessions/`
 - Service Logs: `.conport/logs/conport.log`

--- a/ARCHIVED_RECOVERY/recovery_directories/ALL_RECOVERED_DOCS_EXPANDED/commit_0d15573/docs/master-architecture.md
+++ b/ARCHIVED_RECOVERY/recovery_directories/ALL_RECOVERED_DOCS_EXPANDED/commit_0d15573/docs/master-architecture.md
@@ -46,7 +46,7 @@ foundational_principles:
 
 ## 📚 Complete Architecture Reference
 
-### Arc42 Architecture Documentation (100% Complete)
+### Arc42 Architecture Documentation (10/12 sections present)
 Located in: `./docs/DMPX IMPORT/dopemux-docs/architecture/`
 
 | Section | Status | Implementation Ready |
@@ -62,7 +62,7 @@ Located in: `./docs/DMPX IMPORT/dopemux-docs/architecture/`
 | [11-Risks & Technical Debt](./DMPX%20IMPORT/dopemux-docs/architecture/11-risks/) | ✅ Complete | ✅ Ready |
 | [12-Glossary](./DMPX%20IMPORT/dopemux-docs/architecture/12-glossary/) | ✅ Complete | ✅ Ready |
 
-**Architecture Completeness**: 10/12 sections complete (83% complete), 100% implementation-ready
+**Architecture Completeness**: 10/12 sections present (83% complete); all available sections are implementation-ready. Sections 03 (Context) and 08 (Cross-cutting Concepts) are not yet authored.
 
 ### Critical Architectural Decisions (ADRs)
 Complete set of 14 ADRs covering all major system decisions:


### PR DESCRIPTION
## Summary

Completes post-PR #435 infrastructure work (Phases 0-2 of the 4-phase build plan):

1. **Phase 0 - Infrastructure Polish**: Fixed typo (extended_extended_metadata → extended_metadata) in mcp-integration-bridge
2. **Phase 1 - Naming Normalization**: Standardized prompt filenames across S_INT, FL_INT, and phase_s populations to PROMPT_ prefix for consistency with phase_s naming convention
3. **Phase 2 - SP Template Rendering**: Implemented SP (Synthesis Phase) template rendering module with stub configs and comprehensive test coverage

## Changes

### Phase 0
- Fix double-prefix typo in mcp-integration-bridge column name (lines 107, 122)

### Phase 1 - Naming Convention (13 file renames + model/registry updates)
- **S_INT**: 5 prompts renamed (S16-S20 → PROMPT_S16-PROMPT_S20)
  - Updated s_int/models.py hardcoded filenames (lines 43-48)
  - Updated test glob pattern in test_s_int_prompt_contracts.py
  
- **FL_INT**: 8 prompts renamed (F0-F4, L0-L4 → PROMPT_F0-PROMPT_L4)
  - Updated registry.json prompt_path values dynamically loaded at runtime
  - Verified test coverage passes

### Phase 2 - SP Template Rendering Module
- **New sp/ module structure**:
  - sp/__init__.py: Public API exports
  - sp/models.py: SPStep dataclass with 13 steps (SP0-SP12) and template_vars mapping
  - sp/render.py: render_sp_prompt() function with fail-closed semantics
  
- **Template variable mapping** (verified against extractor-gtm):
  - SP0-SP6: ("SP_PHASE_INPUT_JSON",)
  - SP7: ("SCHEMA_JSON", "RULES_JSON", "CANONICAL_JSON")
  - SP8: ("BASE_JSON", "NEW_JSON")
  - SP9: ("PROMOTION_RULES_JSON", "METRICS_JSON", "CANONICAL_JSON")
  - SP10: ("CANONICAL_JSON",)
  - SP11: ("CONTRACT_RULES_JSON", "CANONICAL_JSON")
  - SP12: ("CANONICAL_JSON",)

- **Stub config files** (to be refined when SP goes live):
  - prompts/phase_s/config/dedupe_sort_rules.json
  - prompts/phase_s/config/contract_rules.json
  - prompts/phase_s/config/promotion_rules.json

- **Test coverage** (9 comprehensive test cases):
  - Rendering with all template variable combinations
  - Error handling (missing variables, unreplaced placeholders)
  - MVP/extractor-gtm divergence tolerance
  - Prompt file existence validation
  - Template variable consistency across actual prompts
  - Integration test (multi-step dependency: SP4→SP7)

## Test Results
All tests pass:
- test_sp_render.py: 9/9 ✅
- test_s_int_prompt_contracts.py: 1/1 ✅
- test_fl_int_prompt_contracts.py: 2/2 ✅
- test_phase_s_prompt_registry.py: 6/6 ✅
- Full runner test suite: 9/9 ✅

## Design Decisions

1. **Fail-Closed Semantics**: render_sp_prompt raises RuntimeError on missing context variables or unreplaced placeholders (no silent failures)

2. **Tolerance for MVP/Extractor-GTM Divergence**: If a template variable is in the SPStep model but not in the actual MVP prompt text, rendering skips it gracefully (MVP S0-S6 don't have {{SP_PHASE_INPUT_JSON}} yet)

3. **Stub Configs**: Rules config files are intentionally minimal placeholders. They establish file structure and loading patterns but contain empty/default content. Rules will be authored when SP pipeline goes live (SP9 PROMOTION_READINESS, SP11 CONTRACT_LINTER defined the requirement)

4. **S_INT vs FL_INT Loading**: Recognized structural difference:
   - S_INT: Hardcodes filenames in models.py dataclass (direct model update required on file renames)
   - FL_INT: Loads from registry.json at runtime (only registry update needed)

## Notes

- Commits 87956a5c1, dc5bb6f87, 5ec4d8f2e on origin/packet/rte-07-post-v1-deferred
- Phase 3 (Audit Script Extension) will be planned and implemented in a separate PR
- Extractor-gtm repo sync deferred to Phase 3 context (can be batched if needed)

🧠 Generated with [Claude Code](https://claude.com/claude-code)