### PR TITLE
Repair pytest execution wiring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,40 +59,40 @@ install-dev:
 
 # Testing targets
 test:
-	uv run --frozen pytest tests
+	uv run --frozen --extra test pytest tests
 
 test-unit:
-	uv run --frozen pytest tests/unit --maxfail=1 --disable-warnings --no-cov
+	uv run --frozen --extra test pytest tests/unit --maxfail=1 --disable-warnings --no-cov
 
 test-integration:
 	uv sync --frozen --extra test --extra services
-	uv run --frozen pytest tests/integration --maxfail=1 --disable-warnings --no-cov
+	uv run --frozen --extra test --extra services pytest tests/integration --maxfail=1 --disable-warnings --no-cov
 
 test-coverage:
 	uv sync --frozen --extra test
-	uv run --frozen pytest --cov-report=term-missing --cov-report=html
+	uv run --frozen --extra test pytest --cov-report=term-missing --cov-report=html
 
 test-fast:
-	uv run --frozen pytest tests/unit --maxfail=1 --disable-warnings --no-cov
+	uv run --frozen --extra test pytest tests/unit --maxfail=1 --disable-warnings --no-cov
 
 test-verbose:
-	uv run --frozen pytest -v
+	uv run --frozen --extra test pytest -v
 
 ci-fast:
 	uv sync --frozen --extra test
-	uv run --frozen pytest tests/unit --maxfail=1 --disable-warnings --no-cov
+	uv run --frozen --extra test pytest tests/unit --maxfail=1 --disable-warnings --no-cov
 
 ci-extended:
 	uv sync --frozen --extra test --extra services
-	uv run --frozen pytest tests/integration --maxfail=1 --disable-warnings --no-cov
+	uv run --frozen --extra test --extra services pytest tests/integration --maxfail=1 --disable-warnings --no-cov
 	./test_installer_basic.sh
 	./scripts/check_coverage.sh
 
 test-extractor:
-	uv run --frozen pytest --no-cov services/repo-truth-extractor/tests
+	uv run --frozen --extra test pytest --no-cov services/repo-truth-extractor/tests
 
 test-extractor-smoke:
-	uv run --frozen pytest --no-cov tests/unit/test_run_extraction_v3_phase_m.py tests/unit/test_run_extraction_v3_pipeline_controls.py
+	uv run --frozen --extra test pytest --no-cov tests/unit/test_run_extraction_v3_phase_m.py tests/unit/test_run_extraction_v3_pipeline_controls.py
 
 # Quality targets
 lint:

--- a/compose.yml
+++ b/compose.yml
@@ -82,7 +82,7 @@ services:
       - dopemux-network
 
     ports:
-      - "6379:6379"
+      - "${REDIS_EVENTS_PORT:-6379}:6379"
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
@@ -97,7 +97,7 @@ services:
     networks:
       - dopemux-network
     ports:
-      - "6380:6379"
+      - "${REDIS_PRIMARY_PORT:-6380}:6379"
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
@@ -162,7 +162,7 @@ services:
     networks:
       - dopemux-network
     ports:
-      - "8080:80"
+      - "${LEANTIME_PORT:-8080}:80"
     depends_on:
       mysql_leantime:
         condition: service_healthy
@@ -208,7 +208,7 @@ services:
     networks:
       - dopemux-network
     ports:
-      - "8081:5540"
+      - "${REDIS_UI_PORT:-8081}:5540"
     # Note: RedisInsight healthcheck disabled - app takes time to start and doesn't respond reliably to health checks
 
   # Qdrant (vector database for embeddings)
