### PR TITLE
[codex] capture provider response metadata

### DIFF
--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_DIFF_SUMMARY.md
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_DIFF_SUMMARY.md
@@ -1,0 +1,25 @@
+# RTE-PKT-07 Diff Summary
+
+Changed files and scope rationale:
+
+| File | Scope rationale |
+| --- | --- |
+| `services/repo-truth-extractor/llm_runtime.py` | Allowed primary runtime path. Adds metadata propagation for requested route identity, returned/effective response fields, structured-output fields, retry/failure flags, and comparison-lane request metadata. Does not change provider selection, model IDs, prompt text, or live dispatch behavior. |
+| `services/repo-truth-extractor/run_extraction_v5.py` | Allowed secondary runtime path. Hardens local response-state summary extraction and request_meta enrichment. Does not change route selection, promptsets, model map, pricing, or compose/deployment files. |
+| `services/repo-truth-extractor/tests/test_rte_pkt_07_xai_metadata.py` | Allowed tests path. Adds local fake-response coverage for OpenAI-compatible, direct xAI-style, OpenRouter x-ai proxy, refusal, incomplete, Gemini-style, structured-output, and no-provider-client invocation checks. |
+| `out/rte-pkt-07-xai-metadata/` | Allowed packet proof output root. Contains evidence artifacts only. |
+
+Forbidden surfaces not touched:
+
+- `services/repo-truth-extractor/promptsets/`
+- `services/repo-truth-extractor/prompts/`
+- `services/repo-truth-extractor/promptsets/v4/model_map.yaml`
+- `services/repo-truth-extractor/lib/structured_output_contracts.py`
+- `config/`
+- `docs/`
+- `compose.yml`
+- `docker-compose.yml`
+
+Known validation note:
+
+- One adjacent live-readiness route test failed during expanded validation. The failure is outside the edited metadata surfaces and concerns benchmark-owned route readiness selection.

--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_FAKE_RESPONSE_FIXTURES.md
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_FAKE_RESPONSE_FIXTURES.md
@@ -1,0 +1,92 @@
+# RTE-PKT-07 Fake Response Fixtures
+
+All fixtures are local, redacted, and synthetic. No provider payload text or credentials are included.
+
+## OpenAI-Compatible
+
+```python
+Obj(
+    id="chatcmpl-local-001",
+    model="gpt-returned-fixture",
+    created=1770000000,
+    system_fingerprint="fp_fixture",
+    choices=[Obj(finish_reason="stop", message=Obj(content="{\"ok\": true}"))],
+    usage=Obj(prompt_tokens=17, completion_tokens=5, total_tokens=22),
+)
+```
+
+Expected summary fields: `response_id`, `returned_model_id`, `effective_model_id`, `finish_reason`, `finish_reasons`, `usage`, token aliases, `response_text_length`, `choice_count`, `created`, and `system_fingerprint_if_present`.
+
+## Direct xAI-Style
+
+```python
+Obj(
+    id="xai-local-001",
+    model="grok-effective-fixture",
+    choices=[Obj(finish_reason="stop", message=Obj(content="{}"))],
+    usage=Obj(prompt_tokens=10, completion_tokens=4, total_tokens=14),
+)
+```
+
+Expected request metadata keeps `requested_provider=xai` and `requested_model_id=grok-requested-fixture` separate from `returned_model_id=grok-effective-fixture`.
+
+## OpenRouter xAI Proxy
+
+```python
+Obj(
+    id="or-local-001",
+    model="x-ai/grok-proxy-fixture",
+    choices=[Obj(finish_reason="stop", message=Obj(content="{}"))],
+    usage={"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+)
+```
+
+Expected request metadata keeps `requested_provider=openrouter`, `requested_model_id=x-ai/grok-proxy-fixture`, and `provider_route_kind=openrouter_proxy_xai`.
+
+## Refusal
+
+```python
+Obj(
+    id="chatcmpl-refusal",
+    model="gpt-refusal-fixture",
+    choices=[
+        Obj(
+            finish_reason="stop",
+            message=Obj(content="", refusal="Cannot comply with [REDACTED]."),
+        )
+    ],
+    usage=Obj(prompt_tokens=3, completion_tokens=1, total_tokens=4),
+)
+```
+
+Expected summary fields: `refusal=true`, sanitized `refusal_reason`, and no local `failure_type`.
+
+## Incomplete
+
+```python
+{
+    "id": "chatcmpl-incomplete",
+    "model": "gpt-incomplete-fixture",
+    "status": "incomplete",
+    "incomplete_details": {"reason": "max_output_tokens"},
+    "choices": [{"finish_reason": "length", "message": {"content": "{\"partial\": true"}}],
+    "usage": {"prompt_tokens": 9, "completion_tokens": 2, "total_tokens": 11},
+}
+```
+
+Expected summary fields: `response_status=incomplete`, `finish_reason=length`, `incomplete=true`, and `incomplete_reason=max_output_tokens`.
+
+## Gemini-Style
+
+```python
+Obj(
+    candidates=[Obj(finish_reason="SAFETY", safety_reason="policy_block")],
+    usage_metadata=Obj(
+        prompt_token_count=13,
+        candidates_token_count=6,
+        total_token_count=19,
+    ),
+)
+```
+
+Expected summary fields: `finish_reason=SAFETY`, `finish_reasons=["SAFETY"]`, `safety_reason=policy_block`, and provider usage aliases.

--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_FINAL_CLOSEOUT.md
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_FINAL_CLOSEOUT.md
@@ -1,0 +1,49 @@
+# RTE-PKT-07 Final Closeout
+
+Generated: 2026-05-15T12:56:16Z
+
+## Status
+
+Closeout status: `READY_FOR_REVIEW_CLEAN` pending final commit and post-commit clean status verification.
+
+## Regression Triage
+
+- Expanded adjacent live-readiness command: FAIL on implementation and FAIL on clean base.
+- Classification: `BASELINE_FAILURE`.
+- Acceptance impact: no new RTE-PKT-07 metadata regression identified.
+
+## Validation Summary
+
+Final local validation commands:
+
+- PASS `python -m py_compile services/repo-truth-extractor/llm_runtime.py services/repo-truth-extractor/run_extraction_v5.py`
+- PASS `pytest services/repo-truth-extractor/tests/test_rte_pkt_07_xai_metadata.py -q`
+- PASS `pytest services/repo-truth-extractor/tests -k 'xai and metadata' -q`
+- PASS `pytest services/repo-truth-extractor/tests -k 'provider and metadata' -q`
+- PASS `pytest services/repo-truth-extractor/tests -k 'llm_runtime or response_summary' -q`
+- PASS `pytest services/repo-truth-extractor/tests/test_artifact_provenance_fields.py services/repo-truth-extractor/tests/test_truth_label_preservation.py -q`
+- PASS `python -m json.tool out/rte-pkt-07-xai-metadata/RTE-PKT-07_MANIFEST.json >/dev/null`
+- PASS `git diff --check`
+
+Observed pytest warning across selected test commands: unknown config option `asyncio_mode`.
+
+## Commit State
+
+Commit SHA: `PENDING_REPORTED_AFTER_COMMIT`
+
+Git commit hashes cannot be embedded into the same commit object that defines them. The final response reports the actual commit SHA after commit creation.
+
+## Live Boundary
+
+No live provider validation was run. No provider call, live extraction, provider preflight, batch submit, batch watch, batch retrieve, or batch cancel occurred.
+
+Live xAI, OpenRouter `x-ai/...`, Gemini, and OpenAI-compatible response shapes remain `LIVE_VALIDATION_REQUIRED`.
+
+## Residual Risks
+
+- Direct xAI live response object shape remains unknown.
+- OpenRouter `x-ai/...` live upstream metadata remains unknown.
+- Gemini/OpenAI-compatible refusal and incomplete edge cases remain fixture-proven only.
+- Batch response metadata remains out of scope for RTE-PKT-07.
+- Comparison lane metadata is static/local only; no live comparison call was executed.
+- Route-readiness benchmark-owned lane test failure is baseline drift, not resolved by this packet.

