### PR TITLE
ui: expose cockpit static renderer through guarded cli

### DIFF
--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -3110,6 +3110,10 @@ from .commands.memory_commands import memory
 
 cli.add_command(memory)
 
+from .commands.cockpit_commands import cockpit
+
+cli.add_command(cockpit)
+
 
 from .commands.trigger_group_commands import trigger_group
 from .commands.personas_commands import personas

--- a/src/dopemux/commands/cockpit_commands.py
+++ b/src/dopemux/commands/cockpit_commands.py
@@ -1,0 +1,36 @@
+"""Guarded CLI wrapper for the static cockpit renderer."""
+
+from __future__ import annotations
+
+import click
+
+from dopemux.ui.cockpit import render_snapshot
+
+BLOCKED_WITHOUT_STATIC_DEMO = (
+    "[BLOCKER] cockpit CLI wrapper disabled.\n"
+    "Problem: this slice exposes only a deterministic static demo.\n"
+    "Why: live cockpit surfaces are out of scope in DMX-COCKPIT-STATIC-002.\n"
+    "Fix: rerun with dopemux cockpit --static-demo --snapshot 120x40.\n"
+    "NEXT: use --static-demo or invoke python -m dopemux.ui.cockpit --snapshot 120x40."
+)
+
+
+@click.command("cockpit")
+@click.option(
+    "--static-demo",
+    is_flag=True,
+    help="Expose the deterministic static cockpit demo only.",
+)
+@click.option(
+    "--snapshot",
+    type=click.Choice(["120x40", "100x32", "80x24"]),
+    required=True,
+    help="Render a fixed static cockpit snapshot size.",
+)
+def cockpit(static_demo: bool, snapshot: str) -> None:
+    """Render the deterministic seed-only cockpit snapshot."""
+
+    if not static_demo:
+        click.echo(BLOCKED_WITHOUT_STATIC_DEMO)
+        raise SystemExit(1)
+    click.echo(render_snapshot(snapshot))

