### PR TITLE
Add deterministic Dopemux cockpit static renderer

### DIFF
--- a/src/dopemux/ui/cockpit/__init__.py
+++ b/src/dopemux/ui/cockpit/__init__.py
@@ -1,0 +1,5 @@
+"""Deterministic static cockpit renderer."""
+
+from .render import render_cockpit, render_snapshot
+
+__all__ = ["render_cockpit", "render_snapshot"]

--- a/src/dopemux/ui/cockpit/__main__.py
+++ b/src/dopemux/ui/cockpit/__main__.py
@@ -1,0 +1,21 @@
+"""Snapshot entry point for the static cockpit renderer."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .render import render_snapshot
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="python -m dopemux.ui.cockpit")
+    parser.add_argument("--snapshot", required=True, help="Snapshot size: 120x40, 100x32, or 80x24.")
+    args = parser.parse_args(argv)
+    sys.stdout.write(render_snapshot(args.snapshot))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/dopemux/ui/cockpit/frame.py
+++ b/src/dopemux/ui/cockpit/frame.py
@@ -1,0 +1,110 @@
+"""Fixed-size framebuffer with protected borders and hard clipping."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Layout:
+    width: int
+    height: int
+    left_divider: int
+    right_divider: int
+    inspector_split: int
+    center_split: int
+    body_rule: int
+    command_row: int
+    status_rule: int
+    status_row: int
+    bottom_row: int
+    gutter_col: int
+
+    @property
+    def protected_columns(self) -> frozenset[int]:
+        return frozenset({0, self.left_divider, self.right_divider, self.width - 1})
+
+    @property
+    def protected_rows(self) -> frozenset[int]:
+        return frozenset({0, 2, 4, self.body_rule, self.status_rule, self.bottom_row})
+
+
+LAYOUTS: dict[str, Layout] = {
+    "120x40": Layout(120, 40, 25, 84, 22, 25, 35, 36, 37, 38, 39, 26),
+    "100x32": Layout(100, 32, 21, 70, 17, 19, 27, 28, 29, 30, 31, 22),
+    "80x24": Layout(80, 24, 17, 56, 11, 13, 19, 20, 21, 22, 23, 18),
+}
+SUPPORTED_SIZES = tuple(LAYOUTS)
+
+
+class FrameBuffer:
+    """Mutable character grid that refuses normal writes into protected cells."""
+
+    def __init__(self, width: int, height: int, layout: Layout | None = None) -> None:
+        self.width = width
+        self.height = height
+        self.layout = layout
+        self._cells = [[" " for _ in range(width)] for _ in range(height)]
+
+    def is_protected(self, row: int, col: int) -> bool:
+        if self.layout is None:
+            return False
+        return row in self.layout.protected_rows or col in self.layout.protected_columns
+
+    def set_cell(self, row: int, col: int, char: str, *, force: bool = False) -> None:
+        if row < 0 or row >= self.height or col < 0 or col >= self.width:
+            return
+        if not force and self.is_protected(row, col):
+            return
+        self._cells[row][col] = char[0] if char else " "
+
+    def write(self, row: int, col: int, text: str, *, force: bool = False) -> None:
+        if row < 0 or row >= self.height or col >= self.width:
+            return
+        for offset, char in enumerate(text):
+            target_col = col + offset
+            if target_col >= self.width:
+                break
+            self.set_cell(row, target_col, char, force=force)
+
+    def render(self) -> str:
+        return "\n".join("".join(row) for row in self._cells)
+
+
+def draw_static_grid(frame: FrameBuffer, layout: Layout) -> None:
+    """Draw the fixed cockpit grid before content writes."""
+
+    last_col = layout.width - 1
+    for col in range(layout.width):
+        frame.set_cell(0, col, "━", force=True)
+        frame.set_cell(layout.bottom_row, col, "━", force=True)
+    frame.set_cell(0, 0, "┏", force=True)
+    frame.set_cell(0, last_col, "┓", force=True)
+    frame.set_cell(layout.bottom_row, 0, "┗", force=True)
+    frame.set_cell(layout.bottom_row, last_col, "┛", force=True)
+
+    for row in range(1, layout.bottom_row):
+        frame.set_cell(row, 0, "┃", force=True)
+        frame.set_cell(row, last_col, "┃", force=True)
+        frame.set_cell(row, layout.left_divider, "│", force=True)
+        frame.set_cell(row, layout.right_divider, "│", force=True)
+
+    for row in layout.protected_rows:
+        if row in {0, layout.bottom_row}:
+            continue
+        for col in range(1, last_col):
+            frame.set_cell(row, col, "─", force=True)
+        frame.set_cell(row, 0, "┠", force=True)
+        frame.set_cell(row, last_col, "┨", force=True)
+        junction = "┬" if row in {2, 4} else "┴"
+        frame.set_cell(row, layout.left_divider, junction, force=True)
+        frame.set_cell(row, layout.right_divider, junction, force=True)
+
+    for split_row, start_col, end_col in (
+        (layout.inspector_split, layout.right_divider + 1, last_col),
+        (layout.center_split, layout.left_divider + 1, layout.right_divider),
+    ):
+        for col in range(start_col, end_col):
+            frame.set_cell(split_row, col, "─", force=True)
+        frame.set_cell(split_row, layout.right_divider, "├", force=True)
+        frame.set_cell(split_row, last_col, "┤", force=True)

