### PR TITLE
docs: restore audit authority evidence files

### DIFF
--- a/docs/03-reference/execution/pal-chaining-doctrine.md
+++ b/docs/03-reference/execution/pal-chaining-doctrine.md
@@ -1,0 +1,564 @@
+---
+id: pal-chaining-doctrine
+title: Pal Chaining Doctrine
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-01'
+last_review: '2026-05-01'
+next_review: '2026-07-30'
+prelude: Pal Chaining Doctrine (reference) for dopemux documentation and developer
+  workflows.
+---
+# PAL_CHAINING_DOCTRINE.md
+
+## Status
+Canonical execution doctrine for PAL MCP tool chaining in software engineering workflows.
+
+## Purpose
+This document defines the authoritative doctrine for how PAL MCP tools should be chained across engineering work. It is intended to govern:
+- understanding and reconnaissance
+- approach selection
+- implementation planning
+- bug investigation
+- implementation hardening
+- diff review
+- documentation generation and validation
+- final verification before commit
+
+It exists to prevent predictable failure modes:
+- acting on shallow understanding
+- planning from guesses
+- implementing before the plan is pressure-tested
+- trusting plausible reasoning over evidence
+- treating tool output as proof
+- using too many tools too early and poisoning context
+- relying on final gates to clean up upstream sloppiness
+
+This doctrine assumes PAL tools are not decorative assistants. They are workflow primitives. Their value comes from sequence, role discipline, and validation boundaries.
+
+## Scope
+This doctrine applies to implementation-oriented workflows where PAL tools are available, including:
+- feature work
+- refactors
+- bug fixes
+- architecture-sensitive changes
+- API/SDK-sensitive changes
+- documentation-sensitive changes
+- security-sensitive changes
+- validation and pre-commit hardening
+
+This doctrine does not replace:
+- repository-specific rules
+- architecture canon
+- change-management policy
+- test requirements
+- review requirements
+- release procedures
+
+Higher-priority local or project-specific rules override this doctrine where they conflict.
+
+---
+
+## 1. Core Thesis
+
+PAL tool chaining should validate engineering work at multiple distinct levels:
+1. understanding validation - did we correctly understand the code, architecture, dependencies, and flows?
+2. approach validation - is the chosen strategy actually sound relative to alternatives?
+3. plan validation - is the work sequenced safely, with verification and rollback built in?
+4. root-cause validation - if behavior is broken, is the diagnosis actually evidenced?
+5. implementation validation - did the change do what it intended without obvious breakage?
+6. diff validation - is the resulting change-set correct, maintainable, safe, and coherent?
+7. documentation validation - do the docs reflect the final implementation and its caveats?
+8. final verification - is the full change ready to commit based on actual evidence?
+
+The doctrine rejects the lazy habit of collapsing these into one vague question like "does this seem right?"
+
+---
+
+## 2. Non-Negotiable Chain Laws
+
+### Law 1. No planner before validated understanding.
+Do not use `planner` to produce an execution plan until understanding has reached at least MEDIUM confidence through `analyze`, `tracer`, or equivalent evidenced inspection.
+
+### Law 2. No implementation before plan challenge.
+Every non-trivial plan must be pressure-tested by `challenge`. High-risk or ambiguous plans should also be deepened with `thinkdeep` first.
+
+### Law 3. No consensus unless real ambiguity exists.
+Do not invoke `consensus` unless there are at least two credible approaches, the choice matters, and the decision is materially expensive to reverse.
+
+### Law 4. No debug without failure, contradiction, or concrete uncertainty.
+`debug` is for investigating behavior that is broken, surprising, or insufficiently explained. It is not a general-purpose thinking ritual.
+
+### Law 5. No precommit without prior diff hardening.
+`precommit` is the final gate, not the first serious review. Minimum acceptable hardening for meaningful changes is `codereview -> precommit`.
+
+### Law 6. No docgen on unstable implementation.
+Do not run `docgen` while implementation is still moving significantly.
+
+### Law 7. No apilookup guessing.
+If current API, SDK, framework, package, or OS-version behavior affects correctness, `apilookup` is mandatory before the plan is locked.
+
+### Law 8. Every major stage artifact must be challenged or discarded.
+Any artifact you are about to act on must be either pressure-tested or replaced. Unchallenged outputs are provisional.
+
+### Law 9. Stage-boundary outputs must be compact.
+At stage boundaries, output must be compressed to decision-grade form. Do not drag whole transcripts, giant diffs, or sprawling summaries into every subsequent stage.
+
+### Law 10. Final completion claims require evidence.
+No task may be called complete without an evidence ledger that records what was inspected, what was changed, what was tested, what was reviewed, and what final gate passed.
+
+### Law 11. Tool output is not proof.
+No PAL analysis tool by itself proves correctness. Tool output may reveal evidence, organize findings, or surface risks, but proof requires inspection, tests, review, or final gate validation.
+
+### Law 12. Chaining must stop when additional tools no longer change the decision.
+If the next tool call would add noise rather than decision value, stop.
+
+---
+
+## 3. Confidence Taxonomy
+
+### LOW
+- speculative
+- weakly evidenced
+- incomplete or contradictory
+- not safe to plan or implement from
+
+### MEDIUM
+- plausible and partially evidenced
+- enough to proceed with bounded caution
+- still requires challenge and often deeper validation
+
+### HIGH
+- strongly evidenced
+- consistent with observed code, flow, or runtime behavior
+- safe to proceed with execution or fix design
+
+### VERIFIED
+- supported by final evidence such as executed tests, confirmed behavior, review findings resolution, and pre-commit validation
+- sufficient for completion claims
+
+### Minimum required confidence by stage
+- understanding before planning: MEDIUM
+- plan before implementation: MEDIUM, preferably HIGH for risky changes
+- root cause before bug fix: HIGH
+- final completion claim: VERIFIED
+
+If confidence does not meet the stage threshold, you must either gather evidence, narrow scope, or stop.
+
+---
+
+## 4. Tool Roles and Trust Boundaries
+
+### 4.1 `analyze`
+Role: systematic code understanding across files, modules, patterns, dependencies, and architecture.
+
+Use for unfamiliar subsystem exploration, architecture scans, responsibility mapping, and invariant discovery.
+
+Validates best: understanding.
+
+Do not trust it for final correctness of a fix, proving runtime behavior, or replacing final review or final verification.
+
+Best chain position: first or early.
+
+Doctrine status: conditional but effectively mandatory when the area is unfamiliar or architecture-sensitive.
+
+### 4.2 `tracer`
+Role: structured tracing of call flow, dependencies, fan-in, and fan-out.
+
+Use for call-flow ambiguity, dependency directionality, safe edit-point discovery, and high-coupling work.
+
+Validates best: trace and flow assumptions.
+
+Do not trust it for full architectural understanding by itself, runtime truth without corroboration, or strategy selection by itself.
+
+Best chain position: after initial orientation, before planning if flow ambiguity blocks safe action.
+
+Doctrine rule: tracer does not replace analyze. It sharpens the flow question. Analysis or equivalent reasoning still has to validate what the trace implies.
+
+### 4.3 `planner`
+Role: stepwise plan generation, sequencing, branching, dependency management.
+
+Use for implementation plans, migration sequencing, safe refactor decomposition, and validation-aware execution paths.
+
+Validates best: plan structure.
+
+Do not trust it for choosing among ambiguous approaches without further challenge or proving feasibility without understanding inputs.
+
+Best chain position: after understanding reaches MEDIUM confidence.
+
+Doctrine status: core.
+
+### 4.4 `thinkdeep`
+Role: deep stage-transition reasoning, edge-case analysis, alternative approach exploration, second-order effect detection.
+
+Use for deepening understanding after reconnaissance, stress-testing plans, probing review findings for deeper implications, and challenging hidden coupling or edge cases.
+
+Validates best: approach and risk discovery.
+
+Do not trust it for current API facts, completion proof, or runtime verification without evidence.
+
+Best chain position: between major stages, not between every micro-step.
+
+Doctrine status: core, budgeted.
+
+### 4.5 `challenge`
+Role: adversarial critique and anti-complacency check.
+
+Use for testing assumptions after understanding, testing executable soundness after planning, questioning review verdicts, and questioning final readiness before commit.
+
+Validates best: assumption strength.
+
+Do not trust it for deep exploration by itself or replacing plan structure or analysis.
+
+Best chain position: immediately after a stage artifact you are tempted to trust.
+
+Doctrine status: core.
+
+### 4.6 `consensus`
+Role: multi-perspective approach comparison.
+
+Use for real design forks, architecture decisions with tradeoffs, reversibility-expensive choices, and decisions involving security, performance, or operability tradeoffs.
+
+Validates best: approach selection under ambiguity.
+
+Do not trust it for trivial decisions or producing truth where facts are missing.
+
+Best chain position: after planner when multiple serious options remain.
+
+Doctrine status: escalation tool.
+
+### 4.7 `debug`
+Role: systematic investigation of concrete failures or surprising behavior.
+
+Use for runtime bugs, flaky tests, unexplained failures, and contradictions between expectation and evidence.
+
+Validates best: root-cause hypotheses.
+
+Do not trust it for general architecture reconnaissance or feature planning without failure evidence.
+
+Best chain position: lead tool for bugs, or conditional escalation from implementation when behavior breaks.
+
+Doctrine status: conditional, mandatory for runtime uncertainty.
+
+### 4.8 `codereview`
+Role: professional diff hardening.
+
+Use for final diff review, security/performance/maintainability review, issue severity triage, and cross-file quality validation.
+
+Validates best: diff quality.
+
+Do not trust it for proving requirements are met end-to-end or replacing executed verification.
+
+Best chain position: after implementation stabilizes, before precommit.
+
+Doctrine status: core.
+
+### 4.9 `precommit`
+Role: final readiness gate.
+
+Use for final change-set validation, dependency impact checks, regression risk checks, and final approval or fix-required output.
+
+Validates best: final verification.
+
+Do not trust it for replacing earlier review hardening or discovering the entire strategy from scratch.
+
+Best chain position: last validation tool before commit.
+
+Doctrine status: mandatory final gate.
+
+### 4.10 `docgen`
+Role: documentation generation and documentation-grounding validation.
+
+Use for public interface changes, complexity-heavy modules, gotcha-rich code, and onboarding-sensitive changes.
+
+Validates best: documentation completeness and implementation alignment.
+
+Do not trust it for correctness if the implementation is still unstable or final truth of docs without checking final code surfaces.
+
+Best chain position: late-middle, once code stabilizes, before final review gates.
+
+Doctrine status: conditional, mandatory where docs are required or behavior is likely to confuse future maintainers.
+
+### 4.11 `apilookup`
+Role: authoritative current API/SDK fact validation.
+
+Use for breaking changes, migrations, version-dependent behavior, deprecations, and OS-specific APIs.
+
+Validates best: API/SDK correctness assumptions.
+
+Do not trust it for codebase-local architectural truth or final implementation safety by itself.
+
+Best chain position: early, before the plan locks, and again if implementation hits external API ambiguity.
+
+Doctrine status: mandatory when API/SDK sensitivity exists.
+
+### 4.12 `testgen`
+Role: generate validation-oriented tests, especially for regressions and edge cases.
+
+Use for bug fixes, risky refactors, logic-heavy flows, and coverage gaps found during review.
+
+Validates best: test strategy and regression coverage.
+
+Do not trust it for correctness without actually executing tests.
+
+Best chain position: middle-late, after the approach is chosen, before final precommit.
+
+Doctrine status: escalation tool, strongly recommended for real regression risk.
+
+### 4.13 `secaudit`
+Role: security-focused validation and threat-surface assessment.
+
+Use for auth/authz changes, secrets handling, sensitive data flows, and internet-facing surface changes.
+
+Validates best: security risk.
+
+Do not trust it for replacing full security engineering or production controls.
+
+Best chain position: late-middle, once the diff exists and the real attack surface is visible.
+
+Doctrine status: escalation tool, mandatory for security-sensitive work.
+
+### 4.14 `refactor`
+Role: refactor-specific decomposition and modernization guidance.
+
+Use for large refactors, decomposition planning, and legacy modernization.
+
+Validates best: refactor structure and seam discovery.
+
+Do not trust it for proving the refactor is safe without tests/review/final validation.
+
+Best chain position: early-middle.
+
+Doctrine status: optional/conditional.
+
+---
+
+## 5. Standard Chain Grammar
+
+The default chain grammar is:
+
+1. Understand: `analyze`, optionally `tracer -> analyze`
+2. Deepen: `thinkdeep`
+3. Adversarial check: `challenge`
+4. Plan: `planner`
+5. Plan check: `challenge`, optionally `thinkdeep`, optionally `consensus`
+6. Execute: implement outside PAL, optionally `testgen`, `refactor`, `secaudit`, `apilookup` re-entry as needed
+7. Review: `codereview`
+8. Final gate: `precommit`
+9. Final sanity: `challenge`
+
+This grammar should be adapted per task type, but not casually violated.
+
+---
+
+## 6. Chain Recipes by Task Type
+
+### 6.1 Unfamiliar subsystem
+Recommended chain: `analyze -> thinkdeep -> challenge -> (tracer -> analyze if needed) -> thinkdeep -> challenge -> planner`
+
+Use when subsystem boundaries or ownership are unclear.
+
+Do not use when the architectural map is already validated.
+
+Required stage outputs:
+- component map
+- key files
+- invariants
+- primary entry points
+- call-flow uncertainty list
+- plan draft
+
+Exit condition: you can name the safe edit points and relevant blast radius.
+
+### 6.2 Architecture-sensitive change
+Recommended chain: `analyze -> thinkdeep -> challenge -> planner -> thinkdeep -> challenge -> codereview -> precommit`
+
+Use when the change spans modules or crosses abstraction boundaries.
+
+Exit condition: impact boundary and regression risks are explicit.
+
+### 6.3 Call-flow-sensitive work
+Recommended chain: `tracer -> analyze -> thinkdeep -> challenge -> planner`
+
+Use when safe edits depend on knowing call hierarchy or fan-out.
+
+Exit condition: the call graph is understood well enough to choose a safe change point.
+
+### 6.4 Ambiguous design fork
+Recommended chain: `planner (alternatives) -> consensus -> thinkdeep -> challenge -> planner (final) -> codereview -> precommit`
+
+Use when at least two credible designs remain and reversibility is expensive.
+
+Exit condition: one approach is selected with explicit rationale and rejected alternatives.
+
+### 6.5 Runtime bug
+Recommended chain: `debug -> thinkdeep -> challenge -> testgen -> codereview -> precommit`
+
+Use when behavior is broken, flaky, or contradicted by evidence.
+
+Exit condition: root cause is HIGH confidence and fix is backed by regression validation.
+
+### 6.6 API/SDK-sensitive change
+Recommended chain: `apilookup -> challenge -> analyze -> planner -> codereview -> precommit`
+
+Use when correctness depends on current external APIs or SDK behavior.
+
+Exit condition: the plan includes version assumptions and verification steps.
+
+### 6.7 Documentation-sensitive change
+Recommended chain: `analyze -> planner -> implement -> docgen -> challenge -> codereview -> precommit`
+
+Use when docs are acceptance criteria or behavior/gotchas must be captured.
+
+Exit condition: docs match final code surfaces and caveats.
+
+### 6.8 Security-sensitive change
+Recommended chain: `analyze -> thinkdeep -> planner -> challenge -> implement -> secaudit -> codereview (security) -> precommit`
+
+Use when auth, secrets, sensitive data, or exposed attack surface changes.
+
+Exit condition: no unresolved material security findings remain.
+
+---
+
+## 7. Implementation-Phase Doctrine
+
+### 7.1 Slice execution rule
+Implementation must proceed in commit-sized slices.
+
+After each meaningful slice:
+- run the smallest relevant verification
+- inspect the diff
+- decide whether to continue, revise the plan, or enter debug
+
+Do not stack multiple unvalidated slices unless the packet explicitly authorizes it.
+
+### 7.2 Slice review loop
+For risky or growing diffs: `(implement slice) -> codereview (quick/full as appropriate) -> challenge -> continue`
+
+Use `testgen` if the slice creates or reveals coverage gaps.
+
+### 7.3 Debug re-entry rule
+If implementation produces surprising failures, contradictions, or unclear behavior:
+- stop speculative patching
+- enter `debug`
+- do not continue implementation until the root cause reaches at least HIGH confidence
+
+### 7.4 Re-plan rule
+If codereview, debug, or precommit reveals architecture-level issues or sequence flaws:
+- return to `planner`
+- revise the plan
+- continue only once the revised plan is challenged again
+
+---
+
+## 8. Output Artifact Contract
+
+Every stage artifact must be:
+- compact
+- evidence-linked
+- decision-oriented
+- challengeable
+
+### Required artifact fields at stage boundaries
+1. summary - what is currently believed
+2. evidence ledger - files, flows, logs, findings, or API docs inspected
+3. assumptions - what remains provisional
+4. confidence - LOW / MEDIUM / HIGH / VERIFIED
+5. next action - and why it is justified
+
+### Output-shape rule
+Use richer output inside investigation workflows. Use compressed output at stage boundaries.
+
+Do not carry forward:
+- giant code dumps
+- full review transcripts
+- repeated summaries
+- giant diffs in-band
+
+If output is not improving the next decision, compress it or discard it.
+
+---
+
+## 9. Escalation Rules
+
+Escalate to `consensus` when there are at least two credible approaches, the decision is expensive to reverse, and tradeoffs matter materially.
+
+Escalate to `debug` when there is a concrete failure, expected behavior is contradicted by evidence, or confidence is too low to justify a fix.
+
+Escalate to `docgen` when docs are required, public interfaces changed, or complexity or gotcha risk is high.
+
+Escalate to `apilookup` when external API or SDK behavior matters, version/deprecation/migration facts affect correctness, or OS-bound behavior is relevant.
+
+Escalate to `testgen` when regression risk is real, a bug fix needs lock-in coverage, or codereview identifies coverage gaps.
+
+Escalate to `secaudit` when auth/authz changes, secrets or sensitive data are touched, or network-facing behavior changes.
+
+Escalate to `refactor` when refactor scope is broad enough that seam discovery matters or decomposition strategy is unclear.
+
+---
+
+## 10. Termination Rules
+
+Stop chaining when any of the following is true:
+- the next tool would not change the decision
+- uncertainty is below the packet's risk threshold
+- remaining uncertainty can only be resolved by implementation or runtime evidence
+- outputs have become repetitive rather than decision-advancing
+- the chain is widening the blast radius instead of narrowing the problem
+- the packet should be split rather than further reasoned about
+
+Stop the packet entirely when:
+- understanding cannot reach MEDIUM confidence
+- the plan cannot be made executable within scope
+- required API facts cannot be sourced
+- runtime evidence is insufficient to reach HIGH confidence on a root cause
+- final verification cannot reach VERIFIED
+
+---
+
+## 11. Anti-Patterns
+
+- using many tools before validating the subsystem map
+- using planner before understanding
+- using consensus for straightforward decisions
+- using debug without concrete failure or contradiction
+- using challenge only after implementation is largely complete
+- carrying giant outputs across every stage
+- letting precommit become the first serious quality step
+- generating docs before code is stable
+- making completion claims without an evidence ledger
+- looping through thinkdeep/challenge/consensus after the decision is already clear
+
+---
+
+## 12. Final Verification Standard
+
+Minimum acceptable final hardening for meaningful work: `codereview -> precommit`
+
+Recommended final hardening for most non-trivial work: `codereview -> challenge -> precommit -> challenge`
+
+A task may only be declared complete when:
+- required scope is satisfied
+- no unresolved material review findings remain
+- final precommit passes or required fixes were completed and rerun
+- evidence ledger is complete
+- final confidence is VERIFIED
+
+---
+
+## 13. Evidence Ledger Requirements
+
+Every completed packet must include:
+- task objective
+- scope actually changed
+- relevant files inspected
+- tools used and why
+- key findings by stage
+- assumptions resolved or remaining
+- tests run or validation performed
+- codereview findings and disposition
+- precommit verdict
+- residual risks
+- final completion status

