### PR TITLE
fix(rte): repair batch result and strict handling

### DIFF
--- a/proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md
+++ b/proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md
@@ -1,0 +1,93 @@
+# TP-RTE-BATCH-005 Implementer Report
+
+## 1. Change summary
+
+Repaired the OpenAI-compatible batch client path so provider result JSONL rows are parsed into `BatchResult` objects before discard-rate enforcement. The same parser is inherited by `XAIBatchClient`.
+
+Strict batch request intent now fails closed unless the request carries an actual `json_schema` response format. When a strict request includes that schema payload, the generated batch JSONL wire body serializes `response_format.type == "json_schema"` instead of silently staying on `json_object`.
+
+## 2. Authority used
+
+- `AGENTS.md`
+- `PROJECT.md`
+- `docs/research/mcp-customization/dopemux-constraints/RULES.md`
+- `docs/research/mcp-customization/dopemux-constraints/SYSTEM_RepoTruthExtractor.md`
+- `docs/research/mcp-customization/dopemux-constraints/TRUTH_GAPS.md`
+- `docs/research/mcp-customization/dopemux-constraints/TRUTH_INTERFACES.md`
+- `task-packets/INDEX.md`
+- `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `services/repo-truth-extractor/lib/batch_clients.py`
+- `services/repo-truth-extractor/lib/structured_output_contracts.py`
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- Existing batch and strict tests under `services/repo-truth-extractor/tests/`
+
+## 3. Files created
+
+- `services/repo-truth-extractor/tests/test_batch_clients_integration.py`
+- `task-packets/generated/TP-RTE-BATCH-005.json`
+- `proof/TP-RTE-BATCH-005/PROOF.json`
+- `proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md`
+
+## 4. Files modified
+
+- `services/repo-truth-extractor/lib/batch_clients.py`
+- `task-packets/INDEX.md`
+
+## 5. Behavior changes
+
+- Added optional `BatchRequest.response_format` for callers that already have a structured-output contract payload.
+- Added strict request validation in `OpenAIBatchClient.submit`: strict metadata requires `response_format.type == "json_schema"` and a schema object, otherwise submission fails before upload.
+- Preserved non-strict `force_json_output` behavior as `response_format: {"type": "json_object"}`.
+- Moved OpenAI-compatible result extraction back into the successful JSONL parse path.
+- Kept discard/corruption threshold enforcement after all lines are parsed and evaluated.
+- Counted malformed and non-object JSON lines as discarded rows.
+
+## 6. Tests added/modified
+
+Added `services/repo-truth-extractor/tests/test_batch_clients_integration.py` with offline fake-client coverage for:
+
+- valid OpenAI-compatible batch result parsing
+- under-threshold corrupt lines preserving valid parsed results
+- over-threshold corrupt lines raising the existing BatchCorruptionError-style RuntimeError
+- strict request body serialization with `json_schema`
+- strict request fail-closed behavior without a schema
+- non-strict `json_object` compatibility
+- xAI inherited OpenAI-compatible result parsing
+
+## 7. Validation commands and exit codes
+
+- `python -m json.tool task-packets/generated/TP-RTE-BATCH-005.json` -> 0
+- `python -m json.tool proof/TP-RTE-BATCH-005/PROOF.json` -> 0
+- Task packet Draft7 schema validation -> 0
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py` -> 1 before fix; reproduced 5 expected blocker failures
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py` -> 0 after fix; 7 passed
+- `python -m compileall -q services/repo-truth-extractor src/dopemux` -> 0
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0; 44 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py` -> 0; 43 passed
+- `rg -n "strict.*pass" services/repo-truth-extractor/lib/batch_clients.py` -> 1 expected no-match
+- Scope grep for promptsets/model/routing/walker/prescan/cockpit/TUI/dependency/docs-sweep files -> 1 expected no-match
+- `git diff --check` -> 0
+- `pre-commit run --files services/repo-truth-extractor/lib/batch_clients.py services/repo-truth-extractor/tests/test_batch_clients_integration.py task-packets/INDEX.md task-packets/generated/TP-RTE-BATCH-005.json proof/TP-RTE-BATCH-005/PROOF.json proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md` -> 0
+
+## 8. Safety boundary confirmation
+
+- No provider calls were run.
+- No live extraction was run.
+- No external batch jobs were submitted.
+- No real provider files were retrieved.
+- No sync extraction path was changed.
+- No promptsets were touched.
+- No model routing files were touched.
+- No walker/prescan files were touched.
+- No docs sweep was included.
+- No dependency files were changed.
+
+## 9. Commit readiness
+
+Manual codereview of the scoped diff passed. Pre-commit passed for changed allowlist files.
+
+## 10. Residual risks and UNKNOWNs
+
+- Strict passthrough attestation risk is narrowed, not fully closed. This TP fixes batch client wire-payload honesty but does not rewrite `STRICT_PASSTHROUGH_ATTESTATIONS` generation.
+- Existing v5 runtime avoids batching strict contract steps, so this TP verifies strict batch handling at the batch client boundary rather than through a live runner path.
+- Proof files live under ignored `proof/` and must be staged with `git add -f`.

