### PR TITLE
Add deterministic runtime authority verifier

### DIFF
--- a/config/runtime_authority_manifest.json
+++ b/config/runtime_authority_manifest.json
@@ -1,0 +1,511 @@
+{
+  "authority_rules": [
+    "Runtime code, config, and tests outrank generated docs.",
+    "Static verification must not call network services or mutate production state.",
+    "Bridge, proxy, retrieval, and mirror surfaces must not be promoted to PM-plane authority."
+  ],
+  "forbidden_legacy_targets": [
+    {
+      "expected_conflict": false,
+      "paths": [
+        "compose.yml",
+        "services/task-orchestrator/Dockerfile"
+      ],
+      "reason": "task_orchestrator.app hard-fails and is not the supported task-orchestrator runtime.",
+      "system": "task-orchestrator",
+      "target": "task_orchestrator.app:app"
+    }
+  ],
+  "generated_by": "TP-DMX-RUNTIME-VERIFY-001",
+  "known_conflicts": [
+    {
+      "evidence": [
+        {
+          "path": "services/dope-memory/mcp_stdio_adapter.py",
+          "patterns": [
+            "8096"
+          ]
+        },
+        {
+          "path": "scripts/mcp_smoke.sh",
+          "patterns": [
+            "8096"
+          ]
+        }
+      ],
+      "expected": "dope-memory registry and compose port 3020",
+      "observed": "legacy dope-memory adapter and smoke references still point at 8096",
+      "system": "dope-memory",
+      "type": "port_conflict"
+    },
+    {
+      "evidence": [
+        {
+          "path": "docker/mcp-servers-source/services/task-orchestrator/Dockerfile",
+          "patterns": [
+            "3014"
+          ]
+        },
+        {
+          "path": "services/mcp-integration-bridge/main.py",
+          "patterns": [
+            "3014"
+          ]
+        }
+      ],
+      "expected": "task-orchestrator registry and compose port 8000",
+      "observed": "legacy MCP bridge surfaces still reference 3014",
+      "system": "task-orchestrator",
+      "type": "port_conflict"
+    },
+    {
+      "evidence": [
+        {
+          "path": "docs/03-reference/truth/truth-canonicals.md",
+          "patterns": [
+            "src/conport/memory_server.py"
+          ]
+        },
+        {
+          "path": "compose.yml",
+          "patterns": [
+            "docker/mcp-servers/conport/Dockerfile"
+          ]
+        },
+        {
+          "path": "docker/mcp-servers/conport/Dockerfile",
+          "patterns": [
+            "docker/mcp-servers-source/conport/enhanced_server.py",
+            "docker/mcp-servers-source/conport/server.py"
+          ]
+        }
+      ],
+      "expected": "ConPort canonicality remains split between source-level memory_server.py and deployed Docker wrapper surfaces",
+      "observed": "runtime source and deployed container entrypoints are not the same file family",
+      "system": "ConPort",
+      "type": "runtime_pointer_conflict"
+    }
+  ],
+  "repo_identity": {
+    "origin_hint": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "require_identity_match": true
+  },
+  "schema_version": "1.0",
+  "systems": [
+    {
+      "authority_notes": [
+        "pyproject.toml exposes the dopemux console script through dopemux.cli:main.",
+        "src/dopemux/cli.py contains the active Click command tree."
+      ],
+      "authority_status": "canonical",
+      "expected_entrypoints": [
+        "dopemux = dopemux.cli:main"
+      ],
+      "expected_paths": [
+        {
+          "path": "src/dopemux/cli.py",
+          "required": true,
+          "role": "CLI runtime"
+        },
+        {
+          "path": "pyproject.toml",
+          "required": true,
+          "role": "console-script declaration"
+        }
+      ],
+      "expected_ports": [],
+      "system": "dopemux",
+      "validation_mode": "static_required"
+    },
+    {
+      "authority_notes": [
+        "scripts/dopetask enforces .dopetaskroot and .dopetask-pin before executing the pinned dopetask binary.",
+        "scripts/taskx is a compatibility shim, not a separate runtime."
+      ],
+      "authority_status": "canonical",
+      "expected_entrypoints": [
+        "scripts/dopetask"
+      ],
+      "expected_paths": [
+        {
+          "path": "scripts/dopetask",
+          "required": true,
+          "role": "dopetask wrapper runtime"
+        },
+        {
+          "path": ".dopetaskroot",
+          "required": true,
+          "role": "repo identity marker"
+        },
+        {
+          "path": ".dopetask-pin",
+          "required": true,
+          "role": "dopetask dependency pin"
+        },
+        {
+          "path": "scripts/taskx",
+          "required": true,
+          "role": "compatibility shim"
+        }
+      ],
+      "expected_ports": [],
+      "system": "dopetask",
+      "validation_mode": "static_required",
+      "wrapper_mappings": [
+        {
+          "expected_conflict": false,
+          "expected_contains": [
+            "/dopetask\" \"$@\""
+          ],
+          "path": "scripts/taskx",
+          "role": "taskx delegates to dopetask"
+        }
+      ]
+    },
+    {
+      "authority_notes": [
+        "app/main.py is the supported FastAPI runtime.",
+        "task_orchestrator/app.py hard-fails and must not be used as runtime authority.",
+        "Registry and compose use port 8000; legacy surfaces still mention 3014."
+      ],
+      "authority_status": "expected_conflict",
+      "expected_entrypoints": [
+        "uvicorn app.main:app --host 0.0.0.0 --port 8000",
+        "services/task-orchestrator/mcp_stdio.py"
+      ],
+      "expected_paths": [
+        {
+          "path": "services/task-orchestrator/app/main.py",
+          "required": true,
+          "role": "HTTP runtime"
+        },
+        {
+          "path": "services/task-orchestrator/mcp_stdio.py",
+          "required": true,
+          "role": "stdio MCP wrapper"
+        },
+        {
+          "path": "services/task-orchestrator/Dockerfile",
+          "required": true,
+          "role": "container entrypoint"
+        },
+        {
+          "path": "services/task-orchestrator/task_orchestrator/app.py",
+          "required": true,
+          "role": "hard-failing legacy runtime marker"
+        }
+      ],
+      "expected_ports": [
+        {
+          "compose_service": "task-orchestrator",
+          "container_port": 8000,
+          "host_port": 8000,
+          "registry_service": "task-orchestrator"
+        }
+      ],
+      "system": "task-orchestrator",
+      "validation_mode": "static_required",
+      "wrapper_mappings": [
+        {
+          "expected_conflict": false,
+          "expected_contains": [
+            "from app.main import mcp"
+          ],
+          "path": "services/task-orchestrator/mcp_stdio.py",
+          "role": "stdio wrapper delegates to app.main MCP object"
+        },
+        {
+          "expected_conflict": false,
+          "expected_contains": [
+            "app.main:app"
+          ],
+          "forbidden_contains": [
+            "task_orchestrator.app:app"
+          ],
+          "path": "services/task-orchestrator/Dockerfile",
+          "role": "container starts canonical app/main.py runtime"
+        }
+      ]
+    },
+    {
+      "authority_notes": [
+        "ConPort runtime authority is conflicted between source-level memory_server.py docs and deployed docker/mcp-servers-source/conport surfaces.",
+        "This verifier records the conflict without selecting a single canonical file."
+      ],
+      "authority_status": "expected_conflict",
+      "expected_entrypoints": [
+        "docker/mcp-servers-source/conport/start_with_info.sh",
+        "src/conport/memory_server.py"
+      ],
+      "expected_paths": [
+        {
+          "path": "docker/mcp-servers/conport/Dockerfile",
+          "required": true,
+          "role": "compose container Dockerfile"
+        },
+        {
+          "path": "docker/mcp-servers-source/conport/start_with_info.sh",
+          "required": true,
+          "role": "container process supervisor"
+        },
+        {
+          "path": "docker/mcp-servers-source/conport/enhanced_server.py",
+          "required": true,
+          "role": "container HTTP API runtime"
+        },
+        {
+          "path": "docker/mcp-servers-source/conport/server.py",
+          "required": true,
+          "role": "container MCP runtime"
+        },
+        {
+          "path": "src/conport/memory_server.py",
+          "required": true,
+          "role": "source-level ConPort runtime candidate"
+        }
+      ],
+      "expected_ports": [
+        {
+          "compose_service": "conport",
+          "container_port": 3004,
+          "host_port": 3004,
+          "registry_service": "conport-http"
+        },
+        {
+          "compose_service": "conport",
+          "container_port": 3005,
+          "host_port": 3005,
+          "registry_service": "conport-mcp"
+        }
+      ],
+      "system": "ConPort",
+      "validation_mode": "static_required"
+    },
+    {
+      "authority_notes": [
+        "dope_memory_main.py is the HTTP runtime and uses canonical_ledger.py for ledger path resolution.",
+        "The dope-memory surface is not canonical PM status authority."
+      ],
+      "authority_status": "canonical_memory_sink",
+      "expected_entrypoints": [
+        "python dope_memory_main.py"
+      ],
+      "expected_paths": [
+        {
+          "path": "services/working-memory-assistant/dope_memory_main.py",
+          "required": true,
+          "role": "Dope-Memory HTTP runtime"
+        },
+        {
+          "path": "services/working-memory-assistant/canonical_ledger.py",
+          "required": true,
+          "role": "canonical ledger resolver"
+        },
+        {
+          "path": "services/working-memory-assistant/Dockerfile.dope-memory",
+          "required": true,
+          "role": "container entrypoint"
+        }
+      ],
+      "expected_ports": [
+        {
+          "compose_service": "dope-memory",
+          "container_port": 3020,
+          "host_port": 3020,
+          "registry_service": "dope-memory"
+        }
+      ],
+      "system": "dope-memory",
+      "validation_mode": "static_required",
+      "wrapper_mappings": [
+        {
+          "expected_conflict": true,
+          "expected_contains": [
+            "http://localhost:8096/tools"
+          ],
+          "path": "services/dope-memory/mcp_stdio_adapter.py",
+          "role": "legacy stdio adapter targets stale port"
+        }
+      ]
+    },
+    {
+      "authority_notes": [
+        "Dope-Context is a retrieval/search surface and must not be promoted to PM authority.",
+        "Dockerfile starts python -m src.mcp.server; runtime port is resolved from MCP_SERVER_PORT with 3010 default."
+      ],
+      "authority_status": "canonical_retrieval_surface",
+      "expected_entrypoints": [
+        "python -m src.mcp.server"
+      ],
+      "expected_paths": [
+        {
+          "path": "services/dope-context/src/mcp/server.py",
+          "required": true,
+          "role": "FastMCP runtime"
+        },
+        {
+          "path": "services/dope-context/Dockerfile",
+          "required": true,
+          "role": "container entrypoint"
+        },
+        {
+          "path": "contracts/dope-context/search.response.schema.json",
+          "required": true,
+          "role": "search response contract"
+        }
+      ],
+      "expected_ports": [
+        {
+          "compose_service": "dope-context",
+          "container_port": 3010,
+          "host_port": 3010,
+          "registry_service": "dope-context"
+        }
+      ],
+      "system": "dope-context",
+      "validation_mode": "static_required"
+    },
+    {
+      "authority_notes": [
+        "DopeconBridge is an adapter/proxy/router layer only.",
+        "routes.py states it must not act as canonical task, workflow, decision, or progress authority."
+      ],
+      "authority_status": "non_authoritative_adapter",
+      "expected_entrypoints": [
+        "python -m dopecon_bridge.app",
+        "python main.py"
+      ],
+      "expected_paths": [
+        {
+          "path": "services/dopecon-bridge/main.py",
+          "required": true,
+          "role": "FastAPI app assembly"
+        },
+        {
+          "path": "services/dopecon-bridge/dopecon_bridge/app.py",
+          "required": true,
+          "role": "package entrypoint wrapper"
+        },
+        {
+          "path": "services/dopecon-bridge/dopecon_bridge/routes.py",
+          "required": true,
+          "role": "route and non-authority boundary declarations"
+        },
+        {
+          "path": "services/dopecon-bridge/Dockerfile",
+          "required": true,
+          "role": "container entrypoint"
+        }
+      ],
+      "expected_ports": [
+        {
+          "compose_service": "dopecon-bridge",
+          "container_port": 3016,
+          "host_port": 3016,
+          "registry_service": "dopecon-bridge"
+        }
+      ],
+      "system": "dopecon-bridge",
+      "validation_mode": "static_required",
+      "wrapper_mappings": [
+        {
+          "expected_conflict": false,
+          "expected_contains": [
+            "from main import app as _legacy_app"
+          ],
+          "path": "services/dopecon-bridge/dopecon_bridge/app.py",
+          "role": "package entrypoint delegates to unified main.py app"
+        },
+        {
+          "expected_conflict": false,
+          "expected_contains": [
+            "must not act as",
+            "canonical task, workflow, decision, or progress authority"
+          ],
+          "path": "services/dopecon-bridge/dopecon_bridge/routes.py",
+          "role": "non-authority boundary text"
+        }
+      ]
+    },
+    {
+      "authority_notes": [
+        "services/adhd_engine is the composed runtime; services/adhd-engine is duplicate residue.",
+        "The ADHD Engine is cognitive support, not PM authority."
+      ],
+      "authority_status": "canonical_support_surface",
+      "expected_entrypoints": [
+        "uvicorn services.adhd_engine.main:app --host 0.0.0.0 --port 8095"
+      ],
+      "expected_paths": [
+        {
+          "path": "services/adhd_engine/main.py",
+          "required": true,
+          "role": "FastAPI runtime"
+        },
+        {
+          "path": "services/adhd_engine/Dockerfile",
+          "required": true,
+          "role": "container entrypoint"
+        },
+        {
+          "path": "services/adhd-engine/auth.py",
+          "required": false,
+          "role": "hyphenated duplicate residue"
+        }
+      ],
+      "expected_ports": [
+        {
+          "compose_service": "adhd-engine",
+          "container_port": 8095,
+          "host_port": 3025,
+          "registry_service": "adhd-engine"
+        }
+      ],
+      "system": "ADHD Engine",
+      "validation_mode": "static_required"
+    },
+    {
+      "authority_notes": [
+        "run_extraction_v5.py is the canonical repo-truth extraction runtime.",
+        "dopemux rte run and compatibility aliases should route to the v5 runner family; dopemux truth is no longer supported."
+      ],
+      "authority_status": "canonical",
+      "expected_entrypoints": [
+        "dopemux rte run",
+        "services/repo-truth-extractor/run_extraction_v5.py"
+      ],
+      "expected_paths": [
+        {
+          "path": "services/repo-truth-extractor/run_extraction_v5.py",
+          "required": true,
+          "role": "canonical extraction runner"
+        },
+        {
+          "path": "src/dopemux/commands/extract_commands.py",
+          "required": true,
+          "role": "dopemux rte run command implementation"
+        },
+        {
+          "path": "src/dopemux/cli.py",
+          "required": true,
+          "role": "CLI command registration"
+        }
+      ],
+      "expected_ports": [],
+      "system": "Repo Truth Extractor",
+      "validation_mode": "static_required"
+    }
+  ],
+  "wrapper_mappings": [
+    {
+      "expected_conflict": false,
+      "expected_contains": [
+        "/dopetask\" \"$@\""
+      ],
+      "path": "scripts/taskx",
+      "role": "taskx delegates to dopetask",
+      "system": "dopetask"
+    }
+  ]
+}

