### PR TITLE
🎨 Palette: Refine Task Sequencer accessibility and Skip logic

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -37,3 +37,7 @@
 ## 2026-03-12 - [Cognitive Load & Feed Management]
 **Learning:** In high-stimulation environments (like a live signal feed), accumulating notifications can contribute to "cognitive clutter," which is particularly taxing for users with ADHD. Providing a "Clear" button that is only visible when the feed is active allows users to reset their visual field and reduce overwhelm once information has been processed.
 **Action:** Always provide a conditional "Clear" or "Reset" mechanism for live data feeds to help users manage cognitive load and maintain a clean workspace.
+
+## 2026-03-25 - [Tooltip Visibility on Disabled Elements]
+**Learning:** Material UI Tooltips do not trigger on disabled elements (like buttons) because they don't emit pointer events. Wrapping the disabled element in a `<span>` ensures the tooltip remains accessible, allowing users to understand *why* an action is unavailable.
+**Action:** Always wrap disabled buttons in a `<span>` when using `Tooltip` to maintain accessibility and user feedback.

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -400,7 +400,19 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               </Button>
             </Tooltip>
             <Tooltip title={optimizedTasks.length <= 1 ? 'No other tasks to skip to' : 'Skip for Now'} arrow>
-              <span>
+              <Box
+                component="span"
+                tabIndex={optimizedTasks.length <= 1 ? 0 : -1}
+                aria-disabled={optimizedTasks.length <= 1 ? 'true' : undefined}
+                sx={{
+                  display: 'inline-flex',
+                  borderRadius: 1,
+                  outline: 'none',
+                  '&:focus-visible': {
+                    boxShadow: `0 0 0 2px ${brandTokens.colors.gremlinPink}`,
+                  },
+                }}
+              >
                 <Button
                   size="small"
                   variant="text"
@@ -412,7 +424,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                 >
                   Skip
                 </Button>
-              </span>
+              </Box>
             </Tooltip>
           </Box>
         </Box>
@@ -506,7 +518,16 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
           <Box
             component="span"
             tabIndex={0}
-            sx={{ display: 'flex', alignItems: 'center', cursor: 'help', outline: 'none' }}
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              cursor: 'help',
+              outline: 'none',
+              borderRadius: 1,
+              '&:focus-visible': {
+                boxShadow: `0 0 0 2px ${brandTokens.colors.gremlinPink}`,
+              },
+            }}
             aria-label="Ritual phases: Consent, Calibration, Chaos, and Care"
           >
             <Flame size={16} color={brandTokens.colors.gremlinPink} aria-hidden="true" />

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -381,7 +381,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               <Button
                 size="small"
                 variant="contained"
-                startIcon={isTimerRunning ? <Pause /> : <Play />}
+                startIcon={isTimerRunning ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
                 onClick={() => setIsTimerRunning(!isTimerRunning)}
                 aria-label={isTimerRunning ? `Pause task: ${currentTask.title}` : `Start task: ${currentTask.title}`}
               >
@@ -392,24 +392,27 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               <Button
                 size="small"
                 variant="outlined"
-                startIcon={<CheckCircle />}
+                startIcon={<CheckCircle aria-hidden="true" />}
                 onClick={() => completeTask(currentTask.id)}
                 aria-label={`Complete task: ${currentTask.title}`}
               >
                 Complete
               </Button>
             </Tooltip>
-            <Tooltip title="Skip for Now" arrow>
-              <Button
-                size="small"
-                variant="text"
-                startIcon={<SkipForward />}
-                onClick={() => skipTask(currentTask.id)}
-                sx={{ color: brandTokens.colors.gremlinPink }}
-                aria-label={`Skip task: ${currentTask.title}`}
-              >
-                Skip
-              </Button>
+            <Tooltip title={optimizedTasks.length <= 1 ? 'No other tasks to skip to' : 'Skip for Now'} arrow>
+              <span>
+                <Button
+                  size="small"
+                  variant="text"
+                  startIcon={<SkipForward aria-hidden="true" />}
+                  onClick={() => skipTask(currentTask.id)}
+                  sx={{ color: brandTokens.colors.gremlinPink }}
+                  aria-label={`Skip task: ${currentTask.title}`}
+                  disabled={optimizedTasks.length <= 1}
+                >
+                  Skip
+                </Button>
+              </span>
             </Tooltip>
           </Box>
         </Box>
@@ -426,7 +429,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
             background: alpha(brandTokens.colors.serumMint, 0.05),
           }}
         >
-          <CheckCircle size={32} color={brandTokens.colors.serumMint} style={{ marginBottom: 8 }} />
+          <CheckCircle size={32} color={brandTokens.colors.serumMint} style={{ marginBottom: 8 }} aria-hidden="true" />
           <Typography variant="h6" sx={{ color: brandTokens.colors.serumMint, mb: 1 }}>
             Ritual Complete
           </Typography>
@@ -437,7 +440,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
             <Button
               variant="outlined"
               size="small"
-              startIcon={<RotateCcw size={16} />}
+              startIcon={<RotateCcw size={16} aria-hidden="true" />}
               onClick={resetTasks}
               sx={{
                 borderColor: brandTokens.colors.serumMint,
@@ -499,8 +502,13 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
             </Typography>
           </Box>
         </Tooltip>
-        <Tooltip title="Consent → Calibration → Chaos → Care" arrow>
-          <Box component="span" tabIndex={0} sx={{ display: 'flex', alignItems: 'center' }}>
+        <Tooltip title="Ritual phases: Consent, Calibration, Chaos, and Care" arrow>
+          <Box
+            component="span"
+            tabIndex={0}
+            sx={{ display: 'flex', alignItems: 'center', cursor: 'help', outline: 'none' }}
+            aria-label="Ritual phases: Consent, Calibration, Chaos, and Care"
+          >
             <Flame size={16} color={brandTokens.colors.gremlinPink} aria-hidden="true" />
           </Box>
         </Tooltip>
@@ -574,7 +582,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                   <Button
                     size="small"
                     variant="outlined"
-                    startIcon={<Play />}
+                    startIcon={<Play aria-hidden="true" />}
                     onClick={() => startTask(task.id)}
                     aria-label={`Start task: ${task.title}`}
                   >


### PR DESCRIPTION
This PR introduces several micro-UX and accessibility refinements to the `TaskSequencer` component:

1.  **Accessibility**: Decorative icons (Play, Pause, SkipForward, etc.) are now hidden from screen readers using `aria-hidden="true"` to reduce noise, as they are redundant to button labels or adjacent text.
2.  **Contextual Clarity**: The shorthand 'Ritual phases' icon now includes a descriptive `aria-label` and is keyboard focusable, ensuring all users can access its contextual information.
3.  **Logical Constraints**: The 'Skip' button is now disabled when the optimized sequence contains only one task, preventing a no-op interaction.
4.  **Feedback Loops**: When the 'Skip' button is disabled, its Tooltip updates to explain the state ("No other tasks to skip to"). The button is wrapped in a `<span>` to ensure the Tooltip remains functional on the disabled element.
5.  **Documentation**: Added a new entry to the Palette journal regarding the `<span>` wrapper pattern for Tooltips on disabled MUI elements.

---
*PR created automatically by Jules for task [9488169393955477618](https://jules.google.com/task/9488169393955477618) started by @hu3mann*