### PR TITLE
docs: point truth references at tracked repo docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,10 +10,13 @@ Repo truth beats docs.
 
 - The task packet names `RULES.md`, `PROJECT.md`, `ARCHITECTURE.md`, `SYSTEM_BOUNDARIES.md`, `PM_PLANE.md`, `DOC_TRUST_MAP.md`, and `DOCS_VS_REPO_DIFF.md` as allowed authority.
 - In this checkout, those files were not present during this rewrite.
-- The repo-truth artifacts present in this pass were:
-  - `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_SYSTEMS.md`
-  - `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_CANONICALS.md`
-  - `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_GAPS.md`
+- The repo-truth artifacts present in this pass are tracked in:
+  - `docs/03-reference/truth/truth-systems.md`
+  - `docs/03-reference/truth/truth-canonicals.md`
+  - `docs/03-reference/truth/truth-gaps.md`
+  - `docs/03-reference/truth/truth-interfaces.md`
+  - `docs/03-reference/truth/truth-data-events.md`
+  - `docs/03-reference/truth/truth-scope.md`
 - Do not invent the contents of `RULES.md`, `SYSTEM_BOUNDARIES.md`, `PM_PLANE.md`, or `DOC_TRUST_MAP.md`. If those files are added later, use them, but repo truth beats docs.
 
 ## 3. Canonical Operator Surfaces
@@ -62,7 +65,7 @@ Repo truth beats docs.
 
 ## 8. Docs Trust
 
-- For this rewrite pass, the usable truth docs were `TRUTH_SYSTEMS.md`, `TRUTH_CANONICALS.md`, and `TRUTH_GAPS.md`.
+- For this rewrite pass, the usable truth docs are the tracked `docs/03-reference/truth/*` references, with `truth-systems.md`, `truth-canonicals.md`, and `truth-gaps.md` carrying the strongest direct operator guidance.
 - `DOC_TRUST_MAP.md` and `DOCS_VS_REPO_DIFF.md` were named in the packet but not present in this checkout.
 - Older docs and README surfaces may drift from runtime reality. Escalate the drift instead of normalizing it away.
 - Repo truth beats docs.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -145,7 +145,7 @@ In practical terms, the repository is shaped as a mixed workspace:
 - `services/*` for the major service families, including task-orchestrator, dopecon-bridge, dope-context, working-memory-assistant/dope-memory, ADHD Engine, and repo-truth-extractor
 - `docker/*` for compose support and container build/runtime sources, including active MCP server source trees
 - `docs/03-reference/*` for current reference documents
-- `docs/03-reference/truth/*`, `tmp/dmx-chatgpt-project-truth-extraction-002/*`, and related generated truth artifacts for prior extraction outputs
+- `docs/03-reference/truth/*` and related generated truth artifacts for prior extraction outputs
 
 This is not a single-package codebase and not a single-service repo. It is a mixed CLI, services, compose, adapters, and generated-artifact workspace.
 

--- a/docs/03-reference/planes/pm/pm-plane.md
+++ b/docs/03-reference/planes/pm/pm-plane.md
@@ -11,7 +11,7 @@ prelude: Pm Plane (reference) for dopemux documentation and developer workflows.
 ---
 # PM_PLANE
 
-This document is derived only from repository truth. Primary authority for this file is, in order: `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_GAPS.md`, `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_DATA_EVENTS.md`, `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_SYSTEMS.md`, `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_CANONICALS.md`, `src/dopemux/pm/writes.py`, `services/dopecon-bridge/README.md`, `services/dopecon-bridge/dopecon_bridge/routes.py`, `services/task-orchestrator/app/services/workflow_store.py`, and `services/task-orchestrator/app/adapters/bridge_adapter.py`.
+This document is derived only from repository truth. Primary authority for this file is, in order: `docs/03-reference/truth/truth-gaps.md`, `docs/03-reference/truth/truth-data-events.md`, `docs/03-reference/truth/truth-systems.md`, `docs/03-reference/truth/truth-canonicals.md`, `src/dopemux/pm/writes.py`, `services/dopecon-bridge/README.md`, `services/dopecon-bridge/dopecon_bridge/routes.py`, `services/task-orchestrator/app/services/workflow_store.py`, and `services/task-orchestrator/app/adapters/bridge_adapter.py`.
 
 It preserves split, ambiguous, and contradictory states where repo truth does not establish a single authority. It does not normalize unresolved drift. No runtime APIs, interfaces, or types are introduced or changed here.
 
