### PR TITLE
Finalize TUI v2 decision docs and close U6 fallback

### DIFF
--- a/docs/03-reference/systems/dopemux/tui-spec-v2-0a.md
+++ b/docs/03-reference/systems/dopemux/tui-spec-v2-0a.md
@@ -22,7 +22,7 @@ This specification defines the terminal-native operator shell for Dopemux Round 
 
 **Non-goals**: web framing, HTML/DOM, mouse, hover effects, automation-invoked human actions, unified task records, unified PM or Implementer records.
 
-**Authority**: This spec is normative for Terminal UI layout, interaction, and visual tokens. Per-backend HTTP/RPC contracts and role models are still UNKNOWN and will block specific implementation steps.
+**Authority**: This spec is normative for Terminal UI layout, interaction, and visual tokens. `dope-context` transport is frozen for this spec pass, but the other six backend HTTP/RPC contracts remain unresolved. The two-role session model is resolved; broader runtime wiring still blocks specific implementation steps.
 
 ---
 
@@ -57,6 +57,7 @@ Tasks, Decisions, Memory, and Search are demoted to supporting views reached by 
 **Left rail** (columns 1–24, rows 5–34):
 - Task list or workflow queue, scoped by mode
 - Each row shows: `[glyph] task-id / title [unread-indicator]`
+- Unread precedence is deterministic: render the newest unread packet; on equal timestamps, PM mode prefers `PKB`, Implementer mode prefers `PKT`; if still tied after mode-aware preference, `PKB` sorts before `PKT` lexically for stable rendering.
 - Pane authority: `task-orchestrator` for workflow state
 
 **Center** (columns 26–83, split at row 25):
@@ -85,8 +86,9 @@ Send does **not** trigger a task-orchestrator state transition and does **not** 
 - **Sent (Active)**: visible in inspector with `sent_at` timestamp; remains active for 30 days
 - **Archived**: after 30 days, moved to history/search
 - **Pinned**: exempt from auto-archive, marked with `[PIN]` chip at archive threshold
+- **Scope-edge PKB content**: if a `PKB` crosses an agreed scope edge, the envelope still renders `[LOGGED]`; the scope-edge condition is body-rendered only. `[EDGE]` is not approved for PKB arrival on the envelope.
 
-Pin state is carried on the envelope and mirrored on the dope-memory chronicle receipt. Unpin writes a new receipt with `pinned_at: null`.
+Pin state is carried on the envelope and mirrored on the dope-memory chronicle receipt. Pin exemption is resolved from the latest dope-memory receipt for the packet id. The dope-memory mirror uses append-only `pinned_at` receipt semantics: pin writes a receipt with non-null `pinned_at`, and unpin writes a new receipt with `pinned_at: null`.
 
 ---
 
@@ -94,15 +96,15 @@ Pin state is carried on the envelope and mirrored on the dope-memory chronicle r
 
 ### 3.1 Service Domain Table
 
-| Domain | Service | Authority Role | Canonical Operations |
-|--------|---------|------------------|----------------------|
-| Workflow state | task-orchestrator | Approver / Operator | status, queue order, blockers, approvals |
-| Metadata | leantime | Operator | title, description, assignee, labels, due date, estimate, linked references |
-| Decisions | conport | Operator | decision log, progress entry, pattern storage |
-| History | dope-memory | System | chronicle receipt, pin state, archive entries |
-| Retrieval | dope-context | System | code search, doc search, codebase navigation |
-| Execution | dopetask | System | task runner, no state ownership |
-| Bridge adapter | dopecon-bridge | Tier-2 (shift-Y) | adapter-only, never canonical |
+| Domain | Service | Authority Role | Transport | Canonical Operations |
+|--------|---------|------------------|-----------|----------------------|
+| Workflow state | task-orchestrator | Approver / Operator | PENDING | status, queue order, blockers, approvals |
+| Metadata | leantime | Operator | PENDING | title, description, assignee, labels, due date, estimate, linked references |
+| Decisions | conport | Operator | PENDING | decision log, progress entry, pattern storage |
+| History | dope-memory | System | PENDING | chronicle receipt, pin state, archive entries |
+| Retrieval | dope-context | System | HTTP/JSON | code search, doc search, codebase navigation |
+| Execution | dopetask | System | PENDING | task runner, no state ownership |
+| Bridge adapter | dopecon-bridge | Tier-2 (shift-Y) | PENDING | adapter-only, never canonical |
 
 ### 3.2 Four Authority Prevention Mechanisms
 
@@ -149,6 +151,14 @@ The following writes are forbidden:
 | History receipt | dope-memory | `WRITE -> dope-memory : <action>` | Step 11+ |
 
 **Note**: A pane displaying a field does not imply that pane's backing service owns that field. The confirm modal's target service name is canonical.
+
+### 3.6 Session Role Model
+
+The TUI uses exactly two canonical human roles:
+- `operator`
+- `approver`
+
+A session may carry `operator`, `approver`, or both. Non-`[a]` canonical writes (`[H] send`, `[c]`, `[x]`, `[p]`, `[o]` when it performs a write) require `operator`. `[a] approve` requires `approver`. Sessions carrying both roles may perform both classes of action without introducing a third role or new authority tier.
 
 ---
 
@@ -275,7 +285,7 @@ On 80×24 terminals:
 - `[p]` — pin packet (dope-memory ownership, with confirmation)
 - `[o]` — open full view (expand to supporting view)
 - `[x]` — close / abandon draft (with confirmation)
-- `[a]` — approve task (role-gated, task-orchestrator-only)
+- `[a]` — approve task (approver-gated, task-orchestrator-only)
 
 **Meta**:
 - `[q]` — quit