--- a/proof/TP-RTE-BATCH-005/PROOF.json
+++ b/proof/TP-RTE-BATCH-005/PROOF.json
@@ -1,0 +1,152 @@
+{
+  "tp_id": "TP-RTE-BATCH-005",
+  "objective": "Close RTE batch correctness blockers by repairing OpenAI-compatible batch result extraction and strict batch response-format honesty without live provider calls.",
+  "starting_head": "c5ea7be47f3ae9e8b5af7e9aee72eea8dc5069f6",
+  "ending_head": null,
+  "ending_head_note": "Self-referential commit caveat: this proof is committed with the code, so the final commit SHA is reported in the closeout rather than embedded here before commit creation.",
+  "branch": "codex/tp-rte-batch-005",
+  "base_branch": "main",
+  "worktree_path": "/Users/hue/.codex/worktrees/tp-rte-batch-005",
+  "repo_identity": {
+    "repo_root": "/Users/hue/.codex/worktrees/tp-rte-batch-005",
+    "repo_marker": ".dopetaskroot",
+    "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "head_at_start": "c5ea7be47f3ae9e8b5af7e9aee72eea8dc5069f6",
+    "dedicated_worktree_verified": true,
+    "primary_checkout_observed": "/Users/hue/code/dopemux-mvp"
+  },
+  "files_created": [
+    "services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+    "task-packets/generated/TP-RTE-BATCH-005.json",
+    "proof/TP-RTE-BATCH-005/PROOF.json",
+    "proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md"
+  ],
+  "files_modified": [
+    "services/repo-truth-extractor/lib/batch_clients.py",
+    "task-packets/INDEX.md"
+  ],
+  "tests_added_or_modified": [
+    "services/repo-truth-extractor/tests/test_batch_clients_integration.py"
+  ],
+  "implementation_evidence": {
+    "broken_result_extraction_observed": "Pre-fix focused test run returned empty parsed results for valid OpenAI-compatible JSONL lines and xAI inherited parsing.",
+    "strict_noop_observed": "Pre-fix focused test run showed BatchRequest rejected response_format and strict metadata without schema serialized without fail-closed behavior.",
+    "result_extraction_fix": "services/repo-truth-extractor/lib/batch_clients.py parses valid JSON object lines inside the fetch_results loop, appends BatchResult rows, counts invalid/non-object lines, and applies the >5% corruption threshold after parsing all rows.",
+    "strict_payload_fix": "BatchRequest now accepts optional response_format; OpenAIBatchClient.submit uses _response_format_for_request so strict metadata requires response_format.type=json_schema and serializes the provided schema instead of json_object.",
+    "non_strict_preservation": "Non-strict force_json_output requests still serialize response_format={\"type\":\"json_object\"}.",
+    "xai_behavior": "XAIBatchClient inherits OpenAIBatchClient.fetch_results and the new test exercises that inherited path with fake OpenAI-compatible result JSONL.",
+    "attestation_boundary": "No attestation/proof writer was changed; strict wire payload honesty is narrowed at the batch client boundary, while broader strict passthrough attestation semantics remain a residual risk."
+  },
+  "validation_commands": [
+    {
+      "command": "python -m json.tool task-packets/generated/TP-RTE-BATCH-005.json",
+      "exit_code": 0,
+      "summary": "Task packet parses as JSON."
+    },
+    {
+      "command": "python -m json.tool proof/TP-RTE-BATCH-005/PROOF.json",
+      "exit_code": 0,
+      "summary": "Proof JSON parses."
+    },
+    {
+      "command": "python -c \"import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-BATCH-005.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); raise SystemExit(0 if not errs else 1)\"",
+      "exit_code": 0,
+      "summary": "Task packet validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+      "exit_code": 1,
+      "summary": "Pre-fix regression reproduction: 5 expected failures for empty parsed results, strict schema payload absence, fail-closed absence, and xAI inherited parsing."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+      "exit_code": 0,
+      "summary": "Post-fix focused batch client tests passed: 7 passed."
+    },
+    {
+      "command": "python -m compileall -q services/repo-truth-extractor src/dopemux",
+      "exit_code": 0,
+      "summary": "Repo Truth Extractor and dopemux Python files compile."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+      "exit_code": 0,
+      "summary": "Broader batch/strict selection passed: 44 passed."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+      "exit_code": 0,
+      "summary": "Existing v5 operator safety preservation tests passed: 43 passed."
+    },
+    {
+      "command": "rg -n \"strict.*pass\" services/repo-truth-extractor/lib/batch_clients.py",
+      "exit_code": 1,
+      "summary": "Expected no-match result: strict batch no-op is removed from batch_clients.py."
+    },
+    {
+      "command": "git diff --name-only | rg '(^services/repo-truth-extractor/promptsets/|model|routing|walker|prescan|cockpit|tui|package-lock|requirements|pyproject|docs/)'",
+      "exit_code": 1,
+      "summary": "Expected no-match result: changed files do not include promptsets, model routing, walker/prescan, cockpit/TUI, dependency files, or docs sweep paths."
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "summary": "No whitespace errors found."
+    },
+    {
+      "command": "pre-commit run --files services/repo-truth-extractor/lib/batch_clients.py services/repo-truth-extractor/tests/test_batch_clients_integration.py task-packets/INDEX.md task-packets/generated/TP-RTE-BATCH-005.json proof/TP-RTE-BATCH-005/PROOF.json proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md",
+      "exit_code": 0,
+      "summary": "Configured pre-commit hooks passed for changed allowlist files."
+    }
+  ],
+  "safety_boundary_confirmation": {
+    "live_provider_calls_run": false,
+    "live_extraction_runs_run": false,
+    "external_batch_jobs_submitted": false,
+    "sync_path_changed": false,
+    "promptsets_touched": false,
+    "model_routing_touched": false,
+    "walker_prescan_touched": false,
+    "docs_sweep_included": false,
+    "dependency_files_changed": false,
+    "real_provider_files_retrieved": false
+  },
+  "live_provider_calls_run": false,
+  "live_extraction_runs_run": false,
+  "external_batch_jobs_submitted": false,
+  "batch_result_extraction_fixed": {
+    "value": true,
+    "evidence": "test_openai_fetch_results_parses_valid_provider_jsonl and test_openai_fetch_results_keeps_valid_rows_when_corrupt_lines_under_threshold passed against OpenAIBatchClient.fetch_results."
+  },
+  "strict_batch_wire_payload_fixed": {
+    "value": true,
+    "evidence": "test_openai_submit_serializes_strict_json_schema_response_format passed and inspected the generated JSONL request body with response_format.type=json_schema; missing-schema strict requests fail closed before upload."
+  },
+  "non_strict_behavior_preserved": {
+    "value": true,
+    "evidence": "test_openai_submit_preserves_non_strict_json_object_payload passed and observed response_format={\"type\":\"json_object\"}."
+  },
+  "xai_batch_behavior_verified": {
+    "value": true,
+    "evidence": "test_xai_fetch_results_uses_inherited_openai_compatible_parser passed against XAIBatchClient with fake OpenAI-compatible result JSONL."
+  },
+  "attestation_risk_status": {
+    "status": "narrowed",
+    "evidence": "Batch client wire payload is now honest for strict requests carrying json_schema response_format. No broad STRICT_PASSTHROUGH_ATTESTATIONS writer rewrite was performed, so end-to-end attestation semantics remain a residual risk."
+  },
+  "blockers": [],
+  "residual_risks": [
+    "Strict batch response_format support is exposed on BatchRequest and covered by direct client tests; existing v5 runtime does not batch strict contract steps, and no broad runner/attestation plumbing was changed.",
+    "Generic cleanup pass blocks still exist in batch_clients.py outside strict handling; exact strict metadata pass/no-op was removed.",
+    "Proof files are under ignored proof/ and must be staged with git add -f."
+  ],
+  "codereview_status": {
+    "status": "passed",
+    "evidence": "Manual diff review found the runtime changes limited to batch_clients.py and focused tests; no sync path, promptset, routing, walker/prescan, dependency, cockpit/TUI, or docs sweep files changed."
+  },
+  "precommit_status": {
+    "status": "passed",
+    "evidence": "pre-commit run --files completed with exit code 0 for changed allowlist files."
+  },
+  "final_git_status_before_commit": "## codex/tp-rte-batch-005...origin/main; modified: services/repo-truth-extractor/lib/batch_clients.py, task-packets/INDEX.md; untracked: services/repo-truth-extractor/tests/test_batch_clients_integration.py, task-packets/generated/TP-RTE-BATCH-005.json; ignored proof/TP-RTE-BATCH-005/* will be staged with git add -f."
+}

