### PR TITLE
Restore deterministic runtime authority verifier

### DIFF
--- a/config/runtime_authority_manifest.json
+++ b/config/runtime_authority_manifest.json
@@ -1,0 +1,937 @@
+{
+  "authority_status_values": [
+    "OBSERVED",
+    "CONFLICTING",
+    "UNKNOWN",
+    "DERIVED",
+    "TRANSPORT_ONLY",
+    "SHIM_ONLY"
+  ],
+  "schema_version": "1.0",
+  "systems": [
+    {
+      "authority_status": "OBSERVED",
+      "domain": "operator-control",
+      "expected_paths": [
+        {
+          "path": "pyproject.toml",
+          "required": true,
+          "role": "console_script_manifest"
+        },
+        {
+          "path": "src/dopemux/cli.py",
+          "required": true,
+          "role": "operator_cli_runtime"
+        },
+        {
+          "path": "src/dopemux/commands/kernel_commands.py",
+          "required": true,
+          "role": "dopetask_delegation"
+        }
+      ],
+      "expected_ports": [],
+      "forbidden_authority_paths": [],
+      "known_conflicts": [
+        {
+          "id": "legacy_truth_command_drift",
+          "markers": [
+            {
+              "contains": "no longer a supported operator entrypoint for Repo Truth Extractor",
+              "path": "src/dopemux/cli.py"
+            }
+          ],
+          "summary": "The legacy dopemux truth command remains present but is not the supported Repo Truth Extractor entrypoint."
+        }
+      ],
+      "notes": [
+        "Authority is limited to operator CLI and local coordination behavior.",
+        "PM, memory, retrieval, and extraction authorities are delegated to narrower downstream systems."
+      ],
+      "system": "dopemux",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "OBSERVED",
+      "domain": "external-task-execution",
+      "expected_paths": [
+        {
+          "path": "scripts/dopetask",
+          "required": true,
+          "role": "execution_wrapper"
+        },
+        {
+          "path": ".dopetask-pin",
+          "required": true,
+          "role": "version_pin"
+        },
+        {
+          "path": ".dopetaskroot",
+          "required": true,
+          "role": "repo_marker"
+        }
+      ],
+      "expected_ports": [],
+      "forbidden_authority_paths": [],
+      "known_conflicts": [],
+      "notes": [
+        "This repository owns the wrapper and pin, not the external dopetask implementation."
+      ],
+      "system": "dopetask",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "SHIM_ONLY",
+      "domain": "external-task-execution",
+      "expected_paths": [
+        {
+          "path": "scripts/taskx",
+          "required": true,
+          "role": "compatibility_shim"
+        }
+      ],
+      "expected_ports": [],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "execution_runtime",
+          "path": "scripts/taskx",
+          "reason": "taskx only execs scripts/dopetask and must not be promoted to runtime authority."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "taskx_wrapper_drift",
+          "markers": [
+            {
+              "contains": "Compatibility shim during taskx -> dopetask transition.",
+              "path": "scripts/taskx"
+            },
+            {
+              "contains": "scripts/taskx",
+              "path": "src/dopemux/commands/kernel_commands.py"
+            }
+          ],
+          "summary": "Operator command code still uses TaskX language while taskx delegates to dopetask."
+        }
+      ],
+      "notes": [
+        "SHIM_ONLY means the path is expected to exist but is forbidden as canonical execution authority."
+      ],
+      "system": "taskx",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "CONFLICTING",
+      "domain": "workflow-coordination-and-pm-transitions",
+      "expected_paths": [
+        {
+          "path": "services/task-orchestrator/app/main.py",
+          "required": true,
+          "role": "runtime_code"
+        },
+        {
+          "path": "services/task-orchestrator/mcp_stdio.py",
+          "required": true,
+          "role": "stdio_transport"
+        },
+        {
+          "path": "services/task-orchestrator/Dockerfile",
+          "required": true,
+          "role": "container_runtime"
+        },
+        {
+          "path": "compose.yml",
+          "required": true,
+          "role": "compose_wiring"
+        },
+        {
+          "path": "services/registry.yaml",
+          "required": true,
+          "role": "port_registry"
+        }
+      ],
+      "expected_ports": [
+        {
+          "port": 8000,
+          "role": "compose_registry_container_port",
+          "source_paths": [
+            "compose.yml",
+            "services/registry.yaml",
+            "services/task-orchestrator/Dockerfile"
+          ],
+          "status": "observed"
+        },
+        {
+          "port": 3014,
+          "role": "legacy_or_default_app_port",
+          "source_paths": [
+            "services/task-orchestrator/app/main.py",
+            "services/task-orchestrator/task_orchestrator/app.py"
+          ],
+          "status": "conflicting"
+        }
+      ],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "runtime_entrypoint",
+          "path": "services/task-orchestrator/task_orchestrator/app.py",
+          "reason": "This module hard-fails and declares itself unsupported."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "task_orchestrator_unsupported_runtime_variant",
+          "markers": [
+            {
+              "contains": "UNSUPPORTED RUNTIME: task_orchestrator/app.py",
+              "path": "services/task-orchestrator/task_orchestrator/app.py"
+            }
+          ],
+          "summary": "A legacy task_orchestrator app module remains present but must not be used as runtime authority."
+        },
+        {
+          "id": "task_orchestrator_port_3014_vs_8000",
+          "markers": [
+            {
+              "contains": "os.getenv(\"PORT\", 3014)",
+              "path": "services/task-orchestrator/app/main.py"
+            },
+            {
+              "contains": "PORT=8000",
+              "path": "services/task-orchestrator/Dockerfile"
+            },
+            {
+              "contains": "${TASK_ORCHESTRATOR_PORT:-8000}:8000",
+              "path": "compose.yml"
+            }
+          ],
+          "summary": "Task Orchestrator still carries 3014 in app code while compose, registry, and Docker use 8000."
+        }
+      ],
+      "notes": [
+        "Workflow transitions are an authority slice, not all PM truth.",
+        "Bridge-backed workflow storage does not promote dopecon-bridge into workflow authority."
+      ],
+      "system": "task-orchestrator",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "CONFLICTING",
+      "domain": "structured-context-decision-progress-and-custom-data",
+      "expected_paths": [
+        {
+          "path": "docker/mcp-servers-source/conport/enhanced_server.py",
+          "required": true,
+          "role": "http_api_runtime"
+        },
+        {
+          "path": "docker/mcp-servers-source/conport/server.py",
+          "required": true,
+          "role": "mcp_transport"
+        },
+        {
+          "path": "docker/mcp-servers-source/conport/start_with_info.sh",
+          "required": true,
+          "role": "multi_process_launcher"
+        },
+        {
+          "path": "compose.yml",
+          "required": true,
+          "role": "compose_wiring"
+        },
+        {
+          "path": "services/registry.yaml",
+          "required": true,
+          "role": "port_registry"
+        }
+      ],
+      "expected_ports": [
+        {
+          "port": 3004,
+          "role": "primary_http_api",
+          "source_paths": [
+            "compose.yml",
+            "services/registry.yaml",
+            "docker/mcp-servers-source/conport/start_with_info.sh"
+          ],
+          "status": "observed"
+        },
+        {
+          "port": 3005,
+          "role": "mcp_sse_transport",
+          "source_paths": [
+            "compose.yml",
+            "services/registry.yaml",
+            "docker/mcp-servers-source/conport/start_with_info.sh"
+          ],
+          "status": "observed"
+        },
+        {
+          "port": 4004,
+          "role": "info_server",
+          "source_paths": [
+            "compose.yml",
+            "docker/mcp-servers-source/conport/start_with_info.sh"
+          ],
+          "status": "observed"
+        }
+      ],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "deployed_conport_runtime",
+          "path": "src/conport/memory_server.py",
+          "reason": "This alternate active-looking ConPort surface is not proven as the deployed runtime authority."
+        },
+        {
+          "forbidden_domain": "conport_domain_authority",
+          "path": "services/dopecon-bridge/dopecon_bridge/routes.py",
+          "reason": "Bridge /kg and /ddg routes proxy ConPort; they are transport surfaces, not ConPort authority."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "conport_runtime_surface_split",
+          "markers": [
+            {
+              "contains": "Enhanced ConPort Server - Real Database Persistence",
+              "path": "docker/mcp-servers-source/conport/enhanced_server.py"
+            },
+            {
+              "contains": "ConPort Memory MCP Server",
+              "path": "src/conport/memory_server.py"
+            }
+          ],
+          "summary": "Docker-packaged ConPort and src/conport memory_server.py both exist; deployment authority is not collapsed."
+        },
+        {
+          "id": "conport_3004_3005_contract_split",
+          "markers": [
+            {
+              "contains": "http://localhost:3004",
+              "path": "src/dopemux/pm/adapters/conport.py"
+            },
+            {
+              "contains": "http://localhost:3005",
+              "path": "src/dopemux/pm/reads.py"
+            }
+          ],
+          "summary": "PM access paths use both ConPort HTTP 3004 and MCP/context 3005 contracts."
+        }
+      ],
+      "notes": [
+        "ConPort authority is limited to its implemented structured context, decision, progress, and custom-data domains.",
+        "ConPort is not PM metadata authority, workflow legality authority, dope-memory chronicle authority, or dope-context retrieval authority."
+      ],
+      "system": "ConPort",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "CONFLICTING",
+      "domain": "chronicle-memory-and-evidence-receipts",
+      "expected_paths": [
+        {
+          "path": "services/working-memory-assistant/dope_memory_main.py",
+          "required": true,
+          "role": "chronicle_runtime"
+        },
+        {
+          "path": "services/working-memory-assistant/canonical_ledger.py",
+          "required": true,
+          "role": "ledger_resolution"
+        },
+        {
+          "path": "services/working-memory-assistant/chronicle/store.py",
+          "required": true,
+          "role": "chronicle_store"
+        },
+        {
+          "path": "services/working-memory-assistant/Dockerfile.dope-memory",
+          "required": true,
+          "role": "container_runtime"
+        },
+        {
+          "path": "compose.yml",
+          "required": true,
+          "role": "compose_wiring"
+        },
+        {
+          "path": "services/registry.yaml",
+          "required": true,
+          "role": "port_registry"
+        }
+      ],
+      "expected_ports": [
+        {
+          "port": 3020,
+          "role": "active_http_tools_runtime",
+          "source_paths": [
+            "services/working-memory-assistant/dope_memory_main.py",
+            "services/working-memory-assistant/Dockerfile.dope-memory",
+            "compose.yml",
+            "services/registry.yaml"
+          ],
+          "status": "observed"
+        },
+        {
+          "port": 8096,
+          "role": "legacy_adapter_target",
+          "source_paths": [
+            "services/dope-memory/mcp_stdio_adapter.py",
+            "services/working-memory-assistant/main.py"
+          ],
+          "status": "conflicting"
+        }
+      ],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "chronicle_runtime",
+          "path": "services/dope-memory/mcp_stdio_adapter.py",
+          "reason": "This adapter targets legacy 8096 and is not the dope-memory runtime authority."
+        },
+        {
+          "forbidden_domain": "chronicle_runtime",
+          "path": "services/working-memory-assistant/mcp/server.py",
+          "reason": "This co-located MCP logic is not proven as the active dope-memory runtime."
+        },
+        {
+          "forbidden_domain": "pm_status_authority",
+          "path": "services/working-memory-assistant/dope_memory_main.py",
+          "reason": "dope-memory records chronicle receipts but does not own current PM status."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "dope_memory_3020_vs_8096",
+          "markers": [
+            {
+              "contains": "port 3020",
+              "path": "services/working-memory-assistant/dope_memory_main.py"
+            },
+            {
+              "contains": "http://localhost:8096/tools",
+              "path": "services/dope-memory/mcp_stdio_adapter.py"
+            }
+          ],
+          "summary": "Active dope-memory runtime is 3020, while the stdio adapter still targets legacy 8096."
+        },
+        {
+          "id": "dope_memory_wma_tree_overlap",
+          "markers": [
+            {
+              "contains": "Working Memory Assistant - FastAPI Service",
+              "path": "services/working-memory-assistant/main.py"
+            },
+            {
+              "contains": "This is the canonical entry point for the Dope-Memory service.",
+              "path": "services/working-memory-assistant/dope_memory_main.py"
+            }
+          ],
+          "summary": "dope-memory runtime lives inside the working-memory-assistant tree, alongside a separate WMA service."
+        }
+      ],
+      "notes": [
+        "Canonicality is limited to chronicle storage and chronicle-derived tool behavior.",
+        "Postgres mirrors, Redis streams, adapters, and PM mirror receipts remain non-authority surfaces."
+      ],
+      "system": "dope-memory",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "UNKNOWN",
+      "domain": "snapshot-recovery-and-memory-support",
+      "expected_paths": [
+        {
+          "path": "services/working-memory-assistant/main.py",
+          "required": true,
+          "role": "support_runtime"
+        },
+        {
+          "path": "services/working-memory-assistant/mcp/server.py",
+          "required": true,
+          "role": "unconfirmed_mcp_logic"
+        }
+      ],
+      "expected_ports": [
+        {
+          "port": 8096,
+          "role": "legacy_or_support_runtime_default",
+          "source_paths": [
+            "services/working-memory-assistant/main.py"
+          ],
+          "status": "observed"
+        }
+      ],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "durable_chronicle_memory",
+          "path": "services/working-memory-assistant/main.py",
+          "reason": "WMA support routes are not the canonical dope-memory chronicle runtime."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "working_memory_assistant_vs_dope_memory_overlap",
+          "markers": [
+            {
+              "contains": "Working Memory Assistant - FastAPI Service",
+              "path": "services/working-memory-assistant/main.py"
+            },
+            {
+              "contains": "Dope-Memory HTTP Server",
+              "path": "services/working-memory-assistant/dope_memory_main.py"
+            }
+          ],
+          "summary": "WMA support runtime and dope-memory chronicle runtime share a tree but do not share authority."
+        }
+      ],
+      "notes": [
+        "The repo proves support surfaces, but durable memory canonicality remains with dope-memory chronicle paths."
+      ],
+      "system": "working-memory-assistant",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "OBSERVED",
+      "domain": "code-and-docs-retrieval",
+      "expected_paths": [
+        {
+          "path": "services/dope-context/src/mcp/server.py",
+          "required": true,
+          "role": "retrieval_runtime"
+        },
+        {
+          "path": "services/dope-context/Dockerfile",
+          "required": true,
+          "role": "container_runtime"
+        },
+        {
+          "path": "compose.yml",
+          "required": true,
+          "role": "compose_wiring"
+        },
+        {
+          "path": "services/registry.yaml",
+          "required": true,
+          "role": "port_registry"
+        }
+      ],
+      "expected_ports": [
+        {
+          "port": 3010,
+          "role": "retrieval_http_or_mcp_transport",
+          "source_paths": [
+            "services/dope-context/src/mcp/server.py",
+            "services/dope-context/Dockerfile",
+            "compose.yml",
+            "services/registry.yaml"
+          ],
+          "status": "observed"
+        }
+      ],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "retrieval_runtime",
+          "path": "scripts/mcp-wrappers/dope-context-wrapper.sh",
+          "reason": "Wrapper still invokes python /app/server.py and is not the canonical python -m src.mcp.server runtime."
+        },
+        {
+          "forbidden_domain": "source_truth",
+          "path": "services/dope-context/src/mcp/server.py",
+          "reason": "dope-context retrieval results are derived views over code, docs, and optional upstream decisions."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "dope_context_wrapper_runtime_drift",
+          "markers": [
+            {
+              "contains": "python /app/server.py",
+              "path": "scripts/mcp-wrappers/dope-context-wrapper.sh"
+            },
+            {
+              "contains": "src.mcp.server",
+              "path": "services/dope-context/Dockerfile"
+            }
+          ],
+          "summary": "The wrapper and Dockerfile point to different dope-context runtime entrypoints."
+        },
+        {
+          "id": "dope_context_legacy_run_mcp_reference",
+          "markers": [
+            {
+              "contains": "services/dope-context/run_mcp.sh",
+              "path": "src/dopemux/config/manager.py"
+            }
+          ],
+          "summary": "Config repair code still recognizes stale services/dope-context/run_mcp.sh references."
+        }
+      ],
+      "notes": [
+        "dope-context is authority for retrieval/index behavior only.",
+        "Retrieved data remains derived from upstream source files or upstream systems."
+      ],
+      "system": "dope-context",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "TRANSPORT_ONLY",
+      "domain": "routing-proxy-event-transport",
+      "expected_paths": [
+        {
+          "path": "services/dopecon-bridge/main.py",
+          "required": true,
+          "role": "bridge_runtime"
+        },
+        {
+          "path": "services/dopecon-bridge/dopecon_bridge/routes.py",
+          "required": true,
+          "role": "transport_policy"
+        },
+        {
+          "path": "services/dopecon-bridge/dopecon_bridge/clients.py",
+          "required": true,
+          "role": "upstream_clients"
+        },
+        {
+          "path": "compose.yml",
+          "required": true,
+          "role": "compose_wiring"
+        },
+        {
+          "path": "services/registry.yaml",
+          "required": true,
+          "role": "port_registry"
+        }
+      ],
+      "expected_ports": [
+        {
+          "port": 3016,
+          "role": "bridge_http_runtime",
+          "source_paths": [
+            "compose.yml",
+            "services/registry.yaml",
+            "services/dopecon-bridge/dopecon_bridge/config.py"
+          ],
+          "status": "observed"
+        }
+      ],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "pm_workflow_decision_progress_authority",
+          "path": "services/dopecon-bridge/dopecon_bridge/routes.py",
+          "reason": "The route module explicitly denies canonical task, workflow, decision, and progress authority."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "bridge_broad_routes_non_authority",
+          "markers": [
+            {
+              "contains": "must not act as\ncanonical task, workflow, decision, or progress authority",
+              "path": "services/dopecon-bridge/dopecon_bridge/routes.py"
+            },
+            {
+              "contains": "source\": \"conport\"",
+              "path": "services/dopecon-bridge/dopecon_bridge/routes.py"
+            }
+          ],
+          "summary": "Bridge exposes PM/KG/DDG surfaces but keeps upstream source labels and transport-only authority."
+        }
+      ],
+      "notes": [
+        "TRANSPORT_ONLY means bridge policy and transport are authoritative, but proxied domain payloads are not bridge truth."
+      ],
+      "system": "dopecon-bridge",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "OBSERVED",
+      "domain": "operator-support-and-cognitive-state",
+      "expected_paths": [
+        {
+          "path": "services/adhd_engine/main.py",
+          "required": true,
+          "role": "service_runtime"
+        },
+        {
+          "path": "services/adhd_engine/config.py",
+          "required": true,
+          "role": "service_config"
+        },
+        {
+          "path": "services/adhd_engine/mcp_stdio.py",
+          "required": true,
+          "role": "stdio_transport"
+        },
+        {
+          "path": "compose.yml",
+          "required": true,
+          "role": "compose_wiring"
+        },
+        {
+          "path": "services/registry.yaml",
+          "required": true,
+          "role": "port_registry"
+        }
+      ],
+      "expected_ports": [
+        {
+          "port": 8095,
+          "role": "container_runtime",
+          "source_paths": [
+            "services/adhd_engine/config.py",
+            "compose.yml",
+            "services/registry.yaml"
+          ],
+          "status": "observed"
+        },
+        {
+          "port": 3025,
+          "role": "host_runtime",
+          "source_paths": [
+            "compose.yml",
+            "services/registry.yaml"
+          ],
+          "status": "observed"
+        }
+      ],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "adhd_engine_runtime",
+          "path": "services/adhd-engine",
+          "reason": "Hyphenated ADHD path is duplicate residue; active runtime is services/adhd_engine."
+        },
+        {
+          "forbidden_domain": "pm_memory_retrieval_authority",
+          "path": "services/adhd_engine/main.py",
+          "reason": "ADHD Engine owns support state and recommendations, not PM, memory, retrieval, or bridge truth."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "adhd_conport_default_port_drift",
+          "markers": [
+            {
+              "contains": "http://localhost:3010",
+              "path": "services/adhd_engine/config.py"
+            },
+            {
+              "contains": "${CONPORT_HTTP_PORT:-3004}:3004",
+              "path": "compose.yml"
+            }
+          ],
+          "summary": "ADHD Engine config defaults ConPort URL to 3010 while compose exposes ConPort HTTP on 3004."
+        }
+      ],
+      "notes": [
+        "ADHD Engine authority is limited to its own service state and generated support recommendations."
+      ],
+      "system": "ADHD Engine",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "OBSERVED",
+      "domain": "repo-truth-extraction-and-proof-artifacts",
+      "expected_paths": [
+        {
+          "path": "services/repo-truth-extractor/run_extraction_v5.py",
+          "required": true,
+          "role": "canonical_extraction_runner"
+        },
+        {
+          "path": "services/repo-truth-extractor/run_extraction_v4.py",
+          "required": true,
+          "role": "compatibility_wrapper"
+        },
+        {
+          "path": "src/dopemux/commands/extractor_commands.py",
+          "required": true,
+          "role": "operator_command_wiring"
+        }
+      ],
+      "expected_ports": [],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "repo_truth_extraction_runtime",
+          "path": "src/dopemux/extractor/runner.py",
+          "reason": "Legacy PipelineRunner path is not the canonical v5 extraction runtime."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "rte_v5_vs_legacy_dopemux_truth",
+          "markers": [
+            {
+              "contains": "Master extraction runner",
+              "path": "services/repo-truth-extractor/run_extraction_v5.py"
+            },
+            {
+              "contains": "dopemux truth",
+              "path": "src/dopemux/cli.py"
+            }
+          ],
+          "summary": "Repo Truth Extractor v5 is the extraction authority while legacy dopemux truth command text remains present."
+        }
+      ],
+      "notes": [
+        "Extractor outputs are evidence artifacts about repo truth, not replacements for runtime code/config/tests."
+      ],
+      "system": "Repo Truth Extractor",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "OBSERVED",
+      "domain": "pm-metadata-and-project-snapshot",
+      "expected_paths": [
+        {
+          "path": "compose.yml",
+          "required": true,
+          "role": "compose_wiring"
+        },
+        {
+          "path": "docker/leantime/Dockerfile",
+          "required": true,
+          "role": "external_app_container"
+        },
+        {
+          "path": "docker/mcp-servers/leantime-bridge/Dockerfile",
+          "required": true,
+          "role": "adapter_container"
+        },
+        {
+          "path": "src/dopemux/pm/writes.py",
+          "required": true,
+          "role": "pm_write_router"
+        }
+      ],
+      "expected_ports": [
+        {
+          "port": 8080,
+          "role": "leantime_http_host",
+          "source_paths": [
+            "compose.yml",
+            "services/registry.yaml"
+          ],
+          "status": "observed"
+        },
+        {
+          "port": 3015,
+          "role": "leantime_bridge_http",
+          "source_paths": [
+            "compose.yml",
+            "services/registry.yaml"
+          ],
+          "status": "observed"
+        }
+      ],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "workflow_transition_authority",
+          "path": "docker/mcp-servers/leantime-bridge",
+          "reason": "Leantime bridge is an adapter for Leantime metadata/project operations, not workflow adjudication authority."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "leantime_adapter_shaped_authority",
+          "markers": [
+            {
+              "contains": "canonical_system=\"leantime\"",
+              "path": "src/dopemux/pm/writes.py"
+            },
+            {
+              "contains": "workflow-significant transitions",
+              "path": "PM_PLANE.md"
+            }
+          ],
+          "summary": "Leantime is PM metadata authority through adapters and PM routing, while workflow transitions remain task-orchestrator authority."
+        }
+      ],
+      "notes": [
+        "Leantime is represented by compose/config as an external PM application, not as repo-owned app source."
+      ],
+      "system": "Leantime",
+      "validation_mode": "static_paths_and_markers"
+    },
+    {
+      "authority_status": "UNKNOWN",
+      "domain": "technical-context-assistance",
+      "expected_paths": [
+        {
+          "path": "docker/mcp-servers-source/serena/Dockerfile",
+          "required": true,
+          "role": "docker_wrapper_build_source"
+        },
+        {
+          "path": "docker/mcp-servers-source/serena/wrapper.py",
+          "required": true,
+          "role": "docker_wrapper_runtime"
+        },
+        {
+          "path": "compose.yml",
+          "required": true,
+          "role": "compose_wiring"
+        },
+        {
+          "path": "services/registry.yaml",
+          "required": true,
+          "role": "port_registry"
+        }
+      ],
+      "expected_ports": [
+        {
+          "port": 3006,
+          "role": "serena_mcp_sse",
+          "source_paths": [
+            "compose.yml",
+            "services/registry.yaml",
+            "docker/mcp-servers-source/serena/wrapper.py"
+          ],
+          "status": "observed"
+        },
+        {
+          "port": 4006,
+          "role": "serena_info_server",
+          "source_paths": [
+            "compose.yml",
+            "docker/mcp-servers-source/serena/Dockerfile"
+          ],
+          "status": "observed"
+        }
+      ],
+      "forbidden_authority_paths": [
+        {
+          "forbidden_domain": "deployed_serena_runtime",
+          "path": "services/serena",
+          "reason": "The local Serena implementation tree is not proven as deployed runtime authority."
+        },
+        {
+          "forbidden_domain": "pm_workflow_decision_progress_authority",
+          "path": "docker/mcp-servers-source/serena",
+          "reason": "Serena is technical-context assistance only and must not become PM/workflow/decision/progress authority."
+        }
+      ],
+      "known_conflicts": [
+        {
+          "id": "serena_wrapper_vs_local_tree",
+          "markers": [
+            {
+              "contains": "git+https://github.com/oraios/serena.git",
+              "path": "docker/mcp-servers-source/serena/Dockerfile"
+            },
+            {
+              "contains": "mcp_server.py",
+              "path": "docs/03-reference/systems/serena/callable-surface-inventory.md"
+            }
+          ],
+          "summary": "Compose points at the Docker wrapper while a larger local services/serena tree remains present but unsanctioned."
+        }
+      ],
+      "notes": [
+        "Runtime evidence is sufficient to track Serena as represented, but canonical implementation authority remains UNKNOWN."
+      ],
+      "system": "Serena",
+      "validation_mode": "static_paths_and_markers"
+    }
+  ],
+  "validation_mode": "static"
+}