--- a/docs/03-reference/runtime-authority-verification.md
+++ b/docs/03-reference/runtime-authority-verification.md
@@ -26,7 +26,13 @@ artifact inspection.
 - Forbidden legacy targets are not referenced from declared active launch files.
 - Known drift is reported as expected conflict instead of silently normalized.
 
-Static mode performs no network calls and does not mutate production state.
+Static mode does not perform external network I/O and does not mutate
+production state. When `repo_identity.require_identity_match` is enabled in the
+manifest, the verifier may still invoke local `git` commands such as
+`git remote get-url origin` to inspect repository identity. In that mode,
+operators need `git` available and an `origin` remote configured in the
+checkout, or they should disable the identity-match requirement in the
+manifest for non-git environments.
 
 ## Authority Boundaries
 
@@ -47,9 +53,9 @@ authority by this manifest:
 ## Commands
 
 ```bash
-python -m json.tool config/runtime_authority_manifest.json
-python -m pytest -q tests/unit/test_runtime_authority_manifest.py
-python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --check static
+python3 -m json.tool config/runtime_authority_manifest.json
+python3 -m pytest -q tests/unit/test_runtime_authority_manifest.py
+python3 scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --check static
 ```
 
 ## Failure Handling

--- a/docs/03-reference/runtime-authority-verification.md
+++ b/docs/03-reference/runtime-authority-verification.md
@@ -4,9 +4,12 @@ title: Runtime Authority Verification
 type: reference
 owner: '@hu3mann'
 date: '2026-04-30'
