### PR TITLE
fix(docker): repair compose yaml for extractor smoke

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -86,9 +86,10 @@ services:
     - MYSQL_DATABASE=${MYSQL_DATABASE:-leantime}
     - MYSQL_USER=${MYSQL_USER:-leantime}
     - MYSQL_PASSWORD=${MYSQL_PASSWORD:-leantime_dev_password}
-command: >-
-      --character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
+    command: '--character-set-server=UTF8MB4 --collation-server=UTF8MB4_unicode_ci
       --default-authentication-plugin=mysql_native_password
+
+      '
     volumes:
     - leantime_mysql_data:/var/lib/mysql
     healthcheck:
@@ -107,8 +108,11 @@ command: >-
     networks:
     - dopemux-network
     command: 'sh -c ''if [ -n "$$REDIS_PASSWORD" ]; then exec redis-server --appendonly
-command: >-
-      sh -c 'if [ -n "$$REDIS_PASSWORD" ]; then exec redis-server --appendonly yes --requirepass "$$REDIS_PASSWORD"; else exec redis-server --appendonly yes; fi'
+      yes --requirepass "$$REDIS_PASSWORD"; else exec redis-server --appendonly yes;
+      fi''
+
+      '
+    environment:
     - REDIS_PASSWORD=${REDIS_PASSWORD:-}
     volumes:
     - leantime_redis_data:/data


### PR DESCRIPTION
## Summary
- cherry-pick only the compose.yml repair from `fix/mcp-docker-build-contexts`
- keep the branch bounded to the current `Extractor Smoke` failure surface
- avoid pulling the older repo-hygiene and audit docs that also exist on the source branch

## Scope
- updates only `compose.yml`
- normalizes the MySQL and Redis command definitions to valid YAML scalar structure
- no runtime, service, or docs changes outside compose configuration

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("compose.yml"); puts "compose_parse_ok_ruby"'`
- prior targeted validation already passed on the earlier verification branch for:
  - `services/repo-truth-extractor/tests/test_run_extraction_v4_core.py -k build_service_catalog_covers_registry_services`

## Notes
The current CI failures on unrelated docs PRs include `Extractor Smoke`, which is consistent with the malformed `compose.yml` surface already audited from this branch line. This PR promotes only that bounded fix.