@@ -285,17 +295,17 @@ On 80×24 terminals:
 
 **Send packet**:
 ```
-[H] send  →  confirm modal names target (ConPort + dope-memory)  →  writes both  →  marks sent_at  →  pin offered
+[H] send  →  operator role check  →  confirm modal names target (ConPort + dope-memory)  →  writes both  →  marks sent_at  →  pin offered
 ```
 
 **Approve task**:
 ```
-[a] approve  →  role check  →  confirm modal → task-orchestrator write  →  return to mode
+[a] approve  →  approver role check  →  confirm modal → task-orchestrator write  →  return to mode
 ```
 
 **Pin packet**:
 ```
-[p] pin  →  dope-memory receipt updated  →  `pinned_at` set  →  exempt from 30-day archive
+[p] pin  →  operator role check  →  dope-memory receipt appended  →  `pinned_at` set  →  exempt from 30-day archive
 ```
 
 ### 5.3 Keyboard vs Mouse
@@ -314,16 +324,18 @@ All write confirms follow this pattern:
 │ target: <canonical service>     │
 │ action: <field or state change> │
 │ affected: <item id and scope>   │
+│ role required: <operator|approver> │
 │                                 │
 │ [Y]es [N]o [?]help              │
 └─────────────────────────────────┘
 ```
 
 **Examples**:
-- `WRITE -> leantime : title` — metadata
-- `WRITE -> task-orchestrator : status = in_progress` — workflow
-- `WRITE -> conport : decision logged` — decision
-- `WRITE -> dope-memory : pinned` — history
+- `WRITE -> leantime : title` — metadata, role required: `operator`
+- `WRITE -> task-orchestrator : status = in_progress` — workflow, role required: `operator`
+- `WRITE -> conport : decision logged` — decision, role required: `operator`
+- `WRITE -> dope-memory : pinned` — history, role required: `operator`
+- `WRITE -> task-orchestrator : approve` — approval, role required: `approver`
 - `ADAPTER -> dopecon-bridge : fallback-read` — bridge (requires `shift-Y`)
 
 ---
@@ -345,9 +357,11 @@ All write confirms follow this pattern:
 - `!` — warning
 
 **Unread indicators**:
-- `⊕` — unread PKT (in PM mode)
-- `⊖` — unread PKB (in Implementer mode)
+- `⊕` — newest unread packet resolves to `PKT`
+- `⊖` — newest unread packet resolves to `PKB`
 - empty — no unread packets
+
+If both unread `PKT` and unread `PKB` exist on the same task, the renderer compares unread timestamps first. If one is newer, it wins. If timestamps tie, PM mode prefers `PKB` and Implementer mode prefers `PKT`. If timestamps and preferred type still fail to break the tie, the renderer falls back to lexical packet-type ordering (`PKB` before `PKT`) so the row remains stable across redraws.
 
 **Authority**: always `task-orchestrator` for workflow state (status, queue order).
 
@@ -359,6 +373,8 @@ All write confirms follow this pattern:
 **Row format**: `field_name: value [SRC:service]`
 
 **Authority**: mixed — each row tagged with its canonical service (leantime, task-orchestrator, conport, dope-memory).
+
+**Unread drill-down rule**: even when the row affordance suppresses one unread type, the packet pane and drill-down view must surface unread `PKT` and unread `PKB` independently.
 
 ### 6.3 Inspector (Detailed View)
 
@@ -391,6 +407,25 @@ Every user action in a confirm modal must include the target service name and ac
 - **History**: `WRITE -> dope-memory : <receipt-type>`
 - **Bridge**: `ADAPTER -> dopecon-bridge : <action>` (shift-Y required)
 
+### 6.7 Scope-Edge Recommendation Rendering
+
+If a `PKB` arrives carrying a recommendation that crosses an agreed scope edge, the envelope renders `[LOGGED]`. The scope-edge condition is rendered in the packet body or inspector text, not by reusing `[EDGE]`. No new chip is introduced.
+
+**Approved fallback copy**:
+- PKB arrival line: `[LOGGED] PKB-0481 received. Scope-edge recommendation in body.`
+- Scope-edge body text: `Scope edge: This recommendation extends beyond the current agreed scope. Review before any workflow transition or metadata write.`
+- Confirm modal text:
+
+```text
+Confirm: apply recommended transition
+target: task-orchestrator
+action: transition after scope-edge review
+affected: T-1203 via PKB-0481
+role required: operator
+```
+
+- Role-required refusal: `[BLOCKER] Operator role required. Scope-edge recommendation cannot be actioned in this session.`
+
 ---
 
 ## 7. Visual Token Mapping
@@ -401,11 +436,13 @@ Every user action in a confirm modal must include the target service name and ac
 |------|-------|---------|-----|
 | `[LIVE]` | chip.live (cyan) | Active / running process | Task in progress, live service |
 | `[BLOCKER]` | chip.blocker (pink) | Blocking error | Task stuck, critical issue |
-| `[OVERRIDE]` | chip.override (gold) | Manual override | Scope edge crossed, decision override |
-| `[LOGGED]` | chip.logged (mint) | Successfully recorded | Packet sent, decision logged |
+| `[OVERRIDE]` | chip.override (gold) | Manual override | Decision override only |
+| `[LOGGED]` | chip.logged (mint) | Successfully recorded | Packet sent, decision logged, fallback packet state |
 | `[AFTERCARE]` | chip.aftercare (violet) | Post-action follow-up | Requires follow-up decision |
 | `[PIN]` | chip.logged (mint) | Pin exemption from archive | Pinned packet at archive threshold |
-| `[EDGE]` | chip.edge (cyan) | Scope edge crossed (pending brand review) | Boundary condition flagged |
+| `[EDGE]` | chip.edge (cyan) | Reserved vocabulary item; not approved for PKB scope-edge fallback | Do not reuse for packet arrival fallback |
+
+**Footnote**: PKB scope-edge recommendations render `[LOGGED]` on the envelope and body text carries the scope-edge meaning. `[EDGE]` is not reused on this surface.
 
 ### 7.2 Glyph Set
 
@@ -480,6 +517,17 @@ trait Source {
 
 **Authority enforcement**: Every pane carries `authority: ServiceId`. Bridge adapter always returns `canonical() = false`.
 
+**Transport note**: `dope-context` is the only backend whose transport surface is treated as resolved in this spec pass. The remaining six backend transports stay open and must not be normalized by assumption.
+
+#### dope-context Source Adapter Contract
+
+- **Protocol**: HTTP/JSON
+- **Auth**: bearer token sourced from environment
+- **Pagination**: cursor pagination
+- **Filter shape**: structured filter object
+- **Rationale binding**: this contract applies only to `dope-context`; the TUI must not assume cross-service transport symmetry
+- **Expected retrieval shape**: top-k retrieval with complexity and breadcrumb-bearing rows for `[g s]` search and the Implementer retrieval pane
+
 ### 9.3 Acceptance Criteria
 
 1. ✓ Five top-level modes (PM, Implementer, Overview, Services, Events)
@@ -490,45 +538,42 @@ trait Source {
 6. ✓ Confirm modals name target service (`WRITE -> <service> : <action>`)
 7. ✓ Bridge adapter output segregated below gold hazard line
 8. ✓ `[H] send` writes to ConPort and dope-memory only (no task-orchestrator transition)
-9. ✓ Pin state owned by dope-memory with `pinned_at` field on chronicle receipt
+9. ✓ Pin state owned by dope-memory with append-only `pinned_at` field on chronicle receipt
 10. ✓ 30-day packet archive with reaper owned by dopemux
 11. ✓ Leantime writes limited to 7 metadata fields only
 12. ✓ Workflow-significant writes blocked from Leantime (routed to task-orchestrator)
-13. ✓ Role gating on `[a] approve` (task-orchestrator-only)
-14. ✓ No mouse, no hover, no HTML/DOM
-15. ✓ DOPEMUX_THEME tokens enforced (no raw hex colors)
+13. ✓ Two-role session model: every authenticated session carries exactly `operator`, `approver`, or both
+14. ✓ Unread precedence algorithm is explicit and deterministic
+15. ✓ Scope-edge fallback remains `[LOGGED]` on the envelope; no packet-level `[EDGE]` reuse
+16. ✓ No mouse, no hover, no HTML/DOM
+17. ✓ DOPEMUX_THEME tokens enforced (no raw hex colors)
 
 ### 9.4 Build Order (17 Steps)
 
 1. **Grid skeleton**: Create 120×40 buffer, render fixed borders, initialize panes
 2. **Mode strip**: Render mode buttons (1–5), global status tile
-3. **Source abstraction**: Wire Source trait, mock backends for proof-of-concept (BLOCKED: U1 surface contract UNKNOWN)
+3. **Source abstraction**: Wire Source trait, concrete `dope-context` adapter, and mock backends for the remaining services (PARTIALLY UNBLOCKED: U1 is resolved for `dope-context`; six other backends remain mock-only)
 4. **Task list pane**: Load and display task-orchestrator task list in left rail
 5. **Task details center**: Display selected task metadata from leantime + conport
 6. **Handoff packet pane**: Draft / active packet rendering in center bottom
 7. **Inspector pane**: Expanded view of selected row, Bridge adapter subpane
-8. **Authority labeling**: Add `authority:` headers and `SRC:` tags to all rows (BLOCKED: Source contract UNKNOWN; degraded to mock until U1 resolved)
-9. **Role model wire**: Implement role resolver and gating for `[a] approve` and `shift-Y` (BLOCKED: U4 role model UNKNOWN; degraded until U4 resolved)
+8. **Authority labeling**: Add `authority:` headers and `SRC:` tags to all rows (PARTIALLY BLOCKED: backend source contracts remain unresolved outside `dope-context`)
+9. **Role model wire**: Implement role resolver and gating for canonical writes using the two-role session model (`operator`, `approver`, or both)
 10. **Confirm modals**: Build confirm dialog with target service name in body
-11. **Pin state**: Implement dope-memory integration for pin/unpin with `pinned_at` field (BLOCKED: U7 field schema UNKNOWN; degraded until U7 resolved)
-12. **Packet lifecycle**: 30-day archive trigger and reaper (BLOCKED: U3 tail retention window UNKNOWN; degraded until U3 resolved)
+11. **Pin state**: Implement dope-memory integration for pin/unpin with append-only `pinned_at` receipt schema
+12. **Packet lifecycle**: 30-day archive trigger and reaper (BLOCKED: U3 tail retention window UNKNOWN)
 13. **Event stream**: Real-time event pane with rate limiting and tail buffer (BLOCKED: U3 event rate limit UNKNOWN; degraded until U3 resolved)
-14. **Supporting views**: Task / Decision / Memory / Search views (BLOCKED: U6 [EDGE] brand-voice pending; degraded until review)
+14. **Supporting views**: Task / Decision / Memory / Search views with `[LOGGED]` packet fallback when a scope edge is crossed; body text carries the scope-edge detail
 15. **Keyboard input**: Command parsing and dispatch (all commands)
-16. **Brand voice gate**: Audit all output strings against DOPEMUX_THEME and hedging vocabulary
+16. **Copy conformance check**: Use the approved packet-body, confirm-modal, and role-refusal copy for scope-edge fallback; do not introduce a new chip
 17. **Resize handling**: Adapt grid to 100×32 and 80×24
 
 ### 9.5 Remaining UNKNOWNs
 
 **See UNKNOWN Resolution Questionnaire (§11.5 → §11.7)**:
-1. U1: Source adapter HTTP/RPC surface per backend
+1. U1: Source adapter HTTP/RPC surface remains open for six backends; `dope-context` only is partially resolved
 2. U2: dopetask health endpoint path
 3. U3: Event stream rate limits and tail retention window
-4. U4: Role model for non-`[a]` canonical writes
-5. U5: Display priority when unread PKT and unread PKB coexist
-6. U6: `[EDGE]` chip reuse on PKB recommendation arrival — pending brand-voice review
-7. U7: Pin-state schema (field name on chronicle receipt, append-only guarantee)
-
 ---
 
 ## 10. Change Log
@@ -536,17 +581,12 @@ trait Source {
 ### v2.0a (2026-04-23) — Clarifications Pass 1
 
 - **Frontmatter**: Bump version to v2.0a
-- **§2.4**: New §2.4.1 and §2.4.2 for send semantics and packet lifecycle (30-day archive, pin exemption)
-- **§3.4**: New Leantime write scope (enumerated 7 allowed fields, 4 forbidden mutations)
-- **§3.5**: New PM-mode authority split table (metadata → leantime, workflow → task-orchestrator, decision/progress → conport, history → dope-memory)
-- **§3.3**: Clarified write refusals (forbidden mutations listed explicitly)
-- **§5.4**: Confirm modal bodies (named target services, with examples)
-- **§6.6**: Action-suffix rules (explicit naming of target + action in every confirm)
-- **§9.3**: New acceptance criteria 11–15 (Leantime scope, role gating, workflow blocking, Bridge segregation, source contract)
-- **§9.4**: Updated build order (17 steps, blocks and degrades noted)
-- **§9.5**: Reduced UNKNOWN list from 10 to 7 items (U1–U7); moved resolved items to §11.6
-- **§11.6**: New resolved log (8 items with rationale)
-- **§11.7**: New data contracts (Packet schema, PinState schema, AppState shape)
+- **§1**: Clarified U1 partial resolution (`dope-context` only) and U4 resolved two-role model
+- **§2.3 / §6.1**: Added deterministic unread precedence algorithm for coexisting unread `PKT` and `PKB`
+- **§2.4 / §11.7**: Hardened append-only `pinned_at` receipt semantics for dope-memory pin mirror
+- **§3.6 / §5.2 / §9.3**: Added session role model (`operator`, `approver`, or both)
+- **§6.7 / §7.1 / §9.4**: Closed U6 with `[LOGGED]` on the envelope, body-rendered scope-edge meaning, approved fallback copy, and no `[EDGE]` reuse for packet fallback
+- **§9.4 / §9.5**: Reduced remaining UNKNOWNs to U1 partial, U2, and U3
 
 ### v2.0 (2026-04-23) — Initial Specification
 
@@ -623,45 +663,70 @@ struct Packet {
     mirror_refs: MirrorRefs, // {conport_progress_id, dope_memory_chronicle_id}
     fields: Map<String, Value>,
     field_src: Map<String, ServiceId>,  // SRC tagging per field
-    pinned: bool,
+    pin_render_state: bool,  // computed from latest dope-memory receipt for render only
 }
 ```
 
 ### 11.5 Remaining UNKNOWNs (See §9.5 for Details)
 
