### PR TITLE
ui(cockpit): wire settings runtime primitives

### DIFF
--- a/out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json
+++ b/out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json
@@ -1,0 +1,181 @@
+{
+  "schema_version": "dopemux.cockpit.settings_runtime.proof.v1",
+  "packet_id": "TP-DMX-COCKPIT-SETTINGS-RUNTIME-001",
+  "proof_role": "closeout proof for Settings/Admin/Runtime primitive wiring",
+  "created_at_utc": "2026-05-04T20:34:34Z",
+  "worktree": "/Users/hue/code/dopemux-worktrees/dopemux-cockpit-settings-runtime-001",
+  "branch": "codex/cockpit-settings-runtime-001",
+  "base_branch": "codex/cockpit-runtime-render-001",
+  "base_head": "9ad522df341375b7fede75eaa8e43e1f44097b41",
+  "head_before": "9ad522df341375b7fede75eaa8e43e1f44097b41",
+  "implementation_commit_sha": "PENDING_FIRST_COMMIT",
+  "final_head_recording_policy": "If proof metadata is updated after the implementation commit, this file records implementation_commit_sha and uses this policy to avoid self-referential final-head churn.",
+  "pr_url": null,
+  "pr_blocker": "PENDING_PR_CREATION",
+  "tp_path": "task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json",
+  "accepted_inputs": {
+    "package_dir": "out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA",
+    "package_proof": "out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA/PROOF.json",
+    "runtime_render_proof": "out/cockpit-runtime-render/TP-DMX-COCKPIT-RUNTIME-RENDER-001/PROOF.json",
+    "settings_admin_handoff": "out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA/SETTINGS_ADMIN_RUNTIME_PACKAGE_HANDOFF.md"
+  },
+  "implementation_summary": [
+    "Added deterministic Settings/Admin/Runtime summary data to the runtime-render model and JSON/text snapshot.",
+    "Added a pure Settings/Admin row tier mapper that maps only from explicit safety/tier/side-effect evidence and fails unresolved rows to TU.",
+    "Kept Settings/Admin/Runtime as a secondary/global surface; exactly five top-level modes remain.",
+    "Preserved Safe Action Gate routing for confirmable/admin rows and kept execution status not_attempted."
+  ],
+  "files_changed": [
+    "src/dopemux/ui/cockpit/runtime_contract.py",
+    "tests/unit/dopemux/ui/cockpit/test_runtime_contract.py",
+    "tests/unit/test_cockpit_cli.py",
+    "task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json",
+    "task-packets/INDEX.md",
+    "proof/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/README.md",
+    "out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json"
+  ],
+  "boundary_preservation": {
+    "safe_for_claude_design": "NO",
+    "READY_FOR_CLAUDE_DESIGN": "not approved",
+    "no_final_screens": true,
+    "no_claude_design_upload": true,
+    "no_runtime_action_execution": true,
+    "no_t4_remote_mutation": true,
+    "no_live_service_adapters": true,
+    "no_canonical_writes": true,
+    "settings_admin_does_not_directly_execute": true,
+    "t4_blocked": true,
+    "tx_tu_never_executable": true
+  },
+  "codereview_status": {
+    "command": "command -v codereview",
+    "exit_code": 1,
+    "result": "codereview command unavailable on PATH; explicit diff review performed with no blockers found"
+  },
+  "precommit_status": {
+    "command": "pre-commit run --files src/dopemux/ui/cockpit/runtime_contract.py tests/unit/dopemux/ui/cockpit/test_runtime_contract.py tests/unit/test_cockpit_cli.py task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json task-packets/INDEX.md out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json proof/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/README.md",
+    "exit_code": 0,
+    "output_summary": "frontmatter/schema/docs hygiene/markdownlint/trim trailing whitespace/end-of-file hooks passed; yaml hook skipped no files"
+  },
+  "settings_admin_runtime_summary": {
+    "surface_name": "Settings/Admin/Runtime",
+    "surface_kind": "secondary/global surface",
+    "source_artifact_path": "out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA/SETTINGS_ADMIN_RUNTIME_PACKAGE_HANDOFF.md",
+    "flow_group_count": 9,
+    "row_count": 62,
+    "mapped_tier_counts": {
+      "T0": 0,
+      "T0i": 0,
+      "T1": 0,
+      "T2": 0,
+      "T3": 0,
+      "T4": 0,
+      "T5": 0,
+      "T6": 0,
+      "TX": 0,
+      "TU": 0
+    },
+    "unknown_tier_count": 62,
+    "refusal_counts": {
+      "UNKNOWN_DRIFT_QUEUE": 62,
+      "SHOW_BLOCKED_REASON": "UNKNOWN"
+    },
+    "gate_required_count": "UNKNOWN",
+    "blocked_count": "UNKNOWN",
+    "open_downstream_owner": "TP-DMX-COCKPIT-SETTINGS-RUNTIME-001"
+  },
+  "validation_commands": [
+    {
+      "command": "python -m json.tool out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA/PACKAGE_REMEDIATION_INDEX.json >/dev/null",
+      "exit_code": 0,
+      "output_summary": "no output"
+    },
+    {
+      "command": "python -m json.tool out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA/PROOF.json >/dev/null",
+      "exit_code": 0,
+      "output_summary": "no output"
+    },
+    {
+      "command": "python -m json.tool out/cockpit-runtime-render/TP-DMX-COCKPIT-RUNTIME-RENDER-001/PROOF.json >/dev/null",
+      "exit_code": 0,
+      "output_summary": "no output"
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json >/dev/null",
+      "exit_code": 0,
+      "output_summary": "no output"
+    },
+    {
+      "command": "python -m json.tool out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json >/dev/null",
+      "exit_code": 0,
+      "output_summary": "no output"
+    },
+    {
+      "command": "python -m compileall -q src/dopemux tests",
+      "exit_code": 0,
+      "output_summary": "no output"
+    },
+    {
+      "command": "python -m pytest tests/unit/dopemux/ui/cockpit -q",
+      "exit_code": 0,
+      "output_summary": "59 passed; warning: unknown pytest asyncio_mode config option"
+    },
+    {
+      "command": "python -m pytest tests/unit/test_cockpit_cli.py -q",
+      "exit_code": 0,
+      "output_summary": "5 passed; warning: unknown pytest asyncio_mode config option"
+    },
+    {
+      "command": "! grep -R -E \"READY_FOR_CLAUDE_DESIGN:\\u0020approved|safe_for_claude_design:\\u0020YES|Claude Design upload\\u0020allowed|T4\\u0020authorized|runtime execution\\u0020implemented|Settings/Admin\\u0020direct\\u0020execution\" -n src/dopemux tests out/cockpit-settings-runtime proof/cockpit-settings-runtime",
+      "exit_code": 0,
+      "output_summary": "no output",
+      "encoding_note": "Spaces in forbidden positive phrases are escaped in this JSON source so boundary greps do not self-trigger."
+    },
+    {
+      "command": "! grep -R -E \"subprocess|shell=True|os\\.system|requests|httpx|urllib|socket|docker|kubectl|gh pr create|git push\" -n src/dopemux/ui/cockpit src/dopemux/commands/cockpit_commands.py tests/unit/dopemux/ui/cockpit tests/unit/test_cockpit_cli.py",
+      "exit_code": 0,
+      "output_summary": "no output"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "output_summary": "no output"
+    },
+    {
+      "command": "git status --short --branch",
+      "exit_code": 0,
+      "output_summary": "modified runtime_contract.py, task-packets/INDEX.md, test_runtime_contract.py, test_cockpit_cli.py; untracked settings-runtime PROOF.json and generated TP"
+    },
+    {
+      "command": "pre-commit run --files src/dopemux/ui/cockpit/runtime_contract.py tests/unit/dopemux/ui/cockpit/test_runtime_contract.py tests/unit/test_cockpit_cli.py task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json task-packets/INDEX.md out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json proof/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/README.md",
+      "exit_code": 0,
+      "output_summary": "hooks passed; check yaml skipped no files"
+    }
+  ],
+  "residual_risks": [
+    "Per-row Settings/Admin tier mapping remains UNKNOWN for the accepted 62-row package inventory because the accepted package provides flow-group defaults, not complete per-row proof.",
+    "T4 remains refused until a separate remote-mutation policy exists and is accepted.",
+    "Blocked row count inside Settings/Admin remains UNKNOWN because only total Settings/Admin row count is proven by the accepted package artifacts.",
+    "Gate-required count inside Settings/Admin remains UNKNOWN until per-row inventory regeneration or row evidence exists.",
+    "Unknown/Drift Queue full runtime surface remains owned by TP-DMX-COCKPIT-UNKNOWN-DRIFT-001.",
+    "Inventory regeneration against current HEAD remains a separate packet."
+  ],
+  "unknowns": [
+    "Root RULES.md absent in this worktree.",
+    "Root TRUTH_*.md absent in this worktree.",
+    "Root SYSTEM_*.md absent in this worktree.",
+    "dopetask-cannonical-spec.json and dopetask-canonical-spec.json absent in this worktree; TP schema was checked manually.",
+    "Operator authentication remains unwired; runtime receipts still use NULL_NOT_AUTHENTICATED."
+  ],
+  "proof_artifact_hashes": [
+    {
+      "path": "proof/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/README.md",
+      "sha256": "aa50ddb875dd057b40c881fadb6882d08e53e07da69e0dde615f87ec7c879eef"
+    },
+    {
+      "path": "out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json",
+      "sha256": "reported externally to avoid self-referential proof churn"
+    }
+  ],
+  "cleanup_status": "PENDING"
+}

--- a/out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json
+++ b/out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json
@@ -8,10 +8,19 @@
   "base_branch": "codex/cockpit-runtime-render-001",
   "base_head": "9ad522df341375b7fede75eaa8e43e1f44097b41",
   "head_before": "9ad522df341375b7fede75eaa8e43e1f44097b41",
-  "implementation_commit_sha": "PENDING_FIRST_COMMIT",
+  "implementation_commit_sha": "8599eae672802d85b7c0d4dfae3d4477381b7ab4",
   "final_head_recording_policy": "If proof metadata is updated after the implementation commit, this file records implementation_commit_sha and uses this policy to avoid self-referential final-head churn.",
-  "pr_url": null,
-  "pr_blocker": "PENDING_PR_CREATION",
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/569",
+  "pr_blocker": null,
+  "pr": {
+    "number": 569,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/569",
+    "state": "OPEN",
+    "is_draft": false,
+    "base": "codex/cockpit-runtime-render-001",
+    "head": "codex/cockpit-settings-runtime-001",
+    "head_ref_oid_at_creation": "8599eae672802d85b7c0d4dfae3d4477381b7ab4"
+  },
   "tp_path": "task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json",
   "accepted_inputs": {
     "package_dir": "out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA",
@@ -150,6 +159,11 @@
       "command": "pre-commit run --files src/dopemux/ui/cockpit/runtime_contract.py tests/unit/dopemux/ui/cockpit/test_runtime_contract.py tests/unit/test_cockpit_cli.py task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json task-packets/INDEX.md out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json proof/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/README.md",
       "exit_code": 0,
       "output_summary": "hooks passed; check yaml skipped no files"
+    },
+    {
+      "command": "gh pr view 569 --json number,url,state,isDraft,baseRefName,headRefName,headRefOid",
+      "exit_code": 0,
+      "output_summary": "PR 569 open, ready, base codex/cockpit-runtime-render-001, head codex/cockpit-settings-runtime-001"
     }
   ],
   "residual_risks": [
@@ -177,5 +191,5 @@
       "sha256": "reported externally to avoid self-referential proof churn"
     }
   ],
-  "cleanup_status": "PENDING"
+  "cleanup_status": "proof metadata cleanup recorded here; final push status is reported in closeout to avoid self-referential proof churn"
 }

--- a/proof/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/README.md
+++ b/proof/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/README.md
@@ -1,0 +1,15 @@
+# TP-DMX-COCKPIT-SETTINGS-RUNTIME-001 Proof Marker
+
+This directory is local proof output only. It is not runtime authority and does not write to PM, memory, ConPort, dopecon-bridge, task-orchestrator, Docker, browser, OpenClaw, CDP, Chaturbate, network, external API, or live service stores.
+
+safe_for_claude_design: NO
+READY_FOR_CLAUDE_DESIGN: not approved
+
+Boundary preserved:
+- no final screens
+- no Claude Design upload
+- no runtime action execution
+- no T4 remote mutation
+- no live service adapters
+- no canonical writes
+- Settings/Admin does not directly execute

--- a/src/dopemux/ui/cockpit/runtime_contract.py
+++ b/src/dopemux/ui/cockpit/runtime_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
 import hashlib
@@ -14,6 +15,8 @@ from uuid import NAMESPACE_URL, uuid5
 
 PACKAGE_PACKET_ID = "TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA"
 RUNTIME_PACKET_ID = "TP-DMX-COCKPIT-RUNTIME-RENDER-001"
+SETTINGS_RUNTIME_PACKET_ID = "TP-DMX-COCKPIT-SETTINGS-RUNTIME-001"
+SETTINGS_ADMIN_SOURCE_ARTIFACT = "SETTINGS_ADMIN_RUNTIME_PACKAGE_HANDOFF.md"
 
 TOP_LEVEL_MODES: tuple[str, ...] = (
     "PM",
@@ -48,6 +51,93 @@ CONFIRMABLE_TIERS: frozenset[str] = frozenset(("T1", "T2", "T3", "T5", "T6"))
 NON_CONFIRM_TIERS: frozenset[str] = frozenset(("T0", "T0i"))
 BLOCKED_TIERS: frozenset[str] = frozenset(("TX",))
 UNKNOWN_TIERS: frozenset[str] = frozenset(("TU",))
+SETTINGS_ADMIN_GATE_REQUIRED_TIERS: frozenset[str] = frozenset(
+    ("T0i", "T1", "T2", "T3", "T4", "T5", "T6")
+)
+
+SETTINGS_ADMIN_FLOW_GROUPS: tuple[dict[str, Any], ...] = (
+    {
+        "name": "Routing / Model Provider",
+        "authority_owner": "routing/model-provider support (LiteLLM/CCR)",
+        "primary_tiers": ("T2",),
+        "inspect_tiers": ("T0i",),
+        "confirmation_strength": "Explicit button + diff acknowledgment",
+        "typical_proof": "CONFIG_DIFF_OR_STATUS",
+        "row_tier_mapping_status": "per-row UNKNOWN until packet evidence exists",
+    },
+    {
+        "name": "Profile management",
+        "authority_owner": "dopemux operator control",
+        "primary_tiers": ("T2",),
+        "inspect_tiers": ("T0i",),
+        "confirmation_strength": "Explicit button + diff acknowledgment",
+        "typical_proof": "CONFIG_DIFF_OR_STATUS",
+        "row_tier_mapping_status": "per-row UNKNOWN until packet evidence exists",
+    },
+    {
+        "name": "Environment management",
+        "authority_owner": "dopemux operator control",
+        "primary_tiers": ("T2",),
+        "inspect_tiers": ("T0i",),
+        "confirmation_strength": "Explicit button + diff acknowledgment",
+        "typical_proof": "CONFIG_DIFF_OR_STATUS",
+        "row_tier_mapping_status": "per-row UNKNOWN until packet evidence exists",
+    },
+    {
+        "name": "MCP server control",
+        "authority_owner": "dopemux operator control + per-MCP authority",
+        "primary_tiers": ("T2", "T5"),
+        "inspect_tiers": ("T0i",),
+        "confirmation_strength": "Explicit button or typed service-id",
+        "typical_proof": "CONFIG_DIFF_OR_STATUS / SERVICE_STATUS_AND_LOG",
+        "row_tier_mapping_status": "per-row UNKNOWN until packet evidence exists",
+    },
+    {
+        "name": "Service startup / lifecycle (admin)",
+        "authority_owner": "per-service authority (Cockpit shows status only)",
+        "primary_tiers": ("T5",),
+        "inspect_tiers": ("T0i",),
+        "confirmation_strength": "Explicit button + typed service-id",
+        "typical_proof": "SERVICE_STATUS_AND_LOG",
+        "row_tier_mapping_status": "per-row UNKNOWN until packet evidence exists",
+    },
+    {
+        "name": "Hooks / native-hooks",
+        "authority_owner": "dopemux operator control",
+        "primary_tiers": ("T2",),
+        "inspect_tiers": ("T0i",),
+        "confirmation_strength": "Explicit button + diff acknowledgment",
+        "typical_proof": "CONFIG_DIFF_OR_STATUS",
+        "row_tier_mapping_status": "per-row UNKNOWN until packet evidence exists",
+    },
+    {
+        "name": "Runtime configuration",
+        "authority_owner": "dopemux operator control",
+        "primary_tiers": ("T2",),
+        "inspect_tiers": ("T0i",),
+        "confirmation_strength": "Explicit button + diff acknowledgment",
+        "typical_proof": "CONFIG_DIFF_OR_STATUS",
+        "row_tier_mapping_status": "per-row UNKNOWN until packet evidence exists",
+    },
+    {
+        "name": "Admin / safe / debug helpers",
+        "authority_owner": "dopemux operator control",
+        "primary_tiers": ("T0i", "T2", "T5"),
+        "inspect_tiers": ("T0i",),
+        "confirmation_strength": "per tier",
+        "typical_proof": "per tier",
+        "row_tier_mapping_status": "per-row UNKNOWN until packet evidence exists",
+    },
+    {
+        "name": "Drift inspection (read-only)",
+        "authority_owner": "drift evidence (no execution)",
+        "primary_tiers": (),
+        "inspect_tiers": ("T0", "T0i"),
+        "confirmation_strength": "None / explicit invoke",
+        "typical_proof": "INSPECT_RESULT_AND_TIMESTAMP",
+        "row_tier_mapping_status": "per-row UNKNOWN until packet evidence exists",
+    },
+)
 
 ALLOWED_SURFACE_ORIGINS: frozenset[str] = frozenset(
     (
@@ -269,6 +359,7 @@ class RuntimeRenderModel:
     ia_verdict: str
     invariants: dict[str, bool]
     config: RuntimeConfig
+    settings_admin_runtime: SettingsAdminRuntimeSummary
 
 
 @dataclass(frozen=True)
@@ -279,6 +370,53 @@ class PreflightResult:
     missing_fields: tuple[str, ...]
     routing_destination: str
     execution_status: str = "not_attempted"
+
+
+@dataclass(frozen=True)
+class SettingsAdminTierMapping:
+    tier: str
+    safety_class: str
+    source: str
+    can_confirm: bool
+    gate_required: bool
+    refusal_route: str
+    refusal_reason: str | None
+    execution_status: str = "not_attempted"
+    remote_policy_required: bool = False
+
+
+@dataclass(frozen=True)
+class SettingsAdminRuntimeSummary:
+    surface_name: str
+    surface_kind: str
+    source_artifact_path: str
+    flow_groups: tuple[dict[str, Any], ...]
+    row_count: int | str
+    mapped_tier_counts: dict[str, int]
+    unknown_tier_count: int | str
+    refusal_counts: dict[str, int | str]
+    gate_required_count: int | str
+    blocked_count: int | str
+    open_downstream_owner: str
+    safe_for_claude_design: str
+    ready_for_claude_design: str
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "surface_name": self.surface_name,
+            "surface_kind": self.surface_kind,
+            "source_artifact_path": self.source_artifact_path,
+            "flow_groups": list(self.flow_groups),
+            "row_count": self.row_count,
+            "mapped_tier_counts": dict(self.mapped_tier_counts),
+            "unknown_tier_count": self.unknown_tier_count,
+            "refusal_counts": dict(self.refusal_counts),
+            "gate_required_count": self.gate_required_count,
+            "blocked_count": self.blocked_count,
+            "open_downstream_owner": self.open_downstream_owner,
+            "safe_for_claude_design": self.safe_for_claude_design,
+            "READY_FOR_CLAUDE_DESIGN": self.ready_for_claude_design,
+        }
 
 
 def stable_sha256(value: Any) -> str:
@@ -356,6 +494,221 @@ def load_package_artifacts(package_dir: str | Path) -> LoadedPackage:
     )
 
 
+def _settings_admin_source_path(package: LoadedPackage) -> str:
+    return str(package.package_dir / SETTINGS_ADMIN_SOURCE_ARTIFACT)
+
+
+def _settings_admin_row_count(package: LoadedPackage) -> int | str:
+    count = (
+        package.index.get("carried_inventory_counts", {})
+        .get("placement", {})
+        .get("Settings/Admin")
+    )
+    return count if isinstance(count, int) else "UNKNOWN"
+
+
+def build_settings_admin_runtime_summary(package: LoadedPackage) -> SettingsAdminRuntimeSummary:
+    row_count = _settings_admin_row_count(package)
+    unknown_tier_count: int | str = row_count if isinstance(row_count, int) else "UNKNOWN"
+    unknown_refusals: int | str = row_count if isinstance(row_count, int) else "UNKNOWN"
+    mapped_tier_counts = {tier: 0 for tier in SAFE_ACTION_TIERS}
+    return SettingsAdminRuntimeSummary(
+        surface_name="Settings/Admin/Runtime",
+        surface_kind="secondary/global surface",
+        source_artifact_path=_settings_admin_source_path(package),
+        flow_groups=SETTINGS_ADMIN_FLOW_GROUPS,
+        row_count=row_count,
+        mapped_tier_counts=mapped_tier_counts,
+        unknown_tier_count=unknown_tier_count,
+        refusal_counts={
+            "UNKNOWN_DRIFT_QUEUE": unknown_refusals,
+            "SHOW_BLOCKED_REASON": "UNKNOWN",
+        },
+        gate_required_count="UNKNOWN",
+        blocked_count="UNKNOWN",
+        open_downstream_owner=SETTINGS_RUNTIME_PACKET_ID,
+        safe_for_claude_design="NO",
+        ready_for_claude_design="not approved",
+    )
+
+
+def _first_present(row: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in row:
+            return row[key]
+    return None
+
+
+def _normalize_token(value: Any) -> str:
+    if value is None:
+        return "UNKNOWN"
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return cleaned if cleaned else "UNKNOWN"
+    return str(value)
+
+
+def _row_evidence_tokens(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, Mapping):
+        tokens: list[str] = []
+        for child in value.values():
+            tokens.extend(_row_evidence_tokens(child))
+        return tuple(tokens)
+    if isinstance(value, (list, tuple, set)):
+        tokens = []
+        for child in value:
+            tokens.extend(_row_evidence_tokens(child))
+        return tuple(tokens)
+    return (_normalize_token(value).lower().replace("-", "_").replace(" ", "_"),)
+
+
+def _settings_admin_side_effect_tokens(row: Mapping[str, Any]) -> tuple[str, ...]:
+    values = (
+        _first_present(row, "side_effect_kind", "side_effect_classification", "operation_class"),
+        row.get("side_effects"),
+        row.get("expected_proof"),
+        row.get("proof_requirement"),
+    )
+    tokens: list[str] = []
+    for value in values:
+        tokens.extend(_row_evidence_tokens(value))
+    return tuple(tokens)
+
+
+def _tokens_match(tokens: tuple[str, ...], *needles: str) -> bool:
+    return any(any(needle in token for needle in needles) for token in tokens)
+
+
+def _settings_admin_mapping(
+    *,
+    tier: str,
+    safety_class: str,
+    source: str,
+    refusal_route: str,
+    refusal_reason: str | None,
+    remote_policy_required: bool = False,
+) -> SettingsAdminTierMapping:
+    return SettingsAdminTierMapping(
+        tier=tier,
+        safety_class=safety_class,
+        source=source,
+        can_confirm=tier in CONFIRMABLE_TIERS and not remote_policy_required,
+        gate_required=tier in SETTINGS_ADMIN_GATE_REQUIRED_TIERS,
+        refusal_route=refusal_route,
+        refusal_reason=refusal_reason,
+        remote_policy_required=remote_policy_required,
+    )
+
+
+def map_settings_admin_row_to_gate_tier(row: Mapping[str, Any]) -> SettingsAdminTierMapping:
+    """Map one Settings/Admin row from explicit evidence; missing evidence fails to TU."""
+
+    safety_class = _normalize_token(_first_present(row, "safety_class", "safe_ui_exposure"))
+    explicit_tier = _normalize_token(_first_present(row, "gate_tier", "proposed_gate_tier"))
+
+    if safety_class == "BLOCKED_IN_COCKPIT" or explicit_tier == "TX":
+        return _settings_admin_mapping(
+            tier="TX",
+            safety_class="BLOCKED_IN_COCKPIT",
+            source="explicit blocked evidence",
+            refusal_route="SHOW_BLOCKED_REASON",
+            refusal_reason="BLOCKED_IN_COCKPIT",
+        )
+    if safety_class in {"UNKNOWN", "EXTERNAL_ONLY"} or explicit_tier == "TU":
+        return _settings_admin_mapping(
+            tier="TU",
+            safety_class=safety_class,
+            source="explicit unknown or external-only evidence",
+            refusal_route="UNKNOWN_DRIFT_QUEUE",
+            refusal_reason="UNKNOWN_CLASS",
+        )
+    if explicit_tier in SAFE_ACTION_TIERS:
+        return _settings_admin_mapping(
+            tier=explicit_tier,
+            safety_class=safety_class,
+            source="explicit gate tier evidence",
+            refusal_route="UNKNOWN_DRIFT_QUEUE" if explicit_tier == "T4" else "NOT_APPLICABLE",
+            refusal_reason="REMOTE_MUTATION_POLICY_MISSING" if explicit_tier == "T4" else None,
+            remote_policy_required=explicit_tier == "T4",
+        )
+    if safety_class == "DISPLAY_ONLY":
+        return _settings_admin_mapping(
+            tier="T0",
+            safety_class=safety_class,
+            source="explicit DISPLAY_ONLY safety class",
+            refusal_route="NOT_APPLICABLE",
+            refusal_reason=None,
+        )
+    if safety_class == "INSPECT_ACTION":
+        return _settings_admin_mapping(
+            tier="T0i",
+            safety_class=safety_class,
+            source="explicit INSPECT_ACTION safety class",
+            refusal_route="NOT_APPLICABLE",
+            refusal_reason=None,
+        )
+    if safety_class != "CONFIRM_REQUIRED":
+        return _settings_admin_mapping(
+            tier="TU",
+            safety_class=safety_class,
+            source="insufficient Settings/Admin tier evidence",
+            refusal_route="UNKNOWN_DRIFT_QUEUE",
+            refusal_reason="GATE_TIER_UNKNOWN",
+        )
+
+    tokens = _settings_admin_side_effect_tokens(row)
+    if _tokens_match(tokens, "remote_mutation", "write_remote", "remote_receipt"):
+        return _settings_admin_mapping(
+            tier="T4",
+            safety_class=safety_class,
+            source="explicit remote mutation evidence",
+            refusal_route="UNKNOWN_DRIFT_QUEUE",
+            refusal_reason="REMOTE_MUTATION_POLICY_MISSING",
+            remote_policy_required=True,
+        )
+    if _tokens_match(tokens, "execution_handoff", "tp_runner_proof"):
+        return _settings_admin_mapping(
+            tier="T6",
+            safety_class=safety_class,
+            source="explicit execution handoff evidence",
+            refusal_route="NOT_APPLICABLE",
+            refusal_reason=None,
+        )
+    if _tokens_match(tokens, "service_start", "service_stop", "start_stop_service", "service_status"):
+        return _settings_admin_mapping(
+            tier="T5",
+            safety_class=safety_class,
+            source="explicit service lifecycle evidence",
+            refusal_route="NOT_APPLICABLE",
+            refusal_reason=None,
+        )
+    if _tokens_match(tokens, "local_write", "write_local", "filesystem_diff"):
+        return _settings_admin_mapping(
+            tier="T3",
+            safety_class=safety_class,
+            source="explicit local write evidence",
+            refusal_route="NOT_APPLICABLE",
+            refusal_reason=None,
+        )
+    if _tokens_match(tokens, "config_mutation", "config_diff", "configuration"):
+        return _settings_admin_mapping(
+            tier="T2",
+            safety_class=safety_class,
+            source="explicit config mutation evidence",
+            refusal_route="NOT_APPLICABLE",
+            refusal_reason=None,
+        )
+    return _settings_admin_mapping(
+        tier="TU",
+        safety_class=safety_class,
+        source="insufficient Settings/Admin tier evidence",
+        refusal_route="UNKNOWN_DRIFT_QUEUE",
+        refusal_reason="GATE_TIER_UNKNOWN",
+    )
+
+
 def build_runtime_render_model(
     package: LoadedPackage,
     *,
@@ -402,6 +755,7 @@ def build_runtime_render_model(
         ia_verdict=str(package.proof.get("ia_verdict", "UNKNOWN")),
         invariants=invariants,
         config=config or RuntimeConfig(),
+        settings_admin_runtime=build_settings_admin_runtime_summary(package),
     )
 
 
@@ -433,6 +787,26 @@ def render_runtime_snapshot(
     ]
     for key in sorted(model.invariants):
         lines.append(f"  {key}: {str(model.invariants[key]).lower()}")
+    settings = model.settings_admin_runtime
+    lines.extend(
+        (
+            "settings_admin_runtime:",
+            f"  surface_name: {settings.surface_name}",
+            f"  surface_kind: {settings.surface_kind}",
+            f"  source_artifact_path: {settings.source_artifact_path}",
+            f"  flow_group_count: {len(settings.flow_groups)}",
+            f"  flow_groups: {' | '.join(group['name'] for group in settings.flow_groups)}",
+            f"  row_count: {settings.row_count}",
+            f"  mapped_tier_counts: {json.dumps(settings.mapped_tier_counts, sort_keys=True)}",
+            f"  unknown_tier_count: {settings.unknown_tier_count}",
+            f"  refusal_counts: {json.dumps(settings.refusal_counts, sort_keys=True)}",
+            f"  gate_required_count: {settings.gate_required_count}",
+            f"  blocked_count: {settings.blocked_count}",
+            f"  open_downstream_owner: {settings.open_downstream_owner}",
+            f"  safe_for_claude_design: {settings.safe_for_claude_design}",
+            f"  READY_FOR_CLAUDE_DESIGN: {settings.ready_for_claude_design}",
+        )
+    )
     lines.extend(
         (
             "runtime_config:",
@@ -473,6 +847,7 @@ def runtime_snapshot_payload(
         "top_level_modes": list(model.top_level_modes),
         "global_surfaces": list(model.global_surfaces),
         "safe_action_tiers": list(model.safe_action_tiers),
+        "settings_admin_runtime": model.settings_admin_runtime.as_payload(),
         "artifact_provenance": [
             {
                 "name": artifact.name,

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -55,6 +55,7 @@ A packet is superseded by another packet
 | TP-DMX-COMPOSE-RESTORE-001 | Infra | Restore canonical Docker Compose authority | Ready | N/A |
 | DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Merged (PR #528) | N/A |
 | TP-DMX-COCKPIT-RUNTIME-RENDER-001 | UI Cockpit | Wire runtime renderer primitives to accepted Cockpit IA package contract | Active | N/A |
+| TP-DMX-COCKPIT-SETTINGS-RUNTIME-001 | UI Cockpit | Wire Settings/Admin/Runtime primitive surface to runtime renderer | Active | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 | DMX-COCKPIT-PMIMPL-PACK-001 | Cockpit / PM Plane | PM/Implementer cockpit processing pack | Ready | N/A |

--- a/task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json
+++ b/task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json
@@ -1,0 +1,105 @@
+{
+  "id": "TP-DMX-COCKPIT-SETTINGS-RUNTIME-001",
+  "project": "dopemux-mvp",
+  "target": "Wire Settings/Admin/Runtime primitive surface to runtime renderer while preserving Safe Action Gate, no execution, no remote mutation, and Claude Design blockers.",
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dopemux-cockpit-ia-remediation",
+    "base_branch": "codex/cockpit-runtime-render-001",
+    "parent_tp_id": "TP-DMX-COCKPIT-RUNTIME-RENDER-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/cockpit-settings-runtime-001"
+  },
+  "commit": {
+    "message": "ui(cockpit): wire settings runtime primitives",
+    "allowlist": [
+      "src/dopemux/ui/cockpit/**",
+      "src/dopemux/commands/cockpit_commands.py",
+      "tests/unit/dopemux/ui/cockpit/**",
+      "tests/unit/test_cockpit_cli.py",
+      "task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json",
+      "task-packets/INDEX.md",
+      "proof/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/**",
+      "out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/**"
+    ],
+    "verify": [
+      "python -m json.tool out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA/PACKAGE_REMEDIATION_INDEX.json >/dev/null",
+      "python -m json.tool out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA/PROOF.json >/dev/null",
+      "python -m json.tool out/cockpit-runtime-render/TP-DMX-COCKPIT-RUNTIME-RENDER-001/PROOF.json >/dev/null",
+      "python -m json.tool task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json >/dev/null",
+      "python -m json.tool out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json >/dev/null",
+      "python -m compileall -q src/dopemux tests",
+      "python -m pytest tests/unit/dopemux/ui/cockpit -q",
+      "python -m pytest tests/unit/test_cockpit_cli.py -q",
+      "! grep -R -E \"READY_FOR_CLAUDE_DESIGN: approved|safe_for_claude_design: YES|Claude Design upload allowed|T4 authorized|runtime execution implemented|Settings/Admin direct execution\" -n src/dopemux tests out/cockpit-settings-runtime proof/cockpit-settings-runtime",
+      "! grep -R -E \"subprocess|shell=True|os\\.system|requests|httpx|urllib|socket|docker|kubectl|gh pr create|git push\" -n src/dopemux/ui/cockpit src/dopemux/commands/cockpit_commands.py tests/unit/dopemux/ui/cockpit tests/unit/test_cockpit_cli.py",
+      "git diff --check",
+      "git status --short --branch"
+    ]
+  },
+  "pr": {
+    "title": "ui(cockpit): wire settings runtime primitives",
+    "body": "## Summary\n- add deterministic Settings/Admin/Runtime primitive summary to the local runtime-render snapshot\n- add pure Settings/Admin row tier mapping with fail-closed TX/TU/T4 behavior\n- preserve five top-level modes, Safe Action Gate routing, and Claude Design blockers\n\n## Strict scope\n- no final screens\n- no Claude Design upload\n- no runtime action execution\n- no T4 remote mutation\n- no live service adapters\n- no canonical writes\n- no Settings/Admin direct execution\n\n## Governance state\nsafe_for_claude_design: NO\nREADY_FOR_CLAUDE_DESIGN: not approved\n\n## Validation\nSee closeout proof for command outputs and exit codes.\n\n## Residual risks and downstream packets\n- remote-mutation policy remains absent, so T4 stays refused\n- accepted package still carries per-row Settings/Admin inventory as unresolved beyond flow groups\n- Unknown/Drift Queue full runtime surface remains owned by TP-DMX-COCKPIT-UNKNOWN-DRIFT-001\n- inventory regeneration against current HEAD remains separate",
+    "base": "codex/cockpit-runtime-render-001"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Inspect repo authority, accepted package/runtime artifacts, and current Cockpit runtime surfaces before implementation.",
+      "validation": [
+        "Dedicated worktree is verified from origin/codex/cockpit-runtime-render-001 at the audited SHA.",
+        "Accepted package and runtime-render proof artifacts parse.",
+        "Missing root authority files are recorded as UNKNOWN rather than inferred."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Implement deterministic Settings/Admin/Runtime surface summary and row tier mapping primitives without execution.",
+      "validation": [
+        "Settings/Admin/Runtime is represented as a secondary/global surface, not a top-level mode.",
+        "Settings/Admin row mapping handles T0, T0i, T2, T3, T4, T5, T6, TX, and TU from explicit evidence.",
+        "Insufficient evidence maps to TU and Unknown/Drift Queue."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Extend runtime-render text and JSON snapshots with Settings/Admin/Runtime summary fields.",
+      "validation": [
+        "Snapshot includes surface name, source artifact, flow groups, row count, tier/refusal/gate/blocked/unknown counts, downstream owner, and blocked governance state.",
+        "CLI runtime-render output includes the Settings/Admin/Runtime summary.",
+        "CLI still fails closed without explicit --runtime-render and --package-dir."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Add focused tests and proof artifacts for the Settings/Admin/Runtime primitive layer.",
+      "validation": [
+        "Focused Cockpit tests pass.",
+        "CLI tests pass.",
+        "Boundary greps pass without forbidden positive claims.",
+        "Proof output is written only under the allowed settings-runtime proof/out paths and records validation evidence."
+      ]
+    }
+  ]
+}

--- a/tests/unit/dopemux/ui/cockpit/test_runtime_contract.py
+++ b/tests/unit/dopemux/ui/cockpit/test_runtime_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import hashlib
 from pathlib import Path
 
 import pytest
@@ -13,11 +14,14 @@ from dopemux.ui.cockpit.runtime_contract import (
     TOP_LEVEL_MODES,
     PackageLoadError,
     RuntimeConfig,
+    build_settings_admin_runtime_summary,
     build_gate_receipt,
     build_runtime_render_model,
     evaluate_safe_action_preflight,
     load_package_artifacts,
+    map_settings_admin_row_to_gate_tier,
     render_runtime_snapshot,
+    runtime_snapshot_payload,
 )
 
 
@@ -78,6 +82,10 @@ def _candidate(**overrides: object) -> dict[str, object]:
     return data
 
 
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
 def test_package_loader_fails_closed_on_missing_required_files(tmp_path: Path):
     with pytest.raises(PackageLoadError, match=r"\[BLOCKER\]"):
         load_package_artifacts(tmp_path)
@@ -124,6 +132,8 @@ def test_runtime_render_model_preserves_modes_surfaces_and_tiers():
     assert TOP_LEVEL_MODES == model.top_level_modes
     assert GLOBAL_SURFACES == model.global_surfaces
     assert SAFE_ACTION_TIERS == model.safe_action_tiers
+    assert "Settings/Admin/Runtime" not in model.top_level_modes
+    assert "Settings/Admin/Runtime" in model.global_surfaces
 
 
 def test_runtime_snapshot_preserves_governance_and_boundaries():
@@ -137,6 +147,192 @@ def test_runtime_snapshot_preserves_governance_and_boundaries():
     assert "cross-cutting and non-executing here" in output
     assert "T4 blocked until remote mutation policy exists" in output
     assert "TX/TU never executable" in output
+    assert "settings_admin_runtime:" in output
+    assert "surface_name: Settings/Admin/Runtime" in output
+    assert "flow_group_count: 9" in output
+    assert "row_count: 62" in output
+    assert "unknown_tier_count: 62" in output
+
+
+def test_settings_admin_summary_uses_package_handoff_without_mutating_artifact():
+    source = PACKAGE_DIR / "SETTINGS_ADMIN_RUNTIME_PACKAGE_HANDOFF.md"
+    before = _sha(source)
+    package = load_package_artifacts(PACKAGE_DIR)
+    summary = build_settings_admin_runtime_summary(package)
+    after = _sha(source)
+    assert before == after
+    assert summary.surface_kind == "secondary/global surface"
+    assert summary.surface_name == "Settings/Admin/Runtime"
+    assert summary.row_count == 62
+    assert summary.unknown_tier_count == 62
+    assert summary.gate_required_count == "UNKNOWN"
+    assert summary.blocked_count == "UNKNOWN"
+    assert summary.open_downstream_owner == "TP-DMX-COCKPIT-SETTINGS-RUNTIME-001"
+    assert len(summary.flow_groups) == 9
+    assert "SETTINGS_ADMIN_RUNTIME_PACKAGE_HANDOFF.md" in summary.source_artifact_path
+
+
+def test_runtime_snapshot_payload_includes_settings_admin_summary():
+    payload = runtime_snapshot_payload(PACKAGE_DIR)
+    settings = payload["settings_admin_runtime"]
+    assert settings["surface_name"] == "Settings/Admin/Runtime"
+    assert settings["surface_kind"] == "secondary/global surface"
+    assert settings["row_count"] == 62
+    assert settings["unknown_tier_count"] == 62
+    assert settings["mapped_tier_counts"]["TU"] == 0
+    assert settings["refusal_counts"]["UNKNOWN_DRIFT_QUEUE"] == 62
+    assert settings["safe_for_claude_design"] == "NO"
+    assert settings["READY_FOR_CLAUDE_DESIGN"] == "not approved"
+    assert len(settings["flow_groups"]) == 9
+
+
+@pytest.mark.parametrize(
+    ("row", "tier", "can_confirm", "gate_required", "route", "reason"),
+    [
+        (
+            {"safety_class": "DISPLAY_ONLY"},
+            "T0",
+            False,
+            False,
+            "NOT_APPLICABLE",
+            None,
+        ),
+        (
+            {"safety_class": "INSPECT_ACTION"},
+            "T0i",
+            False,
+            True,
+            "NOT_APPLICABLE",
+            None,
+        ),
+        (
+            {
+                "safety_class": "CONFIRM_REQUIRED",
+                "side_effect_kind": "config_mutation",
+            },
+            "T2",
+            True,
+            True,
+            "NOT_APPLICABLE",
+            None,
+        ),
+        (
+            {
+                "safety_class": "CONFIRM_REQUIRED",
+                "side_effect_kind": "local_write",
+            },
+            "T3",
+            True,
+            True,
+            "NOT_APPLICABLE",
+            None,
+        ),
+        (
+            {
+                "safety_class": "CONFIRM_REQUIRED",
+                "side_effect_kind": "remote_mutation",
+            },
+            "T4",
+            False,
+            True,
+            "UNKNOWN_DRIFT_QUEUE",
+            "REMOTE_MUTATION_POLICY_MISSING",
+        ),
+        (
+            {
+                "safety_class": "CONFIRM_REQUIRED",
+                "side_effect_kind": "service_start_stop",
+            },
+            "T5",
+            True,
+            True,
+            "NOT_APPLICABLE",
+            None,
+        ),
+        (
+            {
+                "safety_class": "CONFIRM_REQUIRED",
+                "side_effect_kind": "execution_handoff",
+            },
+            "T6",
+            True,
+            True,
+            "NOT_APPLICABLE",
+            None,
+        ),
+        (
+            {"safety_class": "BLOCKED_IN_COCKPIT"},
+            "TX",
+            False,
+            False,
+            "SHOW_BLOCKED_REASON",
+            "BLOCKED_IN_COCKPIT",
+        ),
+        (
+            {"safety_class": "UNKNOWN"},
+            "TU",
+            False,
+            False,
+            "UNKNOWN_DRIFT_QUEUE",
+            "UNKNOWN_CLASS",
+        ),
+    ],
+)
+def test_settings_admin_row_tier_mapping_from_explicit_evidence(
+    row: dict[str, object],
+    tier: str,
+    can_confirm: bool,
+    gate_required: bool,
+    route: str,
+    reason: str | None,
+):
+    mapping = map_settings_admin_row_to_gate_tier(row)
+    assert mapping.tier == tier
+    assert mapping.can_confirm is can_confirm
+    assert mapping.gate_required is gate_required
+    assert mapping.refusal_route == route
+    assert mapping.refusal_reason == reason
+    assert mapping.execution_status == "not_attempted"
+
+
+def test_settings_admin_insufficient_evidence_maps_to_unknown_drift_queue():
+    mapping = map_settings_admin_row_to_gate_tier({"safety_class": "CONFIRM_REQUIRED"})
+    assert mapping.tier == "TU"
+    assert mapping.can_confirm is False
+    assert mapping.gate_required is False
+    assert mapping.refusal_route == "UNKNOWN_DRIFT_QUEUE"
+    assert mapping.refusal_reason == "GATE_TIER_UNKNOWN"
+
+
+def test_settings_admin_blocked_rows_never_confirm():
+    mapping = map_settings_admin_row_to_gate_tier(
+        {"safety_class": "BLOCKED_IN_COCKPIT", "side_effect_kind": "config_mutation"}
+    )
+    assert mapping.tier == "TX"
+    assert mapping.can_confirm is False
+    assert mapping.gate_required is False
+    assert mapping.refusal_route == "SHOW_BLOCKED_REASON"
+
+
+def test_settings_admin_t4_maps_but_refuses_until_remote_policy_exists():
+    mapping = map_settings_admin_row_to_gate_tier(
+        {"safety_class": "CONFIRM_REQUIRED", "side_effect_kind": "remote_mutation"}
+    )
+    assert mapping.tier == "T4"
+    assert mapping.can_confirm is False
+    assert mapping.gate_required is True
+    assert mapping.remote_policy_required is True
+    assert mapping.refusal_reason == "REMOTE_MUTATION_POLICY_MISSING"
+
+
+def test_confirmable_settings_admin_rows_require_safe_action_gate():
+    for side_effect in ("config_mutation", "local_write", "service_start_stop", "execution_handoff"):
+        mapping = map_settings_admin_row_to_gate_tier(
+            {"safety_class": "CONFIRM_REQUIRED", "side_effect_kind": side_effect}
+        )
+        assert mapping.can_confirm is True
+        assert mapping.gate_required is True
+        assert mapping.execution_status == "not_attempted"
 
 
 def test_preflight_allows_confirm_for_resolved_executable_candidate():

--- a/tests/unit/test_cockpit_cli.py
+++ b/tests/unit/test_cockpit_cli.py
@@ -54,6 +54,9 @@ def test_runtime_render_text_snapshot_preserves_blocked_governance_state():
     assert "READY_FOR_CLAUDE_DESIGN: not approved" in output
     assert "top_level_modes: PM | Implementer | Overview | Services | Events" in output
     assert "Command Palette broker-only" in output
+    assert "settings_admin_runtime:" in output
+    assert "surface_name: Settings/Admin/Runtime" in output
+    assert "unknown_tier_count: 62" in output
     assert "T4 blocked until remote mutation policy exists" in output
     assert "TX/TU never executable" in output
 
@@ -87,6 +90,9 @@ def test_runtime_render_json_snapshot_preserves_modes_and_surfaces():
     assert payload["artifact_provenance"][0]["actual_sha256"]
     assert payload["safe_for_claude_design"] == "NO"
     assert payload["READY_FOR_CLAUDE_DESIGN"] == "not approved"
+    assert payload["settings_admin_runtime"]["surface_name"] == "Settings/Admin/Runtime"
+    assert payload["settings_admin_runtime"]["row_count"] == 62
+    assert payload["settings_admin_runtime"]["unknown_tier_count"] == 62
 
 
 def test_runtime_render_output_has_no_forbidden_positive_claims():


### PR DESCRIPTION
@codex
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.

## Summary
- add deterministic Settings/Admin/Runtime primitive summary to the local runtime-render snapshot
- add pure Settings/Admin row tier mapping with fail-closed TX/TU/T4 behavior
- preserve five top-level modes, Safe Action Gate routing, and Claude Design blockers

## Strict scope
- no final screens
- no Claude Design upload
- no runtime action execution
- no T4 remote mutation
- no live service adapters
- no canonical writes
- no Settings/Admin direct execution

## Files changed
- src/dopemux/ui/cockpit/runtime_contract.py
- tests/unit/dopemux/ui/cockpit/test_runtime_contract.py
- tests/unit/test_cockpit_cli.py
- task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json
- task-packets/INDEX.md
- out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json
- proof/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/README.md

## Governance state
safe_for_claude_design: NO
READY_FOR_CLAUDE_DESIGN: not approved

## Validation commands + exit codes
- python -m json.tool out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA/PACKAGE_REMEDIATION_INDEX.json >/dev/null: 0
- python -m json.tool out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA/PROOF.json >/dev/null: 0
- python -m json.tool out/cockpit-runtime-render/TP-DMX-COCKPIT-RUNTIME-RENDER-001/PROOF.json >/dev/null: 0
- python -m json.tool task-packets/generated/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001.json >/dev/null: 0
- python -m json.tool out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json >/dev/null: 0
- python -m compileall -q src/dopemux tests: 0
- python -m pytest tests/unit/dopemux/ui/cockpit -q: 0
- python -m pytest tests/unit/test_cockpit_cli.py -q: 0
- boundary grep: 0
- forbidden runtime token grep: 0
- git diff --check: 0
- pre-commit run --files changed allowlist: 0

## Proof artifact path
out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json

## Explicit boundary preservation
- no final screens
- no Claude Design upload
- no runtime action execution
- no T4 remote mutation
- no live service adapters
- no canonical writes
- no Settings/Admin direct execution

## Residual risks and downstream packets
- remote-mutation policy remains absent, so T4 stays refused
- accepted package still carries per-row Settings/Admin inventory as unresolved beyond flow groups
- Settings/Admin blocked count and gate-required count remain UNKNOWN until per-row inventory exists
- Unknown/Drift Queue full runtime surface remains owned by TP-DMX-COCKPIT-UNKNOWN-DRIFT-001
- inventory regeneration against current HEAD remains separate