### PR TITLE
chore(rte): add RTE-PKT-09 live validation plan

### DIFF
--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_AUTHORIZATION_MODEL.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_AUTHORIZATION_MODEL.md
@@ -1,0 +1,104 @@
+# RTE-PKT-09 Authorization Model
+
+This model defines authorization for a future live validation run. It is not authorization to run one now.
+
+## Required Explicit Approval
+
+A future live validation packet must require operator language equivalent to:
+
+`I authorize bounded live provider validation for RTE under the accepted RTE-PKT-09 plan.`
+
+The future approval must also name:
+- providers and lanes
+- models or route patterns
+- spend cap
+- timeout cap
+- batch request cap
+- artifact root
+- whether cancellation is authorized
+- whether remote file deletion/cleanup is authorized
+
+## Non-Approval Examples
+
+These are not sufficient:
+- `continue`
+- `run the packet`
+- `review the source`
+- `generate proof`
+- credentials exist in environment
+- `DPMX_LIVE_OK` is set
+- dry-run commands
+- draft PR approval
+- acceptance of this planning packet alone
+
+## Relationship To DPMX_LIVE_OK
+
+`DPMX_LIVE_OK` is a runtime guard, not governance approval.
+
+Future live execution must require both:
+- explicit operator authorization in the conversation or future packet
+- runtime live guard satisfaction where the runtime requires it
+
+If either is absent, the future run must stop closed.
+
+## Credential Handling
+
+Allowed:
+- Boolean presence checks, if explicitly needed.
+- Environment variable names.
+- Redacted provider account status.
+- Redacted request IDs.
+
+Forbidden:
+- printing credential values
+- storing authorization headers
+- storing raw request payloads containing secrets
+- copying credentials into proof artifacts
+- treating credential presence as approval
+- writing unredacted downloaded provider files into permanent proof
+
+## Future Cap Requirements
+
+Spend:
+- Must be explicit before any provider contact.
+- Recommended first cap is USD 5.00 or lower.
+- Spend estimate is not billing truth.
+- Provider billing truth requires separately authorized provider-side evidence.
+
+Timeout:
+- Provider preflight: 60 seconds per lane.
+- Minimal sync response probe: 180 seconds per request.
+- Batch pilot: 30 minutes wall-clock maximum for first run.
+
+Batch:
+- 1 to 3 requests total for first pilot.
+- Synthetic non-sensitive content only.
+- No production repo payloads.
+- Polling cadence no faster than every 30 seconds unless future packet justifies otherwise.
+
+Cleanup:
+- Cancel only validation-created jobs.
+- Delete only validation-created files.
+- Remote deletion requires separate explicit authorization.
+
+## Operator Responsibilities For Future Live Run
+
+The operator must provide:
+- approval language
+- provider set
+- cap values
+- confirmation that credentials are intentionally available
+- cleanup/deletion decision
+- acceptance that live results may still be provider/account/region/model-version specific
+
+## Agent Responsibilities For Future Live Run
+
+The implementing agent must:
+- re-run static readiness checks first
+- avoid printing secrets
+- stop on any redaction hit
+- preserve raw failures in redacted form
+- avoid retries beyond the approved cap
+- mark every untested lane `NOT_TESTED`
+- mark every failed lane `LIVE_FAILED` or `LIVE_BLOCKED`
+- avoid upgrading provider billing, retention, or ZDR claims without direct evidence

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_BATCH_LIVE_PILOT_PLAN.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_BATCH_LIVE_PILOT_PLAN.md
@@ -1,0 +1,120 @@
+# RTE-PKT-09 Batch Live Pilot Plan
+
+This is a future pilot plan only. No batch submit, poll, retrieve, cancel, file download, or remote deletion is authorized by this packet.
+
+## Static Basis
+
+Observed:
+- `OpenAIBatchClient` writes a temporary JSONL request file, uploads it for provider batch, creates a batch job, polls by job ID, fetches output file content, parses JSONL rows, and cancels by job ID.
+- `XAIBatchClient` uses the OpenAI-compatible client with xAI base URL.
+- `OpenRouterBatchClient` explicitly rejects live batch submit.
+- `GeminiBatchClient` uses Gemini batch APIs with inlined requests and returns inline responses rather than OpenAI-compatible output/error JSONL.
+- `batch_retriever.py` writes OpenAI-compatible `*_output.jsonl` or `*_error.jsonl` files when provider file IDs exist.
+
+Unknown:
+- Whether xAI currently accepts the exact OpenAI-compatible batch payload.
+- xAI status values and terminal states.
+- xAI output/error JSONL row shape.
+- xAI remote file retention and deletion behavior.
+- Whether the `run_extraction_v5.py` CLI retrieval surface should expose xAI or whether retrieval must be tested through `batch_retriever.py`.
+
+## Future Pilot Inputs
+
+Use only synthetic, non-sensitive payloads.
+
+Request cap:
+- 1 to 3 total requests.
+
+Required request shape:
+- stable `custom_id`
+- requested provider
+- requested model
+- route kind
+- schema mode if structured output is tested
+- expected local validation rule
+
+Forbidden request shape:
+- real repo content
+- secrets
+- user private data
+- production promptsets unless separately authorized
+- raw credentials
+
+## Required Batch Evidence
+
+Future batch proof must include:
+- submit timestamp
+- provider
+- route kind
+- requested model
+- batch ID
+- input request count
+- custom_id map
+- polling timestamps
+- observed statuses in order
+- terminal status
+- output file ID if returned
+- error file ID if returned
+- downloaded output/error file path if authorized
+- SHA-256 for downloaded local files
+- row count reconciliation
+- missing custom IDs
+- duplicate custom IDs
+- provider error rows
+- local parse errors
+- cancellation result if cancellation was authorized
+- cleanup result if cleanup was authorized
+
+## Downloaded JSONL Handling
+
+Rules:
+- Store downloaded files only under the future isolated validation artifact root.
+- Hash every downloaded file.
+- Preserve full local files only if the future packet explicitly permits it and redaction scan passes.
+- Include only redacted excerpts in human-readable proof.
+- Parse each line as JSON.
+- Record invalid JSON lines as failures.
+- Record non-object lines as failures.
+- Reconcile every `custom_id`.
+- Treat missing rows as failure evidence, not as success.
+- Keep downloaded JSONL proof separate from production readiness claims.
+
+## Stop Conditions
+
+Stop before submit if:
+- explicit batch approval is missing
+- spend cap is missing
+- batch cap is missing
+- timeout cap is missing
+- provider is OpenRouter under current runtime
+- request payload includes non-synthetic data
+- credentials would be printed
+
+Stop during poll if:
+- timeout cap is reached
+- terminal failure is observed
+- status sequence is not recorded
+- cost cap is reached
+
+Stop during retrieve if:
+- output/error file ID is missing when expected
+- download would write outside the isolated artifact root
+- downloaded content contains credential-shaped material
+- row count mismatch is not preserved
+
+Stop during cleanup if:
+- cleanup/deletion was not separately authorized
+- target ID was not created by the validation run
+- provider cannot prove target identity
+
+## Future Exit States
+
+Allowed batch verdicts:
+- `NOT_TESTED`
+- `STATIC_ONLY`
+- `LIVE_BATCH_PILOT_VALIDATED`
+- `LIVE_FAILED`
+- `LIVE_BLOCKED`
+- `LIVE_VALIDATION_INCOMPLETE`
+
+This packet leaves batch at `STATIC_ONLY` plus `LIVE_VALIDATION_REQUIRED`.

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_DIFF_SUMMARY.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_DIFF_SUMMARY.md
@@ -1,0 +1,29 @@
+# RTE-PKT-09 Diff Summary
+
+Generated only plan/proof artifacts under:
+
+`out/rte-pkt-09-live-validation-plan/`
+
+Expected files:
+- `RTE-PKT-09_MANIFEST.json`
+- `RTE-PKT-09_LIVE_VALIDATION_PLAN.md`
+- `RTE-PKT-09_AUTHORIZATION_MODEL.md`
+- `RTE-PKT-09_PROVIDER_LANE_MATRIX.md`
+- `RTE-PKT-09_BATCH_LIVE_PILOT_PLAN.md`
+- `RTE-PKT-09_RETENTION_ZDR_EVIDENCE_PLAN.md`
+- `RTE-PKT-09_PROOF_ARTIFACT_SCHEMA.md`
+- `RTE-PKT-09_STOP_CONDITIONS.md`
+- `RTE-PKT-09_NO_PROVIDER_CALLS_ATTESTATION.md`
+- `RTE-PKT-09_REMAINING_UNKNOWNS.md`
+- `RTE-PKT-09_DIFF_SUMMARY.md`
+
+No runtime source, tests, promptsets, model maps, structured-output schemas, config, compose, or docs files are expected to change.
+
+Validation observed:
+- `python -m json.tool out/rte-pkt-09-live-validation-plan/RTE-PKT-09_MANIFEST.json >/dev/null`: PASS, exit code 0.
+- `git diff --check`: PASS, exit code 0.
+- Generated-artifact secret-shaped scan: PASS, exit code 0.
+- `pre-commit run --files <generated packet files>`: PASS, exit code 0.
+- `git status --short --branch`: PASS, only `out/rte-pkt-09-live-validation-plan/` was untracked before final staging/commit decision.
+
+No provider calls, live extraction, batch operations, remote file operations, credential inspection, or external research occurred.

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_LIVE_VALIDATION_PLAN.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_LIVE_VALIDATION_PLAN.md
@@ -1,0 +1,266 @@
+# RTE-PKT-09 Live Validation Plan
+
+This artifact is plan-only. It does not authorize or execute live provider validation.
+
+## Current Packet Boundary
+
+Observed:
+- Repo root is `/Users/hue/.codex/worktrees/227d/dopemux-mvp`.
+- Branch is `codex/rte-pkt-09-live-validation-plan`.
+- Current HEAD before artifact generation is `0179b17b03cf46518aa324bd8f50c805b627631d`.
+- Required repo markers for RTE planning are present.
+- Local `out/` proof outputs exist for RTE-PKT-01, 02, 03, 04, 05, 06, and 15.
+- Local `out/` proof outputs for RTE-PKT-07 and RTE-PKT-08 are missing in this checkout.
+
+Inferred:
+- The active packet treats RTE-PKT-07 and RTE-PKT-08 as accepted. This plan preserves that as a packet claim, not as locally revalidated proof.
+
+Unknown:
+- Direct xAI live response shape.
+- OpenRouter `x-ai/...` live equivalence.
+- OpenAI-compatible edge response behavior across every configured provider lane.
+- Gemini-compatible refusal, incomplete, and safety-field behavior.
+- xAI/OpenAI-compatible downloaded batch output/error JSONL shape.
+- ZDR, retention, billing, and account-level live truth.
+
+## Static Runtime Trace Used
+
+Observed from static source inspection:
+- `run_extraction_v5.py` exposes provider routing ladders that include OpenAI, Gemini, xAI, and OpenRouter routes.
+- `run_extraction_v5.py` live execution requires `--execute` and checks `DPMX_LIVE_OK` before live operation paths.
+- `llm_runtime.py` sanitizes system and user content before provider-bound payload construction.
+- `llm_runtime.py` records provider, requested model, endpoint, transport, status, response summary, retry trace, and structured-output metadata on sync attempts.
+- `batch_clients.py` implements OpenAI-compatible batch behavior and derives `XAIBatchClient` from it.
+- `batch_clients.py` explicitly blocks OpenRouter batch submit.
+- `batch_retriever.py` supports OpenAI-compatible retrieval for `openai` and `xai`, plus Gemini retrieval helpers.
+- `run_extraction_v5.py` CLI `--retrieve-provider` currently exposes `openai` and `gemini` choices only, so future xAI retrieval must not be assumed reachable through that CLI path without rechecking.
+
+## Approval Gate
+
+Future live validation must not start unless all are true:
+- Operator explicitly authorizes bounded live validation in a separate instruction.
+- The approval is equivalent to: `I authorize bounded live provider validation for RTE under the accepted RTE-PKT-09 plan.`
+- RTE-PKT-09 is accepted.
+- A dedicated clean worktree is verified.
+- The future packet defines the exact providers, models, phases, spend cap, timeout cap, batch cap, artifact root, and cleanup authority.
+- Provider credentials are supplied outside proof artifacts.
+- Credentials are not printed, copied, committed, or summarized beyond boolean presence.
+- Static safety proofs remain accepted or are rechecked.
+
+Must not count as approval:
+- Generic continuation language.
+- Credentials existing in the environment.
+- `DPMX_LIVE_OK` alone.
+- A dry-run command.
+- A draft PR approval.
+- A request to review or generate planning artifacts.
+
+## Default Future Caps
+
+Recommended hard caps for any first live execution packet:
+- Provider lanes: only explicitly named lanes.
+- Sync prompts: synthetic, non-sensitive, one request per provider/model/route combination.
+- Sync timeout: 60 seconds for preflight, 180 seconds per minimal response probe.
+- Total wall-clock timeout: 30 minutes unless separately justified.
+- Batch size: 1 to 3 requests total.
+- Batch poll interval: at least 30 seconds.
+- Batch wait timeout: no more than 30 minutes for first pilot.
+- Spend cap: operator-set explicit cap, with a recommended first cap of USD 5.00 or lower.
+- Batch cancellation: authorized only for validation-created job IDs.
+- Remote file cleanup/deletion: separate explicit approval required.
+
+Spend estimates are not billing truth. Billing truth requires provider-side evidence that is separately authorized and redacted.
+
+## Future Phases
+
+### LV-00 Static Readiness Recheck
+
+Live calls: no.
+
+Purpose:
+- Reconfirm clean worktree, branch, HEAD, remotes, markers, packet acceptance, redaction gates, live gate, metadata handling, and batch static proof.
+
+Required artifacts:
+- `static_readiness_report`
+- `accepted_packet_versions`
+- `git_sha`
+- `dirty_state_report`
+- `provider_credentials_presence_boolean_only`
+- `redaction_sanity_report`
+- `no_live_call_preflight_attestation`
+
+Stop if:
+- Worktree is dirty before the run.
+- Required packet proof is missing or not accepted.
+- Explicit live authorization is absent.
+- Spend, timeout, or batch caps are absent.
+- Any credential value would be exposed.
+- Static recheck finds drift in live gate or redaction behavior.
+
+### LV-01 Provider Preflight Only
+
+Live calls: yes, only after explicit approval.
+
+Purpose:
+- Validate minimal auth/model availability/rate-limit surface for explicitly named providers.
+
+Providers:
+- `direct_xai`
+- `openrouter`
+- `openai_compatible`
+- `gemini_if_in_scope`
+
+Required artifacts:
+- `LIVE_PROVIDER_PREFLIGHT.json`
+- redacted auth status
+- redacted model availability
+- rate-limit or quota status if available
+- not-billing-truth marker
+- retention/ZDR unknown-or-observed marker
+
+Stop if:
+- Auth fails.
+- The route or upstream provider differs from the requested lane.
+- Any response lacks minimum metadata.
+- Output contains credential-shaped material.
+- Cost or quota risk exceeds cap.
+
+### LV-02 Minimal Sync Response Metadata Probe
+
+Live calls: yes, only after LV-01 passes for the lane.
+
+Purpose:
+- Validate returned/effective model, finish reason, response ID, usage, refusal, incomplete, and route metadata for minimal non-sensitive payloads.
+
+Providers:
+- direct xAI
+- OpenRouter `x-ai/...`
+- OpenAI-compatible
+- Gemini-compatible if in scope
+
+Required artifacts:
+- `LIVE_RESPONSE_METADATA_MATRIX.json`
+- redacted request metadata
+- redacted response summary
+- requested vs returned model
+- finish reason
+- usage
+- refusal or null marker
+- incomplete or null marker
+- route kind
+- live validation marker
+
+Stop if:
+- Returned route/proxy class is unexpected.
+- Required response metadata is missing.
+- Response content includes unsafe or unredacted data.
+- Cost or timeout exceeds cap.
+
+### LV-03 Structured Output Probe
+
+Live calls: yes, only after LV-02 passes for the lane.
+
+Purpose:
+- Validate JSON object/schema behavior using minimal schemas only.
+
+Providers:
+- direct xAI
+- OpenRouter `x-ai/...`
+- OpenAI-compatible
+- Gemini-compatible only if future packet explicitly includes it.
+
+Required artifacts:
+- `LIVE_STRUCTURED_OUTPUT_RESULTS.json`
+- structured output mode
+- response format type
+- schema name and hash
+- schema acceptance result
+- local schema validation result
+- provider failure/success
+- no silent downgrade marker
+
+Stop if:
+- Schema mode silently downgrades.
+- Provider rejects an expected exact schema and the failure is not preserved.
+- Local validation fails without preserving the failure.
+- Any raw payload or credential-shaped material is emitted.
+
+### LV-04 Minimal Batch Pilot
+
+Live calls: yes, only after explicit batch approval.
+
+Purpose:
+- Validate submit, poll, retrieve, cancel, output/error JSONL inventory, and custom_id reconciliation with a tiny synthetic batch.
+
+Providers:
+- xAI if the future provider contract explicitly supports it.
+- OpenAI-compatible if in scope.
+- Gemini if in scope and artifact schema accounts for JSON rather than OpenAI-compatible JSONL.
+- OpenRouter is not eligible for batch submit unless runtime support changes in a future packet.
+
+Required artifacts:
+- `LIVE_BATCH_PILOT_INDEX.json`
+- submit metadata
+- batch ID
+- custom_id map
+- redacted status watch log
+- output file ID if success
+- error file ID if failure
+- downloaded output JSONL if available and authorized
+- downloaded error JSONL if available and authorized
+- row count reconciliation
+- missing row count
+- terminal status marker
+- partial failure marker
+- cleanup/cancel result if authorized
+
+Stop if:
+- Batch provider is not explicitly authorized.
+- Provider route or remote file lifecycle is unexpected.
+- Downloaded JSONL contains credential-shaped material.
+- Row count mismatch is not preserved as failure.
+- Polling exceeds timeout.
+- Cost exceeds cap.
+
+### LV-05 Remote File Lifecycle / Retention Evidence
+
+Live calls: yes, only after separate cleanup/retention approval.
+
+Purpose:
+- Collect redacted evidence about validation-created remote files, retention support, cleanup/deletion support, and ZDR/retention claims where provider exposes them.
+
+Required artifacts:
+- `LIVE_RETENTION_ZDR_EVIDENCE.md`
+- retention claim source
+- ZDR header or account setting if available
+- validation-created file inventory
+- cleanup attempt and result if authorized
+- retention unknown marker when not observed
+
+Stop if:
+- Cleanup/deletion check is not explicitly authorized.
+- Cleanup could affect non-validation files.
+- Provider does not expose evidence.
+- Evidence would expose account identifiers or secrets.
+
+### LV-06 Final Live Validation Synthesis
+
+Live calls: no.
+
+Purpose:
+- Distinguish what is proven live, what is static-only, and what remains unknown.
+
+Required artifacts:
+- `LIVE_VALIDATION_SUMMARY.md`
+- provider lane verdicts
+- batch lane verdict
+- retention/ZDR verdict
+- spend estimate, explicitly not billing truth
+- remaining unknowns
+- rollback/cleanup status
+
+## Exit State For This Packet
+
+This packet can only move the series to planned-live-validation readiness. It must not move RTE beyond `READY_FOR_LIMITED_DRY_STATIC_USE`.
+
+All provider and batch live behaviors remain `LIVE_VALIDATION_REQUIRED` until a future explicitly approved live execution packet collects evidence.

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_MANIFEST.json
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_MANIFEST.json
@@ -1,0 +1,151 @@
+{
+  "packet_id": "RTE-PKT-09-LIVE-VALIDATION-PLAN",
+  "packet_version": "1.0.0",
+  "generated_at_utc": "2026-05-15T15:53:11Z",
+  "status": "READY_FOR_REVIEW",
+  "classification": {
+    "packet_kind": "live_validation_plan_only",
+    "runtime_code_changes_allowed": false,
+    "test_code_changes_allowed": false,
+    "live_validation_allowed": false,
+    "provider_calls_allowed": false,
+    "batch_provider_operations_allowed": false,
+    "remote_file_operations_allowed": false
+  },
+  "repo": {
+    "name": "dopemux-mvp",
+    "worktree": "/Users/hue/.codex/worktrees/227d/dopemux-mvp",
+    "primary_checkout_observed": "/Users/hue/code/dopemux-mvp",
+    "branch": "codex/rte-pkt-09-live-validation-plan",
+    "base_branch_observed": "origin/main",
+    "before_sha": "0179b17b03cf46518aa324bd8f50c805b627631d",
+    "after_commit_sha": "REPORTED_IN_FINAL_RESPONSE_AFTER_COMMIT",
+    "remote": "origin and mvp point to https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "marker_check": {
+      "pyproject.toml": "PRESENT",
+      "src/dopemux/cli.py": "PRESENT",
+      "services/repo-truth-extractor/run_extraction_v5.py": "PRESENT",
+      "services/repo-truth-extractor/llm_runtime.py": "PRESENT",
+      "services/repo-truth-extractor/lib/batch_clients.py": "PRESENT",
+      "services/repo-truth-extractor/lib/batch_retriever.py": "PRESENT",
+      "services/repo-truth-extractor/tests": "PRESENT"
+    },
+    "initial_dirty_state": "clean before artifact generation",
+    "task_packet_creation": "SKIPPED_BY_ACTIVE_PACKET_SCOPE",
+    "task_packet_creation_conflict": "AGENTS.md default asks for a new Task Packet before implementation, but the active packet explicitly forbids additional Task Packets and allows only out/rte-pkt-09-live-validation-plan/."
+  },
+  "authority_used": [
+    "active operator packet RTE-PKT-09-LIVE-VALIDATION-PLAN",
+    "AGENTS.md",
+    "docs/governance/proof-contract.md",
+    "docs/governance/proof-directory-rules.md",
+    "docs/governance/retention-and-redaction-rules.md",
+    "docs/governance/chain-of-custody-rules.md",
+    "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/llm_runtime.py",
+    "services/repo-truth-extractor/lib/batch_clients.py",
+    "services/repo-truth-extractor/lib/batch_retriever.py",
+    "out/rte-pkt-01-live-gate/",
+    "out/rte-pkt-02-payload-redaction/",
+    "out/rte-pkt-03-prescan-stale/",
+    "out/rte-pkt-04-prescan-influence/",
+    "out/rte-pkt-05-provenance-fields/",
+    "out/rte-pkt-06-truth-labels/",
+    "out/rte-pkt-15-failed-sidecars/"
+  ],
+  "authority_gaps": [
+    {
+      "item": "RTE-PKT-07 local proof outputs",
+      "status": "MISSING_IN_CURRENT_CHECKOUT",
+      "impact": "Provider metadata acceptance is treated as CLAIMED by the active packet, not locally re-proven here."
+    },
+    {
+      "item": "RTE-PKT-08 local proof outputs",
+      "status": "MISSING_IN_CURRENT_CHECKOUT",
+      "impact": "Batch static acceptance is treated as CLAIMED by the active packet, not locally re-proven here."
+    }
+  ],
+  "static_trace_summary": {
+    "live_gate": "run_extraction_v5.py requires --execute plus DPMX_LIVE_OK for live operation paths.",
+    "provider_metadata": "llm_runtime.py records provider/model/status/transport/response summary metadata on sync provider attempts.",
+    "sync_payload_safety": "llm_runtime.py sanitizes system and user content before provider payload construction.",
+    "batch_submit_poll_cancel": "batch_clients.py implements OpenAI-compatible, xAI, and Gemini batch clients; OpenRouter batch submit is explicitly unsupported.",
+    "batch_retrieve": "batch_retriever.py supports openai, xai, and gemini helper retrieval, while run_extraction_v5.py CLI retrieve-provider currently exposes openai and gemini only.",
+    "downloaded_jsonl": "batch_retriever.py writes OpenAI-compatible completed output as *_output.jsonl and terminal error output as *_error.jsonl when file IDs are present."
+  },
+  "proof_outputs": [
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_MANIFEST.json",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_LIVE_VALIDATION_PLAN.md",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_AUTHORIZATION_MODEL.md",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_PROVIDER_LANE_MATRIX.md",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_BATCH_LIVE_PILOT_PLAN.md",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_RETENTION_ZDR_EVIDENCE_PLAN.md",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_PROOF_ARTIFACT_SCHEMA.md",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_STOP_CONDITIONS.md",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_REMAINING_UNKNOWNS.md",
+    "out/rte-pkt-09-live-validation-plan/RTE-PKT-09_DIFF_SUMMARY.md"
+  ],
+  "validation_status": {
+    "provider_calls_performed": false,
+    "live_extraction_performed": false,
+    "batch_provider_operations_performed": false,
+    "remote_file_operations_performed": false,
+    "provider_credentials_required": false,
+    "provider_credentials_inspected": false,
+    "external_research_performed": false,
+    "manifest_json_valid": "PASS",
+    "git_diff_check": "PASS",
+    "secret_scan": "PASS",
+    "pre_commit": "PASS",
+    "git_status_review": "PASS"
+  },
+  "validation_commands_observed": [
+    {
+      "command": "python -m json.tool out/rte-pkt-09-live-validation-plan/RTE-PKT-09_MANIFEST.json >/dev/null",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "python -c '<local secret-shaped scan over generated out/rte-pkt-09-live-validation-plan files>'",
+      "exit_code": 0,
+      "result": "PASS",
+      "observed": "secret scan passed: no configured secret-shaped patterns found"
+    },
+    {
+      "command": "pre-commit run --files <generated packet files>",
+      "exit_code": 0,
+      "result": "PASS",
+      "observed": "hooks passed or skipped according to configured file filters"
+    },
+    {
+      "command": "git status --short --branch",
+      "exit_code": 0,
+      "result": "PASS",
+      "observed": "only out/rte-pkt-09-live-validation-plan/ is untracked before final staging/commit decision"
+    }
+  ],
+  "chain_of_custody": {
+    "documented": true,
+    "source_basis": "active RTE-PKT-09 operator packet plus observed repo authority files and runtime source",
+    "parent_bundle_refs": [
+      "RTE-PKT-00-SOURCE-CLOSURE:CLAIMED_BY_ACTIVE_PACKET_NOT_LOCAL",
+      "RTE-PKT-01-LIVE-GATE:LOCAL_OUT_PRESENT",
+      "RTE-PKT-02-PAYLOAD-REDACTION:LOCAL_OUT_PRESENT",
+      "RTE-PKT-15-FAILED-SIDECARS:LOCAL_OUT_PRESENT",
+      "RTE-PKT-03-PRESCAN-STALE:LOCAL_OUT_PRESENT",
+      "RTE-PKT-04-PRESCAN-INFLUENCE:LOCAL_OUT_PRESENT",
+      "RTE-PKT-05-PROVENANCE-FIELDS:LOCAL_OUT_PRESENT",
+      "RTE-PKT-06-TRUTH-LABELS:LOCAL_OUT_PRESENT",
+      "RTE-PKT-07-XAI-METADATA:CLAIMED_BY_ACTIVE_PACKET_NOT_LOCAL",
+      "RTE-PKT-08-XAI-BATCH-STATIC:CLAIMED_BY_ACTIVE_PACKET_NOT_LOCAL"
+    ],
+    "review_order_hint": 9
+  }
+}

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,29 @@
+# RTE-PKT-09 No Provider Calls Attestation
+
+No live provider calls were performed for this packet.
+
+No live extraction was run.
+
+No xAI, OpenAI, OpenRouter, Gemini, Anthropic, or other provider request was sent.
+
+No provider preflight was run.
+
+No provider batch job was submitted, polled, retrieved, canceled, or deleted.
+
+No remote provider file was retrieved or deleted.
+
+No provider credentials were required or inspected.
+
+No external research was performed.
+
+Evidence:
+- Work was limited to local repo inspection, static source tracing, `git` commands, and generating planning/proof files under `out/rte-pkt-09-live-validation-plan/`.
+- The inspected source files were local files only.
+- The generated plan preserves every live provider and batch behavior as `LIVE_VALIDATION_REQUIRED` until a future explicitly approved live execution packet collects evidence.
+
+Explicit non-actions:
+- No runtime source was changed.
+- No tests were changed.
+- No promptsets or model maps were changed.
+- No structured-output schema was changed.
+- No config, compose, or docs files were changed.

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_PROOF_ARTIFACT_SCHEMA.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_PROOF_ARTIFACT_SCHEMA.md
@@ -1,0 +1,172 @@
+# RTE-PKT-09 Future Proof Artifact Schema
+
+This schema defines required artifact families for a future live validation run. It is not an implementation schema for current runtime code.
+
+## Required Future Artifacts
+
+`LIVE_VALIDATION_MANIFEST.json`
+- packet ID
+- run ID
+- repo root
+- branch
+- git SHA
+- clean status before run
+- operator authorization reference
+- providers authorized
+- models authorized
+- spend cap
+- timeout cap
+- batch cap
+- artifact root
+- validation commands
+- no-secret scan result
+- cleanup status
+
+`LIVE_PROVIDER_PREFLIGHT.json`
+- provider
+- route kind
+- requested model
+- auth status
+- model availability status
+- rate/quota status if available
+- account identifiers redacted
+- retention/ZDR observed/unknown marker
+- not billing truth marker
+
+`LIVE_RESPONSE_METADATA_MATRIX.json`
+- provider
+- route kind
+- transport
+- requested model
+- returned model
+- effective model
+- response ID
+- status code
+- finish reason
+- usage
+- refusal field or null marker
+- incomplete field or null marker
+- provider error reason
+- redacted request metadata reference
+- redacted response summary reference
+
+`LIVE_STRUCTURED_OUTPUT_RESULTS.json`
+- provider
+- route kind
+- requested model
+- response format type
+- schema name
+- schema hash
+- schema acceptance result
+- local schema validation result
+- provider failure or success
+- no silent downgrade marker
+
+`LIVE_BATCH_PILOT_INDEX.json`
+- provider
+- route kind
+- requested model
+- batch ID
+- request count
+- custom_id map
+- poll status log reference
+- terminal status
+- output file ID if present
+- error file ID if present
+- downloaded file hashes
+- row count reconciliation
+- missing rows
+- duplicate rows
+- partial failure marker
+- cancel/cleanup status
+
+`LIVE_BATCH_OUTPUT_ERROR_INVENTORY.md`
+- file inventory
+- hashes
+- line counts
+- parsed row counts
+- invalid row counts
+- output row shape summary
+- error row shape summary
+- redacted excerpts only
+- reconciliation result
+
+`LIVE_RETENTION_ZDR_EVIDENCE.md`
+- provider
+- account scope redacted
+- evidence source
+- evidence timestamp
+- ZDR verdict
+- retention verdict
+- remote file lifecycle verdict
+- cleanup/deletion result
+- unknowns
+
+`LIVE_SPEND_ESTIMATE.md`
+- cap
+- estimated spend
+- provider-reported usage if available
+- explicit not-billing-truth statement
+- billing truth evidence status
+
+`LIVE_REDACTION_SCAN_REPORT.md`
+- scanned artifact root
+- scanner command
+- patterns classed by risk
+- hits
+- dispositions
+- blocking status
+
+`LIVE_VALIDATION_SUMMARY.md`
+- lane verdicts
+- findings disposition
+- evidence references
+- failures
+- remaining unknowns
+- next-step recommendation
+
+`LIVE_NO_SECRET_ATTESTATION.md`
+- credentials not printed
+- headers not stored
+- raw payloads not committed
+- downloaded files scanned
+- any redactions performed
+
+`LIVE_ROLLBACK_CLEANUP_REPORT.md`
+- local artifact rollback path
+- remote validation-created jobs
+- remote validation-created files
+- cancel attempts
+- deletion attempts if authorized
+- remaining remote resources
+- manual operator action required
+
+## Serialization Rules
+
+JSON artifacts:
+- UTF-8
+- stable top-level key order where practical
+- explicit nulls for unavailable live fields
+- no implicit success defaults
+- evidence references must point to local artifact paths
+
+Markdown artifacts:
+- concise
+- evidence-labeled
+- no unredacted secrets
+- no raw provider payload dumps
+- no billing truth overclaim
+
+## Required Evidence Labels
+
+Use only:
+- `OBSERVED`
+- `INFERRED`
+- `CLAIMED`
+- `UNKNOWN`
+- `CONFLICTING`
+- `RECOMMENDED`
+- `LIVE_VALIDATION_REQUIRED`
+- `MISSING`
+- `BLOCKING`
+- `ACCEPTED_WITH_RISK`

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_PROVIDER_LANE_MATRIX.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_PROVIDER_LANE_MATRIX.md
@@ -1,0 +1,46 @@
+# RTE-PKT-09 Provider Lane Matrix
+
+Allowed verdicts:
+- `NOT_TESTED`
+- `STATIC_ONLY`
+- `LIVE_PREFLIGHT_ONLY`
+- `LIVE_SYNC_METADATA_VALIDATED`
+- `LIVE_SCHEMA_VALIDATED`
+- `LIVE_BATCH_PILOT_VALIDATED`
+- `LIVE_FAILED`
+- `LIVE_BLOCKED`
+- `LIVE_VALIDATION_INCOMPLETE`
+
+This packet sets every lane to `STATIC_ONLY` or `NOT_TESTED`. No live verdict is granted here.
+
+| Lane | Current Evidence | Future Evidence Required | Stop Conditions | Packet Verdict |
+| --- | --- | --- | --- | --- |
+| Direct xAI sync | Static routes exist in `run_extraction_v5.py`; xAI client path exists in `llm_runtime.py`. | Auth/model availability, response ID, returned model, usage, finish reason, refusal/incomplete fields, structured-output acceptance, redacted route metadata. | Auth failure, unexpected model, missing response metadata, unredacted output, cap exceeded. | `STATIC_ONLY` |
+| OpenRouter `x-ai/...` sync | OpenRouter route support exists, but current observed ladders do not prove an `x-ai/...` route. | Explicit route configuration or one-off future validation route, upstream/provider metadata, requested vs returned model, proxy behavior, refusal/incomplete fields. | Route not explicitly configured, upstream class unclear, OpenRouter response hides required metadata, cap exceeded. | `NOT_TESTED` |
+| OpenAI-compatible sync | OpenAI and OpenRouter OpenAI-compatible paths are statically present. | Minimal sync response metadata, response format behavior, local schema validation, no silent downgrade proof. | Missing metadata, schema downgrade, provider error not preserved, unredacted payload. | `STATIC_ONLY` |
+| Gemini native sync | Gemini native SDK path exists in `llm_runtime.py`. | Native response text extraction, safety/refusal/incomplete fields where available, usage availability, auth mode evidence. | Safety metadata absent when required, auth pivot ambiguity, unredacted output, cap exceeded. | `STATIC_ONLY` |
+| Gemini OpenAI-compatible sync | `llm_runtime.py` has Gemini OpenAI-compatible transport handling. | Endpoint family, auth mode, response format behavior, failure/metadata shape, no silent downgrade proof. | Auth mode ambiguity not recorded, query/header secret exposure risk, missing metadata. | `STATIC_ONLY` |
+| xAI/OpenAI-compatible batch submit/poll/cancel | `XAIBatchClient` derives from OpenAI-compatible batch client. | Submit metadata, batch ID, poll states, terminal status, cancel behavior for validation-created jobs, output/error file IDs. | Provider contract mismatch, timeout, row mismatch, unredacted downloaded content, cost cap exceeded. | `STATIC_ONLY` |
+| OpenAI batch submit/poll/cancel | `OpenAIBatchClient` implements submit, poll, fetch, cancel. | Same as xAI batch, with downloaded output/error JSONL inventory. | Same as xAI batch. | `STATIC_ONLY` |
+| OpenRouter batch | `OpenRouterBatchClient.submit` raises unsupported-provider error. | Future runtime change would be required before any live batch validation. | Any attempt to submit OpenRouter batch under current runtime. | `LIVE_BLOCKED` |
+| Batch retrieval for xAI | `batch_retriever.py` supports xAI helpers; `run_extraction_v5.py --retrieve-provider` currently exposes only openai/gemini. | Future packet must choose supported helper path and prove CLI/runtime entrypoint alignment before xAI retrieval. | CLI path cannot address xAI retrieval, remote file IDs absent, output/error JSONL shape unparsed. | `NOT_TESTED` |
+| Retention/ZDR | No local live evidence. | Provider docs/account headers/settings or API evidence, redacted and scoped to validation-created artifacts. | Provider evidence unavailable, account ID exposure risk, claims based only on assumptions. | `NOT_TESTED` |
+| Billing/spend truth | Runtime cap support is static; provider billing evidence absent. | Provider-side usage or billing evidence, separately authorized and redacted. | Estimate is treated as billing truth, invoice/account evidence would expose secrets. | `NOT_TESTED` |
+
+## Required Preserved Fields
+
+Future lane verdict rows must preserve:
+- provider
+- route kind
+- requested model
+- returned/effective model
+- auth status
+- metadata status
+- schema status
+- batch status
+- retention status
+- ZDR status
+- spend status
+- evidence references
+
+Missing values must be `UNKNOWN`, `NOT_TESTED`, or `MISSING`; they must not be coerced to success.

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_REMAINING_UNKNOWNS.md
@@ -1,0 +1,46 @@
+# RTE-PKT-09 Remaining Unknowns
+
+These items remain `LIVE_VALIDATION_REQUIRED` after this plan-only packet.
+
+## Provider Lanes
+
+- Direct xAI model availability.
+- Direct xAI returned/effective model shape.
+- Direct xAI refusal and incomplete-state shape.
+- Direct xAI usage and finish-reason shape.
+- Direct xAI structured-output acceptance.
+- OpenRouter `x-ai/...` route configuration and upstream equivalence.
+- OpenRouter `x-ai/...` returned/effective model and proxy metadata.
+- OpenAI-compatible provider edge fields across all configured routes.
+- Gemini native refusal, incomplete, safety, and usage fields.
+- Gemini OpenAI-compatible auth mode and structured-output behavior.
+
+## Batch Lanes
+
+- xAI batch submit acceptance.
+- xAI batch status values.
+- xAI batch polling terminal states.
+- xAI batch cancel behavior.
+- xAI downloaded output JSONL shape.
+- xAI downloaded error JSONL shape.
+- OpenAI-compatible output/error JSONL row reconciliation under live provider responses.
+- Gemini batch output/error artifact shape under live provider responses.
+- Remote file lifecycle for validation-created batch files.
+- Remote deletion/cleanup support.
+- xAI retrieval entrypoint alignment, because `batch_retriever.py` has xAI helpers while `run_extraction_v5.py --retrieve-provider` currently exposes only openai/gemini.
+
+## Governance And Safety
+
+- RTE-PKT-07 proof outputs are not present in this checkout's `out/` tree.
+- RTE-PKT-08 proof outputs are not present in this checkout's `out/` tree.
+- Provider billing truth.
+- Provider ZDR truth.
+- Provider retention truth.
+- Provider account-level rate limits or quotas.
+- Whether future downloaded artifacts can be retained after redaction.
+
+## Readiness Statement
+
+This packet does not move RTE beyond `READY_FOR_LIMITED_DRY_STATIC_USE`.
+
+After acceptance, a future explicitly authorized live-validation execution packet may be proposed. Until then, provider and batch behavior must not be described as live validated.

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_RETENTION_ZDR_EVIDENCE_PLAN.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_RETENTION_ZDR_EVIDENCE_PLAN.md
@@ -1,0 +1,78 @@
+# RTE-PKT-09 Retention And ZDR Evidence Plan
+
+This is a future evidence plan only. It does not assert provider retention, ZDR, storage, or deletion truth.
+
+## Evidence Classes
+
+Acceptable future evidence:
+- provider account setting observed through an authorized redacted API or console export
+- response header or API field that directly states retention/ZDR behavior
+- provider documentation captured with date and source, clearly marked as provider-claimed
+- remote file lifecycle evidence for validation-created artifacts
+- cleanup/delete result for validation-created files, if separately authorized
+
+Insufficient evidence:
+- SDK defaults
+- blog posts without account-specific applicability
+- environment variable names
+- credentials being present
+- static code support for a provider
+- local estimates
+- assumptions from OpenAI-compatible API shape
+
+## Redaction Requirements
+
+Must redact:
+- account IDs unless operator separately authorizes their inclusion
+- organization IDs
+- project IDs
+- request headers
+- credential values
+- raw provider payloads
+- billing identifiers
+- file content unless synthetic and explicitly allowed
+
+Allowed:
+- boolean setting presence
+- redacted setting names
+- provider name
+- validation-created file IDs in redacted or hashed form when needed for cleanup proof
+- response header names without values unless value is non-sensitive and relevant
+
+## Future Retention/ZDR Artifact
+
+`LIVE_RETENTION_ZDR_EVIDENCE.md` must include:
+- provider
+- account scope, redacted
+- evidence source
+- evidence timestamp
+- whether evidence is observed, claimed, inferred, missing, or conflicting
+- ZDR status
+- retention status
+- remote file lifecycle status
+- cleanup/deletion authorization status
+- cleanup/deletion result
+- residual unknowns
+
+## Stop Conditions
+
+Stop if:
+- provider evidence would expose secrets
+- account identifiers cannot be redacted
+- cleanup target was not created by the validation run
+- cleanup/deletion was not explicitly authorized
+- evidence is only inferred but would be reported as observed
+- provider documentation conflicts with observed account/API behavior
+
+## Verdict Rules
+
+Allowed verdicts:
+- `NOT_TESTED`
+- `CLAIMED_BY_PROVIDER_DOCS_ONLY`
+- `OBSERVED_ACCOUNT_SETTING_REDACTED`
+- `OBSERVED_RESPONSE_HEADER_REDACTED`
+- `OBSERVED_REMOTE_FILE_LIFECYCLE`
+- `UNKNOWN`
+- `CONFLICTING`
+
+ZDR and retention must remain `UNKNOWN` unless direct provider/account/API evidence is captured and redacted.

