### PR TITLE
[codex] Quiet system-data scanner evidence noise

### DIFF
--- a/src/dopemux/system_data/scanner.py
+++ b/src/dopemux/system_data/scanner.py
@@ -59,6 +59,55 @@ def _evidence_size(evidence: EvidenceRecord) -> int:
         return 0
 
 
+def _is_under(path: str, root: Path) -> bool:
+    root_text = str(root).rstrip("/")
+    path_text = str(Path(path)).rstrip("/")
+    return path_text == root_text or path_text.startswith(root_text + "/")
+
+
+def _records_for_root(
+    root: Path, evidence_by_path: dict[str, list[EvidenceRecord]]
+) -> tuple[EvidenceRecord, ...]:
+    records: list[EvidenceRecord] = []
+    for path, path_records in evidence_by_path.items():
+        if _is_under(path, root):
+            records.extend(path_records)
+    return tuple(records)
+
+
+def _root_size(root: Path, records: tuple[EvidenceRecord, ...]) -> int:
+    root_text = str(root).rstrip("/")
+    exact = [
+        _evidence_size(record)
+        for record in records
+        if record.path and str(Path(record.path)).rstrip("/") == root_text
+    ]
+    if exact:
+        return max(exact)
+    return max((_evidence_size(record) for record in records), default=0)
+
+
+def _warning(source: str, text: str) -> str:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    denied = [
+        line
+        for line in lines
+        if (
+            "Operation not permitted" in line
+            or "PermissionDenied" in line
+            or "Permission denied" in line
+        )
+    ]
+    if denied:
+        return (
+            f"{source}: {len(denied)} permission-limited paths hidden; "
+            "grant Full Disk Access for deeper visibility"
+        )
+    if len(lines) > 3:
+        return f"{source}: {' | '.join(lines[:3])} | ... ({len(lines)} lines)"
+    return f"{source}: {' | '.join(lines)}"
+
+
 def _finding_from_evidence(
     path: str, size_bytes: int, evidence: tuple[EvidenceRecord, ...]
 ) -> Finding:
@@ -94,7 +143,7 @@ def scan(home: Path, runner: ToolRunner | None = None) -> ScanResult:
     evidence_by_path: dict[str, list[EvidenceRecord]] = {}
     for record in run_dust(runner, paths):
         if record.warning:
-            warnings.append(f"dust: {record.warning}")
+            warnings.append(_warning("dust", record.warning))
             continue
         if record.path:
             evidence_by_path.setdefault(record.path, []).append(record)
@@ -115,12 +164,12 @@ def scan(home: Path, runner: ToolRunner | None = None) -> ScanResult:
         ):
             for record in run_gdu(runner, root):
                 if record.warning:
-                    warnings.append(f"gdu: {record.warning}")
+                    warnings.append(_warning("gdu", record.warning))
                 elif record.path:
                     evidence_by_path.setdefault(record.path, []).append(record)
             for record in run_dua(runner, root):
                 if record.warning:
-                    warnings.append(f"dua: {record.warning}")
+                    warnings.append(_warning("dua", record.warning))
                 elif record.path:
                     evidence_by_path.setdefault(record.path, []).append(record)
 
@@ -128,7 +177,7 @@ def scan(home: Path, runner: ToolRunner | None = None) -> ScanResult:
     for root in (home / "Library" / "Messages" / "Attachments", home / "Downloads"):
         for record in run_ncdu(runner, root):
             if record.warning:
-                warnings.append(f"ncdu: {record.warning}")
+                warnings.append(_warning("ncdu", record.warning))
             elif record.path:
                 evidence_by_path.setdefault(record.path, []).append(record)
 
@@ -154,11 +203,12 @@ def scan(home: Path, runner: ToolRunner | None = None) -> ScanResult:
         )
 
     findings: list[Finding] = []
-    for path, records in evidence_by_path.items():
-        size_bytes = max((_evidence_size(record) for record in records), default=0)
+    for root in paths:
+        records = _records_for_root(root, evidence_by_path)
+        size_bytes = _root_size(root, records)
         if size_bytes <= 0:
             continue
-        findings.append(_finding_from_evidence(path, size_bytes, tuple(records)))
+        findings.append(_finding_from_evidence(str(root), size_bytes, records))
 
     findings.sort(
         key=lambda item: (

--- a/src/dopemux/system_data/tools.py
+++ b/src/dopemux/system_data/tools.py
@@ -14,6 +14,7 @@ from .models import CommandResult, DiskVolume, EvidenceRecord, ToolReport, ToolS
 
 REQUIRED_TOOLS: tuple[str, ...] = ("dust", "duf", "btop", "procs", "gdu", "dua", "ncdu")
 INSTALL_COMMAND = "brew install dust duf btop procs gdu dua-cli ncdu"
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
 class ToolError(RuntimeError):
@@ -195,6 +196,23 @@ def parse_gdu_text(text: str) -> tuple[EvidenceRecord, ...]:
     return tuple(records)
 
 
+def parse_dua_text(text: str) -> tuple[EvidenceRecord, ...]:
+    records: list[EvidenceRecord] = []
+    for line in text.splitlines():
+        cleaned = ANSI_RE.sub("", line).strip()
+        match = re.match(r"^([0-9]+(?:\.[0-9]+)?\s*[A-Za-z]*)\s+(.+)$", cleaned)
+        if not match:
+            continue
+        records.append(
+            EvidenceRecord(
+                source="dua",
+                path=match.group(2),
+                data={"size_bytes": parse_human_size(match.group(1))},
+            )
+        )
+    return tuple(records)
+
+
 def parse_json_export(text: str, *, source: str) -> tuple[EvidenceRecord, ...]:
     cleaned = text.strip()
     if not cleaned:
@@ -269,13 +287,21 @@ def run_ncdu(runner: ToolRunner, path: Path) -> tuple[EvidenceRecord, ...]:
 def run_dua(runner: ToolRunner, path: Path) -> tuple[EvidenceRecord, ...]:
     if not path.exists():
         return ()
-    result = runner.run(["dua", "aggregate", "--format", "json", str(path)], timeout=60)
+    result = runner.run(
+        ["dua", "aggregate", "--format", "bytes", "--no-total", str(path)],
+        timeout=60,
+    )
     if result.returncode != 0:
         return (EvidenceRecord(source="dua", command=result.command, warning=result.stderr.strip()),)
-    try:
-        return parse_json_export(result.stdout, source="dua")
-    except Exception:
-        return (EvidenceRecord(source="dua", command=result.command, warning="dua JSON parse failed"),)
+    return tuple(
+        EvidenceRecord(
+            source=record.source,
+            command=result.command,
+            path=record.path,
+            data=record.data,
+        )
+        for record in parse_dua_text(result.stdout)
+    )
 
 
 def run_procs(runner: ToolRunner, keywords: Iterable[str]) -> tuple[dict[str, Any], ...]:

--- a/tests/system_data/test_classifier_planner.py
+++ b/tests/system_data/test_classifier_planner.py
@@ -9,6 +9,7 @@ from dopemux.system_data.models import (
     ToolReport,
 )
 from dopemux.system_data.planner import build_plan
+from dopemux.system_data.scanner import _records_for_root, _root_size, _warning
 
 
 def _scan_result(
@@ -189,3 +190,41 @@ def test_ios_backups_are_review_first():
 
     assert risk == "review_first"
     assert action == "review_ios_backups"
+
+
+def test_scanner_collapses_nested_cache_evidence_to_root():
+    root = Path("/tmp/home/.npm")
+    records = {
+        "/tmp/home/.npm": [
+            EvidenceRecord(
+                source="dust",
+                path="/tmp/home/.npm",
+                data={"size_bytes": 100},
+            )
+        ],
+        "/tmp/home/.npm/_cacache": [
+            EvidenceRecord(
+                source="dust",
+                path="/tmp/home/.npm/_cacache",
+                data={"size_bytes": 80},
+            )
+        ],
+    }
+
+    root_records = _records_for_root(root, records)
+
+    assert len(root_records) == 2
+    assert _root_size(root, root_records) == 100
+
+
+def test_permission_warnings_are_compacted():
+    warning = _warning(
+        "gdu",
+        "gdu: cannot read directory '/Users/hue/Library/Caches/CloudKit': Operation not permitted\n"
+        "gdu: cannot read directory '/Users/hue/Library/Caches/Safari': Operation not permitted",
+    )
+
+    assert (
+        warning
+        == "gdu: 2 permission-limited paths hidden; grant Full Disk Access for deeper visibility"
+    )

--- a/tests/system_data/test_tools.py
+++ b/tests/system_data/test_tools.py
@@ -2,6 +2,7 @@ import json
 
 from dopemux.system_data.tools import (
     ToolRunner,
+    parse_dua_text,
     parse_duf_json,
     parse_dust_json,
     parse_gdu_text,
@@ -55,6 +56,15 @@ def test_parse_gdu_text_bytes():
 
     assert [record.path for record in records] == ["/tmp/a", "/tmp/b"]
     assert records[1].data["size_bytes"] == 2048
+
+
+def test_parse_dua_text_bytes_with_ansi_color():
+    records = parse_dua_text(
+        "\x1b[32m      4096 b\x1b[39m docs/03-reference/features/mac-system-data-scrubber.md\n"
+    )
+
+    assert records[0].path == "docs/03-reference/features/mac-system-data-scrubber.md"
+    assert records[0].data["size_bytes"] == 4096
 
 
 def test_parse_procs_json():


### PR DESCRIPTION
@codex @clauee @copilot

## Summary
- Fixes `dua 2.34.0` integration by using `dua aggregate --format bytes --no-total` and parsing its ANSI-colored text output instead of requesting unsupported JSON.
- Collapses nested external-tool evidence back to known actionable roots so scans report `/Users/.../.npm` instead of separately listing every `_cacache` child as an independent cleanup target.
- Compacts permission-denied warnings from `gdu`/`ncdu` into one Full Disk Access visibility warning instead of dumping every protected path.

## Why
A live `dopemux system-data doctor` run showed `dua: invalid value 'json'`, noisy permission warnings, and duplicate nested safe-clear rows. This keeps the output truthful while making the cleanup plan safer and easier to act on.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY' ... compile system_data files ... PY` -> passed
- `PYTHONPATH=src PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY' ... run_dua on feature doc ... PY` -> parsed 4096-byte dua evidence
- `PYTHONPATH=src PYTHONDONTWRITEBYTECODE=1 python3 - <<'PY' ... scanner helper assertions ... PY` -> passed
- `git diff --check` -> passed

## Notes
- Full pytest was not rerun because the local `.venv` had been removed to free disk and the machine remains critically space constrained.
- The existing local `AGENTS.md` drift is intentionally excluded.