### PR TITLE
ci(tests): parallelize remaining fast unit gate tests

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -178,8 +178,11 @@ jobs:
 
       - name: ▶️ Run fast unit gate
         run: |
-          uv run --frozen pytest tests/unit -n auto --maxfail=1 --disable-warnings --no-cov
-          uv run --frozen pytest tests/test_voice_core.py tests/test_brand_voice.py --maxfail=1 --disable-warnings --no-cov
+          uv run --frozen pytest \
+            tests/unit \
+            tests/test_voice_core.py \
+            tests/test_brand_voice.py \
+            -n auto --maxfail=1 --disable-warnings --no-cov
 
       - name: 🎨 Run brand lint gate
         run: uv run --frozen python scripts/brand_lint.py


### PR DESCRIPTION
## Summary
- fold the remaining fast Python unit tests into the existing parallel pytest invocation
- remove the serial tail for voice/brand unit tests in the fast gate
- keep scope limited to CI workflow configuration only

## Rationale
- the unit job already uses `pytest-xdist` with `-n auto`
- two extra unit tests were still running as a separate serial invocation
- combining them should reduce wall-clock time for the fast unit gate without broad CI policy changes

## Validation
- verified the workflow diff is limited to `.github/workflows/ci-complete.yml`
- did not claim runtime speedup without CI execution results