### PR TITLE
🎨 Palette: Predictive Skip Tooltips for Task Sequencer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -97,3 +97,7 @@
 ## 2026-05-07 - [Progressive Ritual Awareness]
 **Learning:** For users with ADHD, seeing a list of tasks without a clear progress fraction (e.g., "1/3") can contribute to a sense of being lost in a sequence. Prefixing duration indicators with a task completion counter provides immediate spatial and temporal grounding. Additionally, providing tactile feedback (vertical lift and shadows) on list item hover/focus bridges the gap between static content and interactive ritual steps.
 **Action:** Always provide a clear "n/m tasks" counter in sequential task managers and use subtle vertical transforms for interactive list elements.
+
+## 2026-05-08 - [Predictive Skip Tooltips]
+**Learning:** In sequential task environments, a generic "Skip" action can feel like a step into the unknown, which can increase cognitive friction for users with ADHD. By providing a predictive tooltip and ARIA label that identifies exactly which task is up next (e.g., "Skip to: Implement LSTM..."), the interface provides temporal grounding and reduces the uncertainty of skipping, making the workflow feel more controlled and less overwhelming.
+**Action:** Use dynamic tooltips and descriptive ARIA labels to reveal the destination of "Skip" or "Next" actions in sequential workflows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Dopemux (including the PR Merge Specialist) will be docum
 - CI now includes wrapper-authority coverage, interactive import smoke, and the production `brand_lint.py` gate.
 
 ### Fixed
+- Task sequencer predictive action labels now use the same complete and skip transition rules as the buttons they describe.
 - Claude security review automation now resolves the repository-specific scan and false-positive instruction files referenced by `security-review.yml` and `ci-complete.yml`, preventing missing-path failures during AI security analysis.
 - Restored `compose.yml` as the canonical hand-authored Docker Compose file, removed the stale root unified compose variant, and hardened compose guard checks against future root-level compose drift.
 - Validation-only PRs are no longer shown as queued-for-merge before local verification is complete.

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -197,6 +197,14 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
   };
 
   const currentTask = tasks.find((task) => task.id === currentTaskId);
