### PR TITLE
fix(rte): harden launch boundary and doctor diagnostics

### DIFF
--- a/UPGRADES/PIPELINE_PROOF.md
+++ b/UPGRADES/PIPELINE_PROOF.md
@@ -11,6 +11,8 @@ prelude: Pipeline Proof (explanation) for dopemux documentation and developer wo
 ---
 # Pipeline Proof Pack Runbook
 
+> Scope note: This runbook applies only to `UPGRADES/run_extraction_v3.py`. It does not define v5 launch authority. In v5, shared doctor artifacts under `extraction/doctor/` are diagnostic only, and launch/certification authority use run-scoped artifacts under `extraction/runs/<run_id>/`.
+
 ## 1. Required command sequence
 
 ```bash

--- a/UPGRADES/RUN_ORDER.md
+++ b/UPGRADES/RUN_ORDER.md
@@ -11,6 +11,8 @@ prelude: Run Order (explanation) for dopemux documentation and developer workflo
 ---
 # Upgrade Pipeline Run Order (v3)
 
+> Scope note: This runbook applies only to `UPGRADES/run_extraction_v3.py`. It does not define v5 launch authority. In v5, shared doctor artifacts under `extraction/doctor/` are diagnostic only, and launch/certification authority use run-scoped artifacts under `extraction/runs/<run_id>/`.
+
 This runbook is authoritative for `UPGRADES/run_extraction_v3.py`.
 
 ## Canonical phase folders

--- a/proof/rte-doctor-diagnostic-clarity-and-final-launch-gate-review.proof.json
+++ b/proof/rte-doctor-diagnostic-clarity-and-final-launch-gate-review.proof.json
@@ -1,0 +1,176 @@
+{
+  "packet": "RTE-doctor-diagnostic-clarity-and-final-launch-gate-review",
+  "summary": "Audited shared doctor artifact readers and writers across the current repo-truth extractor slice, confirmed that current v5 launch and certification paths do not promote shared doctor files into authority, and tightened shared-doctor labeling plus operator-facing scope notes so the diagnostic surfaces cannot be reasonably mistaken for launch authority.",
+  "evidence_ledger": [
+    "services/repo-truth-extractor/reporting.py reads run-scoped runs/<run_id>/PROVIDER_PREFLIGHT.json for live_provider_readiness and does not load doctor/PROVIDER_PREFLIGHT.json.",
+    "services/repo-truth-extractor/reporting.py only links doctor/AUTH_DOCTOR.json and doctor/DOCTOR_FULL.json into proof-pack linked_artifacts; it does not treat them as launch or certification authority.",
+    "services/repo-truth-extractor/run_extraction_v5.py uses run-scoped PROVIDER_PREFLIGHT.json for launch preflight reuse checks and writes shared doctor copies only for diagnostic visibility.",
+    "services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py already proves stale shared doctor PASS files do not satisfy certification gates.",
+    "Legacy v3 docs reference shared doctor files in a v3-specific runbook context; scope notes were added so those references are not misread as v5 launch authority."
+  ],
+  "assumptions": [
+    "First full extraction planning is for the canonical v5 runtime, not legacy v3 historical workflows.",
+    "Shared doctor artifacts may remain on disk between invocations and therefore must be treated as advisory diagnostics rather than invocation authority."
+  ],
+  "confidence": "VERIFIED",
+  "next_action": "Use the current branch as the combined PR for both launch-boundary hardening packets, then re-audit main after merge if an independent confirmation pass is still desired.",
+  "consumer_audit": [
+    {
+      "path": "services/repo-truth-extractor/rte_ops_surfaces.py",
+      "artifact": "doctor/PROVIDER_PREFLIGHT.json",
+      "behavior": "write_shared_doctor_copy_only",
+      "classification": "diagnostic_only",
+      "influences_launch_readiness": false,
+      "influences_certification": false,
+      "influences_execution": false,
+      "respects_scope_metadata": true,
+      "notes": "Writes shared doctor copy from provider preflight payload; current packet adds explicit diagnostic-only labels."
+    },
+    {
+      "path": "services/repo-truth-extractor/run_extraction_v5.py",
+      "artifact": "runs/<run_id>/PROVIDER_PREFLIGHT.json",
+      "behavior": "read_run_local_only_for_launch_reuse",
+      "classification": "authoritative",
+      "influences_launch_readiness": true,
+      "influences_certification": false,
+      "influences_execution": true,
+      "respects_scope_metadata": true,
+      "notes": "Current launch preflight reuse checks use only run-local provider preflight plus run-manifest freshness/scope validation."
+    },
+    {
+      "path": "services/repo-truth-extractor/run_extraction_v5.py",
+      "artifact": "doctor/PROVIDER_PREFLIGHT__<PHASE>.json",
+      "behavior": "write_shared_phase_diagnostic_copy_only",
+      "classification": "diagnostic_only",
+      "influences_launch_readiness": false,
+      "influences_certification": false,
+      "influences_execution": false,
+      "respects_scope_metadata": true,
+      "notes": "Phase-scoped doctor copies are partial and now explicitly labeled diagnostic-only."
+    },
+    {
+      "path": "services/repo-truth-extractor/run_extraction_v5.py",
+      "artifact": "doctor/DOCTOR_FULL.json",
+      "behavior": "write_shared_topology_diagnostic_only",
+      "classification": "diagnostic_only",
+      "influences_launch_readiness": false,
+      "influences_certification": false,
+      "influences_execution": false,
+      "respects_scope_metadata": true,
+      "notes": "Shared topology doctor remains advisory; packet adds explicit diagnostic-only labels."
+    },
+    {
+      "path": "services/repo-truth-extractor/run_extraction_v5.py",
+      "artifact": "doctor/AUTH_DOCTOR.json",
+      "behavior": "write_shared_auth_diagnostic_only",
+      "classification": "diagnostic_only",
+      "influences_launch_readiness": false,
+      "influences_certification": false,
+      "influences_execution": false,
+      "respects_scope_metadata": true,
+      "notes": "Shared auth doctor remains advisory; packet adds explicit diagnostic-only labels and text output note."
+    },
+    {
+      "path": "services/repo-truth-extractor/reporting.py",
+      "artifact": "doctor/AUTH_DOCTOR.json and doctor/DOCTOR_FULL.json",
+      "behavior": "link_paths_only_in_proof_pack",
+      "classification": "advisory",
+      "influences_launch_readiness": false,
+      "influences_certification": false,
+      "influences_execution": false,
+      "respects_scope_metadata": true,
+      "notes": "Proof-pack linked_artifacts references shared doctor paths for operator visibility only."
+    },
+    {
+      "path": "services/repo-truth-extractor/reporting.py",
+      "artifact": "doctor/PROVIDER_PREFLIGHT.json",
+      "behavior": "no_reader_found",
+      "classification": "diagnostic_only",
+      "influences_launch_readiness": false,
+      "influences_certification": false,
+      "influences_execution": false,
+      "respects_scope_metadata": true,
+      "notes": "Certification reads only runs/<run_id>/PROVIDER_PREFLIGHT.json."
+    },
+    {
+      "path": "UPGRADES/RUN_ORDER.md and UPGRADES/PIPELINE_PROOF.md",
+      "artifact": "shared doctor references in legacy v3 docs",
+      "behavior": "operator_documentation_reference",
+      "classification": "advisory",
+      "influences_launch_readiness": false,
+      "influences_certification": false,
+      "influences_execution": false,
+      "respects_scope_metadata": false,
+      "notes": "Scope notes added to make the v3-only context explicit and prevent v5 authority confusion."
+    }
+  ],
+  "changes": [
+    {
+      "file": "services/repo-truth-extractor/rte_ops_surfaces.py",
+      "why": "Add explicit diagnostic-only labels to the shared doctor provider preflight copy without changing the run-local authoritative payload."
+    },
+    {
+      "file": "services/repo-truth-extractor/run_extraction_v5.py",
+      "why": "Label shared doctor auth/topology/phase-preflight artifacts as diagnostic-only and tighten CLI/help/error wording around shared doctor versus run-scoped authority."
+    },
+    {
+      "file": "services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+      "why": "Lock the non-authority contract for shared doctor preflight and the run-local precedence rule."
+    },
+    {
+      "file": "services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py",
+      "why": "Assert that shared doctor topology output is labeled diagnostic-only while certification remains UNKNOWN without explicit run-scoped authority."
+    },
+    {
+      "file": "UPGRADES/RUN_ORDER.md",
+      "why": "Add a narrow scope note so legacy v3 references are not mistaken for v5 launch authority."
+    },
+    {
+      "file": "UPGRADES/PIPELINE_PROOF.md",
+      "why": "Add a narrow scope note so legacy v3 proof instructions are not mistaken for v5 launch authority."
+    }
+  ],
+  "validation": {
+    "commands": [
+      {
+        "cmd": "pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+        "status": "pass"
+      },
+      {
+        "cmd": "pytest -q services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py",
+        "status": "pass"
+      },
+      {
+        "cmd": "pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_rollup_reports.py",
+        "status": "pass"
+      },
+      {
+        "cmd": "pytest -q services/repo-truth-extractor/tests/test_router_runtime_integration.py",
+        "status": "pass"
+      },
+      {
+        "cmd": "python -m py_compile services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/rte_output_layout.py services/repo-truth-extractor/reporting.py",
+        "status": "pass"
+      },
+      {
+        "cmd": "git diff --check",
+        "status": "pass"
+      },
+      {
+        "cmd": "pre-commit run --files services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/rte_output_layout.py services/repo-truth-extractor/reporting.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py services/repo-truth-extractor/tests/test_router_runtime_integration.py UPGRADES/RUN_ORDER.md UPGRADES/PIPELINE_PROOF.md",
+        "status": "pass"
+      }
+    ],
+    "blockers": []
+  },
+  "finalization": {
+    "final_confidence": "VERIFIED",
+    "launch_readiness_judgment": "READY_FOR_FIRST_FULL_EXTRACTION_PLANNING",
+    "residual_caveats": [
+      "Broad topology questions remain outside this packet.",
+      "Prescan and IR_FL remain separate advisory surfaces outside this packet.",
+      "Legacy v3 historical docs still exist, but this packet now labels them as v3-only rather than v5 authority."
+    ],
+    "another_packet_required": false
+  }
+}

--- a/services/repo-truth-extractor/rte_ops_surfaces.py
+++ b/services/repo-truth-extractor/rte_ops_surfaces.py
@@ -9,6 +9,29 @@ def argv_has_flag(argv: Sequence[str], *flags: str) -> bool:
     return any(flag in argv for flag in flags)
 
 
+def shared_doctor_advisory_fields(
+    artifact_name: str,
+    *,
+    run_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    authority_note = (
+        "Shared doctor artifacts are diagnostic only. Launch and certification "
+        "authority use run-scoped artifacts under runs/<run_id>/."
+    )
+    if run_id and artifact_name == "PROVIDER_PREFLIGHT.json":
+        authority_note += f" Launch authority for this run is runs/{run_id}/PROVIDER_PREFLIGHT.json."
+    return {
+        "artifact_name": artifact_name,
+        "artifact_origin": "shared_doctor",
+        "authority_class": "diagnostic_only",
+        "advisory_only": True,
+        "launch_authority": False,
+        "certification_authority": False,
+        "execution_readiness_authority": False,
+        "authority_note": authority_note,
+    }
+
+
 def first_live_phase_sequence(
     stage: str,
     *,
@@ -806,5 +829,12 @@ def run_provider_preflight(
     }
     doctor_dir = current_doctor_root(root)
     doctor_dir.mkdir(parents=True, exist_ok=True)
-    write_json(doctor_dir / "PROVIDER_PREFLIGHT.json", payload)
+    doctor_payload = dict(payload)
+    doctor_payload.update(
+        shared_doctor_advisory_fields(
+            "PROVIDER_PREFLIGHT.json",
+            run_id=run_id,
+        )
+    )
+    write_json(doctor_dir / "PROVIDER_PREFLIGHT.json", doctor_payload)
     return (not failures), payload

--- a/services/repo-truth-extractor/rte_output_layout.py
+++ b/services/repo-truth-extractor/rte_output_layout.py
@@ -202,6 +202,7 @@ def resolve_run_context(
         active_output_layout=active_output_layout,
     )
     run_id_source = "generated"
+    resume_requested = bool(getattr(args, "resume", False))
 
     if args.run_id:
         run_id = args.run_id
@@ -213,7 +214,7 @@ def resolve_run_context(
             active_output_layout=active_output_layout,
         )
         run_id_source = "explicit"
-    else:
+    elif resume_requested:
         latest = load_run_id(
             repo_root,
             extraction_root_rel=extraction_root_rel,
@@ -229,21 +230,20 @@ def resolve_run_context(
                 run_id = latest
                 run_id_source = "latest_run_id"
             else:
-                logger.warning(
-                    "latest_run_id.txt points to missing run directory %s; generating new run_id.",
-                    latest_dir,
-                )
-                run_id = generate_run_id(
-                    repo_root,
-                    extraction_root_rel=extraction_root_rel,
-                    active_output_layout=active_output_layout,
+                raise FileNotFoundError(
+                    "Resume requested but latest_run_id.txt points to missing run "
+                    f"directory {latest_dir}."
                 )
         else:
-            run_id = generate_run_id(
-                repo_root,
-                extraction_root_rel=extraction_root_rel,
-                active_output_layout=active_output_layout,
+            raise FileNotFoundError(
+                f"Resume requested but no latest run id exists at {latest_file}."
             )
+    else:
+        run_id = generate_run_id(
+            repo_root,
+            extraction_root_rel=extraction_root_rel,
+            active_output_layout=active_output_layout,
+        )
 
     write_latest = not args.no_write_latest and (
         not args.dry_run or args.write_latest_even_on_dry_run

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -1354,6 +1354,7 @@ class RunnerConfig:
     ledger: Optional[Any] = None
     fl_int_provider_timeout_seconds: int = 180
     fl_int_f0_batch_timeout_seconds: int = 210
+    prescan_allow_scope_reduction: bool = False
 
 
 @dataclass(frozen=True)
@@ -6364,10 +6365,181 @@ def run_provider_preflight(
 
 
 def phase_requires_provider_preflight(phase: str, cfg: RunnerConfig) -> bool:
-    if str(phase or "").upper() != "D" or cfg.dry_run:
+    normalized_phase = str(phase or "").upper()
+    if not normalized_phase or cfg.dry_run:
         return False
-    routes = collect_provider_routes(phases=["D"], routing_policy=cfg.routing_policy)
-    return any(str(row.get("provider")) == "openrouter" for row in routes.values())
+    routes = collect_provider_routes(
+        phases=[normalized_phase],
+        routing_policy=cfg.routing_policy,
+        selected_step_ids_by_phase={
+            normalized_phase: selected_ids
+            for phase_name in [normalized_phase]
+            if (
+                selected_ids := _selected_execution_step_ids_for_phase(
+                    cfg, phase_name
+                )
+            )
+            is not None
+        }
+        or None,
+    )
+    return bool(routes)
+
+
+def _provider_preflight_target_step_scope(
+    cfg: RunnerConfig,
+    phases: Sequence[str],
+) -> Dict[str, List[str]]:
+    scope: Dict[str, List[str]] = {}
+    for phase in phases:
+        normalized_phase = str(phase or "").strip().upper()
+        if not normalized_phase:
+            continue
+        selected_ids = _selected_execution_step_ids_for_phase(cfg, normalized_phase)
+        if selected_ids is None:
+            continue
+        scope[normalized_phase] = [
+            str(step_id).strip().upper() for step_id in selected_ids if str(step_id).strip()
+        ]
+    return scope
+
+
+def _provider_preflight_generated_at(value: Any) -> Optional[datetime]:
+    token = str(value or "").strip()
+    if not token:
+        return None
+    try:
+        return datetime.fromisoformat(token.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _load_json_file(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _shared_doctor_advisory_fields(
+    artifact_name: str,
+    *,
+    run_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    authority_note = (
+        "Shared doctor artifacts are diagnostic only. Launch and certification "
+        "authority use run-scoped artifacts under runs/<run_id>/."
+    )
+    if run_id and artifact_name == "PROVIDER_PREFLIGHT.json":
+        authority_note += f" Launch authority for this run is runs/{run_id}/PROVIDER_PREFLIGHT.json."
+    return {
+        "artifact_name": artifact_name,
+        "artifact_origin": "shared_doctor",
+        "authority_class": "diagnostic_only",
+        "advisory_only": True,
+        "launch_authority": False,
+        "certification_authority": False,
+        "execution_readiness_authority": False,
+        "authority_note": authority_note,
+    }
+
+
+def _current_launch_preflight_reuse_status(
+    run_root: Path,
+    cfg: RunnerConfig,
+    *,
+    required_phase: Optional[str] = None,
+) -> Dict[str, Any]:
+    payload = _load_json_file(run_root / "PROVIDER_PREFLIGHT.json")
+    if not isinstance(payload, dict):
+        return {"valid": False, "reason": "missing_or_invalid_provider_preflight"}
+    manifest = _load_json_file(run_root / "RUN_MANIFEST.json")
+    if not isinstance(manifest, dict):
+        return {"valid": False, "reason": "missing_or_invalid_run_manifest", "payload": payload}
+    manifest_phase_scope = [
+        str(phase).strip().upper()
+        for phase in (manifest.get("routing_step_tiers") or {}).keys()
+        if str(phase).strip()
+    ]
+    payload_phase_scope = [
+        str(phase).strip().upper()
+        for phase in payload.get("phase_scope", [])
+        if str(phase).strip()
+    ]
+    payload_step_scope = {
+        str(phase).strip().upper(): [
+            str(step_id).strip().upper()
+            for step_id in step_ids
+            if str(step_id).strip()
+        ]
+        for phase, step_ids in (payload.get("step_scope") or {}).items()
+        if isinstance(step_ids, list) and str(phase).strip()
+    }
+    expected_step_scope = _provider_preflight_target_step_scope(cfg, manifest_phase_scope)
+    manifest_generated_at = _provider_preflight_generated_at(manifest.get("generated_at"))
+    payload_generated_at = _provider_preflight_generated_at(payload.get("generated_at"))
+    required_phase_token = str(required_phase or "").strip().upper()
+
+    if str(payload.get("run_id") or "").strip() != run_root.name:
+        reason = "run_id_mismatch"
+    elif str(payload.get("scope_kind") or "").strip() != "launch":
+        reason = "scope_kind_not_launch"
+    elif not bool(payload.get("scope_complete_for_launch")):
+        reason = "scope_not_marked_launch_complete"
+    elif payload_phase_scope != manifest_phase_scope:
+        reason = "phase_scope_mismatch"
+    elif payload_step_scope != expected_step_scope:
+        reason = "step_scope_mismatch"
+    elif str(payload.get("routing_policy") or "").strip() != str(cfg.routing_policy).strip():
+        reason = "routing_policy_mismatch"
+    elif manifest_generated_at is not None and (
+        payload_generated_at is None or payload_generated_at < manifest_generated_at
+    ):
+        reason = "provider_preflight_older_than_run_manifest"
+    elif required_phase_token and required_phase_token not in payload_phase_scope:
+        reason = "required_phase_not_covered"
+    else:
+        return {
+            "valid": True,
+            "reason": "launch_preflight_current",
+            "payload": payload,
+            "manifest": manifest,
+        }
+    return {"valid": False, "reason": reason, "payload": payload, "manifest": manifest}
+
+
+def ensure_launch_provider_preflight(
+    root: Path,
+    run_id: str,
+    phases: Sequence[str],
+    cfg: RunnerConfig,
+) -> RunnerConfig:
+    normalized_phases = [
+        str(phase).strip().upper() for phase in phases if str(phase).strip()
+    ]
+    if cfg.dry_run or not normalized_phases:
+        return cfg
+    if not any(phase_requires_provider_preflight(phase, cfg) for phase in normalized_phases):
+        return cfg
+    run_root = current_runs_root(root) / run_id
+    reuse_status = _current_launch_preflight_reuse_status(run_root, cfg)
+    if bool(reuse_status.get("valid")):
+        return cfg
+    ok, payload = run_provider_preflight(root, run_id, cfg, normalized_phases)
+    denylisted = sorted(
+        {str(provider) for provider in payload.get("failed_providers", []) if provider}
+    )
+    if not ok:
+        denied = ",".join(denylisted) if denylisted else "unknown"
+        raise RuntimeError(
+            "Provider preflight blocked launch scope "
+            f"{','.join(normalized_phases)}: denylisted_providers={denied}. "
+            f"reason={reuse_status.get('reason') or 'launch_probe_failed'}. "
+            "See shared diagnostic copy "
+            f"{(current_doctor_root(root) / 'PROVIDER_PREFLIGHT.json').as_posix()}."
+        )
+    return replace(cfg, provider_denylist=tuple(denylisted))
 
 
 def prepare_phase_provider_preflight(
@@ -6381,29 +6553,11 @@ def prepare_phase_provider_preflight(
         return cfg
 
     run_root = current_runs_root(root) / run_id
-    canonical_path = run_root / "PROVIDER_PREFLIGHT.json"
-    if canonical_path.exists():
-        try:
-            canonical_payload = json.loads(canonical_path.read_text(encoding="utf-8"))
-        except Exception:
-            canonical_payload = None
-        canonical_phase_scope = (
-            [
-                str(entry).strip().upper()
-                for entry in canonical_payload.get("phase_scope", [])
-                if str(entry).strip()
-            ]
-            if isinstance(canonical_payload, dict)
-            and isinstance(canonical_payload.get("phase_scope"), list)
-            else []
-        )
-        if (
-            isinstance(canonical_payload, dict)
-            and bool(canonical_payload.get("scope_complete_for_launch"))
-            and str(canonical_payload.get("scope_kind") or "").strip() == "launch"
-            and normalized_phase in canonical_phase_scope
-        ):
-            return cfg
+    reuse_status = _current_launch_preflight_reuse_status(
+        run_root, cfg, required_phase=normalized_phase
+    )
+    if bool(reuse_status.get("valid")):
+        return cfg
 
     ok, payload = run_provider_preflight(
         root,
@@ -6422,12 +6576,20 @@ def prepare_phase_provider_preflight(
     write_json(run_root / f"PROVIDER_PREFLIGHT__{normalized_phase}.json", payload)
     doctor_dir = current_doctor_root(root)
     doctor_dir.mkdir(parents=True, exist_ok=True)
-    write_json(doctor_dir / f"PROVIDER_PREFLIGHT__{normalized_phase}.json", payload)
+    doctor_payload = dict(payload)
+    doctor_payload.update(
+        _shared_doctor_advisory_fields(
+            f"PROVIDER_PREFLIGHT__{normalized_phase}.json",
+            run_id=run_id,
+        )
+    )
+    write_json(doctor_dir / f"PROVIDER_PREFLIGHT__{normalized_phase}.json", doctor_payload)
     if not ok:
         denied = ",".join(denylisted) if denylisted else "unknown"
         raise RuntimeError(
             f"Provider preflight blocked phase {normalized_phase}: denylisted_providers={denied}. "
-            f"See {(doctor_dir / f'PROVIDER_PREFLIGHT__{normalized_phase}.json').as_posix()}"
+            "See shared diagnostic copy "
+            f"{(doctor_dir / f'PROVIDER_PREFLIGHT__{normalized_phase}.json').as_posix()}."
         )
     return replace(cfg, provider_denylist=tuple(denylisted))
 
@@ -6668,6 +6830,7 @@ def run_doctor_full(
             "probes": provider_probes,
         },
     }
+    payload.update(_shared_doctor_advisory_fields("DOCTOR_FULL.json", run_id=run_id))
 
     doctor_dir = current_doctor_root(root)
     doctor_dir.mkdir(parents=True, exist_ok=True)
@@ -6764,11 +6927,13 @@ def build_partitions(
     max_files: int,
     max_chars: int,
     router: Optional[IntelligenceRouter] = None,  # DEPRECATED: use DC2 post-processing via _ACTIVE_INTELLIGENCE_ROUTER
+    allow_prescan_scope_reduction: bool = False,
 ) -> List[Dict[str, Any]]:
     partitions: List[Dict[str, Any]] = []
     current_paths: List[str] = []
     current_chars = 0
     skipped_count = 0
+    blocked_scope_reduction_count = 0
 
     def flush_partition() -> None:
         nonlocal current_paths, current_chars
@@ -6799,8 +6964,10 @@ def build_partitions(
         
         # Intelligence-based skipping
         if router and router.should_skip(path):
-            skipped_count += 1
-            continue
+            if allow_prescan_scope_reduction:
+                skipped_count += 1
+                continue
+            blocked_scope_reduction_count += 1
 
         base_chars = int(item.get("char_count_estimate", 0))
         # Account for per-file headers in context payload construction.
@@ -6818,6 +6985,12 @@ def build_partitions(
     
     if skipped_count > 0:
         logger.info(f"Phase {phase}: skipped {skipped_count} files based on prescan intelligence.")
+    if blocked_scope_reduction_count > 0:
+        logger.warning(
+            "Phase %s: ignored %s prescan skip candidates because scope reduction is disabled.",
+            phase,
+            blocked_scope_reduction_count,
+        )
 
     if not partitions:
         partitions.append(
@@ -9056,6 +9229,7 @@ def run_auth_doctor(root: Path, args: argparse.Namespace, cfg: RunnerConfig) -> 
         "failed_modes": failed_modes,
         "summary": summary,
     }
+    payload.update(_shared_doctor_advisory_fields("AUTH_DOCTOR.json"))
     write_json(doctor_json, payload)
     lines = [summary]
     lines.extend(
@@ -9073,6 +9247,8 @@ def run_auth_doctor(root: Path, args: argparse.Namespace, cfg: RunnerConfig) -> 
             f"modes_tested={','.join(payload['modes_tested'])}",
             f"succeeded_modes={','.join(payload['succeeded_modes'])}",
             f"failed_modes={','.join(payload['failed_modes'])}",
+            f"advisory_only={str(payload['advisory_only']).lower()}",
+            f"authority_note={payload['authority_note']}",
         ]
     )
     doctor_txt.write_text("\n".join(lines) + "\n", encoding="utf-8")
@@ -13833,7 +14009,14 @@ def _run_phase_inner(
     inventory = build_inventory(context_items, cfg.file_truncate_chars)
     max_files = max_files_for_phase(phase, cfg)
     partitions = build_partitions(
-        phase, inventory, max_files=max_files, max_chars=cfg.max_chars, router=cfg.router
+        phase,
+        inventory,
+        max_files=max_files,
+        max_chars=cfg.max_chars,
+        router=cfg.router,
+        allow_prescan_scope_reduction=bool(
+            getattr(cfg, "prescan_allow_scope_reduction", False)
+        ),
     )
 
     partitions = _apply_router_partition_hints(phase, partitions)
@@ -16675,7 +16858,14 @@ def run_phase_R_async_submit(
     inventory = build_inventory(context_items, cfg.file_truncate_chars)
     max_files = max_files_for_phase("R", cfg)
     partitions = build_partitions(
-        "R", inventory, max_files=max_files, max_chars=cfg.max_chars, router=cfg.router
+        "R",
+        inventory,
+        max_files=max_files,
+        max_chars=cfg.max_chars,
+        router=cfg.router,
+        allow_prescan_scope_reduction=bool(
+            getattr(cfg, "prescan_allow_scope_reduction", False)
+        ),
     )
 
     # DC2 Phase 2: Router post-processing for Phase R (async path)
@@ -17578,6 +17768,14 @@ def main() -> None:
     )
     parser.add_argument("--prescan", type=str, help="Path to prescan intelligence directory.")
     parser.add_argument(
+        "--prescan-allow-scope-reduction",
+        action="store_true",
+        help=(
+            "Allow prescan skip hints to remove files from execution scope. Disabled by default "
+            "so prescan remains non-authoritative for first baseline runs."
+        ),
+    )
+    parser.add_argument(
         "--preset",
         choices=[FIRST_LIVE_PRESET_NAME, STAGED_SAFE_PRESET_NAME],
         default=None,
@@ -17796,9 +17994,30 @@ def main() -> None:
         default=0.15,
         help="Fraction of phase outputs to audit with judge model (0 to disable).",
     )
-    parser.add_argument("--doctor", action="store_true")
-    parser.add_argument("--doctor-auth", action="store_true")
-    parser.add_argument("--preflight-providers", action="store_true")
+    parser.add_argument(
+        "--doctor",
+        action="store_true",
+        help=(
+            "Write shared doctor diagnostic artifacts. These are advisory only and do not "
+            "satisfy launch or certification authority."
+        ),
+    )
+    parser.add_argument(
+        "--doctor-auth",
+        action="store_true",
+        help=(
+            "Write shared authentication doctor diagnostics. These are advisory only and do not "
+            "satisfy launch or certification authority."
+        ),
+    )
+    parser.add_argument(
+        "--preflight-providers",
+        action="store_true",
+        help=(
+            "Run provider preflight for the current invocation and write a shared diagnostic copy. "
+            "Launch authority uses the run-scoped PROVIDER_PREFLIGHT.json under runs/<run_id>/."
+        ),
+    )
     parser.add_argument("--coverage-report", action="store_true")
     parser.add_argument("--ui", choices=["auto", "rich", "plain"], default="auto")
     parser.add_argument("--status", action="store_true")
@@ -18449,6 +18668,9 @@ def main() -> None:
         ),
         prescan_dir=getattr(args, "prescan_dir", None),
         router=router,
+        prescan_allow_scope_reduction=bool(
+            getattr(args, "prescan_allow_scope_reduction", False)
+        ),
     )
 
     if SpendLedger is not None:
@@ -18782,16 +19004,6 @@ def main() -> None:
     if not phase_sequence:
         parser.error("--phase is required when running extraction phases.")
     phases = phase_sequence
-    if args.phase == "ALL":
-        ok, payload = run_provider_preflight(root, run_id, cfg, phases)
-        if not ok:
-            logger.error(
-                "Provider preflight failed before phase ALL. failed_providers=%s. See "
-                f"{(current_doctor_root(root) / 'PROVIDER_PREFLIGHT.json').as_posix()}",
-                ",".join(payload.get("failed_providers", [])),
-            )
-            sys.exit(1)
-
     # Load intelligence router from prescan output (if available)
     global _ACTIVE_INTELLIGENCE_ROUTER
     if cfg.prescan_dir and IntelligenceRouter is not None:
@@ -18834,6 +19046,16 @@ def main() -> None:
             )
             logger.error("Cost cap setup failed: %s", exc)
             sys.exit(1)
+    try:
+        cfg = ensure_launch_provider_preflight(root, run_id, phases, cfg)
+    except Exception as exc:
+        update_run_manifest_startup_failure(
+            dirs["root"],
+            failure_reason="launch_provider_preflight_failed",
+            failure_message=str(exc),
+        )
+        logger.error("Launch provider preflight failed: %s", exc)
+        sys.exit(1)
 
     runners = {
         "A": run_phase_A,

--- a/services/repo-truth-extractor/tests/test_router_runtime_integration.py
+++ b/services/repo-truth-extractor/tests/test_router_runtime_integration.py
@@ -100,7 +100,9 @@ def _make_router_from_dir(tmp_path: Path):
     return runner, router
 
 
-def test_build_partitions_uses_router_priority_and_skip_hints(tmp_path: Path) -> None:
+def test_build_partitions_keeps_prescan_skip_candidates_without_explicit_opt_in(
+    tmp_path: Path,
+) -> None:
     runner, router = _make_router_from_dir(tmp_path)
     inventory = [
         {"path": "src/low.py", "char_count_estimate": 10},
@@ -123,6 +125,33 @@ def test_build_partitions_uses_router_priority_and_skip_hints(tmp_path: Path) ->
         "src/high.py",
         "src/medium.py",
     ]
+    assert partitions[0]["paths"] == ["src/high.py", "src/medium.py"]
+    assert partitions[1]["paths"] == ["src/low.py", "src/skipped.py"]
+    assert "src/skipped.py" in {
+        path for partition in partitions for path in partition["paths"]
+    }
+
+
+def test_build_partitions_allows_prescan_skip_candidates_only_with_opt_in(
+    tmp_path: Path,
+) -> None:
+    runner, router = _make_router_from_dir(tmp_path)
+    inventory = [
+        {"path": "src/low.py", "char_count_estimate": 10},
+        {"path": "src/skipped.py", "char_count_estimate": 10},
+        {"path": "src/high.py", "char_count_estimate": 10},
+        {"path": "src/medium.py", "char_count_estimate": 10},
+    ]
+
+    partitions = runner.build_partitions(
+        "A",
+        inventory,
+        max_files=2,
+        max_chars=1000,
+        router=router,
+        allow_prescan_scope_reduction=True,
+    )
+
     assert partitions[0]["paths"] == ["src/high.py", "src/medium.py"]
     assert partitions[1]["paths"] == ["src/low.py"]
     assert "src/skipped.py" not in {

--- a/services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py
+++ b/services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py
@@ -479,6 +479,13 @@ def test_run_doctor_full_certification_stays_unknown_without_explicit_gate_statu
     certification = json.loads(
         (run_root / "CERTIFICATION_RESULT.json").read_text(encoding="utf-8")
     )
+    doctor_full = json.loads(
+        (runner.current_doctor_root(tmp_path) / "DOCTOR_FULL.json").read_text(
+            encoding="utf-8"
+        )
+    )
     assert certification["overall_status"] == "UNKNOWN"
     assert certification["gates"]["live_provider_readiness"]["status"] == "UNKNOWN"
     assert certification["gates"]["operator_topology_resilience"]["status"] == "UNKNOWN"
+    assert doctor_full["advisory_only"] is True
+    assert doctor_full["authority_class"] == "diagnostic_only"

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
@@ -141,6 +141,8 @@ def test_help_output_omits_contract_scope_warning() -> None:
     )
     assert result.returncode == 0
     assert "model_map.yaml steps outside repo_truth_map JSON scope" not in result.stderr
+    assert "shared doctor diagnostic artifacts" in result.stdout
+    assert "run-scoped PROVIDER_PREFLIGHT.json" in result.stdout
 
 
 def test_dry_run_output_omits_unknown_failure_spotlight(tmp_path: Path) -> None:
@@ -184,6 +186,75 @@ def test_output_root_layout_redirects_run_and_doctor_paths(tmp_path: Path) -> No
         assert runner.latest_run_id_path(tmp_path) == artifact_root / "latest_run_id.txt"
     finally:
         runner.configure_output_layout(tmp_path, None)
+
+
+def test_non_resume_launch_generates_fresh_run_id_even_when_latest_exists(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    old_run = runner.current_runs_root(tmp_path) / "existing_run"
+    old_run.mkdir(parents=True, exist_ok=True)
+    runner.persist_latest_run_id(tmp_path, "existing_run")
+
+    args = argparse.Namespace(
+        run_id=None,
+        resume=False,
+        no_write_latest=True,
+        dry_run=False,
+        write_latest_even_on_dry_run=False,
+    )
+
+    run_context = runner.resolve_run_context(
+        tmp_path,
+        args,
+        allow_create_if_missing=False,
+    )
+
+    assert run_context.run_id != "existing_run"
+    assert run_context.source == "generated"
+    assert (runner.current_runs_root(tmp_path) / run_context.run_id).is_dir()
+
+
+def test_resume_without_explicit_run_id_reuses_latest_run_context(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    old_run = runner.current_runs_root(tmp_path) / "resume_me"
+    old_run.mkdir(parents=True, exist_ok=True)
+    runner.persist_latest_run_id(tmp_path, "resume_me")
+
+    args = argparse.Namespace(
+        run_id=None,
+        resume=True,
+        no_write_latest=True,
+        dry_run=False,
+        write_latest_even_on_dry_run=False,
+    )
+
+    run_context = runner.resolve_run_context(
+        tmp_path,
+        args,
+        allow_create_if_missing=False,
+    )
+
+    assert run_context.run_id == "resume_me"
+    assert run_context.source == "latest_run_id"
+
+
+def test_resume_requires_latest_run_directory_to_exist(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    runner.persist_latest_run_id(tmp_path, "missing_run")
+
+    args = argparse.Namespace(
+        run_id=None,
+        resume=True,
+        no_write_latest=True,
+        dry_run=False,
+        write_latest_even_on_dry_run=False,
+    )
+
+    with pytest.raises(FileNotFoundError, match="missing run directory"):
+        runner.resolve_run_context(
+            tmp_path,
+            args,
+            allow_create_if_missing=False,
+        )
 
 
 def test_build_phase_cost_preview_marks_override_risk() -> None:
@@ -438,6 +509,15 @@ def test_run_provider_preflight_records_openrouter_specific_remediation(
     assert run_local["step_scope"] == {}
     assert run_local["scope_kind"] == "launch"
     assert run_local["scope_complete_for_launch"] is True
+    doctor_copy = json.loads(
+        (
+            runner.current_doctor_root(tmp_path) / "PROVIDER_PREFLIGHT.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert doctor_copy["advisory_only"] is True
+    assert doctor_copy["authority_class"] == "diagnostic_only"
+    assert doctor_copy["launch_authority"] is False
+    assert "runs/run_openrouter_blocked/PROVIDER_PREFLIGHT.json" in doctor_copy["authority_note"]
 
 
 def test_prepare_phase_provider_preflight_writes_partial_scope_file_without_canonical_run_root(
@@ -491,6 +571,13 @@ def test_prepare_phase_provider_preflight_writes_partial_scope_file_without_cano
     assert partial["phase_scope"] == ["D"]
     assert partial["scope_kind"] == "phase"
     assert partial["scope_complete_for_launch"] is False
+    doctor_partial = json.loads(
+        (
+            runner.current_doctor_root(tmp_path) / "PROVIDER_PREFLIGHT__D.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert doctor_partial["advisory_only"] is True
+    assert doctor_partial["authority_class"] == "diagnostic_only"
 
 
 def test_prepare_phase_provider_preflight_skips_redundant_probe_when_launch_scope_exists(
@@ -502,15 +589,27 @@ def test_prepare_phase_provider_preflight_skips_redundant_probe_when_launch_scop
 
     run_root = runner.current_runs_root(tmp_path) / "run_d_skip_preflight"
     run_root.mkdir(parents=True, exist_ok=True)
+    (run_root / "RUN_MANIFEST.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-17T08:00:00+00:00",
+                "routing_step_tiers": {"A": {}, "H": {}, "D": {}, "C": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
     canonical = run_root / "PROVIDER_PREFLIGHT.json"
     canonical.write_text(
         json.dumps(
             {
+                "generated_at": "2026-04-17T08:01:00+00:00",
+                "run_id": "run_d_skip_preflight",
                 "status": "PASS",
                 "phase_scope": ["A", "H", "D", "C"],
                 "step_scope": {},
                 "scope_kind": "launch",
                 "scope_complete_for_launch": True,
+                "routing_policy": "cost",
             }
         ),
         encoding="utf-8",
@@ -543,6 +642,242 @@ def test_prepare_phase_provider_preflight_skips_redundant_probe_when_launch_scop
     assert tuple(updated_cfg.provider_denylist) == ()
     assert canonical.exists() is True
     assert (run_root / "PROVIDER_PREFLIGHT__D.json").exists() is False
+
+
+def test_prepare_phase_provider_preflight_reprobes_stale_launch_scope_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    runner = _load_runner_module()
+    cfg = _make_cfg(runner)
+    object.__setattr__(cfg, "dry_run", False)
+
+    run_root = runner.current_runs_root(tmp_path) / "run_d_stale_preflight"
+    run_root.mkdir(parents=True, exist_ok=True)
+    (run_root / "RUN_MANIFEST.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-17T09:00:00+00:00",
+                "routing_step_tiers": {"A": {}, "H": {}, "D": {}, "C": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_root / "PROVIDER_PREFLIGHT.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-17T08:00:00+00:00",
+                "run_id": "run_d_stale_preflight",
+                "status": "PASS",
+                "phase_scope": ["A", "H", "D", "C"],
+                "step_scope": {},
+                "scope_kind": "launch",
+                "scope_complete_for_launch": True,
+                "routing_policy": "cost",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        runner,
+        "collect_provider_routes",
+        lambda phases, routing_policy, selected_step_ids_by_phase=None: {
+            "openrouter:openai/gpt-5.3-codex:OPENROUTER_API_KEY": {
+                "provider": "openrouter",
+                "model_id": "openai/gpt-5.3-codex",
+                "api_key_env": "OPENROUTER_API_KEY",
+            }
+        },
+    )
+
+    called = {"probe": False}
+
+    def fresh_probe(**kwargs):  # type: ignore[no-untyped-def]
+        called["probe"] = True
+        return {
+            "provider": "openrouter",
+            "model_id": "openai/gpt-5.3-codex",
+            "api_key_env_name": "OPENROUTER_API_KEY",
+            "api_key_env_resolved": "OPENROUTER_API_KEY",
+            "failure_type": None,
+            "status_code": 200,
+            "provider_signature": "provider=openrouter;model=openai/gpt-5.3-codex",
+            "ready": True,
+            "readiness_blocker": {"ready": True},
+        }
+
+    monkeypatch.setattr(runner, "run_provider_doctor_probe", fresh_probe)
+
+    runner.prepare_phase_provider_preflight(
+        tmp_path,
+        "run_d_stale_preflight",
+        "D",
+        cfg,
+    )
+
+    assert called["probe"] is True
+    partial = json.loads((run_root / "PROVIDER_PREFLIGHT__D.json").read_text(encoding="utf-8"))
+    assert partial["scope_kind"] == "phase"
+
+
+def test_phase_requires_provider_preflight_tracks_required_active_routes() -> None:
+    runner = _load_runner_module()
+    cfg = _make_cfg(runner)
+    object.__setattr__(cfg, "dry_run", False)
+
+    assert runner.phase_requires_provider_preflight("A", cfg) is True
+    assert runner.phase_requires_provider_preflight("H", cfg) is True
+    assert runner.phase_requires_provider_preflight("C", cfg) is True
+    assert runner.phase_requires_provider_preflight("D", cfg) is True
+
+
+def test_ensure_launch_provider_preflight_blocks_when_required_route_probe_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _load_runner_module()
+    cfg = _make_cfg(runner)
+    object.__setattr__(cfg, "dry_run", False)
+
+    run_root = runner.current_runs_root(tmp_path) / "launch_probe_block"
+    run_root.mkdir(parents=True, exist_ok=True)
+    (run_root / "RUN_MANIFEST.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-17T09:00:00+00:00",
+                "routing_step_tiers": {"A": {}, "H": {}, "D": {}, "C": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        runner,
+        "run_provider_preflight",
+        lambda root, run_id, cfg_arg, phases: (
+            False,
+            {"failed_providers": ["openrouter"], "phase_scope": list(phases)},
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Provider preflight blocked launch scope"):
+        runner.ensure_launch_provider_preflight(
+            tmp_path,
+            "launch_probe_block",
+            ["A", "H", "D", "C"],
+            cfg,
+        )
+
+
+def test_ensure_launch_provider_preflight_ignores_shared_doctor_copy(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _load_runner_module()
+    cfg = _make_cfg(runner)
+    object.__setattr__(cfg, "dry_run", False)
+
+    run_root = runner.current_runs_root(tmp_path) / "launch_probe_ignores_doctor"
+    run_root.mkdir(parents=True, exist_ok=True)
+    (run_root / "RUN_MANIFEST.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-17T09:00:00+00:00",
+                "routing_step_tiers": {"A": {}, "H": {}, "D": {}, "C": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    doctor_root = runner.current_doctor_root(tmp_path)
+    doctor_root.mkdir(parents=True, exist_ok=True)
+    (doctor_root / "PROVIDER_PREFLIGHT.json").write_text(
+        json.dumps(
+            {
+                "status": "PASS",
+                "run_id": "other_run",
+                "advisory_only": True,
+                "authority_class": "diagnostic_only",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        runner,
+        "run_provider_preflight",
+        lambda root, run_id, cfg_arg, phases: (
+            False,
+            {"failed_providers": ["openrouter"], "phase_scope": list(phases)},
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Provider preflight blocked launch scope"):
+        runner.ensure_launch_provider_preflight(
+            tmp_path,
+            "launch_probe_ignores_doctor",
+            ["A", "H", "D", "C"],
+            cfg,
+        )
+
+
+def test_ensure_launch_provider_preflight_prefers_run_local_over_shared_doctor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _load_runner_module()
+    cfg = _make_cfg(runner)
+    object.__setattr__(cfg, "dry_run", False)
+
+    run_root = runner.current_runs_root(tmp_path) / "launch_probe_prefers_run_local"
+    run_root.mkdir(parents=True, exist_ok=True)
+    (run_root / "RUN_MANIFEST.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-17T09:00:00+00:00",
+                "routing_step_tiers": {"A": {}, "H": {}, "D": {}, "C": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_root / "PROVIDER_PREFLIGHT.json").write_text(
+        json.dumps(
+            {
+                "generated_at": "2026-04-17T09:01:00+00:00",
+                "run_id": "launch_probe_prefers_run_local",
+                "status": "PASS",
+                "phase_scope": ["A", "H", "D", "C"],
+                "step_scope": {},
+                "scope_kind": "launch",
+                "scope_complete_for_launch": True,
+                "routing_policy": "cost",
+            }
+        ),
+        encoding="utf-8",
+    )
+    doctor_root = runner.current_doctor_root(tmp_path)
+    doctor_root.mkdir(parents=True, exist_ok=True)
+    (doctor_root / "PROVIDER_PREFLIGHT.json").write_text(
+        json.dumps(
+            {
+                "status": "FAIL",
+                "run_id": "stale_shared_doctor",
+                "advisory_only": True,
+                "authority_class": "diagnostic_only",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fail_probe(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("run-local launch preflight should win over shared doctor copy")
+
+    monkeypatch.setattr(runner, "run_provider_preflight", fail_probe)
+
+    updated_cfg = runner.ensure_launch_provider_preflight(
+        tmp_path,
+        "launch_probe_prefers_run_local",
+        ["A", "H", "D", "C"],
+        cfg,
+    )
+
+    assert updated_cfg == cfg
 
 
 def test_route_readiness_summary_distinguishes_required_fallback_and_configured(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- harden non-resume run context and launch preflight reuse for first full extraction
- expand provider preflight enforcement to phases with required active routes and keep prescan scope reduction opt-in
- label shared doctor artifacts as diagnostic-only, tighten operator help text, and add proof of non-authority
- add targeted tests plus proof artifact for both packets

## Validation
- pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
- pytest -q services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py
- pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_rollup_reports.py
- pytest -q services/repo-truth-extractor/tests/test_router_runtime_integration.py
- python -m py_compile services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/rte_output_layout.py services/repo-truth-extractor/reporting.py
- git diff --check
- pre-commit run --files services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/rte_output_layout.py services/repo-truth-extractor/reporting.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py services/repo-truth-extractor/tests/test_router_runtime_integration.py UPGRADES/RUN_ORDER.md UPGRADES/PIPELINE_PROOF.md

@codex
@clauee
@copilot