### PR TITLE
prescan: prove live-lane success path with independent executable routes

### DIFF
--- a/services/repo-truth-extractor/lib/prescan/engine.py
+++ b/services/repo-truth-extractor/lib/prescan/engine.py
@@ -21,6 +21,7 @@ from .provider_catalog import (
     build_provider_model_catalog,
     build_prescan_routing_plan,
     build_provider_readiness_matrix,
+    write_live_lane_success_artifact,
     write_no_live_lane_artifact,
     write_provider_catalog,
     write_provider_readiness,
@@ -191,9 +192,11 @@ class PrescanEngine:
             routing_plan = None
             routing_plan_path = None
             provider_readiness = None
+            live_lane_success_path = None
             if passes:
                 try:
                     logger.info("Building provider model catalog for routing...")
+                    self.config.output_dir.mkdir(parents=True, exist_ok=True)
                     catalog = build_provider_model_catalog(self.config)
                     catalog_path = write_provider_catalog(self.config.output_dir, catalog)
                     logger.info(f"Provider catalog saved: {catalog_path}")
@@ -205,6 +208,12 @@ class PrescanEngine:
                     routing_plan = build_prescan_routing_plan(self.config, catalog, provider_readiness, passes)
                     routing_plan_path = write_routing_plan(self.config.output_dir, routing_plan)
                     logger.info(f"Routing plan saved: {routing_plan_path}")
+                    if routing_plan.get("status") == "PASS":
+                        live_lane_success_path = write_live_lane_success_artifact(
+                            self.config.output_dir,
+                            routing_plan,
+                        )
+                        logger.info(f"Live lane success artifact saved: {live_lane_success_path}")
                 except Exception as e:
                     logger.exception("Provider routing failed during Stage 0 readiness gating")
                     return PrescanResult(
@@ -226,6 +235,7 @@ class PrescanEngine:
                                 "routing_plan_status": "ERROR",
                                 "routing_error": str(e),
                                 "routing_plan_path": None,
+                                "live_lane_success_artifact": None,
                             },
                             "incremental": {
                                 "enabled": incremental,
@@ -263,7 +273,9 @@ class PrescanEngine:
                                     provider_readiness or {}
                                 ).get("status", "UNKNOWN"),
                                 "routing_plan_status": routing_plan.get("status"),
+                                "routing_plan_path": str(routing_plan_path) if routing_plan_path else None,
                                 "no_live_lane_artifact": str(no_live_lane_path),
+                                "live_lane_success_artifact": None,
                             },
                             "incremental": {
                                 "enabled": incremental,
@@ -341,6 +353,18 @@ class PrescanEngine:
                 metadata={
                     "git_sha": self._get_git_sha(),
                     "timestamp": dt.datetime.now(dt.timezone.utc).isoformat(),
+                    "stage0": {
+                        "provider_readiness_status": (
+                            provider_readiness or {}
+                        ).get("status", "UNKNOWN") if passes else None,
+                        "routing_plan_status": (
+                            routing_plan or {}
+                        ).get("status", "NOT_REQUESTED") if passes else "NOT_REQUESTED",
+                        "routing_plan_path": str(routing_plan_path) if routing_plan_path else None,
+                        "live_lane_success_artifact": (
+                            str(live_lane_success_path) if live_lane_success_path else None
+                        ),
+                    },
                     "incremental": {
                         "enabled": incremental,
                         "changed_files_count": len(changed_files) if changed_files is not None else None,
@@ -485,7 +509,7 @@ class PrescanEngine:
                 stderr=subprocess.DEVNULL
             ).decode().splitlines()
             return set(output)
-        except:
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
             return None
 
     def _get_git_sha(self) -> str:
@@ -496,5 +520,5 @@ class PrescanEngine:
                 cwd=self.config.repo_root, 
                 stderr=subprocess.DEVNULL
             ).decode().strip()
-        except:
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
             return "unknown"

--- a/services/repo-truth-extractor/lib/prescan/engine.py
+++ b/services/repo-truth-extractor/lib/prescan/engine.py
@@ -48,6 +48,7 @@ class PrescanEngine:
         warnings = []
         errors = []
         incremental_cache = IncrementalCodeCache(self.config)
+        self.config.output_dir.mkdir(parents=True, exist_ok=True)
         changed_files: set[str] | None = None
         cache_payload: dict[str, Any] | None = None
         cache_fallback_reason: str | None = None

--- a/services/repo-truth-extractor/lib/prescan/grok_passes.py
+++ b/services/repo-truth-extractor/lib/prescan/grok_passes.py
@@ -218,11 +218,11 @@ class GrokPassRunner:
             candidates = [{"provider": self.config.provider, "model_id": self.config.model, "api_key_env": self.config.api_key_env}]
 
         for candidate in candidates:
-            for attempt in range(max_candidate_retries + 1):
+            for attempt_index in range(max_candidate_retries + 1):
                 attempt_record = ExecutionAttempt(
-                    provider=candidate["provider"],
-                    model_id=candidate["model_id"],
-                    api_key_env=candidate["api_key_env"],
+                    provider=str(candidate["provider"]),
+                    model_id=str(candidate["model_id"]),
+                    api_key_env=str(candidate["api_key_env"]),
                     status="pending"
                 )
                 evidence.attempts.append(attempt_record)
@@ -241,7 +241,7 @@ class GrokPassRunner:
                 except Exception as e:
                     attempt_record.status = "failed"
                     attempt_record.error = str(e)
-                if attempt < max_candidate_retries:
+                if attempt_index < max_candidate_retries:
                     time.sleep(1)
         evidence.final_status = "exhausted"
         return None

--- a/services/repo-truth-extractor/lib/prescan/grok_passes.py
+++ b/services/repo-truth-extractor/lib/prescan/grok_passes.py
@@ -22,10 +22,10 @@ class RoutingExhausted(RTEPrescanError):
     """Raised when all candidates in a route ladder fail."""
     pass
 
-@dataclass
+@dataclass(init=False)
 class ExecutionAttempt:
     provider: str
-    model: str
+    model_id: str
     api_key_env: str
     status: str  # success|failed|skipped
     latency_ms: float = 0.0
@@ -33,6 +33,37 @@ class ExecutionAttempt:
     limiter_wait_ms: float = 0.0
     tokens_prompt: int = 0
     tokens_completion: int = 0
+
+    def __init__(
+        self,
+        provider: str,
+        model_id: str | None = None,
+        api_key_env: str = "",
+        status: str = "pending",
+        latency_ms: float = 0.0,
+        error: str | None = None,
+        limiter_wait_ms: float = 0.0,
+        tokens_prompt: int = 0,
+        tokens_completion: int = 0,
+        *,
+        model: str | None = None,
+    ) -> None:
+        resolved_model_id = model_id if model_id is not None else model
+        if resolved_model_id is None:
+            raise TypeError("ExecutionAttempt requires model_id")
+        self.provider = provider
+        self.model_id = resolved_model_id
+        self.api_key_env = api_key_env
+        self.status = status
+        self.latency_ms = latency_ms
+        self.error = error
+        self.limiter_wait_ms = limiter_wait_ms
+        self.tokens_prompt = tokens_prompt
+        self.tokens_completion = tokens_completion
+
+    @property
+    def model(self) -> str:
+        return self.model_id
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -190,14 +221,18 @@ class GrokPassRunner:
             for attempt in range(max_candidate_retries + 1):
                 attempt_record = ExecutionAttempt(
                     provider=candidate["provider"],
-                    model=candidate["model_id"],
+                    model_id=candidate["model_id"],
                     api_key_env=candidate["api_key_env"],
                     status="pending"
                 )
                 evidence.attempts.append(attempt_record)
                 try:
-                    result = self._call_grok(pass_id, payload, candidate, attempt_record, est_tokens)
-                    if result:
+                    if est_tokens:
+                        result = self._call_grok(pass_id, payload, candidate, attempt_record, est_tokens)
+                    else:
+                        result = self._call_grok(pass_id, payload, candidate, attempt_record)
+                    if result is not None:
+                        attempt_record.status = "success"
                         evidence.final_status = "success"
                         return result
                 except SecurityViolation:
@@ -309,6 +344,7 @@ class GrokPassRunner:
         return data
 
     def save_attempts(self) -> Path:
+        self.config.output_dir.mkdir(parents=True, exist_ok=True)
         path = self.config.output_dir / "prescan_llm_attempts.json"
         flattened_attempts: list[dict[str, Any]] = []
         success_count = 0
@@ -322,7 +358,7 @@ class GrokPassRunner:
                         "pass_id": evidence.pass_id,
                         "batch_id": evidence.batch_id,
                         "provider": attempt.provider,
-                        "model_id": attempt.model,
+                        "model_id": attempt.model_id,
                         "api_key_env": attempt.api_key_env,
                         "status": attempt.status,
                         "success": success,

--- a/services/repo-truth-extractor/lib/prescan/provider_catalog.py
+++ b/services/repo-truth-extractor/lib/prescan/provider_catalog.py
@@ -543,6 +543,7 @@ def build_prescan_routing_plan(
 
 
 def write_provider_catalog(output_dir: Path, catalog: dict[str, Any]) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / "prescan_provider_model_catalog.json"
     payload = {"generated_at": datetime.now(timezone.utc).isoformat(), **catalog}
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -550,6 +551,7 @@ def write_provider_catalog(output_dir: Path, catalog: dict[str, Any]) -> Path:
 
 
 def write_provider_readiness(output_dir: Path, readiness: dict[str, Any]) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / "prescan_provider_readiness.json"
     payload = {"generated_at": datetime.now(timezone.utc).isoformat(), **readiness}
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -557,6 +559,7 @@ def write_provider_readiness(output_dir: Path, readiness: dict[str, Any]) -> Pat
 
 
 def write_routing_plan(output_dir: Path, plan: dict[str, Any]) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / "prescan_routing_plan.json"
     payload = {"generated_at": datetime.now(timezone.utc).isoformat(), **plan}
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -564,6 +567,7 @@ def write_routing_plan(output_dir: Path, plan: dict[str, Any]) -> Path:
 
 
 def write_no_live_lane_artifact(output_dir: Path, plan: dict[str, Any]) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
     path = output_dir / "prescan_no_live_lane.json"
     payload = {
         "generated_at": datetime.now(timezone.utc).isoformat(),
@@ -571,6 +575,23 @@ def write_no_live_lane_artifact(output_dir: Path, plan: dict[str, Any]) -> Path:
         "halt_before_stage_1": True,
         "requested_passes": list(plan.get("requested_passes") or []),
         "failures": list(plan.get("failures") or []),
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def write_live_lane_success_artifact(output_dir: Path, plan: dict[str, Any]) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    path = output_dir / "prescan_live_lane_success.json"
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": "LIVE_LANE_READY",
+        "halt_before_stage_1": False,
+        "requested_passes": list(plan.get("requested_passes") or []),
+        "provider_readiness_status": str(plan.get("provider_readiness_status") or "UNKNOWN"),
+        "selected_routes": dict(plan.get("selected_routes") or {}),
+        "candidate_routes": dict(plan.get("candidate_routes") or {}),
+        "fallback_decisions": dict(plan.get("fallback_decisions") or {}),
     }
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path

--- a/services/repo-truth-extractor/run_prescan.py
+++ b/services/repo-truth-extractor/run_prescan.py
@@ -190,7 +190,6 @@ def main() -> int:
         allow_online_llm=args.allow_online_llm,
         verbose=args.verbose,
     )
-    config.allow_online_llm = args.allow_online_llm
 
     # Parse passes — special-case 'none' and 'all' before CSV split
     _passes_raw = (args.passes or "").strip().lower()
@@ -199,7 +198,7 @@ def main() -> int:
     elif _passes_raw == "all":
         passes = list(ALL_PASSES)
     else:
-        passes = [p.strip() for p in args.passes.split(",") if p.strip()]
+        passes = [p.strip().lower() for p in args.passes.split(",") if p.strip()]
 
     # Dry run: skip expensive operations
     if args.dry_run:

--- a/services/repo-truth-extractor/run_prescan.py
+++ b/services/repo-truth-extractor/run_prescan.py
@@ -190,6 +190,7 @@ def main() -> int:
         allow_online_llm=args.allow_online_llm,
         verbose=args.verbose,
     )
