### PR TITLE
[codex] Harden run manifest precedence truth

### DIFF
--- a/services/repo-truth-extractor/reporting.py
+++ b/services/repo-truth-extractor/reporting.py
@@ -184,6 +184,19 @@ def _gate_payload(status: str, *, source: str, evidence: Dict[str, Any], notes: 
     return payload
 
 
+def build_run_id_resolution_precedence(
+    *,
+    resume: bool,
+    latest_run_file: Path,
+) -> List[str]:
+    precedence = ["explicit(--run-id)"]
+    if resume:
+        precedence.append(f"resume-only implicit({latest_run_file})")
+    else:
+        precedence.append("generated(new timestamp run id)")
+    return precedence
+
+
 def _normalized_phase_scope(values: Any) -> List[str]:
     if not isinstance(values, list):
         return []
@@ -524,11 +537,10 @@ def write_run_manifest(
             "run_id_override": args.run_id,
             "run_id_source": run_context.source,
             "max_cost_usd": args.max_cost_usd,
-            "run_id_resolution_precedence": [
-                "explicit(--run-id)",
-                f"implicit({layout.latest_run_file})",
-                "generated(new timestamp run id)",
-            ],
+            "run_id_resolution_precedence": build_run_id_resolution_precedence(
+                resume=bool(args.resume),
+                latest_run_file=layout.latest_run_file,
+            ),
             "no_write_latest": args.no_write_latest,
             "write_latest_even_on_dry_run": args.write_latest_even_on_dry_run,
             "latest_run_id_written": run_context.latest_written,

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -214,6 +214,7 @@ from rte_reports import (
     write_runner_identity as rte_write_runner_identity,
     write_step_metrics_snapshot as rte_write_step_metrics_snapshot,
 )
+from reporting import build_run_id_resolution_precedence
 from llm_runtime import (
     LLMRuntimeDeps,
     backoff_seconds as llm_runtime_backoff_seconds,
@@ -15328,11 +15329,10 @@ def print_config(
             "print_config": args.print_config,
             "run_id_override": args.run_id,
             "run_id_source": run_context.source,
-            "run_id_resolution_precedence": [
-                "explicit(--run-id)",
-                f"implicit({layout.latest_run_file})",
-                "generated(new timestamp run id)",
-            ],
+            "run_id_resolution_precedence": build_run_id_resolution_precedence(
+                resume=bool(args.resume),
+                latest_run_file=layout.latest_run_file,
+            ),
             "dry_run": args.dry_run,
             "resume": args.resume,
             "no_write_latest": args.no_write_latest,

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
@@ -28,6 +28,47 @@ def _load_runner_module() -> types.ModuleType:
     return module
 
 
+def _run_print_config_and_load_manifest(
+    tmp_path: Path,
+    *,
+    resume: bool,
+    latest_run_id: str | None = None,
+):
+    output_root = tmp_path / "artifact-root"
+    if latest_run_id is not None:
+        (output_root / "runs" / latest_run_id).mkdir(parents=True, exist_ok=True)
+        (output_root / "latest_run_id.txt").write_text(
+            latest_run_id + "\n",
+            encoding="utf-8",
+        )
+
+    cmd = [
+        sys.executable,
+        str(_repo_root() / "services" / "repo-truth-extractor" / "run_extraction_v5.py"),
+        "--phase",
+        "A",
+        "--dry-run",
+        "--print-config",
+        "--no-write-latest",
+        "--output-root",
+        str(output_root),
+    ]
+    if resume:
+        cmd.append("--resume")
+
+    result = subprocess.run(
+        cmd,
+        cwd=str(_repo_root()),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    config_payload = json.loads(result.stdout)
+    manifest_path = output_root / "runs" / config_payload["run_id"] / "RUN_MANIFEST.json"
+    manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return config_payload, manifest_payload
+
+
 def _make_cfg(runner: types.ModuleType):
     cfg = runner.RunnerConfig.__new__(runner.RunnerConfig)
     defaults = {
@@ -184,6 +225,46 @@ def test_output_root_layout_redirects_run_and_doctor_paths(tmp_path: Path) -> No
         assert runner.latest_run_id_path(tmp_path) == artifact_root / "latest_run_id.txt"
     finally:
         runner.configure_output_layout(tmp_path, None)
+
+
+def test_non_resume_manifest_truth_omits_latest_run_reuse(tmp_path: Path) -> None:
+    config_payload, manifest_payload = _run_print_config_and_load_manifest(
+        tmp_path,
+        resume=False,
+    )
+
+    expected = [
+        "explicit(--run-id)",
+        "generated(new timestamp run id)",
+    ]
+    assert config_payload["cli"]["resume"] is False
+    assert manifest_payload["cli"]["resume"] is False
+    assert config_payload["cli"]["run_id_source"] == "generated"
+    assert manifest_payload["cli"]["run_id_source"] == "generated"
+    assert config_payload["cli"]["run_id_resolution_precedence"] == expected
+    assert manifest_payload["cli"]["run_id_resolution_precedence"] == expected
+
+
+def test_resume_manifest_truth_marks_latest_run_reuse_as_resume_only(
+    tmp_path: Path,
+) -> None:
+    config_payload, manifest_payload = _run_print_config_and_load_manifest(
+        tmp_path,
+        resume=True,
+        latest_run_id="resume_me",
+    )
+
+    expected = [
+        "explicit(--run-id)",
+        f"resume-only implicit({(tmp_path / 'artifact-root' / 'latest_run_id.txt').resolve()})",
+    ]
+    assert config_payload["run_id"] == "resume_me"
+    assert config_payload["cli"]["resume"] is True
+    assert manifest_payload["cli"]["resume"] is True
+    assert config_payload["cli"]["run_id_source"] == "latest_run_id"
+    assert manifest_payload["cli"]["run_id_source"] == "latest_run_id"
+    assert config_payload["cli"]["run_id_resolution_precedence"] == expected
+    assert manifest_payload["cli"]["run_id_resolution_precedence"] == expected
 
 
 def test_build_phase_cost_preview_marks_override_risk() -> None:

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_rollup_reports.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_rollup_reports.py
@@ -18,6 +18,26 @@ def _load_runner_module():
     return module
 
 
+def test_run_id_resolution_precedence_helper_is_resume_sensitive(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    latest_run_file = (tmp_path / "latest_run_id.txt").resolve()
+
+    assert runner.build_run_id_resolution_precedence(
+        resume=False,
+        latest_run_file=latest_run_file,
+    ) == [
+        "explicit(--run-id)",
+        "generated(new timestamp run id)",
+    ]
+    assert runner.build_run_id_resolution_precedence(
+        resume=True,
+        latest_run_file=latest_run_file,
+    ) == [
+        "explicit(--run-id)",
+        f"resume-only implicit({latest_run_file})",
+    ]
+
+
 def test_telemetry_snapshot_writers_are_deterministic(tmp_path: Path) -> None:
     runner = _load_runner_module()
 


### PR DESCRIPTION
## What changed
- made emitted run-id resolution precedence match actual runtime behavior
- removed non-resume advertisement of implicit `latest_run_id.txt` reuse from `RUN_MANIFEST.json`
- switched the mirrored `--print-config` payload to the same precedence helper
- added artifact-truth tests for non-resume and resume paths plus helper parity coverage

## Why
`resolve_run_context()` already enforced resume-only reuse of `latest_run_id.txt`, but the emitted manifest and mirrored reporting output still described the old implicit reuse semantics. In this repo, emitted artifacts are evidence, so that drift blocked the boundary hardening.

## Impact
- non-resume launches now emit `explicit(--run-id)` then `generated(new timestamp run id)`
- resume launches now emit `explicit(--run-id)` then `resume-only implicit(<latest_run_id.txt>)`
- manifest and mirrored config output stay aligned through a shared helper

## Validation
- `pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py`
- `pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_rollup_reports.py`
- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/reporting.py`
- `git diff --check`
- `pre-commit run --files services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/reporting.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_run_extraction_v5_rollup_reports.py`