--- a/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_STOP_CONDITIONS.md
+++ b/out/rte-pkt-09-live-validation-plan/RTE-PKT-09_STOP_CONDITIONS.md
@@ -1,0 +1,89 @@
+# RTE-PKT-09 Stop Conditions
+
+## This Packet
+
+Stop this plan-only packet if:
+- provider credentials are required
+- a command would contact xAI, OpenAI, OpenRouter, Gemini, Anthropic, or another provider
+- a command would submit, poll, retrieve, cancel, or delete provider batch jobs/files
+- a change is needed outside `out/rte-pkt-09-live-validation-plan/`
+- runtime source, tests, promptsets, model maps, schemas, config, compose, or docs must change
+- proof output would expose credential-shaped values
+- repo identity or worktree state cannot be verified
+
+## Future LV-00 Static Readiness
+
+Stop if:
+- explicit operator authorization is missing
+- worktree is dirty
+- required packet proof is missing or stale
+- live gate behavior drifted
+- redaction behavior drifted
+- spend cap is absent
+- timeout cap is absent
+- batch cap is absent
+- artifact root is not isolated
+- credentials would be exposed
+
+## Future LV-01 Provider Preflight
+
+Stop if:
+- provider is not explicitly authorized
+- auth fails
+- model availability is missing for the requested lane
+- route kind differs from requested lane
+- preflight output includes secrets
+- provider response lacks minimum metadata
+- quota/cost risk exceeds cap
+
+## Future LV-02 Sync Metadata
+
+Stop if:
+- returned/effective model is missing when required
+- route/proxy class is unexpected
+- response ID, finish reason, usage, refusal, or incomplete fields are absent without an explicit null/unsupported marker
+- response content includes unsafe or unredacted data
+- timeout cap is reached
+- spend cap is reached
+
+## Future LV-03 Structured Output
+
+Stop if:
+- schema mode silently downgrades
+- provider rejects expected schema and failure is not preserved
+- local schema validation fails and the failure is not preserved
+- output has unredacted payload content
+- provider-specific structured-output behavior is inferred as universal
+
+## Future LV-04 Batch Pilot
+
+Stop if:
+- batch validation is not explicitly authorized
+- provider is OpenRouter under current runtime
+- request count exceeds cap
+- payload is not synthetic
+- submit returns unexpected remote lifecycle fields
+- polling exceeds timeout
+- provider status sequence is not recorded
+- output/error file retrieval writes outside artifact root
+- downloaded content contains credential-shaped material
+- custom_id row reconciliation fails without preserving the failure
+- cost cap is reached
+
+## Future LV-05 Retention/ZDR
+
+Stop if:
+- cleanup/deletion check is not explicitly authorized
+- target job/file was not created by the validation run
+- provider evidence would expose account secrets
+- provider does not expose evidence and the plan would overclaim
+- provider documentation conflicts with observed account/API behavior
+
+## Future LV-06 Synthesis
+
+Stop if:
+- any untested lane would be marked as validated
+- spend estimate would be reported as billing truth
+- ZDR/retention would be asserted without direct evidence
+- cleanup status is unknown but reported as complete
+- raw downloaded provider files are included unredacted