--- a/src/dopemux/ui/cockpit/model.py
+++ b/src/dopemux/ui/cockpit/model.py
@@ -1,0 +1,35 @@
+"""Typed seed structures for the static cockpit renderer."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SnapshotState:
+    data: dict[str, Any]
+
+    @property
+    def modes(self) -> list[str]:
+        return list(self.data["top_level_modes"])
+
+    @property
+    def services(self) -> dict[str, Any]:
+        return dict(self.data["services"])
+
+    @property
+    def rte_child_surface(self) -> dict[str, Any]:
+        return dict(self.data["rte_child_surface"])
+
+    @property
+    def placeholder_modes(self) -> dict[str, Any]:
+        return dict(self.data["placeholder_modes"])
+
+    @property
+    def status_rail(self) -> dict[str, str]:
+        return dict(self.data["status_rail"])
+
+
+def state_from_seed(seed: dict[str, Any]) -> SnapshotState:
+    return SnapshotState(seed)

--- a/src/dopemux/ui/cockpit/render.py
+++ b/src/dopemux/ui/cockpit/render.py
@@ -1,0 +1,189 @@
+"""Pure static cockpit rendering."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .frame import LAYOUTS, SUPPORTED_SIZES, FrameBuffer, Layout, draw_static_grid
+from .model import SnapshotState, state_from_seed
+from .seed import load_seed
+from .tokens import normalize_status_chip, validate_rendered_text
+
+UNSUPPORTED_SIZE_MESSAGE = (
+    "[BLOCKER] terminal size unsupported. Problem: cockpit snapshot supports "
+    "120x40, 100x32, or 80x24. Why: layout invariants are size-bound in slice 1. "
+    "Fix: choose a supported size. NEXT: rerun with --snapshot 120x40."
+)
+TOO_SMALL_MESSAGE = (
+    "[BLOCKER] terminal too small.\n"
+    "Problem: cockpit requires at least 80x24.\n"
+    "Why: layout invariants cannot be honored below this size.\n"
+    "Fix: resize to 80x24 or larger.\n"
+    "NEXT: rerun with --snapshot 80x24."
+)
+
+
+def render_snapshot(size: str, *, mode: str = "Services", seed: dict[str, Any] | None = None) -> str:
+    """Render a supported named snapshot or return a blocker for unsupported sizes."""
+
+    if size in LAYOUTS:
+        return render_cockpit(LAYOUTS[size].width, LAYOUTS[size].height, mode=mode, seed=seed)
+    try:
+        width_text, height_text = size.lower().split("x", 1)
+        width = int(width_text)
+        height = int(height_text)
+    except ValueError:
+        return UNSUPPORTED_SIZE_MESSAGE
+    if width < 80 or height < 24:
+        return TOO_SMALL_MESSAGE
+    return UNSUPPORTED_SIZE_MESSAGE
+
+
+def render_cockpit(
+    width: int,
+    height: int,
+    *,
+    mode: str = "Services",
+    seed: dict[str, Any] | None = None,
+) -> str:
+    """Render seed state into a deterministic framebuffer string."""
+
+    size = f"{width}x{height}"
+    layout = LAYOUTS.get(size)
+    if layout is None:
+        return TOO_SMALL_MESSAGE if width < 80 or height < 24 else UNSUPPORTED_SIZE_MESSAGE
+
+    state = state_from_seed(seed or load_seed())
+    frame = FrameBuffer(width, height, layout)
+    draw_static_grid(frame, layout)
+    _render_header(frame, layout, state, mode)
+    _render_modes(frame, layout, state, mode)
+    if mode == "Services":
+        _render_services(frame, layout, state)
+    else:
+        _render_placeholder(frame, layout, state, mode)
+    _render_status(frame, layout, state, mode)
+    output = frame.render()
+    validate_rendered_text(output)
+    return output
+
+
+def _write_in(frame: FrameBuffer, row: int, start: int, end: int, text: str) -> None:
+    if end <= start:
+        return
+    frame.write(row, start, text[: end - start])
+
+
+def _render_header(frame: FrameBuffer, layout: Layout, state: SnapshotState, mode: str) -> None:
+    workspace = state.data["workspace"]
+    _write_in(frame, 1, 2, layout.left_divider, "dopemux cockpit static")
+    _write_in(frame, 1, layout.left_divider + 2, layout.right_divider, f"workspace {workspace['id']} SRC={workspace['SRC']}")
+    _write_in(frame, 1, layout.right_divider + 2, layout.width - 2, f"mode {mode} SRC={workspace['SRC']}")
+
+
+def _render_modes(frame: FrameBuffer, layout: Layout, state: SnapshotState, mode: str) -> None:
+    labels = []
+    for index, name in enumerate(state.modes, start=1):
+        marker = "*" if name == mode else " "
+        labels.append(f"{index} {marker}{name} SRC=dopemux")
+    _write_in(frame, 3, 2, layout.left_divider, labels[0])
+    _write_in(frame, 3, layout.left_divider + 2, layout.right_divider, " | ".join(labels[1:3]))
+    selected_services = "4 *Services SRC=dopemux" if mode == "Services" else "4  Services SRC=dopemux"
+    _write_in(frame, 3, layout.right_divider + 2, layout.width - 2, f"{selected_services} | 5 Events")
+
+
+def _render_services(frame: FrameBuffer, layout: Layout, state: SnapshotState) -> None:
+    services = state.services
+    rte = state.rte_child_surface
+    _write_in(frame, 5, 2, layout.left_divider, f"Services authority: {services['authority']}")
+    _write_in(frame, 5, layout.left_divider + 2, layout.right_divider, f"Services -> {services['selected']} authority: {rte['authority']}")
+    _write_in(frame, 5, layout.right_divider + 2, layout.width - 2, f"Inspector authority: {services['inspector']['authority']}")
+
+    row = 6
+    for service in services["rows"]:
+        chip = normalize_status_chip(service["status"])
+        prefix = ">" if service["name"] == services["selected"] else " "
+        text = f"{prefix} SRC={service['SRC']} [{chip}] {service['name']} {service['kind']}"
+        _write_in(frame, row, 2, layout.left_divider, text)
+        row += 1
+
+    _render_rte_runs(frame, layout, rte)
+    _render_inspector(frame, layout, services["inspector"])
+
+
+def _render_rte_runs(frame: FrameBuffer, layout: Layout, rte: dict[str, Any]) -> None:
+    center_start = layout.left_divider + 2
+    center_end = layout.right_divider
+    _write_in(frame, 6, center_start, center_end, "Tabs SRC=repo-truth-extractor R1 Runs | R2 Active")
+    _write_in(frame, 7, center_start, center_end, "Tabs SRC=repo-truth-extractor R3 Prescan | R4 Doctor")
+    _write_in(frame, 8, center_start, center_end, "Tabs SRC=repo-truth-extractor R5 Coverage | R6 Audit")
+    _write_in(frame, 9, center_start, center_end, "R1 Runs authority: repo-truth-extractor")
+    row = 10
+    for run in rte["runs"]:
+        chip = normalize_status_chip(run["status"])
+        _write_in(frame, row, center_start, center_end, f"SRC={run['SRC']} [{chip}] {run['run_id']}")
+        row += 1
+        _write_in(
+            frame,
+            row,
+            center_start,
+            center_end,
+            f"SRC={run['SRC']} phase={run['phase']} repo={run['repo']} alerts={run['alerts']}",
+        )
+        row += 1
+
+
+def _render_inspector(frame: FrameBuffer, layout: Layout, inspector: dict[str, Any]) -> None:
+    start = layout.right_divider + 2
+    end = layout.width - 2
+    _write_in(frame, 6, start, end, f"subject SRC={inspector['authority']} {inspector['subject']}")
+    _write_in(frame, 7, start, end, f"provenance={inspector['provenance']} SRC={inspector['authority']}")
+    row = 8
+    for item in inspector["rows"]:
+        _write_in(frame, row, start, end, f"SRC={item['SRC']} {item['label']}={item['value']}")
+        row += 1
+
+    bridge = inspector["bridge"]
+    chip = normalize_status_chip(bridge["status_chip"])
+    bridge_row = layout.inspector_split + 1
+    _write_in(frame, bridge_row, start, end, f"Bridge actions authority: dopecon-bridge")
+    _write_in(frame, bridge_row + 1, start, end, f"SRC=dopecon-bridge [{chip}] adapter-only segregated")
+    _write_in(frame, bridge_row + 2, start, end, "WRITE -> <service> : <action>")
+    action = bridge["actions"][0]
+    _write_in(frame, bridge_row + 3, start, end, f"SRC={action['SRC']} {action['label']}")
+    _write_in(frame, bridge_row + 4, start, end, bridge["footer"])
+
+
+def _render_placeholder(frame: FrameBuffer, layout: Layout, state: SnapshotState, mode: str) -> None:
+    placeholder = state.placeholder_modes[mode]
+    _write_in(frame, 5, 2, layout.left_divider, f"{mode} authority: {placeholder['authority']}")
+    _write_in(frame, 5, layout.left_divider + 2, layout.right_divider, f"{mode} placeholder authority: {placeholder['authority']}")
+    _write_in(frame, 5, layout.right_divider + 2, layout.width - 2, f"Inspector authority: {placeholder['authority']}")
+    _write_in(frame, 7, layout.left_divider + 2, layout.right_divider, f"SRC=dopemux [{placeholder['status_chip']}] placeholder mode.")
+    _write_in(frame, 8, layout.left_divider + 2, layout.right_divider, f"SRC=dopemux UNKNOWN: {mode} renderer not wired in slice 1.")
+    if mode == "Implementer":
+        next_text = "NEXT: implement focus and retrieval panes."
+    elif mode == "Overview":
+        next_text = "NEXT: implement rollup view."
+    elif mode == "Events":
+        next_text = "NEXT: implement per-event SRC stream."
+    else:
+        next_text = "NEXT: implement PM mode."
+    _write_in(frame, 9, layout.left_divider + 2, layout.right_divider, f"SRC=dopemux {next_text}")
+
+
+def _render_status(frame: FrameBuffer, layout: Layout, state: SnapshotState, mode: str) -> None:
+    rail = state.status_rail
+    left = rail["left"]
+    middle = f"mode {mode}"
+    right = rail["right"]
+    _write_in(frame, layout.command_row, 2, layout.left_divider, "command authority: dopemux")
+    _write_in(frame, layout.command_row, layout.left_divider + 2, layout.right_divider, "SRC=dopemux snapshot-only")
+    _write_in(frame, layout.command_row, layout.right_divider + 2, layout.width - 2, "no writes no shellouts")
+    _write_in(frame, layout.status_row, 2, layout.left_divider, left)
+    _write_in(frame, layout.status_row, layout.left_divider + 2, layout.right_divider, middle)
+    _write_in(frame, layout.status_row, layout.right_divider + 2, layout.width - 2, right)
+
+
+def supported_sizes() -> tuple[str, ...]:
+    return SUPPORTED_SIZES

