### PR TITLE
feat(rte): show prescan progress and wizard telemetry

### DIFF
--- a/services/repo-truth-extractor/lib/prescan/engine.py
+++ b/services/repo-truth-extractor/lib/prescan/engine.py
@@ -52,6 +52,13 @@ class PrescanEngine:
         self.detector = self.duplicate_detector
         self.code_scanner = self.code_prescan
 
+    def _log_progress(self, message: str, **fields: Any) -> None:
+        if fields:
+            details = " ".join(f"{key}={value}" for key, value in fields.items())
+            logger.info("PRESCAN_PROGRESS %s %s", message, details)
+            return
+        logger.info("PRESCAN_PROGRESS %s", message)
+
     def run(self, passes: list[str] | None = None, incremental: bool = False) -> PrescanResult:
         start_time = time.time()
         warnings: list[str] = []
@@ -60,21 +67,70 @@ class PrescanEngine:
         self.config.output_dir.mkdir(parents=True, exist_ok=True)
 
         try:
+            self._log_progress(
+                "start",
+                repo=self.config.repo_root,
+                output=self.config.output_dir,
+                incremental=bool(incremental),
+            )
+            self._log_progress("walk_corpus")
             entries = self.walker.walk()
+            included_count = sum(1 for entry in entries if entry.include)
+            self._log_progress(
+                "walk_corpus_done",
+                files=len(entries),
+                included=included_count,
+                excluded=len(entries) - included_count,
+            )
+
+            self._log_progress("load_incremental_cache")
             cache = IncrementalCodeCache(self.config)
             cache_payload, fallback_reason, changed_files = self._load_incremental_cache(cache, incremental, warnings)
+            self._log_progress(
+                "incremental_cache_done",
+                changed_files=len(changed_files or set()) if incremental else 0,
+                fallback=bool(fallback_reason),
+            )
             incremental_meta: dict[str, Any] = {
                 "enabled": bool(incremental),
                 "changed_files_count": len(changed_files or set()) if incremental else 0,
                 "fallback_reason": fallback_reason,
             }
 
+            self._log_progress("classify_files", files=len(entries))
             incremental_meta.update(self._classify(entries, cache, cache_payload, changed_files))
+            self._log_progress(
+                "classify_files_done",
+                reused=incremental_meta.get("cached_classifications_reused", 0),
+                reclassified=incremental_meta.get("reclassified_files", 0),
+            )
+            self._log_progress("git_enrichment", enabled=bool(self.config.enable_git_enrichment))
             incremental_meta.update(self._enrich(entries, warnings, cache, cache_payload, changed_files))
+            self._log_progress(
+                "git_enrichment_done",
+                reused=incremental_meta.get("cached_git_enrichment_reused", 0),
+                recomputed=incremental_meta.get("git_enrichment_recomputed", 0),
+            )
+            self._log_progress("duplicate_analysis", files=len(entries))
             duplicates = self._detect_duplicates(entries, cache, cache_payload, changed_files)
             incremental_meta.update(duplicates["metadata"])
+            self._log_progress(
+                "duplicate_analysis_done",
+                groups=len(duplicates["groups"]),
+                version_chains=len(duplicates["chains"]),
+            )
 
             manifest = [entry.to_dict() for entry in entries]
+            code_entries = sum(
+                1
+                for entry in entries
+                if entry.include and not entry.is_ghost and self._is_code_entry(entry)
+            )
+            self._log_progress(
+                "code_intelligence",
+                enabled=bool(self.config.enable_code_prescan),
+                files=code_entries,
+            )
             code_intel, code_incremental_meta = self._analyze_code(
                 entries,
                 manifest,
@@ -83,16 +139,25 @@ class PrescanEngine:
                 changed_files,
             )
             incremental_meta.update(code_incremental_meta)
+            self._log_progress(
+                "code_intelligence_done",
+                analyzed=len(code_intel),
+                reused=incremental_meta.get("cached_code_analysis_reused", 0),
+                reanalyzed=incremental_meta.get("reanalyzed_code_files", 0),
+            )
             incremental_meta["removed_cache_entries"] = cache.removed_entry_count(
                 cache_payload,
                 {entry.rel_path for entry in entries},
             )
             metadata["incremental"] = incremental_meta
+            self._log_progress("write_incremental_cache")
             cache.write(entries, code_intel, self._get_git_sha())
 