-Seven items remain open and will block specific implementation steps:
-1. U1: Source adapter HTTP/RPC surface per backend
+Three items remain open and will block specific implementation steps:
+1. U1: Source adapter HTTP/RPC surface per backend remains open for six backends; `dope-context` only is resolved
 2. U2: dopetask health endpoint path
 3. U3: Event stream rate limits and tail retention window
-4. U4: Role model for non-`[a]` canonical writes
-5. U5: Display priority when unread PKT and unread PKB coexist
-6. U6: `[EDGE]` chip reuse on PKB recommendation — pending brand-voice review
-7. U7: Pin-state schema (field name on chronicle receipt)
 
 ### 11.6 Resolved Items (From §9.5 v2.0)
 
-The following items from the baseline UNKNOWN list have been resolved via locked clarifications:
-1. ✓ Packet send creates mirror records only (clarification 2)
-2. ✓ Chronicle receipts use `[LOGGED]` chip (clarification 3)
-3. ✓ 30-day auto-archive with pin exemption (clarifications 4–5)
-4. ✓ Supporting-view mocks are layout-authoritative only (clarification 6)
-5. ✓ Old 7-tab strip is non-authoritative v1.0 carry-over (clarification 7)
-6. ✓ All mock ports are illustrative, not real (clarification 8)
-7. ✓ Leantime write scope enumerated (clarification 10)
-8. ✓ Forbidden Leantime mutations listed (clarification 11)
+The following items from the baseline UNKNOWN list have been resolved via locked clarifications and this decision pass:
+1. ✓ Packet send creates mirror records only
+2. ✓ Chronicle receipts use `[LOGGED]` chip
+3. ✓ 30-day auto-archive with pin exemption
+4. ✓ Supporting-view mocks are layout-authoritative only
+5. ✓ Old 7-tab strip is non-authoritative v1.0 carry-over
+6. ✓ All mock ports are illustrative, not real
+7. ✓ Leantime write scope enumerated
+8. ✓ Forbidden Leantime mutations listed
+9. ✓ U4 resolved to a two-role session model (`operator`, `approver`, or both)
+10. ✓ U5 resolved to newest-unread precedence with deterministic mode-aware tie break
+11. ✓ U6 closed with `[LOGGED]` on the envelope, body-rendered scope-edge meaning, and no `[EDGE]` reuse
+12. ✓ U7 resolved to append-only `pinned_at` receipt semantics in dope-memory
 
 ### 11.7 Data Contracts (Implementation Anchors)
 
