### PR TITLE
fix(rte): ground strict attestations in runtime evidence

### DIFF
--- a/proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md
+++ b/proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md
@@ -5,6 +5,7 @@
 - Added strict passthrough runtime evidence summaries from BatchRequest, constructed request, and fake wire JSONL payload rows.
 - Updated `STRICT_PASSTHROUGH_ATTESTATIONS` generation to V2 with explicit `VERIFIED`, `UNVERIFIED`, `FAILED`, `UNKNOWN`, and `NOT_APPLICABLE` truth states.
 - Removed the unsafe synthesized OpenRouter strict passthrough bypass for explicit and benchmark selected routes outside primary contract proof.
+- Addressed post-PR review feedback by classifying `selected: false` strict-route misses as `FAILED` before any `NOT_APPLICABLE` fallback, including rows with no `strict_required` field and empty attempts.
 - Applied targeted INDEX hygiene for TP-RTE-BATCH-005, TP-RTE-BATCH-E2E-006, and this packet.
 
 ## 2. Authority used
@@ -40,12 +41,13 @@
 
 - `strict_passthrough_verified` in the attestation artifact is now true only when observed runtime/wire/construction evidence proves `response_format.type == "json_schema"`, `json_schema` exists, `json_schema.strict is true`, and a schema hash exists.
 - Static route claims are retained as `route_strict_passthrough_claim` and `route_strict_capable_claim` rather than promoted to verification.
+- Missing selected strict routes are reported as `FAILED` with `no_selected_strict_route`, not `NOT_APPLICABLE`, even if the attestation row has no attempts.
 - Explicit/benchmark OpenRouter selected route synthesis now uses primary contract proof when present; otherwise strict capability fails closed.
 - Gemini strict routes remain failed/excluded, not verified.
 
 ## 6. Tests added/modified
 
-- Added `services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py`.
+- Added `services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py`, including post-review coverage for selected:false strict-route misses with no attempts.
 
 ## 7. Validation commands and exit codes
 
@@ -53,10 +55,10 @@
 - `python -m json.tool proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json` -> 0
 - `python -c "import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); [print('/'.join(map(str,e.path)) + ': ' + e.message) for e in errs]; raise SystemExit(0 if not errs else 1)"` -> 0
 - `python -m compileall -q services/repo-truth-extractor src/dopemux` -> 0
-- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py` -> 0, 4 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py` -> 0, 5 passed
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 0, 7 passed
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py` -> 0, 7 passed
-- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0, 55 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0, 56 passed
 - `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py` -> 0, 43 passed
 - `git diff --check` -> 0
 - `rg -n "strict_passthrough_verified=True|strict_passthrough_verified = True" services/repo-truth-extractor/run_extraction_v5.py` -> 1, no matches
@@ -77,7 +79,7 @@
 
 ## 9. F3-HIGH-2 classification
 
-CLOSED. Evidence: V2 strict passthrough attestations require observed runtime/wire/construction evidence for VERIFIED, intent-only strict claims are UNVERIFIED, synthesized OpenRouter passthrough proof is no longer hardcoded, and focused plus existing strict/batch tests pass.
+CLOSED. Evidence: V2 strict passthrough attestations require observed runtime/wire/construction evidence for VERIFIED, intent-only strict claims are UNVERIFIED, missing selected strict routes are FAILED, synthesized OpenRouter passthrough proof is no longer hardcoded, and focused plus existing strict/batch tests pass.
 
 ## 10. Index hygiene summary
 

--- a/proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md
+++ b/proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md
@@ -1,0 +1,95 @@
+# TP-RTE-STRICT-ATTESTATION-007 Implementer Report
+
+## 1. Change summary
+
+- Added strict passthrough runtime evidence summaries from BatchRequest, constructed request, and fake wire JSONL payload rows.
+- Updated `STRICT_PASSTHROUGH_ATTESTATIONS` generation to V2 with explicit `VERIFIED`, `UNVERIFIED`, `FAILED`, `UNKNOWN`, and `NOT_APPLICABLE` truth states.
+- Removed the unsafe synthesized OpenRouter strict passthrough bypass for explicit and benchmark selected routes outside primary contract proof.
+- Applied targeted INDEX hygiene for TP-RTE-BATCH-005, TP-RTE-BATCH-E2E-006, and this packet.
+
+## 2. Authority used
+
+- User-provided TP-RTE-STRICT-ATTESTATION-007 implementation prompt
+- `AGENTS.md`
+- `PROJECT.md`
+- `docs/research/mcp-customization/dopemux-constraints/RULES.md`
+- `docs/research/mcp-customization/dopemux-constraints/PROJECT.md`
+- `docs/research/mcp-customization/dopemux-constraints/SYSTEM_RepoTruthExtractor.md`
+- `task-packets/INDEX.md`
+- `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `services/repo-truth-extractor/lib/batch_clients.py`
+- `services/repo-truth-extractor/lib/structured_output_contracts.py`
+- `services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py`
+- `services/repo-truth-extractor/tests/test_batch_clients_integration.py`
+- `services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py`
+
+## 3. Files created
+
+- `services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py`
+- `task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json`
+- `proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json`
+- `proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md`
+
+## 4. Files modified
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `task-packets/INDEX.md`
+
+## 5. Behavior changes
+
+- `strict_passthrough_verified` in the attestation artifact is now true only when observed runtime/wire/construction evidence proves `response_format.type == "json_schema"`, `json_schema` exists, `json_schema.strict is true`, and a schema hash exists.
+- Static route claims are retained as `route_strict_passthrough_claim` and `route_strict_capable_claim` rather than promoted to verification.
+- Explicit/benchmark OpenRouter selected route synthesis now uses primary contract proof when present; otherwise strict capability fails closed.
+- Gemini strict routes remain failed/excluded, not verified.
+
+## 6. Tests added/modified
+
+- Added `services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py`.
+
+## 7. Validation commands and exit codes
+
+- `python -m json.tool task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json` -> 0
+- `python -m json.tool proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json` -> 0
+- `python -c "import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); [print('/'.join(map(str,e.path)) + ': ' + e.message) for e in errs]; raise SystemExit(0 if not errs else 1)"` -> 0
+- `python -m compileall -q services/repo-truth-extractor src/dopemux` -> 0
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py` -> 0, 4 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py` -> 0, 7 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py` -> 0, 7 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"` -> 0, 55 passed
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py` -> 0, 43 passed
+- `git diff --check` -> 0
+- `rg -n "strict_passthrough_verified=True|strict_passthrough_verified = True" services/repo-truth-extractor/run_extraction_v5.py` -> 1, no matches
+- `pre-commit run --files services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py task-packets/INDEX.md task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md` -> 0
+
+## 8. Safety boundary confirmation
+
+- live provider calls: not run
+- live extraction runs: not run
+- external batch jobs: not submitted
+- real provider files: not retrieved
+- sync behavior broadening: no broadening; only metadata evidence propagation
+- promptsets changed: no
+- model routing broad edit: no
+- walker/prescan changed: no
+- docs sweep: no
+- dependency files changed: no
+
+## 9. F3-HIGH-2 classification
+
+CLOSED. Evidence: V2 strict passthrough attestations require observed runtime/wire/construction evidence for VERIFIED, intent-only strict claims are UNVERIFIED, synthesized OpenRouter passthrough proof is no longer hardcoded, and focused plus existing strict/batch tests pass.
+
+## 10. Index hygiene summary
+
+- `TP-RTE-BATCH-005` marked `Merged (PR #614)`.
+- `TP-RTE-BATCH-E2E-006` marked `Merged (PR #615)`.
+- `TP-RTE-STRICT-ATTESTATION-007` added as `Active`.
+
+## 11. Commit readiness
+
+Ready for commit after final JSON parse and git diff review.
+
+## 12. Residual risks and UNKNOWNs
+
+- External provider passthrough was not live-tested because live provider calls and batch submissions are forbidden for this TP.
+- F4-CRIT-2 docs canonical naming inversion remains open and out of scope.

--- a/proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json
+++ b/proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json
@@ -1,0 +1,142 @@
+{
+  "tp_id": "TP-RTE-STRICT-ATTESTATION-007",
+  "objective": "Ground RTE strict passthrough attestations in observed runtime or wire evidence and remove synthesized OpenRouter strict passthrough verification bypass.",
+  "starting_head": "a4227982fde16b99799882506265f29ec0de303d",
+  "ending_head": "SELF_REFERENTIAL_COMMIT_SHA_REPORTED_IN_CLOSEOUT",
+  "ending_head_note": "The commit SHA cannot be embedded in this file before creating the commit without amending; closeout reports the actual commit SHA.",
+  "branch": "codex/tp-rte-strict-attestation-007",
+  "base_branch": "main",
+  "worktree_path": "/Users/hue/.codex/worktrees/tp-rte-strict-attestation-007",
+  "repo_identity": {
+    "root": "/Users/hue/.codex/worktrees/tp-rte-strict-attestation-007",
+    "remote_origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "repo_marker": "AGENTS.md",
+    "base_contains_pr_614": "PASS: 9c30e9e869878e752782b9f95b6a1de262de974b is ancestor of origin/main.",
+    "base_contains_pr_615": "PASS: origin/main is a4227982fde16b99799882506265f29ec0de303d, subject fix(rte): wire strict batch response format (#615)."
+  },
+  "files_created": [
+    "services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py",
+    "task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json",
+    "proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json",
+    "proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md"
+  ],
+  "files_modified": [
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "task-packets/INDEX.md"
+  ],
+  "tests_added_or_modified": [
+    "services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py"
+  ],
+  "validation_commands": [
+    {
+      "command": "python -m json.tool task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json",
+      "exit_code": 0,
+      "summary": "PASS: task packet JSON parses."
+    },
+    {
+      "command": "python -m json.tool proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json",
+      "exit_code": 0,
+      "summary": "PASS: proof JSON parses."
+    },
+    {
+      "command": "python -c \"import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); [print('/'.join(map(str,e.path)) + ': ' + e.message) for e in errs]; raise SystemExit(0 if not errs else 1)\"",
+      "exit_code": 0,
+      "summary": "PASS: task packet conforms to docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+    },
+    {
+      "command": "python -m compileall -q services/repo-truth-extractor src/dopemux",
+      "exit_code": 0,
+      "summary": "PASS: compileall completed."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py",
+      "exit_code": 0,
+      "summary": "PASS: 4 passed; proves wire-payload VERIFIED, intent-only UNVERIFIED, synthesized OpenRouter strict passthrough not verified, and Gemini strict not verified."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+      "exit_code": 0,
+      "summary": "PASS: 7 passed; strict response_format propagation and fail-closed batch construction preserved."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+      "exit_code": 0,
+      "summary": "PASS: 7 passed; batch client strict JSONL serialization and strict missing-schema rejection preserved."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+      "exit_code": 0,
+      "summary": "PASS: 55 passed; broad strict/batch selector passed."
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+      "exit_code": 0,
+      "summary": "PASS: 43 passed; operator safety suite passed."
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "summary": "PASS: no whitespace errors."
+    },
+    {
+      "command": "rg -n \"strict_passthrough_verified=True|strict_passthrough_verified = True\" services/repo-truth-extractor/run_extraction_v5.py",
+      "exit_code": 1,
+      "summary": "PASS: rg returned no matches for hardcoded strict_passthrough_verified=True."
+    },
+    {
+      "command": "pre-commit run --files services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py task-packets/INDEX.md task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md",
+      "exit_code": 0,
+      "summary": "PASS: repo pre-commit hooks passed for the scoped changed files, including ignored proof files."
+    }
+  ],
+  "safety_boundary_confirmation": {
+    "live_provider_calls_run": false,
+    "live_extraction_runs_run": false,
+    "external_batch_jobs_submitted": false,
+    "real_provider_files_retrieved": false,
+    "sync_behavior_broadened": false,
+    "promptsets_changed": false,
+    "model_routing_broad_edit": false,
+    "walker_prescan_changed": false,
+    "docs_sweep_performed": false,
+    "dependencies_changed": false
+  },
+  "live_provider_calls_run": false,
+  "live_extraction_runs_run": false,
+  "external_batch_jobs_submitted": false,
+  "real_provider_files_retrieved": false,
+  "strict_attestation_uses_observed_runtime_or_wire_evidence": {
+    "value": true,
+    "evidence": "write_strict_passthrough_attestations now emits STRICT_PASSTHROUGH_ATTESTATIONS_V2 and sets strict_passthrough_verified only when attestation_status is VERIFIED; VERIFIED requires evidence_source in wire_payload, BatchRequest, or constructed_request plus response_format.type=json_schema, json_schema present, strict=true, and schema hash present."
+  },
+  "strict_intent_alone_not_verified": {
+    "value": true,
+    "evidence": "test_strict_intent_alone_is_not_verified asserts a static strict_route_attestation with strict_passthrough_verified=True but no runtime evidence produces attestation_status=UNVERIFIED and strict_passthrough_verified=false."
+  },
+  "synthesized_openrouter_passthrough_bypass_removed_or_made_honest": {
+    "value": true,
+    "evidence": "Explicit and benchmark synthesized route entries now use primary contract strict_passthrough_verified proof only when present; otherwise OpenRouter strict routes fail strict_capability_reason with openrouter_strict_passthrough_unverified. rg found no strict_passthrough_verified=True hardcode in run_extraction_v5.py."
+  },
+  "gemini_strict_still_excluded": {
+    "value": true,
+    "evidence": "test_gemini_strict_route_cannot_be_verified asserts Gemini strict evidence is FAILED with provider_not_strict_capable:gemini and strict batch construction rejects Gemini strict selected routes."
+  },
+  "batch_response_format_regressions_passed": {
+    "value": true,
+    "evidence": "test_run_extraction_v5_batch_response_format.py, test_batch_clients_integration.py, and tests -k \"batch or strict\" passed."
+  },
+  "index_hygiene_updated": {
+    "value": true,
+    "evidence": "task-packets/INDEX.md marks TP-RTE-BATCH-005 as Merged (PR #614), TP-RTE-BATCH-E2E-006 as Merged (PR #615), and adds TP-RTE-STRICT-ATTESTATION-007 as Active."
+  },
+  "f3_high_2_status": {
+    "value": "closed",
+    "evidence": "The attestation writer now requires runtime/wire/construction evidence for VERIFIED; strict intent alone is UNVERIFIED; synthesized OpenRouter strict passthrough proof is no longer hardcoded and fails closed without primary contract proof; focused and existing strict/batch tests pass."
+  },
+  "blockers": [],
+  "residual_risks": [
+    "No live provider calls, live extraction, external batch submission, or real provider file retrieval was run by design; external provider passthrough is proven only by offline wire-payload construction and BatchRequest evidence.",
+    "F4-CRIT-2 docs canonical naming inversion remains open and out of scope."
+  ],
+  "final_git_status_before_commit": "## codex/tp-rte-strict-attestation-007...origin/main; modified: services/repo-truth-extractor/run_extraction_v5.py, task-packets/INDEX.md; untracked: services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py, task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json; ignored proof/TP-RTE-STRICT-ATTESTATION-007/* will be staged with git add -f."
+}

--- a/proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json
+++ b/proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json
@@ -51,7 +51,7 @@
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py",
       "exit_code": 0,
-      "summary": "PASS: 4 passed; proves wire-payload VERIFIED, intent-only UNVERIFIED, synthesized OpenRouter strict passthrough not verified, and Gemini strict not verified."
+      "summary": "PASS: 5 passed; proves wire-payload VERIFIED, intent-only UNVERIFIED, selected:false strict-route misses FAILED, synthesized OpenRouter strict passthrough not verified, and Gemini strict not verified."
     },
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
@@ -66,7 +66,7 @@
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
       "exit_code": 0,
-      "summary": "PASS: 55 passed; broad strict/batch selector passed."
+      "summary": "PASS: 56 passed; broad strict/batch selector passed."
     },
     {
       "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
@@ -111,7 +111,7 @@
   },
   "strict_intent_alone_not_verified": {
     "value": true,
-    "evidence": "test_strict_intent_alone_is_not_verified asserts a static strict_route_attestation with strict_passthrough_verified=True but no runtime evidence produces attestation_status=UNVERIFIED and strict_passthrough_verified=false."
+    "evidence": "test_strict_intent_alone_is_not_verified asserts a static strict_route_attestation with strict_passthrough_verified=True but no runtime evidence produces attestation_status=UNVERIFIED and strict_passthrough_verified=false. test_missing_strict_route_is_failed_even_without_attempts asserts selected:false strict-route misses are FAILED even when attempts is empty and strict_required is absent."
   },
   "synthesized_openrouter_passthrough_bypass_removed_or_made_honest": {
     "value": true,
@@ -131,12 +131,12 @@
   },
   "f3_high_2_status": {
     "value": "closed",
-    "evidence": "The attestation writer now requires runtime/wire/construction evidence for VERIFIED; strict intent alone is UNVERIFIED; synthesized OpenRouter strict passthrough proof is no longer hardcoded and fails closed without primary contract proof; focused and existing strict/batch tests pass."
+    "evidence": "The attestation writer now requires runtime/wire/construction evidence for VERIFIED; strict intent alone is UNVERIFIED; missing selected strict routes are FAILED; synthesized OpenRouter strict passthrough proof is no longer hardcoded and fails closed without primary contract proof; focused and existing strict/batch tests pass."
   },
   "blockers": [],
   "residual_risks": [
     "No live provider calls, live extraction, external batch submission, or real provider file retrieval was run by design; external provider passthrough is proven only by offline wire-payload construction and BatchRequest evidence.",
     "F4-CRIT-2 docs canonical naming inversion remains open and out of scope."
   ],