--- a/services/repo-truth-extractor/lib/batch_clients.py
+++ b/services/repo-truth-extractor/lib/batch_clients.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import tempfile
 from dataclasses import dataclass, field
@@ -19,6 +20,7 @@ class BatchRequest:
     user_content: str
     force_json_output: bool = False
     metadata: Dict[str, str] = field(default_factory=dict)
+    response_format: Optional[Dict[str, Any]] = None
 
 
 @dataclass(frozen=True)
@@ -56,6 +58,32 @@ class BatchClient(Protocol):
         ...
 
 
+def _metadata_flag_enabled(metadata: Dict[str, str], key: str) -> bool:
+    return str(metadata.get(key) or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _response_format_for_request(req: BatchRequest) -> Optional[Dict[str, Any]]:
+    strict_requested = _metadata_flag_enabled(req.metadata, "strict")
+    if isinstance(req.response_format, dict):
+        response_format = copy.deepcopy(req.response_format)
+        rf_type = str(response_format.get("type") or "").strip()
+        if strict_requested:
+            json_schema = response_format.get("json_schema")
+            schema = json_schema.get("schema") if isinstance(json_schema, dict) else None
+            if (
+                rf_type != "json_schema"
+                or not isinstance(json_schema, dict)
+                or not isinstance(schema, dict)
+            ):
+                raise ValueError("Strict batch request requires response_format.type=json_schema")
+        return response_format
+    if strict_requested:
+        raise ValueError("Strict batch request requires response_format.type=json_schema")
+    if req.force_json_output:
+        return {"type": "json_object"}
+    return None
+
+
 class OpenAIBatchClient:
     def __init__(self, api_key: str, base_url: Optional[str] = None) -> None:
         from openai import OpenAI
@@ -81,10 +109,9 @@ class OpenAIBatchClient:
                 ],
                 "temperature": 0.1,
             }
