### PR TITLE
RTE Prescan Stage 0: operational hardening + provider independence

### DIFF
--- a/services/repo-truth-extractor/lib/prescan/engine.py
+++ b/services/repo-truth-extractor/lib/prescan/engine.py
@@ -2,13 +2,12 @@ import datetime as dt
 import json
 import logging
 import time
-import subprocess
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from .models import PrescanConfig, PrescanResult, FileEntry
 from .corpus_walker import CorpusWalker
-from .classifier import FileClassifier
+from .classifier import Classifier
 from .git_enricher import GitEnricher
 from .duplicate_detector import DuplicateDetector
 from .grok_passes import GrokPassRunner
@@ -16,136 +15,345 @@ from .code_prescan import CodePrescan
 from .dependency_graph import DependencyGraph
 from .batch_planner import BatchPlanner
 from .cost_estimator import CostEstimator
+from .incremental_cache import IncrementalCodeCache
 from .provider_catalog import (
+    NO_LIVE_LANE,
     build_provider_model_catalog,
     build_prescan_routing_plan,
+    build_provider_readiness_matrix,
+    write_no_live_lane_artifact,
     write_provider_catalog,
+    write_provider_readiness,
     write_routing_plan,
 )
 
 logger = logging.getLogger(__name__)
 
 class PrescanEngine:
-    def __init__(self, config: PrescanConfig, limiter: Any | None = None):
+    def __init__(self, config: PrescanConfig):
         self.config = config
         self.walker = CorpusWalker(config)
-        self.classifier = FileClassifier(config)
-        self.enricher = GitEnricher(config)
-        self.detector = DuplicateDetector(config)
-        self.code_scanner = CodePrescan(config)
+        self.classifier = Classifier(config)
+        self.git_enricher = GitEnricher(config)
+        self.duplicate_detector = DuplicateDetector(config)
+        self.grok_runner = GrokPassRunner(config)
+        self.code_prescan = CodePrescan(config)
         self.dep_graph = DependencyGraph()
         self.cost_estimator = CostEstimator(config)
-        self.batch_planner = BatchPlanner(config)
-        self.grok_runner = GrokPassRunner(config, limiter=limiter)
 
     def run(self, passes: list[str] | None = None, incremental: bool = False) -> PrescanResult:
-        """Run the full prescan pipeline."""
+        """Run full or incremental prescan pipeline."""
         start_time = time.time()
         warnings = []
         errors = []
-        
+        incremental_cache = IncrementalCodeCache(self.config)
+        changed_files: set[str] | None = None
+        cache_payload: dict[str, Any] | None = None
+        cache_fallback_reason: str | None = None
+        cached_reuse_count = 0
+        reanalyzed_count = 0
+        removed_cache_entries = 0
+
         try:
             # 1. Walk corpus
             logger.info(f"Walking corpus in {self.config.repo_root}...")
-            files = self.walker.walk()
+            entries = self.walker.walk()
             
-            # 2. Classify files
+            # 2. Incremental logic: Filter unchanged files if requested
+            if incremental:
+                changed_files = self._get_changed_files()
+                if changed_files is None:
+                    warning = (
+                        "Incremental change detection unavailable; running explicit full recompute and regenerating cache."
+                    )
+                    warnings.append(warning)
+                    logger.warning(warning)
+                else:
+                    logger.info(f"Incremental mode: {len(changed_files)} files changed since last run.")
+                    cache_payload, cache_warning = incremental_cache.load()
+                    if cache_warning:
+                        cache_fallback_reason = cache_warning
+                        warnings.append(cache_warning)
+                        logger.warning(cache_warning)
+            
+            # 3. Classify files
             logger.info("Classifying files...")
-            entries = self.classifier.classify(files)
+            self.classifier.classify_all(entries)
             
             # 3. Git enrichment
-            changed_files = None
             if self.config.enable_git_enrichment:
                 logger.info("Enriching with git metadata...")
-                try:
-                    self.enricher.enrich(entries)
-                except Exception as e:
-                    logger.warning(f"Git enrichment failed: {e}")
-                    warnings.append(f"Git enrichment failed: {e}")
-
+                self.git_enricher.enrich(entries)
+                
+                logger.info("Recovering ghost files...")
+                existing_paths = {e.rel_path for e in entries}
+                ghosts = self.git_enricher.recover_ghost_files(existing_paths)
+                entries.extend(ghosts)
+            
             # 4. Duplicate detection
             logger.info("Detecting duplicates and version chains...")
-            duplicates = self.detector.detect(entries)
-            
-            # 5. Code intelligence
+            self.duplicate_detector.detect_duplicates(entries)
+            self.duplicate_detector.detect_version_chains(entries)
+
+            # 5. Code Intelligence (AST)
             code_intel = []
             if self.config.enable_code_prescan:
                 logger.info("Running code intelligence (AST analysis)...")
-                try:
-                    code_entries = [e for e in entries if e.include and e.extension in self.config.code_languages]
-                    code_intel = self.code_scanner.scan([e.rel_path for e in code_entries])
-                    self.dep_graph.build(code_intel)
-                except Exception as e:
-                    logger.warning(f"Code intelligence failed: {e}")
-                    warnings.append(f"Code intelligence failed: {e}")
+                current_paths = {entry.rel_path for entry in entries}
+                removed_cache_entries = incremental_cache.removed_entry_count(cache_payload, current_paths)
+                for entry in entries:
+                    cached = incremental_cache.reusable_analysis(cache_payload, entry, changed_files)
+                    if cached is not None:
+                        cached_reuse_count += 1
+                        code_intel.append(incremental_cache.apply_cached_metrics(entry, cached))
+                        continue
+                    intel = self.code_prescan.analyze_file(entry, self.config.repo_root)
+                    if intel:
+                        reanalyzed_count += 1
+                        code_intel.append(intel)
 
-            # 6. Build intelligence base
-            intelligence = self._build_intelligence_base(entries, code_intel)
-            intelligence["duplicate_groups"] = duplicates["groups"]
-            intelligence["version_chains"] = duplicates["chains"]
-            intelligence["version_chain_count"] = len(duplicates["chains"])
+                if incremental:
+                    logger.info(
+                        "Incremental code analysis: reused=%d reanalyzed=%d removed=%d",
+                        cached_reuse_count,
+                        reanalyzed_count,
+                        removed_cache_entries,
+                    )
+                
+                logger.info("Building dependency graph...")
+                manifest_simple = [e.to_dict() for e in entries]
+                self.dep_graph.build_from_code_intelligence(code_intel, manifest_simple)
             
-            # 7. Optional passes
+            # 6. Build intelligence report (base)
+            intelligence = self._build_intelligence_base(entries, code_intel)
+            manifest = [e.to_dict() for e in entries]
+            
+            # 6a. Cost Estimation (Only if explicitly requested, though we don't have a flag for it in config yet, let's assume we do it if batch_mode or explicitly requested, or we can just keep it fast. Let's wrap in a try block)
+            if self.config.cost_estimate:
+                logger.info("Estimating extraction costs...")
+                intelligence["cost_estimate"] = self.cost_estimator.estimate(entries)
+            
+            # 6b. Code Intelligence Report (if code prescan ran)
+            code_report = None
+            code_report_path = None
+            if self.config.enable_code_prescan and code_intel:
+                try:
+                    from .code_intelligence_report import CodeIntelligenceBuilder
+
+                    builder = CodeIntelligenceBuilder(
+                        code_prescan=self.code_prescan,
+                        dep_graph=self.dep_graph,
+                        entries=entries,
+                        manifest=manifest,
+                    )
+                    code_report = builder.build(self.config.repo_root)
+                    code_report_path = self.config.output_dir / "code_intelligence_report.json"
+                    self.config.output_dir.mkdir(parents=True, exist_ok=True)
+                    code_report_path.write_text(
+                        json.dumps(code_report, indent=2, default=str) + "\n"
+                    )
+                    # Inject summary into intelligence
+                    intelligence.setdefault("code_intelligence", {})
+                    intelligence["code_intelligence"]["report_summary"] = code_report.get("summary", {})
+                    intelligence["code_intelligence"]["processing_order"] = code_report.get("processing_order", [])[:50]
+                    intelligence["code_intelligence"]["hotspots"] = code_report.get("hotspots", [])
+                    intelligence["code_intelligence"]["orphans"] = code_report.get("orphans", [])
+                    logger.info(f"Code intelligence report saved: {code_report_path}")
+                except Exception as e:
+                    logger.warning(f"Code intelligence report failed (non-fatal): {e}")
+
+            # 6c. Batch planning (if batch_mode enabled)
             batch_plans = {}
             batch_plan_path = None
