### PR TITLE
rte: integrate current branch deltas into pre-audit staging branch

### DIFF
--- a/docs/05-audit-reports/rte-branch-integration-audit-2026-04-23.md
+++ b/docs/05-audit-reports/rte-branch-integration-audit-2026-04-23.md
@@ -1,0 +1,148 @@
+---
+id: rte-branch-integration-audit-2026-04-23
+title: RTE Branch Integration Audit 2026-04-23
+type: reference
+owner: codex
+date: 2026-04-23
+status: complete
+author: '@hu3mann'
+last_review: '2026-04-23'
+next_review: '2026-07-22'
+prelude: Evidence-backed classification of RTE-related branches and bounded pre-audit staging integration.
+---
+# RTE Branch Integration Audit 2026-04-23
+
+**Task packet**: `TP-DMX-RTEINT-001`
+**Execution branch**: `codex/rte-integration-staging-audit`
+**Execution date**: `2026-04-23`
+
+## Scope
+
+This packet refreshed current git and PR authority for RTE-related lines, classified each line by observed graph and diff evidence, and integrated only the still-current bounded runtime delta required to make the staging branch suitable for the GPT-5.4 Pro pre-live audit.
+
+It did **not** merge any branch into `main` directly.
+
+## Authority Used
+
+Observed directly during this packet:
+
+- repo root resolves to `/Users/hue/code/dopemux-mvp`
+- `.dopetaskroot` exists
+- `origin` matches `https://github.com/DDD-Enterprises/dopemux-mvp.git`
+- repo-hygiene survivor reports:
+  - `docs/05-audit-reports/repo-branch-worktree-cleanup-phase2.md`
+  - `proof/repo-branch-worktree-cleanup-phase2.proof.json`
+  - `docs/05-audit-reports/repo-branch-worktree-cleanup-phase3.md`
+  - `proof/repo-branch-worktree-cleanup-phase3.proof.json`
+- current git graph, `git cherry`, `git diff --stat`, and `gh pr list --state all`
+- runtime code and tests under `services/repo-truth-extractor/` and `src/dopemux/commands/`
+
+Drift observed:
+
+- the truth-doc paths named in `AGENTS.md` (`TRUTH_SYSTEMS.md`, `TRUTH_CANONICALS.md`, `TRUTH_GAPS.md`, `SYSTEM_RepoTruthExtractor.md`, `TRUTH_INTERFACES.md`, `PAL_EXECUTION_RULES.md`) were not present in this checkout at the expected paths
+- classification therefore fell back to runtime code, tests, git graph, and PR state as the active authority set
+
+## Branch Classification
+
+### Already merged / patch-equivalent / no re-integration
+
+| Branch | Current PR state | Evidence | Classification | Action |
+| --- | --- | --- | --- | --- |
+| `tp/rte-full-run-hygiene-and-launch-readiness` | PR `#461` merged on `2026-04-17` | `git cherry -v origin/main` shows all runtime-bearing commits as `-`; only `3af380e42` remains `+` and is CI-only | merged with non-runtime tail | exclude CI tail |
+| `codex/rte-seam-extraction-foundation-v2` | PR `#444` merged on `2026-04-13` | `git cherry -v origin/main` shows the seam extraction/runtime commits as `-` | already merged / superseded on main | exclude |
+| `codex/rte-intelligence-routing-proof` | PR `#451` merged on `2026-04-15` | `git cherry -v origin/main` shows all commits as `-` | already merged | exclude |
+| `extractor/prompt-governance-gtm` | PR `#435` merged on `2026-04-13` | `git cherry -v origin/main` shows all prompt-governance commits as `-` | already landed on main despite non-main original base | exclude |
+
+### Proof-only / mixed / out-of-scope lines
+
+| Branch | Current PR state | Evidence | Classification | Action |
+| --- | --- | --- | --- | --- |
+| `packet/rte-07-post-v1-deferred` | PR `#440` merged on `2026-04-13` | multiple merge bases, mixed docs/prompt/workflow stack, not a bounded runtime line | mixed branch | exclude |
+| `codex/rte-adapter-smoke` | PR `#437` closed-unmerged on `2026-04-13` | only `smoke_test_integration.py` and `src/dopemux/adhd/rte_adapter.py`; not canonical RTE runtime authority | reference-only / other plane | exclude |
+| `codex/rte-benchmark-r1-first-campaign` | no PR proven in this packet | mixed RTE + Serena + CLI diff; not a bounded mergeable runtime line | mixed branch / incomplete | exclude wholesale |
+| `feat/rte-structured-outputs-all-providers` | merged line includes current `main` commit `b241d427b` | wide structured-output stack; not replayed wholesale in this packet | divergent mixed stack | exclude wholesale |
+
+### Branch families with overlapping prescan/runtime work
+
+| Branch / family | Current PR state | Evidence | Classification | Action |
+| --- | --- | --- | --- | --- |
+| `feat/rte-v5-full-prescan-integration` | PR `#464` merged on `2026-04-21` | `main` already exposes Stage 0 flags and `run_integrated_prescan_stage`; raw cherry-pick conflicted across current runner and CLI surfaces | merged line with stale non-ancestor head | do not replay whole commit |
+| `tp/serena-audit-runtime-io-tools`, `tp/serena-runtime-fix` | no independent PR; both point at `76dfeb6e2` | alias heads for the `feat/rte-v5-full-prescan-integration` commit | alias / duplicate line | exclude |
+| `feat/rte-v5-prescan-contract-unification` | PR `#470` closed-unmerged on `2026-04-18` | `main` already contains `candidate_routes`, `ExecutionEvidence`, `RoutingExhausted`, `prescan_llm_attempts.json`, and `test_prescan_hardening.py`; raw cherry-pick still conflicted across engine/grok/models/provider catalog | closed-unmerged, semantically overlapped, no isolated missing delta proven | exclude wholesale |
+| `tp/serena-upstream-contract-diff` | no independent PR; points at `bf3a9244d` | alias head for `feat/rte-v5-prescan-contract-unification` | alias / duplicate line | exclude |
+| `feat/rte-prescan-first-live-hardening` | PR `#467` closed-unmerged on `2026-04-22` | `main` already contains most hardening surfaces and `test_prescan_hardening.py`; missing `test_prescan_online_gate.py` alone did not prove a required runtime delta | partially overlapped / incomplete line | exclude wholesale |
+| `feat/rte-prescan-stage0-live-lane-proving` | PR `#480` merged on `2026-04-22` | targeted validation on clean staging branch failed on `test_prescan_live_lane.py` because `prescan_live_lane_success.json` was not written and non-batch runs still bypassed attempt evidence | still-current bounded delta survives on this line | integrate bounded behavior only |
+
+## Integrated Delta
+
+The packet did **not** replay any whole historical branch.
+
+Raw cherry-pick attempts against the older prescan commits conflicted with the current `main` line on the canonical Stage 0 surfaces. That made full commit replay non-localized and therefore fail-closed for this packet.
+
+Instead, this packet integrated the smallest still-current runtime delta proven by the failing targeted test:
+
+1. add `write_live_lane_success_artifact(...)` to `services/repo-truth-extractor/lib/prescan/provider_catalog.py`
+2. record `selected_live_routes` in Stage 0 metadata
+3. write `prescan_live_lane_success.json` when an authorized live lane is selected
+4. route non-batch live prescan runs through `run_passes(...)` instead of forcing the batched path
+
+During validation, this packet also found a current `main` blocker unrelated to the preserved branch survivors but still inside RTE scope:
+
+- `services/repo-truth-extractor/run_extraction_v5.py` had an `IndentationError` at line `11083`
+- `git blame` traced the malformed indentation to commit `b241d427b` on `2026-04-23`
+- the staging branch fixes that indentation so the audit target compiles and the targeted operator-safety suite can run
+
+## Validation
+
+### Git / repo identity
+
+Observed during execution:
+
+- `git rev-parse --show-toplevel`
+- `test -f .dopetaskroot`
+- `git remote -v`
+- `git branch --show-current`
+- `git status --short --branch`
+- `git worktree list --porcelain`
+- `git branch -vv`
+
+### Branch / PR refresh
+
+Observed during execution:
+
+- `gh auth status`
+- `gh pr list --state all --limit 200 --json ...`
+- `git merge-base --is-ancestor ... origin/main`
+- `git cherry -v origin/main <branch>`
+- `git diff --stat origin/main...<branch>`
+
+### Runtime validation on staging branch
+
+`python -m py_compile services/repo-truth-extractor/lib/prescan/engine.py services/repo-truth-extractor/lib/prescan/provider_catalog.py services/repo-truth-extractor/run_extraction_v5.py`
+
+Passed after the `run_extraction_v5.py` indentation repair.
+
+`uv run --with pytest python -m pytest -q services/repo-truth-extractor/tests/test_prescan_hardening.py services/repo-truth-extractor/tests/test_prescan_live_lane.py services/repo-truth-extractor/tests/test_prescan_provider_catalog.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py`
+
+Final result: passed.
+
+Important intermediate evidence:
+
+- first run on clean staging branch failed in `test_prescan_live_lane.py::test_authorized_live_lane_writes_success_artifact_and_uses_selected_route`
+- a broader follow-up also exposed the `run_extraction_v5.py` syntax blocker already present on `main`
+- after the bounded Stage 0 patch and the indentation repair, the same targeted suite passed
+
+## Result
+
+The staging branch now reflects the intended most-up-to-date RTE implementation for the bounded pre-audit scope covered by this packet:
+
+- no broad historical branch replay was justified
+- the only still-current missing survivor-branch behavior that was concretely proven has been integrated
+- the current mainline syntax blocker in `run_extraction_v5.py` has been repaired on the staging branch
+- excluded branches remain explicitly classified rather than silently normalized into the staging line
+
+## Residual Risk
+
+- The absent truth-doc paths referenced by `AGENTS.md` remain documentation drift.
+- Several historical prescan branches still differ from `main`, but this packet did not prove any additional bounded missing delta beyond the live-lane success/evidence path.
+- Validation was intentionally narrow. No full live-provider end-to-end run was executed in this packet.