--- a/task-packets/DMX-COCKPIT-STATIC-002.json
+++ b/task-packets/DMX-COCKPIT-STATIC-002.json
@@ -1,0 +1,124 @@
+{
+  "id": "DMX-COCKPIT-STATIC-002",
+  "project": "dopemux-mvp",
+  "target": "Expose the completed deterministic cockpit static renderer through a guarded Dopemux CLI wrapper without changing renderer behavior or adding live surfaces.",
+  "invariants": [
+    "Do not modify the pure cockpit renderer semantics from DMX-COCKPIT-STATIC-001.",
+    "Do not implement a Textual App in this packet.",
+    "Do not add live service adapters.",
+    "Do not add canonical writes.",
+    "Do not run RTE extraction.",
+    "Do not add shellouts.",
+    "Do not add new dependencies.",
+    "Do not treat RTE as a top-level Dopemux mode.",
+    "RTE must remain a child surface under Services.",
+    "Do not introduce status chips outside LIVE, BLOCKER, OVERRIDE, LOGGED, AFTERCARE, EDGE.",
+    "Do not use UNKNOWN as a status chip.",
+    "UNKNOWN may appear only as plain text after an allowed chip.",
+    "Do not use ellipsis for clipping.",
+    "Every pane title must include authority.",
+    "Every list row must include SRC.",
+    "Bridge actions must remain visually segregated and marked non-authoritative.",
+    "The CLI wrapper must be guarded by --static-demo so operators cannot mistake it for a live cockpit."
+  ],
+  "depends_on": [
+    "DMX-COCKPIT-STATIC-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dopemux-cockpit-static",
+    "base_branch": "main",
+    "parent_tp_id": "DMX-COCKPIT-STATIC-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dopemux-cockpit-cli-static-demo"
+  },
+  "commit": {
+    "message": "ui: expose cockpit static renderer through guarded cli",
+    "allowlist": [
+      "src/dopemux/cli.py",
+      "src/dopemux/commands/cockpit_commands.py",
+      "src/dopemux/ui/cockpit/**",
+      "tests/unit/dopemux/ui/cockpit/**",
+      "tests/unit/test_cockpit_cli.py",
+      "task-packets/DMX-COCKPIT-STATIC-002.json",
+      "task-packets/INDEX.md"
+    ],
+    "verify": [
+      "git rev-parse --show-toplevel",
+      "test -f .dopetaskroot",
+      "git remote -v",
+      "git branch --show-current",
+      "git status --short --branch",
+      "python -m json.tool task-packets/DMX-COCKPIT-STATIC-002.json",
+      "python -m dopemux.ui.cockpit --snapshot 120x40",
+      "python -m dopemux.ui.cockpit --snapshot 100x32",
+      "python -m dopemux.ui.cockpit --snapshot 80x24",
+      "dopemux cockpit --static-demo --snapshot 120x40",
+      "dopemux cockpit --static-demo --snapshot 100x32",
+      "dopemux cockpit --static-demo --snapshot 80x24",
+      "NO_COLOR=1 dopemux cockpit --static-demo --snapshot 120x40",
+      "python -m pytest tests/unit/dopemux/ui/cockpit tests/unit/test_cockpit_cli.py -q",
+      "git diff --check -- src/dopemux/cli.py src/dopemux/commands/cockpit_commands.py src/dopemux/ui/cockpit tests/unit/dopemux/ui/cockpit tests/unit/test_cockpit_cli.py task-packets/DMX-COCKPIT-STATIC-002.json task-packets/INDEX.md"
+    ]
+  },
+  "pr": {
+    "title": "ui: expose cockpit static renderer through guarded cli",
+    "body": "## Summary\n- adds a guarded `dopemux cockpit --static-demo --snapshot <size>` wrapper around the completed pure cockpit renderer\n- preserves `python -m dopemux.ui.cockpit --snapshot <size>` as the renderer-level entrypoint\n- keeps the cockpit static, seed-only, read-only, and non-live\n\n## Scope\n- CLI registration and wrapper only\n- no Textual app\n- no live service adapters\n- no writes\n- no RTE runner execution\n- no new dependencies\n\n## Validation\n- renderer module snapshots still pass for 120x40, 100x32, and 80x24\n- guarded CLI snapshots pass for 120x40, 100x32, and 80x24\n- invoking `dopemux cockpit` without `--static-demo` fails closed\n- NO_COLOR output preserves chips, authority, SRC, and bridge warning\n- existing cockpit unit tests remain green",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "step-001",
+      "task": "Create and verify a dedicated worktree before implementation.",
+      "requirements": [
+        "Worktree must be created from main.",
+        "Branch must match codex/dopemux-cockpit-cli-static-demo.",
+        "Repo marker .dopetaskroot must exist.",
+        "Origin must match repo_binding.origin_hint.",
+        "Do not work from the primary checkout.",
+        "Confirm DMX-COCKPIT-STATIC-001 renderer files are present before wiring CLI."
+      ]
+    },
+    {
+      "id": "step-002",
+      "task": "Inspect existing CLI command registration and choose the smallest guarded wrapper shape."
+    },
+    {
+      "id": "step-003",
+      "task": "Add guarded `dopemux cockpit --static-demo --snapshot <size>` wrapper."
+    },
+    {
+      "id": "step-004",
+      "task": "Add focused CLI tests for guarded behavior and snapshot equivalence."
+    },
+    {
+      "id": "step-005",
+      "task": "Record packet and index updates."
+    },
+    {
+      "id": "step-006",
+      "task": "Run final validation, inspect diff, push branch, and open PR."
+    }
+  ]
+}

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -48,7 +48,7 @@ A packet is superseded by another packet
 | TP-DMX-RTEAUDIT-001 | Repo Truth Extractor | Assemble pre-live audit pack for GPT-5.4 Pro | Ready | N/A |
 | TP-DMX-RTEINT-001 | Repo Truth Extractor | Integrate current RTE branch deltas into staging audit branch | Ready | N/A |
 | TP-DMX-RTECANON-001 | Repo Truth Extractor | Establish `dopemux rte` as the canonical operator entrypoint | Ready | N/A |
-| DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Executing | N/A |
+| DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Staged / Draft PR open / blocked on DMX-COCKPIT-STATIC-001 merge | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -48,6 +48,7 @@ A packet is superseded by another packet
 | TP-DMX-RTEAUDIT-001 | Repo Truth Extractor | Assemble pre-live audit pack for GPT-5.4 Pro | Ready | N/A |
 | TP-DMX-RTEINT-001 | Repo Truth Extractor | Integrate current RTE branch deltas into staging audit branch | Ready | N/A |
 | TP-DMX-RTECANON-001 | Repo Truth Extractor | Establish `dopemux rte` as the canonical operator entrypoint | Ready | N/A |
+| DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Executing | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_import_boundaries.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_import_boundaries.py
@@ -2,6 +2,7 @@ import ast
 from pathlib import Path
 
 COCKPIT_ROOT = Path("src/dopemux/ui/cockpit")
+COMMAND_FILE = Path("src/dopemux/commands/cockpit_commands.py")
 FORBIDDEN_IMPORTS = {
     "dopemux.ui.pm_writes",
     "dopemux.ui.service_endpoints",
@@ -28,6 +29,7 @@ def test_cockpit_package_has_no_forbidden_imports() -> None:
     seen: set[str] = set()
     for path in COCKPIT_ROOT.glob("*.py"):
         seen.update(_import_names(path))
+    seen.update(_import_names(COMMAND_FILE))
     for imported in seen:
         assert imported not in FORBIDDEN_IMPORTS
         assert imported.split(".", 1)[0] not in FORBIDDEN_IMPORTS
@@ -35,5 +37,6 @@ def test_cockpit_package_has_no_forbidden_imports() -> None:
 
 def test_cockpit_code_has_no_shellout_tokens() -> None:
     text = "\n".join(path.read_text() for path in COCKPIT_ROOT.glob("*.py"))
+    text += "\n" + COMMAND_FILE.read_text()
     assert "subprocess" not in text
     assert "shell=True" not in text

--- a/tests/unit/test_cockpit_cli.py
+++ b/tests/unit/test_cockpit_cli.py
@@ -1,0 +1,41 @@
+from click.testing import CliRunner
+
+from dopemux.cli import cli
+from dopemux.ui.cockpit import render_snapshot
+from dopemux.commands.cockpit_commands import BLOCKED_WITHOUT_STATIC_DEMO
+
+
+def test_cockpit_requires_static_demo_flag() -> None:
+    result = CliRunner().invoke(cli, ["cockpit", "--snapshot", "120x40"])
+
+    assert result.exit_code == 1
+    assert BLOCKED_WITHOUT_STATIC_DEMO in result.output
+
+
+def test_cockpit_cli_matches_renderer_output_for_120x40() -> None:
+    result = CliRunner().invoke(cli, ["cockpit", "--static-demo", "--snapshot", "120x40"])
+
+    assert result.exit_code == 0
+    assert result.output == render_snapshot("120x40") + "\n"
+
+
+def test_cockpit_cli_supports_all_snapshot_sizes() -> None:
+    runner = CliRunner()
+
+    for size in ("120x40", "100x32", "80x24"):
+        result = runner.invoke(cli, ["cockpit", "--static-demo", "--snapshot", size])
+        assert result.exit_code == 0
+        assert "mode Services" in result.output
+        assert "[UNKNOWN]" not in result.output
+        assert "6 RTE" not in result.output
+
+
+def test_cockpit_cli_no_color_output_has_no_ansi() -> None:
+    runner = CliRunner(env={"NO_COLOR": "1"})
+    result = runner.invoke(cli, ["cockpit", "--static-demo", "--snapshot", "120x40"])
+
+    assert result.exit_code == 0
+    assert "\x1b[" not in result.output
+    assert "SRC=" in result.output
+    assert "authority:" in result.output
+    assert "[EDGE] bridge is adapter/proxy o" in result.output


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary

- adds a guarded `dopemux cockpit --static-demo --snapshot <size>` wrapper around the completed pure cockpit renderer
- preserves `python -m dopemux.ui.cockpit --snapshot <size>` as the renderer-level entrypoint
- keeps the cockpit static, seed-only, read-only, and non-live

## Scope

- CLI registration and wrapper only
- no Textual app
- no live service adapters
- no writes
- no RTE runner execution
- no new dependencies

## Validation

- renderer module snapshots still pass for 120x40, 100x32, and 80x24
- guarded CLI snapshots pass for 120x40, 100x32, and 80x24
- invoking `dopemux cockpit` without `--static-demo` fails closed
- `NO_COLOR` output preserves chips, authority, `SRC`, and bridge warning
- existing cockpit unit tests remain green

## Proof

1. Worktree path
   - `/tmp/dopemux-mvp-wt-cockpit-cli-static-demo`
   - Packet requested a sibling worktree from `main`, but sandbox restrictions prevent creating sibling worktrees under `/Users/hue/code`. A separate clone in `/tmp` was used.

2. Verified branch
   - `git branch --show-current`
   - `codex/dopemux-cockpit-cli-static-demo`

3. Repo identity
   - `git remote -v`
   - fetch/push origin: `https://github.com/DDD-Enterprises/dopemux-mvp.git`
   - `test -f .dopetaskroot`
   - `.dopetaskroot present`

4. Dependency drift note
   - `DMX-COCKPIT-STATIC-001` is not merged to `main` yet.
   - `origin/main` does not contain `src/dopemux/ui/cockpit/**`.
   - This branch is therefore based on `origin/codex/dopemux-cockpit-static` so the guarded CLI wrapper can wrap the completed renderer without reintroducing `001` into this diff.
   - Merge order: this PR must not merge before `DMX-COCKPIT-STATIC-001` lands on `main`. After `001` lands, rebase this branch onto `main` and retarget the PR to `main`.

5. Files changed
   - `src/dopemux/cli.py`
   - `src/dopemux/commands/cockpit_commands.py`
   - `tests/unit/dopemux/ui/cockpit/test_cockpit_import_boundaries.py`
   - `tests/unit/test_cockpit_cli.py`
   - `task-packets/DMX-COCKPIT-STATIC-002.json`
   - `task-packets/INDEX.md`

6. Validation commands
   - `python -m json.tool task-packets/DMX-COCKPIT-STATIC-002.json`
   - passed
   - `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test python -m dopemux.ui.cockpit --snapshot 120x40`
   - `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test python -m dopemux.ui.cockpit --snapshot 100x32`
   - `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test python -m dopemux.ui.cockpit --snapshot 80x24`
   - passed
   - `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test dopemux cockpit --static-demo --snapshot 120x40`
   - `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test dopemux cockpit --static-demo --snapshot 100x32`
   - `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test dopemux cockpit --static-demo --snapshot 80x24`
   - passed
   - `NO_COLOR=1 UV_CACHE_DIR=/tmp/uv-cache uv run --extra test dopemux cockpit --static-demo --snapshot 120x40`
   - passed, no ANSI escapes
   - `UV_CACHE_DIR=/tmp/uv-cache uv run --extra test python -m pytest tests/unit/dopemux/ui/cockpit tests/unit/test_cockpit_cli.py -q`
   - output: `..................................                                       [100%]`
   - `git diff --check -- src/dopemux/cli.py src/dopemux/commands/cockpit_commands.py src/dopemux/ui/cockpit tests/unit/dopemux/ui/cockpit tests/unit/test_cockpit_cli.py task-packets/DMX-COCKPIT-STATIC-002.json task-packets/INDEX.md`
   - passed

7. Equivalence and guard checks
   - `cmp -s /tmp/cockpit-module-120.txt /tmp/cockpit-cli-120.txt`
   - exact match for `120x40`
   - `dopemux cockpit --snapshot 120x40`
   - exits nonzero with `[BLOCKER]` and `NEXT:`

8. Import boundary check
   - scanned `src/dopemux/ui/cockpit` and `src/dopemux/commands/cockpit_commands.py`
   - no `pm_writes`, `service_endpoints`, `httpx`, `requests`, `urllib`, `watchfiles`, or `subprocess`

9. Out of scope
   - no Textual app
   - no live service adapters
   - no writes
   - no RTE execution
   - no new dependencies
