### PR TITLE
feat(rte): add wizard alias and richer prescan telemetry

### DIFF
--- a/services/repo-truth-extractor/lib/prescan/engine.py
+++ b/services/repo-truth-extractor/lib/prescan/engine.py
@@ -59,6 +59,80 @@ class PrescanEngine:
             return
         logger.info("PRESCAN_PROGRESS %s", message)
 
+    def _top_file_extensions(self, entries: list[FileEntry], limit: int = 3) -> str:
+        counts: dict[str, int] = {}
+        for entry in entries:
+            if not entry.include:
+                continue
+            ext = entry.extension or "(no_ext)"
+            counts[ext] = counts.get(ext, 0) + 1
+        ranked = sorted(counts.items(), key=lambda item: (-item[1], item[0]))[:limit]
+        return ",".join(f"{ext}:{count}" for ext, count in ranked) if ranked else "none"
+
+    def _count_code_languages(self, entries: list[FileEntry]) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for entry in entries:
+            if entry.include and not entry.is_ghost and self._is_code_entry(entry):
+                language = entry.extension.lstrip(".").lower() or "unknown"
+                counts[language] = counts.get(language, 0) + 1
+        return dict(sorted(counts.items(), key=lambda item: (-item[1], item[0])))
+
+    def _summarize_batch_plans(self, batch_plans: dict[str, Any]) -> list[dict[str, Any]]:
+        rows: list[dict[str, Any]] = []
+        for pass_id, plan in sorted(batch_plans.items()):
+            oversized = list(getattr(plan, "oversized_files", []) or [])
+            rows.append(
+                {
+                    "pass_id": str(pass_id),
+                    "total_files": int(getattr(plan, "total_files", 0) or 0),
+                    "batch_count": len(getattr(plan, "batches", []) or []),
+                    "estimated_tokens": int(getattr(plan, "total_estimated_tokens", 0) or 0),
+                    "oversized_files": len(oversized),
+                    "oversized_examples": ",".join(
+                        str(item.get("path") or "") for item in oversized[:3] if item.get("path")
+                    )
+                    or "none",
+                }
+            )
+        return rows
+
+    def _summarize_stage0_routes(self, stage0: dict[str, Any]) -> list[dict[str, Any]]:
+        routing_plan = stage0.get("routing_plan") or {}
+        selected_routes = routing_plan.get("selected_routes") or {}
+        fallback_decisions = routing_plan.get("fallback_decisions") or {}
+        rows: list[dict[str, Any]] = []
+        for pass_id, route in sorted(selected_routes.items()):
+            if not isinstance(route, dict):
+                continue
+            decisions = list(fallback_decisions.get(pass_id) or [])
+            admitted = sum(1 for item in decisions if str(item.get("decision")) == "admitted")
+            excluded = sum(1 for item in decisions if str(item.get("decision")) == "excluded")
+            exclusion_reasons: dict[str, int] = {}
+            for item in decisions:
+                if str(item.get("decision")) != "excluded":
+                    continue
+                reason = str(item.get("reason") or "unknown")
+                exclusion_reasons[reason] = exclusion_reasons.get(reason, 0) + 1
+            reason_summary = ",".join(
+                f"{reason}:{count}"
+                for reason, count in sorted(
+                    exclusion_reasons.items(), key=lambda item: (-item[1], item[0])
+                )[:3]
+            ) or "none"
+            rows.append(
+                {
+                    "pass_id": str(pass_id),
+                    "provider": str(route.get("provider") or ""),
+                    "model_id": str(route.get("model_id") or ""),
+                    "selected_tier": str(route.get("selected_tier") or ""),
+                    "tier_adjustment": str(route.get("tier_adjustment") or "exact"),
+                    "admitted_fallbacks": admitted,
+                    "excluded_fallbacks": excluded,
+                    "exclusion_summary": reason_summary,
+                }
+            )
+        return rows
+
     def run(self, passes: list[str] | None = None, incremental: bool = False) -> PrescanResult:
         start_time = time.time()
         warnings: list[str] = []