--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_MANIFEST.json
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_MANIFEST.json
@@ -1,0 +1,99 @@
+{
+  "id": "RTE-PKT-07-XAI-METADATA",
+  "generated_at_utc": "2026-05-15T10:34:49Z",
+  "closeout_generated_at_utc": "2026-05-15T12:56:16Z",
+  "worktree_path": "/Users/hue/.codex/worktrees/39a6/dopemux-mvp",
+  "branch": "codex/rte-pkt-07-xai-metadata",
+  "head_sha": "0179b17b03cf46518aa324bd8f50c805b627631d",
+  "final_commit_sha": "PENDING_REPORTED_AFTER_COMMIT",
+  "task_packet_source": "conversation-provided JSON; no additional task packet file created per packet non-goal",
+  "scope_status": "inside_allowed_code_paths_and_allowed_output_root",
+  "changed_files": [
+    {
+      "path": "services/repo-truth-extractor/llm_runtime.py",
+      "purpose": "Propagate requested route fields, returned/effective response metadata, structured-output metadata, retry/failure flags, and comparison-lane response metadata into request_meta surfaces."
+    },
+    {
+      "path": "services/repo-truth-extractor/run_extraction_v5.py",
+      "purpose": "Harden local response summary extraction for OpenAI-compatible, xAI-style, OpenRouter x-ai proxy, refusal, incomplete, and Gemini-style response objects; flatten summary fields during request_meta enrichment."
+    },
+    {
+      "path": "services/repo-truth-extractor/tests/test_rte_pkt_07_xai_metadata.py",
+      "purpose": "Add local fake-response tests for provider metadata extraction and no-provider-client invocation."
+    },
+    {
+      "path": "out/rte-pkt-07-xai-metadata/",
+      "purpose": "Packet proof artifacts only."
+    }
+  ],
+  "proof_outputs": [
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_MANIFEST.json",
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_PROVIDER_METADATA_MATRIX.md",
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_FAKE_RESPONSE_FIXTURES.md",
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_REQUEST_META_EXAMPLES.md",
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_TEST_REPORT.md",
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_DIFF_SUMMARY.md",
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_REMAINING_UNKNOWNS.md",
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_REGRESSION_TRIAGE_CLOSEOUT.md",
+    "out/rte-pkt-07-xai-metadata/RTE-PKT-07_FINAL_CLOSEOUT.md"
+  ],
+  "validation_status": {
+    "py_compile": "PASS",
+    "targeted_metadata_tests": "PASS",
+    "packet_selector_xai_and_metadata": "PASS",
+    "packet_selector_provider_and_metadata": "PASS",
+    "llm_runtime_or_response_summary_selector": "PASS",
+    "adjacent_runtime_redaction_structured_comparison_suite": "PASS",
+    "provenance_and_truth_label_tests": "PASS",
+    "adjacent_live_readiness_route_test": "BASELINE_FAILURE",
+    "manifest_json_valid": "PASS",
+    "git_diff_check": "PASS"
+  },
+  "regression_triage": {
+    "id": "REG-XM-001",
+    "classification": "BASELINE_FAILURE",
+    "implementation_worktree": "/Users/hue/.codex/worktrees/39a6/dopemux-mvp",
+    "implementation_head_sha": "0179b17b03cf46518aa324bd8f50c805b627631d",
+    "implementation_result": {
+      "exit_code": 1,
+      "failed_test": "services/repo-truth-extractor/tests/test_run_extraction_v5_live_readiness.py::test_route_readiness_summary_honors_benchmark_owned_lane",
+      "observed_providers": [
+        "gemini",
+        "openai",
+        "xai"
+      ],
+      "expected_providers": [
+        "openai"
+      ]
+    },
+    "clean_base_worktree": "/Users/hue/.codex/worktrees/rte-pkt-07-base-0179b17",
+    "clean_base_head_sha": "0179b17b03cf46518aa324bd8f50c805b627631d",
+    "clean_base_result": {
+      "exit_code": 1,
+      "failed_test": "services/repo-truth-extractor/tests/test_run_extraction_v5_live_readiness.py::test_route_readiness_summary_honors_benchmark_owned_lane",
+      "observed_providers": [
+        "gemini",
+        "openai",
+        "xai"
+      ],
+      "expected_providers": [
+        "openai"
+      ]
+    },
+    "acceptance_impact": "Expanded adjacent live-readiness failure is baseline and does not block the RTE-PKT-07 metadata commit."
+  },
+  "no_provider_calls": {
+    "status": "PASS",
+    "basis": "Tests used local fake response objects and one monkeypatch test that raises if provider client constructors are invoked. No live extraction, provider preflight, provider doctor, batch submit, batch poll, batch retrieve, or batch cancel command was run."
+  },
+  "live_validation": {
+    "status": "NOT_RUN",
+    "reason": "Packet forbids live provider validation."
+  },
+  "remaining_unknowns": [
+    "Actual live xAI response object shape remains LIVE_VALIDATION_REQUIRED.",
+    "Actual OpenRouter x-ai upstream response metadata fields remain LIVE_VALIDATION_REQUIRED.",
+    "Actual Gemini SDK and OpenAI-compatible response refusal/incomplete edge cases remain fixture-proven only."
+  ]
+}

--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,16 @@
+# RTE-PKT-07 No Provider Calls Attestation
+
+Status: PASS
+
+Evidence:
+
+- No `run_extraction_v5.py --execute`, provider preflight, doctor, auth probe, batch submit, batch watch, batch retrieve, batch cancel, or live extraction command was run.
+- Tests used local fake response objects only.
+- `test_metadata_extraction_tests_do_not_invoke_provider_clients` monkeypatches `get_xai_client`, `get_openrouter_client`, `get_openai_client`, and `get_gemini_client` to raise if invoked, then exercises metadata extraction successfully.
+- No provider credentials were required or inspected.
+- No external research or web lookup was performed for this packet.
+- Closeout regression triage ran only local pytest commands in the implementation worktree and clean-base comparison worktree.
+
+Remaining boundary:
+
+- This attestation proves static/local validation only. Live provider behavior remains `LIVE_VALIDATION_REQUIRED`.

--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_PROVIDER_METADATA_MATRIX.md
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_PROVIDER_METADATA_MATRIX.md
@@ -1,0 +1,17 @@
+# RTE-PKT-07 Provider Metadata Matrix
+
+Generated: 2026-05-15T10:34:49Z
+
+| Runtime path | Requested route fields | Returned/effective fields | Refusal/incomplete fields | Structured-output fields | Test coverage | Remaining UNKNOWN |
+| --- | --- | --- | --- | --- | --- | --- |
+| OpenAI-compatible Chat Completions object | `requested_provider`, `requested_model_id`, `api_key_env`, endpoint fields, transport, `provider_signature`, `provider_route_kind` | `response_id`, `returned_model_id`, `effective_model_id`, `finish_reason`, `finish_reasons`, `usage`, token aliases, `response_text_length`, `choice_count`, `created`, `system_fingerprint_if_present` | `refusal`, `refusal_reason`, `incomplete`, `incomplete_reason`, `response_status` when fixture provides them | `structured_output_mode`, `response_format_type`, `json_schema_name_if_present`, `strict_schema_required`, `provider_schema_variant` | `test_openai_compatible_response_summary_captures_returned_model_and_usage`, refusal, incomplete, structured-output tests | Live provider response variants not proven |
+| Direct xAI through OpenAI-compatible SDK | `requested_provider=xai`, requested route model, xAI endpoint metadata, `provider_route_kind=direct_provider` | Returned model captured separately from requested route model | Same OpenAI-compatible response-state extraction | Same structured-output propagation if request metadata carries it | `test_direct_xai_request_meta_keeps_requested_and_returned_model_separate` | Live xAI object shape and refusal/incomplete field names remain unknown |
+| OpenRouter `x-ai/...` proxy path | `requested_provider=openrouter`, `requested_model_id=x-ai/...`, OpenRouter endpoint metadata, `provider_route_kind=openrouter_proxy_xai` | Returned model captured without changing provider to direct xAI | Same OpenAI-compatible response-state extraction | Same structured-output propagation if request metadata carries it | `test_openrouter_xai_proxy_request_meta_is_not_direct_xai` | OpenRouter upstream/provider-specific passthrough metadata remains unknown |
+| Gemini SDK/native-style response | `requested_provider=gemini`, requested route model, Gemini endpoint/auth metadata when present | `finish_reason`, `finish_reasons`, usage/token aliases, `choice_count` from candidates | `safety_reason` captured from candidate/prompt feedback when present | Existing Gemini structured-output metadata is flattened when present in request_meta | `test_gemini_style_response_summary_preserves_finish_safety_and_usage` | Live Gemini refusal/incomplete shape remains unknown |
+| Comparison lane | Comparison `request_meta` now copies response summary fields from `llm_meta` plus requested provider/model and `provider_route_kind` | Same copied fields as available from `call_llm` metadata | Same copied fields as available from `call_llm` metadata | Same copied fields as available from `call_llm` metadata | Existing `test_comparison_lane.py` passed in adjacent suite | No live comparison call was run |
+
+Notes:
+
+- Metadata capture improves response provenance only. It does not make extracted content true.
+- Provider refusal and provider incomplete state are recorded as provider response metadata and are not converted into local parse/schema failure fields.
+- Local parse-repair provenance remains separate under existing `response_parse_provenance` paths.

