### PR TITLE
fix(security): remove trusted-workspace mode from gemini plan-execute

### DIFF
--- a/.github/workflows/gemini-plan-execute.yml
+++ b/.github/workflows/gemini-plan-execute.yml
@@ -20,8 +20,6 @@ jobs:
   plan-execute:
     timeout-minutes: 30
     runs-on: 'ubuntu-latest'
-    env:
-      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     permissions:
       contents: 'write'
       id-token: 'write'


### PR DESCRIPTION
### Motivation
- Restore default Gemini CLI workspace trust protections for the write-capable `plan-execute` job because the previous job-level `GEMINI_CLI_TRUST_WORKSPACE: 'true'` override exposed a high-risk path where attacker-controlled issue/PR content could cause repository writes via MCP tools and an inherited token.

### Description
- Removed the job-level `GEMINI_CLI_TRUST_WORKSPACE: 'true'` environment override from `.github/workflows/gemini-plan-execute.yml` and left all other workflow permissions and settings intact.

### Testing
- Ran `git diff -- .github/workflows/gemini-plan-execute.yml && git diff --check`, which reported no issues for the modified file.
- Pre-commit hooks failed to run because a hook requires Python `yaml` (`pyyaml`) and `pip` install was blocked by network/index restrictions, preventing full automated hook validation.
- The workflow file change is present in the working copy and ready for repository-level validation (commit/push/CI) so CI can run the full hook/test matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc9761f05c8326811ebf0fb29c2bb8)