+#### Session Role Schema
+
+```rust
+struct Session {
+    roles: Set<Role>,  // Role in {operator, approver}
+}
+```
+
+Every authenticated TUI session carries exactly one or both of these roles. Unknown-role sessions may render action glyphs but confirm modals must refuse with a role-required message rather than silently succeeding.
+
 #### Pin State Schema
 
-**Owner**: dope-memory (append-only in spirit)
+**Owner**: dope-memory
 
 **Field name on chronicle receipt**: `pinned_at: Option<DateTime>`
 - null = not pinned
 - non-null = pinned at that timestamp
 
+**Write model**: append-only receipt stream; pin and unpin each write a new receipt
+
 **Unpin operation**: writes new receipt with `pinned_at: null` and back-reference to original; reaper reads latest receipt per packet id.
+
+#### dope-context Source Contract
+
+```rust
+struct DopeContextSourceContract {
+    protocol: "HTTP/JSON",
+    auth: "BearerFromEnv",
+    pagination: "Cursor",
+    filter: StructuredFilter,  // language, doc_type, profile, workspace_path, ...
+}
+```
+
+This binding applies only to `dope-context`. Other services remain unresolved and must stay mock-only until their U1 slices are decided.
 
 ---
 
-**NEXT**: Apply ADR-001 and ADR-002 to implementation planning; resolve U1–U7 before build step 3.
+**NEXT**: Apply ADR-001 and ADR-002 to implementation planning; carry the six non-`dope-context` transport decisions, U2, and U3 as separate follow-up work.