--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_REGRESSION_TRIAGE_CLOSEOUT.md
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_REGRESSION_TRIAGE_CLOSEOUT.md
@@ -1,0 +1,39 @@
+# RTE-PKT-07 Regression Triage Closeout
+
+Generated: 2026-05-15T12:56:16Z
+
+## Command Under Triage
+
+```bash
+pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_comparison_lane.py services/repo-truth-extractor/tests/test_structured_output_provider_modes.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py services/repo-truth-extractor/tests/test_output_safety.py services/repo-truth-extractor/tests/test_run_extraction_v5_live_readiness.py -q
+```
+
+## Implementation Worktree Result
+
+- Worktree: `/Users/hue/.codex/worktrees/39a6/dopemux-mvp`
+- Branch: `codex/rte-pkt-07-xai-metadata`
+- HEAD before commit: `0179b17b03cf46518aa324bd8f50c805b627631d`
+- Result: FAIL, exit code 1.
+- Failed test: `services/repo-truth-extractor/tests/test_run_extraction_v5_live_readiness.py::test_route_readiness_summary_honors_benchmark_owned_lane`
+- Assertion: expected provider set `{"openai"}`, observed `{"gemini", "openai", "xai"}`.
+
+## Clean Base Result
+
+- Worktree: `/Users/hue/.codex/worktrees/rte-pkt-07-base-0179b17`
+- Base SHA: `0179b17b03cf46518aa324bd8f50c805b627631d`
+- Checkout state: detached clean base.
+- Result: FAIL, exit code 1.
+- Failed test: `services/repo-truth-extractor/tests/test_run_extraction_v5_live_readiness.py::test_route_readiness_summary_honors_benchmark_owned_lane`
+- Assertion: expected provider set `{"openai"}`, observed `{"gemini", "openai", "xai"}`.
+
+## Classification
+
+`BASELINE_FAILURE`
+
+The implementation and clean base fail the same command, same test, and same provider-set assertion. This does not prove route-readiness correctness; it proves the expanded adjacent failure is not introduced by the RTE-PKT-07 metadata changes.
+
+## Acceptance Impact
+
+The baseline route-readiness failure should remain recorded as unresolved drift, but it does not block committing the RTE-PKT-07 metadata implementation and proof artifacts under the closeout packet rules.
+
+No route-readiness logic, benchmark-owned route behavior, or test expectations were changed.

--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_REMAINING_UNKNOWNS.md
@@ -1,0 +1,21 @@
+# RTE-PKT-07 Remaining UNKNOWNs
+
+## LIVE_VALIDATION_REQUIRED
+
+- Direct xAI live response object shape remains unknown. Local fixtures prove extraction behavior only for expected OpenAI-compatible shapes.
+- OpenRouter `x-ai/...` live upstream metadata remains unknown. Static metadata now preserves `requested_provider=openrouter` and `provider_route_kind=openrouter_proxy_xai`, but does not prove OpenRouter live passthrough fields.
+- Live Gemini refusal and incomplete-state field names remain unknown beyond local SDK-style candidate and usage metadata fixtures.
+- Live OpenAI-compatible aliases may return provider-specific status fields not represented by the local fixtures.
+
+## Static Drift / Residual Risk
+
+- Comparison lane now copies available response metadata from `llm_meta`, but no live comparison lane was executed.
+- Batch response metadata remains outside this packet. RTE-PKT-08-XAI-BATCH-STATIC should inspect batch result metadata separately.
+- The expanded adjacent test command that included `test_run_extraction_v5_live_readiness.py` failed in route-readiness logic on both implementation and clean base. Classification: `BASELINE_FAILURE`. That route-readiness drift remains unresolved by RTE-PKT-07.
+
+## Recommended Next Packets
+
+- RTE-PKT-08-XAI-BATCH-STATIC: inspect static batch result metadata.
+- RTE-PKT-12-OPENROUTER-XAI: verify OpenRouter `x-ai/...` proxy route proof and upstream metadata semantics.
+- RTE-PKT-13-ROUTE-FINGERPRINT: harden route fingerprint evidence if broader route proof is required.
+- RTE-PKT-09-LIVE-VALIDATION-PLAN: plan live validation without performing it in this packet.

--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_REQUEST_META_EXAMPLES.md
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_REQUEST_META_EXAMPLES.md
@@ -1,0 +1,88 @@
+# RTE-PKT-07 Request Meta Examples
+
+Examples are synthetic and redacted.
+
+## Direct xAI
+
+```json
+{
+  "provider": "xai",
+  "model_id": "grok-requested-fixture",
+  "requested_provider": "xai",
+  "requested_model_id": "grok-requested-fixture",
+  "provider_route_kind": "direct_provider",
+  "returned_model_id": "grok-effective-fixture",
+  "effective_model_id": "grok-effective-fixture",
+  "response_id": "xai-local-001",
+  "finish_reason": "stop",
+  "usage": {
+    "input_tokens": 10,
+    "output_tokens": 4,
+    "total_tokens": 14
+  },
+  "api_key_env": "XAI_API_KEY",
+  "transport": "openai_sdk"
+}
+```
+
+## OpenRouter xAI Proxy
+
+```json
+{
+  "provider": "openrouter",
+  "model_id": "x-ai/grok-proxy-fixture",
+  "requested_provider": "openrouter",
+  "requested_model_id": "x-ai/grok-proxy-fixture",
+  "provider_route_kind": "openrouter_proxy_xai",
+  "returned_model_id": "x-ai/grok-proxy-fixture",
+  "effective_model_id": "x-ai/grok-proxy-fixture",
+  "response_id": "or-local-001",
+  "finish_reason": "stop",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "transport": "openai_sdk"
+}
+```
+
+## Refusal
+
+```json
+{
+  "provider": "openai",
+  "model_id": "gpt-refusal-fixture",
+  "response_id": "chatcmpl-refusal",
+  "returned_model_id": "gpt-refusal-fixture",
+  "finish_reason": "stop",
+  "refusal": true,
+  "refusal_reason": "Cannot comply with [REDACTED].",
+  "failure_type": null
+}
+```
+
+## Incomplete
+
+```json
+{
+  "provider": "openai",
+  "model_id": "gpt-incomplete-fixture",
+  "response_id": "chatcmpl-incomplete",
+  "returned_model_id": "gpt-incomplete-fixture",
+  "response_status": "incomplete",
+  "finish_reason": "length",
+  "incomplete": true,
+  "incomplete_reason": "max_output_tokens"
+}
+```
+
+## Structured Output
+
+```json
+{
+  "provider": "openai",
+  "model_id": "gpt-structured-fixture",
+  "structured_output_mode": "json_schema",
+  "response_format_type": "json_schema",
+  "json_schema_name_if_present": "RTEFixtureSchema",
+  "strict_schema_required": true,
+  "provider_schema_variant": "openai_strict_json_schema"
+}
+```

--- a/out/rte-pkt-07-xai-metadata/RTE-PKT-07_TEST_REPORT.md
+++ b/out/rte-pkt-07-xai-metadata/RTE-PKT-07_TEST_REPORT.md
@@ -1,0 +1,39 @@
+# RTE-PKT-07 Test Report
+
+Generated: 2026-05-15T10:34:49Z
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `python -m py_compile services/repo-truth-extractor/llm_runtime.py services/repo-truth-extractor/run_extraction_v5.py` | PASS | Exit 0. |
+| `pytest services/repo-truth-extractor/tests/test_rte_pkt_07_xai_metadata.py -q` | PASS | 8 tests passed. Pytest warned about unknown `asyncio_mode` config. |
+| `pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_comparison_lane.py services/repo-truth-extractor/tests/test_structured_output_provider_modes.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py services/repo-truth-extractor/tests/test_output_safety.py -q` | PASS | 30 adjacent seam, comparison, structured-output, and redaction tests passed. Pytest warned about unknown `asyncio_mode` config. |
+| `pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_comparison_lane.py services/repo-truth-extractor/tests/test_structured_output_provider_modes.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py services/repo-truth-extractor/tests/test_output_safety.py services/repo-truth-extractor/tests/test_run_extraction_v5_live_readiness.py -q` | FAIL | One unrelated route-readiness assertion failed: `test_route_readiness_summary_honors_benchmark_owned_lane` expected only `openai`, observed `gemini`, `openai`, and `xai`. No edited metadata path was implicated. |
+| `pytest services/repo-truth-extractor/tests -k 'xai and metadata' -q` | PASS | 8 selected tests passed. |
+| `pytest services/repo-truth-extractor/tests -k 'provider and metadata' -q` | PASS | 4 selected tests passed. |
+| `pytest services/repo-truth-extractor/tests -k 'llm_runtime or response_summary' -q` | PASS | 5 selected tests passed. |
+| `pytest services/repo-truth-extractor/tests/test_artifact_provenance_fields.py services/repo-truth-extractor/tests/test_truth_label_preservation.py -q` | PASS | 11 provenance/truth-label tests passed. Pytest warned about unknown `asyncio_mode` config. |
+
+## Closeout Regression Triage
+
+| Worktree | Command | Result | Notes |
+| --- | --- | --- | --- |
+| Implementation `/Users/hue/.codex/worktrees/39a6/dopemux-mvp` | `pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_comparison_lane.py services/repo-truth-extractor/tests/test_structured_output_provider_modes.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py services/repo-truth-extractor/tests/test_output_safety.py services/repo-truth-extractor/tests/test_run_extraction_v5_live_readiness.py -q` | FAIL exit 1 | Same failure as parent report: `test_route_readiness_summary_honors_benchmark_owned_lane` expected `openai`, observed `gemini`, `openai`, `xai`. |
+| Clean base `/Users/hue/.codex/worktrees/rte-pkt-07-base-0179b17` at `0179b17b03cf46518aa324bd8f50c805b627631d` | Same command | FAIL exit 1 | Same failing test and same observed provider set. Classification: `BASELINE_FAILURE`. |
+
+Acceptance impact: the expanded adjacent live-readiness route failure is baseline/stale relative to the RTE-PKT-07 dirty implementation and does not indicate a new metadata regression.
+
+## Final Closeout Validation
+
+| Command | Result | Notes |
+| --- | --- | --- |
+| `python -m py_compile services/repo-truth-extractor/llm_runtime.py services/repo-truth-extractor/run_extraction_v5.py` | PASS | Exit 0 after closeout proof update. |
+| `pytest services/repo-truth-extractor/tests/test_rte_pkt_07_xai_metadata.py -q` | PASS | 8 tests passed. Pytest warned about unknown `asyncio_mode` config. |
+| `pytest services/repo-truth-extractor/tests -k 'xai and metadata' -q` | PASS | 8 selected tests passed. Pytest warned about unknown `asyncio_mode` config. |
+| `pytest services/repo-truth-extractor/tests -k 'provider and metadata' -q` | PASS | 4 selected tests passed. Pytest warned about unknown `asyncio_mode` config. |
+| `pytest services/repo-truth-extractor/tests -k 'llm_runtime or response_summary' -q` | PASS | 5 selected tests passed. Pytest warned about unknown `asyncio_mode` config. |
+| `pytest services/repo-truth-extractor/tests/test_artifact_provenance_fields.py services/repo-truth-extractor/tests/test_truth_label_preservation.py -q` | PASS | 11 tests passed. Pytest warned about unknown `asyncio_mode` config. |
+| `python -m json.tool out/rte-pkt-07-xai-metadata/RTE-PKT-07_MANIFEST.json >/dev/null` | PASS | Exit 0. |
+| `git diff --check` | PASS | Exit 0. |
+| `git status --short --branch` | PASS | Dirty only before commit: allowed parent implementation files, new metadata test, and proof output root. |
+
+No live/provider/batch validation command was run.