@@ -305,7 +305,7 @@ services:
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - DATABASE_URL=${LITELLM_DATABASE_URL:-postgresql://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/litellm}
     ports:
-      - "4000:4000"
+      - "${LITELLM_PORT:-4000}:4000"
     depends_on:
       - postgres
     healthcheck:
@@ -615,7 +615,7 @@ services:
     networks:
       - dopemux-network
     ports:
-      - "8790:8790"
+      - "${WEBHOOK_RECEIVER_HOST_PORT:-8790}:8790"
     environment:
       - WEBHOOK_RECEIVER_HOST=0.0.0.0
       - WEBHOOK_RECEIVER_PORT=8790

--- a/src/dopemux/adhd/context_manager.py
+++ b/src/dopemux/adhd/context_manager.py
@@ -446,19 +446,27 @@ class ContextManager:
 
         # Check git status for recent changes
         if git_state.get("status"):
-            status_lines = git_state["status"].split("\n")
+            status_lines = str(git_state["status"]).replace("\\n", "\n").splitlines()
             modified_files = []
             added_files = []
             deleted_files = []
 
-            for line in status_lines:
-                line = line.strip()
-                if line.startswith("M "):
-                    modified_files.append(line[2:])
-                elif line.startswith("A "):
-                    added_files.append(line[2:])
-                elif line.startswith("D "):
-                    deleted_files.append(line[2:])
+            for raw_line in status_lines:
+                line = raw_line.rstrip()
+                if not line.strip():
+                    continue
+
+                status_code = line[:2]
+                path = line[3:].strip() if len(line) > 3 else line[2:].strip()
+                if not path:
+                    continue
+
+                if "A" in status_code:
+                    added_files.append(path)
+                elif "D" in status_code:
+                    deleted_files.append(path)
+                elif "M" in status_code:
+                    modified_files.append(path)
 
             # Generate description based on changes
             if added_files:

--- a/src/dopemux/mcp/registry.yaml
+++ b/src/dopemux/mcp/registry.yaml
@@ -18,40 +18,10 @@ servers:
         - context-portal-mcp
         - conport-mcp
 
-  dopemux-conport:
-    transport: http
-    default_enabled: false
-    required_for_auto: false
-    docker:
-      service: conport
-      compose_file: compose.yml
-      port: 3004
-      health_url: http://localhost:3004/health
-    local:
-      command: uvx
-      args:
-        - --from
-        - context-portal-mcp
-        - conport-mcp
-
   dopemux-serena:
     transport: http
     default_enabled: true
     required_for_auto: true
-    docker:
-      service: serena
-      compose_file: compose.yml
-      port: 3006
-      health_url: http://localhost:4006/health
-    local:
-      command: serena
-      args:
-        - start-mcp-server
-
-  dopemux-serena:
-    transport: http
-    default_enabled: false
-    required_for_auto: false
     docker:
       service: serena
       compose_file: compose.yml

--- a/task-packets/TP-DMX-REPAIR-TEST-WARNINGS-5374.json
+++ b/task-packets/TP-DMX-REPAIR-TEST-WARNINGS-5374.json
@@ -1,0 +1,95 @@
+{
+  "id": "TP-DMX-REPAIR-TEST-WARNINGS-5374",
+  "project": "dopemux-mvp",
+  "target": "Clear residual test warning drift after pytest repair",
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "repair-tests-5374",
+    "base_branch": "origin/main",
+    "parent_tp_id": "TP-DMX-REPAIR-TESTS-5374",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/repair-tests-5374",
+    "base_branch": "origin/main",
+    "stacked_because": "Follow-up cleanup for residual dirty state and warning output on PR 627"
+  },
+  "commit": {
+    "message": "test: clear residual warning drift",
+    "allowlist": [
+      "compose.yml",
+      "tests/regression/test_fnew9_matching_engine.py",
+      "task-packets/TP-DMX-REPAIR-TEST-WARNINGS-5374.json"
+    ],
+    "verify": [
+      "uv run --frozen --extra test python - <<'PY'\nimport json\nfrom pathlib import Path\nfrom jsonschema import Draft7Validator\nschema = json.loads(Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text(encoding='utf-8'))\nfor packet_path in [Path('task-packets/TP-DMX-REPAIR-TEST-WARNINGS-5374.json')]:\n    packet = json.loads(packet_path.read_text(encoding='utf-8'))\n    errors = sorted(Draft7Validator(schema).iter_errors(packet), key=lambda e: list(e.path))\n    if errors:\n        for error in errors:\n            loc = '.'.join(str(part) for part in error.path) or '<root>'\n            print(f'{packet_path}: {loc}: {error.message}')\n        raise SystemExit(1)\n    print(f'PASS {packet_path}')\nPY",
+      "uv run --frozen --extra test pytest tests/arch/test_registry_compose_alignment.py::TestRegistryComposeAlignment::test_no_hardcoded_ports_in_compose tests/regression/test_fnew9_matching_engine.py -W error::UserWarning -W error::pytest.PytestReturnNotNoneWarning -q",
+      "uv run --frozen --extra test pytest tests --maxfail=10",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "Clear residual test warning drift",
+    "body": "Cleans local .claude workspace drift outside the commit, converts hardcoded compose host ports to env-backed defaults, and removes non-None returns from F-NEW-9 regression tests.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "step-1",
+      "task": "Remove local .claude working-tree drift without committing machine-local workspace paths.",
+      "context_files": [
+        ".claude/agents/architect.md",
+        ".claude/agents/developer.md",
+        ".claude/agents/project-manager.md",
+        ".claude/agents/researcher.md",
+        ".claude/claude_config.json"
+      ],
+      "expected_files": [],
+      "validation": [
+        "git status --short --branch"
+      ]
+    },
+    {
+      "id": "step-2",
+      "task": "Replace hardcoded compose host ports reported by the registry/compose alignment warning with env-backed defaults.",
+      "context_files": [
+        "compose.yml",
+        "tests/arch/test_registry_compose_alignment.py"
+      ],
+      "expected_files": [
+        "compose.yml"
+      ],
+      "validation": [
+        "uv run --frozen --extra test pytest tests/arch/test_registry_compose_alignment.py::TestRegistryComposeAlignment::test_no_hardcoded_ports_in_compose -W error::UserWarning -q"
+      ]
+    },
+    {
+      "id": "step-3",
+      "task": "Convert F-NEW-9 regression tests from boolean returns to assertions so pytest emits no return-value warnings.",
+      "context_files": [
+        "tests/regression/test_fnew9_matching_engine.py"
+      ],
+      "expected_files": [
+        "tests/regression/test_fnew9_matching_engine.py"
+      ],
+      "validation": [
+        "uv run --frozen --extra test pytest tests/regression/test_fnew9_matching_engine.py -W error::pytest.PytestReturnNotNoneWarning -q"
+      ]
+    }
+  ]
+}

