### PR TITLE
Add PM Cockpit Textual TUI shell

### DIFF
--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -3175,6 +3175,11 @@ cli.add_command(audit)
 cli.add_command(audit.commands["wizard"], "wizard")
 
 
+from .commands.cockpit_commands import cockpit  # noqa: E402
+
+cli.add_command(cockpit)
+
+
 # ============================================================
 # Commands extracted back from submodules (use @cli.command)
 # ============================================================

--- a/src/dopemux/commands/cockpit_commands.py
+++ b/src/dopemux/commands/cockpit_commands.py
@@ -1,0 +1,74 @@
+"""Cockpit commands for dopemux CLI -- PM Textual TUI shell."""
+
+from __future__ import annotations
+
+import sys
+
+import click
+
+from ..ui.cockpit.app import run_cockpit
+from ..ui.cockpit.render import TOO_SMALL_MESSAGE
+
+
+_SIZE_PRESETS: dict[str, tuple[int, int]] = {
+    "120x40": (120, 40),
+    "100x32": (100, 32),
+    "80x24": (80, 24),
+}
+
+
+def _parse_size(value: str) -> tuple[int, int]:
+    if value in _SIZE_PRESETS:
+        return _SIZE_PRESETS[value]
+    raise click.BadParameter(
+        f"unsupported size {value!r}; choose one of {sorted(_SIZE_PRESETS)}"
+    )
+
+
+@click.group()
+def cockpit() -> None:
+    """Dopemux Cockpit -- architecture-safe PM operator surface (static demo)."""
+
+
+@cockpit.command("run")
+@click.option(
+    "--mode",
+    type=click.Choice(["pm"], case_sensitive=False),
+    default="pm",
+    show_default=True,
+    help="Cockpit mode (only PM is implemented in this slice).",
+)
+@click.option(
+    "--size",
+    "size_str",
+    type=str,
+    default="120x40",
+    show_default=True,
+    help="Viewport size: 120x40 | 100x32 | 80x24.",
+)
+@click.option(
+    "--plain",
+    is_flag=True,
+    default=False,
+    help="Render deterministic plain text (no Textual UI).",
+)
+@click.option(
+    "--audit",
+    is_flag=True,
+    default=False,
+    help="Audit-mode render (log-safe, deterministic, no Textual UI).",
+)
+def cockpit_run(mode: str, size_str: str, plain: bool, audit: bool) -> None:
+    """Launch the cockpit (or render plain / audit text)."""
+    cols, rows = _parse_size(size_str)
+    if cols < 80 or rows < 24:
+        click.echo(TOO_SMALL_MESSAGE)
+        sys.exit(2)
+    output = run_cockpit(
+        mode=mode.lower(),
+        size=(cols, rows),
+        plain=plain,
+        audit=audit,
+    )
+    if output is not None:
+        click.echo(output)

--- a/src/dopemux/ui/cockpit/__init__.py
+++ b/src/dopemux/ui/cockpit/__init__.py
@@ -1,0 +1,29 @@
+"""Dopemux Cockpit TUI package.
+
+Architecture-safe operator control surface. PM authority is split across
+Leantime (metadata), task-orchestrator (workflow), ConPort (decisions/
+progress), dope-memory (chronicle), dope-context (retrieval). The
+dopecon-bridge surface is adapter/proxy only and never canonical
+authority.
+
+This package emits no live writes and no PM mutations. The first slice
+ships static / demo data clearly labeled as such.
+"""
+
+from .render import (
+    TOO_SMALL_MESSAGE,
+    TOP_LEVEL_MODES,
+    PaneDeclaration,
+    Top3Block,
+    render_pm,
+    viewport_supported,
+)
+
+__all__ = [
+    "TOO_SMALL_MESSAGE",
+    "TOP_LEVEL_MODES",
+    "PaneDeclaration",
+    "Top3Block",
+    "render_pm",
+    "viewport_supported",
+]