--- a/docs/03-reference/systems/dopemux/tui-unknown-resolution-questionnaire.md
+++ b/docs/03-reference/systems/dopemux/tui-unknown-resolution-questionnaire.md
@@ -13,29 +13,30 @@ prelude: Seven open questions blocking implementation steps in the TUI Round 2 b
 # TUI Round 2 UNKNOWN Resolution Questionnaire
 
 **Date**: 2026-04-23
-**Status**: Open
+**Status**: Partially Resolved
 **Scope**: Seven items carried forward from SPEC.md §9.5 (v2.0a §11.5)
-**Impact**: Each item blocks one or more build steps. U1 blocks step 3 directly; other items block later steps as noted below.
+**Impact**: U1 remains partially open and still blocks broad source wiring. U2 and U3 remain open. U4, U5, U6, and U7 are resolved for this spec pass.
 
 ---
 
 ## U1: `Source` Adapter HTTP/RPC Surface Per Backend
 
-**Exact decision needed**:
-For each of `task-orchestrator`, `leantime`, `conport`, `dope-memory`, `dope-context`, `dopecon-bridge`, `dopetask`: pick protocol (HTTP/JSON, gRPC, local socket), auth model (bearer, mTLS, unix-socket peer cred, none), pagination contract (cursor, offset, none), and filter surface (query params, structured filter object, server-side preset only).
+**Status**: PARTIAL
 
-**Why it blocks implementation**:
-`Source` trait's concrete methods cannot be written without a per-backend contract. Blocks build steps 3–8. Mock implementations can proceed in parallel, but production deployment requires this surface defined.
+**Resolution applied**:
+`dope-context` only is resolved to HTTP/JSON over bearer token from env, cursor pagination, and a structured filter object. The other six backends (`task-orchestrator`, `leantime`, `conport`, `dope-memory`, `dopecon-bridge`, `dopetask`) remain unresolved and must not be normalized by assumption.
 
-**Suggested normalization target** (not assumed reality):
-HTTP/JSON + bearer token from env + cursor pagination + structured filter object for all seven services. Real implementations will diverge; this is the preferred target for alignment work. Note: `dopecon-bridge` may require different auth (e.g., no auth for local adapter pattern).
+**What remains open**:
+For the six unresolved backends, protocol, auth model, pagination contract, and filter surface still need explicit runtime decisions.
 
-**Fallback if not decided**:
-Use HTTP/JSON as baseline; ship with documented contract mismatches and upgrade plan.
+**Why it still blocks implementation**:
+`Source` trait's concrete methods may now be written for `dope-context`, but multi-backend production wiring remains blocked for the other six services. Build step 3 is unblocked for `dope-context` rows only; build step 8 remains partial outside that slice.
 
 ---
 
 ## U2: `dopetask` Health Endpoint Path
+
+**Status**: PENDING
 
 **Exact decision needed**:
 Does `dopetask` expose its own `/health` endpoint directly, or is its health surfaced only via `task-orchestrator` as a dependency rollup?
@@ -53,6 +54,8 @@ Render as "unknown" on `[4]Services` and mark as TBD. Non-blocking for MVP.
 
 ## U3: Event Stream Rate Limits and Tail Retention
 
+**Status**: PENDING
+
 **Exact decision needed**:
 Max events/sec the `[5]Events` pane will subscribe to without backpressure; tail retention window (minutes of history kept in the client ring buffer).
 
@@ -69,65 +72,66 @@ Use 100 events/sec and 10-minute buffer; mark as experimental and plan first tun
 
 ## U4: Role Model for Non-`[a]` Canonical Writes
 
-**Exact decision needed**:
-Who may invoke `[H] send`, `[c]` (clear/cancel — pane-dependent), `[x]` (close/kill — pane-dependent), `[p] pin`, `[o] open`? Are these gated by the same role that gates `[a] approve`, by a looser operator role, or ungated for any authenticated TUI session?
+**Status**: RESOLVED
 
-**Why it blocks implementation**:
-Confirm modal rendering and action-availability checks need a role resolver. Blocks build step 9 (role model wire). Cannot ship until clear.
+**Resolution applied**:
+The TUI uses exactly two human roles: `operator` and `approver`. A session may carry `operator`, `approver`, or both.
 
-**Suggested default if fast**:
-Single `operator` role for all non-`[a]` human actions; `[a] approve` remains on its own `approver` role. Two roles total. Revisit when a third actor class appears (e.g., auditor, readonly observer).
+**Operational rule**:
+Non-`[a]` canonical writes (`[H] send`, `[c]`, `[x]`, `[p]`, and any write-bearing `[o]` flow) require `operator`. `[a] approve` requires `approver`. No third role is introduced by this decision.
 
-**Fallback if not decided**:
-Ungated for MVP (all authenticated users can `[H] send`, `[p] pin`, etc.). Add role gating in next sprint as a compliance feature.
+**Implementation effect**:
+Build step 9 may wire the role resolver against the two-role session model without waiting for another role pass. Unknown-role sessions render action glyphs but confirm modals must refuse with a role-required message rather than silently succeeding.
 
 ---
 
 ## U5: Display Priority When Unread PKT and Unread PKB Coexist on the Same Task
 
-**Exact decision needed**:
-When a task row has both an unread PM→Implementer packet and an unread Implementer→PM packet, which unread indicator renders in the narrow task-row affordance? Both? Most recent? PKT-first-PKB-second? A combined glyph?
+**Status**: RESOLVED
 
-**Why it blocks implementation**:
-Row rendering function has a single affordance slot. Blocks build step 6 (task list pane detail). Cannot leave ambiguous.
+**Resolution applied**:
+Render the newest unread packet in the single row-affordance slot. If timestamps tie, PM mode prefers `PKB`, Implementer mode prefers `PKT`. If timestamps remain tied after mode-aware preference, fall back to lexical packet-type ordering (`PKB` before `PKT`) for stable redraws.
 