-            
-            if passes:
-                # 7a. Batch planning
+            if self.config.batch_mode and passes:
                 logger.info("Planning token-aware batches...")
-                manifest = [e.to_dict() for e in entries]
-                batch_plans = self.batch_planner.plan(passes, intelligence, manifest)
-                
+                planner = BatchPlanner(self.config, entries, manifest)
+                for pid in passes:
+                    batch_plans[pid] = planner.plan_batches(pid, intelligence)
+                    bp = batch_plans[pid]
+                    logger.info(
+                        f"  {pid}: {len(bp.batches)} batches, "
+                        f"~{bp.total_estimated_tokens:,} tokens, "
+                        f"{bp.total_files} files"
+                    )
+                    if bp.oversized_files:
+                        logger.info(f"  {pid}: {len(bp.oversized_files)} oversized files excluded")
+
                 # Save batch plan
+                self.config.output_dir.mkdir(parents=True, exist_ok=True)
                 batch_plan_path = self.config.output_dir / "batch_plan.json"
+                plan_data = {pid: bp.to_dict() for pid, bp in batch_plans.items()}
                 batch_plan_path.write_text(
-                    json.dumps({p: bp.to_dict() for p, bp in batch_plans.items()}, indent=2) + "\n"
+                    json.dumps(plan_data, indent=2, sort_keys=True) + "\n"
                 )
 
-                # 7b. Provider routing
-                logger.info("Building provider model catalog for routing...")
-                routing_plan = None
+            # 7. Build provider routing plan for grok passes
+            routing_plan = None
+            routing_plan_path = None
+            provider_readiness = None
+            if passes:
                 try:
-                    catalog_data = build_provider_model_catalog(self.config)
-                    routing_plan = build_prescan_routing_plan(self.config, passes, batch_plans, catalog_data)
-                    
-                    # Save routing plan
-                    write_routing_plan(self.config.output_dir, routing_plan)
-                    write_provider_catalog(self.config.output_dir, catalog_data)
-                except Exception as e:
-                    logger.warning(f"Provider routing failed (using defaults): {e}")
-                    warnings.append(f"Provider routing failed: {e}")
+                    logger.info("Building provider model catalog for routing...")
+                    catalog = build_provider_model_catalog(self.config)
+                    catalog_path = write_provider_catalog(self.config.output_dir, catalog)
+                    logger.info(f"Provider catalog saved: {catalog_path}")
 
-                # 7c. Execute Grok passes
+                    provider_readiness = build_provider_readiness_matrix(self.config, catalog)
+                    readiness_path = write_provider_readiness(self.config.output_dir, provider_readiness)
+                    logger.info(f"Provider readiness saved: {readiness_path}")
+
+                    routing_plan = build_prescan_routing_plan(self.config, catalog, provider_readiness, passes)
+                    routing_plan_path = write_routing_plan(self.config.output_dir, routing_plan)
+                    logger.info(f"Routing plan saved: {routing_plan_path}")
+                except Exception as e:
+                    logger.exception("Provider routing failed during Stage 0 readiness gating")
+                    return PrescanResult(
+                        success=False,
+                        intelligence_path=None,
+                        manifest_path=None,
+                        code_graph_path=None,
+                        file_count=len(entries),
+                        included_count=sum(1 for e in entries if e.include),
+                        code_files_analyzed=len(code_intel),
+                        duration_seconds=round(time.time() - start_time, 2),
+                        warnings=warnings,
+                        errors=[f"Stage 0 routing/readiness failed: {e}"],
+                        metadata={
+                            "git_sha": self._get_git_sha(),
+                            "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+                            "stage0": {
+                                "provider_readiness_status": "UNKNOWN",
+                                "routing_plan_status": "ERROR",
+                                "routing_error": str(e),
+                                "routing_plan_path": None,
+                            },
+                            "incremental": {
+                                "enabled": incremental,
+                                "changed_files_count": len(changed_files) if changed_files is not None else None,
+                                "cached_code_analysis_reused": cached_reuse_count,
+                                "reanalyzed_code_files": reanalyzed_count,
+                                "removed_cache_entries": removed_cache_entries,
+                                "fallback_reason": cache_fallback_reason,
+                            },
+                        },
+                        batch_plan_path=batch_plan_path,
+                        batch_count=sum(len(bp.batches) for bp in batch_plans.values()) if batch_plans else 0,
+                        code_report_path=code_report_path,
+                    )
+
+                if routing_plan and routing_plan.get("status") == NO_LIVE_LANE:
+                    no_live_lane_path = write_no_live_lane_artifact(self.config.output_dir, routing_plan)
+                    logger.error(f"No executable prescan route survived Stage 0: {no_live_lane_path}")
+                    return PrescanResult(
+                        success=False,
+                        intelligence_path=None,
+                        manifest_path=None,
+                        code_graph_path=None,
+                        file_count=len(entries),
+                        included_count=sum(1 for e in entries if e.include),
+                        code_files_analyzed=len(code_intel),
+                        duration_seconds=round(time.time() - start_time, 2),
+                        warnings=warnings,
+                        errors=["No executable live prescan lane survived Stage 0 readiness gating."],
+                        metadata={
+                            "git_sha": self._get_git_sha(),
+                            "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+                            "stage0": {
+                                "provider_readiness_status": (
+                                    provider_readiness or {}
+                                ).get("status", "UNKNOWN"),
+                                "routing_plan_status": routing_plan.get("status"),
+                                "no_live_lane_artifact": str(no_live_lane_path),
+                            },
+                            "incremental": {
+                                "enabled": incremental,
+                                "changed_files_count": len(changed_files) if changed_files is not None else None,
+                                "cached_code_analysis_reused": cached_reuse_count,
+                                "reanalyzed_code_files": reanalyzed_count,
+                                "removed_cache_entries": removed_cache_entries,
+                                "fallback_reason": cache_fallback_reason,
+                            },
+                        },
+                        batch_plan_path=batch_plan_path,
+                        batch_count=sum(len(bp.batches) for bp in batch_plans.values()) if batch_plans else 0,
+                        code_report_path=code_report_path,
+                    )
+
+            # 7a. Grok passes (optional)
+            grok_results = {}
+            if passes:
                 logger.info(f"Running Grok passes: {', '.join(passes)}...")
-                grok_results = self.grok_runner.run_passes_batched(
-                    passes, intelligence, manifest, batch_plans, routing_plan=routing_plan
-                )
+                if self.config.batch_mode and batch_plans:
+                    grok_results = self.grok_runner.run_passes_batched(
+                        passes, intelligence, manifest, batch_plans, routing_plan=routing_plan
+                    )
+                else:
+                    grok_results = self.grok_runner.run_passes(passes, intelligence, manifest, routing_plan=routing_plan)
                 intelligence["grok_passes"] = grok_results
 
+            # 7b. Archaeology report (deep mode only)
+            archaeology_report_path = None
+            if self.config.deep_mode and grok_results:
+                try:
+                    from .archaeology_report import ArchaeologyReporter
+
+                    reporter = ArchaeologyReporter(entries, intelligence, grok_results)
+                    arch_report = reporter.generate()
+                    archaeology_report_path = self.config.output_dir / "archaeology_report.json"
+                    archaeology_report_path.write_text(
+                        json.dumps(arch_report, indent=2, default=str) + "\n"
+                    )
+                    logger.info(f"Archaeology report saved: {archaeology_report_path}")
+                except Exception as e:
+                    logger.warning(f"Archaeology report failed (non-fatal): {e}")
+            
             # 8. Save artifacts
             self.config.output_dir.mkdir(parents=True, exist_ok=True)
             
             intel_path = self.config.output_dir / "prescan_intelligence.json"
             manifest_path = self.config.output_dir / "corpus_manifest.json"
+            graph_path = self.config.output_dir / "code_graph.json"
             
-            manifest = [e.to_dict() for e in entries]
             intel_path.write_text(json.dumps(intelligence, indent=2, sort_keys=True) + "\n")
             manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
             
+            if self.config.enable_code_prescan:
+                graph_path.write_text(self.dep_graph.to_json() + "\n")
+
+            if self.config.enable_code_prescan:
+                incremental_cache.write(entries, code_intel, self._get_git_sha())
+            
             duration = time.time() - start_time
