### PR TITLE
fix(rte): add static batch proof metadata

### DIFF
--- a/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_BATCH_STATIC_METADATA_MATRIX.md
+++ b/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_BATCH_STATIC_METADATA_MATRIX.md
@@ -1,0 +1,28 @@
+# RTE-PKT-08 Batch Static Metadata Matrix
+
+## Scope
+
+This packet closes static fixture proof gaps only. It does not prove live xAI/OpenAI-compatible batch behavior.
+
+## Matrix
+
+| Surface | Proof path | Fields now proof-visible | Status |
+| --- | --- | --- | --- |
+| Request row metadata | `build_batch_request_static_metadata` in `services/repo-truth-extractor/lib/batch_clients.py` | `custom_id`, method, URL, requested model, messages-present boolean, response format type, provider, structured-output mode, phase, step, partition | STATIC_FIXTURE_VALIDATED |
+| Output JSONL parser | `parse_openai_compatible_batch_output_jsonl` | `custom_id`, response status, response/body presence, response id, returned model, finish reason, usage, failure type, parse status, schema status, redaction status | STATIC_FIXTURE_VALIDATED |
+| Error JSONL parser | `parse_openai_compatible_batch_error_jsonl` | `custom_id`, error type, code, redacted message, status code, failure type, redaction status | STATIC_FIXTURE_VALIDATED |
+| Corrupt line handling | shared JSONL parser in `batch_clients.py` | total lines, blank lines, valid rows, discarded lines, corrupt lines, redacted discarded-line previews, 5 percent threshold status | STATIC_FIXTURE_VALIDATED |
+| Custom ID correlation | `build_openai_compatible_batch_static_proof` | request count, result count, error count, missing row count, missing IDs, duplicate output/error IDs, partial failure, full success | STATIC_FIXTURE_VALIDATED |
+| Terminal status distinction | `classify_batch_terminal_status`; v5 `_batch_terminal_state` now includes `expired` | completed/succeeded/done as success; failed, expired, cancelled/canceled, timeout as distinct terminal classes | STATIC_FIXTURE_VALIDATED |
+| Retriever file IDs | `retrieve_openai_compatible_batch` in `batch_retriever.py` | `output_file_id`, `error_file_id`, `status_class`, `terminal`, local output/error parse report when files are available | STATIC_METADATA_HARDENED |
+| v5 batch watch failure metadata | `run_batch_watch` in `run_extraction_v5.py` | `batch_status`, `batch_status_class` in success/failure request metadata; `expired` handled as terminal | STATIC_METADATA_HARDENED |
+| Live provider behavior | none | submit/poll/retrieve/cancel behavior, provider file lifecycle, pagination/completeness, ZDR/retention | LIVE_VALIDATION_REQUIRED |
+
+## Distinctions Preserved
+
+- Local fixture parsing is separate from provider batch submission, polling, retrieval, and cancellation.
+- Output JSONL and error JSONL use separate parser entrypoints.
+- Missing result rows are hard failures via `missing_rows_are_hard_failure=true`.
+- Partial failure is distinct from full success via `partial_failure` and `full_success`.
+- Terminal failed, expired, cancelled, timeout, and completed states are classified separately.
+- Static parser confidence is marked with `NOT_LIVE_VALIDATED` and `LIVE_VALIDATION_REQUIRED`.

--- a/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_DIFF_SUMMARY.md
+++ b/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_DIFF_SUMMARY.md
@@ -1,0 +1,32 @@
+# RTE-PKT-08 Diff Summary
+
+## Files Touched
+
+- `services/repo-truth-extractor/lib/batch_clients.py`
+  - Added static proof markers.
+  - Added terminal status classification.
+  - Added proof-safe request metadata helper.
+  - Added output/error JSONL fixture parsers with corrupt-line accounting.
+  - Added custom_id correlation and missing-row proof helper.
+  - Sanitized batch result `error` and `meta` fields returned by OpenAI-compatible result parsing.
+
+- `services/repo-truth-extractor/lib/batch_retriever.py`
+  - Preserves `output_file_id`, `error_file_id`, terminal status class, and local parse reports when downloaded files are available.
+  - Does not add new provider retrieval behavior.
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+  - Treats `expired` as a terminal batch status.
+  - Adds `batch_status` and `batch_status_class` to batch-watch request metadata.
+
+- `services/repo-truth-extractor/tests/test_rte_pkt_08_batch_static_proof.py`
+  - Adds local fixture tests for output JSONL, error JSONL, missing rows, partial failure, terminal statuses, corrupt-line thresholds, request metadata, and no-provider-call safety.
+
+- `services/repo-truth-extractor/tests/test_batch_retriever.py`
+  - Extends existing fake-client retrieval coverage to prove output file IDs remain visible and live-downloaded parse reports are not mislabeled as static-only.
+
+- `out/rte-pkt-08-xai-batch-static/*`
+  - Packet proof artifacts only.
+
+## Boundary Check
+
+No prompt files, promptset YAML, model map YAML, route selection files, config, compose files, pricing files, or docs outside the allowed proof output root were edited.

--- a/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_DOWNLOADED_JSONL_INVENTORY.md
+++ b/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_DOWNLOADED_JSONL_INVENTORY.md
@@ -1,0 +1,24 @@
+# RTE-PKT-08 Downloaded JSONL Inventory
+
+## Commands
+
+```bash
+rg --files -uu | rg '(^|/)[^/]+_(output|error)\.jsonl$'
+rg --files -uu out extraction reports proof services/repo-truth-extractor 2>/dev/null | rg '(^|/)[^/]+_(output|error)\.jsonl$'
+```
+
+## Observed Result
+
+Both commands returned exit code `1` with no matching paths.
+
+## Disposition
+
+Downloaded xAI/OpenAI-compatible batch output/error JSONL artifacts are `MISSING` in the local searched artifact classes.
+
+Markers:
+
+- `DOWNLOADED_JSONL_MISSING_IF_NOT_FOUND`
+- `LIVE_VALIDATION_REQUIRED`
+- `NO_PROVIDER_CALLS_PERFORMED`
+
+No provider retrieval was attempted.

--- a/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_JSONL_FIXTURE_EXAMPLES.md
+++ b/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_JSONL_FIXTURE_EXAMPLES.md
@@ -1,0 +1,63 @@
+# RTE-PKT-08 JSONL Fixture Examples
+
+## Output JSONL Shape
+
+```json
+{"custom_id":"A_P0001","response":{"status_code":200,"request_id":"req_A_P0001","body":{"id":"chatcmpl_A_P0001","model":"gpt-5-nano","choices":[{"finish_reason":"stop","message":{"role":"assistant","content":"{\"ok\": true}"}}],"usage":{"prompt_tokens":11,"completion_tokens":7,"total_tokens":18}}},"error":null}
+```
+
+Accepted metadata:
+
+- `custom_id=A_P0001`
+- `response_status_code=200`
+- `response_body_present=true`
+- `response_id_if_present=chatcmpl_A_P0001`
+- `returned_model_id_if_present=gpt-5-nano`
+- `finish_reason_if_present=stop`
+- `usage_if_present.total_tokens=18`
+
+## Error JSONL Shape
+
+```json
+{"custom_id":"A_P0002","response":{"status_code":400},"error":{"type":"invalid_request_error","code":"bad_request","message":"provider rejected Authorization: Bearer [REDACTED]"}}
+```
+
+Accepted metadata:
+
+- `custom_id=A_P0002`
+- `error_type=invalid_request_error`
+- `error_code=bad_request`
+- `status_code_if_present=400`
+- `failure_type=provider_error`
+- `redaction_status=redacted`
+
+## Corrupt Line Example
+
+```text
+{not-json
+```
+
+The static parser records the corrupt line with a redacted preview and fails closed when discarded nonblank lines exceed 5 percent of nonblank JSONL lines.
+
+## Missing Row Example
+
+Requests:
+
+```text
+A_P0001
+A_P0002
+A_P0003
+```
+
+Observed output/error rows:
+
+```text
+A_P0001 output row
+A_P0002 error row
+```
+
+Static proof result:
+
+```json
+{"missing_custom_ids":["A_P0003"],"missing_row_count":1,"missing_rows_are_hard_failure":true,"partial_failure":true,"full_success":false}
+```

