### PR TITLE
[codex] fix RTE failed sidecar redaction

### DIFF
--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_DIFF_SUMMARY.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_DIFF_SUMMARY.md
@@ -1,0 +1,27 @@
+# RTE-PKT-15 Diff Summary
+
+## Runtime
+
+- `services/repo-truth-extractor/output_safety.py`
+  - Added private-key-block redaction.
+  - Added common provider-token-prefix redaction.
+  - Added `sanitize_failed_sidecar_text` as an explicit wrapper around output text sanitization.
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+  - Added `_is_failed_text_sidecar_path` and `write_failed_sidecar_text`.
+  - Sanitized deferred `.FAILED.txt` writes when scheduling and again at persistence.
+  - Replaced direct batch-watch `.FAILED.txt` writes with `write_failed_sidecar_text`.
+  - Left JSON writers on existing `write_json` sanitizer path.
+
+## Tests
+
+- `services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py`
+  - Added local tests for worker exception, parse failure, schema failure, batch provider error, and batch terminal text redaction.
+  - Tests use local fakes/monkeypatches and no provider calls.
+
+- `services/repo-truth-extractor/tests/test_output_safety.py`
+  - Added sanitizer regression coverage for provider-token-shaped text and private-key-block-shaped text while preserving safe SHA text.
+
+## Scope boundary
+
+No promptsets, model maps, structured-output contract files, provider route configs, compose/deployment files, or docs outside this proof root were changed.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_MATRIX.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_MATRIX.md
@@ -1,0 +1,28 @@
+# RTE-PKT-15 Failed Sidecar Matrix
+
+## In-scope v5 writers
+
+| Surface | Source | Coverage | Lineage preserved | Test coverage |
+| --- | --- | --- | --- | --- |
+| Worker exception `.FAILED.txt` | `run_extraction_v5.py` deferred `_op_write_text` and `_apply_write_ops` | CLOSED: `.FAILED.txt` text is sanitized before scheduling and again before persistence. | phase, step_id, partition_id, failure_type, provider, model_id, routing policy, route hop fields | `test_worker_exception_failed_sidecars_redact_secret_text` |
+| Worker exception `.FAILED.json` | `run_extraction_v5.py` `write_json` | CLOSED: structured payload uses `write_json`, which calls `sanitize_payload_for_output`. | failure_type, status_code, request_meta, provider/model metadata | `test_worker_exception_failed_sidecars_redact_secret_text` |
+| Parse failure `.FAILED.txt` | `run_extraction_v5.py` parse failure branch | CLOSED: raw response text flows through failed-sidecar text sanitizer. | phase, step_id, partition_id, status_code, provider/model via request_meta | `test_parse_failure_failed_sidecars_redact_raw_response_text` |
+| Parse failure `.FAILED.json` | `run_extraction_v5.py` parse failure branch | CLOSED: `write_json` sanitizes structured payload. | failure_type, status_code, request_meta | `test_parse_failure_failed_sidecars_redact_raw_response_text` |
+| Schema failure `.FAILED.txt` | `run_extraction_v5.py` schema gate branch | CLOSED: raw response text flows through failed-sidecar text sanitizer. | phase, step_id, partition_id, schema gate context | `test_schema_failure_failed_sidecars_redact_response_and_preserve_context` |
+| Schema failure `.FAILED.json` | `run_extraction_v5.py` schema gate branch | CLOSED: `write_json` sanitizes structured schema context. | failure_type, status_code, schema_gate_context, request_meta | `test_schema_failure_failed_sidecars_redact_response_and_preserve_context` |
+| Payload-unshrinkable `.FAILED.txt` | `run_extraction_v5.py` payload hard-cap branch | CLOSED through central deferred `.FAILED.txt` writer. | failure_type, phase, step_id, partition_id, payload sizing fields | Covered by central writer; no separate fixture generated |
+| Payload-unshrinkable `.FAILED.json` | `run_extraction_v5.py` payload hard-cap branch | CLOSED through `write_json`. | failure_type, provider/model, status_code, sizing fields | Existing JSON sanitizer coverage |
+| Batch missing-row `.FAILED.txt` | `run_extraction_v5.py` `run_batch_watch` | CLOSED: direct write now uses `write_failed_sidecar_text`. | phase, step_id, partition_id, batch job metadata in paired JSON | Static source check; text is local constant |
+| Batch parse/provider `.FAILED.txt` | `run_extraction_v5.py` `run_batch_watch` | CLOSED: provider result text/error now uses `write_failed_sidecar_text`. | phase, step_id, partition_id, provider/model, batch_job_id in paired JSON | `test_batch_watch_failure_sidecars_redact_provider_error_text` |
+| Batch terminal `.FAILED.txt` | `run_extraction_v5.py` `run_batch_watch` | CLOSED: terminal text now uses `write_failed_sidecar_text`. | terminal state text plus paired JSON request_meta | `test_failed_sidecar_text_writer_redacts_batch_terminal_text` |
+| Batch `.FAILED.json` | `run_extraction_v5.py` `run_batch_watch` | CLOSED: direct structured sidecars use `write_json`. | execution_mode, provider, model_id, batch_provider, batch_job_id, failure_type | `test_batch_watch_failure_sidecars_redact_provider_error_text` |
+
+## Out-of-scope observed writer
+
+| Surface | Source | Coverage | Status |
+| --- | --- | --- | --- |
+| Comparison-lane `.FAILED.txt` | `services/repo-truth-extractor/llm_runtime.py:1342` | Not patched because packet allowed code paths did not include `llm_runtime.py`. | UNKNOWN / FOLLOW-UP REQUIRED if comparison-lane failed sidecars are in live proof scope |
+
+## Notes
+
+`services/repo-truth-extractor/lib/batch_retriever.py` writes downloaded provider output/error files, not `.FAILED.txt` or `.FAILED.json` sidecars. No provider retrieval operation was run.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FINAL_CLOSEOUT.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FINAL_CLOSEOUT.md
@@ -1,0 +1,34 @@
+# RTE-PKT-15 Final Closeout
+
+## Status
+
+`READY_FOR_REVIEW_CLEAN_PENDING_COMMIT`
+
+## Closeout result
+
+RTE-PKT-15 failed-sidecar redaction changes are review-ready. REG-001 was triaged against a detached clean-base worktree and classified `BASELINE_FAILURE`.
+
+## Validation summary
+
+- PASS: `pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q`
+- PASS: `pytest services/repo-truth-extractor/tests/test_output_safety.py -q`
+- PASS: `pytest services/repo-truth-extractor/tests -k 'failed and redaction' -q`
+- PASS: `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py`
+- PASS: `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
+- PASS: `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py::test_classify_request_failure_distinguishes_batch_terminal_and_parse_failures -q`
+- PASS: `git diff --check`
+- BASELINE_FAILURE: broader prelive hardening plus concurrency command failed identically on implementation branch and clean base.
+
+## Commit status
+
+Commit was pending when this proof file was written. The final response records the commit SHA after commit creation because embedding a commit's own SHA inside the same committed file would change the commit identity.
+
+## Residual risks
+
+- `services/repo-truth-extractor/llm_runtime.py:1342` comparison-lane `.FAILED.txt` direct writer remains `UNKNOWN` and out of scope.
+- Legacy v3 failed sidecar fixtures remain out of scope.
+- Sanitizer coverage is pattern-based and should be expanded if new credential formats are discovered.
+
+## Provider boundary
+
+No provider calls, live extraction, provider batch submit, provider batch poll, provider batch retrieve, or provider batch cancel operation occurred during closeout.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json
@@ -1,0 +1,108 @@
+{
+  "packet_id": "RTE-PKT-15-FAILED-SIDECARS",
+  "generated_at_utc": "2026-05-15T03:37:44Z",
+  "repo_root": "/Users/hue/.codex/worktrees/a8da/dopemux-mvp",
+  "branch": "codex/rte-pkt-15-failed-sidecars",
+  "before_commit_sha": "a4214ca5bf431e1b59791661e2b664a6cd24c1da",
+  "after_commit_sha": "REPORTED_IN_FINAL_RESPONSE_AFTER_COMMIT",
+  "remote": "origin and mvp point to https://github.com/DDD-Enterprises/dopemux-mvp.git",
+  "validation_status": "READY_FOR_REVIEW_BASELINE_FAILURE_TRIAGED_PENDING_COMMIT",
+  "provider_calls_performed": false,
+  "batch_provider_operations_performed": false,
+  "live_extraction_performed": false,
+  "raw_secret_fixture_values_quoted_in_proof": false,
+  "changed_runtime_files": [
+    "services/repo-truth-extractor/output_safety.py",
+    "services/repo-truth-extractor/run_extraction_v5.py"
+  ],
+  "changed_test_files": [
+    "services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py",
+    "services/repo-truth-extractor/tests/test_output_safety.py"
+  ],
+  "proof_files": [
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_MATRIX.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TEST_REPORT.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_SECRET_FIXTURE_REDACTION_PROOF.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_DIFF_SUMMARY.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_UNKNOWNS.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REGRESSION_TRIAGE_CLOSEOUT.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FINAL_CLOSEOUT.md",
+    "out/rte-pkt-15-failed-sidecars/implementation-notes.md"
+  ],
+  "regression_triage": {
+    "id": "REG-001",
+    "classification": "BASELINE_FAILURE",
+    "implementation_command": "pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q",
+    "implementation_result": "FAIL: 1 failed, 23 passed; test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback observed escalation_trigger provider_failure",
+    "clean_base_worktree": "/Users/hue/.codex/worktrees/rte-pkt-15a-clean-base",
+    "clean_base_sha": "a4214ca5bf431e1b59791661e2b664a6cd24c1da",
+    "clean_base_result": "FAIL: 1 failed, 23 passed; same test, same assertion, same observed escalation_trigger provider_failure",
+    "acceptance_impact": "Does not block closeout commit under RTE-PKT-15A policy because the broader failure is baseline behavior."
+  },
+  "tests": [
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q",
+      "result": "PASS",
+      "observed": "5 passed; PytestConfigWarning for unknown asyncio_mode"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_output_safety.py -q",
+      "result": "PASS",
+      "observed": "6 passed; PytestConfigWarning for unknown asyncio_mode"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k 'failed and redaction' -q",
+      "result": "PASS",
+      "observed": "5 passed; PytestConfigWarning for unknown asyncio_mode"
+    },
+    {
+      "command": "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py",
+      "result": "PASS",
+      "observed": "exit code 0"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q",
+      "result": "PASS",
+      "observed": "2 passed; PytestConfigWarning for unknown asyncio_mode"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py::test_classify_request_failure_distinguishes_batch_terminal_and_parse_failures -q",
+      "result": "PASS",
+      "observed": "1 passed; PytestConfigWarning for unknown asyncio_mode"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q",
+      "result": "FAIL",
+      "observed": "1 failed, 23 passed; failing assertion expected request_meta.escalation_trigger is None but observed provider_failure"
+    },
+    {
+      "command": "git diff --check",
+      "result": "PASS",
+      "observed": "exit code 0"
+    },
+    {
+      "command": "pre-commit run --files services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_MATRIX.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TEST_REPORT.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_NO_PROVIDER_CALLS_ATTESTATION.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_SECRET_FIXTURE_REDACTION_PROOF.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_DIFF_SUMMARY.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_UNKNOWNS.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REGRESSION_TRIAGE_CLOSEOUT.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FINAL_CLOSEOUT.md out/rte-pkt-15-failed-sidecars/implementation-notes.md",
+      "result": "PASS",
+      "observed": "exit code 0; docs/location/root-hygiene hooks passed or skipped where no files applied"
+    },
+    {
+      "command": "python -m json.tool out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json >/dev/null",
+      "result": "PASS",
+      "observed": "exit code 0"
+    },
+    {
+      "command": "python -c 'from pathlib import Path; pats=[\"RTE\"+\"PKT15\",\"s\"+\"k-\",\"A\"*4,\"B\"*4,\"C\"*4,\"PRIVATE \"+\"KEY-----\",\"Bearer \"+\"X\"]; text=\"\\n\".join(p.read_text(encoding=\"utf-8\") for p in Path(\"out/rte-pkt-15-failed-sidecars\").glob(\"**/*\") if p.is_file()); hits=[p for p in pats if p in text]; raise SystemExit(1 if hits else 0)'",
+      "result": "PASS",
+      "observed": "no matches"
+    }
+  ],
+  "missing_declared_regression_tests": [
+    "services/repo-truth-extractor/tests/test_provider_payload_redaction.py"
+  ],
+  "remaining_unknowns": [
+    "services/repo-truth-extractor/llm_runtime.py comparison-lane .FAILED.txt writer is outside packet allowlist and still writes failure_reason directly.",
+    "Legacy v3 failed sidecar fixtures were not modified by this packet."
+  ]
+}

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,13 @@
+# RTE-PKT-15 No Provider Calls Attestation
+
+No live extraction was run.
+
+No xAI, OpenAI, OpenRouter, Gemini, Anthropic, or other provider call was run.
+
+No provider batch submit, poll, retrieve, or cancel operation was run.
+
+The failed-sidecar tests use local monkeypatches and fake batch clients. The batch-watch test constructs local batch index/input files and replaces `build_batch_client`, `resolve_api_key`, `get_phase_prompts`, and `maybe_send_batch_webhook` with local test doubles.
+
+No provider credentials were required or inspected.
+
+Closeout update: regression triage used only local pytest commands in the implementation worktree and a detached clean-base worktree. No provider credentials, live extraction, provider batch submit, provider batch poll, provider batch retrieve, provider batch cancel, or external research occurred during closeout.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REGRESSION_TRIAGE_CLOSEOUT.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REGRESSION_TRIAGE_CLOSEOUT.md
@@ -1,0 +1,39 @@
+# RTE-PKT-15 Regression Triage Closeout
+
+## REG-001 command
+
+`pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
+
+## Implementation branch result
+
+- Worktree: `/Users/hue/.codex/worktrees/a8da/dopemux-mvp`
+- Branch: `codex/rte-pkt-15-failed-sidecars`
+- HEAD: `a4214ca5bf431e1b59791661e2b664a6cd24c1da`
+- Result: FAIL
+- Summary: 1 failed, 23 passed.
+- Failing test: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback`
+- Assertion: expected `payload["request_meta"]["escalation_trigger"] is None`
+- Observed value: `provider_failure`
+
+## Clean base result
+
+- Worktree: `/Users/hue/.codex/worktrees/rte-pkt-15a-clean-base`
+- Branch: detached HEAD
+- HEAD: `a4214ca5bf431e1b59791661e2b664a6cd24c1da`
+- Result: FAIL
+- Summary: 1 failed, 23 passed.
+- Failing test: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback`
+- Assertion: expected `payload["request_meta"]["escalation_trigger"] is None`
+- Observed value: `provider_failure`
+
+## Classification
+
+`BASELINE_FAILURE`
+
+The implementation branch and clean base fail the same command on the same test with the same assertion and observed value. The line number differs because the implementation branch adds sidecar-redaction code above the logged runtime line, but the tested behavior and assertion are identical.
+
+## Acceptance impact
+
+This failure does not block committing RTE-PKT-15 closeout under the packet policy because it is proven baseline behavior, not a new regression from failed-sidecar redaction.
+
+The failure remains outside this packet's implementation scope. No provider escalation semantics or broader prelive hardening test expectations were changed.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_UNKNOWNS.md
@@ -1,0 +1,21 @@
+# RTE-PKT-15 Remaining Unknowns
+
+## UNKNOWN: comparison-lane failed text sidecar
+
+`services/repo-truth-extractor/llm_runtime.py:1342` writes comparison-lane `.FAILED.txt` content directly from `failure_reason`.
+
+This file is outside the packet allowlist, so it was not patched. If comparison-lane failed sidecars are in the live proof-storage boundary, a follow-up packet should either add `llm_runtime.py` to scope or prove comparison-lane failure text cannot contain provider/source/error secret-shaped content.
+
+## UNKNOWN: legacy v3 failed sidecar fixtures
+
+Legacy v3 fixture sidecars were not modified. This packet focused on RTE v5 runtime failed sidecar safety. Existing fixture contents were not quoted in proof.
+
+## NOT PRESENT: provider payload redaction regression file
+
+The packet named `services/repo-truth-extractor/tests/test_provider_payload_redaction.py` as a conditional regression command. That file was not present in this checkout.
+
+## Drift: broader prelive hardening validation
+
+The broader command `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q` failed one provider escalation assertion unrelated to changed sidecar-redaction lines.
+
+Closeout comparison against `/Users/hue/.codex/worktrees/rte-pkt-15a-clean-base` at `a4214ca5bf431e1b59791661e2b664a6cd24c1da` reproduced the same failing test, assertion, and observed `provider_failure` value. Classification: `BASELINE_FAILURE`.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_SECRET_FIXTURE_REDACTION_PROOF.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_SECRET_FIXTURE_REDACTION_PROOF.md
@@ -1,0 +1,20 @@
+# RTE-PKT-15 Secret Fixture Redaction Proof
+
+Generated tests construct secret-shaped values at runtime and assert absence from persisted `.FAILED.txt` and `.FAILED.json` outputs.
+
+The raw generated fixture values are not quoted in this proof.
+
+Covered assertions:
+
+- Worker exception text: generated secret-shaped exception content is absent from `.FAILED.txt` and paired `.FAILED.json`; redaction markers remain.
+- Parse failure response text: generated secret-shaped model response content is absent from `.FAILED.txt` and paired `.FAILED.json`; `failure_type`, `status_code`, phase, step, and partition remain.
+- Schema failure response text: generated secret-shaped response content is absent from `.FAILED.txt` and paired `.FAILED.json`; schema context remains visible.
+- Batch provider error text: generated secret-shaped provider error content is absent from `.FAILED.txt` and paired `.FAILED.json`; provider, model, and batch ID remain.
+- Batch terminal text helper: generated secret-shaped terminal text is absent from `.FAILED.txt`; terminal failure class text remains.
+- Output safety helper: provider-token-shaped text and private-key-block-shaped text are removed; safe SHA text remains.
+
+Observed redaction markers:
+
+- `[REDACTED]`
+- `[REDACTED PRIVATE KEY]`
+- `REDACTED` for query parameter values

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TEST_REPORT.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TEST_REPORT.md
@@ -1,0 +1,64 @@
+# RTE-PKT-15 Test Report
+
+## PASS
+
+- `pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q`
+  - Result: PASS, 5 passed.
+  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
+- `pytest services/repo-truth-extractor/tests/test_output_safety.py -q`
+  - Result: PASS, 6 passed.
+  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
+- `pytest services/repo-truth-extractor/tests -k 'failed and redaction' -q`
+  - Result: PASS, 5 passed.
+  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
+- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py`
+  - Result: PASS, exit code 0.
+- `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
+  - Result: PASS, 2 passed.
+  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
+- `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py::test_classify_request_failure_distinguishes_batch_terminal_and_parse_failures -q`
+  - Result: PASS, 1 passed.
+  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
+- `git diff --check`
+  - Result: PASS, exit code 0.
+- `pre-commit run --files ...`
+  - Result: PASS, exit code 0.
+  - Observed: docs/location/root-hygiene hooks passed or skipped where no files applied.
+- `python -m json.tool out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json >/dev/null`
+  - Result: PASS, exit code 0.
+- `python -c 'from pathlib import Path; pats=["RTE"+"PKT15","s"+"k-","A"*4,"B"*4,"C"*4,"PRIVATE "+"KEY-----","Bearer "+"X"]; text="\n".join(p.read_text(encoding="utf-8") for p in Path("out/rte-pkt-15-failed-sidecars").glob("**/*") if p.is_file()); hits=[p for p in pats if p in text]; raise SystemExit(1 if hits else 0)'`
+  - Result: PASS, no matches.
+
+## FAIL
+
+- `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
+  - Result: FAIL, 1 failed and 23 passed.
+  - Failing assertion: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback` expected `request_meta["escalation_trigger"] is None`; observed `provider_failure`.
+  - Scope assessment: the changed lines do not modify provider-failure escalation semantics. This packet did not broaden into that failure.
+
+## REGRESSION TRIAGE
+
+- Implementation branch command:
+  - `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
+  - Result: FAIL, 1 failed and 23 passed.
+  - Failing test: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback`.
+  - Observed value: `provider_failure`.
+- Clean base worktree:
+  - Path: `/Users/hue/.codex/worktrees/rte-pkt-15a-clean-base`
+  - SHA: `a4214ca5bf431e1b59791661e2b664a6cd24c1da`
+  - Result: FAIL, 1 failed and 23 passed.
+  - Failing test: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback`.
+  - Observed value: `provider_failure`.
+- Classification: `BASELINE_FAILURE`.
+- Acceptance impact: not a new regression from RTE-PKT-15 sidecar redaction.
+
+## NOT_RUN
+
+- `pytest services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q`
+  - Reason: file is not present in this checkout.
+- Live/provider/batch network validation.
+  - Reason: forbidden by packet.
+
+## Provider boundary
+
+No validation command used provider credentials, submitted provider batch jobs, polled provider batch jobs, retrieved provider batch jobs, cancelled provider batch jobs, or ran live extraction.

--- a/out/rte-pkt-15-failed-sidecars/implementation-notes.md
+++ b/out/rte-pkt-15-failed-sidecars/implementation-notes.md
@@ -1,0 +1,24 @@
+# Implementation Notes
+
+Packet: `RTE-PKT-15-FAILED-SIDECARS`
+
+Worktree: `/Users/hue/.codex/worktrees/a8da/dopemux-mvp`
+
+Branch: `codex/rte-pkt-15-failed-sidecars`
+
+Base SHA: `a4214ca5bf431e1b59791661e2b664a6cd24c1da`
+
+## Implemented
+
+- Added explicit failed-sidecar text sanitization in `output_safety.py`.
+- Routed in-scope v5 `.FAILED.txt` persistence through `write_failed_sidecar_text`.
+- Kept `.FAILED.json` artifacts on `write_json`, preserving existing structured payload redaction.
+- Added targeted local tests for failed sidecar redaction and lineage preservation.
+
+## Validation
+
+Targeted packet tests passed. Compile and diff checks passed. One broader prelive hardening command failed on existing provider-failure escalation semantics outside this packet's edit scope.
+
+## Status
+
+Implementation is ready for review with the documented out-of-scope comparison-lane unknown and broader validation drift.

--- a/services/repo-truth-extractor/output_safety.py
+++ b/services/repo-truth-extractor/output_safety.py
@@ -11,6 +11,21 @@ _SECRET_ASSIGN_RE = re.compile(
 )
 _BEARER_INLINE_RE = re.compile(r"(?i)(\bBearer\s+)([^\s,;]+)")
 _AUTH_HEADER_RE = re.compile(r"(?i)(\b(?:Authorization|x-goog-api-key)\b\s*[:=]\s*)([^\n\r]+)")
+_PRIVATE_KEY_BLOCK_RE = re.compile(
+    r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_PROVIDER_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9_-])(?:"
+    r"sk-[A-Za-z0-9_-]{16,}|"
+    r"sk-proj-[A-Za-z0-9_-]{16,}|"
+    r"xai-[A-Za-z0-9_-]{16,}|"
+    r"gsk_[A-Za-z0-9_-]{16,}|"
+    r"ghp_[A-Za-z0-9_-]{16,}|"
+    r"github_pat_[A-Za-z0-9_-]{16,}|"
+    r"glpat-[A-Za-z0-9_-]{16,}"
+    r")(?![A-Za-z0-9_-])"
+)
 
 
 _SAFE_SENSITIVE_KEYS = {
@@ -62,11 +77,17 @@ def sanitize_text_for_output(text: str) -> str:
     if not text:
         return ""
     value = str(text)
+    value = _PRIVATE_KEY_BLOCK_RE.sub("[REDACTED PRIVATE KEY]", value)
     value = _SECRET_QUERY_RE.sub(r"\1REDACTED", value)
     value = _SECRET_ASSIGN_RE.sub(r"\1[REDACTED]", value)
     value = _AUTH_HEADER_RE.sub(r"\1[REDACTED]", value)
     value = _BEARER_INLINE_RE.sub(r"\1[REDACTED]", value)
+    value = _PROVIDER_TOKEN_RE.sub("[REDACTED]", value)
     return value
+
+
+def sanitize_failed_sidecar_text(text: str) -> str:
+    return sanitize_text_for_output(text)
 
 
 def sanitize_payload_for_output(payload: Any, *, field_name: str | None = None) -> Any:

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -42,7 +42,13 @@ RUNNER_SERVICE_DIR = Path(__file__).resolve().parent
 if str(RUNNER_SERVICE_DIR) not in sys.path:
     sys.path.insert(0, str(RUNNER_SERVICE_DIR))
 
-from output_safety import sanitize_payload_for_output, sanitize_text_for_output, sanitized_json_bytes, sanitized_json_text
+from output_safety import (
+    sanitize_failed_sidecar_text,
+    sanitize_payload_for_output,
+    sanitize_text_for_output,
+    sanitized_json_bytes,
+    sanitized_json_text,
+)
 from phases import (
     CODE_HEAVY_PHASES,
     LEGACY_PHASE_DIR_ALIASES,
@@ -2679,6 +2685,15 @@ def write_json(path: Path, payload: Any) -> None:
         + "\n",
         encoding="utf-8",
     )
+
+
+def _is_failed_text_sidecar_path(path: Path) -> bool:
+    return path.name.endswith(".FAILED.txt")
+
+
+def write_failed_sidecar_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(sanitize_failed_sidecar_text(str(text)), encoding="utf-8")
 
 
 def build_pre_live_validator_command(
@@ -11802,7 +11817,12 @@ def execute_step_for_partitions(
         logs.append((level, message))
 
     def _op_write_text(write_ops: List[Dict[str, Any]], path: Path, text: str) -> None:
-        write_ops.append({"kind": "write_text", "path": str(path), "text": text})
+        text_value = str(text)
+        if _is_failed_text_sidecar_path(path):
+            text_value = sanitize_failed_sidecar_text(text_value)
+        write_ops.append(
+            {"kind": "write_text", "path": str(path), "text": text_value}
+        )
 
     def _op_write_json(
         write_ops: List[Dict[str, Any]], path: Path, payload: Dict[str, Any]
@@ -11824,7 +11844,10 @@ def execute_step_for_partitions(
                     continue
 
                 if kind == "write_text":
-                    op_path.write_text(str(op["text"]), encoding="utf-8")
+                    if _is_failed_text_sidecar_path(op_path):
+                        write_failed_sidecar_text(op_path, str(op["text"]))
+                    else:
+                        op_path.write_text(str(op["text"]), encoding="utf-8")
                 elif kind == "write_json":
                     payload = op["payload"] if isinstance(op["payload"], dict) else {}
                     write_json(op_path, payload)
@@ -17114,8 +17137,9 @@ def run_batch_watch(
                 artifacts_missing = list(output_artifacts)
                 step_stats[step_id]["recomputed"] += 1
                 step_stats[step_id]["failed"] += 1
-                out_failed.write_text(
-                    "batch_missing_result_for_partition\n", encoding="utf-8"
+                write_failed_sidecar_text(
+                    out_failed,
+                    "batch_missing_result_for_partition\n",
                 )
                 write_json(
                     out_failed_json,
@@ -17159,9 +17183,9 @@ def run_batch_watch(
                     row["completed_at_utc"] = now_iso()
                     artifacts_missing = list(output_artifacts)
                     step_stats[step_id]["failed"] += 1
-                    out_failed.write_text(
+                    write_failed_sidecar_text(
+                        out_failed,
                         response_text or (result.error or "batch_parse_failure"),
-                        encoding="utf-8",
                     )
                     write_json(
                         out_failed_json,
@@ -17353,8 +17377,9 @@ def run_batch_watch(
                     },
                 },
             )
-            out_failed.write_text(
-                f"batch_terminal_state:{terminal_status}\n", encoding="utf-8"
+            write_failed_sidecar_text(
+                out_failed,
+                f"batch_terminal_state:{terminal_status}\n",
             )
 
         row["updated_at_utc"] = now_iso()

--- a/services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py
+++ b/services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py
@@ -1,0 +1,356 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _load_runner_module() -> types.ModuleType:
+    module_path = _repo_root() / "services" / "repo-truth-extractor" / "run_extraction_v5.py"
+    spec = importlib.util.spec_from_file_location("run_extraction_v5_failed_sidecars", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_cfg(runner: types.ModuleType) -> Any:
+    cfg = runner.RunnerConfig.__new__(runner.RunnerConfig)
+    defaults = {
+        "dry_run": False,
+        "max_files_docs": 10,
+        "max_files_code": 10,
+        "max_chars": 50000,
+        "max_request_bytes": 100000,
+        "file_truncate_chars": 10000,
+        "home_scan_mode": "safe",
+        "resume": False,
+        "fail_fast_auth": False,
+        "gemini_auth_mode": "auto",
+        "gemini_transport": "sdk",
+        "openai_transport": "openai_sdk",
+        "xai_transport": "openai_sdk",
+        "retry_policy": "none",
+        "retry_max_attempts": 1,
+        "retry_base_seconds": 0.0,
+        "retry_max_seconds": 0.0,
+        "phase_auth_fail_threshold": 5,
+        "partition_workers": 1,
+        "debug_phase_inputs": False,
+        "fail_fast_missing_inputs": False,
+        "executor": "thread",
+        "routing_policy": "cost",
+        "disable_escalation": True,
+        "escalation_max_hops": 1,
+        "batch_mode": False,
+        "batch_provider": "auto",
+        "batch_poll_seconds": 30,
+        "batch_wait_timeout_seconds": 1,
+        "batch_max_requests_per_job": 2000,
+        "batch_submit_only": False,
+        "webhook_url": "",
+        "webhook_secret": "",
+        "webhook_timeout_seconds": 5,
+        "webhook_required": False,
+        "webhook_auto_continue": False,
+        "live_ok": False,
+        "selected_s_steps": None,
+        "selected_execution_step": None,
+        "d0_max_files": None,
+        "d1_max_files": None,
+        "provider_denylist": (),
+        "compare_mode": None,
+        "compare_model": None,
+        "compare_provider": None,
+        "compare_steps": None,
+        "prescan_dir": None,
+        "router": None,
+        "max_cost_usd": None,
+        "ledger": None,
+        "fl_int_provider_timeout_seconds": 180,
+        "fl_int_f0_batch_timeout_seconds": 210,
+    }
+    for key, value in defaults.items():
+        object.__setattr__(cfg, key, value)
+    return cfg
+
+
+def _secret_value() -> str:
+    return "sk-" + "RTEPKT15" + ("A" * 32)
+
+
+def _prompt_spec(runner: types.ModuleType, tmp_path: Path, *, step_id: str = "A0") -> Any:
+    prompt_path = tmp_path / f"PROMPT_{step_id}_TEST.md"
+    prompt_path.write_text("Return OUT.json\n", encoding="utf-8")
+    return runner.PromptSpec(
+        step_id=step_id,
+        prompt_path=prompt_path,
+        output_artifacts=("OUT.json",),
+        contract={},
+    )
+
+
+def _partition(tmp_path: Path) -> dict[str, Any]:
+    source = tmp_path / "source.txt"
+    source.write_text("fixture\n", encoding="utf-8")
+    return {"id": "A_P0001", "paths": [str(source)]}
+
+
+def _assert_secret_redacted(text: str, secret: str) -> None:
+    assert secret not in text
+    assert "[REDACTED]" in text
+
+
+def test_worker_exception_failed_sidecars_redact_secret_text(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _load_runner_module()
+    secret = _secret_value()
+    phase_dir = tmp_path / "A_repo_control_plane"
+    (phase_dir / "raw").mkdir(parents=True, exist_ok=True)
+
+    def forbidden_call_llm(**kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("provider call path must not be reached")
+
+    def raising_context(**kwargs: Any) -> tuple[str, dict[str, int]]:
+        raise RuntimeError(f"worker failed with api_key={secret}")
+
+    monkeypatch.setattr(runner, "call_llm", forbidden_call_llm)
+    monkeypatch.setattr(runner, "build_partition_context", raising_context)
+
+    stats = runner.execute_step_for_partitions(
+        phase="A",
+        prompt_spec=_prompt_spec(runner, tmp_path),
+        partitions=[_partition(tmp_path)],
+        phase_dir=phase_dir,
+        cfg=_make_cfg(runner),
+    )
+
+    assert stats["failed"] == 1
+    failed_text = (phase_dir / "raw" / "A0__A_P0001.FAILED.txt").read_text(encoding="utf-8")
+    failed_json = json.loads(
+        (phase_dir / "raw" / "A0__A_P0001.FAILED.json").read_text(encoding="utf-8")
+    )
+    _assert_secret_redacted(failed_text, secret)
+    assert failed_json["failure_type"] == "worker_exception"
+    assert failed_json["phase"] == "A"
+    assert failed_json["step_id"] == "A0"
+    assert failed_json["partition_id"] == "A_P0001"
+    assert secret not in json.dumps(failed_json, sort_keys=True)
+
+
+def test_parse_failure_failed_sidecars_redact_raw_response_text(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _load_runner_module()
+    secret = _secret_value()
+    phase_dir = tmp_path / "A_repo_control_plane"
+    (phase_dir / "raw").mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        runner,
+        "build_partition_context",
+        lambda **kwargs: (
+            "PARTITION_PATH=source.txt",
+            {"files_included": 1, "files_skipped": 0, "context_bytes": 10, "redaction_hits": 0},
+        ),
+    )
+    monkeypatch.setattr(
+        runner,
+        "call_llm",
+        lambda **kwargs: {
+            "text": f"not json api_key={secret}",
+            "meta": {"failure_type": None, "status_code": 200},
+        },
+    )
+
+    stats = runner.execute_step_for_partitions(
+        phase="A",
+        prompt_spec=_prompt_spec(runner, tmp_path),
+        partitions=[_partition(tmp_path)],
+        phase_dir=phase_dir,
+        cfg=_make_cfg(runner),
+    )
+
+    assert stats["failed"] == 1
+    failed_text = (phase_dir / "raw" / "A0__A_P0001.FAILED.txt").read_text(encoding="utf-8")
+    failed_json = json.loads(
+        (phase_dir / "raw" / "A0__A_P0001.FAILED.json").read_text(encoding="utf-8")
+    )
+    _assert_secret_redacted(failed_text, secret)
+    assert failed_json["failure_type"] == "parse"
+    assert failed_json["status_code"] == 200
+    assert failed_json["phase"] == "A"
+    assert failed_json["step_id"] == "A0"
+    assert failed_json["partition_id"] == "A_P0001"
+    assert secret not in json.dumps(failed_json, sort_keys=True)
+
+
+def test_schema_failure_failed_sidecars_redact_response_and_preserve_context(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _load_runner_module()
+    secret = _secret_value()
+    phase_dir = tmp_path / "A_repo_control_plane"
+    (phase_dir / "raw").mkdir(parents=True, exist_ok=True)
+    response_payload = {
+        "artifacts": [
+            {
+                "artifact_name": "OUT.json",
+                "payload": {
+                    "items": [
+                        {
+                            "id": "item-1",
+                            "path": "services/demo.py",
+                            "note": f"token={secret}",
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+
+    monkeypatch.setattr(
+        runner,
+        "build_partition_context",
+        lambda **kwargs: (
+            "PARTITION_PATH=source.txt",
+            {"files_included": 1, "files_skipped": 0, "context_bytes": 10, "redaction_hits": 0},
+        ),
+    )
+    monkeypatch.setattr(
+        runner,
+        "call_llm",
+        lambda **kwargs: {
+            "text": json.dumps(response_payload),
+            "meta": {"failure_type": None, "status_code": 200},
+        },
+    )
+
+    stats = runner.execute_step_for_partitions(
+        phase="A",
+        prompt_spec=_prompt_spec(runner, tmp_path),
+        partitions=[_partition(tmp_path)],
+        phase_dir=phase_dir,
+        cfg=_make_cfg(runner),
+    )
+
+    assert stats["failed"] == 1
+    failed_text = (phase_dir / "raw" / "A0__A_P0001.FAILED.txt").read_text(encoding="utf-8")
+    failed_json = json.loads(
+        (phase_dir / "raw" / "A0__A_P0001.FAILED.json").read_text(encoding="utf-8")
+    )
+    _assert_secret_redacted(failed_text, secret)
+    assert failed_json["failure_type"] == "schema"
+    assert failed_json["schema_gate_context"]["failure_reason"] == "schema_missing_key:line_range"
+    assert failed_json["schema_gate_context"]["artifact_name"] == "OUT.json"
+    assert failed_json["schema_gate_context"]["item_id"] == "item-1"
+    assert failed_json["schema_gate_context"]["item_path"] == "services/demo.py"
+    assert secret not in json.dumps(failed_json, sort_keys=True)
+
+
+def test_batch_watch_failure_sidecars_redact_provider_error_text(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    runner = _load_runner_module()
+    secret = _secret_value()
+    root = tmp_path / "repo"
+    run_id = "run-rte-pkt-15"
+    phase_dir = tmp_path / run_id / "A_repo_control_plane"
+    batch_dir = phase_dir / "batch"
+    inputs_dir = phase_dir / "inputs"
+    raw_dir = phase_dir / "raw"
+    batch_dir.mkdir(parents=True, exist_ok=True)
+    inputs_dir.mkdir(parents=True, exist_ok=True)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    index_payload = {
+        "jobs": [
+            {
+                "phase_id": "A",
+                "step_id": "A0",
+                "partition_id": "A_P0001",
+                "provider_id": "openai",
+                "model_id": "gpt-test",
+                "api_key_env": "OPENAI_API_KEY",
+                "job_id": "batch-job-1",
+                "state": "completed",
+            }
+        ]
+    }
+    (batch_dir / "BATCH_JOB_INDEX.json").write_text(
+        json.dumps(index_payload), encoding="utf-8"
+    )
+    (inputs_dir / "PARTITIONS.json").write_text(
+        json.dumps({"partitions": [{"id": "A_P0001", "paths": []}]}),
+        encoding="utf-8",
+    )
+
+    class FakeBatchClient:
+        def fetch_results(self, job_id: str) -> list[Any]:
+            assert job_id == "batch-job-1"
+            return [
+                types.SimpleNamespace(
+                    custom_id="A_P0001",
+                    output_text="",
+                    error=f"provider failed with Authorization: Bearer {secret}",
+                    meta={},
+                )
+            ]
+
+    monkeypatch.setattr(
+        runner,
+        "get_phase_prompts",
+        lambda phase: [_prompt_spec(runner, tmp_path)],
+    )
+    monkeypatch.setattr(
+        runner,
+        "resolve_api_key",
+        lambda provider, api_key_env: ("offline-test-key", api_key_env),
+    )
+    monkeypatch.setattr(runner, "build_batch_client", lambda provider, api_key, cfg: FakeBatchClient())
+    monkeypatch.setattr(runner, "maybe_send_batch_webhook", lambda **kwargs: True)
+
+    with pytest.raises(RuntimeError, match="Parse failure threshold exceeded"):
+        runner.run_batch_watch(
+            root=root,
+            run_id=run_id,
+            phase="A",
+            dirs={"A": phase_dir},
+            cfg=_make_cfg(runner),
+        )
+
+    failed_text = (raw_dir / "A0__A_P0001.FAILED.txt").read_text(encoding="utf-8")
+    failed_json = json.loads((raw_dir / "A0__A_P0001.FAILED.json").read_text(encoding="utf-8"))
+    _assert_secret_redacted(failed_text, secret)
+    assert failed_json["failure_type"] == "provider"
+    assert failed_json["request_meta"]["execution_mode"] == "batch_watch"
+    assert failed_json["request_meta"]["provider"] == "openai"
+    assert failed_json["request_meta"]["model_id"] == "gpt-test"
+    assert failed_json["request_meta"]["batch_job_id"] == "batch-job-1"
+    assert secret not in json.dumps(failed_json, sort_keys=True)
+
+
+def test_failed_sidecar_text_writer_redacts_batch_terminal_text(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    secret = _secret_value()
+    failed_path = tmp_path / "raw" / "A0__A_P0001.FAILED.txt"
+
+    runner.write_failed_sidecar_text(
+        failed_path,
+        f"batch_terminal_state:failed Authorization: Bearer {secret}\n",
+    )
+
+    failed_text = failed_path.read_text(encoding="utf-8")
+    _assert_secret_redacted(failed_text, secret)
+    assert "batch_terminal_state:failed" in failed_text

--- a/services/repo-truth-extractor/tests/test_output_safety.py
+++ b/services/repo-truth-extractor/tests/test_output_safety.py
@@ -70,6 +70,27 @@ def test_sanitize_payload_redacts_secret_fields_but_preserves_env_metadata() -> 
     assert sanitized["sha256"] == "abcdef1234567890"
 
 
+def test_failed_sidecar_text_redacts_provider_tokens_and_private_key_blocks() -> None:
+    output_safety = _load_output_safety_module()
+    provider_token = "sk-" + "RTEPKT15" + ("B" * 32)
+    private_key_body = "MII" + ("C" * 48)
+    text = (
+        f"provider_error_reason={provider_token}\n"
+        "-----BEGIN PRIVATE KEY-----\n"
+        f"{private_key_body}\n"
+        "-----END PRIVATE KEY-----\n"
+        "safe_sha256=abcdef1234567890\n"
+    )
+
+    sanitized = output_safety.sanitize_failed_sidecar_text(text)
+
+    assert provider_token not in sanitized
+    assert private_key_body not in sanitized
+    assert "[REDACTED]" in sanitized
+    assert "[REDACTED PRIVATE KEY]" in sanitized
+    assert "safe_sha256=abcdef1234567890" in sanitized
+
+
 def test_ui_events_redact_secret_like_fields(tmp_path: Path) -> None:
     runner = _load_runner_module()
     ui = runner.UI(


### PR DESCRIPTION
## Summary

- Redacts in-scope RTE v5 `.FAILED.txt` sidecar persistence through an explicit failed-sidecar text sanitizer.
- Keeps `.FAILED.json` artifacts on the existing sanitized `write_json` path.
- Adds local failed-sidecar redaction tests plus packet proof under `out/rte-pkt-15-failed-sidecars/`.
- Triages the broader prelive hardening failure against a clean base and classifies it as `BASELINE_FAILURE`.

## Validation

- PASS: `pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q`
- PASS: `pytest services/repo-truth-extractor/tests/test_output_safety.py -q`
- PASS: `pytest services/repo-truth-extractor/tests -k 'failed and redaction' -q`
- PASS: `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py`
- PASS: `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
- PASS: `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py::test_classify_request_failure_distinguishes_batch_terminal_and_parse_failures -q`
- PASS: `git diff --check`
- PASS: `pre-commit run --files ...`
- BASELINE_FAILURE: `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q` fails identically on implementation branch and clean base with observed `provider_failure`.

No provider calls, live extraction, or provider batch operations were run.

## Residual risk

- `services/repo-truth-extractor/llm_runtime.py:1342` comparison-lane `.FAILED.txt` direct writer remains out of scope and documented as `UNKNOWN`.
- Legacy v3 failed sidecar fixtures remain out of scope.
- Sanitizer coverage is pattern-based and should be expanded if new credential formats are discovered.

## Release notes

- Hardened RTE failed-sidecar artifact safety by redacting secret-shaped text before local `.FAILED.txt` persistence.
- Added proof artifacts and local regression coverage for worker exception, parse, schema, batch provider, and batch terminal failure sidecars.

@codex review
@gemini
@copilot