--- a/task-packets/TP-DMX-REPAIR-TESTS-5374.json
+++ b/task-packets/TP-DMX-REPAIR-TESTS-5374.json
@@ -1,0 +1,129 @@
+{
+  "id": "TP-DMX-REPAIR-TESTS-5374",
+  "project": "dopemux-mvp",
+  "target": "Repair pytest execution for the current worktree",
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "repair-tests-5374",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/repair-tests-5374",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "test: repair pytest execution wiring",
+    "allowlist": [
+      "Makefile",
+      "src/dopemux/adhd/context_manager.py",
+      "src/dopemux/mcp/registry.yaml",
+      "tests/system_data/test_cli.py",
+      "tests/system_data/test_tools.py",
+      "tests/integration/test_claude_autoresponder_integration.py",
+      "tests/test_component6_phase1.py",
+      "tests/test_workspace_detection.py",
+      "tests/unit/test_extract_local_smoke.py",
+      "tests/unit/test_repo_truth_extractor_prompt_governance.py",
+      "tests/unit/test_wizard_interactivity.py",
+      "task-packets/TP-DMX-REPAIR-TESTS-5374.json"
+    ],
+    "verify": [
+      "uv run --frozen --extra test pytest tests/test_component6_phase1.py --maxfail=1 -q",
+      "make test-fast",
+      "uv run --frozen --extra test pytest tests --maxfail=10",
+      "git diff --check",
+      "pre-commit run --files Makefile src/dopemux/adhd/context_manager.py src/dopemux/mcp/registry.yaml tests/integration/test_claude_autoresponder_integration.py tests/system_data/test_cli.py tests/system_data/test_tools.py tests/test_component6_phase1.py tests/test_workspace_detection.py tests/unit/test_extract_local_smoke.py tests/unit/test_repo_truth_extractor_prompt_governance.py tests/unit/test_wizard_interactivity.py task-packets/TP-DMX-REPAIR-TESTS-5374.json"
+    ]
+  },
+  "pr": {
+    "title": "Repair pytest execution wiring",
+    "body": "Updates pytest invocation wiring, repairs registry and git-status parsing failures, and hardens brittle full-suite test imports against cross-test package collisions.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "step-1",
+      "task": "Ensure pytest commands install and execute from the project test environment instead of resolving a global pytest executable.",
+      "context_files": [
+        "Makefile",
+        "pyproject.toml",
+        "pytest.ini",
+        "uv.lock"
+      ],
+      "expected_files": [
+        "Makefile"
+      ],
+      "validation": [
+        "uv run --frozen --extra test pytest tests/embeddings/unit/test_integrations.py --maxfail=1 -q"
+      ]
+    },
+    {
+      "id": "step-2",
+      "task": "Isolate the Component 6 Phase 1 test imports from conflicting top-level intelligence packages during full-suite collection.",
+      "context_files": [
+        "tests/test_component6_phase1.py",
+        "services/task-orchestrator/intelligence/context_switch_recovery.py",
+        "services/task-orchestrator/observability/metrics_collector.py",
+        "services/serena/v2/intelligence/__init__.py"
+      ],
+      "expected_files": [
+        "tests/test_component6_phase1.py"
+      ],
+      "validation": [
+        "uv run --frozen --extra test pytest tests/test_component6_phase1.py --maxfail=1 -q",
+        "uv run --frozen --extra test pytest tests --maxfail=10"
+      ]
+    },
+    {
+      "id": "step-3",
+      "task": "Repair later full-suite failures with minimal changes to proven runtime bugs and stale test assertions.",
+      "context_files": [
+        "src/dopemux/mcp/registry.yaml",
+        "src/dopemux/adhd/context_manager.py",
+        "tests/system_data/test_cli.py",
+        "tests/system_data/test_tools.py",
+        "tests/integration/test_claude_autoresponder_integration.py",
+        "tests/test_workspace_detection.py",
+        "tests/unit/test_extract_local_smoke.py",
+        "tests/unit/test_repo_truth_extractor_prompt_governance.py",
+        "tests/unit/test_wizard_interactivity.py",
+        "scripts/mcp-wrappers/_lib.sh",
+        "scripts/mcp-wrappers/conport-wrapper.sh",
+        "scripts/mcp-wrappers/dope-context-wrapper.sh",
+        "scripts/mcp-wrappers/serena-wrapper.sh"
+      ],
+      "expected_files": [
+        "src/dopemux/mcp/registry.yaml",
+        "src/dopemux/adhd/context_manager.py",
+        "tests/system_data/test_cli.py",
+        "tests/system_data/test_tools.py",
+        "tests/integration/test_claude_autoresponder_integration.py",
+        "tests/test_workspace_detection.py",
+        "tests/unit/test_extract_local_smoke.py",
+        "tests/unit/test_repo_truth_extractor_prompt_governance.py",
+        "tests/unit/test_wizard_interactivity.py"
+      ],
+      "validation": [
+        "uv run --frozen --extra test pytest tests/system_data tests/test_config_manager.py::TestConfigManager::test_default_mcp_servers tests/test_session_commands.py::TestContextManagerEnhancements::test_generate_smart_description_from_git_changes tests/test_workspace_detection.py::TestMCPWrapperScripts tests/test_workspace_detection.py::TestPhase1Metrics::test_all_components_migrated tests/unit/test_extract_local_smoke.py::test_extract_pipeline_voyage_embeddings_are_mockable tests/unit/test_repo_truth_extractor_prompt_governance.py tests/unit/test_wizard_interactivity.py::test_require_questionary_raises_deterministic_message tests/integration/test_claude_autoresponder_integration.py::TestPerformanceIntegration::test_concurrent_operations --maxfail=1 -q",
+        "uv run --frozen --extra test pytest tests --maxfail=10"
+      ]
+    }
+  ]
+}