@@ -19,7 +19,7 @@ It preserves split, ambiguous, and contradictory states where repo truth does no
 
 The PM plane is not a single system.
 
-It is a distributed authority model for PM-domain concerns. Repo truth shows PM ownership split by domain slice, not collapsed into one service hub. `src/dopemux/pm/writes.py` assigns different canonical writers to metadata, workflow-significant transitions, and progress or decision logging. `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_GAPS.md` and the derived secondary check in `docs/03-reference/systems/system-boundaries.md` both preserve PM authority as split rather than unified.
+It is a distributed authority model for PM-domain concerns. Repo truth shows PM ownership split by domain slice, not collapsed into one service hub. `src/dopemux/pm/writes.py` assigns different canonical writers to metadata, workflow-significant transitions, and progress or decision logging. `docs/03-reference/truth/truth-gaps.md` and the derived secondary check in `docs/03-reference/systems/system-boundaries.md` both preserve PM authority as split rather than unified.
 
 The safe current interpretation is:
 
@@ -37,7 +37,7 @@ Observed PM authority split from repo truth:
 - Progress -> `ConPort`
 - Memory receipts -> `dope-memory`
 
-This split is stated directly in `src/dopemux/pm/writes.py` and repeated in `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_DATA_EVENTS.md`:
+This split is stated directly in `src/dopemux/pm/writes.py` and repeated in `docs/03-reference/truth/truth-data-events.md`:
 
 - `pm_update_work_item` performs canonical metadata writes through the Leantime client.
 - `pm_transition_work_item` performs canonical workflow transitions through the task-orchestrator client and mirrors the outcome to Leantime.
@@ -51,7 +51,7 @@ Mirror receipts are secondary evidence, not source truth. They record downstream
 
 `User / Agent -> task-orchestrator -> dopecon-bridge -> upstream systems (ConPort / Leantime) -> dope-memory (receipt)`
 
-This is an observed bridge-mediated integration path, not proof that every PM write in the repo currently passes through the bridge. `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_DATA_EVENTS.md` shows task-orchestrator workflow persistence flowing outbound through DopeconBridge custom-data paths, and it separately shows `dopecon-bridge` routing selected PM calls to upstream services. At the same time, repo truth also includes normalized PM write helpers in `src/dopemux/pm/writes.py`, bridge-backed workflow persistence in `services/task-orchestrator/app/services/workflow_store.py`, and bridge-backed ConPort or PM adapters in `services/task-orchestrator/app/adapters/bridge_adapter.py`. The repo therefore contains multiple observed write-capable seams, and this document does not flatten them into one universal runtime path.
+This is an observed bridge-mediated integration path, not proof that every PM write in the repo currently passes through the bridge. `docs/03-reference/truth/truth-data-events.md` shows task-orchestrator workflow persistence flowing outbound through DopeconBridge custom-data paths, and it separately shows `dopecon-bridge` routing selected PM calls to upstream services. At the same time, repo truth also includes normalized PM write helpers in `src/dopemux/pm/writes.py`, bridge-backed workflow persistence in `services/task-orchestrator/app/services/workflow_store.py`, and bridge-backed ConPort or PM adapters in `services/task-orchestrator/app/adapters/bridge_adapter.py`. The repo therefore contains multiple observed write-capable seams, and this document does not flatten them into one universal runtime path.
 
 ## 4. Bridge Role
 
@@ -59,7 +59,7 @@ This is an observed bridge-mediated integration path, not proof that every PM wr
 
 Its active runtime role is adapter, router, translator, proxy, event transport, and policy-check layer. `services/dopecon-bridge/README.md` and `services/dopecon-bridge/dopecon_bridge/routes.py` explicitly constrain it to adapter-safe PM operations, ConPort-backed compatibility routes, and fail-closed blocking for bridge-local task creation or status mutation. Workflow-significant PM mutations are blocked unless adjudicated by task-orchestrator.
 
