### PR TITLE
fix(rte): wire strict batch response format

### DIFF
--- a/proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md
+++ b/proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md
@@ -35,6 +35,7 @@ Wired v5 strict batch request construction to build and attach the existing stru
 ## 5. Behavior changes
 
 - Added `build_v5_batch_request(...)` in `run_extraction_v5.py` as the v5 batch request construction seam used by the real batch branch.
+- Added `_resolve_batch_route_override(...)` so strict 2-tuple route ladders are widened to 3-tuples when a `batch_provider` override selects one.
 - Removed the `not strict_contract_required` exclusion from the v5 batch path.
 - Strict batch construction uses `route_entries_for_stage(...)` and `build_provider_step_contract_output(...)` to populate `BatchRequest.response_format`.
 - Strict batch construction requires `response_format.type == "json_schema"`, a schema object, `json_schema.strict == true`, and non-empty artifact schema metadata.
@@ -49,6 +50,7 @@ Added `services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response
 - fake OpenAI-compatible upload JSONL containing `response_format.type == "json_schema"`
 - strict missing schema failing before fake upload/submission
 - strict `json_object` downgrade rejection
+- strict 2-tuple ladder provider override widening via `PROVIDER_API_KEY_ENV`
 - non-strict OpenAI-compatible behavior preserving omitted `response_format`
 
 ## 7. Validation commands and exit codes
@@ -57,10 +59,10 @@ Added `services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response
 - `python -m json.tool proof/TP-RTE-BATCH-E2E-006/PROOF.json` -> 0
 - Task packet Draft7 schema validation -> 0
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 1 during intermediate guard correction
-- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 0; 4 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 0; 5 passed
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py` -> 0; 7 passed
 - `python -m compileall -q services/repo-truth-extractor src/dopemux` -> 0
-- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0; 48 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0; 49 passed
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py` -> 0; 43 passed
 - Forbidden-scope diff grep -> 1 expected no-match
 - Strict batch exclusion/downgrade grep -> 1 expected no-match

--- a/proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md
+++ b/proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md
@@ -1,0 +1,95 @@
+# TP-RTE-BATCH-E2E-006 Implementer Report
+
+## 1. Change summary
+
+Wired v5 strict batch request construction to build and attach the existing structured-output `json_schema` response format before batch upload/submission. Strict batch construction now fails closed when no valid schema can be resolved or when a strict request would downgrade to `json_object`.
+
+## 2. Authority used
+
+- User-provided TP-RTE-BATCH-E2E-006 implementation prompt
+- `AGENTS.md`
+- `PROJECT.md`
+- `docs/research/mcp-customization/dopemux-constraints/SYSTEM_RepoTruthExtractor.md`
+- `task-packets/INDEX.md`
+- `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `proof/TP-RTE-BATCH-005/PROOF.json`
+- `proof/TP-RTE-BATCH-005/IMPLEMENTER_REPORT.md`
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `services/repo-truth-extractor/lib/batch_clients.py`
+- `services/repo-truth-extractor/lib/structured_output_contracts.py`
+- `services/repo-truth-extractor/lib/phase_contract_map.py`
+- Existing strict/batch tests under `services/repo-truth-extractor/tests/`
+
+## 3. Files created
+
+- `services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py`
+- `task-packets/generated/TP-RTE-BATCH-E2E-006.json`
+- `proof/TP-RTE-BATCH-E2E-006/PROOF.json`
+- `proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md`
+
+## 4. Files modified
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `task-packets/INDEX.md`
+
+## 5. Behavior changes
+
+- Added `build_v5_batch_request(...)` in `run_extraction_v5.py` as the v5 batch request construction seam used by the real batch branch.
+- Removed the `not strict_contract_required` exclusion from the v5 batch path.
+- Strict batch construction uses `route_entries_for_stage(...)` and `build_provider_step_contract_output(...)` to populate `BatchRequest.response_format`.
+- Strict batch construction requires `response_format.type == "json_schema"`, a schema object, `json_schema.strict == true`, and non-empty artifact schema metadata.
+- Strict batch request metadata sets `strict=true`, preserving the TP-RTE-BATCH-005 batch-client fail-closed boundary.
+- Non-strict OpenAI-compatible batch behavior remains unchanged: no `response_format` is emitted when `force_json_output` is false.
+
+## 6. Tests added/modified
+
+Added `services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` with offline coverage for:
+
+- strict v5 batch request construction populating `BatchRequest.response_format`
+- fake OpenAI-compatible upload JSONL containing `response_format.type == "json_schema"`
+- strict missing schema failing before fake upload/submission
+- strict `json_object` downgrade rejection
+- non-strict OpenAI-compatible behavior preserving omitted `response_format`
+
+## 7. Validation commands and exit codes
+
+- `python -m json.tool task-packets/generated/TP-RTE-BATCH-E2E-006.json` -> 0
+- `python -m json.tool proof/TP-RTE-BATCH-E2E-006/PROOF.json` -> 0
+- Task packet Draft7 schema validation -> 0
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 1 during intermediate guard correction
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 0; 4 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py` -> 0; 7 passed
+- `python -m compileall -q services/repo-truth-extractor src/dopemux` -> 0
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0; 48 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py` -> 0; 43 passed
+- Forbidden-scope diff grep -> 1 expected no-match
+- Strict batch exclusion/downgrade grep -> 1 expected no-match
+- Attestation writer diff grep -> 1 expected no-match
+- `git diff --check` -> 0
+- `pre-commit run --files services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py task-packets/INDEX.md task-packets/generated/TP-RTE-BATCH-E2E-006.json proof/TP-RTE-BATCH-E2E-006/PROOF.json proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md` -> 0
+
+## 8. Safety boundary confirmation
+
+- No provider calls were run.
+- No live extraction was run.
+- No external batch jobs were submitted.
+- No real provider files were retrieved.
+- No sync extraction path was changed.
+- No promptsets were touched.
+- No model routing files were touched.
+- No walker/prescan files were touched.
+- No docs sweep was included.
+- No dependency files were changed.
+- No attestation writer rewrite was performed.
+
+## 9. Commit readiness
+
+Manual diff review passed. Pre-commit passed for changed allowlist files. Proof files are under ignored `proof/` and must be staged with `git add -f`.
+
+## 10. Residual risks and UNKNOWNs
+
+- `STRICT_PASSTHROUGH_ATTESTATIONS` writer remains out of scope for TP-RTE-STRICT-ATTESTATION-007.
+- F3-HIGH-2 is `NARROWED_FURTHER`, not closed, because attestation generation is not proven to derive from actual wire/runtime payload.
+- No live provider batch job was submitted; validation uses fake OpenAI-compatible transport only.
+- `GeminiBatchClient` still does not serialize `response_format` directly. Current strict route logic excludes Gemini strict routes, and this TP verified the OpenAI-compatible wire path.
+- `task-packets/INDEX.md` still lists TP-RTE-BATCH-005 as Active despite PR #614 being present on main; this TP only added the new active packet row.

--- a/proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md
+++ b/proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md
@@ -38,6 +38,7 @@ Wired v5 strict batch request construction to build and attach the existing stru
 - Added `_resolve_batch_route_override(...)` so strict 2-tuple route ladders are widened to 3-tuples when a `batch_provider` override selects one.
 - Preserved contract-derived `api_key_env` values when strict route ladders intentionally omit env names, while keeping env names out of strict ladder metadata.
 - Reused `route_entry_by_identity(...)` for exact route matching before falling back to provider/model contract matching for env-redacted strict routes.
+- Accepted already strict-resolved explicit/benchmark selected routes outside `lane.primary_routes` by passing a bounded `selected_route_entry` into batch request construction.
 - Surfaced `strict_capability_reason(...)` before response format construction when a matching route is not strict-capable.
 - Removed the `not strict_contract_required` exclusion from the v5 batch path.
 - Strict batch construction uses `route_entries_for_stage(...)` and `build_provider_step_contract_output(...)` to populate `BatchRequest.response_format`.
@@ -55,6 +56,7 @@ Added `services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response
 - strict `json_object` downgrade rejection
 - strict 2-tuple ladder provider override widening via `PROVIDER_API_KEY_ENV`
 - contract-derived API-key env preservation when strict ladders omit env names
+- strict-capable selected route fallback for explicit/benchmark route ownership outside primary contract routes
 - non-strict OpenAI-compatible behavior preserving omitted `response_format`
 
 ## 7. Validation commands and exit codes
@@ -63,10 +65,10 @@ Added `services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response
 - `python -m json.tool proof/TP-RTE-BATCH-E2E-006/PROOF.json` -> 0
 - Task packet Draft7 schema validation -> 0
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 1 during intermediate guard correction
-- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 0; 6 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 0; 7 passed
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py` -> 0; 7 passed
 - `python -m compileall -q services/repo-truth-extractor src/dopemux` -> 0
-- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0; 50 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0; 51 passed
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py` -> 0; 43 passed
 - Forbidden-scope diff grep -> 1 expected no-match
 - Strict batch exclusion/downgrade grep -> 1 expected no-match

--- a/proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md
+++ b/proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md
@@ -36,6 +36,9 @@ Wired v5 strict batch request construction to build and attach the existing stru
 
 - Added `build_v5_batch_request(...)` in `run_extraction_v5.py` as the v5 batch request construction seam used by the real batch branch.
 - Added `_resolve_batch_route_override(...)` so strict 2-tuple route ladders are widened to 3-tuples when a `batch_provider` override selects one.
+- Preserved contract-derived `api_key_env` values when strict route ladders intentionally omit env names, while keeping env names out of strict ladder metadata.
+- Reused `route_entry_by_identity(...)` for exact route matching before falling back to provider/model contract matching for env-redacted strict routes.
+- Surfaced `strict_capability_reason(...)` before response format construction when a matching route is not strict-capable.
 - Removed the `not strict_contract_required` exclusion from the v5 batch path.
 - Strict batch construction uses `route_entries_for_stage(...)` and `build_provider_step_contract_output(...)` to populate `BatchRequest.response_format`.
 - Strict batch construction requires `response_format.type == "json_schema"`, a schema object, `json_schema.strict == true`, and non-empty artifact schema metadata.
@@ -51,6 +54,7 @@ Added `services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response
 - strict missing schema failing before fake upload/submission
 - strict `json_object` downgrade rejection
 - strict 2-tuple ladder provider override widening via `PROVIDER_API_KEY_ENV`
+- contract-derived API-key env preservation when strict ladders omit env names
 - non-strict OpenAI-compatible behavior preserving omitted `response_format`
 
 ## 7. Validation commands and exit codes
@@ -59,10 +63,10 @@ Added `services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response
 - `python -m json.tool proof/TP-RTE-BATCH-E2E-006/PROOF.json` -> 0
 - Task packet Draft7 schema validation -> 0
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 1 during intermediate guard correction
-- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 0; 5 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 0; 6 passed
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py` -> 0; 7 passed
 - `python -m compileall -q services/repo-truth-extractor src/dopemux` -> 0
-- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0; 49 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0; 50 passed
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py` -> 0; 43 passed
 - Forbidden-scope diff grep -> 1 expected no-match
 - Strict batch exclusion/downgrade grep -> 1 expected no-match

--- a/proof/TP-RTE-BATCH-E2E-006/PROOF.json
+++ b/proof/TP-RTE-BATCH-E2E-006/PROOF.json
@@ -34,7 +34,8 @@
     "schema_source": "build_v5_batch_request uses route_entries_for_stage(...) and build_provider_step_contract_output(...) from structured_output_contracts.py to build the provider-specific json_schema response_format.",
     "batch_path_wiring": "The real run_extraction_v5.py batch branch now calls build_v5_batch_request(...) before resolving API keys or constructing the batch client.",
     "strict_fail_closed": "Strict batch request construction validates response_format.type=json_schema, json_schema.schema object presence, json_schema.strict=true, and non-empty artifact schema metadata before upload/submission.",
-    "non_strict_preservation": "Non-strict OpenAI-compatible batch request construction still returns response_format=None when force_json_output is false; existing batch client force_json_output behavior remains in batch_clients.py."
+    "non_strict_preservation": "Non-strict OpenAI-compatible batch request construction still returns response_format=None when force_json_output is false; existing batch client force_json_output behavior remains in batch_clients.py.",
+    "codex_p1_followup": "_resolve_batch_route_override widens strict route ladder 2-tuples to 3-tuples by deriving api_key_env from PROVIDER_API_KEY_ENV when a batch_provider override selects a strict ladder route."
   },
   "validation_commands": [
     {
@@ -60,7 +61,7 @@
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
       "exit_code": 0,
-      "summary": "Focused v5 batch response_format regression tests passed: 4 passed."
+      "summary": "Focused v5 batch response_format and strict 2-tuple ladder override regression tests passed: 5 passed."
     },
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
@@ -75,7 +76,7 @@
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
       "exit_code": 0,
-      "summary": "Broader batch/strict selection passed: 48 passed."
+      "summary": "Broader batch/strict selection passed: 49 passed."
     },
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
@@ -128,6 +129,10 @@
     "value": true,
     "evidence": "test_v5_batch_request_construction_propagates_strict_response_format_to_wire_payload passed and inspected the BatchRequest plus fake OpenAI-compatible upload JSONL with response_format.type=json_schema and json_schema.strict=true."
   },
+  "strict_two_tuple_ladder_override_supported": {
+    "value": true,
+    "evidence": "test_v5_resolve_batch_route_override_handles_strict_two_tuple_ladder passed and covered no-override passthrough, strict 2-tuple provider override widening through PROVIDER_API_KEY_ENV, and missing override fallback."
+  },
   "strict_missing_schema_fails_closed_before_submit": {
     "value": true,
     "evidence": "test_v5_strict_batch_request_missing_schema_fails_before_upload_or_submit passed and asserted fake files.uploads and fake batches.created stayed empty."
@@ -163,5 +168,5 @@
     "status": "passed",
     "evidence": "pre-commit run --files completed with exit code 0 for changed allowlist files."
   },
-  "final_git_status_before_commit": "## codex/tp-rte-batch-e2e-006; modified: services/repo-truth-extractor/run_extraction_v5.py, task-packets/INDEX.md; untracked: services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py, task-packets/generated/TP-RTE-BATCH-E2E-006.json; ignored proof/TP-RTE-BATCH-E2E-006/* will be staged with git add -f."
+  "final_git_status_before_commit": "## codex/tp-rte-batch-e2e-006...origin/codex/tp-rte-batch-e2e-006; modified: services/repo-truth-extractor/run_extraction_v5.py, services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py, proof/TP-RTE-BATCH-E2E-006/PROOF.json, proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md."
 }

--- a/proof/TP-RTE-BATCH-E2E-006/PROOF.json
+++ b/proof/TP-RTE-BATCH-E2E-006/PROOF.json
@@ -35,7 +35,8 @@
     "batch_path_wiring": "The real run_extraction_v5.py batch branch now calls build_v5_batch_request(...) before resolving API keys or constructing the batch client.",
     "strict_fail_closed": "Strict batch request construction validates response_format.type=json_schema, json_schema.schema object presence, json_schema.strict=true, and non-empty artifact schema metadata before upload/submission.",
     "non_strict_preservation": "Non-strict OpenAI-compatible batch request construction still returns response_format=None when force_json_output is false; existing batch client force_json_output behavior remains in batch_clients.py.",
-    "codex_p1_followup": "_resolve_batch_route_override widens strict route ladder 2-tuples to 3-tuples by deriving api_key_env from PROVIDER_API_KEY_ENV when a batch_provider override selects a strict ladder route."
+    "codex_p1_followup": "_resolve_batch_route_override widens strict route ladder 2-tuples to 3-tuples by deriving api_key_env from PROVIDER_API_KEY_ENV when a batch_provider override selects a strict ladder route.",
+    "codex_review_followup": "Strict batch route resolution now preserves contract-derived api_key_env values when strict ladders omit env names, reuses route_entry_by_identity for exact route matching before provider/model fallback, and surfaces strict_capability_reason before response_format construction."
   },
   "validation_commands": [
     {
@@ -61,7 +62,7 @@
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
       "exit_code": 0,
-      "summary": "Focused v5 batch response_format and strict 2-tuple ladder override regression tests passed: 5 passed."
+      "summary": "Focused v5 batch response_format, strict route matching, and strict 2-tuple ladder override regression tests passed: 6 passed."
     },
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
@@ -76,7 +77,7 @@
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
       "exit_code": 0,
-      "summary": "Broader batch/strict selection passed: 49 passed."
+      "summary": "Broader batch/strict selection passed: 50 passed."
     },
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
@@ -131,7 +132,11 @@
   },
   "strict_two_tuple_ladder_override_supported": {
     "value": true,
-    "evidence": "test_v5_resolve_batch_route_override_handles_strict_two_tuple_ladder passed and covered no-override passthrough, strict 2-tuple provider override widening through PROVIDER_API_KEY_ENV, and missing override fallback."
+    "evidence": "test_v5_resolve_batch_route_override_handles_strict_two_tuple_ladder passed and covered no-override passthrough, strict 2-tuple provider override widening through PROVIDER_API_KEY_ENV, contract-derived api_key_env preservation for omitted strict env names, and missing override fallback."
+  },
+  "strict_contract_api_key_env_preserved": {
+    "value": true,
+    "evidence": "test_v5_batch_request_matches_strict_route_when_api_key_env_was_omitted_from_ladder passed and proved strict response_format construction can match a provider/model contract route even when selected_route carries a fallback/default api_key_env from an env-redacted strict ladder."
   },
   "strict_missing_schema_fails_closed_before_submit": {
     "value": true,

--- a/proof/TP-RTE-BATCH-E2E-006/PROOF.json
+++ b/proof/TP-RTE-BATCH-E2E-006/PROOF.json
@@ -36,7 +36,7 @@
     "strict_fail_closed": "Strict batch request construction validates response_format.type=json_schema, json_schema.schema object presence, json_schema.strict=true, and non-empty artifact schema metadata before upload/submission.",
     "non_strict_preservation": "Non-strict OpenAI-compatible batch request construction still returns response_format=None when force_json_output is false; existing batch client force_json_output behavior remains in batch_clients.py.",
     "codex_p1_followup": "_resolve_batch_route_override widens strict route ladder 2-tuples to 3-tuples by deriving api_key_env from PROVIDER_API_KEY_ENV when a batch_provider override selects a strict ladder route.",
-    "codex_review_followup": "Strict batch route resolution now preserves contract-derived api_key_env values when strict ladders omit env names, reuses route_entry_by_identity for exact route matching before provider/model fallback, and surfaces strict_capability_reason before response_format construction."
+    "codex_review_followup": "Strict batch route resolution now preserves contract-derived api_key_env values when strict ladders omit env names, reuses route_entry_by_identity for exact route matching before provider/model fallback, accepts already strict-resolved explicit/benchmark selected routes outside primary contract routes, and surfaces strict_capability_reason before response_format construction."
   },
   "validation_commands": [
     {
@@ -62,7 +62,7 @@
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
       "exit_code": 0,
-      "summary": "Focused v5 batch response_format, strict route matching, and strict 2-tuple ladder override regression tests passed: 6 passed."
+      "summary": "Focused v5 batch response_format, strict route matching, selected route fallback, and strict 2-tuple ladder override regression tests passed: 7 passed."
     },
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
@@ -77,7 +77,7 @@
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
       "exit_code": 0,
-      "summary": "Broader batch/strict selection passed: 50 passed."
+      "summary": "Broader batch/strict selection passed: 51 passed."
     },
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
@@ -137,6 +137,10 @@
   "strict_contract_api_key_env_preserved": {
     "value": true,
     "evidence": "test_v5_batch_request_matches_strict_route_when_api_key_env_was_omitted_from_ladder passed and proved strict response_format construction can match a provider/model contract route even when selected_route carries a fallback/default api_key_env from an env-redacted strict ladder."
+  },
+  "strict_selected_route_outside_primary_contract_supported": {
+    "value": true,
+    "evidence": "test_v5_batch_request_accepts_strict_selected_route_outside_primary_contract passed and proved build_v5_batch_request can use an already strict-capable selected_route_entry when explicit or benchmark route ownership selects a route outside lane.primary_routes."
   },
   "strict_missing_schema_fails_closed_before_submit": {
     "value": true,

--- a/proof/TP-RTE-BATCH-E2E-006/PROOF.json
+++ b/proof/TP-RTE-BATCH-E2E-006/PROOF.json
@@ -1,0 +1,167 @@
+{
+  "tp_id": "TP-RTE-BATCH-E2E-006",
+  "objective": "Wire strict structured-output response_format propagation into the real v5 batch request construction path without live provider calls.",
+  "starting_head": "9c30e9e869878e752782b9f95b6a1de262de974b",
+  "ending_head": null,
+  "ending_head_note": "Self-referential commit caveat: this proof is committed with the code, so the final commit SHA is reported in the closeout rather than embedded here before commit creation.",
+  "branch": "codex/tp-rte-batch-e2e-006",
+  "base_branch": "main",
+  "worktree_path": "/Users/hue/.codex/worktrees/tp-rte-batch-e2e-006",
+  "repo_identity": {
+    "repo_root": "/Users/hue/.codex/worktrees/tp-rte-batch-e2e-006",
+    "repo_marker": ".dopetaskroot",
+    "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "head_at_start": "9c30e9e869878e752782b9f95b6a1de262de974b",
+    "dedicated_worktree_verified": true,
+    "primary_checkout_observed": "/Users/hue/code/dopemux-mvp"
+  },
+  "files_created": [
+    "services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+    "task-packets/generated/TP-RTE-BATCH-E2E-006.json",
+    "proof/TP-RTE-BATCH-E2E-006/PROOF.json",
+    "proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md"
+  ],
+  "files_modified": [
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "task-packets/INDEX.md"
+  ],
+  "tests_added_or_modified": [
+    "services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py"
+  ],
+  "implementation_evidence": {
+    "pr_614_present": "main/origin-main at 9c30e9e869878e752782b9f95b6a1de262de974b has subject 'fix(rte): repair batch result and strict handling (#614)' and contains proof/TP-RTE-BATCH-005 plus task-packets/generated/TP-RTE-BATCH-005.json.",
+    "pre_change_runtime_gap": "run_extraction_v5.py batch path used 'if cfg.batch_mode and not strict_contract_required', so strict contract steps could not construct BatchRequest objects.",
+    "schema_source": "build_v5_batch_request uses route_entries_for_stage(...) and build_provider_step_contract_output(...) from structured_output_contracts.py to build the provider-specific json_schema response_format.",
+    "batch_path_wiring": "The real run_extraction_v5.py batch branch now calls build_v5_batch_request(...) before resolving API keys or constructing the batch client.",
+    "strict_fail_closed": "Strict batch request construction validates response_format.type=json_schema, json_schema.schema object presence, json_schema.strict=true, and non-empty artifact schema metadata before upload/submission.",
+    "non_strict_preservation": "Non-strict OpenAI-compatible batch request construction still returns response_format=None when force_json_output is false; existing batch client force_json_output behavior remains in batch_clients.py."
+  },
+  "validation_commands": [
+    {
+      "command": "python -m json.tool task-packets/generated/TP-RTE-BATCH-E2E-006.json",
+      "exit_code": 0,
+      "summary": "Task packet parses as JSON."
+    },
+    {
+      "command": "python -m json.tool proof/TP-RTE-BATCH-E2E-006/PROOF.json",
+      "exit_code": 0,
+      "summary": "Proof JSON parses."
+    },
+    {
+      "command": "python -c \"import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-BATCH-E2E-006.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); [print('/'.join(map(str,e.path)) + ': ' + e.message) for e in errs]; raise SystemExit(0 if not errs else 1)\"",
+      "exit_code": 0,
+      "summary": "Task packet validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+      "exit_code": 1,
+      "summary": "Intermediate guard failure after first implementation: explicit json_object downgrade reported missing artifact schema. The guard order was corrected before final validation."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+      "exit_code": 0,
+      "summary": "Focused v5 batch response_format regression tests passed: 4 passed."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+      "exit_code": 0,
+      "summary": "TP-RTE-BATCH-005 batch client boundary regressions passed: 7 passed."
+    },
+    {
+      "command": "python -m compileall -q services/repo-truth-extractor src/dopemux",
+      "exit_code": 0,
+      "summary": "Repo Truth Extractor and dopemux Python files compile."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+      "exit_code": 0,
+      "summary": "Broader batch/strict selection passed: 48 passed."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+      "exit_code": 0,
+      "summary": "Existing v5 operator safety preservation tests passed: 43 passed."
+    },
+    {
+      "command": "git diff --name-only | rg '(^services/repo-truth-extractor/promptsets/|model_map|routing|walker|prescan|cockpit|tui|package-lock|requirements|pyproject|docs/)'",
+      "exit_code": 1,
+      "summary": "Expected no-match result: diff does not include promptsets, model routing, walker/prescan, cockpit/TUI, dependency files, pyproject, or docs sweep paths."
+    },
+    {
+      "command": "rg -n \"cfg\\.batch_mode and not strict_contract_required|response_format=.*json_object|response_format\\]\\s*=\\s*\\{\\\"type\\\":\\s*\\\"json_object\\\"\\}\" services/repo-truth-extractor/run_extraction_v5.py",
+      "exit_code": 1,
+      "summary": "Expected no-match result: the strict-excluding batch gate was removed and no strict json_object downgrade pattern was introduced in run_extraction_v5.py."
+    },
+    {
+      "command": "git diff -- services/repo-truth-extractor/run_extraction_v5.py | rg -n \"STRICT_PASSTHROUGH_ATTESTATIONS|write_strict_passthrough|attestation|promptsets|model_map|prescan|walker\"",
+      "exit_code": 1,
+      "summary": "Expected no-match result: diff does not rewrite attestation writer or forbidden promptset/model-map/prescan/walker paths."
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "summary": "No whitespace errors found."
+    },
+    {
+      "command": "pre-commit run --files services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py task-packets/INDEX.md task-packets/generated/TP-RTE-BATCH-E2E-006.json proof/TP-RTE-BATCH-E2E-006/PROOF.json proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md",
+      "exit_code": 0,
+      "summary": "Configured pre-commit hooks passed for changed allowlist files."
+    }
+  ],
+  "safety_boundary_confirmation": {
+    "live_provider_calls_run": false,
+    "live_extraction_runs_run": false,
+    "external_batch_jobs_submitted": false,
+    "real_provider_files_retrieved": false,
+    "sync_path_changed": false,
+    "promptsets_touched": false,
+    "model_routing_touched": false,
+    "walker_prescan_touched": false,
+    "docs_sweep_included": false,
+    "dependency_files_changed": false,
+    "attestation_writer_rewrite": false
+  },
+  "live_provider_calls_run": false,
+  "live_extraction_runs_run": false,
+  "external_batch_jobs_submitted": false,
+  "v5_batch_response_format_propagated": {
+    "value": true,
+    "evidence": "test_v5_batch_request_construction_propagates_strict_response_format_to_wire_payload passed and inspected the BatchRequest plus fake OpenAI-compatible upload JSONL with response_format.type=json_schema and json_schema.strict=true."
+  },
+  "strict_missing_schema_fails_closed_before_submit": {
+    "value": true,
+    "evidence": "test_v5_strict_batch_request_missing_schema_fails_before_upload_or_submit passed and asserted fake files.uploads and fake batches.created stayed empty."
+  },
+  "non_strict_behavior_preserved": {
+    "value": true,
+    "evidence": "test_v5_non_strict_batch_request_preserves_omitted_openai_response_format passed and observed no response_format in the fake OpenAI-compatible JSONL body."
+  },
+  "batch_client_boundary_regression_passed": {
+    "value": true,
+    "evidence": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py passed: 7 passed."
+  },
+  "attestation_writer_touched": {
+    "value": false,
+    "evidence": "git diff against run_extraction_v5.py had no matches for STRICT_PASSTHROUGH_ATTESTATIONS, write_strict_passthrough, or attestation."
+  },
+  "f3_high_2_status": {
+    "status": "narrowed_further",
+    "evidence": "Runtime v5 batch request construction now carries strict json_schema response_format to BatchRequest and the OpenAI-compatible wire payload in offline tests. The attestation writer remains untouched, so F3-HIGH-2 is not claimed closed."
+  },
+  "blockers": [],
+  "residual_risks": [
+    "STRICT_PASSTHROUGH_ATTESTATIONS writer is intentionally out of scope and remains for TP-RTE-STRICT-ATTESTATION-007.",
+    "No live provider batch job was submitted; validation uses fake OpenAI-compatible file/batch transport.",
+    "GeminiBatchClient still does not serialize response_format directly; strict-capable route logic currently excludes Gemini strict routes, and this TP verified the OpenAI-compatible wire path requested by the task.",
+    "task-packets/INDEX.md still lists TP-RTE-BATCH-005 as Active even though PR #614 is present on main; this TP only added the new active packet row."
+  ],
+  "codereview_status": {
+    "status": "passed",
+    "evidence": "Manual diff review found changes limited to run_extraction_v5.py batch request construction, one focused offline test, task packet/index, and proof/report files."
+  },
+  "precommit_status": {
+    "status": "passed",
+    "evidence": "pre-commit run --files completed with exit code 0 for changed allowlist files."
+  },
+  "final_git_status_before_commit": "## codex/tp-rte-batch-e2e-006; modified: services/repo-truth-extractor/run_extraction_v5.py, task-packets/INDEX.md; untracked: services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py, task-packets/generated/TP-RTE-BATCH-E2E-006.json; ignored proof/TP-RTE-BATCH-E2E-006/* will be staged with git add -f."
+}

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -10520,6 +10520,31 @@ def build_batch_client(
     raise RuntimeError(f"Unsupported batch provider: {provider}")
 
 
+def _resolve_batch_route_override(
+    *,
+    fallback: Tuple[str, str, str],
+    batch_provider: str,
+    step_ladder: Sequence[Sequence[str]],
+) -> Tuple[str, str, str]:
+    fallback_provider = str(fallback[0]) if fallback else ""
+    if batch_provider == fallback_provider:
+        return (str(fallback[0]), str(fallback[1]), str(fallback[2]))
+    for candidate in step_ladder:
+        candidate_tuple = tuple(candidate)
+        if not candidate_tuple or str(candidate_tuple[0]) != batch_provider:
+            continue
+        candidate_provider = str(candidate_tuple[0])
+        candidate_model = (
+            str(candidate_tuple[1]) if len(candidate_tuple) > 1 else ""
+        )
+        if len(candidate_tuple) >= 3:
+            candidate_api_key_env = str(candidate_tuple[2])
+        else:
+            candidate_api_key_env = PROVIDER_API_KEY_ENV.get(candidate_provider, "")
+        return (candidate_provider, candidate_model, candidate_api_key_env)
+    return (str(fallback[0]), str(fallback[1]), str(fallback[2]))
+
+
 def _batch_route_entry_for_selected_route(
     step_contract: Optional[Dict[str, Any]],
     selected_route: Tuple[str, str, str],
@@ -12919,12 +12944,15 @@ else sdk_auth_present_flags(p_provider, True)
                         if cfg.batch_provider != "auto"
                         else route_provider
                     )
-                    selected_route = (route_provider, route_model_id, route_api_key_env)
-                    if batch_provider != route_provider:
-                        for candidate in step_ladder:
-                            if candidate[0] == batch_provider:
-                                selected_route = candidate
-                                break
+                    selected_route = _resolve_batch_route_override(
+                        fallback=(
+                            route_provider,
+                            route_model_id,
+                            route_api_key_env,
+                        ),
+                        batch_provider=batch_provider,
+                        step_ladder=step_ladder,
+                    )
                     batch_provider, batch_model_id, batch_api_key_env = selected_route
                     batch_transport = transport_for_provider(batch_provider, cfg)
                     try:

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -10664,6 +10664,7 @@ def build_v5_batch_request(
     user_content: str,
     provider: str,
     selected_route: Tuple[str, str, str],
+    selected_route_entry: Optional[Dict[str, Any]] = None,
     transport: str,
     strict_contract_required: bool,
     step_contract: Optional[Dict[str, Any]],
@@ -10693,6 +10694,8 @@ def build_v5_batch_request(
         route_entry = _batch_route_entry_for_selected_route(
             step_contract, selected_route
         )
+        if route_entry is None and isinstance(selected_route_entry, dict):
+            route_entry = dict(selected_route_entry)
         if route_entry is None:
             raise ValueError(
                 f"Strict batch request for {phase}/{step_id} requires a strict-capable route contract"
@@ -13030,6 +13033,20 @@ else sdk_auth_present_flags(p_provider, True)
                     )
                     batch_provider, batch_model_id, batch_api_key_env = selected_route
                     batch_transport = transport_for_provider(batch_provider, cfg)
+                    selected_route_entry = None
+                    if strict_contract_required and routing_reason in {
+                        "explicit_step_route_override",
+                        "explicit_phase_route_override",
+                        "benchmark_route_ownership_primary",
+                    }:
+                        selected_route_entry = {
+                            "provider": batch_provider,
+                            "model_id": batch_model_id,
+                            "api_key_env": batch_api_key_env,
+                            "structured_output_mode": "json_schema",
+                            "strict_json_schema": True,
+                            "strict_passthrough_verified": True,
+                        }
                     try:
                         batch_requests = [
                             build_v5_batch_request(
@@ -13039,6 +13056,7 @@ else sdk_auth_present_flags(p_provider, True)
                                 user_content=effective_user_prompt,
                                 provider=batch_provider,
                                 selected_route=selected_route,
+                                selected_route_entry=selected_route_entry,
                                 transport=batch_transport,
                                 strict_contract_required=strict_contract_required,
                                 step_contract=step_contract,

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -10520,6 +10520,122 @@ def build_batch_client(
     raise RuntimeError(f"Unsupported batch provider: {provider}")
 
 
+def _batch_route_entry_for_selected_route(
+    step_contract: Optional[Dict[str, Any]],
+    selected_route: Tuple[str, str, str],
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(step_contract, dict):
+        return None
+    selected_provider, selected_model_id, selected_api_key_env = selected_route
+    for route_entry in route_entries_for_stage(step_contract, "primary"):
+        if not isinstance(route_entry, dict):
+            continue
+        if (
+            str(route_entry.get("provider") or "") == str(selected_provider)
+            and str(route_entry.get("model_id") or "") == str(selected_model_id)
+            and str(route_entry.get("api_key_env") or "")
+            == str(selected_api_key_env)
+        ):
+            return dict(route_entry)
+    return None
+
+
+def _validate_strict_batch_response_format(
+    response_format: Optional[Dict[str, Any]],
+    *,
+    phase: str,
+    step_id: str,
+) -> None:
+    if not isinstance(response_format, dict):
+        raise ValueError(
+            f"Strict batch request for {phase}/{step_id} requires response_format.type=json_schema"
+        )
+    json_schema = response_format.get("json_schema")
+    schema = json_schema.get("schema") if isinstance(json_schema, dict) else None
+    if (
+        response_format.get("type") != "json_schema"
+        or not isinstance(json_schema, dict)
+        or not isinstance(schema, dict)
+    ):
+        raise ValueError(
+            f"Strict batch request for {phase}/{step_id} requires response_format.type=json_schema"
+        )
+    if json_schema.get("strict") is not True:
+        raise ValueError(
+            f"Strict batch request for {phase}/{step_id} requires json_schema.strict=true"
+        )
+
+
+def build_v5_batch_request(
+    *,
+    custom_id: str,
+    model_id: str,
+    system_prompt: str,
+    user_content: str,
+    provider: str,
+    selected_route: Tuple[str, str, str],
+    transport: str,
+    strict_contract_required: bool,
+    step_contract: Optional[Dict[str, Any]],
+    artifact_names: Tuple[str, ...],
+    force_json_output: bool,
+    metadata: Dict[str, Any],
+    schema_name_suffix: str = "batch",
+) -> BatchRequest:
+    batch_metadata = {
+        str(key): str(value)
+        for key, value in dict(metadata or {}).items()
+        if str(key).strip()
+    }
+    response_format: Optional[Dict[str, Any]] = None
+    if strict_contract_required:
+        batch_metadata["strict"] = "true"
+        phase = str(batch_metadata.get("phase") or "")
+        step_id = str(batch_metadata.get("step_id") or "")
+        if not isinstance(step_contract, dict):
+            raise ValueError(
+                f"Strict batch request for {phase}/{step_id} requires a step contract"
+            )
+        if not artifact_names:
+            raise ValueError(
+                f"Strict batch request for {phase}/{step_id} requires at least one artifact schema"
+            )
+        route_entry = _batch_route_entry_for_selected_route(
+            step_contract, selected_route
+        )
+        if route_entry is None:
+            raise ValueError(
+                f"Strict batch request for {phase}/{step_id} requires a strict-capable route contract"
+            )
+        response_format, response_meta = build_provider_step_contract_output(
+            route=route_entry,
+            transport=transport,
+            step_contract=step_contract,
+            artifact_names=artifact_names,
+            schema_name_suffix=schema_name_suffix,
+        )
+        _validate_strict_batch_response_format(
+            response_format,
+            phase=phase,
+            step_id=step_id,
+        )
+        response_artifacts = response_meta.get("artifact_names")
+        if not isinstance(response_artifacts, list) or not response_artifacts:
+            raise ValueError(
+                f"Strict batch request for {phase}/{step_id} requires at least one artifact schema"
+            )
+
+    return BatchRequest(
+        custom_id=custom_id,
+        model_id=model_id,
+        system_prompt=system_prompt,
+        user_content=user_content,
+        force_json_output=bool(force_json_output and not strict_contract_required),
+        metadata=batch_metadata,
+        response_format=response_format,
+    )
+
+
 def validate_success_partition_output(
     success_json_path: Path,
     phase: str,
@@ -12797,7 +12913,7 @@ else sdk_auth_present_flags(p_provider, True)
                 projected_output_tokens = _project_output_tokens(
                     projected_input_tokens
                 )
-                if cfg.batch_mode and not strict_contract_required:
+                if cfg.batch_mode:
                     batch_provider = (
                         cfg.batch_provider
                         if cfg.batch_provider != "auto"
@@ -12810,6 +12926,50 @@ else sdk_auth_present_flags(p_provider, True)
                                 selected_route = candidate
                                 break
                     batch_provider, batch_model_id, batch_api_key_env = selected_route
+                    batch_transport = transport_for_provider(batch_provider, cfg)
+                    try:
+                        batch_requests = [
+                            build_v5_batch_request(
+                                custom_id=partition_id,
+                                model_id=batch_model_id,
+                                system_prompt=prompt_text,
+                                user_content=effective_user_prompt,
+                                provider=batch_provider,
+                                selected_route=selected_route,
+                                transport=batch_transport,
+                                strict_contract_required=strict_contract_required,
+                                step_contract=step_contract,
+                                artifact_names=tuple(output_artifacts),
+                                force_json_output=(batch_provider == "gemini"),
+                                metadata={
+                                    "phase": phase,
+                                    "step_id": step_id,
+                                    "partition_id": partition_id,
+                                },
+                            )
+                        ]
+                    except ValueError as exc:
+                        failed_meta = {
+                            "provider": batch_provider,
+                            "model_id": batch_model_id,
+                            "failure_type": "batch_request_invalid",
+                            "provider_error_reason": str(exc),
+                            "execution_mode": "batch",
+                            "batch_provider": batch_provider,
+                            "batch_job_id": None,
+                            "estimated_input_tokens": projected_input_tokens,
+                            "estimated_output_tokens": projected_output_tokens,
+                            "strict_schema_required": bool(strict_contract_required),
+                        }
+                        return "", enrich_request_meta(
+                            failed_meta,
+                            run_id=run_id,
+                            phase=phase,
+                            step_id=step_id,
+                            partition_id=partition_id,
+                            provider=batch_provider,
+                            model_id=batch_model_id,
+                        )
                     batch_api_key, _ = resolve_api_key(
                         batch_provider, batch_api_key_env
                     )
@@ -12837,20 +12997,6 @@ else sdk_auth_present_flags(p_provider, True)
                     batch_client = build_batch_client(
                         batch_provider, batch_api_key, cfg
                     )
-                    batch_requests = [
-                        BatchRequest(
-                            custom_id=partition_id,
-                            model_id=batch_model_id,
-                            system_prompt=prompt_text,
-                            user_content=effective_user_prompt,
-                            force_json_output=(batch_provider == "gemini"),
-                            metadata={
-                                "phase": phase,
-                                "step_id": step_id,
-                                "partition_id": partition_id,
-                            },
-                        )
-                    ]
                     batch_request_rows.append(
                         {
                             "partition_id": partition_id,

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -364,6 +364,7 @@ try:
         repair_mode as resolve_contract_repair_mode,
         resolve_stage_route,
         route_entries_for_stage,
+        route_entry_by_identity,
         route_for_contract,
         strict_capability_reason,
         sidefill_enabled as resolve_contract_sidefill_enabled,
@@ -415,6 +416,7 @@ except ModuleNotFoundError:
     resolve_contract_repair_mode = structured_contracts_module.repair_mode
     resolve_stage_route = structured_contracts_module.resolve_stage_route
     route_entries_for_stage = structured_contracts_module.route_entries_for_stage
+    route_entry_by_identity = structured_contracts_module.route_entry_by_identity
     route_for_contract = structured_contracts_module.route_for_contract
     strict_capability_reason = structured_contracts_module.strict_capability_reason
     resolve_contract_sidefill_enabled = structured_contracts_module.sidefill_enabled
@@ -10520,15 +10522,63 @@ def build_batch_client(
     raise RuntimeError(f"Unsupported batch provider: {provider}")
 
 
+def _contract_route_entry_for_provider_model(
+    step_contract: Optional[Dict[str, Any]],
+    *,
+    provider: str,
+    model_id: str,
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(step_contract, dict):
+        return None
+    for route_entry in route_entries_for_stage(step_contract, "primary"):
+        if not isinstance(route_entry, dict):
+            continue
+        if (
+            str(route_entry.get("provider") or "") == str(provider)
+            and str(route_entry.get("model_id") or "") == str(model_id)
+        ):
+            return dict(route_entry)
+    return None
+
+
 def _resolve_batch_route_override(
     *,
     fallback: Tuple[str, str, str],
     batch_provider: str,
     step_ladder: Sequence[Sequence[str]],
+    step_contract: Optional[Dict[str, Any]] = None,
+    prefer_contract_api_key_env: bool = False,
 ) -> Tuple[str, str, str]:
+    def _resolved_route(
+        provider: str,
+        model_id: str,
+        api_key_env: str,
+        *,
+        allow_contract_api_key_env: bool,
+    ) -> Tuple[str, str, str]:
+        selected_api_key_env = str(api_key_env)
+        if allow_contract_api_key_env:
+            route_entry = _contract_route_entry_for_provider_model(
+                step_contract,
+                provider=provider,
+                model_id=model_id,
+            )
+            if route_entry is not None:
+                selected_api_key_env = str(
+                    route_entry.get("api_key_env") or selected_api_key_env
+                )
+        if not selected_api_key_env:
+            selected_api_key_env = PROVIDER_API_KEY_ENV.get(provider, "")
+        return (str(provider), str(model_id), str(selected_api_key_env))
+
     fallback_provider = str(fallback[0]) if fallback else ""
     if batch_provider == fallback_provider:
-        return (str(fallback[0]), str(fallback[1]), str(fallback[2]))
+        return _resolved_route(
+            str(fallback[0]),
+            str(fallback[1]),
+            str(fallback[2]),
+            allow_contract_api_key_env=bool(prefer_contract_api_key_env),
+        )
     for candidate in step_ladder:
         candidate_tuple = tuple(candidate)
         if not candidate_tuple or str(candidate_tuple[0]) != batch_provider:
@@ -10540,9 +10590,21 @@ def _resolve_batch_route_override(
         if len(candidate_tuple) >= 3:
             candidate_api_key_env = str(candidate_tuple[2])
         else:
-            candidate_api_key_env = PROVIDER_API_KEY_ENV.get(candidate_provider, "")
-        return (candidate_provider, candidate_model, candidate_api_key_env)
-    return (str(fallback[0]), str(fallback[1]), str(fallback[2]))
+            candidate_api_key_env = ""
+        return _resolved_route(
+            candidate_provider,
+            candidate_model,
+            candidate_api_key_env,
+            allow_contract_api_key_env=bool(
+                prefer_contract_api_key_env and not candidate_api_key_env
+            ),
+        )
+    return _resolved_route(
+        str(fallback[0]),
+        str(fallback[1]),
+        str(fallback[2]),
+        allow_contract_api_key_env=bool(prefer_contract_api_key_env),
+    )
 
 
 def _batch_route_entry_for_selected_route(
@@ -10552,17 +10614,20 @@ def _batch_route_entry_for_selected_route(
     if not isinstance(step_contract, dict):
         return None
     selected_provider, selected_model_id, selected_api_key_env = selected_route
-    for route_entry in route_entries_for_stage(step_contract, "primary"):
-        if not isinstance(route_entry, dict):
-            continue
-        if (
-            str(route_entry.get("provider") or "") == str(selected_provider)
-            and str(route_entry.get("model_id") or "") == str(selected_model_id)
-            and str(route_entry.get("api_key_env") or "")
-            == str(selected_api_key_env)
-        ):
-            return dict(route_entry)
-    return None
+    routes = route_entries_for_stage(step_contract, "primary")
+    route_entry = route_entry_by_identity(
+        routes,
+        provider=str(selected_provider),
+        model_id=str(selected_model_id),
+        api_key_env=str(selected_api_key_env),
+    )
+    if route_entry is not None:
+        return route_entry
+    return _contract_route_entry_for_provider_model(
+        step_contract,
+        provider=str(selected_provider),
+        model_id=str(selected_model_id),
+    )
 
 
 def _validate_strict_batch_response_format(
@@ -10631,6 +10696,11 @@ def build_v5_batch_request(
         if route_entry is None:
             raise ValueError(
                 f"Strict batch request for {phase}/{step_id} requires a strict-capable route contract"
+            )
+        strict_reason = strict_capability_reason(route_entry, transport)
+        if strict_reason is not None:
+            raise ValueError(
+                f"Strict batch request for {phase}/{step_id} requires a strict-capable route contract: {strict_reason}"
             )
         response_format, response_meta = build_provider_step_contract_output(
             route=route_entry,
@@ -12952,6 +13022,11 @@ else sdk_auth_present_flags(p_provider, True)
                         ),
                         batch_provider=batch_provider,
                         step_ladder=step_ladder,
+                        step_contract=step_contract,
+                        prefer_contract_api_key_env=bool(
+                            strict_contract_required
+                            and not route_info.get("api_key_env")
+                        ),
                     )
                     batch_provider, batch_model_id, batch_api_key_env = selected_route
                     batch_transport = transport_for_provider(batch_provider, cfg)

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
@@ -204,6 +204,31 @@ def test_v5_batch_request_matches_strict_route_when_api_key_env_was_omitted_from
     assert request.response_format["json_schema"]["strict"] is True
 
 
+def test_v5_batch_request_accepts_strict_selected_route_outside_primary_contract() -> None:
+    runner = _load_runner_module()
+    selected_route = ("xai", "grok-2", "XAI_API_KEY")
+
+    request = _batch_request(
+        runner,
+        provider="xai",
+        model_id="grok-2",
+        selected_route=selected_route,
+        selected_route_entry={
+            "provider": selected_route[0],
+            "model_id": selected_route[1],
+            "api_key_env": selected_route[2],
+            "structured_output_mode": "json_schema",
+            "strict_json_schema": True,
+            "strict_passthrough_verified": True,
+        },
+        transport="openai_compat_http",
+    )
+
+    assert request.response_format is not None
+    assert request.response_format["type"] == "json_schema"
+    assert request.response_format["json_schema"]["strict"] is True
+
+
 def test_v5_resolve_batch_route_override_handles_strict_two_tuple_ladder() -> None:
     runner = _load_runner_module()
     fallback = ("openai", "gpt-5-nano", "OPENAI_API_KEY")

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+SELECTED_ROUTE = ("openai", "gpt-5-nano", "OPENAI_API_KEY")
+ARTIFACT_NAME = "STRICT_BATCH_RESPONSE.json"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _load_runner_module():
+    module_path = _repo_root() / "services" / "repo-truth-extractor" / "run_extraction_v5.py"
+    spec = importlib.util.spec_from_file_location("run_extraction_v5_batch_response_format", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeFiles:
+    def __init__(self) -> None:
+        self.uploads: list[str] = []
+
+    def create(self, *, file, purpose: str):  # type: ignore[no-untyped-def]
+        assert purpose == "batch"
+        payload = file.read()
+        self.uploads.append(
+            payload.decode("utf-8")
+            if isinstance(payload, (bytes, bytearray))
+            else str(payload)
+        )
+        return SimpleNamespace(id="uploaded-file-1")
+
+
+class _FakeBatches:
+    def __init__(self) -> None:
+        self.created: list[dict[str, Any]] = []
+
+    def create(self, **kwargs):  # type: ignore[no-untyped-def]
+        self.created.append(dict(kwargs))
+        return SimpleNamespace(id="batch-job-1")
+
+
+class _FakeOpenAICompatClient:
+    def __init__(self) -> None:
+        self.files = _FakeFiles()
+        self.batches = _FakeBatches()
+
+
+def _client(runner: Any):
+    client = object.__new__(runner.OpenAIBatchClient)
+    fake = _FakeOpenAICompatClient()
+    client._client = fake
+    return client, fake
+
+
+def _strict_step_contract(
+    *,
+    expected_artifacts: tuple[str, ...] = (ARTIFACT_NAME,),
+    route_overrides: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    route = {
+        "provider": SELECTED_ROUTE[0],
+        "model_id": SELECTED_ROUTE[1],
+        "api_key_env": SELECTED_ROUTE[2],
+        "structured_output_mode": "json_schema",
+        "strict_json_schema": True,
+        "strict_passthrough_verified": True,
+    }
+    route.update(route_overrides or {})
+    return {
+        "phase": "A",
+        "step_id": "A1",
+        "scope": {"json_managed": True},
+        "expected_artifacts": list(expected_artifacts),
+        "artifact_order": list(expected_artifacts),
+        "lane": {
+            "lane_class": "BULK_DOCS_STRICT",
+            "strict_schema_required": True,
+            "strict_schema_required_primary": True,
+            "primary_routes": [route],
+        },
+        "artifacts": {
+            name: {
+                "canonical_schema_id": f"{name.removesuffix('.json')}@v1",
+                "required_fields": ["id", "path", "line_range"],
+                "prompt_required_item_fields": [],
+                "allow_empty_array_fields": [],
+            }
+            for name in expected_artifacts
+        },
+    }
+
+
+def _batch_request(runner: Any, **overrides: Any):
+    payload = {
+        "custom_id": "A_P0001",
+        "model_id": SELECTED_ROUTE[1],
+        "system_prompt": "Return JSON.",
+        "user_content": "Extract the fixture.",
+        "provider": SELECTED_ROUTE[0],
+        "selected_route": SELECTED_ROUTE,
+        "transport": "openai_sdk",
+        "strict_contract_required": True,
+        "step_contract": _strict_step_contract(),
+        "artifact_names": (ARTIFACT_NAME,),
+        "force_json_output": False,
+        "metadata": {"phase": "A", "step_id": "A1", "partition_id": "A_P0001"},
+    }
+    payload.update(overrides)
+    return runner.build_v5_batch_request(**payload)
+
+
+def test_v5_batch_request_construction_propagates_strict_response_format_to_wire_payload() -> None:
+    runner = _load_runner_module()
+    request = _batch_request(runner)
+
+    assert request.metadata["strict"] == "true"
+    assert request.response_format is not None
+    assert request.response_format["type"] == "json_schema"
+    assert request.response_format["json_schema"]["strict"] is True
+    assert request.response_format["json_schema"]["schema"]["type"] == "object"
+
+    client, fake = _client(runner)
+    job_id = client.submit(
+        [request],
+        runner.BatchRoute(*SELECTED_ROUTE),
+        {"phase": "A", "step_id": "A1", "partition_id": "A_P0001"},
+    )
+
+    assert job_id == "batch-job-1"
+    assert len(fake.files.uploads) == 1
+    rows = [json.loads(line) for line in fake.files.uploads[0].splitlines()]
+    assert len(rows) == 1
+    response_format = rows[0]["body"]["response_format"]
+    assert response_format["type"] == "json_schema"
+    assert response_format["json_schema"]["strict"] is True
+    assert response_format["json_schema"]["schema"]["additionalProperties"] is False
+
+
+def test_v5_strict_batch_request_missing_schema_fails_before_upload_or_submit() -> None:
+    runner = _load_runner_module()
+    _unused_client, fake = _client(runner)
+
+    with pytest.raises(ValueError, match="requires at least one artifact schema"):
+        _batch_request(
+            runner,
+            step_contract=_strict_step_contract(expected_artifacts=()),
+            artifact_names=(ARTIFACT_NAME,),
+        )
+
+    assert fake.files.uploads == []
+    assert fake.batches.created == []
+
+
+def test_v5_strict_batch_request_cannot_downgrade_to_json_object() -> None:
+    runner = _load_runner_module()
+
+    with pytest.raises(ValueError, match="response_format.type=json_schema"):
+        _batch_request(
+            runner,
+            step_contract=_strict_step_contract(
+                route_overrides={
+                    "structured_output_mode": "json_object",
+                    "strict_json_schema": False,
+                }
+            ),
+        )
+
+
+def test_v5_non_strict_batch_request_preserves_omitted_openai_response_format() -> None:
+    runner = _load_runner_module()
+    request = _batch_request(
+        runner,
+        strict_contract_required=False,
+        step_contract=None,
+        artifact_names=(),
+        force_json_output=False,
+    )
+
+    assert "strict" not in request.metadata
+    assert request.response_format is None
+
+    client, fake = _client(runner)
+    job_id = client.submit(
+        [request],
+        runner.BatchRoute(*SELECTED_ROUTE),
+        {"phase": "A", "step_id": "A1", "partition_id": "A_P0001"},
+    )
+
+    assert job_id == "batch-job-1"
+    rows = [json.loads(line) for line in fake.files.uploads[0].splitlines()]
+    assert "response_format" not in rows[0]["body"]

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
@@ -152,14 +152,22 @@ def test_v5_batch_request_construction_propagates_strict_response_format_to_wire
 
 def test_v5_strict_batch_request_missing_schema_fails_before_upload_or_submit() -> None:
     runner = _load_runner_module()
-    _unused_client, fake = _client(runner)
+    client, fake = _client(runner)
 
-    with pytest.raises(ValueError, match="requires at least one artifact schema"):
-        _batch_request(
+    def _construct_and_submit() -> None:
+        request = _batch_request(
             runner,
             step_contract=_strict_step_contract(expected_artifacts=()),
             artifact_names=(ARTIFACT_NAME,),
         )
+        client.submit(
+            [request],
+            runner.BatchRoute(*SELECTED_ROUTE),
+            {"phase": "A", "step_id": "A1", "partition_id": "A_P0001"},
+        )
+
+    with pytest.raises(ValueError, match="requires at least one artifact schema"):
+        _construct_and_submit()
 
     assert fake.files.uploads == []
     assert fake.batches.created == []
@@ -168,7 +176,7 @@ def test_v5_strict_batch_request_missing_schema_fails_before_upload_or_submit() 
 def test_v5_strict_batch_request_cannot_downgrade_to_json_object() -> None:
     runner = _load_runner_module()
 
-    with pytest.raises(ValueError, match="response_format.type=json_schema"):
+    with pytest.raises(ValueError, match="strict_json_schema_disabled"):
         _batch_request(
             runner,
             step_contract=_strict_step_contract(
@@ -178,6 +186,22 @@ def test_v5_strict_batch_request_cannot_downgrade_to_json_object() -> None:
                 }
             ),
         )
+
+
+def test_v5_batch_request_matches_strict_route_when_api_key_env_was_omitted_from_ladder() -> None:
+    runner = _load_runner_module()
+
+    request = _batch_request(
+        runner,
+        selected_route=("openai", "gpt-5-nano", "OPENAI_API_KEY"),
+        step_contract=_strict_step_contract(
+            route_overrides={"api_key_env": "OPENAI_TENANT_API_KEY"}
+        ),
+    )
+
+    assert request.response_format is not None
+    assert request.response_format["type"] == "json_schema"
+    assert request.response_format["json_schema"]["strict"] is True
 
 
 def test_v5_resolve_batch_route_override_handles_strict_two_tuple_ladder() -> None:
@@ -201,6 +225,22 @@ def test_v5_resolve_batch_route_override_handles_strict_two_tuple_ladder() -> No
         step_ladder=strict_ladder,
     )
     assert resolved == ("xai", "grok-2", runner.PROVIDER_API_KEY_ENV["xai"])
+
+    contract = _strict_step_contract(
+        route_overrides={
+            "provider": "xai",
+            "model_id": "grok-2",
+            "api_key_env": "XAI_TENANT_API_KEY",
+        }
+    )
+    resolved = runner._resolve_batch_route_override(
+        fallback=fallback,
+        batch_provider="xai",
+        step_ladder=strict_ladder,
+        step_contract=contract,
+        prefer_contract_api_key_env=True,
+    )
+    assert resolved == ("xai", "grok-2", "XAI_TENANT_API_KEY")
 
     # Override target absent from ladder falls back to the supplied default.
     assert runner._resolve_batch_route_override(

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
@@ -180,6 +180,36 @@ def test_v5_strict_batch_request_cannot_downgrade_to_json_object() -> None:
         )
 
 
+def test_v5_resolve_batch_route_override_handles_strict_two_tuple_ladder() -> None:
+    runner = _load_runner_module()
+    fallback = ("openai", "gpt-5-nano", "OPENAI_API_KEY")
+
+    # No override requested: fallback returned untouched.
+    assert runner._resolve_batch_route_override(
+        fallback=fallback,
+        batch_provider="openai",
+        step_ladder=[fallback],
+    ) == fallback
+
+    # Strict ladder rows are 2-tuples by contract; override must widen them
+    # to 3-tuples by deriving api_key_env from PROVIDER_API_KEY_ENV instead
+    # of unpacking 2 values into 3 and crashing.
+    strict_ladder = [("openai", "gpt-5-nano"), ("xai", "grok-2")]
+    resolved = runner._resolve_batch_route_override(
+        fallback=fallback,
+        batch_provider="xai",
+        step_ladder=strict_ladder,
+    )
+    assert resolved == ("xai", "grok-2", runner.PROVIDER_API_KEY_ENV["xai"])
+
+    # Override target absent from ladder falls back to the supplied default.
+    assert runner._resolve_batch_route_override(
+        fallback=fallback,
+        batch_provider="gemini",
+        step_ladder=strict_ladder,
+    ) == fallback
+
+
 def test_v5_non_strict_batch_request_preserves_omitted_openai_response_format() -> None:
     runner = _load_runner_module()
     request = _batch_request(

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -56,6 +56,7 @@ A packet is superseded by another packet
 | TP-RTE-V3-CONSENT-004 | Repo Truth Extractor | Gate legacy v3 execution and fail closed on unknown pipeline versions | Active | N/A |
 | TP-RTE-WALKER-006 | Repo Truth Extractor | Exclude generated artifacts and secret-bearing files from prescan walker input | Active | N/A |
 | TP-RTE-BATCH-005 | Repo Truth Extractor | Repair batch result extraction and strict batch request payload handling | Active | N/A |
+| TP-RTE-BATCH-E2E-006 | Repo Truth Extractor | Wire strict batch response_format through v5 request construction | Active | N/A |
 | TP-DMX-AGENTS-CODEX-ENDTOEND-0001 | Agent Guidance | Make Codex execute TP lifecycle end-to-end by default | Ready | N/A |
 | TP-DMX-COMPOSE-RESTORE-001 | Infra | Restore canonical Docker Compose authority | Ready | N/A |
 | DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Merged (PR #528) | N/A |

--- a/task-packets/generated/TP-RTE-BATCH-E2E-006.json
+++ b/task-packets/generated/TP-RTE-BATCH-E2E-006.json
@@ -1,0 +1,242 @@
+{
+  "id": "TP-RTE-BATCH-E2E-006",
+  "project": "dopemux-mvp",
+  "target": "repo-truth-extractor / v5 batch request response_format propagation",
+  "invariants": [
+    "Treat services/repo-truth-extractor/run_extraction_v5.py as the strongest RTE runtime authority for active v5 batch request construction.",
+    "Treat services/repo-truth-extractor/lib/batch_clients.py as the batch client wire payload serialization authority.",
+    "Use existing structured-output contract helpers; do not invent an unrelated schema builder.",
+    "Strict batch requests must carry response_format.type=json_schema from the v5 structured-output contract path or fail closed before upload/submission.",
+    "Non-strict batch behavior must remain unchanged.",
+    "Do not run live extraction, provider/model calls, external provider batch submission, or real provider result retrieval.",
+    "Do not modify sync extraction behavior, promptsets, model routing, walker/prescan, v3 consent, cockpit/TUI, dependencies, or broad docs."
+  ],
+  "depends_on": [
+    "TP-RTE-BATCH-005"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "RTE-GOLIVE-BLOCKERS",
+    "base_branch": "main",
+    "parent_tp_id": "TP-RTE-BATCH-005",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/tp-rte-batch-e2e-006",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(rte): wire strict batch response format",
+    "allowlist": [
+      "services/repo-truth-extractor/run_extraction_v5.py",
+      "services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-RTE-BATCH-E2E-006.json",
+      "proof/TP-RTE-BATCH-E2E-006/PROOF.json",
+      "proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-RTE-BATCH-E2E-006.json",
+      "python -m json.tool proof/TP-RTE-BATCH-E2E-006/PROOF.json",
+      "python -c \"import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-BATCH-E2E-006.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); raise SystemExit(0 if not errs else 1)\"",
+      "python -m compileall -q services/repo-truth-extractor src/dopemux",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+      "git diff --check",
+      "pre-commit run --files <changed files>"
+    ]
+  },
+  "pr": {
+    "title": "fix(rte): wire strict batch response format",
+    "body": "## Summary\n- wire strict v5 structured-output response_format creation into the real run_extraction_v5 batch request construction path\n- fail closed before upload/submission when strict batch request construction cannot resolve a valid json_schema response_format\n- add offline regression tests using fake batch transport to prove strict request and wire payload behavior while preserving non-strict behavior\n\n## Scope\n- Repo Truth Extractor v5 batch request construction\n- focused tests, task packet, proof, and implementer report\n- no live extraction, provider/model calls, external batch jobs, sync path changes, promptsets, model routing, walker/prescan, docs sweep, dependencies, cockpit/TUI, or attestation writer rewrite\n\n## Validation\n- task packet/proof JSON validation and task packet schema validation\n- compileall for services/repo-truth-extractor and src/dopemux\n- focused v5 batch response_format tests, existing batch client tests, batch/strict subset, and operator safety tests\n- git diff whitespace check and pre-commit on changed files",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Create and validate the repo-bound task packet before implementation.",
+      "requirements": [
+        "Verify repo root, marker, remote, branch, status, and HEAD.",
+        "Confirm main contains TP-RTE-BATCH-005 / PR #614 behavior and proof.",
+        "Inspect RTE runtime, batch client, structured-output contracts, phase contract map, task packet schema, index, and existing strict/batch tests."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/generated/TP-RTE-BATCH-E2E-006.json",
+        "python -c \"import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-BATCH-E2E-006.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); raise SystemExit(0 if not errs else 1)\""
+      ],
+      "expected_files": [
+        "task-packets/generated/TP-RTE-BATCH-E2E-006.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "Task packet parses as JSON.",
+        "Task packet validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "PROJECT.md",
+        "docs/research/mcp-customization/dopemux-constraints/SYSTEM_RepoTruthExtractor.md",
+        "task-packets/INDEX.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "proof/TP-RTE-BATCH-005/PROOF.json",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/lib/batch_clients.py",
+        "services/repo-truth-extractor/lib/structured_output_contracts.py",
+        "services/repo-truth-extractor/lib/phase_contract_map.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Trace v5 batch request construction and strict schema availability.",
+      "requirements": [
+        "Identify the actual BatchRequest construction point in run_extraction_v5.py.",
+        "Identify the existing structured-output response_format helper and route/contract inputs available at that point.",
+        "Do not change attestation writers."
+      ],
+      "commands": [
+        "rg -n \"BatchRequest|response_format|build_provider_step_contract_output|build_openai_response_format|strict_contract_required|cfg.batch_mode\" services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py"
+      ],
+      "validation": [
+        "Evidence identifies the construction path and available schema source before implementation."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/lib/structured_output_contracts.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Wire strict structured response_format into v5 BatchRequest creation.",
+      "requirements": [
+        "Use existing structured-output contract helpers.",
+        "Populate BatchRequest.response_format with response_format.type=json_schema for strict contract batch requests.",
+        "Set strict metadata so the batch client boundary remains fail-closed."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py"
+      ],
+      "validation": [
+        "Focused test proves the v5 construction path creates a strict BatchRequest with response_format.type=json_schema.",
+        "Focused test proves fake OpenAI-compatible upload JSONL contains response_format.type=json_schema."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/lib/batch_clients.py",
+        "services/repo-truth-extractor/lib/structured_output_contracts.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Fail closed for strict batch requests when schema cannot be resolved.",
+      "requirements": [
+        "Raise an explicit exception before upload/submission when strict batch mode cannot resolve a valid json_schema response_format.",
+        "Forbid silent downgrade to json_object for strict requests.",
+        "Assert fake upload/submission was not called."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py"
+      ],
+      "validation": [
+        "Focused missing-schema test observes explicit fail-closed behavior before fake upload/submission."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/lib/batch_clients.py"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Preserve non-strict batch behavior and TP-RTE-BATCH-005 regressions.",
+      "requirements": [
+        "Keep non-strict batch response_format behavior unchanged.",
+        "Keep OpenAIBatchClient strict boundary and batch result extraction behavior intact.",
+        "Do not touch sync extraction, promptsets, model routing, walker/prescan, dependencies, cockpit/TUI, or attestation writer."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py"
+      ],
+      "validation": [
+        "New focused tests pass.",
+        "Existing batch client tests pass.",
+        "Broader batch/strict subset passes or unrelated pre-existing failures are documented.",
+        "Operator safety tests pass."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py"
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Finalize proof, inspect diff, codereview, precommit, commit, push, and open PR.",
+      "requirements": [
+        "Record every validation command and exit code in proof artifacts.",
+        "Run codereview before pre-commit.",
+        "Commit only allowlisted files.",
+        "Push codex/tp-rte-batch-e2e-006 and open a PR against main when gh authentication permits."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/generated/TP-RTE-BATCH-E2E-006.json",
+        "python -m json.tool proof/TP-RTE-BATCH-E2E-006/PROOF.json",
+        "python -m compileall -q services/repo-truth-extractor src/dopemux",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+        "git diff --check",
+        "pre-commit run --files <changed files>",
+        "git commit -m \"fix(rte): wire strict batch response format\"",
+        "git push -u origin codex/tp-rte-batch-e2e-006",
+        "gh pr create --base main --head codex/tp-rte-batch-e2e-006 --title \"fix(rte): wire strict batch response format\" --body-file <body>"
+      ],
+      "expected_files": [
+        "proof/TP-RTE-BATCH-E2E-006/PROOF.json",
+        "proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md"
+      ],
+      "validation": [
+        "Proof JSON parses.",
+        "All required validation results are recorded with exit codes.",
+        "Commit SHA, push result, PR URL or exact blocker, residual risks, and cleanup status are recorded."
+      ],
+      "context_files": [
+        "proof/TP-RTE-BATCH-E2E-006/PROOF.json",
+        "proof/TP-RTE-BATCH-E2E-006/IMPLEMENTER_REPORT.md"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- wire strict v5 structured-output response_format construction into the real run_extraction_v5 batch request path
- fail closed before upload/submission when strict batch request construction cannot resolve a valid json_schema response_format
- add offline fake-transport tests proving strict BatchRequest and OpenAI-compatible JSONL wire payload behavior while preserving non-strict behavior

## Validation
- python -m json.tool task-packets/generated/TP-RTE-BATCH-E2E-006.json
- python -m json.tool proof/TP-RTE-BATCH-E2E-006/PROOF.json
- Task packet Draft7 schema validation against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- python -m compileall -q services/repo-truth-extractor src/dopemux
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
- git diff --check
- pre-commit run --files changed allowlist files

## Safety / Scope
- no provider calls
- no live extraction
- no external batch jobs
- no sync extraction path changes
- no promptsets, model routing, walker/prescan, docs sweep, dependencies, cockpit/TUI, or attestation writer rewrite

## Residual Risks
- F3-HIGH-2 is narrowed further, not closed; STRICT_PASSTHROUGH_ATTESTATIONS remains for TP-RTE-STRICT-ATTESTATION-007
- GeminiBatchClient still does not serialize response_format directly; current strict route logic excludes Gemini strict routes, and this PR verifies the OpenAI-compatible wire path

@codex review
@gemini
@copilot