+            
             total_batches = sum(len(bp.batches) for bp in batch_plans.values()) if batch_plans else 0
 
             return PrescanResult(
                 success=True,
                 intelligence_path=intel_path,
                 manifest_path=manifest_path,
+                code_graph_path=graph_path if self.config.enable_code_prescan else None,
                 file_count=len(entries),
                 included_count=sum(1 for e in entries if e.include),
+                code_files_analyzed=len(code_intel),
                 duration_seconds=round(duration, 2),
                 warnings=warnings,
                 errors=errors,
+                metadata={
+                    "git_sha": self._get_git_sha(),
+                    "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+                    "incremental": {
+                        "enabled": incremental,
+                        "changed_files_count": len(changed_files) if changed_files is not None else None,
+                        "cached_code_analysis_reused": cached_reuse_count,
+                        "reanalyzed_code_files": reanalyzed_count,
+                        "removed_cache_entries": removed_cache_entries,
+                        "fallback_reason": cache_fallback_reason,
+                    },
+                },
                 batch_plan_path=batch_plan_path,
                 batch_count=total_batches,
+                archaeology_report_path=archaeology_report_path,
+                code_report_path=code_report_path,
             )
 
         except Exception as e:
@@ -155,14 +363,6 @@ class PrescanEngine:
                 errors=[str(e)],
                 duration_seconds=round(time.time() - start_time, 2)
             )
-
-        finally:
-            # 9. Save LLM attempts evidence (always)
-            try:
-                self.config.output_dir.mkdir(parents=True, exist_ok=True)
-                self.grok_runner.save_attempts()
-            except Exception as e:
-                logger.warning(f"Failed to save LLM attempts evidence (finally): {e}")
 
     def _build_intelligence_base(self, entries: list[FileEntry], code_intel: list[dict] | None = None) -> dict[str, Any]:
         """Build the basic intelligence structure."""
@@ -178,44 +378,118 @@ class PrescanEngine:
         for e in included:
             by_ext[e.extension] = by_ext.get(e.extension, 0) + 1
 
-        return {
-            "version": "1.0",
+        # Duplicate groups
+        dup_groups = {}
+        for e in included:
+            if e.duplicate_group_id:
+                dup_groups.setdefault(e.duplicate_group_id, []).append(e.rel_path)
+
+        # Version chains
+        chains = {}
+        for e in entries:
+            if e.version_chain_id:
+                chains.setdefault(e.version_chain_id, []).append({
+                    "path": e.rel_path,
+                    "ordinal": e.version_ordinal,
+                    "is_latest": e.is_latest_version
+                })
+
+        lifecycle_distribution: dict[str, int] = {}
+        for e in entries:
+            stage = e.lifecycle_stage or "unknown"
+            lifecycle_distribution[stage] = lifecycle_distribution.get(stage, 0) + 1
+
+        planned_features = {
+            "proposed_adrs": sorted(e.rel_path for e in included if e.is_proposed_adr),
+            "stub_files": sorted(e.rel_path for e in included if e.has_stub_methods),
+            "todo_files": sorted(e.rel_path for e in included if e.has_todo_markers),
+            "draft_docs": sorted(e.rel_path for e in included if e.is_draft_doc),
+        }
+        compression_potential_files = sum(
+            1 for e in included if e.version_chain_id and not e.is_latest_version
+        )
+        high_churn_files = sorted(
+            e.rel_path for e in included if e.churn_score >= 2.0
+        )
+        excluded_files = sum(1 for e in entries if not e.include and not e.is_ghost)
+
+        # API surfaces summary
+        api_surfaces = set()
+        if code_intel:
+            for ci in code_intel:
+                api_surfaces.update(ci.get("api_surfaces", []))
+
+        corpus_health_score = 100
+        if entries:
+            coverage_ratio = len(included) / len(entries)
+            corpus_health_score = int(round(coverage_ratio * 100))
+            corpus_health_score -= min(compression_potential_files * 5, 20)
+            corpus_health_score -= min(len(ghosts) * 2, 10)
+            corpus_health_score = max(0, min(100, corpus_health_score))
+
+        intelligence = {
+            "version": "2.0.0",
             "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
             "repo_root": str(self.config.repo_root),
             "corpus_summary": {
-                "total_files": len(entries),
+                "total_files_scanned": len(entries),
                 "included_files": len(included),
+                "excluded_files": excluded_files,
                 "ghost_files": len(ghosts),
-                "by_class": by_class,
+                "total_included_size_bytes": sum(e.size_bytes for e in included),
+                "by_authority_class": by_class,
                 "by_extension": by_ext,
-                "total_size_bytes": sum(e.size_bytes for e in included),
-                "corpus_health_score": 100,
+                "corpus_health_score": corpus_health_score,
             },
-            "lifecycle_distribution": self._get_lifecycle_dist(included),
-            "planned_features": self._find_planned_features(included),
-            "ghost_files": [g.to_dict() for g in ghosts],
-            "code_intelligence": code_intel or [],
+            "lifecycle_distribution": lifecycle_distribution,
+            "duplicate_groups": dup_groups,
+            "version_chains": chains,
+            "version_chain_count": len(chains),
+            "compression_potential_files": compression_potential_files,
+            "ghost_files": [
+                {
+                    "path": e.rel_path,
+                    "deleted_at_sha": e.deleted_at_sha,
+                    "deleted_date": e.deleted_date,
+                    "recovery_source": e.recovery_source,
+                }
+                for e in ghosts
+            ],
+            "planned_features": planned_features,
             "extraction_hints": {
-                "skip_duplicates": [],
-                "compression_candidates": [],
+                "skip_duplicates": [e.rel_path for e in included if e.is_duplicate],
+                "high_churn_files": high_churn_files,
+                "compress_candidates": [],
+            },
+        }
+
+        if code_intel:
+            intelligence["code_intelligence"] = {
+                "analyzed_files": len(code_intel),
+                "api_surfaces": sorted(list(api_surfaces)),
+                "dependency_clusters": [list(c) for c in self.dep_graph.find_clusters()],
+                "topological_order": self.dep_graph.get_topological_order()[:100] # Limit for report
             }
-        }
 
-    def _get_lifecycle_dist(self, entries: list[FileEntry]) -> dict[str, int]:
-        dist = {}
-        for e in entries:
-            dist[e.lifecycle_stage] = dist.get(e.lifecycle_stage, 0) + 1
-        return dist
+        return intelligence
 
-    def _find_planned_features(self, entries: list[FileEntry]) -> dict[str, list[str]]:
-        return {
-            "proposed_adrs": [e.rel_path for e in entries if "ADR" in e.rel_path and e.lifecycle_stage == "stub"],
-            "stub_files": [e.rel_path for e in entries if e.lifecycle_stage == "stub"],
-            "todo_files": [e.rel_path for e in entries if e.lifecycle_stage == "stale"],
-            "draft_docs": [e.rel_path for e in entries if e.authority_class == "historical"],
-        }
+    def _get_changed_files(self) -> set[str] | None:
+        """Get set of files changed since the last git commit or specified baseline."""
+        import subprocess
+        try:
+            baseline = self.config.incremental_baseline or "HEAD~1"
+            cmd = ["git", "diff", "--name-only", "--diff-filter=ACMR", baseline, "HEAD"]
+            output = subprocess.check_output(
+                cmd, 
+                cwd=self.config.repo_root, 
+                stderr=subprocess.DEVNULL
+            ).decode().splitlines()
+            return set(output)
+        except:
+            return None
 
     def _get_git_sha(self) -> str:
+        import subprocess
         try:
             return subprocess.check_output(
                 ["git", "rev-parse", "HEAD"], 

--- a/services/repo-truth-extractor/lib/prescan/grok_passes.py
+++ b/services/repo-truth-extractor/lib/prescan/grok_passes.py
@@ -265,18 +265,27 @@ class GrokPassRunner:
         provider = candidate["provider"]
         model_id = candidate["model_id"]
         api_key = os.environ.get(candidate["api_key_env"])
+        transport = str(candidate.get("execution_transport") or "openai_sdk")
 
         if not self._online_authorized() and provider != "mock":
              raise SecurityViolation("Spend gate blocked call")
+        if transport != "openai_sdk":
+            raise ValueError(f"Unsupported prescan route transport: {transport}")
         if not api_key:
-            raise ValueError(f"API key not found: {candidate['api_key_env']}")
+            raise ValueError("API key not found for selected route")
 
         if self.limiter:
             attempt_record.limiter_wait_ms = self.limiter.acquire(est_tokens) * 1000
 
         import openai
 
-        client = openai.OpenAI(api_key=api_key, base_url=self.config.xai_base_url)
+        base_url = None
+        if provider == "openrouter":
+            base_url = "https://openrouter.ai/api/v1"
+        elif provider not in {"openai", "mock"}:
+            base_url = self.config.xai_base_url
+
+        client = openai.OpenAI(api_key=api_key, base_url=base_url)
         response = client.chat.completions.create(
             model=model_id,
             messages=[

--- a/services/repo-truth-extractor/lib/prescan/models.py
+++ b/services/repo-truth-extractor/lib/prescan/models.py
@@ -9,94 +9,146 @@ class FileEntry:
     rel_path: str
     size_bytes: int
     extension: str
+    authority_class: str = ""
     include: bool = True
-    authority_class: str = "unknown"
-    lifecycle_stage: str = "active"
-    is_ghost: bool = False
     exclude_reason: str | None = None
     content_hash: str | None = None
-    directory_class: str = "root"
-    git_metadata: dict = field(default_factory=dict)
-    code_intel: dict = field(default_factory=dict)
+    directory_class: str = ""  # top-level directory bucket
+
+    # ── Git enrichment ──
+    last_commit_date: str | None = None
+    last_commit_sha: str | None = None
+    first_commit_date: str | None = None
+    commit_count: int = 0
+    last_author: str | None = None
+    days_since_modified: int | None = None
+    churn_score: float = 0.0
+    contributor_count: int = 0
+    lifecycle_stage: str = ""  # fresh|active|stale|frozen|unknown
+    was_renamed: bool = False
+    previous_paths: list[str] = field(default_factory=list)
+
+    # ── Duplicate detection ──
+    duplicate_group_id: str | None = None
+    is_duplicate: bool = False
+    canonical_duplicate: str | None = None
+
+    # ── Version chain ──
+    version_chain_id: str | None = None
+    version_ordinal: int = 0
+    is_latest_version: bool = True
+
+    # ── Feature gaps ──
+    has_todo_markers: bool = False
+    has_stub_methods: bool = False
+    is_draft_doc: bool = False
+    is_proposed_adr: bool = False
+
+    # ── Ghost recovery ──
+    is_ghost: bool = False
+    deleted_at_sha: str | None = None
+    deleted_date: str | None = None
+    recovery_source: str = ""
+
+    # ── Code intelligence ──
+    import_count: int = 0
+    imported_by_count: int = 0
+    is_entry_point: bool = False
+    function_count: int = 0
+    class_count: int = 0
+    docstring_coverage: float = 0.0
+    complexity_score: float = 0.0
+    is_orphan: bool = False
+    tested_by: str | None = None
+    tests_file: str | None = None
+    primary_author: str | None = None
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        return {k: v for k, v in asdict(self).items() if v is not None}
 
 @dataclass
 class PrescanConfig:
     repo_root: Path
     output_dir: Path
-    
-    # ── Orchestration ──
-    deep_mode: bool = False
-    deep_include_globs: list[str] = field(default_factory=lambda: [
-        "SYSTEM_ARCHIVE/**",
-        "docs/archive/**",
-        "docs/archive/completed-projects/**"
-    ])
-    include_globs: list[str] = field(default_factory=lambda: [
-        "**",
-    ])
-    exclude_globs: list[str] = field(default_factory=lambda: [
-        "node_modules/**",
-        ".venv/**",
-        "venv/**",
-        "__pycache__/**",
-        ".git/**",
-        "dist/**",
-        "build/**",
-    ])
-    
-    # ── Enrichment ──
-    enable_code_prescan: bool = True
+    max_file_size: int = 100 * 1024
+    max_corpus_size: int = 50 * 1024 * 1024
+    large_json_threshold: int = 500 * 1024
+    include_globs: list[str] = field(default_factory=list)
+    exclude_globs: list[str] = field(default_factory=list)
+    model: str = "grok-4.20-beta-0309-non-reasoning"
+    provider: str = "xai"
+    xai_base_url: str = "https://api.x.ai/v1"
+    api_key_env: str = "XAI_API_KEY"
+    temperature: float = 0.1
+    max_response_tokens: int = 200000
+    cost_estimate: bool = True
+    litellm_proxy_url: str = "http://localhost:4000"
+    verbose: bool = False
+    force: bool = False
     code_languages: list[str] = field(default_factory=lambda: ["python", "typescript", "javascript"])
+    enable_code_prescan: bool = True
     enable_git_enrichment: bool = True
-    
-    # ── Execution ──
     incremental: bool = False
     incremental_baseline: str | None = None
     allow_online_llm: bool = False
     online_authorized: bool | None = None
     allow_scope_reduction: bool = False
-    
+
     # ── Batching ──
     batch_mode: bool = True
     max_tokens_per_batch: int = 1_500_000
     chars_per_token: float = 4.0
-    max_file_size: int = 5_000_000
-    large_json_threshold: int = 1_000_000
-    
-    # ── Model & Provider ──
-    provider: str = "xai"
-    model: str = "grok-4.20-beta-0309-non-reasoning"
-    api_key_env: str = "XAI_API_KEY"
-    xai_base_url: str = "https://api.x.ai/v1"
-    temperature: float = 0.0
-    
-    # ── Analysis ──
-    cost_estimate: bool = True
-    verbose: bool = False
+
+    # ── Deep / history mode ──
+    deep_mode: bool = False
+    deep_include_globs: list[str] = field(
+        default_factory=lambda: [
+            "SYSTEM_ARCHIVE/**",
+            "docs/archive/**",
+            "docs/archive/completed-projects/**",
+        ]
+    )
 
     def __post_init__(self) -> None:
         if self.online_authorized is not None:
-            self.allow_online_llm = self.online_authorized
+            self.allow_online_llm = bool(self.online_authorized)
+
+    @classmethod
+    def legacy(cls, repo_root: Path, output_dir: Path, **overrides) -> "PrescanConfig":
+        """Produce config matching pre-batching behaviour exactly."""
+        return cls(
+            repo_root=repo_root,
+            output_dir=output_dir,
+            batch_mode=False,
+            deep_mode=False,
+            **overrides,
+        )
+
+    @classmethod
+    def full(cls, repo_root: Path, output_dir: Path, **overrides) -> "PrescanConfig":
+        """Full batching + code intelligence."""
+        return cls(
+            repo_root=repo_root,
+            output_dir=output_dir,
+            batch_mode=True,
+            deep_mode=False,
+            **overrides,
+        )
 
 @dataclass
 class PrescanResult:
     success: bool
-    duration_seconds: float
+    intelligence_path: Path | None = None      # prescan_intelligence.json
+    manifest_path: Path | None = None          # corpus_manifest.json
+    code_graph_path: Path | None = None        # code_graph.json
     file_count: int = 0
+    included_count: int = 0
     code_files_analyzed: int = 0
-    intelligence_path: Path | None = None
-    manifest_path: Path | None = None
-    code_graph_path: Path | None = None
-    errors: list[str] = field(default_factory=list)
+    duration_seconds: float = 0.0
     warnings: list[str] = field(default_factory=list)
-    
-    # ── Extraction hints ──
-    skip_duplicate_paths: list[str] = field(default_factory=list)
-    version_chains: dict[str, list[str]] = field(default_factory=dict)
-    
+    errors: list[str] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
     # ── Batching results ──
     batch_plan_path: Path | None = None
     batch_count: int = 0

--- a/services/repo-truth-extractor/lib/prescan/provider_catalog.py
+++ b/services/repo-truth-extractor/lib/prescan/provider_catalog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
+from types import ModuleType
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
@@ -11,7 +12,7 @@ from .models import PrescanConfig
 
 try:
     from ..spend_ledger import get_model_cost_rate
-except Exception:  # pragma: no cover - fallback only when imported out of tree
+except ImportError:  # pragma: no cover - fallback only when imported out of tree
     get_model_cost_rate = None
 
 SANCTIONED_PROVIDERS = ("openai", "gemini", "xai", "openrouter")
@@ -27,10 +28,15 @@ PRESCAN_PASS_REQUIREMENTS = {
     "feasibility": "balanced_analysis",
     "optimize": "premium_planning",
 }
+NO_LIVE_LANE = "NO_LIVE_LANE"
+
+
+def _runner_module() -> ModuleType:
+    return importlib.import_module("run_extraction_v5")
 
 
 def _load_runner_authority() -> tuple[dict[str, dict[str, list[tuple[str, str, str]]]], dict[str, str]]:
-    runner = importlib.import_module("run_extraction_v5")
+    runner = _runner_module()
     ladders = getattr(runner, "ACTIVE_ROUTING_LADDERS", {}) or {}
     provider_env = getattr(runner, "PROVIDER_API_KEY_ENV", {}) or {}
     return ladders, provider_env
@@ -48,9 +54,9 @@ def _iter_runner_routes() -> Iterable[tuple[str, str, str, str, str]]:
                 if not isinstance(route, (list, tuple)) or len(route) != 3:
                     continue
                 provider, model_id, api_key_env = (
-                    str(route[0]),
-                    str(route[1]),
-                    str(route[2]),
+                    str(route[0]).strip().lower(),
+                    str(route[1]).strip(),
+                    str(route[2]).strip(),
                 )
                 if provider not in SANCTIONED_PROVIDERS or not model_id or not api_key_env:
                     continue
@@ -97,56 +103,87 @@ def _pricing(provider: str, model_id: str) -> dict[str, Any]:
         input_1m = 10.0
         output_1m = 40.0
         authority = "fallback_default"
-        pricing_status = "UNPRICED_UNKNOWN"
-        pricing_confidence = "UNKNOWN"
+        status = "UNPRICED_UNKNOWN"
+        confidence = "UNKNOWN"
+        source_type = "inferred_estimated_fallback"
     else:
         rate = get_model_cost_rate(provider=provider, model_id=model_id)
-        if isinstance(rate, dict):
-            input_1m = float(rate.get("input_cost_per_1m_usd", 10.0))
-            output_1m = float(rate.get("output_cost_per_1m_usd", 40.0))
-            authority = str(rate.get("pricing_source", "shared_spend_ledger_registry"))
-            pricing_status = str(rate.get("pricing_status", "UNPRICED_UNKNOWN"))
-            pricing_confidence = str(rate.get("pricing_confidence", "UNKNOWN"))
-            source_type = rate.get("pricing_source_type")
-        else:
-            input_1m, output_1m = rate
-            authority = "shared_spend_ledger_registry"
-            pricing_status = "UNPRICED_UNKNOWN"
-            pricing_confidence = "UNKNOWN"
-            source_type = None
-
-    payload = {
+        input_1m = rate.get("input_cost_per_1m_usd", 10.0)
+        output_1m = rate.get("output_cost_per_1m_usd", 40.0)
+        authority = str(rate.get("pricing_source") or "shared_spend_ledger_registry")
+        status = str(rate.get("pricing_status") or "UNPRICED_UNKNOWN")
+        confidence = str(rate.get("pricing_confidence") or "UNKNOWN")
+        source_type = str(rate.get("pricing_source_type") or "unknown")
+    return {
         "input_1m_usd": float(input_1m),
         "output_1m_usd": float(output_1m),
         "pricing_authority": authority,
-        "pricing_status": pricing_status,
-        "pricing_confidence": pricing_confidence,
+        "pricing_status": status,
+        "pricing_confidence": confidence,
+        "pricing_source_type": source_type,
     }
-    if get_model_cost_rate is not None and source_type:
-        payload["pricing_source_type"] = source_type
-    return payload
+
+
+def _route_transport(provider: str) -> str:
+    if provider == "gemini":
+        return "sdk"
+    return "openai_sdk"
+
+
+def _route_admissibility(provider: str) -> dict[str, Any]:
+    transport = _route_transport(provider)
+    if transport != "openai_sdk":
+        return {
+            "route_admissible": False,
+            "route_admissibility_reason": f"unsupported_prescan_transport:{transport}",
+        }
+    return {
+        "route_admissible": True,
+        "route_admissibility_reason": "sanctioned_runtime_route",
+    }
+
+
+def _route_identity(provider: str, model_id: str) -> dict[str, Any]:
+    normalized_provider = str(provider).strip().lower()
+    normalized_model = str(model_id).strip()
+    upstream_provider = normalized_provider
+    if normalized_provider == "openrouter":
+        prefix, sep, _rest = normalized_model.partition("/")
+        if sep and prefix in {"anthropic", "gemini", "openai", "xai", "x-ai"}:
+            upstream_provider = "xai" if prefix == "x-ai" else prefix
+    dependency_class = "proxy" if normalized_provider == "openrouter" else "first_party"
+    if normalized_provider in {"local", "lmstudio", "mock", "ollama", "vllm"}:
+        dependency_class = "local"
+    return {
+        "dependency_class": dependency_class,
+        "economic_surface": normalized_provider or "unknown",
+        "upstream_provider": upstream_provider,
+        "billing_independent_from_upstream": bool(
+            normalized_provider == "openrouter" and upstream_provider != normalized_provider
+        ),
+        "execution_transport": _route_transport(normalized_provider),
+    }
 
 
 def build_provider_model_catalog(config: PrescanConfig) -> dict[str, Any]:
     seen: dict[tuple[str, str, str], dict[str, Any]] = {}
     for policy, ladder_tier, provider, model_id, api_key_env in _iter_runner_routes():
         key = (provider, model_id, api_key_env)
+        credential_present = bool(os.environ.get(api_key_env, "").strip())
         entry = seen.setdefault(
             key,
             {
                 "provider": provider,
                 "model_id": model_id,
                 "api_key_env": api_key_env,
-                "available": bool(os.environ.get(api_key_env, "").strip()),
-                "availability_reason": (
-                    "credential_present"
-                    if os.environ.get(api_key_env, "").strip()
-                    else "missing_credential"
-                ),
+                "available": credential_present,
+                "credential_present": credential_present,
+                "availability_reason": "credential_present" if credential_present else "missing_credential",
                 "prescan_tier": classify_prescan_route(provider, model_id),
                 "pricing": _pricing(provider, model_id),
                 "sources": [],
-                "execution_transport": "openai_sdk_compatible",
+                **_route_identity(provider, model_id),
+                **_route_admissibility(provider),
             },
         )
         source = {"policy": policy, "ladder_tier": ladder_tier}
@@ -155,24 +192,25 @@ def build_provider_model_catalog(config: PrescanConfig) -> dict[str, Any]:
 
     if config.provider in SANCTIONED_PROVIDERS and config.model and config.api_key_env:
         key = (config.provider, config.model, config.api_key_env)
+        credential_present = bool(os.environ.get(config.api_key_env, "").strip())
         entry = seen.setdefault(
             key,
             {
                 "provider": config.provider,
                 "model_id": config.model,
                 "api_key_env": config.api_key_env,
-                "available": bool(os.environ.get(config.api_key_env, "").strip()),
-                "availability_reason": (
-                    "credential_present"
-                    if os.environ.get(config.api_key_env, "").strip()
-                    else "missing_credential"
-                ),
+                "available": credential_present,
+                "credential_present": credential_present,
+                "availability_reason": "credential_present" if credential_present else "missing_credential",
                 "prescan_tier": classify_prescan_route(config.provider, config.model),
                 "pricing": _pricing(config.provider, config.model),
                 "sources": [],
-                "execution_transport": "openai_sdk_compatible",
+                **_route_identity(config.provider, config.model),
+                **_route_admissibility(config.provider),
             },
         )
+        if entry["route_admissible"]:
+            entry["route_admissibility_reason"] = "legacy_prescan_config"
         source = {"policy": "legacy_prescan_config", "ladder_tier": "legacy_default"}
         if source not in entry["sources"]:
             entry["sources"].append(source)
@@ -189,6 +227,119 @@ def build_provider_model_catalog(config: PrescanConfig) -> dict[str, Any]:
         "generated_from": "run_extraction_v5.ACTIVE_ROUTING_LADDERS",
         "sanctioned_providers": list(SANCTIONED_PROVIDERS),
         "routes": rows,
+    }
+
+
+def _offline_blocker(route: dict[str, Any], reason: str) -> dict[str, Any]:
+    if reason == "online_llm_not_authorized":
+        blocker = {
+            "ready": False,
+            "blocker_code": "ONLINE_LLM_NOT_AUTHORIZED",
+            "blocker_class": "operator_policy",
+            "remediation_class": "authorize_online_llm",
+            "rerun_worthiness": "rerun_after_operator_authorization",
+            "human_summary": "Online LLM execution was not authorized for prescan Stage 0 readiness probing.",
+        }
+        failure_type = "operator_policy"
+    else:
+        runner = _runner_module()
+        blocker = runner.classify_provider_readiness_blocker(
+            provider=str(route.get("provider") or ""),
+            model_id=str(route.get("model_id") or ""),
+            api_key_env=str(route.get("api_key_env") or ""),
+            api_key_present=bool(route.get("credential_present")),
+            status_code=None,
+            failure_type="auth_missing" if reason == "missing_credential" else "unknown",
+            provider_error_reason=reason,
+        )
+        failure_type = "auth_missing" if reason == "missing_credential" else "unknown"
+    return {
+        "provider": str(route.get("provider") or ""),
+        "model_id": str(route.get("model_id") or ""),
+        "api_key_env_name": str(route.get("api_key_env") or ""),
+        "api_key_env_resolved": str(route.get("api_key_env") or ""),
+        "api_key_present": bool(route.get("credential_present")),
+        "transport": str(route.get("execution_transport") or ""),
+        "status_code": None,
+        "failure_type": failure_type,
+        "provider_error_reason": reason,
+        "provider_signature": f"{route.get('provider')}:{route.get('model_id')}",
+        "ready": bool(blocker["ready"]),
+        "readiness_blocker": blocker,
+    }
+
+
+def _build_probe_cfg() -> Any:
+    runner = _runner_module()
+    return runner.RunnerConfig(
+        dry_run=True,
+        max_files_docs=35,
+        max_files_code=20,
+        max_chars=650000,
+        max_request_bytes=200000,
+        file_truncate_chars=70000,
+        home_scan_mode="safe",
+        resume=False,
+        fail_fast_auth=True,
+        gemini_auth_mode="auto",
+        gemini_transport="sdk",
+        openai_transport="openai_sdk",
+        xai_transport="openai_sdk",
+        retry_policy="default",
+        retry_max_attempts=1,
+        retry_base_seconds=0.0,
+        retry_max_seconds=0.0,
+        phase_auth_fail_threshold=1,
+        partition_workers=1,
+        debug_phase_inputs=False,
+        fail_fast_missing_inputs=False,
+        routing_policy="cost",
+        batch_mode=False,
+        live_ok=False,
+    )
+
+
+def build_provider_readiness_matrix(config: PrescanConfig, catalog: dict[str, Any]) -> dict[str, Any]:
+    rows: list[dict[str, Any]] = []
+    blocked_codes: set[str] = set()
+    allow_online = bool(getattr(config, "allow_online_llm", False))
+    probe_cfg = _build_probe_cfg() if allow_online else None
+    for route in catalog.get("routes", []):
+        if not isinstance(route, dict) or not bool(route.get("route_admissible")):
+            continue
+        if not allow_online:
+            provider_probe = _offline_blocker(route, "online_llm_not_authorized")
+        elif not bool(route.get("credential_present")):
+            provider_probe = _offline_blocker(route, "missing_credential")
+        else:
+            provider_probe = _runner_module().run_provider_doctor_probe(
+                str(route.get("provider") or ""),
+                str(route.get("model_id") or ""),
+                str(route.get("api_key_env") or ""),
+                probe_cfg,
+            )
+        blocker = dict(provider_probe.get("readiness_blocker") or {})
+        if blocker.get("blocker_code") and blocker.get("blocker_code") != "READY":
+            blocked_codes.add(str(blocker["blocker_code"]))
+        rows.append(
+            {
+                "provider": str(route.get("provider") or ""),
+                "model_id": str(route.get("model_id") or ""),
+                "api_key_env": str(route.get("api_key_env") or ""),
+                "dependency_class": str(route.get("dependency_class") or ""),
+                "economic_surface": str(route.get("economic_surface") or ""),
+                "execution_transport": str(route.get("execution_transport") or ""),
+                "route_admissible": bool(route.get("route_admissible")),
+                "ready": bool(provider_probe.get("ready")),
+                "provider_probe": provider_probe,
+                "exclusion_reason": None if provider_probe.get("ready") else str(blocker.get("blocker_code") or "unknown_readiness_block"),
+            }
+        )
+    rows.sort(key=lambda item: (str(item["provider"]), str(item["model_id"]), str(item["api_key_env"])))
+    return {
+        "status": "PASS" if rows and any(row["ready"] for row in rows) else "FAIL",
+        "routes": rows,
+        "failed_blocker_codes": sorted(blocked_codes),
     }
 
 
@@ -219,50 +370,148 @@ def _select_route_for_tier(
     return selected, adjustment
 
 
+def _ready_routes(catalog: dict[str, Any], readiness: dict[str, Any]) -> tuple[list[dict[str, Any]], dict[tuple[str, str, str], str]]:
+    readiness_by_key = {
+        (str(row.get("provider") or ""), str(row.get("model_id") or ""), str(row.get("api_key_env") or "")): row
+        for row in readiness.get("routes", [])
+        if isinstance(row, dict)
+    }
+    eligible: list[dict[str, Any]] = []
+    exclusions: dict[tuple[str, str, str], str] = {}
+    for route in catalog.get("routes", []):
+        if not isinstance(route, dict):
+            continue
+        key = (str(route.get("provider") or ""), str(route.get("model_id") or ""), str(route.get("api_key_env") or ""))
+        row = readiness_by_key.get(key)
+        if route.get("route_admissible") is False:
+            exclusions[key] = str(route.get("route_admissibility_reason") or "inadmissible")
+        elif row is None:
+            exclusions[key] = "missing_provider_readiness"
+        elif not bool(row.get("ready")):
+            exclusions[key] = str(row.get("exclusion_reason") or "provider_not_ready")
+        else:
+            eligible.append(route)
+    return eligible, exclusions
+
+
+def _candidate_fallbacks(primary: dict[str, Any] | None, routes: list[dict[str, Any]]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if primary is None:
+        return [], []
+    selected = [primary]
+    selected_classes = {str(primary.get("dependency_class") or "")}
+    selected_surfaces = {str(primary.get("economic_surface") or "")}
+    decisions: list[dict[str, Any]] = []
+    for route in routes:
+        if route is primary:
+            continue
+        dependency_class = str(route.get("dependency_class") or "")
+        economic_surface = str(route.get("economic_surface") or "")
+        decision = {
+            "provider": str(route.get("provider") or ""),
+            "model_id": str(route.get("model_id") or ""),
+        }
+        if dependency_class in selected_classes:
+            decisions.append({**decision, "decision": "excluded", "reason": "shared_dependency_class"})
+            continue
+        if economic_surface in selected_surfaces:
+            decisions.append({**decision, "decision": "excluded", "reason": "shared_economic_surface"})
+            continue
+        primary_provider = str(primary.get("provider") or "")
+        route_provider = str(route.get("provider") or "")
+        primary_billing_unconfirmed = primary_provider == "openrouter" and not bool(
+            primary.get("billing_independent_from_upstream")
+        )
+        route_billing_unconfirmed = route_provider == "openrouter" and not bool(
+            route.get("billing_independent_from_upstream")
+        )
+        if primary_billing_unconfirmed or route_billing_unconfirmed:
+            decisions.append({**decision, "decision": "excluded", "reason": "billing_independence_unconfirmed"})
+            continue
+        selected.append(route)
+        selected_classes.add(dependency_class)
+        selected_surfaces.add(economic_surface)
+        decisions.append({**decision, "decision": "admitted", "reason": "distinct_dependency_and_economic_surface"})
+    return selected, decisions
+
+
 def build_prescan_routing_plan(
     config: PrescanConfig,
-    catalog_or_passes: dict[str, Any] | list[str] | None,
-    passes_or_batch_plans: list[str] | dict[str, Any] | None = None,
-    catalog: dict[str, Any] | None = None,
-    *,
+    catalog: dict[str, Any],
+    readiness: dict[str, Any] | list[str] | None = None,
     passes: list[str] | None = None,
 ) -> dict[str, Any]:
-    if catalog is None and isinstance(catalog_or_passes, dict):
-        catalog = catalog_or_passes
-    if passes is not None:
-        pass_list = passes
-    elif isinstance(catalog_or_passes, dict) and catalog is None:
-        pass_list = passes_or_batch_plans if isinstance(passes_or_batch_plans, list) else None
-    else:
-        pass_list = catalog_or_passes if isinstance(catalog_or_passes, list) else None
-        if catalog is None and isinstance(passes_or_batch_plans, dict):
-            catalog = passes_or_batch_plans
-        elif catalog is None:
-            catalog = {}
-
-    requested_passes = [
-        pass_id for pass_id in (pass_list or []) if pass_id in PRESCAN_PASS_REQUIREMENTS
-    ]
-    routes = [
-        row
-        for row in catalog.get("routes", [])
-        if isinstance(row, dict) and bool(row.get("available"))
-    ]
+    compatibility_mode = not isinstance(readiness, dict)
+    if compatibility_mode:
+        if passes is None:
+            passes = readiness if isinstance(readiness, list) else None
+        readiness = {
+            "status": "PASS",
+            "routes": [
+                {
+                    "provider": str(route.get("provider") or ""),
+                    "model_id": str(route.get("model_id") or ""),
+                    "api_key_env": str(route.get("api_key_env") or ""),
+                    "ready": bool(route.get("available", True)),
+                    "exclusion_reason": None if bool(route.get("available", True)) else "missing_provider_readiness",
+                }
+                for route in catalog.get("routes", [])
+                if isinstance(route, dict)
+            ],
+        }
+    if readiness is None:
+        readiness = {"status": "PASS", "routes": []}
+    requested_passes = [pass_id for pass_id in (passes or []) if pass_id in PRESCAN_PASS_REQUIREMENTS]
+    routes, exclusions = _ready_routes(catalog, readiness)
     selected_routes: dict[str, dict[str, Any]] = {}
+    candidate_routes: dict[str, list[dict[str, Any]]] = {}
+    fallback_decisions: dict[str, list[dict[str, Any]]] = {}
     failures: list[dict[str, Any]] = []
     for pass_id in requested_passes:
         required_tier = PRESCAN_PASS_REQUIREMENTS[pass_id]
-        selected, adjustment = _select_route_for_tier(routes, required_tier)
+        tier_routes = [
+            route for route in routes
+            if PRESCAN_TIER_RANK.get(str(route.get("prescan_tier")), 0) >= PRESCAN_TIER_RANK[required_tier]
+        ]
+        selected, adjustment = _select_route_for_tier(tier_routes, required_tier)
         if selected is None:
             failures.append(
                 {
                     "pass_id": pass_id,
                     "required_tier": required_tier,
-                    "reason": "no_available_route_for_required_tier_or_higher",
+                    "reason": "no_executable_route_after_provider_readiness",
+                    "excluded_routes": [
+                        {"provider": p, "model_id": m, "api_key_env": k, "reason": reason}
+                        for (p, m, k), reason in sorted(exclusions.items())
+                    ],
                 }
             )
             continue
-        route = {
+        ordered = sorted(
+            tier_routes,
+            key=lambda row: (
+                PRESCAN_TIER_RANK.get(str(row.get("prescan_tier")), 99),
+                float(((row.get("pricing") or {}).get("input_1m_usd", 999.0))),
+                float(((row.get("pricing") or {}).get("output_1m_usd", 999.0))),
+                str(row.get("provider") or ""),
+                str(row.get("model_id") or ""),
+            ),
+        )
+        candidates, decisions = _candidate_fallbacks(selected, ordered)
+        fallback_decisions[pass_id] = decisions
+        candidate_routes[pass_id] = [
+            {
+                "provider": str(route.get("provider") or ""),
+                "model_id": str(route.get("model_id") or ""),
+                "api_key_env": str(route.get("api_key_env") or ""),
+                "prescan_tier": str(route.get("prescan_tier") or ""),
+                "dependency_class": str(route.get("dependency_class") or ""),
+                "economic_surface": str(route.get("economic_surface") or ""),
+                "execution_transport": str(route.get("execution_transport") or ""),
+                "pricing": dict(route.get("pricing") or {}),
+            }
+            for route in candidates
+        ]
+        selected_routes[pass_id] = {
             "pass_id": pass_id,
             "required_tier": required_tier,
             "selected_tier": str(selected.get("prescan_tier")),
@@ -270,7 +519,9 @@ def build_prescan_routing_plan(
             "provider": str(selected.get("provider")),
             "model_id": str(selected.get("model_id")),
             "api_key_env": str(selected.get("api_key_env")),
-            "selection_basis": "lowest_estimated_cost_within_allowed_tier_band",
+            "dependency_class": str(selected.get("dependency_class") or ""),
+            "economic_surface": str(selected.get("economic_surface") or ""),
+            "selection_basis": "lowest_estimated_cost_within_allowed_tier_band_after_readiness",
             "pricing": dict(selected.get("pricing") or {}),
             "legacy_route_changed": bool(
                 str(config.provider) != str(selected.get("provider"))
@@ -278,32 +529,48 @@ def build_prescan_routing_plan(
                 or str(config.api_key_env) != str(selected.get("api_key_env"))
             ),
         }
-        selected_routes[pass_id] = route
 
     return {
         "requested_passes": requested_passes,
-        "status": "PASS" if not failures else "FAIL",
+        "status": ("FAIL" if compatibility_mode and failures else NO_LIVE_LANE if failures else "PASS"),
+        "halt_before_stage_1": bool(failures),
         "failures": failures,
+        "candidate_routes": candidate_routes,
         "selected_routes": selected_routes,
-        "candidate_routes": selected_routes,
+        "fallback_decisions": fallback_decisions,
+        "provider_readiness_status": str(readiness.get("status") or "UNKNOWN"),
     }
 
 
 def write_provider_catalog(output_dir: Path, catalog: dict[str, Any]) -> Path:
     path = output_dir / "prescan_provider_model_catalog.json"
-    payload = {
-        "generated_at": datetime.now(timezone.utc).isoformat(),
-        **catalog,
-    }
+    payload = {"generated_at": datetime.now(timezone.utc).isoformat(), **catalog}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def write_provider_readiness(output_dir: Path, readiness: dict[str, Any]) -> Path:
+    path = output_dir / "prescan_provider_readiness.json"
+    payload = {"generated_at": datetime.now(timezone.utc).isoformat(), **readiness}
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
 
 
 def write_routing_plan(output_dir: Path, plan: dict[str, Any]) -> Path:
     path = output_dir / "prescan_routing_plan.json"
+    payload = {"generated_at": datetime.now(timezone.utc).isoformat(), **plan}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def write_no_live_lane_artifact(output_dir: Path, plan: dict[str, Any]) -> Path:
+    path = output_dir / "prescan_no_live_lane.json"
     payload = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        **plan,
+        "status": NO_LIVE_LANE,
+        "halt_before_stage_1": True,
+        "requested_passes": list(plan.get("requested_passes") or []),
+        "failures": list(plan.get("failures") or []),
     }
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path

--- a/services/repo-truth-extractor/run_prescan.py
+++ b/services/repo-truth-extractor/run_prescan.py
@@ -143,7 +143,7 @@ def main() -> int:
     parser.add_argument(
         "--allow-online-llm",
         action="store_true",
-        help="Explicitly authorize online LLM execution and API spend",
+        help="Authorize Stage 0 provider readiness probes and online LLM pass execution",
     )
     parser.add_argument(
         "-v",
@@ -212,6 +212,7 @@ def main() -> int:
     logger.info(f"   Passes: {', '.join(passes) if passes else 'none'}")
     logger.info(f"   Code prescan: {config.enable_code_prescan}")
     logger.info(f"   Git enrichment: {config.enable_git_enrichment}")
+    logger.info(f"   Online LLM authorized: {config.allow_online_llm}")
 
     # Run prescan
     engine = PrescanEngine(config)

--- a/services/repo-truth-extractor/tests/test_prescan_provider_catalog.py
+++ b/services/repo-truth-extractor/tests/test_prescan_provider_catalog.py
@@ -13,12 +13,14 @@ if str(SERVICE_ROOT) not in sys.path:
 
 from lib.prescan.models import PrescanConfig
 from lib.prescan.provider_catalog import (
+    NO_LIVE_LANE,
     PRESCAN_PASS_REQUIREMENTS,
     PRESCAN_TIER_RANK,
     SANCTIONED_PROVIDERS,
     _pricing,
     _select_route_for_tier,
     build_prescan_routing_plan,
+    build_provider_readiness_matrix,
     build_provider_model_catalog,
     classify_prescan_route,
 )
@@ -79,8 +81,14 @@ def _available_route(
         "model_id": model_id,
         "api_key_env": api_key_env,
         "available": True,
+        "credential_present": True,
+        "route_admissible": True,
         "prescan_tier": tier,
         "pricing": {"input_1m_usd": input_1m, "output_1m_usd": output_1m},
+        "dependency_class": "proxy" if provider == "openrouter" else "first_party",
+        "economic_surface": provider,
+        "execution_transport": "sdk" if provider == "gemini" else "openai_sdk",
+        "billing_independent_from_upstream": provider == "openrouter",
     }
 
 
@@ -254,6 +262,22 @@ class TestBuildProviderModelCatalog:
         assert tier_map["gpt-5.4"] == "premium_planning"
         assert tier_map["gemini-2.5-pro"] == "premium_planning"
 
+    def test_catalog_marks_gemini_routes_inadmissible_for_prescan_runner(self, tmp_path: Path) -> None:
+        cfg = _make_config(tmp_path)
+        with patch(
+            "lib.prescan.provider_catalog._load_runner_authority",
+            return_value=(_FAKE_LADDERS, _FAKE_PROVIDER_ENV),
+        ), patch(
+            "lib.prescan.provider_catalog.get_model_cost_rate",
+            return_value={"input_cost_per_1m_usd": 1.0, "output_cost_per_1m_usd": 4.0},
+        ):
+            catalog = build_provider_model_catalog(cfg)
+
+        gemini_routes = [r for r in catalog["routes"] if r["provider"] == "gemini"]
+        assert gemini_routes
+        assert all(r["route_admissible"] is False for r in gemini_routes)
+        assert all(r["route_admissibility_reason"] == "unsupported_prescan_transport:sdk" for r in gemini_routes)
+
     def test_catalog_includes_legacy_prescan_config_entry(self, tmp_path: Path) -> None:
         cfg = _make_config(
             tmp_path,
@@ -314,6 +338,8 @@ class TestBuildProviderModelCatalog:
         assert "sanctioned_providers" in catalog
         assert "routes" in catalog
         assert isinstance(catalog["routes"], list)
+        assert "dependency_class" in catalog["routes"][0]
+        assert "economic_surface" in catalog["routes"][0]
 
 
 # ---------------------------------------------------------------------------
@@ -486,3 +512,106 @@ class TestBuildPrescanRoutingPlan:
         assert "pricing" in route
         assert "input_1m_usd" in route["pricing"]
         assert "output_1m_usd" in route["pricing"]
+
+    def test_plan_halts_when_readiness_blocks_all_routes(self, tmp_path: Path) -> None:
+        cfg = _make_config(tmp_path)
+        catalog = self._make_catalog_with_all_tiers()
+        readiness = {
+            "status": "FAIL",
+            "routes": [
+                {
+                    "provider": route["provider"],
+                    "model_id": route["model_id"],
+                    "api_key_env": route["api_key_env"],
+                    "ready": False,
+                    "exclusion_reason": "QUOTA_OR_BILLING_BLOCK",
+                }
+                for route in catalog["routes"]
+            ],
+        }
+        plan = build_prescan_routing_plan(cfg, catalog, readiness, passes=["dedup"])
+        assert plan["status"] == NO_LIVE_LANE
+        assert plan["halt_before_stage_1"] is True
+        assert plan["candidate_routes"] == {}
+        assert plan["failures"][0]["reason"] == "no_executable_route_after_provider_readiness"
+
+    def test_plan_excludes_fallbacks_with_same_dependency_class(self, tmp_path: Path) -> None:
+        cfg = _make_config(tmp_path)
+        catalog = {
+            "routes": [
+                _available_route("openai", "gpt-5-nano", "OPENAI_API_KEY", "cheap_structured", 1.0, 4.0),
+                _available_route("gemini", "gemini-2.5-flash", "GEMINI_API_KEY", "cheap_structured", 2.0, 8.0),
+                _available_route("openrouter", "openai/gpt-5-nano", "OPENROUTER_API_KEY", "cheap_structured", 3.0, 12.0),
+            ]
+        }
+        readiness = {
+            "status": "PASS",
+            "routes": [
+                {
+                    "provider": route["provider"],
+                    "model_id": route["model_id"],
+                    "api_key_env": route["api_key_env"],
+                    "ready": True,
+                    "exclusion_reason": None,
+                }
+                for route in catalog["routes"]
+            ],
+        }
+        plan = build_prescan_routing_plan(cfg, catalog, readiness, passes=["dedup"])
+        assert [row["provider"] for row in plan["candidate_routes"]["dedup"]] == ["openai", "openrouter"]
+        assert any(
+            item["provider"] == "gemini" and item["reason"] == "shared_dependency_class"
+            for item in plan["fallback_decisions"]["dedup"]
+        )
+
+    def test_plan_excludes_openrouter_primary_when_billing_independence_unconfirmed(self, tmp_path: Path) -> None:
+        cfg = _make_config(tmp_path)
+        catalog = {
+            "routes": [
+                {
+                    **_available_route(
+                        "openrouter",
+                        "gpt-5-nano",
+                        "OPENROUTER_API_KEY",
+                        "cheap_structured",
+                        0.5,
+                        2.0,
+                    ),
+                    "billing_independent_from_upstream": False,
+                },
+                _available_route("openai", "gpt-5-nano", "OPENAI_API_KEY", "cheap_structured", 1.0, 4.0),
+            ]
+        }
+        readiness = {
+            "status": "PASS",
+            "routes": [
+                {
+                    "provider": route["provider"],
+                    "model_id": route["model_id"],
+                    "api_key_env": route["api_key_env"],
+                    "ready": True,
+                    "exclusion_reason": None,
+                }
+                for route in catalog["routes"]
+            ],
+        }
+        plan = build_prescan_routing_plan(cfg, catalog, readiness, passes=["dedup"])
+        assert [row["provider"] for row in plan["candidate_routes"]["dedup"]] == ["openrouter"]
+        assert any(
+            item["provider"] == "openai" and item["reason"] == "billing_independence_unconfirmed"
+            for item in plan["fallback_decisions"]["dedup"]
+        )
+
+
+class TestProviderReadinessMatrix:
+    def test_readiness_matrix_marks_offline_authorization_separately(self, tmp_path: Path) -> None:
+        cfg = _make_config(tmp_path, allow_online_llm=False)
+        catalog = {
+            "routes": [
+                _available_route("openai", "gpt-5.4", "OPENAI_API_KEY", "premium_planning"),
+            ]
+        }
+        readiness = build_provider_readiness_matrix(cfg, catalog)
+        assert readiness["status"] == "FAIL"
+        assert readiness["failed_blocker_codes"] == ["ONLINE_LLM_NOT_AUTHORIZED"]
+        assert readiness["routes"][0]["provider_probe"]["readiness_blocker"]["blocker_code"] == "ONLINE_LLM_NOT_AUTHORIZED"


### PR DESCRIPTION
## Why
Prescan route admissibility and provider readiness were collapsed into one route-selection step, so offline, quota-blocked, or economically coupled routes could still leak into the execution plan. Stage 0 needs to fail closed before Grok passes when no live lane is executable.

## What
- split prescan route catalog, provider readiness, and execution routing artifacts
- classify routes by dependency class and economic surface
- block fallback candidates that share dependency class or billing surface
- add `--allow-online-llm` as the explicit readiness/probe authorization gate
- emit `prescan_provider_readiness.json`, `prescan_routing_plan.json`, and `prescan_no_live_lane.json`
- halt before Grok pass execution when Stage 0 returns `NO_LIVE_LANE`
- route Grok execution through the Stage 0 candidate selected for each pass

## Validation
- `UV_CACHE_DIR=/tmp/dmx-uv-cache uv run pytest services/repo-truth-extractor/tests/test_prescan_provider_catalog.py services/repo-truth-extractor/tests/test_prescan_e2e_smoke.py -q`
- `UV_CACHE_DIR=/tmp/dmx-uv-cache uv run python -m py_compile services/repo-truth-extractor/run_prescan.py services/repo-truth-extractor/lib/prescan/models.py services/repo-truth-extractor/lib/prescan/provider_catalog.py services/repo-truth-extractor/lib/prescan/engine.py services/repo-truth-extractor/lib/prescan/grok_passes.py services/repo-truth-extractor/tests/test_prescan_provider_catalog.py`
- `UV_CACHE_DIR=/tmp/dmx-uv-cache uv run python services/repo-truth-extractor/run_prescan.py --repo-root /tmp/dmx-prescan-stage0-pr-repo --output-dir /tmp/dmx-prescan-stage0-pr-out`

The CLI smoke intentionally exited nonzero because online LLM execution was not authorized; it emitted `prescan_no_live_lane.json` and `prescan_provider_readiness.json` with `ONLINE_LLM_NOT_AUTHORIZED`.

## Review Notes
@codex
@clauee
@copilot