--- a/services/repo-truth-extractor/llm_runtime.py
+++ b/services/repo-truth-extractor/llm_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import time
@@ -144,6 +145,109 @@ def _normalize_route_tuple(
     )
 
 
+def _provider_route_kind(provider: str, model_id: str) -> str:
+    provider_token = str(provider or "").strip().lower()
+    model_token = str(model_id or "").strip().lower()
+    if provider_token == "openrouter" and model_token.startswith("x-ai/"):
+        return "openrouter_proxy_xai"
+    return "direct_provider"
+
+
+def _request_route_metadata(
+    provider: str,
+    model_id: str,
+    api_key_env: str,
+) -> Dict[str, Any]:
+    return {
+        "requested_provider": provider,
+        "requested_model_id": model_id,
+        "api_key_env": api_key_env,
+        "provider_route_kind": _provider_route_kind(provider, model_id),
+    }
+
+
+def _structured_output_request_metadata(
+    structured_output: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if not isinstance(structured_output, dict):
+        return {}
+    mode = (
+        structured_output.get("structured_output_mode_effective")
+        or structured_output.get("structured_output_mode_requested")
+        or structured_output.get("transport_mode")
+    )
+    result: Dict[str, Any] = {}
+    if mode is not None:
+        result["structured_output_mode"] = mode
+    response_format_type = structured_output.get("response_format_type")
+    if response_format_type is not None:
+        result["response_format_type"] = response_format_type
+    schema_name = structured_output.get("schema_name") or structured_output.get("schema")
+    if schema_name is not None:
+        result["json_schema_name_if_present"] = schema_name
+    result["strict_schema_required"] = bool(structured_output.get("strict", False))
+    schema_variant = structured_output.get("schema_variant")
+    if schema_variant is not None:
+        result["provider_schema_variant"] = schema_variant
+    return result
+
+
+def _response_summary_metadata(
+    response_summary: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if not isinstance(response_summary, dict):
+        return {}
+    summary = copy.deepcopy(response_summary)
+    result: Dict[str, Any] = {"response_summary": summary}
+    passthrough_keys = (
+        "response_id",
+        "returned_model_id",
+        "effective_model_id",
+        "finish_reason",
+        "finish_reasons",
+        "response_status",
+        "refusal",
+        "refusal_reason",
+        "incomplete",
+        "incomplete_reason",
+        "stop_reason",
+        "safety_reason",
+        "usage",
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "prompt_tokens",
+        "completion_tokens",
+        "response_text_length",
+        "choice_count",
+        "candidate_count",
+        "created",
+        "system_fingerprint_if_present",
+    )
+    for key in passthrough_keys:
+        if key in summary and summary.get(key) is not None:
+            result[key] = copy.deepcopy(summary[key])
+    if "response_text_length" not in result and summary.get("text_length") is not None:
+        result["response_text_length"] = summary.get("text_length")
+    if "choice_count" not in result and summary.get("candidate_count") is not None:
+        result["choice_count"] = summary.get("candidate_count")
+    usage = summary.get("usage")
+    if isinstance(usage, dict):
+        if "input_tokens" not in result and usage.get("input_tokens") is not None:
+            result["input_tokens"] = usage.get("input_tokens")
+        if "output_tokens" not in result and usage.get("output_tokens") is not None:
+            result["output_tokens"] = usage.get("output_tokens")
+        if "total_tokens" not in result and usage.get("total_tokens") is not None:
+            result["total_tokens"] = usage.get("total_tokens")
+    return result
+
+
+def _retry_attempted(retry_trace: Sequence[Dict[str, Any]]) -> bool:
+    return len(retry_trace) > 1 or any(
+        float(row.get("delay_seconds", 0.0) or 0.0) > 0 for row in retry_trace
+    )
+
+
 def call_llm(
     deps: LLMRuntimeDeps,
     provider: str,
@@ -224,9 +328,12 @@ def call_llm(
                 else None
             )
         ),
+        "response_format_type": None,
+        "schema_variant": None,
     }
     if using_structured_override:
         rf_type = str(response_format_override.get("type") or "").strip()
+        structured_output["response_format_type"] = rf_type or None
         if rf_type == "json_schema":
             json_schema = (
                 response_format_override.get("json_schema")
@@ -247,6 +354,7 @@ def call_llm(
                     ),
                 }
             )
