### PR TITLE
🎨 Palette: Ritual Progress Counter & Tactile Feedback (re-filed)

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -93,3 +93,7 @@
 ## 2026-05-20 - [Pulsing Soft Confirmation Feedbacks]
 **Learning:** For destructive actions using a multi-step "soft" confirmation (e.g., "Reset Ritual"), a static label change might be too subtle for users in high-stimulation dashboard environments. Adding a rhythmic scale-and-glow pulse animation during the confirmation window provides a clear "active warning" state that reduces accidental progress loss while increasing the perceived safety of the interaction.
 **Action:** Use subtle `reset-pulse` animations for button components during time-limited confirmation windows to provide stronger visual feedback for destructive actions.
+
+## 2026-05-07 - [Progressive Ritual Awareness]
+**Learning:** For users with ADHD, seeing a list of tasks without a clear progress fraction (e.g., "1/3") can contribute to a sense of being lost in a sequence. Prefixing duration indicators with a task completion counter provides immediate spatial and temporal grounding. Additionally, providing tactile feedback (vertical lift and shadows) on list item hover/focus bridges the gap between static content and interactive ritual steps.
+**Action:** Always provide a clear "n/m tasks" counter in sequential task managers and use subtle vertical transforms for interactive list elements.

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -228,10 +228,16 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
 
   const displayRemainingMinutes = Math.ceil(totalRemainingMinutes);
 