--- a/src/dopemux/ui/cockpit/seed.py
+++ b/src/dopemux/ui/cockpit/seed.py
@@ -1,0 +1,86 @@
+"""Authoritative deterministic seed for static cockpit snapshots."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+SEED_DATA: dict[str, Any] = {
+    "version": "1.0",
+    "generated_at": "2026-04-23T00:00:00Z",
+    "note": "Deterministic seed data for static renderer only. Values are illustrative, not runtime truth.",
+    "workspace": {"id": "dopemux-mvp", "instance": "local", "SRC": "dopemux"},
+    "top_level_modes": ["PM", "Implementer", "Overview", "Services", "Events"],
+    "placeholder_modes": {
+        "PM": {
+            "authority": "conport+leantime",
+            "status_chip": "EDGE",
+            "message": "[EDGE] placeholder mode. UNKNOWN: PM renderer not wired in slice 1. NEXT: implement PM mode.",
+        },
+        "Implementer": {
+            "authority": "task-orchestrator+dope-context",
+            "status_chip": "EDGE",
+            "message": "[EDGE] placeholder mode. UNKNOWN: Implementer renderer not wired in slice 1. NEXT: implement focus and retrieval panes.",
+        },
+        "Overview": {
+            "authority": "dopemux",
+            "status_chip": "EDGE",
+            "message": "[EDGE] placeholder mode. UNKNOWN: Overview renderer not wired in slice 1. NEXT: implement rollup view.",
+        },
+        "Events": {
+            "authority": "split-per-event",
+            "status_chip": "EDGE",
+            "message": "[EDGE] placeholder mode. UNKNOWN: Events renderer not wired in slice 1. NEXT: implement per-event SRC stream.",
+        },
+    },
+    "services": {
+        "authority": "dopemux",
+        "selected": "repo-truth-extractor",
+        "rows": [
+            {"name": "dopemux", "status": "LIVE", "kind": "control", "summary": "operator control surface", "SRC": "dopemux"},
+            {"name": "task-orchestrator", "status": "LIVE", "kind": "workflow", "summary": "workflow transitions", "SRC": "task-orchestrator"},
+            {"name": "conport", "status": "LIVE", "kind": "structured", "summary": "decisions progress context", "SRC": "conport"},
+            {"name": "dope-memory", "status": "LOGGED", "kind": "chronicle", "summary": "durable evidence ledger", "SRC": "dope-memory"},
+            {"name": "dope-context", "status": "LOGGED", "kind": "retrieval", "summary": "code docs retrieval", "SRC": "dope-context"},
+            {"name": "dopecon-bridge", "status": "OVERRIDE", "kind": "adapter", "summary": "proxy only not authority", "SRC": "dopecon-bridge"},
+            {"name": "adhd-engine", "status": "LIVE", "kind": "support", "summary": "operator support state", "SRC": "adhd-engine"},
+            {"name": "repo-truth-extractor", "status": "AFTERCARE", "kind": "extraction", "summary": "repo truth extraction v5", "SRC": "repo-truth-extractor"},
+        ],
+        "inspector": {
+            "subject": "repo-truth-extractor",
+            "authority": "repo-truth-extractor",
+            "provenance": "EXTRACTED",
+            "rows": [
+                {"label": "canonical", "value": "services/repo-truth-extractor/run_extraction_v5.py", "SRC": "repo-truth-extractor"},
+                {"label": "boundary", "value": "workload view not shell owner", "SRC": "dopemux"},
+                {"label": "state", "value": "seed only no live run", "SRC": "repo-truth-extractor"},
+            ],
+            "bridge": {
+                "status_chip": "EDGE",
+                "footer": "[EDGE] bridge is adapter/proxy only. NEXT: prefer canonical write.",
+                "actions": [
+                    {"label": "ADAPTER -> dopecon-bridge : replay-event", "enabled": False, "SRC": "dopecon-bridge"}
+                ],
+            },
+        },
+    },
+    "rte_child_surface": {
+        "parent_mode": "Services",
+        "authority": "repo-truth-extractor",
+        "tabs": ["R1 Runs", "R2 Active", "R3 Prescan", "R4 Doctor", "R5 Coverage", "R6 Audit"],
+        "rendered_tab": "R1 Runs",
+        "runs": [
+            {"run_id": "v5-2026-04-22T14:32Z-a91c", "repo": "dopemux", "branch": "main", "scope": "services", "status": "LIVE", "phase": "normalize", "providers": "anthropic openai", "duration": "00:07:41", "artifacts": 412, "alerts": 2, "SRC": "repo-truth-extractor"},
+            {"run_id": "v5-2026-04-22T11:04Z-7f18", "repo": "dopemux", "branch": "main", "scope": "repo-truth-extractor", "status": "BLOCKER", "phase": "preflight", "providers": "anthropic", "duration": "00:00:22", "artifacts": 3, "alerts": 1, "SRC": "repo-truth-extractor"},
+            {"run_id": "v5-2026-04-22T09:51Z-3e2a", "repo": "dopemux", "branch": "feat-bridge-auth", "scope": "dopecon-bridge", "status": "LOGGED", "phase": "verify", "providers": "anthropic openai groq", "duration": "00:19:04", "artifacts": 1284, "alerts": 1, "SRC": "repo-truth-extractor"},
+            {"run_id": "v5-2026-04-21T22:48Z-1d9b", "repo": "dopemux", "branch": "main", "scope": "docs", "status": "OVERRIDE", "phase": "coverage", "providers": "anthropic", "duration": "00:11:50", "artifacts": 902, "alerts": 6, "SRC": "repo-truth-extractor"},
+        ],
+    },
+    "status_rail": {"left": "workspace dopemux-mvp", "middle": "mode Services", "right": "seed static no-writes"},
+}
+
+
+def load_seed() -> dict[str, Any]:
+    """Return a copy so callers cannot mutate package seed state."""
+
+    return deepcopy(SEED_DATA)

--- a/src/dopemux/ui/cockpit/tokens.py
+++ b/src/dopemux/ui/cockpit/tokens.py
@@ -1,0 +1,72 @@
+"""Closed cockpit token validation."""
+
+from __future__ import annotations
+
+ALLOWED_STATUS_CHIPS = frozenset(
+    {"LIVE", "BLOCKER", "OVERRIDE", "LOGGED", "AFTERCARE", "EDGE"}
+)
+PROVENANCE_LABELS = frozenset(
+    {"RUNTIME_TRUTH", "EXTRACTED", "MIRRORED", "ADAPTER", "UNKNOWN"}
+)
+STATUS_NORMALIZATION = {
+    "DEGRADED": "OVERRIDE",
+    "FAILED": "BLOCKER",
+    "BLOCKED": "BLOCKER",
+    "SYNC": "AFTERCARE",
+    "UNKNOWN": "EDGE",
+}
+FORBIDDEN_STATUS_CHIPS = frozenset(
+    {"UNKNOWN", "DEGRADED", "FAILED", "BLOCKED", "SYNC", "DRAFT", "READY", "SUCCESS", "ERROR"}
+)
+FORBIDDEN_COPY = (
+    "probably",
+    "maybe",
+    "I think",
+    "as an AI",
+    "magic",
+    "brain",
+    "autonomous",
+    "smart",
+    "seamless",
+    "next-gen",
+    "all set",
+    "everything looks good",
+    "supercharged",
+)
+FORBIDDEN_ARROWS = ("→", "⇒", "➜")
+
+
+def normalize_status_chip(value: str) -> str:
+    """Return a closed status chip, mapping known web/RTE values."""
+
+    normalized = value.strip().upper()
+    normalized = STATUS_NORMALIZATION.get(normalized, normalized)
+    if normalized not in ALLOWED_STATUS_CHIPS:
+        raise ValueError(f"status chip not allowed: {value}")
+    return normalized
+
+
+def validate_status_chip(value: str) -> str:
+    """Validate a chip without applying compatibility aliases."""
+
+    normalized = value.strip().upper()
+    if normalized not in ALLOWED_STATUS_CHIPS:
+        raise ValueError(f"status chip not allowed: {value}")
+    return normalized
+
+
+def validate_rendered_text(text: str) -> None:
+    """Reject vocabulary that would weaken the static renderer contract."""
+
+    for arrow in FORBIDDEN_ARROWS:
+        if arrow in text:
+            raise ValueError(f"forbidden arrow: {arrow}")
+    if "..." in text or "…" in text:
+        raise ValueError("ellipsis clipping is forbidden")
+    lowered = text.lower()
+    for phrase in FORBIDDEN_COPY:
+        if phrase.lower() in lowered:
+            raise ValueError(f"forbidden cockpit copy: {phrase}")
+    for chip in FORBIDDEN_STATUS_CHIPS:
+        if f"[{chip}]" in text:
+            raise ValueError(f"forbidden status chip rendered: {chip}")

--- a/tests/unit/dopemux/ui/cockpit/fixtures/cockpit_seed.json
+++ b/tests/unit/dopemux/ui/cockpit/fixtures/cockpit_seed.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0",
+  "generated_at": "2026-04-23T00:00:00Z",
+  "note": "Deterministic seed data for static renderer only. Values are illustrative, not runtime truth."
+}

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_bridge.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_bridge.py
@@ -1,0 +1,13 @@
+from dopemux.ui.cockpit.frame import LAYOUTS
+from dopemux.ui.cockpit.render import render_cockpit
+
+
+def test_bridge_actions_are_in_inspector_area_and_adapter_only() -> None:
+    layout = LAYOUTS["120x40"]
+    lines = render_cockpit(120, 40).splitlines()
+    bridge_lines = [line for line in lines if "ADAPTER -> do" in line]
+    assert len(bridge_lines) == 1
+    assert bridge_lines[0].index("ADAPTER ->") > layout.right_divider
+    assert "[EDGE] bridge is adapter/proxy o" in "\n".join(lines)
+    assert "WRITE -> <service> : <action>" in "\n".join(lines)
+    assert "→" not in "\n".join(lines)

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_frame.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_frame.py
@@ -1,0 +1,34 @@
+from dopemux.ui.cockpit.frame import LAYOUTS, FrameBuffer, draw_static_grid
+
+
+def test_supported_frame_dimensions_are_exact() -> None:
+    for layout in LAYOUTS.values():
+        frame = FrameBuffer(layout.width, layout.height, layout)
+        rendered = frame.render()
+        lines = rendered.splitlines()
+        assert len(lines) == layout.height
+        assert all(len(line) == layout.width for line in lines)
+
+
+def test_normal_writes_do_not_overwrite_protected_cells() -> None:
+    layout = LAYOUTS["80x24"]
+    frame = FrameBuffer(layout.width, layout.height, layout)
+    draw_static_grid(frame, layout)
+    before = frame.render().splitlines()
+    frame.write(0, 0, "blocked")
+    frame.write(5, layout.left_divider, "blocked")
+    frame.write(layout.body_rule, 2, "blocked")
+    after = frame.render().splitlines()
+    assert after[0] == before[0]
+    assert after[5][layout.left_divider] == before[5][layout.left_divider]
+    assert after[layout.body_rule] == before[layout.body_rule]
+
+
+def test_hard_clipping_has_no_ellipsis_or_wrapping() -> None:
+    frame = FrameBuffer(10, 3)
+    frame.write(1, 7, "abcdef")
+    lines = frame.render().splitlines()
+    assert lines[1] == "       abc"
+    assert lines[2] == "          "
+    assert "..." not in frame.render()
+    assert "…" not in frame.render()

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_import_boundaries.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_import_boundaries.py
@@ -1,0 +1,39 @@
+import ast
+from pathlib import Path
+
+COCKPIT_ROOT = Path("src/dopemux/ui/cockpit")
+FORBIDDEN_IMPORTS = {
+    "dopemux.ui.pm_writes",
+    "dopemux.ui.service_endpoints",
+    "httpx",
+    "requests",
+    "urllib",
+    "watchfiles",
+    "subprocess",
+}
+
+
+def _import_names(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text())
+    imports: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.add(node.module)
+    return imports
+
+
+def test_cockpit_package_has_no_forbidden_imports() -> None:
+    seen: set[str] = set()
+    for path in COCKPIT_ROOT.glob("*.py"):
+        seen.update(_import_names(path))
+    for imported in seen:
+        assert imported not in FORBIDDEN_IMPORTS
+        assert imported.split(".", 1)[0] not in FORBIDDEN_IMPORTS
+
+
+def test_cockpit_code_has_no_shellout_tokens() -> None:
+    text = "\n".join(path.read_text() for path in COCKPIT_ROOT.glob("*.py"))
+    assert "subprocess" not in text
+    assert "shell=True" not in text

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_no_color.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_no_color.py
@@ -1,0 +1,12 @@
+from dopemux.ui.cockpit.render import render_cockpit
+
+
+def test_no_color_semantics_have_no_ansi_sequences(monkeypatch) -> None:
+    monkeypatch.setenv("NO_COLOR", "1")
+    output = render_cockpit(120, 40)
+    assert "\x1b[" not in output
+    assert "[LIVE]" in output
+    assert "authority:" in output
+    assert "SRC=" in output
+    assert "dopecon-bridge" in output
+    assert "adapter/proxy o" in output

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_rte_runs.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_rte_runs.py
@@ -1,0 +1,17 @@
+from dopemux.ui.cockpit.render import render_cockpit
+
+
+def test_rte_renders_as_services_child_surface_only() -> None:
+    output = render_cockpit(120, 40)
+    assert "Services -> repo-truth-extractor authority:" in output
+    assert "R1 Runs authority: repo-truth-extractor" in output
+    assert "6 RTE" not in output
+
+
+def test_rte_tabs_and_seed_runs_render_with_src() -> None:
+    output = render_cockpit(120, 40)
+    for tab in ("R1 Runs", "R2 Active", "R3 Prescan", "R4 Doctor", "R5 Coverage", "R6 Audit"):
+        assert tab in output
+    assert "v5-2026-04-22T14:32Z-a91c" in output
+    assert "phase=normalize" in output
+    assert "SRC=repo-truth-extractor" in output

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_services.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_services.py
@@ -1,0 +1,33 @@
+from dopemux.ui.cockpit.render import render_cockpit
+from dopemux.ui.cockpit.seed import load_seed
+
+
+def test_top_level_modes_are_packet_modes_only() -> None:
+    assert load_seed()["top_level_modes"] == ["PM", "Implementer", "Overview", "Services", "Events"]
+
+
+def test_services_mode_contains_authority_src_and_expected_services() -> None:
+    output = render_cockpit(120, 40)
+    for service in (
+        "dopemux",
+        "task-orchestrator",
+        "conport",
+        "dope-memory",
+        "dope-context",
+        "dopecon-bridge",
+        "adhd-engine",
+        "repo-truth-extractor",
+    ):
+        assert service in output
+    assert "Services authority:" in output
+    assert "Inspector authority:" in output
+    assert "SRC=" in output
+    assert "[UNKNOWN]" not in output
+
+
+def test_placeholder_modes_use_edge_chip_plain_unknown_and_next() -> None:
+    output = render_cockpit(120, 40, mode="PM")
+    assert "[EDGE] placeholder mode." in output
+    assert "UNKNOWN: PM renderer not wired" in output
+    assert "NEXT: implement PM mode" in output
+    assert "[UNKNOWN]" not in output

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_snapshots.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_snapshots.py
@@ -1,0 +1,39 @@
+import os
+import sys
+from subprocess import run
+
+from dopemux.ui.cockpit.render import render_snapshot
+
+
+def test_snapshot_outputs_have_exact_dimensions() -> None:
+    for size in ("120x40", "100x32", "80x24"):
+        output = render_snapshot(size)
+        width_text, height_text = size.split("x")
+        width = int(width_text)
+        height = int(height_text)
+        lines = output.splitlines()
+        assert len(lines) == height
+        assert all(len(line) == width for line in lines)
+        assert "..." not in output
+        assert "…" not in output
+
+
+def test_too_small_snapshot_returns_full_screen_blocker() -> None:
+    output = render_snapshot("79x23")
+    assert "[BLOCKER] terminal too small." in output
+    assert "NEXT: rerun with --snapshot 80x24." in output
+
+
+def test_snapshot_module_commands_succeed() -> None:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = "src"
+    for size in ("120x40", "100x32", "80x24"):
+        result = run(
+            [sys.executable, "-m", "dopemux.ui.cockpit", "--snapshot", size],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+        assert result.returncode == 0
+        assert f"mode Services" in result.stdout

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_tokens.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_tokens.py
@@ -1,0 +1,56 @@
+import pytest
+
+from dopemux.ui.cockpit.tokens import (
+    ALLOWED_STATUS_CHIPS,
+    normalize_status_chip,
+    validate_rendered_text,
+    validate_status_chip,
+)
+
+
+def test_status_chip_set_is_closed() -> None:
+    assert ALLOWED_STATUS_CHIPS == {
+        "LIVE",
+        "BLOCKER",
+        "OVERRIDE",
+        "LOGGED",
+        "AFTERCARE",
+        "EDGE",
+    }
+    for chip in ALLOWED_STATUS_CHIPS:
+        assert validate_status_chip(chip) == chip
+
+
+def test_unknown_is_rejected_as_direct_status_chip() -> None:
+    with pytest.raises(ValueError):
+        validate_status_chip("UNKNOWN")
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("DEGRADED", "OVERRIDE"),
+        ("FAILED", "BLOCKER"),
+        ("BLOCKED", "BLOCKER"),
+        ("SYNC", "AFTERCARE"),
+        ("UNKNOWN", "EDGE"),
+    ],
+)
+def test_web_and_rte_statuses_normalize_to_closed_chips(source: str, expected: str) -> None:
+    assert normalize_status_chip(source) == expected
+
+
+@pytest.mark.parametrize("text", ["bad → arrow", "bad ⇒ arrow", "bad ➜ arrow"])
+def test_unicode_arrows_are_rejected(text: str) -> None:
+    with pytest.raises(ValueError):
+        validate_rendered_text(text)
+
+
+@pytest.mark.parametrize("text", ["probably", "magic", "everything looks good", "next-gen"])
+def test_forbidden_copy_is_rejected(text: str) -> None:
+    with pytest.raises(ValueError):
+        validate_rendered_text(text)
+
+
+def test_unknown_plain_text_after_edge_is_allowed() -> None:
+    validate_rendered_text("[EDGE] placeholder mode. UNKNOWN: not wired. NEXT: implement.")


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary

Implements DMX-COCKPIT-STATIC-001 as a deterministic static renderer:

- Adds `python -m dopemux.ui.cockpit --snapshot 120x40|100x32|80x24`.
- Renders seed state only through `SnapshotState -> FrameBuffer -> string`.
- Keeps top-level modes to PM, Implementer, Overview, Services, Events.
- Renders repo-truth-extractor only as `Services -> repo-truth-extractor -> R1 Runs`.
- Enforces closed status chips: LIVE, BLOCKER, OVERRIDE, LOGGED, AFTERCARE, EDGE.
- Normalizes UNKNOWN to EDGE for status-chip input; `[UNKNOWN]` is rejected.
- Uses hard clipping only; no ellipsis insertion.
- Keeps bridge actions segregated in the inspector and marked adapter/proxy only.
- Adds no Textual app, no `dopemux cockpit` command, no live adapters, no writes, no shellouts, and no dependencies.

## Proof

1. Worktree path: `/tmp/dopemux-mvp-wt-cockpit-static`.
   - Packet requested sibling worktree path, but sandbox denied creating `/Users/hue/code/dopemux-mvp-wt-cockpit-static`; separate clone under `/tmp` was used instead.

2. Verified branch:
   - `git branch --show-current`
   - Output: `codex/dopemux-cockpit-static`

3. Repo origin check:
   - `git remote get-url origin`
   - Output: `https://github.com/DDD-Enterprises/dopemux-mvp.git`

4. Repo marker check:
   - `test -f .dopetaskroot`
   - Output: `.dopetaskroot present`

5. Exact files changed:
   - `src/dopemux/ui/cockpit/__init__.py`
   - `src/dopemux/ui/cockpit/__main__.py`
   - `src/dopemux/ui/cockpit/frame.py`
   - `src/dopemux/ui/cockpit/model.py`
   - `src/dopemux/ui/cockpit/render.py`
   - `src/dopemux/ui/cockpit/seed.py`
   - `src/dopemux/ui/cockpit/tokens.py`
   - `tests/unit/dopemux/ui/cockpit/fixtures/cockpit_seed.json`
   - `tests/unit/dopemux/ui/cockpit/test_cockpit_bridge.py`
   - `tests/unit/dopemux/ui/cockpit/test_cockpit_frame.py`
   - `tests/unit/dopemux/ui/cockpit/test_cockpit_import_boundaries.py`
   - `tests/unit/dopemux/ui/cockpit/test_cockpit_no_color.py`
   - `tests/unit/dopemux/ui/cockpit/test_cockpit_rte_runs.py`
   - `tests/unit/dopemux/ui/cockpit/test_cockpit_services.py`
   - `tests/unit/dopemux/ui/cockpit/test_cockpit_snapshots.py`
   - `tests/unit/dopemux/ui/cockpit/test_cockpit_tokens.py`

6. Test output:
   - Command: `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test pytest tests/unit/dopemux/ui/cockpit -q`
   - Output: `..............................                                           [100%]`

7. Snapshot command output:
   - Command: `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test python -m dopemux.ui.cockpit --snapshot 120x40`
   - Output: rendered deterministic cockpit frame with 40 lines and 120 columns per line.
   - Command: `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test python -m dopemux.ui.cockpit --snapshot 100x32`
   - Output: rendered deterministic cockpit frame with 32 lines and 100 columns per line.
   - Command: `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test python -m dopemux.ui.cockpit --snapshot 80x24`
   - Output: rendered deterministic cockpit frame with 24 lines and 80 columns per line.
   - Command: `NO_COLOR=1 UV_CACHE_DIR=/tmp/uv-cache uv run --extra test python -m dopemux.ui.cockpit --snapshot 120x40`
   - Output: `NO_COLOR snapshot has no ANSI escape sequences.`

8. Forbidden import check output:
   - Command: `rg -n "pm_writes|service_endpoints|httpx|requests|urllib|watchfiles|subprocess" src/dopemux/ui/cockpit`
   - Output: `No forbidden cockpit imports or shellout module tokens found.`

9. Forbidden vocabulary check output:
   - Command: rendered 120x40, 100x32, and 80x24 snapshots through `validate_rendered_text`.
   - Output: `Rendered vocabulary check passed for 120x40, 100x32, 80x24.`

10. Confirmation that `pyproject.toml` was not touched:
   - `git diff --name-only origin/main...HEAD -- pyproject.toml`
   - Output: no files.

11. Confirmation that no live service/runtime files were touched:
   - Checked forbidden paths from the packet against `origin/main...HEAD`.
   - Output: no files.

12. Diff stat:
   - `16 files changed, 766 insertions(+)`

## Notes

- Documentation/release note files were not changed because the task packet allowlist only permits `src/dopemux/ui/cockpit/**`, `tests/unit/dopemux/ui/cockpit/**`, and optional cockpit README.
- The renderer intentionally clips long pane content at pane boundaries. Clipping is hard-cut only and does not insert `...` or Unicode ellipsis.
