### PR TITLE
feat(wizard): add provider overrides and interactive cost profile browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Dopemux (including the PR Merge Specialist) will be docum
 - Persistent `RUN_SUMMARY.md` writing at the end of `queue-drain` execution.
 - Git case-insensitivity warning in `preflight` for macOS environments.
 - Production certification audit artifacts and a machine-readable certification status for the repo-truth extractor and Dopemux operator surfaces.
+- A provider-override step in the extraction wizard for session-local API key overrides per supported model provider.
 
 ### Changed
 - `stage_and_push_if_needed` now uses `git add -A` to detect case-only renames on macOS.
@@ -20,6 +21,8 @@ All notable changes to Dopemux (including the PR Merge Specialist) will be docum
 - Active extractor docs now describe the validated bounded v5 lane, the current reliability contract, and the upgrade-design reality check for this branch.
 - `dopemux truth`, `dopemux upgrades trace`, and `dopemux extractor trace` now delegate to the canonical v5 runtime contract instead of legacy `PipelineRunner` behavior.
 - Interactive wizard surfaces now load `questionary` through a deterministic dependency gate, and the production theme defaults to `mint-mojo`.
+- The extraction wizard now lets operators browse cost profiles with inline behavior details before selecting a run profile.
+- The extraction wizard now delegates execution through the v5 upgrades wrapper and defaults first-run posture to routing policy `cost` with `workers=1`.
 - The dashboard and detail views now resolve service endpoints from repo environment authority instead of assuming fixed localhost ports.
 - CI now includes wrapper-authority coverage, interactive import smoke, and the production `brand_lint.py` gate.
 

--- a/docs/02-how-to/extraction-wizard.md
+++ b/docs/02-how-to/extraction-wizard.md
@@ -63,7 +63,7 @@ educational panel explaining what is happening.
 |---|-------|-------|--------------|
 | 0 | 🔬 | **Welcome** | System checks — verifies Python version and git availability |
 | 1 | 🩺 | **Repo Health** | Checks git status, current branch, and working-tree cleanliness |
-| 2 | 📊 | **Corpus Audit** | Runs a prescan classifying files by authority tier (canonical, historical, operational, audit, template, generated) |
+| 2 | 📊 | **Corpus Audit** | Runs the canonical v5 integrated Phase 0 prescan and records reusable prescan artifacts for the current wizard run |
 | 3 | ⚙️ | **Prompt Setup** | Validates the promptset configuration used during extraction |
 | 4 | 🔑 | **Provider Overrides** | Optional session-local API key overrides for OpenAI, OpenRouter, Gemini, xAI, and Anthropic |
 | 5 | 💰 | **Cost Profile** | Interactive browsing and selection from 8 routing policies with per-policy cost estimates and tier-routing detail |
@@ -75,11 +75,10 @@ educational panel explaining what is happening.
 
 ### First-time audit (preview only)
 
-Run the prescan first to build the corpus index, then launch the wizard in
-preview mode:
+Launch the wizard directly in preview mode. Stage 2 now runs the canonical v5
+integrated prescan itself and reuses that output later in the wizard:
 
 ```bash
-dopemux audit prescan --verbose --force
 dopemux audit wizard --no-educate
 ```
 
@@ -119,6 +118,9 @@ DPMX_LIVE_OK=1 dopemux audit wizard --execute --routing-policy quality --workers
 - **Session-local key overrides** — provider overrides entered in the wizard
   apply only to the spawned extraction subprocesses and do not modify local
   shell or repo config.
+- **Canonical prescan reuse** — Stage 2 writes v5 prescan artifacts under the
+  current run root, and Stage 7 reuses them with `--prescan-dir ... --skip-prescan`
+  instead of recomputing Phase 0 for every phase launch.
 - **Per-phase confirmation** — before each extraction phase the wizard asks
   for interactive confirmation.
 - **No direct script execution** — the wizard never runs
@@ -129,7 +131,7 @@ DPMX_LIVE_OK=1 dopemux audit wizard --execute --routing-policy quality --workers
 
 | Problem | Fix |
 |---------|-----|
-| Corpus over 50 MB | Run `dopemux audit prescan --force` before starting the wizard |
+| Corpus over 50 MB | Start with wizard preview mode and review the integrated Phase 0 prescan output before enabling `--execute` |
 | Missing promptset | Stage 3 will guide you through promptset initialisation |
 | API key errors | Verify provider credentials in your `.env` file |
 

--- a/docs/02-how-to/extraction-wizard.md
+++ b/docs/02-how-to/extraction-wizard.md
@@ -53,7 +53,7 @@ DPMX_LIVE_OK=1 dopemux audit wizard --execute --routing-policy quality --workers
 - A **Git repository** (the wizard checks repo health at startup)
 - For extraction: **API keys** configured for your chosen routing policy
 
-## The 9 Stages
+## The 8 Stages
 
 The wizard progresses through nine numbered stages. Each stage performs a
 discrete step in the extraction pipeline and can optionally display an
@@ -63,7 +63,7 @@ educational panel explaining what is happening.
 |---|-------|-------|--------------|
 | 0 | 🔬 | **Welcome** | System checks — verifies Python version and git availability |
 | 1 | 🩺 | **Repo Health** | Checks git status, current branch, and working-tree cleanliness |
-| 2 | 📊 | **Corpus Audit** | Runs the canonical v5 integrated Phase 0 prescan and records reusable prescan artifacts for the current wizard run |
+| 2 | 📊 | **Corpus Audit** | Runs a prescan classifying files by authority tier (canonical, historical, operational, audit, template, generated) |
 | 3 | ⚙️ | **Prompt Setup** | Validates the promptset configuration used during extraction |
 | 4 | 🔑 | **Provider Overrides** | Optional session-local API key overrides for OpenAI, OpenRouter, Gemini, xAI, and Anthropic |
 | 5 | 💰 | **Cost Profile** | Interactive browsing and selection from 8 routing policies with per-policy cost estimates and tier-routing detail |
@@ -75,10 +75,11 @@ educational panel explaining what is happening.
 
 ### First-time audit (preview only)
 
-Launch the wizard directly in preview mode. Stage 2 now runs the canonical v5
-integrated prescan itself and reuses that output later in the wizard:
+Run the prescan first to build the corpus index, then launch the wizard in
+preview mode:
 
 ```bash
+dopemux audit prescan --verbose --force
 dopemux audit wizard --no-educate
 ```
 
@@ -104,10 +105,7 @@ DPMX_LIVE_OK=1 dopemux audit wizard --execute --routing-policy quality --workers
 |------|---------|-------------|
 | `--execute` | off | Enable actual extraction (default: preview only) |
 | `--educate` / `--no-educate` | on | Show educational explanations at each stage |
-| `--routing-policy` | `balanced_openrouter` | LLM routing policy for extraction |
-| `--max-cost` | `5.0` | Maximum estimated spend before execution is blocked |
-| `--validate-live` / `--no-validate-live` | on | Control whether the pre-live validator gate runs before spending |
-| `--skip-hygiene` | off | Legacy compatibility flag; accepted by the wizard but not forwarded to the v5 runner |
+| `--routing-policy` | `cost` | LLM routing policy for extraction |
 | `-w`, `--workers` | `1` | Partition worker count |
 
 ## Safety Features
@@ -121,23 +119,17 @@ DPMX_LIVE_OK=1 dopemux audit wizard --execute --routing-policy quality --workers
 - **Session-local key overrides** — provider overrides entered in the wizard
   apply only to the spawned extraction subprocesses and do not modify local
   shell or repo config.
-- **Canonical prescan reuse** — Stage 2 writes v5 prescan artifacts under the
-  current run root, and Stage 7 reuses them with `--prescan-dir ... --skip-prescan`
-  instead of recomputing Phase 0 for every phase launch.
 - **Per-phase confirmation** — before each extraction phase the wizard asks
   for interactive confirmation.