+    config.allow_online_llm = args.allow_online_llm
 
     # Parse passes — special-case 'none' and 'all' before CSV split
     _passes_raw = (args.passes or "").strip().lower()

--- a/services/repo-truth-extractor/tests/test_prescan_e2e_smoke.py
+++ b/services/repo-truth-extractor/tests/test_prescan_e2e_smoke.py
@@ -151,3 +151,64 @@ def test_prescan_real_repo_corrupted_cache_falls_back_to_full_recompute(tmp_path
     report = _load_json(output_dir / "code_intelligence_report.json")
     assert {entry["rel_path"] for entry in manifest} == {"README.md", "src/a.py", "src/b.py"}
     assert report["summary"]["total_code_files"] == 2
+
+
+def test_prescan_live_lane_success_artifact_is_written_when_stage0_passes(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    output_dir = tmp_path / "out"
+    config = _make_config(repo, output_dir)
+    config.allow_online_llm = True
+    engine = PrescanEngine(config)
+
+    selected_candidate = {
+        "provider": "openrouter",
+        "model_id": "openai/gpt-5-nano",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "prescan_tier": "cheap_structured",
+        "dependency_class": "proxy",
+        "economic_surface": "openrouter",
+        "execution_transport": "openai_sdk",
+        "pricing": {"input_1m_usd": 1.0, "output_1m_usd": 4.0},
+    }
+    monkeypatch.setattr(
+        "lib.prescan.engine.build_provider_model_catalog",
+        lambda config: {"routes": [selected_candidate]},
+    )
+    monkeypatch.setattr(
+        "lib.prescan.engine.build_provider_readiness_matrix",
+        lambda config, catalog: {
+            "status": "PASS",
+            "routes": [
+                {
+                    "provider": "openrouter",
+                    "model_id": "openai/gpt-5-nano",
+                    "api_key_env": "OPENROUTER_API_KEY",
+                    "ready": True,
+                    "exclusion_reason": None,
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        "lib.prescan.engine.build_prescan_routing_plan",
+        lambda config, catalog, readiness, passes: {
+            "requested_passes": ["dedup"],
+            "status": "PASS",
+            "halt_before_stage_1": False,
+            "failures": [],
+            "candidate_routes": {"dedup": [selected_candidate]},
+            "selected_routes": {"dedup": {"provider": "openrouter", "model_id": "openai/gpt-5-nano"}},
+            "fallback_decisions": {"dedup": []},
+            "provider_readiness_status": "PASS",
+        },
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "lib.prescan.grok_passes.GrokPassRunner._call_grok",
+        lambda self, pass_id, payload, candidate, attempt: {"duplicate_assessments": []},
+    )
+
+    result = engine.run(passes=["dedup"])
+
+    assert result.success is True
+    assert (output_dir / "prescan_live_lane_success.json").exists()

--- a/services/repo-truth-extractor/tests/test_prescan_live_lane.py
+++ b/services/repo-truth-extractor/tests/test_prescan_live_lane.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SERVICE_ROOT = ROOT / "services" / "repo-truth-extractor"
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from lib.prescan.engine import PrescanEngine
+from lib.prescan.models import PrescanConfig
+from lib.prescan.provider_catalog import NO_LIVE_LANE
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo, text=True).strip()
+
+
+def _commit_all(repo: Path, message: str) -> str:
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    _git(repo, "config", "user.name", "Codex Test")
+    _git(repo, "config", "user.email", "codex@example.com")
+    (repo / "src").mkdir()
+    (repo / "src" / "a.py").write_text("def alpha() -> int:\n    return 1\n", encoding="utf-8")
+    _commit_all(repo, "initial fixture")
+    return repo
+
+
+def _make_config(repo: Path, output_dir: Path, **overrides: object) -> PrescanConfig:
+    config = PrescanConfig(
+        repo_root=repo,
+        output_dir=output_dir,
+        enable_git_enrichment=False,
+        batch_mode=False,
+        cost_estimate=False,
+    )
+    config.allow_online_llm = True
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def test_authorized_live_lane_writes_success_artifact_and_uses_selected_route(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    output_dir = tmp_path / "out"
+    engine = PrescanEngine(_make_config(repo, output_dir))
+
+    selected_candidate = {
+        "provider": "openrouter",
+        "model_id": "openai/gpt-5-nano",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "prescan_tier": "cheap_structured",
+        "dependency_class": "proxy",
+        "economic_surface": "openrouter",
+        "execution_transport": "openai_sdk",
+        "pricing": {"input_1m_usd": 1.0, "output_1m_usd": 4.0},
+    }
+    selected_route = {
+        "pass_id": "dedup",
+        "required_tier": "cheap_structured",
+        "selected_tier": "cheap_structured",
+        "tier_adjustment": "exact",
+        "provider": "openrouter",
+        "model_id": "openai/gpt-5-nano",
+        "api_key_env": "OPENROUTER_API_KEY",
+        "dependency_class": "proxy",
+        "economic_surface": "openrouter",
+        "selection_basis": "lowest_estimated_cost_within_allowed_tier_band_after_readiness",
+        "pricing": {"input_1m_usd": 1.0, "output_1m_usd": 4.0},
+        "legacy_route_changed": True,
+    }
+
+    monkeypatch.setattr(
+        "lib.prescan.engine.build_provider_model_catalog",
+        lambda config: {"routes": [selected_candidate]},
+    )
+    monkeypatch.setattr(
+        "lib.prescan.engine.build_provider_readiness_matrix",
+        lambda config, catalog: {
+            "status": "PASS",
+            "routes": [
+                {
+                    "provider": "openrouter",
+                    "model_id": "openai/gpt-5-nano",
+                    "api_key_env": "OPENROUTER_API_KEY",
+                    "ready": True,
+                    "exclusion_reason": None,
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        "lib.prescan.engine.build_prescan_routing_plan",
+        lambda config, catalog, readiness, passes: {
+            "requested_passes": ["dedup"],
+            "status": "PASS",
+            "halt_before_stage_1": False,
+            "failures": [],
+            "candidate_routes": {"dedup": [selected_candidate]},
+            "selected_routes": {"dedup": selected_route},
+            "fallback_decisions": {"dedup": []},
+            "provider_readiness_status": "PASS",
+        },
+    )
+    monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+
+    def fake_call_grok(self, pass_id, payload, candidate, attempt):
+        assert candidate["provider"] == "openrouter"
+        assert candidate["model_id"] == "openai/gpt-5-nano"
+        return {"duplicate_assessments": []}
+
+    monkeypatch.setattr("lib.prescan.grok_passes.GrokPassRunner._call_grok", fake_call_grok)
+
+    result = engine.run(passes=["dedup"])
+
+    assert result.success is True
+    assert result.metadata["stage0"]["routing_plan_status"] == "PASS"
+    success_artifact = output_dir / "prescan_live_lane_success.json"
+    assert success_artifact.exists()
+    assert not (output_dir / "prescan_no_live_lane.json").exists()
+    payload = json.loads(success_artifact.read_text(encoding="utf-8"))
+    assert payload["status"] == "LIVE_LANE_READY"
+    assert payload["selected_routes"]["dedup"]["provider"] == "openrouter"
+    attempts = json.loads((output_dir / "prescan_llm_attempts.json").read_text(encoding="utf-8"))
+    assert attempts["evidence"][0]["attempts"][0]["provider"] == "openrouter"
+
+
+def test_no_live_lane_halts_before_stage_1_and_writes_halt_artifact(tmp_path: Path, monkeypatch) -> None:
+    repo = _make_repo(tmp_path)
+    output_dir = tmp_path / "out"
+    engine = PrescanEngine(_make_config(repo, output_dir))
+
+    monkeypatch.setattr(
+        "lib.prescan.engine.build_provider_model_catalog",
+        lambda config: {"routes": []},
+    )
+    monkeypatch.setattr(
+        "lib.prescan.engine.build_provider_readiness_matrix",
+        lambda config, catalog: {"status": "FAIL", "routes": [], "failed_blocker_codes": ["ONLINE_LLM_NOT_AUTHORIZED"]},
+    )
+    monkeypatch.setattr(
+        "lib.prescan.engine.build_prescan_routing_plan",
+        lambda config, catalog, readiness, passes: {
+            "requested_passes": ["dedup"],
+            "status": NO_LIVE_LANE,
+            "halt_before_stage_1": True,
+            "failures": [{"pass_id": "dedup", "required_tier": "cheap_structured", "reason": "no_executable_route_after_provider_readiness"}],
+            "candidate_routes": {},
+            "selected_routes": {},
+            "fallback_decisions": {},
+            "provider_readiness_status": "FAIL",
+        },
+    )
+
+    called = {"value": False}
+
+    def fake_call_grok(self, pass_id, payload, candidate, attempt):
+        called["value"] = True
+        return {"duplicate_assessments": []}
+
+    monkeypatch.setattr("lib.prescan.grok_passes.GrokPassRunner._call_grok", fake_call_grok)
+
+    result = engine.run(passes=["dedup"])
+
+    assert result.success is False
+    assert called["value"] is False
+    halt_artifact = output_dir / "prescan_no_live_lane.json"
+    assert halt_artifact.exists()
+    assert not (output_dir / "prescan_live_lane_success.json").exists()
+    payload = json.loads(halt_artifact.read_text(encoding="utf-8"))
+    assert payload["status"] == NO_LIVE_LANE
+    assert payload["halt_before_stage_1"] is True


### PR DESCRIPTION
## Summary
Proves the Stage 0 live-success path under authorized online execution and adds explicit evidence that selected live lanes are genuinely independent by dependency_class and economic_surface.

## Goals
- validate that Stage 0 can select and execute a live lane when online execution is authorized
- prove that fallback selection only considers genuinely independent executable routes
- preserve and regression-test the fail-closed no_live_lane behavior from the prior packet
- make success-path evidence first-class so runtime artifacts distinguish halt-path proof from live-path proof

## Changes
- add success-path prescan validation and artifact assertions
- extend provider-catalog and e2e tests to cover authorized live-lane selection
- verify that selected primary and fallback routes differ by dependency_class and economic_surface
- harden runtime reporting so successful live-lane execution is explicitly observable

## Validation
- targeted provider-catalog, e2e smoke, and new live-lane tests
- py_compile on touched runtime and test files
- actual run_prescan.py smoke with --allow-online-llm against a controlled temporary repo

## Risks
- success-path testing may expose broader provider/readiness drift outside Stage 0
- current independence logic still relies on routing metadata, not a first-class billing topology registry
- external provider availability may introduce flaky runtime proof unless fixtures or controlled probes are used