--- a/config/runtime_authority_manifest.json
+++ b/config/runtime_authority_manifest.json
@@ -159,15 +159,6 @@
             "services/task-orchestrator/Dockerfile"
           ],
           "status": "observed"
-        },
-        {
-          "port": 3014,
-          "role": "legacy_or_default_app_port",
-          "source_paths": [
-            "services/task-orchestrator/app/main.py",
-            "services/task-orchestrator/task_orchestrator/app.py"
-          ],
-          "status": "conflicting"
         }
       ],
       "forbidden_authority_paths": [
@@ -187,29 +178,12 @@
             }
           ],
           "summary": "A legacy task_orchestrator app module remains present but must not be used as runtime authority."
-        },
-        {
-          "id": "task_orchestrator_port_3014_vs_8000",
-          "markers": [
-            {
-              "contains": "os.getenv(\"PORT\", 3014)",
-              "path": "services/task-orchestrator/app/main.py"
-            },
-            {
-              "contains": "PORT=8000",
-              "path": "services/task-orchestrator/Dockerfile"
-            },
-            {
-              "contains": "${TASK_ORCHESTRATOR_PORT:-8000}:8000",
-              "path": "compose.yml"
-            }
-          ],
-          "summary": "Task Orchestrator still carries 3014 in app code while compose, registry, and Docker use 8000."
         }
       ],
       "notes": [
         "Workflow transitions are an authority slice, not all PM truth.",
-        "Bridge-backed workflow storage does not promote dopecon-bridge into workflow authority."
+        "Bridge-backed workflow storage does not promote dopecon-bridge into workflow authority.",
+        "Active task-orchestrator runtime, compose, and registry wiring now align on 8000; 3014 remains only in legacy and archival surfaces."
       ],
       "system": "task-orchestrator",
       "validation_mode": "static_paths_and_markers"