+            self._log_progress("build_dependency_graph", files=len(code_intel))
             self.dep_graph = DependencyGraph()
             self.dep_graph.build_from_code_intelligence(code_intel, manifest)
 
+            self._log_progress("build_intelligence")
             intelligence = self._build_intelligence_base(entries, code_intel)
             intelligence["duplicate_groups"] = duplicates["groups"]
             intelligence["version_chains"] = duplicates["chains"]
@@ -101,13 +166,21 @@ class PrescanEngine:
             code_graph_path: Path | None = None
             code_report_path: Path | None = None
             if self.config.enable_code_prescan:
+                self._log_progress("write_code_artifacts")
                 code_graph_path = self._write_code_graph()
                 code_report_path = self._write_code_report(entries, manifest)
 
             batch_plans: dict[str, Any] = {}
             batch_plan_path: Path | None = None
             if passes:
+                self._log_progress("plan_llm_passes", passes=",".join(passes))
                 batch_plans, batch_plan_path = self._plan_batches(passes, entries, manifest, intelligence)
+                self._log_progress(
+                    "plan_llm_passes_done",
+                    batches=sum(len(plan.batches) for plan in batch_plans.values()),
+                    tokens=sum(int(getattr(plan, "total_estimated_tokens", 0) or 0) for plan in batch_plans.values()),
+                )
+                self._log_progress("provider_readiness", passes=",".join(passes))
                 stage0 = self._run_stage0(passes)
                 metadata["stage0"] = {
                     "catalog_status": "PASS",
@@ -115,7 +188,13 @@ class PrescanEngine:
                     "routing_plan_status": stage0["routing_plan"]["status"],
                     "selected_live_routes": stage0["routing_plan"].get("selected_routes", {}),
                 }
+                self._log_progress(
+                    "provider_readiness_done",
+                    readiness=stage0["readiness"]["status"],
+                    routing=stage0["routing_plan"]["status"],
+                )
                 if stage0["routing_plan"]["status"] == NO_LIVE_LANE:
+                    self._log_progress("halt_no_live_lane")
                     write_no_live_lane_artifact(self.config.output_dir, stage0["routing_plan"])
                     errors.append("No executable live prescan lane survived Stage 0 readiness gating.")
                     return PrescanResult(
@@ -137,6 +216,10 @@ class PrescanEngine:
                 if self.config.allow_online_llm:
                     write_live_lane_success_artifact(self.config.output_dir, stage0["routing_plan"])
                 if self.config.allow_online_llm:
+                    self._log_progress(
+                        "run_online_passes",
+                        mode="batch" if self.config.batch_mode and batch_plans else "single",
+                    )
                     if self.config.batch_mode and batch_plans:
                         grok_results = self.grok_runner.run_passes_batched(
                             passes,
@@ -153,9 +236,20 @@ class PrescanEngine:
                             routing_plan=stage0["routing_plan"],
                         )
                     intelligence["grok_passes"] = grok_results
+                    self._log_progress("run_online_passes_done", results=len(grok_results))
+                else:
+                    self._log_progress("online_passes_skipped", reason="online_llm_not_authorized")
 
+            self._log_progress("write_prescan_artifacts")
             intelligence_path = self._write_json("prescan_intelligence.json", intelligence)
             manifest_path = self._write_json("corpus_manifest.json", manifest)
+            self._log_progress(
+                "complete",
+                files=len(entries),
+                included=sum(1 for entry in entries if entry.include),
+                code_files=len(code_intel),
+                seconds=round(time.time() - start_time, 2),
+            )
             return PrescanResult(
                 success=True,
                 duration_seconds=round(time.time() - start_time, 2),

--- a/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
+++ b/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
@@ -12,6 +13,7 @@ if str(SERVICE_ROOT) not in sys.path:
 
 from lib.prescan.classifier import Classifier
 from lib.prescan.corpus_walker import CorpusWalker
+from lib.prescan.engine import PrescanEngine
 from lib.prescan.models import FileEntry, PrescanConfig
 
 
@@ -120,6 +122,33 @@ def test_classifier_detects_draft_and_adr(tmp_path: Path) -> None:
 
     archive_entry = next(e for e in entries if "archive" in e.rel_path)
     assert archive_entry.authority_class == "historical"
+
+
+def test_prescan_engine_emits_operator_progress(caplog, tmp_path: Path) -> None:
+    """Prescan should show real stage progress instead of a silent long-running wait."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("def main():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# Fixture\n", encoding="utf-8")
+
+    config = PrescanConfig(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "out",
+        enable_code_prescan=False,
+        enable_git_enrichment=False,
+        batch_mode=False,
+        cost_estimate=False,
+    )
+    engine = PrescanEngine(config)
+
+    with caplog.at_level(logging.INFO, logger="lib.prescan.engine"):
+        result = engine.run()
+
+    assert result.success is True
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("PRESCAN_PROGRESS walk_corpus" in message for message in messages)
+    assert any("PRESCAN_PROGRESS classify_files" in message for message in messages)
+    assert any("PRESCAN_PROGRESS write_prescan_artifacts" in message for message in messages)
+    assert any("PRESCAN_PROGRESS complete" in message for message in messages)
 
 
 

--- a/src/dopemux/ux/wizard/corpus.py
+++ b/src/dopemux/ux/wizard/corpus.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List, Tuple
 
 from dopemux.console import console
 
-from .display import render_corpus_table, render_educational_panel
+from .display import render_corpus_table, render_educational_panel, render_prescan_hud
 from .stages import AUTHORITY_CLASSES, StageResult, StageStatus, WizardState
 
 
@@ -82,6 +82,17 @@ def _run_integrated_v5_prescan(state: WizardState) -> Tuple[Path, Any]:
     return run_root / "prescan", router
 
 
+def _load_optional_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            payload = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
 def run_corpus_audit(state: WizardState) -> StageResult:
     """Stage 2 — Run canonical Stage 0 prescan and parse its manifest/intelligence."""
     if not state.run_id:
@@ -113,13 +124,7 @@ def run_corpus_audit(state: WizardState) -> StageResult:
         console.print(f"[bold red]Failed to parse corpus_manifest.json: {exc}[/bold red]")
         return StageResult(status=StageStatus.FAILED, message="Manifest JSON parse error")
 
-    intelligence: Dict[str, Any] = {}
-    if intelligence_path.exists():
-        try:
-            with open(intelligence_path, encoding="utf-8") as f:
-                intelligence = json.load(f)
-        except (json.JSONDecodeError, OSError):
-            intelligence = {}
+    intelligence = _load_optional_json(intelligence_path)
 
     state.corpus_stats = _build_corpus_stats(state.corpus_manifest or [])
     state.corpus_included_count = state.corpus_stats.get("included_count", 0)
@@ -130,6 +135,15 @@ def run_corpus_audit(state: WizardState) -> StageResult:
 
     # Display integrated prescan results
     console.print()
+    render_prescan_hud(
+        state.corpus_stats,
+        intelligence,
+        {
+            "receipt": _load_optional_json(prescan_dir / "prescan_stage_receipt.json"),
+            "batch_plan": _load_optional_json(prescan_dir / "batch_plan.json"),
+            "routing_plan": _load_optional_json(prescan_dir / "prescan_routing_plan.json"),
+        },
+    )
     render_corpus_table(state.corpus_stats)
 
     excluded = state.corpus_stats.get("excluded_count", 0)

--- a/src/dopemux/ux/wizard/display.py
+++ b/src/dopemux/ux/wizard/display.py
@@ -170,6 +170,131 @@ def render_corpus_table(stats: Dict[str, Any]) -> None:
     console.print(table)
 
 
+def render_prescan_hud(
+    stats: Dict[str, Any],
+    intelligence: Dict[str, Any],
+    artifacts: Dict[str, Any],
+) -> None:
+    """Render the canonical v5 prescan outputs as an operator-facing HUD."""
+    total_scanned = int(stats.get("total_files_scanned", 0) or 0)
+    included = int(stats.get("included_count", 0) or 0)
+    excluded = int(stats.get("excluded_count", 0) or 0)
+    total_size = int(stats.get("total_included_size", 0) or 0)
+    code_intel = intelligence.get("code_intelligence") or {}
+    analyzed_files = int(code_intel.get("analyzed_files", 0) or 0)
+    compression_files = int(intelligence.get("compression_potential_files", 0) or 0)
+    version_chains = int(intelligence.get("version_chain_count", 0) or 0)
+    planned_features = intelligence.get("planned_features") or {}
+    planned_count = sum(
+        len(value) for value in planned_features.values() if isinstance(value, list)
+    )
+
+    receipt = artifacts.get("receipt") or {}
+    batch_plan = artifacts.get("batch_plan") or {}
+    routing_plan = artifacts.get("routing_plan") or {}
+    selected_routes = routing_plan.get("selected_routes") or {}
+    router_loaded = bool(receipt.get("router_loaded"))
+    online_authorized = bool(receipt.get("online_authorized"))
+
+    metric_table = Table.grid(expand=True)
+    metric_table.add_column(ratio=1)
+    metric_table.add_column(ratio=1)
+    metric_table.add_column(ratio=1)
+    metric_table.add_row(
+        f"[bold mint]{included:,}[/bold mint]\n[dim]included files[/dim]",
+        f"[bold warning]{excluded:,}[/bold warning]\n[dim]excluded noise[/dim]",
+        f"[bold info]{total_size / (1024 * 1024):.1f} MB[/bold info]\n[dim]included corpus[/dim]",
+    )
+    metric_table.add_row(
+        f"[bold success]{analyzed_files:,}[/bold success]\n[dim]code files analyzed[/dim]",
+        f"[bold magenta]{compression_files:,}[/bold magenta]\n[dim]compression candidates[/dim]",
+        f"[bold violet]{version_chains:,}[/bold violet]\n[dim]version chains[/dim]",
+    )
+
+    status_lines = [
+        f"[bold]Prescan mode:[/bold] {receipt.get('mode', 'integrated')}",
+        f"[bold]Router loaded:[/bold] {'yes' if router_loaded else 'no'}",
+        f"[bold]Online LLM spend:[/bold] {'authorized' if online_authorized else 'blocked'}",
+        f"[bold]Planned feature signals:[/bold] {planned_count:,}",
+        f"[bold]Files scanned:[/bold] {total_scanned:,}",
+    ]
+    if receipt.get("duration_seconds") is not None:
+        status_lines.append(f"[bold]Runtime:[/bold] {receipt['duration_seconds']}s")
+
+    console.print(
+        Panel(
+            Columns(
+                [
+                    Panel(metric_table, title="[bold]Corpus Signal[/bold]", border_style="mint", box=ROUNDED),
+                    Panel("\n".join(status_lines), title="[bold]Stage 0 State[/bold]", border_style="violet", box=ROUNDED),
+                ],
+                equal=True,
+                expand=True,
+            ),
+            title="[bold white]Integrated Prescan Telemetry[/bold white]",
+            subtitle="[dim]canonical v5 artifacts, local analysis, no provider spend unless explicitly authorized[/dim]",
+            border_style="bright_cyan",
+            box=ROUNDED,
+            padding=(1, 1),
+        )
+    )
+
+    if batch_plan:
+        plan_rows = []
+        for pass_id, plan in sorted(batch_plan.items()):
+            if not isinstance(plan, dict):
+                continue
+            batches = plan.get("batches") or []
+            plan_rows.append(
+                (
+                    pass_id,
+                    int(plan.get("total_files", 0) or 0),
+                    len(batches),
+                    int(plan.get("total_estimated_tokens", 0) or 0),
+                )
+            )
+        if plan_rows:
+            table = Table(
+                title="[bold]Prescan LLM Pass Plan[/bold]",
+                box=ROUNDED,
+                border_style="table.border",
+                padding=(0, 1),
+            )
+            table.add_column("Pass")
+            table.add_column("Files", justify="right")
+            table.add_column("Batches", justify="right")
+            table.add_column("Est. tokens", justify="right")
+            for pass_id, files, batches, tokens in plan_rows:
+                route = selected_routes.get(pass_id) or {}
+                provider = route.get("provider")
+                model_id = route.get("model_id")
+                route_label = f"  [dim]{provider}/{model_id}[/dim]" if provider and model_id else ""
+                table.add_row(pass_id + route_label, f"{files:,}", f"{batches:,}", f"{tokens:,}")
+            console.print(table)
+
+    savings = (
+        intelligence.get("grok_passes", {})
+        .get("optimize", {})
+        .get("estimated_savings")
+    )
+    if isinstance(savings, dict):
+        console.print(
+            Panel(
+                "\n".join(
+                    [
+                        f"[bold]Files skipped:[/bold] {int(savings.get('files_skipped', 0) or 0):,}",
+                        f"[bold]Files compressed:[/bold] {int(savings.get('files_compressed', 0) or 0):,}",
+                        f"[bold]Estimated token reduction:[/bold] {float(savings.get('estimated_token_reduction_pct', 0.0) or 0.0):.1f}%",
+                    ]
+                ),
+                title="[bold]Optimization Savings[/bold]",
+                border_style="success",
+                box=ROUNDED,
+                padding=(1, 2),
+            )
+        )
+
+
 # ── Cost profile comparison ────────────────────────────────────────────────
 
 def render_cost_table(

--- a/tests/unit/test_wizard_interactivity.py
+++ b/tests/unit/test_wizard_interactivity.py
@@ -168,11 +168,30 @@ def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
     (prescan_dir / "prescan_intelligence.json").write_text(
         json.dumps(intelligence), encoding="utf-8"
     )
+    (prescan_dir / "prescan_stage_receipt.json").write_text(
+        json.dumps({"mode": "integrated", "router_loaded": True}),
+        encoding="utf-8",
+    )
+    (prescan_dir / "batch_plan.json").write_text(
+        json.dumps({"dedup": {"total_files": 1, "total_estimated_tokens": 100, "batches": [{"batch_id": "dedup_0"}]}}),
+        encoding="utf-8",
+    )
+    (prescan_dir / "prescan_routing_plan.json").write_text(
+        json.dumps({"selected_routes": {"dedup": {"provider": "openrouter", "model_id": "openai/gpt-5-nano"}}}),
+        encoding="utf-8",
+    )
 
     router = object()
+    rendered: dict[str, object] = {}
     monkeypatch.setattr(
         "dopemux.ux.wizard.corpus._run_integrated_v5_prescan",
         lambda state: (prescan_dir, router),
+    )
+    monkeypatch.setattr(
+        "dopemux.ux.wizard.corpus.render_prescan_hud",
+        lambda stats, intelligence, artifacts: rendered.update(
+            {"stats": stats, "intelligence": intelligence, "artifacts": artifacts}
+        ),
     )
 
     state = WizardState(
@@ -188,6 +207,12 @@ def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
     assert state.corpus_included_count == 1
     assert state.corpus_total_size == 120
     assert state.corpus_stats["excluded_count"] == 1
+    assert rendered["artifacts"]["receipt"]["router_loaded"] is True
+    assert rendered["artifacts"]["batch_plan"]["dedup"]["total_estimated_tokens"] == 100
+    assert (
+        rendered["artifacts"]["routing_plan"]["selected_routes"]["dedup"]["model_id"]
+        == "openai/gpt-5-nano"
+    )
 
 
 def test_run_cost_selection_supports_profile_browsing(


### PR DESCRIPTION
## Summary
@codex
@clauee
@copilot

Adds operator-visible progress for RTE prescan and a richer wizard telemetry display backed by canonical prescan artifacts.

## Changes
- Emit structured PRESCAN_PROGRESS lines from the prescan engine for corpus walking, cache loading, classification, enrichment, duplicate analysis, code intelligence, artifact writes, provider readiness, online pass execution/skips, and completion.
- Render a wizard prescan telemetry HUD from canonical v5 artifacts: prescan_stage_receipt.json, batch_plan.json, and prescan_routing_plan.json.
- Keep optional artifact loading fail-soft so local-only prescan runs do not fail when route/batch artifacts are absent.
- Add regression coverage for progress logging and wizard artifact plumbing.

## RTE command comparison
- dopemux rte is the canonical operator surface.
- dopemux rte run owns integrated v5 prescan flags: --skip-prescan, --prescan-import-dir, --prescan-online, --prescan-allow-scope-reduction, and --allow-online-llm.
- dopemux extractor is legacy promptset/prescan tooling.
- dopemux truth is deprecated legacy UX.

## Validation
- ./.venv/bin/python -m pytest services/repo-truth-extractor/tests/test_prescan_core_pipeline.py tests/unit/test_wizard_interactivity.py -q
- git diff --check --cached

## Release notes
- RTE prescan now shows concrete progress instead of appearing idle during long local analysis.
- The guided extraction wizard now summarizes what prescan scanned, classified, routed, and wrote before showing the corpus breakdown.
