### PR TITLE
fix(rte): exclude generated artifacts from prescan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to Dopemux (including the PR Merge Specialist) will be docum
 - CI now includes wrapper-authority coverage, interactive import smoke, and the production `brand_lint.py` gate.
 
 ### Fixed
+- Repo-truth extractor prescan now excludes generated artifact, proof, audit, operator-local, and known secret-bearing paths from default corpus input, while allowlisting committed `.env.example` / `.env.template` / `.env.sample` placeholders so they remain in the corpus as text. Wired through `run_integrated_prescan_stage` so the v5 integrated path uses the same defaults.
 - Claude security review automation now resolves the repository-specific scan and false-positive instruction files referenced by `security-review.yml` and `ci-complete.yml`, preventing missing-path failures during AI security analysis.
 - Restored `compose.yml` as the canonical hand-authored Docker Compose file, removed the stale root unified compose variant, and hardened compose guard checks against future root-level compose drift.
 - Validation-only PRs are no longer shown as queued-for-merge before local verification is complete.

--- a/proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md
+++ b/proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md
@@ -1,0 +1,87 @@
+# TP-RTE-WALKER-006 Implementer Report
+
+## 1. Change summary
+
+Hardened the Repo Truth Extractor prescan corpus path so default walker input excludes generated RTE outputs, proof/audit outputs, local operator/runtime metadata, common caches, and known secret-bearing files before `FileEntry` creation or hashing.
+
+The v5 integrated prescan stage now explicitly passes the shared default excludes into `LibPrescanConfig`, so the actual `run_integrated_prescan_stage` path uses the hardened walker behavior.
+
+## 2. Authority used
+
+- `AGENTS.md`
+- `PROJECT.md`
+- `docs/research/mcp-customization/dopemux-constraints/RULES.md`
+- `docs/research/mcp-customization/dopemux-constraints/SYSTEM_RepoTruthExtractor.md`
+- `docs/research/mcp-customization/dopemux-constraints/TRUTH_GAPS.md`
+- `docs/research/mcp-customization/dopemux-constraints/TRUTH_INTERFACES.md`
+- `task-packets/INDEX.md`
+- `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `services/repo-truth-extractor/lib/prescan/models.py`
+- `services/repo-truth-extractor/lib/prescan/corpus_walker.py`
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- Existing tests under `services/repo-truth-extractor/tests/`
+
+## 3. Files created
+
+- `task-packets/generated/TP-RTE-WALKER-006.json`
+- `proof/TP-RTE-WALKER-006/PROOF.json`
+- `proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md`
+
+## 4. Files modified
+
+- `services/repo-truth-extractor/lib/prescan/models.py`
+- `services/repo-truth-extractor/lib/prescan/corpus_walker.py`
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `services/repo-truth-extractor/tests/test_prescan_core_pipeline.py`
+- `services/repo-truth-extractor/tests/test_prescan_v5_integration.py`
+- `task-packets/INDEX.md`
+
+## 5. Behavior changes
+
+- Added shared prescan default exclude constants for base dependency/build outputs, RTE generated output trees, operator-local/runtime metadata, caches, and known secret-bearing file patterns.
+- Changed `CorpusWalker` to normalize relative paths to POSIX form and skip effective exclude glob matches before adding them to the corpus inventory or hashing content.
+- Preserved `.claude/**` for now because current runtime code and tests intentionally include `.claude` in non-prescan governance/boundary phases.
+- Wired `run_integrated_prescan_stage` to pass `DEFAULT_PRESCAN_EXCLUDE_GLOBS` explicitly into `LibPrescanConfig`.
+
+## 6. Tests added
+
+- Generated-output default exclusion fixture.
+- Nested generated-output exclusion fixture.
+- Secret-bearing file exclusion fixture.
+- Prescan manifest source-preservation and excluded-input regression.
+- Integrated v5 prescan wrapper fixture proving generated and secret-bearing paths are absent from emitted `corpus_manifest.json`.
+
+## 7. Validation commands and exit codes
+
+- `python -m json.tool task-packets/generated/TP-RTE-WALKER-006.json` -> 0
+- Task packet Draft7 schema validation -> 0
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_core_pipeline.py` -> 0
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_v5_integration.py` -> 0
+- `python -m compileall -q services/repo-truth-extractor` -> 0
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "walker or prescan or corpus or exclude or secret"` -> 1; same failing subset reproduced on untouched starting checkout.
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_output_safety.py` -> 0
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_core_pipeline.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py` -> 0
+- `python -m json.tool proof/TP-RTE-WALKER-006/PROOF.json` -> 0
+- `git diff --check` -> 0
+- `pre-commit run --files <changed allowlist files>` -> 0
+
+## 8. Safety boundary confirmation
+
+- No provider calls were run.
+- No live extraction was run.
+- No batch execution was run.
+- No promptsets were touched.
+- No model routing files were touched.
+- No docs sweep was included.
+- No dependency files were changed.
+- No real extraction artifacts were mutated.
+
+## 9. Commit readiness
+
+Manual codereview of the scoped diff passed with no blockers found. Pre-commit passed for changed allowlist files. Commit, push, and PR creation remain pending at this report update.
+
+## 10. Residual risks and UNKNOWNs
+
+- Broader prescan-related pytest selection still has 7 failures that reproduce on the untouched starting checkout; they are not addressed by this TP.
+- `.claude/**` default prescan treatment remains intentionally unchanged due current runtime evidence. Whether prescan should classify or exclude parts of `.claude/**` is still `UNKNOWN`.
+- The walker still discovers files under excluded trees before skipping them because it uses `Path.rglob`; the poisoning blocker is closed at input/inventory level, not optimized at traversal-pruning level.

--- a/proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md
+++ b/proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md
@@ -63,7 +63,7 @@ The v5 integrated prescan stage now explicitly passes the shared default exclude
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_core_pipeline.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py` -> 0
 - `python -m json.tool proof/TP-RTE-WALKER-006/PROOF.json` -> 0
 - `git diff --check` -> 0
-- `pre-commit run --files <changed allowlist files>` -> 0
+- `pre-commit run --files services/repo-truth-extractor/lib/prescan/models.py services/repo-truth-extractor/lib/prescan/corpus_walker.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_prescan_core_pipeline.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py task-packets/INDEX.md task-packets/generated/TP-RTE-WALKER-006.json proof/TP-RTE-WALKER-006/PROOF.json proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md` -> 0
 
 ## 8. Safety boundary confirmation
 

--- a/proof/TP-RTE-WALKER-006/PROOF.json
+++ b/proof/TP-RTE-WALKER-006/PROOF.json
@@ -1,0 +1,163 @@
+{
+  "tp_id": "TP-RTE-WALKER-006",
+  "objective": "Close the RTE source-truth poisoning blocker by excluding generated outputs, proof/audit outputs, ignored runtime outputs, and known secret-bearing files from default Repo Truth Extractor prescan corpus input.",
+  "starting_head": "8ea182dd38ecd7754dff1c49224221cc49e390f4",
+  "ending_head": "PRE_COMMIT_CAVEAT: proof authored before commit; final commit SHA must be taken from git after commit because this file is part of the commit payload.",
+  "branch": "codex/tp-rte-walker-006",
+  "base_branch": "main",
+  "worktree_path": "/Users/hue/.codex/worktrees/tp-rte-walker-006",
+  "repo_identity": {
+    "repo_root": "/Users/hue/.codex/worktrees/tp-rte-walker-006",
+    "repo_marker": ".dopetaskroot",
+    "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "head_at_start": "8ea182dd38ecd7754dff1c49224221cc49e390f4",
+    "primary_checkout_observed": "/Users/hue/code/dopemux-mvp",
+    "dedicated_worktree_verified": true
+  },
+  "files_created": [
+    "task-packets/generated/TP-RTE-WALKER-006.json",
+    "proof/TP-RTE-WALKER-006/PROOF.json",
+    "proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md"
+  ],
+  "files_modified": [
+    "services/repo-truth-extractor/lib/prescan/models.py",
+    "services/repo-truth-extractor/lib/prescan/corpus_walker.py",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/tests/test_prescan_core_pipeline.py",
+    "services/repo-truth-extractor/tests/test_prescan_v5_integration.py",
+    "task-packets/INDEX.md"
+  ],
+  "tests_added_or_modified": [
+    "services/repo-truth-extractor/tests/test_prescan_core_pipeline.py",
+    "services/repo-truth-extractor/tests/test_prescan_v5_integration.py"
+  ],
+  "implementation_evidence": {
+    "generated_exclude_authority": "services/repo-truth-extractor/lib/prescan/models.py defines DEFAULT_GENERATED_OUTPUT_EXCLUDE_GLOBS and DEFAULT_PRESCAN_EXCLUDE_GLOBS.",
+    "secret_exclude_authority": "services/repo-truth-extractor/lib/prescan/models.py defines DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS for .env, .env.*, *.pem, *.key, *.p12, *.pfx, id_rsa, and id_ed25519.",
+    "walker_usage": "services/repo-truth-extractor/lib/prescan/corpus_walker.py skips paths matching effective exclude globs before FileEntry creation or hashing.",
+    "integrated_prescan_usage": "services/repo-truth-extractor/run_extraction_v5.py imports DEFAULT_PRESCAN_EXCLUDE_GLOBS and passes exclude_globs=list(DEFAULT_PRESCAN_EXCLUDE_GLOBS) into LibPrescanConfig in run_integrated_prescan_stage.",
+    "operator_local_decision": ".codex, .conport, .dopemux, .dopetask, and common cache dirs are excluded by default; .claude is preserved because run_extraction_v5.py and existing tests explicitly include .claude as a governance/boundary input in non-prescan phases."
+  },
+  "validation_commands": [
+    {
+      "command": "python -m json.tool task-packets/generated/TP-RTE-WALKER-006.json",
+      "exit_code": 0,
+      "summary": "Task packet parses as JSON."
+    },
+    {
+      "command": "python - <<'PY' ... Draft7Validator(dopetask-canonical-spec.json) ... PY",
+      "exit_code": 0,
+      "summary": "Task packet validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_core_pipeline.py",
+      "exit_code": 0,
+      "summary": "10 focused walker/core prescan tests passed, including generated-output and secret-bearing exclusion regressions."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_v5_integration.py",
+      "exit_code": 0,
+      "summary": "5 integration tests passed, including run_integrated_prescan_stage fixture proof that generated and secret-bearing paths are absent from integrated corpus_manifest.json."
+    },
+    {
+      "command": "python -m compileall -q services/repo-truth-extractor",
+      "exit_code": 0,
+      "summary": "Repo Truth Extractor Python files compile."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"walker or prescan or corpus or exclude or secret\"",
+      "exit_code": 1,
+      "summary": "Broader selection ran offline but failed 7 pre-existing/off-scope tests: code_prescan_truthfulness missing keys, prescan_contracts optimize payload shape, prescan_e2e incremental reuse count, and prescan_hardening tests requiring unavailable openai module."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q <same failing subset> (run from untouched starting checkout /Users/hue/.codex/worktrees/806d/dopemux-mvp)",
+      "exit_code": 1,
+      "summary": "The same 7 failures reproduce on the untouched starting checkout, supporting classification as pre-existing/off-scope."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_output_safety.py",
+      "exit_code": 0,
+      "summary": "5 existing output safety tests passed."
+    },
+    {
+      "command": "rg -n \"DEFAULT_PRESCAN_EXCLUDE_GLOBS|DEFAULT_GENERATED_OUTPUT_EXCLUDE_GLOBS|DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS|exclude_globs=list\\(DEFAULT_PRESCAN_EXCLUDE_GLOBS\\)|_matches_any_glob|\\.env\\.\\*|id_ed25519|id_rsa|\\*\\.pem|\\*\\.key\" <changed RTE files>",
+      "exit_code": 0,
+      "summary": "Safety grep confirms exclude constants and integrated prescan pass-through are present in the changed files."
+    },
+    {
+      "command": "git diff --name-only | rg '(^services/repo-truth-extractor/promptsets/|routing|batch_clients|package-lock|requirements|pyproject|docs/03-reference|docs/05-audit-reports|ui|cockpit|tui)'",
+      "exit_code": 1,
+      "summary": "Expected no-match result: changed files do not include promptsets, routing/model files, batch clients, dependency files, docs sweep paths, or cockpit/TUI paths."
+    },
+    {
+      "command": "git diff -- services/repo-truth-extractor/run_extraction_v5.py",
+      "exit_code": 0,
+      "summary": "Manual diff inspection: only integrated prescan default exclude import and explicit exclude_globs pass-through changed in run_extraction_v5.py."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_core_pipeline.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py",
+      "exit_code": 0,
+      "summary": "15 focused walker and integrated-prescan tests passed in the final combined run."
+    },
+    {
+      "command": "python -m json.tool proof/TP-RTE-WALKER-006/PROOF.json",
+      "exit_code": 0,
+      "summary": "Proof JSON parses."
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "summary": "No whitespace errors found."
+    },
+    {
+      "command": "pre-commit run --files services/repo-truth-extractor/lib/prescan/models.py services/repo-truth-extractor/lib/prescan/corpus_walker.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_prescan_core_pipeline.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py task-packets/INDEX.md task-packets/generated/TP-RTE-WALKER-006.json proof/TP-RTE-WALKER-006/PROOF.json proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md",
+      "exit_code": 0,
+      "summary": "Configured pre-commit hooks passed for changed allowlist files."
+    }
+  ],
+  "safety_boundary_confirmation": {
+    "live_provider_calls_run": false,
+    "live_extraction_runs_run": false,
+    "batch_execution_run": false,
+    "promptsets_touched": false,
+    "model_routing_touched": false,
+    "docs_sweep_included": false,
+    "provider_behavior_touched": false,
+    "dependency_files_changed": false,
+    "real_extraction_artifacts_mutated": false
+  },
+  "live_provider_calls_run": false,
+  "live_extraction_runs_run": false,
+  "batch_execution_run": false,
+  "generated_dirs_excluded_by_default": {
+    "value": true,
+    "evidence": "test_corpus_walker_excludes_generated_output_dirs_by_default, test_corpus_walker_excludes_nested_generated_output_dirs, and test_integrated_prescan_stage_uses_default_excludes passed."
+  },
+  "integrated_prescan_uses_excludes": {
+    "value": true,
+    "evidence": "run_integrated_prescan_stage passes exclude_globs=list(DEFAULT_PRESCAN_EXCLUDE_GLOBS) and integration test validates the emitted corpus_manifest.json."
+  },
+  "secret_bearing_files_excluded": {
+    "value": true,
+    "evidence": "DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS covers .env, .env.*, *.pem, *.key, *.p12, *.pfx, id_rsa, id_ed25519; focused walker and integration tests passed."
+  },
+  "legitimate_source_preserved": {
+    "value": true,
+    "evidence": "Focused tests assert src/**, services/**, docs/**, tests/**, task-packets/INDEX.md, and non-generated task packet files remain included."
+  },
+  "blockers": [],
+  "residual_risks": [
+    "The broader prescan-related pytest selection has 7 failures that reproduce on the untouched starting checkout; they remain outside this TP scope.",
+    ".claude/** is not excluded in prescan defaults because current run_extraction_v5.py and tests explicitly treat .claude as input for non-prescan governance/boundary phases; whether prescan should also preserve or classify .claude remains a scoped UNKNOWN for a future packet.",
+    "The walker still traverses excluded directories via Path.rglob before skipping matched files; this fixes source input poisoning but does not optimize traversal cost."
+  ],
+  "codereview_status": {
+    "status": "passed",
+    "evidence": "Manual diff review after tests found no scope expansion and no blockers; run_extraction_v5.py diff is limited to integrated prescan exclude wiring."
+  },
+  "precommit_status": {
+    "status": "passed",
+    "evidence": "pre-commit run --files completed with exit code 0 for changed allowlist files."
+  },
+  "final_git_status_before_commit": "## codex/tp-rte-walker-006; modified: services/repo-truth-extractor/lib/prescan/corpus_walker.py, services/repo-truth-extractor/lib/prescan/models.py, services/repo-truth-extractor/run_extraction_v5.py, services/repo-truth-extractor/tests/test_prescan_core_pipeline.py, services/repo-truth-extractor/tests/test_prescan_v5_integration.py, task-packets/INDEX.md; untracked: task-packets/generated/TP-RTE-WALKER-006.json; ignored proof directory: proof/TP-RTE-WALKER-006/ (staged later with git add -f due .gitignore proof/*)."
+}

--- a/proof/TP-RTE-WALKER-006/PROOF.json
+++ b/proof/TP-RTE-WALKER-006/PROOF.json
@@ -2,7 +2,9 @@
   "tp_id": "TP-RTE-WALKER-006",
   "objective": "Close the RTE source-truth poisoning blocker by excluding generated outputs, proof/audit outputs, ignored runtime outputs, and known secret-bearing files from default Repo Truth Extractor prescan corpus input.",
   "starting_head": "8ea182dd38ecd7754dff1c49224221cc49e390f4",
-  "ending_head": "PRE_COMMIT_CAVEAT: proof authored before commit; final commit SHA must be taken from git after commit because this file is part of the commit payload.",
+  "ending_head": "8c8756eba924d89b3e35368b15ededb94c8911ab",
+  "ending_head_note": "Branch tip moves with each review-feedback commit on PR #606; this field records the latest verified implementation snapshot. See pr_url for the live HEAD.",
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/606",
   "branch": "codex/tp-rte-walker-006",
   "base_branch": "main",
   "worktree_path": "/Users/hue/.codex/worktrees/tp-rte-walker-006",
@@ -45,7 +47,7 @@
       "summary": "Task packet parses as JSON."
     },
     {
-      "command": "python - <<'PY' ... Draft7Validator(dopetask-canonical-spec.json) ... PY",
+      "command": "python -c \"import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-WALKER-006.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); raise SystemExit(0 if not errs else (print(errs) or 1))\"",
       "exit_code": 0,
       "summary": "Task packet validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
     },
@@ -70,7 +72,7 @@
       "summary": "Broader selection ran offline but failed 7 pre-existing/off-scope tests: code_prescan_truthfulness missing keys, prescan_contracts optimize payload shape, prescan_e2e incremental reuse count, and prescan_hardening tests requiring unavailable openai module."
     },
     {
-      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q <same failing subset> (run from untouched starting checkout /Users/hue/.codex/worktrees/806d/dopemux-mvp)",
+      "command": "(cd /Users/hue/.codex/worktrees/806d/dopemux-mvp && RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"walker or prescan or corpus or exclude or secret\")",
       "exit_code": 1,
       "summary": "The same 7 failures reproduce on the untouched starting checkout, supporting classification as pre-existing/off-scope."
     },
@@ -80,7 +82,7 @@
       "summary": "5 existing output safety tests passed."
     },
     {
-      "command": "rg -n \"DEFAULT_PRESCAN_EXCLUDE_GLOBS|DEFAULT_GENERATED_OUTPUT_EXCLUDE_GLOBS|DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS|exclude_globs=list\\(DEFAULT_PRESCAN_EXCLUDE_GLOBS\\)|_matches_any_glob|\\.env\\.\\*|id_ed25519|id_rsa|\\*\\.pem|\\*\\.key\" <changed RTE files>",
+      "command": "rg -n \"DEFAULT_PRESCAN_EXCLUDE_GLOBS|DEFAULT_GENERATED_OUTPUT_EXCLUDE_GLOBS|DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS|exclude_globs=list\\(DEFAULT_PRESCAN_EXCLUDE_GLOBS\\)|_matches_any_glob|\\.env\\.\\*|id_ed25519|id_rsa|\\*\\.pem|\\*\\.key\" services/repo-truth-extractor/lib/prescan/models.py services/repo-truth-extractor/lib/prescan/corpus_walker.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_prescan_core_pipeline.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py",
       "exit_code": 0,
       "summary": "Safety grep confirms exclude constants and integrated prescan pass-through are present in the changed files."
     },

--- a/services/repo-truth-extractor/lib/prescan/corpus_walker.py
+++ b/services/repo-truth-extractor/lib/prescan/corpus_walker.py
@@ -29,7 +29,8 @@ HARDCODED_EXCLUDE_DIRS = frozenset(
     {
         "node_modules", ".venv", "venv", "__pycache__", ".git", "dist", "build",
         ".mypy_cache", ".pytest_cache", ".ruff_cache", "htmlcov", ".tox",
-        ".eggs", ".egg-info", ".DS_Store",
+        ".eggs", ".egg-info", ".DS_Store", ".codex", ".conport",
+        ".dopemux", ".dopetask",
     }
 )
 
@@ -46,11 +47,15 @@ class CorpusWalker:
             if not path.is_file():
                 continue
 
+            rel_path = self._relative_posix_path(path, repo_root)
+
             # Skip excluded directories
             if self._is_excluded_dir(path, repo_root):
                 continue
 
-            rel_path = str(path.relative_to(repo_root))
+            if self._matches_any_glob(rel_path, self._effective_exclude_globs()):
+                continue
+
             ext = path.suffix.lower()
             size = path.stat().st_size
 
@@ -64,9 +69,6 @@ class CorpusWalker:
             if ext in BINARY_EXTENSIONS:
                 entry.include = False
                 entry.exclude_reason = f"binary_extension:{ext}"
-            elif self._matches_any_glob(rel_path, self._effective_exclude_globs()):
-                entry.include = False
-                entry.exclude_reason = "matched_exclude_glob"
             elif size > self._effective_max_file_size(ext):
                 entry.include = False
                 entry.exclude_reason = f"size_exceeds_max:{size}>{self.config.max_file_size}"
@@ -96,13 +98,17 @@ class CorpusWalker:
 
         return entries
 
+    def _relative_posix_path(self, path: Path, repo_root: Path) -> str:
+        rel = path.relative_to(repo_root)
+        return PurePosixPath(*rel.parts).as_posix()
+
     def _is_excluded_dir(self, path: Path, repo_root: Path) -> bool:
         """Check if any path component is a hardcoded exclude."""
         try:
             rel = path.relative_to(repo_root)
         except ValueError:
             return False
-        for part in rel.parts:
+        for part in PurePosixPath(*rel.parts).parts:
             if part in HARDCODED_EXCLUDE_DIRS:
                 return True
             if part.endswith(".egg-info"):
@@ -111,10 +117,12 @@ class CorpusWalker:
 
     def _matches_any_glob(self, rel_path_str: str, globs: list[str]) -> bool:
         """Check if relative path matches any glob pattern."""
+        rel_path = PurePosixPath(rel_path_str.replace("\\", "/")).as_posix()
         for pattern in globs:
-            if fnmatch.fnmatch(rel_path_str, pattern):
+            normalized_pattern = PurePosixPath(pattern.replace("\\", "/")).as_posix()
+            if fnmatch.fnmatchcase(rel_path, normalized_pattern):
                 return True
-            if fnmatch.fnmatch(rel_path_str + "/", pattern):
+            if fnmatch.fnmatchcase(rel_path + "/", normalized_pattern):
                 return True
         return False
 

--- a/services/repo-truth-extractor/lib/prescan/corpus_walker.py
+++ b/services/repo-truth-extractor/lib/prescan/corpus_walker.py
@@ -2,7 +2,11 @@ import fnmatch
 import hashlib
 import logging
 from pathlib import Path, PurePosixPath
-from .models import FileEntry, PrescanConfig
+from .models import (
+    DEFAULT_SECRET_BEARING_ALLOWLIST_BASENAMES,
+    FileEntry,
+    PrescanConfig,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +38,10 @@ HARDCODED_EXCLUDE_DIRS = frozenset(
     }
 )
 
+SECRET_BEARING_ALLOWLIST_BASENAMES = frozenset(
+    DEFAULT_SECRET_BEARING_ALLOWLIST_BASENAMES
+)
+
 class CorpusWalker:
     def __init__(self, config: PrescanConfig):
         self.config = config
@@ -48,12 +56,15 @@ class CorpusWalker:
                 continue
 
             rel_path = self._relative_posix_path(path, repo_root)
+            template_allowlisted = path.name in SECRET_BEARING_ALLOWLIST_BASENAMES
 
             # Skip excluded directories
             if self._is_excluded_dir(path, repo_root):
                 continue
 
-            if self._matches_any_glob(rel_path, self._effective_exclude_globs()):
+            if not template_allowlisted and self._matches_any_glob(
+                rel_path, self._effective_exclude_globs()
+            ):
                 continue
 
             ext = path.suffix.lower()
@@ -77,7 +88,11 @@ class CorpusWalker:
                 entry.exclude_reason = (
                     f"large_json_blob:{size}>{self.config.large_json_threshold}"
                 )
-            elif ext not in TEXT_EXTENSIONS and ext != "":
+            elif (
+                ext not in TEXT_EXTENSIONS
+                and ext != ""
+                and not template_allowlisted
+            ):
                 # Unknown extension — exclude unless it's small and looks textual
                 entry.include = False
                 entry.exclude_reason = f"unknown_extension:{ext}"

--- a/services/repo-truth-extractor/lib/prescan/corpus_walker.py
+++ b/services/repo-truth-extractor/lib/prescan/corpus_walker.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path, PurePosixPath
 from .models import (
     DEFAULT_SECRET_BEARING_ALLOWLIST_BASENAMES,
+    DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS,
     FileEntry,
     PrescanConfig,
 )
@@ -41,6 +42,7 @@ HARDCODED_EXCLUDE_DIRS = frozenset(
 SECRET_BEARING_ALLOWLIST_BASENAMES = frozenset(
     DEFAULT_SECRET_BEARING_ALLOWLIST_BASENAMES
 )
+SECRET_BEARING_EXCLUDE_GLOB_SET = frozenset(DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS)
 
 class CorpusWalker:
     def __init__(self, config: PrescanConfig):
@@ -62,8 +64,16 @@ class CorpusWalker:
             if self._is_excluded_dir(path, repo_root):
                 continue
 
+            non_secret_excludes, secret_excludes = self._partition_exclude_globs(
+                self._effective_exclude_globs()
+            )
+            # Path-level excludes (generated trees, caches, operator-local dirs) are
+            # always honored — the secret-template allowlist only overrides
+            # secret-bearing patterns, not unrelated directory excludes.
+            if self._matches_any_glob(rel_path, non_secret_excludes):
+                continue
             if not template_allowlisted and self._matches_any_glob(
-                rel_path, self._effective_exclude_globs()
+                rel_path, secret_excludes
             ):
                 continue
 
@@ -140,6 +150,19 @@ class CorpusWalker:
             if fnmatch.fnmatchcase(rel_path + "/", normalized_pattern):
                 return True
         return False
+
+    def _partition_exclude_globs(
+        self, globs: list[str]
+    ) -> tuple[list[str], list[str]]:
+        """Split exclude globs into (non_secret, secret) groups."""
+        non_secret: list[str] = []
+        secret: list[str] = []
+        for pattern in globs:
+            if pattern in SECRET_BEARING_EXCLUDE_GLOB_SET:
+                secret.append(pattern)
+            else:
+                non_secret.append(pattern)
+        return non_secret, secret
 
     def _effective_exclude_globs(self) -> list[str]:
         """Return exclude globs adjusted for deep mode.

--- a/services/repo-truth-extractor/lib/prescan/models.py
+++ b/services/repo-truth-extractor/lib/prescan/models.py
@@ -11,6 +11,10 @@ def _root_and_nested_globs(*dir_names: str) -> tuple[str, ...]:
     return tuple(patterns)
 
 
+def _root_globs(*dir_names: str) -> tuple[str, ...]:
+    return tuple(f"{dir_name}/**" for dir_name in dir_names)
+
+
 DEFAULT_BASE_EXCLUDE_GLOBS = (
     ".git/**",
     "**/.git/**",
@@ -29,13 +33,20 @@ DEFAULT_BASE_EXCLUDE_GLOBS = (
 )
 
 DEFAULT_GENERATED_OUTPUT_EXCLUDE_GLOBS = (
-    *_root_and_nested_globs(
+    # Root-only: these directory names also occur as legitimate source/doc trees
+    # (e.g. src/dopemux/extraction, docs/02-how-to/extraction, docs/archive/claudedocs),
+    # so excluding `**/<name>/**` would drop canonical sources.
+    *_root_globs(
         "extraction",
+        "claudedocs",
+    ),
+    # Root + nested: these names are unambiguously generated output trees in this
+    # repo and have no legitimate non-generated occurrences.
+    *_root_and_nested_globs(
         "proof",
         "out",
         "audit_prep",
         "_audit_out",
-        "claudedocs",
     ),
     "task-packets/generated/**",
     "**/task-packets/generated/**",

--- a/services/repo-truth-extractor/lib/prescan/models.py
+++ b/services/repo-truth-extractor/lib/prescan/models.py
@@ -4,6 +4,95 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 
+def _root_and_nested_globs(*dir_names: str) -> tuple[str, ...]:
+    patterns: list[str] = []
+    for dir_name in dir_names:
+        patterns.extend((f"{dir_name}/**", f"**/{dir_name}/**"))
+    return tuple(patterns)
+
+
+DEFAULT_BASE_EXCLUDE_GLOBS = (
+    ".git/**",
+    "**/.git/**",
+    "node_modules/**",
+    "**/node_modules/**",
+    ".venv/**",
+    "**/.venv/**",
+    "venv/**",
+    "**/venv/**",
+    "__pycache__/**",
+    "**/__pycache__/**",
+    "dist/**",
+    "**/dist/**",
+    "build/**",
+    "**/build/**",
+)
+
+DEFAULT_GENERATED_OUTPUT_EXCLUDE_GLOBS = (
+    *_root_and_nested_globs(
+        "extraction",
+        "proof",
+        "out",
+        "audit_prep",
+        "_audit_out",
+        "claudedocs",
+    ),
+    "task-packets/generated/**",
+    "**/task-packets/generated/**",
+)
+
+DEFAULT_OPERATOR_LOCAL_EXCLUDE_GLOBS = (
+    ".codex/**",
+    "**/.codex/**",
+    ".conport/**",
+    "**/.conport/**",
+    ".dopemux/**",
+    "**/.dopemux/**",
+    ".dopetask/**",
+    "**/.dopetask/**",
+    ".pytest_cache/**",
+    "**/.pytest_cache/**",
+    ".mypy_cache/**",
+    "**/.mypy_cache/**",
+    ".ruff_cache/**",
+    "**/.ruff_cache/**",
+    ".tox/**",
+    "**/.tox/**",
+    ".eggs/**",
+    "**/.eggs/**",
+    "*.egg-info/**",
+    "**/*.egg-info/**",
+    "htmlcov/**",
+    "**/htmlcov/**",
+)
+
+DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS = (
+    ".env",
+    ".env.*",
+    "**/.env",
+    "**/.env.*",
+    "*.pem",
+    "**/*.pem",
+    "*.key",
+    "**/*.key",
+    "*.p12",
+    "**/*.p12",
+    "*.pfx",
+    "**/*.pfx",
+    "id_rsa",
+    "**/id_rsa",
+    "id_ed25519",
+    "**/id_ed25519",
+)
+
+DEFAULT_PRESCAN_EXCLUDE_GLOBS = (
+    *DEFAULT_BASE_EXCLUDE_GLOBS,
+    *DEFAULT_GENERATED_OUTPUT_EXCLUDE_GLOBS,
+    *DEFAULT_OPERATOR_LOCAL_EXCLUDE_GLOBS,
+    *DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS,
+)
+
+
 @dataclass
 class FileEntry:
     rel_path: str
