### PR TITLE
fix(docker): unify build context to root for all MCP services

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -86,10 +86,9 @@ services:
     - MYSQL_DATABASE=${MYSQL_DATABASE:-leantime}
     - MYSQL_USER=${MYSQL_USER:-leantime}
     - MYSQL_PASSWORD=${MYSQL_PASSWORD:-leantime_dev_password}
-    command: '--character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
+command: >-
+      --character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
       --default-authentication-plugin=mysql_native_password
-
-      '
     volumes:
     - leantime_mysql_data:/var/lib/mysql
     healthcheck:
@@ -108,11 +107,8 @@ services:
     networks:
     - dopemux-network
     command: 'sh -c ''if [ -n "$$REDIS_PASSWORD" ]; then exec redis-server --appendonly
-      yes --requirepass "$$REDIS_PASSWORD"; else exec redis-server --appendonly yes;
-      fi''
-
-      '
-    environment:
+command: >-
+      sh -c 'if [ -n "$$REDIS_PASSWORD" ]; then exec redis-server --appendonly yes --requirepass "$$REDIS_PASSWORD"; else exec redis-server --appendonly yes; fi'
     - REDIS_PASSWORD=${REDIS_PASSWORD:-}
     volumes:
     - leantime_redis_data:/data

--- a/compose.yml
+++ b/compose.yml
@@ -1,158 +1,129 @@
-# Dopemux Canonical Docker Compose
-#
-# CANONICAL DEVELOPMENT ENTRYPOINT
-# This is the single source of truth for running Dopemux services.
-#
-# Services Included:
-# - Infrastructure: PostgreSQL (AGE), Redis (2x), Qdrant
-# - MCP Servers: ConPort, PAL, LiteLLM, Dope-Context, Serena, GPT-Researcher, Exa, Desktop Commander, Leantime Bridge
-# - Application Services: DopeconBridge, Task Orchestrator, ADHD Engine, Genetic Agent
-#
-# Usage:
-#   docker compose up -d                    # Start all services
-#   docker compose ps                       # View running services
-#   docker compose down                     # Stop all services
-#   docker compose logs -f <service>        # View logs
-#
-# Guidelines:
-# - `compose.yml` is the canonical runtime file for this repository.
-# - Do not add overlay compose files for normal runtime operation.
-# - Instance-aware services must be parameterized through env overrides, not duplicated service definitions.
-
 name: dopemux
-
 networks:
   dopemux-network:
     external: true
     name: dopemux-network
-
 volumes:
-  pg_age_data:
-  mcp_litellm_data:
-  mcp_logs:
-  mcp_cache:
-  dope-decision-graph-qdrant-data:
-  leantime_mysql_data:
-  leantime_redis_data:
-  leantime_public_userfiles:
-  leantime_userfiles:
-  leantime_logs:
-  leantime_config:
-  mcp_client_data:
-  mcp_client_logs:
-  mcp_plane_coordinator_data:
-  mcp_plane_coordinator_logs:
-
-
+  pg_age_data: null
+  mcp_litellm_data: null
+  mcp_logs: null
+  mcp_cache: null
+  dope-decision-graph-qdrant-data: null
+  leantime_mysql_data: null
+  leantime_redis_data: null
+  leantime_public_userfiles: null
+  leantime_userfiles: null
+  leantime_logs: null
+  leantime_config: null
+  mcp_client_data: null
+  mcp_client_logs: null
+  mcp_plane_coordinator_data: null
+  mcp_plane_coordinator_logs: null
 services:
-  # ========================================
-  # INFRASTRUCTURE SERVICES
-  # ========================================
-
-  # PostgreSQL with AGE (primary database)
   postgres:
     image: apache/age:release_PG16_1.6.0
     container_name: dopemux-postgres-age
     restart: unless-stopped
     networks:
-      - dopemux-network
-
+    - dopemux-network
     environment:
-      - POSTGRES_USER=dopemux_age
-      - POSTGRES_PASSWORD=${AGE_PASSWORD:-dopemux_age_dev_password}
-      - POSTGRES_DB=dopemux_knowledge_graph
+    - POSTGRES_USER=dopemux_age
+    - POSTGRES_PASSWORD=${AGE_PASSWORD:-dopemux_age_dev_password}
+    - POSTGRES_DB=dopemux_knowledge_graph
     volumes:
-      - pg_age_data:/var/lib/postgresql/data
-      - ./docker/postgres/01-init-age.sql:/docker-entrypoint-initdb.d/01-init-age.sql
+    - pg_age_data:/var/lib/postgresql/data
+    - ./docker/postgres/01-init-age.sql:/docker-entrypoint-initdb.d/01-init-age.sql
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+    - ${POSTGRES_PORT:-5432}:5432
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U dopemux_age -d dopemux_knowledge_graph || exit 1" ]
+      test:
+      - CMD-SHELL
+      - pg_isready -U dopemux_age -d dopemux_knowledge_graph || exit 1
       timeout: 5s
       retries: 10
       interval: 10s
       start_period: 20s
-
-  # Redis Events (for EventBus streaming)
   redis-events:
     image: redis:7-alpine
     container_name: redis-events
     restart: unless-stopped
     networks:
-      - dopemux-network
-
+    - dopemux-network
     ports:
-      - "6379:6379"
+    - 6379:6379
     healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
+      test:
+      - CMD
+      - redis-cli
+      - ping
       interval: 10s
       timeout: 3s
       retries: 3
-
-  # Redis Primary (for caching)
   redis-primary:
     image: redis:7-alpine
     container_name: redis-primary
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "6380:6379"
+    - 6380:6379
     healthcheck:
-      test: [ "CMD", "redis-cli", "ping" ]
+      test:
+      - CMD
+      - redis-cli
+      - ping
       interval: 10s
       timeout: 3s
       retries: 3
-
-  # MySQL (Leantime)
   mysql_leantime:
     image: mysql:8.0
     container_name: mysql_leantime
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-leantime_root_dev}
-      - MYSQL_DATABASE=${MYSQL_DATABASE:-leantime}
-      - MYSQL_USER=${MYSQL_USER:-leantime}
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-leantime_dev_password}
-    command: >
-      --character-set-server=UTF8MB4
-      --collation-server=UTF8MB4_unicode_ci
+    - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-leantime_root_dev}
+    - MYSQL_DATABASE=${MYSQL_DATABASE:-leantime}
+    - MYSQL_USER=${MYSQL_USER:-leantime}
+    - MYSQL_PASSWORD=${MYSQL_PASSWORD:-leantime_dev_password}
+    command: '--character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
       --default-authentication-plugin=mysql_native_password
+
+      '
     volumes:
-      - leantime_mysql_data:/var/lib/mysql
+    - leantime_mysql_data:/var/lib/mysql
     healthcheck:
-      test: ["CMD-SHELL", "mysqladmin ping -h localhost -u root -p${MYSQL_ROOT_PASSWORD:-leantime_root_dev} || exit 1"]
+      test:
+      - CMD-SHELL
+      - mysqladmin ping -h localhost -u root -p${MYSQL_ROOT_PASSWORD:-leantime_root_dev}
+        || exit 1
       timeout: 5s
       retries: 10
       interval: 10s
       start_period: 30s
-
-  # Redis (Leantime cache/session support)
   redis_leantime:
     image: redis:7-alpine
     container_name: redis_leantime
     restart: unless-stopped
     networks:
-      - dopemux-network
-    command: >
-      sh -c 'if [ -n "$$REDIS_PASSWORD" ]; then
-      exec redis-server --appendonly yes --requirepass "$$REDIS_PASSWORD";
-      else
-      exec redis-server --appendonly yes;
-      fi'
+    - dopemux-network
+    command: 'sh -c ''if [ -n "$$REDIS_PASSWORD" ]; then exec redis-server --appendonly
+      yes --requirepass "$$REDIS_PASSWORD"; else exec redis-server --appendonly yes;
+      fi''
+
+      '
     environment:
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+    - REDIS_PASSWORD=${REDIS_PASSWORD:-}
     volumes:
-      - leantime_redis_data:/data
+    - leantime_redis_data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test:
+      - CMD
+      - redis-cli
+      - ping
       timeout: 3s
       retries: 5
       interval: 10s
-
-  # Leantime PM container (canonical stack member)
   leantime:
     build:
       context: ./docker/leantime
@@ -160,219 +131,203 @@ services:
     container_name: leantime
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "8080:80"
+    - 8080:80
     depends_on:
       mysql_leantime:
         condition: service_healthy
       redis_leantime:
         condition: service_started
     environment:
-      - LEAN_DB_HOST=mysql_leantime
-      - LEAN_DB_USER=${MYSQL_USER:-leantime}
-      - LEAN_DB_PASSWORD=${MYSQL_PASSWORD:-leantime_dev_password}
-      - LEAN_DB_DATABASE=${MYSQL_DATABASE:-leantime}
-      - LEAN_DB_PORT=3306
-      - LEAN_SITENAME=${LEAN_SITENAME:-Dopemux Leantime}
-      - LEAN_SESSION_PASSWORD=${LEAN_SESSION_PASSWORD:-dopemux_session_password_minimum_32_chars}
-      - LEAN_APP_URL=${LEAN_APP_URL:-http://localhost:8080}
-      - LEAN_SESSION_EXPIRATION=${LEAN_SESSION_EXPIRATION:-28800}
-      - LEAN_DEBUG=${LEAN_DEBUG:-0}
-      - LEAN_API_ENABLED=${LEAN_API_ENABLED:-true}
-      - LEAN_MCP_ENABLED=${LEAN_MCP_ENABLED:-true}
-      - LEAN_MCP_TOKEN=${LEAN_MCP_TOKEN:-}
-      - LEAN_ADHD_MODE=${LEAN_ADHD_MODE:-true}
-      - LEAN_NOTIFICATION_BATCH=${LEAN_NOTIFICATION_BATCH:-true}
-      - LEAN_CONTEXT_PRESERVATION=${LEAN_CONTEXT_PRESERVATION:-true}
-      - REDIS_HOST=redis_leantime
-      - REDIS_PASSWORD=${REDIS_PASSWORD:-}
+    - LEAN_DB_HOST=mysql_leantime
+    - LEAN_DB_USER=${MYSQL_USER:-leantime}
+    - LEAN_DB_PASSWORD=${MYSQL_PASSWORD:-leantime_dev_password}
+    - LEAN_DB_DATABASE=${MYSQL_DATABASE:-leantime}
+    - LEAN_DB_PORT=3306
+    - LEAN_SITENAME=${LEAN_SITENAME:-Dopemux Leantime}
+    - LEAN_SESSION_PASSWORD=${LEAN_SESSION_PASSWORD:-dopemux_session_password_minimum_32_chars}
+    - LEAN_APP_URL=${LEAN_APP_URL:-http://localhost:8080}
+    - LEAN_SESSION_EXPIRATION=${LEAN_SESSION_EXPIRATION:-28800}
+    - LEAN_DEBUG=${LEAN_DEBUG:-0}
+    - LEAN_API_ENABLED=${LEAN_API_ENABLED:-true}
+    - LEAN_MCP_ENABLED=${LEAN_MCP_ENABLED:-true}
+    - LEAN_MCP_TOKEN=${LEAN_MCP_TOKEN:-}
+    - LEAN_ADHD_MODE=${LEAN_ADHD_MODE:-true}
+    - LEAN_NOTIFICATION_BATCH=${LEAN_NOTIFICATION_BATCH:-true}
+    - LEAN_CONTEXT_PRESERVATION=${LEAN_CONTEXT_PRESERVATION:-true}
+    - REDIS_HOST=redis_leantime
+    - REDIS_PASSWORD=${REDIS_PASSWORD:-}
     volumes:
-      - leantime_public_userfiles:/var/www/html/public/userfiles
-      - leantime_userfiles:/var/www/html/userfiles
-      - ./docker/leantime/plugins:/var/www/html/app/Plugins
-      - leantime_logs:/var/www/html/storage/logs
-      - leantime_config:/var/www/html/config
+    - leantime_public_userfiles:/var/www/html/public/userfiles
+    - leantime_userfiles:/var/www/html/userfiles
+    - ./docker/leantime/plugins:/var/www/html/app/Plugins
+    - leantime_logs:/var/www/html/storage/logs
+    - leantime_config:/var/www/html/config
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:80/ >/dev/null || exit 1"]
+      test:
+      - CMD-SHELL
+      - curl -fsS http://localhost:80/ >/dev/null || exit 1
       timeout: 10s
       retries: 5
       interval: 30s
       start_period: 60s
-
-  # Redis UI (optional web interface)
   redis-ui:
     image: redislabs/redisinsight:latest
     container_name: dopemux-redis-ui
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "8081:5540"
-    # Note: RedisInsight healthcheck disabled - app takes time to start and doesn't respond reliably to health checks
-
-  # Qdrant (vector database for embeddings)
+    - 8081:5540
   mcp-qdrant:
     image: qdrant/qdrant:latest
     container_name: mcp-qdrant
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "${QDRANT_PORT:-6333}:6333"
-      - "${QDRANT_GRPC_PORT:-6334}:6334"
+    - ${QDRANT_PORT:-6333}:6333
+    - ${QDRANT_GRPC_PORT:-6334}:6334
     volumes:
-      - dope-decision-graph-qdrant-data:/qdrant/storage
-
-  # ========================================
-  # MCP SERVERS (Core Intelligence)
-  # ========================================
-
-  # ConPort - Knowledge Graph & Context Management
+    - dope-decision-graph-qdrant-data:/qdrant/storage
   conport:
     build:
-      context: ./docker/mcp-servers/conport
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/mcp-servers/conport/Dockerfile
     container_name: ${CONPORT_CONTAINER_NAME:-mcp-conport}
     restart: unless-stopped
     networks:
-      - dopemux-network
-
+    - dopemux-network
     environment:
-      - DOPEMUX_INSTANCE_ID=${DOPEMUX_INSTANCE_ID:-}
-      - MCP_SERVER_PORT=3005
-      - DOPECON_BRIDGE_URL=http://dopecon-bridge:3016
-      - DATABASE_URL=postgresql://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/dopemux_knowledge_graph
-      - POSTGRES_URL=postgresql+asyncpg://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/dopemux_knowledge_graph
-      - AGE_HOST=dopemux-postgres-age
-      - AGE_PORT=5432
-      - AGE_PASSWORD=${AGE_PASSWORD:-dopemux_age_dev_password}
-      - REDIS_URL=redis://redis-primary:6379
-      - QDRANT_URL=http://mcp-qdrant:6333
+    - DOPEMUX_INSTANCE_ID=${DOPEMUX_INSTANCE_ID:-}
+    - MCP_SERVER_PORT=3005
+    - DOPECON_BRIDGE_URL=http://dopecon-bridge:3016
+    - DATABASE_URL=postgresql://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/dopemux_knowledge_graph
+    - POSTGRES_URL=postgresql+asyncpg://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/dopemux_knowledge_graph
+    - AGE_HOST=dopemux-postgres-age
+    - AGE_PORT=5432
+    - AGE_PASSWORD=${AGE_PASSWORD:-dopemux_age_dev_password}
+    - REDIS_URL=redis://redis-primary:6379
+    - QDRANT_URL=http://mcp-qdrant:6333
     ports:
-      - "${CONPORT_HTTP_PORT:-3004}:3004"
-      - "${CONPORT_MCP_PORT:-3005}:3005"
-      - "${CONPORT_INFO_PORT:-4004}:4004"
+    - ${CONPORT_HTTP_PORT:-3004}:3004
+    - ${CONPORT_MCP_PORT:-3005}:3005
+    - ${CONPORT_INFO_PORT:-4004}:4004
     depends_on:
-      - postgres
-      - redis-primary
-      - mcp-qdrant
-      - dopecon-bridge
+    - postgres
+    - redis-primary
+    - mcp-qdrant
+    - dopecon-bridge
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:3004/health || exit 0" ]
+      test:
+      - CMD-SHELL
+      - curl -f http://localhost:3004/health || exit 0
       timeout: 10s
       retries: 3
       interval: 30s
       start_period: 30s
-
-  # Zen - Multi-Model Reasoning
   pal:
     build:
-      context: ./docker/mcp-servers/pal
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/mcp-servers/pal/Dockerfile
     container_name: mcp-pal
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     environment:
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-      - GEMINI_API_KEY=${GEMINI_API_KEY}
-      - MCP_SERVER_PORT=${PAL_PORT:-3003}
+    - OPENAI_API_KEY=${OPENAI_API_KEY}
+    - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+    - GEMINI_API_KEY=${GEMINI_API_KEY}
+    - MCP_SERVER_PORT=${PAL_PORT:-3003}
     ports:
-      - "${PAL_PORT:-3003}:3003"
+    - ${PAL_PORT:-3003}:3003
     healthcheck:
-      test: [ "CMD-SHELL", "exit 0" ]
+      test:
+      - CMD-SHELL
+      - exit 0
       timeout: 10s
       retries: 3
       interval: 30s
-
-  # LiteLLM - Model Router
   litellm:
     build:
-      context: ./docker/mcp-servers/litellm
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/mcp-servers/litellm/Dockerfile
     container_name: mcp-litellm
     restart: unless-stopped
     networks:
-      - dopemux-network
-
+    - dopemux-network
     environment:
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - XAI_API_KEY=${XAI_API_KEY}
-      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-      - GEMINI_API_KEY=${GEMINI_API_KEY}
-      - DATABASE_URL=${LITELLM_DATABASE_URL:-postgresql://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/litellm}
+    - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    - OPENAI_API_KEY=${OPENAI_API_KEY}
+    - XAI_API_KEY=${XAI_API_KEY}
+    - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+    - GEMINI_API_KEY=${GEMINI_API_KEY}
+    - DATABASE_URL=${LITELLM_DATABASE_URL:-postgresql://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/litellm}
     ports:
-      - "4000:4000"
+    - 4000:4000
     depends_on:
-      - postgres
+    - postgres
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f -H 'Authorization: Bearer <REDACTED_LITELLM_MASTER_KEY>' http://localhost:4000/health || exit 1" ]
+      test:
+      - CMD-SHELL
+      - 'curl -f -H ''Authorization: Bearer <REDACTED_LITELLM_MASTER_KEY>'' http://localhost:4000/health
+        || exit 1'
       timeout: 10s
       retries: 3
       interval: 30s
-
-  # Dope-Context - Semantic Code & Docs Search
   dope-context:
     build:
-      context: ./services/dope-context
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/dope-context/Dockerfile
     container_name: mcp-dope-context
     restart: unless-stopped
     networks:
-      - dopemux-network
-
+    - dopemux-network
     environment:
-      - MCP_SERVER_PORT=${DOPE_CONTEXT_PORT:-3010}
-      - VOYAGE_API_KEY=${VOYAGE_API_KEY}
-      - VOYAGEAI_API_KEY=${VOYAGE_API_KEY}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - QDRANT_URL=http://mcp-qdrant:6333
-      - HOST_CODE_PARENT_DIR=${HOST_CODE_PARENT_DIR}
-      - HOST_PROJECT_RELATIVE_PATH=${HOST_PROJECT_RELATIVE_PATH}
-      - DOPEMUX_WORKSPACE_ROOT=/workspaces/${HOST_PROJECT_RELATIVE_PATH}
+    - MCP_SERVER_PORT=${DOPE_CONTEXT_PORT:-3010}
+    - VOYAGE_API_KEY=${VOYAGE_API_KEY}
+    - VOYAGEAI_API_KEY=${VOYAGE_API_KEY}
+    - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+    - OPENAI_API_KEY=${OPENAI_API_KEY}
+    - QDRANT_URL=http://mcp-qdrant:6333
+    - HOST_CODE_PARENT_DIR=${HOST_CODE_PARENT_DIR}
+    - HOST_PROJECT_RELATIVE_PATH=${HOST_PROJECT_RELATIVE_PATH}
+    - DOPEMUX_WORKSPACE_ROOT=/workspaces/${HOST_PROJECT_RELATIVE_PATH}
     ports:
-      - "${DOPE_CONTEXT_PORT:-3010}:3010"
+    - ${DOPE_CONTEXT_PORT:-3010}:3010
     volumes:
-      - ./services/dope-context/data:/app/data
-      - ./services/dope-context/logs:/app/logs
-      - ${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces
+    - ./services/dope-context/data:/app/data
+    - ./services/dope-context/logs:/app/logs
+    - ${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces
     depends_on:
-      - mcp-qdrant
+    - mcp-qdrant
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:3010/health || exit 0" ]
+      test:
+      - CMD-SHELL
+      - curl -f http://localhost:3010/health || exit 0
       timeout: 10s
       retries: 3
       interval: 30s
       start_period: 45s
-
-  # ========================================
-  # APPLICATION SERVICES (Event System)
-  # ========================================
-
-  # DopeconBridge - Event Processing & Pattern Detection
   dopecon-bridge:
     build:
-      context: ./services/dopecon-bridge
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: services/dopecon-bridge/Dockerfile
     container_name: dope-decision-graph-bridge
     restart: unless-stopped
     networks:
-      - dopemux-network
-
+    - dopemux-network
     ports:
-      - "${DOPECON_BRIDGE_PORT:-3016}:3016"
+    - ${DOPECON_BRIDGE_PORT:-3016}:3016
     environment:
-      - PORT_BASE=${DOPEMUX_PORT_BASE:-3000}
-      - POSTGRES_URL=postgresql+asyncpg://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/dopemux_knowledge_graph
-      - AGE_HOST=dopemux-postgres-age
-      - AGE_PORT=5432
-      - AGE_PASSWORD=${AGE_PASSWORD:-dopemux_age_dev_password}
-      - QDRANT_URL=http://mcp-qdrant:6333
-      - REDIS_URL=redis://redis-events:6379
+    - PORT_BASE=${DOPEMUX_PORT_BASE:-3000}
+    - POSTGRES_URL=postgresql+asyncpg://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/dopemux_knowledge_graph
+    - AGE_HOST=dopemux-postgres-age
+    - AGE_PORT=5432
+    - AGE_PASSWORD=${AGE_PASSWORD:-dopemux_age_dev_password}
+    - QDRANT_URL=http://mcp-qdrant:6333
+    - REDIS_URL=redis://redis-events:6379
     depends_on:
       postgres:
         condition: service_healthy
@@ -381,13 +336,13 @@ services:
       mcp-qdrant:
         condition: service_started
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:3016/health || exit 1" ]
+      test:
+      - CMD-SHELL
+      - curl -f http://localhost:3016/health || exit 1
       timeout: 10s
       retries: 3
       interval: 30s
       start_period: 30s
-
-  # Task Orchestrator - ADHD Task Coordination
   task-orchestrator:
     build:
       context: .
@@ -395,221 +350,231 @@ services:
     container_name: task-orchestrator
     restart: unless-stopped
     networks:
-      - dopemux-network
-
+    - dopemux-network
     environment:
-      - LEANTIME_URL=${LEANTIME_URL:-http://leantime:80}
-      - LEANTIME_TOKEN=${LEANTIME_TOKEN}
-      - REDIS_URL=redis://redis-primary:6379
-      - WORKSPACE_ID=${DOPEMUX_WORKSPACE_ID:-/app}
-      - CONPORT_URL=http://conport:3005
-      - DOPECON_BRIDGE_URL=http://dopecon-bridge:3016
-      - DOPECON_BRIDGE_SOURCE_PLANE=cognitive_plane
-      - TASK_ORCHESTRATOR_API_KEY=${TASK_ORCHESTRATOR_API_KEY:-dev-key-456}
-      - DOPECON_BRIDGE_REDIS_URL=redis://redis-primary:6379
-      - PORT=8000
+    - LEANTIME_URL=${LEANTIME_URL:-http://leantime:80}
+    - LEANTIME_TOKEN=${LEANTIME_TOKEN}
+    - REDIS_URL=redis://redis-primary:6379
+    - WORKSPACE_ID=${DOPEMUX_WORKSPACE_ID:-/app}
+    - CONPORT_URL=http://conport:3005
+    - DOPECON_BRIDGE_URL=http://dopecon-bridge:3016
+    - DOPECON_BRIDGE_SOURCE_PLANE=cognitive_plane
+    - TASK_ORCHESTRATOR_API_KEY=${TASK_ORCHESTRATOR_API_KEY:-dev-key-456}
+    - DOPECON_BRIDGE_REDIS_URL=redis://redis-primary:6379
+    - PORT=8000
     ports:
-      - "${TASK_ORCHESTRATOR_PORT:-8000}:8000"
+    - ${TASK_ORCHESTRATOR_PORT:-8000}:8000
     depends_on:
-      - redis-primary
-      - conport
-      - leantime
+    - redis-primary
+    - conport
+    - leantime
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8000/health" ]
+      test:
+      - CMD
+      - curl
+      - -f
+      - http://localhost:8000/health
       timeout: 10s
       retries: 3
       interval: 30s
       start_period: 40s
-
-  # ADHD Engine - Real-time ADHD Accommodation Service
   adhd-engine:
     build:
       context: .
       dockerfile: services/adhd_engine/Dockerfile
     restart: unless-stopped
     networks:
-      - dopemux-network
-
+    - dopemux-network
     environment:
-      - API_PORT=8095
-      - HOST=0.0.0.0
-      - ADHD_ENGINE_API_KEY=${ADHD_ENGINE_API_KEY:-dev-key-123}
-      - REDIS_URL=redis://redis-primary:6379
-      - CONPORT_URL=http://conport:3005
-      - DOPECON_BRIDGE_URL=http://dopecon-bridge:3016
-      - DOPECON_BRIDGE_SOURCE_PLANE=cognitive_plane
-      - ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8097,http://adhd-dashboard:8097
+    - API_PORT=8095
+    - HOST=0.0.0.0
+    - ADHD_ENGINE_API_KEY=${ADHD_ENGINE_API_KEY:-dev-key-123}
+    - REDIS_URL=redis://redis-primary:6379
+    - CONPORT_URL=http://conport:3005
+    - DOPECON_BRIDGE_URL=http://dopecon-bridge:3016
+    - DOPECON_BRIDGE_SOURCE_PLANE=cognitive_plane
+    - ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8097,http://adhd-dashboard:8097
     ports:
-      - "${ADHD_ENGINE_PORT:-3025}:8095"
+    - ${ADHD_ENGINE_PORT:-3025}:8095
     depends_on:
-      - redis-primary
+    - redis-primary
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f http://localhost:8095/health || exit 1" ]
+      test:
+      - CMD-SHELL
+      - curl -f http://localhost:8095/health || exit 1
       timeout: 10s
       retries: 3
       interval: 30s
       start_period: 30s
-
-  # Dope-Memory - Temporal Chronicle and Working Context
   dope-memory:
     build:
-      context: ./services/working-memory-assistant
-      dockerfile: Dockerfile.dope-memory
+      context: .
+      dockerfile: services/working-memory-assistant/Dockerfile.dope-memory
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "${DOPE_MEMORY_PORT:-3020}:3020"
+    - ${DOPE_MEMORY_PORT:-3020}:3020
     environment:
-      - WMA_SECRET_KEY=${WMA_SECRET_KEY:-dev-only-change-me}
-      - WMA_ENCRYPTION_KEY=${WMA_ENCRYPTION_KEY:-dev-only-change-me}
-      - POSTGRES_HOST=postgres
-      - POSTGRES_PORT=5432
-      - POSTGRES_DB=dopemux_knowledge_graph
-      - POSTGRES_USER=dopemux_age
-      - POSTGRES_PASSWORD=${AGE_PASSWORD:-dopemux_age_dev_password}
-      - REDIS_URL=redis://redis-events:6379
-      - ENABLE_EVENTBUS=true
-      - ENABLE_MIRROR_SYNC=${ENABLE_MIRROR_SYNC:-false}
-      - MIRROR_SCHEMA_RESET=${MIRROR_SCHEMA_RESET:-false}
-      - DOPE_MEMORY_WORKSPACE_ID=${DOPE_MEMORY_WORKSPACE_ID:-default}
-      - POSTGRES_URL=postgresql://dopemux_age:${AGE_PASSWORD:-dopemux_age_dev_password}@postgres:5432/dopemux_knowledge_graph
-      - DOPEMUX_CAPTURE_LEDGER_PATH=/data/chronicle.sqlite
-      - DOPEMUX_SQLITE_JOURNAL_MODE=DELETE
-      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:8097,http://adhd-dashboard:8097}
+    - WMA_SECRET_KEY=${WMA_SECRET_KEY:-dev-only-change-me}
+    - WMA_ENCRYPTION_KEY=${WMA_ENCRYPTION_KEY:-dev-only-change-me}
+    - POSTGRES_HOST=postgres
+    - POSTGRES_PORT=5432
+    - POSTGRES_DB=dopemux_knowledge_graph
+    - POSTGRES_USER=dopemux_age
+    - POSTGRES_PASSWORD=${AGE_PASSWORD:-dopemux_age_dev_password}
+    - REDIS_URL=redis://redis-events:6379
+    - ENABLE_EVENTBUS=true
+    - ENABLE_MIRROR_SYNC=${ENABLE_MIRROR_SYNC:-false}
+    - MIRROR_SCHEMA_RESET=${MIRROR_SCHEMA_RESET:-false}
+    - DOPE_MEMORY_WORKSPACE_ID=${DOPE_MEMORY_WORKSPACE_ID:-default}
+    - POSTGRES_URL=postgresql://dopemux_age:${AGE_PASSWORD:-dopemux_age_dev_password}@postgres:5432/dopemux_knowledge_graph
+    - DOPEMUX_CAPTURE_LEDGER_PATH=/data/chronicle.sqlite
+    - DOPEMUX_SQLITE_JOURNAL_MODE=DELETE
+    - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3000,http://localhost:8097,http://adhd-dashboard:8097}
     volumes:
-      - ./.dopemux:/data
+    - ./.dopemux:/data
     depends_on:
       postgres:
         condition: service_healthy
       redis-events:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3020/health" ]
+      test:
+      - CMD
+      - curl
+      - -f
+      - http://localhost:3020/health
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 30s
-
-  # Serena v2 - ADHD Engine MCP
   serena:
     build:
-      context: ./docker/mcp-servers/serena
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/mcp-servers/serena/Dockerfile
     container_name: ${SERENA_CONTAINER_NAME:-dopemux-mcp-serena}
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "${SERENA_PORT:-3006}:3006"
-      - "${SERENA_HTTP_PORT:-4006}:4006"
+    - ${SERENA_PORT:-3006}:3006
+    - ${SERENA_HTTP_PORT:-4006}:4006
     environment:
-      - DOPEMUX_INSTANCE_ID=${DOPEMUX_INSTANCE_ID:-}
-      - MCP_SERVER_PORT=${SERENA_PORT:-3006}
-      - HTTP_PORT=${SERENA_HTTP_PORT:-4006}
-      - WORKSPACE_ID=${WORKSPACE_ID:-/workspace}
-      - HOST_CODE_PARENT_DIR=${HOST_CODE_PARENT_DIR}
-      - HOST_PROJECT_RELATIVE_PATH=${HOST_PROJECT_RELATIVE_PATH}
+    - DOPEMUX_INSTANCE_ID=${DOPEMUX_INSTANCE_ID:-}
+    - MCP_SERVER_PORT=${SERENA_PORT:-3006}
+    - HTTP_PORT=${SERENA_HTTP_PORT:-4006}
+    - WORKSPACE_ID=${WORKSPACE_ID:-/workspace}
+    - HOST_CODE_PARENT_DIR=${HOST_CODE_PARENT_DIR}
+    - HOST_PROJECT_RELATIVE_PATH=${HOST_PROJECT_RELATIVE_PATH}
     volumes:
-      - ${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces
-      - ${HOME:?HOME is required}/.serena:/root/.serena:rw
-      - ${HOME:?HOME is required}/code:${HOME:?HOME is required}/code:ro
+    - ${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces
+    - ${HOME:?HOME is required}/.serena:/root/.serena:rw
+    - ${HOME:?HOME is required}/code:${HOME:?HOME is required}/code:ro
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:4006/health || exit 1"]
+      test:
+      - CMD-SHELL
+      - curl -f http://localhost:4006/health || exit 1
       timeout: 10s
       retries: 3
       interval: 30s
       start_period: 30s
-
-  # GPT Researcher - Deep research MCP
   gptr-mcp:
     build:
-      context: ./docker/mcp-servers/gptr-mcp
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/mcp-servers/gptr-mcp/Dockerfile
     container_name: dopemux-mcp-gptr-mcp
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "${GPT_RESEARCHER_PORT:-3009}:3009"
+    - ${GPT_RESEARCHER_PORT:-3009}:3009
     environment:
-      - MCP_SERVER_PORT=${GPT_RESEARCHER_PORT:-3009}
-      - LLM_BACKEND=openai
-      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
-      - TAVILY_API_KEY=${TAVILY_API_KEY:-}
+    - MCP_SERVER_PORT=${GPT_RESEARCHER_PORT:-3009}
+    - LLM_BACKEND=openai
+    - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+    - TAVILY_API_KEY=${TAVILY_API_KEY:-}
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3009/health || exit 1"]
+      test:
+      - CMD-SHELL
+      - curl -f http://localhost:3009/health || exit 1
       timeout: 10s
       retries: 3
       interval: 30s
-  # Desktop Commander - Desktop automation
   desktop-commander:
     build:
-      context: ./docker/mcp-servers/desktop-commander
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/mcp-servers/desktop-commander/Dockerfile
     container_name: dopemux-mcp-desktop-commander
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "${DESKTOP_COMMANDER_PORT:-3012}:3012"
+    - ${DESKTOP_COMMANDER_PORT:-3012}:3012
     environment:
-      - MCP_SERVER_PORT=${DESKTOP_COMMANDER_PORT:-3012}
-      - DISPLAY=${DISPLAY:-:0}
+    - MCP_SERVER_PORT=${DESKTOP_COMMANDER_PORT:-3012}
+    - DISPLAY=${DISPLAY:-:0}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3012/health"]
+      test:
+      - CMD
+      - curl
+      - -f
+      - http://localhost:3012/health
       timeout: 10s
       retries: 3
       interval: 30s
-
-  # Leantime Bridge - Project management integration
   exa:
     build:
-      context: ./docker/mcp-servers/exa
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/mcp-servers/exa/Dockerfile
     container_name: mcp-exa
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "${EXA_PORT:-3011}:3011"
+    - ${EXA_PORT:-3011}:3011
     environment:
-      - EXA_API_KEY=${EXA_API_KEY:-}
-      - MCP_SERVER_PORT=${EXA_PORT:-3011}
+    - EXA_API_KEY=${EXA_API_KEY:-}
+    - MCP_SERVER_PORT=${EXA_PORT:-3011}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3011/health"]
+      test:
+      - CMD
+      - curl
+      - -f
+      - http://localhost:3011/health
       timeout: 5s
       retries: 3
       interval: 30s
-
   leantime-bridge:
     build:
-      context: ./docker/mcp-servers/leantime-bridge
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: docker/mcp-servers/leantime-bridge/Dockerfile
     container_name: dopemux-mcp-leantime-bridge
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "${LEANTIME_BRIDGE_PORT:-3015}:3015"
+    - ${LEANTIME_BRIDGE_PORT:-3015}:3015
     env_file:
-      - ./docker/mcp-servers/leantime-bridge/.env
+    - ./docker/mcp-servers/leantime-bridge/.env
     environment:
-      - MCP_SERVER_HOST=0.0.0.0
-      - MCP_SERVER_PORT=${LEANTIME_BRIDGE_PORT:-3015}
-      - LEANTIME_API_URL=${LEANTIME_API_URL:-${LEANTIME_URL:-http://leantime:80}}
-      - LEANTIME_API_TOKEN=${LEANTIME_API_TOKEN:-${LEANTIME_TOKEN:-}}
-      - REDIS_URL=redis://redis-primary:6379
+    - MCP_SERVER_HOST=0.0.0.0
+    - MCP_SERVER_PORT=${LEANTIME_BRIDGE_PORT:-3015}
+    - LEANTIME_API_URL=${LEANTIME_API_URL:-${LEANTIME_URL:-http://leantime:80}}
+    - LEANTIME_API_TOKEN=${LEANTIME_API_TOKEN:-${LEANTIME_TOKEN:-}}
+    - REDIS_URL=redis://redis-primary:6379
     depends_on:
-      - mcp-qdrant
-      - leantime
+    - mcp-qdrant
+    - leantime
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3015/health"]
+      test:
+      - CMD
+      - curl
+      - -f
+      - http://localhost:3015/health
       timeout: 10s
       retries: 3
       interval: 30s
-
-  # OpenAI Webhook Receiver Sidecar
   webhook-receiver:
     build:
       context: .
@@ -617,30 +582,29 @@ services:
     container_name: dopemux-webhook-receiver
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     ports:
-      - "8790:8790"
+    - 8790:8790
     environment:
-      - WEBHOOK_RECEIVER_HOST=0.0.0.0
-      - WEBHOOK_RECEIVER_PORT=8790
-      # Default to SQLite at WEBHOOK_DB_PATH; set WEBHOOK_DB_URL to use PostgreSQL instead.
-      - WEBHOOK_DB_PATH=/data/webhook_receiver.db
-      - WEBHOOK_DB_URL=${WEBHOOK_DB_URL:-}
-      - DPMX_ENV=${DPMX_ENV:-development}
-      - OPENAI_WEBHOOK_SECRET=${OPENAI_WEBHOOK_SECRET}
-      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+    - WEBHOOK_RECEIVER_HOST=0.0.0.0
+    - WEBHOOK_RECEIVER_PORT=8790
+    - WEBHOOK_DB_PATH=/data/webhook_receiver.db
+    - WEBHOOK_DB_URL=${WEBHOOK_DB_URL:-}
+    - DPMX_ENV=${DPMX_ENV:-development}
+    - OPENAI_WEBHOOK_SECRET=${OPENAI_WEBHOOK_SECRET}
+    - OPENAI_API_KEY=${OPENAI_API_KEY:-}
     volumes:
-      - ./.dopemux/webhook_receiver:/data
+    - ./.dopemux/webhook_receiver:/data
     healthcheck:
       test:
-        - CMD
-        - python
-        - -c
-        - import urllib.request; urllib.request.urlopen('http://localhost:8790/healthz', timeout=2)
+      - CMD
+      - python
+      - -c
+      - import urllib.request; urllib.request.urlopen('http://localhost:8790/healthz',
+        timeout=2)
       timeout: 5s
       retries: 3
       interval: 30s
-
   webhook-poller:
     build:
       context: .
@@ -648,10 +612,16 @@ services:
     container_name: dopemux-webhook-poller
     restart: unless-stopped
     networks:
-      - dopemux-network
+    - dopemux-network
     environment:
-      - WEBHOOK_DB_PATH=/data/webhook_receiver.db
-      - WEBHOOK_DB_URL=${WEBHOOK_DB_URL:-}
+    - WEBHOOK_DB_PATH=/data/webhook_receiver.db
+    - WEBHOOK_DB_URL=${WEBHOOK_DB_URL:-}
     volumes:
-      - ./.dopemux/webhook_receiver:/data
-    command: ["python", "/app/services/webhook_receiver/poller.py", "--providers", "xai,gemini", "--interval-seconds", "10"]
+    - ./.dopemux/webhook_receiver:/data
+    command:
+    - python
+    - /app/services/webhook_receiver/poller.py
+    - --providers
+    - xai,gemini
+    - --interval-seconds
+    - '10'

--- a/docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md
+++ b/docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md
@@ -1,0 +1,227 @@
+---
+id: repo-branch-worktree-audit-2026-04-23
+title: Repo Branch and Worktree Audit
+type: reference
+owner: codex
+date: 2026-04-23
+status: complete
+author: '@hu3mann'
+last_review: '2026-04-23'
+next_review: '2026-07-22'
+prelude: Branch, remote, and worktree phase-1 audit for deterministic cleanup planning.
+---
+# Repo Branch and Worktree Audit
+
+**Audit packet**: `TP-DMX-REPOHYG-001`  
+**Audit date**: `2026-04-23`  
+**Execution branch**: `codex/repo-hygiene-audit-phase1`  
+**Base branch**: `main`  
+**Scope**: phase-1 evidence collection and non-destructive cleanup planning only
+
+---
+
+## Repo Identity
+
+Observed directly:
+
+- Repo root resolved to `/Users/hue/code/dopemux-mvp`
+- `.dopetaskroot` exists at repo root
+- `origin` remote is `https://github.com/DDD-Enterprises/dopemux-mvp.git`
+- A second remote, `gtm-ssh`, points at `DDD-Enterprises/dopemux-extractor-gtm.git` and was treated as out-of-scope for this audit
+
+Authority used for this audit:
+
+- Runtime repo truth from git surfaces: `git remote -v`, `git branch`, `git branch -vv`, `git worktree list --porcelain`, `git status --short --branch`
+- Remote PR evidence from `gh pr list --state open/all`
+- Repo operating contract from `AGENTS.md`
+
+Drift observed:
+
+- `AGENTS.md` names `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_CANONICALS.md` and related truth files as available in this checkout. Those paths were not present during this audit, so they were not used as authority.
+
+---
+
+## Remote Evidence Summary
+
+Observed directly at audit time:
+
+- `gh pr list --state open` returned `[]`
+- No open PR heads were present in the current GitHub remote evidence set
+- Recent merged heads that still intersect local branches or worktrees include:
+  - `codex/pal-sse-wrapper` via PR `#500`
+  - `codex/phase0` via PR `#497`
+  - `docs/multi-agent-ingress-architecture-revision` via PR `#496`
+  - `design/wave7-rte-ui-contract` via PR `#495`
+  - `feat/rte-prescan-stage0-live-lane-proving` via PR `#480`
+  - `tp/gh-review-thread-agent` via PR `#465`
+  - `tp/rte-full-run-hygiene-and-launch-readiness` via PR `#461`
+- Recent closed-unmerged heads that still intersect local branches or worktrees include:
+  - `codex/ci-unit-shard-experiment` via PR `#499` against `codex/ci-fast-unit-gate`
+  - `feat/rte-prescan-first-live-hardening` via PR `#467`
+  - `feat/rte-v5-prescan-contract-unification` via PR `#470`
+  - `codex/dopecode-ast-navigation-20260417` via PR `#471`
+  - `tp/dopecode-ast-navigation` via PR `#469`
+  - `tp/serena-tool-surface-audit` via PR `#468`
+  - `tp/dopecode-phase2-harden` via PR `#473`
+  - `tp/dopecode-phase3-decompose-policy` via PR `#474` and `#477`
+  - `tp/dopecode-phase4-language-approval` via PR `#476`
+
+Remote branch naming clusters observed from `refs/remotes/origin`:
+
+- Active-looking prefixes: `codex/`, `tp/`, `feat/`, `docs/`, `design/`
+- Legacy or cleanup-sensitive prefixes: `bundle/`, `copilot/`, `dependabot/`, `palette/`, `rescue/`, `prmerge/`
+- Branches whose commit subjects explicitly mention supersession or rescue exist on remote and should not be auto-deleted without packeted review
+
+Deterministic rule used in this audit:
+
+- A remote branch was not marked `delete-remote` unless both of these were true:
+  - there was explicit merged or closed-unmerged PR evidence, and
+  - no active local worktree, dirty state, detached checkout dependency, or unresolved branch-purpose ambiguity blocked deletion
+
+No remote branch met that standard in this phase-1 packet.
+
+---
+
+## Local Worktree Evidence
+
+### Inventory Counts
+
+| Surface | Count | Notes |
+| --- | --- | --- |
+| Local worktrees listed | 26 | Includes main checkout |
+| Detached worktrees | 6 | `/private/tmp/dopemux-pr492`, `pr493`, `pr494`, `pr495`, `pr497`, `pr497b` |
+| Explicitly prunable worktrees | 2 | `/private/tmp/dopemux-pr467`, `/private/tmp/dopemux-pr480` |
+| Worktrees with observed dirty state | 7 | Main checkout plus 6 additional worktrees |
+| Worktrees on branches whose upstream is gone | 4 | Includes `codex/prompts-prefix-mirror` and `tp/rte-full-run-hygiene-and-launch-readiness` |
+
+### Dirty or Ambiguous Worktrees
+
+| Worktree | Branch / State | Observed condition | Classification | Reason | Blocking risk |
+| --- | --- | --- | --- | --- | --- |
+| `/Users/hue/code/dopemux-mvp` | `codex/repo-hygiene-audit-phase1` | Dirty: `AGENTS.md`, untracked `.claude/worktrees/` | `keep` | Active audit workspace for this packet | Current packet in progress |
+| `/private/tmp/dopemux-pr467` | `pr/467` | `prunable gitdir file points to non-existent location`; `git status` failed | `unknown` | Broken worktree metadata; branch tied to closed-unmerged PR `#467` | Worktree repair/removal needs explicit follow-up |
+| `/private/tmp/dopemux-pr480` | `pr/480` | `prunable gitdir file points to non-existent location`; `git status` failed | `unknown` | Broken worktree metadata; branch tied to merged PR `#480` | Worktree repair/removal needs explicit follow-up |
+| `/private/tmp/dopemux-pr497` | detached | Dirty: `M task-packets/TP-DMX-AIG-001.md` | `keep` | Detached worktree has uncommitted changes | Must be reconciled before any deletion |
+| `/Users/hue/code/dopemux-mvp-rte-seams` | `codex/rte-seam-extraction-foundation` | Dirty: workflow file modified, test file untracked | `keep` | Active non-audited local changes present | Deletion would discard unresolved work |
+| `/Users/hue/code/dopemux-mvp-worktrees/v1-runtime-proof-linkage` | `codex/v1-runtime-proof-linkage` | Untracked `.operator/`; behind `origin/main` by 242 | `archive` | Local worktree is stale and off `main`, but contains local-only material | Archive/review local-only content before cleanup |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/gracious-poitras-850e4f` | `claude/gracious-poitras-850e4f` | Untracked `.claude/brand-voice-guidelines.md`; behind `origin/main` by 19 | `archive` | Stale assistant worktree with local-only file | Local content needs review before deletion |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/rte-decompose` | `refactor/rte-decompose-snapshot` | Large dirty multi-file change set plus untracked `reporting.py` | `keep` | Active unresolved implementation work | Unsafe for cleanup in phase 1 |
+
+### Clean but Review-Relevant Worktrees
+
+| Worktree | Branch / State | Remote / PR relation | Classification | Reason | Blocking risk |
+| --- | --- | --- | --- | --- | --- |
+| `/private/tmp/dopemux-ci-pr` | `codex/ci-unit-shard-experiment` | Closed-unmerged PR `#499`; upstream present | `archive` | Branch has explicit closed-unmerged disposition; preserve until reviewer decides whether to keep experiment history | Closed-unmerged branch still mounted in a worktree |
+| `/private/tmp/dopemux-pr496` | `docs/multi-agent-ingress-architecture-revision` | Merged PR `#496`; upstream present | `archive` | Worktree still mounted after merge | Remove only in follow-up packet after confirming no local-only deltas |
+| `/private/tmp/dopemux-pr492` | detached at merged PR `#492` head | No branch attached | `archive` | Detached PR checkout with no local changes | Safe candidate for later cleanup, but detached state warrants explicit action |
+| `/private/tmp/dopemux-pr493` | detached at merged PR `#493` head | No branch attached | `archive` | Detached PR checkout with no local changes | Same as above |
+| `/private/tmp/dopemux-pr494` | detached at merged PR `#494` head | No branch attached | `archive` | Detached PR checkout with no local changes | Same as above |
+| `/private/tmp/dopemux-pr495` | detached at merged PR `#495` head | No branch attached | `archive` | Detached PR checkout with no local changes | Same as above |
+| `/private/tmp/dopemux-pr497b` | detached near merged PR `#497` lineage | No branch attached | `archive` | Detached temp checkout with no local changes | Detached history should be removed explicitly, not silently |
+| `/Users/hue/code/dopemux-extractor-gtm` | `codex/prompts-prefix-mirror` | Upstream gone | `archive` | Out-of-scope GTM worktree still tied into this repo’s git worktree registry | Needs separate owner review |
+| `/Users/hue/code/dopemux-mvp-rte-main-integration-audit-staging` | `tp/rte-full-run-hygiene-and-launch-readiness` | Merged PR `#461`; upstream gone | `archive` | Historic merged packet branch still mounted | Follow-up can remove after owner confirmation |
+| `/Users/hue/code/dopemux-mvp-rte-seams-v2` | `codex/rte-seam-extraction-foundation-v2` | Upstream gone; branch merged earlier via PR `#444` | `archive` | Mounted historical branch with no observed dirty state | Follow-up can remove after review |
+| `/Users/hue/code/dopemux-mvp-wt-dopecode-ast` | `codex/dopecode-ast-navigation-20260417` | Closed-unmerged PR `#471`; behind upstream by 14 | `archive` | Explicit closed-unmerged branch line still mounted | Needs disposition before delete |
+| `/Users/hue/code/dopemux-mvp-wt-rte-benchmark-r1` | `codex/rte-benchmark-r1-first-campaign` | No PR evidence in sampled recent set | `unknown` | Branch purpose unresolved in phase-1 evidence | Needs owner review |
+| `/Users/hue/code/dopemux-mvp-wt-rte-v5-prescan-contract-unification` | `feat/rte-v5-prescan-contract-unification` | Closed-unmerged PR `#470` | `archive` | Closed-unmerged branch still mounted cleanly | Needs disposition before delete |
+| `/Users/hue/code/dopemux-mvp-wt-serena-audit` | `tp/serena-audit-runtime-io-tools` | No recent PR resolution observed | `unknown` | Branch line unresolved by available evidence | Needs owner review |
+| `/Users/hue/code/dopemux-mvp-wt-serena-fix` | `tp/serena-runtime-fix` | No recent PR resolution observed | `unknown` | Branch line unresolved by available evidence | Needs owner review |
+| `/Users/hue/code/dopemux-mvp-wt-serena-upstream-diff` | `tp/serena-upstream-contract-diff` | No recent PR resolution observed | `unknown` | Branch line unresolved by available evidence | Needs owner review |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/inspiring-nobel-101730` | `claude/inspiring-nobel-101730` | Tracks `origin/main`, behind 19 | `archive` | No local changes; stale assistant worktree | Remove only in follow-up |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/optimistic-mayer-6f6e75` | `claude/optimistic-mayer-6f6e75` | Tracks `origin/main`, behind 19 | `archive` | No local changes; stale assistant worktree | Remove only in follow-up |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/rte-structured-outputs-all-providers` | `feat/rte-structured-outputs-all-providers` | No recent PR evidence in sampled set | `unknown` | Clean but unresolved branch purpose | Needs owner review |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/serene-swirles-f50ab3` | `claude/serene-swirles-f50ab3` | Tracks `origin/main`, behind 30 | `archive` | No local changes; stale assistant worktree | Remove only in follow-up |
+| `/Users/hue/code/dopemux-mvp/.worktrees/tp-gh-review-thread-agent` | `tp/gh-review-thread-agent` | Merged PR `#465` | `archive` | Merged branch still mounted as worktree | Follow-up can remove after review |
+
+---
+
+## Local Branch Ledger
+
+This ledger is intentionally bounded to branches materially intersecting worktrees, recent PR evidence, or upstream-gone state.
+
+| Branch | Remote / PR evidence | Recommendation | Reason | Blocking risk |
+| --- | --- | --- | --- | --- |
+| `codex/repo-hygiene-audit-phase1` | Local audit branch only | `keep` | Active packet branch for this phase-1 work | Current packet not complete until reviewed |
+| `main` | Tracks `origin/main` | `keep` | Canonical base branch | None |
+| `codex/ci-unit-shard-experiment` | Closed-unmerged PR `#499`; mounted clean worktree | `archive` | Explicit closed-unmerged experimental branch; not safe for silent deletion | Local worktree exists |
+| `docs/multi-agent-ingress-architecture-revision` | Merged PR `#496`; mounted clean worktree | `archive` | Merged branch still has attached worktree | Follow-up must remove worktree first |
+| `design/wave7-rte-ui-contract` | Merged PR `#495`; local branch ahead 1 / behind 14 | `merge-first` | Diverged local branch shares merged PR lineage but local/remote drift remains | Local divergence unresolved |
+| `codex/pal-sse-wrapper` | Merged PR `#500` | `archive` | Recently merged branch; no destruction in phase 1 | Fresh merge; follow-up can delete after review |
+| `codex/phase0` | Merged PR `#497`; local branch ahead 1 / behind 4 | `merge-first` | Local branch diverged after merged PR line | Needs explicit review of extra local commit |
+| `feat/rte-prescan-first-live-hardening` | Closed-unmerged PR `#467`; duplicate local `pr/467` broken worktree | `archive` | Closed-unmerged plus duplicate branch line | Broken temp worktree blocks safe cleanup |
+| `feat/rte-prescan-stage0-live-lane-proving` | Merged PR `#480`; duplicate local `pr/480` broken worktree | `archive` | Merged but temp worktree metadata is broken | Broken temp worktree blocks safe cleanup |
+| `feat/rte-v5-prescan-contract-unification` | Closed-unmerged PR `#470`; mounted clean worktree | `archive` | Closed-unmerged branch still mounted | Needs explicit disposition |
+| `codex/dopecode-ast-navigation-20260417` | Closed-unmerged PR `#471`; mounted clean worktree | `archive` | Closed-unmerged branch with attached worktree | Needs disposition |
+| `tp/dopecode-ast-navigation` | Closed-unmerged PR `#469` | `archive` | Closed-unmerged packet branch | No safe deletion proof in phase 1 |
+| `tp/dopecode-phase2-harden` | Closed-unmerged PR `#473` | `archive` | Closed-unmerged packet branch | No safe deletion proof in phase 1 |
+| `tp/dopecode-phase3-decompose-policy` | Closed-unmerged PRs `#474`, `#477` | `archive` | Duplicate closed-unmerged PR line; explicit disposition required | Duplicate PR history |
+| `tp/dopecode-phase4-language-approval` | Closed-unmerged PR `#476` | `archive` | Closed-unmerged packet branch | No safe deletion proof in phase 1 |
+| `tp/dopecode-phase8-events-replay` | Merged PR `#481` | `archive` | Merged branch remains local | Follow-up can delete after review |
+| `tp/gh-review-thread-agent` | Merged PR `#465`; mounted clean worktree | `archive` | Merged branch still mounted | Follow-up must remove worktree first |
+| `tp/rte-full-run-hygiene-and-launch-readiness` | Merged PR `#461`; upstream gone; mounted clean worktree | `archive` | Historic merged branch with mounted worktree and gone upstream | Worktree cleanup needed first |
+| `codex/rte-seam-extraction-foundation` | Dirty mounted worktree; no current remote evidence in recent PR slice | `keep` | Local unresolved modifications exist | Unsafe for cleanup |
+| `codex/rte-seam-extraction-foundation-v2` | Upstream gone; historical merged lineage | `archive` | Historic clean worktree remains | Follow-up review required |
+| `codex/v1-runtime-proof-linkage` | Tracks `origin/main`; behind 242; dirty untracked state | `archive` | Highly stale and carries local-only content | Local content must be reviewed |
+| `claude/gracious-poitras-850e4f` | Tracks `origin/main`; dirty untracked file | `archive` | Assistant branch with local-only artifact | Local file review required |
+| `refactor/rte-decompose-snapshot` | Dirty mounted worktree | `keep` | Large unresolved change set | Unsafe for cleanup |
+| `tp/serena-audit-runtime-io-tools` | No definitive PR evidence in current slice | `unknown` | Authority unresolved | Owner review required |
+| `tp/serena-runtime-fix` | No definitive PR evidence in current slice | `unknown` | Authority unresolved | Owner review required |
+| `tp/serena-upstream-contract-diff` | No definitive PR evidence in current slice | `unknown` | Authority unresolved | Owner review required |
+
+---
+
+## Deterministic Cleanup Plan
+
+Phase 1 issues recommendations only. No deletion or worktree removal is executed here.
+
+### Follow-up Packet Order
+
+1. Reconcile dirty worktrees first:
+   - `/private/tmp/dopemux-pr497`
+   - `/Users/hue/code/dopemux-mvp-rte-seams`
+   - `/Users/hue/code/dopemux-mvp-worktrees/v1-runtime-proof-linkage`
+   - `/Users/hue/code/dopemux-mvp/.claude/worktrees/gracious-poitras-850e4f`
+   - `/Users/hue/code/dopemux-mvp/.claude/worktrees/rte-decompose`
+2. Repair or remove broken prunable temp worktrees explicitly:
+   - `/private/tmp/dopemux-pr467`
+   - `/private/tmp/dopemux-pr480`
+3. Resolve closed-unmerged branch lines by owner decision, not heuristic deletion:
+   - `codex/ci-unit-shard-experiment`
+   - `feat/rte-prescan-first-live-hardening`
+   - `feat/rte-v5-prescan-contract-unification`
+   - `codex/dopecode-ast-navigation-20260417`
+   - `tp/dopecode-ast-navigation`
+   - `tp/dopecode-phase2-harden`
+   - `tp/dopecode-phase3-decompose-policy`
+   - `tp/dopecode-phase4-language-approval`
+4. Remove merged but still-mounted worktrees only after confirming clean state in the follow-up packet:
+   - `/private/tmp/dopemux-pr496`
+   - `/private/tmp/dopemux-pr492`
+   - `/private/tmp/dopemux-pr493`
+   - `/private/tmp/dopemux-pr494`
+   - `/private/tmp/dopemux-pr495`
+   - `/private/tmp/dopemux-pr497b`
+   - `/Users/hue/code/dopemux-mvp-rte-main-integration-audit-staging`
+   - `/Users/hue/code/dopemux-mvp-rte-seams-v2`
+   - `/Users/hue/code/dopemux-mvp/.worktrees/tp-gh-review-thread-agent`
+5. Handle `unknown` branches and worktrees with explicit owner review, not silent cleanup:
+   - `codex/rte-benchmark-r1-first-campaign`
+   - `tp/serena-audit-runtime-io-tools`
+   - `tp/serena-runtime-fix`
+   - `tp/serena-upstream-contract-diff`
+   - `feat/rte-structured-outputs-all-providers`
+
+### Explicit Non-Recommendations
+
+- No branch is marked `delete-remote` in this packet.
+- No worktree is marked immediately safe to remove in this packet without a follow-up execution packet.
+- No unknown item was downgraded to delete/cleanup based on naming convention alone.
+
+---
+
+## Residual Risk
+
+- The PR evidence set proves there are no open PRs at audit time, but absence of an open PR does not prove branch irrelevance.
+- Several local branches have no recent PR evidence in the sampled set and remain `unknown`.
+- The repo contains pre-existing dirty state outside this packet, so a later execution packet must re-validate current status before acting.
+- `AGENTS.md` truth-doc path drift means some repo-truth documentation references are stale relative to this checkout.

--- a/docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md
+++ b/docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md
@@ -1,0 +1,158 @@
+---
+id: repo-branch-worktree-cleanup-phase2
+title: Repo Branch and Worktree Cleanup Phase 2
+type: reference
+owner: codex
+date: 2026-04-23
+status: complete
+author: '@hu3mann'
+last_review: '2026-04-23'
+next_review: '2026-07-22'
+prelude: Phase-2 execution ledger for evidence-backed safe archive cleanup.
+---
+# Repo Branch and Worktree Cleanup Phase 2
+
+**Task packet**: `TP-DMX-REPOHYG-002`  
+**Parent packet**: `TP-DMX-REPOHYG-001`  
+**Execution branch**: `codex/repo-hygiene-phase2-safe-archive-cleanup`  
+**Execution date**: `2026-04-23`
+
+---
+
+## Change Scope
+
+This packet executed only the low-risk subset of the phase-1 `archive` class.
+
+Preserved by rule:
+
+- anything `unknown`
+- anything `merge-first`
+- anything dirty
+- anything closed-unmerged
+- anything owner-ambiguous or out-of-scope
+
+Current-state change from phase 1:
+
+- `codex/repo-hygiene-audit-phase1` now has open PR [#501](https://github.com/DDD-Enterprises/dopemux-mvp/pull/501), so it is explicitly preserved.
+
+---
+
+## Authority Refresh
+
+Observed directly before deletion:
+
+- repo root still resolves to `/Users/hue/code/dopemux-mvp`
+- `.dopetaskroot` still exists
+- `origin` still matches `https://github.com/DDD-Enterprises/dopemux-mvp.git`
+- `gh pr list --state open` returned one open PR: `#501` on `codex/repo-hygiene-audit-phase1`
+
+Implication:
+
+- no cleanup action in phase 2 touched `codex/repo-hygiene-audit-phase1`
+- the phase-2 cleanup set was recomputed from current status, not copied blindly from phase 1
+
+---
+
+## Frozen Cleanup Set
+
+### Removed Worktrees
+
+These remained archive-class and rechecked as clean or detached-clean at execution time:
+
+| Worktree | Prior phase-1 classification | Current recheck | Action |
+| --- | --- | --- | --- |
+| `/private/tmp/dopemux-pr492` | archive | detached, clean | removed |
+| `/private/tmp/dopemux-pr493` | archive | detached, clean | removed |
+| `/private/tmp/dopemux-pr494` | archive | detached, clean | removed |
+| `/private/tmp/dopemux-pr495` | archive | detached, clean | removed |
+| `/private/tmp/dopemux-pr497b` | archive | detached, clean | removed |
+| `/private/tmp/dopemux-pr496` | archive | merged PR branch, clean | removed |
+| `/Users/hue/code/dopemux-mvp-rte-main-integration-audit-staging` | archive | merged branch worktree, clean | removed |
+| `/Users/hue/code/dopemux-mvp-rte-seams-v2` | archive | merged branch worktree, clean | removed |
+| `/Users/hue/code/dopemux-mvp/.worktrees/tp-gh-review-thread-agent` | archive | merged branch worktree, clean | removed |
+
+### Removed Local Branches
+
+| Branch | Reason it remained eligible | Action |
+| --- | --- | --- |
+| `docs/multi-agent-ingress-architecture-revision` | merged PR `#496`, worktree removed, `git branch -d` succeeded | deleted |
+
+### Preserved / Blocked Survivors
+
+These were excluded even if phase 1 called them `archive`:
+
+| Item | Why preserved |
+| --- | --- |
+| `codex/ci-unit-shard-experiment` and `/private/tmp/dopemux-ci-pr` | closed-unmerged PR `#499` |
+| `codex/prompts-prefix-mirror` and `/Users/hue/code/dopemux-extractor-gtm` | owner-ambiguous and out-of-scope GTM worktree |
+| `codex/dopecode-ast-navigation-20260417` and `/Users/hue/code/dopemux-mvp-wt-dopecode-ast` | closed-unmerged PR `#471` |
+| `feat/rte-v5-prescan-contract-unification` and `/Users/hue/code/dopemux-mvp-wt-rte-v5-prescan-contract-unification` | closed-unmerged PR `#470` |
+| `claude/inspiring-nobel-101730`, `claude/optimistic-mayer-6f6e75`, `claude/serene-swirles-f50ab3` | owner-ambiguous assistant worktrees |
+| `tp/rte-full-run-hygiene-and-launch-readiness` | `git branch -d` failed; current branch graph does not prove merged to `origin/main` |
+| `codex/rte-seam-extraction-foundation-v2` | `git branch -d` failed; current branch graph does not prove merged to `origin/main` |
+| `tp/gh-review-thread-agent` | `git branch -d` failed; current branch graph does not prove merged to `origin/main` |
+| `/private/tmp/dopemux-pr467` and `/private/tmp/dopemux-pr480` | broken prunable worktrees from phase 1 remain `unknown` |
+| `/private/tmp/dopemux-pr497` | detached but dirty; preserve |
+
+---
+
+## Exact Cleanup Commands
+
+### Worktree Removal Commands
+
+Executed successfully:
+
+```text
+git worktree remove /private/tmp/dopemux-pr492
+git worktree remove /private/tmp/dopemux-pr493
+git worktree remove /private/tmp/dopemux-pr494
+git worktree remove /private/tmp/dopemux-pr495
+git worktree remove /private/tmp/dopemux-pr497b
+git worktree remove /private/tmp/dopemux-pr496
+git worktree remove /Users/hue/code/dopemux-mvp-rte-main-integration-audit-staging
+git worktree remove /Users/hue/code/dopemux-mvp-rte-seams-v2
+git worktree remove /Users/hue/code/dopemux-mvp/.worktrees/tp-gh-review-thread-agent
+```
+
+### Branch Deletion Commands
+
+Succeeded:
+
+```text
+git branch -d docs/multi-agent-ingress-architecture-revision
+```
+
+Attempted but blocked:
+
+```text
+git branch -d tp/rte-full-run-hygiene-and-launch-readiness
+git branch -d codex/rte-seam-extraction-foundation-v2
+git branch -d tp/gh-review-thread-agent
+```
+
+Blocking result:
+
+- all three returned `error: the branch '<name>' is not fully merged`
+- follow-up ancestor checks against `origin/main` returned `NO`
+- phase 2 therefore did **not** escalate to `git branch -D`
+
+---
+
+## Post-Cleanup State
+
+Observed directly after execution:
+
+- removed worktrees no longer appear in `git worktree list --porcelain`
+- `docs/multi-agent-ingress-architecture-revision` no longer appears in `git branch -vv`
+- blocked branches still exist locally and are called out explicitly
+- pre-existing unrelated local state remains:
+  - modified `AGENTS.md`
+  - untracked `.claude/worktrees/`
+
+---
+
+## Residual Risk
+
+- Phase 2 did not achieve full repo hygiene closure; unknown, merge-first, dirty, closed-unmerged, and owner-ambiguous survivors remain by design.
+- `tp/rte-full-run-hygiene-and-launch-readiness`, `codex/rte-seam-extraction-foundation-v2`, and `tp/gh-review-thread-agent` need a later packet if force-delete is ever proposed.
+- Broken `pr/467` and `pr/480` temp worktrees still require explicit repair/removal handling.

--- a/docs/05-audit-reports/repo-branch-worktree-cleanup-phase3.md
+++ b/docs/05-audit-reports/repo-branch-worktree-cleanup-phase3.md
@@ -1,0 +1,138 @@
+---
+id: repo-branch-worktree-cleanup-phase3
+title: Repo Branch and Worktree Cleanup Phase 3
+type: reference
+owner: codex
+date: 2026-04-23
+status: complete
+author: '@hu3mann'
+last_review: '2026-04-23'
+next_review: '2026-07-22'
+prelude: Phase-3 survivor resolution after phase-2 safe archive cleanup.
+---
+# Repo Branch and Worktree Cleanup Phase 3
+
+**Task packet**: `TP-DMX-REPOHYG-003`  
+**Parent packet**: `TP-DMX-REPOHYG-002`  
+**Execution branch**: `codex/repo-hygiene-phase3-unresolved-survivors`  
+**Execution date**: `2026-04-23`
+
+---
+
+## Scope
+
+Phase 3 revisited only the survivors left after phase 2:
+
+- broken temp worktrees
+- blocked local branches
+- dirty survivors
+- closed-unmerged worktree/branch lines
+- owner-ambiguous assistant and GTM worktrees
+- unresolved `unknown` lines
+
+Current open PR authority at phase-3 start:
+
+- [#501](https://github.com/DDD-Enterprises/dopemux-mvp/pull/501) on `codex/repo-hygiene-audit-phase1`
+- [#502](https://github.com/DDD-Enterprises/dopemux-mvp/pull/502) on `codex/repo-hygiene-phase2-safe-archive-cleanup`
+
+No action in phase 3 touched either open-PR branch.
+
+---
+
+## Refreshed Survivor Classes
+
+### Broken Temp Worktrees
+
+| Item | Current authority | Phase-3 result |
+| --- | --- | --- |
+| `/private/tmp/dopemux-pr467` + `pr/467` | directory existed but was not a valid git worktree; `git worktree remove --force` failed; `git worktree prune --expire now` removed stale admin entry | orphan temp directory removed from filesystem; local branch preserved |
+| `/private/tmp/dopemux-pr480` + `pr/480` | directory existed but was not a valid git worktree; `git worktree remove --force` failed; `git worktree prune --expire now` removed stale admin entry | orphan temp directory removed from filesystem; local branch preserved |
+
+### Blocked Local Branches
+
+These remain blocked because current graph proof still fails:
+
+| Branch | Current proof result | Classification | Action |
+| --- | --- | --- | --- |
+| `tp/rte-full-run-hygiene-and-launch-readiness` | `git merge-base --is-ancestor ... origin/main` => `NO` | blocked / merge-first-adjacent | preserved |
+| `codex/rte-seam-extraction-foundation-v2` | `git merge-base --is-ancestor ... origin/main` => `NO` | blocked / archive-not-delete-safe | preserved |
+| `tp/gh-review-thread-agent` | `git merge-base --is-ancestor ... origin/main` => `NO` | blocked / archive-not-delete-safe | preserved |
+
+### Closed-Unmerged Survivors
+
+| Branch / Worktree | Current authority | Action |
+| --- | --- | --- |
+| `codex/ci-unit-shard-experiment` + `/private/tmp/dopemux-ci-pr` | closed-unmerged PR `#499` | preserved |
+| `codex/dopecode-ast-navigation-20260417` + `/Users/hue/code/dopemux-mvp-wt-dopecode-ast` | closed-unmerged PR `#471`; branch still not ancestor of `origin/main` | preserved |
+| `feat/rte-v5-prescan-contract-unification` + `/Users/hue/code/dopemux-mvp-wt-rte-v5-prescan-contract-unification` | closed-unmerged PR `#470`; branch still not ancestor of `origin/main` | preserved |
+
+### Dirty Survivors
+
+| Worktree | Observed state | Action |
+| --- | --- | --- |
+| `/private/tmp/dopemux-pr497` | detached with modified `task-packets/TP-DMX-AIG-001.md` | preserved |
+| `/Users/hue/code/dopemux-mvp-rte-seams` | modified workflow file and untracked test file | preserved |
+| `/Users/hue/code/dopemux-mvp-worktrees/v1-runtime-proof-linkage` | untracked `.operator/` | preserved |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/gracious-poitras-850e4f` | untracked `.claude/brand-voice-guidelines.md` | preserved |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/rte-decompose` | large dirty implementation set | preserved |
+
+### Owner-Ambiguous Survivors
+
+| Worktree | Why preserved |
+| --- | --- |
+| `/Users/hue/code/dopemux-extractor-gtm` on `codex/prompts-prefix-mirror` | GTM/out-of-scope owner boundary |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/inspiring-nobel-101730` | assistant-owned worktree; no current delete proof |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/optimistic-mayer-6f6e75` | assistant-owned worktree; no current delete proof |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/serene-swirles-f50ab3` | assistant-owned worktree; no current delete proof |
+
+### Unknown Survivors
+
+| Worktree / Branch | Why still unknown |
+| --- | --- |
+| `/Users/hue/code/dopemux-mvp-wt-rte-benchmark-r1` on `codex/rte-benchmark-r1-first-campaign` | no explicit PR or supersession proof gathered in this packet |
+| `/Users/hue/code/dopemux-mvp-wt-serena-audit` on `tp/serena-audit-runtime-io-tools` | no current authority establishing canonical disposition |
+| `/Users/hue/code/dopemux-mvp-wt-serena-fix` on `tp/serena-runtime-fix` | no current authority establishing canonical disposition |
+| `/Users/hue/code/dopemux-mvp-wt-serena-upstream-diff` on `tp/serena-upstream-contract-diff` | no current authority establishing canonical disposition |
+| `/Users/hue/code/dopemux-mvp/.claude/worktrees/rte-structured-outputs-all-providers` on `feat/rte-structured-outputs-all-providers` | no current authority establishing canonical disposition |
+
+---
+
+## Executed Actions
+
+### Attempted but Blocked
+
+```text
+git worktree remove --force /private/tmp/dopemux-pr467
+git worktree remove --force /private/tmp/dopemux-pr480
+```
+
+Both failed with:
+
+```text
+fatal: validation failed, cannot remove working tree: '<path>/.git' does not exist
+```
+
+### Executed Successfully
+
+```text
+git worktree prune --verbose --expire now
+rm -rf /private/tmp/dopemux-pr467
+rm -rf /private/tmp/dopemux-pr480
+```
+
+Observed result:
+
+- `git worktree prune` removed the stale admin entries for `dopemux-pr467` and `dopemux-pr480`
+- both `/private/tmp/dopemux-pr467` and `/private/tmp/dopemux-pr480` were absent after filesystem cleanup
+- local branches `pr/467` and `pr/480` were preserved
+
+No local branch deletion occurred in phase 3.
+
+---
+
+## Residual Risk
+
+- `tp/rte-full-run-hygiene-and-launch-readiness`, `codex/rte-seam-extraction-foundation-v2`, and `tp/gh-review-thread-agent` remain blocked because current graph proof still does not justify deletion.
+- Closed-unmerged branches remain intentionally preserved.
+- Dirty and owner-ambiguous survivors remain unresolved by design.
+- `unknown` lines are still unknown; phase 3 did not invent deletion proof where none existed.

--- a/docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md
+++ b/docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md
@@ -1,0 +1,272 @@
+---
+id: rte-prelive-audit-pack-2026-04-23
+title: RTE Pre-Live Audit Pack
+type: reference
+owner: codex
+date: 2026-04-23
+status: complete
+author: '@codex'
+last_review: '2026-04-23'
+next_review: '2026-07-22'
+prelude: Deterministic pre-live Repo Truth Extractor audit pack for GPT-5.4 Pro review.
+---
+# RTE Pre-Live Audit Pack
+
+**Task packet**: `TP-DMX-RTEAUDIT-001`  
+**Audit date**: `2026-04-23`  
+**Execution branch**: `codex/rte-audit-pack-assembly`  
+**Target reviewer**: `GPT-5.4 Pro`  
+**Scope**: assemble evidence only; no live RTE execution
+
+---
+
+## 1. Repo Identity And Scope Guard
+
+Observed directly in this checkout:
+
+- Repo root resolves to `/Users/hue/code/dopemux-mvp`
+- `.dopetaskroot` exists at repo root
+- `origin` remote is `https://github.com/DDD-Enterprises/dopemux-mvp.git`
+- Current execution branch for this packet is `codex/rte-audit-pack-assembly`
+
+Working constraints honored:
+
+- No runtime code, service code, prompt content, or production config was edited for this packet
+- No live repo-truth-extractor run was executed
+- This pack uses runtime code, registries, tests, emitted artifacts, and existing proofs as evidence
+- Documentation-only claims are called out separately from code-path evidence
+
+Current worktree drift observed before this packet:
+
+- Modified `AGENTS.md`
+- Modified `task-packets/INDEX.md`
+- Untracked `.claude/worktrees/`
+- Untracked `docs/05-audit-reports/repo-branch-worktree-cleanup-phase3.md`
+- Untracked `task-packets/TP-DMX-REPOHYG-003.json`
+
+This packet does not normalize or overwrite that unrelated state.
+
+---
+
+## 2. Authority Used
+
+### 2.1 Runtime Code Authority
+
+- Canonical RTE runtime entrypoint: `services/repo-truth-extractor/run_extraction_v5.py`
+- Compatibility runtime: `services/repo-truth-extractor/run_extraction_v4.py`
+- Launch gate validator: `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+- Prescan runtime prompt source: `services/repo-truth-extractor/lib/prescan/grok_passes.py`
+
+### 2.2 Prompt And Registry Authority
+
+- Canonical v4 promptset manifest: `services/repo-truth-extractor/promptsets/v4/promptset.yaml`
+- Canonical phase-SP registry: `services/repo-truth-extractor/prompts/phase_s/registry.json`
+- Canonical prescan governance registry: `services/repo-truth-extractor/prompts/prescan/registry.json`
+
+### 2.3 Test Authority
+
+- `tests/unit/test_repo_truth_extractor_prompt_governance.py`
+- `tests/unit/test_prescan_online_gate.py`
+
+### 2.4 Existing Audit And Proof Context
+
+- `docs/03-reference/systems/repo-truth-extractor/system-repotruthextractor.md`
+- `services/repo-truth-extractor/README.md`
+- `docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md`
+- `docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md`
+- `proof/repo-branch-worktree-cleanup-phase2.proof.json`
+- `proof/rte-provider-preflight-scope-truth-hardening.proof.json`
+- `proof/rte-doctor-diagnostic-clarity-and-final-launch-gate-review.proof.json`
+- `reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_VERDICT.json`
+- `services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/{RUN_MANIFEST.json,PHASE_GATE_DECISION.json,RUN_ROUTING_FINGERPRINT.json}`
+
+### 2.5 Named-But-Absent Or Drifted Authority
+
+The repo-level `AGENTS.md` still names these truth-doc paths as available:
+
+- `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_SYSTEMS.md`
+- `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_CANONICALS.md`
+- `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_GAPS.md`
+
+Those exact paths were not present in this checkout during this packet. They were therefore not used as authority.
+
+---
+
+## 3. Canonical Runtime And Launch Surfaces
+
+### 3.1 Canonical Runtime
+
+Observed directly:
+
+- `services/repo-truth-extractor/run_extraction_v5.py` is the strongest execution authority for current RTE runs
+- `docs/03-reference/systems/repo-truth-extractor/system-repotruthextractor.md` aligns with that code-path and classifies v4 as compatibility and v3 as legacy/fallback
+- `run_extraction_v5.py` imports promptset, routing, output layout, reporting, phase wrappers, and LLM runtime surfaces directly, which makes it the canonical launch-relevant orchestration surface
+
+### 3.2 Compatibility And Drift Surfaces
+
+- `services/repo-truth-extractor/run_extraction_v4.py`: compatibility writer preserving v4 prompt/artifact contracts while delegating supported execution to v5
+- `services/repo-truth-extractor/README.md`: documentation surface that broadly matches v5 authority, but remains documentation-only and can drift from runtime
+- `dopemux extractor` references described in docs are not treated here as canonical runtime because runtime truth is centered in the v5 runner and validator code
+
+### 3.3 Launch-Relevant Open PRs
+
+Observed directly from `gh pr list --state open --limit 20` on `2026-04-23`:
+
+- PR `#502`: `docs(audit): execute phase2 safe archive cleanup` on `codex/repo-hygiene-phase2-safe-archive-cleanup`
+- PR `#501`: `docs(repo-hygiene): audit branches and worktrees, add cleanup plan` on `codex/repo-hygiene-audit-phase1`
+
+Observed directly:
+
+- No open PR in the sampled remote set is an RTE runtime or prompt change PR
+- The open PRs are hygiene/documentation-adjacent and still matter to launch readiness because repo cleanup state can affect operator trust and audit clarity
+
+---
+
+## 4. Prompt Surface Classification
+
+This section classifies only prompt surfaces that materially affect current RTE execution or launch gating.
+
+| Surface | Classification | Why it belongs in the pack | Code-path evidence |
+| --- | --- | --- | --- |
+| `services/repo-truth-extractor/promptsets/v4/promptset.yaml` | canonical | Declares active v4 prompt/artifact contract consumed by runtime and validator | Referenced by `run_extraction_v4.py`, `validate_pre_live_gate_v25.py`, and snapshot tests |
+| `services/repo-truth-extractor/promptsets/v4/prompts/` | canonical | Contains the main phase prompt files enumerated into current run manifests | `RUN_MANIFEST.json` for `run_20260418T040217Z` lists these prompt files |
+| `services/repo-truth-extractor/prompts/phase_s/registry.json` | canonical | Governs SP post-review registry-driven prompts and outputs | Verified by `tests/unit/test_repo_truth_extractor_prompt_governance.py` |
+| `services/repo-truth-extractor/prompts/phase_s/PROMPT_SP11_CONTRACT_LINTER.md` | canonical | High-value launch-relevant contract-lint prompt referenced by registry and snapshot tests | Registry and validator-suite snapshot test reference it directly |
+| `services/repo-truth-extractor/prompts/prescan/registry.json` | canonical_governance | Canonical governance metadata for prescan steps, schemas, and intended providers | Verified by `tests/unit/test_repo_truth_extractor_prompt_governance.py` |
+| `services/repo-truth-extractor/lib/prescan/grok_passes.py` | canonical_runtime | Actual prescan system prompt constants and online gating logic live here, not in markdown prompt files | Verified by `tests/unit/test_prescan_online_gate.py` and governance test |
+| `services/repo-truth-extractor/prompts/phase_fl_int/registry.json` | compatibility | Present as a registry population checked by governance tests, but not demonstrated here as the canonical first-live runtime path | Governance test checks presence; no stronger launch-path proof assembled in this packet |
+| `services/repo-truth-extractor/prompts/phase_s_int/registry.json` | compatibility | Same status as `phase_fl_int`; registry exists and is tested, but this packet does not prove it as the canonical pre-live path | Governance test checks presence; canonicality not elevated here |
+| `audit_prep/*` bundles and `audit_inputs/*` seeds | drifted | Useful historical/operator prep material, but not shown as active runtime prompt authority | Located in repo, not referenced by current v5 runtime evidence in this packet |
+| `docs/archive/**/prompt*` | drifted | Historical prompt materials; inclusion would add noise and authority confusion | Archive location signals non-canonical status |
+| `services/repo-truth-extractor/README.md` prompt examples | documentation_only | Helpful operator guidance, but not canonical prompt authority | README is prose, not prompt registry/runtime |
+| Any `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_*.md` prompt-related inference | unknown | Named by AGENTS, absent in checkout | Files not present |
+
+Key observed drift:
+
+- `services/repo-truth-extractor/prompts/prescan/registry.json` says prescan prompts are Python constants in `lib/prescan/grok_passes.py`; therefore the registry is governance metadata, not the canonical prompt text source
+- `reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_VERDICT.json` records `repo_drift_tests` failure in `services/repo-truth-extractor/tests/test_promptset_v4_lint.py` because prescan constants were reported as not found even though `_DEDUP_SYSTEM_PROMPT`, `_DISCOVER_SYSTEM_PROMPT`, `_FEASIBILITY_SYSTEM_PROMPT`, and `_OPTIMIZE_SYSTEM_PROMPT` are present in `lib/prescan/grok_passes.py`
+
+That mismatch is preserved as current launch-relevant drift, not normalized away.
+
+---
+
+## 5. Recommended Upload Set
+
+This set is intentionally bounded for ChatGPT Project upload use. It favors canonical runtime, compact registries/manifests, targeted tests, current run evidence, and current gate evidence.
+
+### 5.1 Upload Set A: Core Runtime And Prompt Contract
+
+1. `services/repo-truth-extractor/run_extraction_v5.py`
+2. `services/repo-truth-extractor/run_extraction_v4.py`
+3. `services/repo-truth-extractor/validate_pre_live_gate_v25.py`
+4. `services/repo-truth-extractor/promptsets/v4/promptset.yaml`
+5. `services/repo-truth-extractor/prompts/phase_s/registry.json`
+6. `services/repo-truth-extractor/prompts/prescan/registry.json`
+7. `services/repo-truth-extractor/lib/prescan/grok_passes.py`
+
+### 5.2 Upload Set B: Targeted Tests
+
+8. `tests/unit/test_repo_truth_extractor_prompt_governance.py`
+9. `tests/unit/test_prescan_online_gate.py`
+
+### 5.3 Upload Set C: Current Launch Evidence
+
+10. `reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_VERDICT.json`
+11. `services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_MANIFEST.json`
+12. `services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_GATE_DECISION.json`
+13. `services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_ROUTING_FINGERPRINT.json`
+
+### 5.4 Upload Set D: Compact Context
+
+14. `docs/03-reference/systems/repo-truth-extractor/system-repotruthextractor.md`
+15. `proof/rte-provider-preflight-scope-truth-hardening.proof.json`
+16. `proof/rte-doctor-diagnostic-clarity-and-final-launch-gate-review.proof.json`
+17. `docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md`
+
+Recommended use:
+
+- Upload Set A+B+C as the minimum launch-review pack
+- Add Set D only if the review needs compact narrative context or prior hardening provenance
+
+Not recommended for the first upload:
+
+- Full prompt directories beyond the active registries and manifests
+- Archive prompt bundles
+- Large historical run trees
+- Proofs unrelated to current launch readiness
+
+---
+
+## 6. Deterministic File Inventory
+
+Each included file below has a stated reason and an upload recommendation.
+
+| Path | Authority class | Reason for inclusion | Upload to GPT-5.4 Pro |
+| --- | --- | --- | --- |
+| `services/repo-truth-extractor/run_extraction_v5.py` | canonical_runtime | Strongest execution authority for current RTE launch behavior | yes |
+| `services/repo-truth-extractor/run_extraction_v4.py` | compatibility_runtime | Shows current compatibility layer and v4 contract preservation boundary | yes |
+| `services/repo-truth-extractor/validate_pre_live_gate_v25.py` | canonical_gate | Defines the bounded pre-live validator used by first-live flows | yes |
+| `services/repo-truth-extractor/promptsets/v4/promptset.yaml` | canonical_prompt_contract | Declares active promptset contract and phase/step outputs | yes |
+| `services/repo-truth-extractor/prompts/phase_s/registry.json` | canonical_prompt_registry | Direct registry authority for SP prompt steps and outputs | yes |
+| `services/repo-truth-extractor/prompts/prescan/registry.json` | canonical_governance_registry | Governs prescan step metadata and explains registry-vs-runtime split | yes |
+| `services/repo-truth-extractor/lib/prescan/grok_passes.py` | canonical_runtime_prompt_source | Holds real prescan prompt constants and online gate enforcement | yes |
+| `tests/unit/test_repo_truth_extractor_prompt_governance.py` | canonical_test | Verifies prompt registry population, prompt existence, and deterministic snapshot behavior | yes |
+| `tests/unit/test_prescan_online_gate.py` | canonical_test | Verifies online gate behavior for prescan runtime | yes |
+| `reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_VERDICT.json` | emitted_launch_evidence | Current no-go gate evidence for provider and drift blockers | yes |
+| `services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_MANIFEST.json` | emitted_run_evidence | Shows prompt files, routing summary, output layout, and dry-run state for a recent first-live preset run | yes |
+| `services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_GATE_DECISION.json` | emitted_run_evidence | Compact gate outcome for the recent first-live preset run | yes |
+| `services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_ROUTING_FINGERPRINT.json` | emitted_run_evidence | Detailed per-step routing and prompt-file mapping evidence | yes |
+| `docs/03-reference/systems/repo-truth-extractor/system-repotruthextractor.md` | documentation_context | Concise current reference doc that largely matches runtime authority | optional |
+| `proof/rte-provider-preflight-scope-truth-hardening.proof.json` | prior_hardening_proof | Shows earlier proof about run-scoped provider preflight authority boundaries | optional |
+| `proof/rte-doctor-diagnostic-clarity-and-final-launch-gate-review.proof.json` | prior_hardening_proof | Shows earlier proof separating diagnostic doctor artifacts from launch authority | optional |
+| `docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md` | repo_hygiene_context | Compact evidence that open hygiene PRs are docs-only and bounded | optional |
+
+---
+
+## 7. Current Launch-Relevant Drift
+
+Observed directly from current evidence:
+
+1. `VALIDATION_VERDICT.json` records `operator_verdict = NO_GO_EXTERNAL` and `verdict = NO_GO` for `pre_live_gate_v25_20260418T031822Z`.
+2. The same verdict records a P0 `ONLINE_PREFLIGHT_FAILURE` for `openrouter:openai/gpt-5.4` with HTTP `402` and quota/billing classification.
+3. The same verdict records a repo drift failure in `services/repo-truth-extractor/tests/test_promptset_v4_lint.py` tied to prescan prompt constant discovery.
+4. `PHASE_GATE_DECISION.json` for `run_20260418T040217Z` is `BLOCKED`, with `provider_preflight_status = FAIL` and phase sequence `A,H,D,C`.
+5. `RUN_MANIFEST.json` for `run_20260418T040217Z` is a dry-run artifact with `preset = first-live`, `routing_policy = cost`, and `blocked_promptset = false`; it is useful launch evidence but not proof of a successful live run.
+6. `AGENTS.md` still points to absent truth-doc paths under `tmp/dmx-chatgpt-project-truth-extraction-002/`, which is documentation drift in the repo’s operator-control layer.
+
+None of these contradictions were normalized away in this packet.
+
+---
+
+## 8. Code-Path Evidence vs Documentation Claims
+
+### 8.1 Code-Path Evidence
+
+- `run_extraction_v5.py` is the canonical runtime authority
+- `validate_pre_live_gate_v25.py` is the bounded launch gate authority for pre-live validation
+- `grok_passes.py` contains the actual prescan system prompt constants and online gating logic
+- Registry and prompt governance tests directly verify active registry surfaces
+- Current `VALIDATION_VERDICT.json`, `RUN_MANIFEST.json`, `PHASE_GATE_DECISION.json`, and `RUN_ROUTING_FINGERPRINT.json` are emitted evidence artifacts from prior executions
+
+### 8.2 Documentation-Only Claims
+
+- `system-repotruthextractor.md` and `README.md` are useful summaries, but they do not outrank runtime code or emitted run artifacts
+- Open hygiene PRs indicate cleanup work in flight, but they do not by themselves alter RTE runtime authority
+
+---
+
+## 9. Audit Judgment
+
+This pack is ready for a bounded GPT-5.4 Pro pre-live review because:
+
+- it is grounded in the current runtime entrypoint, validator, prompt contracts, registries, tests, and emitted launch artifacts
+- each included file has an explicit reason for inclusion
+- canonical, compatibility, drifted, and unknown prompt surfaces are separated
+- the upload recommendation is small enough for a ChatGPT Project workflow
+
+This pack is not evidence of live-launch readiness. Current emitted evidence still shows:
+
+- provider/billing blockage for the sampled `openrouter:openai/gpt-5.4` live preflight path
+- repo drift around prescan prompt linting
+- absent named truth-doc paths in repo-level operator guidance
+

--- a/proof/repo-branch-worktree-audit-2026-04-23.proof.json
+++ b/proof/repo-branch-worktree-audit-2026-04-23.proof.json
@@ -1,0 +1,288 @@
+{
+  "audit_id": "repo-branch-worktree-audit-2026-04-23",
+  "task_packet_id": "TP-DMX-REPOHYG-001",
+  "audit_date": "2026-04-23",
+  "phase": "phase1-non-destructive",
+  "execution_branch": "codex/repo-hygiene-audit-phase1",
+  "repo_identity": {
+    "repo_root": "/Users/hue/code/dopemux-mvp",
+    "repo_marker_present": true,
+    "origin_remote": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "origin_identity_match": true,
+    "out_of_scope_remotes": [
+      "git@github.com:DDD-Enterprises/dopemux-extractor-gtm.git"
+    ]
+  },
+  "authority_used": {
+    "files": [
+      "/Users/hue/code/dopemux-mvp/AGENTS.md",
+      "/Users/hue/code/dopemux-mvp/task-packets/INDEX.md"
+    ],
+    "commands": [
+      "git rev-parse --show-toplevel",
+      "test -f .dopetaskroot",
+      "git remote -v",
+      "git branch --format='%(refname:short) %(upstream:short) %(objectname:short)'",
+      "git branch -vv",
+      "git worktree list --porcelain",
+      "git status --short --branch",
+      "gh pr list --state open --json number,headRefName,baseRefName,title,url",
+      "gh pr list --limit 200 --state all --json number,title,state,isDraft,headRefName,baseRefName,createdAt,updatedAt,closedAt,mergedAt,url,author",
+      "git for-each-ref --sort=committerdate --format='%(refname:short)|%(upstream:short)|%(objectname:short)|%(committerdate:iso8601)|%(subject)' refs/heads refs/remotes/origin"
+    ],
+    "drift": [
+      {
+        "path": "tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_CANONICALS.md",
+        "status": "not_present_in_checkout"
+      },
+      {
+        "path": "tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_GAPS.md",
+        "status": "not_present_in_checkout"
+      },
+      {
+        "path": "tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_SYSTEMS.md",
+        "status": "not_present_in_checkout"
+      }
+    ]
+  },
+  "remote_state": {
+    "open_prs": [],
+    "recent_pr_heads": {
+      "merged": [
+        {
+          "number": 500,
+          "head": "codex/pal-sse-wrapper",
+          "base": "main"
+        },
+        {
+          "number": 497,
+          "head": "codex/phase0",
+          "base": "main"
+        },
+        {
+          "number": 496,
+          "head": "docs/multi-agent-ingress-architecture-revision",
+          "base": "main"
+        },
+        {
+          "number": 495,
+          "head": "design/wave7-rte-ui-contract",
+          "base": "main"
+        },
+        {
+          "number": 481,
+          "head": "tp/dopecode-phase8-events-replay",
+          "base": "main"
+        },
+        {
+          "number": 480,
+          "head": "feat/rte-prescan-stage0-live-lane-proving",
+          "base": "main"
+        },
+        {
+          "number": 465,
+          "head": "tp/gh-review-thread-agent",
+          "base": "main"
+        },
+        {
+          "number": 461,
+          "head": "tp/rte-full-run-hygiene-and-launch-readiness",
+          "base": "main"
+        }
+      ],
+      "closed_unmerged": [
+        {
+          "number": 499,
+          "head": "codex/ci-unit-shard-experiment",
+          "base": "codex/ci-fast-unit-gate"
+        },
+        {
+          "number": 471,
+          "head": "codex/dopecode-ast-navigation-20260417",
+          "base": "main"
+        },
+        {
+          "number": 470,
+          "head": "feat/rte-v5-prescan-contract-unification",
+          "base": "main"
+        },
+        {
+          "number": 469,
+          "head": "tp/dopecode-ast-navigation",
+          "base": "main"
+        },
+        {
+          "number": 468,
+          "head": "tp/serena-tool-surface-audit",
+          "base": "main"
+        },
+        {
+          "number": 467,
+          "head": "feat/rte-prescan-first-live-hardening",
+          "base": "main"
+        },
+        {
+          "number": 477,
+          "head": "tp/dopecode-phase3-decompose-policy",
+          "base": "main"
+        },
+        {
+          "number": 474,
+          "head": "tp/dopecode-phase3-decompose-policy",
+          "base": "main"
+        },
+        {
+          "number": 476,
+          "head": "tp/dopecode-phase4-language-approval",
+          "base": "main"
+        },
+        {
+          "number": 473,
+          "head": "tp/dopecode-phase2-harden",
+          "base": "main"
+        }
+      ]
+    },
+    "naming_clusters": [
+      "codex/",
+      "tp/",
+      "feat/",
+      "docs/",
+      "design/",
+      "bundle/",
+      "copilot/",
+      "dependabot/",
+      "palette/",
+      "rescue/",
+      "prmerge/"
+    ],
+    "delete_remote_recommendations": []
+  },
+  "local_state": {
+    "branch_count": 55,
+    "worktree_count": 26,
+    "detached_worktree_count": 6,
+    "prunable_worktree_count": 2,
+    "dirty_worktree_count": 7,
+    "worktrees": [
+      {
+        "path": "/Users/hue/code/dopemux-mvp",
+        "branch": "codex/repo-hygiene-audit-phase1",
+        "state": "dirty",
+        "recommendation": "keep"
+      },
+      {
+        "path": "/private/tmp/dopemux-pr467",
+        "branch": "pr/467",
+        "state": "prunable_broken",
+        "recommendation": "unknown"
+      },
+      {
+        "path": "/private/tmp/dopemux-pr480",
+        "branch": "pr/480",
+        "state": "prunable_broken",
+        "recommendation": "unknown"
+      },
+      {
+        "path": "/private/tmp/dopemux-pr497",
+        "branch": null,
+        "state": "detached_dirty",
+        "recommendation": "keep"
+      },
+      {
+        "path": "/Users/hue/code/dopemux-mvp-rte-seams",
+        "branch": "codex/rte-seam-extraction-foundation",
+        "state": "dirty",
+        "recommendation": "keep"
+      },
+      {
+        "path": "/Users/hue/code/dopemux-mvp-worktrees/v1-runtime-proof-linkage",
+        "branch": "codex/v1-runtime-proof-linkage",
+        "state": "dirty_stale",
+        "recommendation": "archive"
+      },
+      {
+        "path": "/Users/hue/code/dopemux-mvp/.claude/worktrees/gracious-poitras-850e4f",
+        "branch": "claude/gracious-poitras-850e4f",
+        "state": "dirty_stale",
+        "recommendation": "archive"
+      },
+      {
+        "path": "/Users/hue/code/dopemux-mvp/.claude/worktrees/rte-decompose",
+        "branch": "refactor/rte-decompose-snapshot",
+        "state": "dirty_large_delta",
+        "recommendation": "keep"
+      }
+    ]
+  },
+  "recommendation_ledger": [
+    {
+      "subject": "codex/ci-unit-shard-experiment",
+      "domain": "branch",
+      "recommendation": "archive",
+      "reason": "Closed-unmerged PR #499 with clean attached worktree",
+      "blocking_risk": "Local worktree exists"
+    },
+    {
+      "subject": "design/wave7-rte-ui-contract",
+      "domain": "branch",
+      "recommendation": "merge-first",
+      "reason": "Merged PR lineage but local branch is ahead 1 and behind 14",
+      "blocking_risk": "Diverged local branch"
+    },
+    {
+      "subject": "codex/phase0",
+      "domain": "branch",
+      "recommendation": "merge-first",
+      "reason": "Merged PR #497 but local branch remains ahead 1 and behind 4",
+      "blocking_risk": "Diverged local branch"
+    },
+    {
+      "subject": "feat/rte-prescan-first-live-hardening",
+      "domain": "branch",
+      "recommendation": "archive",
+      "reason": "Closed-unmerged PR #467 and broken temp worktree line still exists",
+      "blocking_risk": "Prunable broken worktree"
+    },
+    {
+      "subject": "/private/tmp/dopemux-pr496",
+      "domain": "worktree",
+      "recommendation": "archive",
+      "reason": "Merged PR #496 worktree still mounted",
+      "blocking_risk": "Needs explicit follow-up removal"
+    },
+    {
+      "subject": "/private/tmp/dopemux-pr492",
+      "domain": "worktree",
+      "recommendation": "archive",
+      "reason": "Detached checkout at merged PR head with no local changes observed",
+      "blocking_risk": "Detached state"
+    },
+    {
+      "subject": "/Users/hue/code/dopemux-mvp-rte-main-integration-audit-staging",
+      "domain": "worktree",
+      "recommendation": "archive",
+      "reason": "Merged PR #461 branch still mounted and upstream is gone",
+      "blocking_risk": "Follow-up must remove worktree first"
+    },
+    {
+      "subject": "tp/serena-audit-runtime-io-tools",
+      "domain": "branch",
+      "recommendation": "unknown",
+      "reason": "No definitive recent PR disposition established by available evidence",
+      "blocking_risk": "Owner review required"
+    }
+  ],
+  "phase1_constraints_honored": {
+    "deleted_local_branches": false,
+    "deleted_remote_branches": false,
+    "deleted_worktrees": false,
+    "runtime_or_service_code_modified": false,
+    "production_config_modified": false
+  },
+  "residual_risk": [
+    "No branch met the proof standard for delete-remote in phase 1.",
+    "Several clean worktrees remain unknown because current evidence does not establish final branch disposition.",
+    "Pre-existing dirty state means any execution packet must re-run status collection before acting."
+  ]
+}

--- a/proof/repo-branch-worktree-cleanup-phase2.proof.json
+++ b/proof/repo-branch-worktree-cleanup-phase2.proof.json
@@ -1,0 +1,199 @@
+{
+  "cleanup_id": "repo-branch-worktree-cleanup-phase2",
+  "task_packet_id": "TP-DMX-REPOHYG-002",
+  "parent_task_packet_id": "TP-DMX-REPOHYG-001",
+  "execution_date": "2026-04-23",
+  "execution_branch": "codex/repo-hygiene-phase2-safe-archive-cleanup",
+  "repo_identity": {
+    "repo_root": "/Users/hue/code/dopemux-mvp",
+    "repo_marker_present": true,
+    "origin_remote": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "origin_identity_match": true
+  },
+  "phase1_reference": {
+    "audit_doc": "/Users/hue/code/dopemux-mvp/docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+    "audit_proof": "/Users/hue/code/dopemux-mvp/proof/repo-branch-worktree-audit-2026-04-23.proof.json",
+    "audit_packet": "/Users/hue/code/dopemux-mvp/task-packets/TP-DMX-REPOHYG-001.json"
+  },
+  "authority_refresh": {
+    "open_prs": [
+      {
+        "number": 501,
+        "head": "codex/repo-hygiene-audit-phase1",
+        "base": "main",
+        "title": "docs(repo-hygiene): audit branches and worktrees, add cleanup plan",
+        "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/501"
+      }
+    ],
+    "current_branch_before_cleanup": "codex/repo-hygiene-audit-phase1",
+    "phase2_branch_created": "codex/repo-hygiene-phase2-safe-archive-cleanup",
+    "preserved_due_to_current_authority": [
+      "codex/repo-hygiene-audit-phase1"
+    ]
+  },
+  "frozen_cleanup_set": {
+    "worktrees_to_remove": [
+      "/private/tmp/dopemux-pr492",
+      "/private/tmp/dopemux-pr493",
+      "/private/tmp/dopemux-pr494",
+      "/private/tmp/dopemux-pr495",
+      "/private/tmp/dopemux-pr497b",
+      "/private/tmp/dopemux-pr496",
+      "/Users/hue/code/dopemux-mvp-rte-main-integration-audit-staging",
+      "/Users/hue/code/dopemux-mvp-rte-seams-v2",
+      "/Users/hue/code/dopemux-mvp/.worktrees/tp-gh-review-thread-agent"
+    ],
+    "branches_to_try_delete_with_d": [
+      "docs/multi-agent-ingress-architecture-revision",
+      "tp/rte-full-run-hygiene-and-launch-readiness",
+      "codex/rte-seam-extraction-foundation-v2",
+      "tp/gh-review-thread-agent"
+    ],
+    "excluded_survivors": [
+      {
+        "item": "codex/ci-unit-shard-experiment",
+        "reason": "closed-unmerged PR #499"
+      },
+      {
+        "item": "codex/prompts-prefix-mirror",
+        "reason": "owner-ambiguous GTM worktree"
+      },
+      {
+        "item": "codex/dopecode-ast-navigation-20260417",
+        "reason": "closed-unmerged PR #471"
+      },
+      {
+        "item": "feat/rte-v5-prescan-contract-unification",
+        "reason": "closed-unmerged PR #470"
+      },
+      {
+        "item": "claude/inspiring-nobel-101730",
+        "reason": "owner-ambiguous assistant worktree"
+      },
+      {
+        "item": "claude/optimistic-mayer-6f6e75",
+        "reason": "owner-ambiguous assistant worktree"
+      },
+      {
+        "item": "claude/serene-swirles-f50ab3",
+        "reason": "owner-ambiguous assistant worktree"
+      }
+    ]
+  },
+  "worktree_removals": [
+    {
+      "command": "git worktree remove /private/tmp/dopemux-pr492",
+      "exit_code": 0
+    },
+    {
+      "command": "git worktree remove /private/tmp/dopemux-pr493",
+      "exit_code": 0
+    },
+    {
+      "command": "git worktree remove /private/tmp/dopemux-pr494",
+      "exit_code": 0
+    },
+    {
+      "command": "git worktree remove /private/tmp/dopemux-pr495",
+      "exit_code": 0
+    },
+    {
+      "command": "git worktree remove /private/tmp/dopemux-pr497b",
+      "exit_code": 0
+    },
+    {
+      "command": "git worktree remove /private/tmp/dopemux-pr496",
+      "exit_code": 0
+    },
+    {
+      "command": "git worktree remove /Users/hue/code/dopemux-mvp-rte-main-integration-audit-staging",
+      "exit_code": 0
+    },
+    {
+      "command": "git worktree remove /Users/hue/code/dopemux-mvp-rte-seams-v2",
+      "exit_code": 0
+    },
+    {
+      "command": "git worktree remove /Users/hue/code/dopemux-mvp/.worktrees/tp-gh-review-thread-agent",
+      "exit_code": 0
+    }
+  ],
+  "branch_delete_attempts": [
+    {
+      "command": "git branch -d docs/multi-agent-ingress-architecture-revision",
+      "exit_code": 0,
+      "result": "deleted"
+    },
+    {
+      "command": "git branch -d tp/rte-full-run-hygiene-and-launch-readiness",
+      "exit_code": 1,
+      "result": "blocked_not_fully_merged"
+    },
+    {
+      "command": "git branch -d codex/rte-seam-extraction-foundation-v2",
+      "exit_code": 1,
+      "result": "blocked_not_fully_merged"
+    },
+    {
+      "command": "git branch -d tp/gh-review-thread-agent",
+      "exit_code": 1,
+      "result": "blocked_not_fully_merged"
+    }
+  ],
+  "ancestor_checks_after_block": [
+    {
+      "branch": "tp/rte-full-run-hygiene-and-launch-readiness",
+      "against": "origin/main",
+      "is_ancestor": false
+    },
+    {
+      "branch": "codex/rte-seam-extraction-foundation-v2",
+      "against": "origin/main",
+      "is_ancestor": false
+    },
+    {
+      "branch": "tp/gh-review-thread-agent",
+      "against": "origin/main",
+      "is_ancestor": false
+    }
+  ],
+  "post_cleanup_state": {
+    "removed_worktrees_absent_from_inventory": [
+      "/private/tmp/dopemux-pr492",
+      "/private/tmp/dopemux-pr493",
+      "/private/tmp/dopemux-pr494",
+      "/private/tmp/dopemux-pr495",
+      "/private/tmp/dopemux-pr497b",
+      "/private/tmp/dopemux-pr496",
+      "/Users/hue/code/dopemux-mvp-rte-main-integration-audit-staging",
+      "/Users/hue/code/dopemux-mvp-rte-seams-v2",
+      "/Users/hue/code/dopemux-mvp/.worktrees/tp-gh-review-thread-agent"
+    ],
+    "deleted_local_branches": [
+      "docs/multi-agent-ingress-architecture-revision"
+    ],
+    "blocked_local_branches": [
+      "tp/rte-full-run-hygiene-and-launch-readiness",
+      "codex/rte-seam-extraction-foundation-v2",
+      "tp/gh-review-thread-agent"
+    ],
+    "pre_existing_unrelated_state": [
+      "M AGENTS.md",
+      "?? .claude/worktrees/"
+    ]
+  },
+  "constraints_honored": {
+    "no_runtime_code_modified": true,
+    "no_service_code_modified": true,
+    "no_production_config_modified": true,
+    "no_remote_branches_deleted": true,
+    "unknown_items_preserved": true,
+    "merge_first_items_preserved": true,
+    "dirty_items_preserved": true
+  },
+  "residual_risk": [
+    "Phase 2 is incomplete by design; blocked and unknown survivors remain.",
+    "The three blocked local branches were not force-deleted because current graph proof against origin/main failed.",
+    "Broken temp worktrees pr/467 and pr/480 remain unresolved."
+  ]
+}

--- a/proof/repo-branch-worktree-cleanup-phase3.proof.json
+++ b/proof/repo-branch-worktree-cleanup-phase3.proof.json
@@ -1,0 +1,164 @@
+{
+  "cleanup_id": "repo-branch-worktree-cleanup-phase3",
+  "task_packet_id": "TP-DMX-REPOHYG-003",
+  "parent_task_packet_id": "TP-DMX-REPOHYG-002",
+  "execution_date": "2026-04-23",
+  "execution_branch": "codex/repo-hygiene-phase3-unresolved-survivors",
+  "repo_identity": {
+    "repo_root": "/Users/hue/code/dopemux-mvp",
+    "repo_marker_present": true,
+    "origin_remote": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "origin_identity_match": true
+  },
+  "open_pr_authority": [
+    {
+      "number": 501,
+      "head": "codex/repo-hygiene-audit-phase1",
+      "base": "main",
+      "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/501"
+    },
+    {
+      "number": 502,
+      "head": "codex/repo-hygiene-phase2-safe-archive-cleanup",
+      "base": "main",
+      "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/502"
+    }
+  ],
+  "refreshed_classes": {
+    "broken_temp_worktrees": [
+      {
+        "path": "/private/tmp/dopemux-pr467",
+        "branch": "pr/467",
+        "class": "broken-prunable",
+        "branch_deleted": false
+      },
+      {
+        "path": "/private/tmp/dopemux-pr480",
+        "branch": "pr/480",
+        "class": "broken-prunable",
+        "branch_deleted": false
+      }
+    ],
+    "blocked_branches": [
+      "tp/rte-full-run-hygiene-and-launch-readiness",
+      "codex/rte-seam-extraction-foundation-v2",
+      "tp/gh-review-thread-agent"
+    ],
+    "closed_unmerged_survivors": [
+      "codex/ci-unit-shard-experiment",
+      "codex/dopecode-ast-navigation-20260417",
+      "feat/rte-v5-prescan-contract-unification"
+    ],
+    "dirty_survivors": [
+      "/private/tmp/dopemux-pr497",
+      "/Users/hue/code/dopemux-mvp-rte-seams",
+      "/Users/hue/code/dopemux-mvp-worktrees/v1-runtime-proof-linkage",
+      "/Users/hue/code/dopemux-mvp/.claude/worktrees/gracious-poitras-850e4f",
+      "/Users/hue/code/dopemux-mvp/.claude/worktrees/rte-decompose"
+    ],
+    "owner_ambiguous_survivors": [
+      "/Users/hue/code/dopemux-extractor-gtm",
+      "/Users/hue/code/dopemux-mvp/.claude/worktrees/inspiring-nobel-101730",
+      "/Users/hue/code/dopemux-mvp/.claude/worktrees/optimistic-mayer-6f6e75",
+      "/Users/hue/code/dopemux-mvp/.claude/worktrees/serene-swirles-f50ab3"
+    ],
+    "unknown_survivors": [
+      "codex/rte-benchmark-r1-first-campaign",
+      "tp/serena-audit-runtime-io-tools",
+      "tp/serena-runtime-fix",
+      "tp/serena-upstream-contract-diff",
+      "feat/rte-structured-outputs-all-providers"
+    ]
+  },
+  "graph_checks": [
+    {
+      "branch": "tp/rte-full-run-hygiene-and-launch-readiness",
+      "against": "origin/main",
+      "is_ancestor": false
+    },
+    {
+      "branch": "codex/rte-seam-extraction-foundation-v2",
+      "against": "origin/main",
+      "is_ancestor": false
+    },
+    {
+      "branch": "tp/gh-review-thread-agent",
+      "against": "origin/main",
+      "is_ancestor": false
+    },
+    {
+      "branch": "codex/ci-unit-shard-experiment",
+      "against": "origin/main",
+      "is_ancestor": false
+    },
+    {
+      "branch": "codex/dopecode-ast-navigation-20260417",
+      "against": "origin/main",
+      "is_ancestor": false
+    },
+    {
+      "branch": "feat/rte-v5-prescan-contract-unification",
+      "against": "origin/main",
+      "is_ancestor": false
+    }
+  ],
+  "cleanup_attempts": [
+    {
+      "command": "git worktree remove --force /private/tmp/dopemux-pr467",
+      "exit_code": 128,
+      "result": "blocked_missing_gitlink"
+    },
+    {
+      "command": "git worktree remove --force /private/tmp/dopemux-pr480",
+      "exit_code": 128,
+      "result": "blocked_missing_gitlink"
+    },
+    {
+      "command": "git worktree prune --verbose --expire now",
+      "exit_code": 0,
+      "result": "removed stale admin entries for dopemux-pr467 and dopemux-pr480"
+    },
+    {
+      "command": "rm -rf /private/tmp/dopemux-pr467",
+      "exit_code": 0,
+      "result": "orphan temp directory removed"
+    },
+    {
+      "command": "rm -rf /private/tmp/dopemux-pr480",
+      "exit_code": 0,
+      "result": "orphan temp directory removed"
+    }
+  ],
+  "post_cleanup_observations": {
+    "worktree_list_absent": [
+      "/private/tmp/dopemux-pr467",
+      "/private/tmp/dopemux-pr480"
+    ],
+    "filesystem_absent": [
+      "/private/tmp/dopemux-pr467",
+      "/private/tmp/dopemux-pr480"
+    ],
+    "preserved_local_branches": [
+      "pr/467",
+      "pr/480"
+    ],
+    "no_local_branch_deletions": true,
+    "pre_existing_unrelated_state": [
+      "M AGENTS.md",
+      "?? .claude/worktrees/"
+    ]
+  },
+  "constraints_honored": {
+    "no_runtime_code_modified": true,
+    "no_service_code_modified": true,
+    "no_production_config_modified": true,
+    "no_remote_branches_deleted": true,
+    "no_force_deleted_local_branches": true,
+    "open_pr_branches_preserved": true
+  },
+  "residual_risk": [
+    "Blocked local branches still lack current ancestor proof to origin/main.",
+    "Closed-unmerged survivors remain intentionally preserved.",
+    "Dirty, owner-ambiguous, and unknown survivors remain unresolved."
+  ]
+}

--- a/proof/rte-prelive-audit-pack-2026-04-23.proof.json
+++ b/proof/rte-prelive-audit-pack-2026-04-23.proof.json
@@ -1,0 +1,238 @@
+{
+  "audit_id": "rte-prelive-audit-pack-2026-04-23",
+  "task_packet_id": "TP-DMX-RTEAUDIT-001",
+  "execution_date": "2026-04-23",
+  "execution_branch": "codex/rte-audit-pack-assembly",
+  "scope": {
+    "assemble_evidence_only": true,
+    "live_rte_run_executed": false,
+    "runtime_code_modified": false,
+    "service_code_modified": false,
+    "prompt_content_modified": false,
+    "production_config_modified": false
+  },
+  "repo_identity": {
+    "repo_root": "/Users/hue/code/dopemux-mvp",
+    "repo_marker_present": true,
+    "origin_remote": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "origin_identity_match": true
+  },
+  "authority_used": {
+    "runtime_code": [
+      "services/repo-truth-extractor/run_extraction_v5.py",
+      "services/repo-truth-extractor/run_extraction_v4.py",
+      "services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+      "services/repo-truth-extractor/lib/prescan/grok_passes.py"
+    ],
+    "prompt_and_registry": [
+      "services/repo-truth-extractor/promptsets/v4/promptset.yaml",
+      "services/repo-truth-extractor/prompts/phase_s/registry.json",
+      "services/repo-truth-extractor/prompts/prescan/registry.json"
+    ],
+    "tests": [
+      "tests/unit/test_repo_truth_extractor_prompt_governance.py",
+      "tests/unit/test_prescan_online_gate.py"
+    ],
+    "emitted_evidence": [
+      "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_VERDICT.json",
+      "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_MANIFEST.json",
+      "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_GATE_DECISION.json",
+      "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_ROUTING_FINGERPRINT.json"
+    ],
+    "docs_and_prior_proofs": [
+      "docs/03-reference/systems/repo-truth-extractor/system-repotruthextractor.md",
+      "services/repo-truth-extractor/README.md",
+      "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+      "docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md",
+      "proof/repo-branch-worktree-cleanup-phase2.proof.json",
+      "proof/rte-provider-preflight-scope-truth-hardening.proof.json",
+      "proof/rte-doctor-diagnostic-clarity-and-final-launch-gate-review.proof.json"
+    ]
+  },
+  "prompt_surface_classification": [
+    {
+      "path": "services/repo-truth-extractor/promptsets/v4/promptset.yaml",
+      "classification": "canonical",
+      "reason": "Active v4 prompt and artifact contract consumed by compatibility runtime and validator."
+    },
+    {
+      "path": "services/repo-truth-extractor/promptsets/v4/prompts/",
+      "classification": "canonical",
+      "reason": "Prompt files listed into current run manifests."
+    },
+    {
+      "path": "services/repo-truth-extractor/prompts/phase_s/registry.json",
+      "classification": "canonical",
+      "reason": "Registry authority for SP prompt steps and outputs."
+    },
+    {
+      "path": "services/repo-truth-extractor/prompts/prescan/registry.json",
+      "classification": "canonical_governance",
+      "reason": "Governance metadata for prescan steps, schemas, and providers."
+    },
+    {
+      "path": "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+      "classification": "canonical_runtime",
+      "reason": "Actual prescan prompt constants and online gate logic live here."
+    },
+    {
+      "path": "services/repo-truth-extractor/prompts/phase_fl_int/registry.json",
+      "classification": "compatibility",
+      "reason": "Registry population exists and is tested, but this packet does not prove it as the canonical pre-live runtime path."
+    },
+    {
+      "path": "services/repo-truth-extractor/prompts/phase_s_int/registry.json",
+      "classification": "compatibility",
+      "reason": "Registry population exists and is tested, but this packet does not prove it as the canonical pre-live runtime path."
+    },
+    {
+      "path": "audit_prep/",
+      "classification": "drifted",
+      "reason": "Historical prep bundles present in repo but not shown as active runtime authority in this packet."
+    },
+    {
+      "path": "docs/archive/",
+      "classification": "drifted",
+      "reason": "Archive location indicates non-canonical prompt history."
+    },
+    {
+      "path": "tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_*.md",
+      "classification": "unknown",
+      "reason": "Named in AGENTS.md but absent from this checkout."
+    }
+  ],
+  "recommended_upload_set": [
+    {
+      "path": "services/repo-truth-extractor/run_extraction_v5.py",
+      "authority_class": "canonical_runtime",
+      "audit_relevance": "Current execution authority.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "services/repo-truth-extractor/run_extraction_v4.py",
+      "authority_class": "compatibility_runtime",
+      "audit_relevance": "Shows current v4 contract preservation boundary.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+      "authority_class": "canonical_gate",
+      "audit_relevance": "Defines pre-live validation gates.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "services/repo-truth-extractor/promptsets/v4/promptset.yaml",
+      "authority_class": "canonical_prompt_contract",
+      "audit_relevance": "Declares active prompt contract.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "services/repo-truth-extractor/prompts/phase_s/registry.json",
+      "authority_class": "canonical_prompt_registry",
+      "audit_relevance": "Registry-driven SP authority.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "services/repo-truth-extractor/prompts/prescan/registry.json",
+      "authority_class": "canonical_governance_registry",
+      "audit_relevance": "Prescan governance metadata.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+      "authority_class": "canonical_runtime_prompt_source",
+      "audit_relevance": "Real prescan prompt constants and online gate logic.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "tests/unit/test_repo_truth_extractor_prompt_governance.py",
+      "authority_class": "canonical_test",
+      "audit_relevance": "Prompt registry and deterministic snapshot verification.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "tests/unit/test_prescan_online_gate.py",
+      "authority_class": "canonical_test",
+      "audit_relevance": "Prescan online-gate verification.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_VERDICT.json",
+      "authority_class": "emitted_launch_evidence",
+      "audit_relevance": "Current no-go gate evidence.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_MANIFEST.json",
+      "authority_class": "emitted_run_evidence",
+      "audit_relevance": "Shows resolved prompts, routing, and dry-run state.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_GATE_DECISION.json",
+      "authority_class": "emitted_run_evidence",
+      "audit_relevance": "Compact gate outcome.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_ROUTING_FINGERPRINT.json",
+      "authority_class": "emitted_run_evidence",
+      "audit_relevance": "Per-step routing and prompt-file mapping.",
+      "upload_to_gpt54_pro": true
+    },
+    {
+      "path": "docs/03-reference/systems/repo-truth-extractor/system-repotruthextractor.md",
+      "authority_class": "documentation_context",
+      "audit_relevance": "Compact narrative context aligned to runtime authority.",
+      "upload_to_gpt54_pro": false
+    },
+    {
+      "path": "proof/rte-provider-preflight-scope-truth-hardening.proof.json",
+      "authority_class": "prior_hardening_proof",
+      "audit_relevance": "Provider preflight scope-hardening provenance.",
+      "upload_to_gpt54_pro": false
+    },
+    {
+      "path": "proof/rte-doctor-diagnostic-clarity-and-final-launch-gate-review.proof.json",
+      "authority_class": "prior_hardening_proof",
+      "audit_relevance": "Shared-doctor vs launch-authority provenance.",
+      "upload_to_gpt54_pro": false
+    },
+    {
+      "path": "docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md",
+      "authority_class": "repo_hygiene_context",
+      "audit_relevance": "Documents current open hygiene PR context.",
+      "upload_to_gpt54_pro": false
+    }
+  ],
+  "launch_relevant_open_prs": [
+    {
+      "number": 502,
+      "title": "docs(audit): execute phase2 safe archive cleanup",
+      "head": "codex/repo-hygiene-phase2-safe-archive-cleanup",
+      "base": "main",
+      "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/502",
+      "classification": "docs_hygiene_context"
+    },
+    {
+      "number": 501,
+      "title": "docs(repo-hygiene): audit branches and worktrees, add cleanup plan",
+      "head": "codex/repo-hygiene-audit-phase1",
+      "base": "main",
+      "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/501",
+      "classification": "docs_hygiene_context"
+    }
+  ],
+  "current_drift": [
+    "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_VERDICT.json reports NO_GO with ONLINE_PREFLIGHT_FAILURE for openrouter model openai/gpt-5.4.",
+    "The same validation verdict reports repo_drift_tests failure in services/repo-truth-extractor/tests/test_promptset_v4_lint.py for missing prescan prompt constants.",
+    "services/repo-truth-extractor/lib/prescan/grok_passes.py currently contains _DEDUP_SYSTEM_PROMPT, _DISCOVER_SYSTEM_PROMPT, _FEASIBILITY_SYSTEM_PROMPT, and _OPTIMIZE_SYSTEM_PROMPT, so the lint failure and runtime surface are presently out of sync.",
+    "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_GATE_DECISION.json is BLOCKED with provider_preflight_status FAIL.",
+    "AGENTS.md names tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_SYSTEMS.md, TRUTH_CANONICALS.md, and TRUTH_GAPS.md as present truth docs, but those exact paths are absent in this checkout."
+  ],
+  "audit_result": {
+    "pack_ready_for_project_upload": true,
+    "pack_ready_for_live_launch_claim": false,
+    "reason": "The upload pack is bounded and evidence-backed, but current emitted gate evidence still shows provider and drift blockers."
+  }
+}

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -45,6 +45,7 @@ A packet is superseded by another packet
 | TP-DMX-REPOHYG-001 | Repo Hygiene | Branch and worktree audit with deterministic cleanup plan | Ready | N/A |
 | TP-DMX-REPOHYG-002 | Repo Hygiene | Execute phase2 safe archive cleanup | Ready | N/A |
 | TP-DMX-REPOHYG-003 | Repo Hygiene | Resolve blocked and ambiguous cleanup survivors | Ready | N/A |
+| TP-DMX-RTEAUDIT-001 | Repo Truth Extractor | Assemble pre-live audit pack for GPT-5.4 Pro | Ready | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -43,6 +43,7 @@ A packet is superseded by another packet
 | TP-SIA-EXEC-0008 | Workflow Plane | Replay Repro Suite + Projection Hardening | Ready | SIA Packet Execution ADR |
 | TP-DMX-AIG-001 | Adaptive Ingress Plane | Service Census + Ingress Map + First Safe Slice | Ready | ADR — Adopt a Dopemux Adaptive Ingress Plane with Local Runtime Shims |
 | TP-DMX-REPOHYG-001 | Repo Hygiene | Branch and worktree audit with deterministic cleanup plan | Ready | N/A |
+| TP-DMX-REPOHYG-002 | Repo Hygiene | Execute phase2 safe archive cleanup | Ready | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -42,6 +42,7 @@ A packet is superseded by another packet
 | TP-SIA-EXEC-0007 | Workflow Plane | Manual Handoff + Operator Resume Semantics | Ready | SIA Packet Execution ADR |
 | TP-SIA-EXEC-0008 | Workflow Plane | Replay Repro Suite + Projection Hardening | Ready | SIA Packet Execution ADR |
 | TP-DMX-AIG-001 | Adaptive Ingress Plane | Service Census + Ingress Map + First Safe Slice | Ready | ADR — Adopt a Dopemux Adaptive Ingress Plane with Local Runtime Shims |
+| TP-DMX-REPOHYG-001 | Repo Hygiene | Branch and worktree audit with deterministic cleanup plan | Ready | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -44,6 +44,7 @@ A packet is superseded by another packet
 | TP-DMX-AIG-001 | Adaptive Ingress Plane | Service Census + Ingress Map + First Safe Slice | Ready | ADR — Adopt a Dopemux Adaptive Ingress Plane with Local Runtime Shims |
 | TP-DMX-REPOHYG-001 | Repo Hygiene | Branch and worktree audit with deterministic cleanup plan | Ready | N/A |
 | TP-DMX-REPOHYG-002 | Repo Hygiene | Execute phase2 safe archive cleanup | Ready | N/A |
+| TP-DMX-REPOHYG-003 | Repo Hygiene | Resolve blocked and ambiguous cleanup survivors | Ready | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 

--- a/task-packets/TP-DMX-REPOHYG-001.json
+++ b/task-packets/TP-DMX-REPOHYG-001.json
@@ -96,8 +96,7 @@
         "RULES.md",
         "ARCHITECTURE.md",
         "SYSTEM_Dopetask.md",
-        "PAL_EXECUTION_RULES.md",
-        "dopetask-cannonical-spec.json"
+"PAL_EXECUTION_RULES.md"
       ]
     },
     {

--- a/task-packets/TP-DMX-REPOHYG-001.json
+++ b/task-packets/TP-DMX-REPOHYG-001.json
@@ -1,0 +1,195 @@
+{
+  "id": "TP-DMX-REPOHYG-001",
+  "project": "dopemux-mvp",
+  "target": "Remote branch and local worktree audit with deterministic cleanup plan and non-destructive first-pass proof.",
+  "invariants": [
+    "Do not delete any local or remote branch in phase 1.",
+    "Do not delete any worktree in phase 1.",
+    "Do not modify runtime code, service code, or production configs.",
+    "Preserve Dopemux architectural authority boundaries.",
+    "Treat GitHub remote state and local worktree state as separate evidence domains.",
+    "Every branch/worktree recommendation must be evidence-backed and deterministic.",
+    "Open PRs and branches with unresolved or active work must not be marked safe-to-delete.",
+    "Merged, closed-unmerged, stale, duplicate, superseded, and unknown states must be explicitly distinguished.",
+    "No hidden heuristics or LLM-only scoring for cleanup decisions.",
+    "All outputs must be commit-sized, reviewable, and reproducible."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-REPO-HYGIENE-SERIES-001",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/repo-hygiene-audit-phase1"
+  },
+  "commit": {
+    "message": "docs(repo-hygiene): add branch and worktree audit with cleanup plan",
+    "allowlist": [
+      "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+      "proof/repo-branch-worktree-audit-2026-04-23.proof.json",
+      "task-packets/TP-DMX-REPOHYG-001.json",
+      "task-packets/INDEX.md"
+    ],
+    "verify": [
+      "git rev-parse --show-toplevel",
+      "test -f .dopetaskroot",
+      "git remote -v",
+      "git branch --format='%(refname:short) %(upstream:short) %(objectname:short)'",
+      "git worktree list --porcelain",
+      "git status --short --branch",
+      "python -m json.tool task-packets/TP-DMX-REPOHYG-001.json",
+      "python -m json.tool proof/repo-branch-worktree-audit-2026-04-23.proof.json"
+    ]
+  },
+  "pr": {
+    "title": "docs(repo-hygiene): audit branches and worktrees, add cleanup plan",
+    "body": "## Summary\n- audit remote branches, recent PR heads, and local worktrees\n- classify keep / merge-first / archive / delete-local / delete-remote / unknown with evidence\n- produce a non-destructive cleanup plan only\n\n## Scope\n- docs, proof, and task-packet surfaces only\n- no runtime code changes\n- no branch or worktree deletion in this PR\n\n## Validation\n- repo identity confirmed from .dopetaskroot and origin remote\n- remote branch and PR evidence collected\n- local worktree and branch evidence collected\n- proof JSON validates and matches audit report\n\n## Follow-up\nA separate packet will execute approved cleanup actions after review.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Establish repo identity and collect authoritative remote cleanup evidence.",
+      "requirements": [
+        "Confirm repo root via .dopetaskroot.",
+        "Confirm origin remote matches DDD-Enterprises/dopemux-mvp.",
+        "Collect recent PR evidence, including open PRs, closed-unmerged PRs, merged PRs, and branch heads.",
+        "Capture remote branch naming clusters and obvious duplicate or superseded lines."
+      ],
+      "commands": [
+        "git rev-parse --show-toplevel",
+        "test -f .dopetaskroot",
+        "git remote -v"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+        "proof/repo-branch-worktree-audit-2026-04-23.proof.json"
+      ],
+      "validation": [
+        "Repo identity is explicit and matches the intended project.",
+        "Remote evidence distinguishes open, merged, closed-unmerged, duplicate, and unknown branch lines.",
+        "No deletion recommendations are issued without remote-state evidence."
+      ],
+      "context_files": [
+        "RULES.md",
+        "ARCHITECTURE.md",
+        "SYSTEM_Dopetask.md",
+        "PAL_EXECUTION_RULES.md",
+        "dopetask-cannonical-spec.json"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Collect authoritative local worktree and local branch evidence.",
+      "requirements": [
+        "Enumerate all local worktrees.",
+        "Enumerate local branches and upstream tracking state.",
+        "Capture ahead/behind or detached conditions where visible.",
+        "Record uncommitted or dirty state per worktree when present.",
+        "Detect orphaned, duplicate, stale, or ambiguous local worktrees."
+      ],
+      "commands": [
+        "git worktree list --porcelain",
+        "git branch --format='%(refname:short) %(upstream:short) %(objectname:short)'",
+        "git status --short --branch"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+        "proof/repo-branch-worktree-audit-2026-04-23.proof.json"
+      ],
+      "validation": [
+        "Every local worktree is tied to a branch, detached state, or explicit unknown state.",
+        "Dirty state is surfaced instead of hidden.",
+        "Local-only branches are called out separately from remote branches."
+      ],
+      "context_files": [
+        "RULES.md",
+        "SYSTEM_BOUNDARIES.md",
+        "AGENTS.md",
+        "PAL_EXECUTION_RULES.md"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Produce a deterministic cleanup ledger and recommendation table.",
+      "requirements": [
+        "Classify each branch/worktree as keep, merge-first, archive, delete-local-only, delete-remote, or unknown.",
+        "Every recommendation must include reason and blocking risk.",
+        "Open PR branches default to keep unless explicit supersession is proved.",
+        "Closed-unmerged branches require explicit disposition instead of silent deletion."
+      ],
+      "commands": [
+        "python -m json.tool proof/repo-branch-worktree-audit-2026-04-23.proof.json"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+        "proof/repo-branch-worktree-audit-2026-04-23.proof.json"
+      ],
+      "validation": [
+        "The cleanup ledger is deterministic and reviewable.",
+        "No item is recommended for destructive cleanup without explicit evidence.",
+        "Unknown items remain unknown instead of being guessed into deletion."
+      ],
+      "context_files": [
+        "RULES.md",
+        "TRUTH_GAPS.md",
+        "TRUTH_CANONICALS.md",
+        "PAL_PACKET_TEMPLATE.md"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Package the phase-1 audit as docs, proof, and indexed task-packet output, then open a PR.",
+      "requirements": [
+        "Write the audit report.",
+        "Write the proof JSON.",
+        "Check in the task packet itself.",
+        "Update the task-packet index if required by repo convention.",
+        "Open a PR containing only phase-1 audit artifacts."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/TP-DMX-REPOHYG-001.json",
+        "python -m json.tool proof/repo-branch-worktree-audit-2026-04-23.proof.json"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+        "proof/repo-branch-worktree-audit-2026-04-23.proof.json",
+        "task-packets/TP-DMX-REPOHYG-001.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "PR scope is docs/proof/packet only.",
+        "No branch deletions, worktree removals, or runtime file changes occur in phase 1.",
+        "The PR body clearly states that execution cleanup is deferred to a follow-up packet."
+      ],
+      "context_files": [
+        "dopetask-cannonical-spec.json",
+        "PAL_EXECUTION_RULES.md",
+        "PAL_PACKET_TEMPLATE.md",
+        "INDEX.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/TP-DMX-REPOHYG-002.json
+++ b/task-packets/TP-DMX-REPOHYG-002.json
@@ -1,0 +1,214 @@
+{
+  "id": "TP-DMX-REPOHYG-002",
+  "project": "dopemux-mvp",
+  "target": "Execute evidence-backed safe archive cleanup for phase-1 archive-class branches and worktrees only, removing only items proven disposable from the phase-1 audit while preserving unknown, merge-first, dirty, or owner-ambiguous survivors.",
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-repo-hygiene",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-REPOHYG-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/repo-hygiene-phase2-safe-archive-cleanup"
+  },
+  "commit": {
+    "message": "docs(audit): execute phase2 safe archive cleanup",
+    "allowlist": [
+      "docs/05-audit-reports/**",
+      "proof/**",
+      "task-packets/**"
+    ],
+    "verify": [
+      "git rev-parse --show-toplevel",
+      "test -f .dopetaskroot",
+      "git remote -v",
+      "git branch --show-current",
+      "git status --short --branch",
+      "git worktree list --porcelain",
+      "git branch -vv",
+      "gh pr list --state open --json number,headRefName,baseRefName,title,url",
+      "python -m json.tool task-packets/TP-DMX-REPOHYG-002.json",
+      "python -m json.tool proof/repo-branch-worktree-cleanup-phase2.proof.json",
+      "git diff --check -- docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md proof/repo-branch-worktree-cleanup-phase2.proof.json task-packets/TP-DMX-REPOHYG-002.json task-packets/INDEX.md"
+    ]
+  },
+  "pr": {
+    "title": "docs(audit): execute phase2 safe archive cleanup",
+    "body": "## Summary\n- execute non-destructive-to-low-risk cleanup for only phase-1 archive-class items\n- remove only branches/worktrees proven disposable by the phase-1 audit and current verification\n- publish cleanup ledger and proof bundle with exact commands and raw outputs\n\n## Why\nPhase 1 established archive, keep, merge-first, and unknown states without deleting anything. Phase 2 should now remove only clearly disposable archive items while preserving ambiguous or risky survivors.\n\n## Validation\n- repo identity revalidated\n- each removed item was archive-class and rechecked before deletion\n- unknown, merge-first, dirty, and owner-ambiguous items were preserved\n- cleanup report and proof bundle committed and PR opened",
+    "base": "main"
+  },
+  "steps": [
+    {
+      "id": "step-01-refresh-phase1-authority",
+      "task": "Revalidate the repo identity and refresh the current local/remote state against the phase-1 audit so no cleanup action is taken on stale evidence.",
+      "requirements": [
+        "Use current git and GitHub state as primary authority.",
+        "Do not delete anything in this step.",
+        "If phase-1 archive items have become dirty or ambiguous, downgrade them from cleanup scope."
+      ],
+      "commands": [
+        "git rev-parse --show-toplevel",
+        "test -f .dopetaskroot",
+        "git remote -v",
+        "git branch --show-current",
+        "git status --short --branch",
+        "git worktree list --porcelain",
+        "git branch -vv",
+        "gh pr list --state open --json number,headRefName,baseRefName,title,url",
+        "gh pr list --limit 200 --state all --json number,title,state,isDraft,headRefName,baseRefName,closedAt,mergedAt,url,author"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+        "proof/repo-branch-worktree-audit-2026-04-23.proof.json",
+        "task-packets/TP-DMX-REPOHYG-001.json"
+      ],
+      "validation": [
+        "Repo identity still matches dopemux-mvp origin.",
+        "Current worktree/branch state has been refreshed.",
+        "No deletion has happened yet."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/INDEX.md"
+      ]
+    },
+    {
+      "id": "step-02-freeze-phase2-cleanup-set",
+      "task": "Build the exact phase-2 cleanup set from phase-1 archive-class recommendations and current rechecks, excluding anything now dirty, diverged, unknown, merge-first, or owner-ambiguous.",
+      "requirements": [
+        "Only archive-class items are eligible.",
+        "Each candidate must be rechecked for local dirt and branch/worktree attachment state.",
+        "Anything uncertain is preserved and explicitly excluded."
+      ],
+      "commands": [
+        "git status --short --branch --worktree=/Users/hue/code/dopemux-mvp",
+        "git for-each-ref --sort=committerdate --format='%(refname:short)|%(upstream:short)|%(objectname:short)|%(committerdate:iso8601)|%(subject)' refs/heads refs/remotes/origin"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+        "proof/repo-branch-worktree-audit-2026-04-23.proof.json"
+      ],
+      "validation": [
+        "A finite phase-2 cleanup set exists.",
+        "Every cleanup target is archive-class and currently disposable.",
+        "Excluded survivors are listed explicitly."
+      ],
+      "context_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md"
+      ]
+    },
+    {
+      "id": "step-03-execute-safe-worktree-removals",
+      "task": "Remove only archive-class worktrees proven disposable, recording exact commands and raw outputs.",
+      "requirements": [
+        "Prefer removing worktrees before deleting their attached local branches.",
+        "Do not remove dirty or ambiguous worktrees.",
+        "If a worktree removal fails, record the blocker and preserve it."
+      ],
+      "commands": [
+        "git worktree remove <archive_worktree_path>"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/**",
+        "proof/**"
+      ],
+      "validation": [
+        "Only pre-approved archive worktrees were removed.",
+        "Each worktree removal has exact command/output evidence.",
+        "No keep/unknown/merge-first worktree was touched."
+      ],
+      "context_files": [
+        "proof/repo-branch-worktree-audit-2026-04-23.proof.json"
+      ]
+    },
+    {
+      "id": "step-04-execute-safe-branch-removals",
+      "task": "Delete only archive-class local branches proven disposable after worktree removal or confirmed unattached, using the least-destructive git command that succeeds.",
+      "requirements": [
+        "Use `git branch -d` first.",
+        "Use `git branch -D` only if the branch is still archive-class and evidence proves forced deletion is safe.",
+        "Do not delete unknown, merge-first, keep, or dirty-attached branches."
+      ],
+      "commands": [
+        "git branch -d <archive_branch>",
+        "git branch -D <archive_branch_if_safe_and_required>"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/**",
+        "proof/**"
+      ],
+      "validation": [
+        "Only pre-approved archive branches were deleted.",
+        "Every deletion has exact command/output evidence.",
+        "No non-archive branch was touched."
+      ],
+      "context_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md"
+      ]
+    },
+    {
+      "id": "step-05-publish-phase2-ledger-and-proof",
+      "task": "Publish the phase-2 cleanup report and proof bundle, including removed items, preserved survivors, blocked removals, and the exact evidence trail for every decision.",
+      "requirements": [
+        "The report must distinguish removed, preserved, and blocked items.",
+        "The proof bundle must record current repo identity and every cleanup command/output.",
+        "Do not claim full repo hygiene closure if unknown or merge-first items remain."
+      ],
+      "commands": [
+        "python -m json.tool proof/repo-branch-worktree-cleanup-phase2.proof.json",
+        "git diff --check -- docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md proof/repo-branch-worktree-cleanup-phase2.proof.json task-packets/TP-DMX-REPOHYG-002.json task-packets/INDEX.md"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md",
+        "proof/repo-branch-worktree-cleanup-phase2.proof.json",
+        "task-packets/TP-DMX-REPOHYG-002.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "Cleanup docs and proof are syntactically valid.",
+        "Removed and preserved items are both explicitly listed.",
+        "Residual risk and next-phase recommendations are documented."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/INDEX.md"
+      ]
+    },
+    {
+      "id": "step-06-commit-push-pr",
+      "task": "Commit the allowlisted cleanup artifacts, push the packet branch, and open the PR.",
+      "requirements": [
+        "Only allowlisted docs/proof/task-packet files may be staged.",
+        "No runtime or service code changes are allowed.",
+        "Final report must include commit hash and PR reference."
+      ],
+      "commands": [
+        "git add docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md proof/repo-branch-worktree-cleanup-phase2.proof.json task-packets/TP-DMX-REPOHYG-002.json task-packets/INDEX.md",
+        "git commit -m \"docs(audit): execute phase2 safe archive cleanup\"",
+        "git push -u origin codex/repo-hygiene-phase2-safe-archive-cleanup",
+        "gh pr create --base main --head codex/repo-hygiene-phase2-safe-archive-cleanup --title \"docs(audit): execute phase2 safe archive cleanup\" --body-file <prepared_pr_body_file>"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md",
+        "proof/repo-branch-worktree-cleanup-phase2.proof.json",
+        "task-packets/TP-DMX-REPOHYG-002.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "Commit created successfully.",
+        "Branch pushed successfully.",
+        "PR reference exists."
+      ],
+      "context_files": [
+        "task-packets/TP-DMX-REPOHYG-001.json"
+      ]
+    }
+  ]
+}

--- a/task-packets/TP-DMX-REPOHYG-003.json
+++ b/task-packets/TP-DMX-REPOHYG-003.json
@@ -121,8 +121,7 @@
       "context_files": [
         "RULES.md",
         "TRUTH_GAPS.md",
-        "SYSTEM_BOUNDARIES.md",
-        "dopetask-cannonical-spec.json"
+"SYSTEM_BOUNDARIES.md"
       ]
     },
     {

--- a/task-packets/TP-DMX-REPOHYG-003.json
+++ b/task-packets/TP-DMX-REPOHYG-003.json
@@ -1,0 +1,182 @@
+{
+  "id": "TP-DMX-REPOHYG-003",
+  "project": "dopemux-mvp",
+  "target": "Resolve remaining broken, blocked, unknown, dirty, and owner-ambiguous branch/worktree survivors after safe archive cleanup phase 2.",
+  "invariants": [
+    "Do not delete any local or remote branch without current graph proof.",
+    "Do not force-delete blocked branches unless a separate proof step establishes supersession or disposal safety.",
+    "Do not modify runtime code, service code, or production configs.",
+    "Treat broken temp worktrees, owner-ambiguous survivors, dirty state, and closed-unmerged PR heads as separate classes.",
+    "Every destructive recommendation must be evidence-backed and reproducible.",
+    "Open PR branches and active review branches must be preserved unless explicitly superseded by current authority."
+  ],
+  "depends_on": [
+    "TP-DMX-REPOHYG-001",
+    "TP-DMX-REPOHYG-002"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-REPO-HYGIENE-SERIES-001",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-REPOHYG-002",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/repo-hygiene-phase3-unresolved-survivors"
+  },
+  "commit": {
+    "message": "docs(repo-hygiene): resolve broken and ambiguous survivors after phase 2",
+    "allowlist": [
+      "docs/05-audit-reports/repo-branch-worktree-cleanup-phase3.md",
+      "proof/repo-branch-worktree-cleanup-phase3.proof.json",
+      "task-packets/TP-DMX-REPOHYG-003.json",
+      "task-packets/INDEX.md"
+    ],
+    "verify": [
+      "git rev-parse --show-toplevel",
+      "test -f .dopetaskroot",
+      "git remote -v",
+      "git branch --show-current",
+      "git status --short --branch",
+      "git worktree list --porcelain",
+      "git branch -vv",
+      "python -m json.tool task-packets/TP-DMX-REPOHYG-003.json",
+      "python -m json.tool proof/repo-branch-worktree-cleanup-phase3.proof.json"
+    ]
+  },
+  "pr": {
+    "title": "docs(repo-hygiene): resolve blocked and ambiguous cleanup survivors",
+    "body": "## Summary\n- re-audit blocked local branches, broken temp worktrees, unknown survivors, dirty survivors, and owner-ambiguous survivors after phase 2\n- classify each item with current graph proof and current PR authority\n- execute only those cleanup actions newly proven safe in this phase\n\n## Scope\n- docs, proof, and task-packet outputs only unless specific cleanup actions are executed and recorded in proof\n- no runtime code changes\n- no remote branch deletion unless explicitly proven safe and within packet scope\n\n## Validation\n- current git graph, worktree, branch tracking, and PR state refreshed\n- proof JSON matches executed actions and preserved survivors\n- all unresolved items remain explicitly classified\n\n## Follow-up\nAdditional cleanup, if any, will be packetized separately.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Refresh current authority for all unresolved survivors from phases 1 and 2.",
+      "requirements": [
+        "Re-check open PRs, closed-unmerged PR heads, current branch graph, and worktree inventory.",
+        "Explicitly revisit broken temp worktrees pr/467 and pr/480.",
+        "Reconfirm status of blocked branches: tp/rte-full-run-hygiene-and-launch-readiness, codex/rte-seam-extraction-foundation-v2, tp/gh-review-thread-agent."
+      ],
+      "commands": [
+        "git worktree list --porcelain",
+        "git branch -vv",
+        "git status --short --branch"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-cleanup-phase3.md",
+        "proof/repo-branch-worktree-cleanup-phase3.proof.json"
+      ],
+      "validation": [
+        "Current authority is refreshed rather than inherited blindly from prior packets.",
+        "Broken and blocked survivors are individually classified."
+      ],
+      "context_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+        "docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md",
+        "proof/repo-branch-worktree-cleanup-phase2.proof.json",
+        "task-packets/TP-DMX-REPOHYG-002.json"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Determine whether each blocked or ambiguous survivor is keep, merge-first, archive, broken-prunable, owner-ambiguous, or delete-safe.",
+      "requirements": [
+        "Use current graph proof and current PR authority for every recommendation.",
+        "Do not collapse unknown and owner-ambiguous into delete-safe.",
+        "Do not promote blocked branches to deletion without explicit ancestor or supersession proof."
+      ],
+      "commands": [
+        "git merge-base --is-ancestor tp/rte-full-run-hygiene-and-launch-readiness origin/main",
+        "git merge-base --is-ancestor codex/rte-seam-extraction-foundation-v2 origin/main",
+        "git merge-base --is-ancestor tp/gh-review-thread-agent origin/main"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-cleanup-phase3.md",
+        "proof/repo-branch-worktree-cleanup-phase3.proof.json"
+      ],
+      "validation": [
+        "Every survivor has explicit class, reason, and action.",
+        "No destructive action occurs without proof."
+      ],
+      "context_files": [
+        "RULES.md",
+        "TRUTH_GAPS.md",
+        "SYSTEM_BOUNDARIES.md",
+        "dopetask-cannonical-spec.json"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Execute only newly proven-safe cleanup actions and record exact command results.",
+      "requirements": [
+        "Record every attempted cleanup command and exit code.",
+        "Preserve any item that fails proof or deletion safety checks.",
+        "Do not use force deletion unless explicitly authorized by proof and packet scope."
+      ],
+      "commands": [
+        "python -m json.tool proof/repo-branch-worktree-cleanup-phase3.proof.json"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-cleanup-phase3.md",
+        "proof/repo-branch-worktree-cleanup-phase3.proof.json"
+      ],
+      "validation": [
+        "Executed actions exactly match proof.",
+        "Preserved survivors remain explicitly listed."
+      ],
+      "context_files": [
+        "proof/repo-branch-worktree-cleanup-phase2.proof.json",
+        "RULES.md",
+        "PAL_PACKET_TEMPLATE.md"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Publish the phase 3 cleanup record and open a PR.",
+      "requirements": [
+        "Write the phase 3 report and proof.",
+        "Update the task-packet index.",
+        "Open a PR with only packet/report/proof surfaces unless cleanup commands required tracked metadata changes."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/TP-DMX-REPOHYG-003.json",
+        "python -m json.tool proof/repo-branch-worktree-cleanup-phase3.proof.json"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/repo-branch-worktree-cleanup-phase3.md",
+        "proof/repo-branch-worktree-cleanup-phase3.proof.json",
+        "task-packets/TP-DMX-REPOHYG-003.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "PR is scoped and reviewable.",
+        "Residual risk is explicitly documented."
+      ],
+      "context_files": [
+        "task-packets/INDEX.md",
+        "dopetask-cannonical-spec.json",
+        "PAL_EXECUTION_RULES.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/TP-DMX-RTEAUDIT-001.json
+++ b/task-packets/TP-DMX-RTEAUDIT-001.json
@@ -1,0 +1,200 @@
+{
+  "id": "TP-DMX-RTEAUDIT-001",
+  "project": "dopemux-mvp",
+  "target": "Assemble a deterministic pre-live RTE audit pack for GPT-5.4 Pro covering canonical code paths, prompt surfaces, proofs, tests, and current launch-relevant drift.",
+  "invariants": [
+    "Do not modify runtime code, service code, prompt content, or production configs in this packet.",
+    "Assemble evidence only; do not execute a live RTE run.",
+    "Prefer canonical runtime, prompt, and proof surfaces over legacy, shadow, or compatibility paths.",
+    "Every included file must have a stated reason for inclusion in the audit pack.",
+    "Prompt surfaces must be classified as canonical, compatibility, drifted, or unknown.",
+    "The audit pack must distinguish code-path evidence from documentation-only claims.",
+    "No hidden heuristics or LLM-only scoring for file selection.",
+    "Outputs must be deterministic, reviewable, and reproducible.",
+    "The pack must be small enough to work cleanly in a ChatGPT Project upload flow.",
+    "Do not normalize contradictions; preserve drift and UNKNOWN where repo truth requires it."
+  ],
+  "depends_on": [
+    "TP-DMX-REPOHYG-001",
+    "TP-DMX-REPOHYG-002"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-RTE-AUDIT-SERIES-001",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/rte-audit-pack-assembly"
+  },
+  "commit": {
+    "message": "docs(rte): assemble pre-live audit pack for 5.4 Pro",
+    "allowlist": [
+      "docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md",
+      "proof/rte-prelive-audit-pack-2026-04-23.proof.json",
+      "task-packets/TP-DMX-RTEAUDIT-001.json",
+      "task-packets/INDEX.md"
+    ],
+    "verify": [
+      "git rev-parse --show-toplevel",
+      "test -f .dopetaskroot",
+      "git remote -v",
+      "git branch --show-current",
+      "git status --short --branch",
+      "python -m json.tool task-packets/TP-DMX-RTEAUDIT-001.json",
+      "python -m json.tool proof/rte-prelive-audit-pack-2026-04-23.proof.json",
+      "git diff --check -- docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md proof/rte-prelive-audit-pack-2026-04-23.proof.json task-packets/TP-DMX-RTEAUDIT-001.json task-packets/INDEX.md"
+    ]
+  },
+  "pr": {
+    "title": "docs(rte): assemble pre-live audit pack for 5.4 Pro",
+    "body": "## Summary\n- assemble a deterministic pre-live RTE audit pack for GPT-5.4 Pro\n- include canonical code paths, prompt surfaces, proofs, tests, and current drift notes\n- classify prompt and runtime surfaces by authority and launch relevance\n\n## Scope\n- packet, report, and proof only\n- no runtime code or prompt content changes\n- no live run execution\n\n## Validation\n- repo identity confirmed from .dopetaskroot and origin remote\n- included files are enumerated with authority classification and rationale\n- proof JSON matches the assembled audit pack\n\n## Follow-up\nUse the pack inside a ChatGPT Project for a GPT-5.4 Pro pre-live audit of code and prompts.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Refresh repo identity and collect the canonical RTE authority surfaces relevant to a pre-live audit.",
+      "requirements": [
+        "Confirm repo root from .dopetaskroot.",
+        "Confirm origin remote matches dopemux-mvp.",
+        "Identify the canonical RTE runtime entrypoint and adjacent compatibility surfaces.",
+        "Identify launch-relevant docs and truth artifacts.",
+        "Identify current open PRs that may affect RTE launch readiness."
+      ],
+      "commands": [
+        "git rev-parse --show-toplevel",
+        "test -f .dopetaskroot",
+        "git remote -v",
+        "git branch --show-current",
+        "git status --short --branch"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md",
+        "proof/rte-prelive-audit-pack-2026-04-23.proof.json"
+      ],
+      "validation": [
+        "Repo identity is explicit and correct.",
+        "Canonical RTE runtime and truth docs are named explicitly.",
+        "Launch-relevant open PRs are surfaced in the pack."
+      ],
+      "context_files": [
+        "RULES.md",
+        "ARCHITECTURE.md",
+        "SYSTEM_RepoTruthExtractor.md",
+        "TRUTH_GAPS.md",
+        "TRUTH_CANONICALS.md",
+        "TRUTH_INTERFACES.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Collect and classify the prompt surfaces that materially affect RTE execution.",
+      "requirements": [
+        "Identify canonical promptset files, manifests, routing config, and preflight/prompt gating surfaces.",
+        "Separate canonical prompts from compatibility, drifted, shadow, or unknown prompt paths.",
+        "Record why each prompt surface belongs in the audit pack.",
+        "Do not rewrite or edit prompt content."
+      ],
+      "commands": [
+        "git status --short --branch"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md",
+        "proof/rte-prelive-audit-pack-2026-04-23.proof.json"
+      ],
+      "validation": [
+        "Prompt surfaces are classified by authority.",
+        "Compatibility and drift paths are not collapsed into canonical by narrative.",
+        "The pack contains an explicit prompt inventory."
+      ],
+      "context_files": [
+        "SYSTEM_RepoTruthExtractor.md",
+        "TRUTH_GAPS.md",
+        "TRUTH_CANONICALS.md",
+        "PAL_EXECUTION_RULES.md"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Collect launch-relevant code, tests, and proof artifacts into a deterministic audit pack manifest.",
+      "requirements": [
+        "Include canonical runner files, prescan/stage-0 files, highest-value tests, and recent launch-relevant proofs.",
+        "Include cleanup hygiene outputs only where they affect launch trust.",
+        "For each file, record: path, authority class, audit relevance, and whether it should be uploaded to 5.4 Pro.",
+        "Produce a recommended upload set sized for ChatGPT Project constraints."
+      ],
+      "commands": [
+        "python -m json.tool proof/rte-prelive-audit-pack-2026-04-23.proof.json"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md",
+        "proof/rte-prelive-audit-pack-2026-04-23.proof.json"
+      ],
+      "validation": [
+        "Every included file has a reason.",
+        "The recommended upload set is bounded and usable.",
+        "Tests and proofs included are directly relevant to pre-live readiness."
+      ],
+      "context_files": [
+        "docs/05-audit-reports/repo-branch-worktree-audit-2026-04-23.md",
+        "docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md",
+        "proof/repo-branch-worktree-cleanup-phase2.proof.json",
+        "SYSTEM_RepoTruthExtractor.md",
+        "PAL_PACKET_TEMPLATE.md"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Publish the pack report, proof, and packet, then open a PR.",
+      "requirements": [
+        "Write the audit-pack report.",
+        "Write the audit-pack proof JSON.",
+        "Check in the task packet.",
+        "Update the task-packet index if required by repo convention.",
+        "Open a PR limited to docs/proof/packet surfaces."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/TP-DMX-RTEAUDIT-001.json",
+        "python -m json.tool proof/rte-prelive-audit-pack-2026-04-23.proof.json",
+        "git diff --check -- docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md proof/rte-prelive-audit-pack-2026-04-23.proof.json task-packets/TP-DMX-RTEAUDIT-001.json task-packets/INDEX.md"
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md",
+        "proof/rte-prelive-audit-pack-2026-04-23.proof.json",
+        "task-packets/TP-DMX-RTEAUDIT-001.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "PR scope is bounded to packet/report/proof surfaces.",
+        "No code or prompt edits are included.",
+        "The resulting pack is ready to hand to GPT-5.4 Pro."
+      ],
+      "context_files": [
+        "dopetask-cannonical-spec.json",
+        "PAL_EXECUTION_RULES.md",
+        "PAL_PACKET_TEMPLATE.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/TP-DMX-RTEAUDIT-001.json
+++ b/task-packets/TP-DMX-RTEAUDIT-001.json
@@ -191,7 +191,6 @@
         "The resulting pack is ready to hand to GPT-5.4 Pro."
       ],
       "context_files": [
-        "dopetask-cannonical-spec.json",
         "PAL_EXECUTION_RULES.md",
         "PAL_PACKET_TEMPLATE.md"
       ]


### PR DESCRIPTION
## Summary
- Updated `compose.yml` to use the repository root as the build context for all MCP services.
- Adjusted `dockerfile` paths relative to the new context.
- This ensures that `COPY pyproject.toml .` and other root-relative commands in the Dockerfiles work correctly during build.

## Validation
- Ran `scripts/start-all-mcp-servers.sh` and confirmed that builds now succeed and containers are starting correctly.