### PR DESCRIPTION
@codex review
@gemini
@copilot

## Summary
- Adds RTE-PKT-09 plan-only proof artifacts under `out/rte-pkt-09-live-validation-plan/`.
- Defines future live validation authorization, phases, provider lane matrix, batch pilot plan, retention/ZDR evidence plan, proof schema, and stop conditions.
- Records observed local proof gap: RTE-PKT-07 and RTE-PKT-08 outputs are not present in this checkout and are treated as active-packet claims rather than locally re-proven facts.

## Validation
- `python -m json.tool out/rte-pkt-09-live-validation-plan/RTE-PKT-09_MANIFEST.json >/dev/null`: PASS
- `git diff --check`: PASS
- generated-artifact secret-shaped scan: PASS
- required artifact completeness check: PASS
- provider matrix verdict check: PASS
- `pre-commit run --files <generated packet files>`: PASS

## Release Notes
- No runtime behavior change. Planning and proof artifacts only.

## Changelog
- Added RTE-PKT-09 live-validation planning packet artifacts.

## Feature List
- No feature/runtime changes.

## Risk
- No provider calls, live extraction, batch operations, remote file operations, credential inspection, or external research were performed.
- Live provider and batch behavior remains `LIVE_VALIDATION_REQUIRED` until a future explicitly authorized live execution packet collects evidence.