--- a/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_LIVE_UNVALIDATED_MARKERS.md
+++ b/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_LIVE_UNVALIDATED_MARKERS.md
@@ -1,0 +1,15 @@
+# RTE-PKT-08 Live-Unvalidated Markers
+
+## Marker Locations
+
+| Marker | Location | Meaning |
+| --- | --- | --- |
+| `STATIC_FIXTURE_VALIDATED` | `BATCH_STATIC_PROOF_MARKERS` in `batch_clients.py`; parser reports and static proof output | Local fixtures exercised the parser/correlation paths. |
+| `DOWNLOADED_JSONL_MISSING_IF_NOT_FOUND` | `BATCH_STATIC_PROOF_MARKERS`; downloaded inventory proof | Downloaded provider JSONL artifacts were not found locally. |
+| `NOT_LIVE_VALIDATED` | `BATCH_STATIC_PROOF_MARKERS`; parser reports and static proof output | Static fixture validation does not prove live provider behavior. |
+| `LIVE_VALIDATION_REQUIRED` | `BATCH_STATIC_PROOF_MARKERS`; downloaded inventory and unknowns ledger | Submit/poll/retrieve/cancel and actual provider file shapes remain unproven. |
+| `NO_PROVIDER_CALLS_PERFORMED` | `BATCH_STATIC_PROOF_MARKERS`; no-provider attestation | Validation used local fixtures and fake clients only. |
+
+## Boundary
+
+The markers apply to static parser and proof confidence. They do not declare live readiness, production readiness, remote file lifecycle correctness, or provider retention behavior.

--- a/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_MANIFEST.json
+++ b/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_MANIFEST.json
@@ -1,0 +1,68 @@
+{
+  "id": "RTE-PKT-08-XAI-BATCH-STATIC",
+  "version": "1.0.0",
+  "generated_at_utc": "2026-05-15T15:30:31Z",
+  "worktree": "/Users/hue/.codex/worktrees/d17a/dopemux-mvp",
+  "branch": "codex/rte-pkt-08-xai-batch-static-d17a",
+  "base_branch_observed": "origin/main",
+  "head_at_preflight": "0179b17b03cf46518aa324bd8f50c805b627631d",
+  "repo_remote_observed": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+  "active_packet_source": "conversation_supplied_packet_json",
+  "implementation_source": {
+    "observed_local_branch": "codex/rte-pkt-08-xai-batch-static",
+    "observed_commit": "261a06dc9d8047f7ba1e82f74a63f13cd8ea4f0d",
+    "applied_via": "git cherry-pick into current dedicated worktree before revalidation"
+  },
+  "task_packet_conflict": {
+    "observed": true,
+    "summary": "AGENTS.md requires creating and validating a local task packet; active packet forbids additional task packets and limits writes to code/tests plus this proof output root. No task-packets/ file was written."
+  },
+  "changed_files": [
+    "services/repo-truth-extractor/lib/batch_clients.py",
+    "services/repo-truth-extractor/lib/batch_retriever.py",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/tests/test_batch_retriever.py",
+    "services/repo-truth-extractor/tests/test_rte_pkt_08_batch_static_proof.py",
+    "out/rte-pkt-08-xai-batch-static/RTE-PKT-08_MANIFEST.json",
+    "out/rte-pkt-08-xai-batch-static/RTE-PKT-08_BATCH_STATIC_METADATA_MATRIX.md",
+    "out/rte-pkt-08-xai-batch-static/RTE-PKT-08_JSONL_FIXTURE_EXAMPLES.md",
+    "out/rte-pkt-08-xai-batch-static/RTE-PKT-08_DOWNLOADED_JSONL_INVENTORY.md",
+    "out/rte-pkt-08-xai-batch-static/RTE-PKT-08_LIVE_UNVALIDATED_MARKERS.md",
+    "out/rte-pkt-08-xai-batch-static/RTE-PKT-08_TEST_REPORT.md",
+    "out/rte-pkt-08-xai-batch-static/RTE-PKT-08_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-08-xai-batch-static/RTE-PKT-08_DIFF_SUMMARY.md",
+    "out/rte-pkt-08-xai-batch-static/RTE-PKT-08_REMAINING_UNKNOWNS.md",
+    "out/rte-pkt-08-xai-batch-static/implementation-notes.md"
+  ],
+  "markers": [
+    "STATIC_FIXTURE_VALIDATED",
+    "DOWNLOADED_JSONL_MISSING_IF_NOT_FOUND",
+    "NOT_LIVE_VALIDATED",
+    "LIVE_VALIDATION_REQUIRED",
+    "NO_PROVIDER_CALLS_PERFORMED"
+  ],
+  "downloaded_jsonl_inventory": {
+    "searched_patterns": [
+      "*_output.jsonl",
+      "*_error.jsonl"
+    ],
+    "found_count": 0,
+    "status": "DOWNLOADED_JSONL_MISSING"
+  },
+  "validation_summary": {
+    "python_py_compile": "PASS",
+    "new_static_tests": "PASS",
+    "batch_and_static_selector": "PASS",
+    "existing_batch_strict_redaction_suite": "PASS",
+    "provider_payload_redaction": "PASS",
+    "downloaded_jsonl_inventory": "PASS",
+    "manifest_json": "PASS",
+    "git_diff_check": "PASS",
+    "pre_commit": "PASS"
+  },
+  "no_provider_calls_performed": true,
+  "live_validation_allowed": false,
+  "provider_calls_allowed": false,
+  "batch_provider_operations_allowed": false,
+  "commit_state": "proof_generated_before_final_amend; final SHA reported in closeout"
+}

--- a/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,14 @@
+# RTE-PKT-08 No Provider Calls Attestation
+
+No provider calls were performed for this packet.
+
+Observed controls:
+
+- Tests used local JSONL strings, in-memory fake clients, and monkeypatch guards.
+- New safety test monkeypatches OpenAI-compatible batch client constructors to raise if reached while exercising static helpers.
+- No provider credentials were required or read for validation.
+- No live extraction command was run.
+- No batch submit, poll, retrieve, cancel, delete, or remote file retrieval was run.
+- Downloaded JSONL inventory used local `rg --files -uu` searches only.
+
+Status: `NO_PROVIDER_CALLS_PERFORMED`.