@@ -81,6 +155,7 @@ class PrescanEngine:
                 files=len(entries),
                 included=included_count,
                 excluded=len(entries) - included_count,
+                top_extensions=self._top_file_extensions(entries),
             )
 
             self._log_progress("load_incremental_cache")
@@ -90,6 +165,7 @@ class PrescanEngine:
                 "incremental_cache_done",
                 changed_files=len(changed_files or set()) if incremental else 0,
                 fallback=bool(fallback_reason),
+                fallback_reason=(fallback_reason or "none").replace(" ", "_"),
             )
             incremental_meta: dict[str, Any] = {
                 "enabled": bool(incremental),
@@ -144,6 +220,11 @@ class PrescanEngine:
                 analyzed=len(code_intel),
                 reused=incremental_meta.get("cached_code_analysis_reused", 0),
                 reanalyzed=incremental_meta.get("reanalyzed_code_files", 0),
+                languages=",".join(
+                    f"{lang}:{count}"
+                    for lang, count in self._count_code_languages(entries).items()
+                )
+                or "none",
             )
             incremental_meta["removed_cache_entries"] = cache.removed_entry_count(
                 cache_payload,
@@ -180,6 +261,16 @@ class PrescanEngine:
                     batches=sum(len(plan.batches) for plan in batch_plans.values()),
                     tokens=sum(int(getattr(plan, "total_estimated_tokens", 0) or 0) for plan in batch_plans.values()),
                 )
+                for row in self._summarize_batch_plans(batch_plans):
+                    self._log_progress(
+                        "plan_llm_pass_detail",
+                        pass_id=row["pass_id"],
+                        files=row["total_files"],
+                        batches=row["batch_count"],
+                        tokens=row["estimated_tokens"],
+                        oversized=row["oversized_files"],
+                        oversized_examples=row["oversized_examples"],
+                    )
                 self._log_progress("provider_readiness", passes=",".join(passes))
                 stage0 = self._run_stage0(passes)
                 metadata["stage0"] = {
@@ -193,6 +284,17 @@ class PrescanEngine:
                     readiness=stage0["readiness"]["status"],
                     routing=stage0["routing_plan"]["status"],
                 )
+                for row in self._summarize_stage0_routes(stage0):
+                    self._log_progress(
+                        "provider_readiness_detail",
+                        pass_id=row["pass_id"],
+                        route=f"{row['provider']}/{row['model_id']}",
+                        tier=row["selected_tier"],
+                        adjustment=row["tier_adjustment"],
+                        admitted_fallbacks=row["admitted_fallbacks"],
+                        excluded_fallbacks=row["excluded_fallbacks"],
+                        exclusion_summary=row["exclusion_summary"],
+                    )
                 if stage0["routing_plan"]["status"] == NO_LIVE_LANE:
                     self._log_progress("halt_no_live_lane")
                     write_no_live_lane_artifact(self.config.output_dir, stage0["routing_plan"])

--- a/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
+++ b/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
@@ -6,6 +6,8 @@ import logging
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[3]
 SERVICE_ROOT = ROOT / "services" / "repo-truth-extractor"
 if str(SERVICE_ROOT) not in sys.path:
@@ -149,6 +151,76 @@ def test_prescan_engine_emits_operator_progress(caplog, tmp_path: Path) -> None:
     assert any("PRESCAN_PROGRESS classify_files" in message for message in messages)
     assert any("PRESCAN_PROGRESS write_prescan_artifacts" in message for message in messages)
     assert any("PRESCAN_PROGRESS complete" in message for message in messages)