-  "final_git_status_before_commit": "## codex/tp-rte-strict-attestation-007...origin/main; modified: services/repo-truth-extractor/run_extraction_v5.py, task-packets/INDEX.md; untracked: services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py, task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json; ignored proof/TP-RTE-STRICT-ATTESTATION-007/* will be staged with git add -f."
+  "final_git_status_before_commit": "## codex/tp-rte-strict-attestation-007...origin/codex/tp-rte-strict-attestation-007; modified: proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md, proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json, services/repo-truth-extractor/run_extraction_v5.py, services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py."
 }

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -4597,12 +4597,20 @@ def _resolve_explicit_route_override(
     if selected is None:
         return None
     provider, model_id, api_key_env = selected
+    contract_route_entry = _contract_route_entry_for_provider_model(
+        step_contract,
+        provider=str(provider),
+        model_id=str(model_id),
+    )
+    contract_strict_passthrough_verified = bool(
+        contract_route_entry.get("strict_passthrough_verified", False)
+    ) if isinstance(contract_route_entry, dict) else False
     route = {
         "provider": str(provider),
         "model_id": str(model_id),
         "api_key_env": str(api_key_env),
         "strict_json_schema": strict_required,
-        "strict_passthrough_verified": strict_required,
+        "strict_passthrough_verified": contract_strict_passthrough_verified,
     }
     transport = transport_for_provider(str(provider), cfg)
     strict_reason = strict_capability_reason(route, transport) if strict_required else None
@@ -4619,8 +4627,8 @@ def _resolve_explicit_route_override(
                 "model_id": str(model_id),
                 "transport": transport,
                 "strict_json_schema": True,
-                "strict_passthrough_verified": True,
-                "strict_capable": True,
+                "strict_passthrough_verified": contract_strict_passthrough_verified,
+                "strict_capable": strict_reason is None,
                 "reason": None,
                 "ownership_mode": "explicit_step_routes_v1",
                 "ownership_source": "explicit_step_routes_env",
@@ -4686,6 +4694,15 @@ def _resolve_benchmark_owned_stage_route(
             payload.get("strict_passthrough_verified", False)
         ),
     }
+    contract_route_entry = _contract_route_entry_for_provider_model(
+        step_contract,
+        provider=str(route["provider"]),
+        model_id=str(route["model_id"]),
+    )
+    if str(route["provider"]) == "openrouter":
+        route["strict_passthrough_verified"] = bool(
+            contract_route_entry.get("strict_passthrough_verified", False)
+        ) if isinstance(contract_route_entry, dict) else False
     transport = transport_for_provider(str(route["provider"]), cfg)
     reason = strict_capability_reason(route, transport)
     attempts = [
@@ -10656,6 +10673,229 @@ def _validate_strict_batch_response_format(
         )
 
 
+STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY = "strict_passthrough_runtime_evidence"
+STRICT_PASSTHROUGH_VERIFIED_STATES = {"VERIFIED"}
+STRICT_PASSTHROUGH_OBSERVED_EVIDENCE_SOURCES = {
+    "wire_payload",
+    "BatchRequest",
+    "constructed_request",
+}
+
+
+def _stable_schema_hash(payload: Any) -> Optional[str]:
+    if not isinstance(payload, dict):
+        return None
+    serialized = json.dumps(
+        payload,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def _strict_passthrough_evidence_from_response_format(
+    *,
+    response_format: Any,
+    evidence_source: str,
+    provider: str,
+    model_id: str,
+    transport: str,
+    phase: str,
+    step_id: str,
+    partition_id: str,
+    custom_id: Optional[str] = None,
+    request_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    response_format_obj = response_format if isinstance(response_format, dict) else {}
+    json_schema = (
+        response_format_obj.get("json_schema")
+        if isinstance(response_format_obj.get("json_schema"), dict)
+        else {}
+    )
+    schema = json_schema.get("schema") if isinstance(json_schema, dict) else None
+    return {
+        "evidence_source": str(evidence_source or "unavailable"),
+        "provider": str(provider),
+        "model_id": str(model_id),
+        "transport": str(transport),
+        "phase": str(phase).strip().upper(),
+        "step_id": str(step_id).strip().upper(),
+        "partition_id": str(partition_id),
+        "custom_id": str(custom_id or partition_id or ""),
+        "request_id": str(request_id or custom_id or partition_id or ""),
+        "response_format_present": isinstance(response_format, dict),
+        "response_format_type": str(response_format_obj.get("type") or ""),
+        "json_schema_present": isinstance(json_schema, dict) and bool(json_schema),
+        "json_schema_strict": (
+            json_schema.get("strict") if isinstance(json_schema, dict) else None
+        ),
+        "schema_name": str(json_schema.get("name") or "")
+        if isinstance(json_schema, dict)
+        else "",
+        "schema_present": isinstance(schema, dict),
+        "schema_sha256": _stable_schema_hash(schema),
+    }
+
+
+def build_strict_passthrough_evidence_from_batch_request(
+    request: BatchRequest,
+    *,
+    provider: str,
+    transport: str,
+    phase: str,
+    step_id: str,
+    partition_id: str,
+    evidence_source: str = "BatchRequest",
+) -> Dict[str, Any]:
+    return _strict_passthrough_evidence_from_response_format(
+        response_format=request.response_format,
+        evidence_source=evidence_source,
+        provider=provider,
+        model_id=request.model_id,
+        transport=transport,
+        phase=phase,
+        step_id=step_id,
+        partition_id=partition_id,
+        custom_id=request.custom_id,
+        request_id=request.custom_id,
+    )
+
+
+def build_strict_passthrough_evidence_from_wire_payload(
+    payload_row: Dict[str, Any],
+    *,
+    provider: str,
+    model_id: str,
+    transport: str,
+    phase: str,
+    step_id: str,
+    partition_id: str,
+) -> Dict[str, Any]:
+    body = payload_row.get("body") if isinstance(payload_row.get("body"), dict) else {}
+    custom_id = str(payload_row.get("custom_id") or partition_id)
+    return _strict_passthrough_evidence_from_response_format(
+        response_format=body.get("response_format"),
+        evidence_source="wire_payload",
+        provider=provider,
+        model_id=model_id,
+        transport=transport,
+        phase=phase,
+        step_id=step_id,
+        partition_id=partition_id,
+        custom_id=custom_id,
+        request_id=custom_id,
+    )
+
+
+def _append_strict_passthrough_evidence(
+    request_meta: Dict[str, Any],
+    evidence_rows: Sequence[Dict[str, Any]],
+) -> None:
+    rows = [
+        dict(row)
+        for row in evidence_rows
+        if isinstance(row, dict) and str(row.get("evidence_source") or "").strip()
+    ]
+    if not rows:
+        return
+    existing = request_meta.get(STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY)
+    if isinstance(existing, list):
+        request_meta[STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY] = [
+            row for row in existing if isinstance(row, dict)
+        ] + rows
+    else:
+        request_meta[STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY] = rows
+
+
+def _evidence_matches_strict_attestation(
+    evidence: Dict[str, Any],
+    *,
+    phase: str,
+    step_id: str,
+    partition_id: str,
+    provider: str,
+    model_id: str,
+) -> bool:
+    comparisons = {
+        "phase": phase,
+        "step_id": step_id,
+        "partition_id": partition_id,
+        "provider": provider,
+        "model_id": model_id,
+    }
+    for key, expected in comparisons.items():
+        observed = str(evidence.get(key) or "").strip()
+        wanted = str(expected or "").strip()
+        if observed and wanted and observed != wanted:
+            return False
+    return True
+
+
+def _select_strict_passthrough_evidence(
+    evidence_rows: Sequence[Dict[str, Any]],
+    *,
+    phase: str,
+    step_id: str,
+    partition_id: str,
+    provider: str,
+    model_id: str,
+) -> Optional[Dict[str, Any]]:
+    for row in evidence_rows:
+        if not isinstance(row, dict):
+            continue
+        if _evidence_matches_strict_attestation(
+            row,
+            phase=phase,
+            step_id=step_id,
+            partition_id=partition_id,
+            provider=provider,
+            model_id=model_id,
+        ):
+            return dict(row)
+    return None
+
+
+def _strict_passthrough_truth_state(
+    entry: Dict[str, Any],
+    evidence: Optional[Dict[str, Any]],
+) -> Tuple[str, str]:
+    if "strict_required" in entry:
+        strict_expected = bool(entry.get("strict_required"))
+    else:
+        strict_expected = bool(
+            entry.get("strict_json_schema")
+            or entry.get("strict_capable")
+            or entry.get("strict_passthrough_verified")
+            or entry.get("attempts")
+        )
+    if not strict_expected:
+        return "NOT_APPLICABLE", "strict_schema_not_required"
+    provider = str(entry.get("provider") or "").strip().lower()
+    if provider == "gemini":
+        return "FAILED", "provider_not_strict_capable:gemini"
+    if entry.get("selected") is False:
+        return "FAILED", "no_selected_strict_route"
+    if evidence is None:
+        return "UNVERIFIED", "runtime_or_wire_evidence_missing"
+    source = str(evidence.get("evidence_source") or "").strip()
+    if source not in STRICT_PASSTHROUGH_OBSERVED_EVIDENCE_SOURCES:
+        return "UNKNOWN", f"unsupported_evidence_source:{source or 'missing'}"
+    if not bool(evidence.get("response_format_present", False)):
+        return "FAILED", "response_format_missing"
+    if str(evidence.get("response_format_type") or "") != "json_schema":
+        return "FAILED", "response_format_not_json_schema"
+    if not bool(evidence.get("json_schema_present", False)):
+        return "FAILED", "json_schema_missing"
+    if evidence.get("json_schema_strict") is not True:
+        return "FAILED", "json_schema_strict_not_true"
+    if not bool(evidence.get("schema_present", False)) or not evidence.get(
+        "schema_sha256"
+    ):
+        return "FAILED", "json_schema_schema_missing"
+    return "VERIFIED", "observed_strict_json_schema"
+
+
 def build_v5_batch_request(
     *,
     custom_id: str,
@@ -13039,13 +13279,24 @@ else sdk_auth_present_flags(p_provider, True)
                         "explicit_phase_route_override",
                         "benchmark_route_ownership_primary",
                     }:
+                        contract_route_entry = _contract_route_entry_for_provider_model(
+                            step_contract,
+                            provider=batch_provider,
+                            model_id=batch_model_id,
+                        )
                         selected_route_entry = {
                             "provider": batch_provider,
                             "model_id": batch_model_id,
                             "api_key_env": batch_api_key_env,
                             "structured_output_mode": "json_schema",
                             "strict_json_schema": True,
-                            "strict_passthrough_verified": True,
+                            "strict_passthrough_verified": bool(
+                                contract_route_entry.get(
+                                    "strict_passthrough_verified", False
+                                )
+                            )
+                            if isinstance(contract_route_entry, dict)
+                            else False,
                         }
                     try:
                         batch_requests = [
@@ -13069,6 +13320,20 @@ else sdk_auth_present_flags(p_provider, True)
                                 },
                             )
                         ]
+                        strict_passthrough_evidence_rows = (
+                            [
+                                build_strict_passthrough_evidence_from_batch_request(
+                                    batch_requests[0],
+                                    provider=batch_provider,
+                                    transport=batch_transport,
+                                    phase=phase,
+                                    step_id=step_id,
+                                    partition_id=partition_id,
+                                )
+                            ]
+                            if strict_contract_required
+                            else []
+                        )
                     except ValueError as exc:
                         failed_meta = {
                             "provider": batch_provider,
@@ -13106,6 +13371,10 @@ else sdk_auth_present_flags(p_provider, True)
                             "estimated_input_tokens": projected_input_tokens,
                             "estimated_output_tokens": projected_output_tokens,
                         }
+                        _append_strict_passthrough_evidence(
+                            failed_meta,
+                            strict_passthrough_evidence_rows,
+                        )
                         return "", enrich_request_meta(
                             failed_meta,
                             run_id=run_id,
@@ -13224,6 +13493,10 @@ else sdk_auth_present_flags(p_provider, True)
                             "estimated_output_tokens": projected_output_tokens,
                             **capture_exception_metadata(exc),
                         }
+                        _append_strict_passthrough_evidence(
+                            failed_meta,
+                            strict_passthrough_evidence_rows,
+                        )
                         return "", enrich_request_meta(
                             failed_meta,
                             run_id=run_id,
@@ -13264,6 +13537,10 @@ else sdk_auth_present_flags(p_provider, True)
                                 reserved_spend if "reserved_spend" in locals() else None
                             ),
                         }
+                        _append_strict_passthrough_evidence(
+                            meta,
+                            strict_passthrough_evidence_rows,
+                        )
                         return json.dumps(
                             submit_payload, ensure_ascii=True, sort_keys=True
                         ), enrich_request_meta(
@@ -13307,6 +13584,10 @@ else sdk_auth_present_flags(p_provider, True)
                                 "estimated_input_tokens": projected_input_tokens,
                                 "estimated_output_tokens": projected_output_tokens,
                             }
+                            _append_strict_passthrough_evidence(
+                                failed_meta,
+                                strict_passthrough_evidence_rows,
+                            )
                             return "", enrich_request_meta(
                                 failed_meta,
                                 run_id=run_id,
@@ -13366,6 +13647,10 @@ else sdk_auth_present_flags(p_provider, True)
                             "estimated_input_tokens": projected_input_tokens,
                             "estimated_output_tokens": projected_output_tokens,
                         }
+                        _append_strict_passthrough_evidence(
+                            failed_meta,
+                            strict_passthrough_evidence_rows,
+                        )
                         return "", enrich_request_meta(
                             failed_meta,
                             run_id=run_id,
@@ -13388,6 +13673,10 @@ else sdk_auth_present_flags(p_provider, True)
                         "estimated_input_tokens": projected_input_tokens,
                         "estimated_output_tokens": projected_output_tokens,
                     }
+                    _append_strict_passthrough_evidence(
+                        meta,
+                        strict_passthrough_evidence_rows,
+                    )
                     for job_row in batch_job_rows:
                         if (
                             str(job_row.get("partition_id")) == partition_id
@@ -13494,6 +13783,24 @@ else sdk_auth_present_flags(p_provider, True)
                     provider=route_provider,
                     model_id=route_model_id,
                 )
+                if strict_contract_required and isinstance(draft_response_format, dict):
+                    _append_strict_passthrough_evidence(
+                        request_meta_local,
+                        [
+                            _strict_passthrough_evidence_from_response_format(
+                                response_format=draft_response_format,
+                                evidence_source="constructed_request",
+                                provider=route_provider,
+                                model_id=route_model_id,
+                                transport=transport_for_provider(route_provider, cfg),
+                                phase=phase,
+                                step_id=step_id,
+                                partition_id=partition_id,
+                                custom_id=partition_id,
+                                request_id=partition_id,
+                            )
+                        ],
+                    )
                 if request_meta_local.get("response_received") or llm_result.get("ok"):
                     spend_record = _accumulate_runtime_spend(
                         cfg,
@@ -15905,6 +16212,7 @@ def write_strict_passthrough_attestations(
     rows: List[Dict[str, Any]] = []
     by_provider = Counter()
     by_stage = Counter()
+    by_status = Counter()
     strict_capable_rows = 0
     for phase in phases:
         phase_dir = dirs.get(phase)
@@ -15930,24 +16238,95 @@ def write_strict_passthrough_attestations(
             phase_id = str(payload.get("phase") or phase).strip().upper()
             step_id = str(payload.get("step_id") or "").strip().upper()
             partition_id = str(payload.get("partition_id") or "").strip()
+            evidence_rows = (
+                request_meta.get(STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY)
+                if isinstance(
+                    request_meta.get(STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY), list
+                )
+                else []
+            )
             for entry in attestations:
                 if not isinstance(entry, dict):
                     continue
+                provider = str(entry.get("provider") or "").strip()
+                model_id = str(entry.get("model_id") or "").strip()
+                entry_evidence = (
+                    entry.get(STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY)
+                    if isinstance(
+                        entry.get(STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY), dict
+                    )
+                    else None
+                )
+                evidence = entry_evidence or _select_strict_passthrough_evidence(
+                    evidence_rows,
+                    phase=phase_id,
+                    step_id=step_id,
+                    partition_id=partition_id,
+                    provider=provider,
+                    model_id=model_id,
+                )
+                attestation_status, attestation_reason = _strict_passthrough_truth_state(
+                    entry,
+                    evidence,
+                )
+                verified = attestation_status in STRICT_PASSTHROUGH_VERIFIED_STATES
                 row = {
                     "phase": phase_id,
                     "step_id": step_id,
                     "partition_id": partition_id,
                     "stage": str(entry.get("stage") or "").strip(),
                     "selected": bool(entry.get("selected", False)),
-                    "provider": str(entry.get("provider") or "").strip(),
-                    "model_id": str(entry.get("model_id") or "").strip(),
+                    "provider": provider,
+                    "model_id": model_id,
                     "api_key_env": str(entry.get("api_key_env") or "").strip(),
                     "transport": str(entry.get("transport") or "").strip(),
+                    "strict_required": bool(entry.get("strict_required", False)),
                     "strict_json_schema": bool(entry.get("strict_json_schema", False)),
-                    "strict_passthrough_verified": bool(
+                    "route_strict_passthrough_claim": bool(
                         entry.get("strict_passthrough_verified", False)
                     ),
-                    "strict_capable": bool(entry.get("strict_capable", False)),
+                    "route_strict_capable_claim": bool(
+                        entry.get("strict_capable", False)
+                    ),
+                    "strict_passthrough_verified": verified,
+                    "strict_capable": verified,
+                    "attestation_status": attestation_status,
+                    "attestation_reason": attestation_reason,
+                    "evidence_source": (
+                        str(evidence.get("evidence_source") or "")
+                        if isinstance(evidence, dict)
+                        else "unavailable"
+                    ),
+                    "response_format_present": (
+                        bool(evidence.get("response_format_present", False))
+                        if isinstance(evidence, dict)
+                        else False
+                    ),
+                    "response_format_type": (
+                        str(evidence.get("response_format_type") or "")
+                        if isinstance(evidence, dict)
+                        else ""
+                    ),
+                    "json_schema_present": (
+                        bool(evidence.get("json_schema_present", False))
+                        if isinstance(evidence, dict)
+                        else False
+                    ),
+                    "json_schema_strict": (
+                        evidence.get("json_schema_strict")
+                        if isinstance(evidence, dict)
+                        else None
+                    ),
+                    "schema_name": (
+                        str(evidence.get("schema_name") or "")
+                        if isinstance(evidence, dict)
+                        else ""
+                    ),
+                    "schema_sha256": (
+                        str(evidence.get("schema_sha256") or "")
+                        if isinstance(evidence, dict)
+                        else ""
+                    ),
                     "attempts": (
                         entry.get("attempts")
                         if isinstance(entry.get("attempts"), list)
@@ -15961,17 +16340,25 @@ def write_strict_passthrough_attestations(
                     by_stage[row["stage"]] += 1
                 if row["strict_capable"]:
                     strict_capable_rows += 1
+                if row["attestation_status"]:
+                    by_status[row["attestation_status"]] += 1
     payload = {
-        "version": "STRICT_PASSTHROUGH_ATTESTATIONS_V1",
+        "version": "STRICT_PASSTHROUGH_ATTESTATIONS_V2",
         "generated_at": now_iso(),
         "run_id": run_id,
-        "policy": {"no_auto_transport_flips": True},
+        "policy": {
+            "no_auto_transport_flips": True,
+            "verified_requires_observed_runtime_or_wire_evidence": True,
+            "intent_or_static_route_config_alone_verified": False,
+        },
         "rows": rows,
         "summary": {
             "row_count": len(rows),
             "strict_capable_rows": strict_capable_rows,
+            "verified_rows": by_status.get("VERIFIED", 0),
             "provider_histogram": dict(sorted(by_provider.items())),
             "stage_histogram": dict(sorted(by_stage.items())),
+            "attestation_status_histogram": dict(sorted(by_status.items())),
         },
     }
     write_json(dirs["root"] / STRICT_PASSTHROUGH_ATTESTATIONS_FILENAME, payload)

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -10869,13 +10869,13 @@ def _strict_passthrough_truth_state(
             or entry.get("strict_passthrough_verified")
             or entry.get("attempts")
         )
+    if entry.get("selected") is False:
+        return "FAILED", "no_selected_strict_route"
     if not strict_expected:
         return "NOT_APPLICABLE", "strict_schema_not_required"
     provider = str(entry.get("provider") or "").strip().lower()
     if provider == "gemini":
         return "FAILED", "provider_not_strict_capable:gemini"
-    if entry.get("selected") is False:
-        return "FAILED", "no_selected_strict_route"
     if evidence is None:
         return "UNVERIFIED", "runtime_or_wire_evidence_missing"
     source = str(evidence.get("evidence_source") or "").strip()

--- a/services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py
+++ b/services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py
@@ -299,6 +299,31 @@ def test_strict_intent_alone_is_not_verified(tmp_path: Path) -> None:
     assert row["route_strict_passthrough_claim"] is True
 
 
+def test_missing_strict_route_is_failed_even_without_attempts(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    dirs = _dirs(runner, tmp_path)
+    _write_raw(
+        dirs,
+        request_meta={
+            "strict_route_attestations": [
+                {
+                    "stage": "primary",
+                    "selected": False,
+                    "attempts": [],
+                }
+            ]
+        },
+    )
+
+    payload = runner.write_strict_passthrough_attestations(dirs, "run-test", ["A"])
+
+    row = payload["rows"][0]
+    assert row["attestation_status"] == "FAILED"
+    assert row["attestation_reason"] == "no_selected_strict_route"
+    assert row["strict_passthrough_verified"] is False
+    assert payload["summary"]["attestation_status_histogram"]["FAILED"] == 1
+
+
 def test_explicit_openrouter_route_outside_primary_contract_is_not_synthesized_verified(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py
+++ b/services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py
@@ -1,0 +1,399 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+
+OPENAI_ROUTE = ("openai", "gpt-5-nano", "OPENAI_API_KEY")
+ARTIFACT_NAME = "STRICT_ATTESTATION.json"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _load_runner_module():
+    module_path = _repo_root() / "services" / "repo-truth-extractor" / "run_extraction_v5.py"
+    spec = importlib.util.spec_from_file_location("run_extraction_v5_strict_attestation", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_cfg(runner: Any):
+    cfg = runner.RunnerConfig.__new__(runner.RunnerConfig)
+    defaults = {
+        "dry_run": True,
+        "max_files_docs": 35,
+        "max_files_code": 20,
+        "max_chars": 650000,
+        "max_request_bytes": 200000,
+        "file_truncate_chars": 70000,
+        "home_scan_mode": "safe",
+        "resume": False,
+        "fail_fast_auth": False,
+        "gemini_auth_mode": "auto",
+        "gemini_transport": "sdk",
+        "openai_transport": "openai_sdk",
+        "xai_transport": "openai_sdk",
+        "retry_policy": "default",
+        "retry_max_attempts": 4,
+        "retry_base_seconds": 2.0,
+        "retry_max_seconds": 30.0,
+        "phase_auth_fail_threshold": 5,
+        "partition_workers": 1,
+        "debug_phase_inputs": False,
+        "fail_fast_missing_inputs": False,
+        "executor": "thread",
+        "routing_policy": "cost",
+        "disable_escalation": False,
+        "escalation_max_hops": 2,
+        "batch_mode": False,
+        "batch_provider": "auto",
+        "batch_poll_seconds": 30,
+        "batch_wait_timeout_seconds": 1800,
+        "batch_max_requests_per_job": 2000,
+        "batch_submit_only": False,
+        "webhook_url": "",
+        "webhook_secret": "",
+        "webhook_timeout_seconds": 5,
+        "webhook_required": False,
+        "webhook_auto_continue": False,
+        "live_ok": False,
+        "selected_s_steps": None,
+        "selected_execution_step": None,
+        "d0_max_files": None,
+        "d1_max_files": None,
+        "provider_denylist": (),
+        "compare_mode": None,
+        "compare_model": None,
+        "compare_provider": None,
+        "compare_steps": None,
+        "prescan_dir": None,
+        "router": None,
+        "prescan_skip": False,
+        "prescan_online": False,
+        "prescan_import_dir": None,
+        "prescan_allow_scope_reduction": False,
+        "allow_online_llm": False,
+        "max_cost_usd": None,
+        "ledger": None,
+        "fl_int_provider_timeout_seconds": 180,
+        "fl_int_f0_batch_timeout_seconds": 210,
+    }
+    for key, value in defaults.items():
+        object.__setattr__(cfg, key, value)
+    return cfg
+
+
+class _FakeFiles:
+    def __init__(self) -> None:
+        self.uploads: list[str] = []
+
+    def create(self, *, file, purpose: str):  # type: ignore[no-untyped-def]
+        assert purpose == "batch"
+        payload = file.read()
+        self.uploads.append(
+            payload.decode("utf-8")
+            if isinstance(payload, (bytes, bytearray))
+            else str(payload)
+        )
+        return SimpleNamespace(id="uploaded-file-1")
+
+
+class _FakeBatches:
+    def create(self, **kwargs):  # type: ignore[no-untyped-def]
+        return SimpleNamespace(id="batch-job-1")
+
+
+class _FakeOpenAICompatClient:
+    def __init__(self) -> None:
+        self.files = _FakeFiles()
+        self.batches = _FakeBatches()
+
+
+def _client(runner: Any):
+    client = object.__new__(runner.OpenAIBatchClient)
+    fake = _FakeOpenAICompatClient()
+    client._client = fake
+    return client, fake
+
+
+def _strict_step_contract(
+    *,
+    provider: str = OPENAI_ROUTE[0],
+    model_id: str = OPENAI_ROUTE[1],
+    api_key_env: str = OPENAI_ROUTE[2],
+    strict_passthrough_verified: bool = True,
+) -> dict[str, Any]:
+    return {
+        "phase": "A",
+        "step_id": "A1",
+        "scope": {"json_managed": True},
+        "expected_artifacts": [ARTIFACT_NAME],
+        "artifact_order": [ARTIFACT_NAME],
+        "lane": {
+            "lane_class": "BULK_DOCS_STRICT",
+            "strict_schema_required": True,
+            "strict_schema_required_primary": True,
+            "primary_routes": [
+                {
+                    "provider": provider,
+                    "model_id": model_id,
+                    "api_key_env": api_key_env,
+                    "structured_output_mode": "json_schema",
+                    "strict_json_schema": True,
+                    "strict_passthrough_verified": strict_passthrough_verified,
+                }
+            ],
+        },
+        "artifacts": {
+            ARTIFACT_NAME: {
+                "canonical_schema_id": "STRICT_ATTESTATION@v1",
+                "required_fields": ["id", "path", "line_range"],
+                "prompt_required_item_fields": [],
+                "allow_empty_array_fields": [],
+            }
+        },
+    }
+
+
+def _batch_request(runner: Any, **overrides: Any):
+    payload = {
+        "custom_id": "A_P0001",
+        "model_id": OPENAI_ROUTE[1],
+        "system_prompt": "Return JSON.",
+        "user_content": "Extract the fixture.",
+        "provider": OPENAI_ROUTE[0],
+        "selected_route": OPENAI_ROUTE,
+        "transport": "openai_sdk",
+        "strict_contract_required": True,
+        "step_contract": _strict_step_contract(),
+        "artifact_names": (ARTIFACT_NAME,),
+        "force_json_output": False,
+        "metadata": {"phase": "A", "step_id": "A1", "partition_id": "A_P0001"},
+    }
+    payload.update(overrides)
+    return runner.build_v5_batch_request(**payload)
+
+
+def _dirs(runner: Any, tmp_path: Path) -> dict[str, Path]:
+    root = tmp_path / "run"
+    phase_dir = root / runner.PHASE_DIR_NAMES["A"]
+    (phase_dir / "raw").mkdir(parents=True, exist_ok=True)
+    return {"root": root, "A": phase_dir}
+
+
+def _write_raw(
+    dirs: dict[str, Path],
+    *,
+    request_meta: dict[str, Any],
+    phase: str = "A",
+    step_id: str = "A1",
+    partition_id: str = "A_P0001",
+) -> None:
+    raw_path = dirs[phase] / "raw" / f"{step_id}__{partition_id}.json"
+    raw_path.write_text(
+        json.dumps(
+            {
+                "phase": phase,
+                "step_id": step_id,
+                "partition_id": partition_id,
+                "artifacts": [],
+                "request_meta": request_meta,
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def _strict_attestation(**overrides: Any) -> dict[str, Any]:
+    row = {
+        "stage": "primary",
+        "selected": True,
+        "provider": OPENAI_ROUTE[0],
+        "model_id": OPENAI_ROUTE[1],
+        "api_key_env": OPENAI_ROUTE[2],
+        "transport": "openai_sdk",
+        "strict_required": True,
+        "strict_json_schema": True,
+        "strict_passthrough_verified": True,
+        "strict_capable": True,
+        "attempts": [],
+    }
+    row.update(overrides)
+    return row
+
+
+def test_strict_attestation_verifies_only_observed_wire_payload(
+    tmp_path: Path,
+) -> None:
+    runner = _load_runner_module()
+    request = _batch_request(runner)
+    client, fake = _client(runner)
+
+    client.submit(
+        [request],
+        runner.BatchRoute(*OPENAI_ROUTE),
+        {"phase": "A", "step_id": "A1", "partition_id": "A_P0001"},
+    )
+
+    wire_row = json.loads(fake.files.uploads[0].splitlines()[0])
+    evidence = runner.build_strict_passthrough_evidence_from_wire_payload(
+        wire_row,
+        provider=OPENAI_ROUTE[0],
+        model_id=OPENAI_ROUTE[1],
+        transport="openai_sdk",
+        phase="A",
+        step_id="A1",
+        partition_id="A_P0001",
+    )
+    dirs = _dirs(runner, tmp_path)
+    _write_raw(
+        dirs,
+        request_meta={
+            runner.STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY: [evidence],
+            "strict_route_attestations": [_strict_attestation()],
+        },
+    )
+
+    payload = runner.write_strict_passthrough_attestations(dirs, "run-test", ["A"])
+
+    assert payload["version"] == "STRICT_PASSTHROUGH_ATTESTATIONS_V2"
+    row = payload["rows"][0]
+    assert row["attestation_status"] == "VERIFIED"
+    assert row["attestation_reason"] == "observed_strict_json_schema"
+    assert row["strict_passthrough_verified"] is True
+    assert row["route_strict_passthrough_claim"] is True
+    assert row["evidence_source"] == "wire_payload"
+    assert row["response_format_type"] == "json_schema"
+    assert row["json_schema_present"] is True
+    assert row["json_schema_strict"] is True
+    assert row["schema_sha256"]
+
+
+def test_strict_intent_alone_is_not_verified(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    dirs = _dirs(runner, tmp_path)
+    _write_raw(
+        dirs,
+        request_meta={"strict_route_attestations": [_strict_attestation()]},
+    )
+
+    payload = runner.write_strict_passthrough_attestations(dirs, "run-test", ["A"])
+
+    row = payload["rows"][0]
+    assert row["attestation_status"] == "UNVERIFIED"
+    assert row["attestation_reason"] == "runtime_or_wire_evidence_missing"
+    assert row["strict_passthrough_verified"] is False
+    assert row["route_strict_passthrough_claim"] is True
+
+
+def test_explicit_openrouter_route_outside_primary_contract_is_not_synthesized_verified(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_runner_module()
+    cfg = _make_cfg(runner)
+    contract = runner._step_contract_for("A", "A0")
+    monkeypatch.setenv(
+        "DPMX_EXPLICIT_STEP_ROUTES",
+        json.dumps(
+            {
+                "enabled": True,
+                "steps": {"A:A0": "openrouter/anthropic/claude-opus-4-6"},
+                "phases": {},
+            }
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="openrouter_strict_passthrough_unverified"):
+        runner.resolve_effective_step_route("A", "A0", cfg, step_contract=contract)
+
+    selected_route = ("openrouter", "anthropic/claude-opus-4-6", "OPENROUTER_API_KEY")
+    with pytest.raises(ValueError, match="openrouter_strict_passthrough_unverified"):
+        _batch_request(
+            runner,
+            provider=selected_route[0],
+            model_id=selected_route[1],
+            selected_route=selected_route,
+            selected_route_entry={
+                "provider": selected_route[0],
+                "model_id": selected_route[1],
+                "api_key_env": selected_route[2],
+                "structured_output_mode": "json_schema",
+                "strict_json_schema": True,
+                "strict_passthrough_verified": False,
+            },
+            transport="openai_sdk",
+        )
+
+
+def test_gemini_strict_route_cannot_be_verified(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    evidence = runner._strict_passthrough_evidence_from_response_format(
+        response_format={
+            "type": "json_schema",
+            "json_schema": {
+                "name": "gemini_strict_fixture",
+                "strict": True,
+                "schema": {"type": "object", "additionalProperties": False},
+            },
+        },
+        evidence_source="constructed_request",
+        provider="gemini",
+        model_id="gemini-3.1-pro-preview",
+        transport="sdk",
+        phase="A",
+        step_id="A1",
+        partition_id="A_P0001",
+    )
+    dirs = _dirs(runner, tmp_path)
+    _write_raw(
+        dirs,
+        request_meta={
+            runner.STRICT_PASSTHROUGH_RUNTIME_EVIDENCE_KEY: [evidence],
+            "strict_route_attestations": [
+                _strict_attestation(
+                    provider="gemini",
+                    model_id="gemini-3.1-pro-preview",
+                    api_key_env="GEMINI_API_KEY",
+                    transport="sdk",
+                )
+            ],
+        },
+    )
+
+    payload = runner.write_strict_passthrough_attestations(dirs, "run-test", ["A"])
+
+    row = payload["rows"][0]
+    assert row["attestation_status"] == "FAILED"
+    assert row["attestation_reason"] == "provider_not_strict_capable:gemini"
+    assert row["strict_passthrough_verified"] is False
+
+    selected_route = ("gemini", "gemini-3.1-pro-preview", "GEMINI_API_KEY")
+    with pytest.raises(ValueError, match="provider_not_strict_capable:gemini"):
+        _batch_request(
+            runner,
+            provider=selected_route[0],
+            model_id=selected_route[1],
+            selected_route=selected_route,
+            selected_route_entry={
+                "provider": selected_route[0],
+                "model_id": selected_route[1],
+                "api_key_env": selected_route[2],
+                "structured_output_mode": "json_schema",
+                "strict_json_schema": True,
+                "strict_passthrough_verified": True,
+            },
+            transport="sdk",
+        )

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -55,8 +55,9 @@ A packet is superseded by another packet
 | TP-DMX-RTECANON-001 | Repo Truth Extractor | Establish `dopemux rte` as the canonical operator entrypoint | Ready | N/A |
 | TP-RTE-V3-CONSENT-004 | Repo Truth Extractor | Gate legacy v3 execution and fail closed on unknown pipeline versions | Active | N/A |
 | TP-RTE-WALKER-006 | Repo Truth Extractor | Exclude generated artifacts and secret-bearing files from prescan walker input | Active | N/A |
-| TP-RTE-BATCH-005 | Repo Truth Extractor | Repair batch result extraction and strict batch request payload handling | Active | N/A |
-| TP-RTE-BATCH-E2E-006 | Repo Truth Extractor | Wire strict batch response_format through v5 request construction | Active | N/A |
+| TP-RTE-BATCH-005 | Repo Truth Extractor | Repair batch result extraction and strict batch request payload handling | Merged (PR #614) | N/A |
+| TP-RTE-BATCH-E2E-006 | Repo Truth Extractor | Wire strict batch response_format through v5 request construction | Merged (PR #615) | N/A |
+| TP-RTE-STRICT-ATTESTATION-007 | Repo Truth Extractor | Ground strict passthrough attestations in runtime evidence | Active | N/A |
 | TP-DMX-AGENTS-CODEX-ENDTOEND-0001 | Agent Guidance | Make Codex execute TP lifecycle end-to-end by default | Ready | N/A |
 | TP-DMX-COMPOSE-RESTORE-001 | Infra | Restore canonical Docker Compose authority | Ready | N/A |
 | DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Merged (PR #528) | N/A |

--- a/task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json
+++ b/task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json
@@ -1,0 +1,298 @@
+{
+  "id": "TP-RTE-STRICT-ATTESTATION-007",
+  "project": "dopemux-mvp",
+  "target": "repo-truth-extractor / strict passthrough attestations",
+  "invariants": [
+    "Treat services/repo-truth-extractor/run_extraction_v5.py as the strongest RTE runtime authority for active v5 extraction and strict attestation assembly.",
+    "Treat services/repo-truth-extractor/lib/batch_clients.py as the OpenAI-compatible batch JSONL serialization authority.",
+    "Strict passthrough attestation VERIFIED status must derive from observed runtime, constructed request, BatchRequest, or wire payload evidence, not requested intent alone.",
+    "Synthesized explicit or benchmark OpenRouter routes outside contract primary routes must not self-attest strict passthrough verification.",
+    "Do not run live extraction, provider/model calls, external provider batch submission, or real provider file retrieval.",
+    "Do not modify promptsets, broad model routing, walker/prescan, v3 consent, cockpit/TUI, dependencies, or docs outside targeted task-packet index hygiene."
+  ],
+  "depends_on": [
+    "TP-RTE-BATCH-005",
+    "TP-RTE-BATCH-E2E-006"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "RTE-GOLIVE-BLOCKERS",
+    "base_branch": "main",
+    "parent_tp_id": "TP-RTE-BATCH-E2E-006",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/tp-rte-strict-attestation-007",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(rte): ground strict attestations in runtime evidence",
+    "allowlist": [
+      "services/repo-truth-extractor/run_extraction_v5.py",
+      "services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json",
+      "proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json",
+      "proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json",
+      "python -m json.tool proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json",
+      "python -c \"import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); raise SystemExit(0 if not errs else 1)\"",
+      "python -m compileall -q services/repo-truth-extractor src/dopemux",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
+      "git diff --check",
+      "pre-commit run --files <changed files>"
+    ]
+  },
+  "pr": {
+    "title": "fix(rte): ground strict attestations in runtime evidence",
+    "body": "## Summary\n- derive strict passthrough attestation VERIFIED status from observed runtime/request/wire evidence instead of route intent\n- prevent synthesized explicit or benchmark OpenRouter routes from self-attesting strict passthrough verification\n- add offline regression tests for strict evidence, intent-only non-verification, OpenRouter bypass closure, Gemini exclusion, and existing batch behavior\n\n## Scope\n- Repo Truth Extractor v5 strict batch attestation and route proof semantics\n- focused tests, task packet, proof, implementer report, and targeted task-packet index hygiene\n- no live extraction, provider/model calls, external batch jobs, real provider file retrieval, promptsets, broad routing, walker/prescan, dependencies, cockpit/TUI, or docs sweep\n\n## Validation\n- task packet/proof JSON validation and schema validation\n- compileall for services/repo-truth-extractor and src/dopemux\n- focused strict attestation tests, existing batch response_format and batch client tests, batch/strict subset, and operator safety tests\n- git diff whitespace check and pre-commit on changed files",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Create and validate the repo-bound task packet before implementation.",
+      "requirements": [
+        "Verify repo root, marker, remote, branch, status, and HEAD.",
+        "Confirm origin/main contains PR #614 and PR #615 merge commits or equivalent behavior.",
+        "Inspect RTE runtime, batch client, structured-output contracts, phase contract map, task packet schema, index, and existing strict/batch tests."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json",
+        "python -c \"import json, pathlib; from jsonschema import Draft7Validator; schema=json.loads(pathlib.Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()); doc=json.loads(pathlib.Path('task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json').read_text()); errs=sorted(Draft7Validator(schema).iter_errors(doc), key=lambda e: e.path); raise SystemExit(0 if not errs else 1)\""
+      ],
+      "expected_files": [
+        "task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json"
+      ],
+      "validation": [
+        "Task packet parses as JSON.",
+        "Task packet validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "PROJECT.md",
+        "docs/research/mcp-customization/dopemux-constraints/RULES.md",
+        "docs/research/mcp-customization/dopemux-constraints/SYSTEM_RepoTruthExtractor.md",
+        "docs/research/mcp-customization/dopemux-constraints/TRUTH_CANONICALS.md",
+        "task-packets/INDEX.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/lib/batch_clients.py",
+        "services/repo-truth-extractor/lib/structured_output_contracts.py",
+        "services/repo-truth-extractor/lib/phase_contract_map.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Trace current strict attestation writer and strict route inputs.",
+      "requirements": [
+        "Locate write_strict_passthrough_attestations and all current metadata inputs.",
+        "Identify current selected route and strict capability fields.",
+        "Identify whether current VERIFIED-style output is derived from intent, config, contract, request construction, runtime request metadata, or wire payload."
+      ],
+      "commands": [
+        "rg -n \"STRICT_PASSTHROUGH_ATTESTATIONS|write_strict_passthrough_attestations|strict_passthrough_verified|selected_route_entry|explicit_step_route_override|explicit_phase_route_override|benchmark_route_ownership_primary|BatchRequest|response_format|json_schema\" services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib services/repo-truth-extractor/tests"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py"
+      ],
+      "validation": [
+        "Evidence identifies the attestation writer, strict metadata producers, and synthesized route bypass before implementation."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/lib/structured_output_contracts.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_benchmark_route_ownership.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Add minimal runtime/request/wire evidence records for strict batch requests.",
+      "requirements": [
+        "Capture provider, model, transport, phase, step, partition, response_format presence, response_format.type, json_schema presence, json_schema.strict, schema hash, schema name, and evidence source.",
+        "Use the existing BatchRequest and response_format construction path.",
+        "Do not dump full schemas into proof artifacts."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py"
+      ],
+      "validation": [
+        "Focused test proves strict evidence can be derived from fake OpenAI-compatible JSONL wire payload.",
+        "Focused test proves strict evidence records a stable schema hash instead of full schema proof sprawl."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/lib/batch_clients.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Update strict passthrough attestation writer to classify truth state from evidence.",
+      "requirements": [
+        "Classify VERIFIED only when evidence proves response_format.type=json_schema with json_schema.strict=true.",
+        "Classify missing evidence as UNVERIFIED or UNKNOWN, malformed or downgraded evidence as FAILED, and non-strict as NOT_APPLICABLE.",
+        "Do not treat requested strict intent or static strict_passthrough_verified=True as VERIFIED."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py"
+      ],
+      "validation": [
+        "Focused test proves VERIFIED comes from observed strict json_schema evidence.",
+        "Focused test proves strict intent alone is not VERIFIED."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Remove or neutralize synthesized OpenRouter strict passthrough bypass.",
+      "requirements": [
+        "Do not hardcode strict_passthrough_verified=True in synthesized explicit or benchmark selected_route_entry paths.",
+        "Require contract-side proof for OpenRouter strict passthrough before strict capability passes outside lane.primary_routes.",
+        "Preserve useful explicit/benchmark fallback behavior for direct strict-capable providers."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py"
+      ],
+      "validation": [
+        "Focused test proves an explicit or benchmark OpenRouter route outside primary contract cannot become VERIFIED from a synthesized selected route alone.",
+        "Grep proves no hardcoded strict_passthrough_verified=True remains in synthesized OpenRouter selected_route_entry logic."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_benchmark_route_ownership.py"
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Preserve existing strict batch behavior and Gemini exclusion.",
+      "requirements": [
+        "Keep strict response_format propagation to fake OpenAI-compatible JSONL.",
+        "Keep missing strict schema and json_object downgrade fail-closed behavior.",
+        "Keep Gemini strict excluded or fail-closed according to strict_capability_reason.",
+        "Preserve non-strict batch behavior."
+      ],
+      "commands": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k \"batch or strict\"",
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py"
+      ],
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py"
+      ],
+      "validation": [
+        "Existing batch response_format tests pass.",
+        "Existing batch client tests pass.",
+        "Batch/strict test subset passes or any unrelated pre-existing failures are documented.",
+        "Operator safety tests pass."
+      ],
+      "context_files": [
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py",
+        "services/repo-truth-extractor/tests/test_batch_clients_integration.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py"
+      ]
+    },
+    {
+      "id": "S7",
+      "task": "Apply targeted task-packet index hygiene and write proof artifacts.",
+      "requirements": [
+        "Mark TP-RTE-BATCH-005 and TP-RTE-BATCH-E2E-006 as merged using repo index convention.",
+        "Add TP-RTE-STRICT-ATTESTATION-007 as active or ready using repo index convention.",
+        "Create PROOF.json and IMPLEMENTER_REPORT.md with truthful validation and safety evidence.",
+        "Do not perform a broad documentation sweep."
+      ],
+      "commands": [
+        "python -m json.tool proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json",
+        "python -m compileall -q services/repo-truth-extractor src/dopemux",
+        "git diff --check",
+        "pre-commit run --files <changed files>"
+      ],
+      "expected_files": [
+        "task-packets/INDEX.md",
+        "proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json",
+        "proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md"
+      ],
+      "validation": [
+        "Proof JSON parses.",
+        "Compileall passes.",
+        "Diff whitespace check passes.",
+        "Pre-commit passes or exact blocker is documented."
+      ],
+      "context_files": [
+        "task-packets/INDEX.md",
+        "proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json",
+        "proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md"
+      ]
+    },
+    {
+      "id": "S8",
+      "task": "Review, commit, push, and open PR when authenticated.",
+      "requirements": [
+        "Inspect git diff stat and full diff before commit.",
+        "Commit only allowlisted files.",
+        "Push branch and open a PR when gh auth permits.",
+        "Report exact blocker if push or PR creation fails."
+      ],
+      "commands": [
+        "git diff --stat",
+        "git diff",
+        "git status --short --branch",
+        "git add <allowlisted files>",
+        "git commit -m \"fix(rte): ground strict attestations in runtime evidence\"",
+        "git push -u origin codex/tp-rte-strict-attestation-007",
+        "gh pr create --base main --head codex/tp-rte-strict-attestation-007 --title \"fix(rte): ground strict attestations in runtime evidence\" --body-file <generated body file>"
+      ],
+      "expected_files": [
+        "task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json",
+        "proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json",
+        "proof/TP-RTE-STRICT-ATTESTATION-007/IMPLEMENTER_REPORT.md"
+      ],
+      "validation": [
+        "Diff contains only authorized files.",
+        "Commit SHA exists on the TP branch.",
+        "PR URL or exact PR creation blocker is recorded."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.

## Summary
- Derive STRICT_PASSTHROUGH_ATTESTATIONS V2 VERIFIED status from observed runtime/request/wire evidence instead of route intent.
- Prevent synthesized explicit/benchmark OpenRouter selected routes outside primary contract proof from self-attesting strict passthrough verification.
- Add focused offline regressions for wire evidence, intent-only non-verification, OpenRouter bypass closure, and Gemini strict exclusion.

## Validation
- python -m json.tool task-packets/generated/TP-RTE-STRICT-ATTESTATION-007.json
- python -m json.tool proof/TP-RTE-STRICT-ATTESTATION-007/PROOF.json
- Draft7Validator against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- python -m compileall -q services/repo-truth-extractor src/dopemux
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k "batch or strict"
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
- git diff --check
- pre-commit run --files scoped changed files

## Safety
No live extraction, provider/model calls, external batch jobs, real provider file retrieval, promptset edits, broad model-routing edits, walker/prescan edits, dependency changes, cockpit/TUI work, or docs sweep were performed.

## F3-HIGH-2
Classified CLOSED in proof: VERIFIED now requires observed runtime/wire/construction evidence; strict intent alone is UNVERIFIED; synthesized OpenRouter bypass is removed/made honest.