### PR TITLE
security: harden Desktop Commander argv handling and restrict network exposure

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -552,7 +552,7 @@ services:
     networks:
       - dopemux-network
     ports:
-      - "${DESKTOP_COMMANDER_PORT:-3012}:3012"
+      - "127.0.0.1:${DESKTOP_COMMANDER_PORT:-3012}:3012"
     environment:
       - MCP_SERVER_PORT=${DESKTOP_COMMANDER_PORT:-3012}
       - DISPLAY=${DISPLAY:-:0}

--- a/docker/mcp-servers-source/desktop-commander/server.py
+++ b/docker/mcp-servers-source/desktop-commander/server.py
@@ -41,7 +41,7 @@ async def screenshot(filename: str = "/tmp/screenshot.png") -> Dict[str, Any]:
         if IS_MACOS:
             result = subprocess.run(["screencapture", "-x", filename], capture_output=True, text=True, timeout=10)
         else:
-            result = subprocess.run(["scrot", filename], capture_output=True, text=True, timeout=10)
+            result = subprocess.run(["scrot", "--", filename], capture_output=True, text=True, timeout=10)
 
         if result.returncode == 0:
             return {"success": True, "filename": filename, "message": f"Screenshot saved to {filename}"}
@@ -107,7 +107,7 @@ async def type_text(text: str) -> Dict[str, Any]:
             result = subprocess.run(["osascript", "-e", applescript], capture_output=True, text=True, timeout=10)
             return {"success": result.returncode == 0, "message": "Typed text"}
         else:
-            result = subprocess.run(["xdotool", "type", text], capture_output=True, text=True, timeout=10)
+            result = subprocess.run(["xdotool", "type", "--", text], capture_output=True, text=True, timeout=10)
             return {"success": result.returncode == 0, "message": "Typed text"}
     except Exception as e:
         return {"success": False, "error": str(e)}
@@ -124,4 +124,4 @@ if __name__ == "__main__":
     app = mcp.sse_app()
     app.routes.append(Route("/health", health_check))
 
-    uvicorn.run(app, host="0.0.0.0", port=port)
+    uvicorn.run(app, host=os.getenv("MCP_SERVER_HOST", "127.0.0.1"), port=port)

--- a/docker/mcp-servers-source/desktop-commander/server.py
+++ b/docker/mcp-servers-source/desktop-commander/server.py
@@ -29,17 +29,23 @@ mcp = FastMCP(
     name="Desktop Commander"
 )
 
+def _macos_safe_path(filename: str) -> str:
+    if filename.startswith("-"):
+        return f"./{filename}"
+    return filename
+
+
 @mcp.tool()
 async def screenshot(filename: str = "/tmp/screenshot.png") -> Dict[str, Any]:
     """
     Take a screenshot of the current desktop.
-    
+
     Args:
         filename: Output filename for the screenshot
     """
     try:
         if IS_MACOS:
-            result = subprocess.run(["screencapture", "-x", filename], capture_output=True, text=True, timeout=10)
+            result = subprocess.run(["screencapture", "-x", _macos_safe_path(filename)], capture_output=True, text=True, timeout=10)
         else:
             result = subprocess.run(["scrot", "--", filename], capture_output=True, text=True, timeout=10)
 

--- a/tests/unit/test_desktop_commander_security.py
+++ b/tests/unit/test_desktop_commander_security.py
@@ -94,7 +94,7 @@ class TestDesktopCommanderSecurity(unittest.TestCase):
             args, kwargs = mock_run.call_args
             cmd_list = args[0]
 
-            self.assertEqual(cmd_list, ["xdotool", "type", input_with_dash])
+            self.assertEqual(cmd_list, ["xdotool", "type", "--", input_with_dash])
             self.assertEqual(kwargs["timeout"], 10)
 
     def test_screenshot_linux_argument_passthrough(self):
@@ -110,7 +110,7 @@ class TestDesktopCommanderSecurity(unittest.TestCase):
             args, kwargs = mock_run.call_args
             cmd_list = args[0]
 
-            self.assertEqual(cmd_list, ["scrot", input_with_dash])
+            self.assertEqual(cmd_list, ["scrot", "--", input_with_dash])
             self.assertEqual(kwargs["timeout"], 10)
 
 

--- a/tests/unit/test_desktop_commander_security.py
+++ b/tests/unit/test_desktop_commander_security.py
@@ -113,6 +113,34 @@ class TestDesktopCommanderSecurity(unittest.TestCase):
             self.assertEqual(cmd_list, ["scrot", "--", input_with_dash])
             self.assertEqual(kwargs["timeout"], 10)
 
+    def test_screenshot_macos_leading_dash_filename_canonicalized(self):
+        server = _import_server_module()
+        with patch.object(server, "IS_MACOS", True), patch.object(
+            server.subprocess, "run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            self.run_async(server.screenshot("-rm-rf.png"))
+
+            args, _ = mock_run.call_args
+            cmd_list = args[0]
+
+            self.assertEqual(cmd_list, ["screencapture", "-x", "./-rm-rf.png"])
+
+    def test_screenshot_macos_normal_filename_passthrough(self):
+        server = _import_server_module()
+        with patch.object(server, "IS_MACOS", True), patch.object(
+            server.subprocess, "run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+
+            self.run_async(server.screenshot("/tmp/screenshot.png"))
+
+            args, _ = mock_run.call_args
+            cmd_list = args[0]
+
+            self.assertEqual(cmd_list, ["screencapture", "-x", "/tmp/screenshot.png"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Motivation
- Close a command-injection vector where user-controlled values were passed as leading operands to `scrot`/`xdotool`, allowing option-style payloads (e.g. `--exec=...`) to be interpreted as program options. 
- Reduce default network exposure of the Desktop Commander MCP server which previously bound to all interfaces (`0.0.0.0`) while the service port was published to the host.
- Align unit tests with the hardened invocation semantics to prevent regressions.

### Description
- Insert explicit option delimiters before untrusted operands on Linux so that `scrot` and `xdotool` treat user values strictly as positional arguments by using `--` in the command argv (updated in `docker/mcp-servers-source/desktop-commander/server.py`).
- Restrict default bind address for the server to loopback by honoring `MCP_SERVER_HOST` with a fallback of `127.0.0.1` instead of `0.0.0.0` to avoid exposing the SSE endpoint by default (updated in `docker/mcp-servers-source/desktop-commander/server.py`).
- Update compose service port mapping for `desktop-commander` to bind to loopback host-side by default (changed in `compose.yml`).
- Update unit tests to assert the new hardened argv format (changed in `tests/unit/test_desktop_commander_security.py`).

### Testing
- Ran `pytest -q tests/unit/test_desktop_commander_security.py`, which failed in this environment due to a missing test runtime dependency `rich` imported via `tests/conftest.py` (test harness issue, not a regression in these changes).
- Ran `python -m unittest tests.unit.test_desktop_commander_security`, which failed due to a missing `starlette` runtime dependency in this environment (test module import error unrelated to the changed logic).
- Ran repository hygiene check `git diff --check`, which passed; pre-commit hooks in the environment reported a docs-check hook failure caused by a missing Python module `yaml` in the hook runtime, indicating CI/runtime dependency gaps rather than functional regressions in the patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fce6aa47c48326ba1bd87f21357313)