+
+
+def test_prescan_engine_emits_detailed_route_and_batch_progress(
+    caplog, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Detailed operator telemetry should expose batch plans and selected routes."""
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "main.py").write_text("def main():\n    return 1\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# Fixture\n", encoding="utf-8")
+
+    config = PrescanConfig(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "out",
+        enable_code_prescan=False,
+        enable_git_enrichment=False,
+        batch_mode=False,
+        cost_estimate=False,
+    )
+    engine = PrescanEngine(config)
+
+    monkeypatch.setattr(
+        PrescanEngine,
+        "_run_stage0",
+        lambda self, passes: {
+            "catalog": {"routes": [{"provider": "openrouter"}]},
+            "readiness": {"status": "ready"},
+            "routing_plan": {
+                "status": "READY",
+                "selected_routes": {
+                    "dedup": {
+                        "provider": "openrouter",
+                        "model_id": "openai/gpt-5-nano",
+                        "selected_tier": "budget",
+                        "tier_adjustment": "none",
+                    }
+                },
+                "fallback_decisions": {
+                    "dedup": [
+                        {
+                            "decision": "admitted",
+                            "provider": "openai",
+                            "model_id": "gpt-5-mini",
+                        },
+                        {
+                            "decision": "excluded",
+                            "provider": "anthropic",
+                            "model_id": "claude-sonnet-4.5",
+                            "reason": "missing_credentials",
+                        },
+                    ]
+                },
+            },
+        },
+    )
+
+    with caplog.at_level(logging.INFO, logger="lib.prescan.engine"):
+        result = engine.run(passes=["dedup"])
+
+    assert result.success is True
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "PRESCAN_PROGRESS plan_llm_pass_detail" in message and "pass_id=dedup" in message
+        for message in messages
+    )
+    assert any(
+        "PRESCAN_PROGRESS provider_readiness_detail" in message
+        and "route=openrouter/openai/gpt-5-nano" in message
+        and "excluded_fallbacks=1" in message
+        for message in messages
+    )
 
 
 

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -5275,6 +5275,7 @@ rte.add_command(extractor_status, "status")
 rte.add_command(extractor_preflight, "preflight")
 rte.add_command(extractor_validate_live, "validate-live")
 rte.add_command(extractor_trace, "trace")
+rte.add_command(audit.commands["wizard"], "wizard")
 
 
 @extractor.group("promptset")

--- a/src/dopemux/ux/wizard/corpus.py
+++ b/src/dopemux/ux/wizard/corpus.py
@@ -142,6 +142,16 @@ def run_corpus_audit(state: WizardState) -> StageResult:
             "receipt": _load_optional_json(prescan_dir / "prescan_stage_receipt.json"),
             "batch_plan": _load_optional_json(prescan_dir / "batch_plan.json"),
             "routing_plan": _load_optional_json(prescan_dir / "prescan_routing_plan.json"),
+            "provider_readiness": _load_optional_json(
+                prescan_dir / "prescan_provider_readiness.json"
+            ),
+            "provider_catalog": _load_optional_json(
+                prescan_dir / "prescan_provider_model_catalog.json"
+            ),
+            "no_live_lane": _load_optional_json(prescan_dir / "prescan_no_live_lane.json"),
+            "live_lane_success": _load_optional_json(
+                prescan_dir / "prescan_live_lane_success.json"
+            ),
         },
     )
     render_corpus_table(state.corpus_stats)

--- a/src/dopemux/ux/wizard/display.py
+++ b/src/dopemux/ux/wizard/display.py
@@ -192,6 +192,10 @@ def render_prescan_hud(
     receipt = artifacts.get("receipt") or {}
     batch_plan = artifacts.get("batch_plan") or {}
     routing_plan = artifacts.get("routing_plan") or {}
+    readiness = artifacts.get("provider_readiness") or {}
+    provider_catalog = artifacts.get("provider_catalog") or {}
+    live_lane_success = artifacts.get("live_lane_success") or {}
+    no_live_lane = artifacts.get("no_live_lane") or {}
     selected_routes = routing_plan.get("selected_routes") or {}
     router_loaded = bool(receipt.get("router_loaded"))
     online_authorized = bool(receipt.get("online_authorized"))
@@ -220,6 +224,10 @@ def render_prescan_hud(
     ]
     if receipt.get("duration_seconds") is not None:
         status_lines.append(f"[bold]Runtime:[/bold] {receipt['duration_seconds']}s")
+    if no_live_lane:
+        status_lines.append("[bold red]Launch posture:[/bold red] blocked before Stage 1")
+    elif live_lane_success:
+        status_lines.append("[bold green]Launch posture:[/bold green] live lane ready")
 
     console.print(
         Panel(
@@ -239,6 +247,57 @@ def render_prescan_hud(
         )
     )
 
+    highlights = Table(
+        title="[bold]Corpus Highlights[/bold]",
+        box=ROUNDED,
+        border_style="table.border",
+        padding=(0, 1),
+    )
+    highlights.add_column("Dimension")
+    highlights.add_column("Top values", min_width=40)
+
+    top_directories = sorted(
+        (stats.get("by_directory") or {}).items(),
+        key=lambda item: (-int(item[1] or 0), str(item[0])),
+    )[:5]
+    top_extensions = sorted(
+        (stats.get("by_extension") or {}).items(),
+        key=lambda item: (-int(item[1] or 0), str(item[0])),
+    )[:5]
+    highlights.add_row(
+        "Directories",
+        ", ".join(f"{name}:{count}" for name, count in top_directories) or "none",
+    )
+    highlights.add_row(
+        "Extensions",
+        ", ".join(f"{name or '(no_ext)'}:{count}" for name, count in top_extensions) or "none",
+    )
+    console.print(highlights)
+
+    incremental = intelligence.get("incremental") or {}
+    if not incremental:
+        incremental = (artifacts.get("receipt") or {}).get("incremental") or {}
+    if incremental or receipt:
+        cache_lines = [
+            f"[bold]Incremental:[/bold] {'enabled' if incremental.get('enabled') else 'disabled'}",
+            f"[bold]Changed files:[/bold] {int(incremental.get('changed_files_count', 0) or 0):,}",
+            f"[bold]Classifications:[/bold] reused {int(incremental.get('cached_classifications_reused', 0) or 0):,} / recomputed {int(incremental.get('reclassified_files', 0) or 0):,}",
+            f"[bold]Git enrichment:[/bold] reused {int(incremental.get('cached_git_enrichment_reused', 0) or 0):,} / recomputed {int(incremental.get('git_enrichment_recomputed', 0) or 0):,}",
+            f"[bold]Code analysis:[/bold] reused {int(incremental.get('cached_code_analysis_reused', 0) or 0):,} / reanalyzed {int(incremental.get('reanalyzed_code_files', 0) or 0):,}",
+        ]
+        fallback_reason = incremental.get("fallback_reason")
+        if fallback_reason:
+            cache_lines.append(f"[bold]Fallback reason:[/bold] {fallback_reason}")
+        console.print(
+            Panel(
+                "\n".join(cache_lines),
+                title="[bold]Incremental Cache Summary[/bold]",
+                border_style="gilt.edge",
+                box=ROUNDED,
+                padding=(1, 2),
+            )
+        )
+
     if batch_plan:
         plan_rows = []
         for pass_id, plan in sorted(batch_plan.items()):
@@ -251,6 +310,7 @@ def render_prescan_hud(
                     int(plan.get("total_files", 0) or 0),
                     len(batches),
                     int(plan.get("total_estimated_tokens", 0) or 0),
+                    int(plan.get("oversized_files_count", 0) or 0),
                 )
             )
         if plan_rows:
@@ -264,13 +324,158 @@ def render_prescan_hud(
             table.add_column("Files", justify="right")
             table.add_column("Batches", justify="right")
             table.add_column("Est. tokens", justify="right")
-            for pass_id, files, batches, tokens in plan_rows:
+            table.add_column("Oversized", justify="right")
+            for pass_id, files, batches, tokens, oversized in plan_rows:
                 route = selected_routes.get(pass_id) or {}
                 provider = route.get("provider")
                 model_id = route.get("model_id")
                 route_label = f"  [dim]{provider}/{model_id}[/dim]" if provider and model_id else ""
-                table.add_row(pass_id + route_label, f"{files:,}", f"{batches:,}", f"{tokens:,}")
+                table.add_row(pass_id + route_label, f"{files:,}", f"{batches:,}", f"{tokens:,}", f"{oversized:,}")
             console.print(table)
+
+        oversized_rows = []
+        for pass_id, plan in sorted(batch_plan.items()):
+            if not isinstance(plan, dict):
+                continue
+            for item in (plan.get("oversized_files") or [])[:3]:
+                oversized_rows.append(
+                    (
+                        pass_id,
+                        str(item.get("path") or ""),
+                        int(item.get("tokens", 0) or 0),
+                        str(item.get("reason") or ""),
+                    )
+                )
+        if oversized_rows:
+            oversized_table = Table(
+                title="[bold]Oversized Batch Exclusions[/bold]",
+                box=ROUNDED,
+                border_style="warning",
+                padding=(0, 1),
+            )
+            oversized_table.add_column("Pass")
+            oversized_table.add_column("Path", min_width=32)
+            oversized_table.add_column("Tokens", justify="right")
+            oversized_table.add_column("Reason")
+            for pass_id, path, tokens, reason in oversized_rows[:6]:
+                oversized_table.add_row(pass_id, path, f"{tokens:,}", reason)
+            console.print(oversized_table)
+
+    if selected_routes:
+        route_table = Table(
+            title="[bold]Route Readiness Summary[/bold]",
+            box=ROUNDED,
+            border_style="table.border",
+            padding=(0, 1),
+        )
+        route_table.add_column("Pass")
+        route_table.add_column("Selected route", min_width=24)
+        route_table.add_column("Tier")
+        route_table.add_column("Adjustment")
+        route_table.add_column("Ready")
+        route_table.add_column("Fallbacks")
+
+        readiness_rows = {}
+        for row in (readiness.get("routes") or []):
+            if isinstance(row, dict):
+                readiness_rows[
+                    (
+                        str(row.get("provider") or ""),
+                        str(row.get("model_id") or ""),
+                        str(row.get("api_key_env") or ""),
+                    )
+                ] = row
+
+        fallback_decisions = routing_plan.get("fallback_decisions") or {}
+        for pass_id, route in sorted(selected_routes.items()):
+            key = (
+                str(route.get("provider") or ""),
+                str(route.get("model_id") or ""),
+                str(route.get("api_key_env") or ""),
+            )
+            readiness_row = readiness_rows.get(key) or {}
+            decisions = list(fallback_decisions.get(pass_id) or [])
+            admitted = sum(1 for item in decisions if str(item.get("decision")) == "admitted")
+            excluded = sum(1 for item in decisions if str(item.get("decision")) == "excluded")
+            route_table.add_row(
+                pass_id,
+                f"{route.get('provider', '?')}/{route.get('model_id', '?')}",
+                str(route.get("selected_tier") or "?"),
+                str(route.get("tier_adjustment") or "?"),
+                "yes" if readiness_row.get("ready", True) else "no",
+                f"+{admitted} / -{excluded}",
+            )
+        console.print(route_table)
+
+        exclusion_counts: Dict[str, int] = {}
+        example_exclusions: List[Tuple[str, str, str]] = []
+        for pass_id, decisions in sorted(fallback_decisions.items()):
+            for item in decisions:
+                if str(item.get("decision")) != "excluded":
+                    continue
+                reason = str(item.get("reason") or "unknown")
+                exclusion_counts[reason] = exclusion_counts.get(reason, 0) + 1
+                if len(example_exclusions) < 6:
+                    example_exclusions.append(
+                        (
+                            str(pass_id),
+                            f"{item.get('provider', '?')}/{item.get('model_id', '?')}",
+                            reason,
+                        )
+                    )
+        if exclusion_counts:
+            summary = ", ".join(
+                f"{reason}:{count}"
+                for reason, count in sorted(
+                    exclusion_counts.items(), key=lambda item: (-item[1], item[0])
+                )
+            )
+            console.print(
+                Panel(
+                    f"[bold]Excluded fallback reasons:[/bold] {summary}",
+                    title="[bold]Fallback Summary[/bold]",
+                    border_style="violet",
+                    box=ROUNDED,
+                    padding=(1, 2),
+                )
+            )
+        if example_exclusions:
+            example_table = Table(
+                title="[bold]Fallback Exclusion Examples[/bold]",
+                box=ROUNDED,
+                border_style="table.border",
+                padding=(0, 1),
+            )
+            example_table.add_column("Pass")
+            example_table.add_column("Route", min_width=24)
+            example_table.add_column("Reason")
+            for pass_id, route_name, reason in example_exclusions:
+                example_table.add_row(pass_id, route_name, reason)
+            console.print(example_table)
+
+    catalog_routes = list(provider_catalog.get("routes") or [])
+    if catalog_routes:
+        surfaces: Dict[str, int] = {}
+        for row in catalog_routes:
+            if not isinstance(row, dict):
+                continue
+            surface = str(row.get("economic_surface") or "unknown")
+            surfaces[surface] = surfaces.get(surface, 0) + 1
+        console.print(
+            Panel(
+                "\n".join(
+                    [
+                        f"[bold]Catalog routes:[/bold] {len(catalog_routes):,}",
+                        "[bold]Economic surfaces:[/bold] "
+                        + (", ".join(f"{name}:{count}" for name, count in sorted(surfaces.items())) or "none"),
+                    ]
+                ),
+                title="[bold]Provider Catalog Snapshot[/bold]",
+                border_style="info",
+                box=ROUNDED,
+                padding=(1, 2),
+            )
+        )
 
     savings = (
         intelligence.get("grok_passes", {})

--- a/src/dopemux/ux/wizard/display.py
+++ b/src/dopemux/ux/wizard/display.py
@@ -215,6 +215,11 @@ def render_prescan_hud(
         f"[bold violet]{version_chains:,}[/bold violet]\n[dim]version chains[/dim]",
     )
 
+    readiness_status = str(readiness.get("status") or "")
+    failed_blocker_codes = list(readiness.get("failed_blocker_codes") or [])
+    ready_routes = sum(1 for r in (readiness.get("routes") or []) if r.get("ready"))
+    total_routes = len(readiness.get("routes") or [])
+
     status_lines = [
         f"[bold]Prescan mode:[/bold] {receipt.get('mode', 'integrated')}",
         f"[bold]Router loaded:[/bold] {'yes' if router_loaded else 'no'}",
@@ -224,8 +229,21 @@ def render_prescan_hud(
     ]
     if receipt.get("duration_seconds") is not None:
         status_lines.append(f"[bold]Runtime:[/bold] {receipt['duration_seconds']}s")
+    if readiness_status:
+        color = "green" if readiness_status == "PASS" else "red"
+        route_detail = f" ({ready_routes}/{total_routes} routes ready)" if total_routes else ""
+        status_lines.append(f"[bold]Provider readiness:[/bold] [{color}]{readiness_status}{route_detail}[/{color}]")
+    if failed_blocker_codes:
+        status_lines.append(f"[bold yellow]Blocker codes:[/bold yellow] {', '.join(failed_blocker_codes)}")
     if no_live_lane:
-        status_lines.append("[bold red]Launch posture:[/bold red] blocked before Stage 1")
+        nl_passes = ", ".join(str(p) for p in (no_live_lane.get("requested_passes") or []))
+        nl_failures = no_live_lane.get("failures") or []
+        blocker_summary = ", ".join(
+            str(f.get("blocker_code") or "unknown") for f in nl_failures if isinstance(f, dict)
+        )
+        halt_detail = f" passes=[{nl_passes}]" if nl_passes else ""
+        blocker_detail = f" blockers=[{blocker_summary}]" if blocker_summary else ""
+        status_lines.append(f"[bold red]Launch posture:[/bold red] blocked before Stage 1{halt_detail}{blocker_detail}")
     elif live_lane_success:
         status_lines.append("[bold green]Launch posture:[/bold green] live lane ready")
 

--- a/tests/unit/test_cli_upgrades_commands.py
+++ b/tests/unit/test_cli_upgrades_commands.py
@@ -260,6 +260,25 @@ def test_upgrades_run_rejects_prescan_flags_for_v4() -> None:
     assert "only supported with --version v5" in result.output
 
 
+def test_rte_wizard_alias_exposes_audit_wizard_options() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        [
+            "rte",
+            "wizard",
+            "--help",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "guided extraction flight-deck walkthrough" in result.output.lower()
+    assert "--routing-policy" in result.output
+    assert "--educate / --no-educate" in result.output
+    assert "--execute" in result.output
+
+
 def test_upgrades_run_forwards_prescan_flags_for_v5() -> None:
     runner = CliRunner()
     with runner.isolated_filesystem():

--- a/tests/unit/test_wizard_interactivity.py
+++ b/tests/unit/test_wizard_interactivity.py
@@ -183,26 +183,39 @@ def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
     (prescan_dir / "prescan_provider_readiness.json").write_text(
         json.dumps(
             {
-                "passes": {
-                    "dedup": {
-                        "provider_ready": True,
-                        "selected_route": {
-                            "provider": "openrouter",
-                            "model_id": "openai/gpt-5-nano",
-                            "tier": "budget",
-                        },
+                "status": "PASS",
+                "routes": [
+                    {
+                        "provider": "openrouter",
+                        "model_id": "openai/gpt-5-nano",
+                        "api_key_env": "OPENROUTER_API_KEY",
+                        "dependency_class": "primary",
+                        "economic_surface": "budget",
+                        "execution_transport": "openai_sdk",
+                        "route_admissible": True,
+                        "ready": True,
+                        "provider_probe": {"ready": True},
+                        "exclusion_reason": None,
                     }
-                }
+                ],
+                "failed_blocker_codes": [],
             }
         ),
         encoding="utf-8",
     )
     (prescan_dir / "prescan_provider_model_catalog.json").write_text(
-        json.dumps({"routes": [{"provider": "openrouter", "model_id": "openai/gpt-5-nano"}]}),
+        json.dumps({"routes": [{"provider": "openrouter", "model_id": "openai/gpt-5-nano", "economic_surface": "budget"}]}),
         encoding="utf-8",
     )
     (prescan_dir / "prescan_no_live_lane.json").write_text(
-        json.dumps({"reason": "missing credentials"}),
+        json.dumps(
+            {
+                "status": "NO_LIVE_LANE",
+                "halt_before_stage_1": True,
+                "requested_passes": ["dedup"],
+                "failures": [{"pass": "dedup", "blocker_code": "MISSING_CREDENTIAL"}],
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -238,9 +251,13 @@ def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
         rendered["artifacts"]["routing_plan"]["selected_routes"]["dedup"]["model_id"]
         == "openai/gpt-5-nano"
     )
-    assert rendered["artifacts"]["provider_readiness"]["passes"]["dedup"]["provider_ready"] is True
+    assert rendered["artifacts"]["provider_readiness"]["status"] == "PASS"
+    assert rendered["artifacts"]["provider_readiness"]["routes"][0]["ready"] is True
+    assert rendered["artifacts"]["provider_readiness"]["failed_blocker_codes"] == []
     assert rendered["artifacts"]["provider_catalog"]["routes"][0]["provider"] == "openrouter"
-    assert rendered["artifacts"]["no_live_lane"]["reason"] == "missing credentials"
+    assert rendered["artifacts"]["no_live_lane"]["status"] == "NO_LIVE_LANE"
+    assert rendered["artifacts"]["no_live_lane"]["halt_before_stage_1"] is True
+    assert "dedup" in rendered["artifacts"]["no_live_lane"]["requested_passes"]
 
 
 def test_run_cost_selection_supports_profile_browsing(

--- a/tests/unit/test_wizard_interactivity.py
+++ b/tests/unit/test_wizard_interactivity.py
@@ -180,6 +180,31 @@ def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
         json.dumps({"selected_routes": {"dedup": {"provider": "openrouter", "model_id": "openai/gpt-5-nano"}}}),
         encoding="utf-8",
     )
+    (prescan_dir / "prescan_provider_readiness.json").write_text(
+        json.dumps(
+            {
+                "passes": {
+                    "dedup": {
+                        "provider_ready": True,
+                        "selected_route": {
+                            "provider": "openrouter",
+                            "model_id": "openai/gpt-5-nano",
+                            "tier": "budget",
+                        },
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (prescan_dir / "prescan_provider_model_catalog.json").write_text(
+        json.dumps({"routes": [{"provider": "openrouter", "model_id": "openai/gpt-5-nano"}]}),
+        encoding="utf-8",
+    )
+    (prescan_dir / "prescan_no_live_lane.json").write_text(
+        json.dumps({"reason": "missing credentials"}),
+        encoding="utf-8",
+    )
 
     router = object()
     rendered: dict[str, object] = {}
@@ -213,6 +238,9 @@ def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
         rendered["artifacts"]["routing_plan"]["selected_routes"]["dedup"]["model_id"]
         == "openai/gpt-5-nano"
     )
+    assert rendered["artifacts"]["provider_readiness"]["passes"]["dedup"]["provider_ready"] is True
+    assert rendered["artifacts"]["provider_catalog"]["routes"][0]["provider"] == "openrouter"
+    assert rendered["artifacts"]["no_live_lane"]["reason"] == "missing credentials"
 
 
 def test_run_cost_selection_supports_profile_browsing(

--- a/tests/unit/test_wizard_interactivity.py
+++ b/tests/unit/test_wizard_interactivity.py
@@ -255,6 +255,7 @@ def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
     assert rendered["artifacts"]["provider_readiness"]["routes"][0]["ready"] is True
     assert rendered["artifacts"]["provider_readiness"]["failed_blocker_codes"] == []
     assert rendered["artifacts"]["provider_catalog"]["routes"][0]["provider"] == "openrouter"
+    assert rendered["artifacts"]["provider_catalog"]["routes"][0]["economic_surface"] == "budget"
     assert rendered["artifacts"]["no_live_lane"]["status"] == "NO_LIVE_LANE"
     assert rendered["artifacts"]["no_live_lane"]["halt_before_stage_1"] is True
     assert "dedup" in rendered["artifacts"]["no_live_lane"]["requested_passes"]


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary
- add the existing extraction wizard as `dopemux rte wizard` so the canonical RTE surface exposes the guided launch flow
- expand prescan progress output with per-stage operator-visible detail for corpus shape, cache fallback, language mix, batch planning, and route readiness
- enrich the wizard Stage 2 HUD with canonical prescan artifact summaries for route readiness, fallback exclusions, corpus composition, and batch sizing

## Validation
- `./.venv/bin/python -m pytest tests/unit/test_cli_upgrades_commands.py services/repo-truth-extractor/tests/test_prescan_core_pipeline.py tests/unit/test_wizard_interactivity.py -q`
- `git diff --check`

## Notes
- excludes pre-existing local changes in `AGENTS.md` and untracked generated promptset artifacts
- updates docs-adjacent operator UX only through canonical runtime and existing wizard surfaces