--- a/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_REMAINING_UNKNOWNS.md
@@ -1,0 +1,26 @@
+# RTE-PKT-08 Remaining Unknowns
+
+## LIVE_VALIDATION_REQUIRED
+
+- Live xAI/OpenAI-compatible batch submit behavior remains unproven.
+- Live polling behavior remains unproven.
+- Live result retrieval behavior remains unproven.
+- Live cancellation behavior remains unproven.
+- Actual provider output JSONL and error JSONL shape remains unproven because no downloaded artifacts were found locally and none were retrieved.
+- Provider pagination/completeness behavior remains unproven.
+- Remote file lifecycle, deletion, retention, and ZDR behavior remain unproven.
+
+## ACCEPTED_WITH_RISK
+
+- Static fixture parsers prove local behavior against synthetic OpenAI-compatible row shapes only.
+- `output_file_id` and `error_file_id` are preserved when metadata is present, but this does not prove providers always return those fields.
+- Existing local RTE-PKT-07 proof artifacts were not found under `out/`; provider metadata acceptance basis remains conversation-supplied context for this packet.
+
+## MISSING
+
+- Downloaded `*_output.jsonl` artifacts: none found.
+- Downloaded `*_error.jsonl` artifacts: none found.
+
+## Governance Conflict
+
+Repo `AGENTS.md` requires a local task packet file and schema validation. The active packet forbids additional task packets and restricts writes outside code/tests/proof output. This run preserved the active packet boundary and did not write `task-packets/`.

--- a/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_TEST_REPORT.md
+++ b/out/rte-pkt-08-xai-batch-static/RTE-PKT-08_TEST_REPORT.md
@@ -1,0 +1,71 @@
+# RTE-PKT-08 Test Report
+
+## PASS
+
+```bash
+python -m py_compile services/repo-truth-extractor/lib/batch_clients.py services/repo-truth-extractor/lib/batch_retriever.py services/repo-truth-extractor/run_extraction_v5.py
+```
+
+Exit code: `0`.
+
+```bash
+RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_rte_pkt_08_batch_static_proof.py
+```
+
+Exit code: `0`. Result: `7 passed`.
+
+```bash
+RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k 'batch and static'
+```
+
+Exit code: `0`. Result: `7 passed`.
+
+```bash
+RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_batch_clients_integration.py services/repo-truth-extractor/tests/test_batch_retriever.py services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py
+```
+
+Exit code: `0`. Result: `28 passed`.
+
+```bash
+RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_provider_payload_redaction.py
+```
+
+Exit code: `0`. Result: `10 passed`.
+
+```bash
+RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_rte_pkt_08_batch_static_proof.py services/repo-truth-extractor/tests/test_batch_clients_integration.py services/repo-truth-extractor/tests/test_batch_retriever.py services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py
+```
+
+Exit code: `0`. Result: `45 passed`.
+
+```bash
+python -m json.tool out/rte-pkt-08-xai-batch-static/RTE-PKT-08_MANIFEST.json >/dev/null
+```
+
+Exit code: `0`.
+
+```bash
+git diff --check
+```
+
+Exit code: `0`.
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Exit code: `0`.
+
+```bash
+changed=$(git diff --name-only origin/main...HEAD); if command -v pre-commit >/dev/null 2>&1; then pre-commit run --files $changed; else echo 'pre-commit NOT_FOUND'; exit 127; fi
+```
+
+Exit code: `0`. Hooks either passed or skipped according to their configured file filters.
+
+## Warnings
+
+Pytest emitted an existing warning: `Unknown config option: asyncio_mode`.
+
+## NOT_RUN
+
+No live extraction, provider call, batch submit, batch poll, batch retrieve, batch cancel, or remote provider file retrieval was run.

--- a/out/rte-pkt-08-xai-batch-static/implementation-notes.md
+++ b/out/rte-pkt-08-xai-batch-static/implementation-notes.md
@@ -1,0 +1,32 @@
+# RTE-PKT-08 Implementation Notes
+
+## Scope
+
+Implemented static-only xAI/OpenAI-compatible batch proof hardening. No live provider validation was performed.
+
+## Changed Runtime Surfaces
+
+- `services/repo-truth-extractor/lib/batch_clients.py`
+  - Added static markers, terminal status classification, request metadata extraction, output/error JSONL fixture parsers, corrupt-line accounting, and custom_id correlation proof.
+  - Sanitized OpenAI-compatible batch result error/meta values before returning `BatchResult` metadata.
+- `services/repo-truth-extractor/lib/batch_retriever.py`
+  - Preserves output/error file IDs and terminal status class in retrieval metadata.
+  - Parses downloaded files only after the existing retrieval path has produced local files; no new retrieval operation was introduced.
+- `services/repo-truth-extractor/run_extraction_v5.py`
+  - Treats `expired` as terminal for batch watch.
+  - Emits `batch_status` and `batch_status_class` into batch-watch metadata.
+- `services/repo-truth-extractor/tests/`
+  - Added static fixture tests for output rows, error rows, missing rows, partial failures, terminal states, corrupt-line thresholds, request metadata, and no-provider-call safety.
+
+## Validation Summary
+
+- `python -m py_compile` passed for changed runtime modules.
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_rte_pkt_08_batch_static_proof.py` passed: 7 tests.
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k 'batch and static'` passed: 7 tests.
+- Targeted batch/retriever/strict/redaction suite passed: 45 tests.
+
+## Remaining Risk
+
+Live xAI/OpenAI-compatible batch submit, poll, retrieve, cancel, output/error JSONL shape, pagination, remote file lifecycle, and retention behavior remain `LIVE_VALIDATION_REQUIRED`.
+
+<workflow-checkpoint phase="implement" status="complete" task="RTE-PKT-08-XAI-BATCH-STATIC" summary="Static batch proof implementation validated on local fixtures" artifact="/Users/hue/.codex/worktrees/d17a/dopemux-mvp/out/rte-pkt-08-xai-batch-static/implementation-notes.md" verification="python -m py_compile; pytest targeted static batch suites" />

--- a/services/repo-truth-extractor/lib/batch_clients.py
+++ b/services/repo-truth-extractor/lib/batch_clients.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import importlib.util
 import json
 import sys
 import tempfile
@@ -12,18 +11,10 @@ from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple
 try:
     from output_safety import sanitize_payload_for_output, sanitize_text_for_output
 except ModuleNotFoundError:  # pragma: no cover - supports direct importlib test loading
-    _service_dir = Path(__file__).resolve().parents[1]
-    _safety_path = _service_dir / "output_safety.py"
-    _safety_spec = importlib.util.spec_from_file_location(
-        "repo_truth_output_safety_for_batch_clients", _safety_path
-    )
-    if _safety_spec is None or _safety_spec.loader is None:
-        raise
-    _safety_module = importlib.util.module_from_spec(_safety_spec)
-    sys.modules[_safety_spec.name] = _safety_module
-    _safety_spec.loader.exec_module(_safety_module)
-    sanitize_payload_for_output = _safety_module.sanitize_payload_for_output
-    sanitize_text_for_output = _safety_module.sanitize_text_for_output
+    _service_dir = str(Path(__file__).resolve().parents[1])
+    if _service_dir not in sys.path:
+        sys.path.insert(0, _service_dir)
+    from output_safety import sanitize_payload_for_output, sanitize_text_for_output
 
 
 class UnsupportedBatchProvider(RuntimeError):