-            if req.force_json_output:
-                body["response_format"] = {"type": "json_object"}
-                if req.metadata.get("strict") == "true":
-                    pass
+            response_format = _response_format_for_request(req)
+            if response_format is not None:
+                body["response_format"] = response_format
             payload_rows.append(
                 {
                     "custom_id": req.custom_id,
@@ -94,7 +121,9 @@ class OpenAIBatchClient:
                 }
             )
 
-        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".jsonl", delete=False) as handle:
+        with tempfile.NamedTemporaryFile(
+            "w", encoding="utf-8", suffix=".jsonl", delete=False
+        ) as handle:
             for row in payload_rows:
                 handle.write(json.dumps(row, ensure_ascii=False) + "\n")
             payload_path = Path(handle.name)
@@ -146,7 +175,11 @@ class OpenAIBatchClient:
             raw_text = str(content_obj.text)
         elif hasattr(content_obj, "read"):
             value = content_obj.read()
-            raw_text = value.decode("utf-8", errors="replace") if isinstance(value, (bytes, bytearray)) else str(value)
+            raw_text = (
+                value.decode("utf-8", errors="replace")
+                if isinstance(value, (bytes, bytearray))
+                else str(value)
+            )
         else:
             raw_text = str(content_obj)
 
@@ -156,7 +189,7 @@ class OpenAIBatchClient:
         results: List[BatchResult] = []
         total_lines = 0
         discarded_lines = 0
-        
+
         for line in raw_text.splitlines():
             line = line.strip()
             if not line:
@@ -166,11 +199,16 @@ class OpenAIBatchClient:
                 row = json.loads(line)
             except Exception as e:
                 discarded_lines += 1
-                logger.warning(f"Discarding invalid JSON line in batch result: {line[:200]}... Error: {e}")
+                logger.warning(
+                    "Discarding invalid JSON line in batch result: %s... Error: %s",
+                    line[:200],
+                    e,
+                )
                 continue
-
-        if total_lines > 0 and (discarded_lines / total_lines) > 0.05:
-            raise RuntimeError(f"BatchCorruptionError: {discarded_lines}/{total_lines} results discarded (>5%)")
+            if not isinstance(row, dict):
+                discarded_lines += 1
+                logger.warning("Discarding non-object JSON line in batch result: %s", line[:200])
+                continue
             custom_id = str(row.get("custom_id") or "")
             response = row.get("response") if isinstance(row.get("response"), dict) else {}
             body = response.get("body") if isinstance(response.get("body"), dict) else {}
@@ -184,10 +222,19 @@ class OpenAIBatchClient:
             error = None
             if isinstance(error_row, dict):
                 error = str(error_row.get("message") or error_row.get("code") or "batch_error")
-            results.append(BatchResult(custom_id=custom_id, output_text=output_text, error=error, meta=row))
+            results.append(
+                BatchResult(
+                    custom_id=custom_id,
+                    output_text=output_text,
+                    error=error,
+                    meta=row,
+                )
+            )
 
         if total_lines > 0 and (discarded_lines / total_lines) > 0.05:
-            raise RuntimeError(f"BatchCorruptionError: {discarded_lines}/{total_lines} results discarded (>5%)")
+            raise RuntimeError(
+                f"BatchCorruptionError: {discarded_lines}/{total_lines} results discarded (>5%)"
+            )
         return results
 
     def cancel(self, job_id: str) -> None:

