### PR TITLE
[codex] Reject stale imported prescan

### DIFF
--- a/services/repo-truth-extractor/lib/prescan/engine.py
+++ b/services/repo-truth-extractor/lib/prescan/engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import hashlib
 import json
 import logging
 import subprocess
@@ -37,6 +38,18 @@ from ..intelligence_router import (
 )
 
 logger = logging.getLogger(__name__)
+
+PRESCAN_ARTIFACT_VERSION = "1.0"
+
+
+def _stable_json_hash(payload: Any) -> str:
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
 
 
 class PrescanEngine:
@@ -685,6 +698,7 @@ class PrescanEngine:
     def _build_intelligence_base(self, entries: list[FileEntry], code_intel: list[dict[str, Any]] | None = None) -> dict[str, Any]:
         included = [entry for entry in entries if entry.include and not entry.is_ghost]
         ghosts = [entry for entry in entries if entry.is_ghost]
+        manifest = [entry.to_dict() for entry in entries]
         by_class: dict[str, int] = {}
         for entry in entries:
             by_class[entry.authority_class] = by_class.get(entry.authority_class, 0) + 1
@@ -696,8 +710,12 @@ class PrescanEngine:
         compression_potential_files = sum(1 for entry in entries if entry.is_duplicate or (entry.version_chain_id and not entry.is_latest_version))
         return {
             "version": "1.0",
+            "prescan_artifact_version": PRESCAN_ARTIFACT_VERSION,
             "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
-            "repo_root": str(self.config.repo_root),
+            "repo_root": str(self.config.repo_root.resolve()),
+            "source_root": str(self.config.repo_root.resolve()),
+            "git_sha": self._get_git_sha(),
+            "corpus_manifest_hash": _stable_json_hash(manifest),
             "corpus_summary": {
                 "total_files": len(entries),
                 "included_files": len(included),


### PR DESCRIPTION
## Summary
- Validate imported prescan against current repo/source identity, artifact version, corpus manifest hash, and optional git SHA before it can influence RTE execution.
- Emit local prescan identity metadata and explicit prescan receipts with `can_influence_execution` and `advisory_only` flags.
- Add targeted tests and packet proof artifacts for accepted, stale, missing-metadata, malformed, skipped, and non-authoritative influence paths.

## Validation
- PASS: `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/intelligence_router.py services/repo-truth-extractor/lib/prescan/engine.py`
- PASS: `pytest services/repo-truth-extractor/tests/test_prescan_import_staleness.py -q` - 8 passed
- PASS: `pytest services/repo-truth-extractor/tests/test_prescan_v5_integration.py -q` - 5 passed
- PASS: `pytest services/repo-truth-extractor/tests/test_router_runtime_integration.py services/repo-truth-extractor/tests/test_prescan_consumers.py -q` - 5 passed
- PASS: `pytest services/repo-truth-extractor/tests -k 'prescan and stale' -q` - 8 passed
- PASS: `pytest services/repo-truth-extractor/tests -k 'prescan and default_excludes' -q` - 1 passed
- PASS: `pytest services/repo-truth-extractor/tests/test_prescan_import_staleness.py services/repo-truth-extractor/tests/test_prescan_v5_integration.py services/repo-truth-extractor/tests/test_router_runtime_integration.py services/repo-truth-extractor/tests/test_prescan_consumers.py -q` - 18 passed
- PASS: `pre-commit run --files ...`
- PASS: `git diff --check HEAD^ HEAD`
- FAIL: `pytest services/repo-truth-extractor/tests -k 'prescan and import' -q` - unrelated existing failure in `test_code_prescan_truthfulness.py::test_code_prescan_emits_dotted_relative_python_imports`

## Residual risk
- RTE-PKT-04 still owns full downstream prescan influence labeling.
- `source_root` is currently the resolved Stage 0 root; no separate runtime source-root authority was found.
- `--prescan-dir` is validated before global router loading, but the runtime does not write a separate receipt for that late-load path.

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.