+            structured_output["json_schema_name_if_present"] = schema_name
         elif rf_type == "json_object":
             structured_output.update(
                 {
@@ -303,8 +411,15 @@ def call_llm(
                 "endpoint_base_url": base_url,
                 "endpoint_effective": deps.endpoint_effective(endpoint_url),
                 **deps.endpoint_fingerprint(endpoint_url),
+                **_request_route_metadata(provider, model_id, resolved_api_key_env or api_key_env),
+                **_structured_output_request_metadata(structured_output),
                 "status_code": None,
                 "failure_type": "auth_missing",
+                "retry_attempted": False,
+                "auth_failure": True,
+                "quota_or_billing": False,
+                "timeout": False,
+                "provider_failure": False,
                 "sent_header_keys": sent_header_keys,
                 "auth_present_flags": auth_flags,
                 "gemini_auth_mode_requested": gemini_mode_requested,
@@ -330,29 +445,41 @@ def call_llm(
         }
 
     if deps.is_spend_aborted():
+        cost_meta = deps.cost_abort_failure_meta(
+            provider=provider,
+            model_id=model_id,
+            api_key_env=api_key_env,
+            base_url=base_url,
+            request_payload_bytes=request_payload_bytes,
+            request_payload_bytes_mode=request_payload_bytes_mode,
+            sent_header_keys=sent_header_keys,
+            auth_flags=auth_flags,
+            transport=transport,
+            gemini_mode_requested=gemini_mode_requested,
+            gemini_mode_effective=(
+                effective_mode if provider == "gemini" else None
+            ),
+            gemini_family=gemini_family,
+            auth_mode_sequence=(
+                auth_mode_sequence if provider == "gemini" else None
+            ),
+            structured_output=structured_output,
+        )
+        cost_meta.update(
+            {
+                **_request_route_metadata(provider, model_id, resolved_api_key_env or api_key_env),
+                **_structured_output_request_metadata(structured_output),
+                "retry_attempted": False,
+                "auth_failure": False,
+                "quota_or_billing": False,
+                "timeout": False,
+                "provider_failure": False,
+            }
+        )
         return {
             "ok": False,
             "text": "",
-            "meta": deps.cost_abort_failure_meta(
-                provider=provider,
-                model_id=model_id,
-                api_key_env=api_key_env,
-                base_url=base_url,
-                request_payload_bytes=request_payload_bytes,
-                request_payload_bytes_mode=request_payload_bytes_mode,
-                sent_header_keys=sent_header_keys,
-                auth_flags=auth_flags,
-                transport=transport,
-                gemini_mode_requested=gemini_mode_requested,
-                gemini_mode_effective=(
-                    effective_mode if provider == "gemini" else None
-                ),
-                gemini_family=gemini_family,
-                auth_mode_sequence=(
-                    auth_mode_sequence if provider == "gemini" else None
-                ),
-                structured_output=structured_output,
-            ),
+            "meta": cost_meta,
         }
 
     last_failure_meta: Dict[str, Any] = {
@@ -361,8 +488,15 @@ def call_llm(
         "endpoint_base_url": base_url,
         "endpoint_effective": deps.endpoint_effective(endpoint_url),
         **deps.endpoint_fingerprint(endpoint_url),
+        **_request_route_metadata(provider, model_id, resolved_api_key_env or api_key_env),
+        **_structured_output_request_metadata(structured_output),
         "status_code": None,
         "failure_type": "unknown",
+        "retry_attempted": False,
+        "auth_failure": False,
+        "quota_or_billing": False,
+        "timeout": False,
+        "provider_failure": False,
         "request_payload_bytes": request_payload_bytes,
         "request_payload_bytes_mode": request_payload_bytes_mode,
         "sent_header_keys": sent_header_keys,
@@ -541,8 +675,16 @@ def call_llm(
                     "endpoint_base_url": base_url,
                     "endpoint_effective": deps.endpoint_effective(endpoint_url),
                     **deps.endpoint_fingerprint(endpoint_url),
+                    **_request_route_metadata(provider, model_id, resolved_api_key_env or api_key_env),
+                    **_response_summary_metadata(response_summary),
+                    **_structured_output_request_metadata(structured_output),
                     "status_code": status_code,
                     "failure_type": None,
+                    "retry_attempted": _retry_attempted(retry_trace),
+                    "auth_failure": False,
+                    "quota_or_billing": False,
+                    "timeout": False,
+                    "provider_failure": False,
                     "request_payload_bytes": request_payload_bytes,
                     "request_payload_bytes_mode": request_payload_bytes_mode,
                     "max_completion_tokens_requested": max_completion_tokens_override,
@@ -571,7 +713,6 @@ def call_llm(
                     "parent_span_id": request_parent_span_id,
                     "retry_trace": retry_trace,
                     "response_received": True,
-                    "response_summary": response_summary,
                     "structured_output": structured_output,
                 },
             }
@@ -603,8 +744,15 @@ def call_llm(
                 "endpoint_base_url": base_url,
                 "endpoint_effective": deps.endpoint_effective(endpoint_url),
                 **deps.endpoint_fingerprint(endpoint_url),
+                **_request_route_metadata(provider, model_id, resolved_api_key_env or api_key_env),
+                **_structured_output_request_metadata(structured_output),
                 "status_code": status_code,
                 "failure_type": failure_type,
+                "retry_attempted": _retry_attempted(retry_trace),
+                "auth_failure": deps.is_auth_classified_failure(failure_type),
+                "quota_or_billing": failure_type == "quota_or_billing",
+                "timeout": failure_type == "timeout",
+                "provider_failure": failure_type in {"provider", "rate_limit", "quota_or_billing", "timeout"},
                 "request_payload_bytes": request_payload_bytes,
                 "request_payload_bytes_mode": request_payload_bytes_mode,
                 "max_completion_tokens_requested": max_completion_tokens_override,
@@ -709,6 +857,7 @@ def call_llm(
         total_retry_delay,
     )
     last_failure_meta["total_retry_delay_seconds"] = total_retry_delay
+    last_failure_meta["retry_attempted"] = _retry_attempted(retry_trace)
     return {
         "ok": False,
         "text": "",
@@ -787,6 +936,18 @@ def call_llm_with_ladder(
                 "hop_index": hop_index + 1,
                 "provider": provider,
                 "model_id": model_id,
+                "requested_provider": request_meta.get("requested_provider", provider),
+                "requested_model_id": request_meta.get("requested_model_id", model_id),
+                "provider_route_kind": request_meta.get(
+                    "provider_route_kind",
+                    _provider_route_kind(provider, model_id),
+                ),
+                "returned_model_id": request_meta.get("returned_model_id"),
+                "effective_model_id": request_meta.get("effective_model_id"),
+                "finish_reason": request_meta.get("finish_reason"),
+                "response_id": request_meta.get("response_id"),
+                "refusal": request_meta.get("refusal"),
+                "incomplete": request_meta.get("incomplete"),
                 "api_key_env": api_key_env,
                 "failure_type": request_meta.get("failure_type"),
                 "status_code": request_meta.get("status_code"),
@@ -1265,6 +1426,9 @@ def run_comparison_lane(
                 "authoritative": False,
                 "provider": compare_provider,
                 "model_id": compare_model,
+                "requested_provider": compare_provider,
+                "requested_model_id": compare_model,
+                "provider_route_kind": _provider_route_kind(compare_provider, compare_model),
                 "comparison_of_step": step_id,
                 "elapsed_ms": elapsed_ms,
                 "final_contract_status": "pass",
@@ -1272,6 +1436,32 @@ def run_comparison_lane(
                 "repair_successes": 0,
                 "response_parse_provenance": parse_provenance,
             }
+            for key, value in _response_summary_metadata(
+                llm_meta.get("response_summary")
+                if isinstance(llm_meta.get("response_summary"), dict)
+                else None
+            ).items():
+                request_meta.setdefault(key, value)
+            for key in (
+                "endpoint_base_url",
+                "endpoint_effective",
+                "endpoint_host",
+                "endpoint_path",
+                "transport",
+                "provider_signature",
+                "response_received",
+                "status_code",
+                "failure_type",
+                "retry_attempted",
+                "retry_trace",
+                "structured_output_mode",
+                "response_format_type",
+                "json_schema_name_if_present",
+                "strict_schema_required",
+                "provider_schema_variant",
+            ):
+                if key in llm_meta and llm_meta.get(key) is not None:
+                    request_meta.setdefault(key, copy.deepcopy(llm_meta[key]))
             if llm_meta.get("response_received") or llm_result.get("ok"):
                 spend_record = deps.accumulate_runtime_spend(
                     cfg,

--- a/services/repo-truth-extractor/llm_runtime.py
+++ b/services/repo-truth-extractor/llm_runtime.py
@@ -192,6 +192,33 @@ def _structured_output_request_metadata(
     return result
 
 
+_RESPONSE_SUMMARY_PASSTHROUGH_KEYS: tuple = (
+    "response_id",
+    "returned_model_id",
+    "effective_model_id",
+    "finish_reason",
+    "finish_reasons",
+    "response_status",
+    "refusal",
+    "refusal_reason",
+    "incomplete",
+    "incomplete_reason",
+    "stop_reason",
+    "safety_reason",
+    "usage",
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "prompt_tokens",
+    "completion_tokens",
+    "response_text_length",
+    "choice_count",
+    "candidate_count",
+    "created",
+    "system_fingerprint_if_present",
+)
+
+
 def _response_summary_metadata(
     response_summary: Optional[Dict[str, Any]],
 ) -> Dict[str, Any]:
@@ -199,32 +226,7 @@ def _response_summary_metadata(
         return {}
     summary = copy.deepcopy(response_summary)
     result: Dict[str, Any] = {"response_summary": summary}
-    passthrough_keys = (
-        "response_id",
-        "returned_model_id",
-        "effective_model_id",
-        "finish_reason",
-        "finish_reasons",
-        "response_status",
-        "refusal",
-        "refusal_reason",
-        "incomplete",
-        "incomplete_reason",
-        "stop_reason",
-        "safety_reason",
-        "usage",
-        "input_tokens",
-        "output_tokens",
-        "total_tokens",
-        "prompt_tokens",
-        "completion_tokens",
-        "response_text_length",
-        "choice_count",
-        "candidate_count",
-        "created",
-        "system_fingerprint_if_present",
-    )
-    for key in passthrough_keys:
+    for key in _RESPONSE_SUMMARY_PASSTHROUGH_KEYS:
         if key in summary and summary.get(key) is not None:
             result[key] = copy.deepcopy(summary[key])
     if "response_text_length" not in result and summary.get("text_length") is not None:

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -9267,6 +9267,95 @@ def extract_text_from_gemini_response(response_obj: Any) -> str:
     return ""
 
 
+def _metadata_value(source: Any, *keys: str) -> Any:
+    for key in keys:
+        if isinstance(source, dict) and key in source:
+            value = source.get(key)
+            if value not in (None, ""):
+                return value
+        value = getattr(source, key, None)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _metadata_int(value: Any) -> Optional[int]:
+    try:
+        if value in (None, ""):
+            return None
+        return int(value)
+    except Exception:
+        return None
+
+
+def _metadata_text(value: Any, *, limit: int = 240) -> Optional[str]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, dict):
+        reason = _metadata_value(
+            value,
+            "reason",
+            "type",
+            "code",
+            "message",
+            "finish_reason",
+            "finishReason",
+        )
+        if reason in (None, ""):
+            reason = json.dumps(value, ensure_ascii=True, sort_keys=True, default=str)
+    else:
+        reason = str(value)
+    sanitized = sanitize_text_for_provider_payload(str(reason)).strip()
+    if not sanitized:
+        return None
+    if len(sanitized) > limit:
+        return sanitized[:limit] + "...[TRUNCATED]"
+    return sanitized
+
+
+def _metadata_sequence(value: Any) -> List[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return []
+
+
+def _first_metadata_value(sources: Sequence[Any], *keys: str) -> Any:
+    for source in sources:
+        value = _metadata_value(source, *keys)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _provider_route_kind(provider: str, model_id: str) -> str:
+    provider_token = str(provider or "").strip().lower()
+    model_token = str(model_id or "").strip().lower()
+    if provider_token == "openrouter" and model_token.startswith("x-ai/"):
+        return "openrouter_proxy_xai"
+    return "direct_provider"
+
+
+def _choice_message(choice: Any) -> Any:
+    return _metadata_value(choice, "message", "delta") or {}
+
+
+def _finish_reasons(choices: Sequence[Any]) -> List[str]:
+    reasons: List[str] = []
+    for choice in choices:
+        reason = _metadata_text(_metadata_value(choice, "finish_reason", "finishReason"))
+        if reason:
+            reasons.append(reason)
+    return reasons
+
+
 def summarize_llm_response(
     provider: str,
     transport: str,
@@ -9274,59 +9363,138 @@ def summarize_llm_response(
     response_json: Optional[Dict[str, Any]],
     response_text: str,
 ) -> Dict[str, Any]:
-    summary: Dict[str, Any] = {"text_length": len(response_text)}
-    finish_reason = None
-    candidate_count: Optional[int] = None
-    response_id: Optional[str] = None
-    prompt_tokens: Optional[int] = None
-    completion_tokens: Optional[int] = None
-    total_tokens: Optional[int] = None
+    response_text_length = len(response_text)
+    summary: Dict[str, Any] = {
+        "text_length": response_text_length,
+        "response_text_length": response_text_length,
+    }
+    response_payload = response_json if isinstance(response_json, dict) else {}
+    sources = [response_payload, response_obj]
+    finish_reason: Optional[str] = None
+    finish_reasons: List[str] = []
+    choice_count: Optional[int] = None
+    response_id: Optional[str] = _metadata_text(
+        _first_metadata_value(sources, "id", "response_id", "responseId")
+    )
+    returned_model_id: Optional[str] = _metadata_text(
+        _first_metadata_value(sources, "model", "model_id", "modelId")
+    )
+    response_status: Optional[str] = _metadata_text(
+        _first_metadata_value(sources, "status", "response_status", "responseStatus")
+    )
+    created = _first_metadata_value(sources, "created", "created_at", "createdAt")
+    system_fingerprint = _metadata_text(
+        _first_metadata_value(
+            sources,
+            "system_fingerprint",
+            "systemFingerprint",
+            "system_fingerprint_if_present",
+        )
+    )
 
     if provider == "gemini":
-        candidates = getattr(response_obj, "candidates", None) or []
-        candidate_count = len(candidates)
+        candidates = _metadata_sequence(
+            _metadata_value(response_payload, "candidates")
+            or getattr(response_obj, "candidates", None)
+        )
+        choice_count = len(candidates)
         if candidates:
-            finish_reason = getattr(candidates[0], "finish_reason", None)
-        usage_metadata = getattr(response_obj, "usage_metadata", None)
-        if usage_metadata is not None:
-            prompt_tokens = getattr(usage_metadata, "prompt_token_count", None)
-            completion_tokens = getattr(usage_metadata, "candidates_token_count", None)
-            total_tokens = getattr(usage_metadata, "total_token_count", None)
+            finish_reasons = _finish_reasons(candidates)
+            finish_reason = finish_reasons[0] if finish_reasons else None
+        prompt_feedback = _metadata_value(
+            response_payload, "prompt_feedback", "promptFeedback"
+        ) or getattr(response_obj, "prompt_feedback", None)
+        safety_reason = _metadata_text(
+            _first_metadata_value(
+                [candidates[0] if candidates else {}, prompt_feedback],
+                "safety_reason",
+                "safetyReason",
+                "block_reason",
+                "blockReason",
+            )
+        )
+        if safety_reason:
+            summary["safety_reason"] = safety_reason
     else:
-        choices = None
-        if isinstance(response_json, dict):
-            choices = response_json.get("choices")
-            response_id = str(response_json.get("id") or "") or None
-            usage = response_json.get("usage")
-            if isinstance(usage, dict):
-                prompt_tokens = usage.get("prompt_tokens")
-                completion_tokens = usage.get("completion_tokens")
-                total_tokens = usage.get("total_tokens")
-        else:
-            choices = getattr(response_obj, "choices", None)
-            response_id = str(getattr(response_obj, "id", "") or "") or None
-            usage = getattr(response_obj, "usage", None)
-            if usage is not None:
-                prompt_tokens = getattr(usage, "prompt_tokens", None)
-                completion_tokens = getattr(usage, "completion_tokens", None)
-                total_tokens = getattr(usage, "total_tokens", None)
-        if isinstance(choices, list):
-            candidate_count = len(choices)
-            if choices:
-                finish_reason = getattr(choices[0], "finish_reason", None)
+        choices = _metadata_sequence(
+            _metadata_value(response_payload, "choices")
+            or getattr(response_obj, "choices", None)
+        )
+        choice_count = len(choices)
+        if choices:
+            finish_reasons = _finish_reasons(choices)
+            finish_reason = finish_reasons[0] if finish_reasons else None
+            first_choice = choices[0]
+            message = _choice_message(first_choice)
+            refusal_value = _first_metadata_value(
+                [message, first_choice, response_payload, response_obj],
+                "refusal",
+                "refusal_reason",
+                "refusalReason",
+            )
+            refusal_reason_value = _first_metadata_value(
+                [message, first_choice, response_payload, response_obj],
+                "refusal_reason",
+                "refusalReason",
+            )
+            if isinstance(refusal_value, bool):
+                summary["refusal"] = refusal_value
+            elif refusal_value not in (None, ""):
+                summary["refusal"] = True
+                summary["refusal_reason"] = _metadata_text(
+                    refusal_reason_value or refusal_value
+                )
+            elif refusal_reason_value not in (None, ""):
+                summary["refusal"] = True
+                summary["refusal_reason"] = _metadata_text(refusal_reason_value)
+            incomplete_value = _first_metadata_value(
+                [first_choice, response_payload, response_obj],
+                "incomplete",
+                "incomplete_details",
+                "incompleteDetails",
+            )
+            incomplete_reason = _metadata_text(
+                _first_metadata_value(
+                    [incomplete_value, first_choice, response_payload, response_obj],
+                    "reason",
+                    "incomplete_reason",
+                    "incompleteReason",
+                )
+            )
+            provider_incomplete = (
+                bool(incomplete_value)
+                or str(response_status or "").strip().lower() == "incomplete"
+                or str(finish_reason or "").strip().lower()
+                in {"length", "max_tokens", "max_output_tokens"}
+            )
+            if provider_incomplete:
+                summary["incomplete"] = True
+                if incomplete_reason:
+                    summary["incomplete_reason"] = incomplete_reason
 
-    if candidate_count is not None:
-        summary["candidate_count"] = candidate_count
+    if choice_count is not None:
+        summary["choice_count"] = choice_count
+        summary["candidate_count"] = choice_count
+    if finish_reasons:
+        summary["finish_reasons"] = finish_reasons
     if finish_reason:
         summary["finish_reason"] = finish_reason
+        if str(finish_reason).strip().lower() != "stop":
+            summary["stop_reason"] = finish_reason
     if response_id:
         summary["response_id"] = response_id
-    if prompt_tokens is not None:
-        summary["prompt_tokens"] = int(prompt_tokens)
-    if completion_tokens is not None:
-        summary["completion_tokens"] = int(completion_tokens)
-    if total_tokens is not None:
-        summary["total_tokens"] = int(total_tokens)
+    if returned_model_id:
+        summary["returned_model_id"] = returned_model_id
+        summary["effective_model_id"] = returned_model_id
+    if response_status:
+        summary["response_status"] = response_status
+    created_int = _metadata_int(created)
+    if created_int is not None:
+        summary["created"] = created_int
+    elif created not in (None, ""):
+        summary["created"] = _metadata_text(created)
+    if system_fingerprint:
+        summary["system_fingerprint_if_present"] = system_fingerprint
     usage = _normalized_usage_from_payload(
         getattr(response_obj, "usage", None)
         or getattr(response_obj, "usage_metadata", None)
@@ -9344,6 +9512,11 @@ def summarize_llm_response(
     )
     if usage is not None:
         summary["usage"] = usage
+        summary["input_tokens"] = int(usage.get("input_tokens", 0) or 0)
+        summary["output_tokens"] = int(usage.get("output_tokens", 0) or 0)
+        summary["total_tokens"] = int(usage.get("total_tokens", 0) or 0)
+        summary["prompt_tokens"] = summary["input_tokens"]
+        summary["completion_tokens"] = summary["output_tokens"]
     return summary
 
 
@@ -10152,7 +10325,112 @@ def enrich_request_meta(
     enriched["partition_id"] = partition_id
     enriched.setdefault("provider", provider)
     enriched.setdefault("model_id", model_id)
+    enriched.setdefault("requested_provider", provider)
+    enriched.setdefault("requested_model_id", model_id)
+    enriched.setdefault("provider_route_kind", _provider_route_kind(provider, model_id))
+    api_key_env = (
+        enriched.get("api_key_env")
+        or enriched.get("api_key_env_resolved")
+        or enriched.get("api_key_env_requested")
+        or PROVIDER_API_KEY_ENV.get(provider)
+    )
+    if api_key_env:
+        enriched.setdefault("api_key_env", api_key_env)
     enriched.setdefault("endpoint_base_url", endpoint_base)
+    response_summary = (
+        enriched.get("response_summary")
+        if isinstance(enriched.get("response_summary"), dict)
+        else {}
+    )
+    if isinstance(response_summary, dict) and response_summary:
+        for key in (
+            "response_id",
+            "returned_model_id",
+            "effective_model_id",
+            "finish_reason",
+            "finish_reasons",
+            "response_status",
+            "refusal",
+            "refusal_reason",
+            "incomplete",
+            "incomplete_reason",
+            "stop_reason",
+            "safety_reason",
+            "usage",
+            "input_tokens",
+            "output_tokens",
+            "total_tokens",
+            "prompt_tokens",
+            "completion_tokens",
+            "response_text_length",
+            "choice_count",
+            "candidate_count",
+            "created",
+            "system_fingerprint_if_present",
+        ):
+            if key in response_summary and response_summary.get(key) is not None:
+                enriched.setdefault(key, copy.deepcopy(response_summary[key]))
+        if (
+            "response_text_length" not in enriched
+            and response_summary.get("text_length") is not None
+        ):
+            enriched["response_text_length"] = response_summary.get("text_length")
+        if (
+            "choice_count" not in enriched
+            and response_summary.get("candidate_count") is not None
+        ):
+            enriched["choice_count"] = response_summary.get("candidate_count")
+        usage = response_summary.get("usage")
+        if isinstance(usage, dict):
+            enriched.setdefault("input_tokens", usage.get("input_tokens"))
+            enriched.setdefault("output_tokens", usage.get("output_tokens"))
+            enriched.setdefault("total_tokens", usage.get("total_tokens"))
+    structured_output = (
+        enriched.get("structured_output")
+        if isinstance(enriched.get("structured_output"), dict)
+        else {}
+    )
+    if isinstance(structured_output, dict) and structured_output:
+        structured_mode = (
+            structured_output.get("structured_output_mode_effective")
+            or structured_output.get("structured_output_mode_requested")
+            or structured_output.get("transport_mode")
+        )
+        if structured_mode is not None:
+            enriched.setdefault("structured_output_mode", structured_mode)
+        if structured_output.get("response_format_type") is not None:
+            enriched.setdefault(
+                "response_format_type", structured_output.get("response_format_type")
+            )
+        schema_name = structured_output.get("schema_name") or structured_output.get("schema")
+        if schema_name is not None:
+            enriched.setdefault("json_schema_name_if_present", schema_name)
+        enriched.setdefault(
+            "strict_schema_required", bool(structured_output.get("strict", False))
+        )
+        if structured_output.get("schema_variant") is not None:
+            enriched.setdefault(
+                "provider_schema_variant", structured_output.get("schema_variant")
+            )
+    failure_type = str(enriched.get("failure_type") or "").strip()
+    retry_trace = enriched.get("retry_trace")
+    if isinstance(retry_trace, list):
+        enriched.setdefault(
+            "retry_attempted",
+            len(retry_trace) > 1
+            or any(
+                float(row.get("delay_seconds", 0.0) or 0.0) > 0
+                for row in retry_trace
+                if isinstance(row, dict)
+            ),
+        )
+    enriched.setdefault("auth_failure", is_auth_classified_failure(failure_type))
+    enriched.setdefault("quota_or_billing", failure_type == "quota_or_billing")
+    enriched.setdefault("timeout", failure_type == "timeout")
+    enriched.setdefault(
+        "provider_failure",
+        failure_type in {"provider", "rate_limit", "quota_or_billing", "timeout"},
+    )
     if "provider_signature" not in enriched:
         enriched["provider_signature"] = provider_signature(
             provider,

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -224,6 +224,8 @@ from rte_reports import (
 from reporting import build_run_id_resolution_precedence
 from llm_runtime import (
     LLMRuntimeDeps,
+    _RESPONSE_SUMMARY_PASSTHROUGH_KEYS,
+    _provider_route_kind,
     backoff_seconds as llm_runtime_backoff_seconds,
     call_llm as llm_runtime_call_llm,
     call_llm_with_ladder as llm_runtime_call_llm_with_ladder,
@@ -9284,7 +9286,7 @@ def _metadata_int(value: Any) -> Optional[int]:
         if value in (None, ""):
             return None
         return int(value)
-    except Exception:
+    except (TypeError, ValueError):
         return None
 
 
@@ -9333,14 +9335,6 @@ def _first_metadata_value(sources: Sequence[Any], *keys: str) -> Any:
         if value not in (None, ""):
             return value
     return None
-
-
-def _provider_route_kind(provider: str, model_id: str) -> str:
-    provider_token = str(provider or "").strip().lower()
-    model_token = str(model_id or "").strip().lower()
-    if provider_token == "openrouter" and model_token.startswith("x-ai/"):
-        return "openrouter_proxy_xai"
-    return "direct_provider"
 
 
 def _choice_message(choice: Any) -> Any:
@@ -10343,31 +10337,7 @@ def enrich_request_meta(
         else {}
     )
     if isinstance(response_summary, dict) and response_summary:
-        for key in (
-            "response_id",
-            "returned_model_id",
-            "effective_model_id",
-            "finish_reason",
-            "finish_reasons",
-            "response_status",
-            "refusal",
-            "refusal_reason",
-            "incomplete",
-            "incomplete_reason",
-            "stop_reason",
-            "safety_reason",
-            "usage",
-            "input_tokens",
-            "output_tokens",
-            "total_tokens",
-            "prompt_tokens",
-            "completion_tokens",
-            "response_text_length",
-            "choice_count",
-            "candidate_count",
-            "created",
-            "system_fingerprint_if_present",
-        ):
+        for key in _RESPONSE_SUMMARY_PASSTHROUGH_KEYS:
             if key in response_summary and response_summary.get(key) is not None:
                 enriched.setdefault(key, copy.deepcopy(response_summary[key]))
         if (

--- a/services/repo-truth-extractor/tests/test_rte_pkt_07_xai_metadata.py
+++ b/services/repo-truth-extractor/tests/test_rte_pkt_07_xai_metadata.py
@@ -1,0 +1,298 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _load_runner_module() -> types.ModuleType:
+    module_path = (
+        _repo_root() / "services" / "repo-truth-extractor" / "run_extraction_v5.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "run_extraction_v5_rte_pkt_07", module_path
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class Obj:
+    def __init__(self, **kwargs: Any) -> None:
+        self.__dict__.update(kwargs)
+
+
+def _choice(content: str, finish_reason: str = "stop", **message_fields: Any) -> Obj:
+    return Obj(
+        finish_reason=finish_reason,
+        message=Obj(content=content, **message_fields),
+    )
+
+
+def test_openai_compatible_response_summary_captures_returned_model_and_usage() -> None:
+    runner = _load_runner_module()
+    response = Obj(
+        id="chatcmpl-local-001",
+        model="gpt-returned-fixture",
+        created=1770000000,
+        system_fingerprint="fp_fixture",
+        choices=[_choice('{"ok": true}', "stop")],
+        usage=Obj(prompt_tokens=17, completion_tokens=5, total_tokens=22),
+    )
+
+    summary = runner.summarize_llm_response(
+        provider="openai",
+        transport="openai_sdk",
+        response_obj=response,
+        response_json=None,
+        response_text='{"ok": true}',
+    )
+
+    assert summary["response_id"] == "chatcmpl-local-001"
+    assert summary["returned_model_id"] == "gpt-returned-fixture"
+    assert summary["effective_model_id"] == "gpt-returned-fixture"
+    assert summary["finish_reason"] == "stop"
+    assert summary["finish_reasons"] == ["stop"]
+    assert summary["usage"] == {
+        "input_tokens": 17,
+        "output_tokens": 5,
+        "total_tokens": 22,
+    }
+    assert summary["response_text_length"] == len('{"ok": true}')
+    assert summary["choice_count"] == 1
+    assert summary["created"] == 1770000000
+    assert summary["system_fingerprint_if_present"] == "fp_fixture"
+
+
+def test_direct_xai_request_meta_keeps_requested_and_returned_model_separate() -> None:
+    runner = _load_runner_module()
+    summary = runner.summarize_llm_response(
+        provider="xai",
+        transport="openai_sdk",
+        response_obj=Obj(
+            id="xai-local-001",
+            model="grok-effective-fixture",
+            choices=[_choice("{}", "stop")],
+            usage=Obj(prompt_tokens=10, completion_tokens=4, total_tokens=14),
+        ),
+        response_json=None,
+        response_text="{}",
+    )
+
+    meta = runner.enrich_request_meta(
+        {
+            "provider": "xai",
+            "model_id": "grok-requested-fixture",
+            "api_key_env_requested": "XAI_API_KEY",
+            "transport": "openai_sdk",
+            "endpoint_effective": "https://api.x.ai/v1/chat/completions",
+            "response_summary": summary,
+        },
+        run_id="run-local",
+        phase="D",
+        step_id="D0",
+        partition_id="D_P0001",
+        provider="xai",
+        model_id="grok-requested-fixture",
+    )
+
+    assert meta["requested_provider"] == "xai"
+    assert meta["requested_model_id"] == "grok-requested-fixture"
+    assert meta["provider_route_kind"] == "direct_provider"
+    assert meta["returned_model_id"] == "grok-effective-fixture"
+    assert meta["effective_model_id"] == "grok-effective-fixture"
+    assert meta["response_id"] == "xai-local-001"
+    assert meta["api_key_env"] == "XAI_API_KEY"
+
+
+def test_openrouter_xai_proxy_request_meta_is_not_direct_xai() -> None:
+    runner = _load_runner_module()
+    summary = runner.summarize_llm_response(
+        provider="openrouter",
+        transport="openai_sdk",
+        response_obj=Obj(
+            id="or-local-001",
+            model="x-ai/grok-proxy-fixture",
+            choices=[_choice("{}", "stop")],
+            usage={"prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18},
+        ),
+        response_json=None,
+        response_text="{}",
+    )
+
+    meta = runner.enrich_request_meta(
+        {
+            "provider": "openrouter",
+            "model_id": "x-ai/grok-proxy-fixture",
+            "api_key_env_requested": "OPENROUTER_API_KEY",
+            "transport": "openai_sdk",
+            "endpoint_effective": "https://openrouter.ai/api/v1/chat/completions",
+            "response_summary": summary,
+        },
+        run_id="run-local",
+        phase="D",
+        step_id="D0",
+        partition_id="D_P0002",
+        provider="openrouter",
+        model_id="x-ai/grok-proxy-fixture",
+    )
+
+    assert meta["requested_provider"] == "openrouter"
+    assert meta["requested_model_id"] == "x-ai/grok-proxy-fixture"
+    assert meta["provider_route_kind"] == "openrouter_proxy_xai"
+    assert meta["returned_model_id"] == "x-ai/grok-proxy-fixture"
+
+
+def test_provider_refusal_state_is_captured_without_parse_failure() -> None:
+    runner = _load_runner_module()
+    response = Obj(
+        id="chatcmpl-refusal",
+        model="gpt-refusal-fixture",
+        choices=[
+            _choice(
+                "",
+                "stop",
+                refusal="Cannot comply with token=Abcd1234Abcd1234Abcd1234Abcd1234Abcd1234.",
+            )
+        ],
+        usage=Obj(prompt_tokens=3, completion_tokens=1, total_tokens=4),
+    )
+
+    summary = runner.summarize_llm_response(
+        provider="openai",
+        transport="openai_sdk",
+        response_obj=response,
+        response_json=None,
+        response_text="",
+    )
+
+    assert summary["refusal"] is True
+    assert "[REDACTED]" in summary["refusal_reason"]
+    assert "Abcd1234" not in summary["refusal_reason"]
+    assert "failure_type" not in summary
+
+
+def test_provider_incomplete_state_is_separate_from_local_parse_repair() -> None:
+    runner = _load_runner_module()
+    response_json = {
+        "id": "chatcmpl-incomplete",
+        "model": "gpt-incomplete-fixture",
+        "status": "incomplete",
+        "incomplete_details": {"reason": "max_output_tokens"},
+        "choices": [
+            {
+                "finish_reason": "length",
+                "message": {"content": "{\"partial\": true"},
+            }
+        ],
+        "usage": {"prompt_tokens": 9, "completion_tokens": 2, "total_tokens": 11},
+    }
+
+    summary = runner.summarize_llm_response(
+        provider="openai",
+        transport="openai_compat_http",
+        response_obj=response_json,
+        response_json=response_json,
+        response_text='{"partial": true',
+    )
+
+    assert summary["response_status"] == "incomplete"
+    assert summary["finish_reason"] == "length"
+    assert summary["incomplete"] is True
+    assert summary["incomplete_reason"] == "max_output_tokens"
+
+
+def test_gemini_style_response_summary_preserves_finish_safety_and_usage() -> None:
+    runner = _load_runner_module()
+    response = Obj(
+        candidates=[Obj(finish_reason="SAFETY", safety_reason="policy_block")],
+        usage_metadata=Obj(
+            prompt_token_count=13,
+            candidates_token_count=6,
+            total_token_count=19,
+        ),
+    )
+
+    summary = runner.summarize_llm_response(
+        provider="gemini",
+        transport="sdk",
+        response_obj=response,
+        response_json=None,
+        response_text="{}",
+    )
+
+    assert summary["finish_reason"] == "SAFETY"
+    assert summary["finish_reasons"] == ["SAFETY"]
+    assert summary["safety_reason"] == "policy_block"
+    assert summary["usage"] == {
+        "input_tokens": 13,
+        "output_tokens": 6,
+        "total_tokens": 19,
+    }
+
+
+def test_structured_output_metadata_is_flattened_into_request_meta() -> None:
+    runner = _load_runner_module()
+    meta = runner.enrich_request_meta(
+        {
+            "provider": "openai",
+            "model_id": "gpt-structured-fixture",
+            "structured_output": {
+                "enabled": True,
+                "structured_output_mode_effective": "json_schema",
+                "response_format_type": "json_schema",
+                "schema_name": "RTEFixtureSchema",
+                "strict": True,
+                "schema_variant": "openai_strict_json_schema",
+                "transport_mode": "response_format_json_schema",
+            },
+        },
+        run_id="run-local",
+        phase="D",
+        step_id="D0",
+        partition_id="D_P0003",
+        provider="openai",
+        model_id="gpt-structured-fixture",
+    )
+
+    assert meta["structured_output_mode"] == "json_schema"
+    assert meta["response_format_type"] == "json_schema"
+    assert meta["json_schema_name_if_present"] == "RTEFixtureSchema"
+    assert meta["strict_schema_required"] is True
+    assert meta["provider_schema_variant"] == "openai_strict_json_schema"
+
+
+def test_metadata_extraction_tests_do_not_invoke_provider_clients(monkeypatch) -> None:
+    runner = _load_runner_module()
+
+    def fail_provider_call(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("provider client must not be invoked by metadata tests")
+
+    monkeypatch.setattr(runner, "get_xai_client", fail_provider_call)
+    monkeypatch.setattr(runner, "get_openrouter_client", fail_provider_call)
+    monkeypatch.setattr(runner, "get_openai_client", fail_provider_call)
+    monkeypatch.setattr(runner, "get_gemini_client", fail_provider_call)
+
+    summary = runner.summarize_llm_response(
+        provider="openrouter",
+        transport="openai_sdk",
+        response_obj=Obj(
+            id="local-only",
+            model="x-ai/local-only",
+            choices=[_choice("{}", "stop")],
+            usage=Obj(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        ),
+        response_json=None,
+        response_text="{}",
+    )
+
+    assert summary["response_id"] == "local-only"


### PR DESCRIPTION
## Summary

- Capture provider response metadata for OpenAI-compatible, direct xAI, OpenRouter `x-ai/...`, and Gemini-style local response objects.
- Preserve requested provider/model separately from returned/effective model metadata in RTE request metadata surfaces.
- Add local fake-response tests and RTE-PKT-07 proof artifacts, including no-provider-call attestation and closeout regression triage.

## Validation

- PASS `python -m py_compile services/repo-truth-extractor/llm_runtime.py services/repo-truth-extractor/run_extraction_v5.py`
- PASS `pytest services/repo-truth-extractor/tests/test_rte_pkt_07_xai_metadata.py -q`
- PASS `pytest services/repo-truth-extractor/tests -k 'xai and metadata' -q`
- PASS `pytest services/repo-truth-extractor/tests -k 'provider and metadata' -q`
- PASS `pytest services/repo-truth-extractor/tests -k 'llm_runtime or response_summary' -q`
- PASS `pytest services/repo-truth-extractor/tests/test_artifact_provenance_fields.py services/repo-truth-extractor/tests/test_truth_label_preservation.py -q`
- PASS `python -m json.tool out/rte-pkt-07-xai-metadata/RTE-PKT-07_MANIFEST.json >/dev/null`
- PASS `git diff --check`
- PASS `pre-commit run --files ...`

## Regression triage

The expanded adjacent live-readiness command failed on both the implementation branch and a clean base worktree at `0179b17b03cf46518aa324bd8f50c805b627631d` with the same failing test and provider-set assertion. Classification: `BASELINE_FAILURE`.

## Live boundary

No live provider validation, provider calls, live extraction, provider preflight, or provider batch operations were run. Live xAI/OpenRouter/Gemini/OpenAI behavior remains `LIVE_VALIDATION_REQUIRED`.

## Review routing

@codex review
@gemini
@copilot

Generate release notes, ensure documentation referencing code changes is updated, ensure all tests pass, and update release notes, changelog, and feature lists where applicable.