--- a/tests/integration/test_claude_autoresponder_integration.py
+++ b/tests/integration/test_claude_autoresponder_integration.py
@@ -473,9 +473,10 @@ class TestPerformanceIntegration:
 
         # Wait for completion
         for thread in threads:
-            thread.join(timeout=5)
+            thread.join(timeout=10)
 
         # All should succeed
+        assert not any(thread.is_alive() for thread in threads)
         assert len(results) == 5
         assert all("stopped" in str(result) for result in results)
 

--- a/tests/regression/test_fnew9_matching_engine.py
+++ b/tests/regression/test_fnew9_matching_engine.py
@@ -53,7 +53,7 @@ def test_energy_complexity_matching():
             print(f"  ❌ {desc}: {score:.2f} (expected {expected_range})")
 
     print(f"  Result: {passed}/{len(test_cases)} cases passed\n")
-    return passed == len(test_cases)
+    assert passed == len(test_cases)
 
 
 def test_attention_task_matching():
@@ -103,7 +103,7 @@ def test_attention_task_matching():
             print(f"  ❌ {desc}: {score:.2f} (expected {expected_range})")
 
     print(f"  Result: {passed}/{len(test_cases)} cases passed\n")
-    return passed == len(test_cases)
+    assert passed == len(test_cases)
 
 
 def test_time_duration_matching():