--- a/proof/rte-branch-integration-audit-2026-04-23.proof.json
+++ b/proof/rte-branch-integration-audit-2026-04-23.proof.json
@@ -1,0 +1,156 @@
+{
+  "packet_id": "TP-DMX-RTEINT-001",
+  "audit_id": "rte-branch-integration-audit-2026-04-23",
+  "execution_branch": "codex/rte-integration-staging-audit",
+  "execution_date": "2026-04-23",
+  "repo_identity": {
+    "repo_root": "/Users/hue/code/dopemux-mvp",
+    "repo_marker_present": true,
+    "origin_remote": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "origin_identity_match": true
+  },
+  "authority": {
+    "used": [
+      "runtime code under services/repo-truth-extractor/",
+      "wrapper code under src/dopemux/commands/",
+      "repo hygiene reports and proofs from TP-DMX-REPOHYG-002 and TP-DMX-REPOHYG-003",
+      "current git graph",
+      "current PR state from gh CLI"
+    ],
+    "missing_expected_docs": [
+      "TRUTH_SYSTEMS.md",
+      "TRUTH_CANONICALS.md",
+      "TRUTH_GAPS.md",
+      "SYSTEM_RepoTruthExtractor.md",
+      "TRUTH_INTERFACES.md",
+      "PAL_EXECUTION_RULES.md"
+    ]
+  },
+  "branch_inventory": [
+    {
+      "branch": "tp/rte-full-run-hygiene-and-launch-readiness",
+      "classification": "merged_with_ci_tail_excluded",
+      "integrated": false,
+      "evidence": [
+        "git cherry -v origin/main shows runtime-bearing commits as patch-equivalent (-)",
+        "only remaining positive tail is 3af380e42 chore(ci): retrigger CodeQL with updated workflow"
+      ]
+    },
+    {
+      "branch": "codex/rte-seam-extraction-foundation-v2",
+      "classification": "already_merged_or_superseded",
+      "integrated": false,
+      "evidence": [
+        "git cherry -v origin/main shows seam extraction commits as patch-equivalent (-)"
+      ]
+    },
+    {
+      "branch": "feat/rte-v5-full-prescan-integration",
+      "classification": "merged_line_with_stale_non_ancestor_head",
+      "integrated": false,
+      "evidence": [
+        "main already contains Stage 0 flags and run_integrated_prescan_stage",
+        "raw cherry-pick of 76dfeb6e2 conflicted with current runner and CLI surfaces"
+      ]
+    },
+    {
+      "branch": "feat/rte-v5-prescan-contract-unification",
+      "classification": "closed_unmerged_semantically_overlapped",
+      "integrated": false,
+      "evidence": [
+        "main already contains candidate_routes, ExecutionEvidence, RoutingExhausted, prescan_llm_attempts.json, and test_prescan_hardening.py",
+        "raw cherry-pick of bf3a9244d conflicted across current engine/grok/models/provider catalog surfaces"
+      ]
+    },
+    {
+      "branch": "feat/rte-prescan-first-live-hardening",
+      "classification": "closed_unmerged_partially_overlapped",
+      "integrated": false,
+      "evidence": [
+        "main already contains most hardening surfaces and test_prescan_hardening.py",
+        "no isolated required runtime delta was proven from this line"
+      ]
+    },
+    {
+      "branch": "feat/rte-prescan-stage0-live-lane-proving",
+      "classification": "still_current_bounded_delta",
+      "integrated": true,
+      "integration_mode": "manual_bounded_patch",
+      "evidence": [
+        "targeted validation initially failed in test_prescan_live_lane.py because prescan_live_lane_success.json was not written",
+        "non-batch live prescan runs were still forced through the batched path, leaving attempt evidence empty"
+      ]
+    },
+    {
+      "branch": "codex/rte-benchmark-r1-first-campaign",
+      "classification": "mixed_branch_not_mergeable",
+      "integrated": false
+    },
+    {
+      "branch": "feat/rte-structured-outputs-all-providers",
+      "classification": "divergent_multi_plane_branch",
+      "integrated": false
+    },
+    {
+      "branch": "codex/rte-intelligence-routing-proof",
+      "classification": "already_merged",
+      "integrated": false
+    },
+    {
+      "branch": "extractor/prompt-governance-gtm",
+      "classification": "already_landed_on_main",
+      "integrated": false
+    },
+    {
+      "branch": "packet/rte-07-post-v1-deferred",
+      "classification": "mixed_branch_excluded",
+      "integrated": false
+    },
+    {
+      "branch": "codex/rte-adapter-smoke",
+      "classification": "reference_only_other_plane",
+      "integrated": false
+    }
+  ],
+  "integrated_delta": {
+    "files_changed": [
+      "services/repo-truth-extractor/lib/prescan/engine.py",
+      "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+      "services/repo-truth-extractor/run_extraction_v5.py"
+    ],
+    "branch_line_delta": [
+      "write prescan_live_lane_success.json when an authorized live lane is selected",
+      "record selected_live_routes in stage0 metadata",
+      "run non-batch live prescan passes through run_passes instead of forcing the batched path"
+    ],
+    "validation_blocker_repair": {
+      "file": "services/repo-truth-extractor/run_extraction_v5.py",
+      "problem": "IndentationError at line 11083 on current main",
+      "source_commit": "b241d427b",
+      "repair": "re-indent route_entry assignment inside strict_contract_required block"
+    }
+  },
+  "validation": {
+    "commands": [
+      "python -m py_compile services/repo-truth-extractor/lib/prescan/engine.py services/repo-truth-extractor/lib/prescan/provider_catalog.py services/repo-truth-extractor/run_extraction_v5.py",
+      "uv run --with pytest python -m pytest -q services/repo-truth-extractor/tests/test_prescan_hardening.py services/repo-truth-extractor/tests/test_prescan_live_lane.py services/repo-truth-extractor/tests/test_prescan_provider_catalog.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py"
+    ],
+    "intermediate_failures": [
+      {
+        "test": "services/repo-truth-extractor/tests/test_prescan_live_lane.py::test_authorized_live_lane_writes_success_artifact_and_uses_selected_route",
+        "observed_problem": "prescan_live_lane_success.json absent, then attempt evidence empty on non-batch path"
+      },
+      {
+        "command": "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py",
+        "observed_problem": "IndentationError: unexpected indent (run_extraction_v5.py, line 11083)"
+      }
+    ],
+    "final_result": "pass",
+    "warning": "pytest reported PytestConfigWarning: Unknown config option: asyncio_mode"
+  },
+  "residual_risk": [
+    "Expected truth-doc paths referenced by AGENTS.md remain absent in this checkout.",
+    "No full live-provider end-to-end run was executed in this packet.",
+    "Several historical RTE branches still diverge from main, but no additional bounded missing delta was proven here."
+  ]
+}