-This creates a boundary risk. `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_GAPS.md` calls out that downstream operators may still treat bridge endpoints as authoritative because they expose `/kg/*`, `/ddg/*`, and PM routing surfaces while repo truth simultaneously says the bridge must not be canonical task, workflow, decision, or progress authority.
+This creates a boundary risk. `docs/03-reference/truth/truth-gaps.md` calls out that downstream operators may still treat bridge endpoints as authoritative because they expose `/kg/*`, `/ddg/*`, and PM routing surfaces while repo truth simultaneously says the bridge must not be canonical task, workflow, decision, or progress authority.
 
 The repo also contains a contradiction that must be preserved. `services/shared/dopecon_bridge_client/README.md` describes the bridge as a "single authority point" for coordination and several shared access paths. That wording conflicts with the sanctioned runtime truth in `services/dopecon-bridge/README.md` and the active route policy in `services/dopecon-bridge/dopecon_bridge/routes.py`, both of which explicitly deny canonical PM authority to the bridge. For PM-plane purposes, the sanctioned active runtime wins; the shared-client wording is terminology drift, not canonical PM authority.
 
@@ -92,7 +92,7 @@ The safe current model is eventual consistency where mirrors exist:
 Observed risks from current repo truth:
 
 - Split authority risk
-  - `tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_GAPS.md` states that PM authority is split across Leantime, task-orchestrator, ConPort, and dope-memory mirror receipts, and warns that any service expanding beyond its declared slice creates silent contract drift.
+  - `docs/03-reference/truth/truth-gaps.md` states that PM authority is split across Leantime, task-orchestrator, ConPort, and dope-memory mirror receipts, and warns that any service expanding beyond its declared slice creates silent contract drift.
 - Bridge confusion
   - `TRUTH_GAPS.md`, `services/dopecon-bridge/README.md`, and the active bridge routes all show the same risk: bridge endpoints can look authoritative while the sanctioned runtime explicitly says they are not.
 - Multiple write-capable paths

--- a/docs/03-reference/systems/system-boundaries.md
+++ b/docs/03-reference/systems/system-boundaries.md
@@ -11,7 +11,7 @@ prelude: System Boundaries (reference) for dopemux documentation and developer w
 ---
 # SYSTEM_BOUNDARIES
 
-This document is derived only from `TRUTH_SYSTEMS.md`, `TRUTH_INTERFACES.md`, `TRUTH_DATA_EVENTS.md`, `TRUTH_CANONICALS.md`, and `TRUTH_GAPS.md` in `tmp/dmx-chatgpt-project-truth-extraction-002/`. It does not normalize contradictions. It preserves `UNKNOWN`, `ambiguous`, and `split` where the truth packet does not establish a single authority. No public APIs, interfaces, or types are introduced or changed here.
+This document is derived only from the tracked truth references in `docs/03-reference/truth/`: `truth-systems.md`, `truth-interfaces.md`, `truth-data-events.md`, `truth-canonicals.md`, and `truth-gaps.md`. It does not normalize contradictions. It preserves `UNKNOWN`, `ambiguous`, and `split` where the truth packet does not establish a single authority. No public APIs, interfaces, or types are introduced or changed here.
 
 ## Authority Model Overview
 

--- a/docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md
+++ b/docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md
@@ -139,7 +139,7 @@ Storage surfaces:
 - Mixed implementation maturity in coordinator health:
   `/Users/hue/code/dopemux-mvp/services/task-orchestrator/app/core/coordinator.py` reports several plane-health dependencies as placeholders returning `"healthy"` without observed real checks for Leantime, Task Master, Serena, or ConPort.
 - Older docs can overstate a cleaner architecture than the runtime earns:
-  repo-truth artifacts already record unresolved canonicality for Task Orchestrator in `/Users/hue/code/dopemux-mvp/tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_CANONICALS.md` and `/Users/hue/code/dopemux-mvp/tmp/dmx-chatgpt-project-truth-extraction-002/TRUTH_GAPS.md`.
+  repo-truth artifacts already record unresolved canonicality for Task Orchestrator in `/Users/hue/code/dopemux-mvp/docs/03-reference/truth/truth-canonicals.md` and `/Users/hue/code/dopemux-mvp/docs/03-reference/truth/truth-gaps.md`.
 
 ## 8. Working Rules
 


### PR DESCRIPTION
## Summary
- point active operator/reference docs at the tracked truth docs under 
- stop citing the old  bundle as the live source path
- leave historical audit reports untouched so past drift stays auditable

## Validation
- confirmed the tracked  files semantically match the sibling checkout extraction artifacts
- rescanned active docs for stale  references
- confirmed the sibling checkout's only tracked delta is a stale prescan test commit, not missing truth-doc content

## Notes
-  had unrelated local appended memory context; that remained unstaged and was not included in this commit.
- one historical command reference remains inside  because it records commands used in the original extraction pass rather than acting as current path guidance.

@codex 
@clauee
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated