### PR TITLE
docs(repo-hygiene): deep audit remaining local work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,6 +363,7 @@ proof/*
 !proof/rte-provider-preflight-scope-truth-hardening.proof.json
 !proof/repo-branch-worktree-stash-audit-2026-05-02.proof.json
 !proof/repo-remaining-work-disposition-2026-05-02.proof.json
+!proof/repo-deep-remaining-work-audit-2026-05-02.proof.json
 !proof/TP-OPS-MAC-SCRUBBER-001/
 !proof/TP-OPS-MAC-SCRUBBER-001/**
 

--- a/docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md
+++ b/docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md
@@ -1,0 +1,208 @@
+---
+id: repo-deep-remaining-work-audit-2026-05-02
+title: Repo Deep Remaining Work Audit
+type: reference
+owner: codex
+date: 2026-05-02
+status: complete
+author: '@hu3mann'
+last_review: '2026-05-02'
+next_review: '2026-08-01'
+prelude: Phase-6 repo hygiene deep audit and recovery queue classification.
+---
+# Repo Deep Remaining Work Audit
+
+**Task packet**: `TP-DMX-REPOHYG-006`
+**Parent packet**: `TP-DMX-REPOHYG-005`
+**Execution branch**: `codex/repo-hygiene-deep-audit-20260502`
+**Execution worktree**: `/Users/hue/.codex/worktrees/repo-hygiene-20260502-tp006/dopemux-mvp`
+**Stacked base**: `origin/codex/repo-hygiene-remaining-disposition-20260502`
+**Recovery root**: `/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502`
+**Current origin/main**: `4959a089f1ba456faee86649ce88215402f9bc65`
+**Local main**: `af5c462747860ad8382efa72304dd18970374205`
+
+## Scope and Policy
+
+TP006 is a docs/proof-only deep audit. It does not delete branches, worktrees, remote refs, or stashes, and it does not recover runtime code. Dirty worktree diffs, branch evidence, and stash patches were written to the local recovery root for later subsystem PRs.
+
+## Base Drift and PR Gate
+
+`origin/main` advanced after TP005. PR #561 is now behind `main`, and PR #563 remains stacked on #561. The known failing gate is the external Gemini `review / review` provider path; local TP005 validation had passed before this packet. TP006 therefore stays stacked and compares every candidate against current `origin/main`.
+
+## Disposition Counts
+
+The worktree total is `28` because the fresh TP006 execution worktree is included and classified as `blocked`; the pre-existing remaining worktree registry count was `27`.
+
+**Worktrees**
+
+| Class | Count |
+| --- | --- |
+| blocked | 3 |
+| cleanup-safe-next | 1 |
+| dirty-local | 10 |
+| operator-local-artifact | 10 |
+| topic-pr-ready-review | 3 |
+| unfinished-abandoned | 1 |
+
+**Branches**
+
+| Class | Count |
+| --- | --- |
+| blocked | 4 |
+| cleanup-safe-next | 1 |
+| dirty-local | 14 |
+| recover-partial | 5 |
+| topic-pr-ready-review | 14 |
+| unfinished-abandoned | 8 |
+
+**Stashes**
+
+| Class | Count |
+| --- | --- |
+| cleanup-safe-next | 2 |
+| operator-local-artifact | 7 |
+| recover-partial | 3 |
+| topic-pr-ready-review | 4 |
+
+## Recovery Queue
+
+| Priority | Kind | Name | Class | Subsystem | Size | Candidate branch |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | branch | work/pr-554 | topic-pr-ready-review | cli/system | 1 | codex/recover-cli-system-20260502-work-pr-554 |
+| 2 | branch | work/pr-554-fix | topic-pr-ready-review | cli/system | 1 | codex/recover-cli-system-20260502-work-pr-554-fix |
+| 3 | branch | recover/tp1-547 | topic-pr-ready-review | cli/system | 4 | codex/recover-cli-system-20260502-recover-tp1-547 |
+| 4 | branch | tp/gh-review-thread-agent | topic-pr-ready-review | cli/system | 1 | codex/recover-cli-system-20260502-tp-gh-review-thread-agent |
+| 5 | branch | feat/rte-cost-stabilization-v2 | topic-pr-ready-review | rte/dopecode | 1 | codex/recover-rte-dopecode-20260502-feat-rte-cost-stabilization-v2 |
+| 6 | branch | pr/480 | topic-pr-ready-review | rte/dopecode | 2 | codex/recover-rte-dopecode-20260502-pr-480 |
+| 7 | branch | codex/rte-wizard-prescan-telemetry | topic-pr-ready-review | rte/dopecode | 2 | codex/recover-rte-dopecode-20260502-codex-rte-wizard-prescan-telemetry |
+| 8 | branch | pr/464 | topic-pr-ready-review | rte/dopecode | 3 | codex/recover-rte-dopecode-20260502-pr-464 |
+| 9 | branch | pr/481 | topic-pr-ready-review | rte/dopecode | 18 | codex/recover-rte-dopecode-20260502-pr-481 |
+| 10 | branch | tp/dopecode-phase8-events-replay | topic-pr-ready-review | rte/dopecode | 23 | codex/recover-rte-dopecode-20260502-tp-dopecode-phase8-events-replay |
+| 11 | branch | feat/rte-intelligence-wiring | topic-pr-ready-review | rte/dopecode | 1 | codex/recover-rte-dopecode-20260502-feat-rte-intelligence-wiring |
+| 12 | stash | stash@{1} | topic-pr-ready-review | rte/dopecode | 11 | codex/recover-rte-dopecode-20260502-stash1 |
+| 13 | stash | stash@{13} | topic-pr-ready-review | cli/system | 6 | codex/recover-cli-system-20260502-stash13 |
+| 14 | stash | stash@{14} | topic-pr-ready-review | rte/dopecode | 17 | codex/recover-rte-dopecode-20260502-stash14 |
+| 15 | stash | stash@{15} | topic-pr-ready-review | rte/dopecode | 62 | codex/recover-rte-dopecode-20260502-stash15 |
+| 16 | worktree | /Users/hue/.codex/worktrees/558a/dopemux-mvp-wt-cockpit-pm-textual | dirty-local | mixed/unknown | 4 | - |
+| 17 | worktree | /Users/hue/.codex/worktrees/7f48/dopemux-mvp-wt-cockpit-pm-textual | dirty-local | mixed/unknown | 3 | - |
+| 18 | worktree | /Users/hue/.codex/worktrees/e252/dopemux-mvp-wt-cockpit-pm-textual | dirty-local | cli/system | 9 | - |
+| 19 | worktree | /Users/hue/code/dopemux-mvp-wt-agents-copilot-specs | dirty-local | docs/audit | 2 | - |
+| 20 | worktree | /Users/hue/code/dopemux-mvp-wt-cockpit-design-system | dirty-local | cli/system | 24 | - |
+| 21 | worktree | /Users/hue/code/dopemux-mvp-wt-cockpit-pm-textual | dirty-local | cli/system | 48 | - |
+| 22 | worktree | /Users/hue/code/dopemux-mvp-wt-mcp-audit-hardening | dirty-local | infra/services | 17 | - |
+| 23 | worktree | /Users/hue/code/dopemux-mvp-wt-mcp-customization-dr-data | dirty-local | docs/audit | 7 | - |
+| 24 | worktree | /Users/hue/code/dopemux-mvp-wt-runtime-authority-20260430-201805 | dirty-local | cli/system | 5 | - |
+| 25 | worktree | /Users/hue/code/dopemux-mvp-wt-tui-hardening | dirty-local | ui/cockpit | 3 | - |
+| 26 | branch | audit/rte-cost-profiles-ladders-wizard-gemini-001 | topic-pr-ready-review | rte/dopecode | 7 | codex/recover-rte-dopecode-20260502-audit-rte-cost-profiles-ladders-wiza |
+| 27 | branch | audit/runtime-authority-verifier-project-docs-improvement | topic-pr-ready-review | cli/system | 1 | codex/recover-cli-system-20260502-audit-runtime-authority-verifier-pro |
+| 28 | branch | codex/pm-writes-phase1 | topic-pr-ready-review | mixed/unknown | 3 | codex/recover-mixed-20260502-codex-pm-writes-phase1 |
+| 29 | branch | codex/pm-writes-phase1-local-pre-remote-sync | recover-partial | mixed/unknown | 2 | codex/recover-mixed-20260502-codex-pm-writes-phase1-local-pre-rem |
+| 30 | branch | prmerge/539 | recover-partial | cli/system | 2 | codex/recover-cli-system-20260502-prmerge-539 |
+| 31 | branch | repo-precommit-debt-cleanup | recover-partial | rte/dopecode | 6 | codex/recover-rte-dopecode-20260502-repo-precommit-debt-cleanup |
+| 32 | branch | tp/dopecode-ast-navigation-phase1 | recover-partial | rte/dopecode | 3 | codex/recover-rte-dopecode-20260502-tp-dopecode-ast-navigation-phase1 |
+| 33 | branch | tp/serena-v2-truth | recover-partial | rte/dopecode | 1 | codex/recover-rte-dopecode-20260502-tp-serena-v2-truth |
+
+## Topic PR Ready Branches
+
+| Branch | Subsystem | Unique commits | Unique paths | PR proof | Candidate recovery branch |
+| --- | --- | --- | --- | --- | --- |
+| audit/rte-cost-profiles-ladders-wizard-gemini-001 | rte/dopecode | 7 | 50 | #520 MERGED | codex/recover-rte-dopecode-20260502-audit-rte-cost-profiles-ladders-wiza |
+| audit/runtime-authority-verifier-project-docs-improvement | cli/system | 1 | 4 | #547 MERGED | codex/recover-cli-system-20260502-audit-runtime-authority-verifier-pro |
+| codex/pm-writes-phase1 | mixed/unknown | 3 | 13 | #512 MERGED | codex/recover-mixed-20260502-codex-pm-writes-phase1 |
+| codex/rte-wizard-prescan-telemetry | rte/dopecode | 2 | 10 | #523 MERGED | codex/recover-rte-dopecode-20260502-codex-rte-wizard-prescan-telemetry |
+| feat/rte-cost-stabilization-v2 | rte/dopecode | 1 | 5 | #516 MERGED | codex/recover-rte-dopecode-20260502-feat-rte-cost-stabilization-v2 |
+| feat/rte-intelligence-wiring | rte/dopecode | 1 | 194 | #514 MERGED | codex/recover-rte-dopecode-20260502-feat-rte-intelligence-wiring |
+| pr/464 | rte/dopecode | 3 | 12 | #464 MERGED | codex/recover-rte-dopecode-20260502-pr-464 |
+| pr/480 | rte/dopecode | 2 | 8 | #480 MERGED | codex/recover-rte-dopecode-20260502-pr-480 |
+| pr/481 | rte/dopecode | 18 | 163 | #481 MERGED | codex/recover-rte-dopecode-20260502-pr-481 |
+| recover/tp1-547 | cli/system | 4 | 4 | #547 MERGED | codex/recover-cli-system-20260502-recover-tp1-547 |
+| tp/dopecode-phase8-events-replay | rte/dopecode | 23 | 166 | #481 MERGED | codex/recover-rte-dopecode-20260502-tp-dopecode-phase8-events-replay |
+| tp/gh-review-thread-agent | cli/system | 1 | 5 | #465 MERGED | codex/recover-cli-system-20260502-tp-gh-review-thread-agent |
+| work/pr-554 | cli/system | 1 | 19 | #554 MERGED | codex/recover-cli-system-20260502-work-pr-554 |
+| work/pr-554-fix | cli/system | 1 | 19 | #554 MERGED | codex/recover-cli-system-20260502-work-pr-554-fix |
+
+## Recover Partial Branches
+
+| Branch | Subsystem | Unique commits | Unique paths | PR proof | Reason |
+| --- | --- | --- | --- | --- | --- |
+| codex/pm-writes-phase1-local-pre-remote-sync | mixed/unknown | 2 | 12 | - | patch-unique commits exist without merged PR proof; needs manual partial recovery decision |
+| prmerge/539 | cli/system | 2 | 8 | - | patch-unique commits exist without merged PR proof; needs manual partial recovery decision |
+| repo-precommit-debt-cleanup | rte/dopecode | 6 | 29 | - | patch-unique commits exist without merged PR proof; needs manual partial recovery decision |
+| tp/dopecode-ast-navigation-phase1 | rte/dopecode | 3 | 16 | - | patch-unique commits exist without merged PR proof; needs manual partial recovery decision |
+| tp/serena-v2-truth | rte/dopecode | 1 | 10 | - | patch-unique commits exist without merged PR proof; needs manual partial recovery decision |
+
+## Unfinished or Abandoned Branches
+
+| Branch | Subsystem | Unique commits | Unique paths | PR proof | Reason |
+| --- | --- | --- | --- | --- | --- |
+| codex/dopecode-ast-navigation-20260417 | rte/dopecode | 1 | 7 | #471 CLOSED | closed/unmerged PR or superseded branch with patch-unique commits |
+| codex/infra-compose-uv-db-init | rte/dopecode | 6 | 41 | #436 CLOSED | closed/unmerged PR or superseded branch with patch-unique commits |
+| pr/467 | rte/dopecode | 2 | 11 | #467 CLOSED | closed/unmerged PR or superseded branch with patch-unique commits |
+| tp/dopecode-ast-navigation | rte/dopecode | 1 | 7 | #469 CLOSED | closed/unmerged PR or superseded branch with patch-unique commits |
+| tp/dopecode-phase2-harden | rte/dopecode | 7 | 34 | #473 CLOSED | closed/unmerged PR or superseded branch with patch-unique commits |
+| tp/dopecode-phase3-decompose-policy | rte/dopecode | 9 | 41 | #474 CLOSED | closed/unmerged PR or superseded branch with patch-unique commits |
+| tp/dopecode-phase4-language-approval | rte/dopecode | 20 | 50 | #476 CLOSED | closed/unmerged PR or superseded branch with patch-unique commits |
+| tp/serena-tool-surface-audit | rte/dopecode | 3 | 16 | #468 CLOSED | closed/unmerged PR or superseded branch with patch-unique commits |
+
+## Dirty Local Worktrees
+
+| Class | Worktree | Branch/state | Subsystem | Dirty paths | Untracked | Reason |
+| --- | --- | --- | --- | --- | --- | --- |
+| operator-local-artifact | /Users/hue/code/dopemux-mvp | main | docs/audit | 3 | 2 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| operator-local-artifact | /Users/hue/.codex/worktrees/11a0/dopemux-mvp | DETACHED | docs/audit | 20 | 19 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| operator-local-artifact | /Users/hue/.codex/worktrees/22c5/dopemux-mvp-wt-cockpit-pm-textual | DETACHED | docs/audit | 1 | 0 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| operator-local-artifact | /Users/hue/.codex/worktrees/38c4/dopemux-mvp | codex/remove-stale-root-next-surface | docs/audit | 1 | 0 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| dirty-local | /Users/hue/.codex/worktrees/558a/dopemux-mvp-wt-cockpit-pm-textual | DETACHED | mixed/unknown | 4 | 0 | dirty tracked or untracked content includes docs/source/test/operator files |
+| dirty-local | /Users/hue/.codex/worktrees/7f48/dopemux-mvp-wt-cockpit-pm-textual | codex/add-audit-authority-files | mixed/unknown | 3 | 1 | dirty tracked or untracked content includes docs/source/test/operator files |
+| operator-local-artifact | /Users/hue/.codex/worktrees/8444/dopemux-mvp-wt-cockpit-pm-textual | DETACHED | docs/audit | 1 | 0 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| operator-local-artifact | /Users/hue/.codex/worktrees/b840/dopemux-mvp-wt-cockpit-pm-textual | codex/restore-system-data-command | cli/system | 1 | 0 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| operator-local-artifact | /Users/hue/.codex/worktrees/b8c4/dopemux-mvp | codex/installer-smoke-python-deps | cli/system | 1 | 0 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| dirty-local | /Users/hue/.codex/worktrees/e252/dopemux-mvp-wt-cockpit-pm-textual | codex/dopemux-cli-audit-remediation | cli/system | 9 | 4 | dirty tracked or untracked content includes docs/source/test/operator files |
+| operator-local-artifact | /Users/hue/.codex/worktrees/e270/dopemux-mvp-wt-cockpit-pm-textual | codex/freeflow-strict-router | cli/system | 1 | 0 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| operator-local-artifact | /Users/hue/code/ARCH-5.5-PRO | DETACHED | mixed/unknown | 2 | 1 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| dirty-local | /Users/hue/code/dopemux-mvp-wt-agents-copilot-specs | agents/dopemux-copilot-agent-specs | docs/audit | 2 | 1 | dirty tracked or untracked content includes docs/source/test/operator files |
+| dirty-local | /Users/hue/code/dopemux-mvp-wt-cockpit-design-system | codex/cockpit-design-system | cli/system | 24 | 11 | dirty tracked or untracked content includes docs/source/test/operator files |
+| dirty-local | /Users/hue/code/dopemux-mvp-wt-cockpit-pm-textual | test/pm-authority-ports | cli/system | 48 | 44 | dirty tracked or untracked content includes docs/source/test/operator files |
+| dirty-local | /Users/hue/code/dopemux-mvp-wt-mcp-audit-hardening | codex/mcp-audit-hardening | infra/services | 17 | 10 | dirty tracked or untracked content includes docs/source/test/operator files |
+| dirty-local | /Users/hue/code/dopemux-mvp-wt-mcp-customization-dr-data | research/dmx-mcp-customization-dr-data | docs/audit | 7 | 1 | dirty tracked or untracked content includes docs/source/test/operator files |
+| operator-local-artifact | /Users/hue/code/dopemux-mvp-wt-runtime-authority-20260430-195535 | audit/runtime-authority-verifier-20260430-195535 | docs/audit | 1 | 0 | dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval |
+| dirty-local | /Users/hue/code/dopemux-mvp-wt-runtime-authority-20260430-201805 | audit/runtime-authority-verifier-20260430-201805 | cli/system | 5 | 0 | dirty tracked or untracked content includes docs/source/test/operator files |
+| dirty-local | /Users/hue/code/dopemux-mvp-wt-tui-hardening | codex/tui-runtime-unknown-hardening | ui/cockpit | 3 | 3 | dirty tracked or untracked content includes docs/source/test/operator files |
+
+## Stash Disposition
+
+| Class | Stash | Object | Subsystem | Files | Branch hint | Reason |
+| --- | --- | --- | --- | --- | --- | --- |
+| operator-local-artifact | stash@{0} | 15de39d769b2 | docs/audit | 1 | main | AGENTS.md-only stash retained as operator-local instruction surface |
+| topic-pr-ready-review | stash@{1} | 8dce51ff197f | rte/dopecode | 11 | codex/rte-wizard-prescan-telemetry | stash contains source/test/operator files requiring recovery branch review |
+| operator-local-artifact | stash@{2} | 9eefe8bfcd57 | rte/dopecode | 1 | codex/rte-prescan-progress-hud | AGENTS.md-only stash retained as operator-local instruction surface |
+| operator-local-artifact | stash@{3} | d02a81793565 | rte/dopecode | 1 | audit/rte-cost-profiles-ladders-wizard-gemini-001 | AGENTS.md-only stash retained as operator-local instruction surface |
+| operator-local-artifact | stash@{4} | 6c9ad669d473 | rte/dopecode | 1 | audit/rte-cost-profiles-ladders-wizard-gemini-001 | AGENTS.md-only stash retained as operator-local instruction surface |
+| recover-partial | stash@{5} | fc2a3b4c8a8a | rte/dopecode | 18 | audit/rte-pre-run-hygiene-gemini-001 | stash contains docs/proof/task-packet changes requiring manual recovery decision |
+| operator-local-artifact | stash@{6} | 21e7fce76072 | rte/dopecode | 1 | audit/rte-pre-run-hygiene-gemini-001 | AGENTS.md-only stash retained as operator-local instruction surface |
+| operator-local-artifact | stash@{7} | f1527ae23c15 | rte/dopecode | 1 | audit/rte-pre-run-hygiene-gemini-001 | AGENTS.md-only stash retained as operator-local instruction surface |
+| operator-local-artifact | stash@{8} | d1c2b3e08245 | rte/dopecode | 1 | feat/rte-cost-stabilization-v2 | AGENTS.md-only stash retained as operator-local instruction surface |
+| recover-partial | stash@{9} | 957cec606b3e | ui/cockpit | 6 | main | stash contains docs/proof/task-packet changes requiring manual recovery decision |
+| cleanup-safe-next | stash@{10} | 4a63bece58ce | mixed/unknown | 0 | claude/gracious-poitras-850e4f | stash has zero visible files; eligible only for explicit stash-drop follow-up after object ID proof |
+| cleanup-safe-next | stash@{11} | 3ef0715d6330 | mixed/unknown | 0 | codex/v1-runtime-proof-linkage | stash has zero visible files; eligible only for explicit stash-drop follow-up after object ID proof |
+| recover-partial | stash@{12} | 879592566819 | ui/cockpit | 5 | codex/truth-doc-placement | stash contains docs/proof/task-packet changes requiring manual recovery decision |
+| topic-pr-ready-review | stash@{13} | 2ab1207b74c8 | cli/system | 6 | main | stash contains source/test/operator files requiring recovery branch review |
+| topic-pr-ready-review | stash@{14} | e59bb13f2c17 | rte/dopecode | 17 | tp/dopecode-phase8-events-replay | stash contains source/test/operator files requiring recovery branch review |
+| topic-pr-ready-review | stash@{15} | e5c5cdbd7acd | rte/dopecode | 62 | tp/serena-v2-truth | stash contains source/test/operator files requiring recovery branch review |
+
+## Cleanup Follow-Up
+
+- Cleanup-safe branches: `1` (codex/restore-canonical-compose)
+- Cleanup-safe worktrees: `1`
+- Cleanup-safe stashes: `2`
+- Operator-local artifact items: `17`
+
+No cleanup action is authorized by this packet; these are follow-up inputs only.
+
+## Required Follow-Up Order
+
+1. Recover CLI/system small candidates: `work/pr-554`, `work/pr-554-fix`, `recover/tp1-547`, `tp/gh-review-thread-agent`.
+2. Recover RTE/dopecode small candidates: `feat/rte-cost-stabilization-v2`, `pr/480`, `codex/rte-wizard-prescan-telemetry`, `pr/464`.
+3. Review large RTE/dopecode candidates and source-bearing stashes.
+4. Review dirty worktrees with source/test changes before any deletion.
+5. Run a cleanup-only packet for `codex/restore-canonical-compose`, AGENTS/out-only artifacts, and zero-visible-file stashes after explicit proof.

--- a/proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md
+++ b/proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md
@@ -6,3 +6,4 @@
 - Classified 28 worktrees, 46 local branches, and 16 stashes into the declared TP006 classes; the worktree count includes the new TP006 execution worktree as `blocked`, so the pre-existing remaining worktree count remains 27.
 - Did not delete any branch, worktree, remote ref, or stash.
 - Did not change runtime/source/test files; recovered work remains queued for later subsystem PRs.
+- Opened PR #564: https://github.com/DDD-Enterprises/dopemux-mvp/pull/564

--- a/proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md
+++ b/proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md
@@ -1,9 +1,0 @@
-# TP-DMX-REPOHYG-006 Implementation Notes
-
-- Created a dedicated TP006 worktree at `/Users/hue/.codex/worktrees/repo-hygiene-20260502-tp006/dopemux-mvp` from `origin/codex/repo-hygiene-remaining-disposition-20260502`.
-- Compared all remaining branches and worktrees against current `origin/main` `4959a089f1ba456faee86649ce88215402f9bc65`.
-- Wrote local raw command output, branch evidence, dirty worktree diffs/manifests, and stash patches under `/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502`.
-- Classified 28 worktrees, 46 local branches, and 16 stashes into the declared TP006 classes; the worktree count includes the new TP006 execution worktree as `blocked`, so the pre-existing remaining worktree count remains 27.
-- Did not delete any branch, worktree, remote ref, or stash.
-- Did not change runtime/source/test files; recovered work remains queued for later subsystem PRs.
-- Opened PR #564: https://github.com/DDD-Enterprises/dopemux-mvp/pull/564

--- a/proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md
+++ b/proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md
@@ -1,0 +1,8 @@
+# TP-DMX-REPOHYG-006 Implementation Notes
+
+- Created a dedicated TP006 worktree at `/Users/hue/.codex/worktrees/repo-hygiene-20260502-tp006/dopemux-mvp` from `origin/codex/repo-hygiene-remaining-disposition-20260502`.
+- Compared all remaining branches and worktrees against current `origin/main` `4959a089f1ba456faee86649ce88215402f9bc65`.
+- Wrote local raw command output, branch evidence, dirty worktree diffs/manifests, and stash patches under `/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502`.
+- Classified 28 worktrees, 46 local branches, and 16 stashes into the declared TP006 classes; the worktree count includes the new TP006 execution worktree as `blocked`, so the pre-existing remaining worktree count remains 27.
+- Did not delete any branch, worktree, remote ref, or stash.
+- Did not change runtime/source/test files; recovered work remains queued for later subsystem PRs.

--- a/proof/repo-deep-remaining-work-audit-2026-05-02.proof.json
+++ b/proof/repo-deep-remaining-work-audit-2026-05-02.proof.json
@@ -2395,6 +2395,14 @@
       "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/561"
     }
   ],
+  "proof_tracking_policy": {
+    "gitignore_allowlist": [
+      "proof/repo-branch-worktree-stash-audit-2026-05-02.proof.json",
+      "proof/repo-remaining-work-disposition-2026-05-02.proof.json",
+      "proof/repo-deep-remaining-work-audit-2026-05-02.proof.json"
+    ],
+    "implementation_notes": "The TP006 implementation notes are retained as local recovery evidence only, not as a tracked proof/ markdown artifact."
+  },
   "recovery_queue": [
     {
       "candidate_recovery_branch": "codex/recover-cli-system-20260502-work-pr-554",
@@ -3309,7 +3317,29 @@
     "topic-pr-ready-review",
     "unfinished-abandoned"
   ],
-  "validation": [],
+  "validation": [
+    {
+      "command": "python -m json.tool task-packets/TP-DMX-REPOHYG-006.json",
+      "exit_code": 0
+    },
+    {
+      "command": "python -m json.tool proof/repo-deep-remaining-work-audit-2026-05-02.proof.json",
+      "exit_code": 0,
+      "note": "stdout intentionally omitted because this command emits self-referential proof JSON"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0
+    },
+    {
+      "command": "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir /Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/stack-unblock-20260502/pr-564-self-check",
+      "exit_code": 0
+    },
+    {
+      "command": "pre-commit run --files .gitignore task-packets/TP-DMX-REPOHYG-006.json docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md proof/repo-deep-remaining-work-audit-2026-05-02.proof.json task-packets/INDEX.md",
+      "exit_code": 0
+    }
+  ],
   "validation_performed": {
     "final_inventory": [
       {
@@ -3360,13 +3390,14 @@
       }
     ],
     "prestage_results_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/validation-results-prestage.json",
+    "proof_self_validation_note": "Self-referential json.tool stdout is intentionally not embedded; command exit codes are recorded and rerun after final proof updates.",
     "staged_checks": [
       {
-        "command": "git diff --cached --check",
+        "command": "git diff --check",
         "exit_code": 0
       },
       {
-        "command": "pre-commit run --files task-packets/TP-DMX-REPOHYG-006.json docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md proof/repo-deep-remaining-work-audit-2026-05-02.proof.json proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md task-packets/INDEX.md",
+        "command": "pre-commit run --files .gitignore task-packets/TP-DMX-REPOHYG-006.json docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md proof/repo-deep-remaining-work-audit-2026-05-02.proof.json task-packets/INDEX.md",
         "exit_code": 0
       }
     ],

--- a/proof/repo-deep-remaining-work-audit-2026-05-02.proof.json
+++ b/proof/repo-deep-remaining-work-audit-2026-05-02.proof.json
@@ -1,0 +1,3916 @@
+{
+  "base": {
+    "execution_branch": "codex/repo-hygiene-deep-audit-20260502",
+    "execution_worktree": "/Users/hue/.codex/worktrees/repo-hygiene-20260502-tp006/dopemux-mvp",
+    "head": "93cff5922389b72c75d60b4763d708b35b05f401",
+    "local_main": "af5c462747860ad8382efa72304dd18970374205",
+    "origin_main": "4959a089f1ba456faee86649ce88215402f9bc65",
+    "stacked_base": "origin/codex/repo-hygiene-remaining-disposition-20260502"
+  },
+  "branch": "codex/repo-hygiene-deep-audit-20260502",
+  "branches": [
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/agents_dopemux-copilot-agent-specs-225477ce199e",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T06:05:47Z",
+          "headRefName": "agents/dopemux-copilot-agent-specs",
+          "headRefOid": "552ce36c864001390862865e1f97cad769e770e9",
+          "mergedAt": "2026-05-01T06:05:47Z",
+          "number": 543,
+          "state": "MERGED",
+          "title": "Create deterministic Dopemux Copilot agent specs",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/543"
+        }
+      ],
+      "name": "agents/dopemux-copilot-agent-specs",
+      "object": "225477ce199e0c068428cc6fe0b563c6dce1c11e",
+      "patch_equivalent_commits": 1,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-audit-rte-cost-profiles-ladders-wiza",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/audit_rte-cost-profiles-ladders-wizard-gemini-001-1d79eb6b22b3",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-24T03:39:47Z",
+          "headRefName": "audit/rte-cost-profiles-ladders-wizard-gemini-001",
+          "headRefOid": "1d79eb6b22b3aebb91594d1af1d5e6a28bda983b",
+          "mergedAt": "2026-04-24T03:39:47Z",
+          "number": 520,
+          "state": "MERGED",
+          "title": "audit: stabilize RTE cost profiles, routing ladders, and dopemux wizard launch policy",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/520"
+        }
+      ],
+      "name": "audit/rte-cost-profiles-ladders-wizard-gemini-001",
+      "object": "1d79eb6b22b3aebb91594d1af1d5e6a28bda983b",
+      "patch_equivalent_commits": 1,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 7,
+      "unique_path_count": 50,
+      "unique_paths": [
+        ".github/workflows/gemini-review.yml",
+        "docker/mcp-servers-source/dopemux",
+        "docs/02-how-to/extraction-wizard.md",
+        "docs/03-reference/extraction-wizard.md",
+        "proof/rte_pre_run_hygiene_codereview.md",
+        "proof/rte_pre_run_hygiene_do_not_touch_ledger.md",
+        "proof/rte_pre_run_hygiene_final.json",
+        "proof/rte_pre_run_hygiene_final.md",
+        "proof/rte_pre_run_hygiene_final_challenge.md",
+        "proof/rte_pre_run_hygiene_precommit.md",
+        "proof/rte_pre_run_hygiene_stage1_boundary_model.md",
+        "proof/rte_pre_run_hygiene_stage1_challenge.md",
+        "proof/rte_pre_run_hygiene_stage2_challenge.md",
+        "proof/rte_pre_run_hygiene_stage2_worktree_ledger.md",
+        "proof/rte_pre_run_hygiene_stage3_challenge.md",
+        "proof/rte_pre_run_hygiene_stage3_input_boundary.md",
+        "proof/rte_pre_run_hygiene_stage4_arbitration.md",
+        "proof/rte_pre_run_hygiene_stage4_challenge.md",
+        "proof/rte_pre_run_hygiene_stage4_consensus.md",
+        "proof/rte_pre_run_hygiene_stage5_quarantine_ledger.md",
+        "proof/rte_pre_run_hygiene_stage5_review.md",
+        "reports/repo_truth_map.json",
+        "services/repo-truth-extractor/lib/phase_contract_map.py",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/incremental_cache.py",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_phase_d_contract_map.py",
+        "services/repo-truth-extractor/tests/test_prescan_incremental.py",
+        "services/repo-truth-extractor/tests/test_rte_v5_characterization.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_promptset_truth.py",
+        "src/dopemux/cli.py",
+        "src/dopemux/commands/audit_commands.py",
+        "src/dopemux/commands/extractor_validation.py",
+        "src/dopemux/commands/extractor_validation_ui.py",
+        "src/dopemux/ux/wizard/corpus.py",
+        "src/dopemux/ux/wizard/cost_profiles.py",
+        "src/dopemux/ux/wizard/display.py",
+        "src/dopemux/ux/wizard/extraction.py",
+        "src/dopemux/ux/wizard/partitions.py",
+        "src/dopemux/ux/wizard/preflight.py",
+        "src/dopemux/ux/wizard/prescan_stages.py",
+        "src/dopemux/ux/wizard/provider_overrides.py",
+        "src/dopemux/ux/wizard/runner.py",
+        "src/dopemux/ux/wizard/stages.py",
+        "src/dopemux/ux/wizard/summary.py",
+        "tests/unit/test_extractor_command_authority.py",
+        "tests/unit/test_extractor_validation.py",
+        "tests/unit/test_extractor_validation_ui.py",
+        "tests/unit/test_repo_truth_extractor_prompt_governance.py",
+        "tests/unit/test_wizard_interactivity.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/audit_runtime-authority-verifier-20260430-195535-5f216582cf34",
+      "matched_prs": [],
+      "name": "audit/runtime-authority-verifier-20260430-195535",
+      "object": "5f216582cf3443777cbbf8eedf8b50f68f0d511d",
+      "patch_equivalent_commits": 0,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/audit_runtime-authority-verifier-20260430-201805-5f216582cf34",
+      "matched_prs": [],
+      "name": "audit/runtime-authority-verifier-20260430-201805",
+      "object": "5f216582cf3443777cbbf8eedf8b50f68f0d511d",
+      "patch_equivalent_commits": 0,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-audit-runtime-authority-verifier-pro",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/audit_runtime-authority-verifier-project-docs-improvement-00cb80dd9cd2",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T05:58:47Z",
+          "headRefName": "audit/runtime-authority-verifier-project-docs-improvement",
+          "headRefOid": "2e42f81476b4d18e9fea706d6e378f9ac56a5524",
+          "mergedAt": "2026-05-01T05:58:47Z",
+          "number": 547,
+          "state": "MERGED",
+          "title": "Add deterministic runtime authority verifier",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/547"
+        }
+      ],
+      "name": "audit/runtime-authority-verifier-project-docs-improvement",
+      "object": "00cb80dd9cd2763ef42472503505692f5895c949",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 1,
+      "unique_path_count": 4,
+      "unique_paths": [
+        "config/runtime_authority_manifest.json",
+        "docs/03-reference/governance/runtime-authority-verification.md",
+        "scripts/verify_runtime_authority.py",
+        "tests/unit/test_runtime_authority_manifest.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_add-audit-authority-files-5ad4be889fc7",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T23:19:57Z",
+          "headRefName": "codex/add-audit-authority-files",
+          "headRefOid": "725a9d62ad36059ee48e8b9888804e976834d17e",
+          "mergedAt": "2026-05-01T23:19:57Z",
+          "number": 551,
+          "state": "MERGED",
+          "title": "docs: restore audit authority evidence files",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/551"
+        }
+      ],
+      "name": "codex/add-audit-authority-files",
+      "object": "5ad4be889fc738fae83547027ad24e8d89d21304",
+      "patch_equivalent_commits": 1,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-ui-cockpit-20260502-codex-cockpit-design-system",
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_cockpit-design-system-c836e3410a74",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-28T03:53:31Z",
+          "headRefName": "codex/cockpit-design-system",
+          "headRefOid": "c836e3410a74cd19e342e4748970255b1e7346ac",
+          "mergedAt": "2026-04-28T03:53:30Z",
+          "number": 535,
+          "state": "MERGED",
+          "title": "refactor(cockpit-tui): upgrade Architecture Safety Overlay section",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/535"
+        },
+        {
+          "closedAt": "2026-04-28T01:54:41Z",
+          "headRefName": "codex/cockpit-design-system",
+          "headRefOid": "05d7a4c3acdcdb232fea004677645cde57b94692",
+          "mergedAt": "2026-04-28T01:54:41Z",
+          "number": 532,
+          "state": "MERGED",
+          "title": "Add audited Cockpit TUI design system",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/532"
+        }
+      ],
+      "name": "codex/cockpit-design-system",
+      "object": "c836e3410a74cd19e342e4748970255b1e7346ac",
+      "patch_equivalent_commits": 5,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "npm test -- --runInBand ui-dashboard || npm test",
+        "python -m pytest -q tests/unit"
+      ],
+      "subsystem": "ui/cockpit",
+      "unique_commits": 1,
+      "unique_path_count": 2,
+      "unique_paths": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/acceptance.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/readme.md"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "unfinished-abandoned",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_dopecode-ast-navigation-20260417-40edc271c8f9",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-22T01:01:06Z",
+          "headRefName": "codex/dopecode-ast-navigation-20260417",
+          "headRefOid": "feed99c76d3b3278b991e3b09a099a7a846018bd",
+          "mergedAt": null,
+          "number": 471,
+          "state": "CLOSED",
+          "title": "feat(serena): add dopecode AST navigation layer",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/471"
+        }
+      ],
+      "name": "codex/dopecode-ast-navigation-20260417",
+      "object": "40edc271c8f9f8c6d41fcf126d708c22db1ba1bc",
+      "patch_equivalent_commits": 0,
+      "reason": "closed/unmerged PR or superseded branch with patch-unique commits",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 1,
+      "unique_path_count": 7,
+      "unique_paths": [
+        "services/serena/dopecode/__init__.py",
+        "services/serena/dopecode/navigation/ast_engine.py",
+        "services/serena/dopecode/navigation/symbol_manager.py",
+        "services/serena/dopecode/transform/refactor_layer.py",
+        "services/serena/dopecode/transform/write_layer.py",
+        "services/serena/mcp_server.py",
+        "services/serena/tests/test_dopecode_ast_engine.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-codex-dopemux-cli-audit-remediation",
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_dopemux-cli-audit-remediation-d18ddab40a91",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T23:22:58Z",
+          "headRefName": "codex/dopemux-cli-audit-remediation",
+          "headRefOid": "991190ecd9399d889c2509a7a290bceaaa657cb9",
+          "mergedAt": "2026-05-01T23:22:58Z",
+          "number": 554,
+          "state": "MERGED",
+          "title": "fix(cli): harden dopemux audit surfaces",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/554"
+        }
+      ],
+      "name": "codex/dopemux-cli-audit-remediation",
+      "object": "d18ddab40a91f57c2566ff5826a12045d7925a14",
+      "patch_equivalent_commits": 0,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 1,
+      "unique_path_count": 19,
+      "unique_paths": [
+        "docs/03-reference/systems/dopemux/system-dopemux.md",
+        "reports/dopemux-cli-command-audit-2026-05-01.md",
+        "reports/dopemux-cli-command-reference-2026-05-01.md",
+        "reports/dopemux-cli-command-remediation-plan-2026-05-01.md",
+        "reports/implementation-notes.md",
+        "src/dopemux/cli.py",
+        "src/dopemux/commands/code_commands.py",
+        "src/dopemux/commands/decisions_commands.py",
+        "src/dopemux/commands/mcp_commands.py",
+        "src/dopemux/commands/profile_commands.py",
+        "src/dopemux/commands/update_commands.py",
+        "src/dopemux/routing_cli.py",
+        "src/dopemux_pr_merge_specialist/cli.py",
+        "src/dopemux_pr_merge_specialist/strategy_library.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/cli.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/policy.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/schema.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/strategy_library.py",
+        "tests/unit/test_cli_audit_remediations.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_freeflow-strict-router-5eccaee6e0fc",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T23:11:04Z",
+          "headRefName": "codex/freeflow-strict-router",
+          "headRefOid": "d87160dd087dfd7b3a0651de89e076af08959d4b",
+          "mergedAt": "2026-05-01T23:11:04Z",
+          "number": 552,
+          "state": "MERGED",
+          "title": "feat(freeflow): add strict-free llm router",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/552"
+        }
+      ],
+      "name": "codex/freeflow-strict-router",
+      "object": "5eccaee6e0fc7aa0c4c3694218da5a8c02f3e073",
+      "patch_equivalent_commits": 2,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "unfinished-abandoned",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_infra-compose-uv-db-init-bc9df1385535",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-13T12:04:24Z",
+          "headRefName": "codex/infra-compose-uv-db-init",
+          "headRefOid": "bc9df1385535c19249b9c3a449061d2b5d3a0fa7",
+          "mergedAt": null,
+          "number": 436,
+          "state": "CLOSED",
+          "title": "chore(infra): migrate Dockerfiles to uv, fix compose build contexts, add unified DB init",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/436"
+        }
+      ],
+      "name": "codex/infra-compose-uv-db-init",
+      "object": "bc9df1385535c19249b9c3a449061d2b5d3a0fa7",
+      "patch_equivalent_commits": 0,
+      "reason": "closed/unmerged PR or superseded branch with patch-unique commits",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 6,
+      "unique_path_count": 41,
+      "unique_paths": [
+        "CHANGELOG.md",
+        "docker-compose.unified.yml",
+        "docker/mcp-servers-source/conport/Dockerfile",
+        "docker/mcp-servers-source/gptr-mcp/Dockerfile",
+        "docker/mcp-servers-source/serena/Dockerfile",
+        "docs/03-reference/releases/release-notes-v0-1-0.md",
+        "docs/releases/release-notes-v0-1-0.md",
+        "scripts/init-multiple-databases.sql",
+        "scripts/repo_truth_extractor_promptset_audit_v4.py",
+        "services/dope-context/Dockerfile",
+        "services/dope-context/src/mcp/server.py",
+        "services/mcp-integration-bridge/Dockerfile",
+        "services/mcp-integration-bridge/main.py",
+        "services/mcp-integration-bridge/requirements.txt",
+        "services/repo-truth-extractor/prompts/phase_fl_int/PROMPT_F0_design_claims_raw.md",
+        "services/repo-truth-extractor/prompts/phase_fl_int/PROMPT_F1_design_claims_classified.md",
+        "services/repo-truth-extractor/prompts/phase_fl_int/PROMPT_F2_design_contradictions.md",
+        "services/repo-truth-extractor/prompts/phase_fl_int/PROMPT_F4_canonical_design.md",
+        "services/repo-truth-extractor/prompts/phase_fl_int/PROMPT_L0_feature_candidates_raw.md",
+        "services/repo-truth-extractor/prompts/phase_fl_int/PROMPT_L1_feature_candidates_normalized.md",
+        "services/repo-truth-extractor/prompts/phase_fl_int/PROMPT_L3_feature_ledger_routing.md",
+        "services/repo-truth-extractor/prompts/phase_fl_int/PROMPT_L4_master_feature_ledger.md",
+        "services/repo-truth-extractor/prompts/phase_fl_int/registry.json",
+        "services/repo-truth-extractor/prompts/phase_s/config/contract_rules.json",
+        "services/repo-truth-extractor/prompts/phase_s/config/dedupe_sort_rules.json",
+        "services/repo-truth-extractor/prompts/phase_s/config/promotion_rules.json",
+        "services/repo-truth-extractor/prompts/phase_s_int/PROMPT_S16_mcp_split_validity.md",
+        "services/repo-truth-extractor/prompts/phase_s_int/PROMPT_S17_hook_surface_map.md",
+        "services/repo-truth-extractor/prompts/phase_s_int/PROMPT_S18_contract_coverage.md",
+        "services/repo-truth-extractor/prompts/phase_s_int/PROMPT_S19_gradecard.md",
+        "services/repo-truth-extractor/prompts/phase_s_int/PROMPT_S20_v1_release_plan.md",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/s_int/models.py",
+        "services/repo-truth-extractor/sp/__init__.py",
+        "services/repo-truth-extractor/sp/models.py",
+        "services/repo-truth-extractor/sp/render.py",
+        "services/repo-truth-extractor/tests/test_promptset_v4_lint.py",
+        "services/repo-truth-extractor/tests/test_s_int_prompt_contracts.py",
+        "services/repo-truth-extractor/tests/test_sp_render.py",
+        "services/task-orchestrator/Dockerfile",
+        "src/dopemux/__init__.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_installer-smoke-python-deps-75454e5d373d",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T22:47:09Z",
+          "headRefName": "codex/installer-smoke-python-deps",
+          "headRefOid": "0a02ce9dcb95316d05e26429a01a5feb0fb49019",
+          "mergedAt": "2026-05-01T22:47:09Z",
+          "number": 549,
+          "state": "MERGED",
+          "title": "[codex] stabilize installer smoke python deps",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/549"
+        }
+      ],
+      "name": "codex/installer-smoke-python-deps",
+      "object": "75454e5d373d760f062d0dadad2960cc22c03e41",
+      "patch_equivalent_commits": 1,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_mcp-audit-hardening-087f993291aa",
+      "matched_prs": [],
+      "name": "codex/mcp-audit-hardening",
+      "object": "087f993291aaa404e514c2616dd77cc7984c5097",
+      "patch_equivalent_commits": 0,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-mixed-20260502-codex-pm-writes-phase1",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_pm-writes-phase1-94c5086050cc",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-23T15:13:34Z",
+          "headRefName": "codex/pm-writes-phase1",
+          "headRefOid": "94c5086050cc8b873acf0c9f5397c3c0435abd2e",
+          "mergedAt": "2026-04-23T15:13:34Z",
+          "number": 512,
+          "state": "MERGED",
+          "title": "test: verify and harden phase-1 PM writes slice",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/512"
+        }
+      ],
+      "name": "codex/pm-writes-phase1",
+      "object": "94c5086050cc8b873acf0c9f5397c3c0435abd2e",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 3,
+      "unique_path_count": 13,
+      "unique_paths": [
+        "docs/archive/unclassified-top-level/implementation/pm-writes-phase1-authority-map.md",
+        "docs/archive/unclassified-top-level/implementation/pm-writes-phase1-verification.md",
+        "docs/implementation/pm-writes-phase1-authority-map.md",
+        "services/dopecon-bridge/dopecon_bridge/services/task_integration.py",
+        "src/dopemux/pm/__init__.py",
+        "src/dopemux/pm/adapters/orchestrator.py",
+        "src/dopemux/pm/api.py",
+        "src/dopemux/pm/writes.py",
+        "src/dopemux/ui/pm_writes.py",
+        "tests/test_pm_api.py",
+        "tests/unit/dopemux/pm/test_writes.py",
+        "tests/unit/dopemux/ui/test_pm_writes.py",
+        "tests/unit/pm/test_pm_route_contracts.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-mixed-20260502-codex-pm-writes-phase1-local-pre-rem",
+      "class": "recover-partial",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_pm-writes-phase1-local-pre-remote-sync-5c3e362f3155",
+      "matched_prs": [],
+      "name": "codex/pm-writes-phase1-local-pre-remote-sync",
+      "object": "5c3e362f3155201b54c074a4f3ccc689cfcc626c",
+      "patch_equivalent_commits": 0,
+      "reason": "patch-unique commits exist without merged PR proof; needs manual partial recovery decision",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 2,
+      "unique_path_count": 12,
+      "unique_paths": [
+        "docs/implementation/pm-writes-phase1-authority-map.md",
+        "docs/implementation/pm-writes-phase1-verification.md",
+        "services/dopecon-bridge/dopecon_bridge/services/task_integration.py",
+        "src/dopemux/pm/__init__.py",
+        "src/dopemux/pm/adapters/orchestrator.py",
+        "src/dopemux/pm/api.py",
+        "src/dopemux/pm/writes.py",
+        "src/dopemux/ui/pm_writes.py",
+        "tests/test_pm_api.py",
+        "tests/unit/dopemux/pm/test_writes.py",
+        "tests/unit/dopemux/ui/test_pm_writes.py",
+        "tests/unit/pm/test_pm_route_contracts.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_remove-stale-root-next-surface-d661b6e1cd6a",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T23:52:48Z",
+          "headRefName": "codex/remove-stale-root-next-surface",
+          "headRefOid": "d661b6e1cd6a6592e3db3e60c1b5e9820942c9fe",
+          "mergedAt": "2026-05-01T23:52:48Z",
+          "number": 550,
+          "state": "MERGED",
+          "title": "[codex] Remove stale root Next surface",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/550"
+        }
+      ],
+      "name": "codex/remove-stale-root-next-surface",
+      "object": "d661b6e1cd6a6592e3db3e60c1b5e9820942c9fe",
+      "patch_equivalent_commits": 2,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "blocked",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_repo-hygiene-deep-audit-20260502-93cff5922389",
+      "matched_prs": [
+        {
+          "closedAt": null,
+          "headRefName": "codex/repo-hygiene-remaining-disposition-20260502",
+          "headRefOid": "93cff5922389b72c75d60b4763d708b35b05f401",
+          "mergedAt": null,
+          "number": 563,
+          "state": "OPEN",
+          "title": "docs(repo-hygiene): classify remaining work and cleanup safe locals",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/563"
+        }
+      ],
+      "name": "codex/repo-hygiene-deep-audit-20260502",
+      "object": "93cff5922389b72c75d60b4763d708b35b05f401",
+      "patch_equivalent_commits": 0,
+      "reason": "active hygiene stack branch or current TP006 branch",
+      "required_validation": [
+        "git diff --check",
+        "pre-commit run --files <recovered docs/proof/task-packet files>"
+      ],
+      "subsystem": "docs/audit",
+      "unique_commits": 2,
+      "unique_path_count": 8,
+      "unique_paths": [
+        "docs/05-audit-reports/repo-branch-worktree-stash-audit-2026-05-02.md",
+        "docs/05-audit-reports/repo-remaining-work-disposition-2026-05-02.md",
+        "proof/repo-branch-worktree-stash-audit-2026-05-02.proof.json",
+        "proof/repo-remaining-work-disposition-2026-05-02.implementation-notes.md",
+        "proof/repo-remaining-work-disposition-2026-05-02.proof.json",
+        "task-packets/INDEX.md",
+        "task-packets/TP-DMX-REPOHYG-004.json",
+        "task-packets/TP-DMX-REPOHYG-005.json"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "blocked",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_repo-hygiene-lost-work-audit-20260502-c2daf3808e0d",
+      "matched_prs": [
+        {
+          "closedAt": null,
+          "headRefName": "codex/repo-hygiene-lost-work-audit-20260502",
+          "headRefOid": "c2daf3808e0d2a2a929abe0a4e4cd7298f47be45",
+          "mergedAt": null,
+          "number": 561,
+          "state": "OPEN",
+          "title": "docs(repo-hygiene): audit lost work and execute conservative cleanup",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/561"
+        }
+      ],
+      "name": "codex/repo-hygiene-lost-work-audit-20260502",
+      "object": "c2daf3808e0d2a2a929abe0a4e4cd7298f47be45",
+      "patch_equivalent_commits": 0,
+      "reason": "active hygiene stack branch or current TP006 branch",
+      "required_validation": [
+        "git diff --check",
+        "pre-commit run --files <recovered docs/proof/task-packet files>"
+      ],
+      "subsystem": "docs/audit",
+      "unique_commits": 1,
+      "unique_path_count": 4,
+      "unique_paths": [
+        "docs/05-audit-reports/repo-branch-worktree-stash-audit-2026-05-02.md",
+        "proof/repo-branch-worktree-stash-audit-2026-05-02.proof.json",
+        "task-packets/INDEX.md",
+        "task-packets/TP-DMX-REPOHYG-004.json"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "blocked",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_repo-hygiene-remaining-disposition-20260502-93cff5922389",
+      "matched_prs": [
+        {
+          "closedAt": null,
+          "headRefName": "codex/repo-hygiene-remaining-disposition-20260502",
+          "headRefOid": "93cff5922389b72c75d60b4763d708b35b05f401",
+          "mergedAt": null,
+          "number": 563,
+          "state": "OPEN",
+          "title": "docs(repo-hygiene): classify remaining work and cleanup safe locals",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/563"
+        }
+      ],
+      "name": "codex/repo-hygiene-remaining-disposition-20260502",
+      "object": "93cff5922389b72c75d60b4763d708b35b05f401",
+      "patch_equivalent_commits": 0,
+      "reason": "active hygiene stack branch or current TP006 branch",
+      "required_validation": [
+        "git diff --check",
+        "pre-commit run --files <recovered docs/proof/task-packet files>"
+      ],
+      "subsystem": "docs/audit",
+      "unique_commits": 2,
+      "unique_path_count": 8,
+      "unique_paths": [
+        "docs/05-audit-reports/repo-branch-worktree-stash-audit-2026-05-02.md",
+        "docs/05-audit-reports/repo-remaining-work-disposition-2026-05-02.md",
+        "proof/repo-branch-worktree-stash-audit-2026-05-02.proof.json",
+        "proof/repo-remaining-work-disposition-2026-05-02.implementation-notes.md",
+        "proof/repo-remaining-work-disposition-2026-05-02.proof.json",
+        "task-packets/INDEX.md",
+        "task-packets/TP-DMX-REPOHYG-004.json",
+        "task-packets/TP-DMX-REPOHYG-005.json"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "cleanup-safe-next",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_restore-canonical-compose-72900b234412",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-02T07:20:44Z",
+          "headRefName": "codex/restore-canonical-compose",
+          "headRefOid": "72900b2344121c8b291d5015544d1dbdc8442a65",
+          "mergedAt": "2026-05-02T07:20:44Z",
+          "number": 562,
+          "state": "MERGED",
+          "title": "[codex] restore canonical compose",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/562"
+        }
+      ],
+      "name": "codex/restore-canonical-compose",
+      "object": "72900b2344121c8b291d5015544d1dbdc8442a65",
+      "patch_equivalent_commits": 1,
+      "reason": "no patch-unique commits versus current origin/main and no dirty attached worktree",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_restore-system-data-command-042a60bdd055",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-02T06:00:12Z",
+          "headRefName": "codex/restore-system-data-command",
+          "headRefOid": "042a60bdd05541b06216a9f8bc4ddd9568939e3f",
+          "mergedAt": "2026-05-02T06:00:11Z",
+          "number": 560,
+          "state": "MERGED",
+          "title": "[codex] Quiet system-data scanner evidence noise",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/560"
+        },
+        {
+          "closedAt": "2026-05-02T05:45:35Z",
+          "headRefName": "codex/restore-system-data-command",
+          "headRefOid": "71b3627235da021485cddf1e210291162188a904",
+          "mergedAt": "2026-05-02T05:45:35Z",
+          "number": 559,
+          "state": "MERGED",
+          "title": "[codex] Restore system-data command after main overwrite",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/559"
+        }
+      ],
+      "name": "codex/restore-system-data-command",
+      "object": "042a60bdd05541b06216a9f8bc4ddd9568939e3f",
+      "patch_equivalent_commits": 0,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-codex-rte-wizard-prescan-telemetry",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_rte-wizard-prescan-telemetry-a442ed141bd4",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-28T02:15:39Z",
+          "headRefName": "codex/rte-wizard-prescan-telemetry",
+          "headRefOid": "4e983609d3ae7f3d62f26630428ccee53b307166",
+          "mergedAt": "2026-04-28T02:15:39Z",
+          "number": 523,
+          "state": "MERGED",
+          "title": "feat(rte): add wizard alias and richer prescan telemetry",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/523"
+        }
+      ],
+      "name": "codex/rte-wizard-prescan-telemetry",
+      "object": "a442ed141bd4302038dc5b9347e76672453f5450",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 2,
+      "unique_path_count": 10,
+      "unique_paths": [
+        "AGENTS.md",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/promptsets/generated/dopemux-mvp-2e346e2084bc/AUTO_FEATURES.json",
+        "services/repo-truth-extractor/promptsets/generated/dopemux-mvp-2e346e2084bc/PHASE_PLAN.json",
+        "services/repo-truth-extractor/tests/test_prescan_core_pipeline.py",
+        "src/dopemux/cli.py",
+        "src/dopemux/ux/wizard/corpus.py",
+        "src/dopemux/ux/wizard/display.py",
+        "tests/unit/test_cli_upgrades_commands.py",
+        "tests/unit/test_wizard_interactivity.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/codex_tui-runtime-unknown-hardening-f23c3294c572",
+      "matched_prs": [],
+      "name": "codex/tui-runtime-unknown-hardening",
+      "object": "f23c3294c5726b569a9903dd242559afca649577",
+      "patch_equivalent_commits": 1,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "npm test -- --runInBand ui-dashboard || npm test",
+        "python -m pytest -q tests/unit"
+      ],
+      "subsystem": "ui/cockpit",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-feat-rte-cost-stabilization-v2",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/feat_rte-cost-stabilization-v2-bd16c3eadf23",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-24T00:28:42Z",
+          "headRefName": "feat/rte-cost-stabilization-v2",
+          "headRefOid": "bd16c3eadf23b15d800e7aba2415cf7a4d6f6268",
+          "mergedAt": "2026-04-24T00:28:41Z",
+          "number": 516,
+          "state": "MERGED",
+          "title": "feat(rte): enforce tiktoken tokenization and authoritative pricing",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/516"
+        }
+      ],
+      "name": "feat/rte-cost-stabilization-v2",
+      "object": "bd16c3eadf23b15d800e7aba2415cf7a4d6f6268",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 1,
+      "unique_path_count": 5,
+      "unique_paths": [
+        "config/pricing.yaml",
+        "llm-plans/RTE_COST_STABILIZATION_PLAN.md",
+        "services/repo-truth-extractor/lib/prescan/cost_estimator.py",
+        "services/repo-truth-extractor/lib/prescan/token_counter.py",
+        "services/repo-truth-extractor/run_extraction_v5.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-feat-rte-intelligence-wiring",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/feat_rte-intelligence-wiring-6566ac6c8efa",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-24T00:06:18Z",
+          "headRefName": "feat/rte-intelligence-wiring",
+          "headRefOid": "31524517f3bf1c89d3107adad76cb3e14f7a81a1",
+          "mergedAt": "2026-04-24T00:06:18Z",
+          "number": 514,
+          "state": "MERGED",
+          "title": "feat(rte): wire intelligence router to dynamic model routing",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/514"
+        }
+      ],
+      "name": "feat/rte-intelligence-wiring",
+      "object": "6566ac6c8efa1206f53c818fac9224da4ea7d833",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 1,
+      "unique_path_count": 194,
+      "unique_paths": [
+        "llm-plans/RTE_DEEP_AUDIT_PLAN.md",
+        "llm-plans/RTE_REMEDIATION_PLAN.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193452Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193452Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193452Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193452Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193452Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193452Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193452Z/VALIDATION_VERDICT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193533Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193533Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193533Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193533Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193533Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193533Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193533Z/VALIDATION_VERDICT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193604Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193604Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193604Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193604Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193604Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193604Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193604Z/VALIDATION_VERDICT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193642Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193642Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193642Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193642Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193642Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193642Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260423T193642Z/VALIDATION_VERDICT.json",
+        "services/repo-truth-extractor/benchmarking/campaigns/route_separation.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_campaign_runner.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_live_route_readiness_smoke.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_route_ownership_smoke.py",
+        "services/repo-truth-extractor/benchmarking/direct_model/adapters/openrouter.py",
+        "services/repo-truth-extractor/benchmarking/direct_model/adapters/xai.py",
+        "services/repo-truth-extractor/benchmarking/direct_model/runner.py",
+        "services/repo-truth-extractor/benchmarking/executors/extraction_v5_adapter.py",
+        "services/repo-truth-extractor/benchmarking/executors/phase_s_adapter.py",
+        "services/repo-truth-extractor/benchmarking/registry/registry_loader.py",
+        "services/repo-truth-extractor/benchmarking/registry/seed_records.py",
+        "services/repo-truth-extractor/benchmarking/registry/snapshot_capture.py",
+        "services/repo-truth-extractor/extraction_hygiene.py",
+        "services/repo-truth-extractor/fl_int/collect_input.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A0_REPO_CONTROL_INVENTORY___PARTITION_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A10_LEANTIME_SURFACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A1_INSTRUCTION_SURFACES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A2_MCP_SERVER_DEFS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A3_MCP_PROXY_SURFACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A4_ROUTER_SURFACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A5_HOOKS_SURFACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A6_COMPOSE_SERVICE_GRAPH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A7_LITELLM_SURFACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A8_TASKX_SURFACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A99_MERGE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_A9_IMPLICIT_BEHAVIOR_HINTS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_B0_BOUNDARY_INVENTORY___PARTITION_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_B1_BOUNDARY_ASSERTIONS___CODE_ENFORCEMENT_POINTS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_B2_REFUSAL_RAILS___GUARDRAILS_SURFACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_B3_BYPASS_PATHS___WEAK_GUARDS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_B9_MERGE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C0_CODE_INVENTORY___PARTITION_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C11_LEANTIME_INTEGRATION_SURFACES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C1_SERVICE_ENTRYPOINTS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C2_EVENTBUS_WIRING_TRUTH_SURFACES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C3_DOPE_MEMORY_SURFACES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C4_TRINITY_BOUNDARY_ENFORCEMENT_SURFACES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C5_TASKX_INTEGRATION_SURFACES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C6_WORKFLOW_RUNNERS___MULTI_SERVICE_COORDINATION.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C7_API___DASHBOARDS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C8_DETERMINISM___IDEMPOTENCY___CONCURRENCY_LOCATION_SCANS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_C9_MERGE___NORMALIZE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_D0_INVENTORY___PARTITION_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_D1_CLAIMS___BOUNDARIES___SUPERSESSION.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_D2_DEEP_EXTRACTION.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_D3_CITATION___REFERENCE_GRAPH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_D4_MERGE___NORMALIZE___COVERAGE_QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_D5_DOC_TOPIC_CLUSTERS_JSON.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_E0_EXECUTION_INVENTORY___PARTITION_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_E1_BOOTSTRAP_COMMANDS_SURFACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_E2_ENV_LOADING___CONFIG_CHAIN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_E3_SERVICE_STARTUP_GRAPH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_E4_RUNTIME_MODES___DELTA_REPORT.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_E5_ARTIFACT_OUTPUTS___LOGS___STATE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_E6_EXECUTION_RISKS___ORDERING___STATE_DEPENDENCY.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_E9_MERGE___NORMALIZE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_G0_GOVERNANCE_INVENTORY___PARTITION_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_G1_CI_GATES___QUALITY_BARS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_G2_REPO_HYGIENE___ALLOWLISTS___POLICIES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_G3_POLICY_FILES___ENFORCEMENT.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_G4_SECURITY___SECRETS___REDUCTION_FACTS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_G9_MERGE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_H0_INVENTORY___PARTITION_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_H1_KEYS___REFERENCES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_H2_MCP_SURFACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_H3_ROUTER___PROVIDER_LADDERS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_H4_LITELLM_SURFACES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_H5_PROFILES___SESSIONS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_H6_TMUX___WORKFLOW_HELPERS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_H7_SQLITE___STATE_DB_METADATA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_H9_MERGE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_M0_RUNTIME_EXPORT_INVENTORY.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_M1_SQLITE_SCHEMA_SNAPSHOTS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_M2_SQLITE_TABLE_COUNTS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_M3_CONPORT_EXPORT_SAFE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_M4_DOPE_CONTEXT_EXPORT_SAFE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_M5_MCP_HEALTH_EXPORT_SAFE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_M6_RUNTIME_EXPORT_INDEX.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_Q0_PIPELINE_COMPLETENESS___MANIFEST.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_Q1_MISSING_ARTIFACTS___RECOVERY_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_Q2_DUPLICATE_IDS___PROMPT_COLLISIONS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_Q3_DRIFT_DETECTION___NORM_DIFFS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_Q9_MERGE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R0_CONTROL_PLANE_TRUTH_MAP.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R10_TWO_PLANE_ARCHITECTURE_TRUTH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R1_DOPE_MEMORY_IMPLEMENTATION_TRUTH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R2_EVENTBUS_WIRING_TRUTH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R3_TRINITY_BOUNDARY_ENFORCEMENT_TRACE.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R4_TASKX_INTEGRATION_TRUTH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R5_WORKFLOWS_TRUTH_GRAPH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R6_PORTABILITY_AND_MIGRATION_RISK_LEDGER.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R7_CONFLICT_LEDGER.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R8_RISK_REGISTER_TOP20.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_R9_LEANTIME_INTEGRATION_TRUTH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_T0_TASK_PACKET_FACTORY.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_T1_EMIT_TASK_PACKETS___TOP10.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_T2_PACKET_SCHEMA___AUTHORITY_RULES.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_T3_PACKET_GENERATION___BATCHED.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_T4_PACKET_DEDUP___COLLISION_RESOLUTION.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_T5_PACKET_ORDERING___RUN_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_T9_MERGE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_W0_WORKFLOW_INVENTORY___PARTITION_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_W1_WORKFLOW_CATALOG___RUNBOOK_FACTS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_W2_WORKFLOW_INPUTS_OUTPUTS___ARTIFACTS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_W3_MULTI_SERVICE_COORDINATION___COMPOSE_TMUX.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_W4_WORKFLOW_FAILURE_MODES___RECOVERY.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_W5_WORKFLOW_STATE_DEPENDENCIES___HOME_VS_REPO.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_W9_MERGE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_X0_FEATURE_INDEX_INVENTORY___PARTITION_PLAN.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_X1_FEATURE_SURFACE_EXTRACT.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_X2_FEATURE_TO_CODE_MAP.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_X3_FEATURE_TO_DOC_MAP.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_X4_FEATURE_DEPENDENCY_GRAPH.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_X9_MERGE___QA.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_Z0_FREEZE_INVENTORY___CHECKSUMS.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_Z1_PROOF_PACK___RUNBOOK.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_Z2_OPUS_INPUT_BUNDLE___MANIFEST.md",
+        "services/repo-truth-extractor/promptsets/v4/prompts/PROMPT_Z9_FREEZE_MANIFEST___CHECKSUMS.md",
+        "services/repo-truth-extractor/rte_config.py",
+        "services/repo-truth-extractor/rte_promptset.py",
+        "services/repo-truth-extractor/run_extraction.py",
+        "services/repo-truth-extractor/run_extraction_v4.py",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/run_fl_int.py",
+        "services/repo-truth-extractor/tests/_v5_smoke_helpers.py",
+        "services/repo-truth-extractor/tests/test_comparison_lane.py",
+        "services/repo-truth-extractor/tests/test_comparison_summary.py",
+        "services/repo-truth-extractor/tests/test_hygiene_version_path.py",
+        "services/repo-truth-extractor/tests/test_intelligence_routing_integration.py",
+        "services/repo-truth-extractor/tests/test_live_llm_guard.py",
+        "services/repo-truth-extractor/tests/test_output_safety.py",
+        "services/repo-truth-extractor/tests/test_phase_d_json_salvage.py",
+        "services/repo-truth-extractor/tests/test_phase_d_pressure_caps.py",
+        "services/repo-truth-extractor/tests/test_phase_d_sidefill.py",
+        "services/repo-truth-extractor/tests/test_phase_execution_step_filter.py",
+        "services/repo-truth-extractor/tests/test_phase_interaction.py",
+        "services/repo-truth-extractor/tests/test_phases_seam.py",
+        "services/repo-truth-extractor/tests/test_pre_live_gate_v25.py",
+        "services/repo-truth-extractor/tests/test_promptset_rules_injection.py",
+        "services/repo-truth-extractor/tests/test_repair_counters_thread_safety.py",
+        "services/repo-truth-extractor/tests/test_rte_config_seam.py",
+        "services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py",
+        "services/repo-truth-extractor/tests/test_rte_v5_characterization.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_benchmark_route_ownership.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_cost_cap.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_live_readiness.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_promptset_truth.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_rollup_reports.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_soft_gate_logging.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_ui_events.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_validator_repair_provenance.py",
+        "services/repo-truth-extractor/tests/test_snapshot_capture.py",
+        "services/repo-truth-extractor/tests/test_spend_ledger.py",
+        "services/repo-truth-extractor/tests/test_structured_output_provider_modes.py",
+        "services/repo-truth-extractor/tests/test_task_scoring.py",
+        "services/repo-truth-extractor/tests/test_truth_run_cli.py",
+        "services/repo-truth-extractor/tests/test_v5_observability_improvements.py",
+        "services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+        "src/dopemux/commands/extractor_commands.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "blocked",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/main-af5c46274786",
+      "matched_prs": [],
+      "name": "main",
+      "object": "af5c462747860ad8382efa72304dd18970374205",
+      "patch_equivalent_commits": 0,
+      "reason": "local main is behind origin/main and attached primary worktree is dirty",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-pr-464",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/pr_464-57354faec7e6",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-21T23:18:19Z",
+          "headRefName": "feat/rte-v5-full-prescan-integration",
+          "headRefOid": "c009ee91a55f661277e38361278a919e3e97bb6d",
+          "mergedAt": "2026-04-21T23:18:19Z",
+          "number": 464,
+          "state": "MERGED",
+          "title": "feat(rte): integrate prescan as stage 0 of v5 extraction",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/464"
+        }
+      ],
+      "name": "pr/464",
+      "object": "57354faec7e659828ba665a912f2fea2f694558a",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 3,
+      "unique_path_count": 12,
+      "unique_paths": [
+        "docs/02-how-to/extraction/run-prescan.md",
+        "llm-plans/RTE_V5_FULL_PRESCAN_INTEGRATION_PLAN.md",
+        "proof/rte_v5_full_prescan_integration.proof.json",
+        "services/repo-truth-extractor/lib/prescan/batch_planner.py",
+        "services/repo-truth-extractor/lib/prescan/classifier.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_prescan_online_gate.py",
+        "src/dopemux/cli.py",
+        "src/dopemux/commands/extract_commands.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "unfinished-abandoned",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/pr_467-c50af8a575af",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-22T00:31:22Z",
+          "headRefName": "feat/rte-prescan-first-live-hardening",
+          "headRefOid": "54aedf26a8ef5a65164c1b07ff35f39ec8ae7a1c",
+          "mergedAt": null,
+          "number": 467,
+          "state": "CLOSED",
+          "title": "feat(rte): harden prescan for first-live spend and auditability",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/467"
+        }
+      ],
+      "name": "pr/467",
+      "object": "c50af8a575af76e0ae1b95295385613cc8d2e37a",
+      "patch_equivalent_commits": 0,
+      "reason": "closed/unmerged PR or superseded branch with patch-unique commits",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 2,
+      "unique_path_count": 11,
+      "unique_paths": [
+        "proof/RTE_PRESCAN_FIRST_LIVE_HARDENING.proof.json",
+        "services/repo-truth-extractor/lib/prescan/classifier.py",
+        "services/repo-truth-extractor/lib/prescan/duplicate_detector.py",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/run_prescan.py",
+        "services/repo-truth-extractor/tests/test_prescan_hardening.py",
+        "services/repo-truth-extractor/tests/test_prescan_online_gate.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-pr-480",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/pr_480-8ff407fab18b",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-22T00:26:52Z",
+          "headRefName": "feat/rte-prescan-stage0-live-lane-proving",
+          "headRefOid": "fa4bf30cbcc80bd2724d8d6f9eb4d14c0a72911a",
+          "mergedAt": "2026-04-22T00:26:52Z",
+          "number": 480,
+          "state": "MERGED",
+          "title": "prescan: prove live-lane success path with independent executable routes",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/480"
+        }
+      ],
+      "name": "pr/480",
+      "object": "8ff407fab18b80e14fe719b4474d006f350bf638",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 2,
+      "unique_path_count": 8,
+      "unique_paths": [
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_prescan.py",
+        "services/repo-truth-extractor/tests/test_prescan_e2e_smoke.py",
+        "services/repo-truth-extractor/tests/test_prescan_live_lane.py",
+        "services/repo-truth-extractor/tests/test_prescan_provider_catalog.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-pr-481",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/pr_481-ecda19ac006e",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-21T23:16:37Z",
+          "headRefName": "tp/dopecode-phase8-events-replay",
+          "headRefOid": "4320ef8148147cba2041b05d3685d459fd6614cc",
+          "mergedAt": "2026-04-21T23:16:37Z",
+          "number": 481,
+          "state": "MERGED",
+          "title": "dopeCode Phase 8: event receipts and replay-safe audit trail",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/481"
+        }
+      ],
+      "name": "pr/481",
+      "object": "ecda19ac006e60fd7ddd6757e0c93a0db4209754",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 18,
+      "unique_path_count": 163,
+      "unique_paths": [
+        ".claude/worktrees/cli-refactor",
+        "local_tools.txt",
+        "proof/dopecode_phase2.proof.json",
+        "proof/dopecode_phase2_implementation.md",
+        "proof/dopecode_phase3.proof.json",
+        "proof/dopecode_phase4.proof.json",
+        "proof/dopecode_phase5.proof.json",
+        "proof/dopecode_phase5_implementation.md",
+        "proof/dopecode_phase6.proof.json",
+        "proof/dopecode_phase6_contract.md",
+        "proof/dopecode_phase6_implementation.md",
+        "proof/dopecode_phase8.proof.json",
+        "proof/dopecode_phase8_contract.md",
+        "proof/dopecode_phase8_implementation.md",
+        "python",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/VALIDATION_VERDICT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/VALIDATION_VERDICT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/VALIDATION_VERDICT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_VERDICT.json",
+        "scripts/env_extract.py",
+        "scripts/env_outputs/env_vars.txt",
+        "scripts/env_outputs/manifests.txt",
+        "scripts/env_outputs/packages.txt",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_campaign_runner.py",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/spend_ledger.json",
+        "services/serena/dopecode/execution_receipts.py",
+        "services/serena/dopecode/navigation/ast_engine.py",
+        "services/serena/dopecode/navigation/symbol_manager.py",
+        "services/serena/dopecode/policy/mutation_policy.py",
+        "services/serena/dopecode/runtime.py",
+        "services/serena/dopecode/transform/orchestration.py",
+        "services/serena/dopecode/transform/refactor_layer.py",
+        "services/serena/dopecode/transform/write_layer.py",
+        "services/serena/tests/test_dopecode_ast_engine.py",
+        "services/serena/tests/test_dopecode_execution_receipts.py",
+        "services/serena/tests/test_dopecode_policy.py",
+        "services/serena/tests/test_dopecode_refactor_layer.py",
+        "services/serena/tests/test_dopecode_write_layer.py",
+        "src/dopemux/execution/dopecode_receipts.py",
+        "tests/scripts/test_env_extract.py",
+        "upstream_tools.txt"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-prmerge-539",
+      "class": "recover-partial",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/prmerge_539-eeafc5ad89b4",
+      "matched_prs": [],
+      "name": "prmerge/539",
+      "object": "eeafc5ad89b40ba0d8ee28125d3192ded6406297",
+      "patch_equivalent_commits": 0,
+      "reason": "patch-unique commits exist without merged PR proof; needs manual partial recovery decision",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 2,
+      "unique_path_count": 8,
+      "unique_paths": [
+        ".Jules/palette.md",
+        "config/runtime_authority_manifest.json",
+        "docs/03-reference/governance/runtime-authority-verification.md",
+        "scripts/verify_runtime_authority.py",
+        "tests/unit/test_runtime_authority_manifest.py",
+        "ui-dashboard/src/App.tsx",
+        "ui-dashboard/src/components/TaskSequencer.tsx",
+        "ui-dashboard/src/components/__tests__/Accessibility.test.ts"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-recover-tp1-547",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/recover_tp1-547-2e42f81476b4",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T05:58:47Z",
+          "headRefName": "audit/runtime-authority-verifier-project-docs-improvement",
+          "headRefOid": "2e42f81476b4d18e9fea706d6e378f9ac56a5524",
+          "mergedAt": "2026-05-01T05:58:47Z",
+          "number": 547,
+          "state": "MERGED",
+          "title": "Add deterministic runtime authority verifier",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/547"
+        }
+      ],
+      "name": "recover/tp1-547",
+      "object": "2e42f81476b4d18e9fea706d6e378f9ac56a5524",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 4,
+      "unique_path_count": 4,
+      "unique_paths": [
+        "config/runtime_authority_manifest.json",
+        "docs/03-reference/governance/runtime-authority-verification.md",
+        "scripts/verify_runtime_authority.py",
+        "tests/unit/test_runtime_authority_manifest.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-repo-precommit-debt-cleanup",
+      "class": "recover-partial",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/repo-precommit-debt-cleanup-0ca2fb13d723",
+      "matched_prs": [],
+      "name": "repo-precommit-debt-cleanup",
+      "object": "0ca2fb13d723556855a4529f755e500ad1d08956",
+      "patch_equivalent_commits": 9,
+      "reason": "patch-unique commits exist without merged PR proof; needs manual partial recovery decision",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 6,
+      "unique_path_count": 29,
+      "unique_paths": [
+        "QUICK_START.md",
+        "README.md",
+        "docs/05-audit-reports/root-relocated/docs-audit.md",
+        "docs/05-audit-reports/rte-live-certification-gates.md",
+        "docs/archive/unclassified-top-level/marketing/features-and-benefits.md",
+        "proof/repo-precommit-debt-cleanup.proof.json",
+        "proof/rte-live-cert-and-artifact-contract-hardening.proof.json",
+        "proof/rte-topology-gate-and-precommit-debt-triage.proof.json",
+        "pyproject.toml",
+        "reports/rte-production-certification-status.json",
+        "services/repo-truth-extractor/reporting.py",
+        "services/repo-truth-extractor/rte_config.py",
+        "services/repo-truth-extractor/rte_reports.py",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_rte_live_cert_characterization.py",
+        "services/repo-truth-extractor/tests/test_rte_v5_characterization.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+        "services/repo-truth-extractor/tests/test_truth_run_cli.py",
+        "src/dopemux/cli.py",
+        "src/dopemux/commands/extract_commands.py",
+        "src/dopemux/extractor/runner.py",
+        "src/dopemux/ux/interactive_prompts.py",
+        "src/dopemux/ux/questionary_support.py",
+        "src/dopemux/ux/wizard/cost_profiles.py",
+        "src/dopemux/ux/wizard/extraction.py",
+        "src/dopemux/ux/wizard/prompts.py",
+        "tests/unit/test_cli_upgrades_commands.py",
+        "tests/unit/test_wizard_interactivity.py",
+        "uv.lock"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/research_dmx-mcp-customization-dr-data-cba686305c91",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T07:08:50Z",
+          "headRefName": "research/dmx-mcp-customization-dr-data",
+          "headRefOid": "4149bf2b7085393ce57a412caf4ec437d6776ad3",
+          "mergedAt": "2026-05-01T07:08:50Z",
+          "number": 537,
+          "state": "MERGED",
+          "title": "docs: MCP customization deep research data packs",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/537"
+        }
+      ],
+      "name": "research/dmx-mcp-customization-dr-data",
+      "object": "cba686305c91e46556e522aacc326989462b8fa3",
+      "patch_equivalent_commits": 1,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 0,
+      "unique_path_count": 0,
+      "unique_paths": []
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-mixed-20260502-test-pm-authority-ports",
+      "class": "dirty-local",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/test_pm-authority-ports-c90ed07c0d5c",
+      "matched_prs": [],
+      "name": "test/pm-authority-ports",
+      "object": "c90ed07c0d5c9150f767ab2e5b27b3b1973cff7d",
+      "patch_equivalent_commits": 2,
+      "reason": "attached worktree has dirty state; branch deletion/recovery blocked until dirty content is resolved",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown",
+      "unique_commits": 1,
+      "unique_path_count": 2,
+      "unique_paths": [
+        "docs/03-reference/planes/pm-plane.md",
+        "tests/unit/test_pm_authority_endpoints.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "unfinished-abandoned",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/tp_dopecode-ast-navigation-bf3a9244df9d",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-18T09:38:16Z",
+          "headRefName": "tp/dopecode-ast-navigation",
+          "headRefOid": "b6147b85346c958423db8a7162ee847a01e282d4",
+          "mergedAt": null,
+          "number": 469,
+          "state": "CLOSED",
+          "title": "feat: Implement dopeCode AST navigation and controlled transform foundation",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/469"
+        }
+      ],
+      "name": "tp/dopecode-ast-navigation",
+      "object": "bf3a9244df9dc4e18497b9306ff8ef27893c81a6",
+      "patch_equivalent_commits": 0,
+      "reason": "closed/unmerged PR or superseded branch with patch-unique commits",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 1,
+      "unique_path_count": 7,
+      "unique_paths": [
+        "proof/RTE_PRESCAN_FIRST_LIVE_HARDENING.proof.json",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_prescan.py",
+        "services/repo-truth-extractor/tests/test_prescan_hardening.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-tp-dopecode-ast-navigation-phase1",
+      "class": "recover-partial",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/tp_dopecode-ast-navigation-phase1-6683ef825f4b",
+      "matched_prs": [],
+      "name": "tp/dopecode-ast-navigation-phase1",
+      "object": "6683ef825f4b417405cf57df4f074b0f384b5b02",
+      "patch_equivalent_commits": 0,
+      "reason": "patch-unique commits exist without merged PR proof; needs manual partial recovery decision",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 3,
+      "unique_path_count": 16,
+      "unique_paths": [
+        ".claude/worktrees/cli-refactor",
+        "llm-plans/GH_REVIEW_THREAD_AGENT_PLAN.md",
+        "proof/RTE_PRESCAN_FIRST_LIVE_HARDENING.proof.json",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_prescan.py",
+        "services/repo-truth-extractor/tests/test_prescan_hardening.py",
+        "services/serena/dopecode/__init__.py",
+        "services/serena/dopecode/navigation/ast_engine.py",
+        "services/serena/dopecode/navigation/symbol_manager.py",
+        "services/serena/dopecode/transform/refactor_layer.py",
+        "services/serena/dopecode/transform/write_layer.py",
+        "services/serena/mcp_server.py",
+        "src/dopemux/commands/extractor_commands.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "unfinished-abandoned",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/tp_dopecode-phase2-harden-3046c2364c67",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-22T01:01:06Z",
+          "headRefName": "tp/dopecode-phase2-harden",
+          "headRefOid": "82fcf8d149e9714cca67db40f64e0f5ee9f3a913",
+          "mergedAt": null,
+          "number": 473,
+          "state": "CLOSED",
+          "title": "dopeCode Phase 2 Hardening and Final Verification",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/473"
+        }
+      ],
+      "name": "tp/dopecode-phase2-harden",
+      "object": "3046c2364c67624a2eb95a7d6dc574ed01469c84",
+      "patch_equivalent_commits": 0,
+      "reason": "closed/unmerged PR or superseded branch with patch-unique commits",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 7,
+      "unique_path_count": 34,
+      "unique_paths": [
+        ".claude/worktrees/cli-refactor",
+        "llm-plans/GH_REVIEW_THREAD_AGENT_PLAN.md",
+        "proof/RTE_PRESCAN_FIRST_LIVE_HARDENING.proof.json",
+        "proof/dopecode_phase2.proof.json",
+        "proof/dopecode_phase2_contract.md",
+        "proof/dopecode_phase2_implementation.md",
+        "services/repo-truth-extractor/benchmarking/campaigns/route_identity.py",
+        "services/repo-truth-extractor/benchmarking/campaigns/selection.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_campaign_runner.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_live_route_readiness_smoke.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_route_admissibility_smoke.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_route_ownership_smoke.py",
+        "services/repo-truth-extractor/benchmarking/executors/extraction_v5_adapter.py",
+        "services/repo-truth-extractor/benchmarking/orchestration/attempt_executor.py",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_prescan.py",
+        "services/repo-truth-extractor/tests/test_benchmark_attempt_executor.py",
+        "services/repo-truth-extractor/tests/test_benchmark_campaign_runner.py",
+        "services/repo-truth-extractor/tests/test_benchmark_live_route_readiness_smoke.py",
+        "services/repo-truth-extractor/tests/test_campaign_selection.py",
+        "services/repo-truth-extractor/tests/test_prescan_hardening.py",
+        "services/serena/dopecode/__init__.py",
+        "services/serena/dopecode/navigation/ast_engine.py",
+        "services/serena/dopecode/navigation/symbol_manager.py",
+        "services/serena/dopecode/transform/refactor_layer.py",
+        "services/serena/dopecode/transform/write_layer.py",
+        "services/serena/mcp_server.py",
+        "services/serena/tests/test_dopecode_ast_engine.py",
+        "services/serena/tests/test_dopecode_refactor_layer.py",
+        "services/serena/tests/test_dopecode_write_layer.py",
+        "src/dopemux/commands/extractor_commands.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "unfinished-abandoned",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/tp_dopecode-phase3-decompose-policy-4aec5e150097",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-22T01:01:06Z",
+          "headRefName": "tp/dopecode-phase3-decompose-policy",
+          "headRefOid": "ac56fb3bfad311552d698b3715f76d7e588f4282",
+          "mergedAt": null,
+          "number": 474,
+          "state": "CLOSED",
+          "title": "dopeCode Phase 3: runtime decomposition and mutation policy",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/474"
+        }
+      ],
+      "name": "tp/dopecode-phase3-decompose-policy",
+      "object": "4aec5e1500978dacf5eb93b98ba79d21b164a18d",
+      "patch_equivalent_commits": 0,
+      "reason": "closed/unmerged PR or superseded branch with patch-unique commits",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 9,
+      "unique_path_count": 41,
+      "unique_paths": [
+        ".claude/worktrees/cli-refactor",
+        "llm-plans/GH_REVIEW_THREAD_AGENT_PLAN.md",
+        "proof/RTE_PRESCAN_FIRST_LIVE_HARDENING.proof.json",
+        "proof/dopecode_phase2.proof.json",
+        "proof/dopecode_phase2_contract.md",
+        "proof/dopecode_phase2_implementation.md",
+        "proof/dopecode_phase3.proof.json",
+        "proof/dopecode_phase3_contract.md",
+        "proof/dopecode_phase3_implementation.md",
+        "services/repo-truth-extractor/benchmarking/campaigns/route_identity.py",
+        "services/repo-truth-extractor/benchmarking/campaigns/selection.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_campaign_runner.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_live_route_readiness_smoke.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_route_admissibility_smoke.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_route_ownership_smoke.py",
+        "services/repo-truth-extractor/benchmarking/executors/extraction_v5_adapter.py",
+        "services/repo-truth-extractor/benchmarking/orchestration/attempt_executor.py",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_prescan.py",
+        "services/repo-truth-extractor/tests/test_benchmark_attempt_executor.py",
+        "services/repo-truth-extractor/tests/test_benchmark_campaign_runner.py",
+        "services/repo-truth-extractor/tests/test_benchmark_live_route_readiness_smoke.py",
+        "services/repo-truth-extractor/tests/test_campaign_selection.py",
+        "services/repo-truth-extractor/tests/test_prescan_hardening.py",
+        "services/serena/dopecode/__init__.py",
+        "services/serena/dopecode/navigation/ast_engine.py",
+        "services/serena/dopecode/navigation/symbol_manager.py",
+        "services/serena/dopecode/policy/__init__.py",
+        "services/serena/dopecode/policy/mutation_policy.py",
+        "services/serena/dopecode/runtime.py",
+        "services/serena/dopecode/transform/refactor_layer.py",
+        "services/serena/dopecode/transform/write_layer.py",
+        "services/serena/mcp_server.py",
+        "services/serena/tests/test_dopecode_ast_engine.py",
+        "services/serena/tests/test_dopecode_policy.py",
+        "services/serena/tests/test_dopecode_refactor_layer.py",
+        "services/serena/tests/test_dopecode_write_layer.py",
+        "src/dopemux/commands/extractor_commands.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "unfinished-abandoned",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/tp_dopecode-phase4-language-approval-c47e7d49c808",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-18T09:39:50Z",
+          "headRefName": "tp/dopecode-phase4-language-approval",
+          "headRefOid": "b6147b85346c958423db8a7162ee847a01e282d4",
+          "mergedAt": null,
+          "number": 476,
+          "state": "CLOSED",
+          "title": "dopeCode Phase 4: language expansion and approval-aware execution",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/476"
+        }
+      ],
+      "name": "tp/dopecode-phase4-language-approval",
+      "object": "c47e7d49c808aa5a5cc2bd3a7b0486da339abdb6",
+      "patch_equivalent_commits": 0,
+      "reason": "closed/unmerged PR or superseded branch with patch-unique commits",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 20,
+      "unique_path_count": 50,
+      "unique_paths": [
+        ".claude/worktrees/cli-refactor",
+        "llm-plans/GH_REVIEW_THREAD_AGENT_PLAN.md",
+        "proof/RTE_PRESCAN_FIRST_LIVE_HARDENING.proof.json",
+        "proof/dopecode_phase2.proof.json",
+        "proof/dopecode_phase2_contract.md",
+        "proof/dopecode_phase2_implementation.md",
+        "proof/dopecode_phase3.proof.json",
+        "proof/dopecode_phase3_contract.md",
+        "proof/dopecode_phase3_implementation.md",
+        "proof/dopecode_phase4.proof.json",
+        "proof/dopecode_phase4_contract.md",
+        "proof/dopecode_phase4_implementation.md",
+        "proof/dopecode_phase5.proof.json",
+        "proof/dopecode_phase5_contract.md",
+        "proof/dopecode_phase5_implementation.md",
+        "proof/dopecode_phase6.proof.json",
+        "proof/dopecode_phase6_contract.md",
+        "proof/dopecode_phase6_implementation.md",
+        "services/repo-truth-extractor/benchmarking/campaigns/route_identity.py",
+        "services/repo-truth-extractor/benchmarking/campaigns/selection.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_campaign_runner.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_live_route_readiness_smoke.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_route_admissibility_smoke.py",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_route_ownership_smoke.py",
+        "services/repo-truth-extractor/benchmarking/executors/extraction_v5_adapter.py",
+        "services/repo-truth-extractor/benchmarking/orchestration/attempt_executor.py",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_prescan.py",
+        "services/repo-truth-extractor/tests/test_benchmark_attempt_executor.py",
+        "services/repo-truth-extractor/tests/test_benchmark_campaign_runner.py",
+        "services/repo-truth-extractor/tests/test_benchmark_live_route_readiness_smoke.py",
+        "services/repo-truth-extractor/tests/test_campaign_selection.py",
+        "services/repo-truth-extractor/tests/test_prescan_hardening.py",
+        "services/serena/dopecode/__init__.py",
+        "services/serena/dopecode/navigation/ast_engine.py",
+        "services/serena/dopecode/navigation/symbol_manager.py",
+        "services/serena/dopecode/policy/__init__.py",
+        "services/serena/dopecode/policy/mutation_policy.py",
+        "services/serena/dopecode/runtime.py",
+        "services/serena/dopecode/transform/refactor_layer.py",
+        "services/serena/dopecode/transform/write_layer.py",
+        "services/serena/mcp_server.py",
+        "services/serena/tests/test_dopecode_ast_engine.py",
+        "services/serena/tests/test_dopecode_policy.py",
+        "services/serena/tests/test_dopecode_refactor_layer.py",
+        "services/serena/tests/test_dopecode_write_layer.py",
+        "src/dopemux/commands/extractor_commands.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-tp-dopecode-phase8-events-replay",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/tp_dopecode-phase8-events-replay-4320ef814814",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-21T23:16:37Z",
+          "headRefName": "tp/dopecode-phase8-events-replay",
+          "headRefOid": "4320ef8148147cba2041b05d3685d459fd6614cc",
+          "mergedAt": "2026-04-21T23:16:37Z",
+          "number": 481,
+          "state": "MERGED",
+          "title": "dopeCode Phase 8: event receipts and replay-safe audit trail",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/481"
+        }
+      ],
+      "name": "tp/dopecode-phase8-events-replay",
+      "object": "4320ef8148147cba2041b05d3685d459fd6614cc",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 23,
+      "unique_path_count": 166,
+      "unique_paths": [
+        ".claude/worktrees/cli-refactor",
+        "local_tools.txt",
+        "proof/dopecode_phase2.proof.json",
+        "proof/dopecode_phase2_implementation.md",
+        "proof/dopecode_phase3.proof.json",
+        "proof/dopecode_phase4.proof.json",
+        "proof/dopecode_phase5.proof.json",
+        "proof/dopecode_phase5_implementation.md",
+        "proof/dopecode_phase6.proof.json",
+        "proof/dopecode_phase6_contract.md",
+        "proof/dopecode_phase6_implementation.md",
+        "proof/dopecode_phase8.proof.json",
+        "proof/dopecode_phase8_contract.md",
+        "proof/dopecode_phase8_implementation.md",
+        "python",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031149Z/VALIDATION_VERDICT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031613Z/VALIDATION_VERDICT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031811Z/VALIDATION_VERDICT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/OFFLINE_GATE_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/ONLINE_PREFLIGHT_RESULTS.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/PAL_VALIDATION.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/TRUTH_SPLIT_REPORT.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_SCOPE.json",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_SUMMARY.md",
+        "reports/repo-truth-extractor/pre_live_gate_v25/pre_live_gate_v25_20260418T031822Z/VALIDATION_VERDICT.json",
+        "scripts/env_extract.py",
+        "scripts/env_outputs/env_vars.txt",
+        "scripts/env_outputs/manifests.txt",
+        "scripts/env_outputs/packages.txt",
+        "scripts/python",
+        "services/repo-truth-extractor/benchmarking/cli/benchmark_campaign_runner.py",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T030942Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031028Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031122Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T031748Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T035946Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040018Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040050Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040138Z/spend_ledger.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/BATCH_PILOT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/BREAKER_STATE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/CERTIFICATION_RESULT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_CONTRACT_MAP.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_GATE_DECISION.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PHASE_SLICE.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUNNER_IDENTITY.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_MANIFEST.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/RUN_ROUTING_FINGERPRINT.json",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/run_20260418T040217Z/spend_ledger.json",
+        "services/serena/dopecode/execution_receipts.py",
+        "services/serena/dopecode/navigation/ast_engine.py",
+        "services/serena/dopecode/navigation/symbol_manager.py",
+        "services/serena/dopecode/policy/mutation_policy.py",
+        "services/serena/dopecode/runtime.py",
+        "services/serena/dopecode/transform/orchestration.py",
+        "services/serena/dopecode/transform/refactor_layer.py",
+        "services/serena/dopecode/transform/write_layer.py",
+        "services/serena/tests/test_dopecode_ast_engine.py",
+        "services/serena/tests/test_dopecode_execution_receipts.py",
+        "services/serena/tests/test_dopecode_policy.py",
+        "services/serena/tests/test_dopecode_refactor_layer.py",
+        "services/serena/tests/test_dopecode_write_layer.py",
+        "src/dopemux/execution/dopecode_receipts.py",
+        "tests/scripts/test_env_extract.py",
+        "tmp/local_tools.txt",
+        "tmp/upstream_tools.txt",
+        "upstream_tools.txt"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-tp-gh-review-thread-agent",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/tp_gh-review-thread-agent-82486613b03f",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-18T06:43:17Z",
+          "headRefName": "tp/gh-review-thread-agent",
+          "headRefOid": "62aed297a6d6a8f3669ce48348ecf4031aaa6c2a",
+          "mergedAt": "2026-04-18T06:43:17Z",
+          "number": 465,
+          "state": "MERGED",
+          "title": "Add deterministic review-thread remediation workflow",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/465"
+        }
+      ],
+      "name": "tp/gh-review-thread-agent",
+      "object": "82486613b03f6f3039ab028ff3a00a06eed134f9",
+      "patch_equivalent_commits": 0,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 1,
+      "unique_path_count": 5,
+      "unique_paths": [
+        "proof/gh_review_thread_agent.proof.json",
+        "src/dopemux_pr_merge_specialist/queue_drain.py",
+        "src/dopemux_pr_merge_specialist/schema.py",
+        "src/dopemux_pr_merge_specialist/thread_resolution.py",
+        "tests/pr_merge_specialist/test_agentic_fix_classification.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": null,
+      "class": "unfinished-abandoned",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/tp_serena-tool-surface-audit-6683ef825f4b",
+      "matched_prs": [
+        {
+          "closedAt": "2026-04-18T09:38:42Z",
+          "headRefName": "tp/serena-tool-surface-audit",
+          "headRefOid": "b6147b85346c958423db8a7162ee847a01e282d4",
+          "mergedAt": null,
+          "number": 468,
+          "state": "CLOSED",
+          "title": "feat(serena): add dopecode layers and mcp tool surface updates",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/468"
+        }
+      ],
+      "name": "tp/serena-tool-surface-audit",
+      "object": "6683ef825f4b417405cf57df4f074b0f384b5b02",
+      "patch_equivalent_commits": 0,
+      "reason": "closed/unmerged PR or superseded branch with patch-unique commits",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 3,
+      "unique_path_count": 16,
+      "unique_paths": [
+        ".claude/worktrees/cli-refactor",
+        "llm-plans/GH_REVIEW_THREAD_AGENT_PLAN.md",
+        "proof/RTE_PRESCAN_FIRST_LIVE_HARDENING.proof.json",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_prescan.py",
+        "services/repo-truth-extractor/tests/test_prescan_hardening.py",
+        "services/serena/dopecode/__init__.py",
+        "services/serena/dopecode/navigation/ast_engine.py",
+        "services/serena/dopecode/navigation/symbol_manager.py",
+        "services/serena/dopecode/transform/refactor_layer.py",
+        "services/serena/dopecode/transform/write_layer.py",
+        "services/serena/mcp_server.py",
+        "src/dopemux/commands/extractor_commands.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-tp-serena-v2-truth",
+      "class": "recover-partial",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/tp_serena-v2-truth-76dfeb6e2628",
+      "matched_prs": [],
+      "name": "tp/serena-v2-truth",
+      "object": "76dfeb6e2628bf37786104d2ffd65227d838495a",
+      "patch_equivalent_commits": 0,
+      "reason": "patch-unique commits exist without merged PR proof; needs manual partial recovery decision",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode",
+      "unique_commits": 1,
+      "unique_path_count": 10,
+      "unique_paths": [
+        "docs/02-how-to/extraction/run-prescan.md",
+        "llm-plans/RTE_V5_FULL_PRESCAN_INTEGRATION_PLAN.md",
+        "proof/rte_v5_full_prescan_integration.proof.json",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_prescan_online_gate.py",
+        "src/dopemux/cli.py",
+        "src/dopemux/commands/extract_commands.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-work-pr-554",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/work_pr-554-7c75b6171007",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T23:22:58Z",
+          "headRefName": "codex/dopemux-cli-audit-remediation",
+          "headRefOid": "991190ecd9399d889c2509a7a290bceaaa657cb9",
+          "mergedAt": "2026-05-01T23:22:58Z",
+          "number": 554,
+          "state": "MERGED",
+          "title": "fix(cli): harden dopemux audit surfaces",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/554"
+        }
+      ],
+      "name": "work/pr-554",
+      "object": "7c75b61710073d327dbc2919b64a2480ba5cd194",
+      "patch_equivalent_commits": 1,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 1,
+      "unique_path_count": 19,
+      "unique_paths": [
+        "docs/03-reference/systems/dopemux/system-dopemux.md",
+        "reports/dopemux-cli-command-audit-2026-05-01.md",
+        "reports/dopemux-cli-command-reference-2026-05-01.md",
+        "reports/dopemux-cli-command-remediation-plan-2026-05-01.md",
+        "reports/implementation-notes.md",
+        "src/dopemux/cli.py",
+        "src/dopemux/commands/code_commands.py",
+        "src/dopemux/commands/decisions_commands.py",
+        "src/dopemux/commands/mcp_commands.py",
+        "src/dopemux/commands/profile_commands.py",
+        "src/dopemux/commands/update_commands.py",
+        "src/dopemux/routing_cli.py",
+        "src/dopemux_pr_merge_specialist/cli.py",
+        "src/dopemux_pr_merge_specialist/strategy_library.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/cli.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/policy.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/schema.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/strategy_library.py",
+        "tests/unit/test_cli_audit_remediations.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-work-pr-554-fix",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/branches/work_pr-554-fix-98da7f5525c6",
+      "matched_prs": [
+        {
+          "closedAt": "2026-05-01T23:22:58Z",
+          "headRefName": "codex/dopemux-cli-audit-remediation",
+          "headRefOid": "991190ecd9399d889c2509a7a290bceaaa657cb9",
+          "mergedAt": "2026-05-01T23:22:58Z",
+          "number": 554,
+          "state": "MERGED",
+          "title": "fix(cli): harden dopemux audit surfaces",
+          "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/554"
+        }
+      ],
+      "name": "work/pr-554-fix",
+      "object": "98da7f5525c6dd55028fe1cbe42d68bbe6660be1",
+      "patch_equivalent_commits": 1,
+      "reason": "merged PR exists but local ref still has patch-unique commits needing file-level recovery review",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system",
+      "unique_commits": 1,
+      "unique_path_count": 19,
+      "unique_paths": [
+        "docs/03-reference/systems/dopemux/system-dopemux.md",
+        "reports/dopemux-cli-command-audit-2026-05-01.md",
+        "reports/dopemux-cli-command-reference-2026-05-01.md",
+        "reports/dopemux-cli-command-remediation-plan-2026-05-01.md",
+        "reports/implementation-notes.md",
+        "src/dopemux/cli.py",
+        "src/dopemux/commands/code_commands.py",
+        "src/dopemux/commands/decisions_commands.py",
+        "src/dopemux/commands/mcp_commands.py",
+        "src/dopemux/commands/profile_commands.py",
+        "src/dopemux/commands/update_commands.py",
+        "src/dopemux/routing_cli.py",
+        "src/dopemux_pr_merge_specialist/cli.py",
+        "src/dopemux_pr_merge_specialist/strategy_library.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/cli.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/policy.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/schema.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/strategy_library.py",
+        "tests/unit/test_cli_audit_remediations.py"
+      ]
+    }
+  ],
+  "cleanup_followup": {
+    "branches": [
+      "codex/restore-canonical-compose"
+    ],
+    "operator_local_artifacts": [
+      "/Users/hue/code/dopemux-mvp",
+      "/Users/hue/.codex/worktrees/11a0/dopemux-mvp",
+      "/Users/hue/.codex/worktrees/22c5/dopemux-mvp-wt-cockpit-pm-textual",
+      "/Users/hue/.codex/worktrees/38c4/dopemux-mvp",
+      "/Users/hue/.codex/worktrees/8444/dopemux-mvp-wt-cockpit-pm-textual",
+      "/Users/hue/.codex/worktrees/b840/dopemux-mvp-wt-cockpit-pm-textual",
+      "/Users/hue/.codex/worktrees/b8c4/dopemux-mvp",
+      "/Users/hue/.codex/worktrees/e270/dopemux-mvp-wt-cockpit-pm-textual",
+      "/Users/hue/code/ARCH-5.5-PRO",
+      "/Users/hue/code/dopemux-mvp-wt-runtime-authority-20260430-195535",
+      "stash@{0}",
+      "stash@{2}",
+      "stash@{3}",
+      "stash@{4}",
+      "stash@{6}",
+      "stash@{7}",
+      "stash@{8}"
+    ],
+    "stashes": [
+      "stash@{10}",
+      "stash@{11}"
+    ],
+    "worktrees": [
+      "/Users/hue/.codex/worktrees/dopemux-compose-restore"
+    ]
+  },
+  "commit_and_pr": {
+    "base": "codex/repo-hygiene-remaining-disposition-20260502",
+    "branch": "codex/repo-hygiene-deep-audit-20260502",
+    "commit_sha": "pending_until_commit; final response records exact SHA because proof file cannot self-reference its containing commit without changing that SHA",
+    "pr_url": "pending_until_pr_creation"
+  },
+  "counts": {
+    "branches_by_class": {
+      "blocked": 4,
+      "cleanup-safe-next": 1,
+      "dirty-local": 14,
+      "recover-partial": 5,
+      "topic-pr-ready-review": 14,
+      "unfinished-abandoned": 8
+    },
+    "branches_total": 46,
+    "dirty_worktrees_by_subsystem": {
+      "cli/system": 4,
+      "docs/audit": 2,
+      "infra/services": 1,
+      "mixed/unknown": 2,
+      "ui/cockpit": 1
+    },
+    "stashes_by_class": {
+      "cleanup-safe-next": 2,
+      "operator-local-artifact": 7,
+      "recover-partial": 3,
+      "topic-pr-ready-review": 4
+    },
+    "stashes_total": 16,
+    "topic_branches_by_subsystem": {
+      "cli/system": 5,
+      "mixed/unknown": 1,
+      "rte/dopecode": 8
+    },
+    "worktrees_by_class": {
+      "blocked": 3,
+      "cleanup-safe-next": 1,
+      "dirty-local": 10,
+      "operator-local-artifact": 10,
+      "topic-pr-ready-review": 3,
+      "unfinished-abandoned": 1
+    },
+    "worktrees_total": 28
+  },
+  "id": "repo-deep-remaining-work-audit-2026-05-02",
+  "local_recovery_root": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502",
+  "open_hygiene_prs": [
+    {
+      "baseRefName": "codex/repo-hygiene-lost-work-audit-20260502",
+      "closedAt": null,
+      "headRefName": "codex/repo-hygiene-remaining-disposition-20260502",
+      "headRefOid": "93cff5922389b72c75d60b4763d708b35b05f401",
+      "isDraft": false,
+      "mergeCommit": null,
+      "mergeStateStatus": "UNSTABLE",
+      "mergedAt": null,
+      "number": 563,
+      "state": "OPEN",
+      "title": "docs(repo-hygiene): classify remaining work and cleanup safe locals",
+      "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/563"
+    },
+    {
+      "baseRefName": "main",
+      "closedAt": null,
+      "headRefName": "codex/repo-hygiene-lost-work-audit-20260502",
+      "headRefOid": "c2daf3808e0d2a2a929abe0a4e4cd7298f47be45",
+      "isDraft": false,
+      "mergeCommit": null,
+      "mergeStateStatus": "BEHIND",
+      "mergedAt": null,
+      "number": 561,
+      "state": "OPEN",
+      "title": "docs(repo-hygiene): audit lost work and execute conservative cleanup",
+      "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/561"
+    }
+  ],
+  "recovery_queue": [
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-work-pr-554",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "work/pr-554",
+      "priority": 1,
+      "subsystem": "cli/system",
+      "unique_commits": 1,
+      "unique_paths": 19,
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-work-pr-554-fix",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "work/pr-554-fix",
+      "priority": 2,
+      "subsystem": "cli/system",
+      "unique_commits": 1,
+      "unique_paths": 19,
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-recover-tp1-547",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "recover/tp1-547",
+      "priority": 3,
+      "subsystem": "cli/system",
+      "unique_commits": 4,
+      "unique_paths": 4,
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-tp-gh-review-thread-agent",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "tp/gh-review-thread-agent",
+      "priority": 4,
+      "subsystem": "cli/system",
+      "unique_commits": 1,
+      "unique_paths": 5,
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-feat-rte-cost-stabilization-v2",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "feat/rte-cost-stabilization-v2",
+      "priority": 5,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 1,
+      "unique_paths": 5,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-pr-480",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "pr/480",
+      "priority": 6,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 2,
+      "unique_paths": 8,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-codex-rte-wizard-prescan-telemetry",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "codex/rte-wizard-prescan-telemetry",
+      "priority": 7,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 2,
+      "unique_paths": 10,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-pr-464",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "pr/464",
+      "priority": 8,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 3,
+      "unique_paths": 12,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-pr-481",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "pr/481",
+      "priority": 9,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 18,
+      "unique_paths": 163,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-tp-dopecode-phase8-events-replay",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "tp/dopecode-phase8-events-replay",
+      "priority": 10,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 23,
+      "unique_paths": 166,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-feat-rte-intelligence-wiring",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "feat/rte-intelligence-wiring",
+      "priority": 11,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 1,
+      "unique_paths": 194,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-stash1",
+      "class": "topic-pr-ready-review",
+      "file_count": 11,
+      "kind": "stash",
+      "name": "stash@{1}",
+      "priority": 12,
+      "subsystem": "rte/dopecode",
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-stash13",
+      "class": "topic-pr-ready-review",
+      "file_count": 6,
+      "kind": "stash",
+      "name": "stash@{13}",
+      "priority": 13,
+      "subsystem": "cli/system",
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-stash14",
+      "class": "topic-pr-ready-review",
+      "file_count": 17,
+      "kind": "stash",
+      "name": "stash@{14}",
+      "priority": 14,
+      "subsystem": "rte/dopecode",
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-stash15",
+      "class": "topic-pr-ready-review",
+      "file_count": 62,
+      "kind": "stash",
+      "name": "stash@{15}",
+      "priority": 15,
+      "subsystem": "rte/dopecode",
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 4,
+      "kind": "worktree",
+      "name": "/Users/hue/.codex/worktrees/558a/dopemux-mvp-wt-cockpit-pm-textual",
+      "priority": 16,
+      "subsystem": "mixed/unknown",
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 3,
+      "kind": "worktree",
+      "name": "/Users/hue/.codex/worktrees/7f48/dopemux-mvp-wt-cockpit-pm-textual",
+      "priority": 17,
+      "subsystem": "mixed/unknown",
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 9,
+      "kind": "worktree",
+      "name": "/Users/hue/.codex/worktrees/e252/dopemux-mvp-wt-cockpit-pm-textual",
+      "priority": 18,
+      "subsystem": "cli/system",
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 2,
+      "kind": "worktree",
+      "name": "/Users/hue/code/dopemux-mvp-wt-agents-copilot-specs",
+      "priority": 19,
+      "subsystem": "docs/audit",
+      "validation": [
+        "git diff --check",
+        "pre-commit run --files <recovered docs/proof/task-packet files>"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 24,
+      "kind": "worktree",
+      "name": "/Users/hue/code/dopemux-mvp-wt-cockpit-design-system",
+      "priority": 20,
+      "subsystem": "cli/system",
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 48,
+      "kind": "worktree",
+      "name": "/Users/hue/code/dopemux-mvp-wt-cockpit-pm-textual",
+      "priority": 21,
+      "subsystem": "cli/system",
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 17,
+      "kind": "worktree",
+      "name": "/Users/hue/code/dopemux-mvp-wt-mcp-audit-hardening",
+      "priority": 22,
+      "subsystem": "infra/services",
+      "validation": [
+        "git diff --check",
+        "pytest -q services/task-orchestrator/tests tests/unit"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 7,
+      "kind": "worktree",
+      "name": "/Users/hue/code/dopemux-mvp-wt-mcp-customization-dr-data",
+      "priority": 23,
+      "subsystem": "docs/audit",
+      "validation": [
+        "git diff --check",
+        "pre-commit run --files <recovered docs/proof/task-packet files>"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 5,
+      "kind": "worktree",
+      "name": "/Users/hue/code/dopemux-mvp-wt-runtime-authority-20260430-201805",
+      "priority": 24,
+      "subsystem": "cli/system",
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "class": "dirty-local",
+      "dirty_path_count": 3,
+      "kind": "worktree",
+      "name": "/Users/hue/code/dopemux-mvp-wt-tui-hardening",
+      "priority": 25,
+      "subsystem": "ui/cockpit",
+      "validation": [
+        "git diff --check",
+        "npm test -- --runInBand ui-dashboard || npm test",
+        "python -m pytest -q tests/unit"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-audit-rte-cost-profiles-ladders-wiza",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "audit/rte-cost-profiles-ladders-wizard-gemini-001",
+      "priority": 26,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 7,
+      "unique_paths": 50,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-audit-runtime-authority-verifier-pro",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "audit/runtime-authority-verifier-project-docs-improvement",
+      "priority": 27,
+      "subsystem": "cli/system",
+      "unique_commits": 1,
+      "unique_paths": 4,
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-mixed-20260502-codex-pm-writes-phase1",
+      "class": "topic-pr-ready-review",
+      "kind": "branch",
+      "name": "codex/pm-writes-phase1",
+      "priority": 28,
+      "subsystem": "mixed/unknown",
+      "unique_commits": 3,
+      "unique_paths": 13,
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-mixed-20260502-codex-pm-writes-phase1-local-pre-rem",
+      "class": "recover-partial",
+      "kind": "branch",
+      "name": "codex/pm-writes-phase1-local-pre-remote-sync",
+      "priority": 29,
+      "subsystem": "mixed/unknown",
+      "unique_commits": 2,
+      "unique_paths": 12,
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-prmerge-539",
+      "class": "recover-partial",
+      "kind": "branch",
+      "name": "prmerge/539",
+      "priority": 30,
+      "subsystem": "cli/system",
+      "unique_commits": 2,
+      "unique_paths": 8,
+      "validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-repo-precommit-debt-cleanup",
+      "class": "recover-partial",
+      "kind": "branch",
+      "name": "repo-precommit-debt-cleanup",
+      "priority": 31,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 6,
+      "unique_paths": 29,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-tp-dopecode-ast-navigation-phase1",
+      "class": "recover-partial",
+      "kind": "branch",
+      "name": "tp/dopecode-ast-navigation-phase1",
+      "priority": 32,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 3,
+      "unique_paths": 16,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    },
+    {
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-tp-serena-v2-truth",
+      "class": "recover-partial",
+      "kind": "branch",
+      "name": "tp/serena-v2-truth",
+      "priority": 33,
+      "subsystem": "rte/dopecode",
+      "unique_commits": 1,
+      "unique_paths": 10,
+      "validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ]
+    }
+  ],
+  "residual_risks": [
+    "TP006 is intentionally stacked behind #563 and #561; both hygiene PRs still need their external GitHub gate resolved.",
+    "Topic-pr-ready-review does not mean ready to merge; each recovery branch needs semantic file-level selection and subsystem tests.",
+    "Dirty worktree evidence is preserved locally, but operator-local generated outputs are not committed.",
+    "No stash was dropped; zero-visible-file stashes still require explicit drop proof.",
+    "Remote branch cleanup remains out of scope."
+  ],
+  "scope_notes": {
+    "cleanup_mutations": "No branches, worktrees, remote refs, or stashes were deleted or dropped in TP006.",
+    "runtime_mutations": "No runtime/source/test files were changed by TP006.",
+    "worktree_count_note": "The 28 worktree ledger count includes the fresh TP006 execution worktree, classified as blocked; the pre-existing remaining worktree count was 27."
+  },
+  "stashes": [
+    {
+      "branch_hint": "main",
+      "candidate_recovery_branch": null,
+      "class": "operator-local-artifact",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_00-15de39d769b2",
+      "file_count": 1,
+      "files": [
+        "AGENTS.md"
+      ],
+      "maps_to_existing_branch": "main",
+      "object": "15de39d769b2d5b7888e94ac5d51b791c24bcea7",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_00-15de39d769b2/patch.patch",
+      "reason": "AGENTS.md-only stash retained as operator-local instruction surface",
+      "ref": "stash@{0}",
+      "required_validation": [
+        "git diff --check",
+        "pre-commit run --files <recovered docs/proof/task-packet files>"
+      ],
+      "subsystem": "docs/audit"
+    },
+    {
+      "branch_hint": "codex/rte-wizard-prescan-telemetry",
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-stash1",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_01-8dce51ff197f",
+      "file_count": 11,
+      "files": [
+        "AGENTS.md",
+        "docs/05-audit-reports/cockpit-pm-implementer-callable-inventory-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-pm-implementer-design-brief-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-pm-implementer-processing-pack-2026-04-24.md",
+        "proof/cockpit-pm-implementer-processing-pack-2026-04-24.proof.json",
+        "services/repo-truth-extractor/lib/promptgen/feature_detector.py",
+        "services/repo-truth-extractor/tests/test_universal_extractor.py",
+        "src/dopemux/commands/extractor_commands.py",
+        "task-packets/DMX-COCKPIT-PMIMPL-PACK-001.json",
+        "task-packets/INDEX.md",
+        "tests/unit/test_extractor_command_authority.py"
+      ],
+      "maps_to_existing_branch": "codex/rte-wizard-prescan-telemetry",
+      "object": "8dce51ff197f9ebe8ef0500140392d0977d637db",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_01-8dce51ff197f/patch.patch",
+      "reason": "stash contains source/test/operator files requiring recovery branch review",
+      "ref": "stash@{1}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    },
+    {
+      "branch_hint": "codex/rte-prescan-progress-hud",
+      "candidate_recovery_branch": null,
+      "class": "operator-local-artifact",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_02-9eefe8bfcd57",
+      "file_count": 1,
+      "files": [
+        "AGENTS.md"
+      ],
+      "maps_to_existing_branch": null,
+      "object": "9eefe8bfcd573b709779a89e811db8569ab35ec8",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_02-9eefe8bfcd57/patch.patch",
+      "reason": "AGENTS.md-only stash retained as operator-local instruction surface",
+      "ref": "stash@{2}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    },
+    {
+      "branch_hint": "audit/rte-cost-profiles-ladders-wizard-gemini-001",
+      "candidate_recovery_branch": null,
+      "class": "operator-local-artifact",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_03-d02a81793565",
+      "file_count": 1,
+      "files": [
+        "AGENTS.md"
+      ],
+      "maps_to_existing_branch": "audit/rte-cost-profiles-ladders-wizard-gemini-001",
+      "object": "d02a81793565a5e59c69281ca72709f862d65321",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_03-d02a81793565/patch.patch",
+      "reason": "AGENTS.md-only stash retained as operator-local instruction surface",
+      "ref": "stash@{3}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    },
+    {
+      "branch_hint": "audit/rte-cost-profiles-ladders-wizard-gemini-001",
+      "candidate_recovery_branch": null,
+      "class": "operator-local-artifact",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_04-6c9ad669d473",
+      "file_count": 1,
+      "files": [
+        "AGENTS.md"
+      ],
+      "maps_to_existing_branch": "audit/rte-cost-profiles-ladders-wizard-gemini-001",
+      "object": "6c9ad669d473abc5bc87f85fc7cf7ea163b65b42",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_04-6c9ad669d473/patch.patch",
+      "reason": "AGENTS.md-only stash retained as operator-local instruction surface",
+      "ref": "stash@{4}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    },
+    {
+      "branch_hint": "audit/rte-pre-run-hygiene-gemini-001",
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-stash5",
+      "class": "recover-partial",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_05-fc2a3b4c8a8a",
+      "file_count": 18,
+      "files": [
+        "AGENTS.md",
+        "proof/rte_pre_run_hygiene_codereview.md",
+        "proof/rte_pre_run_hygiene_do_not_touch_ledger.md",
+        "proof/rte_pre_run_hygiene_final.json",
+        "proof/rte_pre_run_hygiene_final.md",
+        "proof/rte_pre_run_hygiene_final_challenge.md",
+        "proof/rte_pre_run_hygiene_precommit.md",
+        "proof/rte_pre_run_hygiene_stage1_boundary_model.md",
+        "proof/rte_pre_run_hygiene_stage1_challenge.md",
+        "proof/rte_pre_run_hygiene_stage2_challenge.md",
+        "proof/rte_pre_run_hygiene_stage2_worktree_ledger.md",
+        "proof/rte_pre_run_hygiene_stage3_challenge.md",
+        "proof/rte_pre_run_hygiene_stage3_input_boundary.md",
+        "proof/rte_pre_run_hygiene_stage4_arbitration.md",
+        "proof/rte_pre_run_hygiene_stage4_challenge.md",
+        "proof/rte_pre_run_hygiene_stage4_consensus.md",
+        "proof/rte_pre_run_hygiene_stage5_quarantine_ledger.md",
+        "proof/rte_pre_run_hygiene_stage5_review.md"
+      ],
+      "maps_to_existing_branch": null,
+      "object": "fc2a3b4c8a8ae695331e15ae182906f34c4d691f",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_05-fc2a3b4c8a8a/patch.patch",
+      "reason": "stash contains docs/proof/task-packet changes requiring manual recovery decision",
+      "ref": "stash@{5}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    },
+    {
+      "branch_hint": "audit/rte-pre-run-hygiene-gemini-001",
+      "candidate_recovery_branch": null,
+      "class": "operator-local-artifact",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_06-21e7fce76072",
+      "file_count": 1,
+      "files": [
+        "AGENTS.md"
+      ],
+      "maps_to_existing_branch": null,
+      "object": "21e7fce76072d577726a3d17810b979503a23d6e",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_06-21e7fce76072/patch.patch",
+      "reason": "AGENTS.md-only stash retained as operator-local instruction surface",
+      "ref": "stash@{6}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    },
+    {
+      "branch_hint": "audit/rte-pre-run-hygiene-gemini-001",
+      "candidate_recovery_branch": null,
+      "class": "operator-local-artifact",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_07-f1527ae23c15",
+      "file_count": 1,
+      "files": [
+        "AGENTS.md"
+      ],
+      "maps_to_existing_branch": null,
+      "object": "f1527ae23c1522ba9ce4c6e144032e426bc41533",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_07-f1527ae23c15/patch.patch",
+      "reason": "AGENTS.md-only stash retained as operator-local instruction surface",
+      "ref": "stash@{7}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    },
+    {
+      "branch_hint": "feat/rte-cost-stabilization-v2",
+      "candidate_recovery_branch": null,
+      "class": "operator-local-artifact",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_08-d1c2b3e08245",
+      "file_count": 1,
+      "files": [
+        "AGENTS.md"
+      ],
+      "maps_to_existing_branch": "feat/rte-cost-stabilization-v2",
+      "object": "d1c2b3e0824564c1e300870f62cea2a8da839485",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_08-d1c2b3e08245/patch.patch",
+      "reason": "AGENTS.md-only stash retained as operator-local instruction surface",
+      "ref": "stash@{8}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    },
+    {
+      "branch_hint": "main",
+      "candidate_recovery_branch": "codex/recover-ui-cockpit-20260502-stash9",
+      "class": "recover-partial",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_09-957cec606b3e",
+      "file_count": 6,
+      "files": [
+        "AGENTS.md",
+        "docs/03-reference/systems/dopemux/tui-spec-v2-0a.md",
+        "docs/03-reference/systems/dopemux/tui-unknown-resolution-questionnaire.md",
+        "docs/90-adr/adr-001-workflow-centric-ia-and-handoff-packet-model.md",
+        "docs/90-adr/adr-002-pm-mode-authority-split-and-bounded-leantime-write-scope.md",
+        "docs/90-adr/adr-dope-memory-as-chronicle-memory-authority.md"
+      ],
+      "maps_to_existing_branch": "main",
+      "object": "957cec606b3e2bf4550b2ec13e3cd69b69ce3b8d",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_09-957cec606b3e/patch.patch",
+      "reason": "stash contains docs/proof/task-packet changes requiring manual recovery decision",
+      "ref": "stash@{9}",
+      "required_validation": [
+        "git diff --check",
+        "npm test -- --runInBand ui-dashboard || npm test",
+        "python -m pytest -q tests/unit"
+      ],
+      "subsystem": "ui/cockpit"
+    },
+    {
+      "branch_hint": "claude/gracious-poitras-850e4f",
+      "candidate_recovery_branch": null,
+      "class": "cleanup-safe-next",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_10-4a63bece58ce",
+      "file_count": 0,
+      "files": [],
+      "maps_to_existing_branch": null,
+      "object": "4a63bece58ce6239667bc48470cddebaa52372d5",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_10-4a63bece58ce/patch.patch",
+      "reason": "stash has zero visible files; eligible only for explicit stash-drop follow-up after object ID proof",
+      "ref": "stash@{10}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown"
+    },
+    {
+      "branch_hint": "codex/v1-runtime-proof-linkage",
+      "candidate_recovery_branch": null,
+      "class": "cleanup-safe-next",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_11-3ef0715d6330",
+      "file_count": 0,
+      "files": [],
+      "maps_to_existing_branch": null,
+      "object": "3ef0715d6330b7d50be8703505a8d285c831180b",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_11-3ef0715d6330/patch.patch",
+      "reason": "stash has zero visible files; eligible only for explicit stash-drop follow-up after object ID proof",
+      "ref": "stash@{11}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit"
+      ],
+      "subsystem": "mixed/unknown"
+    },
+    {
+      "branch_hint": "codex/truth-doc-placement",
+      "candidate_recovery_branch": "codex/recover-ui-cockpit-20260502-stash12",
+      "class": "recover-partial",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_12-879592566819",
+      "file_count": 5,
+      "files": [
+        "AGENTS.md",
+        "docs/03-reference/systems/dopemux/tui-spec-v2-0a.md",
+        "docs/90-adr/adr-001-workflow-centric-ia-and-handoff-packet-model.md",
+        "docs/90-adr/adr-002-pm-mode-authority-split-and-bounded-leantime-write-scope.md",
+        "docs/90-adr/adr-index.md"
+      ],
+      "maps_to_existing_branch": null,
+      "object": "87959256681959d53e21452dfad8ae41709eb249",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_12-879592566819/patch.patch",
+      "reason": "stash contains docs/proof/task-packet changes requiring manual recovery decision",
+      "ref": "stash@{12}",
+      "required_validation": [
+        "git diff --check",
+        "npm test -- --runInBand ui-dashboard || npm test",
+        "python -m pytest -q tests/unit"
+      ],
+      "subsystem": "ui/cockpit"
+    },
+    {
+      "branch_hint": "main",
+      "candidate_recovery_branch": "codex/recover-cli-system-20260502-stash13",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_13-2ab1207b74c8",
+      "file_count": 6,
+      "files": [
+        ".claude/worktrees/cli-refactor",
+        ".github/copilot-instructions.md",
+        ".github/workflows/ci-complete.yml",
+        "AGENTS.md",
+        "compose.yml",
+        "docker/mcp-servers-source/pal/pal_http_wrapper.py"
+      ],
+      "maps_to_existing_branch": "main",
+      "object": "2ab1207b74c83031bfb90bcbd8468de4815e21fa",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_13-2ab1207b74c8/patch.patch",
+      "reason": "stash contains source/test/operator files requiring recovery branch review",
+      "ref": "stash@{13}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q tests/unit/test_cli_audit_remediations.py tests/unit/test_cli_repscan_passthrough.py",
+        "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir proof/pr_merge/recovery"
+      ],
+      "subsystem": "cli/system"
+    },
+    {
+      "branch_hint": "tp/dopecode-phase8-events-replay",
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-stash14",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_14-e59bb13f2c17",
+      "file_count": 17,
+      "files": [
+        "INSTALL.md",
+        "docs/00-MASTER-INDEX.md",
+        "docs/02-how-to/install.md",
+        "docs/03-reference/overview.md",
+        "install.sh",
+        "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/doctor/PROVIDER_PREFLIGHT.json",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/tests/test_prescan_provider_catalog.py",
+        "services/serena/dopecode/transform/refactor_layer.py",
+        "services/serena/dopecode/transform/write_layer.py",
+        "services/serena/mcp_server.py",
+        "services/serena/tests/test_dopecode_execution_receipts.py",
+        "services/serena/tests/test_dopecode_refactor_layer.py",
+        "services/serena/tests/test_dopecode_write_layer.py",
+        "src/dopemux_pr_merge_specialist/queue_drain.py"
+      ],
+      "maps_to_existing_branch": "tp/dopecode-phase8-events-replay",
+      "object": "e59bb13f2c177c6e55a2512bac8fc9ec78cc0127",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_14-e59bb13f2c17/patch.patch",
+      "reason": "stash contains source/test/operator files requiring recovery branch review",
+      "ref": "stash@{14}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    },
+    {
+      "branch_hint": "tp/serena-v2-truth",
+      "candidate_recovery_branch": "codex/recover-rte-dopecode-20260502-stash15",
+      "class": "topic-pr-ready-review",
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_15-e5c5cdbd7acd",
+      "file_count": 62,
+      "files": [
+        ".claude/WORKTREE_MCP_SETUP.md",
+        ".gitignore",
+        "docker/mcp-servers-source/serena/Dockerfile",
+        "docker/mcp-servers-source/serena/info_server.py",
+        "docker/mcp-servers-source/serena/wrapper.py",
+        "docs/02-how-to/extraction/run-prescan.md",
+        "services/repo-truth-extractor/lib/prescan/classifier.py",
+        "services/repo-truth-extractor/lib/prescan/engine.py",
+        "services/repo-truth-extractor/lib/prescan/grok_passes.py",
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+        "services/repo-truth-extractor/run_prescan.py",
+        "services/repo-truth-extractor/tests/test_prescan_online_gate.py",
+        "services/serena/mcp_server.py",
+        "services/serena/v2/__init__.py",
+        "services/serena/v2/adhd_features.py",
+        "services/serena/v2/claude_context_integration.py",
+        "services/serena/v2/code_graph_storage.py",
+        "services/serena/v2/code_structure_analyzer.py",
+        "services/serena/v2/developer_learning_engine.py",
+        "services/serena/v2/enhanced_lsp.py",
+        "services/serena/v2/focus_manager.py",
+        "services/serena/v2/indexing_pipeline.py",
+        "services/serena/v2/intelligence/DATABASE_AUDIT.md",
+        "services/serena/v2/intelligence/__init__.py",
+        "services/serena/v2/intelligence/accommodation_harmonizer.py",
+        "services/serena/v2/intelligence/adaptive_learning.py",
+        "services/serena/v2/intelligence/adhd_relationship_filter.py",
+        "services/serena/v2/intelligence/cognitive_load_orchestrator.py",
+        "services/serena/v2/intelligence/complete_system_integration_test.py",
+        "services/serena/v2/intelligence/conport_bridge.py",
+        "services/serena/v2/intelligence/context_switching_optimizer.py",
+        "services/serena/v2/intelligence/convergence_test.py",
+        "services/serena/v2/intelligence/cross_session_persistence_bridge.py",
+        "services/serena/v2/intelligence/database.py",
+        "services/serena/v2/intelligence/effectiveness_evolution_system.py",
+        "services/serena/v2/intelligence/effectiveness_tracker.py",
+        "services/serena/v2/intelligence/enhanced_tree_sitter.py",
+        "services/serena/v2/intelligence/fatigue_detection_engine.py",
+        "services/serena/v2/intelligence/graph_operations.py",
+        "services/serena/v2/intelligence/integration_test.py",
+        "services/serena/v2/intelligence/intelligent_relationship_builder.py",
+        "services/serena/v2/intelligence/learning_profile_manager.py",
+        "services/serena/v2/intelligence/navigation_success_validator.py",
+        "services/serena/v2/intelligence/pattern_recognition.py",
+        "services/serena/v2/intelligence/pattern_reuse_recommendation_engine.py",
+        "services/serena/v2/intelligence/performance_validation_system.py",
+        "services/serena/v2/intelligence/personal_pattern_adapter.py",
+        "services/serena/v2/intelligence/personalized_threshold_coordinator.py",
+        "services/serena/v2/intelligence/progressive_disclosure_director.py",
+        "services/serena/v2/intelligence/realtime_relevance_scorer.py",
+        "services/serena/v2/intelligence/schema.sql",
+        "services/serena/v2/intelligence/schema_manager.py",
+        "services/serena/v2/intelligence/strategy_template_manager.py",
+        "services/serena/v2/layer1_validation.py",
+        "services/serena/v2/mcp_client.py",
+        "services/serena/v2/navigation_cache.py",
+        "services/serena/v2/performance_monitor.py",
+        "services/serena/v2/redis_optimizer.py",
+        "services/serena/v2/tree_sitter_analyzer.py",
+        "src/dopemux/claude_config.py",
+        "src/dopemux/cli.py"
+      ],
+      "maps_to_existing_branch": "tp/serena-v2-truth",
+      "object": "e5c5cdbd7acdce4ffb0418e12d7df70b2f3dbee0",
+      "patch_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/stashes/stash_15-e5c5cdbd7acd/patch.patch",
+      "reason": "stash contains source/test/operator files requiring recovery branch review",
+      "ref": "stash@{15}",
+      "required_validation": [
+        "git diff --check",
+        "pytest -q services/repo-truth-extractor/tests services/serena/tests tests/unit/test_extractor_command_authority.py"
+      ],
+      "subsystem": "rte/dopecode"
+    }
+  ],
+  "task_packet": "TP-DMX-REPOHYG-006",
+  "valid_classes": [
+    "already-in-main",
+    "blocked",
+    "cleanup-safe-next",
+    "dirty-local",
+    "operator-local-artifact",
+    "recover-partial",
+    "topic-pr-ready-review",
+    "unfinished-abandoned"
+  ],
+  "validation": [],
+  "validation_performed": {
+    "final_inventory": [
+      {
+        "command": "git worktree list --porcelain",
+        "exit_code": 0,
+        "stderr_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/final-inventory/worktree_list_porcelain.stderr.txt",
+        "stdout_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/final-inventory/worktree_list_porcelain.stdout.txt"
+      },
+      {
+        "command": "git branch -vv",
+        "exit_code": 0,
+        "stderr_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/final-inventory/branch_vv.stderr.txt",
+        "stdout_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/final-inventory/branch_vv.stdout.txt"
+      },
+      {
+        "command": "git stash list --date=iso",
+        "exit_code": 0,
+        "stderr_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/final-inventory/stash_list_iso.stderr.txt",
+        "stdout_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/final-inventory/stash_list_iso.stdout.txt"
+      },
+      {
+        "command": "git status --short --branch",
+        "exit_code": 0,
+        "stderr_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/final-inventory/status_short_branch.stderr.txt",
+        "stdout_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/final-inventory/status_short_branch.stdout.txt"
+      }
+    ],
+    "internal_codereview": {
+      "continuation_id": "8f38326c-f0e0-441b-a71c-18bbda6320d7",
+      "issues_found": 0,
+      "model": "gpt-5-codex",
+      "review_validation_type": "internal",
+      "status": "complete_no_blocking_findings",
+      "tool": "mcp__pal__.codereview"
+    },
+    "json_and_self_check": [
+      {
+        "command": "python -m json.tool task-packets/TP-DMX-REPOHYG-006.json",
+        "exit_code": 0
+      },
+      {
+        "command": "python -m json.tool proof/repo-deep-remaining-work-audit-2026-05-02.proof.json",
+        "exit_code": 0
+      },
+      {
+        "command": "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir /Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/pr-merge-self-check",
+        "exit_code": 0
+      }
+    ],
+    "prestage_results_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/validation-results-prestage.json",
+    "staged_checks": [
+      {
+        "command": "git diff --cached --check",
+        "exit_code": 0
+      },
+      {
+        "command": "pre-commit run --files task-packets/TP-DMX-REPOHYG-006.json docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md proof/repo-deep-remaining-work-audit-2026-05-02.proof.json proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md task-packets/INDEX.md",
+        "exit_code": 0
+      }
+    ],
+    "staged_results_path": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/validation-results-staged-1.json"
+  },
+  "worktrees": [
+    {
+      "branch": "main",
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 3,
+      "dirty_paths_sample": [
+        "AGENTS.md",
+        "out/DMX-AUTHORITY-SERIES-EXECUTION-PLAN.md",
+        "out/DMX-AUTHORITY-SERIES-MASTER.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-af5c46274786",
+      "head": "af5c462747860ad8382efa72304dd18970374205",
+      "path": "/Users/hue/code/dopemux-mvp",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "docs/audit",
+      "untracked_count": 2
+    },
+    {
+      "branch": null,
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 20,
+      "dirty_paths_sample": [
+        "AGENTS.md",
+        "out/ARCHITECTURE.md",
+        "out/PM_PLANE.md",
+        "out/PROJECT.md",
+        "out/RULES.md",
+        "out/SERVICE_CATALOG.md",
+        "out/SYSTEM_ADHDEngine.md",
+        "out/SYSTEM_ConPort.md",
+        "out/SYSTEM_DopeContext.md",
+        "out/SYSTEM_DopeMemory.md",
+        "out/SYSTEM_DopeconBridge.md",
+        "out/SYSTEM_Dopemux.md",
+        "out/SYSTEM_TaskOrchestrator.md",
+        "out/TRUTH_CANONICALS.md",
+        "out/TRUTH_DATA_EVENTS.md",
+        "out/TRUTH_GAPS.md",
+        "out/TRUTH_INTERFACES.md",
+        "out/TRUTH_SCOPE.md",
+        "out/TRUTH_SYSTEMS.md",
+        "out/system-boundaries.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_11a0_dopemux-mvp-1fdf61b457fb",
+      "head": "1fdf61b457fb7894f1d34dedf188b8d3d58a98b9",
+      "path": "/Users/hue/.codex/worktrees/11a0/dopemux-mvp",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "docs/audit",
+      "untracked_count": 19
+    },
+    {
+      "branch": null,
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 1,
+      "dirty_paths_sample": [
+        "AGENTS.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_22c5_dopemux-mvp-wt-cockpit-pm-textual-1fdf61b457fb",
+      "head": "1fdf61b457fb7894f1d34dedf188b8d3d58a98b9",
+      "path": "/Users/hue/.codex/worktrees/22c5/dopemux-mvp-wt-cockpit-pm-textual",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "docs/audit",
+      "untracked_count": 0
+    },
+    {
+      "branch": "codex/remove-stale-root-next-surface",
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 1,
+      "dirty_paths_sample": [
+        "AGENTS.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_38c4_dopemux-mvp-d661b6e1cd6a",
+      "head": "d661b6e1cd6a6592e3db3e60c1b5e9820942c9fe",
+      "path": "/Users/hue/.codex/worktrees/38c4/dopemux-mvp",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "docs/audit",
+      "untracked_count": 0
+    },
+    {
+      "branch": null,
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 4,
+      "dirty_paths_sample": [
+        ".claude/agents/architect.md",
+        ".claude/agents/developer.md",
+        ".claude/agents/project-manager.md",
+        ".claude/agents/researcher.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_558a_dopemux-mvp-wt-cockpit-pm-textual-3bb5464db6eb",
+      "head": "3bb5464db6eb35e1666fe487257e8cf68ef47b71",
+      "path": "/Users/hue/.codex/worktrees/558a/dopemux-mvp-wt-cockpit-pm-textual",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "mixed/unknown",
+      "untracked_count": 0
+    },
+    {
+      "branch": null,
+      "class": "blocked",
+      "dirty": true,
+      "dirty_path_count": 1,
+      "dirty_paths_sample": [
+        "out/cockpit-command-inventory/"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_7f12_dopemux-mvp-af5c46274786",
+      "head": "af5c462747860ad8382efa72304dd18970374205",
+      "path": "/Users/hue/.codex/worktrees/7f12/dopemux-mvp",
+      "reason": "operator or active hygiene stack checkout intentionally retained",
+      "subsystem": "ui/cockpit",
+      "untracked_count": 1
+    },
+    {
+      "branch": "codex/add-audit-authority-files",
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 3,
+      "dirty_paths_sample": [
+        "AGENTS.md",
+        "docs/05-audit-reports/mcp-customization/07-mcp-customization-synthesis-dr-report.md",
+        "artifacts/"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_7f48_dopemux-mvp-wt-cockpit-pm-textual-5ad4be889fc7",
+      "head": "5ad4be889fc738fae83547027ad24e8d89d21304",
+      "path": "/Users/hue/.codex/worktrees/7f48/dopemux-mvp-wt-cockpit-pm-textual",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "mixed/unknown",
+      "untracked_count": 1
+    },
+    {
+      "branch": null,
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 1,
+      "dirty_paths_sample": [
+        "AGENTS.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_8444_dopemux-mvp-wt-cockpit-pm-textual-420d40ff3fe5",
+      "head": "420d40ff3fe508423a68103a81a9e692486b12a0",
+      "path": "/Users/hue/.codex/worktrees/8444/dopemux-mvp-wt-cockpit-pm-textual",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "docs/audit",
+      "untracked_count": 0
+    },
+    {
+      "branch": "codex/restore-system-data-command",
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 1,
+      "dirty_paths_sample": [
+        "AGENTS.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_b840_dopemux-mvp-wt-cockpit-pm-textual-042a60bdd055",
+      "head": "042a60bdd05541b06216a9f8bc4ddd9568939e3f",
+      "path": "/Users/hue/.codex/worktrees/b840/dopemux-mvp-wt-cockpit-pm-textual",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "cli/system",
+      "untracked_count": 0
+    },
+    {
+      "branch": "codex/installer-smoke-python-deps",
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 1,
+      "dirty_paths_sample": [
+        "AGENTS.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_b8c4_dopemux-mvp-75454e5d373d",
+      "head": "75454e5d373d760f062d0dadad2960cc22c03e41",
+      "path": "/Users/hue/.codex/worktrees/b8c4/dopemux-mvp",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "cli/system",
+      "untracked_count": 0
+    },
+    {
+      "branch": "codex/restore-canonical-compose",
+      "class": "cleanup-safe-next",
+      "dirty": false,
+      "dirty_path_count": 0,
+      "dirty_paths_sample": [],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_dopemux-compose-restore-72900b234412",
+      "head": "72900b2344121c8b291d5015544d1dbdc8442a65",
+      "path": "/Users/hue/.codex/worktrees/dopemux-compose-restore",
+      "reason": "clean attached worktree on cleanup-safe branch",
+      "subsystem": "cli/system",
+      "untracked_count": 0
+    },
+    {
+      "branch": "codex/dopemux-cli-audit-remediation",
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 9,
+      "dirty_paths_sample": [
+        "AGENTS.md",
+        "reports/dopemux-cli-command-audit-2026-05-01.md",
+        "reports/dopemux-cli-command-reference-2026-05-01.md",
+        "reports/dopemux-cli-command-remediation-plan-2026-05-01.md",
+        "reports/implementation-notes.md",
+        "reports/dopemux-cli-exhaustive-fix-plan-2026-05-01.md",
+        "reports/dopemux-cli-live-side-effects-2026-05-01.md",
+        "reports/dopemux-cli-live-side-effects/",
+        "scripts/audit/"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_e252_dopemux-mvp-wt-cockpit-pm-textual-d18ddab40a91",
+      "head": "d18ddab40a91f57c2566ff5826a12045d7925a14",
+      "path": "/Users/hue/.codex/worktrees/e252/dopemux-mvp-wt-cockpit-pm-textual",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "cli/system",
+      "untracked_count": 4
+    },
+    {
+      "branch": "codex/freeflow-strict-router",
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 1,
+      "dirty_paths_sample": [
+        "AGENTS.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_e270_dopemux-mvp-wt-cockpit-pm-textual-5eccaee6e0fc",
+      "head": "5eccaee6e0fc7aa0c4c3694218da5a8c02f3e073",
+      "path": "/Users/hue/.codex/worktrees/e270/dopemux-mvp-wt-cockpit-pm-textual",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "cli/system",
+      "untracked_count": 0
+    },
+    {
+      "branch": "work/pr-554-fix",
+      "class": "topic-pr-ready-review",
+      "dirty": false,
+      "dirty_path_count": 0,
+      "dirty_paths_sample": [],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_eb8e_dopemux-pr-554-fix-98da7f5525c6",
+      "head": "98da7f5525c6dd55028fe1cbe42d68bbe6660be1",
+      "path": "/Users/hue/.codex/worktrees/eb8e/dopemux-pr-554-fix",
+      "reason": "clean attached worktree on topic recovery candidate branch",
+      "subsystem": "mixed/unknown",
+      "untracked_count": 0
+    },
+    {
+      "branch": "codex/repo-hygiene-remaining-disposition-20260502",
+      "class": "blocked",
+      "dirty": false,
+      "dirty_path_count": 0,
+      "dirty_paths_sample": [],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_repo-hygiene-20260502-tp005_dopemux-mvp-93cff5922389",
+      "head": "93cff5922389b72c75d60b4763d708b35b05f401",
+      "path": "/Users/hue/.codex/worktrees/repo-hygiene-20260502-tp005/dopemux-mvp",
+      "reason": "operator or active hygiene stack checkout intentionally retained",
+      "subsystem": "mixed/unknown",
+      "untracked_count": 0
+    },
+    {
+      "branch": "codex/repo-hygiene-deep-audit-20260502",
+      "class": "blocked",
+      "dirty": false,
+      "dirty_path_count": 0,
+      "dirty_paths_sample": [],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_.codex_worktrees_repo-hygiene-20260502-tp006_dopemux-mvp-93cff5922389",
+      "head": "93cff5922389b72c75d60b4763d708b35b05f401",
+      "path": "/Users/hue/.codex/worktrees/repo-hygiene-20260502-tp006/dopemux-mvp",
+      "reason": "active TP006 execution worktree",
+      "subsystem": "mixed/unknown",
+      "untracked_count": 0
+    },
+    {
+      "branch": null,
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 2,
+      "dirty_paths_sample": [
+        "AGENTS.md",
+        ".codex/"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_ARCH-5.5-PRO-5f216582cf34",
+      "head": "5f216582cf3443777cbbf8eedf8b50f68f0d511d",
+      "path": "/Users/hue/code/ARCH-5.5-PRO",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "mixed/unknown",
+      "untracked_count": 1
+    },
+    {
+      "branch": "agents/dopemux-copilot-agent-specs",
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 2,
+      "dirty_paths_sample": [
+        "docs/03-reference/governance/AGENT_WORKFLOW.md",
+        "docs/03-reference/governance/agent-workflow.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-agents-copilot-specs-225477ce199e",
+      "head": "225477ce199e0c068428cc6fe0b563c6dce1c11e",
+      "path": "/Users/hue/code/dopemux-mvp-wt-agents-copilot-specs",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "docs/audit",
+      "untracked_count": 1
+    },
+    {
+      "branch": "codex/cockpit-design-system",
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 24,
+      "dirty_paths_sample": [
+        "AGENTS.md",
+        "\"docs/03-reference/Dopemux Cockpit TUI Design System/review-pack.md\"",
+        "out/AUDIT_ARTIFACTS_SHA256SUMS.txt",
+        "out/AUDIT_BUNDLE.md",
+        "out/AUDIT_PREFLIGHT_ZIP_AUDIT.md",
+        "out/AUDIT_UPLOAD_README.md",
+        "out/AUDIT_VALIDATION.log",
+        "out/AUDIT_ZIPINFO.txt",
+        "out/DMX-COCKPIT-DESIGN-PACK-REMEDIATE-003-CURRENT.zip",
+        "out/REVIEW_PACK.md",
+        "src/dopemux_pr_merge_specialist/merge.py",
+        "templates/skills/pr-merge-specialist/scripts/dopemux_pr_merge_specialist/merge.py",
+        "templates/skills/pr-merge-specialist/tests/test_thread_and_merge_logic.py",
+        "AUDIT_BUNDLE.md",
+        "docs/03-reference/gpt55_pm_implementer_redesign.md",
+        "docs/05-audit-reports/cockpit-adhd-lifestyle-feature-map-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-archive-intent-pack-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-design-input-merged-brief-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-pm-implementer-callable-inventory-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-pm-implementer-design-brief-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-pm-implementer-processing-pack-2026-04-24.md",
+        "out/opus-design-pack/",
+        "task-packets/DMX-COCKPIT-ARCHIVE-INTENT-001.json",
+        "task-packets/DMX-COCKPIT-PMIMPL-PACK-001.json"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-cockpit-design-system-c836e3410a74",
+      "head": "c836e3410a74cd19e342e4748970255b1e7346ac",
+      "path": "/Users/hue/code/dopemux-mvp-wt-cockpit-design-system",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "cli/system",
+      "untracked_count": 11
+    },
+    {
+      "branch": "test/pm-authority-ports",
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 48,
+      "dirty_paths_sample": [
+        "AGENTS.md",
+        "\"docs/03-reference/Dopemux Cockpit TUI Design System/surfaces/A1-services-repo-truth-workload-120x40.html\"",
+        "\"docs/03-reference/Dopemux Cockpit TUI Design System/surfaces/A2-services-repo-truth-workload-100x32.html\"",
+        "\"docs/03-reference/Dopemux Cockpit TUI Design System/surfaces/A3-services-repo-truth-workload-80x24.html\"",
+        "PAL_CHAINING_DOCTRINE.md",
+        "PAL_EXECUTION_RULES.md",
+        "PAL_PACKET_TEMPLATE.md",
+        "RULES.md",
+        "SYSTEM_ADHDEngine.md",
+        "SYSTEM_ConPort.md",
+        "SYSTEM_DopeContext.md",
+        "SYSTEM_DopeMemory.md",
+        "SYSTEM_DopeconBridge.md",
+        "SYSTEM_Dopemux.md",
+        "SYSTEM_Dopetask.md",
+        "SYSTEM_RepoTruthExtractor.md",
+        "SYSTEM_TaskOrchestrator.md",
+        "TRUTH_CANONICALS.md",
+        "TRUTH_DATA_EVENTS.md",
+        "TRUTH_GAPS.md",
+        "TRUTH_INTERFACES.md",
+        "TRUTH_SCOPE.md",
+        "TRUTH_SYSTEMS.md",
+        "clean-53-file-design-pack/",
+        "docs/03-reference/mcp-customization/",
+        "docs/assembled/",
+        "\"dopemux_uploaded_files_bundle 2/\"",
+        "\"dopemux_uploaded_files_bundle 3/\"",
+        "dopemux_uploaded_files_bundle/",
+        "dopemux_uploaded_files_bundle_manifest.json",
+        "dopetask-cannonical-spec.json",
+        "out/CLAUDE-DESIGN-CLEAN_AUDIT.md",
+        "out/CLAUDE-DESIGN-CLEAN_SHA256SUMS.txt",
+        "out/CLAUDE-DESIGN-CLEAN_ZIPINFO.txt",
+        "out/CLAUDE-DESIGN-LINEFIT-PATCH-002-CLEAN-NORMALIZED_AUDIT.md",
+        "out/CLAUDE-DESIGN-LINEFIT-PATCH-002-CLEAN-NORMALIZED_SHA256SUMS.txt",
+        "out/CLAUDE-DESIGN-LINEFIT-PATCH-002-CLEAN-NORMALIZED_ZIPINFO.txt",
+        "out/DOPMUX_REPO_TRUTH_EXTRACTOR_MAIN_AUDIT_2026-04-30_FILE_LIST.txt",
+        "out/DOPMUX_REPO_TRUTH_EXTRACTOR_MAIN_AUDIT_2026-04-30_MANIFEST.json",
+        "out/DOPMUX_REPO_TRUTH_EXTRACTOR_MAIN_AUDIT_2026-04-30_README.md",
+        "out/DOPMUX_REPO_TRUTH_EXTRACTOR_MAIN_AUDIT_2026-04-30_SHA256SUMS.txt",
+        "out/PROOF_PACK_003_ACTUAL_SOURCE/",
+        "out/PROOF_PACK_003_CLEAN_NORMALIZED/",
+        "out/cockpit-linefit/",
+        "out/cockpit-proof/",
+        "out/cockpit-uikit-render/",
+        "scripts/assemble_project_docs.py",
+        "scripts/assemble_project_sources.py"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-cockpit-pm-textual-c90ed07c0d5c",
+      "head": "c90ed07c0d5c9150f767ab2e5b27b3b1973cff7d",
+      "path": "/Users/hue/code/dopemux-mvp-wt-cockpit-pm-textual",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "cli/system",
+      "untracked_count": 44
+    },
+    {
+      "branch": "codex/dopecode-ast-navigation-20260417",
+      "class": "unfinished-abandoned",
+      "dirty": false,
+      "dirty_path_count": 0,
+      "dirty_paths_sample": [],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-dopecode-ast-40edc271c8f9",
+      "head": "40edc271c8f9f8c6d41fcf126d708c22db1ba1bc",
+      "path": "/Users/hue/code/dopemux-mvp-wt-dopecode-ast",
+      "reason": "clean attached worktree follows branch classification",
+      "subsystem": "rte/dopecode",
+      "untracked_count": 0
+    },
+    {
+      "branch": "codex/mcp-audit-hardening",
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 17,
+      "dirty_paths_sample": [
+        "docs/03-reference/services/server-registry-2.md",
+        "docs/03-reference/services/task-orchestrator.md",
+        "services/task-orchestrator/app/main.py",
+        "services/task-orchestrator/query_server.py",
+        "services/task-orchestrator/task_orchestrator/app.py",
+        "services/task-orchestrator/tests/test_health_route.py",
+        "task-packets/INDEX.md",
+        "docs/03-reference/services/mcp-audit-universe-2026-04-23.md",
+        "task-packets/TP-MCP-AUDIT-001.json",
+        "task-packets/TP-MCP-HARDEN-001.json",
+        "task-packets/TP-MCP-HARDEN-002.json",
+        "task-packets/TP-MCP-HARDEN-003.json",
+        "task-packets/TP-MCP-HARDEN-004.json",
+        "task-packets/TP-MCP-HARDEN-005.json",
+        "task-packets/TP-MCP-HARDEN-006.json",
+        "task-packets/TP-MCP-HARDEN-007.json",
+        "task-packets/TP-MCP-HARDEN-008.json"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-mcp-audit-hardening-087f993291aa",
+      "head": "087f993291aaa404e514c2616dd77cc7984c5097",
+      "path": "/Users/hue/code/dopemux-mvp-wt-mcp-audit-hardening",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "infra/services",
+      "untracked_count": 10
+    },
+    {
+      "branch": "research/dmx-mcp-customization-dr-data",
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 7,
+      "dirty_paths_sample": [
+        "docs/research/mcp-customization/data/dopemux-authority-map.json",
+        "docs/research/mcp-customization/data/evidence-ledger.md",
+        "docs/research/mcp-customization/data/responsibility-collision-matrix.md",
+        "docs/research/mcp-customization/data/upstream-source-manifest.json",
+        "docs/research/mcp-customization/data/upstream-surface-inventory.json",
+        "docs/research/mcp-customization/dr-upload/01-conport.md",
+        "docs/research/mcp-customization/dopemux-constraints/"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-mcp-customization-dr-data-cba686305c91",
+      "head": "cba686305c91e46556e522aacc326989462b8fa3",
+      "path": "/Users/hue/code/dopemux-mvp-wt-mcp-customization-dr-data",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "docs/audit",
+      "untracked_count": 1
+    },
+    {
+      "branch": "codex/pm-writes-phase1",
+      "class": "topic-pr-ready-review",
+      "dirty": false,
+      "dirty_path_count": 0,
+      "dirty_paths_sample": [],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-pm-writes-phase1-94c5086050cc",
+      "head": "94c5086050cc8b873acf0c9f5397c3c0435abd2e",
+      "path": "/Users/hue/code/dopemux-mvp-wt-pm-writes-phase1",
+      "reason": "clean attached worktree on topic recovery candidate branch",
+      "subsystem": "mixed/unknown",
+      "untracked_count": 0
+    },
+    {
+      "branch": "audit/runtime-authority-verifier-20260430-195535",
+      "class": "operator-local-artifact",
+      "dirty": true,
+      "dirty_path_count": 1,
+      "dirty_paths_sample": [
+        "AGENTS.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-runtime-authority-20260430-195535-5f216582cf34",
+      "head": "5f216582cf3443777cbbf8eedf8b50f68f0d511d",
+      "path": "/Users/hue/code/dopemux-mvp-wt-runtime-authority-20260430-195535",
+      "reason": "dirty state is local instruction/generated artifact only; cleanup requires explicit operator approval",
+      "subsystem": "docs/audit",
+      "untracked_count": 0
+    },
+    {
+      "branch": "audit/runtime-authority-verifier-20260430-201805",
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 5,
+      "dirty_paths_sample": [
+        "AGENTS.md",
+        "config/runtime_authority_manifest.json",
+        "docs/03-reference/governance/runtime-authority-verification.md",
+        "scripts/verify_runtime_authority.py",
+        "tests/unit/test_runtime_authority_manifest.py"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-runtime-authority-20260430-201805-5f216582cf34",
+      "head": "5f216582cf3443777cbbf8eedf8b50f68f0d511d",
+      "path": "/Users/hue/code/dopemux-mvp-wt-runtime-authority-20260430-201805",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "cli/system",
+      "untracked_count": 0
+    },
+    {
+      "branch": "codex/tui-runtime-unknown-hardening",
+      "class": "dirty-local",
+      "dirty": true,
+      "dirty_path_count": 3,
+      "dirty_paths_sample": [
+        ".github/hooks/",
+        "docs/tui-v2/",
+        "task-packets/TP-DMX-TUI-U1-U3-HARDENING-005.md"
+      ],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_dopemux-mvp-wt-tui-hardening-f23c3294c572",
+      "head": "f23c3294c5726b569a9903dd242559afca649577",
+      "path": "/Users/hue/code/dopemux-mvp-wt-tui-hardening",
+      "reason": "dirty tracked or untracked content includes docs/source/test/operator files",
+      "subsystem": "ui/cockpit",
+      "untracked_count": 3
+    },
+    {
+      "branch": "audit/runtime-authority-verifier-project-docs-improvement",
+      "class": "topic-pr-ready-review",
+      "dirty": false,
+      "dirty_path_count": 0,
+      "dirty_paths_sample": [],
+      "evidence_dir": "/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/worktrees/Users_hue_code_project-docs-improvement-00cb80dd9cd2",
+      "head": "00cb80dd9cd2763ef42472503505692f5895c949",
+      "path": "/Users/hue/code/project-docs-improvement",
+      "reason": "clean attached worktree on topic recovery candidate branch",
+      "subsystem": "mixed/unknown",
+      "untracked_count": 0
+    }
+  ]
+}

--- a/proof/repo-deep-remaining-work-audit-2026-05-02.proof.json
+++ b/proof/repo-deep-remaining-work-audit-2026-05-02.proof.json
@@ -2320,8 +2320,9 @@
   "commit_and_pr": {
     "base": "codex/repo-hygiene-remaining-disposition-20260502",
     "branch": "codex/repo-hygiene-deep-audit-20260502",
-    "commit_sha": "pending_until_commit; final response records exact SHA because proof file cannot self-reference its containing commit without changing that SHA",
-    "pr_url": "pending_until_pr_creation"
+    "commit_sha": "recorded in final response; a proof file cannot contain the hash of the commit that contains it without changing that hash",
+    "pr_number": 564,
+    "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/564"
   },
   "counts": {
     "branches_by_class": {

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -47,6 +47,7 @@ A packet is superseded by another packet
 | TP-DMX-REPOHYG-003 | Repo Hygiene | Resolve blocked and ambiguous cleanup survivors | Ready | N/A |
 | TP-DMX-REPOHYG-004 | Repo Hygiene | Lost-work audit, stash preservation, and conservative cleanup | Ready | N/A |
 | TP-DMX-REPOHYG-005 | Repo Hygiene | Remaining work disposition audit and cleanup-safe local pruning | Ready | N/A |
+| TP-DMX-REPOHYG-006 | Repo Hygiene | Deep remaining work audit and recovery queue classification | Ready | N/A |
 | TP-DMX-RTEAUDIT-001 | Repo Truth Extractor | Assemble pre-live audit pack for GPT-5.4 Pro | Ready | N/A |
 | TP-DMX-RTEINT-001 | Repo Truth Extractor | Integrate current RTE branch deltas into staging audit branch | Ready | N/A |
 | TP-DMX-RTECANON-001 | Repo Truth Extractor | Establish `dopemux rte` as the canonical operator entrypoint | Ready | N/A |

--- a/task-packets/TP-DMX-REPOHYG-006.json
+++ b/task-packets/TP-DMX-REPOHYG-006.json
@@ -1,10 +1,10 @@
 {
   "commit": {
     "allowlist": [
+      ".gitignore",
       "task-packets/TP-DMX-REPOHYG-006.json",
       "docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md",
       "proof/repo-deep-remaining-work-audit-2026-05-02.proof.json",
-      "proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md",
       "task-packets/INDEX.md"
     ],
     "message": "docs(repo-hygiene): deep audit remaining local work",
@@ -13,7 +13,7 @@
       "python -m json.tool proof/repo-deep-remaining-work-audit-2026-05-02.proof.json",
       "git diff --check",
       "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir /Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/pr-merge-self-check",
-      "pre-commit run --files task-packets/TP-DMX-REPOHYG-006.json docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md proof/repo-deep-remaining-work-audit-2026-05-02.proof.json proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md task-packets/INDEX.md"
+      "pre-commit run --files .gitignore task-packets/TP-DMX-REPOHYG-006.json docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md proof/repo-deep-remaining-work-audit-2026-05-02.proof.json task-packets/INDEX.md"
     ]
   },
   "depends_on": [
@@ -127,7 +127,7 @@
         "Commit only allowlisted hygiene files.",
         "Leave local recovery evidence untracked."
       ],
-      "task": "Publish TP006 packet, report, proof, implementation notes, and index update.",
+      "task": "Publish TP006 packet, report, proof, and index update.",
       "validation": [
         "JSON, whitespace, self-check, codereview, and pre-commit validations pass or exact blocker is recorded."
       ]

--- a/task-packets/TP-DMX-REPOHYG-006.json
+++ b/task-packets/TP-DMX-REPOHYG-006.json
@@ -1,0 +1,137 @@
+{
+  "commit": {
+    "allowlist": [
+      "task-packets/TP-DMX-REPOHYG-006.json",
+      "docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md",
+      "proof/repo-deep-remaining-work-audit-2026-05-02.proof.json",
+      "proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md",
+      "task-packets/INDEX.md"
+    ],
+    "message": "docs(repo-hygiene): deep audit remaining local work",
+    "verify": [
+      "python -m json.tool task-packets/TP-DMX-REPOHYG-006.json",
+      "python -m json.tool proof/repo-deep-remaining-work-audit-2026-05-02.proof.json",
+      "git diff --check",
+      "python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir /Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/pr-merge-self-check",
+      "pre-commit run --files task-packets/TP-DMX-REPOHYG-006.json docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md proof/repo-deep-remaining-work-audit-2026-05-02.proof.json proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md task-packets/INDEX.md"
+    ]
+  },
+  "depends_on": [
+    "TP-DMX-REPOHYG-001",
+    "TP-DMX-REPOHYG-002",
+    "TP-DMX-REPOHYG-003",
+    "TP-DMX-REPOHYG-004",
+    "TP-DMX-REPOHYG-005"
+  ],
+  "execution": {
+    "agent": "codex",
+    "base_branch": "origin/codex/repo-hygiene-remaining-disposition-20260502",
+    "branch": "codex/repo-hygiene-deep-audit-20260502",
+    "stacked_because": "PR #561 is behind current main and PR #563 remains stacked/unstable due to the external Gemini review provider failure."
+  },
+  "id": "TP-DMX-REPOHYG-006",
+  "invariants": [
+    "Do not delete local branches, remote branches, worktrees, or stashes in this packet.",
+    "Do not modify runtime/source/test files in this packet.",
+    "Compare all remaining candidates against current origin/main, not the TP005 origin/main snapshot.",
+    "Preserve dirty deltas, untracked manifests, branch evidence, and stash patches under the local recovery root.",
+    "Classify each item into exactly one declared disposition class.",
+    "Recovered runtime/docs/test work must land through later subsystem topic PRs."
+  ],
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "pr": {
+    "base": "codex/repo-hygiene-remaining-disposition-20260502",
+    "body": "## Summary\n- deep-audit remaining local worktrees, branches, and stashes against current origin/main\n- preserve local dirty/stash/branch evidence under the recovery root\n- publish a decision-ready recovery queue without runtime changes or cleanup mutations\n\n## Validation\n- packet/proof JSON validation\n- git diff whitespace check\n- dopemux-pr-merge self-check\n- internal codereview\n- pre-commit on allowlisted files\n\n## Follow-up\nLater packets should recover topic candidates and perform cleanup-safe deletion/drop work.",
+    "title": "docs(repo-hygiene): deep audit remaining local work"
+  },
+  "project": "dopemux-mvp",
+  "repo_binding": {
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "require_identity_match": true
+  },
+  "series": {
+    "base_branch": "main",
+    "final_packet": false,
+    "id": "DMX-REPO-HYGIENE-SERIES-001",
+    "parent_tp_id": "TP-DMX-REPOHYG-005"
+  },
+  "steps": [
+    {
+      "commands": [
+        "git fetch origin --prune",
+        "git worktree list --porcelain",
+        "git branch -vv",
+        "git stash list --date=iso",
+        "gh pr list --state all --limit 1000"
+      ],
+      "id": "S1",
+      "requirements": [
+        "Use the TP005 hygiene branch as stack base while comparing all candidates against current origin/main.",
+        "Record open hygiene PR state and base drift."
+      ],
+      "task": "Refresh current repo and GitHub authority from a dedicated TP006 worktree.",
+      "validation": [
+        "Raw command outputs are captured under the local recovery root."
+      ]
+    },
+    {
+      "commands": [
+        "git -C <worktree> status --porcelain",
+        "git -C <worktree> diff --binary",
+        "git cherry -v origin/main <branch>",
+        "git stash show --patch --binary <stash>"
+      ],
+      "id": "S2",
+      "requirements": [
+        "Write dirty status, binary diffs, staged diffs, untracked manifests, branch cherry/diff logs, stash object IDs, stash name-status, and stash patches.",
+        "Do not archive or commit large operator-local output directories into the repo."
+      ],
+      "task": "Preserve local evidence for dirty worktrees, branches, and stashes.",
+      "validation": [
+        "Local evidence directories are referenced from the machine-readable ledger."
+      ]
+    },
+    {
+      "commands": [
+        "classification script driven by Git and GitHub outputs"
+      ],
+      "id": "S3",
+      "requirements": [
+        "Use exactly already-in-main, cleanup-safe-next, topic-pr-ready-review, recover-partial, unfinished-abandoned, dirty-local, operator-local-artifact, or blocked.",
+        "Record subsystem, unique commits, unique paths, nearest PR proof, candidate recovery branch, and validation commands where relevant."
+      ],
+      "task": "Classify every remaining item into a declared disposition class.",
+      "validation": [
+        "Proof and report include class counts and recovery queue."
+      ]
+    },
+    {
+      "commands": [
+        "python -m json.tool task-packets/TP-DMX-REPOHYG-006.json",
+        "python -m json.tool proof/repo-deep-remaining-work-audit-2026-05-02.proof.json",
+        "git diff --check",
+        "pre-commit run --files <allowlist>"
+      ],
+      "id": "S4",
+      "requirements": [
+        "Commit only allowlisted hygiene files.",
+        "Leave local recovery evidence untracked."
+      ],
+      "task": "Publish TP006 packet, report, proof, implementation notes, and index update.",
+      "validation": [
+        "JSON, whitespace, self-check, codereview, and pre-commit validations pass or exact blocker is recorded."
+      ]
+    }
+  ],
+  "target": "Deep-audit every remaining local worktree, branch, and stash against current origin/main; preserve local evidence; produce a decision-ready recovery and cleanup ledger without changing runtime code or deleting refs/stashes."
+}


### PR DESCRIPTION
@codex
@clauee
@copilot

## Summary
- Adds TP-DMX-REPOHYG-006 as a docs/proof-only deep audit of the remaining local worktree, branch, and stash inventory against current origin/main.
- Preserves local dirty/stash/branch evidence under `/Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/`.
- Publishes a decision-ready recovery queue without deleting refs/stashes/worktrees and without changing runtime/source/test files.

## Validation
- `python -m json.tool task-packets/TP-DMX-REPOHYG-006.json`
- `python -m json.tool proof/repo-deep-remaining-work-audit-2026-05-02.proof.json`
- `python3 -m dopemux_pr_merge_specialist.cli self-check --out-dir /Users/hue/.codex/recovery/dopemux-mvp/repo-hygiene-20260502/deep-audit-20260502/pr-merge-self-check`
- internal `mcp__pal__.codereview` review: no blocking findings
- `git diff --cached --check`
- `pre-commit run --files task-packets/TP-DMX-REPOHYG-006.json docs/05-audit-reports/repo-deep-remaining-work-audit-2026-05-02.md proof/repo-deep-remaining-work-audit-2026-05-02.proof.json proof/repo-deep-remaining-work-audit-2026-05-02.implementation-notes.md task-packets/INDEX.md`

## Residual risk
- This is intentionally stacked behind #563 and #561; those hygiene PRs remain affected by external review-provider state.
- TP006 only classifies and queues recovery/cleanup. Runtime recovery and deletion/drop actions are left for later subsystem or cleanup PRs.