--- a/services/repo-truth-extractor/tests/test_batch_clients_integration.py
+++ b/services/repo-truth-extractor/tests/test_batch_clients_integration.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+
+def _load_batch_clients_module():
+    root = Path(__file__).resolve().parents[3]
+    module_path = root / "services" / "repo-truth-extractor" / "lib" / "batch_clients.py"
+    spec = importlib.util.spec_from_file_location("batch_clients_under_test", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeFiles:
+    def __init__(self, result_text: str = "") -> None:
+        self.result_text = result_text
+        self.uploads: list[str] = []
+
+    def create(self, *, file, purpose: str):  # type: ignore[no-untyped-def]
+        assert purpose == "batch"
+        payload = file.read()
+        self.uploads.append(
+            payload.decode("utf-8")
+            if isinstance(payload, (bytes, bytearray))
+            else str(payload)
+        )
+        return SimpleNamespace(id="uploaded-file-1")
+
+    def content(self, file_id: str):  # type: ignore[no-untyped-def]
+        assert file_id == "result-file-1"
+        return SimpleNamespace(text=self.result_text)
+
+
+class _FakeBatches:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    def create(self, **kwargs):  # type: ignore[no-untyped-def]
+        self.created.append(dict(kwargs))
+        return SimpleNamespace(id="batch-job-1")
+
+    def retrieve(self, job_id: str):  # type: ignore[no-untyped-def]
+        assert job_id == "batch-job-1"
+        return SimpleNamespace(
+            id=job_id,
+            status="completed",
+            output_file_id="result-file-1",
+            error_file_id="",
+        )
+
+    def cancel(self, job_id: str) -> None:
+        assert job_id == "batch-job-1"
+
+
+class _FakeOpenAICompatClient:
+    def __init__(self, result_text: str = "") -> None:
+        self.files = _FakeFiles(result_text)
+        self.batches = _FakeBatches()
+
+
+def _client(module: Any, cls: type, result_text: str = ""):
+    client = object.__new__(cls)
+    fake = _FakeOpenAICompatClient(result_text)
+    client._client = fake
+    return client, fake
+
+
+def _route(module: Any, provider: str = "openai"):
+    return module.BatchRoute(
+        provider=provider,
+        model_id="gpt-5-nano",
+        api_key_env="OPENAI_API_KEY",
+    )
+
+
+def _batch_request(module: Any, **overrides: Any):
+    payload = {
+        "custom_id": "A_P0001",
+        "model_id": "gpt-5-nano",
+        "system_prompt": "Return JSON.",
+        "user_content": "Summarize this fixture.",
+        "force_json_output": True,
+        "metadata": {"phase": "A", "step_id": "A1", "partition_id": "A_P0001"},
+    }
+    payload.update(overrides)
+    return module.BatchRequest(**payload)
+
+
+def _result_line(custom_id: str, content: str) -> str:
+    return json.dumps(
+        {
+            "id": f"batch_req_{custom_id}",
+            "custom_id": custom_id,
+            "response": {
+                "status_code": 200,
+                "request_id": f"req_{custom_id}",
+                "body": {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": content,
+                            }
+                        }
+                    ]
+                },
+            },
+            "error": None,
+        }
+    )
+
+
+def _strict_response_format() -> dict[str, Any]:
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "batch_fixture_schema",
+            "strict": True,
+            "schema": {
+                "type": "object",
+                "properties": {"ok": {"type": "boolean"}},
+                "required": ["ok"],
+                "additionalProperties": False,
+            },
+        },
+    }
+
+
+def test_openai_fetch_results_parses_valid_provider_jsonl() -> None:
+    module = _load_batch_clients_module()
+    raw_text = "\n".join(
+        [
+            _result_line("A_P0001", "{\"ok\": true}"),
+            _result_line("A_P0002", "{\"ok\": false}"),
+        ]
+    )
+    client, _ = _client(module, module.OpenAIBatchClient, raw_text)
+
+    results = client.fetch_results("batch-job-1")
+
+    assert [result.custom_id for result in results] == ["A_P0001", "A_P0002"]
+    assert [result.output_text for result in results] == [
+        "{\"ok\": true}",
+        "{\"ok\": false}",
+    ]
+    assert results[0].error is None
+    assert results[0].meta["response"]["status_code"] == 200
+
+
+def test_openai_fetch_results_keeps_valid_rows_when_corrupt_lines_under_threshold() -> None:
+    module = _load_batch_clients_module()
+    valid_rows = [_result_line(f"A_P{i:04d}", "{\"ok\": true}") for i in range(20)]
+    raw_text = "\n".join([*valid_rows, "{not-json"])
+    client, _ = _client(module, module.OpenAIBatchClient, raw_text)
+
+    results = client.fetch_results("batch-job-1")
+
+    assert len(results) == 20
+    assert results[0].custom_id == "A_P0000"
+    assert results[-1].custom_id == "A_P0019"
+
+
+def test_openai_fetch_results_raises_when_corrupt_threshold_exceeded() -> None:
+    module = _load_batch_clients_module()
+    raw_text = "\n".join([_result_line("A_P0001", "{\"ok\": true}"), "{not-json"])
+    client, _ = _client(module, module.OpenAIBatchClient, raw_text)
+
+    try:
+        client.fetch_results("batch-job-1")
+    except RuntimeError as exc:
+        assert "BatchCorruptionError" in str(exc)
+        assert "1/2" in str(exc)
+    else:
+        raise AssertionError("Expected BatchCorruptionError-style RuntimeError")
+
+
+def test_openai_submit_serializes_strict_json_schema_response_format() -> None:
+    module = _load_batch_clients_module()
+    client, fake = _client(module, module.OpenAIBatchClient)
+    request = _batch_request(
+        module,
+        metadata={"strict": "true", "phase": "A", "step_id": "A1"},
+        response_format=_strict_response_format(),
+    )
+
+    job_id = client.submit([request], _route(module), {"phase": "A", "step_id": "A1"})
+
+    assert job_id == "batch-job-1"
+    rows = [json.loads(line) for line in fake.files.uploads[0].splitlines()]
+    assert len(rows) == 1
+    response_format = rows[0]["body"]["response_format"]
+    assert response_format["type"] == "json_schema"
+    assert response_format["json_schema"]["strict"] is True
+    assert response_format["json_schema"]["schema"]["additionalProperties"] is False
+
+
+def test_openai_submit_fails_closed_for_strict_without_schema() -> None:
+    module = _load_batch_clients_module()
+    client, fake = _client(module, module.OpenAIBatchClient)
+    request = _batch_request(module, metadata={"strict": "true"})
+
+    try:
+        client.submit([request], _route(module), {"phase": "A", "step_id": "A1"})
+    except ValueError as exc:
+        assert "Strict batch request requires response_format.type=json_schema" in str(exc)
+    else:
+        raise AssertionError("Expected strict batch request without json_schema to fail closed")
+
+    assert fake.files.uploads == []
+    assert fake.batches.created == []
+
+
+def test_openai_submit_preserves_non_strict_json_object_payload() -> None:
+    module = _load_batch_clients_module()
+    client, fake = _client(module, module.OpenAIBatchClient)
+    request = _batch_request(module, metadata={"phase": "A", "step_id": "A1"})
+
+    job_id = client.submit([request], _route(module), {"phase": "A", "step_id": "A1"})
+
+    assert job_id == "batch-job-1"
+    rows = [json.loads(line) for line in fake.files.uploads[0].splitlines()]
+    assert rows[0]["body"]["response_format"] == {"type": "json_object"}
+
+
+def test_xai_fetch_results_uses_inherited_openai_compatible_parser() -> None:
+    module = _load_batch_clients_module()
+    raw_text = _result_line("X_P0001", "{\"provider\": \"xai\"}")
+    client, _ = _client(module, module.XAIBatchClient, raw_text)
+
+    results = client.fetch_results("batch-job-1")
+
+    assert len(results) == 1
+    assert results[0].custom_id == "X_P0001"
+    assert results[0].output_text == "{\"provider\": \"xai\"}"

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -55,6 +55,7 @@ A packet is superseded by another packet
 | TP-DMX-RTECANON-001 | Repo Truth Extractor | Establish `dopemux rte` as the canonical operator entrypoint | Ready | N/A |
 | TP-RTE-V3-CONSENT-004 | Repo Truth Extractor | Gate legacy v3 execution and fail closed on unknown pipeline versions | Active | N/A |
 | TP-RTE-WALKER-006 | Repo Truth Extractor | Exclude generated artifacts and secret-bearing files from prescan walker input | Active | N/A |