+  const nextTask = useMemo(() => {
+    if (!currentTaskId || optimizedTasks.length <= 1) return null;
+    const currentIndex = optimizedTasks.findIndex((task) => task.id === currentTaskId);
+    if (currentIndex === -1) return null;
+    const nextIndex = (currentIndex + 1) % optimizedTasks.length;
+    return optimizedTasks[nextIndex];
+  }, [optimizedTasks, currentTaskId]);
+
   const statusTone = statusStyles[cognitiveState.status];
 
   const isOvertime = useMemo(() => {
@@ -457,7 +465,16 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                 Complete
               </Button>
             </Tooltip>
-            <Tooltip title={optimizedTasks.length <= 1 ? 'No other tasks to skip to' : 'Skip for Now'} arrow>
+            <Tooltip
+              title={
+                nextTask
+                  ? `Skip to: ${nextTask.title}`
+                  : optimizedTasks.length <= 1
+                    ? 'No other tasks to skip to'
+                    : 'Skip for Now'
+              }
+              arrow
+            >
               <Box
                 component="span"
                 tabIndex={optimizedTasks.length <= 1 ? 0 : -1}
@@ -477,7 +494,11 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                   startIcon={<SkipForward aria-hidden="true" />}
                   onClick={() => skipTask(currentTask.id)}
                   sx={{ color: brandTokens.colors.gremlinPink }}
-                  aria-label={`Skip task: ${currentTask.title}`}
+                  aria-label={
+                    nextTask
+                      ? `Skip ${currentTask.title}, proceed to ${nextTask.title}`
+                      : `Skip task: ${currentTask.title}`
+                  }
                   disabled={optimizedTasks.length <= 1}
                 >
                   Skip

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -28,6 +28,7 @@ import {
   AlertTriangle,
 } from 'lucide-react';
 import { brandTokens, statusStyles } from '../theme';
+import { getCompletionTransitionTask, getSkipTransitionTask } from './taskSequencerTransitions';
 
 interface Task {
   id: string;
@@ -133,8 +134,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
 
   const completeTask = (taskId: string) => {
     setTasks((prev) => prev.map((task) => (task.id === taskId ? { ...task, status: 'completed' } : task)));
-    const remainingTasks = tasks.filter((task) => task.id !== taskId && task.status !== 'completed');
-    const nextTask = optimizedTasks.find((task) => task.id !== taskId) ?? remainingTasks[0];
+    const nextTask = getCompletionTransitionTask(taskId, tasks, optimizedTasks);
     setCurrentTaskId(nextTask ? nextTask.id : null);
     if (!nextTask) {
       headerRef.current?.focus();
@@ -142,10 +142,9 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
   };
 
   const skipTask = (taskId: string) => {
-    if (optimizedTasks.length <= 1) return;
-    const currentIndex = optimizedTasks.findIndex((task) => task.id === taskId);
-    const nextIndex = (currentIndex + 1) % optimizedTasks.length;
-    setCurrentTaskId(optimizedTasks[nextIndex].id);
+    const nextTask = getSkipTransitionTask(taskId, optimizedTasks);
+    if (!nextTask) return;
+    setCurrentTaskId(nextTask.id);
   };
 
   const resetTasks = () => {
@@ -197,13 +196,16 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
   };
 
   const currentTask = tasks.find((task) => task.id === currentTaskId);
-  const nextTask = useMemo(() => {
-    if (!currentTaskId || optimizedTasks.length <= 1) return null;
-    const currentIndex = optimizedTasks.findIndex((task) => task.id === currentTaskId);
-    if (currentIndex === -1) return null;
-    const nextIndex = (currentIndex + 1) % optimizedTasks.length;
-    return optimizedTasks[nextIndex];
-  }, [optimizedTasks, currentTaskId]);
+
+  const nextTaskAfterCompletion = useMemo(
+    () => getCompletionTransitionTask(currentTaskId, tasks, optimizedTasks),
+    [currentTaskId, optimizedTasks, tasks]
+  );
+
+  const nextTaskAfterSkip = useMemo(
+    () => getSkipTransitionTask(currentTaskId, optimizedTasks),
+    [currentTaskId, optimizedTasks]
+  );
 
   const statusTone = statusStyles[cognitiveState.status];
 
@@ -454,24 +456,35 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                 {isTimerRunning ? 'Pause' : 'Start'}
               </Button>
             </Tooltip>
-            <Tooltip title="Complete and Proceed" arrow>
+            <Tooltip
+              title={
+                nextTaskAfterCompletion
+                  ? `Complete ${currentTask.title} and proceed to ${nextTaskAfterCompletion.title}`
+                  : `Complete ${currentTask.title} and finish ritual`
+              }
+              arrow
+            >
               <Button
                 size="small"
                 variant="outlined"
                 startIcon={<CheckCircle aria-hidden="true" />}
                 onClick={() => completeTask(currentTask.id)}
-                aria-label={`Complete task: ${currentTask.title}`}
+                aria-label={
+                  nextTaskAfterCompletion
+                    ? `Complete ${currentTask.title}, proceed to ${nextTaskAfterCompletion.title}`
+                    : `Complete ${currentTask.title}, finish ritual`
+                }
               >
                 Complete
               </Button>
             </Tooltip>
             <Tooltip
               title={
-                nextTask
-                  ? `Skip to: ${nextTask.title}`
-                  : optimizedTasks.length <= 1
-                    ? 'No other tasks to skip to'
-                    : 'Skip for Now'
+                optimizedTasks.length <= 1
+                  ? 'No other tasks to skip to'
+                  : nextTaskAfterSkip
+                    ? `Skip to: ${nextTaskAfterSkip.title}`
+                    : 'Skip to next task'
               }
               arrow
             >
@@ -495,8 +508,8 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                   onClick={() => skipTask(currentTask.id)}
                   sx={{ color: brandTokens.colors.gremlinPink }}
                   aria-label={
-                    nextTask
-                      ? `Skip ${currentTask.title}, proceed to ${nextTask.title}`
+                    nextTaskAfterSkip
+                      ? `Skip ${currentTask.title}, proceed to ${nextTaskAfterSkip.title}`
                       : `Skip task: ${currentTask.title}`
                   }
                   disabled={optimizedTasks.length <= 1}
@@ -520,7 +533,15 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
             background: alpha(brandTokens.colors.serumMint, 0.05),
           }}
         >
-          <CheckCircle size={32} color={brandTokens.colors.serumMint} style={{ marginBottom: 8 }} aria-hidden="true" />
+          <CheckCircle
+            size={32}
+            color={brandTokens.colors.serumMint}
+            style={{
+              marginBottom: 8,
+              animation: 'done-glow 2s infinite ease-in-out',
+            }}
+            aria-hidden="true"
+          />
           <Typography variant="h6" sx={{ color: brandTokens.colors.serumMint, mb: 1 }}>
             Ritual Complete
           </Typography>

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -66,7 +66,10 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   const content = fs.readFileSync(path.join(componentsDir, 'TaskSequencer.tsx'), 'utf8');
   expect(content).toContain('aria-label={isTimerRunning ? `Pause task: ${currentTask.title}` : `Start task: ${currentTask.title}`}');
   expect(content).toContain('aria-label={`Complete task: ${currentTask.title}`}');
-  expect(content).toContain('aria-label={`Skip task: ${currentTask.title}`}');
+  expect(content).toContain('aria-label={');
+  expect(content).toContain('nextTask');
+  expect(content).toContain('? `Skip ${currentTask.title}, proceed to ${nextTask.title}`');
+  expect(content).toContain(': `Skip task: ${currentTask.title}`');
   expect(content).toContain('aria-label={`Start task: ${task.title}`}');
   // New LinearProgress for task progress
   expect(content).toContain('aria-label="Current task progress"');

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -65,11 +65,10 @@ test('App.tsx exposes metric card tooltips with focus indicators and labels', ()
 test('TaskSequencer.tsx has contextual aria-labels and current step indicator', () => {
   const content = fs.readFileSync(path.join(componentsDir, 'TaskSequencer.tsx'), 'utf8');
   expect(content).toContain('aria-label={isTimerRunning ? `Pause task: ${currentTask.title}` : `Start task: ${currentTask.title}`}');
-  expect(content).toContain('aria-label={`Complete task: ${currentTask.title}`}');
-  expect(content).toContain('aria-label={');
-  expect(content).toContain('nextTask');
-  expect(content).toContain('? `Skip ${currentTask.title}, proceed to ${nextTask.title}`');
-  expect(content).toContain(': `Skip task: ${currentTask.title}`');
+  expect(content).toContain('getCompletionTransitionTask(currentTaskId, tasks, optimizedTasks)');
+  expect(content).toContain('getSkipTransitionTask(currentTaskId, optimizedTasks)');
+  expect(content).toMatch(/aria-label=\{\s*nextTaskAfterCompletion\s*\?\s*`Complete \$\{currentTask\.title\}, proceed to \$\{nextTaskAfterCompletion\.title\}`\s*:\s*`Complete \$\{currentTask\.title\}, finish ritual`\s*\}/);
+  expect(content).toMatch(/aria-label=\{\s*nextTaskAfterSkip\s*\?\s*`Skip \$\{currentTask\.title\}, proceed to \$\{nextTaskAfterSkip\.title\}`\s*:\s*`Skip task: \$\{currentTask\.title\}`\s*\}/);
   expect(content).toContain('aria-label={`Start task: ${task.title}`}');
   // New LinearProgress for task progress
   expect(content).toContain('aria-label="Current task progress"');

--- a/ui-dashboard/src/components/__tests__/taskSequencerTransitions.test.ts
+++ b/ui-dashboard/src/components/__tests__/taskSequencerTransitions.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest';
+
+import {
+  getCompletionTransitionTask,
+  getSkipTransitionTask,
+  type SequencerTransitionTask,
+} from '../taskSequencerTransitions';
+
+interface TestTask extends SequencerTransitionTask {
+  title: string;
+}
+
+const tasks: TestTask[] = [
+  { id: '1', title: 'Current', status: 'in_progress' },
+  { id: '2', title: 'Medium follow-up', status: 'pending' },
+  { id: '3', title: 'Low follow-up', status: 'pending' },
+];
+
+test('completion transition mirrors the sequencer completion action', () => {
+  const optimizedTasks = [tasks[2], tasks[1], tasks[0]];
+
+  expect(getCompletionTransitionTask('1', tasks, optimizedTasks)?.id).toBe('3');
+});
+
+test('completion transition falls back to remaining task order when optimized state is stale', () => {
+  const optimizedTasks = [tasks[0]];
+
+  expect(getCompletionTransitionTask('1', tasks, optimizedTasks)?.id).toBe('2');
+});
+
+test('completion transition returns null when the current task is the final incomplete task', () => {
+  const finalTaskState = [
+    { id: '1', title: 'Current', status: 'in_progress' },
+    { id: '2', title: 'Completed', status: 'completed' },
+  ] satisfies TestTask[];
+
+  expect(getCompletionTransitionTask('1', finalTaskState, [finalTaskState[0]])).toBeNull();
+});
+
+test('skip transition mirrors the sequencer skip action and wraps to the first task', () => {
+  const optimizedTasks = [tasks[2], tasks[1], tasks[0]];
+
+  expect(getSkipTransitionTask('3', optimizedTasks)?.id).toBe('2');
+  expect(getSkipTransitionTask('1', optimizedTasks)?.id).toBe('3');
+});
+
+test('skip transition returns null when there is no other task to skip to', () => {
+  expect(getSkipTransitionTask('1', [tasks[0]])).toBeNull();
+});

--- a/ui-dashboard/src/components/taskSequencerTransitions.ts
+++ b/ui-dashboard/src/components/taskSequencerTransitions.ts
@@ -1,0 +1,30 @@
+export interface SequencerTransitionTask {
+  id: string;
+  status: 'pending' | 'in_progress' | 'completed';
+}
+
+export const getCompletionTransitionTask = <Task extends SequencerTransitionTask>(
+  taskId: string | null,
+  allTasks: Task[],
+  optimizedTasks: Task[]
+): Task | null => {
+  if (!taskId) return null;
+
+  const remainingTasks = allTasks.filter(
+    (task) => task.id !== taskId && task.status !== 'completed'
+  );
+
+  return optimizedTasks.find((task) => task.id !== taskId) ?? remainingTasks[0] ?? null;
+};
+
+export const getSkipTransitionTask = <Task extends SequencerTransitionTask>(
+  taskId: string | null,
+  optimizedTasks: Task[]
+): Task | null => {
+  if (!taskId || optimizedTasks.length <= 1) return null;
+
+  const currentIndex = optimizedTasks.findIndex((task) => task.id === taskId);
+  const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % optimizedTasks.length;
+
+  return optimizedTasks[nextIndex] ?? null;
+};


### PR DESCRIPTION
### 💡 What: The UX enhancement added
Enhanced the "Skip" button in the `TaskSequencer` component with predictive context. The button now displays a dynamic tooltip (e.g., "Skip to: [Next Task Title]") and a descriptive ARIA label (e.g., "Skip [Current Task], proceed to [Next Task]") when multiple tasks are available.

### 🎯 Why: The user problem it solves
For users in high-concentration states or those with ADHD, generic "Skip" actions can create "sequential uncertainty"—a small but significant cognitive friction point. By revealing the immediate destination of a skip, the interface provides temporal grounding and makes the ritual sequence feel more controlled and predictable.

### ♿ Accessibility: Any a11y improvements made
- Improved the `aria-label` for the Skip button from a static "Skip task: [Current]" to a more informative "Skip [Current], proceed to [Next]".
- Verified the change with updated Vitest accessibility tests.

### 📓 Journal Entry
Added a new entry to `.Jules/palette.md` documenting the "Predictive Skip Tooltips" pattern.

---
*PR created automatically by Jules for task [7553322930986018207](https://jules.google.com/task/7553322930986018207) started by @hu3mann*