--- a/docs/03-reference/governance/runtime-authority-verification.md
+++ b/docs/03-reference/governance/runtime-authority-verification.md
@@ -1,0 +1,107 @@
+---
+id: runtime-authority-verification
+title: Runtime Authority Verification
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-01'
+last_review: '2026-05-01'
+next_review: '2026-07-30'
+prelude: Runtime Authority Verification (reference) for dopemux documentation and
+  developer workflows.
+---
+# Runtime Authority Verification
+
+## Purpose
+
+`config/runtime_authority_manifest.json` and `scripts/verify_runtime_authority.py` provide the first static verification layer for Dopemux runtime authority claims.
+
+The verifier records observed runtime pointers, ports, known conflicts, wrapper drift, and non-authority surfaces. It is designed to block later packets from silently promoting bridges, shims, wrappers, mirrors, retrieval results, or stale ports into canonical authority.
+
+## Authority Hierarchy
+
+The verifier resolves evidence priority as follows:
+
+1. Runtime code, config, compose wiring, tests, and active entrypoints
+2. `TRUTH_*.md`
+3. `RULES.md`, `PROJECT.md`, `ARCHITECTURE.md`, `SYSTEM_BOUNDARIES.md`, `PM_PLANE.md`, and `SERVICE_CATALOG.md`
+4. `SYSTEM_*.md`
+5. PAL, TP, proof, and adapter contracts
+6. Generated navigation and meta docs
+7. Everything else
+
+Note: this is the manifest's evidence priority for resolving runtime claims, not the operator Task Packet authority precedence order. The governing authority precedence (Task Packet → `.claude/PROJECT_INSTRUCTIONS.md` → `.claude/PRIMER.md` → ADRs → other docs) is defined in `task-packets/README.md`.
+
+When docs and runtime disagree, runtime evidence wins. The manifest preserves conflict instead of normalizing it.
+
+## What Static Checks Prove
+
+The static verifier proves that:
+
+- required authority pointer paths still exist
+- known conflict markers are still present in the expected files
+- stale port drift represented in the manifest is still visible
+- forbidden paths are not also declared with canonical roles in the same manifest entry
+- output ordering is stable and filterable by system
+
+It does not call services, Docker, network endpoints, or external tools.
+
+## What Static Checks Do Not Prove
+
+The static verifier does not prove that:
+
+- Docker images build
+- services boot
+- HTTP, MCP, WebSocket, Redis, PostgreSQL, Qdrant, or Leantime endpoints respond
+- PM writes reconcile correctly at runtime
+- ConPort, dope-memory, dope-context, Serena, or task-orchestrator storage semantics are healthy
+- bridge-proxied payloads are canonical domain truth
+
+Runtime proof must be supplied by later packets.
+
+## How To Run
+
+Run all static checks:
+
+```bash
+python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --check static
+```
+
+Run one system:
+
+```bash
+python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --system task-orchestrator --check static
+python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --system ConPort --check static
+```
+
+System matching is case-insensitive and ignores punctuation.
+
+## Known Conflicts Preserved
+
+The manifest intentionally preserves these conflicts:
+
+- `task-orchestrator`: active runtime code is `services/task-orchestrator/app/main.py`, while unsupported legacy `services/task-orchestrator/task_orchestrator/app.py` remains present and port evidence still includes `3014` versus `8000`.
+- `ConPort`: Docker-packaged ConPort and `src/conport/memory_server.py` both exist, and PM access paths still use both `3004` and `3005`.
+- `dope-memory`: active HTTP runtime is `3020`, while the stdio adapter still targets legacy `8096`.
+- `taskx`: `scripts/taskx` is a compatibility shim only.
+- `dopecon-bridge`: bridge exposes broad PM/KG/DDG routes but is transport-only for domain truth.
+- `dope-context`: Docker uses `python -m src.mcp.server`, while a wrapper still invokes `python /app/server.py`.
+- `Serena`: compose points to the Docker wrapper, while `services/serena` remains a larger local implementation tree with unresolved canonicality.
+
+## Downstream Consumers
+
+These packets should consume this verifier before making stronger runtime claims:
+
+- `TP-DMX-TASKORCH-RUNTIME-001`
+- `TP-DMX-CONPORT-AUTH-001`
+- `TP-DMX-PM-PORTS-001`
+
+## Proof Expectations
+
+For any packet changing runtime authority:
+
+- update the manifest only when runtime/config evidence changes
+- keep conflict entries until the conflicting path or marker is actually removed or superseded
+- run the static verifier for all systems and for the touched system filter
+- run targeted runtime validation separately when claiming live behavior
+- do not mark bridge, shim, wrapper, mirror, or retrieval output as canonical authority without direct runtime evidence