-**Suggested default if fast**:
-Show most-recent unread only, with mode-aware tiebreak: in PM mode prefer PKB (replies are what PM needs to see); in Implementer mode prefer PKT (new work is what Implementer needs to see). The other is visible one level deeper on drill-down into the packet pane.
-
-**Fallback if not decided**:
-Show PKT priority always (work-from-PM-first convention); document as provisional and revisit after user feedback.
+**Implementation effect**:
+Build step 6 may implement a deterministic precedence algorithm rather than a heuristic or dual-glyph compromise.
 
 ---
 
 ## U6: `[EDGE]` Chip Reuse on PKB Recommendation Arrival — Brand-Voice Review
 
-**Exact decision needed**:
-When a PKB arrives carrying a recommendation that crosses an agreed scope edge, does it chip `[EDGE]` (reusing the existing closed vocabulary), or does it require a new chip? Brand-voice gate must confirm `[EDGE]` reads as "scope edge crossed" and not as "experimental" or "fringe".
+**Status**: RESOLVED
 
-**Why it blocks implementation**:
-Adding a chip is a closed-vocabulary amendment and needs the brand-voice pass before it lands in rendering. Blocks build step 14 (supporting views, PKB chip rendering).
+**Resolution applied**:
+`[EDGE]` is not approved for PKB scope-edge arrival on the envelope. `[LOGGED]` remains on the envelope. Scope-edge meaning is rendered in packet body or inspector copy only. `[OVERRIDE]` is explicitly rejected for this meaning.
 
-**Suggested default if fast**:
-Hold `[EDGE]` as preferred fallback. **Pending brand review — do not let this read like approval.** Reserve final decision until brand-voice pass completes. Use `[OVERRIDE]` as interim placeholder if needed.
+**Approved fallback copy**:
+1. PKB arrival line: `[LOGGED] PKB-0481 received. Scope-edge recommendation in body.`
+2. Scope-edge body text: `Scope edge: This recommendation extends beyond the current agreed scope. Review before any workflow transition or metadata write.`
+3. Confirm modal text:
+   `Confirm: apply recommended transition`
+   `target: task-orchestrator`
+   `action: transition after scope-edge review`
+   `affected: T-1203 via PKB-0481`
+   `role required: operator`
+4. Role-required refusal: `[BLOCKER] Operator role required. Scope-edge recommendation cannot be actioned in this session.`
 
-**Fallback if not decided**:
-Use `[LOGGED]` (packet sent, always correct); upgrade chip after brand-voice review in next release.
+**Implementation effect**:
+Build step 14 may proceed with a closed result: `[LOGGED]` on the envelope, body-rendered scope-edge meaning, and no chip vocabulary change.
 
 ---
 
 ## U7: Pin-State Schema: Owner and Field Name
 
-**Exact decision needed**:
-Confirm `dope-memory` owns pin state (not `dopemux`). Name the exact field on the chronicle receipt that carries pin state (e.g. `pinned: bool`, `pin_state: enum`, `pinned_at: timestamp|null`). Confirm that unpin writes a new receipt rather than mutating the old one.
+**Status**: RESOLVED
 
-**Why it blocks implementation**:
-Reaper query and pin-toggle action both need a stable read path. Blocks build step 11 (pin state implementation).
+**Resolution applied**:
+`dope-memory` owns the pin mirror state. The chronicle receipt field is `pinned_at: timestamp|null`.
 
-**Suggested default if fast**:
-`dope-memory` owns pin state and is append-only in spirit. Field: `pinned_at: timestamp|null` on the chronicle receipt (null = not pinned, non-null = pinned at that time). Unpin writes a new receipt with `pinned_at: null` and a back-reference to original; the reaper reads latest receipt per packet id.
+**Append-only rule**:
+Pin and unpin each write a new dope-memory receipt. Unpin writes a new receipt with `pinned_at: null`; the reaper reads the latest receipt per packet id.
 
-**Fallback if not decided**:
-Use `pinned: bool` on both envelope and receipt (simpler schema, mutable on receipt). Migrate to append-only schema in next sprint if append-only assumption becomes important.
+**Implementation effect**:
+Build step 11 may implement pin/unpin against append-only receipt semantics without mutating prior receipts.
 
 ---
 