+| TP-RTE-BATCH-005 | Repo Truth Extractor | Repair batch result extraction and strict batch request payload handling | Active | N/A |
 | TP-DMX-AGENTS-CODEX-ENDTOEND-0001 | Agent Guidance | Make Codex execute TP lifecycle end-to-end by default | Ready | N/A |
 | TP-DMX-COMPOSE-RESTORE-001 | Infra | Restore canonical Docker Compose authority | Ready | N/A |
 | DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Merged (PR #528) | N/A |

--- a/task-packets/generated/TP-RTE-BATCH-005.json
+++ b/task-packets/generated/TP-RTE-BATCH-005.json
@@ -1,0 +1,234 @@
+{
+  "id": "TP-RTE-BATCH-005",
+  "project": "dopemux-mvp",
+  "target": "repo-truth-extractor / batch clients",
+  "invariants": [
+    "Treat services/repo-truth-extractor/lib/batch_clients.py as the batch client request and result parsing authority for this slice.",
+    "Treat services/repo-truth-extractor/run_extraction_v5.py as the strongest RTE runtime authority for active batch invocation context.",
+    "Do not run live extraction, provider/model calls, external provider batch submission, or real provider result retrieval.",
+    "Do not modify sync extraction behavior, promptsets, model routing, walker/prescan, v3 consent, docs canonical naming, cockpit/TUI, dependencies, or unrelated tests.",
+    "Valid batch result lines must be parsed into BatchResult entries before corruption/discard threshold enforcement.",
+    "Strict batch request intent must not silently serialize as response_format.type=json_object."
+  ],
+  "depends_on": [
+    "TP-RTE-V3-CONSENT-004",
+    "TP-RTE-WALKER-006"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "RTE-GOLIVE-BLOCKERS",
+    "base_branch": "main",
+    "parent_tp_id": "TP-RTE-WALKER-006",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/tp-rte-batch-005",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(rte): repair batch result and strict handling",
+    "allowlist": [
+      "services/repo-truth-extractor/lib/batch_clients.py",
+      "services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-RTE-BATCH-005.json",
+      "proof/TP-RTE-BATCH-005/PROOF.json",
+      "proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-RTE-BATCH-005.json",
+      "python -m json.tool proof/TP-RTE-BATCH-005/PROOF.json",
+      "python -m compileall -q services/repo-truth-extractor src/dopemux",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+      "git diff --check",
+      "pre-commit run --files <changed files>"
+    ]
+  },
+  "pr": {
+    "title": "fix(rte): repair batch result and strict handling",
+    "body": "## Summary\n- repair OpenAI-compatible batch result parsing so valid JSONL result rows produce BatchResult entries before corruption threshold enforcement\n- make strict batch request intent fail closed unless an actual json_schema response_format is supplied, and serialize that schema on the wire when present\n- add offline fake-client regression tests for valid results, corruption thresholds, strict/non-strict request bodies, and xAI inherited parsing\n\n## Scope\n- Repo Truth Extractor batch client request/result handling\n- focused tests, task packet, proof, and implementer report\n- no live extraction, provider/model calls, external batch jobs, sync path changes, promptsets, model routing, walker/prescan, docs sweep, dependencies, or cockpit/TUI work\n\n## Validation\n- task packet/proof JSON validation and task packet schema validation\n- compileall for services/repo-truth-extractor and src/dopemux\n- focused batch regression tests and batch/strict test selection\n- operator safety preservation tests\n- git diff whitespace check and pre-commit on changed files",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Create and validate the repo-bound task packet before implementation.",
+      "requirements": [
+        "Verify repo root, marker, remote, branch, status, and HEAD.",
+        "Confirm PR #605 and PR #606 are present in current main.",
+        "Inspect batch client runtime code, active RTE runtime context, task packet schema, task packet index, and existing batch/strict tests."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/generated/TP-RTE-BATCH-005.json",
+        "python -c \"import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-BATCH-005.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); raise SystemExit(0 if not errs else 1)\""
+      ],
+      "expected_files": [
+        "task-packets/generated/TP-RTE-BATCH-005.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "Task packet parses as JSON.",
+        "Task packet validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "PROJECT.md",
+        "docs/research/mcp-customization/dopemux-constraints/RULES.md",
+        "docs/research/mcp-customization/dopemux-constraints/SYSTEM_RepoTruthExtractor.md",
+        "task-packets/INDEX.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "services/repo-truth-extractor/lib/batch_clients.py",
+        "services/repo-truth-extractor/run_extraction_v5.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Add offline regression tests for OpenAI-compatible batch result parsing and strict/non-strict request serialization.",
+      "requirements": [
+        "Use fake client/file/batch transports at the provider boundary only.",
+        "Exercise actual fetch_results parsing and submit payload construction.",
+        "Prove no credentials, network, live extraction, or real provider files are required."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/tests/test_batch_clients_integration.py"
+      ],
+      "validation": [
+        "New tests fail before the runtime fix and pass after it.",
+        "Tests prove valid result extraction, under/over threshold behavior, strict json_schema serialization, non-strict json_object compatibility, and xAI inherited parsing."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/tests/test_run_extraction_v3_batch_mode.py",
+        "services/repo-truth-extractor/lib/batch_clients.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Fix batch result extraction reachability and corruption threshold ordering.",
+      "requirements": [
+        "Parse valid JSONL rows into BatchResult entries inside the result loop.",
+        "Count malformed/discarded rows.",
+        "Apply the existing corruption threshold after parsing all rows.",
+        "Preserve public method names and return shape."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/lib/batch_clients.py",
+        "services/repo-truth-extractor/tests/test_batch_clients_integration.py"
+      ],
+      "validation": [
+        "Valid fixture results return non-empty BatchResult rows.",
+        "Malformed rows under threshold do not suppress valid results.",
+        "Malformed rows over threshold raise the existing BatchCorruptionError-style RuntimeError."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/lib/batch_clients.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Fix strict batch response-format honesty without changing non-strict behavior.",
+      "requirements": [
+        "Strict batch requests must serialize response_format.type=json_schema when supplied with a valid schema payload.",
+        "Strict batch requests without a json_schema response format must fail closed before upload/submission.",
+        "Non-strict force_json_output requests must preserve existing json_object behavior."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/lib/batch_clients.py",
+        "services/repo-truth-extractor/tests/test_batch_clients_integration.py"
+      ],
+      "validation": [
+        "Strict payload test observes actual serialized request body with response_format.type=json_schema.",
+        "Strict missing-schema test observes explicit fail-closed behavior.",
+        "Non-strict payload test observes existing json_object behavior."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/lib/structured_output_contracts.py",
+        "services/repo-truth-extractor/lib/batch_clients.py"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Verify xAI inherited batch behavior and preserve runtime boundaries.",
+      "requirements": [
+        "If XAIBatchClient inherits OpenAIBatchClient parsing, test the inherited path directly.",
+        "Do not alter OpenRouter unsupported-batch behavior or Gemini batch behavior unless tests prove a required minimal fix.",
+        "Do not touch run_extraction_v5.py unless runtime inspection proves a tiny metadata plumbing change is required."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/lib/batch_clients.py",
+        "services/repo-truth-extractor/tests/test_batch_clients_integration.py"
+      ],
+      "validation": [
+        "xAI inherited fetch_results path returns parsed results from fake OpenAI-compatible result JSONL.",
+        "Scope grep confirms promptsets, model routing, walker/prescan, dependencies, cockpit/TUI, and docs sweep paths were not touched."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/lib/batch_clients.py"
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Run final validation, update proof, inspect diff, codereview, precommit, commit, push, and open PR.",
+      "requirements": [
+        "Record every validation command and exit code in proof artifacts.",
+        "Run codereview before pre-commit.",
+        "Commit only allowlisted files.",
+        "Push codex/tp-rte-batch-005 and open a PR against main when gh authentication permits."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/generated/TP-RTE-BATCH-005.json",
+        "python -m json.tool proof/TP-RTE-BATCH-005/PROOF.json",
+        "python -m compileall -q services/repo-truth-extractor src/dopemux",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+        "git diff --check",
+        "pre-commit run --files <changed files>",
+        "git commit -m \"fix(rte): repair batch result and strict handling\"",
+        "git push -u origin codex/tp-rte-batch-005",
+        "gh pr create --base main --head codex/tp-rte-batch-005 --title \"fix(rte): repair batch result and strict handling\" --body-file <body>"
+      ],
+      "expected_files": [
+        "proof/TP-RTE-BATCH-005/PROOF.json",
+        "proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md"
+      ],
+      "validation": [
+        "Proof JSON parses.",
+        "All required validation results are recorded with exit codes.",
+        "Commit SHA, push result, PR URL or exact blocker, residual risks, and cleanup status are recorded."
+      ],
+      "context_files": [
+        "proof/TP-RTE-BATCH-005/PROOF.json",
+        "proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- repair OpenAI-compatible batch result parsing so valid JSONL result rows produce BatchResult entries before corruption threshold enforcement
- make strict batch request intent fail closed unless an actual json_schema response_format is supplied, and serialize that schema on the batch wire payload when present
- add offline fake-client regression tests for result parsing, corruption thresholds, strict/non-strict payloads, and xAI inherited parsing

## Validation
- PASS: python -m json.tool task-packets/generated/TP-RTE-BATCH-005.json
- PASS: python -m json.tool proof/TP-RTE-BATCH-005/PROOF.json
- PASS: task packet Draft7 schema validation against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: python -m compileall -q services/repo-truth-extractor src/dopemux
- PASS: RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py
- PASS: RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"
- PASS: RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
- PASS: git diff --check
- PASS: pre-commit run --files <changed files>

## Safety
- no provider calls, live extraction, external batch jobs, or real provider file retrieval
- no sync path, promptset, model routing, walker/prescan, docs sweep, dependency, cockpit, or TUI changes

## Residual risk
- strict passthrough attestation risk is narrowed at the batch client wire-payload boundary, not broadly closed; no STRICT_PASSTHROUGH_ATTESTATIONS writer rewrite was included

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.