@@ -52,15 +141,9 @@ class PrescanConfig:
     repo_root: Path
     output_dir: Path
     include_globs: list[str] = field(default_factory=lambda: ["**/*"])
-    exclude_globs: list[str] = field(default_factory=lambda: [
-        ".git/**",
-        "node_modules/**",
-        ".venv/**",
-        "venv/**",
-        "__pycache__/**",
-        "dist/**",
-        "build/**",
-    ])
+    exclude_globs: list[str] = field(
+        default_factory=lambda: list(DEFAULT_PRESCAN_EXCLUDE_GLOBS)
+    )
     max_file_size: int = 5 * 1024 * 1024
     large_json_threshold: int = 256 * 1024
     max_corpus_size: int = 500 * 1024 * 1024

--- a/services/repo-truth-extractor/lib/prescan/models.py
+++ b/services/repo-truth-extractor/lib/prescan/models.py
@@ -85,6 +85,15 @@ DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS = (
     "**/id_ed25519",
 )
 
+# Repo-visible env templates that look like secret-bearing files but are intentionally
+# committed (placeholders only). These are kept in the prescan corpus and treated as text.
+# See docs/02-how-to/create-llm-archive.md for the parallel rule on .env handling.
+DEFAULT_SECRET_BEARING_ALLOWLIST_BASENAMES = (
+    ".env.example",
+    ".env.template",
+    ".env.sample",
+)
+
 DEFAULT_PRESCAN_EXCLUDE_GLOBS = (
     *DEFAULT_BASE_EXCLUDE_GLOBS,
     *DEFAULT_GENERATED_OUTPUT_EXCLUDE_GLOBS,

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -6523,6 +6523,7 @@ def run_integrated_prescan_stage(
     # 2. Run local prescan
     try:
         from lib.prescan.engine import PrescanEngine
+        from lib.prescan.models import DEFAULT_PRESCAN_EXCLUDE_GLOBS
         from lib.prescan.models import PrescanConfig as LibPrescanConfig
     except ImportError as e:
         logger.warning(f"Prescan library not available: {e}")
@@ -6537,6 +6538,7 @@ def run_integrated_prescan_stage(
         output_dir=prescan_output_dir,
         online_authorized=cfg.prescan_online or cfg.allow_online_llm,
         allow_scope_reduction=cfg.prescan_allow_scope_reduction,
+        exclude_globs=list(DEFAULT_PRESCAN_EXCLUDE_GLOBS),
         verbose=True,
     )
 

--- a/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
+++ b/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
@@ -180,6 +180,44 @@ def test_corpus_walker_excludes_secret_bearing_files_by_default(tmp_path: Path) 
     assert {"src/app.py", "docs/source.md"} <= _included_paths(entries)
 
 
+def test_corpus_walker_allowlists_env_templates(tmp_path: Path) -> None:
+    """Repo-visible env templates must remain in prescan corpus, while real .env files stay excluded."""
+    templates = {
+        ".env.example",
+        ".env.template",
+        ".env.sample",
+        "nested/.env.example",
+        "config/.env.template",
+    }
+    real_secrets = {
+        ".env",
+        ".env.local",
+        ".env.production",
+        "nested/.env",
+    }
+    for rel_path in sorted(templates):
+        _write_fixture_file(tmp_path, rel_path, "API_KEY=placeholder\n")
+    for rel_path in sorted(real_secrets):
+        _write_fixture_file(tmp_path, rel_path, "SECRET_VALUE_SHOULD_NOT_APPEAR=true\n")
+
+    config = PrescanConfig(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "prescan-output",
+        enable_code_prescan=False,
+        enable_git_enrichment=False,
+    )
+    entries = CorpusWalker(config).walk()
+
+    paths = _all_paths(entries)
+    included = _included_paths(entries)
+    assert templates <= included, (
+        f"env templates dropped from corpus: {templates - included}"
+    )
+    assert real_secrets.isdisjoint(paths), (
+        f"real secret files leaked into corpus: {real_secrets & paths}"
+    )
+
+
 def test_prescan_engine_manifest_preserves_source_and_omits_excluded_inputs(tmp_path: Path) -> None:
     """The emitted prescan manifest should not reintroduce excluded generated or secret paths."""
     _write_fixture_file(tmp_path, "src/app.py", "def app():\n    return 1\n")

--- a/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
+++ b/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
@@ -126,7 +126,12 @@ def test_corpus_walker_excludes_generated_output_dirs_by_default(tmp_path: Path)
 
 
 def test_corpus_walker_excludes_nested_generated_output_dirs(tmp_path: Path) -> None:
-    """Nested generated trees are excluded when the walker sees nested workspace copies."""
+    """Nested generated trees are excluded for unambiguous output names (proof, out, task-packets/generated).
+
+    Ambiguous names like ``extraction`` and ``claudedocs`` are only excluded at repo
+    root, since they also appear as legitimate source/doc directories
+    (e.g. ``src/dopemux/extraction``, ``docs/archive/claudedocs``).
+    """
     _write_fixture_file(tmp_path, "src/app.py")
     _write_fixture_file(tmp_path, "some/project/extraction/generated.json")
     _write_fixture_file(tmp_path, "nested/proof/PROOF.json")
@@ -142,11 +147,49 @@ def test_corpus_walker_excludes_nested_generated_output_dirs(tmp_path: Path) -> 
     entries = CorpusWalker(config).walk()
 
     paths = _all_paths(entries)
-    assert "src/app.py" in _included_paths(entries)
-    assert "some/project/extraction/generated.json" not in paths
+    included = _included_paths(entries)
+    assert "src/app.py" in included
+    # extraction is ambiguous → nested instances stay in corpus
+    assert "some/project/extraction/generated.json" in included
+    # proof, out, task-packets/generated remain excluded at any nesting depth
     assert "nested/proof/PROOF.json" not in paths
     assert "nested/out/report.md" not in paths
     assert "nested/task-packets/generated/TP-OLD.json" not in paths
+
+
+def test_corpus_walker_includes_legit_extraction_and_claudedocs_subtrees(tmp_path: Path) -> None:
+    """Legit nested 'extraction' and 'claudedocs' dirs (real source/docs) must be included."""
+    legitimate = {
+        "src/dopemux/extraction/parser.py",
+        "services/repo-truth-extractor/extraction/runtime.py",
+        "docs/02-how-to/extraction/guide.md",
+        "docs/03-reference/extraction/spec.md",
+        "docs/archive/claudedocs/old-note.md",
+    }
+    # And the root-level generated dirs must still be excluded.
+    generated_at_root = {
+        "extraction/run/output.json",
+        "claudedocs/work-note.md",
+    }
+    for rel_path in sorted(legitimate | generated_at_root):
+        _write_fixture_file(tmp_path, rel_path)
+
+    config = PrescanConfig(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "prescan-output",
+        enable_code_prescan=False,
+        enable_git_enrichment=False,
+    )
+    entries = CorpusWalker(config).walk()
+
+    paths = _all_paths(entries)
+    included = _included_paths(entries)
+    assert legitimate <= included, (
+        f"legit nested extraction/claudedocs dropped: {legitimate - included}"
+    )
+    assert generated_at_root.isdisjoint(paths), (
+        f"root-level generated tree leaked: {generated_at_root & paths}"
+    )
 
 
 def test_corpus_walker_excludes_secret_bearing_files_by_default(tmp_path: Path) -> None:
@@ -216,6 +259,39 @@ def test_corpus_walker_allowlists_env_templates(tmp_path: Path) -> None:
     assert real_secrets.isdisjoint(paths), (
         f"real secret files leaked into corpus: {real_secrets & paths}"
     )
+
+
+def test_corpus_walker_template_allowlist_does_not_bypass_directory_excludes(
+    tmp_path: Path,
+) -> None:
+    """Env templates are allowlisted only against secret-bearing patterns; directory excludes still apply."""
+    _write_fixture_file(tmp_path, ".env.example", "API_KEY=placeholder\n")
+    _write_fixture_file(tmp_path, "src/.env.template", "API_KEY=placeholder\n")
+    # These should remain excluded even though basename is allowlisted: directory excludes win.
+    _write_fixture_file(
+        tmp_path, "proof/TP-FOO/.env.example", "LEAKED=should_be_excluded\n"
+    )
+    _write_fixture_file(
+        tmp_path, "task-packets/generated/.env.example", "LEAKED=should_be_excluded\n"
+    )
+    _write_fixture_file(
+        tmp_path, "extraction/.env.example", "LEAKED=should_be_excluded\n"
+    )
+
+    config = PrescanConfig(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "prescan-output",
+        enable_code_prescan=False,
+        enable_git_enrichment=False,
+    )
+    entries = CorpusWalker(config).walk()
+
+    paths = _all_paths(entries)
+    included = _included_paths(entries)
+    assert {".env.example", "src/.env.template"} <= included
+    assert "proof/TP-FOO/.env.example" not in paths
+    assert "task-packets/generated/.env.example" not in paths
+    assert "extraction/.env.example" not in paths
 
 
 def test_prescan_engine_manifest_preserves_source_and_omits_excluded_inputs(tmp_path: Path) -> None:

--- a/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
+++ b/services/repo-truth-extractor/tests/test_prescan_core_pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sys
 from pathlib import Path
@@ -17,6 +18,20 @@ from lib.prescan.classifier import Classifier
 from lib.prescan.corpus_walker import CorpusWalker
 from lib.prescan.engine import PrescanEngine
 from lib.prescan.models import FileEntry, PrescanConfig
+
+
+def _write_fixture_file(root: Path, rel_path: str, text: str = "fixture\n") -> None:
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _included_paths(entries: list[FileEntry]) -> set[str]:
+    return {entry.rel_path for entry in entries if entry.include}
+
+
+def _all_paths(entries: list[FileEntry]) -> set[str]:
+    return {entry.rel_path for entry in entries}
 
 
 def test_corpus_walker_finds_files(tmp_path: Path) -> None:
@@ -72,6 +87,132 @@ def test_corpus_walker_respects_exclusions(tmp_path: Path) -> None:
     assert "src/main.py" in paths
     assert not any("node_modules" in p for p in paths)
     assert not any(".venv" in p for p in paths)
+
+
+def test_corpus_walker_excludes_generated_output_dirs_by_default(tmp_path: Path) -> None:
+    """Generated RTE/proof/audit output trees must not become source corpus input."""
+    legitimate = {
+        "src/app.py",
+        "services/example/service.py",
+        "docs/source.md",
+        "tests/test_example.py",
+        "task-packets/INDEX.md",
+        "task-packets/TP-SOURCE.json",
+    }
+    generated = {
+        "extraction/repo-truth-extractor/v5/runs/old/PROOF_PACK.json",
+        "proof/TP-OLD/PROOF.json",
+        "out/report.md",
+        "audit_prep/input.md",
+        "task-packets/generated/TP-OLD.json",
+        "_audit_out/findings.md",
+        "claudedocs/old.md",
+    }
+    for rel_path in sorted(legitimate | generated):
+        _write_fixture_file(tmp_path, rel_path)
+
+    config = PrescanConfig(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "prescan-output",
+        enable_code_prescan=False,
+        enable_git_enrichment=False,
+    )
+    entries = CorpusWalker(config).walk()
+
+    paths = _all_paths(entries)
+    included = _included_paths(entries)
+    assert legitimate <= included
+    assert generated.isdisjoint(paths)
+
+
+def test_corpus_walker_excludes_nested_generated_output_dirs(tmp_path: Path) -> None:
+    """Nested generated trees are excluded when the walker sees nested workspace copies."""
+    _write_fixture_file(tmp_path, "src/app.py")
+    _write_fixture_file(tmp_path, "some/project/extraction/generated.json")
+    _write_fixture_file(tmp_path, "nested/proof/PROOF.json")
+    _write_fixture_file(tmp_path, "nested/out/report.md")
+    _write_fixture_file(tmp_path, "nested/task-packets/generated/TP-OLD.json")
+
+    config = PrescanConfig(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "prescan-output",
+        enable_code_prescan=False,
+        enable_git_enrichment=False,
+    )
+    entries = CorpusWalker(config).walk()
+
+    paths = _all_paths(entries)
+    assert "src/app.py" in _included_paths(entries)
+    assert "some/project/extraction/generated.json" not in paths
+    assert "nested/proof/PROOF.json" not in paths
+    assert "nested/out/report.md" not in paths
+    assert "nested/task-packets/generated/TP-OLD.json" not in paths
+
+
+def test_corpus_walker_excludes_secret_bearing_files_by_default(tmp_path: Path) -> None:
+    """Secret-bearing local files must not be inventoried for prescan input."""
+    secrets = {
+        ".env",
+        ".env.local",
+        ".env.production",
+        "private.pem",
+        "deploy.key",
+        "id_rsa",
+        "id_ed25519",
+        "nested/.env",
+        "nested/private.pem",
+    }
+    for rel_path in sorted(secrets):
+        _write_fixture_file(tmp_path, rel_path, "SECRET_VALUE_SHOULD_NOT_APPEAR=true\n")
+    _write_fixture_file(tmp_path, "src/app.py", "print('ok')\n")
+    _write_fixture_file(tmp_path, "docs/source.md", "# source\n")
+
+    config = PrescanConfig(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "prescan-output",
+        enable_code_prescan=False,
+        enable_git_enrichment=False,
+    )
+    entries = CorpusWalker(config).walk()
+
+    paths = _all_paths(entries)
+    assert secrets.isdisjoint(paths)
+    assert {"src/app.py", "docs/source.md"} <= _included_paths(entries)
+
+
+def test_prescan_engine_manifest_preserves_source_and_omits_excluded_inputs(tmp_path: Path) -> None:
+    """The emitted prescan manifest should not reintroduce excluded generated or secret paths."""
+    _write_fixture_file(tmp_path, "src/app.py", "def app():\n    return 1\n")
+    _write_fixture_file(tmp_path, "services/example/service.py", "def service():\n    return 1\n")
+    _write_fixture_file(tmp_path, "docs/source.md", "# Source\n")
+    _write_fixture_file(tmp_path, "tests/test_example.py", "def test_example():\n    assert True\n")
+    _write_fixture_file(tmp_path, "proof/TP-OLD/PROOF.json", "{}\n")
+    _write_fixture_file(tmp_path, "extraction/repo-truth-extractor/v5/runs/old/PROOF_PACK.json", "{}\n")
+    _write_fixture_file(tmp_path, ".env", "SECRET_VALUE_SHOULD_NOT_APPEAR=true\n")
+
+    config = PrescanConfig(
+        repo_root=tmp_path,
+        output_dir=tmp_path / "prescan-output",
+        enable_code_prescan=False,
+        enable_git_enrichment=False,
+        batch_mode=False,
+        cost_estimate=False,
+    )
+    result = PrescanEngine(config).run()
+
+    assert result.success is True
+    manifest = json.loads((tmp_path / "prescan-output" / "corpus_manifest.json").read_text())
+    paths = {item["rel_path"] for item in manifest}
+    assert {
+        "src/app.py",
+        "services/example/service.py",
+        "docs/source.md",
+        "tests/test_example.py",
+    } <= paths
+    assert "proof/TP-OLD/PROOF.json" not in paths
+    assert "extraction/repo-truth-extractor/v5/runs/old/PROOF_PACK.json" not in paths
+    assert ".env" not in paths
+    assert "SECRET_VALUE_SHOULD_NOT_APPEAR" not in json.dumps(manifest)
 
 
 def test_classifier_categorizes_files(tmp_path: Path) -> None:

--- a/services/repo-truth-extractor/tests/test_prescan_v5_integration.py
+++ b/services/repo-truth-extractor/tests/test_prescan_v5_integration.py
@@ -6,11 +6,14 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[3]
 SERVICE_ROOT = ROOT / "services" / "repo-truth-extractor"
 if str(SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(SERVICE_ROOT))
 
+import run_extraction_v5 as runner
 from lib.intelligence_router import IntelligenceRouter
 from lib.prescan.engine import PrescanEngine
 from lib.prescan.models import FileEntry, PrescanConfig
@@ -207,6 +210,112 @@ def test_grok_passes_result_structure_compatible_with_router(tmp_path: Path) -> 
     assert "src/old_impl.py" in router.skip_list  # Original skip list
     assert router._phase_routing.get("src/api.py") == "phase2"
     assert len(router._model_routing) == 1
+
+
+def _write_fixture_file(root: Path, rel_path: str, text: str = "fixture\n") -> None:
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _make_runner_config() -> runner.RunnerConfig:
+    return runner.RunnerConfig(
+        dry_run=True,
+        max_files_docs=35,
+        max_files_code=20,
+        max_chars=650000,
+        max_request_bytes=200000,
+        file_truncate_chars=70000,
+        home_scan_mode="safe",
+        resume=False,
+        fail_fast_auth=True,
+        gemini_auth_mode="auto",
+        gemini_transport="sdk",
+        openai_transport="openai_sdk",
+        xai_transport="openai_sdk",
+        retry_policy="default",
+        retry_max_attempts=1,
+        retry_base_seconds=0.0,
+        retry_max_seconds=0.0,
+        phase_auth_fail_threshold=1,
+        partition_workers=1,
+        debug_phase_inputs=False,
+        fail_fast_missing_inputs=False,
+        routing_policy="cost",
+        batch_mode=False,
+        live_ok=False,
+        prescan_skip=False,
+        prescan_online=False,
+        allow_online_llm=False,
+    )
+
+
+def test_integrated_prescan_stage_uses_default_excludes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The actual v5 integrated prescan wrapper must apply the hardened walker excludes."""
+    repo_root = tmp_path / "repo"
+    run_root = tmp_path / "run"
+    _write_fixture_file(repo_root, "src/app.py", "def app():\n    return 1\n")
+    _write_fixture_file(repo_root, "services/example/service.py", "def service():\n    return 1\n")
+    _write_fixture_file(repo_root, "docs/source.md", "# Source\n")
+    _write_fixture_file(repo_root, "tests/test_example.py", "def test_example():\n    assert True\n")
+    _write_fixture_file(repo_root, "task-packets/INDEX.md", "# Index\n")
+    _write_fixture_file(repo_root, "task-packets/TP-SOURCE.json", "{}\n")
+    _write_fixture_file(repo_root, "task-packets/generated/TP-OLD.json", "{}\n")
+    _write_fixture_file(repo_root, "extraction/repo-truth-extractor/v5/runs/old/PROOF_PACK.json", "{}\n")
+    _write_fixture_file(repo_root, "proof/TP-OLD/PROOF.json", "{}\n")
+    _write_fixture_file(repo_root, "out/report.md", "# old report\n")
+    _write_fixture_file(repo_root, "audit_prep/input.md", "# audit\n")
+    _write_fixture_file(repo_root, "_audit_out/findings.md", "# findings\n")
+    _write_fixture_file(repo_root, "claudedocs/old.md", "# old\n")
+    _write_fixture_file(repo_root, ".env", "SECRET_VALUE_SHOULD_NOT_APPEAR=true\n")
+    _write_fixture_file(repo_root, "deploy.key", "SECRET_VALUE_SHOULD_NOT_APPEAR\n")
+
+    monkeypatch.setattr(
+        PrescanEngine,
+        "_run_stage0",
+        lambda self, passes: {
+            "catalog": {"routes": []},
+            "readiness": {"status": "PASS"},
+            "routing_plan": {
+                "status": "READY",
+                "selected_routes": {},
+                "fallback_decisions": {},
+            },
+        },
+    )
+
+    router_obj = runner.run_integrated_prescan_stage(repo_root, run_root, _make_runner_config())
+
+    assert router_obj is not None
+    prescan_dir = run_root / "prescan"
+    manifest = json.loads((prescan_dir / "corpus_manifest.json").read_text())
+    manifest_text = json.dumps(manifest, sort_keys=True)
+    paths = {item["rel_path"] for item in manifest}
+    assert {
+        "src/app.py",
+        "services/example/service.py",
+        "docs/source.md",
+        "tests/test_example.py",
+        "task-packets/INDEX.md",
+        "task-packets/TP-SOURCE.json",
+    } <= paths
+    assert "task-packets/generated/TP-OLD.json" not in paths
+    assert "extraction/repo-truth-extractor/v5/runs/old/PROOF_PACK.json" not in paths
+    assert "proof/TP-OLD/PROOF.json" not in paths
+    assert "out/report.md" not in paths
+    assert "audit_prep/input.md" not in paths
+    assert "_audit_out/findings.md" not in paths
+    assert "claudedocs/old.md" not in paths
+    assert ".env" not in paths
+    assert "deploy.key" not in paths
+    assert "SECRET_VALUE_SHOULD_NOT_APPEAR" not in manifest_text
+
+    receipt = json.loads((prescan_dir / "prescan_stage_receipt.json").read_text())
+    assert receipt["status"] == "success"
+    assert receipt["mode"] == "integrated"
 
 
 if __name__ == "__main__":

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -53,6 +53,7 @@ A packet is superseded by another packet
 | TP-DMX-RTEAUDIT-001 | Repo Truth Extractor | Assemble pre-live audit pack for GPT-5.4 Pro | Ready | N/A |
 | TP-DMX-RTEINT-001 | Repo Truth Extractor | Integrate current RTE branch deltas into staging audit branch | Ready | N/A |
 | TP-DMX-RTECANON-001 | Repo Truth Extractor | Establish `dopemux rte` as the canonical operator entrypoint | Ready | N/A |
+| TP-RTE-WALKER-006 | Repo Truth Extractor | Exclude generated artifacts and secret-bearing files from prescan walker input | Active | N/A |
 | TP-DMX-AGENTS-CODEX-ENDTOEND-0001 | Agent Guidance | Make Codex execute TP lifecycle end-to-end by default | Ready | N/A |
 | TP-DMX-COMPOSE-RESTORE-001 | Infra | Restore canonical Docker Compose authority | Ready | N/A |
 | DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Merged (PR #528) | N/A |

--- a/task-packets/generated/TP-RTE-WALKER-006.json
+++ b/task-packets/generated/TP-RTE-WALKER-006.json
@@ -1,0 +1,218 @@
+{
+  "id": "TP-RTE-WALKER-006",
+  "project": "dopemux-mvp",
+  "target": "repo-truth-extractor / prescan / walker",
+  "invariants": [
+    "Treat services/repo-truth-extractor/run_extraction_v5.py as the strongest RTE runtime authority for integrated prescan wiring.",
+    "Treat services/repo-truth-extractor/lib/prescan/corpus_walker.py and services/repo-truth-extractor/lib/prescan/models.py as the prescan corpus inventory authority for this slice.",
+    "Do not run live extraction, provider/model calls, or batch execution.",
+    "Do not modify promptsets, model routing, docs sweep logic, batch clients, v3 consent gates, cockpit/TUI surfaces, provider behavior, or dependency declarations.",
+    "Preserve normal source scanning for src, services, docs, tests, task-packets/INDEX.md, and non-generated task packet sources.",
+    "Generated output, proof, audit, ignored runtime output, and known secret-bearing files must not be default source corpus input.",
+    "PR #605 / TP-RTE-V3-CONSENT-004 is open, not merged, at packet creation time; this packet therefore records no accepted parent."
+  ],
+  "depends_on": [
+    "TP-RTE-V3-CONSENT-004"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "RTE-GOLIVE-BLOCKERS",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/tp-rte-walker-006",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(rte): exclude generated artifacts from prescan",
+    "allowlist": [
+      "services/repo-truth-extractor/lib/prescan/models.py",
+      "services/repo-truth-extractor/lib/prescan/corpus_walker.py",
+      "services/repo-truth-extractor/run_extraction_v5.py",
+      "services/repo-truth-extractor/tests/test_prescan_core_pipeline.py",
+      "services/repo-truth-extractor/tests/test_prescan_v5_integration.py",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-RTE-WALKER-006.json",
+      "proof/TP-RTE-WALKER-006/PROOF.json",
+      "proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-RTE-WALKER-006.json",
+      "python -m compileall -q services/repo-truth-extractor",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_core_pipeline.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py",
+      "git diff --check",
+      "python -m json.tool proof/TP-RTE-WALKER-006/PROOF.json"
+    ]
+  },
+  "pr": {
+    "title": "fix(rte): exclude generated artifacts from prescan",
+    "body": "## Summary\n- harden the RTE prescan corpus walker so generated outputs, proof/audit outputs, caches, local operator metadata, and secret-bearing files are excluded from default source corpus input\n- wire the default exclusions through the integrated v5 prescan stage\n- add fixture-based regression tests for generated-output, nested-output, secret-file, integrated-prescan, and preserved-source behavior\n\n## Scope\n- Repo Truth Extractor prescan walker/config/integrated prescan path\n- focused tests, task packet, proof, and implementer report\n- no live extraction, provider/model calls, batch execution, promptset edits, model routing edits, docs sweep, dependency changes, or generated artifact cleanup\n\n## Validation\n- task packet JSON and schema validation\n- compileall for services/repo-truth-extractor\n- focused prescan/walker/integration pytest tests\n- proof JSON validation\n- git diff whitespace check",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Create and validate the repo-bound task packet before implementation.",
+      "requirements": [
+        "Verify repo root, marker, remote, branch, status, and HEAD.",
+        "Inspect RTE authority files and existing walker/prescan tests.",
+        "Record PR #605 status before selecting parent_tp_id."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/generated/TP-RTE-WALKER-006.json"
+      ],
+      "expected_files": [
+        "task-packets/generated/TP-RTE-WALKER-006.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "Task packet parses as JSON.",
+        "Task packet validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "PROJECT.md",
+        "docs/research/mcp-customization/dopemux-constraints/RULES.md",
+        "docs/research/mcp-customization/dopemux-constraints/SYSTEM_RepoTruthExtractor.md",
+        "docs/research/mcp-customization/dopemux-constraints/TRUTH_GAPS.md",
+        "docs/research/mcp-customization/dopemux-constraints/TRUTH_INTERFACES.md",
+        "task-packets/INDEX.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Centralize deterministic default excludes for generated-output, audit/proof, cache/runtime, and secret-bearing paths.",
+      "requirements": [
+        "Exclude extraction, proof, out, audit_prep, task-packets/generated, _audit_out, and claudedocs by default.",
+        "Exclude known secret-bearing local files such as .env, .env.*, *.pem, *.key, *.p12, *.pfx, id_rsa, and id_ed25519 by default.",
+        "Use normalized POSIX-style relative paths and deterministic matching for root-level and nested paths.",
+        "Preserve legitimate source files in src, services, docs, tests, task-packets/INDEX.md, and non-generated task packets."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_core_pipeline.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/corpus_walker.py",
+        "services/repo-truth-extractor/tests/test_prescan_core_pipeline.py"
+      ],
+      "validation": [
+        "Focused walker tests prove generated-output directories and secret-bearing files are excluded by default.",
+        "Focused walker tests prove legitimate source files remain included."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/corpus_walker.py",
+        "services/repo-truth-extractor/tests/test_prescan_core_pipeline.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Wire default excludes through the actual integrated v5 prescan call path.",
+      "requirements": [
+        "Ensure run_integrated_prescan_stage uses the same default generated-output and secret-bearing exclusions as the walker.",
+        "Prove this through the actual integrated prescan wrapper or the closest testable call path.",
+        "Do not run live extraction or provider/model calls."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_v5_integration.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_prescan_v5_integration.py"
+      ],
+      "validation": [
+        "Integrated prescan fixture output excludes generated and secret-bearing paths.",
+        "Integrated prescan fixture output preserves legitimate source paths."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_prescan_v5_integration.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Run focused validation, inspect the diff, and produce proof artifacts.",
+      "requirements": [
+        "Run JSON, schema, compileall, focused pytest, proof JSON, and whitespace checks.",
+        "Inspect git diff stat and full diff before commit.",
+        "Record validation exit codes and residual UNKNOWNs in proof artifacts."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/generated/TP-RTE-WALKER-006.json",
+        "python -m compileall -q services/repo-truth-extractor",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_core_pipeline.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py",
+        "git diff --check",
+        "python -m json.tool proof/TP-RTE-WALKER-006/PROOF.json"
+      ],
+      "expected_files": [
+        "proof/TP-RTE-WALKER-006/PROOF.json",
+        "proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md"
+      ],
+      "validation": [
+        "Validation results are recorded with exit codes.",
+        "Proof JSON parses.",
+        "Final git status before commit is recorded."
+      ],
+      "context_files": [
+        "proof/TP-RTE-WALKER-006/PROOF.json",
+        "proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Run codereview/precommit flow, commit allowlisted files, push, and open a PR when authenticated.",
+      "requirements": [
+        "Run codereview before precommit.",
+        "Run pre-commit on changed files if configured and safe.",
+        "Commit only allowlisted files.",
+        "Push codex/tp-rte-walker-006 and open a PR against main when gh authentication permits."
+      ],
+      "commands": [
+        "git diff --stat",
+        "git diff",
+        "pre-commit run --files <files changed>",
+        "git commit -m \"fix(rte): exclude generated artifacts from prescan\"",
+        "git push -u origin codex/tp-rte-walker-006",
+        "gh pr create --base main --head codex/tp-rte-walker-006 --title \"fix(rte): exclude generated artifacts from prescan\" --body-file <body>"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/lib/prescan/models.py",
+        "services/repo-truth-extractor/lib/prescan/corpus_walker.py",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_prescan_core_pipeline.py",
+        "services/repo-truth-extractor/tests/test_prescan_v5_integration.py",
+        "task-packets/INDEX.md",
+        "task-packets/generated/TP-RTE-WALKER-006.json",
+        "proof/TP-RTE-WALKER-006/PROOF.json",
+        "proof/TP-RTE-WALKER-006/IMPLEMENTER_REPORT.md"
+      ],
+      "validation": [
+        "Commit SHA is recorded.",
+        "Push succeeds or exact blocker is recorded.",
+        "PR URL is recorded or exact blocker is recorded."
+      ],
+      "context_files": [
+        "task-packets/generated/TP-RTE-WALKER-006.json"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
@codex review
@gemini
@copilot

## Summary
- harden RTE prescan defaults to exclude generated output/proof/audit trees, operator-local runtime metadata, caches, and known secret-bearing files before corpus inventory/hash creation
- wire the shared defaults through run_integrated_prescan_stage so the actual v5 integrated prescan path uses them
- add fixture tests for generated-output, nested-output, secret-file, integrated-prescan, and preserved-source behavior

## Validation
- python -m json.tool task-packets/generated/TP-RTE-WALKER-006.json
- task packet schema validation against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- python -m compileall -q services/repo-truth-extractor
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_prescan_core_pipeline.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_output_safety.py
- git diff --check
- python -m json.tool proof/TP-RTE-WALKER-006/PROOF.json
- pre-commit run --files <changed allowlist files>

## Residual Risk
- Broader prescan-related pytest selection still has 7 failures that reproduce on untouched starting checkout; recorded in proof as pre-existing/off-scope.
- .claude/** remains preserved because current runtime/tests use it in non-prescan governance and boundary phases; future treatment for prescan remains scoped UNKNOWN.

Generate release notes, ensure documentation referencing code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.