@@ -129,7 +129,7 @@ def test_time_duration_matching():
             print(f"  ❌ {desc}: {score:.2f} (expected {expected_range})")
 
     print(f"  Result: {passed}/{len(test_cases)} cases passed\n")
-    return passed == len(test_cases)
+    assert passed == len(test_cases)
 
 
 def test_integrated_matching():
@@ -167,7 +167,7 @@ def test_integrated_matching():
         print(f"     #{i}: {sug.task.title} - Match: {sug.match_score:.2f}")
 
     print()
-    return result
+    assert result
 
 
 def test_mismatch_detection():
@@ -201,7 +201,7 @@ def test_mismatch_detection():
         result = False
 
     print()
-    return result
+    assert result
 
 
 def main():
@@ -213,11 +213,19 @@ def main():
     print()
 
     results = []
-    results.append(test_energy_complexity_matching())
-    results.append(test_attention_task_matching())
-    results.append(test_time_duration_matching())
-    results.append(test_integrated_matching())
-    results.append(test_mismatch_detection())
+    for test_func in [
+        test_energy_complexity_matching,
+        test_attention_task_matching,
+        test_time_duration_matching,
+        test_integrated_matching,
+        test_mismatch_detection,
+    ]:
+        try:
+            test_func()
+        except AssertionError:
+            results.append(False)
+        else:
+            results.append(True)
 
     print("=" * 70)
     print(f"Results: {sum(results)}/{len(results)} tests passed")

--- a/tests/system_data/test_cli.py
+++ b/tests/system_data/test_cli.py
@@ -1,5 +1,6 @@
 from click.testing import CliRunner
 
+import dopemux.system_data.cli as system_data_cli
 from dopemux.system_data.cli import system_data
 from dopemux.system_data.models import (
     EnvironmentSnapshot,
@@ -62,7 +63,7 @@ def test_doctor_missing_required_tool_exits_nonzero(monkeypatch):
                 statuses=(ToolStatus(name="dust", path=None, version=None, available=False),),
             )
 
-    monkeypatch.setattr("dopemux.system_data.cli.ToolRunner", DummyRunner)
+    monkeypatch.setattr(system_data_cli, "ToolRunner", DummyRunner)
 
     result = CliRunner().invoke(system_data, ["doctor"])
 
@@ -71,7 +72,7 @@ def test_doctor_missing_required_tool_exits_nonzero(monkeypatch):
 
 
 def test_scan_json_uses_scan_result(monkeypatch):
-    monkeypatch.setattr("dopemux.system_data.cli.scan", lambda home: _scan_result())
+    monkeypatch.setattr(system_data_cli, "scan", lambda home: _scan_result())
 
     result = CliRunner().invoke(system_data, ["scan", "--json", "--home", "/tmp"])
 
@@ -80,7 +81,7 @@ def test_scan_json_uses_scan_result(monkeypatch):
 
 
 def test_clean_execute_requires_yes(monkeypatch):
-    monkeypatch.setattr("dopemux.system_data.cli.scan", lambda home: _scan_result())
+    monkeypatch.setattr(system_data_cli, "scan", lambda home: _scan_result())
 
     result = CliRunner().invoke(system_data, ["clean", "--execute"])
 
@@ -89,7 +90,7 @@ def test_clean_execute_requires_yes(monkeypatch):
 
 
 def test_clean_execute_rejects_foreign_home(monkeypatch):
-    monkeypatch.setattr("dopemux.system_data.cli.scan", lambda home: _scan_result())
+    monkeypatch.setattr(system_data_cli, "scan", lambda home: _scan_result())
 
     result = CliRunner().invoke(system_data, ["clean", "--execute", "--yes", "--home", "/"])
 
