### PR TITLE
🎨 Palette: Consolidate notification clear button and improve Chip accessibility

### DIFF
--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -458,27 +458,6 @@ function App() {
             >
               Live Signal Feed
             </Typography>
-            {notifications.length > 0 && (
-              <Tooltip title="Clear all notifications" arrow>
-                <IconButton
-                  size="small"
-                  onClick={() => {
-                    setNotifications([]);
-                    feedHeadingRef.current?.focus();
-                  }}
-                  aria-label="Clear all notifications"
-                  sx={{
-                    ml: 1,
-                    color: brandTokens.colors.gremlinPink,
-                    '&:focus-visible': {
-                      outline: `2px solid ${brandTokens.colors.gremlinPink}`,
-                    },
-                  }}
-                >
-                  <Trash2 size={16} aria-hidden="true" />
-                </IconButton>
-              </Tooltip>
-            )}
             {isLoading && <CircularProgress size={16} sx={{ ml: 'auto' }} />}
             {notifications.length > 0 && (
               <Tooltip title="Clear all notifications to reduce visual noise" arrow>
@@ -487,24 +466,13 @@ function App() {
                   variant="outlined"
                   icon={<Trash2 size={14} />}
                   label="Clear"
-                  onClick={() => setNotifications([])}
-                  sx={{
-                    ml: 'auto',
-                    cursor: 'pointer',
-                    bgcolor: alpha(brandTokens.colors.gremlinPink, 0.1),
-                    color: brandTokens.colors.gremlinPink,
-                    borderColor: brandTokens.colors.gremlinPink,
-                    '&:hover': {
-                      bgcolor: alpha(brandTokens.colors.gremlinPink, 0.2),
-                    },
+                  onClick={() => {
+                    setNotifications([]);
+                    feedHeadingRef.current?.focus();
                   }}
-                />
-                  size="small"
-                  icon={<Trash2 size={14} />}
-                  label="Clear"
-                  onClick={() => setNotifications([])}
+                  aria-label="Clear all notifications"
                   sx={{
-                    ml: 1,
+                    ml: isLoading ? 1 : 'auto',
                     cursor: 'pointer',
                     bgcolor: alpha(brandTokens.colors.gremlinPink, 0.1),
                     color: brandTokens.colors.gremlinPink,

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -122,6 +122,7 @@ test('TaskSequencer.tsx displays total remaining duration with accessibility', (
 
 test('App.tsx has accessible header chips and skip link', () => {
   const appContent = fs.readFileSync(path.resolve(__dirname, '../../App.tsx'), 'utf8');
+  const themeContent = fs.readFileSync(path.resolve(__dirname, '../../theme.ts'), 'utf8');
   expect(appContent).toContain('href="#main-dashboard"');
   expect(appContent).toContain('aria-label={`System is actively monitoring ritual state: ${connectionLabel} DØPEMÜX Ritual Daemon`}');
   expect(appContent).toContain('<Tooltip title="Current cognitive status and load percentage" arrow>');
@@ -131,7 +132,8 @@ test('App.tsx has accessible header chips and skip link', () => {
   expect(appContent).toContain('aria-label={`System is actively monitoring ritual state: ${connectionLabel} DØPEMÜX Ritual Daemon`}');
   expect(appContent).toContain('aria-label="Clear all notifications"');
   expect(appContent).toMatch(/<Tooltip title="Clear all notifications to reduce visual noise" arrow>/);
-  expect(appContent).toContain('&:focus-visible');
+  expect(themeContent).toContain('MuiChip');
+  expect(themeContent).toContain('&:focus-visible');
   expect(appContent).toContain('ref={feedHeadingRef}');
   expect(appContent).toContain('tabIndex={-1}');
 });

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -130,7 +130,7 @@ test('App.tsx has accessible header chips and skip link', () => {
   expect(appContent).toMatch(/<Tooltip title="AI-generated recommendation based on current load" arrow>[\s\S]*tabIndex=\{0\}/);
   expect(appContent).toContain('aria-label={`System is actively monitoring ritual state: ${connectionLabel} DØPEMÜX Ritual Daemon`}');
   expect(appContent).toContain('aria-label="Clear all notifications"');
-  expect(appContent).toMatch(/<Tooltip title="Clear all notifications" arrow>/);
+  expect(appContent).toMatch(/<Tooltip title="Clear all notifications to reduce visual noise" arrow>/);
   expect(appContent).toContain('&:focus-visible');
   expect(appContent).toContain('ref={feedHeadingRef}');
   expect(appContent).toContain('tabIndex={-1}');

--- a/ui-dashboard/src/theme.ts
+++ b/ui-dashboard/src/theme.ts
@@ -156,6 +156,10 @@ const theme = createTheme({
           fontFamily: '"JetBrains Mono","IBM Plex Mono",monospace',
           borderRadius: 999,
           letterSpacing: '0.08em',
+          '&:focus-visible': {
+            outline: `2px solid ${brandTokens.colors.ritualCyan}`,
+            outlineOffset: '2px',
+          },
         },
       },
     },


### PR DESCRIPTION
🎨 Palette: Consolidate notification clear button and improve Chip accessibility

### 💡 What: The UX enhancement added
- Consolidated the "Clear all notifications" action into a single, accessible `Chip` component in `App.tsx`.
- Implemented explicit focus management: when notifications are cleared, focus is programmatically moved back to the "Live Signal Feed" heading to prevent the screen reader focus from being lost.
- Added a global focus-visible ring for all `Chip` components in the Material UI theme (`src/theme.ts`).
- Fixed a JSX syntax error in `App.tsx` where duplicate code had been partially and incorrectly added.

### 🎯 Why: The user problem it solves
- Redundant buttons and broken code in the feed header were confusing and visually cluttered.
- Removing a focused element from the DOM (the clear button) without moving focus elsewhere causes focus to reset to the top of the document, which is a jarring experience for keyboard and screen reader users.
- Many interactive elements (Chips) were focusable but lacked a visible focus indicator, making keyboard navigation difficult.

### ♿ Accessibility: Any a11y improvements made
- **Focus Management:** Added `feedHeadingRef` and `feedHeadingRef.current?.focus()` after clearing notifications.
- **Visible Focus:** Added `&:focus-visible` styles to the `MuiChip` theme override.
- **Descriptive Labels:** Added `aria-label="Clear all notifications"` and improved the Tooltip text to include the intent ("...to reduce visual noise").
- **Semantic Structure:** Ensured the heading being focused has `tabIndex={-1}` to be programmatically focusable without being in the natural tab order.

---
*PR created automatically by Jules for task [17700124124658925004](https://jules.google.com/task/17700124124658925004) started by @hu3mann*