--- a/docs/03-reference/execution/pal-execution-rules.md
+++ b/docs/03-reference/execution/pal-execution-rules.md
@@ -1,0 +1,159 @@
+---
+id: pal-execution-rules
+title: Pal Execution Rules
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-01'
+last_review: '2026-05-01'
+next_review: '2026-07-30'
+prelude: Pal Execution Rules (reference) for dopemux documentation and developer workflows.
+---
+# PAL_EXECUTION_RULES.md
+
+## Status
+Compressed operational rules derived from `PAL_CHAINING_DOCTRINE.md`.
+
+## Purpose
+Daily-use rules for running PAL-driven engineering packets without re-litigating the doctrine every time.
+
+---
+
+## 1. Hard Rules
+
+1. No planner before validated understanding.
+2. No implementation before plan challenge.
+3. No consensus unless at least two credible approaches exist.
+4. No debug without failure, contradiction, or concrete uncertainty.
+5. No precommit without codereview first.
+6. No docgen on unstable code.
+7. No API guessing. Use apilookup when external behavior matters.
+8. Every major artifact must be challenged or discarded.
+9. Keep stage-boundary outputs compressed.
+10. Final completion requires an evidence ledger.
+
+---
+
+## 2. Confidence Thresholds
+
+- LOW: speculative, not actionable
+- MEDIUM: partially evidenced, safe for bounded planning
+- HIGH: strongly evidenced, safe for implementation or bug-fix targeting
+- VERIFIED: passed final evidence gates, safe for completion claims
+
+Minimum thresholds:
+- understanding before planner: MEDIUM
+- plan before implementation: MEDIUM or HIGH depending on risk
+- root cause before bug fix: HIGH
+- final completion: VERIFIED
+
+---
+
+## 3. Standard Chain Grammar
+
+### Default
+`analyze -> thinkdeep -> challenge -> planner -> challenge -> codereview -> precommit -> challenge`
+
+### Add tracer when
+- call-flow ambiguity blocks safe planning or editing
+
+### Add consensus when
+- multiple credible approaches remain
+- the choice is expensive to reverse
+
+### Add debug when
+- runtime behavior is broken, surprising, or contradictory
+
+### Add testgen when
+- regression risk is real
+- codereview finds coverage gaps
+- bug fixes need durable lock-in
+
+### Add secaudit when
+- auth, secrets, sensitive data, or attack surface changes
+
+### Add docgen when
+- docs are required
+- public interfaces changed
+- complexity or gotchas need documentation
+
+### Add apilookup when
+- API/SDK/OS behavior affects correctness
+
+---
+
+## 4. Task Recipes
+
+### Unknown subsystem
+`analyze -> thinkdeep -> challenge -> (tracer -> analyze if needed) -> planner`
+
+### Architecture-sensitive change
+`analyze -> thinkdeep -> challenge -> planner -> codereview -> precommit`
+
+### Runtime bug
+`debug -> thinkdeep -> challenge -> testgen -> codereview -> precommit`
+
+### Ambiguous design fork
+`planner (alts) -> consensus -> thinkdeep -> challenge -> planner (final)`
+
+### API-sensitive work
+`apilookup -> challenge -> analyze -> planner -> codereview -> precommit`
+
+### Documentation-sensitive work
+`analyze -> planner -> implement -> docgen -> challenge -> codereview -> precommit`
+
+### Security-sensitive work
+`analyze -> planner -> implement -> secaudit -> codereview -> precommit`
+
+---
+
+## 5. Slice Execution Rule
+
+Work in commit-sized slices.
+
+After each meaningful slice:
+- run the smallest relevant verification
+- inspect the diff
+- decide whether to continue, re-plan, or enter debug
+
+Do not accumulate multiple unvalidated slices unless explicitly authorized.
+
+---
+
+## 6. Artifact Contract
+
+Every stage artifact must include:
+- summary
+- evidence ledger
+- assumptions
+- confidence
+- next action
+
+Keep it compact.
+
+---
+
+## 7. Stop Rules
+
+Stop chaining when:
+- the next tool would not change the decision
+- uncertainty can only be resolved by implementation or runtime evidence
+- outputs are repetitive rather than decision-advancing
+- blast radius is growing instead of narrowing
+
+Stop the packet when:
+- understanding cannot reach MEDIUM
+- the plan cannot be made executable in scope
+- required API facts cannot be sourced
+- root cause cannot reach HIGH
+- final verification cannot reach VERIFIED
+
+---
+
+## 8. Minimum Completion Standard
+
+Before commit:
+- codereview complete
+- precommit passed
+- evidence ledger complete
+- final confidence = VERIFIED

--- a/docs/03-reference/governance/rules.md
+++ b/docs/03-reference/governance/rules.md
@@ -1,0 +1,332 @@
+---
+id: rules
+title: Rules
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-01'
+last_review: '2026-05-01'
+next_review: '2026-07-30'
+prelude: Rules (reference) for dopemux documentation and developer workflows.
+---
+# RULES.md
+
+This document defines the rules of engagement for the `dopemux-mvp` repository.
+
+These rules are constraints on reasoning, implementation, validation, and completion. They are not suggestions.
+
+---
+
+## 1. Truth Hierarchy
+
+When sources conflict, use this order:
+
+1. Runtime code, config, compose wiring, tests, and active entrypoints
+2. Standard workspace truth artifacts: `TRUTH_*.md`
+3. Canonical documentation: `RULES.md`, `PROJECT.md`, `ARCHITECTURE.md`, `SYSTEM_BOUNDARIES.md`, `PM_PLANE.md`, `SERVICE_CATALOG.md`
+4. Historical, exploratory, generated, or design docs
+
+Historical or exploratory docs are treated as untrusted until runtime or truth artifacts support them.
+
+Never let extracted artifacts outrank the runtime they describe.
+
+---
+
+## 2. Evidence-Based Reasoning
+
+Required:
+
+- Cite or name the artifact behind every success claim.
+- Distinguish observed fact from inference.
+- Mark unresolved truth as `UNKNOWN`.
+- Preserve contradiction when contradiction exists.
+- Prefer exact paths, commands, ports, service names, branch names, and PR URLs.
+- Do not infer implementation from intent, README prose, naming, diagrams, or package presence.
+
+Forbidden:
+
+- “No issues” without checks.
+- “Done” without evidence.
+- Normalizing drift into a cleaner story.
+- Promoting mirrors, adapters, shims, or proxies into authority.
+
+---
+
+## 3. System Boundary Discipline
+
+Dopemux is a multi-system workspace, not a unified monolith.
+
+Keep these authority slices distinct:
+
+- `dopemux`: operator control, CLI, startup, routing, MCP/service coordination
+- `dopetask`: external execution runtime reached through `scripts/dopetask`
+- Leantime: passive PM metadata and project/ticket snapshots
+- task-orchestrator: workflow-significant transitions and workflow views
+- ConPort: structured decisions, progress, project context, custom data
+- dope-memory: chronicle, historical receipts, evidence-preserving memory
+- dope-context: code/docs indexing and retrieval
+- dopecon-bridge: adapter, proxy, event transport, compatibility routing
+- ADHD Engine: operator-support and cognitive-state surfaces
+- Repo Truth Extractor: extraction/audit artifacts about the repo
+
+Rules:
+
+- Planes are not services.
+- Services can span planes.
+- Authority is per domain, not per service.
+- Name the canonical writer before any write.
+- Do not collapse PM, memory, retrieval, execution, bridge, agents, or operator support into one system.
+- Do not treat bridge/proxy routes as source truth.
+- Do not treat derived retrieval output as source truth.
+- Do not treat mirrors as canonical unless the canonical writer and mirror receipt are explicit.
+
+---
+
+## 4. PM, Memory, Retrieval, And Bridge Rules
+
+PM authority is split:
+
+- metadata -> Leantime
+- workflow transitions -> task-orchestrator
+- decisions/progress/context -> ConPort
+- historical receipts -> dope-memory
+
+Memory and retrieval are split:
+
+- chronicle -> dope-memory
+- structured memory/context -> ConPort
+- code/docs retrieval -> dope-context
+
+Bridge rules:
+
+- dopecon-bridge routes, adapts, proxies, and transports events.
+- dopecon-bridge must not become task, workflow, decision, progress, PM, chronicle, or retrieval authority.
+- Any bridge-mediated write must still identify the upstream canonical writer.
+
+---
+
+## 5. Task Packet Contract
+
+All non-trivial implementation or repo-changing work requires a Task Packet conforming to `dopetask-cannonical-spec.json`.
+
+Required fields:
+
+- `id`
+- `project`
+- `target`
+- `repo_binding`
+- `series`
+- `commit`
+- `pr`
+- `steps`
+
+Rules:
+
+- No missing required fields.
+- No undeclared fields.
+- Every step includes `task` and `validation`.
+- Every packet is repo-bound, series-bound, commit-sized, and verifiable.
+- If `execution.agent = "gemini"`, then `pal_chain.enabled = true` is required.
+- Codex work follows `analyze -> planner -> codereview -> precommit` unless the packet requires a stricter PAL chain.
+
+---
+
+## 6. Worktree And Branch Discipline
+
+Every TP series starts in a fresh dedicated worktree.
+
+Before implementation in every TP, verify:
+
+- repo identity matches `repo_binding`
+- required repo marker exists
+- current directory is inside the intended dedicated worktree
+- checked-out branch matches TP / series scope
+- work is not happening from the primary checkout unless explicitly authorized
+
+If verification fails:
+
+- stop
+- report the mismatch
+- do not modify files
+- do not continue
+
+End-state for completed implementation work:
+
+- codereview complete
+- precommit complete
+- branch pushed
+- PR opened
+- dedicated worktree removed
+
+If cleanup is blocked, report the blocker and mark the series incomplete.
+
+---
+
+## 7. PAL Execution Discipline
+
+For non-trivial work, do not skip stage discipline.
+
+Hard rules:
+
+1. No planner before validated understanding.
+2. No implementation before plan challenge.
+3. No debug without concrete failure, contradiction, or uncertainty.
+4. No consensus unless at least two credible approaches exist.
+5. No precommit without codereview first.
+6. No API guessing; use current API lookup when external behavior matters.
+7. No docgen on unstable implementation.
+8. Final completion requires an evidence ledger.
+9. Final confidence must be `VERIFIED`.
+
+Default chain:
+
+`analyze -> thinkdeep -> challenge -> planner -> challenge -> codereview -> precommit -> challenge`
+
+Minimum Codex chain:
+
+`analyze -> planner -> codereview -> precommit`
+
+Escalate when needed:
+
+- `tracer`: call-flow ambiguity
+- `debug`: broken or contradictory runtime behavior
+- `testgen`: regression risk or coverage gap
+- `secaudit`: auth, secrets, sensitive data, network exposure
+- `docgen`: public interfaces, docs acceptance, gotchas
+- `apilookup`: external API / SDK / OS behavior
+
+---
+
+## 8. Operational Safety
+
+Required:
+
+- Work in commit-sized slices.
+- Run the smallest relevant validation after each slice.
+- Inspect diffs before continuing.
+- Reproduce bugs empirically before fixing.
+- Use deterministic ordering and explicit ranking.
+- Preserve idempotency and safe retries.
+- Redact before storage and before promotion.
+- Fail closed when authority, ownership, or safety is unresolved.
+
+Forbidden:
+
+- Opportunistic cleanup outside scope.
+- Silent side effects.
+- Duplicate writers for the same domain.
+- Silent mirroring without receipts.
+- Extraction runner execution unless explicitly instructed.
+- Production-code edits in docs/research packets unless explicitly authorized.
+
+---
+
+## 9. Event And Data Rules
+
+All durable state is event-shaped or evidence-backed.
+
+Required event envelope:
+
+- `id`
+- `ts`
+- `workspace_id`
+- `instance_id`
+- `type`
+- `source`
+- `data`
+
+Promotion rules:
+
+- Promote only decisions, task outcomes, errors, and workflow transitions.
+- Redact before storage.
+- Redact again at promotion.
+- Use `event_id` for idempotency.
+- Expect duplicates, retries, partial failure, and replay.
+
+Storage rules:
+
+- SQLite is canonical where declared.
+- Postgres is a mirror where declared.
+- SQLite must succeed independently.
+- Postgres mirror writes must be idempotent and failure-tolerant.
+
+---
+
+## 10. Retrieval Rules
+
+Phase 1 retrieval is deterministic and keyword-only.
+
+Rules:
+
+- No semantic magic in Phase 1.
+- No LLM scoring in Phase 1.
+- Ranking must be stable and explainable.
+- Controlled boosts are Phase 2+ only.
+- DopeContext owns code/docs retrieval.
+- ConPort owns structured/semantic context and relationship surfaces where runtime proves it.
+- Retrieval output is derived evidence, not source truth.
+
+---
+
+## 11. Output Contract
+
+Default operator-facing output uses the ADHD contract:
+
+- max Top-3 items
+- always include `items`, `more_count`, and `next_token` when listing or summarizing state
+- avoid large dumps
+- avoid mixed signal/noise
+
+Completion reports must include:
+
+- slices completed
+- validations run
+- risks
+- PR URL
+- worktree path
+- verified branch
+- repo identity result
+- cleanup status
+
+No proof means not complete.
+
+---
+
+## 12. Drift Handling
+
+Required:
+
+- Acknowledge drift directly.
+- Document docs-vs-runtime divergence.
+- Preserve `UNKNOWN`, `split`, and `ambiguous` where truth is unresolved.
+- Treat deprecated, duplicate, shadow, or hard-failing paths as risks.
+- Do not narratively clean up runtime contradiction.
+
+Known drift classes to watch:
+
+- task-orchestrator runtime/package/port contradictions
+- Serena canonical authority ambiguity
+- agent authority ambiguity
+- ConPort port/client split
+- dope-memory vs working-memory-assistant overlap
+- TaskX naming vs `dopetask` runtime
+- legacy truth runner vs extractor v5
+- bridge routes that appear authoritative but are not
+
+---
+
+## 13. Finality Standard
+
+A task is complete only when:
+
+- scope is satisfied
+- required validations passed
+- codereview passed
+- precommit passed
+- evidence ledger is complete
+- residual risks are explicit
+- final confidence is `VERIFIED`
+- PR is opened when repo changes are involved
+- worktree cleanup is complete or blocked with evidence
+
+Anything less is incomplete, partial, or blocked.

--- a/docs/03-reference/spec/dopetask/dopetask-cannonical-spec.json
+++ b/docs/03-reference/spec/dopetask/dopetask-cannonical-spec.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "dopeTask TaskPacket - strict repo policy",
+  "description": "Stricter Task Packet contract for repo-bound, series-driven execution with mandatory repo identity binding and Gemini PAL chaining.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "project": {
+      "type": "string"
+    },
+    "target": {
+      "type": "string"
+    },
+    "invariants": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "depends_on": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "default": []
+    },
+    "repo_binding": {
+      "type": "object",
+      "properties": {
+        "project_id": {
+          "type": "string"
+        },
+        "repo_marker": {
+          "type": "string"
+        },
+        "origin_hint": {
+          "type": "string"
+        },
+        "require_identity_match": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "project_id",
+        "repo_marker",
+        "require_identity_match"
+      ],
+      "additionalProperties": false
+    },
+    "series": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "base_branch": {
+          "type": "string"
+        },
+        "parent_tp_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "final_packet": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "id",
+        "base_branch",
+        "parent_tp_id",
+        "final_packet"
+      ],
+      "additionalProperties": false
+    },
+    "execution": {
+      "type": "object",
+      "properties": {
+        "agent": {
+          "type": "string",
+          "enum": [
+            "gemini",
+            "codex",
+            "vibe",
+            "shell"
+          ]
+        },
+        "branch": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "agent"
+      ],
+      "additionalProperties": false
+    },
+    "commit": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string"
+        },
+        "allowlist": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "verify": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "message",
+        "allowlist"
+      ],
+      "additionalProperties": false
+    },
+    "pr": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "base": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "body",
+        "base"
+      ],
+      "additionalProperties": false
+    },
+    "pal_chain": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "enabled",
+        "steps"
+      ],
+      "additionalProperties": false
+    },
+    "steps": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "task": {
+            "type": "string"
+          },
+          "requirements": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "commands": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "expected_files": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "validation": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string"
+            }
+          },
+          "context_files": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "task",
+          "validation"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "id",
+    "project",
+    "target",
+    "repo_binding",
+    "series",
+    "commit",
+    "pr",
+    "steps"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "execution": {
+            "properties": {
+              "agent": {
+                "const": "gemini"
+              }
+            },
+            "required": [
+              "agent"
+            ]
+          }
+        },
+        "required": [
+          "execution"
+        ]
+      },
+      "then": {
+        "required": [
+          "pal_chain"
+        ],
+        "properties": {
+          "pal_chain": {
+            "properties": {
+              "enabled": {
+                "const": true
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "additionalProperties": false
+}

--- a/docs/05-audit-reports/mcp-customization/07-mcp-customization-synthesis-dr-report.md
+++ b/docs/05-audit-reports/mcp-customization/07-mcp-customization-synthesis-dr-report.md
@@ -1,0 +1,498 @@
+---
+id: 07-mcp-customization-synthesis-dr-report
+title: 07 Mcp Customization Synthesis Dr Report
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-01'
+last_review: '2026-05-01'
+next_review: '2026-07-30'
+prelude: 07 Mcp Customization Synthesis Dr Report (reference) for dopemux documentation
+  and developer workflows.
+---
+# MCP Customization Synthesis DR Report
+
+Target file: `07_mcp_customization_synthesis_DR_report.md`
+
+## Executive Findings
+
+items:
+1. The safe Dopemux strategy is **not** to pick a single “best server,” but to keep the existing split-authority model intact and add a boundary-enforcing custom MCP layer that routes each action to the already-declared canonical writer: Leantime for passive PM metadata, Task Orchestrator for workflow transitions and workflow views, ConPort for structured decisions/progress/context/custom data, dope-memory for chronicle receipts and evidence history, dope-context for derived code/docs retrieval, and dopecon-bridge for transport only. Any synthesis that turns bridge, retrieval, or external memory into source truth would violate the repo rules and truth docs. (Sources: `RULES(6).md` L44-L93; `ARCHITECTURE(7).md` L11-L23, L29-L84; `PM_PLANE(7).md` L7-L9, L28-L30, L40-L60; `system-boundaries(8).md` L16-L23, L71-L109; `00-dopemux-context-boundaries(4).md` L35-L49)
+2. Among the researched upstreams, only **ConPort** and **Task Orchestrator** fit canonical write slices in Dopemux, and even then only within their narrow domains. **Serena** fits as read-mostly symbolic code intelligence; **Claude Context** fits as a derived retrieval sidecar or benchmark/fallback, not default truth-bearing retrieval; **Claude-Mem** fits as read-only operator-support continuity memory with promotion-only reviewed flows; and **Mem0** should remain deferred by default and, if explored at all, limited to an isolated self-hosted, search-only pilot with destructive paths hidden. (Sources: `01_conport_DR_report.md` L5-L9, L82-L123; `02_task_orchestrator_DR_report.md` L6-L8, L320-L362, L400-L403; `03_serena_DR_report.md` L9-L10, L164-L177, L181-L208, L230-L233; `04_claude_context_DR_report.md` L9-L11, L120-L156, L174-L181; `05_claude_mem_DR_report.md` L11-L12, L134-L193, L215-L220; `06_mem0_DR_report.md` L7-L15, L96-L165, L187-L192)
+3. The main failure mode is **hidden authority transfer** through mutating memory tools, semantic retrieval presented as truth, bridge/proxy routes that look canonical, and support tooling that bypasses worktree, task-packet, redaction, or provenance rules. The synthesis therefore has to default to read-mostly exposures, explicit writer naming, double redaction, receipt mirroring, event-shaped idempotent writes, and deterministic retrieval phases with fail-closed behavior when provenance or ownership is unresolved. (Sources: `RULES(6).md` L26-L33, L189-L256; `TRUTH_GAPS(7).md` L19-L28, L70-L89; `responsibility-collision-matrix(8).md` L5-L14; `07-cross-system-synthesis.md` L36-L42, L49-L75)
+
+more_count: 8
+next_token: 5_5_pro_audit_prompt
+
+**Scope and evidence base.** This synthesis used the six server-specific reports that were uploaded in this session, the cross-system synthesis seed, and the Dopemux authority/truth documents that describe current boundaries, runtime slices, and known drift. No fresh broad upstream research was performed; where upstream contradictions remained unresolved in the uploaded reports, they are carried forward as `UNKNOWN` rather than reinterpreted here. The six server reports were usable, but several of them explicitly inherited a missing-baseline limitation, and the separately named `00_baseline_DR_report.md` was not present among the accessible uploads in this session. I therefore treated `00-dopemux-context-boundaries(4).md` plus the current authority docs as the practical baseline surrogate, while preserving that substitution itself as a blocker. (Sources: `07-cross-system-synthesis.md` L7-L21, L36-L42, L73-L91; `00-dopemux-context-boundaries(4).md` L35-L49, L60-L91)
+
+| Evidence class | Used in this synthesis | Notes |
+|---|---|---|
+| Server-specific DR reports | `01_conport_DR_report.md`, `02_task_orchestrator_DR_report.md`, `03_serena_DR_report.md`, `04_claude_context_DR_report.md`, `05_claude_mem_DR_report.md`, `06_mem0_DR_report.md` | All six were present and materially useful. |
+| Cross-system seed | `07-cross-system-synthesis.md` | Used for objective, required fields, conflict checks, and validation constraints. |
+| Core authority docs | `RULES(6).md`, `ARCHITECTURE(7).md`, `PM_PLANE(7).md`, `system-boundaries(8).md` | Used as the primary repo-side synthesis baseline. |
+| System docs | `SYSTEM_ConPort(4).md`, `SYSTEM_DopeContext(4).md`, `SYSTEM_DopeMemory(4).md`, `SYSTEM_TaskOrchestrator(1).md` | Used to ground canonical writer, active runtime, and non-responsibilities. |
+| Truth docs | `TRUTH_DATA_EVENTS(9).md`, `TRUTH_GAPS(7).md` | Used for determinism, event contract, and drift/unknowns. |
+| Baseline substitute | `00-dopemux-context-boundaries(4).md`, `responsibility-collision-matrix(8).md` | Used because the separately named `00_baseline_DR_report.md` was not accessible. |
+| Not used | Fresh broad web research; unuploaded local wrapper/build files; unuploaded `dopetask-cannonical-spec.json` | These gaps are carried as `UNKNOWN` or blockers rather than guessed across. |
+
+**Baseline authority restatement.** Dopemux is a multi-system workspace, not a monolith. The repo-level docs are consistent that `dopemux` owns operator control and routing, `dopetask` is the external execution runtime after wrapper handoff, PM authority is split across Leantime, Task Orchestrator, ConPort, and dope-memory receipts, memory is split across dope-memory and ConPort, retrieval is split across dope-context and ConPort, and bridge/proxy transport must never be promoted into source truth. The docs also repeatedly say that services may span planes, but authority remains domain-specific, with the canonical writer named before any write. (Sources: `RULES(6).md` L44-L93; `ARCHITECTURE(7).md` L11-L23, L41-L84; `system-boundaries(8).md` L16-L23, L24-L50, L61-L69, L93-L109; `00-dopemux-context-boundaries(4).md` L37-L49)
+
+| Dopemux slice | Canonical owner today |
+|---|---|
+| Operator control and routing | `dopemux` |
+| External execution runtime | `dopetask` after wrapper handoff |
+| Passive PM metadata and snapshots | Leantime |
+| Workflow transitions, workflow queue/state/blockers, workflow views | Task Orchestrator |
+| Structured decisions, structured progress, project/active context, custom data | ConPort |
+| Chronicle receipts and evidence history | dope-memory |
+| Derived code/docs retrieval and indexing | dope-context |
+| Bridge, proxy, compatibility, event transport | dopecon-bridge only |
+| Operator-support and cognitive-state surfaces | ADHD Engine |
+| Repo extraction and audit artifacts | Repo Truth Extractor |
+
+**Observed fact vs synthesis inference.** The authority split, canonical writers, event envelope requirements, retrieval-phase rules, bridge restrictions, and system non-responsibilities are observed from the authority docs and truth docs. The custom surface names, exposure tiers, roadmap ordering, Telegram topic mapping, and Task Packet drafts below are synthesis inferences built to preserve those observed boundaries rather than replace them. (Sources: `RULES(6).md` L26-L33, L44-L93, L97-L119, L189-L256; `00-dopemux-context-boundaries(4).md` L75-L91)
+
+## Server Posture And Authority Mapping
+
+**Per-server final posture.** The table below synthesizes the six server-specific reports against the Dopemux authority docs. Each row answers the question, “What should this upstream be used for in Dopemux, and what must it not become?” (Evidence basis: `01_conport_DR_report.md` L5-L9, L82-L123; `02_task_orchestrator_DR_report.md` L320-L362, L400-L403; `03_serena_DR_report.md` L72-L84, L164-L208, L230-L233; `04_claude_context_DR_report.md` L120-L156, L174-L181; `05_claude_mem_DR_report.md` L134-L193, L215-L220; `06_mem0_DR_report.md` L96-L165, L187-L192; plus repo authority docs cited in the notes below.)
+
+| Server | Recommended role in Dopemux | Classification | Allowed writes | Allowed reads | Forbidden ownership | Primary guardrail | Confidence |
+|---|---|---|---|---|---|---|---|
+| ConPort | Canonical structured context plane for decisions, progress, project/active context, and constrained custom data; relationship/query surfaces where runtime proof exists | canonical | Structured decisions, structured progress, project/active context, namespaced custom data; relationship writes only after runtime validation | Same domains plus typed/FTS retrieval; semantic search only as derived enrichment | Passive PM metadata, workflow legality/transitions, chronicle authority, dope-context code/docs retrieval | Typed boundary adapter with Dopemux-owned external IDs, hidden delete paths by default, semantic results labeled derived | High for decisions/progress/context/custom data; Medium for relationship writes |
+| Task Orchestrator | Canonical workflow authority for transitions, queue/state/blockers, dependencies, and workflow-serving views | canonical | Workflow transitions, execution dependencies, scoped execution decomposition, queue/blocker state | Workflow context, blocker views, readiness/next-item views | Passive PM metadata, ConPort decision/progress truth, dope-memory chronology, bridge authority | Freeze a validated tool subset first; claims/leases remain deferred until shipped-surface validation | High for workflow core; Medium for claims |
+| Serena | Read-mostly symbolic code-intelligence support and operator-scoped project activation | support-only | None in default profile; symbolic edit lane only under separate operator-approved flow | Symbol lookups, references, project scoping, Serena help/introspection | Canonical retrieval truth, canonical memory, workflow truth, repo-truth extraction, default shell execution | Default read-only profile with memories, onboarding, file writes, raw edits, query-project, dashboard-open, and shell disabled | Medium |
+| Claude Context | Derived retrieval sidecar for approved-repo code and repo-doc search; useful as benchmark or fallback, not as default truth-bearing retrieval plane | derived | Index/cache maintenance only inside approved roots and derived stores | Code and repo-doc retrieval with provenance wrapper | Canonical code/docs truth, project state, workflow state, structured memory, remote infra auto-provisioning by default | Approved-root wrapper, `clear_index` hidden, watcher opt-in only, auto-provision rejected | Medium-High |
+| Claude-Mem | Read-only operator-support continuity memory for Claude sessions, with reviewed promotion-only candidate flows | support-only | No canonical writes; upstream local observations remain isolated in its own derived store only | `search`, `timeline`, `get_observations`, plus optional candidate extraction for review | dope-memory chronicle authority, ConPort structured truth, dope-context retrieval truth, default-generated repo `CLAUDE.md` authority | Read-only adapter, redaction gate before any promotion, folder context disabled by default | Medium |
+| Mem0 | Deferred optional external-memory adapter; if explored, restrict to isolated self-hosted, search-only continuity experiments | support-only | None into canonical Dopemux stores by default; any experimental writes remain inside isolated derived Mem0 storage | Search-only derived continuity and recall hints | dope-memory chronicle authority, ConPort structured truth, dope-context retrieval truth, workflow/PM authority | Hosted mode hidden by default, destructive tools hidden, exportability and data-movement receipts required before pilot | Medium-Low |
+
+**Important row-level caveats.** First, ConPort is clearly authoritative for decisions/progress/context/custom data, but the local system doc proves relationship traversal/query surfaces more clearly than relationship-write authority; relationship writes therefore remain `UNKNOWN` until runtime validation. Second, local Task Orchestrator workflow behavior is canonical for the workflow slice, but its persistence is bridge-mediated custom data, so the bridge remains transport, not owner. Third, Serena’s upstream identity is clear, but the Dopemux-local Serena implementation/deployment writer remains unresolved because the truth docs still show duplicate local surfaces and alias sprawl. (Sources: `SYSTEM_ConPort(4).md` L35-L63, L65-L76; `SYSTEM_TaskOrchestrator(1).md` L17-L24, L39-L40, L79-L88, L110-L119; `TRUTH_GAPS(7).md` L30-L39, L44-L55, L57-L68; `system-boundaries(8).md` L80-L84)
+
+**Authority slice mapping.** This table answers the operational question, “Which server should write each kind of data, and which systems may only read, mirror, enrich, or adapt?” (Sources: `RULES(6).md` L74-L93, L189-L256; `PM_PLANE(7).md` L28-L30, L40-L60; `SYSTEM_ConPort(4).md` L14-L18, L35-L52; `SYSTEM_DopeMemory(4).md` L14-L20, L35-L40, L72-L80; `SYSTEM_DopeContext(4).md` L16-L28, L31-L40, L86-L97; `SYSTEM_TaskOrchestrator(1).md` L17-L24, L27-L50; `TRUTH_DATA_EVENTS(9).md` L64-L79, L123-L145, L187-L205)
+
+| Dopemux slice | Canonical writer | Allowed upstream support servers | Adapter/proxy surfaces | Forbidden servers or claims | Required validation |
+|---|---|---|---|---|---|
+| Passive PM metadata | Leantime | Task Orchestrator may read workflow-correlated items; ConPort may hold related context only | `dopemux` PM write router | Task Orchestrator CRUD becoming PM metadata authority; ConPort task/progress status becoming PM canon | PM-to-workflow crosswalk test; Leantime receipt check |
+| Workflow transitions | Task Orchestrator | None as canonical peers; ConPort may read for enrichment | `dopemux` workflow shim | ConPort progress states, Serena edits, Mem0/Claude-Mem memory claims | Transition legality and mirror-status tests |
+| Workflow queue/state/blockers | Task Orchestrator | None as canonical peers | Project workflow APIs, adapter-only views | Leantime roadmap priority, bridge persistence being mistaken for owner | Queue/blocker read-model tests |
+| Structured decisions | ConPort | Claude-Mem candidate promotion only after review; Mem0 none by default | ConPort adapter only | Claude-Mem observations as decisions; Mem0 facts as decisions; Task Orchestrator notes as decisions | External-ID/idempotency tests and reviewed-promotion path |
+| Structured progress | ConPort | Task Orchestrator may read; ADHD Engine may consume | ConPort adapter only | Task Orchestrator workflow state becoming progress canon or vice versa | Separation tests between workflow status and progress log |
+| Project / active context | ConPort | Claude-Mem candidate hints only after review | ConPort adapter only | Serena onboarding summary or Mem0 memory becoming active context canon | Context round-trip and namespace tests |
+| Custom data | ConPort | Task Orchestrator may persist workflow_* categories through bridge as derived operational data | ConPort adapter; bridge transport only | PM metadata namespaces or bridge routes becoming custom-data authority | Namespace reservation and category allowlist tests |
+| Relationship graph | ConPort where runtime proof exists; relationship-write authority otherwise `UNKNOWN` | Mem0 graph/entity hints only as advisory; Claude-Mem corpora deferred | ConPort adapter only | Mem0 graph memory or ConPort query surfaces being treated as global graph truth without proof | Runtime proof of relation-write support; neighbor query tests |
+| Chronicle / evidence receipts | dope-memory | ConPort and Task Orchestrator may emit source events; external memories may produce candidate receipts only | dope-memory HTTP tools and adapters | Claude-Mem summaries, Mem0 histories, bridge events as chronicle replacement | Receipt provenance, supersession, replay, and mirror tests |
+| Code/docs deterministic retrieval | dope-context | Claude Context only as secondary derived adapter or benchmark; Serena symbol read as support only | dope-context wrapper only | Claude Context or Serena appearing as default source-truth retrieval | Provenance-complete retrieval and stable-sort tests |
+| Semantic retrieval enrichment | No independent canonical writer; derived layer only | dope-context hybrid, ConPort semantic, Claude Context hybrid, optionally Mem0/Claude-Mem memory search in separate lane | Derived ranking wrapper only | Any semantic/vector layer becoming source truth or phase-1 default | Separate phase labeling and rehydration tests |
+| Operator-support memory | None canonical by default | Claude-Mem read-only; ADHD Engine operational support; Mem0 optional self-hosted pilot only | Adapter-only, derived-lane surfaces | External or local support memory becoming project truth | Derived-label and promotion-gate tests |
+| Session continuity | None canonical by default | Claude-Mem first; Mem0 optional self-hosted only | Read-only adapters | Carrying continuity summaries into canonical context without review | Session-memory labeling and retention tests |
+| Code-intelligence / edit support | Local repo changes remain canonical only through approved worktree/task-packet flow, not Serena state | Serena read-mostly symbol support | Dopemux Serena wrapper | Serena memory, shell, raw edits, or repo-truth claims by default | Read-only profile and separate edit-lane tests |
+| Bridge/event transport | dopecon-bridge is transport only; canonical writer depends on payload domain | ConPort and Task Orchestrator may publish events; dope-memory may consume/promote | dopecon-bridge only as proxy/transport | `/kg/*`, `/ddg/*`, `/route/pm` being treated as canonical authority | Event-envelope and proxy non-authority tests |
+
+## Capability Disposition And Collision Controls
+
+**Adopt / adapt / reject / hide / defer matrix.** The synthesis below prioritizes architecture-safe customizations over feature maximization. “Adopt” means the capability aligns cleanly with an existing canonical slice. “Adapt” means the capability is useful only behind a Dopemux boundary wrapper. “Hide” means existing upstream capability should remain internal-only or disabled on the default operator surface. “Defer” means the idea is interesting but blocked by evidence gaps or unacceptable default risk. (Evidence basis: `01_conport_DR_report.md` L100-L123; `02_task_orchestrator_DR_report.md` L335-L349; `03_serena_DR_report.md` L164-L177; `04_claude_context_DR_report.md` L120-L156; `05_claude_mem_DR_report.md` L148-L193; `06_mem0_DR_report.md` L122-L165; `responsibility-collision-matrix(8).md` L5-L14)
+
+| Upstream server | Capability | Recommendation | Reason | Dopemux boundary impact | Validation required | Priority |
+|---|---|---|---|---|---|---|
+| ConPort | Project / active context | adopt | Best-aligned existing canonical slice | Strengthens existing writer without changing ownership | Context versioning and workspace isolation tests | P0 |
+| ConPort | Custom data | adopt | Strongest fit for deterministic keyed context | Safe if namespaces are reserved | Namespace allowlist and idempotent upsert tests | P0 |
+| ConPort | Structured decisions | adapt | Canonical fit, but upstream IDs are auto-increment | Needs external-ID boundary shim | External-ID and reviewed-delete/correction tests | P0 |
+| ConPort | Structured progress | adapt | Canonical fit, but must stay separate from workflow legality | High collision if status semantics blur | Progress-vs-transition separation tests | P0 |
+| ConPort | Relationship graph/query | adapt | Strong fit for query surfaces, but relation writes remain less proven | Requires explicit runtime validation | Relation-write proof and neighbor query tests | P1 |
+| ConPort | Semantic search | adapt | Useful enrichment only, not truth-bearing retrieval | Must remain derived evidence | Rehydration and stable-sort tests | P1 |
+| Task Orchestrator | Workflow transitions | adopt | Strongest evidence-backed workflow fit | Matches canonical workflow slice | State-mapping tests | P0 |
+| Task Orchestrator | Queue/state/blockers | adopt | Native execution readiness surface | Safe if not promoted into PM canon | Queue and blocker read-model tests | P0 |
+| Task Orchestrator | Dependencies | adopt | Directly aligned with workflow sequencing | Safe inside execution slice only | `BLOCKS` and `unblockAt` tests | P0 |
+| Task Orchestrator | Decomposition / work trees | adapt | Useful for execution children, unsafe for PM breakdown canon | Needs parent-source linkage | Parent-link and scope-limit tests | P1 |
+| Task Orchestrator | Claims / leases | defer | Valuable, but release-image presence still uncertain | Medium workflow benefit, unresolved surface drift | Validate shipped `claim_item` support first | blocked |
+| Serena | Symbol navigation and references | adopt | Best differentiated Serena value | Read-mostly support, no authority transfer | Wrapper allowlist tests | P1 |
+| Serena | Project activation / scoping | adapt | Useful operationally, but not PM or workflow authority | Medium risk of identity confusion | Single-project binding tests | P1 |
+| Serena | File/code search fallback | adapt | Useful occasionally, but dope-context owns retrieval | Must never become default retrieval | Provenance labeling and fallback gating tests | P2 |
+| Serena | Memory / onboarding | hide | Highest collision with ConPort and dope-memory | High memory-plane risk | Default `no-memories` / `no-onboarding` tests | P0 |
+| Serena | Symbolic edit tools | hide | Potentially useful later, but unsafe as default surface | High worktree/task-packet collision | Separate edit-lane validation | P1 |
+| Serena | Shell command execution | reject | Highest-risk authority expansion for least Dopemux gain | Critical security and mutation risk | Assert disabled in default profile | P0 |
+| Claude Context | Approved-root retrieval wrapper | adapt | Valuable derived search, not canonical retrieval | Useful sidecar/benchmark if provenance-complete | Provenance envelope and root-control tests | P1 |
+| Claude Context | Trigger watcher / background sync | hide | Widens mutation and scoping surface | High ops risk | Explicit opt-in and scoping tests | P1 |
+| Claude Context | `clear_index` | hide | Destructive operational tool | High accidental disruption risk | Operator-only authorization tests | P0 |
+| Claude Context | Token-driven remote infra auto-provision | reject | Would silently create egress and infra | Critical platform-risk collision | Launch wrapper fail-closed test | P0 |
+| Claude-Mem | Read-only session-memory search | adopt | Strongest safe fit for continuity | Safe if clearly derived | Read-only adapter tests | P1 |
+| Claude-Mem | Fact/decision candidates | adapt | Useful hints, not truth | Needs reviewed promotion path | Promotion-to-ConPort/dope-memory tests | P1 |
+| Claude-Mem | Folder `CLAUDE.md` generation | hide | Derived files can masquerade as repo truth | High retrieval-plane collision | Default-off and repo-cleanliness tests | P0 |
+| Claude-Mem | Import / export | defer | Useful but sensitive | Data-movement and privacy risk | Export policy and redaction review | blocked |
+| Mem0 | Self-hosted search-only pilot | adapt | Only safe lane is isolated, self-hosted, search-only | Medium value, high guardrail need | Local deployment, export, and egress audit | P2 |
+| Mem0 | Hosted cloud MCP memory | defer | Default hosted path conflicts with local evidence plane | High privacy and authority risk | Explicit opt-in and outbound data audit | blocked |
+| Mem0 | Update / delete / correction tools | hide | Collide with chronicle preservation and structured truth | High mutation risk | Destructive-tool hiding tests | P0 |
+| Mem0 | Graph memory / entity linking | defer | Upstream docs drift remains unresolved | High relationship-truth risk | Runtime semantics validation | blocked |
+
+**Responsibility collision matrix.** This is the synthesis-critical control table: where a capability collides, the canonical Dopemux owner wins, and the upstream remains read-only, derived, or disabled. (Evidence basis: `responsibility-collision-matrix(8).md` L5-L14; `03_serena_DR_report.md` L181-L208; `04_claude_context_DR_report.md` L137-L156; `05_claude_mem_DR_report.md` L167-L193; `06_mem0_DR_report.md` L144-L165; `01_conport_DR_report.md` L113-L123; `02_task_orchestrator_DR_report.md` L351-L376; plus core authority docs.)
+
+| Collision | Servers involved | Canonical Dopemux owner | Risk severity | Safe integration posture | Required guardrail | Validation required |
+|---|---|---|---|---|---|---|
+| Mem0 vs dope-memory | Mem0, dope-memory | dope-memory | critical | Mem0 search-only, derived continuity only | Hide update/delete/history; require local receipts for any external interaction | Destructive-tool hiding, outbound data audit, receipt test |
+| Mem0 vs ConPort | Mem0, ConPort | ConPort | critical | No direct decision/progress/context writes from Mem0 | Promotion-only reviewed flow; explicit canonical writer on promotion | ConPort promotion and provenance tests |
+| Claude-Mem vs dope-memory | Claude-Mem, dope-memory | dope-memory | critical | Claude-Mem observations remain candidate or derived continuity only | No automatic chronicle transfer; require receipt mapping | Candidate-to-receipt tests and redaction tests |
+| Claude-Mem vs ConPort | Claude-Mem, ConPort | ConPort | high | Facts/decisions only as review candidates | Promotion queue, not direct write | Decision-promotion path tests |
+| Claude Context vs dope-context | Claude Context, dope-context | dope-context | high | Claude Context only as secondary sidecar or benchmark | Provenance overlay and explicit “derived sidecar” labeling | Same-query comparison and labeling tests |
+| Serena vs dope-context | Serena, dope-context | dope-context | high | Serena search only as symbolic fallback or support | Retrieval ownership banner; default-hide generic file search | Source-owner labeling tests |
+| Serena vs Repo Truth Extractor | Serena, Repo Truth Extractor | Repo Truth Extractor | high | Serena must never populate repo-truth surfaces | No “repo truth” naming or output paths in Serena wrapper | Surface-name audit and routing tests |
+| ConPort progress vs Task Orchestrator workflow | ConPort, Task Orchestrator | Task Orchestrator for legality/transitions; ConPort for structured progress | critical | Keep progress logs and transitions separate | Explicit type split and forbidden cross-write paths | Status/progress separation tests |
+| Bridge/proxy surfaces vs canonical authorities | dopecon-bridge with ConPort, Task Orchestrator, PM routes | Upstream canonical writer per domain; bridge owns none | critical | Bridge remains transport only | Every bridge-mediated write must name upstream writer | Proxy non-authority tests and event-envelope inspection |
+| Serena edits vs worktree/task-packet controls | Serena, repo worktree flow | Approved worktree/task-packet flow | critical | Separate operator-approved edit lane only | Read-only default Serena profile | Worktree verification and disabled-tool tests |
+| Claude-Mem or Mem0 semantic memory vs dope-context retrieval | Claude-Mem, Mem0, dope-context | dope-context | high | Keep memory search on a separate continuity lane | Never merge memory hits into code/docs ranking without labels | Lane-separation and UI-labeling tests |
+
+## Custom MCP Architecture, Governance, And Retrieval
+
+**Target custom MCP architecture.** The safest end state is a Dopemux-owned policy and exposure layer that sits in front of the canonical systems and support-only sidecars. It should expose small, domain-named operator surfaces, while keeping raw upstream tool surfaces internal or disabled by default. That preserves the rule that `dopemux` is the operator/control surface and that no bridge, retrieval cache, or support memory becomes source truth. (Sources: `RULES(6).md` L44-L70; `ARCHITECTURE(7).md` L27-L84; `07-cross-system-synthesis.md` L36-L42, L84-L91)
+
+```mermaid
+flowchart LR
+    O[Operator] --> DMX[dopemux custom MCP policy layer]
+
+    DMX -->|workflow.*| TO[Task Orchestrator]
+    DMX -->|context.*| CP[ConPort]
+    DMX -->|chronicle.*| MEM[dope-memory]
+    DMX -->|retrieval.*| DC[dope-context]
+    DMX -->|symbol.*| SER[Serena]
+    DMX -->|session_memory.*| CM[Claude-Mem]
+
+    DMX -. optional self-hosted search-only .-> M0[Mem0]
+    TO -. transport only .-> BR[dopecon-bridge]
+    CP -. transport/events only .-> BR
+    DC -. optional decision lookup .-> BR
+
+    RT[Repo Truth Extractor] -->|repo_truth.*| DMX
+
+    classDef canonical fill:#eef,stroke:#446;
+    classDef derived fill:#f7f7f7,stroke:#777,stroke-dasharray: 4 2;
+    class TO,CP,MEM,DC,RT canonical;
+    class SER,CM,M0,BR derived;
+```
+
+**Operator-facing surfaces, internal-only tools, and disabled defaults.**
+
+| Exposure tier | Proposed custom surface names | Backing system | Default visibility | Notes |
+|---|---|---|---|---|
+| Operator-facing read | `workflow.get_queue`, `workflow.get_blockers`, `workflow.get_state`, `context.get_active`, `context.search_decisions`, `chronicle.search`, `chronicle.recap`, `retrieval.search_code`, `retrieval.search_docs`, `symbol.find`, `symbol.references`, `session_memory.search` | Task Orchestrator, ConPort, dope-memory, dope-context, Serena, Claude-Mem | visible | These are the safe first-wave surfaces because they are read-mostly or domain-correct reads. |
+| Operator-facing write with explicit confirmation | `workflow.transition`, `context.log_progress`, `context.log_decision`, `session_memory.promote_candidate` | Task Orchestrator, ConPort | visible-with-confirm | Each write surface must declare the canonical writer before execution. |
+| Internal-only adapters | `internal.to.advance_item`, `internal.to.manage_dependencies`, `internal.conport.write_context`, `internal.conport.write_custom_data`, `internal.dopememory.append_receipt`, `internal.claude_context.search_code`, `internal.claude_mem.search`, `internal.mem0.search`, `internal.serena.symbol` | Mixed | hidden | Keep raw upstream naming and quirks away from the operator surface. |
+| Disabled/hidden by default | ConPort delete tools; Task Orchestrator claims until validated; Serena memory tools, onboarding, raw file-edit, symbolic-edit, query-project, dashboard-open, shell; Claude Context watcher, `clear_index`, token-driven auto-provision; Claude-Mem folder `CLAUDE.md`, import/export, uncontrolled saves; Mem0 hosted MCP, update/delete/correction/history/import | Mixed | blocked | These either collide directly with authority boundaries or remain blocked by unresolved evidence. |
+
+The operator-facing tool list above is a synthesis recommendation, not an observed runtime fact. It is grounded in the safe subsets identified in the six server reports and in the repo rule that bridges, mirrors, and derived retrieval outputs must not be promoted into authority. (Sources: `01_conport_DR_report.md` L104-L123; `02_task_orchestrator_DR_report.md` L339-L349; `03_serena_DR_report.md` L166-L177, L183-L208; `04_claude_context_DR_report.md` L143-L155; `05_claude_mem_DR_report.md` L152-L165, L171-L193; `06_mem0_DR_report.md` L126-L165; `RULES(6).md` L35-L40, L63-L70, L197-L208)
+
+**Data governance and storage rules.** Each proposed write path below names its canonical writer, required redaction points, idempotency rule, and failure model. This is where the synthesis answers the question “Which server may write, and which may only mirror, enrich, or adapt?” (Sources: `RULES(6).md` L189-L240; `TRUTH_DATA_EVENTS(9).md` L21-L49, L64-L79, L169-L205; `SYSTEM_ConPort(4).md` L35-L52, L56-L63; `SYSTEM_DopeMemory(4).md` L14-L20, L35-L40, L53-L59, L72-L80; `SYSTEM_DopeContext(4).md` L20-L29, L57-L60; `SYSTEM_TaskOrchestrator(1).md` L27-L40, L79-L81)
+
+| Write path | Canonical writer | Storage backend | Mirror / receipt behavior | Redaction before storage | Redaction before promotion | Idempotency key | Retry behavior | Deletion / correction / supersession model | Must fail closed when |
+|---|---|---|---|---|---|---|---|---|---|
+| Passive PM metadata update | Leantime | Leantime metadata store | Optional workflow mirror only after successful PM update | Yes | N/A | `event_id` + PM object ID + field set | Retry only through PM router | Update in Leantime; no silent delete from other systems | PM object mapping or writer identity is unresolved |
+| Workflow transition | Task Orchestrator | Current local runtime uses workflow state plus bridge-mediated workflow_* custom-data persistence | Mirror status back to PM only as explicit mirror, not ownership transfer | Yes, especially notes/guidance payloads | N/A | `event_id` + work item ID + trigger | Safe retry only if same transition envelope; reject duplicate conflicting trigger | Compensating transition or cancellation, not silent erase | Transition legality, source mapping, or claim status is unresolved |
+| Structured decision log | ConPort | ConPort PostgreSQL decisions/context/custom-data surfaces | Append dope-memory receipt after primary success where the event matters historically | Yes | Yes if promoted further | `event_id` + external decision ID | Retry on same external ID only | Prefer correction/supersession receipt over operator-facing delete | External ID, provenance, or namespace is missing |
+| Structured progress log | ConPort | ConPort PostgreSQL progress surfaces | Append dope-memory receipt after primary success for auditable progress events | Yes | Yes | `event_id` + external progress ID + progress type | Retry idempotently on same external ID | Allow ConPort update, but require chronicle correction receipt for material changes | Payload looks like workflow legality/state instead of progress |
+| Project / active context write | ConPort | ConPort workspace context or namespaced custom data | No default chronicle mirror unless policy says the change is historically material | Yes | Yes for any derivative promotion | `workspace_id` + context namespace + external key | Retry only on same namespace/key | Update-in-place allowed; major changes may emit explicit receipt event | Namespace overlaps PM metadata or workflow state |
+| Relationship write | `UNKNOWN` until runtime proof; treat query surfaces as safe, writes as blocked | ConPort only if relation-write runtime is proven | Optional dope-memory receipt for major structural changes | Yes | Yes | `event_id` + relation tuple | No write retries until runtime support is proven | Correction via compensating relation event, not silent delete | Runtime relation-write support is unproven |
+| Chronicle receipt append | dope-memory | Canonical SQLite ledger; optional Postgres mirror downstream | Postgres mirror only where declared; never source truth | Yes | Yes again at promotion | `event_id` and chronicle provenance fields (`source_event_id`, `source_event_type`, `source_adapter`, `source_event_ts_utc`, `promotion_rule`, `promotion_ts_utc`) | Expect duplicates and replay; SQLite must succeed independently | Prefer correction/supersession over destructive delete | Redaction, provenance, or ledger resolution fails |
+| Retrieval index update | dope-context | Qdrant collections plus BM25 snapshots under `~/.dope-context` | None; index is derived state only | Path, root, and sensitive-doc redaction/exclusion first | N/A | `workspace_id` + content hash + source path | Reindex idempotently by content identity | Reindex or clear derived index only; never source delete | Root approval, ignore policy, or provenance is missing |
+| Session-memory promotion candidate | None canonical until promoted; source remains Claude-Mem or Mem0 derived store | Derived local store only until promoted | On promotion, write into ConPort or dope-memory with a new canonical envelope | Yes | Yes | `source_id` + candidate type + review decision | No automatic retries into canonical stores | Promotion creates new canonical record; source memory remains derived | Candidate lacks provenance, redaction, or review decision |
+| External-memory search result caching | None canonical by default | Avoid durable caching initially | None | Yes | N/A | Query fingerprint only if local ephemeral cache is later added | Best-effort only | Expire only; no authoritative mutation | Search result lacks source label or data-movement disclosure |
+
+**Required event envelope and provenance fields.** Every proposed cross-system event should use the repo-required shape `id`, `ts`, `workspace_id`, `instance_id`, `type`, `source`, and `data`. When the destination is dope-memory, the receipt also needs chronicle provenance fields such as `source_event_id`, `source_event_type`, `source_adapter`, `source_event_ts_utc`, `promotion_rule`, and `promotion_ts_utc`. This is not optional decoration; it is the boundary control that distinguishes a mirror receipt from a silent authority transfer. (Sources: `RULES(6).md` L213-L240; `TRUTH_DATA_EVENTS(9).md` L43-L49)
+
+**Retrieval strategy.** The repo rules explicitly require a deterministic, keyword-only Phase 1 and reserve controlled boosts for later phases. That means the custom MCP layer should separate lexical retrieval from semantic enrichment instead of blending them into one opaque answer surface. It also means memory-search results and symbol-navigation results must never silently mix into code/docs truth. (Sources: `RULES(6).md` L244-L256; `TRUTH_DATA_EVENTS(9).md` L187-L205; `SYSTEM_DopeContext(4).md` L20-L29, L86-L97)
+
+| Retrieval phase | Participating systems | Ranking rule | Labeling rule | Must not happen |
+|---|---|---|---|---|
+| Phase 1 | dope-context under a lexical-only wrapper or equivalent fail-closed adapter; ConPort FTS-only for structured decisions/custom data | Stable, explainable ordering; explicit tie-break; no LLM scoring | `derived=true`, canonical owner named, source path/ID attached | No semantic/vector-only result in this phase; no Claude Context, Claude-Mem, Mem0, or Serena memory hits mixed into code/docs truth |
+| Phase 2 | dope-context hybrid results with known tie-break discipline; ConPort semantic only after typed rehydration; Claude Context as sidecar only if benchmarked | Controlled boosts only; stable secondary key required; repeated runs must preserve order | Retrieval mode and score/rank exposed; source system explicit | No result without rehydratable provenance; no semantic result outranks canonical lexical result without declared policy |
+| Separate continuity lane | Claude-Mem read-only; Mem0 optional self-hosted search-only | Not part of code/docs ranking at all | Always labeled “session memory” or “external memory,” never “repo truth” | No continuity-memory hit in workflow, PM, or code/docs result sets unless explicitly promoted through review |
+
+The most important retrieval blocker is that the current dope-context runtime is described as embedding-capable and hybrid, while the repo rules demand a keyword-only first phase. The synthesis answer is therefore to implement a lexical-only wrapper or fail closed until such a wrapper is proven. That exact lexical-only enforcement path is `UNKNOWN` in the uploaded authority materials and should be audited before rollout. (Sources: `SYSTEM_DopeContext(4).md` L20-L29; `RULES(6).md` L244-L256)
+
+## Operator Experience And Delivery Plan
+
+**Operator UX and Telegram topic routing.** No uploaded runtime document in this session established the current Telegram Topics implementation, so the mapping below is a synthesis assumption for operator ergonomics, not an observed fact. The purpose is to keep operator-visible domains aligned with canonical writers, while leaving transport details and raw upstream tools internal.
+
+| Operator workflow | Proposed custom MCP surfaces | Approval state | Error / blocked state | Telegram topic assumption | What the operator sees | What remains internal |
+|---|---|---|---|---|---|---|
+| Workflow execution | `workflow.get_queue`, `workflow.get_blockers`, `workflow.get_state`, `workflow.transition` | Reads auto; transitions require explicit confirmation unless policy grants automation | Block if PM-to-workflow mapping is unresolved or release-drifted capability is requested | `Execution` topic | Queue, blockers, current workflow state, legal next transitions, canonical owner label | Raw Task Orchestrator tool names, bridge persistence details |
+| Context and progress | `context.get_active`, `context.search_decisions`, `context.log_progress`, `context.log_decision` | Reads auto; writes confirm | Block if namespace, external ID, or writer identity is missing | `Project Context` topic | Context snapshot, decision hits, progress updates, provenance banner | Raw ConPort IDs, delete tools, raw semantic scores unless requested |
+| Retrieval | `retrieval.search_code`, `retrieval.search_docs` | Auto | Block if path root is unapproved, provenance is missing, or lexical phase cannot be enforced | `Retrieval` topic | File path, line range, score/rank, source system, “derived evidence” badge | Sidecar benchmarking, index IDs, destructive index tools |
+| Chronicle | `chronicle.search`, `chronicle.recap` | Auto | Block if ledger resolution or provenance mapping fails | `History` topic | Receipts, recap, replay summaries, correction indicators | Low-level raw Redis/event bus details |
+| Session continuity | `session_memory.search`, `session_memory.promote_candidate` | Search auto; promotion explicit confirm only | Block if redaction fails, source labels missing, or policy forbids external memory | `Session Continuity` topic | Derived continuity memory with source labels and promotion prompt | Underlying Claude-Mem / Mem0 implementation details and raw provider settings |
+| Code intelligence | `symbol.find`, `symbol.references` | Auto | Block any edit/shell request in default profile | `Code Intelligence` topic | Symbol locations and references, clearly labeled as support-only | Serena memories, onboarding, shell, raw edits, dashboard |
+| Audit and boundary status | `operator.boundary_status`, `operator.hidden_tool_request` | Operator/admin only | Show blocked reason and required next action | `Ops / Audit` topic | Why a tool is blocked, which system owns the domain, what validation is missing | Raw config, secret material, unsafe upstream surface names |
+
+**Implementation roadmap.** Each row below is a commit-sized synthesis slice grouped into the required series. The intent is to normalize evidence first, then enforce boundaries, then expose safe surfaces, then add retrieval/memory guardrails, then connect operator UX, and finally harden with tests and audit hooks. (Sources: `07-cross-system-synthesis.md` L23-L34, L77-L91; `RULES(6).md` L97-L119, L123-L150, L189-L256; server-report implementation slices throughout)
+
+| Series | Task | Repo surface | Validation | Guardrail | Dependencies | Risk |
+|---|---|---|---|---|---|---|
+| Series A | Normalize synthesis evidence, missing-file ledger, and per-server posture registry | Docs and policy registry surfaces | All six reports and authority docs indexed in one manifest; missing baseline and missing spec marked `UNKNOWN` | No authority rewrite during normalization | None | Low |
+| Series A | Add boundary matrix for canonical writers and forbidden claims | Docs plus boundary config | Mapping matches repo authority docs exactly | Prevents “best server” collapse | Evidence registry | Low |
+| Series B | Implement ConPort adapter with external-ID shim, namespace reservation, and reviewed delete/correction policy | ConPort adapter layer | Round-trip tests for decisions/progress/context/custom data | ConPort never swallows PM or workflow authority | Series A posture registry | Medium |
+| Series B | Implement Task Orchestrator workflow shim for transitions, queue, blockers, and dependency reads | Workflow adapter layer | Transition legality, queue/blocker, and PM/workflow separation tests | Leantime stays PM metadata owner | Series A posture registry | Medium |
+| Series C | Add default exposure controls and hidden-tool policy for Serena, Claude Context, Claude-Mem, Mem0, and destructive ConPort/TO surfaces | Tool exposure config / wrapper policy | Default profiles expose only approved safe subset | Read-only by default where required | Series B adapters | Medium |
+| Series C | Add operator-facing domain names and source labels | dopemux custom MCP surface layer | Surface inventory audit passes; blocked tools explain ownership | Operators see domains, not raw unsafe tools | Series C exposure controls | Low |
+| Series D | Implement derived-memory promotion gate with double redaction and provenance envelopes | Adapter ingress / promotion queue | Promotion requires explicit review and writer declaration | Derived memory never auto-becomes truth | Series B ConPort + dope-memory hooks | Medium |
+| Series D | Implement retrieval phase separation and provenance wrapper | Retrieval adapter layer | Phase-1 lexical-only test passes or feature fails closed | No semantic truth drift | Series C exposure controls | High |
+| Series E | Add operator UX state machine and Telegram topic routing metadata | Operator UX layer | Approval, blocked, and error states render consistently | No hidden writes from chat surfaces | Series C-D | Medium |
+| Series E | Add explicit edit-lane design behind feature flag for Serena symbolic edits only | Separate policy lane | Worktree/task-packet checks enforced before any edit surface appears | Default Serena stays read-only | Series C exposure controls | Medium |
+| Series F | Build authority-boundary, determinism, redaction, and proxy non-authority test suites | Tests and CI | Full plan in next section passes | No “No issues” shortcut | Series A-E | Medium |
+| Series F | Prepare 5.5 Pro audit bundle and surface inventory diff | Audit docs and generated manifests | Audit prompt reproduces all blockers and `UNKNOWN`s | Prevents silent authority transfer before rollout | Series A-E | Low |
+
+**Task Packet drafts.** The repo rules require Task Packets to conform to `dopetask-cannonical-spec.json`, require the named top-level fields, require worktree verification as the first step, and require Codex work to follow `analyze -> planner -> codereview -> precommit`. The actual schema file was **not** uploaded in this session, so the drafts below are intentionally marked **BLOCKED_BY_UNKNOWN** even though they include the fields named in `RULES(6).md` plus the requested `execution` and `pal_chain` objects. They should be treated as near-schema drafts, not merge-ready packets. (Sources: `RULES(6).md` L97-L119, L123-L176)
+
+**Draft TP-A1 — BLOCKED_BY_UNKNOWN**
+
+```json
+{
+  "id": "TP-A1-mcp-synthesis-evidence-registry",
+  "project": "dopemux-mvp",
+  "target": "docs/research/mcp-customization and policy registry surfaces",
+  "repo_binding": "dopemux-mvp",
+  "series": "A",
+  "commit": "docs(mcp): normalize synthesis evidence and unknown ledger",
+  "pr": "docs/mcp-synthesis-evidence-registry",
+  "steps": [
+    {
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-A1 scope."
+    },
+    {
+      "task": "Create a single evidence registry that lists the six server reports, the cross-system synthesis seed, and all authority/truth docs used by the synthesis.",
+      "validation": "Registry file exists and names every source used in this report, including missing baseline and missing spec as explicit blockers."
+    },
+    {
+      "task": "Add a per-server posture registry that records canonical, derived, support-only, reject, and deferred classifications with canonical Dopemux writer mapping.",
+      "validation": "Registry entries for ConPort, Task Orchestrator, Serena, Claude Context, Claude-Mem, and Mem0 match the synthesized posture matrix."
+    },
+    {
+      "task": "Record all known UNKNOWNs and blockers in one normalized ledger for later 5.5 Pro audit consumption.",
+      "validation": "Ledger includes missing baseline report, missing dopetask schema file, local Serena runtime ambiguity, Task Orchestrator drift, and Mem0 graph/lineage uncertainty."
+    }
+  ],
+  "execution": {
+    "agent": "codex"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "sequence": ["analyze", "planner", "codereview", "precommit"]
+  }
+}
+```
+
+**Draft TP-B1 — BLOCKED_BY_UNKNOWN**
+
+```json
+{
+  "id": "TP-B1-boundary-enforcing-adapters",
+  "project": "dopemux-mvp",
+  "target": "ConPort and Task Orchestrator adapter surfaces",
+  "repo_binding": "dopemux-mvp",
+  "series": "B",
+  "commit": "feat(boundaries): add conport and workflow shims with explicit writer guards",
+  "pr": "feat/boundary-enforcing-adapters",
+  "steps": [
+    {
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-B1 scope."
+    },
+    {
+      "task": "Implement a ConPort adapter that uses Dopemux-owned external IDs, enforces namespace reservations, and keeps decisions/progress/context/custom data separate from PM metadata and workflow state.",
+      "validation": "Round-trip adapter tests pass for context, custom data, decisions, and progress; forbidden namespace writes are rejected."
+    },
+    {
+      "task": "Implement a Task Orchestrator adapter that wraps workflow transitions, queue/state/blockers, and dependencies without transferring PM ownership.",
+      "validation": "Workflow transition legality, queue, blocker, and dependency tests pass; PM metadata is not writable through the adapter."
+    },
+    {
+      "task": "Add explicit bridge non-authority labeling to any persistence path that traverses dopecon-bridge.",
+      "validation": "Logs and envelopes show upstream canonical writer, while bridge is labeled transport/proxy only."
+    }
+  ],
+  "execution": {
+    "agent": "codex"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "sequence": ["analyze", "planner", "codereview", "precommit"]
+  }
+}
+```
+
+**Draft TP-C1 — BLOCKED_BY_UNKNOWN**
+
+```json
+{
+  "id": "TP-C1-exposure-controls",
+  "project": "dopemux-mvp",
+  "target": "custom MCP exposure policy and wrapper config",
+  "repo_binding": "dopemux-mvp",
+  "series": "C",
+  "commit": "feat(mcp): add safe exposure profiles and hidden-tool policy",
+  "pr": "feat/mcp-exposure-controls",
+  "steps": [
+    {
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-C1 scope."
+    },
+    {
+      "task": "Create default-safe exposure profiles that keep Serena read-only, hide Claude Context destructive/auto-provisioning surfaces, expose Claude-Mem as read-only session memory, and hide Mem0 destructive or hosted surfaces.",
+      "validation": "Tool inventory snapshot shows only approved surfaces are exposed in the default profile."
+    },
+    {
+      "task": "Hide ConPort delete tools and Task Orchestrator claims/leases from the default operator profile until separate validation gates are satisfied.",
+      "validation": "Default operator profile cannot invoke destructive ConPort tools or unvalidated Task Orchestrator claim surfaces."
+    },
+    {
+      "task": "Add operator-visible blocked reasons that name the canonical owner whenever a hidden tool is requested.",
+      "validation": "Blocked tool requests return a domain-safe explanation containing the canonical writer and next validation action."
+    }
+  ],
+  "execution": {
+    "agent": "codex"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "sequence": ["analyze", "planner", "codereview", "precommit"]
+  }
+}
+```
+
+**Draft TP-D1 — BLOCKED_BY_UNKNOWN**
+
+```json
+{
+  "id": "TP-D1-retrieval-and-memory-guardrails",
+  "project": "dopemux-mvp",
+  "target": "retrieval wrappers and derived-memory promotion gate",
+  "repo_binding": "dopemux-mvp",
+  "series": "D",
+  "commit": "feat(guardrails): split retrieval phases and gate derived memory promotion",
+  "pr": "feat/retrieval-memory-guardrails",
+  "steps": [
+    {
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-D1 scope."
+    },
+    {
+      "task": "Add a lexical-first retrieval wrapper that enforces Phase 1 determinism and fails closed if lexical-only behavior cannot be proven.",
+      "validation": "Phase-1 retrieval tests show stable lexical ordering or explicit fail-closed behavior when lexical-only enforcement is unavailable."
+    },
+    {
+      "task": "Add a derived-memory promotion gate that redacts before storage, redacts again at promotion, and requires canonical writer declaration before any ConPort or dope-memory write.",
+      "validation": "Promotion tests fail when provenance or redaction is missing and pass only with explicit review and full envelope fields."
+    },
+    {
+      "task": "Keep Claude-Mem and Mem0 on separate continuity lanes that never enter code/docs retrieval ranking.",
+      "validation": "Search result sets for code/docs never contain continuity-memory hits unless explicit promotion has occurred."
+    }
+  ],
+  "execution": {
+    "agent": "codex"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "sequence": ["analyze", "planner", "codereview", "precommit"]
+  }
+}
+```
+
+**Draft TP-F1 — BLOCKED_BY_UNKNOWN**
+
+```json
+{
+  "id": "TP-F1-boundary-test-and-audit-pack",
+  "project": "dopemux-mvp",
+  "target": "tests, CI checks, and audit bundle generation",
+  "repo_binding": "dopemux-mvp",
+  "series": "F",
+  "commit": "test(boundaries): add authority, determinism, redaction, and proxy-leak checks",
+  "pr": "test/boundary-audit-pack",
+  "steps": [
+    {
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-F1 scope."
+    },
+    {
+      "task": "Add authority-boundary tests, redaction tests, no-secrets-persisted tests, retrieval determinism tests, and adapter/proxy non-authority tests.",
+      "validation": "All new tests fail on known boundary violations and pass on the intended safe profiles."
+    },
+    {
+      "task": "Add integration-flow tests for workflow transitions, ConPort writes plus dope-memory receipts, retrieval wrappers, and session-memory promotion gates.",
+      "validation": "End-to-end flows pass with explicit provenance and canonical writer declarations."
+    },
+    {
+      "task": "Generate an audit bundle for 5.5 Pro containing surface inventories, enabled/disabled tool lists, UNKNOWNs, blockers, and Task Packet drafts.",
+      "validation": "Audit bundle includes all required artifacts and matches the final synthesis report."
+    }
+  ],
+  "execution": {
+    "agent": "codex"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "sequence": ["analyze", "planner", "codereview", "precommit"]
+  }
+}
+```
+
+## Validation, Blockers, Audit Seed, And Final Recommendation
+
+**Test and validation plan.** The repo rules explicitly forbid “No issues” without checks, require deterministic ordering, idempotency, safe retries, double redaction, and fail-closed behavior when ownership or safety is unresolved. The plan below translates those rules into implementation-facing tests. (Sources: `RULES(6).md` L26-L40, L189-L256; `TRUTH_DATA_EVENTS(9).md` L169-L205; `TRUTH_GAPS(7).md` L19-L28, L70-L89)
+
+| Test class | What to test | Minimum acceptance |
+|---|---|---|
+| Determinism tests | Retrieval ordering for lexical phase, dope-context hybrid tie handling, dope-memory chronicle search ordering, ConPort semantic rehydration ordering where enabled | Repeated runs produce stable order; tie-break is explicit; semantic result without rehydratable provenance fails closed |
+| Redaction tests | Redaction before storage and again before promotion; `<private>` and non-tagged secret-like inputs for Claude-Mem / Mem0 candidate paths; notes/guidance payload scrubbing | Secret-like content never lands in canonical stores without approved redaction; failed redaction blocks write |
+| No-secrets-persisted tests | Canonical stores and derived stores after representative flows | Secrets are absent from stored canonical records and derived operator-facing caches |
+| Authority-boundary tests | PM metadata through Leantime only, workflow through Task Orchestrator only, decisions/progress/context/custom data through ConPort only, receipts through dope-memory only | Attempts to cross-write into the wrong owner fail visibly |
+| Adapter/proxy non-authority tests | dopecon-bridge, wrapper profiles, internal adapters | Logs and envelopes always report the upstream canonical writer; bridge never appears as canonical owner |
+| Retrieval ranking tests | Phase separation, provenance fields, result-lane separation between code/docs search and continuity memory | Continuity memory never enters code/docs ranking; provenance fields are present on every returned item |
+| Integration flow tests | Workflow transition plus PM mirror, ConPort write plus dope-memory receipt, retrieval wrapper plus operator view, session-memory candidate promotion | End-to-end flow preserves writer naming, receipts, and labels |
+| Failure / retry / idempotency tests | Duplicate events, partial failure, replay, retry against same external ID, SQLite mirror failure scenarios | Same `event_id` or external ID does not duplicate canonical state; mirrors tolerate retry without claiming source truth |
+| Performance targets | Warm-path adapter and wrapper calls where applicable | p50 under 50 ms and p99 under 250 ms for warm local read paths and envelope assembly; explicitly exclude cold indexing, first-run model/provider calls, and disabled external-memory pilots |
+| Safety-profile tests | Default-safe Tool inventory across Serena, Claude Context, Claude-Mem, Mem0, Task Orchestrator claims, and ConPort deletes | Default profile exposes only approved safe subset; blocked requests explain why |
+
+**Blockers and `UNKNOWN`s.** Because the synthesis is supposed to preserve contradictions instead of smoothing them over, the unresolved items are grouped below by category rather than buried in prose.
+
+| Category | Unresolved fact or blocker |
+|---|---|
+| Upstream lineage | `00_baseline_DR_report.md` was not accessible in this session; several server reports therefore already carried a missing-baseline blocker. |
+| Upstream lineage | `dopetask-cannonical-spec.json` was not uploaded, so exact Task Packet schema allowance beyond the fields named in `RULES(6).md` remains `UNKNOWN`. |
+| Upstream feature uncertainty | Task Orchestrator surface drift remains unresolved: README/Quick Start say 13 tools, API docs say 14 including `claim_item`, and `server.json` still shows `3.2.0` while the report anchored `v3.3.0`. |
+| Upstream feature uncertainty | Serena’s local Dopemux canonical implementation/deployment writer remains `UNKNOWN` because local truth docs still show duplicate surfaces and alias sprawl. |
+| Upstream feature uncertainty | ConPort relationship-query surfaces are proven more clearly than relationship-write authority; relation writes remain `UNKNOWN` until runtime proof. |
+| Upstream feature uncertainty | Claude Context exact package-registry state, resources/prompts, and fully documented lexical-only enforcement path remain `UNKNOWN`. |
+| Upstream feature uncertainty | Claude-Mem observation-level delete/correction semantics, full auth model, and exact event-id replay guarantees remain `UNKNOWN`. |
+| Upstream feature uncertainty | Mem0 graph-memory/entity-linking semantics and `mem0-mcp-server` source lineage remain `UNKNOWN`; hosted-memory default posture is still too risky. |
+| Dopemux runtime drift | dope-memory active runtime is on `3020`, but older adapter assumptions still point to `8096`; any custom exposure must avoid inheriting stale transport assumptions. |
+| Dopemux runtime drift | Local Task Orchestrator runtime, Docker target, and port surfaces remain partly contradictory in the truth docs; workflow ownership is clear, packaging alignment is not. |
+| Security / privacy | Serena upstream security model assumes trusted surroundings; shell and edit surfaces therefore remain unsafe as defaults. |
+| Security / privacy | Claude-Mem may send captured content to hosted model providers unless constrained; Mem0 hosted cloud MCP would externalize project memory by default. |
+| Storage / delete / correction | ConPort and upstream memories all expose mutable surfaces; a uniform correction/supersession policy for canonical writes is still not fully specified in the uploaded docs. |
+| Retrieval determinism | Phase-1 lexical-only enforcement path for dope-context is not proven in the uploaded docs even though the repo rules require it. |
+| Operator UX | Telegram Topic implementation details were not evidenced in the uploaded files; the mapping in this report is therefore design guidance, not runtime fact. |
+
+**What 5.5 Pro should audit after this synthesis.** The audit should focus on the places where architecture safety is easy to lose: hidden authority transfer, schema drift, and unsupported write exposure. At minimum, it should verify that no custom surface collapses PM, workflow, context, chronicle, retrieval, bridge, support memory, and execution into one server; that all write paths name the canonical writer; that proxy routes remain labeled as transport; that hidden tools are actually hidden in default profiles; that retrieval phase separation is real; that Task Packet drafts are not falsely claimed conformant in the absence of the uploaded schema; and that no hosted/external memory mode is enabled without explicit policy, exportability, and data-movement disclosure. (Sources: `07-cross-system-synthesis.md` L49-L91; `RULES(6).md` L26-L40, L44-L93, L97-L119, L189-L256; `TRUTH_GAPS(7).md` L19-L28, L70-L89)
+
+**5.5 Pro audit prompt seed**
+
+> Audit this Dopemux MCP customization synthesis for boundary collapse and unsupported claims. Check that:
+> - no section silently merges PM, workflow, ConPort context/progress/decisions, dope-memory chronicle, dope-context retrieval, dopecon-bridge transport, execution, and operator-support into one owner;
+> - every proposed write names one canonical Dopemux-side writer;
+> - bridge/proxy routes are never treated as source truth;
+> - retrieval outputs remain derived and phase-separated;
+> - Serena, Claude Context, Claude-Mem, and Mem0 are not granted hidden canonical ownership;
+> - default-safe tool exposure really hides shell, edit, mutation, onboarding, external-project, destructive index, destructive memory, and hosted-memory surfaces where the synthesis says it does;
+> - all unresolved facts stay marked `UNKNOWN`;
+> - the Task Packet drafts are explicitly blocked by the missing uploaded `dopetask-cannonical-spec.json` and are not overclaimed as schema-valid;
+> - the test plan covers determinism, redaction, no-secrets-persisted, authority boundaries, proxy non-authority, ranking stability, performance, and idempotent retry behavior;
+> - no recommendation assumes a hosted external-memory service is safe by default.
+
+**Final recommendation.**
+
+items:
+1. Implement a **Dopemux-owned custom MCP policy layer** that keeps ConPort and Task Orchestrator as the only write-bearing upstream integrations for canonical slices, while exposing Serena, Claude Context, Claude-Mem, and Mem0 only through derived, read-mostly, or deferred adapter lanes. (Sources: `RULES(6).md` L44-L93; `01_conport_DR_report.md` L82-L123; `02_task_orchestrator_DR_report.md` L320-L362; `03_serena_DR_report.md` L230-L233; `04_claude_context_DR_report.md` L174-L181; `05_claude_mem_DR_report.md` L217-L220; `06_mem0_DR_report.md` L187-L192)
+2. The highest risk is **hidden authority transfer** through mutable memory tools, semantic retrieval presented as truth, bridge routes that look canonical, and support tooling that bypasses worktree, task-packet, redaction, or provenance controls. (Sources: `RULES(6).md` L26-L40, L189-L256; `TRUTH_GAPS(7).md` L19-L28, L70-L89; `responsibility-collision-matrix(8).md` L5-L14)
+3. The next action is to execute **Series A and Series B first**, then run the 5.5 Pro audit before enabling any additional write-capable upstream surfaces or any external-memory pilot. (Sources: `07-cross-system-synthesis.md` L84-L91; `RULES(6).md` L97-L119; roadmap in this report)
+
+more_count: 6
+next_token: 5_5_pro_audit_prompt

--- a/docs/05-audit-reports/mcp-customization/07-mcp-customization-synthesis-dr-report.md
+++ b/docs/05-audit-reports/mcp-customization/07-mcp-customization-synthesis-dr-report.md
@@ -12,7 +12,7 @@ prelude: 07 Mcp Customization Synthesis Dr Report (reference) for dopemux docume
 ---
 # MCP Customization Synthesis DR Report
 
-Target file: `07_mcp_customization_synthesis_DR_report.md`
+Target file: `07-mcp-customization-synthesis-dr-report.md`
 
 ## Executive Findings
 
@@ -34,7 +34,8 @@ next_token: 5_5_pro_audit_prompt
 | System docs | `SYSTEM_ConPort(4).md`, `SYSTEM_DopeContext(4).md`, `SYSTEM_DopeMemory(4).md`, `SYSTEM_TaskOrchestrator(1).md` | Used to ground canonical writer, active runtime, and non-responsibilities. |
 | Truth docs | `TRUTH_DATA_EVENTS(9).md`, `TRUTH_GAPS(7).md` | Used for determinism, event contract, and drift/unknowns. |
 | Baseline substitute | `00-dopemux-context-boundaries(4).md`, `responsibility-collision-matrix(8).md` | Used because the separately named `00_baseline_DR_report.md` was not accessible. |
-| Not used | Fresh broad web research; unuploaded local wrapper/build files; unuploaded `dopetask-cannonical-spec.json` | These gaps are carried as `UNKNOWN` or blockers rather than guessed across. |
+| Task Packet schema | `docs/03-reference/spec/dopetask/dopetask-cannonical-spec.json` | Used to align the draft packet examples to the repo contract. |
+| Not used | Fresh broad web research; unuploaded local wrapper/build files | These gaps are carried as `UNKNOWN` or blockers rather than guessed across. |
 
 **Baseline authority restatement.** Dopemux is a multi-system workspace, not a monolith. The repo-level docs are consistent that `dopemux` owns operator control and routing, `dopetask` is the external execution runtime after wrapper handoff, PM authority is split across Leantime, Task Orchestrator, ConPort, and dope-memory receipts, memory is split across dope-memory and ConPort, retrieval is split across dope-context and ConPort, and bridge/proxy transport must never be promoted into source truth. The docs also repeatedly say that services may span planes, but authority remains domain-specific, with the canonical writer named before any write. (Sources: `RULES(6).md` L44-L93; `ARCHITECTURE(7).md` L11-L23, L41-L84; `system-boundaries(8).md` L16-L23, L24-L50, L61-L69, L93-L109; `00-dopemux-context-boundaries(4).md` L37-L49)
 
@@ -224,7 +225,7 @@ The most important retrieval blocker is that the current dope-context runtime is
 
 | Series | Task | Repo surface | Validation | Guardrail | Dependencies | Risk |
 |---|---|---|---|---|---|---|
-| Series A | Normalize synthesis evidence, missing-file ledger, and per-server posture registry | Docs and policy registry surfaces | All six reports and authority docs indexed in one manifest; missing baseline and missing spec marked `UNKNOWN` | No authority rewrite during normalization | None | Low |
+| Series A | Normalize synthesis evidence, missing-file ledger, and per-server posture registry | Docs and policy registry surfaces | All six reports and authority docs indexed in one manifest; missing baseline marked `UNKNOWN`; Task Packet schema aligned to the in-repo spec | No authority rewrite during normalization | None | Low |
 | Series A | Add boundary matrix for canonical writers and forbidden claims | Docs plus boundary config | Mapping matches repo authority docs exactly | Prevents “best server” collapse | Evidence registry | Low |
 | Series B | Implement ConPort adapter with external-ID shim, namespace reservation, and reviewed delete/correction policy | ConPort adapter layer | Round-trip tests for decisions/progress/context/custom data | ConPort never swallows PM or workflow authority | Series A posture registry | Medium |
 | Series B | Implement Task Orchestrator workflow shim for transitions, queue, blockers, and dependency reads | Workflow adapter layer | Transition legality, queue/blocker, and PM/workflow separation tests | Leantime stays PM metadata owner | Series A posture registry | Medium |
@@ -237,200 +238,402 @@ The most important retrieval blocker is that the current dope-context runtime is
 | Series F | Build authority-boundary, determinism, redaction, and proxy non-authority test suites | Tests and CI | Full plan in next section passes | No “No issues” shortcut | Series A-E | Medium |
 | Series F | Prepare 5.5 Pro audit bundle and surface inventory diff | Audit docs and generated manifests | Audit prompt reproduces all blockers and `UNKNOWN`s | Prevents silent authority transfer before rollout | Series A-E | Low |
 
-**Task Packet drafts.** The repo rules require Task Packets to conform to `dopetask-cannonical-spec.json`, require the named top-level fields, require worktree verification as the first step, and require Codex work to follow `analyze -> planner -> codereview -> precommit`. The actual schema file was **not** uploaded in this session, so the drafts below are intentionally marked **BLOCKED_BY_UNKNOWN** even though they include the fields named in `RULES(6).md` plus the requested `execution` and `pal_chain` objects. They should be treated as near-schema drafts, not merge-ready packets. (Sources: `RULES(6).md` L97-L119, L123-L176)
+**Task Packet drafts.** The repo rules require Task Packets to conform to `docs/03-reference/spec/dopetask/dopetask-cannonical-spec.json`, require the named top-level fields, require worktree verification as the first step, and require Codex work to follow `analyze -> planner -> codereview -> precommit`. The schema file is present in this PR, so the drafts below are schema-aligned examples rather than placeholders blocked by a missing contract. They remain illustrative and still need tooling validation before execution. (Sources: `RULES(6).md` L97-L119, L123-L176)
 
-**Draft TP-A1 — BLOCKED_BY_UNKNOWN**
+**Draft TP-A1 — schema-aligned draft**
 
 ```json
 {
   "id": "TP-A1-mcp-synthesis-evidence-registry",
   "project": "dopemux-mvp",
   "target": "docs/research/mcp-customization and policy registry surfaces",
-  "repo_binding": "dopemux-mvp",
-  "series": "A",
-  "commit": "docs(mcp): normalize synthesis evidence and unknown ledger",
-  "pr": "docs/mcp-synthesis-evidence-registry",
-  "steps": [
-    {
-      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
-      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-A1 scope."
-    },
-    {
-      "task": "Create a single evidence registry that lists the six server reports, the cross-system synthesis seed, and all authority/truth docs used by the synthesis.",
-      "validation": "Registry file exists and names every source used in this report, including missing baseline and missing spec as explicit blockers."
-    },
-    {
-      "task": "Add a per-server posture registry that records canonical, derived, support-only, reject, and deferred classifications with canonical Dopemux writer mapping.",
-      "validation": "Registry entries for ConPort, Task Orchestrator, Serena, Claude Context, Claude-Mem, and Mem0 match the synthesized posture matrix."
-    },
-    {
-      "task": "Record all known UNKNOWNs and blockers in one normalized ledger for later 5.5 Pro audit consumption.",
-      "validation": "Ledger includes missing baseline report, missing dopetask schema file, local Serena runtime ambiguity, Task Orchestrator drift, and Mem0 graph/lineage uncertainty."
-    }
-  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "require_identity_match": true,
+    "origin_hint": "docs/05-audit-reports/mcp-customization/07-mcp-customization-synthesis-dr-report.md"
+  },
+  "series": {
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false,
+    "id": "A"
+  },
+  "commit": {
+    "message": "docs(mcp): normalize synthesis evidence and unknown ledger",
+    "allowlist": [
+      "docs/05-audit-reports/mcp-customization/07-mcp-customization-synthesis-dr-report.md"
+    ],
+    "verify": [
+      "schema alignment check",
+      "docs lint"
+    ]
+  },
+  "pr": {
+    "title": "docs(mcp): normalize synthesis evidence and unknown ledger",
+    "body": "Draft packet for the MCP synthesis evidence registry slice.",
+    "base": "main"
+  },
   "execution": {
-    "agent": "codex"
+    "agent": "codex",
+    "branch": "work/pr-551"
   },
   "pal_chain": {
     "enabled": true,
-    "sequence": ["analyze", "planner", "codereview", "precommit"]
-  }
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "TP-A1-1",
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": [
+        "repo_binding matches checkout",
+        "repo marker exists",
+        "current directory is inside a dedicated worktree",
+        "branch matches TP-A1 scope"
+      ]
+    },
+    {
+      "id": "TP-A1-2",
+      "task": "Create a single evidence registry that lists the six server reports, the cross-system synthesis seed, and all authority/truth docs used by the synthesis.",
+      "validation": [
+        "Registry file exists",
+        "Registry names every source used in this report",
+        "Missing baseline is explicit"
+      ]
+    },
+    {
+      "id": "TP-A1-3",
+      "task": "Record all known UNKNOWNs and blockers in one normalized ledger for later 5.5 Pro audit consumption.",
+      "validation": [
+        "Ledger captures the remaining uncertainty set",
+        "Schema references are aligned to the in-repo spec",
+        "Ledger is evidence-backed rather than speculative"
+      ]
+    }
+  ]
 }
 ```
 
-**Draft TP-B1 — BLOCKED_BY_UNKNOWN**
+**Draft TP-B1 — schema-aligned draft**
 
 ```json
 {
   "id": "TP-B1-boundary-enforcing-adapters",
   "project": "dopemux-mvp",
   "target": "ConPort and Task Orchestrator adapter surfaces",
-  "repo_binding": "dopemux-mvp",
-  "series": "B",
-  "commit": "feat(boundaries): add conport and workflow shims with explicit writer guards",
-  "pr": "feat/boundary-enforcing-adapters",
-  "steps": [
-    {
-      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
-      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-B1 scope."
-    },
-    {
-      "task": "Implement a ConPort adapter that uses Dopemux-owned external IDs, enforces namespace reservations, and keeps decisions/progress/context/custom data separate from PM metadata and workflow state.",
-      "validation": "Round-trip adapter tests pass for context, custom data, decisions, and progress; forbidden namespace writes are rejected."
-    },
-    {
-      "task": "Implement a Task Orchestrator adapter that wraps workflow transitions, queue/state/blockers, and dependencies without transferring PM ownership.",
-      "validation": "Workflow transition legality, queue, blocker, and dependency tests pass; PM metadata is not writable through the adapter."
-    },
-    {
-      "task": "Add explicit bridge non-authority labeling to any persistence path that traverses dopecon-bridge.",
-      "validation": "Logs and envelopes show upstream canonical writer, while bridge is labeled transport/proxy only."
-    }
-  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "require_identity_match": true,
+    "origin_hint": "work/pr-551"
+  },
+  "series": {
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false,
+    "id": "B"
+  },
+  "commit": {
+    "message": "feat(boundaries): add conport and workflow shims with explicit writer guards",
+    "allowlist": [
+      "src/dopemux/commands/mcp_commands.py",
+      "src/dopemux_pr_merge_specialist/thread_resolution.py"
+    ],
+    "verify": [
+      "adapter tests",
+      "boundary audit"
+    ]
+  },
+  "pr": {
+    "title": "feat(boundaries): add conport and workflow shims with explicit writer guards",
+    "body": "Draft packet for the boundary-enforcing adapter slice.",
+    "base": "main"
+  },
   "execution": {
-    "agent": "codex"
+    "agent": "codex",
+    "branch": "work/pr-551"
   },
   "pal_chain": {
     "enabled": true,
-    "sequence": ["analyze", "planner", "codereview", "precommit"]
-  }
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "TP-B1-1",
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": [
+        "repo_binding matches checkout",
+        "repo marker exists",
+        "current directory is inside a dedicated worktree",
+        "branch matches TP-B1 scope"
+      ]
+    },
+    {
+      "id": "TP-B1-2",
+      "task": "Implement a ConPort adapter that uses Dopemux-owned external IDs, enforces namespace reservations, and keeps decisions/progress/context/custom data separate from PM metadata and workflow state.",
+      "validation": [
+        "Round-trip adapter tests pass",
+        "Forbidden namespace writes are rejected"
+      ]
+    },
+    {
+      "id": "TP-B1-3",
+      "task": "Implement a Task Orchestrator adapter that wraps workflow transitions, queue/state/blockers, and dependencies without transferring PM ownership.",
+      "validation": [
+        "Workflow legality tests pass",
+        "PM metadata is not writable through the adapter"
+      ]
+    }
+  ]
 }
 ```
 
-**Draft TP-C1 — BLOCKED_BY_UNKNOWN**
+**Draft TP-C1 — schema-aligned draft**
 
 ```json
 {
   "id": "TP-C1-exposure-controls",
   "project": "dopemux-mvp",
   "target": "custom MCP exposure policy and wrapper config",
-  "repo_binding": "dopemux-mvp",
-  "series": "C",
-  "commit": "feat(mcp): add safe exposure profiles and hidden-tool policy",
-  "pr": "feat/mcp-exposure-controls",
-  "steps": [
-    {
-      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
-      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-C1 scope."
-    },
-    {
-      "task": "Create default-safe exposure profiles that keep Serena read-only, hide Claude Context destructive/auto-provisioning surfaces, expose Claude-Mem as read-only session memory, and hide Mem0 destructive or hosted surfaces.",
-      "validation": "Tool inventory snapshot shows only approved surfaces are exposed in the default profile."
-    },
-    {
-      "task": "Hide ConPort delete tools and Task Orchestrator claims/leases from the default operator profile until separate validation gates are satisfied.",
-      "validation": "Default operator profile cannot invoke destructive ConPort tools or unvalidated Task Orchestrator claim surfaces."
-    },
-    {
-      "task": "Add operator-visible blocked reasons that name the canonical owner whenever a hidden tool is requested.",
-      "validation": "Blocked tool requests return a domain-safe explanation containing the canonical writer and next validation action."
-    }
-  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "require_identity_match": true,
+    "origin_hint": "work/pr-551"
+  },
+  "series": {
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false,
+    "id": "C"
+  },
+  "commit": {
+    "message": "feat(mcp): add safe exposure profiles and hidden-tool policy",
+    "allowlist": [
+      "src/dopemux/cli.py",
+      "src/dopemux/commands/mcp_commands.py"
+    ],
+    "verify": [
+      "tool inventory audit",
+      "blocked-tool checks"
+    ]
+  },
+  "pr": {
+    "title": "feat(mcp): add safe exposure profiles and hidden-tool policy",
+    "body": "Draft packet for the safe MCP exposure slice.",
+    "base": "main"
+  },
   "execution": {
-    "agent": "codex"
+    "agent": "codex",
+    "branch": "work/pr-551"
   },
   "pal_chain": {
     "enabled": true,
-    "sequence": ["analyze", "planner", "codereview", "precommit"]
-  }
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "TP-C1-1",
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": [
+        "repo_binding matches checkout",
+        "repo marker exists",
+        "current directory is inside a dedicated worktree",
+        "branch matches TP-C1 scope"
+      ]
+    },
+    {
+      "id": "TP-C1-2",
+      "task": "Create default-safe exposure profiles that keep Serena read-only, hide Claude Context destructive surfaces, expose Claude-Mem as read-only session memory, and hide Mem0 destructive or hosted surfaces.",
+      "validation": [
+        "Default tool inventory shows only approved surfaces",
+        "Destructive surfaces remain hidden"
+      ]
+    },
+    {
+      "id": "TP-C1-3",
+      "task": "Add operator-visible blocked reasons that name the canonical owner whenever a hidden tool is requested.",
+      "validation": [
+        "Blocked requests return a domain-safe explanation",
+        "Explanation names the canonical writer and next validation step"
+      ]
+    }
+  ]
 }
 ```
 
-**Draft TP-D1 — BLOCKED_BY_UNKNOWN**
+**Draft TP-D1 — schema-aligned draft**
 
 ```json
 {
   "id": "TP-D1-retrieval-and-memory-guardrails",
   "project": "dopemux-mvp",
   "target": "retrieval wrappers and derived-memory promotion gate",
-  "repo_binding": "dopemux-mvp",
-  "series": "D",
-  "commit": "feat(guardrails): split retrieval phases and gate derived memory promotion",
-  "pr": "feat/retrieval-memory-guardrails",
-  "steps": [
-    {
-      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
-      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-D1 scope."
-    },
-    {
-      "task": "Add a lexical-first retrieval wrapper that enforces Phase 1 determinism and fails closed if lexical-only behavior cannot be proven.",
-      "validation": "Phase-1 retrieval tests show stable lexical ordering or explicit fail-closed behavior when lexical-only enforcement is unavailable."
-    },
-    {
-      "task": "Add a derived-memory promotion gate that redacts before storage, redacts again at promotion, and requires canonical writer declaration before any ConPort or dope-memory write.",
-      "validation": "Promotion tests fail when provenance or redaction is missing and pass only with explicit review and full envelope fields."
-    },
-    {
-      "task": "Keep Claude-Mem and Mem0 on separate continuity lanes that never enter code/docs retrieval ranking.",
-      "validation": "Search result sets for code/docs never contain continuity-memory hits unless explicit promotion has occurred."
-    }
-  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "require_identity_match": true,
+    "origin_hint": "work/pr-551"
+  },
+  "series": {
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false,
+    "id": "D"
+  },
+  "commit": {
+    "message": "feat(guardrails): split retrieval phases and gate derived memory promotion",
+    "allowlist": [
+      "src/dopemux_pr_merge_specialist/github_api.py",
+      "src/dopemux_pr_merge_specialist/thread_resolution.py"
+    ],
+    "verify": [
+      "retrieval phase tests",
+      "redaction gate tests"
+    ]
+  },
+  "pr": {
+    "title": "feat(guardrails): split retrieval phases and gate derived memory promotion",
+    "body": "Draft packet for the retrieval and memory guardrail slice.",
+    "base": "main"
+  },
   "execution": {
-    "agent": "codex"
+    "agent": "codex",
+    "branch": "work/pr-551"
   },
   "pal_chain": {
     "enabled": true,
-    "sequence": ["analyze", "planner", "codereview", "precommit"]
-  }
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "TP-D1-1",
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": [
+        "repo_binding matches checkout",
+        "repo marker exists",
+        "current directory is inside a dedicated worktree",
+        "branch matches TP-D1 scope"
+      ]
+    },
+    {
+      "id": "TP-D1-2",
+      "task": "Add a lexical-first retrieval wrapper that enforces Phase 1 determinism and fails closed if lexical-only behavior cannot be proven.",
+      "validation": [
+        "Phase-1 retrieval tests preserve stable lexical ordering",
+        "Lexical-only enforcement fails closed when unavailable"
+      ]
+    },
+    {
+      "id": "TP-D1-3",
+      "task": "Add a derived-memory promotion gate that redacts before storage, redacts again at promotion, and requires canonical writer declaration before any ConPort or dope-memory write.",
+      "validation": [
+        "Promotion is blocked without reviewer confirmation",
+        "Double-redaction checks pass",
+        "Source labeling is present"
+      ]
+    }
+  ]
 }
 ```
 
-**Draft TP-F1 — BLOCKED_BY_UNKNOWN**
+**Draft TP-F1 — schema-aligned draft**
 
 ```json
 {
-  "id": "TP-F1-boundary-test-and-audit-pack",
+  "id": "TP-F1-audit-bundle-and-surface-inventory",
   "project": "dopemux-mvp",
-  "target": "tests, CI checks, and audit bundle generation",
-  "repo_binding": "dopemux-mvp",
-  "series": "F",
-  "commit": "test(boundaries): add authority, determinism, redaction, and proxy-leak checks",
-  "pr": "test/boundary-audit-pack",
-  "steps": [
-    {
-      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
-      "validation": "Confirm repo_binding matches checkout, required repo marker exists, current directory is inside a dedicated worktree, and branch matches TP-F1 scope."
-    },
-    {
-      "task": "Add authority-boundary tests, redaction tests, no-secrets-persisted tests, retrieval determinism tests, and adapter/proxy non-authority tests.",
-      "validation": "All new tests fail on known boundary violations and pass on the intended safe profiles."
-    },
-    {
-      "task": "Add integration-flow tests for workflow transitions, ConPort writes plus dope-memory receipts, retrieval wrappers, and session-memory promotion gates.",
-      "validation": "End-to-end flows pass with explicit provenance and canonical writer declarations."
-    },
-    {
-      "task": "Generate an audit bundle for 5.5 Pro containing surface inventories, enabled/disabled tool lists, UNKNOWNs, blockers, and Task Packet drafts.",
-      "validation": "Audit bundle includes all required artifacts and matches the final synthesis report."
-    }
-  ],
+  "target": "audit bundle and surface inventory artifacts",
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "require_identity_match": true,
+    "origin_hint": "work/pr-551"
+  },
+  "series": {
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false,
+    "id": "F"
+  },
+  "commit": {
+    "message": "docs(audit): package 5.5 pro bundle and surface inventory diff",
+    "allowlist": [
+      "docs/05-audit-reports/mcp-customization/07-mcp-customization-synthesis-dr-report.md"
+    ],
+    "verify": [
+      "audit bundle check",
+      "surface inventory diff"
+    ]
+  },
+  "pr": {
+    "title": "docs(audit): package 5.5 pro bundle and surface inventory diff",
+    "body": "Draft packet for the audit bundle and inventory slice.",
+    "base": "main"
+  },
   "execution": {
-    "agent": "codex"
+    "agent": "codex",
+    "branch": "work/pr-551"
   },
   "pal_chain": {
     "enabled": true,
-    "sequence": ["analyze", "planner", "codereview", "precommit"]
-  }
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "TP-F1-1",
+      "task": "Verify dedicated worktree, repo identity, repo marker, and branch scope before any modification.",
+      "validation": [
+        "repo_binding matches checkout",
+        "repo marker exists",
+        "current directory is inside a dedicated worktree",
+        "branch matches TP-F1 scope"
+      ]
+    },
+    {
+      "id": "TP-F1-2",
+      "task": "Generate an audit bundle for 5.5 Pro containing surface inventories, enabled/disabled tool lists, UNKNOWNs, blockers, and Task Packet drafts.",
+      "validation": [
+        "Bundle includes the audit prompt",
+        "Bundle includes the surface inventory",
+        "Bundle includes the blocker ledger"
+      ]
+    },
+    {
+      "id": "TP-F1-3",
+      "task": "Create a surface inventory diff that shows canonical, derived, support-only, reject, and deferred classifications.",
+      "validation": [
+        "Diff matches the posture matrix",
+        "Diff names the canonical writer for each write-capable surface"
+      ]
+    }
+  ]
 }
 ```
 
@@ -456,7 +659,7 @@ The most important retrieval blocker is that the current dope-context runtime is
 | Category | Unresolved fact or blocker |
 |---|---|
 | Upstream lineage | `00_baseline_DR_report.md` was not accessible in this session; several server reports therefore already carried a missing-baseline blocker. |
-| Upstream lineage | `dopetask-cannonical-spec.json` was not uploaded, so exact Task Packet schema allowance beyond the fields named in `RULES(6).md` remains `UNKNOWN`. |
+| Validation status | The Task Packet drafts are schema-aligned to `docs/03-reference/spec/dopetask/dopetask-cannonical-spec.json` but still need repo-tool validation before execution. |
 | Upstream feature uncertainty | Task Orchestrator surface drift remains unresolved: README/Quick Start say 13 tools, API docs say 14 including `claim_item`, and `server.json` still shows `3.2.0` while the report anchored `v3.3.0`. |
 | Upstream feature uncertainty | Serena’s local Dopemux canonical implementation/deployment writer remains `UNKNOWN` because local truth docs still show duplicate surfaces and alias sprawl. |
 | Upstream feature uncertainty | ConPort relationship-query surfaces are proven more clearly than relationship-write authority; relation writes remain `UNKNOWN` until runtime proof. |
@@ -471,7 +674,7 @@ The most important retrieval blocker is that the current dope-context runtime is
 | Retrieval determinism | Phase-1 lexical-only enforcement path for dope-context is not proven in the uploaded docs even though the repo rules require it. |
 | Operator UX | Telegram Topic implementation details were not evidenced in the uploaded files; the mapping in this report is therefore design guidance, not runtime fact. |
 
-**What 5.5 Pro should audit after this synthesis.** The audit should focus on the places where architecture safety is easy to lose: hidden authority transfer, schema drift, and unsupported write exposure. At minimum, it should verify that no custom surface collapses PM, workflow, context, chronicle, retrieval, bridge, support memory, and execution into one server; that all write paths name the canonical writer; that proxy routes remain labeled as transport; that hidden tools are actually hidden in default profiles; that retrieval phase separation is real; that Task Packet drafts are not falsely claimed conformant in the absence of the uploaded schema; and that no hosted/external memory mode is enabled without explicit policy, exportability, and data-movement disclosure. (Sources: `07-cross-system-synthesis.md` L49-L91; `RULES(6).md` L26-L40, L44-L93, L97-L119, L189-L256; `TRUTH_GAPS(7).md` L19-L28, L70-L89)
+**What 5.5 Pro should audit after this synthesis.** The audit should focus on the places where architecture safety is easy to lose: hidden authority transfer, schema drift, and unsupported write exposure. At minimum, it should verify that no custom surface collapses PM, workflow, context, chronicle, retrieval, bridge, support memory, and execution into one server; that all write paths name the canonical writer; that proxy routes remain labeled as transport; that hidden tools are actually hidden in default profiles; that retrieval phase separation is real; that Task Packet drafts are schema-aligned to the in-repo spec but still require validation before execution; and that no hosted/external memory mode is enabled without explicit policy, exportability, and data-movement disclosure. (Sources: `07-cross-system-synthesis.md` L49-L91; `RULES(6).md` L26-L40, L44-L93, L97-L119, L189-L256; `TRUTH_GAPS(7).md` L19-L28, L70-L89)
 
 **5.5 Pro audit prompt seed**
 
@@ -483,7 +686,7 @@ The most important retrieval blocker is that the current dope-context runtime is
 > - Serena, Claude Context, Claude-Mem, and Mem0 are not granted hidden canonical ownership;
 > - default-safe tool exposure really hides shell, edit, mutation, onboarding, external-project, destructive index, destructive memory, and hosted-memory surfaces where the synthesis says it does;
 > - all unresolved facts stay marked `UNKNOWN`;
-> - the Task Packet drafts are explicitly blocked by the missing uploaded `dopetask-cannonical-spec.json` and are not overclaimed as schema-valid;
+> - the Task Packet drafts are schema-aligned to `docs/03-reference/spec/dopetask/dopetask-cannonical-spec.json` and are not overclaimed as executed artifacts;
 > - the test plan covers determinism, redaction, no-secrets-persisted, authority boundaries, proxy non-authority, ranking stability, performance, and idempotent retry behavior;
 > - no recommendation assumes a hosted external-memory service is safe by default.
 


### PR DESCRIPTION
@codex @clauee @copilot

## Summary
- Restore recovered audit/reference inputs in repo-approved docs locations instead of root-level duplicates.
- Add PAL execution guidance under docs/03-reference/execution/.
- Add the dopetask schema under docs/03-reference/spec/dopetask/.
- Add the MCP customization synthesis DR report under docs/05-audit-reports/mcp-customization/ with repo-compliant kebab-case naming and frontmatter.

## Placement decision
- Did not add root SYSTEM_* or TRUTH_* files. Their recovered content already matches existing canonical equivalents under docs/03-reference/systems/ and docs/03-reference/truth/.
- Did not change root hygiene or pre-commit policy in the final revision.

## Validation
- python3 -m json.tool docs/03-reference/spec/dopetask/dopetask-cannonical-spec.json
- git diff --check origin/main...HEAD
- uvx pre-commit run --files docs/03-reference/governance/rules.md docs/03-reference/execution/pal-execution-rules.md docs/03-reference/execution/pal-chaining-doctrine.md docs/03-reference/spec/dopetask/dopetask-cannonical-spec.json docs/05-audit-reports/mcp-customization/07-mcp-customization-synthesis-dr-report.md

## Release Notes
- Documentation-only audit/reference evidence restoration.
- No runtime behavior changes intended.

## Residual Risk
- Recovered files came from local disk; semantic freshness versus current runtime remains review scope.
- Existing unstaged local changes were left untouched: AGENTS.md and artifacts/.