### PR TITLE
🎨 Palette: Improve connection status feedback and accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -41,3 +41,11 @@
 ## 2026-03-25 - [Tooltip Visibility on Disabled Elements]
 **Learning:** Material UI Tooltips do not trigger on disabled elements (like buttons) because they don't emit pointer events. Wrapping the disabled element in a `<span>` ensures the tooltip remains accessible, allowing users to understand *why* an action is unavailable.
 **Action:** Always wrap disabled buttons in a `<span>` when using `Tooltip` to maintain accessibility and user feedback.
+
+## 2026-03-26 - [Multi-State Connection Indicators]
+**Learning:** For systems with asynchronous background services, a binary "Live/Down" connection status is insufficient. Introducing an explicit "Connecting" state with distinct visual (Gold/Secondary) and semantic cues reduces user uncertainty during initialization.
+**Action:** Implement three-tier status logic (Connecting, Live, Degraded) for all real-time service indicators.
+
+## 2026-03-26 - [Reducing Screen Reader Noise in Status Chips]
+**Learning:** Decorative pulsing animations inside status chips are helpful for sighted users but can be noisy for screen readers if not properly hidden. Since the Chip's `aria-label` already provides the full status context, the internal pulsing element should be marked `aria-hidden="true"`.
+**Action:** Always add `aria-hidden="true"` to purely visual status icons or animations when they are part of a larger component that already has a descriptive label.

--- a/ui-dashboard/src/App.tsx
+++ b/ui-dashboard/src/App.tsx
@@ -223,9 +223,19 @@ function App() {
         : { showTeamDashboard: true, showPredictions: true, compactMode: false };
 
   const statusMeta = statusStyles[cognitiveState.status];
-  const connectionLabel = connectionStatus === 'live' ? brandTokens.chips.live : '[DEGRADED]';
+  const connectionLabel =
+    connectionStatus === 'live'
+      ? brandTokens.chips.live
+      : connectionStatus === 'connecting'
+        ? brandTokens.chips.connecting
+        : brandTokens.chips.degraded;
+
   const connectionColor =
-    connectionStatus === 'live' ? brandTokens.colors.ritualCyan : brandTokens.colors.gremlinPink;
+    connectionStatus === 'live'
+      ? brandTokens.colors.ritualCyan
+      : connectionStatus === 'connecting'
+        ? brandTokens.colors.saintGold
+        : brandTokens.colors.gremlinPink;
 
   const metricCards = [
     {
@@ -300,6 +310,7 @@ function App() {
               <Chip
                 icon={
                   <Box
+                    aria-hidden="true"
                     sx={{
                       width: 8,
                       height: 8,
@@ -318,7 +329,13 @@ function App() {
                 label={`${connectionLabel} DØPEMÜX Ritual Daemon`}
                 aria-label={`System is actively monitoring ritual state: ${connectionLabel} DØPEMÜX Ritual Daemon`}
                 className="dopemux-chip"
-                color="primary"
+                color={
+                  connectionStatus === 'live'
+                    ? 'primary'
+                    : connectionStatus === 'connecting'
+                      ? 'secondary'
+                      : 'error'
+                }
                 tabIndex={0}
               />
             </Tooltip>
@@ -459,7 +476,13 @@ function App() {
             >
               Live Signal Feed
             </Typography>
-            {isLoading && <CircularProgress size={16} sx={{ ml: 'auto' }} />}
+            {isLoading && (
+              <CircularProgress
+                size={16}
+                sx={{ ml: 'auto' }}
+                aria-label="Loading updates"
+              />
+            )}
             {notifications.length > 0 && (
               <Tooltip title="Clear all notifications to reduce visual noise" arrow>
                 <Chip

--- a/ui-dashboard/src/theme.ts
+++ b/ui-dashboard/src/theme.ts
@@ -37,6 +37,8 @@ export const brandTokens = {
   },
   chips: {
     live: '[LIVE]',
+    connecting: '[CONNECTING]',
+    degraded: '[DEGRADED]',
     override: '[OVERRIDE]',
     blocker: '[BLOCKER]',
     aftercare: '[AFTERCARE]',


### PR DESCRIPTION
I've implemented a micro-UX enhancement focused on the system connection status and overall dashboard accessibility.

### 💡 What
- Added a new `[CONNECTING]` state to the dashboard initialization flow.
- Refined the connection status `Chip` to use dynamic Material UI colors (`primary`, `secondary`, `error`) and theme-aware colors for the status dot.
- Improved accessibility by adding `aria-hidden="true"` to purely visual animations and `aria-label="Loading updates"` to the signal feed progress indicator.
- Centralized status strings in the `brandTokens` system.

### 🎯 Why
- **User Feedback:** Previously, the UI would flicker to `[DEGRADED]` immediately if the backend wasn't instantly available. Now, it accurately shows `[CONNECTING]` during the initial handshake.
- **Accessibility:** Screen reader users will no longer hear redundant descriptions of the pulsing dot, and will have clear context for the loading state in the signal feed.

### ♿ Accessibility
- Added `aria-hidden="true"` to the pulsing status dot.
- Added `aria-label="Loading updates"` to the `CircularProgress`.
- Ensured consistent `tabIndex` and `aria-label` patterns for all status indicators.

### 📸 Before/After
- **Before:** Connection chip stayed primary/cyan or flipped to pink/degraded with a hardcoded string.
- **After:** Connection chip transitions through Gold/Secondary (`[CONNECTING]`) during initialization, providing better visual and semantic feedback.

---
*PR created automatically by Jules for task [10917406669760513145](https://jules.google.com/task/10917406669760513145) started by @hu3mann*