-prelude: Static runtime authority verification harness for Dopemux entrypoints, ports, wrappers, and known drift.
+prelude: Static runtime authority verification harness for Dopemux entrypoints, ports,
+  wrappers, and known drift.
+author: '@hu3mann'
+last_review: '2026-04-30'
+next_review: '2026-07-29'
 ---
-
 # Runtime Authority Verification
 
 ## Purpose

--- a/docs/03-reference/runtime-authority-verification.md
+++ b/docs/03-reference/runtime-authority-verification.md
@@ -1,0 +1,75 @@
+---
+id: runtime_authority_verification
+title: Runtime Authority Verification
+type: reference
+owner: '@hu3mann'
+date: '2026-04-30'
+prelude: Static runtime authority verification harness for Dopemux entrypoints, ports, wrappers, and known drift.
+---
+
+# Runtime Authority Verification
+
+## Purpose
+
+`scripts/verify_runtime_authority.py` checks the static authority manifest at
+`config/runtime_authority_manifest.json`.
+
+The verifier supports runtime truth review. It does not replace runtime
+execution, container startup, health probes, integration tests, or generated
+artifact inspection.
+
+## What Static Mode Checks
+
+- Required runtime pointer files exist.
+- Registry and compose port declarations match the manifest.
+- Wrapper files still delegate to their expected targets.
+- Forbidden legacy targets are not referenced from declared active launch files.
+- Known drift is reported as expected conflict instead of silently normalized.
+
+Static mode performs no network calls and does not mutate production state.
+
+## Authority Boundaries
+
+Runtime code, config, and tests outrank generated docs. Generated and derived
+truth docs are useful evidence, but the verifier intentionally checks active
+code/config surfaces first.
+
+Bridge, proxy, retrieval, and mirror services are not promoted to PM-plane
+authority by this manifest:
+
+- DopeconBridge remains an adapter/proxy/router layer.
+- Dope-Context remains a retrieval/search surface.
+- Dope-Memory remains a durable memory sink and mirror receipt surface, not PM
+  status authority.
+- ConPort conflict is reported rather than resolved because source-level and
+  deployed runtime pointers still diverge.
+
+## Commands
+
+```bash
+python -m json.tool config/runtime_authority_manifest.json
+python -m pytest -q tests/unit/test_runtime_authority_manifest.py
+python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --check static
+```
+
+## Failure Handling
+
+Unexpected missing required files are errors and produce a nonzero exit.
+
+Expected conflicts are warnings. They mean the repo still contains known drift,
+not that the verifier accepted the drift as resolved runtime truth.
+
+If an `UNKNOWN` surface is added to the manifest, keep its validation advisory
+and avoid asserting runtime authority until code/config evidence proves it.
+
+## Proof Expectations
+
+For manifest-only changes, proof requires JSON parsing and the unit test above.
+
+For verifier logic changes, proof requires the unit test and a direct static
+verifier invocation against the checked-in manifest.
+
+For runtime entrypoint, port, or wrapper changes, static verification is only the
+first proof layer. Follow it with the narrow runtime check for the touched
+surface, such as a container start, service health check, CLI invocation, or
+artifact-generation flow.