@@ -272,9 +263,13 @@ def _error_row_metadata(row: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+_DISCARDED_LINES_SAMPLE_LIMIT = 50
+
+
 def _parse_jsonl_rows(raw_text: str) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
     rows: List[Dict[str, Any]] = []
     discarded_lines: List[Dict[str, Any]] = []
+    discarded_count = 0
     total_lines = 0
     blank_line_count = 0
     for line_number, raw_line in enumerate(str(raw_text or "").splitlines(), start=1):
@@ -286,26 +281,29 @@ def _parse_jsonl_rows(raw_text: str) -> Tuple[List[Dict[str, Any]], Dict[str, An
         try:
             row = json.loads(line)
         except Exception as exc:
-            discarded_lines.append(
-                {
-                    "line_number": line_number,
-                    "reason": "invalid_json",
-                    "error_type": type(exc).__name__,
-                    "preview_redacted": sanitize_text_for_output(line[:200]),
-                }
-            )
+            discarded_count += 1
+            if len(discarded_lines) < _DISCARDED_LINES_SAMPLE_LIMIT:
+                discarded_lines.append(
+                    {
+                        "line_number": line_number,
+                        "reason": "invalid_json",
+                        "error_type": type(exc).__name__,
+                        "preview_redacted": sanitize_text_for_output(line[:200]),
+                    }
+                )
             continue
         if not isinstance(row, dict):
-            discarded_lines.append(
-                {
-                    "line_number": line_number,
-                    "reason": "non_object_json",
-                    "preview_redacted": sanitize_text_for_output(line[:200]),
-                }
-            )
+            discarded_count += 1
+            if len(discarded_lines) < _DISCARDED_LINES_SAMPLE_LIMIT:
+                discarded_lines.append(
+                    {
+                        "line_number": line_number,
+                        "reason": "non_object_json",
+                        "preview_redacted": sanitize_text_for_output(line[:200]),
+                    }
+                )
             continue
         rows.append(row)
-    discarded_count = len(discarded_lines)
     threshold_exceeded = (
         total_lines > 0
         and (discarded_count / total_lines) > BATCH_JSONL_CORRUPTION_THRESHOLD
@@ -610,12 +608,19 @@ class OpenAIBatchClient:
                     str(error_row.get("message") or error_row.get("code") or "batch_error")
                 )
             safe_meta = sanitize_payload_for_output(row)
+            if not isinstance(safe_meta, dict):
+                logger.warning(
+                    "sanitize_payload_for_output returned non-dict for custom_id=%s; "
+                    "dropping row metadata",
+                    custom_id,
+                )
+                safe_meta = {}
             results.append(
                 BatchResult(
                     custom_id=custom_id,
                     output_text=output_text,
                     error=error,
-                    meta=safe_meta if isinstance(safe_meta, dict) else {},
+                    meta=safe_meta,
                 )
             )
 

--- a/services/repo-truth-extractor/lib/batch_clients.py
+++ b/services/repo-truth-extractor/lib/batch_clients.py
@@ -1,11 +1,29 @@
 from __future__ import annotations
 
 import copy
+import importlib.util
 import json
+import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Protocol, Sequence
+from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple
+
+try:
+    from output_safety import sanitize_payload_for_output, sanitize_text_for_output
+except ModuleNotFoundError:  # pragma: no cover - supports direct importlib test loading
+    _service_dir = Path(__file__).resolve().parents[1]
+    _safety_path = _service_dir / "output_safety.py"
+    _safety_spec = importlib.util.spec_from_file_location(
+        "repo_truth_output_safety_for_batch_clients", _safety_path
+    )
+    if _safety_spec is None or _safety_spec.loader is None:
+        raise
+    _safety_module = importlib.util.module_from_spec(_safety_spec)
+    sys.modules[_safety_spec.name] = _safety_module
+    _safety_spec.loader.exec_module(_safety_module)
+    sanitize_payload_for_output = _safety_module.sanitize_payload_for_output
+    sanitize_text_for_output = _safety_module.sanitize_text_for_output
 
 
 class UnsupportedBatchProvider(RuntimeError):
@@ -39,6 +57,24 @@ class BatchRoute:
     base_url: Optional[str] = None
 
 
+BATCH_STATIC_PROOF_MARKERS: Tuple[str, ...] = (
+    "STATIC_FIXTURE_VALIDATED",
+    "DOWNLOADED_JSONL_MISSING_IF_NOT_FOUND",
+    "NOT_LIVE_VALIDATED",
+    "LIVE_VALIDATION_REQUIRED",
+    "NO_PROVIDER_CALLS_PERFORMED",
+)
+
+OPENAI_COMPATIBLE_SUCCESS_STATUSES = frozenset({"completed", "succeeded", "done"})
+OPENAI_COMPATIBLE_FAILURE_STATUSES = frozenset(
+    {"failed", "expired", "cancelled", "canceled", "timeout"}
+)
+OPENAI_COMPATIBLE_TERMINAL_STATUSES = (
+    OPENAI_COMPATIBLE_SUCCESS_STATUSES | OPENAI_COMPATIBLE_FAILURE_STATUSES
+)
+BATCH_JSONL_CORRUPTION_THRESHOLD = 0.05
+
+
 class BatchClient(Protocol):
     def submit(
         self,
@@ -60,6 +96,355 @@ class BatchClient(Protocol):
 
 def _metadata_flag_enabled(metadata: Dict[str, str], key: str) -> bool:
     return str(metadata.get(key) or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def classify_batch_terminal_status(status: str) -> Dict[str, Any]:
+    token = str(status or "").strip().lower()
+    if token in OPENAI_COMPATIBLE_SUCCESS_STATUSES:
+        status_class = "success"
+    elif token == "failed":
+        status_class = "failed"
+    elif token == "expired":
+        status_class = "expired"
+    elif token in {"cancelled", "canceled"}:
+        status_class = "cancelled"
+    elif token == "timeout":
+        status_class = "timeout"
+    elif token:
+        status_class = "non_terminal"
+    else:
+        status_class = "unknown"
+    return {
+        "status": token or "unknown",
+        "status_class": status_class,
+        "terminal": token in OPENAI_COMPATIBLE_TERMINAL_STATUSES,
+        "successful": token in OPENAI_COMPATIBLE_SUCCESS_STATUSES,
+        "failure_terminal": token in OPENAI_COMPATIBLE_FAILURE_STATUSES,
+    }
+
+
+def _safe_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _safe_list(value: Any) -> List[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value))
+    except Exception:
+        return None
+
+
+def _redaction_status(raw: str, redacted: str) -> str:
+    return "redacted" if raw != redacted else "clean"
+
+
+def _partition_id_from_custom_id(custom_id: str) -> str:
+    token = str(custom_id or "").strip()
+    return token if "_P" in token else ""
+
+
+def _phase_from_custom_id(custom_id: str) -> str:
+    token = str(custom_id or "").strip()
+    if "_P" not in token:
+        return ""
+    prefix = token.split("_P", 1)[0].strip()
+    return prefix if prefix else ""
+
+
+def build_batch_request_static_metadata(
+    request: BatchRequest,
+    route: Optional[BatchRoute] = None,
+    *,
+    wire_row: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Return proof-safe request-row metadata without raw prompt payload text."""
+
+    body = _safe_dict(_safe_dict(wire_row).get("body")) if isinstance(wire_row, dict) else {}
+    response_format = (
+        _safe_dict(body.get("response_format"))
+        if isinstance(body.get("response_format"), dict)
+        else _safe_dict(request.response_format)
+    )
+    metadata = dict(request.metadata or {})
+    custom_id = str(
+        (_safe_dict(wire_row).get("custom_id") if isinstance(wire_row, dict) else "")
+        or request.custom_id
+        or ""
+    )
+    provider = str(route.provider if route is not None else metadata.get("provider", "")).strip()
+    requested_model_id = str(
+        body.get("model")
+        or request.model_id
+        or (route.model_id if route is not None else "")
+        or ""
+    )
+    return {
+        "custom_id": custom_id,
+        "method": str(_safe_dict(wire_row).get("method") or "POST"),
+        "url": str(_safe_dict(wire_row).get("url") or "/v1/chat/completions"),
+        "body.model": requested_model_id,
+        "body.messages_present_boolean": bool(
+            isinstance(body.get("messages"), list)
+            if body
+            else request.system_prompt is not None and request.user_content is not None
+        ),
+        "body.response_format_type_if_present": str(response_format.get("type") or ""),
+        "provider": provider,
+        "requested_model_id": requested_model_id,
+        "structured_output_mode_if_present": str(
+            metadata.get("structured_output_mode")
+            or response_format.get("type")
+            or ""
+        ),
+        "partition_id_if_encoded": str(
+            metadata.get("partition_id") or _partition_id_from_custom_id(custom_id)
+        ),
+        "phase_if_encoded": str(metadata.get("phase") or _phase_from_custom_id(custom_id)),
+        "step_id_if_encoded": str(metadata.get("step_id") or ""),
+        "payload_text_included": False,
+        "redaction_status": "metadata_only_no_raw_payload",
+    }
+
+
+def _output_row_metadata(row: Dict[str, Any]) -> Dict[str, Any]:
+    response = _safe_dict(row.get("response"))
+    body = _safe_dict(response.get("body"))
+    choices = _safe_list(body.get("choices"))
+    first_choice = _safe_dict(choices[0]) if choices else {}
+    message = _safe_dict(first_choice.get("message"))
+    error = _safe_dict(row.get("error"))
+    status_code = _safe_int(response.get("status_code"))
+    failure_type = ""
+    if error:
+        failure_type = "provider_error"
+    elif status_code is not None and status_code >= 400:
+        failure_type = "provider_response_status"
+    elif not body:
+        failure_type = "response_body_missing"
+    return {
+        "custom_id": str(row.get("custom_id") or ""),
+        "response_status_code": status_code,
+        "response_body_present": bool(body),
+        "response_id_if_present": str(body.get("id") or response.get("request_id") or ""),
+        "returned_model_id_if_present": str(body.get("model") or ""),
+        "finish_reason_if_present": str(first_choice.get("finish_reason") or ""),
+        "usage_if_present": sanitize_payload_for_output(body.get("usage", {})),
+        "failure_type_if_any": failure_type,
+        "parse_status": "parsed",
+        "schema_status_if_any": "not_checked_static_fixture",
+        "redaction_status": "metadata_only_no_raw_payload",
+        "response_message_present": bool(message),
+    }
+
+
+def _error_row_metadata(row: Dict[str, Any]) -> Dict[str, Any]:
+    error = _safe_dict(row.get("error"))
+    response = _safe_dict(row.get("response"))
+    body = _safe_dict(response.get("body"))
+    body_error = _safe_dict(body.get("error"))
+    source_error = error or body_error
+    raw_message = str(
+        source_error.get("message")
+        or row.get("message")
+        or response.get("error")
+        or "batch_error"
+    )
+    redacted_message = sanitize_text_for_output(raw_message)
+    status_code = _safe_int(row.get("status_code"))
+    if status_code is None:
+        status_code = _safe_int(response.get("status_code"))
+    return {
+        "custom_id": str(row.get("custom_id") or ""),
+        "error_type": str(source_error.get("type") or row.get("type") or "batch_error"),
+        "error_code": str(source_error.get("code") or row.get("code") or ""),
+        "error_message_redacted": redacted_message,
+        "status_code_if_present": status_code,
+        "failure_type": "provider_error",
+        "redaction_status": _redaction_status(raw_message, redacted_message),
+    }
+
+
+def _parse_jsonl_rows(raw_text: str) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    discarded_lines: List[Dict[str, Any]] = []
+    total_lines = 0
+    blank_line_count = 0
+    for line_number, raw_line in enumerate(str(raw_text or "").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line:
+            blank_line_count += 1
+            continue
+        total_lines += 1
+        try:
+            row = json.loads(line)
+        except Exception as exc:
+            discarded_lines.append(
+                {
+                    "line_number": line_number,
+                    "reason": "invalid_json",
+                    "error_type": type(exc).__name__,
+                    "preview_redacted": sanitize_text_for_output(line[:200]),
+                }
+            )
+            continue
+        if not isinstance(row, dict):
+            discarded_lines.append(
+                {
+                    "line_number": line_number,
+                    "reason": "non_object_json",
+                    "preview_redacted": sanitize_text_for_output(line[:200]),
+                }
+            )
+            continue
+        rows.append(row)
+    discarded_count = len(discarded_lines)
+    threshold_exceeded = (
+        total_lines > 0
+        and (discarded_count / total_lines) > BATCH_JSONL_CORRUPTION_THRESHOLD
+    )
+    report = {
+        "total_line_count": total_lines,
+        "blank_line_count": blank_line_count,
+        "valid_row_count": len(rows),
+        "discarded_line_count": discarded_count,
+        "corrupt_line_count": discarded_count,
+        "discarded_lines": discarded_lines,
+        "corruption_threshold": BATCH_JSONL_CORRUPTION_THRESHOLD,
+        "corruption_threshold_exceeded": threshold_exceeded,
+        "parse_status": (
+            "corrupt_threshold_exceeded"
+            if threshold_exceeded
+            else ("parsed_with_discards" if discarded_count else "parsed")
+        ),
+    }
+    return rows, report
+
+
+def parse_openai_compatible_batch_output_jsonl(
+    raw_text: str,
+    *,
+    raise_on_corruption: bool = False,
+    not_live_validated: bool = True,
+) -> Dict[str, Any]:
+    rows, report = _parse_jsonl_rows(raw_text)
+    metadata_rows = [_output_row_metadata(row) for row in rows]
+    report = dict(report)
+    report.update(
+        {
+            "artifact_class": "provider_output_jsonl_fixture",
+            "rows": metadata_rows,
+            "custom_ids": sorted(
+                str(row.get("custom_id") or "") for row in metadata_rows if row.get("custom_id")
+            ),
+            "markers": list(BATCH_STATIC_PROOF_MARKERS) if not_live_validated else [],
+            "not_live_validated": bool(not_live_validated),
+        }
+    )
+    if raise_on_corruption and report["corruption_threshold_exceeded"]:
+        raise RuntimeError(
+            "BatchCorruptionError: "
+            f"{report['discarded_line_count']}/{report['total_line_count']} "
+            "results discarded (>5%)"
+        )
+    return report
+
+
+def parse_openai_compatible_batch_error_jsonl(
+    raw_text: str,
+    *,
+    raise_on_corruption: bool = False,
+    not_live_validated: bool = True,
+) -> Dict[str, Any]:
+    rows, report = _parse_jsonl_rows(raw_text)
+    metadata_rows = [_error_row_metadata(row) for row in rows]
+    report = dict(report)
+    report.update(
+        {
+            "artifact_class": "provider_error_jsonl_fixture",
+            "rows": metadata_rows,
+            "custom_ids": sorted(
+                str(row.get("custom_id") or "") for row in metadata_rows if row.get("custom_id")
+            ),
+            "markers": list(BATCH_STATIC_PROOF_MARKERS) if not_live_validated else [],
+            "not_live_validated": bool(not_live_validated),
+        }
+    )
+    if raise_on_corruption and report["corruption_threshold_exceeded"]:
+        raise RuntimeError(
+            "BatchCorruptionError: "
+            f"{report['discarded_line_count']}/{report['total_line_count']} "
+            "error rows discarded (>5%)"
+        )
+    return report
+
+
+def build_openai_compatible_batch_static_proof(
+    *,
+    request_custom_ids: Sequence[str],
+    output_rows: Sequence[Dict[str, Any]],
+    error_rows: Sequence[Dict[str, Any]],
+    batch_info: Optional[Dict[str, Any]] = None,
+    provider: str = "",
+    requested_provider: str = "",
+    requested_model_id: str = "",
+) -> Dict[str, Any]:
+    info = dict(batch_info or {})
+    status = str(info.get("status") or "fixture_static").strip().lower()
+    terminal = classify_batch_terminal_status(status)
+    requested_ids = sorted({str(custom_id) for custom_id in request_custom_ids if str(custom_id)})
+    result_ids = sorted(
+        {
+            str(row.get("custom_id") or "")
+            for row in output_rows
+            if isinstance(row, dict) and str(row.get("custom_id") or "")
+        }
+    )
+    error_ids = sorted(
+        {
+            str(row.get("custom_id") or "")
+            for row in error_rows
+            if isinstance(row, dict) and str(row.get("custom_id") or "")
+        }
+    )
+    observed_ids = set(result_ids) | set(error_ids)
+    missing_ids = sorted(set(requested_ids) - observed_ids)
+    duplicate_ids = sorted(set(result_ids) & set(error_ids))
+    partial_failure = bool(error_ids or missing_ids or duplicate_ids)
+    return {
+        "batch_id": str(info.get("id") or info.get("batch_id") or ""),
+        "provider": provider or str(info.get("provider") or ""),
+        "requested_provider": requested_provider or provider or str(info.get("requested_provider") or ""),
+        "requested_model_id": requested_model_id or str(info.get("requested_model_id") or ""),
+        "status": status,
+        "status_class": terminal["status_class"],
+        "created_at": str(info.get("created_at") or ""),
+        "completed_at_if_present": str(info.get("completed_at") or ""),
+        "failed_at_if_present": str(info.get("failed_at") or ""),
+        "cancelled_at_if_present": str(info.get("cancelled_at") or info.get("canceled_at") or ""),
+        "expired_at_if_present": str(info.get("expired_at") or ""),
+        "output_file_id": str(info.get("output_file_id") or ""),
+        "error_file_id": str(info.get("error_file_id") or ""),
+        "request_count": len(requested_ids),
+        "result_count": len(result_ids),
+        "error_count": len(error_ids),
+        "missing_row_count": len(missing_ids),
+        "missing_custom_ids": missing_ids,
+        "duplicate_custom_ids_in_output_and_error": duplicate_ids,
+        "partial_failure": partial_failure,
+        "full_success": not partial_failure and bool(requested_ids),
+        "missing_rows_are_hard_failure": bool(missing_ids),
+        "not_live_validated": True,
+        "markers": list(BATCH_STATIC_PROOF_MARKERS),
+        "proof_scope": "local_static_fixture_only",
+    }
 
 
 def _response_format_for_request(req: BatchRequest) -> Optional[Dict[str, Any]]:
@@ -221,13 +606,16 @@ class OpenAIBatchClient:
             error_row = row.get("error")
             error = None
             if isinstance(error_row, dict):
-                error = str(error_row.get("message") or error_row.get("code") or "batch_error")
+                error = sanitize_text_for_output(
+                    str(error_row.get("message") or error_row.get("code") or "batch_error")
+                )
+            safe_meta = sanitize_payload_for_output(row)
             results.append(
                 BatchResult(
                     custom_id=custom_id,
                     output_text=output_text,
                     error=error,
-                    meta=row,
+                    meta=safe_meta if isinstance(safe_meta, dict) else {},
                 )
             )
 

--- a/services/repo-truth-extractor/lib/batch_retriever.py
+++ b/services/repo-truth-extractor/lib/batch_retriever.py
@@ -12,19 +12,27 @@ from typing import Any, Dict, List, Tuple
 
 try:
     from .batch_clients import (
+        BATCH_STATIC_PROOF_MARKERS,
         BatchResult,
         GeminiBatchClient,
         OpenAIBatchClient,
         UnsupportedBatchProvider,
         XAIBatchClient,
+        classify_batch_terminal_status,
+        parse_openai_compatible_batch_error_jsonl,
+        parse_openai_compatible_batch_output_jsonl,
     )
 except ImportError:
     from batch_clients import (  # type: ignore
+        BATCH_STATIC_PROOF_MARKERS,
         BatchResult,
         GeminiBatchClient,
         OpenAIBatchClient,
         UnsupportedBatchProvider,
         XAIBatchClient,
+        classify_batch_terminal_status,
+        parse_openai_compatible_batch_error_jsonl,
+        parse_openai_compatible_batch_output_jsonl,
     )
 
 logging.basicConfig(level=logging.INFO)
@@ -129,10 +137,18 @@ def retrieve_openai_compatible_batch(
         "batch_id": batch_id,
         "provider": provider_id,
         "status": "unknown",
+        "status_class": "unknown",
+        "terminal": False,
         "output_file": None,
         "error_file": None,
+        "output_file_id": None,
+        "error_file_id": None,
+        "output_parse": None,
+        "error_parse": None,
         "error": None,
         "results": [],
+        "static_parser_markers": list(BATCH_STATIC_PROOF_MARKERS),
+        "static_parser_marker_scope": "offline_fixture_tests_only",
     }
 
     try:
@@ -147,6 +163,11 @@ def retrieve_openai_compatible_batch(
 
         output_file_id = str(batch_info.get("output_file_id") or "")
         error_file_id = str(batch_info.get("error_file_id") or "")
+        result["output_file_id"] = output_file_id or None
+        result["error_file_id"] = error_file_id or None
+        status_meta = classify_batch_terminal_status(status)
+        result["status_class"] = status_meta["status_class"]
+        result["terminal"] = status_meta["terminal"]
 
         if status in {"completed", "succeeded", "done"}:
             results = client.fetch_results(batch_id)
@@ -166,6 +187,10 @@ def retrieve_openai_compatible_batch(
                     )
                 else:
                     result["output_file"] = str(output_path)
+                    result["output_parse"] = parse_openai_compatible_batch_output_jsonl(
+                        output_path.read_text(encoding="utf-8"),
+                        not_live_validated=False,
+                    )
         elif status in {"failed", "expired", "cancelled", "canceled", "timeout"} and error_file_id:
             error_path = output_dir / f"{batch_id}_error.jsonl"
             download_error = _download_openai_compatible_file(
@@ -181,6 +206,10 @@ def retrieve_openai_compatible_batch(
                 )
             else:
                 result["error_file"] = str(error_path)
+                result["error_parse"] = parse_openai_compatible_batch_error_jsonl(
+                    error_path.read_text(encoding="utf-8"),
+                    not_live_validated=False,
+                )
         return True, result
     except Exception as exc:
         result["error"] = f"Batch retrieval failed: {exc}"

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -256,6 +256,7 @@ try:
         OpenAIBatchClient,
         OpenRouterBatchClient,
         XAIBatchClient,
+        classify_batch_terminal_status,
     )
 except ModuleNotFoundError:
     batch_clients_path = RUNNER_SERVICE_DIR / "lib" / "batch_clients.py"
@@ -274,6 +275,7 @@ except ModuleNotFoundError:
     OpenAIBatchClient = batch_clients_module.OpenAIBatchClient
     XAIBatchClient = batch_clients_module.XAIBatchClient
     OpenRouterBatchClient = batch_clients_module.OpenRouterBatchClient
+    classify_batch_terminal_status = batch_clients_module.classify_batch_terminal_status
 
 try:
     from lib.intelligence_router import IntelligenceRouter
@@ -18405,6 +18407,7 @@ def _batch_terminal_state(status: str) -> bool:
         "succeeded",
         "done",
         "failed",
+        "expired",
         "cancelled",
         "canceled",
         "timeout",
@@ -18616,6 +18619,7 @@ def run_batch_watch(
         event_detail = f"state={terminal_status}"
         row["state"] = terminal_status
         row["last_polled_at_utc"] = now_iso()
+        batch_status_meta = classify_batch_terminal_status(terminal_status)
 
         if terminal_status in {"completed", "succeeded", "done"}:
             results = batch_client.fetch_results(job_id)
@@ -18647,6 +18651,8 @@ def run_batch_watch(
                             "model_id": model_id,
                             "batch_provider": provider_id,
                             "batch_job_id": job_id,
+                            "batch_status": terminal_status,
+                            "batch_status_class": batch_status_meta.get("status_class"),
                         },
                     },
                 )
@@ -18693,6 +18699,8 @@ def run_batch_watch(
                                 "model_id": model_id,
                                 "batch_provider": provider_id,
                                 "batch_job_id": job_id,
+                                "batch_status": terminal_status,
+                                "batch_status_class": batch_status_meta.get("status_class"),
                                 "provider_error_reason": result.error,
                                 "schema_gate_reason": schema_reason,
                             },
@@ -18722,6 +18730,7 @@ def run_batch_watch(
                             "batch_job_id": job_id,
                             "response_summary": {
                                 "batch_status": terminal_status,
+                                "batch_status_class": batch_status_meta.get("status_class"),
                                 "watch_mode": True,
                             },
                         },
@@ -18864,6 +18873,8 @@ def run_batch_watch(
                         "model_id": model_id,
                         "batch_provider": provider_id,
                         "batch_job_id": job_id,
+                        "batch_status": terminal_status,
+                        "batch_status_class": batch_status_meta.get("status_class"),
                         "provider_error_reason": f"batch_terminal_state:{terminal_status}",
                     },
                 },

--- a/services/repo-truth-extractor/tests/test_batch_retriever.py
+++ b/services/repo-truth-extractor/tests/test_batch_retriever.py
@@ -109,8 +109,12 @@ def test_retrieve_batches_dispatches_openai_and_xai(monkeypatch, tmp_path: Path)
 
     assert openai_results["job-openai"]["provider"] == "openai"
     assert openai_results["job-openai"]["output_file"].endswith("job-openai_output.jsonl")
+    assert openai_results["job-openai"]["output_file_id"] == "file-1"
+    assert openai_results["job-openai"]["output_parse"]["not_live_validated"] is False
+    assert openai_results["job-openai"]["static_parser_marker_scope"] == "offline_fixture_tests_only"
     assert xai_results["job-xai"]["provider"] == "xai"
     assert xai_results["job-xai"]["output_file"].endswith("job-xai_output.jsonl")
+    assert xai_results["job-xai"]["output_file_id"] == "file-1"
 
 
 def test_retrieve_batches_dispatches_gemini(monkeypatch, tmp_path: Path) -> None:

--- a/services/repo-truth-extractor/tests/test_rte_pkt_08_batch_static_proof.py
+++ b/services/repo-truth-extractor/tests/test_rte_pkt_08_batch_static_proof.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_batch_clients_module():
+    root = Path(__file__).resolve().parents[3]
+    module_path = root / "services" / "repo-truth-extractor" / "lib" / "batch_clients.py"
+    spec = importlib.util.spec_from_file_location("rte_pkt_08_batch_clients", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_runner_module():
+    root = Path(__file__).resolve().parents[3]
+    module_path = root / "services" / "repo-truth-extractor" / "run_extraction_v5.py"
+    spec = importlib.util.spec_from_file_location("rte_pkt_08_runner", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _output_row(custom_id: str, *, model: str = "gpt-5-nano") -> dict[str, Any]:
+    return {
+        "id": f"batch_req_{custom_id}",
+        "custom_id": custom_id,
+        "response": {
+            "status_code": 200,
+            "request_id": f"req_{custom_id}",
+            "body": {
+                "id": f"chatcmpl_{custom_id}",
+                "model": model,
+                "choices": [
+                    {
+                        "finish_reason": "stop",
+                        "message": {"role": "assistant", "content": "{\"ok\": true}"},
+                    }
+                ],
+                "usage": {
+                    "prompt_tokens": 11,
+                    "completion_tokens": 7,
+                    "total_tokens": 18,
+                },
+            },
+        },
+        "error": None,
+    }
+
+
+def _error_row(custom_id: str, secret: str) -> dict[str, Any]:
+    return {
+        "custom_id": custom_id,
+        "response": {"status_code": 400},
+        "error": {
+            "type": "invalid_request_error",
+            "code": "bad_request",
+            "message": f"provider rejected Authorization: Bearer {secret}",
+        },
+    }
+
+
+def test_batch_static_output_jsonl_preserves_custom_id_and_response_metadata() -> None:
+    module = _load_batch_clients_module()
+    raw_text = "\n".join(
+        json.dumps(row, sort_keys=True)
+        for row in [_output_row("A_P0001"), _output_row("A_P0002", model="gpt-5-mini")]
+    )
+
+    report = module.parse_openai_compatible_batch_output_jsonl(raw_text)
+
+    assert report["artifact_class"] == "provider_output_jsonl_fixture"
+    assert report["parse_status"] == "parsed"
+    assert report["custom_ids"] == ["A_P0001", "A_P0002"]
+    row = report["rows"][0]
+    assert row["custom_id"] == "A_P0001"
+    assert row["response_status_code"] == 200
+    assert row["response_body_present"] is True
+    assert row["response_id_if_present"] == "chatcmpl_A_P0001"
+    assert row["returned_model_id_if_present"] == "gpt-5-nano"
+    assert row["finish_reason_if_present"] == "stop"
+    assert row["usage_if_present"]["total_tokens"] == 18
+    assert row["parse_status"] == "parsed"
+    assert "NOT_LIVE_VALIDATED" in report["markers"]
+
+
+def test_batch_static_error_jsonl_preserves_custom_id_and_redacts_error_metadata() -> None:
+    module = _load_batch_clients_module()
+    secret = "sk-proj-" + ("A" * 32)
+    raw_text = json.dumps(_error_row("A_P0002", secret), sort_keys=True)
+
+    report = module.parse_openai_compatible_batch_error_jsonl(raw_text)
+
+    assert report["artifact_class"] == "provider_error_jsonl_fixture"
+    assert report["custom_ids"] == ["A_P0002"]
+    row = report["rows"][0]
+    assert row["custom_id"] == "A_P0002"
+    assert row["error_type"] == "invalid_request_error"
+    assert row["error_code"] == "bad_request"
+    assert row["status_code_if_present"] == 400
+    assert row["failure_type"] == "provider_error"
+    assert row["redaction_status"] == "redacted"
+    assert secret not in json.dumps(report, sort_keys=True)
+    assert "[REDACTED]" in row["error_message_redacted"]
+
+
+def test_batch_static_missing_rows_are_hard_failures_and_partial_is_distinct() -> None:
+    module = _load_batch_clients_module()
+    output_report = module.parse_openai_compatible_batch_output_jsonl(
+        json.dumps(_output_row("A_P0001"), sort_keys=True)
+    )
+    error_report = module.parse_openai_compatible_batch_error_jsonl(
+        json.dumps(_error_row("A_P0002", "sk-proj-" + ("B" * 32)), sort_keys=True)
+    )
+
+    partial = module.build_openai_compatible_batch_static_proof(
+        request_custom_ids=["A_P0001", "A_P0002", "A_P0003"],
+        output_rows=output_report["rows"],
+        error_rows=error_report["rows"],
+        batch_info={
+            "id": "batch_fixture",
+            "status": "completed",
+            "output_file_id": "file-output-1",
+            "error_file_id": "file-error-1",
+        },
+        provider="xai",
+        requested_provider="xai",
+        requested_model_id="grok-code-fast-1",
+    )
+    full = module.build_openai_compatible_batch_static_proof(
+        request_custom_ids=["A_P0001"],
+        output_rows=output_report["rows"],
+        error_rows=[],
+        batch_info={"id": "batch_fixture", "status": "completed"},
+        provider="openai",
+        requested_provider="openai",
+        requested_model_id="gpt-5-nano",
+    )
+
+    assert partial["request_count"] == 3
+    assert partial["result_count"] == 1
+    assert partial["error_count"] == 1
+    assert partial["missing_row_count"] == 1
+    assert partial["missing_custom_ids"] == ["A_P0003"]
+    assert partial["missing_rows_are_hard_failure"] is True
+    assert partial["partial_failure"] is True
+    assert partial["full_success"] is False
+    assert partial["output_file_id"] == "file-output-1"
+    assert partial["error_file_id"] == "file-error-1"
+    assert partial["not_live_validated"] is True
+    assert full["partial_failure"] is False
+    assert full["full_success"] is True
+
+
+def test_batch_static_terminal_statuses_are_distinct_and_runner_treats_expired_terminal() -> None:
+    module = _load_batch_clients_module()
+    runner = _load_runner_module()
+
+    assert module.classify_batch_terminal_status("completed")["status_class"] == "success"
+    assert module.classify_batch_terminal_status("failed")["status_class"] == "failed"
+    assert module.classify_batch_terminal_status("expired")["status_class"] == "expired"
+    assert module.classify_batch_terminal_status("cancelled")["status_class"] == "cancelled"
+    assert module.classify_batch_terminal_status("timeout")["status_class"] == "timeout"
+    assert module.classify_batch_terminal_status("submitted")["terminal"] is False
+    assert runner._batch_terminal_state("expired") is True
+
+
+def test_batch_static_corrupt_jsonl_lines_are_counted_and_threshold_is_explicit() -> None:
+    module = _load_batch_clients_module()
+    valid_rows = [json.dumps(_output_row(f"A_P{i:04d}"), sort_keys=True) for i in range(20)]
+    under_threshold = module.parse_openai_compatible_batch_output_jsonl(
+        "\n".join([*valid_rows, "{not-json"])
+    )
+
+    assert under_threshold["parse_status"] == "parsed_with_discards"
+    assert under_threshold["valid_row_count"] == 20
+    assert under_threshold["discarded_line_count"] == 1
+    assert under_threshold["corruption_threshold_exceeded"] is False
+    assert under_threshold["discarded_lines"][0]["reason"] == "invalid_json"
+
+    try:
+        module.parse_openai_compatible_batch_output_jsonl(
+            "\n".join([json.dumps(_output_row("A_P0001"), sort_keys=True), "{not-json"]),
+            raise_on_corruption=True,
+        )
+    except RuntimeError as exc:
+        assert "BatchCorruptionError" in str(exc)
+        assert "1/2" in str(exc)
+    else:
+        raise AssertionError("Expected corrupt JSONL threshold to fail closed")
+
+
+def test_batch_static_request_metadata_excludes_raw_payload_text() -> None:
+    module = _load_batch_clients_module()
+    request = module.BatchRequest(
+        custom_id="A_P0001",
+        model_id="gpt-5-nano",
+        system_prompt="Return JSON. Authorization: Bearer sk-proj-" + ("C" * 32),
+        user_content="fixture body",
+        force_json_output=False,
+        metadata={
+            "phase": "A",
+            "step_id": "A1",
+            "partition_id": "A_P0001",
+            "structured_output_mode": "json_schema",
+        },
+        response_format={
+            "type": "json_schema",
+            "json_schema": {"strict": True, "schema": {"type": "object"}},
+        },
+    )
+    wire_row = {
+        "custom_id": "A_P0001",
+        "method": "POST",
+        "url": "/v1/chat/completions",
+        "body": {
+            "model": "gpt-5-nano",
+            "messages": [{"role": "system", "content": "[omitted]"}],
+            "response_format": request.response_format,
+        },
+    }
+
+    metadata = module.build_batch_request_static_metadata(
+        request,
+        module.BatchRoute("openai", "gpt-5-nano", "OPENAI_API_KEY"),
+        wire_row=wire_row,
+    )
+
+    assert metadata["custom_id"] == "A_P0001"
+    assert metadata["body.model"] == "gpt-5-nano"
+    assert metadata["body.messages_present_boolean"] is True
+    assert metadata["body.response_format_type_if_present"] == "json_schema"
+    assert metadata["provider"] == "openai"
+    assert metadata["requested_model_id"] == "gpt-5-nano"
+    assert metadata["structured_output_mode_if_present"] == "json_schema"
+    assert metadata["phase_if_encoded"] == "A"
+    assert metadata["step_id_if_encoded"] == "A1"
+    assert metadata["partition_id_if_encoded"] == "A_P0001"
+    assert metadata["payload_text_included"] is False
+    assert "sk-proj-" not in json.dumps(metadata, sort_keys=True)
+
+
+def test_batch_static_helpers_do_not_instantiate_provider_clients(monkeypatch) -> None:
+    module = _load_batch_clients_module()
+
+    def fail_provider_init(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("provider client construction must not be reached")
+
+    monkeypatch.setattr(module.OpenAIBatchClient, "__init__", fail_provider_init)
+    monkeypatch.setattr(module.XAIBatchClient, "__init__", fail_provider_init)
+
+    report = module.parse_openai_compatible_batch_output_jsonl(
+        json.dumps(_output_row("A_P0001"), sort_keys=True)
+    )
+    proof = module.build_openai_compatible_batch_static_proof(
+        request_custom_ids=["A_P0001"],
+        output_rows=report["rows"],
+        error_rows=[],
+        batch_info={"status": "completed"},
+        provider="xai",
+    )
+
+    assert proof["markers"] == list(module.BATCH_STATIC_PROOF_MARKERS)
+    assert proof["not_live_validated"] is True
+    assert proof["request_count"] == 1


### PR DESCRIPTION
@codex review
@gemini
@copilot

## Summary
- add static-only OpenAI-compatible/xAI batch proof helpers for request metadata, output/error JSONL parsing, custom_id correlation, terminal status classification, and missing-row/partial-failure proof
- preserve output/error file IDs and batch status class in retriever/watch metadata without enabling provider operations
- add RTE-PKT-08 proof artifacts under out/rte-pkt-08-xai-batch-static/

## Validation
- python -m py_compile services/repo-truth-extractor/lib/batch_clients.py services/repo-truth-extractor/lib/batch_retriever.py services/repo-truth-extractor/run_extraction_v5.py
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_rte_pkt_08_batch_static_proof.py
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests -k 'batch and static'\n- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest -q services/repo-truth-extractor/tests/test_rte_pkt_08_batch_static_proof.py services/repo-truth-extractor/tests/test_batch_clients_integration.py services/repo-truth-extractor/tests/test_batch_retriever.py services/repo-truth-extractor/tests/test_run_extraction_v5_batch_response_format.py services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py\n- python -m json.tool out/rte-pkt-08-xai-batch-static/RTE-PKT-08_MANIFEST.json >/dev/null\n- git diff --check && git diff --check origin/main...HEAD\n- pre-commit run --files $(git diff --name-only origin/main...HEAD)\n\n## Notes\nNo live extraction, provider call, batch submit, poll, retrieve, cancel, delete, or remote provider JSONL retrieval was run. Live xAI/OpenAI-compatible batch behavior remains LIVE_VALIDATION_REQUIRED.\n\nRelease notes: Static RTE batch proof now records fixture-validated metadata and live-unvalidated markers for OpenAI-compatible/xAI batch paths.