--- a/src/dopemux/ui/cockpit/app.py
+++ b/src/dopemux/ui/cockpit/app.py
@@ -1,0 +1,103 @@
+"""Textual shell for the Dopemux Cockpit PM slice.
+
+The deterministic render is in :mod:`render`. This module is a thin
+Textual surface over it: a top-level mode bar, a PM screen body, and a
+chrome footer. It performs no live writes and no PM mutations.
+"""
+
+from __future__ import annotations
+
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Footer, Header, Static
+
+from .render import (
+    TOO_SMALL_MESSAGE,
+    TOP_LEVEL_MODES,
+    render_pm,
+    viewport_supported,
+)
+
+
+class CockpitModeBar(Static):
+    """Top-level mode bar (PM, Implementer, Overview, Services, Events)."""
+
+    def __init__(self, active: str = "PM") -> None:
+        super().__init__(id="cockpit-mode-bar")
+        self._active = active
+
+    def render(self) -> str:
+        cells: list[str] = []
+        for mode in TOP_LEVEL_MODES:
+            if mode == self._active:
+                cells.append(f"[ {mode} ]")
+            else:
+                cells.append(f"  {mode}  ")
+        return " | ".join(cells)
+
+
+class CockpitPMScreen(Static):
+    """Static PM render. Reuses the deterministic render module."""
+
+    def __init__(self, *, cols: int, rows: int) -> None:
+        super().__init__(id="cockpit-pm-screen")
+        self._cols = cols
+        self._rows = rows
+
+    def render(self) -> str:
+        return render_pm(cols=self._cols, rows=self._rows)
+
+
+class CockpitApp(App):
+    """Dopemux Cockpit Textual shell (PM slice)."""
+
+    TITLE = "Dopemux Cockpit  mode=PM"
+    SUB_TITLE = "STATIC DEMO  NO WRITES"
+
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+    ]
+
+    def __init__(self, *, cols: int = 120, rows: int = 40) -> None:
+        super().__init__()
+        self._cols = cols
+        self._rows = rows
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        if not viewport_supported(self._cols, self._rows):
+            yield Static(TOO_SMALL_MESSAGE, id="cockpit-too-small")
+            yield Footer()
+            return
+        with Vertical():
+            yield CockpitModeBar(active="PM")
+            yield CockpitPMScreen(cols=self._cols, rows=self._rows)
+        yield Footer()
+
+
+def run_cockpit(
+    *,
+    mode: str = "pm",
+    size: tuple[int, int] = (120, 40),
+    plain: bool = False,
+    audit: bool = False,
+) -> str | None:
+    """Entry point used by the ``dopemux cockpit`` CLI command.
+
+    Plain / audit modes print the deterministic render and return the text
+    so the CLI can stream it. Interactive mode launches the Textual shell.
+    """
+    if mode != "pm":
+        raise ValueError(f"unsupported cockpit mode: {mode!r}")
+
+    cols, rows = size
+
+    if plain or audit:
+        return render_pm(cols=cols, rows=rows, plain=True)
+
+    if not viewport_supported(cols, rows):
+        return TOO_SMALL_MESSAGE
+
+    app = CockpitApp(cols=cols, rows=rows)
+    app.run()
+    return None