--- a/scripts/verify_runtime_authority.py
+++ b/scripts/verify_runtime_authority.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Deterministic static verifier for Dopemux runtime authority pointers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REQUIRED_SYSTEM_KEYS = {"system", "expected_paths", "authority_status", "validation_mode"}
+ERROR = "error"
+WARNING = "warning"
+INFO = "info"
+
+
+def _finding(
+    *,
+    severity: str,
+    code: str,
+    system: str,
+    message: str,
+    path: str | None = None,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    finding: dict[str, Any] = {
+        "code": code,
+        "message": message,
+        "severity": severity,
+        "system": system,
+    }
+    if path is not None:
+        finding["path"] = path
+    if details:
+        finding["details"] = details
+    return finding
+
+
+def _sort_findings(findings: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    severity_order = {ERROR: 0, WARNING: 1, INFO: 2}
+    return sorted(
+        findings,
+        key=lambda item: (
+            severity_order.get(str(item.get("severity")), 99),
+            str(item.get("system", "")),
+            str(item.get("code", "")),
+            str(item.get("path", "")),
+            str(item.get("message", "")),
+        ),
+    )
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("manifest root must be a JSON object")
+    return payload
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    try:
+        import yaml
+    except ImportError as exc:  # pragma: no cover - PyYAML is present in repo test envs
+        raise RuntimeError("PyYAML is required for static registry and compose checks") from exc
+
+    if not path.exists():
+        return {}
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def _path_text(repo_root: Path, rel_path: str) -> str:
+    return (repo_root / rel_path).read_text(encoding="utf-8", errors="replace")
+
+
+def _path_exists(repo_root: Path, rel_path: str) -> bool:
+    return (repo_root / rel_path).exists()
+
+
+def _entry_path(entry: str | dict[str, Any]) -> str:
+    if isinstance(entry, str):
+        return entry
+    return str(entry.get("path", ""))
+
+
+def _entry_required(entry: str | dict[str, Any], *, system_status: str, validation_mode: str) -> bool:
+    if system_status == "unknown" or validation_mode == "advisory":
+        return False
+    if isinstance(entry, str):
+        return True
+    return bool(entry.get("required", True))
+
+
+def _registry_services(repo_root: Path) -> dict[str, dict[str, Any]]:
+    payload = _load_yaml(repo_root / "services" / "registry.yaml")
+    services = payload.get("services", [])
+    if not isinstance(services, list):
+        return {}
+    return {
+        str(item.get("name")): item
+        for item in services
+        if isinstance(item, dict) and item.get("name")
+    }
+
+
+def _compose_services(repo_root: Path) -> dict[str, dict[str, Any]]:
+    payload = _load_yaml(repo_root / "compose.yml")
+    services = payload.get("services", {})
+    if not isinstance(services, dict):
+        return {}
+    return {
+        str(name): cfg
+        for name, cfg in services.items()
+        if isinstance(cfg, dict)
+    }
+
+
+def _defaulted_port(value: str) -> int | None:
+    text = value.strip()
+    match = re.fullmatch(r"\$\{[^:}]+:-(\d+)\}", text)
+    if match:
+        return int(match.group(1))
+    if text.isdigit():
+        return int(text)
+    return None
+
+
+def _compose_ports(compose_cfg: dict[str, Any]) -> set[tuple[int | None, int | None]]:
+    ports = compose_cfg.get("ports", [])
+    resolved: set[tuple[int | None, int | None]] = set()
+    if not isinstance(ports, list):
+        return resolved
+
+    for item in ports:
+        if isinstance(item, str):
+            match = re.fullmatch(r"(?P<host>\$\{[^}]+\}|\d+):(?P<container>\d+)", item.strip())
+            if match:
+                resolved.add((_defaulted_port(match.group("host")), _defaulted_port(match.group("container"))))
+        elif isinstance(item, dict):
+            published = item.get("published")
+            target = item.get("target")
+            resolved.add(
+                (
+                    int(published) if isinstance(published, int) else _defaulted_port(str(published)),
+                    int(target) if isinstance(target, int) else _defaulted_port(str(target)),
+                )
+            )
+    return resolved
+
+
+def _check_repo_identity(manifest: dict[str, Any], repo_root: Path) -> list[dict[str, Any]]:
+    identity = manifest.get("repo_identity", {})
+    if not isinstance(identity, dict):
+        return []
+
+    findings: list[dict[str, Any]] = []
+    marker = str(identity.get("repo_marker") or "")
+    if marker and not _path_exists(repo_root, marker):
+        findings.append(
+            _finding(
+                severity=ERROR,
+                code="repo_marker_missing",
+                system="repo",
+                path=marker,
+                message=f"Required repo marker is missing: {marker}",
+            )
+        )
+
+    if identity.get("require_identity_match"):
+        hint = str(identity.get("origin_hint") or "").strip()
+        if hint:
+            result = subprocess.run(
+                ["git", "remote", "get-url", "origin"],
+                cwd=repo_root,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            origin = result.stdout.strip()
+            if result.returncode != 0:
+                findings.append(
+                    _finding(
+                        severity=ERROR,
+                        code="origin_unreadable",
+                        system="repo",
+                        message=(result.stderr or "Could not read origin remote").strip(),
+                    )
+                )
+            elif hint not in origin:
+                findings.append(
+                    _finding(
+                        severity=ERROR,
+                        code="origin_mismatch",
+                        system="repo",
+                        message=f"Origin remote does not contain required hint {hint!r}",
+                        details={"origin": origin},
+                    )
+                )
+    return findings
+
+
+def _check_system_entries(manifest: dict[str, Any], repo_root: Path) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    systems = manifest.get("systems", [])
+    if not isinstance(systems, list):
+        return [
+            _finding(
+                severity=ERROR,
+                code="manifest_systems_invalid",
+                system="manifest",
+                message="Manifest field 'systems' must be a list.",
+            )
+        ]
+
+    for system_entry in sorted(systems, key=lambda item: str(item.get("system", "")) if isinstance(item, dict) else ""):
+        if not isinstance(system_entry, dict):
+            findings.append(
+                _finding(
+                    severity=ERROR,
+                    code="manifest_system_invalid",
+                    system="manifest",
+                    message="Each system entry must be a JSON object.",
+                )
+            )
+            continue
+
+        system = str(system_entry.get("system") or "UNKNOWN")
+        missing_keys = REQUIRED_SYSTEM_KEYS - set(system_entry)
+        if missing_keys:
+            findings.append(
+                _finding(
+                    severity=ERROR,
+                    code="manifest_required_key_missing",
+                    system=system,
+                    message=f"System entry is missing required keys: {', '.join(sorted(missing_keys))}",
+                )
+            )
+
+        status = str(system_entry.get("authority_status", "unknown"))
+        validation_mode = str(system_entry.get("validation_mode", "advisory"))
+        if status == "expected_conflict":
+            findings.append(
+                _finding(
+                    severity=WARNING,
+                    code="expected_authority_conflict",
+                    system=system,
+                    message="Manifest marks this runtime authority surface as an expected conflict.",
+                )
+            )
+        if status == "unknown":
+            findings.append(
+                _finding(
+                    severity=INFO,
+                    code="unknown_authority_not_asserted",
+                    system=system,
+                    message="Manifest marks authority unknown; required-path assertions are advisory only.",
+                )
+            )
+
+        expected_paths = system_entry.get("expected_paths", [])
+        if not isinstance(expected_paths, list):
+            findings.append(
+                _finding(
+                    severity=ERROR,
+                    code="expected_paths_invalid",
+                    system=system,
+                    message="expected_paths must be a list.",
+                )
+            )
+            continue
+
+        for path_entry in sorted(expected_paths, key=_entry_path):
+            rel_path = _entry_path(path_entry)
+            if not rel_path:
+                findings.append(
+                    _finding(
+                        severity=ERROR,
+                        code="expected_path_blank",
+                        system=system,
+                        message="Expected path entry is blank.",
+                    )
+                )
+                continue
+            if not _path_exists(repo_root, rel_path):
+                required = _entry_required(path_entry, system_status=status, validation_mode=validation_mode)
+                findings.append(
+                    _finding(
+                        severity=ERROR if required else WARNING,
+                        code="expected_path_missing",
+                        system=system,
+                        path=rel_path,
+                        message=f"Expected runtime authority path is missing: {rel_path}",
+                    )
+                )
+
+        findings.extend(_check_wrapper_mappings(system_entry.get("wrapper_mappings", []), repo_root, default_system=system))
+
+    return findings
+
+
+def _check_ports(manifest: dict[str, Any], repo_root: Path) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    registry = _registry_services(repo_root)
+    compose = _compose_services(repo_root)
+
+    systems = manifest.get("systems", [])
+    if not isinstance(systems, list):
+        return findings
+
+    for system_entry in sorted(systems, key=lambda item: str(item.get("system", "")) if isinstance(item, dict) else ""):
+        if not isinstance(system_entry, dict):
+            continue
+        system = str(system_entry.get("system") or "UNKNOWN")
+        expected_ports = system_entry.get("expected_ports", [])
+        if not isinstance(expected_ports, list):
+            findings.append(
+                _finding(
+                    severity=ERROR,
+                    code="expected_ports_invalid",
+                    system=system,
+                    message="expected_ports must be a list.",
+                )
+            )
+            continue
+
+        for port_entry in sorted(expected_ports, key=lambda item: str(item.get("registry_service", "")) if isinstance(item, dict) else ""):
+            if not isinstance(port_entry, dict):
+                continue
+            registry_name = str(port_entry.get("registry_service") or "")
+            compose_name = str(port_entry.get("compose_service") or registry_name)
+            expected_host = int(port_entry["host_port"])
+            expected_container = int(port_entry["container_port"])
+
+            registry_entry = registry.get(registry_name)
+            if registry_entry is None:
+                findings.append(
+                    _finding(
+                        severity=ERROR,
+                        code="registry_service_missing",
+                        system=system,
+                        message=f"Registry service is missing: {registry_name}",
+                    )
+                )
+            else:
+                actual_host = registry_entry.get("port")
+                actual_container = registry_entry.get("container_port", actual_host)
+                if actual_host != expected_host or actual_container != expected_container:
+                    findings.append(
+                        _finding(
+                            severity=ERROR,
+                            code="registry_port_mismatch",
+                            system=system,
+                            message=f"Registry port mismatch for {registry_name}",
+                            details={
+                                "actual_container_port": actual_container,
+                                "actual_host_port": actual_host,
+                                "expected_container_port": expected_container,
+                                "expected_host_port": expected_host,
+                            },
+                        )
+                    )
+
+            compose_entry = compose.get(compose_name)
+            if compose_entry is None:
+                findings.append(
+                    _finding(
+                        severity=ERROR,
+                        code="compose_service_missing",
+                        system=system,
+                        message=f"Compose service is missing: {compose_name}",
+                    )
+                )
+                continue
+            compose_ports = _compose_ports(compose_entry)
+            if (expected_host, expected_container) not in compose_ports:
+                findings.append(
+                    _finding(
+                        severity=ERROR,
+                        code="compose_port_mismatch",
+                        system=system,
+                        message=f"Compose port mapping mismatch for {compose_name}",
+                        details={
+                            "actual_mappings": sorted([list(item) for item in compose_ports]),
+                            "expected_mapping": [expected_host, expected_container],
+                        },
+                    )
+                )
+
+    return findings
+
+
+def _check_wrapper_mappings(
+    mappings: Any,
+    repo_root: Path,
+    *,
+    default_system: str = "manifest",
+) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    if not mappings:
+        return findings
+    if not isinstance(mappings, list):
+        return [
+            _finding(
+                severity=ERROR,
+                code="wrapper_mappings_invalid",
+                system=default_system,
+                message="wrapper_mappings must be a list.",
+            )
+        ]
+
+    for mapping in sorted(mappings, key=lambda item: str(item.get("path", "")) if isinstance(item, dict) else ""):
+        if not isinstance(mapping, dict):
+            continue
+        system = str(mapping.get("system") or default_system)
+        rel_path = str(mapping.get("path") or "")
+        expected_conflict = bool(mapping.get("expected_conflict", False))
+        if not rel_path:
+            findings.append(
+                _finding(
+                    severity=ERROR,
+                    code="wrapper_path_blank",
+                    system=system,
+                    message="Wrapper mapping path is blank.",
+                )
+            )
+            continue
+        if not _path_exists(repo_root, rel_path):
+            findings.append(
+                _finding(
+                    severity=ERROR if not expected_conflict else WARNING,
+                    code="wrapper_path_missing",
+                    system=system,
+                    path=rel_path,
+                    message=f"Wrapper mapping file is missing: {rel_path}",
+                )
+            )
+            continue
+
+        text = _path_text(repo_root, rel_path)
+        for expected in sorted(mapping.get("expected_contains", [])):
+            if expected not in text:
+                findings.append(
+                    _finding(
+                        severity=ERROR if not expected_conflict else WARNING,
+                        code="wrapper_expected_target_missing",
+                        system=system,
+                        path=rel_path,
+                        message=f"Wrapper file does not contain expected target text: {expected}",
+                    )
+                )
+            elif expected_conflict:
+                findings.append(
+                    _finding(
+                        severity=WARNING,
+                        code="expected_wrapper_conflict_observed",
+                        system=system,
+                        path=rel_path,
+                        message=f"Expected wrapper conflict remains present: {expected}",
+                    )
+                )
+
+        for forbidden in sorted(mapping.get("forbidden_contains", [])):
+            if forbidden in text:
+                findings.append(
+                    _finding(
+                        severity=ERROR if not expected_conflict else WARNING,
+                        code="wrapper_forbidden_target_present",
+                        system=system,
+                        path=rel_path,
+                        message=f"Wrapper file contains forbidden target text: {forbidden}",
+                    )
+                )
+
+    return findings
+
+
+def _check_forbidden_legacy_targets(manifest: dict[str, Any], repo_root: Path) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    targets = manifest.get("forbidden_legacy_targets", [])
+    if not isinstance(targets, list):
+        return [
+            _finding(
+                severity=ERROR,
+                code="forbidden_legacy_targets_invalid",
+                system="manifest",
+                message="forbidden_legacy_targets must be a list.",
+            )
+        ]
+
+    for target in sorted(targets, key=lambda item: str(item.get("target", "")) if isinstance(item, dict) else ""):
+        if not isinstance(target, dict):
+            continue
+        system = str(target.get("system") or "manifest")
+        needle = str(target.get("target") or "")
+        expected_conflict = bool(target.get("expected_conflict", False))
+        for rel_path in sorted(target.get("paths", [])):
+            if not _path_exists(repo_root, str(rel_path)):
+                findings.append(
+                    _finding(
+                        severity=ERROR,
+                        code="forbidden_target_scan_path_missing",
+                        system=system,
+                        path=str(rel_path),
+                        message=f"Cannot scan missing forbidden-target path: {rel_path}",
+                    )
+                )
+                continue
+            if needle and needle in _path_text(repo_root, str(rel_path)):
+                findings.append(
+                    _finding(
+                        severity=WARNING if expected_conflict else ERROR,
+                        code="forbidden_legacy_target_present",
+                        system=system,
+                        path=str(rel_path),
+                        message=f"Forbidden legacy target is referenced: {needle}",
+                    )
+                )
+    return findings
+
+
+def _check_known_conflicts(manifest: dict[str, Any], repo_root: Path) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    conflicts = manifest.get("known_conflicts", [])
+    if not isinstance(conflicts, list):
+        return [
+            _finding(
+                severity=ERROR,
+                code="known_conflicts_invalid",
+                system="manifest",
+                message="known_conflicts must be a list.",
+            )
+        ]
+
+    for conflict in sorted(conflicts, key=lambda item: (str(item.get("system", "")), str(item.get("type", ""))) if isinstance(item, dict) else ("", "")):
+        if not isinstance(conflict, dict):
+            continue
+        system = str(conflict.get("system") or "UNKNOWN")
+        conflict_type = str(conflict.get("type") or "conflict")
+        observed_paths: list[str] = []
+        missing_paths: list[str] = []
+        for evidence in conflict.get("evidence", []):
+            if not isinstance(evidence, dict):
+                continue
+            rel_path = str(evidence.get("path") or "")
+            if not rel_path:
+                continue
+            if not _path_exists(repo_root, rel_path):
+                missing_paths.append(rel_path)
+                continue
+            text = _path_text(repo_root, rel_path)
+            patterns = [str(pattern) for pattern in evidence.get("patterns", [])]
+            if all(pattern in text for pattern in patterns):
+                observed_paths.append(rel_path)
+
+        if observed_paths:
+            findings.append(
+                _finding(
+                    severity=WARNING,
+                    code=f"expected_{conflict_type}",
+                    system=system,
+                    message=str(conflict.get("observed") or "Expected conflict remains present."),
+                    details={
+                        "expected": conflict.get("expected"),
+                        "observed_paths": sorted(observed_paths),
+                    },
+                )
+            )
+        elif missing_paths:
+            findings.append(
+                _finding(
+                    severity=WARNING,
+                    code=f"expected_{conflict_type}_evidence_missing",
+                    system=system,
+                    message="Expected-conflict evidence path is missing.",
+                    details={"missing_paths": sorted(missing_paths)},
+                )
+            )
+        else:
+            findings.append(
+                _finding(
+                    severity=INFO,
+                    code=f"expected_{conflict_type}_not_observed",
+                    system=system,
+                    message="Expected conflict was not observed in the declared evidence paths.",
+                )
+            )
+    return findings
+
+
+def verify_manifest(manifest: dict[str, Any], repo_root: Path) -> dict[str, Any]:
+    """Run deterministic static checks and return a machine-readable report."""
+    findings: list[dict[str, Any]] = []
+    findings.extend(_check_repo_identity(manifest, repo_root))
+    findings.extend(_check_system_entries(manifest, repo_root))
+    findings.extend(_check_wrapper_mappings(manifest.get("wrapper_mappings", []), repo_root))
+    findings.extend(_check_forbidden_legacy_targets(manifest, repo_root))
+    findings.extend(_check_ports(manifest, repo_root))
+    findings.extend(_check_known_conflicts(manifest, repo_root))
+
+    sorted_findings = _sort_findings(findings)
+    summary = {
+        "errors": sum(1 for finding in sorted_findings if finding["severity"] == ERROR),
+        "infos": sum(1 for finding in sorted_findings if finding["severity"] == INFO),
+        "warnings": sum(1 for finding in sorted_findings if finding["severity"] == WARNING),
+    }
+    return {
+        "check": "static",
+        "findings": sorted_findings,
+        "ok": summary["errors"] == 0,
+        "summary": summary,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Verify Dopemux runtime authority manifest.")
+    parser.add_argument(
+        "--manifest",
+        default="config/runtime_authority_manifest.json",
+        help="Path to runtime authority manifest JSON.",
+    )
+    parser.add_argument(
+        "--check",
+        choices=("static",),
+        default="static",
+        help="Verification mode. Static mode performs no network calls and no mutations.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    manifest_path = Path(args.manifest)
+    if not manifest_path.is_absolute():
+        manifest_path = REPO_ROOT / manifest_path
+
+    try:
+        manifest = _read_json(manifest_path)
+        report = verify_manifest(manifest, REPO_ROOT)
+    except Exception as exc:
+        report = {
+            "check": args.check,
+            "findings": [
+                _finding(
+                    severity=ERROR,
+                    code="verifier_exception",
+                    system="verifier",
+                    message=str(exc),
+                )
+            ],
+            "ok": False,
+            "summary": {"errors": 1, "infos": 0, "warnings": 0},
+        }
+
+    sys.stdout.write(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_runtime_authority.py
+++ b/scripts/verify_runtime_authority.py
@@ -336,8 +336,22 @@ def _check_ports(manifest: dict[str, Any], repo_root: Path) -> list[dict[str, An
                 continue
             registry_name = str(port_entry.get("registry_service") or "")
             compose_name = str(port_entry.get("compose_service") or registry_name)
-            expected_host = int(port_entry["host_port"])
-            expected_container = int(port_entry["container_port"])
+            host_port = port_entry.get("host_port")
+            container_port = port_entry.get("container_port")
+            try:
+                expected_host = int(host_port)
+                expected_container = int(container_port)
+            except (TypeError, ValueError):
+                findings.append(
+                    _finding(
+                        severity=ERROR,
+                        code="expected_port_entry_invalid",
+                        system=system,
+                        message="expected_ports[*].host_port and expected_ports[*].container_port must be integers.",
+                        details={"registry_service": registry_name} if registry_name else None,
+                    )
+                )
+                continue
 
             registry_entry = registry.get(registry_name)
             if registry_entry is None:

--- a/scripts/verify_runtime_authority.py
+++ b/scripts/verify_runtime_authority.py
@@ -501,7 +501,7 @@ def _check_forbidden_legacy_targets(manifest: dict[str, Any], repo_root: Path) -
         system = str(target.get("system") or "manifest")
         needle = str(target.get("target") or "")
         expected_conflict = bool(target.get("expected_conflict", False))
-paths = target.get("paths", [])
+        paths = target.get("paths", [])
         if not isinstance(paths, list) or any(not isinstance(rel_path, str) for rel_path in paths):
             findings.append(
                 _finding(
@@ -546,42 +546,17 @@ def _check_known_conflicts(manifest: dict[str, Any], repo_root: Path) -> list[di
             _finding(
                 severity=ERROR,
                 code="known_conflicts_invalid",
-evidence_entries = conflict.get("evidence", [])
-        if not isinstance(evidence_entries, list):
-            findings.append(
-                _finding(
-                    severity=ERROR,
-                    code="known_conflict_evidence_invalid",
-                    system=system,
-                    message="known_conflicts[*].evidence must be a list.",
-                    details={"conflict_type": conflict_type},
-                )
+                system="manifest",
+                message="known_conflicts must be a list.",
             )
-            continue
+        ]
 
-        for evidence in evidence_entries:
-            if not isinstance(evidence, dict):
-                continue
-            rel_path = str(evidence.get("path") or "")
-            if not rel_path:
-                continue
-            patterns = evidence.get("patterns", [])
-            if not isinstance(patterns, list) or not all(isinstance(pattern, str) for pattern in patterns):
-                findings.append(
-                    _finding(
-                        severity=ERROR,
-                        code="known_conflict_patterns_invalid",
-                        system=system,
-                        path=rel_path,
-                        message="known_conflicts[*].evidence[*].patterns must be a list of strings.",
-                        details={"conflict_type": conflict_type},
-                    )
-                )
-                continue
-            if not _path_exists(repo_root, rel_path):
-                missing_paths.append(rel_path)
-                continue
-            text = _path_text(repo_root, rel_path)
+    for conflict in sorted(conflicts, key=lambda item: (str(item.get("system", "")), str(item.get("type", ""))) if isinstance(item, dict) else ("", "")):
+        if not isinstance(conflict, dict):
+            continue
+        system = str(conflict.get("system") or "UNKNOWN")
+        conflict_type = str(conflict.get("type") or "conflict")
+        observed_paths: list[str] = []
         missing_paths: list[str] = []
         for evidence in conflict.get("evidence", []):
             if not isinstance(evidence, dict):

--- a/scripts/verify_runtime_authority.py
+++ b/scripts/verify_runtime_authority.py
@@ -501,25 +501,37 @@ def _check_forbidden_legacy_targets(manifest: dict[str, Any], repo_root: Path) -
         system = str(target.get("system") or "manifest")
         needle = str(target.get("target") or "")
         expected_conflict = bool(target.get("expected_conflict", False))
-        for rel_path in sorted(target.get("paths", [])):
-            if not _path_exists(repo_root, str(rel_path)):
+paths = target.get("paths", [])
+        if not isinstance(paths, list) or any(not isinstance(rel_path, str) for rel_path in paths):
+            findings.append(
+                _finding(
+                    severity=ERROR,
+                    code="forbidden_target_paths_invalid",
+                    system=system,
+                    message="forbidden_legacy_targets[*].paths must be a list of strings.",
+                    details={"target": needle} if needle else None,
+                )
+            )
+            continue
+        for rel_path in sorted(paths):
+            if not _path_exists(repo_root, rel_path):
                 findings.append(
                     _finding(
                         severity=ERROR,
                         code="forbidden_target_scan_path_missing",
                         system=system,
-                        path=str(rel_path),
+                        path=rel_path,
                         message=f"Cannot scan missing forbidden-target path: {rel_path}",
                     )
                 )
                 continue
-            if needle and needle in _path_text(repo_root, str(rel_path)):
+            if needle and needle in _path_text(repo_root, rel_path):
                 findings.append(
                     _finding(
                         severity=WARNING if expected_conflict else ERROR,
                         code="forbidden_legacy_target_present",
                         system=system,
-                        path=str(rel_path),
+                        path=rel_path,
                         message=f"Forbidden legacy target is referenced: {needle}",
                     )
                 )
@@ -534,17 +546,42 @@ def _check_known_conflicts(manifest: dict[str, Any], repo_root: Path) -> list[di
             _finding(
                 severity=ERROR,
                 code="known_conflicts_invalid",
-                system="manifest",
-                message="known_conflicts must be a list.",
+evidence_entries = conflict.get("evidence", [])
+        if not isinstance(evidence_entries, list):
+            findings.append(
+                _finding(
+                    severity=ERROR,
+                    code="known_conflict_evidence_invalid",
+                    system=system,
+                    message="known_conflicts[*].evidence must be a list.",
+                    details={"conflict_type": conflict_type},
+                )
             )
-        ]
-
-    for conflict in sorted(conflicts, key=lambda item: (str(item.get("system", "")), str(item.get("type", ""))) if isinstance(item, dict) else ("", "")):
-        if not isinstance(conflict, dict):
             continue
-        system = str(conflict.get("system") or "UNKNOWN")
-        conflict_type = str(conflict.get("type") or "conflict")
-        observed_paths: list[str] = []
+
+        for evidence in evidence_entries:
+            if not isinstance(evidence, dict):
+                continue
+            rel_path = str(evidence.get("path") or "")
+            if not rel_path:
+                continue
+            patterns = evidence.get("patterns", [])
+            if not isinstance(patterns, list) or not all(isinstance(pattern, str) for pattern in patterns):
+                findings.append(
+                    _finding(
+                        severity=ERROR,
+                        code="known_conflict_patterns_invalid",
+                        system=system,
+                        path=rel_path,
+                        message="known_conflicts[*].evidence[*].patterns must be a list of strings.",
+                        details={"conflict_type": conflict_type},
+                    )
+                )
+                continue
+            if not _path_exists(repo_root, rel_path):
+                missing_paths.append(rel_path)
+                continue
+            text = _path_text(repo_root, rel_path)
         missing_paths: list[str] = []
         for evidence in conflict.get("evidence", []):
             if not isinstance(evidence, dict):

--- a/tests/unit/test_runtime_authority_manifest.py
+++ b/tests/unit/test_runtime_authority_manifest.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "config" / "runtime_authority_manifest.json"
+SCRIPT_PATH = REPO_ROOT / "scripts" / "verify_runtime_authority.py"
+
+
+def _load_verifier_module():
+    spec = importlib.util.spec_from_file_location("verify_runtime_authority", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def test_manifest_has_required_system_entry_keys() -> None:
+    manifest = _load_manifest()
+
+    assert manifest["schema_version"] == "1.0"
+    systems = manifest["systems"]
+    assert isinstance(systems, list)
+    assert {entry["system"] for entry in systems} == {
+        "ADHD Engine",
+        "ConPort",
+        "Repo Truth Extractor",
+        "dope-context",
+        "dope-memory",
+        "dopecon-bridge",
+        "dopemux",
+        "dopetask",
+        "task-orchestrator",
+    }
+
+    for entry in systems:
+        assert {"system", "expected_paths", "authority_status", "validation_mode"} <= set(entry)
+        assert isinstance(entry["expected_paths"], list)
+        assert entry["authority_status"]
+        assert entry["validation_mode"]
+
+
+def test_static_verifier_passes_current_manifest_and_reports_known_conflicts() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--manifest",
+            str(MANIFEST_PATH),
+            "--check",
+            "static",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    report = json.loads(result.stdout)
+    assert report["ok"] is True
+    assert report["summary"]["errors"] == 0
+
+    codes = [finding["code"] for finding in report["findings"]]
+    assert "expected_port_conflict" in codes
+    assert "expected_runtime_pointer_conflict" in codes
+
+    sort_keys = [
+        (
+            finding["severity"],
+            finding["system"],
+            finding["code"],
+            finding.get("path", ""),
+            finding["message"],
+        )
+        for finding in report["findings"]
+    ]
+    assert sort_keys == sorted(
+        sort_keys,
+        key=lambda item: (
+            {"error": 0, "warning": 1, "info": 2}.get(item[0], 99),
+            item[1],
+            item[2],
+            item[3],
+            item[4],
+        ),
+    )
+
+
+def test_verifier_returns_nonzero_for_unexpected_missing_authority_file(tmp_path: Path) -> None:
+    manifest = {
+        "repo_identity": {
+            "origin_hint": "",
+            "repo_marker": "",
+            "require_identity_match": False,
+        },
+        "systems": [
+            {
+                "authority_status": "canonical",
+                "expected_paths": [
+                    {
+                        "path": "missing-authority.py",
+                        "required": True,
+                    }
+                ],
+                "system": "missing-system",
+                "validation_mode": "static_required",
+            }
+        ],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--manifest",
+            str(manifest_path),
+            "--check",
+            "static",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    report = json.loads(result.stdout)
+    assert report["ok"] is False
+    assert report["summary"]["errors"] == 1
+    assert report["findings"][0]["code"] == "expected_path_missing"
+
+
+def test_unknown_authority_paths_are_advisory(tmp_path: Path) -> None:
+    module = _load_verifier_module()
+    repo_root = tmp_path
+    manifest = {
+        "systems": [
+            {
+                "authority_status": "unknown",
+                "expected_paths": [
+                    {
+                        "path": "candidate-only.py",
+                        "required": True,
+                    }
+                ],
+                "system": "unknown-system",
+                "validation_mode": "static_required",
+            }
+        ],
+    }
+
+    report = module.verify_manifest(manifest, repo_root)
+
+    assert report["ok"] is True
+    assert report["summary"]["errors"] == 0
+    assert any(finding["code"] == "unknown_authority_not_asserted" for finding in report["findings"])
+    assert any(
+        finding["code"] == "expected_path_missing" and finding["severity"] == "warning"
+        for finding in report["findings"]
+    )


### PR DESCRIPTION
Adds a static/runtime authority verification harness for Dopemux entrypoints, ports, wrappers, and canonical writer boundaries.

@codex
@clauee
@copilot

Release notes:
- Added a static runtime authority manifest covering Dopemux, dopetask, task-orchestrator, ConPort, dope-memory, dope-context, dopecon-bridge, ADHD Engine, and Repo Truth Extractor.
- Added a deterministic static verifier for required authority files, wrapper targets, compose/registry ports, forbidden legacy targets, and expected conflicts.
- Added focused unit coverage and operator documentation for verification behavior, failure handling, and proof expectations.

Validation:
- python3 -m json.tool config/runtime_authority_manifest.json
- python3 -m pytest -q tests/unit/test_runtime_authority_manifest.py
- python3 scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --check static

Note: this machine has no `python` executable on PATH; the equivalent `python3` commands passed.