--- a/services/repo-truth-extractor/lib/prescan/engine.py
+++ b/services/repo-truth-extractor/lib/prescan/engine.py
@@ -25,6 +25,7 @@ from .provider_catalog import (
     build_prescan_routing_plan,
     build_provider_model_catalog,
     build_provider_readiness_matrix,
+    write_live_lane_success_artifact,
     write_no_live_lane_artifact,
     write_provider_catalog,
     write_provider_readiness,
@@ -91,6 +92,7 @@ class PrescanEngine:
                     "catalog_status": "PASS",
                     "provider_readiness_status": stage0["readiness"]["status"],
                     "routing_plan_status": stage0["routing_plan"]["status"],
+                    "selected_live_routes": stage0["routing_plan"].get("selected_routes", {}),
                 }
                 if stage0["routing_plan"]["status"] == NO_LIVE_LANE:
                     write_no_live_lane_artifact(self.config.output_dir, stage0["routing_plan"])
@@ -112,13 +114,23 @@ class PrescanEngine:
                         metadata=metadata,
                     )
                 if self.config.allow_online_llm:
-                    grok_results = self.grok_runner.run_passes_batched(
-                        passes,
-                        intelligence,
-                        manifest,
-                        batch_plans,
-                        routing_plan=stage0["routing_plan"],
-                    )
+                    write_live_lane_success_artifact(self.config.output_dir, stage0["routing_plan"])
+                if self.config.allow_online_llm:
+                    if self.config.batch_mode and batch_plans:
+                        grok_results = self.grok_runner.run_passes_batched(
+                            passes,
+                            intelligence,
+                            manifest,
+                            batch_plans,
+                            routing_plan=stage0["routing_plan"],
+                        )
+                    else:
+                        grok_results = self.grok_runner.run_passes(
+                            passes,
+                            intelligence,
+                            manifest,
+                            routing_plan=stage0["routing_plan"],
+                        )
                     intelligence["grok_passes"] = grok_results
 
             intelligence_path = self._write_json("prescan_intelligence.json", intelligence)

