### PR TITLE
fix(cockpit): repair runtime contract fidelity gaps

### DIFF
--- a/out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json
+++ b/out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json
@@ -151,5 +151,6 @@
     "proof/cockpit-merge-execute/TP-DMX-COCKPIT-MERGE-EXECUTE-001/BLOCKER_REPORT.md absent."
   ],
   "upstream_artifact_mutation": "not_modified",
+  "cleanup_status": "WORKTREE_RETAINED_FOR_USER_INSPECTION_AFTER_CLEAN_PUSH_AND_PR",
   "confidence": "VERIFIED"
 }

--- a/out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json
+++ b/out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json
@@ -1,0 +1,155 @@
+{
+  "schema_version": "dopemux.cockpit.runtime_contract_fidelity.proof.v1",
+  "packet_id": "TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001",
+  "created_at_utc": "2026-05-05T03:20:42Z",
+  "project": "dopemux-mvp",
+  "branch": "codex/cockpit-runtime-contract-fidelity-001",
+  "base_branch": "pack/cockpit-pack-remediate-006-ia",
+  "base_head": "b173efd83c871c30f2bd86530921c866d08e7e45",
+  "worktree_path": "/Users/hue/code/dopemux-worktrees/dopemux-cockpit-runtime-contract-fidelity-001",
+  "repo_identity": {
+    "marker": ".dopetaskroot",
+    "marker_verified": true,
+    "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "origin_match": true
+  },
+  "governance_state": {
+    "safe_for_claude_design": "NO",
+    "READY_FOR_CLAUDE_DESIGN": "not approved",
+    "claude_design_upload": "not_authorized",
+    "final_screen_generation": "not_authorized",
+    "runtime_action_execution": "not_authorized",
+    "t4_remote_mutation": "not_authorized",
+    "canonical_writes": "not_authorized",
+    "unknown_drift_runtime_reclassification": "disabled",
+    "tx_tu_execution": "disabled"
+  },
+  "review_thread_classifications": [
+    {
+      "issue": "EXTERNAL_ONLY candidates could reach confirmable gate logic",
+      "classification": "runtime_contract_gap",
+      "implemented_fix": "Safe Action preflight now refuses EXTERNAL_ONLY before confirmable-tier checks and routes to the originating inspect/copy surface."
+    },
+    {
+      "issue": "Receipt action_row_hash trusted caller-supplied input",
+      "classification": "receipt_provenance_gap",
+      "implemented_fix": "Gate receipts now recompute action_row_hash from a redacted canonical candidate payload with caller action_row_hash removed."
+    },
+    {
+      "issue": "Receipt payload missed lifecycle fields from SAFE_ACTION_GATE_EVENT_RECEIPTS.md",
+      "classification": "schema_fidelity_gap",
+      "implemented_fix": "Gate receipts now include event, gate-open, confirm, proof, typed-confirmation, diff, remote policy, task, service, stale-proof, and normative schema fields modeled by the local primitive."
+    },
+    {
+      "issue": "palette_request_id remained populated for non-palette origins",
+      "classification": "correlation_contract_gap",
+      "implemented_fix": "Gate receipts now set palette_request_id to null unless surface_origin is COMMAND_PALETTE."
+    },
+    {
+      "issue": "gate_request_id fallback changed across lifecycle events",
+      "classification": "lifecycle_correlation_gap",
+      "implemented_fix": "Default gate_request_id derivation now uses the canonical action hash rather than event timestamp."
+    },
+    {
+      "issue": "UNKNOWN aggregate counts could remain zero when an aggregate item had unknown count",
+      "classification": "unknown_preservation_gap",
+      "implemented_fix": "Aggregate counters now preserve UNKNOWN when any item for the bucket has a non-integer count."
+    },
+    {
+      "issue": "Unknown/Drift queue IDs and row hashes were derived before redaction",
+      "classification": "redaction_order_gap",
+      "implemented_fix": "Queue row_hash and queue_item_id derivation now uses redacted seed values."
+    },
+    {
+      "issue": "Package directory resolution was coupled to process cwd and direct parent names",
+      "classification": "artifact_resolution_gap",
+      "implemented_fix": "Relative package directories can now resolve through the repo marker while accepted artifact path validation remains fail-closed."
+    },
+    {
+      "issue": "Inventory metadata tests did not validate source artifact digest placeholders or runtime source line counts",
+      "classification": "artifact_test_gap",
+      "implemented_fix": "Inventory tests now verify sha256 values are real digests or documented UNKNOWN placeholders and verify line_count for present runtime source files."
+    }
+  ],
+  "changed_files": [
+    "src/dopemux/ui/cockpit/runtime_contract.py",
+    "tests/unit/dopemux/ui/cockpit/test_runtime_contract.py",
+    "tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py",
+    "task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json",
+    "task-packets/INDEX.md",
+    "out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json",
+    "proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md"
+  ],
+  "validations": [
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json >/dev/null",
+      "exit_code": 0
+    },
+    {
+      "command": "python -m compileall -q src/dopemux tests",
+      "exit_code": 0
+    },
+    {
+      "command": "python -m pytest tests/unit/dopemux/ui/cockpit -q",
+      "exit_code": 0,
+      "notes": "83 passed; pytest emitted existing asyncio_mode warning."
+    },
+    {
+      "command": "python -m pytest tests/unit/test_cockpit_cli.py -q",
+      "exit_code": 0,
+      "notes": "5 passed; pytest emitted existing asyncio_mode warning."
+    },
+    {
+      "command": "python -m pytest tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py -q",
+      "exit_code": 0,
+      "notes": "12 passed; pytest emitted existing asyncio_mode warning."
+    },
+    {
+      "command": "command -v codereview || true",
+      "exit_code": 0,
+      "notes": "codereview was not present on PATH; explicit diff review used instead."
+    },
+    {
+      "command": "python -m json.tool out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json >/dev/null",
+      "exit_code": 0
+    },
+    {
+      "command": "forbidden governance grep over src/dopemux tests packet-owned out/proof paths",
+      "exit_code": 0
+    },
+    {
+      "command": "! grep -R -E \"subprocess|shell=True|os\\.system|requests|httpx|urllib|socket|docker|kubectl\" -n src/dopemux/ui/cockpit src/dopemux/commands/cockpit_commands.py tests/unit/dopemux/ui/cockpit tests/unit/test_cockpit_cli.py",
+      "exit_code": 0
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0
+    },
+    {
+      "command": "pre-commit run --files src/dopemux/ui/cockpit/runtime_contract.py tests/unit/dopemux/ui/cockpit/test_runtime_contract.py tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py tests/unit/test_cockpit_cli.py task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json task-packets/INDEX.md out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md",
+      "exit_code": 0
+    }
+  ],
+  "pending_final_validations": [],
+  "codereview_status": "UNAVAILABLE_COMMAND_NOT_FOUND",
+  "explicit_diff_review_status": "performed_before_proof_creation",
+  "implementation_commit": "PENDING_BEFORE_COMMIT",
+  "pr_url": "PENDING_BEFORE_PR_CREATE",
+  "final_head_recording_policy": "PROOF.json records implementation evidence before the final commit and PR exist. Final commit SHA, pushed branch, PR URL, and any proof metadata drift are reported in closeout to avoid self-referential proof churn.",
+  "residual_risks": [
+    "The absent proof/cockpit-merge-execute paths named by the TP could not be inspected in this worktree.",
+    "No dopetask-canonical-spec.json exists in this checkout; TP validation used JSON parsing and manual required-field checks.",
+    "The local receipt primitive still models receipts in memory only; it does not write an evidence stream or execute actions.",
+    "Default gate_request_id derivation is deterministic for the same canonical action payload; a real multi-invocation runtime would need an invocation id from gate_open."
+  ],
+  "unknowns": [
+    "Root RULES.md absent in this worktree.",
+    "Root TRUTH_*.md absent in this worktree.",
+    "Root SYSTEM_*.md absent in this worktree.",
+    "dopetask-canonical-spec.json absent in this worktree.",
+    "proof/cockpit-merge-execute/TP-DMX-COCKPIT-MERGE-EXECUTE-001/PROOF.json absent.",
+    "proof/cockpit-merge-execute/TP-DMX-COCKPIT-MERGE-EXECUTE-001/BLOCKER_REPORT.md absent."
+  ],
+  "upstream_artifact_mutation": "not_modified",
+  "confidence": "VERIFIED"
+}

--- a/out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json
+++ b/out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json
@@ -133,9 +133,9 @@
   "pending_final_validations": [],
   "codereview_status": "UNAVAILABLE_COMMAND_NOT_FOUND",
   "explicit_diff_review_status": "performed_before_proof_creation",
-  "implementation_commit": "PENDING_BEFORE_COMMIT",
-  "pr_url": "PENDING_BEFORE_PR_CREATE",
-  "final_head_recording_policy": "PROOF.json records implementation evidence before the final commit and PR exist. Final commit SHA, pushed branch, PR URL, and any proof metadata drift are reported in closeout to avoid self-referential proof churn.",
+  "implementation_commit": "3b1c426379ee141a7929cfc31644f86830fe9f0d",
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/573",
+  "final_head_recording_policy": "PROOF.json records implementation commit 3b1c426379ee141a7929cfc31644f86830fe9f0d and PR https://github.com/DDD-Enterprises/dopemux-mvp/pull/573. The proof metadata cleanup commit and final branch HEAD are reported in closeout rather than self-hashed inside PROOF.json.",
   "residual_risks": [
     "The absent proof/cockpit-merge-execute paths named by the TP could not be inspected in this worktree.",
     "No dopetask-canonical-spec.json exists in this checkout; TP validation used JSON parsing and manual required-field checks.",

--- a/proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md
+++ b/proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md
@@ -1,0 +1,54 @@
+# TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001 Proof
+
+## Boundary State
+
+- safe_for_claude_design: NO
+- READY_FOR_CLAUDE_DESIGN: not approved
+- No Claude Design upload.
+- No final screen generation.
+- No runtime action execution.
+- No T4 remote mutation.
+- No live service adapters, PM writes, memory writes, bridge writes, or canonical writes.
+- Unknown / Drift Queue remains non-executing and runtime reclassification remains disabled.
+- TX and TU remain non-executable.
+
+## Implemented Repairs
+
+- EXTERNAL_ONLY Safe Action candidates now fail closed before confirmable gate checks and route back to the originating inspect/copy surface.
+- Gate receipts recompute action_row_hash from a redacted canonical candidate payload instead of trusting caller input.
+- Gate receipts include the local lifecycle fields required by the accepted receipt contract: event timestamp, gate-open timestamp, confirm/proof timestamps, typed-confirmation state, diff acknowledgement, remote policy, task, service, stale-proof tag, event type, and normative schema version.
+- Non-palette receipt origins now emit `palette_request_id: null`.
+- Default gate_request_id derivation is stable across modeled lifecycle events for the same canonical candidate payload.
+- Unknown / Drift aggregate counts now preserve UNKNOWN when any contributing aggregate item has unknown count.
+- Unknown / Drift queue row hashes and queue item IDs are derived after redaction.
+- Package directory resolution now supports deterministic repo-relative lookup through `.dopetaskroot` while keeping accepted package path validation fail-closed.
+- Inventory tests now validate source artifact sha256 values and runtime source line counts.
+
+## Validation Recorded
+
+The machine-readable validation table is in `out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json`.
+
+Validated so far:
+
+- `python -m json.tool task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json >/dev/null` exit 0
+- `python -m compileall -q src/dopemux tests` exit 0
+- `python -m pytest tests/unit/dopemux/ui/cockpit -q` exit 0
+- `python -m pytest tests/unit/test_cockpit_cli.py -q` exit 0
+- `python -m pytest tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py -q` exit 0
+- `python -m json.tool out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json >/dev/null` exit 0
+- Forbidden governance grep exit 0
+- Forbidden runtime-token grep exit 0
+- `git diff --check` exit 0
+- Packet allowlist `pre-commit run --files ...` exit 0
+
+## UNKNOWNs
+
+- `dopetask-canonical-spec.json` is absent in this checkout; TP validation used JSON parsing and manual root-field checks.
+- Root `RULES.md`, `TRUTH_*.md`, and `SYSTEM_*.md` files are absent in this checkout.
+- `proof/cockpit-merge-execute/TP-DMX-COCKPIT-MERGE-EXECUTE-001/PROOF.json` is absent.
+- `proof/cockpit-merge-execute/TP-DMX-COCKPIT-MERGE-EXECUTE-001/BLOCKER_REPORT.md` is absent.
+- The local receipt primitive still models receipt payloads only; it does not write an evidence stream or execute actions.
+
+## Final Head Policy
+
+`PROOF.json` records implementation evidence before the final commit and PR exist. Final commit SHA, pushed branch, PR URL, and any proof metadata drift are reported in closeout to avoid self-referential proof churn.

--- a/proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md
+++ b/proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md
@@ -52,3 +52,7 @@ Validated so far:
 ## Final Head Policy
 
 `PROOF.json` records implementation commit `3b1c426379ee141a7929cfc31644f86830fe9f0d` and PR https://github.com/DDD-Enterprises/dopemux-mvp/pull/573. The proof metadata cleanup commit and final branch HEAD are reported in closeout rather than self-hashed inside `PROOF.json`.
+
+## Cleanup Status
+
+The dedicated worktree is retained for user inspection after clean push and PR creation.

--- a/proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md
+++ b/proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md
@@ -51,4 +51,4 @@ Validated so far:
 
 ## Final Head Policy
 
-`PROOF.json` records implementation evidence before the final commit and PR exist. Final commit SHA, pushed branch, PR URL, and any proof metadata drift are reported in closeout to avoid self-referential proof churn.
+`PROOF.json` records implementation commit `3b1c426379ee141a7929cfc31644f86830fe9f0d` and PR https://github.com/DDD-Enterprises/dopemux-mvp/pull/573. The proof metadata cleanup commit and final branch HEAD are reported in closeout rather than self-hashed inside `PROOF.json`.

--- a/src/dopemux/ui/cockpit/runtime_contract.py
+++ b/src/dopemux/ui/cockpit/runtime_contract.py
@@ -12,7 +12,6 @@ import re
 from typing import Any
 from uuid import NAMESPACE_URL, uuid5
 
-
 PACKAGE_PACKET_ID = "TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA"
 RUNTIME_PACKET_ID = "TP-DMX-COCKPIT-RUNTIME-RENDER-001"
 SETTINGS_RUNTIME_PACKET_ID = "TP-DMX-COCKPIT-SETTINGS-RUNTIME-001"
@@ -334,14 +333,11 @@ PROOF_BY_TIER: dict[str, str] = {
     "TU": "INVESTIGATION_PACKET_REFERENCE",
 }
 
-
 class PackageLoadError(RuntimeError):
     """Fail-closed package loader error with an operator-visible blocker."""
 
-
 class RuntimeContractError(RuntimeError):
     """Fail-closed runtime contract validation error."""
-
 
 @dataclass(frozen=True)
 class RuntimeConfig:
@@ -349,14 +345,12 @@ class RuntimeConfig:
     confirm_flow_timeout_seconds: int = 900
     unauthenticated_operator_id: str = "NULL_NOT_AUTHENTICATED"
 
-
 @dataclass(frozen=True)
 class ArtifactProvenance:
     name: str
     path: str
     expected_sha256: str | None
     actual_sha256: str
-
 
 @dataclass(frozen=True)
 class LoadedPackage:
@@ -379,7 +373,6 @@ class LoadedPackage:
                 return artifact.actual_sha256
         raise RuntimeContractError(f"[BLOCKER] artifact provenance missing for {name}")
 
-
 @dataclass(frozen=True)
 class RuntimeRenderModel:
     top_level_modes: tuple[str, ...]
@@ -397,7 +390,6 @@ class RuntimeRenderModel:
     settings_admin_runtime: SettingsAdminRuntimeSummary
     unknown_drift_queue: UnknownDriftQueueSummary
 
-
 @dataclass(frozen=True)
 class PreflightResult:
     status: str
@@ -406,7 +398,6 @@ class PreflightResult:
     missing_fields: tuple[str, ...]
     routing_destination: str
     execution_status: str = "not_attempted"
-
 
 @dataclass(frozen=True)
 class SettingsAdminTierMapping:
@@ -419,7 +410,6 @@ class SettingsAdminTierMapping:
     refusal_reason: str | None
     execution_status: str = "not_attempted"
     remote_policy_required: bool = False
-
 
 @dataclass(frozen=True)
 class SettingsAdminRuntimeSummary:
@@ -453,7 +443,6 @@ class SettingsAdminRuntimeSummary:
             "safe_for_claude_design": self.safe_for_claude_design,
             "READY_FOR_CLAUDE_DESIGN": self.ready_for_claude_design,
         }
-
 
 @dataclass(frozen=True)
 class UnknownDriftQueueItem:
@@ -504,7 +493,6 @@ class UnknownDriftQueueItem:
             "aggregated_count": self.aggregated_count,
         }
 
-
 @dataclass(frozen=True)
 class UnknownDriftQueueSummary:
     surface_name: str
@@ -554,11 +542,9 @@ class UnknownDriftQueueSummary:
             "items": [item.as_payload() for item in self.items],
         }
 
-
 def stable_sha256(value: Any) -> str:
     payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
-
 
 def _file_sha256(path: Path) -> str:
     digest = hashlib.sha256()
@@ -566,7 +552,6 @@ def _file_sha256(path: Path) -> str:
         for block in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(block)
     return digest.hexdigest()
-
 
 def _load_json(path: Path) -> dict[str, Any]:
     try:
@@ -576,7 +561,6 @@ def _load_json(path: Path) -> dict[str, Any]:
     if not isinstance(data, dict):
         raise PackageLoadError(f"[BLOCKER] required JSON is not an object: {path}")
     return data
-
 
 def _read_sha256sums(package_dir: Path) -> dict[str, str]:
     sha_file = package_dir / "sha256sums.txt"
@@ -592,9 +576,16 @@ def _read_sha256sums(package_dir: Path) -> dict[str, str]:
             checksums[parts[1].strip()] = parts[0].strip()
     return checksums
 
+def _repo_root_marker(start: Path) -> Path | None:
+    resolved = start.resolve()
+    current = resolved.parent if resolved.is_file() else resolved
+    return next((path for path in (current, *current.parents) if (path / ".dopetaskroot").is_file()), None)
 
 def load_package_artifacts(package_dir: str | Path) -> LoadedPackage:
-    root = Path(package_dir)
+    raw = Path(package_dir)
+    root = raw.resolve() if raw.is_absolute() else (Path.cwd() / raw).resolve()
+    if not raw.is_absolute() and not root.exists() and (repo_root := _repo_root_marker(Path.cwd())):
+        root = (repo_root / raw).resolve()
     if not root.exists() or not root.is_dir():
         raise PackageLoadError(f"[BLOCKER] package directory missing: {root}")
 
@@ -629,10 +620,8 @@ def load_package_artifacts(package_dir: str | Path) -> LoadedPackage:
         artifacts=tuple(artifacts),
     )
 
-
 def _settings_admin_source_path(package: LoadedPackage) -> str:
     return str(package.package_dir / SETTINGS_ADMIN_SOURCE_ARTIFACT)
-
 
 def _settings_admin_row_count(package: LoadedPackage) -> int | str:
     count = (
@@ -641,7 +630,6 @@ def _settings_admin_row_count(package: LoadedPackage) -> int | str:
         .get("Settings/Admin")
     )
     return count if isinstance(count, int) else "UNKNOWN"
-
 
 def build_settings_admin_runtime_summary(package: LoadedPackage) -> SettingsAdminRuntimeSummary:
     row_count = _settings_admin_row_count(package)
@@ -667,26 +655,25 @@ def build_settings_admin_runtime_summary(package: LoadedPackage) -> SettingsAdmi
         ready_for_claude_design="not approved",
     )
 
-
 def _repo_root_from_package(package: LoadedPackage) -> Path:
     package_dir = package.package_dir.resolve()
-    if (
-        package_dir.name != PACKAGE_PACKET_ID
-        or package_dir.parent.name != "cockpit-pack-remediation"
-        or package_dir.parent.parent.name != "out"
-    ):
+    repo_root = _repo_root_marker(package_dir)
+    expected = (
+        (repo_root / "out" / "cockpit-pack-remediation" / PACKAGE_PACKET_ID).resolve()
+        if repo_root is not None
+        else None
+    )
+    if repo_root is None or package_dir != expected:
         raise RuntimeContractError(
             "[BLOCKER] package directory is not the accepted cockpit package artifact path"
         )
-    return package_dir.parent.parent.parent
-
+    return repo_root
 
 def _required_source_path(repo_root: Path, *parts: str) -> Path:
     path = repo_root.joinpath(*parts)
     if not path.is_file():
         raise RuntimeContractError(f"[BLOCKER] accepted source artifact missing: {path}")
     return path
-
 
 def _source_created_at(*sources: Mapping[str, Any]) -> str:
     for source in sources:
@@ -695,10 +682,8 @@ def _source_created_at(*sources: Mapping[str, Any]) -> str:
             return value.strip()
     return "UNKNOWN"
 
-
 def _count_value(value: Any) -> int | str:
     return value if isinstance(value, int) else "UNKNOWN"
-
 
 def _redact_queue_text(value: Any) -> str:
     redacted = redact_secrets(value)
@@ -706,10 +691,8 @@ def _redact_queue_text(value: Any) -> str:
         return redacted
     return json.dumps(redacted, sort_keys=True, default=str)
 
-
 def _redact_queue_refs(values: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(_redact_queue_text(value) for value in values)
-
 
 def build_unknown_drift_queue_item(
     *,
@@ -733,22 +716,22 @@ def build_unknown_drift_queue_item(
     if reason_code not in UNKNOWN_DRIFT_REASON_CODES:
         raise RuntimeContractError(f"[BLOCKER] unsupported Unknown / Drift reason: {reason_code}")
     seed = {
-        "source_surface": source_surface,
-        "source_artifact_path": source_artifact_path,
-        "source_packet_id": source_packet_id,
-        "source_row_id": source_row_id,
-        "command_or_row_label": command_or_row_label,
+        "source_surface": _redact_queue_text(source_surface),
+        "source_artifact_path": _redact_queue_text(source_artifact_path),
+        "source_packet_id": _redact_queue_text(source_packet_id),
+        "source_row_id": _redact_queue_text(source_row_id),
+        "command_or_row_label": _redact_queue_text(command_or_row_label),
         "reason_code": reason_code,
     }
     row_hash = stable_sha256(seed)
     return UnknownDriftQueueItem(
         queue_item_id=f"unknown-drift-{row_hash[:16]}",
-        source_surface=_redact_queue_text(source_surface),
-        source_artifact_path=_redact_queue_text(source_artifact_path),
-        source_packet_id=_redact_queue_text(source_packet_id),
-        source_row_id=_redact_queue_text(source_row_id),
+        source_surface=seed["source_surface"],
+        source_artifact_path=seed["source_artifact_path"],
+        source_packet_id=seed["source_packet_id"],
+        source_row_id=seed["source_row_id"],
         row_hash=row_hash,
-        command_or_row_label=_redact_queue_text(command_or_row_label),
+        command_or_row_label=seed["command_or_row_label"],
         reason_code=reason_code,
         reason_detail=_redact_queue_text(reason_detail),
         authority_domain=_redact_queue_text(authority_domain),
@@ -762,7 +745,6 @@ def build_unknown_drift_queue_item(
         aggregated_count=aggregated_count,
     )
 
-
 def _increment_count(
     counts: dict[str, int | str],
     key: str,
@@ -772,9 +754,7 @@ def _increment_count(
         current = counts.get(key, 0)
         counts[key] = current + amount if isinstance(current, int) else current
         return
-    if key not in counts:
-        counts[key] = "UNKNOWN"
-
+    counts[key] = "UNKNOWN"
 
 def _top_unresolved_owners(counts: dict[str, int | str]) -> tuple[dict[str, int | str], ...]:
     sortable: list[tuple[int, str, int | str]] = []
@@ -783,7 +763,6 @@ def _top_unresolved_owners(counts: dict[str, int | str]) -> tuple[dict[str, int 
         sortable.append((rank, owner, count))
     sortable.sort(key=lambda item: (-item[0], item[1]))
     return tuple({"owner_packet": owner, "count": count} for _, owner, count in sortable[:5])
-
 
 def _aggregate_unknown_drift_items(
     package: LoadedPackage,
@@ -1130,7 +1109,6 @@ def _aggregate_unknown_drift_items(
 
     return tuple(sorted(items, key=lambda item: item.queue_item_id))
 
-
 def build_unknown_drift_queue_summary(
     package: LoadedPackage,
     *,
@@ -1182,7 +1160,6 @@ def build_unknown_drift_queue_summary(
         ready_for_claude_design="not approved",
         allowed_affordances=ALLOWED_UNKNOWN_DRIFT_AFFORDANCES,
     )
-
 
 def _first_present(row: Mapping[str, Any], *keys: str) -> Any:
     for key in keys:
@@ -1269,12 +1246,13 @@ def map_settings_admin_row_to_gate_tier(row: Mapping[str, Any]) -> SettingsAdmin
             refusal_reason="BLOCKED_IN_COCKPIT",
         )
     if safety_class in {"UNKNOWN", "EXTERNAL_ONLY"} or explicit_tier == "TU":
+        is_external = safety_class == "EXTERNAL_ONLY"
         return _settings_admin_mapping(
             tier="TU",
             safety_class=safety_class,
             source="explicit unknown or external-only evidence",
-            refusal_route="UNKNOWN_DRIFT_QUEUE",
-            refusal_reason="UNKNOWN_CLASS",
+            refusal_route="ORIGINATING_SURFACE" if is_external else "UNKNOWN_DRIFT_QUEUE",
+            refusal_reason="EXTERNAL_ONLY" if is_external else "UNKNOWN_CLASS",
         )
     if explicit_tier in SAFE_ACTION_TIERS:
         return _settings_admin_mapping(
@@ -1625,13 +1603,14 @@ def evaluate_safe_action_preflight(
             (),
             "SHOW_BLOCKED_REASON",
         )
-    if tier in UNKNOWN_TIERS or safety_class == "UNKNOWN":
+    if tier in UNKNOWN_TIERS or safety_class in {"UNKNOWN", "EXTERNAL_ONLY"}:
+        is_external = safety_class == "EXTERNAL_ONLY"
         return PreflightResult(
-            "REFUSE_UNKNOWN",
+            "REFUSE_EXTERNAL_ONLY" if is_external else "REFUSE_UNKNOWN",
             False,
-            "UNKNOWN_CLASS",
+            "EXTERNAL_ONLY" if is_external else "UNKNOWN_CLASS",
             (),
-            "UNKNOWN_DRIFT_QUEUE",
+            "ORIGINATING_SURFACE" if is_external else "UNKNOWN_DRIFT_QUEUE",
         )
     if surface_origin in UNSAFE_SURFACE_ORIGINS or (
         surface_origin != "UNKNOWN" and surface_origin not in ALLOWED_SURFACE_ORIGINS
@@ -1788,6 +1767,12 @@ def _gate_request_id(seed: str) -> str:
     return str(uuid5(NAMESPACE_URL, f"dopemux:{RUNTIME_PACKET_ID}:{seed}"))
 
 
+def _canonical_action_hash(candidate: dict[str, Any]) -> str:
+    return stable_sha256(
+        {str(key): value for key, value in redact_secrets(candidate).items() if key != "action_row_hash"}
+    )
+
+
 def build_gate_receipt(
     *,
     event_type: str,
@@ -1804,8 +1789,9 @@ def build_gate_receipt(
 
     cfg = config or RuntimeConfig()
     event_timestamp = created_at_utc or _utc_now_string()
-    action_row_hash = str(candidate.get("action_row_hash") or stable_sha256(candidate))
-    request_id = gate_request_id or _gate_request_id(f"{action_row_hash}:{event_timestamp}")
+    action_row_hash = _canonical_action_hash(candidate)
+    request_id = gate_request_id or _gate_request_id(action_row_hash)
+    surface_origin = str(candidate.get("surface_origin", "UNKNOWN"))
     confirmation_status = {
         "gate_open": "pending" if preflight.can_confirm else "refused",
         "gate_refuse": "refused",
@@ -1828,7 +1814,7 @@ def build_gate_receipt(
     }[event_type]
     receipt = {
         "gate_request_id": request_id,
-        "palette_request_id": candidate.get("palette_request_id"),
+        "palette_request_id": candidate.get("palette_request_id") if surface_origin == "COMMAND_PALETTE" else None,
         "action_row_hash": action_row_hash,
         "tier": candidate.get("gate_tier", "UNKNOWN"),
         "safety_class": candidate.get("safety_class", "UNKNOWN"),
@@ -1845,10 +1831,24 @@ def build_gate_receipt(
         "proof_artifacts": proof_artifacts or {},
         "refusal_reason": preflight.refusal_reason,
         "routing_destination": preflight.routing_destination,
-        "surface_origin": candidate.get("surface_origin", "UNKNOWN"),
+        "surface_origin": surface_origin,
         "operator_id": operator_id or cfg.unauthenticated_operator_id,
         "created_at_utc": event_timestamp,
+        "event_timestamp_utc": event_timestamp,
+        "gate_open_timestamp_utc": candidate.get("gate_open_timestamp_utc") or event_timestamp,
+        "confirm_timestamp_utc": event_timestamp
+        if event_type in {"gate_confirmed", "gate_proof_captured", "gate_proof_incomplete"}
+        else None,
+        "proof_timestamp_utc": event_timestamp
+        if event_type in {"gate_proof_captured", "gate_proof_incomplete"}
+        else None,
+        "typed_confirmation_match": candidate.get("typed_confirmation_match", "not_required"),
+        "diff_acknowledged": candidate.get("diff_acknowledged"),
+        "remote_mutation_policy_reference": candidate.get("remote_mutation_policy_reference"),
+        "tp_or_task_id": candidate.get("tp_or_task_id"),
+        "service_id": candidate.get("service_id"),
+        "stale_proof_tag": event_type in {"gate_proof_incomplete", "gate_proof_stale"},
         "event_type": event_type,
-        "schema_version": "dopemux.cockpit.safe_action_gate.receipt.runtime_render.v1",
+        "schema_version": "dopemux.cockpit.safe_action_gate.receipt.v1",
     }
     return redact_secrets(receipt)

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -58,6 +58,7 @@ A packet is superseded by another packet
 | TP-DMX-COCKPIT-SETTINGS-RUNTIME-001 | UI Cockpit | Wire Settings/Admin/Runtime primitive surface to runtime renderer | Active | N/A |
 | TP-DMX-COCKPIT-UNKNOWN-DRIFT-001 | UI Cockpit | Wire Unknown / Drift Queue primitive surface to runtime renderer | Active | N/A |
 | TP-DMX-COCKPIT-INVENTORY-REGEN-001 | UI Cockpit | Regenerate current-head Cockpit command/surface inventory artifacts | Active | N/A |
+| TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001 | UI Cockpit | Repair Cockpit runtime contract-fidelity gaps | Active | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 | DMX-COCKPIT-PMIMPL-PACK-001 | Cockpit / PM Plane | PM/Implementer cockpit processing pack | Ready | N/A |

--- a/task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json
+++ b/task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json
@@ -1,0 +1,313 @@
+{
+  "id": "TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001",
+  "project": "dopemux-mvp",
+  "target": "Repair Cockpit runtime contract-fidelity issues found during post-merge review-thread audit while preserving no runtime execution, no T4 mutation, no Claude Design unlock, and no canonical writes.",
+  "invariants": [
+    "safe_for_claude_design remains NO.",
+    "READY_FOR_CLAUDE_DESIGN remains not approved.",
+    "No Claude Design upload or final-screen generation is authorized.",
+    "No runtime action execution is authorized.",
+    "No T4 remote mutation is authorized.",
+    "No live service adapters, network calls, Docker calls, browser/OpenClaw/CDP calls, PM writes, ConPort writes, dope-memory writes, dopecon-bridge writes, or canonical writes are authorized.",
+    "Safe Action Gate remains cross-cutting and non-executing.",
+    "Unknown / Drift Queue remains non-executing and runtime reclassification remains disabled.",
+    "TX and TU remain non-executable.",
+    "External-only rows must never reach a confirmable execution path.",
+    "Proof and receipts must preserve provenance without trusting caller-supplied hashes.",
+    "Secrets must be redacted before labels, evidence refs, row hashes, queue item IDs, or receipts can persist or display derived values.",
+    "No accepted upstream proof/artifact directories may be mutated."
+  ],
+  "depends_on": [
+    "TP-DMX-COCKPIT-MERGE-EXECUTE-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dopemux-cockpit-ia-remediation",
+    "base_branch": "pack/cockpit-pack-remediate-006-ia",
+    "parent_tp_id": "TP-DMX-COCKPIT-MERGE-EXECUTE-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/cockpit-runtime-contract-fidelity-001"
+  },
+  "commit": {
+    "message": "fix(cockpit): repair runtime contract fidelity gaps",
+    "allowlist": [
+      "src/dopemux/ui/cockpit/runtime_contract.py",
+      "tests/unit/dopemux/ui/cockpit/test_runtime_contract.py",
+      "tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py",
+      "tests/unit/test_cockpit_cli.py",
+      "task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json",
+      "task-packets/INDEX.md",
+      "out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/**",
+      "proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json >/dev/null",
+      "python -m json.tool out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json >/dev/null",
+      "python -m compileall -q src/dopemux tests",
+      "python -m pytest tests/unit/dopemux/ui/cockpit -q",
+      "python -m pytest tests/unit/test_cockpit_cli.py -q",
+      "python -m pytest tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py -q",
+      "! grep -R -E \"READY_FOR_CLAUDE_DESIGN: approved|safe_for_claude_design: YES|Claude Design upload allowed|T4 authorized|runtime execution implemented|Unknown / Drift execution|runtime reclassification allowed|execute anyway|approve anyway|resolve now|final screens approved\" -n src/dopemux tests out/cockpit-runtime-contract-fidelity proof/cockpit-runtime-contract-fidelity",
+      "! grep -R -E \"subprocess|shell=True|os\\.system|requests|httpx|urllib|socket|docker|kubectl\" -n src/dopemux/ui/cockpit src/dopemux/commands/cockpit_commands.py tests/unit/dopemux/ui/cockpit tests/unit/test_cockpit_cli.py",
+      "git diff --check",
+      "pre-commit run --files src/dopemux/ui/cockpit/runtime_contract.py tests/unit/dopemux/ui/cockpit/test_runtime_contract.py tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py tests/unit/test_cockpit_cli.py task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json task-packets/INDEX.md out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md"
+    ]
+  },
+  "pr": {
+    "title": "fix(cockpit): repair runtime contract fidelity gaps",
+    "body": "Implements TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001. Repairs post-merge review-thread contract-fidelity issues in Cockpit runtime primitives: EXTERNAL_ONLY fail-closed gating, canonical action row hashing, receipt schema completeness, palette_request_id nullability, gate_request_id lifecycle stability, package-dir resolution coupling, UNKNOWN aggregate counting, redaction-before-hash for queue IDs, and inventory metadata tests. Preserves safe_for_claude_design: NO and READY_FOR_CLAUDE_DESIGN: not approved. No final screens, no Claude Design upload, no runtime action execution, no T4 remote mutation, no live service adapters, no canonical writes, and no runtime reclassification.",
+    "base": "pack/cockpit-pack-remediate-006-ia"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight the dedicated worktree and verify the post-merge base before making any edits.",
+      "requirements": [
+        "Create a fresh dedicated worktree from origin/pack/cockpit-pack-remediate-006-ia.",
+        "Use worktree path /Users/hue/code/dopemux-worktrees/dopemux-cockpit-runtime-contract-fidelity-001.",
+        "Use branch codex/cockpit-runtime-contract-fidelity-001.",
+        "Verify repo marker .dopetaskroot.",
+        "Verify origin is DDD-Enterprises/dopemux-mvp.",
+        "Verify base branch HEAD is b173efd83c871c30f2bd86530921c866d08e7e45 or stop and report drift.",
+        "Verify worktree is clean before edits.",
+        "Do not run live services."
+      ],
+      "commands": [
+        "git fetch origin --prune",
+        "git worktree list",
+        "git worktree add -b codex/cockpit-runtime-contract-fidelity-001 /Users/hue/code/dopemux-worktrees/dopemux-cockpit-runtime-contract-fidelity-001 origin/pack/cockpit-pack-remediate-006-ia",
+        "cd /Users/hue/code/dopemux-worktrees/dopemux-cockpit-runtime-contract-fidelity-001",
+        "pwd",
+        "git rev-parse --show-toplevel",
+        "test -f .dopetaskroot",
+        "git remote -v",
+        "git branch --show-current",
+        "git rev-parse HEAD",
+        "git status --short --branch",
+        "git ls-remote --heads origin pack/cockpit-pack-remediate-006-ia"
+      ],
+      "expected_files": [],
+      "validation": [
+        "pwd prints /Users/hue/code/dopemux-worktrees/dopemux-cockpit-runtime-contract-fidelity-001.",
+        "git branch --show-current prints codex/cockpit-runtime-contract-fidelity-001.",
+        "git rev-parse HEAD equals b173efd83c871c30f2bd86530921c866d08e7e45.",
+        "git status --short --branch shows a clean worktree.",
+        ".dopetaskroot exists."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "PROJECT.md",
+        "ARCHITECTURE.md",
+        "PM_PLANE.md",
+        "SERVICE_CATALOG.md",
+        "task-packets/INDEX.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Create the TP JSON and inspect accepted proof/audit evidence for the post-merge contract-fidelity defects.",
+      "requirements": [
+        "Create task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json before implementation.",
+        "Read the merge execute audit summary and local proof artifacts if present.",
+        "Inspect accepted Safe Action receipt, preflight, refusal, runtime-render, Settings/Admin, Unknown/Drift, and inventory proof artifacts.",
+        "Record missing root RULES/TRUTH/SYSTEM/dopetask schema files as UNKNOWN if absent.",
+        "Do not mutate accepted upstream artifacts."
+      ],
+      "commands": [
+        "test -f task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json || true",
+        "python -m json.tool task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json >/dev/null",
+        "rg -n \"EXTERNAL_ONLY|action_row_hash|gate_request_id|palette_request_id|receipt|SAFE_ACTION_GATE_EVENT_RECEIPTS|_increment_count|queue_item_id|row_hash|redact|source_artifacts|runtime_sources|line_count\" src/dopemux tests out proof task-packets -S"
+      ],
+      "expected_files": [
+        "task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json"
+      ],
+      "validation": [
+        "Generated TP JSON parses.",
+        "Relevant contract files and runtime/test files are identified.",
+        "Accepted upstream artifact directories remain unmodified."
+      ],
+      "context_files": [
+        "out/cockpit-safe-actions/TP-DMX-COCKPIT-SAFE-ACTIONS-001/SAFE_ACTION_GATE_CONTRACT.md",
+        "out/cockpit-safe-actions/TP-DMX-COCKPIT-SAFE-ACTIONS-001/SAFE_ACTION_PREFLIGHT_SCHEMA.json",
+        "out/cockpit-safe-actions/TP-DMX-COCKPIT-SAFE-ACTIONS-001/SAFE_ACTION_REFUSAL_RULES.md",
+        "out/cockpit-safe-actions/TP-DMX-COCKPIT-SAFE-ACTIONS-001/SAFE_ACTION_GATE_EVENT_RECEIPTS.md",
+        "out/cockpit-runtime-render/TP-DMX-COCKPIT-RUNTIME-RENDER-001/PROOF.json",
+        "out/cockpit-settings-runtime/TP-DMX-COCKPIT-SETTINGS-RUNTIME-001/PROOF.json",
+        "out/cockpit-unknown-drift/TP-DMX-COCKPIT-UNKNOWN-DRIFT-001/PROOF.json",
+        "out/cockpit-inventory-regen/TP-DMX-COCKPIT-INVENTORY-REGEN-001/PROOF.json",
+        "proof/cockpit-merge-execute/TP-DMX-COCKPIT-MERGE-EXECUTE-001/PROOF.json",
+        "proof/cockpit-merge-execute/TP-DMX-COCKPIT-MERGE-EXECUTE-001/BLOCKER_REPORT.md"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Repair Safe Action preflight and receipt contract fidelity in runtime_contract.py.",
+      "requirements": [
+        "Ensure EXTERNAL_ONLY candidates cannot reach a confirmable gate path and route only to inspect/copy behavior.",
+        "Recompute action_row_hash from a canonical preflight/action representation at gate-open time instead of trusting caller-supplied input.",
+        "Complete receipt payload fields required by SAFE_ACTION_GATE_EVENT_RECEIPTS.md where local runtime primitives model them.",
+        "Set palette_request_id to null for non-palette origins.",
+        "Keep gate_request_id stable across a modeled gate lifecycle and avoid timestamp-derived fallback churn between events.",
+        "Add or update tests for each behavior.",
+        "Do not add execution, network, subprocess, live-service, database, PM, memory, bridge, or T4 behavior."
+      ],
+      "commands": [
+        "python -m pytest tests/unit/dopemux/ui/cockpit/test_runtime_contract.py -q"
+      ],
+      "expected_files": [
+        "src/dopemux/ui/cockpit/runtime_contract.py",
+        "tests/unit/dopemux/ui/cockpit/test_runtime_contract.py"
+      ],
+      "validation": [
+        "Tests prove EXTERNAL_ONLY cannot confirm or execute.",
+        "Tests prove action_row_hash is recomputed canonically.",
+        "Tests prove receipt required fields are present.",
+        "Tests prove palette_request_id is null for non-palette origins.",
+        "Tests prove gate_request_id remains stable across lifecycle events.",
+        "Focused cockpit tests pass."
+      ],
+      "context_files": [
+        "src/dopemux/ui/cockpit/runtime_contract.py",
+        "tests/unit/dopemux/ui/cockpit/test_runtime_contract.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Repair Unknown/Drift queue and inventory fidelity gaps.",
+      "requirements": [
+        "Make UNKNOWN aggregate counting preserve UNKNOWN when any aggregate item has an unknown/non-integer count instead of silently leaving a zero.",
+        "Redact secret-like values before deriving queue_item_id, row_hash, labels, details, or evidence-derived display values.",
+        "Reduce package-dir hard-coupling where safe by resolving package-dir through deterministic repo-relative behavior, while preserving fail-closed behavior for missing or invalid paths.",
+        "Add inventory artifact tests that validate source_artifacts[*].sha256 fields are either valid sha256 digests or explicitly documented UNKNOWN placeholders.",
+        "Add inventory artifact tests that validate runtime_sources[*].line_count matches current source files where the file exists.",
+        "Do not create row-level precision when only aggregate evidence exists."
+      ],
+      "commands": [
+        "python -m pytest tests/unit/dopemux/ui/cockpit/test_runtime_contract.py -q",
+        "python -m pytest tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py -q"
+      ],
+      "expected_files": [
+        "src/dopemux/ui/cockpit/runtime_contract.py",
+        "tests/unit/dopemux/ui/cockpit/test_runtime_contract.py",
+        "tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py"
+      ],
+      "validation": [
+        "Tests prove UNKNOWN aggregate counts are preserved.",
+        "Tests prove redaction occurs before queue item ID / row hash derivation.",
+        "Tests prove package-dir resolution is deterministic and fail-closed.",
+        "Inventory artifact tests validate sha256 placeholders and real digests.",
+        "Inventory artifact tests validate runtime source line counts."
+      ],
+      "context_files": [
+        "out/cockpit-inventory-regen/TP-DMX-COCKPIT-INVENTORY-REGEN-001/COMMAND_SURFACE_INVENTORY.json",
+        "out/cockpit-inventory-regen/TP-DMX-COCKPIT-INVENTORY-REGEN-001/CURRENT_HEAD_COCKPIT_STATUS.json",
+        "tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Create proof artifacts for the contract-fidelity cleanup.",
+      "requirements": [
+        "Create out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json.",
+        "Create proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md.",
+        "Record review-thread classifications and implemented fixes.",
+        "Record validation commands and exit codes.",
+        "Record changed files, branch, base, implementation commit placeholder, PR URL or blocker, residual risks, and UNKNOWNs.",
+        "Use final_head_recording_policy if proof metadata cleanup happens.",
+        "Preserve safe_for_claude_design: NO and READY_FOR_CLAUDE_DESIGN: not approved.",
+        "Do not claim runtime execution, T4 authorization, Claude Design approval, or final screens."
+      ],
+      "commands": [
+        "python -m json.tool out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json >/dev/null"
+      ],
+      "expected_files": [
+        "out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json",
+        "proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md"
+      ],
+      "validation": [
+        "PROOF.json parses.",
+        "Proof README preserves no-runtime/no-Claude/no-T4/no-canonical-write boundaries.",
+        "Proof records all contract-fidelity fixes and residual risks."
+      ],
+      "context_files": [
+        "proof/cockpit-merge-execute/TP-DMX-COCKPIT-MERGE-EXECUTE-001/PROOF.json",
+        "proof/cockpit-merge-execute/TP-DMX-COCKPIT-MERGE-EXECUTE-001/BLOCKER_REPORT.md"
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Run full validation, inspect diff, commit, push, and open PR.",
+      "requirements": [
+        "Run JSON validation, compileall, focused tests, forbidden greps, git diff checks, codereview if available, and pre-commit.",
+        "If codereview is unavailable, record that and perform explicit diff review.",
+        "Commit only allowlisted files.",
+        "Push codex/cockpit-runtime-contract-fidelity-001.",
+        "Open PR against pack/cockpit-pack-remediate-006-ia.",
+        "Return closeout with exact commands, exit codes, commit SHA, PR URL or blocker, proof paths, and residual risks."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json >/dev/null",
+        "python -m json.tool out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json >/dev/null",
+        "python -m compileall -q src/dopemux tests",
+        "python -m pytest tests/unit/dopemux/ui/cockpit -q",
+        "python -m pytest tests/unit/test_cockpit_cli.py -q",
+        "python -m pytest tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py -q",
+        "! grep -R -E \"READY_FOR_CLAUDE_DESIGN: approved|safe_for_claude_design: YES|Claude Design upload allowed|T4 authorized|runtime execution implemented|Unknown / Drift execution|runtime reclassification allowed|execute anyway|approve anyway|resolve now|final screens approved\" -n src/dopemux tests out/cockpit-runtime-contract-fidelity proof/cockpit-runtime-contract-fidelity",
+        "! grep -R -E \"subprocess|shell=True|os\\.system|requests|httpx|urllib|socket|docker|kubectl\" -n src/dopemux/ui/cockpit src/dopemux/commands/cockpit_commands.py tests/unit/dopemux/ui/cockpit tests/unit/test_cockpit_cli.py",
+        "git diff --check",
+        "command -v codereview || true",
+        "pre-commit run --files src/dopemux/ui/cockpit/runtime_contract.py tests/unit/dopemux/ui/cockpit/test_runtime_contract.py tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py tests/unit/test_cockpit_cli.py task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json task-packets/INDEX.md out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md",
+        "git status --short --branch"
+      ],
+      "expected_files": [
+        "src/dopemux/ui/cockpit/runtime_contract.py",
+        "tests/unit/dopemux/ui/cockpit/test_runtime_contract.py",
+        "tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py",
+        "tests/unit/test_cockpit_cli.py",
+        "task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json",
+        "task-packets/INDEX.md",
+        "out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json",
+        "proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md"
+      ],
+      "validation": [
+        "All JSON files parse.",
+        "compileall passes.",
+        "Focused cockpit UI tests pass.",
+        "Focused CLI tests pass.",
+        "Inventory artifact tests pass.",
+        "Forbidden governance grep has no matches.",
+        "Forbidden runtime token grep has no matches.",
+        "git diff --check passes.",
+        "pre-commit passes.",
+        "Branch is pushed and PR is opened or exact blocker is reported."
+      ],
+      "context_files": [
+        "src/dopemux/ui/cockpit/runtime_contract.py",
+        "tests/unit/dopemux/ui/cockpit/test_runtime_contract.py",
+        "tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py",
+        "tests/unit/test_cockpit_cli.py"
+      ]
+    }
+  ]
+}

--- a/tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py
+++ b/tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import re
 
 
 REPO_ROOT = Path(__file__).resolve().parents[5]
 PACKET_ID = "TP-DMX-COCKPIT-INVENTORY-REGEN-001"
 ARTIFACT_DIR = REPO_ROOT / "out" / "cockpit-inventory-regen" / PACKET_ID
 PROOF_DIR = REPO_ROOT / "proof" / "cockpit-inventory-regen" / PACKET_ID
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+DOCUMENTED_UNKNOWN_SHA256 = {"UNKNOWN_NOT_HASHED_IN_PREFLIGHT_SAMPLE"}
 
 
 def _load_json(name: str) -> dict[str, object]:
@@ -54,6 +57,21 @@ def test_inventory_preserves_five_modes_and_four_global_surfaces():
     assert runtime["global_surface_count"] == 4
     assert status["runtime_model_status"]["five_top_level_modes"] == runtime["top_level_modes"]
     assert status["runtime_model_status"]["four_global_surfaces"] == runtime["global_surfaces"]
+
+
+def test_source_artifact_sha256_values_are_hashes_or_documented_unknowns():
+    inventory = _load_json("COMMAND_SURFACE_INVENTORY.json")
+    for artifact in inventory["source_artifacts"]:
+        value = artifact["sha256"]
+        assert SHA256_RE.fullmatch(value) or value in DOCUMENTED_UNKNOWN_SHA256
+
+
+def test_runtime_source_line_counts_match_current_files_when_present():
+    inventory = _load_json("COMMAND_SURFACE_INVENTORY.json")
+    for source in inventory["runtime_sources"]:
+        path = REPO_ROOT / source["path"]
+        if path.is_file():
+            assert source["line_count"] == len(path.read_text(encoding="utf-8").splitlines())
 
 
 def test_settings_admin_and_unknown_drift_summaries_are_included():

--- a/tests/unit/dopemux/ui/cockpit/test_runtime_contract.py
+++ b/tests/unit/dopemux/ui/cockpit/test_runtime_contract.py
@@ -24,8 +24,10 @@ from dopemux.ui.cockpit.runtime_contract import (
     evaluate_safe_action_preflight,
     load_package_artifacts,
     map_settings_admin_row_to_gate_tier,
+    redact_secrets,
     render_runtime_snapshot,
     runtime_snapshot_payload,
+    stable_sha256,
 )
 
 
@@ -102,6 +104,14 @@ def test_package_loader_parses_accepted_proof_and_index_files():
     assert package.proof["ready_for_claude_design"] is False
     assert len(package.package_index_sha256) == 64
     assert len(package.proof_sha256) == 64
+
+
+def test_package_loader_resolves_repo_relative_package_dir_from_subdirectory(monkeypatch):
+    monkeypatch.chdir(REPO_ROOT / "src")
+    package = load_package_artifacts(
+        "out/cockpit-pack-remediation/TP-DMX-COCKPIT-PACK-REMEDIATE-006-IA"
+    )
+    assert package.package_dir == PACKAGE_DIR
 
 
 def test_runtime_render_model_preserves_modes_surfaces_and_tiers():
@@ -251,6 +261,31 @@ def test_unknown_drift_queue_item_defaults_and_redacts_secret_like_values():
     ]
 
 
+def test_unknown_drift_queue_hashes_redacted_seed_before_deriving_ids():
+    first = build_unknown_drift_queue_item(
+        source_surface="Command Palette",
+        source_artifact_path="out/example.md",
+        source_packet_id="TP-EXAMPLE",
+        source_row_id="row-1",
+        command_or_row_label="rotate token=alpha",
+        reason_code="UNKNOWN",
+        reason_detail="blocked because token=alpha",
+    )
+    second = build_unknown_drift_queue_item(
+        source_surface="Command Palette",
+        source_artifact_path="out/example.md",
+        source_packet_id="TP-EXAMPLE",
+        source_row_id="row-1",
+        command_or_row_label="rotate token=beta",
+        reason_code="UNKNOWN",
+        reason_detail="blocked because token=beta",
+    )
+    assert first.row_hash == second.row_hash
+    assert first.queue_item_id == second.queue_item_id
+    assert "alpha" not in str(first.as_payload())
+    assert "beta" not in str(second.as_payload())
+
+
 def test_unknown_drift_summary_uses_accepted_sources_without_mutating_artifacts():
     source_paths = [
         PACKAGE_DIR / "PACKAGE_REMEDIATION_INDEX.json",
@@ -291,10 +326,11 @@ def test_unknown_drift_snapshot_payload_contains_aggregate_counts_and_sources():
     assert queue["reason_counts"]["OPTIONAL_IMPORT_UNKNOWN"] == 2
     assert queue["reason_counts"]["DEPRECATED_BLOCKED"] == 7
     assert queue["reason_counts"]["AUTHORITY_CONFLICT"] == 14
-    assert queue["reason_counts"]["SETTINGS_ROW_TIER_UNKNOWN"] == 62
-    assert queue["reason_counts"]["REMOTE_MUTATION_POLICY_MISSING"] == 1
+    assert queue["reason_counts"]["SETTINGS_ROW_TIER_UNKNOWN"] == "UNKNOWN"
+    assert queue["reason_counts"]["REMOTE_MUTATION_POLICY_MISSING"] == "UNKNOWN"
+    assert queue["reason_counts"]["UNKNOWN"] == "UNKNOWN"
     assert queue["stale_proof_count"] == 1
-    assert queue["index_drift_count"] == 1
+    assert queue["index_drift_count"] == "UNKNOWN"
     assert queue["settings_unknown_tier_count"] == 62
     assert queue["execution_allowed"] is False
     assert queue["runtime_reclassification_allowed"] is False
@@ -405,6 +441,14 @@ def test_unknown_drift_queue_allows_only_display_copy_inspect_affordances():
             False,
             "UNKNOWN_DRIFT_QUEUE",
             "UNKNOWN_CLASS",
+        ),
+        (
+            {"safety_class": "EXTERNAL_ONLY"},
+            "TU",
+            False,
+            False,
+            "ORIGINATING_SURFACE",
+            "EXTERNAL_ONLY",
         ),
     ],
 )
@@ -518,6 +562,18 @@ def test_tx_and_tu_never_reach_confirm_affordance(
     assert result.can_confirm is False
 
 
+def test_external_only_preflight_routes_to_originating_inspect_copy_path():
+    result = evaluate_safe_action_preflight(
+        _candidate(safety_class="EXTERNAL_ONLY"),
+        current_row_hash="row-hash-001",
+        evaluated_at_utc=EVALUATED_AT,
+    )
+    assert result.status == "REFUSE_EXTERNAL_ONLY"
+    assert result.can_confirm is False
+    assert result.refusal_reason == "EXTERNAL_ONLY"
+    assert result.routing_destination == "ORIGINATING_SURFACE"
+
+
 def test_missing_required_preflight_field_refuses():
     candidate = _candidate()
     candidate.pop("output_target_path")
@@ -601,11 +657,81 @@ def test_receipts_include_required_fields_and_utc_timestamp():
         "surface_origin",
         "operator_id",
         "created_at_utc",
+        "event_timestamp_utc",
+        "gate_open_timestamp_utc",
+        "confirm_timestamp_utc",
+        "proof_timestamp_utc",
+        "typed_confirmation_match",
+        "diff_acknowledged",
+        "remote_mutation_policy_reference",
+        "tp_or_task_id",
+        "service_id",
+        "stale_proof_tag",
+        "event_type",
+        "schema_version",
     }
     assert required_fields <= set(receipt)
     assert receipt["created_at_utc"].endswith("Z")
+    assert receipt["event_timestamp_utc"] == BASE_TIME
+    assert receipt["gate_open_timestamp_utc"] == BASE_TIME
+    assert receipt["schema_version"] == "dopemux.cockpit.safe_action_gate.receipt.v1"
     assert receipt["operator_id"] == "NULL_NOT_AUTHENTICATED"
     assert receipt["execution_status"] == "not_attempted"
+
+
+def test_receipt_recomputes_action_hash_from_redacted_canonical_candidate():
+    candidate = _candidate(action_row_hash="caller-supplied", token="secret-one")
+    preflight = evaluate_safe_action_preflight(
+        candidate,
+        current_row_hash="row-hash-001",
+        evaluated_at_utc=EVALUATED_AT,
+    )
+    receipt = build_gate_receipt(
+        event_type="gate_open",
+        candidate=candidate,
+        preflight=preflight,
+        created_at_utc=BASE_TIME,
+    )
+    canonical = redact_secrets(candidate)
+    canonical.pop("action_row_hash")
+    assert receipt["action_row_hash"] == stable_sha256(canonical)
+    assert receipt["action_row_hash"] != "caller-supplied"
+
+
+def test_receipt_nulls_palette_request_id_for_non_palette_origin():
+    preflight = evaluate_safe_action_preflight(
+        _candidate(surface_origin="PM"),
+        current_row_hash="row-hash-001",
+        evaluated_at_utc=EVALUATED_AT,
+    )
+    receipt = build_gate_receipt(
+        event_type="gate_open",
+        candidate=_candidate(surface_origin="PM"),
+        preflight=preflight,
+        created_at_utc=BASE_TIME,
+    )
+    assert receipt["palette_request_id"] is None
+
+
+def test_receipt_default_gate_request_id_is_stable_across_lifecycle_events():
+    preflight = evaluate_safe_action_preflight(
+        _candidate(),
+        current_row_hash="row-hash-001",
+        evaluated_at_utc=EVALUATED_AT,
+    )
+    opened = build_gate_receipt(
+        event_type="gate_open",
+        candidate=_candidate(),
+        preflight=preflight,
+        created_at_utc=BASE_TIME,
+    )
+    confirmed = build_gate_receipt(
+        event_type="gate_confirmed",
+        candidate=_candidate(),
+        preflight=preflight,
+        created_at_utc="2026-05-04T12:01:00Z",
+    )
+    assert opened["gate_request_id"] == confirmed["gate_request_id"]
 
 
 def test_receipt_redacts_secret_payloads():


### PR DESCRIPTION
Implements TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.

@codex
@gemini
@copilot

## Summary
- Repairs Cockpit runtime contract-fidelity gaps for EXTERNAL_ONLY gating, canonical action-row hashing, receipt lifecycle fields, palette_request_id nullability, gate_request_id stability, UNKNOWN aggregate counting, redaction-before-hash queue IDs, deterministic package-dir resolution, and inventory metadata tests.
- Preserves safe_for_claude_design: NO and READY_FOR_CLAUDE_DESIGN: not approved.
- Adds packet JSON, index entry, and packet-owned proof artifacts.

## Boundaries
- No Claude Design upload or final-screen generation.
- No runtime action execution.
- No T4 remote mutation.
- No live service adapters, PM writes, ConPort writes, dope-memory writes, dopecon-bridge writes, or canonical writes.
- Unknown / Drift Queue remains non-executing; runtime reclassification remains disabled.
- TX and TU remain non-executable.

## Validation
- `python -m json.tool task-packets/generated/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001.json >/dev/null`
- `python -m json.tool out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json >/dev/null`
- `python -m compileall -q src/dopemux tests`
- `python -m pytest tests/unit/dopemux/ui/cockpit -q`
- `python -m pytest tests/unit/test_cockpit_cli.py -q`
- `python -m pytest tests/unit/dopemux/ui/cockpit/test_inventory_regen_artifacts.py -q`
- Forbidden governance grep passed.
- Forbidden runtime-token grep passed.
- `git diff --check`
- Packet allowlist `pre-commit run --files ...`

## Proof
- `out/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/PROOF.json`
- `proof/cockpit-runtime-contract-fidelity/TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001/README.md`

## Release notes and docs
- Task packet index updated.
- Proof artifacts document residual UNKNOWNs and validation evidence.
- No changelog or feature-list surface was found in the packet allowlist; no unrelated docs were changed.