@@ -98,7 +99,7 @@ def test_clean_execute_rejects_foreign_home(monkeypatch):
 
 
 def test_plan_accepts_no_dry_run(monkeypatch):
-    monkeypatch.setattr("dopemux.system_data.cli.scan", lambda home: _scan_result())
+    monkeypatch.setattr(system_data_cli, "scan", lambda home: _scan_result())
 
     result = CliRunner().invoke(system_data, ["plan", "--no-dry-run", "--home", "/tmp"])
 

--- a/tests/system_data/test_tools.py
+++ b/tests/system_data/test_tools.py
@@ -1,5 +1,6 @@
 import json
 
+import dopemux.system_data.tools as system_data_tools
 from dopemux.system_data.tools import (
     ToolRunner,
     parse_dua_text,
@@ -11,7 +12,7 @@ from dopemux.system_data.tools import (
 
 
 def test_required_tool_preflight_reports_missing(monkeypatch):
-    monkeypatch.setattr("dopemux.system_data.tools.shutil.which", lambda name: None)
+    monkeypatch.setattr(system_data_tools.shutil, "which", lambda name: None)
 
     report = ToolRunner().check_required_tools()
 

--- a/tests/test_component6_phase1.py
+++ b/tests/test_component6_phase1.py
@@ -8,16 +8,43 @@ Purpose: Validate Phase 1 implementation before Phase 2 development
 """
 
 import asyncio
+import importlib.util
 import os
 import sys
 from datetime import datetime
 from pathlib import Path
 
-# Add services to path
-sys.path.insert(0, str(Path(__file__).parent.parent / "services" / "task-orchestrator"))
+TASK_ORCHESTRATOR_ROOT = (
+    Path(__file__).parent.parent / "services" / "task-orchestrator"
+).resolve()
 
-from intelligence.context_switch_recovery import ContextSwitchRecovery, SwitchReason
-from observability.metrics_collector import MetricsCollector, get_metrics
+
+def _load_task_orchestrator_module(module_name: str, relative_path: str):
+    module_path = TASK_ORCHESTRATOR_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load {module_name} from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_context_switch_recovery = _load_task_orchestrator_module(
+    "task_orchestrator_component6_context_switch_recovery",
+    "intelligence/context_switch_recovery.py",
+)
+_metrics_collector = _load_task_orchestrator_module(
+    "task_orchestrator_component6_metrics_collector",
+    "observability/metrics_collector.py",
+)
+
+ContextSwitch = _context_switch_recovery.ContextSwitch
+ContextSwitchRecovery = _context_switch_recovery.ContextSwitchRecovery
+SwitchReason = _context_switch_recovery.SwitchReason
+MetricsCollector = _metrics_collector.MetricsCollector
+get_metrics = _metrics_collector.get_metrics
 
 
 class MockConPortClient:
@@ -229,9 +256,6 @@ async def test_recovery_assistance():
         metrics_collector=get_metrics()
     )
 
-    # Create a mock context switch
-    from intelligence.context_switch_recovery import ContextSwitch
-
     switch = ContextSwitch(
         from_context={
             "task": {
@@ -380,9 +404,6 @@ async def test_recovery_statistics():
         conport_client=MockConPortClient(workspace_id),
         metrics_collector=get_metrics()
     )
-
-    # Create mock switches to populate history
-    from intelligence.context_switch_recovery import ContextSwitch
 
     for i in range(3):
         switch = ContextSwitch(

--- a/tests/test_workspace_detection.py
+++ b/tests/test_workspace_detection.py
@@ -188,7 +188,8 @@ class TestMCPWrapperScripts:
         wrapper_path = project_root / "scripts" / "mcp-wrappers" / "conport-wrapper.sh"
         content = wrapper_path.read_text()
 
-        assert "detect_workspace()" in content
+        assert 'source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"' in content
+        assert 'workspace_id="$(detect_workspace)"' in content
         assert "DOPEMUX_WORKSPACE_ID" in content
         assert "docker exec" in content
 
@@ -197,7 +198,8 @@ class TestMCPWrapperScripts:
         wrapper_path = project_root / "scripts" / "mcp-wrappers" / "serena-wrapper.sh"
         content = wrapper_path.read_text()
 
-        assert "detect_workspace()" in content
+        assert 'source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"' in content
+        assert 'workspace_id="$(detect_workspace)"' in content
         assert "DOPEMUX_WORKSPACE_ID" in content
         assert "mcp_server.py" in content
 
@@ -206,7 +208,8 @@ class TestMCPWrapperScripts:
         wrapper_path = project_root / "scripts" / "mcp-wrappers" / "dope-context-wrapper.sh"
         content = wrapper_path.read_text()
 
-        assert "detect_workspace()" in content
+        assert 'source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"' in content
+        assert 'workspace_id="$(detect_workspace)"' in content
         assert "DOPEMUX_WORKSPACE_ID" in content
         assert "docker exec" in content
 
@@ -302,7 +305,9 @@ class TestPhase1Metrics:
 
         # 3. MCP wrappers
         conport_wrapper = project_root / "scripts" / "mcp-wrappers" / "conport-wrapper.sh"
-        assert "detect_workspace()" in conport_wrapper.read_text()
+        conport_content = conport_wrapper.read_text()
+        assert 'source "$(dirname "${BASH_SOURCE[0]}")/_lib.sh"' in conport_content
+        assert 'workspace_id="$(detect_workspace)"' in conport_content
 
     def test_worktree_bug_fixed(self):
         """CRITICAL: .git directory checks eliminated"""

--- a/tests/unit/test_extract_local_smoke.py
+++ b/tests/unit/test_extract_local_smoke.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+import dopemux.embeddings.storage.hybrid_store as hybrid_store
 from dopemux.cli import cli
 from dopemux.commands.extract_commands import extract
 
@@ -93,10 +94,7 @@ def test_extract_pipeline_voyage_embeddings_are_mockable(tmp_path: Path, monkeyp
             return [[0.1] * self.config.embedding_dimension for _ in texts]
 
     monkeypatch.setenv("VOYAGE_API_KEY", "test-key")
-    monkeypatch.setattr(
-        "dopemux.embeddings.storage.hybrid_store.VoyageAPIClient",
-        FakeVoyageClient,
-    )
+    monkeypatch.setattr(hybrid_store, "VoyageAPIClient", FakeVoyageClient)
 
     source_dir = tmp_path / "docs"
     output_dir = tmp_path / "out"

--- a/tests/unit/test_repo_truth_extractor_prompt_governance.py
+++ b/tests/unit/test_repo_truth_extractor_prompt_governance.py
@@ -17,6 +17,18 @@ PRESCAN_ROOT = SERVICE_ROOT / "prompts" / "prescan"
 
 
 def _load_runner_module():
+    service_root = str(SERVICE_ROOT)
+    if service_root in sys.path:
+        sys.path.remove(service_root)
+    sys.path.insert(0, service_root)
+
+    for module_name, module in list(sys.modules.items()):
+        if module_name != "extractor" and not module_name.startswith("extractor."):
+            continue
+        module_file = getattr(module, "__file__", None)
+        if module_file is None or not Path(module_file).resolve().is_relative_to(SERVICE_ROOT):
+            sys.modules.pop(module_name, None)
+
     spec = importlib.util.spec_from_file_location(
         "run_extraction_v5_prompt_governance", RUNNER_PATH
     )

--- a/tests/unit/test_wizard_interactivity.py
+++ b/tests/unit/test_wizard_interactivity.py
@@ -8,6 +8,11 @@ from types import SimpleNamespace
 
 import pytest
 
+import dopemux.ux.questionary_support as questionary_support
+import dopemux.ux.wizard.corpus as wizard_corpus
+import dopemux.ux.wizard.cost_profiles as wizard_cost_profiles
+import dopemux.ux.wizard.extraction as wizard_extraction
+import dopemux.ux.wizard.provider_overrides as wizard_provider_overrides
 from dopemux.ux.questionary_support import (
     MissingInteractiveDependencyError,
     QUESTIONARY_INSTALL_MESSAGE,
@@ -45,11 +50,15 @@ def test_require_questionary_raises_deterministic_message(
         return real_import_module(name, package)
 
     monkeypatch.setattr(
-        "dopemux.ux.questionary_support.importlib.import_module",
+        questionary_support.importlib,
+        "import_module",
         _fake_import_module,
     )
 
-    with pytest.raises(MissingInteractiveDependencyError, match="Interactive Dopemux UX requires `questionary`"):
+    with pytest.raises(
+        MissingInteractiveDependencyError,
+        match="Interactive Dopemux UX requires `questionary`",
+    ):
         require_questionary()
 
     assert "uv sync --frozen --extra test --extra services" in QUESTIONARY_INSTALL_MESSAGE
@@ -83,14 +92,17 @@ def test_run_extraction_uses_v5_upgrades_wrapper_with_resume_and_rich_ui(
             return None
 
     monkeypatch.setattr(
-        "dopemux.ux.wizard.extraction.require_questionary",
+        wizard_extraction,
+        "require_questionary",
         lambda: fake_questionary,
     )
-    monkeypatch.setattr("dopemux.ux.wizard.extraction.PHASES", ["A"])
+    monkeypatch.setattr(wizard_extraction, "PHASES", ["A"])
     monkeypatch.setenv("PYTHONPATH", "")
     monkeypatch.setattr(
-        "dopemux.ux.wizard.extraction.subprocess.Popen",
-        lambda cmd, **kwargs: recorded.update({"env": dict(kwargs.get("env") or {})}) or _Proc(cmd),
+        wizard_extraction.subprocess,
+        "Popen",
+        lambda cmd, **kwargs: recorded.update({"env": dict(kwargs.get("env") or {})})
+        or _Proc(cmd),
     )
 
     result = run_extraction(
@@ -222,11 +234,13 @@ def test_run_corpus_audit_uses_integrated_v5_prescan_outputs(
     router = object()
     rendered: dict[str, object] = {}
     monkeypatch.setattr(
-        "dopemux.ux.wizard.corpus._run_integrated_v5_prescan",
+        wizard_corpus,
+        "_run_integrated_v5_prescan",
         lambda state: (prescan_dir, router),
     )
     monkeypatch.setattr(
-        "dopemux.ux.wizard.corpus.render_prescan_hud",
+        wizard_corpus,
+        "render_prescan_hud",
         lambda stats, intelligence, artifacts: rendered.update(
             {"stats": stats, "intelligence": intelligence, "artifacts": artifacts}
         ),
@@ -276,7 +290,8 @@ def test_run_cost_selection_supports_profile_browsing(
     )
 
     monkeypatch.setattr(
-        "dopemux.ux.wizard.cost_profiles.require_questionary",
+        wizard_cost_profiles,
+        "require_questionary",
         lambda: fake_questionary,
     )
 
@@ -312,7 +327,8 @@ def test_run_provider_overrides_sets_session_key(
     )
 
     monkeypatch.setattr(
-        "dopemux.ux.wizard.provider_overrides.require_questionary",
+        wizard_provider_overrides,
+        "require_questionary",
         lambda: fake_questionary,
     )
 


### PR DESCRIPTION
@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated

## Summary
- Ensure Makefile pytest targets install and run the project test extra instead of falling through to a global pytest executable.
- Remove duplicate disabled ConPort/Serena registry entries so required defaults are generated.
- Harden brittle full-suite tests against package/import cache collisions and update wrapper assertions for the shared `_lib.sh` workspace detector.
- Improve smart git-status description parsing for escaped newlines and porcelain spacing.

## Validation
- PASS: Task Packet schema validation for `task-packets/TP-DMX-REPAIR-TESTS-5374.json`
- PASS: `uv run --frozen --extra test pytest tests/embeddings/unit/test_integrations.py --maxfail=1 -q && uv run --frozen --extra test pytest tests/test_component6_phase1.py --maxfail=1 -q`
- PASS: targeted 48-test repair subset
- PASS: `make test-fast` (814 passed, 2 skipped)
- PASS: `uv run --frozen --extra test pytest tests --maxfail=10` (2306 passed, 3 skipped)
- PASS: `git diff --check` and `git diff --cached --check`
- PASS: scoped `pre-commit run --files ...`

## Residual risk
- Existing unrelated `.claude` working-tree changes were not included in this commit.
- Full suite reports existing warnings for hardcoded compose ports and several tests returning non-None values.