--- a/services/repo-truth-extractor/lib/prescan/provider_catalog.py
+++ b/services/repo-truth-extractor/lib/prescan/provider_catalog.py
@@ -609,3 +609,19 @@ def write_no_live_lane_artifact(output_dir: Path, plan: dict[str, Any]) -> Path:
     }
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return path
+
+
+def write_live_lane_success_artifact(output_dir: Path, plan: dict[str, Any]) -> Path:
+    path = output_dir / "prescan_live_lane_success.json"
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": "LIVE_LANE_READY",
+        "halt_before_stage_1": False,
+        "requested_passes": list(plan.get("requested_passes") or []),
+        "provider_readiness_status": str(plan.get("provider_readiness_status") or "UNKNOWN"),
+        "selected_routes": dict(plan.get("selected_routes") or {}),
+        "candidate_routes": dict(plan.get("candidate_routes") or {}),
+        "fallback_decisions": dict(plan.get("fallback_decisions") or {}),
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -11069,7 +11069,7 @@ def execute_step_for_partitions(
     draft_structured_output_meta: Dict[str, Any] = {}
     if strict_contract_required and isinstance(step_contract, dict):
         primary_routes = route_entries_for_stage(step_contract, "primary")
-route_entry = next(
+        route_entry = next(
             (
                 candidate
                 for candidate in primary_routes

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -46,6 +46,7 @@ A packet is superseded by another packet
 | TP-DMX-REPOHYG-002 | Repo Hygiene | Execute phase2 safe archive cleanup | Ready | N/A |
 | TP-DMX-REPOHYG-003 | Repo Hygiene | Resolve blocked and ambiguous cleanup survivors | Ready | N/A |
 | TP-DMX-RTEAUDIT-001 | Repo Truth Extractor | Assemble pre-live audit pack for GPT-5.4 Pro | Ready | N/A |
+| TP-DMX-RTEINT-001 | Repo Truth Extractor | Integrate current RTE branch deltas into staging audit branch | Ready | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 

--- a/task-packets/TP-DMX-RTEINT-001.json
+++ b/task-packets/TP-DMX-RTEINT-001.json
@@ -1,0 +1,69 @@
+{
+  "id": "TP-DMX-RTEINT-001",
+  "project": "dopemux-mvp",
+  "target": "Determine which RTE-related branches contain current, incomplete, superseded, or mergeable implementation work; integrate the missing current work into a single staging branch before GPT-5.4 Pro performs the pre-live audit.",
+  "invariants": [
+    "Do not assume any RTE-related branch is mergeable solely from its name.",
+    "Do not merge branches into main directly in this packet; use a staging integration branch first.",
+    "Do not modify unrelated runtime, service, or product areas outside the RTE integration scope.",
+    "Preserve Dopemux architectural authority boundaries and repo-truth hierarchy.",
+    "Every branch classification must be evidence-backed using current git graph, PR state, diff scope, and validation state.",
+    "Explicitly distinguish already-merged, superseded, incomplete, conflicting, proof-only, and code-bearing branches.",
+    "Do not collapse docs/proof-only branches into code-bearing implementation lines.",
+    "Do not claim readiness for audit until the staging branch reflects the intended most-up-to-date RTE implementation.",
+    "All merge or cherry-pick actions must be reproducible and recorded in proof.",
+    "If integration conflicts or validation failures remain unresolved, stop fail-closed and record blockers instead of proceeding to audit."
+  ],
+  "depends_on": [
+    "TP-DMX-REPOHYG-001",
+    "TP-DMX-REPOHYG-002",
+    "TP-DMX-REPOHYG-003"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-RTE-INTEGRATION-SERIES-001",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/rte-integration-staging-audit"
+  },
+  "commit": {
+    "message": "rte: integrate current branch deltas into pre-audit staging branch",
+    "allowlist": [
+      "docs/05-audit-reports/rte-branch-integration-audit-2026-04-23.md",
+      "proof/rte-branch-integration-audit-2026-04-23.proof.json",
+      "task-packets/TP-DMX-RTEINT-001.json",
+      "task-packets/INDEX.md",
+      "services/repo-truth-extractor/**",
+      "src/dopemux/commands/extractor_commands.py",
+      "src/dopemux/commands/**",
+      "UPGRADES/**",
+      "proof/**",
+      "docs/05-audit-reports/**"
+    ],
+    "verify": [
+      "git rev-parse --show-toplevel",
+      "test -f .dopetaskroot",
+      "git remote -v",
+      "git branch --show-current",
+      "git status --short --branch",
+      "git worktree list --porcelain",
+      "git branch -vv",
+      "python -m json.tool task-packets/TP-DMX-RTEINT-001.json",
+      "python -m json.tool proof/rte-branch-integration-audit-2026-04-23.proof.json"
+    ]
+  },
+  "pr": {
+    "title": "rte: integrate current branch deltas into pre-audit staging branch",
+    "body": "## Summary\n- audit all RTE-related branch lines against main\n- classify each line as merged, superseded, incomplete, conflicting, proof-only, or code-bearing\n- integrate the still-current code-bearing deltas into a single staging branch\n- validate the staging branch as the most up-to-date implementation for the GPT-5.4 Pro pre-live audit\n\n## Scope\n- RTE runner, prescan/stage-0, routing/gating, prompt/promptset, directly related tests, proofs, and directly affected wrapper/docs surfaces only\n- no unrelated runtime changes\n- no direct merge to main in this packet\n\n## Validation\n- current git graph and PR authority refreshed\n- integrated branch deltas recorded with reasons\n- targeted RTE validation run on staging branch\n- blockers recorded fail-closed if integration is incomplete\n\n## Follow-up\nUse the staging branch or the merged result as the authoritative target for the GPT-5.4 Pro code and prompt audit.",
+    "base": "main"
+  }
+}


### PR DESCRIPTION
## Summary
- audit all RTE-related branch lines against main
- classify each line as merged, superseded, incomplete, conflicting, proof-only, or code-bearing
- integrate the still-current code-bearing deltas into a single staging branch
- validate the staging branch as the most up-to-date implementation for the GPT-5.4 Pro pre-live audit

## Scope
- RTE runner, prescan/stage-0, routing/gating, prompt/promptset, directly related tests, proofs, and directly affected wrapper/docs surfaces only
- no unrelated runtime changes
- no direct merge to main in this packet

## Validation
- current git graph and PR authority refreshed
- integrated branch deltas recorded with reasons
- targeted RTE validation run on staging branch
- blockers recorded fail-closed if integration is incomplete

## Follow-up
Use the staging branch or the merged result as the authoritative target for the GPT-5.4 Pro code and prompt audit.