-- **Direct runner execution** — the wizard invokes
-  `services/repo-truth-extractor/run_extraction_v5.py` directly with the
-  selected routing policy, `--prescan-dir`, `--skip-prescan`, and
-  `--skip-pre-live-validator` when `--no-validate-live` is selected.
-- **Compatibility-only hygiene flag** — `--skip-hygiene` remains available for
-  legacy wizard flows, but it is not forwarded to the v5 runner.
+- **No direct script execution** — the wizard never runs
+  `run_extraction_v5.py` directly; it delegates to
+  `dopemux upgrades run --pipeline-version v5 --ui rich --resume`.
 
 ## Troubleshooting
 
 | Problem | Fix |
 |---------|-----|
-| Corpus over 50 MB | Start with wizard preview mode and review the integrated Phase 0 prescan output before enabling `--execute` |
+| Corpus over 50 MB | Run `dopemux audit prescan --force` before starting the wizard |
 | Missing promptset | Stage 3 will guide you through promptset initialisation |
 | API key errors | Verify provider credentials in your `.env` file |
 

--- a/docs/03-reference/extraction-wizard.md
+++ b/docs/03-reference/extraction-wizard.md
@@ -68,7 +68,7 @@ No options. Shows latest run ID, directory, phases completed, and total size.
 |---|------|------|--------|-------------|
 | 0 | Welcome | 🔬 | `preflight.py` | System checks — Python version, git, dependencies |
 | 1 | Repo Health | 🩺 | `preflight.py` | Git status, branch, working tree cleanliness |
-| 2 | Corpus Audit | 📊 | `corpus.py` | Runs prescan subprocess, parses JSON stats |
+| 2 | Corpus Audit | 📊 | `corpus.py` | Runs canonical v5 integrated Stage 0 prescan and normalizes `corpus_manifest.json` into wizard stats |
 | 3 | Prompt Setup | ⚙️ | `prompts.py` | Promptset validation and interactive initialization |
 | 4 | Provider Overrides | 🔑 | `provider_overrides.py` | Optional session-local provider key overrides before cost selection |
 | 5 | Cost Profile | 💰 | `cost_profiles.py` | Interactive routing policy browsing, per-profile detail, and final selection |
@@ -105,7 +105,7 @@ The pipeline defines **14 phases** executed in order. Phases A–G produce prima
 
 ## Authority Classes
 
-Every file in the corpus is classified into one of six authority classes during the prescan audit.
+Every file in the corpus is classified into one of six authority classes during the integrated Phase 0 prescan.
 
 | Class | Icon | Color | Description |
 |-------|------|-------|-------------|
@@ -176,7 +176,7 @@ src/dopemux/ux/wizard/
 ├── stages.py            # StageStatus, StageResult, WizardState dataclasses + constants
 ├── display.py           # Rich rendering helpers (10 functions)
 ├── preflight.py         # Stages 0-1: welcome + repo health
-├── corpus.py            # Stage 2: prescan audit
+├── corpus.py            # Stage 2: integrated v5 Stage 0 prescan
 ├── prompts.py           # Stage 3: promptset validation
 ├── cost_profiles.py     # Stage 4: routing policies + cost estimation
 ├── partitions.py        # Stage 5: file→phase mapping
@@ -193,7 +193,8 @@ src/dopemux/ux/wizard/
 - **Per-phase confirmation** — each extraction phase requires interactive confirmation before proceeding.
 - **Session-local provider overrides** — provider keys entered in stage 4 override shell defaults only for wizard-launched subprocesses.
 - **Static routing snapshot** — `ROUTING_LADDERS` is defined as a static snapshot inside the wizard to avoid importing `run_extraction_v5.py`, which has import-time side effects.
-- **No direct v5 execution** — `run_extraction_v5.py` is **never** executed directly. All extraction is delegated through `dopemux upgrades run --pipeline-version v5 --ui rich --resume`.
+- **Canonical integrated prescan** — Stage 2 now uses the v5 Stage 0 prescan authority and stores its output under `extraction/repo-truth-extractor/v5/runs/<run_id>/prescan`.
+- **No direct v5 phase execution** — phase extraction is delegated through `dopemux upgrades run --pipeline-version v5 --ui rich --resume`, with the wizard passing `--prescan-dir` and `--skip-prescan` after Stage 2 succeeds.
 - ⚠️ **CRITICAL:** Accidental direct execution of v5 can cost **$10+** in provider preflight probes. See the workspace safety instructions for details.
 
 ---

--- a/docs/03-reference/extraction-wizard.md
+++ b/docs/03-reference/extraction-wizard.md
@@ -53,10 +53,7 @@ Commands:
 |--------|------|---------|-------------|
 | `--execute` | flag | off | Enable actual extraction |
 | `--educate/--no-educate` | flag | on | Educational explanations |
-| `--routing-policy` | text | balanced_openrouter | Routing policy name |
-| `--max-cost` | float | 5.0 | Maximum estimated spend before extraction is blocked |
-| `--validate-live/--no-validate-live` | flag | on | Control whether the pre-live validator gate runs before spending |
-| `--skip-hygiene` | flag | off | Legacy compatibility flag; accepted by the wizard but not forwarded to the v5 runner |
+| `--routing-policy` | text | cost | Routing policy name |
 | `-w, --workers` | int | 1 | Partition worker count |
 
 ### `dopemux audit status`
@@ -71,12 +68,12 @@ No options. Shows latest run ID, directory, phases completed, and total size.
 |---|------|------|--------|-------------|
 | 0 | Welcome | 🔬 | `preflight.py` | System checks — Python version, git, dependencies |
 | 1 | Repo Health | 🩺 | `preflight.py` | Git status, branch, working tree cleanliness |
-| 2 | Corpus Audit | 📊 | `corpus.py` | Runs canonical v5 integrated Stage 0 prescan and normalizes `corpus_manifest.json` into wizard stats |
+| 2 | Corpus Audit | 📊 | `corpus.py` | Runs prescan subprocess, parses JSON stats |
 | 3 | Prompt Setup | ⚙️ | `prompts.py` | Promptset validation and interactive initialization |
 | 4 | Provider Overrides | 🔑 | `provider_overrides.py` | Optional session-local provider key overrides before cost selection |
 | 5 | Cost Profile | 💰 | `cost_profiles.py` | Interactive routing policy browsing, per-profile detail, and final selection |
 | 6 | Partition Preview | 🧩 | `partitions.py` | File→phase mapping and partition estimates |
-| 7 | Extraction | 🚀 | `extraction.py` | Per-phase direct `run_extraction_v5.py` delegation with confirmation |
+| 7 | Extraction | 🚀 | `extraction.py` | Per-phase v5 upgrades-run delegation with confirmation |
 | 8 | Summary | 🏆 | `summary.py` | Telemetry parsing and completion display |
 
 ---
@@ -108,7 +105,7 @@ The pipeline defines **14 phases** executed in order. Phases A–G produce prima
 
 ## Authority Classes
 
-Every file in the corpus is classified into one of six authority classes during the integrated Phase 0 prescan.
+Every file in the corpus is classified into one of six authority classes during the prescan audit.
 
 | Class | Icon | Color | Description |
 |-------|------|-------|-------------|
@@ -179,12 +176,12 @@ src/dopemux/ux/wizard/
 ├── stages.py            # StageStatus, StageResult, WizardState dataclasses + constants
 ├── display.py           # Rich rendering helpers (10 functions)
 ├── preflight.py         # Stages 0-1: welcome + repo health
-├── corpus.py            # Stage 2: integrated v5 Stage 0 prescan
+├── corpus.py            # Stage 2: prescan audit
 ├── prompts.py           # Stage 3: promptset validation