--- a/docs/03-reference/governance/runtime-authority-verification.md
+++ b/docs/03-reference/governance/runtime-authority-verification.md
@@ -80,7 +80,7 @@ System matching is case-insensitive and ignores punctuation.
 
 The manifest intentionally preserves these conflicts:
 
-- `task-orchestrator`: active runtime code is `services/task-orchestrator/app/main.py`, while unsupported legacy `services/task-orchestrator/task_orchestrator/app.py` remains present and port evidence still includes `3014` versus `8000`.
+- `task-orchestrator`: active runtime code is `services/task-orchestrator/app/main.py`, while unsupported legacy `services/task-orchestrator/task_orchestrator/app.py` remains present and active runtime, compose, and registry wiring now align on `8000`.
 - `ConPort`: Docker-packaged ConPort and `src/conport/memory_server.py` both exist, and PM access paths still use both `3004` and `3005`.
 - `dope-memory`: active HTTP runtime is `3020`, while the stdio adapter still targets legacy `8096`.
 - `taskx`: `scripts/taskx` is a compatibility shim only.

--- a/scripts/verify_runtime_authority.py
+++ b/scripts/verify_runtime_authority.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Static verifier for Dopemux runtime authority manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+ALLOWED_AUTHORITY_STATUSES = {
+    "OBSERVED",
+    "CONFLICTING",
+    "UNKNOWN",
+    "DERIVED",
+    "TRANSPORT_ONLY",
+    "SHIM_ONLY",
+}
+
+CANONICAL_ROLES = {
+    "canonical_runtime",
+    "canonical_store",
+    "canonical_extraction_runner",
+    "domain_authority",
+    "runtime_entrypoint",
+}
+
+REQUIRED_ENTRY_FIELDS = {
+    "system",
+    "domain",
+    "authority_status",
+    "expected_paths",
+    "expected_ports",
+    "forbidden_authority_paths",
+    "known_conflicts",
+    "validation_mode",
+    "notes",
+}
+
+
+def _dict_sort_value(item: Any, key: str) -> str:
+    if isinstance(item, dict):
+        return str(item.get(key, ""))
+    return str(item)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _normalize_system(value: str) -> str:
+    return "".join(char.lower() for char in value if char.isalnum())
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError("Manifest root must be a JSON object.")
+    systems = payload.get("systems")
+    if not isinstance(systems, list) or not systems:
+        raise ValueError("Manifest must contain a non-empty systems list.")
+    return payload
+
+
+def _iter_selected_systems(
+    manifest: dict[str, Any],
+    requested_system: str | None,
+) -> list[dict[str, Any]]:
+    systems = list(manifest["systems"])
+    systems.sort(key=lambda entry: str(entry.get("system", "")).casefold())
+    if requested_system is None:
+        return systems
+
+    requested = _normalize_system(requested_system)
+    selected = [
+        entry
+        for entry in systems
+        if _normalize_system(str(entry.get("system", ""))) == requested
+    ]
+    if not selected:
+        known = ", ".join(str(entry.get("system", "")) for entry in systems)
+        raise KeyError(f"Unknown system {requested_system!r}. Known systems: {known}")
+    return selected
+
+
+def _as_list(value: Any, field_name: str, system: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{system}: {field_name} must be a list.")
+    return value
+
+
+def _validate_entry_shape(entry: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    system = str(entry.get("system", "<unknown>"))
+    missing = sorted(REQUIRED_ENTRY_FIELDS - set(entry))
+    if missing:
+        failures.append(f"{system}: missing required fields {missing}")
+
+    status = entry.get("authority_status")
+    if status not in ALLOWED_AUTHORITY_STATUSES:
+        failures.append(f"{system}: invalid authority_status {status!r}")
+
+    for list_field in (
+        "expected_paths",
+        "expected_ports",
+        "forbidden_authority_paths",
+        "known_conflicts",
+        "notes",
+    ):
+        try:
+            _as_list(entry.get(list_field), list_field, system)
+        except ValueError as exc:
+            failures.append(str(exc))
+
+    return failures
+
+
+def _safe_resolve(repo_root: Path, raw_path: str) -> Path | None:
+    """Return the resolved absolute path only if it stays within repo_root.
+
+    Returns None for absolute raw_path values or any path that resolves
+    outside repo_root (e.g. paths containing '..'), and prints a warning
+    to stderr so rejected paths are visible for debugging.
+    """
+    if Path(raw_path).is_absolute():
+        print(
+            f"WARNING: rejected absolute path {raw_path!r} (only relative paths are allowed)",
+            file=sys.stderr,
+        )
+        return None
+    resolved = (repo_root / raw_path).resolve()
+    try:
+        resolved.relative_to(repo_root.resolve())
+    except ValueError:
+        print(
+            f"WARNING: rejected path {raw_path!r} (resolves outside repository root via '..')",
+            file=sys.stderr,
+        )
+        return None
+    return resolved
+
+
+def _path_exists(repo_root: Path, raw_path: str) -> bool:
+    safe = _safe_resolve(repo_root, raw_path)
+    return safe is not None and safe.exists()
+
+
+def _read_text(repo_root: Path, raw_path: str) -> str:
+    safe = _safe_resolve(repo_root, raw_path)
+    if safe is None:
+        if Path(raw_path).is_absolute():
+            raise ValueError(
+                f"Path {raw_path!r} is rejected (absolute path is not allowed)."
+            )
+        raise ValueError(
+            f"Path {raw_path!r} is rejected (absolute path or escapes repository root)."
+        )
+    return safe.read_text(encoding="utf-8", errors="replace")
+
+
+def _validate_expected_paths(
+    repo_root: Path,
+    entry: dict[str, Any],
+    lines: list[str],
+) -> list[str]:
+    failures: list[str] = []
+    system = entry["system"]
+    expected_paths = _as_list(entry.get("expected_paths"), "expected_paths", system)
+    for item in sorted(expected_paths, key=lambda path_item: _dict_sort_value(path_item, "path")):
+        if not isinstance(item, dict):
+            failures.append(f"{system}: expected_paths entries must be objects.")
+            continue
+        raw_path = str(item.get("path", ""))
+        role = str(item.get("role", "unspecified"))
+        required = bool(item.get("required", True))
+        exists = bool(raw_path) and _path_exists(repo_root, raw_path)
+        state = "OK" if exists else "MISSING"
+        requirement = "required" if required else "optional"
+        lines.append(f"PATH {state} {system} {requirement} {role} {raw_path}")
+        if required and not exists:
+            failures.append(f"{system}: missing required expected path {raw_path}")
+    return failures
+
+
+def _validate_forbidden_paths(
+    repo_root: Path,
+    entry: dict[str, Any],
+    lines: list[str],
+) -> list[str]:
+    failures: list[str] = []
+    system = entry["system"]
+    forbidden_paths = _as_list(
+        entry.get("forbidden_authority_paths"),
+        "forbidden_authority_paths",
+        system,
+    )
+    expected_paths = _as_list(entry.get("expected_paths"), "expected_paths", system)
+    canonical_expected_paths = {
+        str(item.get("path", ""))
+        for item in expected_paths
+        if isinstance(item, dict) and str(item.get("role", "")) in CANONICAL_ROLES
+    }
+
+    for item in sorted(forbidden_paths, key=lambda path_item: _dict_sort_value(path_item, "path")):
+        if not isinstance(item, dict):
+            failures.append(f"{system}: forbidden_authority_paths entries must be objects.")
+            continue
+        raw_path = str(item.get("path", ""))
+        forbidden_domain = str(item.get("forbidden_domain", "unspecified"))
+        exists = bool(raw_path) and _path_exists(repo_root, raw_path)
+        state = "PRESENT" if exists else "ABSENT"
+        lines.append(f"FORBIDDEN {state} {system} {forbidden_domain} {raw_path}")
+        if raw_path in canonical_expected_paths:
+            failures.append(
+                f"{system}: forbidden authority path is also listed with canonical role: {raw_path}"
+            )
+    return failures
+
+
+def _validate_conflict_markers(
+    repo_root: Path,
+    entry: dict[str, Any],
+    lines: list[str],
+) -> list[str]:
+    failures: list[str] = []
+    system = entry["system"]
+    conflicts = _as_list(entry.get("known_conflicts"), "known_conflicts", system)
+    for conflict in sorted(conflicts, key=lambda item: _dict_sort_value(item, "id")):
+        if not isinstance(conflict, dict):
+            failures.append(f"{system}: known_conflicts entries must be objects.")
+            continue
+        conflict_id = str(conflict.get("id", "unnamed_conflict"))
+        markers = conflict.get("markers", [])
+        if not isinstance(markers, list):
+            failures.append(f"{system}: conflict {conflict_id} markers must be a list.")
+            continue
+        marker_failures = 0
+        for marker in sorted(markers, key=lambda item: _dict_sort_value(item, "path")):
+            if not isinstance(marker, dict):
+                failures.append(
+                    f"{system}: conflict {conflict_id} marker entries must be objects."
+                )
+                marker_failures += 1
+                continue
+            raw_path = str(marker.get("path", ""))
+            expected_text = str(marker.get("contains", ""))
+            if not raw_path or not _path_exists(repo_root, raw_path):
+                marker_failures += 1
+                failures.append(
+                    f"{system}: conflict {conflict_id} marker path missing: {raw_path}"
+                )
+                continue
+            content = _read_text(repo_root, raw_path)
+            if expected_text not in content:
+                marker_failures += 1
+                failures.append(
+                    f"{system}: conflict {conflict_id} marker not found in {raw_path}"
+                )
+        state = "OBSERVED" if marker_failures == 0 else "MISSING_MARKER"
+        lines.append(f"CONFLICT {state} {system} {conflict_id}")
+    return failures
+
+
+def _port_sort_key(item: Any) -> tuple[int, str]:
+    if not isinstance(item, dict):
+        return (-1, "")
+    port_val = item.get("port")
+    try:
+        port_int = int(port_val)
+    except (TypeError, ValueError):
+        port_int = -1
+    return (port_int, str(item.get("role", "")))
+
+
+def _report_ports(entry: dict[str, Any], lines: list[str]) -> None:
+    system = entry["system"]
+    expected_ports = _as_list(entry.get("expected_ports"), "expected_ports", system)
+    for port_info in sorted(expected_ports, key=_port_sort_key):
+        if not isinstance(port_info, dict):
+            lines.append(f"PORT INVALID {system}")
+            continue
+        port = port_info.get("port")
+        if port is None:
+            lines.append(f"PORT INVALID_PORT {system} missing_port unspecified")
+            continue
+        try:
+            int(port)
+        except (TypeError, ValueError):
+            lines.append(f"PORT INVALID_PORT {system} {port!r} unspecified")
+            continue
+        status = str(port_info.get("status", "unspecified"))
+        role = str(port_info.get("role", "unspecified"))
+        lines.append(f"PORT {status.upper()} {system} {port} {role}")
+
+
+def run_static_check(
+    manifest: dict[str, Any],
+    *,
+    requested_system: str | None,
+    repo_root: Path,
+) -> tuple[int, list[str]]:
+    lines: list[str] = []
+    failures: list[str] = []
+
+    selected = _iter_selected_systems(manifest, requested_system)
+    lines.append(
+        f"RUNTIME_AUTHORITY_STATIC_CHECK schema={manifest.get('schema_version')} systems={len(selected)}"
+    )
+
+    for entry in selected:
+        shape_failures = _validate_entry_shape(entry)
+        failures.extend(shape_failures)
+        if shape_failures:
+            continue
+
+        system = str(entry["system"])
+        lines.append(
+            "SYSTEM "
+            f"{system} status={entry['authority_status']} "
+            f"domain={entry['domain']} validation={entry['validation_mode']}"
+        )
+        failures.extend(_validate_expected_paths(repo_root, entry, lines))
+        failures.extend(_validate_forbidden_paths(repo_root, entry, lines))
+        _report_ports(entry, lines)
+        failures.extend(_validate_conflict_markers(repo_root, entry, lines))
+
+    if failures:
+        for failure in sorted(failures):
+            lines.append(f"FAIL {failure}")
+        lines.append(f"SUMMARY status=failed failures={len(failures)}")
+        return 1, lines
+
+    lines.append("SUMMARY status=passed failures=0")
+    return 0, lines
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify Dopemux runtime authority manifest without network or Docker."
+    )
+    parser.add_argument(
+        "--manifest",
+        required=True,
+        type=Path,
+        help="Path to config/runtime_authority_manifest.json.",
+    )
+    parser.add_argument(
+        "--system",
+        help="Optional system filter. Matching is case-insensitive and ignores punctuation.",
+    )
+    parser.add_argument(
+        "--check",
+        choices=["static"],
+        default="static",
+        help="Check mode. Only static mode is supported.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        manifest_path = args.manifest
+        if not manifest_path.is_absolute():
+            manifest_path = _repo_root() / manifest_path
+        manifest = _load_manifest(manifest_path)
+        exit_code, lines = run_static_check(
+            manifest,
+            requested_system=args.system,
+            repo_root=_repo_root(),
+        )
+    except Exception as exc:
+        print(f"ERROR {exc}", file=sys.stderr)
+        return 2
+
+    for line in lines:
+        print(line)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_runtime_authority_manifest.py
+++ b/tests/unit/test_runtime_authority_manifest.py
@@ -76,7 +76,10 @@ def test_known_task_orchestrator_conflict_is_represented() -> None:
     task_orchestrator = systems_by_name()["task-orchestrator"]
     assert task_orchestrator["authority_status"] == "CONFLICTING"
     assert "task_orchestrator_unsupported_runtime_variant" in conflict_ids(task_orchestrator)
-    assert "task_orchestrator_port_3014_vs_8000" in conflict_ids(task_orchestrator)
+    assert "task_orchestrator_port_3014_vs_8000" not in conflict_ids(task_orchestrator)
+    ports = {item["port"]: item["status"] for item in task_orchestrator["expected_ports"]}
+    assert ports[8000] == "observed"
+    assert 3014 not in ports
 
 
 def test_known_conport_conflict_is_represented() -> None:

--- a/tests/unit/test_runtime_authority_manifest.py
+++ b/tests/unit/test_runtime_authority_manifest.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "config" / "runtime_authority_manifest.json"
+VERIFIER = REPO_ROOT / "scripts" / "verify_runtime_authority.py"
+
+REQUIRED_SYSTEMS = {
+    "dopemux",
+    "dopetask",
+    "taskx",
+    "task-orchestrator",
+    "ConPort",
+    "dope-memory",
+    "working-memory-assistant",
+    "dope-context",
+    "dopecon-bridge",
+    "ADHD Engine",
+    "Repo Truth Extractor",
+    "Leantime",
+    "Serena",
+}
+
+REQUIRED_FIELDS = {
+    "system",
+    "domain",
+    "authority_status",
+    "expected_paths",
+    "expected_ports",
+    "forbidden_authority_paths",
+    "known_conflicts",
+    "validation_mode",
+    "notes",
+}
+
+
+def load_manifest() -> dict:
+    return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+
+def systems_by_name() -> dict[str, dict]:
+    return {entry["system"]: entry for entry in load_manifest()["systems"]}
+
+
+def conflict_ids(entry: dict) -> set[str]:
+    return {conflict["id"] for conflict in entry["known_conflicts"]}
+
+
+def test_manifest_json_parses() -> None:
+    manifest = load_manifest()
+    assert manifest["schema_version"] == "1.0"
+    assert isinstance(manifest["systems"], list)
+
+
+def test_required_systems_exist() -> None:
+    assert set(systems_by_name()) == REQUIRED_SYSTEMS
+
+
+def test_every_entry_has_required_fields() -> None:
+    for entry in load_manifest()["systems"]:
+        assert REQUIRED_FIELDS <= set(entry)
+        assert isinstance(entry["expected_paths"], list)
+        assert isinstance(entry["expected_ports"], list)
+        assert isinstance(entry["forbidden_authority_paths"], list)
+        assert isinstance(entry["known_conflicts"], list)
+        assert isinstance(entry["notes"], list)
+
+
+def test_known_task_orchestrator_conflict_is_represented() -> None:
+    task_orchestrator = systems_by_name()["task-orchestrator"]
+    assert task_orchestrator["authority_status"] == "CONFLICTING"
+    assert "task_orchestrator_unsupported_runtime_variant" in conflict_ids(task_orchestrator)
+    assert "task_orchestrator_port_3014_vs_8000" in conflict_ids(task_orchestrator)
+
+
+def test_known_conport_conflict_is_represented() -> None:
+    conport = systems_by_name()["ConPort"]
+    assert conport["authority_status"] == "CONFLICTING"
+    assert "conport_runtime_surface_split" in conflict_ids(conport)
+    assert "conport_3004_3005_contract_split" in conflict_ids(conport)
+
+
+def test_dope_memory_port_drift_is_represented() -> None:
+    dope_memory = systems_by_name()["dope-memory"]
+    ports = {item["port"]: item["status"] for item in dope_memory["expected_ports"]}
+    assert ports[3020] == "observed"
+    assert ports[8096] == "conflicting"
+    assert "dope_memory_3020_vs_8096" in conflict_ids(dope_memory)
+
+
+def test_taskx_is_shim_only_not_runtime_authority() -> None:
+    taskx = systems_by_name()["taskx"]
+    assert taskx["authority_status"] == "SHIM_ONLY"
+    forbidden_domains = {
+        item["forbidden_domain"] for item in taskx["forbidden_authority_paths"]
+    }
+    assert "execution_runtime" in forbidden_domains
+
+
+def test_dopecon_bridge_is_transport_only_not_domain_authority() -> None:
+    bridge = systems_by_name()["dopecon-bridge"]
+    assert bridge["authority_status"] == "TRANSPORT_ONLY"
+    forbidden_domains = {
+        item["forbidden_domain"] for item in bridge["forbidden_authority_paths"]
+    }
+    assert "pm_workflow_decision_progress_authority" in forbidden_domains
+
+
+def run_verifier(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(VERIFIER), *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_verifier_produces_stable_output() -> None:
+    args = (
+        "--manifest",
+        "config/runtime_authority_manifest.json",
+        "--check",
+        "static",
+    )
+    first = run_verifier(*args)
+    second = run_verifier(*args)
+    assert first.returncode == 0, first.stdout + first.stderr
+    assert second.returncode == 0, second.stdout + second.stderr
+    assert first.stdout == second.stdout
+    assert "SUMMARY status=passed failures=0" in first.stdout
+
+
+def test_verifier_exits_nonzero_for_missing_required_path(tmp_path: Path) -> None:
+    manifest = copy.deepcopy(load_manifest())
+    by_name = {entry["system"]: entry for entry in manifest["systems"]}
+    target_entry = by_name["dopemux"]
+    required_path = next(
+        (p for p in target_entry["expected_paths"] if p.get("required", True)),
+        None,
+    )
+    assert required_path is not None, "dopemux must have at least one required expected_path"
+    required_path["path"] = "missing-required-file.txt"
+    temp_manifest = tmp_path / "runtime_authority_manifest.json"
+    temp_manifest.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    result = run_verifier(
+        "--manifest",
+        str(temp_manifest),
+        "--system",
+        "dopemux",
+        "--check",
+        "static",
+    )
+
+    assert result.returncode == 1
+    assert "missing required expected path missing-required-file.txt" in result.stdout


### PR DESCRIPTION
Restores the TP-DMX-RUNTIME-VERIFY-001 artifacts required before TP-DMX-TASKORCH-RUNTIME-001.

Adds:
- config/runtime_authority_manifest.json
- scripts/verify_runtime_authority.py
- tests/unit/test_runtime_authority_manifest.py
- docs/03-reference/governance/runtime-authority-verification.md

Validation:
- python -m json.tool config/runtime_authority_manifest.json
- python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --check static
- python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --system task-orchestrator --check static
- python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json --system conport --check static
- UV_CACHE_DIR=/private/tmp/uv-cache-dopemux-runtime-verify uv run --with pytest python -m pytest -q tests/unit/test_runtime_authority_manifest.py
- git diff --check

Notes:
- Preserves task-orchestrator, ConPort, dope-memory, bridge, WMA, retrieval, and Serena drift as explicit UNKNOWN/CONFLICTING/TRANSPORT_ONLY/SHIM_ONLY states.
- Does not claim live Docker, MCP, database, network, or PM-write proof.