--- a/src/dopemux/ui/cockpit/render.py
+++ b/src/dopemux/ui/cockpit/render.py
@@ -1,0 +1,353 @@
+"""Deterministic render model for the Dopemux Cockpit TUI.
+
+This module is the single source of truth for the architecture-safe PM
+cockpit slice. It produces deterministic text output for tests and for
+plain / audit modes, and it provides the structured data the Textual
+shell consumes.
+
+Authority model (per
+``docs/03-reference/Dopemux Cockpit TUI Design System/architecture-safety-overlay.md``):
+
+- Leantime owns PM metadata.
+- task-orchestrator owns workflow transitions, queue, blockers.
+- ConPort owns decisions / progress / project context.
+- dope-memory owns chronicle / receipts.
+- dope-context owns retrieval surfaces.
+- dopecon-bridge is adapter / proxy only -- never canonical authority.
+- dopemux is the operator control surface. It does NOT own PM truth.
+
+This slice emits NO live writes and NO PM mutations. All values are
+static demo data clearly labeled as such.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, Sequence
+
+
+# ---------------------------------------------------------------------------
+# Top-level modes (exactly five)
+# ---------------------------------------------------------------------------
+
+TOP_LEVEL_MODES: tuple[str, ...] = (
+    "PM",
+    "Implementer",
+    "Overview",
+    "Services",
+    "Events",
+)
+
+STATIC_DEMO_BANNER: str = "STATIC DEMO  NO WRITES  no live PM mutations"
+
+TOO_SMALL_MESSAGE: str = "[BLOCKER] terminal too small (minimum 80x24)"
+
+# Smallest supported viewport
+MIN_COLS: int = 80
+MIN_ROWS: int = 24
+
+
+# ---------------------------------------------------------------------------
+# Pane and Top-3 data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PaneDeclaration:
+    """Four-field pane declaration required by the safety overlay."""
+
+    domain: str
+    authority: str
+    role: str  # canonical | derived | mirrored | proxied | authoring | chrome
+    next_action: str
+
+    def header_lines(self) -> tuple[str, str, str, str]:
+        return (
+            f"domain: {self.domain}",
+            f"authority: {self.authority}",
+            f"role: {self.role}",
+            f"next_action: {self.next_action}",
+        )
+
+
+@dataclass(frozen=True)
+class Top3Block:
+    """ADHD output contract for list-like PM surfaces."""
+
+    items: tuple[str, ...]
+    more_count: int
+    next_token: str | None
+
+    def to_lines(self) -> list[str]:
+        out: list[str] = []
+        for index, item in enumerate(self.items[:3], start=1):
+            out.append(f"  {index}. {item}")
+        out.append(f"  more_count: {self.more_count}")
+        out.append(f"  next_token: {self.next_token if self.next_token else 'none'}")
+        return out
+
+
+@dataclass(frozen=True)
+class PaneRender:
+    """A single PM pane: declaration, body lines, optional SRC tag."""
+
+    title: str
+    declaration: PaneDeclaration
+    body: tuple[str, ...]
+    src: str | None = None  # provenance only, never on chrome
+
+
+# ---------------------------------------------------------------------------
+# Static PM model (demo data; no backend calls)
+# ---------------------------------------------------------------------------
+
+
+def _workflow_slice_map() -> PaneRender:
+    block = Top3Block(
+        items=(
+            "[LIVE]    DMX-COCKPIT-PM-TEXTUAL-001 -- ready_for_triage",
+            "[LOGGED]  DMX-PM-PLANE-AUDIT-014 -- adjudication",
+            "[EDGE]    DMX-BRIDGE-PROXY-AUDIT-002 -- waiting_on_proxy_review",
+        ),
+        more_count=4,
+        next_token="slice_cursor_DMX-PM-PLANE-AUDIT-019",
+    )
+    return PaneRender(
+        title="LEFT RAIL  workflow / slice map",
+        declaration=PaneDeclaration(
+            domain="workflow_slice",
+            authority="task-orchestrator workflow transitions",
+            role="derived",
+            next_action="open",
+        ),
+        body=tuple(block.to_lines()),
+        src="task-orchestrator",
+    )
+
+
+def _readiness_queue() -> PaneRender:
+    block = Top3Block(
+        items=(
+            "[LIVE]    DMX-COCKPIT-PM-TEXTUAL-001  legality=ok  blockers=0",
+            "[LOGGED]  DMX-PM-PLANE-AUDIT-014     legality=ok  blockers=1",
+            "[EDGE]    DMX-BRIDGE-PROXY-AUDIT-002 legality=UNKNOWN  blockers=0",
+        ),
+        more_count=2,
+        next_token="queue_cursor_priority=2",
+    )
+    return PaneRender(
+        title="CENTER UPPER  workflow triage / readiness queue",
+        declaration=PaneDeclaration(
+            domain="readiness_queue",
+            authority="task-orchestrator workflow transitions",
+            role="canonical",
+            next_action="triage",
+        ),
+        body=tuple(block.to_lines()),
+        src="task-orchestrator",
+    )
+
+
+def _adjudication_context() -> PaneRender:
+    body = (
+        "blocker:        UNKNOWN -- needs verification from task-orchestrator",
+        "transitions:    triage -> ready -> handoff",
+        "linked_decision SRC=conport  D-2026.04-PM-014  status=LOGGED",
+        "linked_decision SRC=conport  D-2026.04-PM-019  status=LOGGED",
+        "chronicle SRC=dope-memory     R-2026.04-CHRON-882  status=AFTERCARE",
+        "metadata SRC=leantime         LT-1422  ticket_age=3d",
+        "handoff_ready:  false (acceptance subset incomplete)",
+    )
+    return PaneRender(
+        title="CENTER LOWER  adjudication context",
+        declaration=PaneDeclaration(
+            domain="adjudication",
+            authority="task-orchestrator workflow transitions",
+            role="canonical",
+            next_action="inspect",
+        ),
+        body=body,
+        src=None,  # SRC appears inline per record (see body)
+    )
+
+
+def _selected_slice_detail() -> PaneRender:
+    body = (
+        "slice_id:        DMX-COCKPIT-PM-TEXTUAL-001",
+        "metadata SRC=leantime         LT-1422  owner=hu3mann",
+        "context  SRC=conport          PC-DMX-COCKPIT  scope=cockpit pm tui",
+        "progress SRC=conport          P-2026.04-PM-022  status=in_progress",
+        "transitions: open|triage|handoff  current=triage",
+    )
+    return PaneRender(
+        title="INSPECTOR UPPER  selected slice detail",
+        declaration=PaneDeclaration(
+            domain="slice_detail",
+            authority="task-orchestrator workflow transitions",
+            role="canonical",
+            next_action="inspect",
+        ),
+        body=body,
+        src=None,
+    )
+
+
+def _canonical_actions() -> PaneRender:
+    body = (
+        "action: log_decision     SRC=conport            via=conport_action_surface",
+        "action: log_progress     SRC=conport            via=conport_action_surface",
+        "action: workflow.advance SRC=task-orchestrator  via=task_orchestrator_api",
+        "action: chronicle.read   SRC=dope-memory        via=dope_memory_api",
+        "action: retrieval.query  SRC=dope-context       via=dope_context_api",
+        "note: canonical writes route through their own service surface; not via bridge",
+    )
+    return PaneRender(
+        title="INSPECTOR LOWER UPPER  canonical actions",
+        declaration=PaneDeclaration(
+            domain="decisions",
+            authority="conport decisions/progress context",
+            role="authoring",
+            next_action="log_decision",
+        ),
+        body=body,
+        src=None,  # body rows carry SRC per record
+    )
+
+
+def _bridge_segregator() -> PaneRender:
+    body = (
+        "Bridge adapter/proxy: dopecon-bridge",
+        "[EDGE] adapter-only segregated",
+        "transport_ref: bridge.adapter.kg.read_decisions",
+        "transport_ref: bridge.adapter.task_orchestrator.list_blockers",
+        "note: adapter actions only; canonical writes route through their owners.",
+    )
+    return PaneRender(
+        title="INSPECTOR LOWER LOWER  bridge segregator (adapter/proxy only)",
+        declaration=PaneDeclaration(
+            domain="bridge_transport",
+            authority="dopecon-bridge adapter/proxy routing",
+            role="proxied",
+            next_action="inspect_adapter_ref",
+        ),
+        body=body,
+        src="dopecon-bridge",
+    )
+
+
+def _command_status_rail() -> tuple[str, ...]:
+    # Chrome: no SRC, no canonical data, no transition controls.
+    return (
+        "[chrome]  filter=triage  legality=ok  warnings=0  ctrl+k=palette",
+        "[chrome]  cue: ADHD_engine: focused; suggest 25-min focus block (advisory only)",
+    )
+
+
+def pm_panes() -> list[PaneRender]:
+    """Return the canonical ordered PM pane list (excluding chrome rail)."""
+    return [
+        _workflow_slice_map(),
+        _readiness_queue(),
+        _adjudication_context(),
+        _selected_slice_detail(),
+        _canonical_actions(),
+        _bridge_segregator(),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Viewport handling
+# ---------------------------------------------------------------------------
+
+
+def viewport_supported(cols: int, rows: int) -> bool:
+    """Return True iff the viewport meets the minimum 80x24 contract."""
+    return cols >= MIN_COLS and rows >= MIN_ROWS
+
+
+def _bridge_role_for_viewport(cols: int, rows: int) -> str:
+    """Per-Viewport Degradation Law from architecture-safety-overlay.md.
+
+    - 120 x 40: dedicated bridge segregator pane allowed.
+    - 100 x 32: bridge lives in inspector / lower detail (no segregator pane).
+    - 80 x 24:  bridge collapses into inspector detail only (no peer pane).
+    """
+    if cols >= 120 and rows >= 40:
+        return "segregator-pane"
+    if cols >= 100 and rows >= 32:
+        return "inspector-lower-detail"
+    return "inspector-detail-collapsed"
+
+
+# ---------------------------------------------------------------------------
+# Deterministic text render
+# ---------------------------------------------------------------------------
+
+
+def _format_pane(pane: PaneRender) -> list[str]:
+    out: list[str] = []
+    out.append(f"## {pane.title}")
+    for line in pane.declaration.header_lines():
+        out.append(line)
+    if pane.src is not None:
+        out.append(f"SRC={pane.src}")
+    out.append("")
+    out.extend(pane.body)
+    return out
+
+
+def render_pm(cols: int = 120, rows: int = 40, *, plain: bool = False) -> str:
+    """Render PM mode deterministically for the given viewport.
+
+    The output is plain text, ANSI-free, and stable across calls with
+    identical inputs. Tests rely on this stability.
+    """
+    if not viewport_supported(cols, rows):
+        return TOO_SMALL_MESSAGE
+
+    bridge_role = _bridge_role_for_viewport(cols, rows)
+
+    lines: list[str] = []
+    lines.append("# Dopemux Cockpit  mode=PM")
+    lines.append(STATIC_DEMO_BANNER)
+    lines.append(f"viewport: {cols}x{rows}  bridge_placement: {bridge_role}")
+    lines.append(f"modes: {' | '.join(TOP_LEVEL_MODES)}")
+    lines.append("")
+
+    panes = pm_panes()
+
+    if bridge_role == "inspector-detail-collapsed":
+        # 80x24: bridge is collapsed into inspector detail only -- not a peer pane.
+        primary_panes = [p for p in panes if p.declaration.domain != "bridge_transport"]
+        for pane in primary_panes:
+            lines.extend(_format_pane(pane))
+            lines.append("")
+        # Collapsed inline detail (one annotated line, NOT a pane).
+        lines.append("[inspector-detail] bridge collapsed: dopecon-bridge adapter/proxy ref only")
+    else:
+        for pane in panes:
+            lines.extend(_format_pane(pane))
+            lines.append("")
+
+    # Chrome rail: no SRC, no authority claim on data.
+    lines.append("---")
+    lines.extend(_command_status_rail())
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_audit(cols: int = 120, rows: int = 40) -> str:
+    """Audit-mode render: identical contract, log-safe (alias of plain)."""
+    return render_pm(cols=cols, rows=rows, plain=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers exposed for the Textual shell
+# ---------------------------------------------------------------------------
+
+
+def iter_top_level_modes() -> Iterable[str]:
+    return iter(TOP_LEVEL_MODES)
+
+
+def pane_titles() -> Sequence[str]:
+    return tuple(p.title for p in pm_panes())

--- a/task-packets/DMX-COCKPIT-PM-TEXTUAL-001.json
+++ b/task-packets/DMX-COCKPIT-PM-TEXTUAL-001.json
@@ -1,0 +1,100 @@
+{
+  "id": "DMX-COCKPIT-PM-TEXTUAL-001",
+  "project": "dopemux-mvp",
+  "target": "Implement the first repo-bound Dopemux Cockpit PM Textual TUI slice with deterministic render output, split authority labels, viewport degradation law, and architecture safety tests.",
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "codex/cockpit-pm-textual",
+    "base_branch": "main",
+    "parent_tp_id": "DMX-COCKPIT-PMIMPL-PACK-001",
+    "final_packet": false
+  },
+  "commit": {
+    "message": "ui: add PM cockpit textual shell",
+    "allowlist": [
+      "src/dopemux/ui/cockpit/__init__.py",
+      "src/dopemux/ui/cockpit/render.py",
+      "src/dopemux/ui/cockpit/app.py",
+      "src/dopemux/commands/cockpit_commands.py",
+      "src/dopemux/cli.py",
+      "tests/unit/dopemux/ui/cockpit/__init__.py",
+      "tests/unit/dopemux/ui/cockpit/test_cockpit_render.py",
+      "tests/unit/dopemux/ui/cockpit/test_cockpit_command.py",
+      "task-packets/DMX-COCKPIT-PM-TEXTUAL-001.json"
+    ],
+    "verify": [
+      "uv run --with pytest python -m pytest tests/unit/dopemux/ui/cockpit -q",
+      "uv run --with pytest --with pytest-asyncio python -m pytest tests/unit -q --ignore=tests/unit/conport",
+      "rg -n 'Run History|authority: dopemux|Services authority: dopemux|command authority: dopemux|Bridge actions authority|SRC=dopemux|UNKNOWN.?->.?EDGE|UNKNOWN.?\u2192.?EDGE|UNKNOWN=EDGE' src/dopemux/ui/cockpit src/dopemux/commands/cockpit_commands.py tests/unit/dopemux/ui/cockpit || echo 'clean'"
+    ]
+  },
+  "pr": {
+    "number": 536,
+    "title": "Add PM cockpit Textual shell",
+    "body": "Adds the first architecture-safe PM cockpit Textual TUI slice with deterministic render output, PM pane declarations, split authority labels, viewport degradation law, and architecture safety tests. This introduces `dopemux cockpit run --mode pm --size 120x40|100x32|80x24 [--plain|--audit]` as the primary entrypoint. No live PM writes or backend mutations are included.",
+    "base": "main"
+  },
+  "steps": [
+    {
+      "id": "step-1",
+      "task": "Inspect existing cockpit surfaces, CLI patterns, and Textual/static renderer patterns.",
+      "validation": [
+        "Implementation path chosen from runtime evidence in src/dopemux/ui/ and src/dopemux/commands/.",
+        "No unrelated RTE, agent, or design-system files are edited."
+      ]
+    },
+    {
+      "id": "step-2",
+      "task": "Create deterministic PM cockpit render module (src/dopemux/ui/cockpit/render.py).",
+      "validation": [
+        "render.py exports TOP_LEVEL_MODES with exactly [PM, Implementer, Overview, Services, Events].",
+        "pm_panes() returns 6 panes each with complete four-field declaration (domain, authority, role, next_action).",
+        "All split-authority labels present: task-orchestrator, leantime, conport, dope-memory, dope-context, dopecon-bridge.",
+        "render_pm(cols, rows) produces deterministic output stable across calls.",
+        "render_pm() enforces viewport degradation law at 120x40, 100x32, 80x24, <80x24."
+      ]
+    },
+    {
+      "id": "step-3",
+      "task": "Create Textual app shell (src/dopemux/ui/cockpit/app.py) and CLI command (src/dopemux/commands/cockpit_commands.py).",
+      "validation": [
+        "CockpitApp is a textual.app.App subclass with mode bar and PM screen.",
+        "run_cockpit(mode='pm', size=(120, 40), plain=False, audit=False) entry function works.",
+        "CLI command `dopemux cockpit run --mode pm --size {120x40,100x32,80x24} [--plain|--audit]` is registered in cli.py.",
+        "Plain and audit modes return deterministic text output instead of launching TUI."
+      ]
+    },
+    {
+      "id": "step-4",
+      "task": "Verify Top-3 list contract (items, more_count, next_token) in render output.",
+      "validation": [
+        "Top3Block.to_lines() returns items 1, 2, 3 with more_count and next_token fields.",
+        "All PM list panes render Top-3 contract correctly.",
+        "more_count and next_token fields visible in render_pm() output."
+      ]
+    },
+    {
+      "id": "step-5",
+      "task": "Verify SRC placement and authority claims.",
+      "validation": [
+        "SRC= labels appear only on data rows (never on chrome).",
+        "SRC values are: task-orchestrator, leantime, conport, dope-memory, dope-context, dopecon-bridge (never dopemux).",
+        "No forbidden phrases present: authority: dopemux, Services authority: dopemux, command authority: dopemux, Bridge actions authority, SRC=dopemux, UNKNOWN\u2192EDGE, UNKNOWN -> EDGE, UNKNOWN=EDGE."
+      ]
+    },
+    {
+      "id": "step-6",
+      "task": "Write architecture safety tests covering all contract requirements.",
+      "validation": [
+        "Test suite covers: top-level modes, pane declarations, split authority, forbidden strings, SRC placement, viewport degradation, Top-3 contract, determinism.",
+        "Cockpit unit suite passes (25 tests minimum).",
+        "Broad unit lane passes (tests/unit excluding quarantined conport)."
+      ]
+    }
+  ]
+}

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_command.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_command.py
@@ -1,0 +1,82 @@
+"""CLI contract tests for the dopemux cockpit command."""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from dopemux.commands.cockpit_commands import cockpit
+from dopemux.ui.cockpit.render import TOO_SMALL_MESSAGE
+
+
+def _invoke(*args: str) -> "tuple[int, str]":
+    runner = CliRunner()
+    result = runner.invoke(cockpit, list(args))
+    return result.exit_code, result.output
+
+
+def test_plain_render_at_120x40_succeeds():
+    code, output = _invoke("run", "--mode", "pm", "--size", "120x40", "--plain")
+    assert code == 0
+    assert "STATIC DEMO" in output
+    assert "bridge segregator" in output
+    assert "more_count:" in output
+
+
+def test_plain_render_at_100x32_succeeds():
+    code, output = _invoke("run", "--mode", "pm", "--size", "100x32", "--plain")
+    assert code == 0
+    assert "STATIC DEMO" in output
+    # 100x32 lives in the inspector-lower-detail bridge mode.
+    assert "inspector-lower-detail" in output
+
+
+def test_audit_render_at_80x24_collapses_bridge():
+    code, output = _invoke("run", "--mode", "pm", "--size", "80x24", "--audit")
+    assert code == 0
+    assert "[inspector-detail]" in output
+    assert "bridge segregator" not in output
+
+
+def test_below_minimum_viewport_emits_blocker_and_exits_nonzero():
+    runner = CliRunner()
+    # Use an unsupported preset to trigger BadParameter.
+    bad = runner.invoke(cockpit, ["run", "--size", "70x20", "--plain"])
+    assert bad.exit_code != 0
+
+
+def test_unsupported_size_token_rejected():
+    runner = CliRunner()
+    result = runner.invoke(cockpit, ["run", "--size", "999x999", "--plain"])
+    assert result.exit_code != 0
+
+
+def test_default_size_is_120x40_plain():
+    code, output = _invoke("run", "--plain")
+    assert code == 0
+    assert "120x40" in output
+
+
+def test_no_forbidden_phrases_via_cli():
+    forbidden = (
+        "Run History",
+        "authority: dopemux",
+        "Services authority: dopemux",
+        "command authority: dopemux",
+        "Bridge actions authority",
+        "SRC=dopemux",
+        "UNKNOWN→EDGE",
+        "UNKNOWN -> EDGE",
+        "UNKNOWN=EDGE",
+    )
+    for size in ("120x40", "100x32", "80x24"):
+        code, output = _invoke("run", "--size", size, "--plain")
+        assert code == 0
+        for phrase in forbidden:
+            assert phrase not in output, (
+                f"forbidden phrase {phrase!r} leaked at size {size}"
+            )
+
+
+def test_blocker_message_content():
+    # Sanity: the canonical BLOCKER token used elsewhere in the cockpit.
+    assert TOO_SMALL_MESSAGE.startswith("[BLOCKER]")

--- a/tests/unit/dopemux/ui/cockpit/test_cockpit_render.py
+++ b/tests/unit/dopemux/ui/cockpit/test_cockpit_render.py
@@ -1,0 +1,185 @@
+"""Architecture-safety contract tests for the PM cockpit render."""
+
+from __future__ import annotations
+
+import pytest
+
+from dopemux.ui.cockpit.render import (
+    TOO_SMALL_MESSAGE,
+    TOP_LEVEL_MODES,
+    PaneDeclaration,
+    Top3Block,
+    pm_panes,
+    render_audit,
+    render_pm,
+    viewport_supported,
+)
+
+
+# Forbidden phrases per architecture-safety-overlay.md and the slice contract.
+FORBIDDEN_PHRASES: tuple[str, ...] = (
+    "Run History",
+    "authority: dopemux",
+    "Services authority: dopemux",
+    "command authority: dopemux",
+    "Bridge actions authority",
+    "SRC=dopemux",
+    "UNKNOWN→EDGE",
+    "UNKNOWN -> EDGE",
+    "UNKNOWN=EDGE",
+)
+
+
+# Authority strings that must appear because PM is a split surface.
+SPLIT_AUTHORITY_LABELS: tuple[str, ...] = (
+    "leantime",
+    "task-orchestrator",
+    "conport",
+    "dope-memory",
+    "dope-context",
+)
+
+
+def test_top_level_modes_are_exactly_five_in_order():
+    assert TOP_LEVEL_MODES == (
+        "PM",
+        "Implementer",
+        "Overview",
+        "Services",
+        "Events",
+    )
+
+
+def test_every_pm_pane_has_four_field_declaration():
+    panes = pm_panes()
+    assert panes, "PM pane list must not be empty"
+    for pane in panes:
+        decl = pane.declaration
+        assert isinstance(decl, PaneDeclaration)
+        # All four fields populated, no field is None or empty.
+        assert decl.domain
+        assert decl.authority
+        assert decl.role in {
+            "canonical",
+            "derived",
+            "mirrored",
+            "proxied",
+            "authoring",
+            "chrome",
+        }
+        assert decl.next_action
+        # The four header lines are emitted in canonical order.
+        lines = decl.header_lines()
+        assert lines[0].startswith("domain: ")
+        assert lines[1].startswith("authority: ")
+        assert lines[2].startswith("role: ")
+        assert lines[3].startswith("next_action: ")
+
+
+def test_split_authority_labels_present_in_render():
+    text = render_pm(cols=120, rows=40).lower()
+    for label in SPLIT_AUTHORITY_LABELS:
+        assert label in text, f"missing split-authority label: {label}"
+    # dopecon-bridge is adapter/proxy only, must appear in proxied context.
+    assert "dopecon-bridge" in text
+    assert "proxied" in text or "proxy" in text
+
+
+@pytest.mark.parametrize("size", [(120, 40), (100, 32), (80, 24)])
+def test_no_forbidden_phrases_in_any_supported_viewport(size):
+    cols, rows = size
+    text = render_pm(cols=cols, rows=rows)
+    for phrase in FORBIDDEN_PHRASES:
+        assert phrase not in text, (
+            f"forbidden phrase {phrase!r} appeared at {cols}x{rows}"
+        )
+
+
+def test_src_only_appears_on_data_rows_never_on_chrome_rail():
+    text = render_pm(cols=120, rows=40)
+    lines = text.splitlines()
+    chrome_lines = [line for line in lines if line.startswith("[chrome]")]
+    assert chrome_lines, "chrome rail must be present"
+    for line in chrome_lines:
+        assert "SRC=" not in line, f"SRC must not appear on chrome rail: {line!r}"
+    # Also: the chrome rail must not claim authority for data.
+    for line in chrome_lines:
+        assert "authority:" not in line
+
+
+def test_top3_block_contract_items_more_count_next_token():
+    block = Top3Block(
+        items=("a", "b", "c", "d"),
+        more_count=4,
+        next_token="cursor_X",
+    )
+    rendered = block.to_lines()
+    # Top-3 only.
+    assert rendered[0] == "  1. a"
+    assert rendered[1] == "  2. b"
+    assert rendered[2] == "  3. c"
+    # more_count + next_token always present.
+    assert any(line.strip().startswith("more_count:") for line in rendered)
+    assert any(line.strip().startswith("next_token:") for line in rendered)
+
+
+def test_top3_contract_visible_in_pm_render():
+    text = render_pm(cols=120, rows=40)
+    assert "more_count:" in text
+    assert "next_token:" in text
+
+
+def test_bridge_collapses_at_80x24():
+    text = render_pm(cols=80, rows=24)
+    # Bridge segregator pane title must NOT appear at minimum viewport.
+    assert "bridge segregator" not in text
+    # Bridge MUST be represented as inspector detail only.
+    assert "[inspector-detail]" in text
+    assert "dopecon-bridge" in text
+
+
+def test_bridge_pane_present_at_120x40():
+    text = render_pm(cols=120, rows=40)
+    assert "bridge segregator" in text
+
+
+def test_below_minimum_viewport_returns_blocker():
+    assert render_pm(cols=79, rows=24) == TOO_SMALL_MESSAGE
+    assert render_pm(cols=80, rows=23) == TOO_SMALL_MESSAGE
+    assert render_pm(cols=40, rows=10) == TOO_SMALL_MESSAGE
+    assert TOO_SMALL_MESSAGE.startswith("[BLOCKER]")
+
+
+def test_viewport_supported_predicate():
+    assert viewport_supported(80, 24)
+    assert viewport_supported(120, 40)
+    assert not viewport_supported(79, 24)
+    assert not viewport_supported(80, 23)
+
+
+def test_render_is_deterministic_across_calls():
+    a = render_pm(cols=120, rows=40)
+    b = render_pm(cols=120, rows=40)
+    assert a == b
+    c = render_pm(cols=100, rows=32)
+    d = render_pm(cols=100, rows=32)
+    assert c == d
+    e = render_pm(cols=80, rows=24)
+    f = render_pm(cols=80, rows=24)
+    assert e == f
+
+
+def test_render_audit_alias_matches_plain_render():
+    assert render_audit(cols=120, rows=40) == render_pm(cols=120, rows=40, plain=True)
+
+
+def test_static_demo_banner_present():
+    text = render_pm(cols=120, rows=40)
+    assert "STATIC DEMO" in text
+    assert "NO WRITES" in text
+
+
+def test_top_level_mode_bar_present_in_render():
+    text = render_pm(cols=120, rows=40)
+    for mode in TOP_LEVEL_MODES:
+        assert mode in text


### PR DESCRIPTION
## Summary
Adds the first architecture-safe PM Cockpit Textual TUI slice.
This introduces:
- deterministic PM cockpit renderer
- Textual shell wrapper
- `dopemux cockpit run --mode pm --size 120x40|100x32|80x24 [--plain|--audit]`
- PM pane contract with split authority labels
- viewport degradation rules
- architecture safety tests
- task packet `DMX-COCKPIT-PM-TEXTUAL-001`
## Architecture safety
This slice preserves the cockpit authority model:
- PM is a workflow triage/adjudication shell, not PM truth owner.
- `dopemux` is chrome/control surface only.
- task-orchestrator, Leantime, ConPort, dope-memory, and dopecon-bridge remain separate authority slices.
- Bridge remains adapter/proxy only.
- `SRC=` is provenance only and never appears on chrome rows.
- UNKNOWN is not collapsed into EDGE.
- Repo-truth-extractor is not promoted to a top-level mode.
## Viewport behavior
- `120x40`: full layout with dedicated bridge segregator.
- `100x32`: bridge appears in lower inspector/provenance region.
- `80x24`: bridge collapses inline into inspector detail.
- `<80x24`: emits `[BLOCKER] terminal too small`.
## Validation
Passed:
- cockpit unit suite: `25 passed`
- broad unit lane: `tests/unit`, excluding ConPort: all passed
- quarantined skips: `2`, expected
- forbidden-string scan over cockpit runtime + command module: clean
- deterministic render checks
- Top-3 contract checks:
  - `items`
  - `more_count`
  - `next_token`
- `SRC=` absence on chrome rows
- no `dopemux` authority collapse
## Not included
This PR does not add:
- live PM writes
- Leantime/task-orchestrator/ConPort integration
- bridge-routed workflow transitions
- Implementer runtime mode beyond scaffold/top-level mode visibility
- Claude Design final-screen readiness