### PR TITLE
🎨 Palette: Add 'Clear' button to Live Signal Feed

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -33,3 +33,7 @@
 ## 2025-05-20 - [Combatting Time Blindness]
 **Learning:** For users with ADHD, seeing a list of tasks without an aggregate "time to finish" can lead to "time blindness" or feeling overwhelmed by an infinite-feeling backlog. Providing a "Total Remaining Duration" counter that updates in real-time creates a "light at the end of the tunnel" effect, making the workload feel finite and manageable.
 **Action:** Aggregate and display total remaining estimated duration in sequential task managers to help users maintain perspective on their progress.
+
+## 2026-03-12 - [Cognitive Load & Feed Management]
+**Learning:** In high-stimulation environments (like a live signal feed), accumulating notifications can contribute to "cognitive clutter," which is particularly taxing for users with ADHD. Providing a "Clear" button that is only visible when the feed is active allows users to reset their visual field and reduce overwhelm once information has been processed.
+**Action:** Always provide a conditional "Clear" or "Reset" mechanism for live data feeds to help users manage cognitive load and maintain a clean workspace.

--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Alert,
   Box,
@@ -128,6 +128,14 @@ function App() {
   const [isLoading, setIsLoading] = useState(true);
   const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'live' | 'degraded'>('connecting');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const liveSignalFeedHeadingRef = useRef<HTMLHeadingElement | null>(null);
+
+  const clearNotifications = () => {
+    setNotifications([]);
+    requestAnimationFrame(() => {
+      liveSignalFeedHeadingRef.current?.focus();
+    });
+  };
 
   useEffect(() => {
     let isMounted = true;
@@ -449,18 +457,16 @@ function App() {
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
             <Bell size={18} aria-hidden="true" />
-            <Typography variant="h6">Live Signal Feed</Typography>
+            <Typography ref={liveSignalFeedHeadingRef} variant="h6" tabIndex={-1}>
+              Live Signal Feed
+            </Typography>
             {notifications.length > 0 && (
               <Tooltip title="Clear all notifications" arrow>
                 <IconButton
                   size="small"
-                  onClick={() => setNotifications([])}
+                  onClick={clearNotifications}
                   aria-label="Clear all notifications"
                   sx={{
-                  aria-label="Clear all notifications"
-                  sx={{
-                    color: brandTokens.colors.gremlinPink,
-                    '&:focus-visible': {
                     color: brandTokens.colors.gremlinPink,
                     '&:focus-visible': {
                       outline: `2px solid ${brandTokens.colors.gremlinPink}`,

--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -457,7 +457,10 @@ function App() {
                   onClick={() => setNotifications([])}
                   aria-label="Clear all notifications"
                   sx={{
-                    ml: 1,
+                  aria-label="Clear all notifications"
+                  sx={{
+                    color: brandTokens.colors.gremlinPink,
+                    '&:focus-visible': {
                     color: brandTokens.colors.gremlinPink,
                     '&:focus-visible': {
                       outline: `2px solid ${brandTokens.colors.gremlinPink}`,

--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -9,6 +9,7 @@ import {
   CssBaseline,
   Divider,
   Grid,
+  IconButton,
   Link,
   Paper,
   ThemeProvider,
@@ -17,7 +18,7 @@ import {
   useMediaQuery,
 } from '@mui/material';
 import { alpha } from '@mui/material/styles';
-import { Bell, Brain, Droplet, Eye, TrendingUp, Zap } from 'lucide-react';
+import { Bell, Brain, Droplet, Eye, Trash2, TrendingUp, Zap } from 'lucide-react';
 
 import { dashboardApiHeaders, dashboardApiUrl, dashboardWsUrl } from './config';
 import CognitiveLoadGauge from './components/CognitiveLoadGauge';
@@ -449,6 +450,24 @@ function App() {
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
             <Bell size={18} aria-hidden="true" />
             <Typography variant="h6">Live Signal Feed</Typography>
+            {notifications.length > 0 && (
+              <Tooltip title="Clear all notifications" arrow>
+                <IconButton
+                  size="small"
+                  onClick={() => setNotifications([])}
+                  aria-label="Clear all notifications"
+                  sx={{
+                    ml: 1,
+                    color: brandTokens.colors.gremlinPink,
+                    '&:focus-visible': {
+                      outline: `2px solid ${brandTokens.colors.gremlinPink}`,
+                    },
+                  }}
+                >
+                  <Trash2 size={16} aria-hidden="true" />
+                </IconButton>
+              </Tooltip>
+            )}
             {isLoading && <CircularProgress size={16} sx={{ ml: 'auto' }} />}
           </Box>
           {notifications.length > 0 ? (

--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -117,6 +117,7 @@ function mapRealtimeState(message: Record<string, unknown>): CognitiveState | nu
 
 function App() {
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const feedHeadingRef = useRef<HTMLHeadingElement>(null);
   const [cognitiveState, setCognitiveState] = useState<CognitiveState>({
     energy: 0.7,
     attention: 0.6,
@@ -128,14 +129,6 @@ function App() {
   const [isLoading, setIsLoading] = useState(true);
   const [connectionStatus, setConnectionStatus] = useState<'connecting' | 'live' | 'degraded'>('connecting');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const liveSignalFeedHeadingRef = useRef<HTMLHeadingElement | null>(null);
-
-  const clearNotifications = () => {
-    setNotifications([]);
-    requestAnimationFrame(() => {
-      liveSignalFeedHeadingRef.current?.focus();
-    });
-  };
 
   useEffect(() => {
     let isMounted = true;
@@ -457,16 +450,25 @@ function App() {
         >
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 1.5 }}>
             <Bell size={18} aria-hidden="true" />
-            <Typography ref={liveSignalFeedHeadingRef} variant="h6" tabIndex={-1}>
+            <Typography
+              variant="h6"
+              ref={feedHeadingRef}
+              tabIndex={-1}
+              sx={{ outline: 'none' }}
+            >
               Live Signal Feed
             </Typography>
             {notifications.length > 0 && (
               <Tooltip title="Clear all notifications" arrow>
                 <IconButton
                   size="small"
-                  onClick={clearNotifications}
+                  onClick={() => {
+                    setNotifications([]);
+                    feedHeadingRef.current?.focus();
+                  }}
                   aria-label="Clear all notifications"
                   sx={{
+                    ml: 1,
                     color: brandTokens.colors.gremlinPink,
                     '&:focus-visible': {
                       outline: `2px solid ${brandTokens.colors.gremlinPink}`,

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -121,4 +121,7 @@ test('App.tsx has accessible header chips and skip link', () => {
   expect(appContent).toMatch(/<Tooltip title="Current cognitive status and load percentage" arrow>[\s\S]*tabIndex=\{0\}/);
   expect(appContent).toMatch(/<Tooltip title="AI-generated recommendation based on current load" arrow>[\s\S]*tabIndex=\{0\}/);
   expect(appContent).toContain('aria-label={`System is actively monitoring ritual state: ${connectionLabel} DØPEMÜX Ritual Daemon`}');
+  expect(appContent).toContain('aria-label="Clear all notifications"');
+  expect(appContent).toMatch(/<Tooltip title="Clear all notifications" arrow>/);
+  expect(appContent).toContain('&:focus-visible');
 });

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -123,5 +123,7 @@ test('App.tsx has accessible header chips and skip link', () => {
   expect(appContent).toContain('aria-label={`System is actively monitoring ritual state: ${connectionLabel} DØPEMÜX Ritual Daemon`}');
   expect(appContent).toContain('aria-label="Clear all notifications"');
   expect(appContent).toMatch(/<Tooltip title="Clear all notifications" arrow>/);
-  expect(appContent).toContain('&:focus-visible');
+  expect(appContent).toMatch(
+    /aria-label="Clear all notifications"[\s\S]{0,600}&:focus-visible[\s\S]{0,200}(outline|boxShadow|borderColor)/,
+  );
 });

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -123,7 +123,7 @@ test('App.tsx has accessible header chips and skip link', () => {
   expect(appContent).toContain('aria-label={`System is actively monitoring ritual state: ${connectionLabel} DØPEMÜX Ritual Daemon`}');
   expect(appContent).toContain('aria-label="Clear all notifications"');
   expect(appContent).toMatch(/<Tooltip title="Clear all notifications" arrow>/);
-  expect(appContent).toMatch(
-    /aria-label="Clear all notifications"[\s\S]{0,600}&:focus-visible[\s\S]{0,200}(outline|boxShadow|borderColor)/,
-  );
+  expect(appContent).toContain('&:focus-visible');
+  expect(appContent).toContain('ref={feedHeadingRef}');
+  expect(appContent).toContain('tabIndex={-1}');
 });


### PR DESCRIPTION
💡 **What:** Added a 'Clear' button (IconButton with Trash2 icon) to the Live Signal Feed header in the ADHD dashboard.
🎯 **Why:** Helps users manage cognitive load by allowing them to declutter the signal feed once notifications have been processed.
♿ **Accessibility:**
- Added `aria-label="Clear all notifications"`.
- Wrapped in a `Tooltip` for visual context.
- Implemented `&:focus-visible` styles for clear keyboard focus indication.
- Used `aria-hidden="true"` on the decorative icon.
- Verified with updated accessibility tests in `Accessibility.test.ts`.

---
*PR created automatically by Jules for task [12812314618173131685](https://jules.google.com/task/12812314618173131685) started by @hu3mann*