-├── cost_profiles.py     # Stage 5: routing policies + cost estimation
-├── partitions.py        # Stage 6: file→phase mapping
-├── extraction.py        # Stage 7: phase-by-phase extraction
-├── summary.py           # Stage 8: telemetry + completion
+├── cost_profiles.py     # Stage 4: routing policies + cost estimation
+├── partitions.py        # Stage 5: file→phase mapping
+├── extraction.py        # Stage 6: phase-by-phase extraction
+├── summary.py           # Stage 7: telemetry + completion
 └── runner.py            # WizardRunner orchestrator class
 ```
 
@@ -195,10 +192,8 @@ src/dopemux/ux/wizard/
 - **Preview-only by default** — no API calls are made without the `--execute` flag.
 - **Per-phase confirmation** — each extraction phase requires interactive confirmation before proceeding.
 - **Session-local provider overrides** — provider keys entered in stage 4 override shell defaults only for wizard-launched subprocesses.
-- **Runtime ladder parsing** — the wizard reads `ROUTING_LADDERS` from the v5 runner source at runtime and pairs it with `config/pricing.yaml` for cost estimation.
-- **Canonical integrated prescan** — Stage 2 now uses the v5 Stage 0 prescan authority and stores its output under `extraction/repo-truth-extractor/v5/runs/<run_id>/prescan`.
-- **Direct v5 phase execution** — phase extraction invokes `services/repo-truth-extractor/run_extraction_v5.py` directly with `--prescan-dir`, `--skip-prescan`, and `--skip-pre-live-validator` when live validation is disabled.
-- **Compatibility-only hygiene flag** — `--skip-hygiene` is retained as a wizard flag for legacy workflows, but it is not forwarded to the v5 runner.
+- **Static routing snapshot** — `ROUTING_LADDERS` is defined as a static snapshot inside the wizard to avoid importing `run_extraction_v5.py`, which has import-time side effects.
+- **No direct v5 execution** — `run_extraction_v5.py` is **never** executed directly. All extraction is delegated through `dopemux upgrades run --pipeline-version v5 --ui rich --resume`.
 - ⚠️ **CRITICAL:** Accidental direct execution of v5 can cost **$10+** in provider preflight probes. See the workspace safety instructions for details.
 
 ---

--- a/src/dopemux/commands/audit_commands.py
+++ b/src/dopemux/commands/audit_commands.py
@@ -89,27 +89,9 @@ def prescan(ctx, verbose: bool, force: bool, config: Optional[str]):
 )
 @click.option(
     "--routing-policy",
-    default="balanced_openrouter",
+    default="cost",
     show_default=True,
-    help="🧠 Cognitive Routing: LLM policy for the extraction ritual. Use balanced_openrouter for unified billing.",
-)
-@click.option(
-    "--max-cost",
-    type=float,
-    default=5.0,
-    show_default=True,
-    help="💰 Spend Ceiling: Maximum USD to spend across all extraction phases before halting.",
-)
-@click.option(
-    "--validate-live/--no-validate-live",
-    default=True,
-    show_default=True,
-    help="✅ Pre-Live Gate: Enforce the pre-live validator gate before spending.",
-)
-@click.option(
-    "--skip-hygiene",
-    is_flag=True,
-    help="⚠️ Compatibility Flag: Accepted by the wizard UI but not forwarded to the v5 runner.",
+    help="🧠 Cognitive Routing: LLM policy for the extraction ritual. Use cost for the bounded first-run lane.",
 )
 @click.option(
     "--workers",
@@ -119,7 +101,7 @@ def prescan(ctx, verbose: bool, force: bool, config: Optional[str]):
     help="⚡ Ritual Workers: Number of concurrent workers for partitioning. Keep this at 1 for deterministic first runs.",
 )
 @click.pass_context
-def wizard(ctx, execute: bool, educate: bool, routing_policy: str, max_cost: float, validate_live: bool, skip_hygiene: bool, workers: int):
+def wizard(ctx, execute: bool, educate: bool, routing_policy: str, workers: int):
     """
     🧙 Ritual Guide: Guided extraction flight-deck walkthrough
 
@@ -134,9 +116,6 @@ def wizard(ctx, execute: bool, educate: bool, routing_policy: str, max_cost: flo
         educate=educate,
         routing_policy=routing_policy,
         workers=workers,
-        max_cost=max_cost,
-        validate_live=validate_live,
-        skip_hygiene=skip_hygiene,
     )
     runner.run()
 

--- a/src/dopemux/ux/wizard/cost_profiles.py
+++ b/src/dopemux/ux/wizard/cost_profiles.py
@@ -1,121 +1,160 @@
-"""Stage 5: Cost profile selection sourced from canonical repo truth.
+"""Stage 4: Cost profile selection with static routing policy data.
 
-This module intentionally avoids importing ``run_extraction_v5.py`` directly.
-The runner has heavyweight runtime dependencies, so the wizard reads the
-canonical ladder literal from source and pricing from ``config/pricing.yaml``.
+Contains a **static snapshot** of ROUTING_LADDERS from run_extraction_v5.py.
+We do NOT import from v5 to avoid side effects and expensive provider probes.
 """
 
 from __future__ import annotations
 
-import ast
 import os
-from functools import lru_cache
-from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
-
-import yaml
 
 from dopemux.console import console
 
 from ..questionary_support import MissingInteractiveDependencyError, require_questionary
 from .display import render_cost_table, render_educational_panel, render_policy_detail
-from .stages import StageResult, StageStatus, WizardState
+from .stages import PROVIDER_COLORS, StageResult, StageStatus, WizardState
 
-_REPO_ROOT = Path(__file__).resolve().parents[4]
-_RUNNER_PATH = _REPO_ROOT / "services" / "repo-truth-extractor" / "run_extraction_v5.py"
-_PRICING_PATH = _REPO_ROOT / "config" / "pricing.yaml"
+# ── Static routing ladder snapshot ──────────────────────────────────────────
+# Last synced from run_extraction_v5.py on 2026-07-12.
+# Each policy maps 4 tiers → list of (provider, model, env_var) tuples.
 
-POLICY_DESCRIPTIONS: Dict[str, Dict[str, str]] = {
-    "cost": {"label": "Budget", "emoji": "💚", "tier": "low", "desc": "Lowest-spend ladder for exploratory and validator-first runs."},
-    "balanced": {"label": "Balanced", "emoji": "💛", "tier": "mid", "desc": "General mixed-provider ladder without preset overrides."},
-    "balanced_openrouter": {"label": "Balanced OR", "emoji": "💛", "tier": "mid", "desc": "Canonical v5 general default outside preset rewrites."},
-    "balanced_grok_openrouter": {"label": "Grok+OR", "emoji": "🟠", "tier": "high", "desc": "xAI/OpenRouter-biased ladder with premium synthesis risk."},
-    "quality": {"label": "Quality", "emoji": "🟠", "tier": "high", "desc": "Higher-quality ladder with moderate premium exposure."},
-    "openrouter": {"label": "OpenRouter", "emoji": "💙", "tier": "high", "desc": "OpenRouter-heavy ladder with wider premium variance."},
-    "gemini_primary": {"label": "Gemini", "emoji": "💙", "tier": "mid", "desc": "Gemini-first non-code routing with premium escape hatches."},
-    "optimal": {"label": "Optimal", "emoji": "🔴", "tier": "max", "desc": "Highest-cost quality-biased ladder, not budget-safe by default."},
+ROUTING_LADDERS: Dict[str, Dict[str, List[Tuple[str, str, str]]]] = {
+    "cost": {
+        "bulk": [("openai", "gpt-5-nano", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-flash", "GEMINI_API_KEY"), ("xai", "grok-code-fast-1", "XAI_API_KEY")],
+        "extract": [("openai", "gpt-5-mini", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-flash", "GEMINI_API_KEY"), ("xai", "grok-code-fast-1", "XAI_API_KEY")],
+        "synthesis": [("openai", "gpt-5.2", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-pro", "GEMINI_API_KEY"), ("xai", "grok-code-fast-1", "XAI_API_KEY")],
+        "qa": [("openai", "gpt-5-nano", "OPENAI_API_KEY"), ("openai", "gpt-5-mini", "OPENAI_API_KEY"), ("openai", "gpt-5.2", "OPENAI_API_KEY")],
+    },
+    "balanced": {
+        "bulk": [("openai", "gpt-5-mini", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-flash", "GEMINI_API_KEY"), ("xai", "grok-code-fast-1", "XAI_API_KEY")],
+        "extract": [("openai", "gpt-5.1", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-pro", "GEMINI_API_KEY"), ("anthropic", "claude-sonnet-4-5", "ANTHROPIC_API_KEY")],
+        "synthesis": [("openai", "gpt-5.2", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-pro", "GEMINI_API_KEY"), ("anthropic", "claude-sonnet-4-5", "ANTHROPIC_API_KEY")],
+        "qa": [("openai", "gpt-5-mini", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-flash", "GEMINI_API_KEY"), ("xai", "grok-code-fast-1", "XAI_API_KEY")],
+    },
+    "balanced_openrouter": {
+        "bulk": [("openrouter", "openai/gpt-5-mini", "OPENROUTER_API_KEY"), ("openrouter", "google/gemini-2.5-flash", "OPENROUTER_API_KEY"), ("xai", "grok-code-fast-1", "XAI_API_KEY")],
+        "extract": [("openrouter", "openai/gpt-5.1", "OPENROUTER_API_KEY"), ("openrouter", "google/gemini-2.5-pro", "OPENROUTER_API_KEY"), ("xai", "grok-code-fast-1", "XAI_API_KEY")],
+        "synthesis": [("openrouter", "openai/gpt-5.2", "OPENROUTER_API_KEY"), ("openrouter", "anthropic/claude-sonnet-4-5", "OPENROUTER_API_KEY"), ("xai", "grok-4-1-fast-non-reasoning", "XAI_API_KEY")],
+        "qa": [("openrouter", "openai/gpt-5-mini", "OPENROUTER_API_KEY"), ("xai", "grok-code-fast-1", "XAI_API_KEY")],
+    },
+    "balanced_grok_openrouter": {
+        "bulk": [("xai", "grok-code-fast-1", "XAI_API_KEY"), ("openrouter", "openai/gpt-5-mini", "OPENROUTER_API_KEY")],
+        "extract": [("xai", "grok-4-1-fast-non-reasoning", "XAI_API_KEY"), ("openrouter", "openai/gpt-5.1", "OPENROUTER_API_KEY")],
+        "synthesis": [("xai", "grok-4.20-beta-0309-non-reasoning", "XAI_API_KEY"), ("openrouter", "openai/gpt-5.2", "OPENROUTER_API_KEY")],
+        "qa": [("xai", "grok-code-fast-1", "XAI_API_KEY"), ("openrouter", "openai/gpt-5-mini", "OPENROUTER_API_KEY")],
+    },
+    "quality": {
+        "bulk": [("openai", "gpt-5.1", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-pro", "GEMINI_API_KEY"), ("anthropic", "claude-sonnet-4-5", "ANTHROPIC_API_KEY")],
+        "extract": [("openai", "gpt-5.2", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-pro", "GEMINI_API_KEY"), ("anthropic", "claude-sonnet-4-5", "ANTHROPIC_API_KEY")],
+        "synthesis": [("openai", "gpt-5.2", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-pro", "GEMINI_API_KEY"), ("anthropic", "claude-sonnet-4-5", "ANTHROPIC_API_KEY")],
+        "qa": [("openai", "gpt-5.1", "OPENAI_API_KEY"), ("gemini", "gemini-2.5-pro", "GEMINI_API_KEY")],
+    },
+    "openrouter": {
+        "bulk": [("openrouter", "openai/gpt-5-mini", "OPENROUTER_API_KEY"), ("openrouter", "google/gemini-2.5-flash", "OPENROUTER_API_KEY")],
+        "extract": [("openrouter", "openai/gpt-5.1", "OPENROUTER_API_KEY"), ("openrouter", "google/gemini-2.5-pro", "OPENROUTER_API_KEY")],
+        "synthesis": [("openrouter", "openai/gpt-5.2", "OPENROUTER_API_KEY"), ("openrouter", "anthropic/claude-sonnet-4-5", "OPENROUTER_API_KEY")],
+        "qa": [("openrouter", "openai/gpt-5-mini", "OPENROUTER_API_KEY"), ("openrouter", "google/gemini-2.5-flash", "OPENROUTER_API_KEY")],
+    },
+    "gemini_primary": {
+        "bulk": [("gemini", "gemini-3-flash", "GEMINI_API_KEY"), ("gemini", "gemini-2.5-flash", "GEMINI_API_KEY")],
+        "extract": [("gemini", "gemini-3-pro", "GEMINI_API_KEY"), ("gemini", "gemini-2.5-pro", "GEMINI_API_KEY")],
+        "synthesis": [("gemini", "gemini-3-pro", "GEMINI_API_KEY"), ("gemini", "gemini-2.5-pro", "GEMINI_API_KEY")],
+        "qa": [("gemini", "gemini-3-flash", "GEMINI_API_KEY"), ("gemini", "gemini-2.5-flash", "GEMINI_API_KEY")],
+    },
+    "optimal": {
+        "bulk": [("xai", "grok-4-1-fast-non-reasoning", "XAI_API_KEY"), ("xai", "grok-4.20-beta-0309-non-reasoning", "XAI_API_KEY")],
+        "extract": [("xai", "grok-4.20-beta-0309-non-reasoning", "XAI_API_KEY"), ("xai", "grok-4.20-beta-0309-reasoning", "XAI_API_KEY")],
+        "synthesis": [("xai", "grok-4.20-beta-0309-reasoning", "XAI_API_KEY"), ("openrouter", "openai/gpt-5.4", "OPENROUTER_API_KEY"), ("openrouter", "anthropic/claude-opus-4-6", "OPENROUTER_API_KEY")],
+        "qa": [("xai", "grok-4.20-beta-0309-non-reasoning", "XAI_API_KEY"), ("openrouter", "openai/gpt-5-mini", "OPENROUTER_API_KEY")],
+    },
 }
 
+# ── Model pricing (USD per 1M tokens) ──────────────────────────────────────
+# (input_per_1m, output_per_1m) — last updated 2026-07-12
+
+MODEL_PRICING: Dict[str, Tuple[float, float]] = {
+    "gpt-5-nano": (0.10, 0.40),
+    "gpt-5-mini": (0.40, 1.60),
+    "gpt-5.1": (1.00, 4.00),
+    "gpt-5.2": (2.00, 8.00),
+    "gpt-5.4": (5.00, 20.00),
+    "gemini-2.5-flash": (0.15, 0.60),
+    "gemini-2.5-pro": (1.25, 10.00),
+    "gemini-3-pro": (1.25, 10.00),
+    "gemini-3-flash": (0.10, 0.40),
+    "grok-code-fast-1": (0.10, 0.40),
+    "grok-4-1-fast-non-reasoning": (0.50, 2.00),
+    "grok-4.20-beta-0309-non-reasoning": (2.00, 8.00),
+    "grok-4.20-beta-0309-reasoning": (3.00, 15.00),
+    "claude-sonnet-4-5": (3.00, 15.00),
+    "claude-opus-4-6": (15.00, 75.00),
+}
+
+# ── Policy display metadata ────────────────────────────────────────────────
+
+POLICY_DESCRIPTIONS: Dict[str, Dict[str, str]] = {
+    "cost": {"label": "Budget", "emoji": "💚", "tier": "low", "desc": "Cheapest models — nano + flash"},
+    "balanced": {"label": "Balanced", "emoji": "💛", "tier": "mid", "desc": "Mixed providers, good quality/cost ratio"},
+    "balanced_openrouter": {"label": "Balanced OR", "emoji": "💛", "tier": "mid", "desc": "OpenRouter primary — v5 default"},
+    "balanced_grok_openrouter": {"label": "Grok+OR", "emoji": "💛", "tier": "mid", "desc": "Grok primary with OpenRouter fallback"},
+    "quality": {"label": "Quality", "emoji": "🟠", "tier": "high", "desc": "Premium models across all providers"},
+    "openrouter": {"label": "OpenRouter", "emoji": "💛", "tier": "mid", "desc": "Pure OpenRouter routing"},
+    "gemini_primary": {"label": "Gemini", "emoji": "💙", "tier": "mid", "desc": "Gemini 3-series primary"},
+    "optimal": {"label": "Optimal", "emoji": "🔴", "tier": "max", "desc": "Best quality — Grok 4.20 + GPT-5.4"},
+}
+
+# Tier weight distribution for cost estimation
 TIER_WEIGHTS = {"bulk": 0.50, "extract": 0.30, "synthesis": 0.15, "qa": 0.05}
 
 
-def _extract_assignment_literal(path: Path, target_name: str) -> Any:
-    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-    for node in tree.body:
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == target_name:
-                    return ast.literal_eval(node.value)
-        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            if node.target.id == target_name:
-                return ast.literal_eval(node.value)
-    raise RuntimeError(f"{target_name} not found in {path}")
+# ── Helper functions ────────────────────────────────────────────────────────
 
-
-@lru_cache(maxsize=1)
-def _routing_ladders() -> Dict[str, Dict[str, List[Tuple[str, str, str]]]]:
-    payload = _extract_assignment_literal(_RUNNER_PATH, "ROUTING_LADDERS")
-    if not isinstance(payload, dict):
-        raise RuntimeError("ROUTING_LADDERS must decode to a dict")
-    return payload
-
-
-@lru_cache(maxsize=1)
-def _pricing_registry() -> Dict[str, Tuple[float, float]]:
-    payload = yaml.safe_load(_PRICING_PATH.read_text(encoding="utf-8"))
-    models = payload.get("models") if isinstance(payload, dict) else None
-    if not isinstance(models, dict):
-        return {}
-    registry: Dict[str, Tuple[float, float]] = {}
-    for key, row in models.items():
-        if not isinstance(row, dict):
-            continue
-        in_cost = row.get("input_cost_per_m")
-        out_cost = row.get("output_cost_per_m")
-        if in_cost is None or out_cost is None:
-            continue
-        try:
-            registry[str(key).strip().lower()] = (float(in_cost), float(out_cost))
-        except (TypeError, ValueError):
-            continue
-    return registry
-
-
-def _model_price(provider: str, model_id: str) -> Tuple[float, float]:
-    registry = _pricing_registry()
-    provider_key = f"{provider}/{model_id}".strip().lower()
-    if provider_key in registry:
-        return registry[provider_key]
-    bare = model_id.split("/")[-1].strip().lower()
-    if bare in registry:
-        return registry[bare]
-    for key, price in registry.items():
-        if key.endswith(f"/{bare}") or key == bare:
+def _model_price(model_id: str) -> Tuple[float, float]:
+    """Look up (input, output) price per 1M tokens. Strips provider prefix."""
+    # Strip OpenRouter-style prefixes (openai/gpt-5-mini → gpt-5-mini)
+    bare = model_id.split("/")[-1] if "/" in model_id else model_id
+    if bare in MODEL_PRICING:
+        return MODEL_PRICING[bare]
+    # Fuzzy match — try prefix matching
+    for key, price in MODEL_PRICING.items():
+        if bare.startswith(key.rsplit("-", 1)[0]):
             return price
+    # Unknown model — assume mid-range
     return (1.00, 4.00)
 
 
 def get_required_keys(policy: str, overrides: Optional[Dict[str, str]] = None) -> Dict[str, bool]:
-    ladder = _routing_ladders().get(policy, {})
+    """Return {env_var: is_set} for all keys needed by this policy."""
+    ladder = ROUTING_LADDERS.get(policy, {})
     keys: Dict[str, bool] = {}
     override_map = overrides or {}
     for tier_routes in ladder.values():
         for _provider, _model, env_var in tier_routes:
-            if env_var in keys:
-                continue
-            keys[env_var] = bool(
-                override_map.get(env_var, "").strip()
-                or os.environ.get(env_var, "").strip()
-            )
+            if env_var not in keys:
+                keys[env_var] = bool(
+                    override_map.get(env_var, "").strip()
+                    or os.environ.get(env_var, "").strip()
+                )
     return keys
 
 
 def estimate_cost(policy: str, corpus_size_bytes: int) -> Tuple[float, float]:
-    corpus_chars = corpus_size_bytes
+    """Return (low_estimate, high_estimate) in USD for a full 14-phase extraction.
+
+    Estimation formula:
+    - input_tokens ≈ corpus_chars / 4  (rough char-to-token ratio)
+    - output_tokens ≈ input_tokens × 0.3
+    - Each tier has a weight: bulk=50%, extract=30%, synthesis=15%, qa=5%
+    - Low estimate uses cheapest model per tier; high uses most expensive
+    - Multiply by 14 phases, divide by 1M for per-1M pricing
+    """
+    corpus_chars = corpus_size_bytes  # bytes ≈ chars for text
     input_tokens = corpus_chars / 4.0
     output_tokens = input_tokens * 0.3
 
-    ladder = _routing_ladders().get(policy, _routing_ladders()["balanced_openrouter"])
+    ladder = ROUTING_LADDERS.get(policy, ROUTING_LADDERS["balanced_openrouter"])
+
     total_low = 0.0
     total_high = 0.0
 
@@ -123,50 +162,63 @@ def estimate_cost(policy: str, corpus_size_bytes: int) -> Tuple[float, float]:
         routes = ladder.get(tier, [])
         if not routes:
             continue
-        prices = [_model_price(provider, model) for provider, model, _env in routes]
+
+        prices = [_model_price(model) for _, model, _ in routes]
+        # Low = cheapest model in tier; High = most expensive
         tier_low_input = min(p[0] for p in prices)
         tier_low_output = min(p[1] for p in prices)
         tier_high_input = max(p[0] for p in prices)
         tier_high_output = max(p[1] for p in prices)
+
         tier_tokens_in = input_tokens * weight
         tier_tokens_out = output_tokens * weight
+
         total_low += (tier_tokens_in * tier_low_input + tier_tokens_out * tier_low_output) / 1_000_000
         total_high += (tier_tokens_in * tier_high_input + tier_tokens_out * tier_high_output) / 1_000_000
 
-    phase_factor = 14 * 0.3
-    return (round(total_low * phase_factor, 2), round(total_high * phase_factor, 2))
+    # Scale by number of phases (rough — not all phases process full corpus)
+    phase_factor = 14 * 0.3  # ~30% of corpus per phase on average
+    total_low *= phase_factor
+    total_high *= phase_factor
+
+    return (round(total_low, 2), round(total_high, 2))
 
 
 def _build_policy_rows(corpus_size: int) -> List[Dict[str, Any]]:
+    """Build display rows for all policies."""
     rows = []
-    for policy_name, ladder in _routing_ladders().items():
+    for policy_name in ROUTING_LADDERS:
+        ladder = ROUTING_LADDERS.get(policy_name, {})
         meta = POLICY_DESCRIPTIONS.get(policy_name, {"label": policy_name, "emoji": "💛", "desc": ""})
-        keys = get_required_keys(policy_name)
+        keys = get_required_keys(policy_name, overrides=None)
         keys_set = sum(1 for v in keys.values() if v)
+        keys_total = len(keys)
         low, high = estimate_cost(policy_name, corpus_size)
-        rows.append(
-            {
-                "name": policy_name,
-                "label": meta.get("label", policy_name),
-                "emoji": meta.get("emoji", "💛"),
-                "desc": meta.get("desc", ""),
-                "tier": meta.get("tier", "mid"),
-                "low_cost": low,
-                "high_cost": high,
-                "keys_ok": keys_set == len(keys),
-                "keys_status": f"{keys_set}/{len(keys)}",
-                "keys_detail": keys,
-                "tier_routes": ladder,
-                "authority": str(_RUNNER_PATH),
-                "pricing_authority": str(_PRICING_PATH),
-            }
-        )
+
+        rows.append({
+            "name": policy_name,
+            "label": meta.get("label", policy_name),
+            "emoji": meta.get("emoji", "💛"),
+            "desc": meta.get("desc", ""),
+            "tier": meta.get("tier", "mid"),
+            "low_cost": low,
+            "high_cost": high,
+            "keys_ok": keys_set == keys_total,
+            "keys_status": f"{keys_set}/{keys_total}",
+            "keys_detail": keys,
+            "tier_routes": ladder,
+        })
+
     return rows
 
 
+# ── Stage function ──────────────────────────────────────────────────────────
+
 def run_cost_selection(state: WizardState) -> StageResult:
-    """Stage 5 — display routing policies and let the operator pick one."""
-    corpus_size = state.corpus_total_size or 50_000_000
+    """Stage 4 — Display cost profiles and let user select a routing policy."""
+    corpus_size = state.corpus_total_size or 50_000_000  # fallback to ~50MB
+
+    # Factor in prescan savings if intelligence router is available
     if state.intelligence_router:
         savings = state.intelligence_router.estimate_token_savings(state.corpus_manifest)
         savings_pct = savings.get("estimated_reduction_pct", 0)
@@ -187,17 +239,21 @@ def run_cost_selection(state: WizardState) -> StageResult:
         row["keys_detail"] = keys
     render_cost_table(rows, corpus_size, selected=state.selected_policy)
 
+    # Educational content
     if state.educate_mode:
         render_educational_panel(
             "How routing policies work",
-            "These rows are read from the canonical v5 runner and repo pricing catalog.\n\n"
-            "  • Bulk    — high-volume, lower-complexity scanning (50%)\n"
-            "  • Extract — targeted extraction (30%)\n"
-            "  • Synthesis — cross-reference and merge work (15%)\n"
-            "  • QA      — validation and checks (5%)\n\n"
-            "Displayed prices are bounded estimates from repo pricing authority, not live provider quotes.",
+            "Each policy defines which LLM models handle the four extraction tiers:\n\n"
+            "  • Bulk    — high-volume, low-complexity file scanning (50% of work)\n"
+            "  • Extract — targeted content extraction (30%)\n"
+            "  • Synthesis — cross-referencing and synthesis (15%)\n"
+            "  • QA      — quality assurance validation (5%)\n\n"
+            "Cheaper policies use smaller models (nano/flash) for bulk work.\n"
+            "Premium policies use larger models for higher extraction quality.\n"
+            "Cost estimates are approximate — actual cost depends on file sizes.",
         )
 
+    # Interactive selection
     try:
         questionary = require_questionary()
     except MissingInteractiveDependencyError as exc:
@@ -268,23 +324,19 @@ def run_cost_selection(state: WizardState) -> StageResult:
 
     policy_name = rows[selected_idx]["name"]
     state.selected_policy = policy_name
-    keys = get_required_keys(policy_name, overrides=state.provider_key_overrides)
-    missing = [key for key, present in keys.items() if not present]
+
+    # Warn if keys are missing
+    keys = get_required_keys(policy_name)
+    missing = [k for k, v in keys.items() if not v]
     if missing:
         console.print(f"\n  [yellow]⚠  Missing API keys: {', '.join(missing)}[/yellow]")
-        console.print("  [dim]Set these environment variables or add session overrides before running extraction.[/dim]\n")
+        console.print("  [dim]Set these environment variables before running extraction.[/dim]\n")
 
     low, high = estimate_cost(policy_name, corpus_size)
     console.print(f"\n  [green]✓  Selected: {policy_name}  •  Estimated ${low:.0f}–${high:.0f}[/green]\n")
+
     return StageResult(
         status=StageStatus.COMPLETED,
         message=f"{policy_name} (~${low:.0f}–${high:.0f})",
-        data={
-            "policy": policy_name,
-            "low": low,
-            "high": high,
-            "missing_keys": missing,
-            "routing_authority": str(_RUNNER_PATH),
-            "pricing_authority": str(_PRICING_PATH),
-        },
+        data={"policy": policy_name, "low": low, "high": high, "missing_keys": missing},
     )

--- a/src/dopemux/ux/wizard/extraction.py
+++ b/src/dopemux/ux/wizard/extraction.py
@@ -25,7 +25,7 @@ def _wizard_pythonpath(repo_root: Path) -> str:
 
 
 def _build_wizard_phase_command(state: WizardState, phase_key: str) -> list[str]:
-    return [
+    cmd = [
         sys.executable,
         "-m",
         "dopemux.cli",
@@ -44,8 +44,11 @@ def _build_wizard_phase_command(state: WizardState, phase_key: str) -> list[str]
         "--ui",
         "rich",
         "--resume",
-        "--execute",
     ]
+    if state.prescan_dir:
+        cmd.extend(["--prescan-dir", state.prescan_dir, "--skip-prescan"])
+    cmd.append("--execute")
+    return cmd
 
 
 def run_extraction(state: WizardState) -> StageResult:

--- a/src/dopemux/ux/wizard/extraction.py
+++ b/src/dopemux/ux/wizard/extraction.py
@@ -1,4 +1,4 @@
-"""Stage 7: Phase-by-phase extraction via the canonical v5 runner."""
+"""Stage 6: Phase-by-phase extraction via the safe v5 wrapper."""
 
 from __future__ import annotations
 
@@ -24,18 +24,15 @@ def _wizard_pythonpath(repo_root: Path) -> str:
     return str(src_root)
 
 
-def _runner_path(repo_root: Path) -> Path:
-    return repo_root / "services" / "repo-truth-extractor" / "run_extraction_v5.py"
-
-
-def _promptset_root(repo_root: Path) -> Path:
-    return repo_root / "extraction" / "promptset"
-
-
 def _build_wizard_phase_command(state: WizardState, phase_key: str) -> list[str]:
-    cmd = [
+    return [
         sys.executable,
-        str(_runner_path(state.repo_root)),
+        "-m",
+        "dopemux.cli",
+        "upgrades",
+        "run",
+        "--pipeline-version",
+        "v5",
         "--phase",
         phase_key,
         "--run-id",
@@ -44,34 +41,18 @@ def _build_wizard_phase_command(state: WizardState, phase_key: str) -> list[str]
         str(state.workers),
         "--routing-policy",
         state.selected_policy,
-        "--promptset-root",
-        str(_promptset_root(state.repo_root)),
         "--ui",
         "rich",
         "--resume",
+        "--execute",
     ]
-    if state.max_cost is not None:
-        cmd.extend(["--max-cost-usd", str(state.max_cost)])
-    if not state.validate_live:
-        cmd.append("--skip-pre-live-validator")
-        console.print(
-            "[yellow]Pre-live validator is disabled for this run; the runner will skip the validator-first gate.[/yellow]"
-        )
-    if state.skip_hygiene:
-        console.print(
-            "[yellow]Wizard skip-hygiene does not map to the canonical v5 runner and will not be forwarded.[/yellow]"
-        )
-    if state.prescan_dir:
-        cmd.extend(["--prescan-dir", state.prescan_dir, "--skip-prescan"])
-    cmd.append("--execute")
-    return cmd
 
 
 def run_extraction(state: WizardState) -> StageResult:
-    """Stage 7 — Walk through extraction phases with interactive confirmation.
+    """Stage 6 — Walk through extraction phases with interactive confirmation.
 
     In preview mode (default), shows what would run without executing.
-    With --execute, delegates each phase to the canonical v5 runner.
+    With --execute, delegates each phase to the canonical v5 upgrades wrapper.
     """
     if not state.execute_mode:
         console.print(
@@ -103,10 +84,10 @@ def run_extraction(state: WizardState) -> StageResult:
     if state.educate_mode:
         render_educational_panel(
             "Phase-by-phase extraction",
-            "Each phase will be executed via the canonical 'run_extraction_v5.py' runner.\n"
+            "Each phase will be executed via 'dopemux upgrades run --pipeline-version v5'.\n"
             "You can Run, Skip, or Abort at each phase.\n\n"
-            "This keeps routing-policy, promptset-root, resume state, cost cap,\n"
-            "and validator enforcement aligned with the runtime authority.\n\n"
+            "The v5 upgrades wrapper gives the wizard explicit control over\n"
+            "dry-run/live mode, rich UI, resume behavior, and current prescan flags.\n\n"
             "Completed phases write artifacts to:\n"
             f"  extraction/repo-truth-extractor/v5/runs/{state.run_id}/",
         )

--- a/src/dopemux/ux/wizard/runner.py
+++ b/src/dopemux/ux/wizard/runner.py
@@ -1,4 +1,4 @@
-"""WizardRunner — orchestrates the 9-stage guided extraction wizard."""
+"""WizardRunner — orchestrates the 8-stage guided extraction wizard."""
 
 from __future__ import annotations
 
@@ -38,20 +38,14 @@ class WizardRunner:
         self,
         execute: bool = False,
         educate: bool = True,
-        routing_policy: str = "balanced_openrouter",
+        routing_policy: str = "cost",
         workers: int = 1,
-        max_cost: Optional[float] = 5.0,
-        validate_live: bool = True,
-        skip_hygiene: bool = False,
     ) -> None:
         self.state = WizardState(
             execute_mode=execute,
             educate_mode=educate,
             selected_policy=routing_policy,
             workers=workers,
-            max_cost=max_cost,
-            validate_live=validate_live,
-            skip_hygiene=skip_hygiene,
             run_id=datetime.now().strftime("RUN-%Y%m%dT%H%M%S"),
         )
 

--- a/src/dopemux/ux/wizard/stages.py
+++ b/src/dopemux/ux/wizard/stages.py
@@ -40,18 +40,14 @@ class WizardState:
     grok_response: Optional[Dict[str, Any]] = None
     code_intelligence: Optional[Dict[str, Any]] = None
     intelligence_router: Optional[Any] = None
-    prescan_dir: str = ""
     promptset_ready: bool = False
-    selected_policy: str = "balanced_openrouter"
+    selected_policy: str = "cost"
     run_id: str = ""
     workers: int = 1
     provider_key_overrides: Dict[str, str] = field(default_factory=dict)
     phase_results: Dict[str, "StageResult"] = field(default_factory=dict)
     execute_mode: bool = False
     educate_mode: bool = True
-    max_cost: Optional[float] = 5.0
-    validate_live: bool = True
-    skip_hygiene: bool = False
 
 
 # ── 14 extraction phases in pipeline order ──────────────────────────────────

--- a/src/dopemux/ux/wizard/stages.py
+++ b/src/dopemux/ux/wizard/stages.py
@@ -40,6 +40,7 @@ class WizardState:
     grok_response: Optional[Dict[str, Any]] = None
     code_intelligence: Optional[Dict[str, Any]] = None
     intelligence_router: Optional[Any] = None
+    prescan_dir: str = ""
     promptset_ready: bool = False
     selected_policy: str = "cost"
     run_id: str = ""

--- a/tests/unit/test_wizard_interactivity.py
+++ b/tests/unit/test_wizard_interactivity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -12,6 +13,7 @@ from dopemux.ux.questionary_support import (
     QUESTIONARY_INSTALL_MESSAGE,
     require_questionary,
 )
+from dopemux.ux.wizard.corpus import run_corpus_audit
 from dopemux.ux.wizard.cost_profiles import run_cost_selection
 from dopemux.ux.wizard.extraction import run_extraction
 from dopemux.ux.wizard.provider_overrides import run_provider_overrides
@@ -99,6 +101,7 @@ def test_run_extraction_uses_v5_upgrades_wrapper_with_resume_and_rich_ui(
             selected_policy="cost",
             workers=1,
             run_id="RUN-20260415T120000",
+            prescan_dir=str(tmp_path / "prescan"),
         )
     )
 
@@ -122,9 +125,69 @@ def test_run_extraction_uses_v5_upgrades_wrapper_with_resume_and_rich_ui(
         "--ui",
         "rich",
         "--resume",
+        "--prescan-dir",
+        str(tmp_path / "prescan"),
+        "--skip-prescan",
         "--execute",
     ]
     assert recorded["env"]["PYTHONPATH"] == str(tmp_path / "src")
+
+
+def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    prescan_dir = tmp_path / "extraction" / "repo-truth-extractor" / "v5" / "runs" / "RUN-20260415T120000" / "prescan"
+    prescan_dir.mkdir(parents=True)
+    manifest = [
+        {
+            "rel_path": "src/app.py",
+            "include": True,
+            "authority_class": "canonical",
+            "size_bytes": 120,
+            "extension": ".py",
+        },
+        {
+            "rel_path": ".pytest_cache/v/cache",
+            "include": False,
+            "authority_class": "generated",
+            "size_bytes": 20,
+            "extension": "",
+        },
+    ]
+    intelligence = {
+        "corpus_summary": {
+            "included_files": 1,
+            "total_files": 2,
+            "total_size_bytes": 120,
+        },
+        "code_intelligence": {"analyzed_files": 1},
+    }
+    (prescan_dir / "corpus_manifest.json").write_text(
+        json.dumps(manifest), encoding="utf-8"
+    )
+    (prescan_dir / "prescan_intelligence.json").write_text(
+        json.dumps(intelligence), encoding="utf-8"
+    )
+
+    router = object()
+    monkeypatch.setattr(
+        "dopemux.ux.wizard.corpus._run_integrated_v5_prescan",
+        lambda state: (prescan_dir, router),
+    )
+
+    state = WizardState(
+        repo_root=tmp_path,
+        run_id="RUN-20260415T120000",
+        educate_mode=False,
+    )
+    result = run_corpus_audit(state)
+
+    assert result.status is StageStatus.COMPLETED
+    assert state.prescan_dir == str(prescan_dir)
+    assert state.intelligence_router is router
+    assert state.corpus_included_count == 1
+    assert state.corpus_total_size == 120
+    assert state.corpus_stats["excluded_count"] == 1
 
 
 def test_run_cost_selection_supports_profile_browsing(

--- a/tests/unit/test_wizard_interactivity.py
+++ b/tests/unit/test_wizard_interactivity.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib
-import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -13,7 +12,6 @@ from dopemux.ux.questionary_support import (
     QUESTIONARY_INSTALL_MESSAGE,
     require_questionary,
 )
-from dopemux.ux.wizard.corpus import run_corpus_audit
 from dopemux.ux.wizard.cost_profiles import run_cost_selection
 from dopemux.ux.wizard.extraction import run_extraction
 from dopemux.ux.wizard.provider_overrides import run_provider_overrides
@@ -101,14 +99,18 @@ def test_run_extraction_uses_v5_upgrades_wrapper_with_resume_and_rich_ui(
             selected_policy="cost",
             workers=1,
             run_id="RUN-20260415T120000",
-            prescan_dir=str(tmp_path / "prescan"),
         )
     )
 
     assert result.status is StageStatus.COMPLETED
     assert recorded["cmd"] == [
         sys.executable,
-        str(tmp_path / "services" / "repo-truth-extractor" / "run_extraction_v5.py"),
+        "-m",
+        "dopemux.cli",
+        "upgrades",
+        "run",
+        "--pipeline-version",
+        "v5",
         "--phase",
         "A",
         "--run-id",
@@ -117,129 +119,12 @@ def test_run_extraction_uses_v5_upgrades_wrapper_with_resume_and_rich_ui(
         "1",
         "--routing-policy",
         "cost",
-        "--promptset-root",
-        str(tmp_path / "extraction" / "promptset"),
         "--ui",
         "rich",
         "--resume",
-        "--max-cost-usd",
-        "5.0",
-        "--prescan-dir",
-        str(tmp_path / "prescan"),
-        "--skip-prescan",
         "--execute",
     ]
     assert recorded["env"]["PYTHONPATH"] == str(tmp_path / "src")
-
-
-def test_run_extraction_skips_pre_live_validator_when_disabled(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    recorded: dict[str, object] = {}
-
-    class _Prompt:
-        def ask(self) -> str:
-            return "Run"
-
-    fake_questionary = SimpleNamespace(
-        Style=lambda styles: styles,
-        select=lambda *args, **kwargs: _Prompt(),
-        confirm=lambda *args, **kwargs: _Prompt(),
-    )
-
-    class _Proc:
-        def __init__(self, cmd):
-            self.stdout = []
-            self.returncode = 0
-            recorded["cmd"] = list(cmd)
-
-        def wait(self) -> None:
-            return None
-
-    monkeypatch.setattr(
-        "dopemux.ux.wizard.extraction.require_questionary",
-        lambda: fake_questionary,
-    )
-    monkeypatch.setattr("dopemux.ux.wizard.extraction.PHASES", ["A"])
-    monkeypatch.setenv("PYTHONPATH", "")
-    monkeypatch.setattr(
-        "dopemux.ux.wizard.extraction.subprocess.Popen",
-        lambda cmd, **kwargs: recorded.update({"env": dict(kwargs.get("env") or {})}) or _Proc(cmd),
-    )
-
-    result = run_extraction(
-        WizardState(
-            repo_root=tmp_path,
-            execute_mode=True,
-            educate_mode=False,
-            selected_policy="balanced_openrouter",
-            workers=1,
-            run_id="RUN-20260415T120000",
-            validate_live=False,
-            skip_hygiene=True,
-        )
-    )
-
-    assert result.status is StageStatus.COMPLETED
-    assert "--skip-pre-live-validator" in recorded["cmd"]
-    assert "--skip-hygiene" not in recorded["cmd"]
-
-
-def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    prescan_dir = tmp_path / "extraction" / "repo-truth-extractor" / "v5" / "runs" / "RUN-20260415T120000" / "prescan"
-    prescan_dir.mkdir(parents=True)
-    manifest = [
-        {
-            "rel_path": "src/app.py",
-            "include": True,
-            "authority_class": "canonical",
-            "size_bytes": 120,
-            "extension": ".py",
-        },
-        {
-            "rel_path": ".pytest_cache/v/cache",
-            "include": False,
-            "authority_class": "generated",
-            "size_bytes": 20,
-            "extension": "",
-        },
-    ]
-    intelligence = {
-        "corpus_summary": {
-            "included_files": 1,
-            "total_files": 2,
-            "total_size_bytes": 120,
-        },
-        "code_intelligence": {"analyzed_files": 1},
-    }
-    (prescan_dir / "corpus_manifest.json").write_text(
-        json.dumps(manifest), encoding="utf-8"
-    )
-    (prescan_dir / "prescan_intelligence.json").write_text(
-        json.dumps(intelligence), encoding="utf-8"
-    )
-
-    router = object()
-    monkeypatch.setattr(
-        "dopemux.ux.wizard.corpus._run_integrated_v5_prescan",
-        lambda state: (prescan_dir, router),
-    )
-
-    state = WizardState(
-        repo_root=tmp_path,
-        run_id="RUN-20260415T120000",
-        educate_mode=False,
-    )
-    result = run_corpus_audit(state)
-
-    assert result.status is StageStatus.COMPLETED
-    assert state.prescan_dir == str(prescan_dir)
-    assert state.intelligence_router is router
-    assert state.corpus_included_count == 1
-    assert state.corpus_total_size == 120
-    assert state.corpus_stats["excluded_count"] == 1
 
 
 def test_run_cost_selection_supports_profile_browsing(
@@ -271,20 +156,6 @@ def test_run_cost_selection_supports_profile_browsing(
     assert result.status is StageStatus.COMPLETED
     assert state.selected_policy == "balanced"
     assert "balanced" in result.message
-
-
-def test_cost_profiles_read_balanced_openrouter_from_runner_source() -> None:
-    rows = run_cost_selection.__globals__["_build_policy_rows"](10 * 1024 * 1024)
-    by_name = {row["name"]: row for row in rows}
-
-    assert by_name["balanced_openrouter"]["tier_routes"]["extract"][0] == (
-        "openrouter",
-        "openai/gpt-5-mini",
-        "OPENROUTER_API_KEY",
-    )
-    assert by_name["balanced_openrouter"]["authority"].endswith(
-        "services/repo-truth-extractor/run_extraction_v5.py"
-    )
 
 
 def test_run_provider_overrides_sets_session_key(


### PR DESCRIPTION
## Summary
- add a provider override step to the extraction wizard for session-local API key overrides
- add interactive cost-profile browsing with previous/next navigation and inline profile detail
- route wizard phase execution through `dopemux upgrades run --pipeline-version v5`
- change first-run wizard defaults to `--routing-policy cost` and `--partition-workers 1`
- update wizard docs and changelog to match the runtime behavior

## Validation
- `python scripts/check_root_hygiene.py --all-files` ✅
- `python -m py_compile src/dopemux/ux/wizard/provider_overrides.py src/dopemux/ux/wizard/cost_profiles.py src/dopemux/ux/wizard/display.py src/dopemux/ux/wizard/runner.py src/dopemux/ux/wizard/extraction.py tests/unit/test_wizard_interactivity.py` ✅
- `PYTHONPATH=/tmp/dopemux-wizard-pr-local/src /Users/hue/code/dopemux-mvp/.venv/bin/pytest -q tests/unit/test_wizard_interactivity.py` ✅
- `./test_installer_basic.sh` ✅
- `PYTHONPATH=/tmp/dopemux-wizard-pr-local/src /Users/hue/code/dopemux-mvp/.venv/bin/pytest tests/unit --maxfail=1 --disable-warnings --no-cov` ⚠️ fails outside this change in `tests/unit/test_dopetask_wrapper_submodule.py::test_wrapper_triggers_install_on_version_drift` with `Operation not permitted` under `~/.local/lib/python3.11/site-packages/shellingham`

## Review checklist
- provider overrides remain session-local and are only injected into wizard-launched subprocesses
- cost-profile browsing supports previous/next/detail/selection
- wizard execution path uses the v5 upgrades wrapper, not `truth-run`
- docs match the implemented wizard flow
- `CHANGELOG.md` includes the user-facing wizard entry

## Rollback
- revert commit `78e12b61b`
- that restores the previous wizard execution path and removes the new provider-override and interactive cost-profile browsing behavior
