### PR TITLE
Harden Serena mount to project-only read-only workspace

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -508,10 +508,8 @@ services:
       - MCP_SERVER_PORT=${SERENA_PORT:-3006}
       - HTTP_PORT=${SERENA_HTTP_PORT:-4006}
       - WORKSPACE_ID=${WORKSPACE_ID:-/workspace}
-      - HOST_CODE_PARENT_DIR=${HOST_CODE_PARENT_DIR}
-      - HOST_PROJECT_RELATIVE_PATH=${HOST_PROJECT_RELATIVE_PATH}
     volumes:
-      - ${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces
+      - ${DOPEMUX_WORKSPACE_ROOT:-.}:/workspace:ro
       - ${HOME:?HOME is required}/.serena:/root/.serena:rw
       - ${HOME:?HOME is required}/code:${HOME:?HOME is required}/code:ro
     healthcheck:

--- a/compose.yml
+++ b/compose.yml
@@ -511,7 +511,6 @@ services:
     volumes:
       - ${DOPEMUX_WORKSPACE_ROOT:-.}:/workspace:ro
       - ${HOME:?HOME is required}/.serena:/root/.serena:rw
-      - ${HOME:?HOME is required}/code:${HOME:?HOME is required}/code:ro
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:4006/health || exit 1"]
       timeout: 10s


### PR DESCRIPTION
### Motivation
- A recent change propagated \`HOST_CODE_PARENT_DIR\`/\`HOST_PROJECT_RELATIVE_PATH\` and bind-mounted the host code parent into the network-exposed Serena container, giving unauthenticated MCP clients read/write access to sibling repos and host secrets.
- The intent of this change is to eliminate every host-tree mount and restrict Serena to the current project workspace to close the host/container data boundary breach.

### What changes
- Drop \`HOST_CODE_PARENT_DIR\` and \`HOST_PROJECT_RELATIVE_PATH\` from the Serena service environment.
- Replace the broad rw parent-of-project mount (\`\${HOST_CODE_PARENT_DIR:-/tmp}:/workspaces\`) with a project-scoped, read-only mount: \`\${DOPEMUX_WORKSPACE_ROOT:-.}:/workspace:ro\`.
- **Drop** the secondary \`\${HOME}/code:\${HOME}/code:ro\` mount as well — it leaked read access to all sibling repos and contradicted the project-only intent. Operators who specifically need cross-worktree navigation can add it back via a local \`docker-compose.override.yml\`.

### Result
Serena now sees only:
- \`/workspace\` (project content, ro)
- \`/root/.serena\` (per-user Serena state, rw)

### Testing
- \`git diff --check\` clean.

### Co-author
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fceba9d240832688b470e0af71d118)