@@ -135,21 +139,18 @@ Use `pinned: bool` on both envelope and receipt (simpler schema, mutable on rece
 
 | Item | Decision | Decided By | Date | Notes |
 |------|----------|-----------|------|-------|
-| U1 | PENDING | | | Normalization target ready; real implementation TBD per service |
+| U1 | PARTIAL: dope-context resolved (HTTP/JSON + bearer + cursor + structured filter); 6 remaining | Packet TP-DMX-TUI-DOCS-PATCH-003 | 2026-04-23 | `dope-context` only; six backend transport decisions still open |
 | U2 | PENDING | | | Direct endpoint preferred; rollup acceptable if no direct surface |
 | U3 | PENDING | | | 200 events/sec + 15-min buffer suggested; tune post-launch |
-| U4 | PENDING | | | `operator` + `approver` roles suggested; two roles total |
-| U5 | PENDING | | | Most-recent + mode-aware tiebreak suggested |
-| U6 | PENDING | | | **Pending brand-voice review — do not finalize** |
-| U7 | PENDING | | | Append-only chronicle with `pinned_at` field suggested |
+| U4 | RESOLVED | Packet TP-DMX-TUI-DOCS-PATCH-003 | 2026-04-23 | Two-role session model: `operator`, `approver`, or both |
+| U5 | RESOLVED | Packet TP-DMX-TUI-DOCS-PATCH-003 | 2026-04-23 | Newest unread wins; mode-aware tie break; stable fallback ordering |
+| U6 | RESOLVED: `[LOGGED]` remains on the envelope; `[EDGE]` not approved for PKB arrival | Packet TP-DMX-TUI-U6-BRAND-CLOSURE-004 | 2026-04-23 | Scope-edge meaning is body-rendered only; no new chip |
+| U7 | RESOLVED | Packet TP-DMX-TUI-DOCS-PATCH-003 | 2026-04-23 | Append-only dope-memory receipt with `pinned_at` |
 
 ---
 
 ## Next Steps
 
-1. User resolves U1–U7 via inline or separate decision session
-2. Each resolution is added to SPEC.md §11.5 (resolved) or §9.5 (remaining)
-3. Build order adjusts based on remaining blockers
-4. Implementation proceeds with resolved items as hard constraints
-
-**Timeline**: U6 requires brand-voice pass (schedule separately). Others can be resolved inline.
+1. Resolve the six non-`dope-context` transport decisions as engineering/runtime work.
+2. Resolve U2 and U3 against runtime evidence.
+3. Proceed with implementation planning using the resolved U4/U5/U6/U7 constraints and the partial U1 constraint as hard bounds.

--- a/docs/90-adr/adr-001-workflow-centric-ia-and-handoff-packet-model.md
+++ b/docs/90-adr/adr-001-workflow-centric-ia-and-handoff-packet-model.md
@@ -35,6 +35,8 @@ v1.0 of the Dopemux TUI exposed seven top-level tabs keyed to services (`Tasks`,
 
 A naive reading of "PM mode" and "Implementer mode" invites the creation of a unified PM record and a unified Implementer record inside `dopemux`, which would silently centralize authority that is in fact split across `task-orchestrator`, `leantime`, `conport`, `dope-memory`, and `dope-context`. The handoff artifacts (`PKT-*`, `PKB-*`) amplify this risk: if they are modeled as new canonical objects, `dopemux` becomes a task-state authority by accident.
 
+The packet rendering review identified one brand-sensitive point: a `PKB` may arrive with a recommendation that crosses an agreed scope edge. The closed result is that this condition does not expand the chip vocabulary and does not alter the envelope chip.
+
 ## Decision
 
 1. **Top-level IA is `[1]PM [2]Implementer [3]Overview [4]Services [5]Events`.** Tasks, Decisions, Memory, and Search are demoted to supporting views reached by `g o` / `g d` / `g m` / `g s` from PM or Implementer, or by `Enter` drill-down on a pane row. They do not appear in the mode strip.
@@ -45,26 +47,32 @@ A naive reading of "PM mode" and "Implementer mode" invites the creation of a un
 
 4. **`[H] send` is the only action that converts a draft envelope into a sent packet.** Send is human-only, dopemux-authored, and produces exactly two mirror writes: one `conport` progress/log entry and one `dope-memory` chronicle receipt chipped `[LOGGED]`. Send does not transition `task-orchestrator` state and does not mutate `leantime` metadata.
 
-5. **Packet lifecycle**: sent packets remain active for 30 days, then archive to history/search. Pinned packets are exempt from auto-archive. Pin state is carried on the envelope and mirrored on the chronicle receipt. The archive reaper is owned by `dopemux` and runs daily.
+5. **Packet lifecycle**: sent packets remain active for 30 days, then archive to history/search. Pinned packets are exempt from auto-archive. Pin state is carried on the envelope and mirrored on append-only dope-memory chronicle receipts using `pinned_at`. The archive reaper is owned by `dopemux` and runs daily.
 
-6. **Supporting-view mocks (§4.4–§4.7) are authoritative for pane content and geometry only.** Their port numbers are illustrative only.
+6. **If a `PKB` carries a scope-edge recommendation, the envelope remains `[LOGGED]`.** The scope-edge condition is rendered in body text or inspector detail only. This ADR does not approve `[EDGE]` reuse for packet arrival state and does not introduce a new chip.
+
+7. **Supporting-view mocks (§4.4–§4.7) are authoritative for pane content and geometry only.** Their port numbers are illustrative only.
 
 ## Consequences
 
 **Accepted**:
 - `dopemux` gains an authoring store for envelopes (draft/sent/pinned/archived) and for reaper scheduling. This store is not a task store.
 - The integration test matrix must prove that no `[H] send` invocation ever triggers a `task-orchestrator` transition or a `leantime` write.
+- Packet fallback for scope-edge recommendations remains truthful without silently expanding the closed chip vocabulary.
 - The UI must surface `authority:` and `SRC` everywhere without exception; absence of either is a rendering bug.
 
 **Rejected alternatives**:
 - *Unified PM record inside dopemux*: rejected — collapses authority, violates §3.3, makes rollback of packet state ambiguous.
 - *Three top-level modes (PM, Implementer, Services)*: rejected — buries Overview and Events below operator shells, breaks monitor workflows.
 - *Packet send auto-transitioning task-orchestrator state*: rejected — makes the operator's handoff gesture a silent workflow mutation, violates clarification 2.
+- *Treat `[EDGE]` as implicitly approved for `PKB` arrival fallback*: rejected — the closed result keeps `[LOGGED]` on the envelope and body-renders the scope-edge meaning instead of amending vocabulary.
 
 **Citations**: SPEC.md §2.4, §3.3, §11.1, §11.4; locked clarifications 1–5; revision brief constraints 1–5.
 
 ## Implementation Notes
 
 - Grid skeleton work (step 1) is not blocked by this ADR. Authority labeling (step 8) is.
-- Mock `Source` implementations can proceed in parallel until the HTTP/RPC surface (U1) is finalized.
+- Mock `Source` implementations can proceed in parallel until the HTTP/RPC surface (U1) is finalized; only `dope-context` is partially frozen.
 - Integration tests must validate that `[H] send` produces exactly two writes (ConPort + dope-memory) and no side effects in other services.
+- Supporting views render scope-edge detail in packet body text while retaining `[LOGGED]` on the packet envelope.
+- U6 is closed: no chip vocabulary change is allowed for PKB scope-edge arrival without a future ADR that explicitly reopens the decision.

--- a/docs/90-adr/adr-002-pm-mode-authority-split-and-bounded-leantime-write-scope.md
+++ b/docs/90-adr/adr-002-pm-mode-authority-split-and-bounded-leantime-write-scope.md
@@ -27,7 +27,7 @@ graph_metadata:
 
 PM mode must support feature design, research packets, ideas/epics/stories, task breakdown, workflow queue/blockers/approvals, Leantime metadata visibility, ConPort decisions/progress/context, and dope-memory historical receipts. Left unscoped, a PM-mode "edit task" action is ambiguous: does it write title (metadata) or status (workflow)? Left unscoped, `leantime` becomes a convenient write sink for every field visible in a Leantime pane, including status — which is owned by `task-orchestrator`. This would silently route workflow-significant mutations through a metadata service.
 
-`PM_PLANE.md` and `system-boundaries.md` already enumerate split authorities; this ADR ratifies the PM-mode dispatch table and the Leantime write bound.
+`PM_PLANE.md` and `system-boundaries.md` already enumerate split authorities; this ADR ratifies the PM-mode dispatch table, the Leantime write bound, and the finalized two-role session model needed for PM-mode action availability.
 
 ## Decision
 
@@ -59,7 +59,7 @@ PM mode must support feature design, research packets, ideas/epics/stories, task
 
    These route to `task-orchestrator` regardless of which pane the operator invokes them from.
 
-5. **`[a] approve` is role-gated** and operates only on `task-orchestrator`-controlled workflow objects. Approvals never route through `leantime`.
+5. **The human role model is exactly two roles: `operator` and `approver`.** A session may carry `operator`, `approver`, or both. Non-`[a]` canonical writes require `operator`. `[a] approve` requires `approver`. This decision does not create a third role and does not alter bounded Leantime write scope.
 
 6. **Bridge and proxy services never own canonical state.** `dopecon-bridge` actions require `shift-Y` and render the adapter confirm label `ADAPTER -> dopecon-bridge : <action>`. `dopetask` is execution-only and does not own task or packet state.
 
@@ -67,6 +67,7 @@ PM mode must support feature design, research packets, ideas/epics/stories, task
 
 **Accepted**:
 - PM-mode input handling must disambiguate intent before dispatch, not after. The confirm modal text is the contract surface.
+- A session carrying both roles may perform both operator and approver actions without collapsing their distinct checks.
 - A Leantime pane showing `status: in_progress` is read-only for that field from the Leantime authority; editing status from that pane dispatches to `task-orchestrator` and the confirm label reflects it.
 - Integration tests must assert that no forbidden Leantime mutation ever lands on the `leantime` service, regardless of invocation path.
 
@@ -74,6 +75,7 @@ PM mode must support feature design, research packets, ideas/epics/stories, task
 - *Route all PM-mode writes through a dopemux dispatcher that fans out silently*: rejected — hides the authority boundary the confirm modal is designed to expose.
 - *Allow Leantime status writes as a convenience and reconcile later*: rejected — makes `leantime` and `task-orchestrator` race on the same field, violates single-writer invariant.
 - *Let `dopecon-bridge` carry canonical state during outages*: rejected — bridges are adapters; §3.2 mechanism 3 requires visual segregation precisely to prevent this drift.
+- *Introduce a third generic write role for packet operations*: rejected — the finalized role model is the bounded two-role session model.
 
 **Citations**: SPEC.md §3.1, §3.2, §3.4, §3.5, §5.4; `PM_PLANE.md`; `system-boundaries.md`; locked clarifications 9–12.
 
@@ -81,5 +83,6 @@ PM mode must support feature design, research packets, ideas/epics/stories, task
 
 - Step 8 (authority labeling) depends on this decision being binding. All confirm modals must validate their target service at runtime.
 - The input handler must include a dispatch table mapping action intent → canonical service. This table is the implementation of this ADR.
-- Role-gating for `[a] approve` does not block this ADR but depends on U4 (role model) being resolved.
+- Role-gating is no longer blocked on U4; implementation should wire the two-role session model directly.
+- U4 resolved: operator + approver, two roles, per TUI session.
 - Supporting-view panes may show read-only status fields from `task-orchestrator` even when the backing pane implementation is `leantime`-centric. The `SRC:` tag must be accurate.

--- a/docs/90-adr/adr-dope-memory-as-chronicle-memory-authority.md
+++ b/docs/90-adr/adr-dope-memory-as-chronicle-memory-authority.md
@@ -258,6 +258,22 @@ This preserves a clean split:
 
 ## Mirror and transport rules
 
+When other systems mirror packet lifecycle into dope-memory chronicle space, dope-memory remains authoritative only for the chronicle receipt, not the packet's canonical workflow or PM state.
+
+For Dopemux TUI packet pin mirrors, the chronicle receipt model is:
+
+- append-only receipt stream
+- field name `pinned_at`
+- `pinned_at: <timestamp>` means pinned at that time
+- `pinned_at: null` means an explicit unpin receipt
+- the effective pin state is resolved from the latest receipt for the packet id
+
+This preserves chronicle truthfulness:
+
+- no prior receipt is mutated
+- pin and unpin are both historical events
+- downstream readers can reconstruct pin history without inventing mutable state inside dope-memory
+
 ### SQLite chronicle
 
 The local SQLite chronicle is canonical.


### PR DESCRIPTION
## Summary
Finalize the Dopemux TUI v2.0a governance docs for U1, U4, U5, U6, and U7, and close U6 with the logged-only envelope fallback.

## Included
- restore and patch the TUI v2.0a spec, questionnaire, ADR-001, and ADR-002 on this branch
- bind `dope-context` transport only for U1
- bind the two-role session model for U4
- bind deterministic unread precedence for U5
- bind append-only `pinned_at` receipt semantics for U7
- close U6 with `[LOGGED]` on the envelope, body-rendered scope-edge meaning, approved fallback copy, and no `[EDGE]` reuse for PKB arrival
- align the dope-memory ADR with append-only `pinned_at` pin receipts

## Out of Scope
- implementation code
- transport decisions for the remaining six backends
- `dopetask` direct health work
- event retention / throughput policy
- chip vocabulary expansion

## Validation
- repo marker verified in the target worktree
- branch verified as `claude/inspiring-nobel-101730`
- doc existence checks passed for the patched files
- targeted `rg` sweeps passed for U1/U4/U5/U6/U7 terms and stale U6 pending-review wording