-  const { completedCount, totalCount } = useMemo(() => {
+  const { completedCount, totalCount, isComplete } = useMemo(() => {
+    const completed = tasks.filter((t) => t.status === 'completed').length;
+    const total = tasks.length;
     return {
-      completedCount: tasks.filter((t) => t.status === 'completed').length,
-      totalCount: tasks.length,
+      completedCount: completed,
+      totalCount: total,
+      // Real completion state: every task is marked done.
+      // Distinct from displayRemainingMinutes === 0, which can fire when the
+      // current task overruns its estimate but later tasks remain.
+      isComplete: total > 0 && completed === total,
     };
   }, [tasks]);
 
@@ -268,7 +274,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         </Typography>
         <Tooltip
           title={
-            displayRemainingMinutes === 0
+            isComplete
               ? 'Task sequence complete'
               : `${completedCount}/${totalCount} tasks • ${getDurationAriaLabel(displayRemainingMinutes)} (${finishTimeLabel})`
           }
@@ -277,7 +283,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
           <Box
             role="status"
             aria-label={
-              displayRemainingMinutes === 0
+              isComplete
                 ? 'Task sequence complete'
                 : `${completedCount}/${totalCount} tasks completed. ${getDurationAriaLabel(displayRemainingMinutes)}. Estimated completion: ${finishTimeLabel}`
             }
@@ -287,10 +293,10 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               display: 'flex',
               alignItems: 'center',
               gap: 0.5,
-              color: displayRemainingMinutes === 0 ? brandTokens.colors.serumMint : brandTokens.colors.saintGold,
+              color: isComplete ? brandTokens.colors.serumMint : brandTokens.colors.saintGold,
               cursor: 'help',
               transition: 'all 0.3s ease',
-              ...(displayRemainingMinutes === 0 && {
+              ...(isComplete && {
                 animation: 'done-glow 2s infinite ease-in-out',
                 '@keyframes done-glow': {
                   '0%, 100%': { transform: 'scale(1)', filter: 'drop-shadow(0 0 0px transparent)' },
@@ -300,17 +306,17 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               '&:focus-visible': {
                 outline: 'none',
                 borderRadius: 1,
-                boxShadow: `0 0 0 2px ${displayRemainingMinutes === 0 ? brandTokens.colors.serumMint : brandTokens.colors.saintGold}`,
+                boxShadow: `0 0 0 2px ${isComplete ? brandTokens.colors.serumMint : brandTokens.colors.saintGold}`,
               },
             }}
           >
-            {displayRemainingMinutes === 0 ? (
+            {isComplete ? (
               <CheckCircle size={16} aria-hidden="true" />
             ) : (
               <Clock size={16} aria-hidden="true" />
             )}
             <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-              {displayRemainingMinutes === 0 ? 'DONE' : `${completedCount}/${totalCount} • ${displayRemainingMinutes}m`}
+              {isComplete ? 'DONE' : `${completedCount}/${totalCount} • ${displayRemainingMinutes}m`}
             </Typography>
           </Box>
         </Tooltip>
@@ -551,7 +557,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
         </Typography>
         <Tooltip
           title={
-            displayRemainingMinutes === 0
+            isComplete
               ? 'Task sequence complete'
               : `${completedCount}/${totalCount} tasks • ${getDurationAriaLabel(displayRemainingMinutes)} (${finishTimeLabel})`
           }
@@ -563,33 +569,33 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               alignItems: 'center',
               gap: 0.5,
               ml: 'auto',
-              color: displayRemainingMinutes === 0 ? brandTokens.colors.serumMint : brandTokens.colors.ritualCyan,
+              color: isComplete ? brandTokens.colors.serumMint : brandTokens.colors.ritualCyan,
               cursor: 'help',
               transition: 'all 0.3s ease',
-              ...(displayRemainingMinutes === 0 && {
+              ...(isComplete && {
                 animation: 'done-glow 2s infinite ease-in-out',
               }),
               '&:focus-visible': {
                 outline: 'none',
                 borderRadius: 1,
-                boxShadow: `0 0 0 2px ${displayRemainingMinutes === 0 ? brandTokens.colors.serumMint : brandTokens.colors.ritualCyan}`,
+                boxShadow: `0 0 0 2px ${isComplete ? brandTokens.colors.serumMint : brandTokens.colors.ritualCyan}`,
               }
             }}
             tabIndex={0}
             role="status"
             aria-label={
-              displayRemainingMinutes === 0
+              isComplete
                 ? 'Task sequence complete'
                 : `${completedCount}/${totalCount} tasks completed. ${getDurationAriaLabel(displayRemainingMinutes)}. Estimated completion: ${finishTimeLabel}`
             }
           >
-            {displayRemainingMinutes === 0 ? (
+            {isComplete ? (
               <CheckCircle size={14} aria-hidden="true" />
             ) : (
               <Clock size={14} aria-hidden="true" />
             )}
             <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-              {displayRemainingMinutes === 0 ? 'DONE' : `${completedCount}/${totalCount} • ${displayRemainingMinutes}m`}
+              {isComplete ? 'DONE' : `${completedCount}/${totalCount} • ${displayRemainingMinutes}m`}
             </Typography>
           </Box>
         </Tooltip>
@@ -625,6 +631,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                 alignItems="flex-start"
                 aria-current={isCurrent ? 'step' : undefined}
                 sx={{
+                  position: 'relative',
                   bgcolor: isCurrent ? alpha(brandTokens.colors.ritualCyan, 0.08) : 'transparent',
                   borderRadius: 2,
                   border: isCurrent
@@ -639,6 +646,8 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                     transform: 'translateY(-2px)',
                     boxShadow: `0 4px 12px ${alpha(brandTokens.colors.inkBlack, 0.4)}`,
                     borderColor: alpha(brandTokens.colors.ritualCyan, 0.4),
+                    // Lift above the next sibling so the drop shadow isn't clipped.
+                    zIndex: 1,
                   },
                 }}
               >

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -276,7 +276,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
           title={
             isComplete
               ? 'Task sequence complete'
-              : `${completedCount}/${totalCount} tasks • ${getDurationAriaLabel(displayRemainingMinutes)} (${finishTimeLabel})`
+              : `${completedCount}/${totalCount} tasks • ${getDurationAriaLabel(displayRemainingMinutes)}${finishTimeLabel ? ` (${finishTimeLabel})` : ''}`
           }
           arrow
         >
@@ -285,7 +285,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
             aria-label={
               isComplete
                 ? 'Task sequence complete'
-                : `${completedCount}/${totalCount} tasks completed. ${getDurationAriaLabel(displayRemainingMinutes)}. Estimated completion: ${finishTimeLabel}`
+                : `${completedCount}/${totalCount} tasks completed. ${getDurationAriaLabel(displayRemainingMinutes)}.${finishTimeLabel ? ` Estimated completion: ${finishTimeLabel}` : ''}`
             }
             tabIndex={0}
             sx={{
@@ -559,7 +559,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
           title={
             isComplete
               ? 'Task sequence complete'
-              : `${completedCount}/${totalCount} tasks • ${getDurationAriaLabel(displayRemainingMinutes)} (${finishTimeLabel})`
+              : `${completedCount}/${totalCount} tasks • ${getDurationAriaLabel(displayRemainingMinutes)}${finishTimeLabel ? ` (${finishTimeLabel})` : ''}`
           }
           arrow
         >
@@ -586,7 +586,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
             aria-label={
               isComplete
                 ? 'Task sequence complete'
-                : `${completedCount}/${totalCount} tasks completed. ${getDurationAriaLabel(displayRemainingMinutes)}. Estimated completion: ${finishTimeLabel}`
+                : `${completedCount}/${totalCount} tasks completed. ${getDurationAriaLabel(displayRemainingMinutes)}.${finishTimeLabel ? ` Estimated completion: ${finishTimeLabel}` : ''}`
             }
           >
             {isComplete ? (

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -228,6 +228,13 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
 
   const displayRemainingMinutes = Math.ceil(totalRemainingMinutes);
 
+  const { completedCount, totalCount } = useMemo(() => {
+    return {
+      completedCount: tasks.filter((t) => t.status === 'completed').length,
+      totalCount: tasks.length,
+    };
+  }, [tasks]);
+
   const finishTimeLabel = useMemo(() => {
     if (totalRemainingMinutes === 0) return '';
     // Use fractional minutes to ensure a stable finish time that only moves with taskTimer
@@ -263,7 +270,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
           title={
             displayRemainingMinutes === 0
               ? 'Task sequence complete'
-              : `${getDurationAriaLabel(displayRemainingMinutes)} (${finishTimeLabel})`
+              : `${completedCount}/${totalCount} tasks • ${getDurationAriaLabel(displayRemainingMinutes)} (${finishTimeLabel})`
           }
           arrow
         >
@@ -272,7 +279,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
             aria-label={
               displayRemainingMinutes === 0
                 ? 'Task sequence complete'
-                : `${getDurationAriaLabel(displayRemainingMinutes)}. Estimated completion: ${finishTimeLabel}`
+                : `${completedCount}/${totalCount} tasks completed. ${getDurationAriaLabel(displayRemainingMinutes)}. Estimated completion: ${finishTimeLabel}`
             }
             tabIndex={0}
             sx={{
@@ -282,7 +289,14 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               gap: 0.5,
               color: displayRemainingMinutes === 0 ? brandTokens.colors.serumMint : brandTokens.colors.saintGold,
               cursor: 'help',
-              transition: 'color 0.3s ease',
+              transition: 'all 0.3s ease',
+              ...(displayRemainingMinutes === 0 && {
+                animation: 'done-glow 2s infinite ease-in-out',
+                '@keyframes done-glow': {
+                  '0%, 100%': { transform: 'scale(1)', filter: 'drop-shadow(0 0 0px transparent)' },
+                  '50%': { transform: 'scale(1.05)', filter: `drop-shadow(0 0 4px ${alpha(brandTokens.colors.serumMint, 0.4)})` },
+                },
+              }),
               '&:focus-visible': {
                 outline: 'none',
                 borderRadius: 1,
@@ -296,7 +310,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               <Clock size={16} aria-hidden="true" />
             )}
             <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-              {displayRemainingMinutes === 0 ? 'DONE' : `${displayRemainingMinutes}m`}
+              {displayRemainingMinutes === 0 ? 'DONE' : `${completedCount}/${totalCount} • ${displayRemainingMinutes}m`}
             </Typography>
           </Box>
         </Tooltip>
@@ -539,7 +553,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
           title={
             displayRemainingMinutes === 0
               ? 'Task sequence complete'
-              : `${getDurationAriaLabel(displayRemainingMinutes)} (${finishTimeLabel})`
+              : `${completedCount}/${totalCount} tasks • ${getDurationAriaLabel(displayRemainingMinutes)} (${finishTimeLabel})`
           }
           arrow
         >
@@ -551,7 +565,10 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               ml: 'auto',
               color: displayRemainingMinutes === 0 ? brandTokens.colors.serumMint : brandTokens.colors.ritualCyan,
               cursor: 'help',
-              transition: 'color 0.3s ease',
+              transition: 'all 0.3s ease',
+              ...(displayRemainingMinutes === 0 && {
+                animation: 'done-glow 2s infinite ease-in-out',
+              }),
               '&:focus-visible': {
                 outline: 'none',
                 borderRadius: 1,
@@ -563,7 +580,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
             aria-label={
               displayRemainingMinutes === 0
                 ? 'Task sequence complete'
-                : `${getDurationAriaLabel(displayRemainingMinutes)}. Estimated completion: ${finishTimeLabel}`
+                : `${completedCount}/${totalCount} tasks completed. ${getDurationAriaLabel(displayRemainingMinutes)}. Estimated completion: ${finishTimeLabel}`
             }
           >
             {displayRemainingMinutes === 0 ? (
@@ -572,7 +589,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
               <Clock size={14} aria-hidden="true" />
             )}
             <Typography variant="caption" sx={{ fontWeight: 'bold' }}>
-              {displayRemainingMinutes === 0 ? 'DONE' : `${displayRemainingMinutes}m`}
+              {displayRemainingMinutes === 0 ? 'DONE' : `${completedCount}/${totalCount} • ${displayRemainingMinutes}m`}
             </Typography>
           </Box>
         </Tooltip>
@@ -614,11 +631,14 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                     ? `1px solid ${brandTokens.borders.cyan}`
                     : `1px solid ${brandTokens.borders.subtle}`,
                   mb: 0.5,
-                  transition: 'background-color 0.2s ease',
-                  '&:hover': {
+                  transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+                  '&:hover, &:focus-within': {
                     bgcolor: isCurrent
                       ? alpha(brandTokens.colors.ritualCyan, 0.12)
                       : alpha(brandTokens.colors.ritualCyan, 0.04),
+                    transform: 'translateY(-2px)',
+                    boxShadow: `0 4px 12px ${alpha(brandTokens.colors.inkBlack, 0.4)}`,
+                    borderColor: alpha(brandTokens.colors.ritualCyan, 0.4),
                   },
                 }}
               >

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -74,13 +74,13 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('aria-label={getTimerAriaLabel(taskTimer)}');
   // Total remaining duration
   expect(content).toContain('role="status"');
-  expect(content).toMatch(/aria-label=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks completed\. \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\. Estimated completion: \$\{finishTimeLabel\}`\s*\}/);
+  expect(content).toMatch(/aria-label=\{\s*isComplete\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks completed\. \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\.\$\{finishTimeLabel\s*\?\s*` Estimated completion: \$\{finishTimeLabel\}`\s*:\s*''\}`\s*\}/);
   expect(content).toMatch(/<Tooltip[^>]*title="Real-time task synchronization active"[^>]*arrow/);
   expect(content).toContain('aria-label="Real-time task synchronization active"');
   expect(content).toContain('aria-current={isCurrent ? \'step\' : undefined}');
   // Total remaining duration display and completed-state accessibility
   expect(content).toContain('role="status"');
-  expect(content).toMatch(/aria-label=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks completed\. \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\. Estimated completion: \$\{finishTimeLabel\}`\s*\}/);
+  expect(content).toMatch(/aria-label=\{\s*isComplete\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks completed\. \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\.\$\{finishTimeLabel\s*\?\s*` Estimated completion: \$\{finishTimeLabel\}`\s*:\s*''\}`\s*\}/);
   expect(content).toContain('aria-label="Ritual Complete: All tasks finished"');
   expect(content).toContain('const headerRef = useRef<HTMLHeadingElement>(null);');
   expect(content).toContain('ref={headerRef}');
@@ -119,9 +119,9 @@ test('TaskSequencer.tsx has accessible timer with pluralization', () => {
 test('TaskSequencer.tsx displays total remaining duration with accessibility', () => {
   const content = fs.readFileSync(path.join(componentsDir, 'TaskSequencer.tsx'), 'utf8');
   expect(content).toContain('const totalRemainingMinutes = useMemo(() =>');
-  expect(content).toMatch(/aria-label=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks completed\. \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\. Estimated completion: \$\{finishTimeLabel\}`\s*\}/);
+  expect(content).toMatch(/aria-label=\{\s*isComplete\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks completed\. \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\.\$\{finishTimeLabel\s*\?\s*` Estimated completion: \$\{finishTimeLabel\}`\s*:\s*''\}`\s*\}/);
   expect(content).toContain('tabIndex={0}');
-  expect(content).toMatch(/<Tooltip\s+title=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks • \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\s+\(\$\{finishTimeLabel\}\)`\s*\}\s+arrow\s*>/);
+  expect(content).toMatch(/<Tooltip\s+title=\{\s*isComplete\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks • \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\$\{finishTimeLabel\s*\?\s*` \(\$\{finishTimeLabel\}\)`\s*:\s*''\}`\s*\}\s+arrow\s*>/);
 });
 
 test('App.tsx has accessible header chips and skip link', () => {

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -74,13 +74,13 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('aria-label={getTimerAriaLabel(taskTimer)}');
   // Total remaining duration
   expect(content).toContain('role="status"');
-  expect(content).toMatch(/aria-label=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\. Estimated completion: \$\{finishTimeLabel\}`\s*\}/);
+  expect(content).toMatch(/aria-label=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks completed\. \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\. Estimated completion: \$\{finishTimeLabel\}`\s*\}/);
   expect(content).toMatch(/<Tooltip[^>]*title="Real-time task synchronization active"[^>]*arrow/);
   expect(content).toContain('aria-label="Real-time task synchronization active"');
   expect(content).toContain('aria-current={isCurrent ? \'step\' : undefined}');
   // Total remaining duration display and completed-state accessibility
   expect(content).toContain('role="status"');
-  expect(content).toMatch(/aria-label=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\. Estimated completion: \$\{finishTimeLabel\}`\s*\}/);
+  expect(content).toMatch(/aria-label=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks completed\. \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\. Estimated completion: \$\{finishTimeLabel\}`\s*\}/);
   expect(content).toContain('aria-label="Ritual Complete: All tasks finished"');
   expect(content).toContain('const headerRef = useRef<HTMLHeadingElement>(null);');
   expect(content).toContain('ref={headerRef}');
@@ -119,9 +119,9 @@ test('TaskSequencer.tsx has accessible timer with pluralization', () => {
 test('TaskSequencer.tsx displays total remaining duration with accessibility', () => {
   const content = fs.readFileSync(path.join(componentsDir, 'TaskSequencer.tsx'), 'utf8');
   expect(content).toContain('const totalRemainingMinutes = useMemo(() =>');
-  expect(content).toMatch(/aria-label=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\. Estimated completion: \$\{finishTimeLabel\}`\s*\}/);
+  expect(content).toMatch(/aria-label=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks completed\. \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\. Estimated completion: \$\{finishTimeLabel\}`\s*\}/);
   expect(content).toContain('tabIndex={0}');
-  expect(content).toMatch(/<Tooltip\s+title=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\s+\(\$\{finishTimeLabel\}\)`\s*\}\s+arrow\s*>/);
+  expect(content).toMatch(/<Tooltip\s+title=\{\s*displayRemainingMinutes === 0\s*\?\s*'Task sequence complete'\s*:\s*`\$\{completedCount\}\/\$\{totalCount\} tasks • \$\{getDurationAriaLabel\(displayRemainingMinutes\)\}\s+\(\$\{finishTimeLabel\}\)`\s*\}\s+arrow\s*>/);
 });
 
 test('App.tsx has accessible header chips and skip link', () => {


### PR DESCRIPTION
Re-files the ritual-progress feature originally proposed in #596 onto a clean branch from current `main`. The previous branch was corrupted by an automation that re-introduced 68 already-deleted files and removed 62 freshly-merged ones; closed in favor of this PR.

## Summary
- Adds an `n/m tasks` progress counter prefix to the duration indicator in TaskSequencer.
- Adds tactile lift (translateY -2px) and drop-shadow on hover/focus for the optimized-sequence list items, with `position: 'relative'` + `zIndex: 1` so the lift shadow stacks above the next sibling.
- Centralises the real completion check as `isComplete = totalCount > 0 && completedCount === totalCount` and routes the six "done" visual cues (tooltip title, ARIA `role="status"` label, color, done-glow animation, focus boxShadow, icon swap, "DONE" text) through it. Previously these all keyed off `displayRemainingMinutes === 0`, which fired prematurely when the current task overran its estimate but later tasks remained.
- Guards the ETA fragment in tooltip and aria-label so the `(${finishTimeLabel})` / `Estimated completion: ${finishTimeLabel}` only render when `finishTimeLabel` is non-empty (avoids "Estimated completion: " with empty value during overrun-on-last-task).
- Updates `Accessibility.test.ts` regex matchers to track the new `isComplete` branches and the ETA-guarded format.

## Commits
- `dc83eb3fc` 🎨 Palette: Ritual Progress Counter & Tactile Feedback (original feature)
- `50bc10e29` fix(ui): gate TaskSequencer 'done' UI on real completion not time exhaustion (Copilot review fixes)
- `e95217e5a` fix(ui): guard ETA in TaskSequencer status text and re-sync accessibility test (Codex P1/P2 fixes)

## Test plan
- [x] `pnpm vitest run src/components/__tests__/Accessibility.test.ts` — 10/10 pass locally
- [ ] Visual confirmation of hover lift + completion announcement timing in `pnpm dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)