### PR TITLE
feat(rte): classify proof contract conformance

### DIFF
--- a/out/rte-pkt-10-proof-contract/RTE-PKT-10_ARTIFACT_AUTHORITY_MAP.md
+++ b/out/rte-pkt-10-proof-contract/RTE-PKT-10_ARTIFACT_AUTHORITY_MAP.md
@@ -1,0 +1,36 @@
+# RTE-PKT-10 Artifact Authority Map
+
+Generated: 2026-05-15T16:13:41Z
+
+## Authority Rule
+
+Runtime source authority outranks generated proof evidence. Generated artifacts may support review, but they do not become source truth without explicit runtime/schema evidence.
+
+## Classification Map
+
+| Artifact family | Observed paths | Classification | Authority role | Review risk |
+| --- | --- | --- | --- | --- |
+| RTE primary runtime | `services/repo-truth-extractor/run_extraction_v5.py` | `runtime_authority` | Runtime behavior authority for v5 orchestration entrypoint. | Must be inspected before changing proof semantics. |
+| RTE proof writer implementation | `services/repo-truth-extractor/reporting.py` through `rte_reports.py` seam | `runtime_authority` | Canonical writer for `PROOF_PACK.json`, `RUN_MANIFEST.json`, certification, rollups, dashboard, and failure index. | Outside this packet allowlist, so it was not modified. |
+| RTE run manifests and certification files | `services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/*/RUN_MANIFEST.json`, `CERTIFICATION_RESULT.json` | `runtime_generated_evidence` | Runtime-generated evidence about prior runs. | Useful witness evidence; not proof-bundle complete by default. |
+| `PROOF_PACK.json` writer shape | `reporting.py::update_proof_pack` and `write_blocked_promptset_proof_pack` | `runtime_generated_evidence` | Run evidence surface with run ID, git SHA, runner hash, argv, cwd, phase counts, and linked artifacts. | Not full proof-contract bundle unless governance fields are present. |
+| Packet proof outputs | `out/rte-pkt-01-*` through `out/rte-pkt-06-*`, `out/rte-pkt-15-*` where present | `proof_governance_artifact` | Packet closeout evidence and review context. | Does not outrank runtime source or prove live provider behavior unless live evidence is present. |
+| RTE TP proof files | `proof/TP-RTE-*.json` where present | `proof_governance_artifact` | Historical implementation proof and safety boundary evidence. | Often lacks canonical bundle fields such as `bundle_id` and `chain_of_custody`. |
+| Audit-pack material | `out/rte-55pro-audit-pack/*`, `audit_inputs/*` | `generated_audit_context` | Review input and synthesis context. | Must remain below runtime code/config/tests in authority order. |
+| External advisory reports | External DR/advisory files, when present | `external_advisory_context` | Advisory context only. | Cannot establish repo truth without local evidence. |
+| Test fixtures and samples | `services/repo-truth-extractor/tests/fixtures/*`, sample proof payloads | `sample_artifact_uncertain_lineage` | Local test/sample evidence. | Cannot prove exact Pass 1 identity without exact hashes and run IDs. |
+| Missing packet roots | `out/rte-pkt-07-xai-metadata`, `out/rte-pkt-08-xai-batch-static`, `out/rte-pkt-09-live-validation-plan` | `unknown` in this worktree | Not locally available in this checkout. | Must not be inferred from packet text alone. |
+
+## Ordering Used By Helper
+
+| Classification | Rank |
+| --- | ---: |
+| `runtime_authority` | 100 |
+| `proof_governance_artifact` | 60 |
+| `runtime_generated_evidence` | 50 |
+| `generated_audit_context` | 40 |
+| `external_advisory_context` | 30 |
+| `sample_artifact_uncertain_lineage` | 20 |
+| `unknown` | 0 |
+
+The rank is deliberately conservative: runtime source remains higher than all generated evidence, while packet proof evidence remains higher than audit context but still below source authority.

--- a/out/rte-pkt-10-proof-contract/RTE-PKT-10_CONFORMANCE_EXAMPLES.md
+++ b/out/rte-pkt-10-proof-contract/RTE-PKT-10_CONFORMANCE_EXAMPLES.md
@@ -1,0 +1,77 @@
+# RTE-PKT-10 Conformance Examples
+
+Generated: 2026-05-15T16:13:41Z
+
+These examples describe the local helper behavior added in `services/repo-truth-extractor/lib/proof_contract.py`.
+
+## SATISFIED Example
+
+A payload containing every required field, explicit artifact role lists, custody, statuses, no-provider status, and artifact hashes returns:
+
+```json
+{
+  "overall_status": "SATISFIED",
+  "is_full_proof_contract_bundle": true,
+  "provider_call_status": "NOT_RUN",
+  "batch_operation_status": "NOT_RUN"
+}
+```
+
+This is a governance-bundle example, not a claim that current RTE `PROOF_PACK.json` outputs have this shape.
+
+## PARTIAL Example
+
+A run-proof-shaped payload with `run_id`, `git_sha`, `runner_sha256`, `argv`, `cwd`, `updated_at`, `phases`, and `linked_artifacts` returns:
+
+```json
+{
+  "overall_status": "PARTIAL",
+  "proof_posture": "run_proof_or_packet_evidence_not_full_bundle",
+  "missing_fields": [
+    "bundle_id",
+    "source_version",
+    "authoritative_artifacts",
+    "supporting_artifacts",
+    "chain_of_custody",
+    "artifact_hashes"
+  ]
+}
+```
+
+The important behavior is that run evidence remains useful without being promoted to full proof-bundle compliance.
+
+## MISSING Example
+
+If `authoritative_artifacts` and `supporting_artifacts` are absent, those fields return `MISSING`, and the full-bundle flag remains false. This prevents a manifest or proof pack from passing merely because it exists.
+
+## UNKNOWN Example
+
+For sample or uncertain-lineage artifacts without `run_id`, `artifact_hashes`, and `pass1_artifact_identity`, exact Pass 1 identity returns:
+
+```json
+{
+  "status": "UNKNOWN",
+  "reason": "exact Pass 1 identity lacks run_id, artifact_hashes, and pass1_artifact_identity evidence"
+}
+```
+
+This preserves the RTE-FS-020 risk instead of hiding it.
+
+## NOT_APPLICABLE Example
+
+The helper supports explicit caller-declared `not_applicable_fields`. It does not infer NOT_APPLICABLE silently. For example, a caller may mark `handoff_refs` as not applicable only when the bundle is not a handoff:
+
+```json
+{
+  "handoff_refs": {
+    "status": "NOT_APPLICABLE",
+    "reason": "field explicitly marked not applicable by caller"
+  }
+}
+```
+
+Silent absence still returns `MISSING`.
+
+## Static / Live Boundary Example
+
+Payloads with `live_validation_status=NOT_LIVE_VALIDATED`, `provider_call_status=NOT_RUN`, and `batch_operation_status=NOT_RUN` remain `static_only=true`. They do not prove live provider behavior.

--- a/out/rte-pkt-10-proof-contract/RTE-PKT-10_DIFF_SUMMARY.md
+++ b/out/rte-pkt-10-proof-contract/RTE-PKT-10_DIFF_SUMMARY.md
@@ -1,0 +1,34 @@
+# RTE-PKT-10 Diff Summary
+
+Generated: 2026-05-15T16:13:41Z
+
+## Source Changes
+
+| Path | Scope | Purpose |
+| --- | --- | --- |
+| `services/repo-truth-extractor/lib/proof_contract.py` | Conditional code path allowed by packet | Adds deterministic proof-contract field mapping, conformance classification, artifact authority classification, exact Pass 1 identity gap assessment, and static/no-provider status derivation. |
+| `services/repo-truth-extractor/tests/test_proof_contract.py` | Allowed test path | Adds focused local tests for all requested proof-contract boundary cases. |
+
+## Proof Output Changes
+
+| Path | Scope | Purpose |
+| --- | --- | --- |
+| `out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json` | Allowed output root | Packet manifest with repo identity, authority used, changed files, validation summary, and no-provider boundary. |
+| `out/rte-pkt-10-proof-contract/RTE-PKT-10_PROOF_CONTRACT_GAP_MATRIX.md` | Allowed output root | Field-by-field proof-contract gap matrix. |
+| `out/rte-pkt-10-proof-contract/RTE-PKT-10_ARTIFACT_AUTHORITY_MAP.md` | Allowed output root | Artifact authority classification map. |
+| `out/rte-pkt-10-proof-contract/RTE-PKT-10_CONFORMANCE_EXAMPLES.md` | Allowed output root | Examples for satisfied, partial, missing, unknown, and not-applicable statuses. |
+| `out/rte-pkt-10-proof-contract/RTE-PKT-10_RUN_PROOF_VS_BUNDLE_PROOF.md` | Allowed output root | Operator-facing distinction between run proof and bundle proof. |
+| `out/rte-pkt-10-proof-contract/RTE-PKT-10_TEST_REPORT.md` | Allowed output root | Targeted validation commands and results. |
+| `out/rte-pkt-10-proof-contract/RTE-PKT-10_NO_PROVIDER_CALLS_ATTESTATION.md` | Allowed output root | No-live/no-provider/no-batch attestation. |
+| `out/rte-pkt-10-proof-contract/RTE-PKT-10_DIFF_SUMMARY.md` | Allowed output root | Scope and diff summary. |
+| `out/rte-pkt-10-proof-contract/RTE-PKT-10_REMAINING_UNKNOWNS.md` | Allowed output root | Unknowns and residual risks ledger. |
+
+## Explicit Non-Changes
+
+- No prompt files changed.
+- No promptset YAML changed.
+- No model map or provider route selection changed.
+- No provider client behavior changed.
+- No batch provider protocol changed.
+- No compose/config/deployment files changed.
+- No proof writer refactor was performed because the observed writer is `reporting.py`, outside this packet allowlist.

--- a/out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json
+++ b/out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json
@@ -1,0 +1,191 @@
+{
+  "packet_id": "RTE-PKT-10-PROOF-CONTRACT",
+  "title": "Proof Contract Gap Report and Run-Proof Classification for Dopemux RTE",
+  "generated_at_utc": "2026-05-15T16:13:41Z",
+  "status": "READY_FOR_REVIEW",
+  "validation_state": "PASSED_TARGETED_STATIC_VALIDATION",
+  "worktree_path": "/Users/hue/.codex/worktrees/e3e0/dopemux-mvp",
+  "branch": "codex/rte-pkt-10-proof-contract",
+  "starting_head": "0179b17b03cf46518aa324bd8f50c805b627631d",
+  "base_branch_observed": "origin/main is remote HEAD; active packet base_branch is UNKNOWN and this worktree started from detached HEAD 0179b17b03cf46518aa324bd8f50c805b627631d.",
+  "repo_identity": {
+    "repository_name": "dopemux-mvp",
+    "remotes": [
+      "origin https://github.com/DDD-Enterprises/dopemux-mvp.git",
+      "mvp https://github.com/DDD-Enterprises/dopemux-mvp.git"
+    ],
+    "markers_verified": [
+      "pyproject.toml",
+      "src/dopemux/cli.py",
+      "services/repo-truth-extractor/run_extraction_v5.py",
+      "services/repo-truth-extractor/tests/",
+      ".dopetaskroot"
+    ]
+  },
+  "active_task_packet": {
+    "id": "RTE-PKT-10-PROOF-CONTRACT",
+    "source": "conversation",
+    "canonical_schema_validation": "NOT_RUN",
+    "schema": "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+    "reason": "The conversation packet is the active scope but uses an audit-packet shape with undeclared fields under the strict dopetask schema. The packet also says not to create additional Task Packets, so no extra task-packet file was written."
+  },
+  "authority_used": [
+    "AGENTS.md",
+    "docs/03-reference/governance/agent-workflow.md",
+    "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+    "docs/03-reference/governance/proof-contract.md",
+    "docs/03-reference/governance/proof-bundle-schema.md",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/rte_reports.py",
+    "services/repo-truth-extractor/reporting.py",
+    "out/rte-pkt-01-live-gate through out/rte-pkt-06-truth-labels where present",
+    "out/rte-pkt-15-failed-sidecars where present",
+    "proof/TP-RTE-* proof files where present"
+  ],
+  "runtime_trace": {
+    "primary_runtime": "services/repo-truth-extractor/run_extraction_v5.py",
+    "proof_writer_observed": "services/repo-truth-extractor/reporting.py via services/repo-truth-extractor/rte_reports.py imports used by run_extraction_v5.py",
+    "proof_writer_changed": false,
+    "proof_writer_change_reason": "reporting.py is outside the active packet allowlist; this packet added a narrow conformance helper and tests instead of changing runtime proof semantics."
+  },
+  "changed_files": [
+    {
+      "path": "services/repo-truth-extractor/lib/proof_contract.py",
+      "scope_status": "conditional_code_path",
+      "purpose": "Small deterministic helper for proof-contract field mapping, artifact authority classification, conformance status, static/live status carry-forward, and exact Pass 1 identity gap reporting."
+    },
+    {
+      "path": "services/repo-truth-extractor/tests/test_proof_contract.py",
+      "scope_status": "allowed_test_path",
+      "purpose": "Focused local tests for run proof vs full bundle proof, missing declarations, static-only proof, source authority ordering, exact Pass 1 unknowns, packet proof authority, redaction/no-provider status, and no-provider-client safety."
+    },
+    {
+      "path": "out/rte-pkt-10-proof-contract/",
+      "scope_status": "allowed_output_root",
+      "purpose": "Packet proof reports and no-provider-call attestation."
+    }
+  ],
+  "proof_files": [
+    "out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json",
+    "out/rte-pkt-10-proof-contract/RTE-PKT-10_PROOF_CONTRACT_GAP_MATRIX.md",
+    "out/rte-pkt-10-proof-contract/RTE-PKT-10_ARTIFACT_AUTHORITY_MAP.md",
+    "out/rte-pkt-10-proof-contract/RTE-PKT-10_CONFORMANCE_EXAMPLES.md",
+    "out/rte-pkt-10-proof-contract/RTE-PKT-10_RUN_PROOF_VS_BUNDLE_PROOF.md",
+    "out/rte-pkt-10-proof-contract/RTE-PKT-10_TEST_REPORT.md",
+    "out/rte-pkt-10-proof-contract/RTE-PKT-10_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-10-proof-contract/RTE-PKT-10_DIFF_SUMMARY.md",
+    "out/rte-pkt-10-proof-contract/RTE-PKT-10_REMAINING_UNKNOWNS.md"
+  ],
+  "local_artifact_inventory": {
+    "present_packet_roots": [
+      "out/rte-pkt-01-live-gate",
+      "out/rte-pkt-02-payload-redaction",
+      "out/rte-pkt-03-prescan-stale",
+      "out/rte-pkt-04-prescan-influence",
+      "out/rte-pkt-05-provenance-fields",
+      "out/rte-pkt-06-truth-labels",
+      "out/rte-pkt-15-failed-sidecars"
+    ],
+    "missing_packet_roots_in_this_worktree": [
+      "out/rte-pkt-07-xai-metadata",
+      "out/rte-pkt-08-xai-batch-static",
+      "out/rte-pkt-09-live-validation-plan"
+    ],
+    "runtime_run_artifact_examples": [
+      "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/*/RUN_MANIFEST.json",
+      "services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/*/CERTIFICATION_RESULT.json"
+    ],
+    "runtime_proof_pack_examples_found": []
+  },
+  "conformance_helper": {
+    "required_fields_count": 32,
+    "artifact_classifications": [
+      "runtime_authority",
+      "runtime_generated_evidence",
+      "proof_governance_artifact",
+      "generated_audit_context",
+      "external_advisory_context",
+      "sample_artifact_uncertain_lineage",
+      "unknown"
+    ],
+    "status_values": [
+      "SATISFIED",
+      "PARTIAL",
+      "MISSING",
+      "UNKNOWN",
+      "NOT_APPLICABLE"
+    ],
+    "full_bundle_requires_explicit_declarations": true
+  },
+  "validation_summary": [
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_proof_contract.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "9 passed; existing PytestConfigWarning for unknown asyncio_mode."
+    },
+    {
+      "command": "python -m py_compile services/repo-truth-extractor/lib/proof_contract.py",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "No syntax errors."
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k 'proof_contract or artifact_authority' -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "9 passed; existing PytestConfigWarning for unknown asyncio_mode."
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k 'proof and contract' -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "9 passed; existing PytestConfigWarning for unknown asyncio_mode."
+    },
+    {
+      "command": "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/proof_contract.py",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "No syntax errors in the v5 runner or proof-contract helper."
+    },
+    {
+      "command": "python -m json.tool out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Packet manifest parses as JSON."
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "No whitespace errors."
+    },
+    {
+      "command": "git status --short --branch",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Dirty state before staging was limited to the helper, tests, and allowed packet proof output root."
+    },
+    {
+      "command": "pre-commit run --files services/repo-truth-extractor/lib/proof_contract.py services/repo-truth-extractor/tests/test_proof_contract.py out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json out/rte-pkt-10-proof-contract/RTE-PKT-10_PROOF_CONTRACT_GAP_MATRIX.md out/rte-pkt-10-proof-contract/RTE-PKT-10_ARTIFACT_AUTHORITY_MAP.md out/rte-pkt-10-proof-contract/RTE-PKT-10_CONFORMANCE_EXAMPLES.md out/rte-pkt-10-proof-contract/RTE-PKT-10_RUN_PROOF_VS_BUNDLE_PROOF.md out/rte-pkt-10-proof-contract/RTE-PKT-10_TEST_REPORT.md out/rte-pkt-10-proof-contract/RTE-PKT-10_NO_PROVIDER_CALLS_ATTESTATION.md out/rte-pkt-10-proof-contract/RTE-PKT-10_DIFF_SUMMARY.md out/rte-pkt-10-proof-contract/RTE-PKT-10_REMAINING_UNKNOWNS.md",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Configured hooks passed or skipped for the changed file set."
+    }
+  ],
+  "provider_boundary": {
+    "provider_credentials_required": false,
+    "provider_calls_run": false,
+    "live_extraction_run": false,
+    "batch_submit_poll_retrieve_cancel_run": false,
+    "external_research_run": false
+  },
+  "commit_created": "PENDING_FINAL_COMMIT",
+  "commit_sha_note": "The final commit SHA is reported in the Codex closeout after commit creation; embedding it here would require a self-referential proof-only amend.",
+  "pr_created": "PENDING_PUSH_OR_PR",
+  "remaining_unknowns": [
+    "Exact Pass 1 artifact identity remains UNKNOWN because no exact Pass 1 hashes plus run IDs were found in local proof examples.",
+    "RTE-PKT-07, RTE-PKT-08, and RTE-PKT-09 packet output roots were not present in this worktree.",
+    "The active conversation packet is not schema-validated as a canonical dopetask packet because it intentionally uses a different audit packet shape and forbids creating additional Task Packets."
+  ]
+}

--- a/out/rte-pkt-10-proof-contract/RTE-PKT-10_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-10-proof-contract/RTE-PKT-10_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,24 @@
+# RTE-PKT-10 No Provider Calls Attestation
+
+Generated: 2026-05-15T16:13:41Z
+
+## Attestation
+
+No live extraction was run.
+
+No calls were made to xAI, OpenAI, OpenRouter, Gemini, Anthropic, or another model provider.
+
+No provider credentials were required or inspected.
+
+No provider batch jobs were submitted, polled, retrieved, or canceled.
+
+No external web research was run for this packet.
+
+## Evidence
+
+Executed validation was limited to:
+
+- `pytest services/repo-truth-extractor/tests/test_proof_contract.py -q`
+- `python -m py_compile services/repo-truth-extractor/lib/proof_contract.py`
+
+The helper imports only Python standard-library modules and does not import provider clients.

--- a/out/rte-pkt-10-proof-contract/RTE-PKT-10_PROOF_CONTRACT_GAP_MATRIX.md
+++ b/out/rte-pkt-10-proof-contract/RTE-PKT-10_PROOF_CONTRACT_GAP_MATRIX.md
@@ -1,0 +1,56 @@
+# RTE-PKT-10 Proof Contract Gap Matrix
+
+Generated: 2026-05-15T16:13:41Z
+
+This matrix compares the packet proof-contract requirements against observed local RTE run-proof and packet-proof shapes. Status values use `SATISFIED`, `PARTIAL`, `MISSING`, `UNKNOWN`, and `NOT_APPLICABLE`.
+
+## Observed Artifact Shapes
+
+| Artifact family | Observed examples | Current conformance classification |
+| --- | --- | --- |
+| RTE runtime source | `services/repo-truth-extractor/run_extraction_v5.py`, `services/repo-truth-extractor/reporting.py` | Runtime authority, not proof artifact. |
+| RTE generated run manifest | `services/repo-truth-extractor/extraction/repo-truth-extractor/v5/runs/*/RUN_MANIFEST.json` | Runtime-generated evidence, partial proof-contract shape. |
+| RTE proof pack writer shape | `reporting.py::update_proof_pack` writes `PROOF_PACK.json` with run evidence fields | Run proof only unless governance declarations are also present. No local `PROOF_PACK.json` example was found under v5 runs in this worktree. |
+| Packet proof manifests | `out/rte-pkt-01-*` through `out/rte-pkt-06-*`, `out/rte-pkt-15-*` where present | Proof/governance evidence, not runtime source authority. |
+| TP proof files | `proof/TP-RTE-*.json` where present | Proof/governance evidence, not full proof-bundle-complete unless required fields are present. |
+
+## Field Matrix
+
+| Proof-contract field | Observed mapping | Status | Gap / risk |
+| --- | --- | --- | --- |
+| `bundle_id` | Not observed in RTE run manifests or sampled packet manifests. | MISSING | Required to distinguish governance bundle identity from run evidence identity. |
+| `run_id` | Present in runtime `RUN_MANIFEST.json`; proof writer sets `run_id` in `PROOF_PACK.json`. | SATISFIED for run proof, PARTIAL for packet proof | Packet proof manifests often use packet IDs instead of run IDs. |
+| `source_version` | Canonical proof docs require source version; RTE run proof uses runner hashes instead. | MISSING | Runner hash is useful evidence but is not the same declaration as source version. |
+| `repo_root` | Present in local `RUN_MANIFEST.json`; packet manifests record worktree paths. | PARTIAL | Some proof artifacts have worktree/cwd instead of explicit repo root. |
+| `git_sha` | Present in RTE `RUN_MANIFEST.json`, proof writer shape, and packet manifests. | SATISFIED | Keep as evidence, not as full custody by itself. |
+| `runner_sha` | Proof writer shape records `runner_sha256`; some manifests omit it. | PARTIAL | Field naming drift exists between `runner_sha` and `runner_sha256`. |
+| `command_argv` | Proof writer shape records `argv`; run manifests have `cli`. | PARTIAL | Existing names map to the concept but are not consistently declared. |
+| `cwd` | Proof writer shape records `cwd`; packet manifests often record worktree path. | PARTIAL | Missing from several proof/governance manifests. |
+| `status` | Packet manifests often include status; run manifests use `run_status` and `phase_status`. | PARTIAL | Runtime status is not equivalent to governance bundle status. |
+| `validation_state` | Some packet proof files list validations; many lack explicit `validation_state`. | PARTIAL | Validation evidence without an explicit state must not become a pass. |
+| `run_posture` | Static/no-provider posture can be derived in packet proofs but is not consistently explicit. | PARTIAL | Static-only and live-validated proof remain easy to confuse without explicit labeling. |
+| `generated_at` | Present as `generated_at`, `generated_at_utc`, or `updated_at` depending artifact family. | PARTIAL | Timestamp naming drift exists. |
+| `phase_list` | Present as `phases` or `routing_step_tiers` in run evidence. | PARTIAL | Packet proof manifests are not always phase-scoped. |
+| `generated_artifact_list` | Present as `linked_artifacts`, `artifacts`, `proof_files`, or `changed_files`. | PARTIAL | Lists exist but roles are not canonicalized. |
+| `authoritative_artifacts` | Required by proof contract; absent from sampled RTE run proof and packet manifests. | MISSING | Main overtrust risk: proof artifact presence is not the same as authoritative declaration. |
+| `supporting_artifacts` | Required/expected by proof contract; absent from sampled RTE run proof and packet manifests. | MISSING | Reviewers cannot mechanically separate decision artifacts from context artifacts. |
+| `runtime_authority_artifacts` | Not explicitly declared in sampled proof outputs. | MISSING | Generated proof can be mistaken for source truth without this boundary. |
+| `generated_evidence_artifacts` | Not explicitly declared as a role list in sampled proof outputs. | MISSING | Evidence surfaces need role labels. |
+| `proof_governance_artifacts` | Not explicitly declared as a role list in sampled proof outputs. | MISSING | Packet proof outputs need governance role labels. |
+| `external_advisory_artifacts` | Not explicitly declared in sampled proof outputs. | MISSING | External advisory context must not outrank repo truth. |
+| `sample_or_uncertain_lineage_artifacts` | Not explicitly declared in sampled proof outputs. | MISSING | Exact Pass 1 identity remains unsafe to infer without lineage labels. |
+| `chain_of_custody` | Required by proof docs; absent from sampled RTE run evidence and many packet proof manifests. | MISSING | Custody is not complete without explicit source and parent declarations. |
+| `warnings` | Present in some proof files, absent in others. | PARTIAL | Empty warnings should be declared explicitly when reviewed as a bundle. |
+| `blockers` | Present in some proof files, absent in others. | PARTIAL | Empty blockers should be declared explicitly when reviewed as a bundle. |
+| `handoff_refs` | Required/expected by packet; absent unless proof bundle declares no handoff. | MISSING | Absence is ambiguous without explicit empty list or NOT_APPLICABLE. |
+| `parent_bundle_refs` | Required/expected by packet; absent in sampled outputs. | MISSING | Upstream chain cannot be reconstructed mechanically. |
+| `review_order_hint` | Present in the active packet, absent from sampled proof outputs. | MISSING | Review sequencing is not embedded in most generated evidence. |
+| `live_validation_status` | Present or derivable in some packet proofs as NOT_RUN/NOT_LIVE_VALIDATED; not universal. | PARTIAL | Static packet proof must not be treated as live provider proof. |
+| `provider_call_status` | Present or derivable in no-provider attestations and safety boundaries. | PARTIAL | Must remain NOT_RUN unless live provider calls are actually observed. |
+| `batch_operation_status` | Present or derivable in some packet proofs as NOT_RUN. | PARTIAL | Static batch proof does not prove provider batch behavior. |
+| `redaction_status` | RTE-PKT-02 has redaction evidence, but sampled manifests do not consistently expose `redaction_status`. | PARTIAL | Provider-bound redaction must stay visible at bundle review time. |
+| `artifact_hashes` | Required for exact lineage; not observed as a complete artifact hash map in sampled RTE packet proof manifests. | MISSING | Exact Pass 1 identity remains UNKNOWN without hashes plus run IDs. |
+
+## Contract Conclusion
+
+Observed RTE run proof is useful evidence, but sampled proof outputs are not full proof-contract-compliant governance bundles. Missing authoritative/supporting declarations, custody fields, role-specific artifact lists, and artifact hashes keep conformance at PARTIAL or MISSING.

--- a/out/rte-pkt-10-proof-contract/RTE-PKT-10_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-10-proof-contract/RTE-PKT-10_REMAINING_UNKNOWNS.md
@@ -1,0 +1,24 @@
+# RTE-PKT-10 Remaining Unknowns
+
+Generated: 2026-05-15T16:13:41Z
+
+## UNKNOWN
+
+1. Exact Pass 1 artifact identity remains UNKNOWN. No local evidence combined exact Pass 1 identity, run ID, and artifact hashes.
+2. Local packet roots for `out/rte-pkt-07-xai-metadata`, `out/rte-pkt-08-xai-batch-static`, and `out/rte-pkt-09-live-validation-plan` were not present in this worktree.
+3. The active conversation packet does not conform to the strict local dopetask canonical schema. This packet did not create an additional Task Packet because the active packet explicitly says not to create additional Task Packets.
+4. Current RTE proof writer semantics remain unchanged. The observed writer path is `services/repo-truth-extractor/reporting.py`, which is outside the active packet allowlist.
+5. Live provider behavior remains unvalidated. This packet improves static proof governance only.
+6. Redaction status is preserved by the helper when present, but not all sampled proof manifests expose a top-level `redaction_status` field.
+
+## Residual Risk
+
+Operators still need to inspect the gap matrix before treating any RTE proof artifact as governance-bundle complete. The helper reduces the risk of accidental overtrust, but it does not rewrite historical artifacts or change runtime proof emission.
+
+## RTE Finding Disposition
+
+| Finding | Disposition after this packet |
+| --- | --- |
+| RTE-FS-010 | Reduced: run proof and full proof-bundle compliance are now separated by helper/tests/reports. |
+| RTE-FS-017 | Reduced: generated proof artifacts are explicitly lower authority than runtime source. |
+| RTE-FS-020 | Still UNKNOWN: exact Pass 1 identity was not proven. |

--- a/out/rte-pkt-10-proof-contract/RTE-PKT-10_RUN_PROOF_VS_BUNDLE_PROOF.md
+++ b/out/rte-pkt-10-proof-contract/RTE-PKT-10_RUN_PROOF_VS_BUNDLE_PROOF.md
@@ -1,0 +1,62 @@
+# RTE-PKT-10 Run Proof vs Bundle Proof
+
+Generated: 2026-05-15T16:13:41Z
+
+## Operator Rule
+
+`PROOF_PACK.json`, `RUN_MANIFEST.json`, dashboards, coverage rollups, failure indexes, and packet closeout manifests are evidence surfaces. They are not automatically proof-contract-compliant governance bundles.
+
+## Run Proof
+
+Run proof can establish facts such as:
+
+- A run ID existed.
+- A git SHA or runner hash was recorded.
+- A command or cwd was recorded.
+- Phases, counts, linked artifacts, and telemetry existed.
+- Static no-provider or no-live-call attestations were recorded.
+
+Run proof cannot by itself establish:
+
+- Authoritative vs supporting artifact roles.
+- Full chain of custody.
+- Handoff lineage.
+- Review order.
+- Exact Pass 1 identity without hashes and run IDs.
+- Live provider behavior when validation is static only.
+
+## Proof-Contract Governance Bundle
+
+A proof-contract-compliant governance bundle requires explicit fields such as:
+
+- `bundle_id`
+- `run_id`
+- `status`
+- `validation_state`
+- `authoritative_artifacts`
+- `supporting_artifacts`
+- `chain_of_custody`
+- `handoff_refs`
+- `parent_bundle_refs`
+- `review_order_hint`
+- role-specific artifact lists
+- live/provider/batch/redaction statuses
+- `artifact_hashes`
+
+The helper added by this packet returns `SATISFIED` only when those fields are present or explicitly marked not applicable by the caller. Missing declarations stay `MISSING`; validation evidence without explicit `validation_state` stays `PARTIAL`.
+
+## Current RTE Posture
+
+Observed local RTE proof examples are best treated as run evidence or packet proof evidence. They are not full governance bundles unless the required proof-contract declarations are present and validated.
+
+## Static Proof Boundary
+
+Static proof artifacts and no-provider attestations do not prove live provider behavior. They should be read as:
+
+```text
+provider_call_status=NOT_RUN
+live_validation_status=NOT_RUN or NOT_LIVE_VALIDATED
+batch_operation_status=NOT_RUN
+```
+
+Any later live-readiness claim must cite separate live validation evidence.

--- a/out/rte-pkt-10-proof-contract/RTE-PKT-10_TEST_REPORT.md
+++ b/out/rte-pkt-10-proof-contract/RTE-PKT-10_TEST_REPORT.md
@@ -1,0 +1,30 @@
+# RTE-PKT-10 Test Report
+
+Generated: 2026-05-15T16:13:41Z
+
+## PASS
+
+| Command | Exit | Result | Notes |
+| --- | ---: | --- | --- |
+| `pytest services/repo-truth-extractor/tests/test_proof_contract.py -q` | 0 | PASS | 9 passed; existing PytestConfigWarning for unknown `asyncio_mode`. |
+| `python -m py_compile services/repo-truth-extractor/lib/proof_contract.py` | 0 | PASS | No syntax errors. |
+| `pytest services/repo-truth-extractor/tests -k 'proof_contract or artifact_authority' -q` | 0 | PASS | 9 passed; existing PytestConfigWarning for unknown `asyncio_mode`. |
+| `pytest services/repo-truth-extractor/tests -k 'proof and contract' -q` | 0 | PASS | 9 passed; existing PytestConfigWarning for unknown `asyncio_mode`. |
+| `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/proof_contract.py` | 0 | PASS | No syntax errors in the v5 runner or helper. |
+| `python -m json.tool out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json` | 0 | PASS | Manifest parses as JSON. |
+| `git diff --check` | 0 | PASS | No whitespace errors. |
+| `git status --short --branch` | 0 | PASS | Dirty state before staging was limited to helper, tests, and packet proof outputs. |
+| `pre-commit run --files <changed RTE-PKT-10 files>` | 0 | PASS | Configured hooks passed or skipped for the changed file set. |
+
+## NOT_RUN
+
+| Command / validation | Reason |
+| --- | --- |
+| Live extraction | Out of scope and forbidden by packet. |
+| Provider calls to xAI, OpenAI, OpenRouter, Gemini, Anthropic, or other providers | Out of scope and forbidden by packet. |
+| Batch submit, poll, retrieve, or cancel | Out of scope and forbidden by packet. |
+| Full RTE suite | Narrow packet changed only helper/tests/proof outputs; broader suite not required by packet and not run. |
+
+## Safety Result
+
+All executed tests used local fixtures or in-memory dictionaries. No provider credentials were required.

--- a/services/repo-truth-extractor/lib/proof_contract.py
+++ b/services/repo-truth-extractor/lib/proof_contract.py
@@ -127,12 +127,25 @@ _AUTHORITY_RANK = {
 }
 
 
-def _normalize_rel_path(path: str | Path) -> str:
-    text = str(path).replace("\\", "/")
-    marker = "/dopemux-mvp/"
-    if marker in text:
-        return text.split(marker, 1)[1]
-    return text.lstrip("./")
+_REPO_TOP_LEVEL_DIRS = frozenset(
+    {"services", "src", "out", "tests", "task-packets", "proof", "docs", "ui-dashboard"}
+)
+
+
+def _normalize_rel_path(path: str | Path, repo_root: Optional[Path] = None) -> str:
+    p = Path(str(path).replace("\\", "/"))
+    if repo_root is not None:
+        try:
+            return str(p.relative_to(repo_root))
+        except ValueError:
+            pass
+    if p.is_absolute():
+        # Walk up until we find a segment that is a known top-level directory.
+        parts = p.parts
+        for i, part in enumerate(parts):
+            if part.lower() in _REPO_TOP_LEVEL_DIRS:
+                return str(Path(*parts[i:]))
+    return str(p).lstrip("./")
 
 
 def _get_path(payload: Mapping[str, Any], dotted_path: str) -> tuple[bool, Any]:
@@ -161,7 +174,7 @@ def _walk_values(value: Any) -> Iterable[Any]:
         for key in sorted(value.keys(), key=str):
             yield from _walk_values(value[key])
         return
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+    if isinstance(value, (list, tuple)):
         for item in value:
             yield from _walk_values(item)
         return
@@ -279,7 +292,8 @@ def classify_artifact(
     name = Path(rel_path).name
     payload = payload or {}
 
-    if "/fixtures/" in f"/{rel_path}/" or "sample" in rel_path.lower():
+    rel_path_parts = {seg.lower() for seg in Path(rel_path).parts}
+    if "/fixtures/" in f"/{rel_path}/" or rel_path_parts & {"sample", "samples"}:
         classification = "sample_artifact_uncertain_lineage"
     elif rel_path == "services/repo-truth-extractor/run_extraction_v5.py":
         classification = "runtime_authority"
@@ -367,15 +381,11 @@ def _field_status(
             continue
         seen.append(alias)
         if _has_value(value, require_non_empty=require_non_empty):
-            status = (
-                "SATISFIED"
-                if alias == field or field != "source_version"
-                else "PARTIAL"
-            )
+            status = "SATISFIED" if alias == field else "PARTIAL"
             reason = (
                 "field present"
                 if status == "SATISFIED"
-                else "alias present but exact source_version absent"
+                else f"alias '{alias}' present but exact field '{field}' absent"
             )
             return {
                 "status": status,

--- a/services/repo-truth-extractor/lib/proof_contract.py
+++ b/services/repo-truth-extractor/lib/proof_contract.py
@@ -1,0 +1,539 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence, Tuple
+
+
+CONFORMANCE_STATUSES: Tuple[str, ...] = (
+    "SATISFIED",
+    "PARTIAL",
+    "MISSING",
+    "UNKNOWN",
+    "NOT_APPLICABLE",
+)
+
+ARTIFACT_CLASSIFICATIONS: Tuple[str, ...] = (
+    "runtime_authority",
+    "runtime_generated_evidence",
+    "proof_governance_artifact",
+    "generated_audit_context",
+    "external_advisory_context",
+    "sample_artifact_uncertain_lineage",
+    "unknown",
+)
+
+PROOF_CONTRACT_REQUIRED_FIELDS: Tuple[str, ...] = (
+    "bundle_id",
+    "run_id",
+    "source_version",
+    "repo_root",
+    "git_sha",
+    "runner_sha",
+    "command_argv",
+    "cwd",
+    "status",
+    "validation_state",
+    "run_posture",
+    "generated_at",
+    "phase_list",
+    "generated_artifact_list",
+    "authoritative_artifacts",
+    "supporting_artifacts",
+    "runtime_authority_artifacts",
+    "generated_evidence_artifacts",
+    "proof_governance_artifacts",
+    "external_advisory_artifacts",
+    "sample_or_uncertain_lineage_artifacts",
+    "chain_of_custody",
+    "warnings",
+    "blockers",
+    "handoff_refs",
+    "parent_bundle_refs",
+    "review_order_hint",
+    "live_validation_status",
+    "provider_call_status",
+    "batch_operation_status",
+    "redaction_status",
+    "artifact_hashes",
+)
+
+_FIELD_ALIASES: Mapping[str, Tuple[str, ...]] = {
+    "runner_sha": ("runner_sha", "runner_sha256"),
+    "command_argv": ("command_argv", "argv", "cli.argv"),
+    "generated_at": ("generated_at", "generated_at_utc", "created_at", "updated_at"),
+    "phase_list": ("phase_list", "phases", "routing_step_tiers"),
+    "generated_artifact_list": (
+        "generated_artifact_list",
+        "linked_artifacts",
+        "artifacts",
+        "proof_files",
+        "changed_files",
+    ),
+    "warnings": ("warnings", "residual_risks"),
+    "blockers": ("blockers", "blocking_reasons"),
+    "artifact_hashes": ("artifact_hashes", "checksums"),
+}
+
+_NON_EMPTY_REQUIRED_FIELDS = frozenset(
+    {
+        "bundle_id",
+        "run_id",
+        "source_version",
+        "repo_root",
+        "git_sha",
+        "runner_sha",
+        "command_argv",
+        "cwd",
+        "status",
+        "validation_state",
+        "run_posture",
+        "generated_at",
+        "phase_list",
+        "generated_artifact_list",
+        "authoritative_artifacts",
+        "supporting_artifacts",
+        "runtime_authority_artifacts",
+        "generated_evidence_artifacts",
+        "proof_governance_artifacts",
+        "external_advisory_artifacts",
+        "sample_or_uncertain_lineage_artifacts",
+        "chain_of_custody",
+        "artifact_hashes",
+    }
+)
+
+_RUNTIME_GENERATED_NAMES = frozenset(
+    {
+        "PROOF_PACK.json",
+        "RUN_MANIFEST.json",
+        "COVERAGE_ROLLUP.json",
+        "RESUME_PROOF.json",
+        "CERTIFICATION_RESULT.json",
+        "RUN_DASHBOARD.json",
+        "STEP_METRICS.json",
+        "FAILURE_INDEX.json",
+        "STRICT_PASSTHROUGH_ATTESTATIONS.json",
+    }
+)
+
+_AUTHORITY_RANK = {
+    "runtime_authority": 100,
+    "proof_governance_artifact": 60,
+    "runtime_generated_evidence": 50,
+    "generated_audit_context": 40,
+    "external_advisory_context": 30,
+    "sample_artifact_uncertain_lineage": 20,
+    "unknown": 0,
+}
+
+
+def _normalize_rel_path(path: str | Path) -> str:
+    text = str(path).replace("\\", "/")
+    marker = "/dopemux-mvp/"
+    if marker in text:
+        return text.split(marker, 1)[1]
+    return text.lstrip("./")
+
+
+def _get_path(payload: Mapping[str, Any], dotted_path: str) -> tuple[bool, Any]:
+    cursor: Any = payload
+    for part in dotted_path.split("."):
+        if not isinstance(cursor, Mapping) or part not in cursor:
+            return False, None
+        cursor = cursor[part]
+    return True, cursor
+
+
+def _has_value(value: Any, *, require_non_empty: bool) -> bool:
+    if value is None:
+        return False
+    if not require_non_empty:
+        return True
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return True
+
+
+def _walk_values(value: Any) -> Iterable[Any]:
+    if isinstance(value, Mapping):
+        for key in sorted(value.keys(), key=str):
+            yield from _walk_values(value[key])
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            yield from _walk_values(item)
+        return
+    yield value
+
+
+def _contains_marker(payload: Mapping[str, Any], markers: set[str]) -> bool:
+    for value in _walk_values(payload):
+        if isinstance(value, str) and value in markers:
+            return True
+    return False
+
+
+def _derive_provider_call_status(payload: Mapping[str, Any]) -> Optional[str]:
+    explicit, value = _get_path(payload, "provider_call_status")
+    if explicit and _has_value(value, require_non_empty=True):
+        return str(value)
+
+    provider_calls, row = _get_path(payload, "provider_calls.live_provider_calls_run")
+    if provider_calls:
+        return "RUN" if bool(row) else "NOT_RUN"
+
+    for path in (
+        "safety_boundary_confirmation.live_provider_calls_run",
+        "live_provider_calls_run",
+    ):
+        present, value = _get_path(payload, path)
+        if present:
+            return "RUN" if bool(value) else "NOT_RUN"
+    return None
+
+
+def _derive_batch_operation_status(payload: Mapping[str, Any]) -> Optional[str]:
+    explicit, value = _get_path(payload, "batch_operation_status")
+    if explicit and _has_value(value, require_non_empty=True):
+        return str(value)
+
+    for path in (
+        "batch_provider_operations",
+        "provider_calls.batch_submit_poll_retrieve_cancel_run",
+        "safety_boundary_confirmation.external_batch_jobs_submitted",
+        "external_batch_jobs_submitted",
+    ):
+        present, value = _get_path(payload, path)
+        if present:
+            if isinstance(value, str):
+                return value
+            return "RUN" if bool(value) else "NOT_RUN"
+    return None
+
+
+def _derive_live_validation_status(payload: Mapping[str, Any]) -> Optional[str]:
+    explicit, value = _get_path(payload, "live_validation_status")
+    if explicit and _has_value(value, require_non_empty=True):
+        return str(value)
+
+    if _contains_marker(payload, {"LIVE_VALIDATION_REQUIRED"}):
+        return "LIVE_VALIDATION_REQUIRED"
+    if _contains_marker(payload, {"NOT_LIVE_VALIDATED"}):
+        return "NOT_LIVE_VALIDATED"
+
+    present, value = _get_path(payload, "live_validation_run")
+    if present:
+        return "RUN" if bool(value) else "NOT_RUN"
+
+    present, value = _get_path(payload, "live_extraction_runs_run")
+    if present:
+        return "RUN" if bool(value) else "NOT_RUN"
+    return None
+
+
+def _derive_run_posture(payload: Mapping[str, Any]) -> Optional[str]:
+    explicit, value = _get_path(payload, "run_posture")
+    if explicit and _has_value(value, require_non_empty=True):
+        return str(value)
+    live_status = _derive_live_validation_status(payload)
+    provider_status = _derive_provider_call_status(payload)
+    if live_status in {"NOT_RUN", "NOT_LIVE_VALIDATED", "LIVE_VALIDATION_REQUIRED"}:
+        return "STATIC_ONLY"
+    if provider_status == "NOT_RUN":
+        return "STATIC_ONLY"
+    return None
+
+
+def _derive_redaction_status(payload: Mapping[str, Any]) -> Optional[str]:
+    explicit, value = _get_path(payload, "redaction_status")
+    if explicit and _has_value(value, require_non_empty=True):
+        return str(value)
+    present, value = _get_path(payload, "redaction.status")
+    if present and _has_value(value, require_non_empty=True):
+        return str(value)
+    return None
+
+
+def _derived_status(field: str, payload: Mapping[str, Any]) -> Optional[str]:
+    if field == "provider_call_status":
+        return _derive_provider_call_status(payload)
+    if field == "batch_operation_status":
+        return _derive_batch_operation_status(payload)
+    if field == "live_validation_status":
+        return _derive_live_validation_status(payload)
+    if field == "run_posture":
+        return _derive_run_posture(payload)
+    if field == "redaction_status":
+        return _derive_redaction_status(payload)
+    return None
+
+
+def classify_artifact(
+    artifact_path: str | Path,
+    *,
+    payload: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    rel_path = _normalize_rel_path(artifact_path)
+    name = Path(rel_path).name
+    payload = payload or {}
+
+    if "/fixtures/" in f"/{rel_path}/" or "sample" in rel_path.lower():
+        classification = "sample_artifact_uncertain_lineage"
+    elif rel_path == "services/repo-truth-extractor/run_extraction_v5.py":
+        classification = "runtime_authority"
+    elif (
+        rel_path.startswith("services/repo-truth-extractor/")
+        and rel_path.endswith(".py")
+        and "/tests/" not in rel_path
+        and "/extraction/" not in rel_path
+    ):
+        classification = "runtime_authority"
+    elif rel_path.startswith("src/dopemux/") and rel_path.endswith(".py"):
+        classification = "runtime_authority"
+    elif (
+        rel_path.startswith("services/repo-truth-extractor/extraction/")
+        or name in _RUNTIME_GENERATED_NAMES
+    ):
+        classification = "runtime_generated_evidence"
+    elif (
+        rel_path.startswith("out/rte-pkt-")
+        or rel_path.startswith("proof/TP-RTE-")
+        or rel_path.startswith("proof/rte-")
+    ):
+        classification = "proof_governance_artifact"
+    elif (
+        rel_path.startswith("out/rte-55pro-audit-pack/")
+        or rel_path.startswith("audit_inputs/")
+    ):
+        classification = "generated_audit_context"
+    elif "external" in rel_path.lower() or "/dr-upload/" in f"/{rel_path}/":
+        classification = "external_advisory_context"
+    else:
+        classification = "unknown"
+
+    live_validation_status = _derive_live_validation_status(payload)
+    provider_call_status = _derive_provider_call_status(payload)
+    static_only = live_validation_status in {
+        "NOT_RUN",
+        "NOT_LIVE_VALIDATED",
+        "LIVE_VALIDATION_REQUIRED",
+    } or provider_call_status == "NOT_RUN"
+
+    return {
+        "artifact_path": rel_path,
+        "classification": classification,
+        "authority_rank": _AUTHORITY_RANK[classification],
+        "is_runtime_source_authority": classification == "runtime_authority",
+        "is_generated_evidence": classification
+        in {
+            "runtime_generated_evidence",
+            "proof_governance_artifact",
+            "generated_audit_context",
+            "sample_artifact_uncertain_lineage",
+        },
+        "static_only": bool(static_only),
+        "live_validation_status": live_validation_status or "UNKNOWN",
+        "provider_call_status": provider_call_status or "UNKNOWN",
+        "authority_boundary": (
+            "runtime source authority outranks generated proof evidence"
+            if classification != "runtime_authority"
+            else "runtime source authority"
+        ),
+    }
+
+
+def classify_artifact_authority_order(
+    artifact_paths: Sequence[str | Path],
+) -> list[Dict[str, Any]]:
+    rows = [classify_artifact(path) for path in artifact_paths]
+    return sorted(
+        rows,
+        key=lambda row: (-int(row["authority_rank"]), row["artifact_path"]),
+    )
+
+
+def _field_status(
+    field: str,
+    payload: Mapping[str, Any],
+) -> Dict[str, Any]:
+    aliases = (field,) + _FIELD_ALIASES.get(field, ())
+    seen = []
+    require_non_empty = field in _NON_EMPTY_REQUIRED_FIELDS
+    for alias in aliases:
+        present, value = _get_path(payload, alias)
+        if not present:
+            continue
+        seen.append(alias)
+        if _has_value(value, require_non_empty=require_non_empty):
+            status = (
+                "SATISFIED"
+                if alias == field or field != "source_version"
+                else "PARTIAL"
+            )
+            reason = (
+                "field present"
+                if status == "SATISFIED"
+                else "alias present but exact source_version absent"
+            )
+            return {
+                "status": status,
+                "observed_field": alias,
+                "observed_value": value,
+                "reason": reason,
+            }
+
+    derived = _derived_status(field, payload)
+    if derived is not None:
+        return {
+            "status": "SATISFIED",
+            "observed_field": f"derived.{field}",
+            "observed_value": derived,
+            "reason": "derived from explicit run-safety fields",
+        }
+
+    if field == "validation_state":
+        for evidence_field in (
+            "validations",
+            "validation_summary",
+            "validation_commands",
+            "final_closeout_validation",
+        ):
+            present, value = _get_path(payload, evidence_field)
+            if present and _has_value(value, require_non_empty=True):
+                return {
+                    "status": "PARTIAL",
+                    "observed_field": evidence_field,
+                    "observed_value": None,
+                    "reason": (
+                        "validation evidence present but validation_state is not "
+                        "explicit"
+                    ),
+                }
+
+    return {
+        "status": "MISSING",
+        "observed_field": None,
+        "observed_value": None,
+        "reason": (
+            "field absent"
+            if not seen
+            else (
+                "field present only with empty value where non-empty declaration is "
+                "required"
+            )
+        ),
+    }
+
+
+def assess_exact_pass1_identity(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    run_present, run_id = _get_path(payload, "run_id")
+    hashes_present, hashes = _get_path(payload, "artifact_hashes")
+    pass1_present, pass1 = _get_path(payload, "pass1_artifact_identity")
+    if (
+        run_present
+        and _has_value(run_id, require_non_empty=True)
+        and hashes_present
+        and _has_value(hashes, require_non_empty=True)
+        and pass1_present
+        and _has_value(pass1, require_non_empty=True)
+    ):
+        return {
+            "status": "SATISFIED",
+            "reason": (
+                "run_id, artifact_hashes, and pass1_artifact_identity are present"
+            ),
+        }
+    if run_present or hashes_present or pass1_present:
+        return {
+            "status": "PARTIAL",
+            "reason": (
+                "only part of run_id, artifact_hashes, and pass1_artifact_identity "
+                "is present"
+            ),
+        }
+    return {
+        "status": "UNKNOWN",
+        "reason": (
+            "exact Pass 1 identity lacks run_id, artifact_hashes, and "
+            "pass1_artifact_identity evidence"
+        ),
+    }
+
+
+def build_conformance_report(
+    payload: Mapping[str, Any],
+    *,
+    artifact_path: str | Path = "UNKNOWN",
+    not_applicable_fields: Optional[Iterable[str]] = None,
+) -> Dict[str, Any]:
+    not_applicable = set(not_applicable_fields or ())
+    if not isinstance(payload, Mapping):
+        return {
+            "overall_status": "UNKNOWN",
+            "reason": "payload is not a JSON object",
+            "artifact": classify_artifact(artifact_path),
+            "fields": {},
+            "missing_fields": list(PROOF_CONTRACT_REQUIRED_FIELDS),
+        }
+
+    fields = {}
+    for field in PROOF_CONTRACT_REQUIRED_FIELDS:
+        if field in not_applicable:
+            fields[field] = {
+                "status": "NOT_APPLICABLE",
+                "observed_field": None,
+                "observed_value": None,
+                "reason": "field explicitly marked not applicable by caller",
+            }
+        else:
+            fields[field] = _field_status(field, payload)
+    status_counts: Dict[str, int] = {status: 0 for status in CONFORMANCE_STATUSES}
+    for result in fields.values():
+        status_counts[str(result["status"])] += 1
+
+    if (
+        status_counts["MISSING"] == 0
+        and status_counts["UNKNOWN"] == 0
+        and status_counts["PARTIAL"] == 0
+    ):
+        overall_status = "SATISFIED"
+    elif status_counts["SATISFIED"] == 0 and status_counts["PARTIAL"] == 0:
+        overall_status = "MISSING"
+    else:
+        overall_status = "PARTIAL"
+
+    artifact = classify_artifact(artifact_path, payload=payload)
+    pass1_identity = assess_exact_pass1_identity(payload)
+    is_full_bundle = overall_status == "SATISFIED"
+    if is_full_bundle:
+        proof_posture = "proof_contract_compliant_governance_bundle"
+    elif artifact["classification"] in {
+        "runtime_generated_evidence",
+        "proof_governance_artifact",
+    }:
+        proof_posture = "run_proof_or_packet_evidence_not_full_bundle"
+    else:
+        proof_posture = "not_proof_contract_bundle"
+
+    return {
+        "overall_status": overall_status,
+        "is_full_proof_contract_bundle": is_full_bundle,
+        "proof_posture": proof_posture,
+        "artifact": artifact,
+        "fields": fields,
+        "status_counts": status_counts,
+        "missing_fields": [
+            field
+            for field, result in fields.items()
+            if result["status"] in {"MISSING", "UNKNOWN"}
+        ],
+        "partial_fields": [
+            field for field, result in fields.items() if result["status"] == "PARTIAL"
+        ],
+        "exact_pass1_identity": pass1_identity,
+        "authority_boundary": (
+            "generated artifacts do not outrank runtime source authority"
+        ),
+    }

--- a/services/repo-truth-extractor/tests/test_proof_contract.py
+++ b/services/repo-truth-extractor/tests/test_proof_contract.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from lib import proof_contract
+from lib.proof_contract import (
+    build_conformance_report,
+    classify_artifact,
+    classify_artifact_authority_order,
+)
+
+
+def _partial_proof_pack() -> dict:
+    return {
+        "run_id": "run-static-001",
+        "git_sha": "abc123",
+        "runner_sha256": "runner-digest",
+        "argv": ["run_extraction_v5.py", "--phase", "D", "--dry-run"],
+        "cwd": "/repo",
+        "updated_at": "2026-05-15T00:00:00Z",
+        "phases": {"D": {"counts": {"raw": 1}}},
+        "linked_artifacts": {"coverage_rollup": "/repo/COVERAGE_ROLLUP.json"},
+    }
+
+
+def _full_bundle() -> dict:
+    return {
+        "bundle_id": "RTE-PKT-10-BUNDLE",
+        "run_id": "rte-pkt-10-local",
+        "source_version": "proof-contract-helper-v1",
+        "repo_root": "/repo",
+        "git_sha": "abc123",
+        "runner_sha": "runner-digest",
+        "command_argv": ["pytest", "test_proof_contract.py"],
+        "cwd": "/repo",
+        "status": "READY_FOR_REVIEW",
+        "validation_state": "PASSED",
+        "run_posture": "STATIC_ONLY",
+        "generated_at": "2026-05-15T00:00:00Z",
+        "phase_list": ["proof-contract"],
+        "generated_artifact_list": ["RTE-PKT-10_MANIFEST.json"],
+        "authoritative_artifacts": ["RTE-PKT-10_MANIFEST.json"],
+        "supporting_artifacts": ["RTE-PKT-10_TEST_REPORT.md"],
+        "runtime_authority_artifacts": [
+            "services/repo-truth-extractor/run_extraction_v5.py"
+        ],
+        "generated_evidence_artifacts": ["PROOF_PACK.json"],
+        "proof_governance_artifacts": [
+            "out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json"
+        ],
+        "external_advisory_artifacts": ["external-report-redacted"],
+        "sample_or_uncertain_lineage_artifacts": ["sample-proof-pack"],
+        "chain_of_custody": {
+            "documented": True,
+            "source_version": "proof-contract-helper-v1",
+        },
+        "warnings": [],
+        "blockers": [],
+        "handoff_refs": [],
+        "parent_bundle_refs": [],
+        "review_order_hint": 10,
+        "live_validation_status": "NOT_RUN",
+        "provider_call_status": "NOT_RUN",
+        "batch_operation_status": "NOT_RUN",
+        "redaction_status": "REDACTED",
+        "artifact_hashes": {"RTE-PKT-10_MANIFEST.json": "sha256:abc"},
+    }
+
+
+def test_partial_proof_pack_is_run_proof_not_full_contract_bundle() -> None:
+    report = build_conformance_report(
+        _partial_proof_pack(),
+        artifact_path=(
+            "services/repo-truth-extractor/extraction/repo-truth-extractor/"
+            "v5/runs/run/PROOF_PACK.json"
+        ),
+    )
+
+    assert report["overall_status"] == "PARTIAL"
+    assert report["is_full_proof_contract_bundle"] is False
+    assert report["proof_posture"] == "run_proof_or_packet_evidence_not_full_bundle"
+    assert report["artifact"]["classification"] == "runtime_generated_evidence"
+    assert report["fields"]["authoritative_artifacts"]["status"] == "MISSING"
+    assert report["fields"]["supporting_artifacts"]["status"] == "MISSING"
+
+
+def test_missing_authoritative_and_supporting_declarations_do_not_pass() -> None:
+    payload = _full_bundle()
+    payload.pop("authoritative_artifacts")
+    payload.pop("supporting_artifacts")
+
+    report = build_conformance_report(
+        payload,
+        artifact_path="out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json",
+    )
+
+    assert report["overall_status"] == "PARTIAL"
+    assert report["fields"]["authoritative_artifacts"]["status"] == "MISSING"
+    assert report["fields"]["supporting_artifacts"]["status"] == "MISSING"
+    assert report["is_full_proof_contract_bundle"] is False
+
+
+def test_static_batch_proof_remains_live_unvalidated() -> None:
+    payload = {
+        "packet_id": "RTE-PKT-08-XAI-BATCH-STATIC",
+        "status": "READY_FOR_REVIEW",
+        "live_validation_status": "NOT_LIVE_VALIDATED",
+        "provider_call_status": "NOT_RUN",
+        "batch_operation_status": "NOT_RUN",
+        "warnings": ["LIVE_VALIDATION_REQUIRED"],
+    }
+
+    report = build_conformance_report(
+        payload,
+        artifact_path="proof/TP-RTE-BATCH-E2E-006/PROOF.json",
+    )
+
+    assert report["artifact"]["classification"] == "proof_governance_artifact"
+    assert report["artifact"]["static_only"] is True
+    assert (
+        report["fields"]["live_validation_status"]["observed_value"]
+        == "NOT_LIVE_VALIDATED"
+    )
+    assert report["fields"]["provider_call_status"]["observed_value"] == "NOT_RUN"
+
+
+def test_generated_artifacts_do_not_outrank_runtime_source_authority() -> None:
+    ordered = classify_artifact_authority_order(
+        [
+            "out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json",
+            "services/repo-truth-extractor/run_extraction_v5.py",
+        ]
+    )
+
+    assert ordered[0]["classification"] == "runtime_authority"
+    assert ordered[1]["classification"] == "proof_governance_artifact"
+    assert ordered[1]["authority_rank"] < ordered[0]["authority_rank"]
+
+
+def test_exact_pass1_identity_stays_unknown_without_run_id_and_hashes() -> None:
+    report = build_conformance_report(
+        {"status": "READY_FOR_REVIEW"},
+        artifact_path=(
+            "services/repo-truth-extractor/tests/fixtures/proof_pack_sample.json"
+        ),
+    )
+
+    assert report["artifact"]["classification"] == "sample_artifact_uncertain_lineage"
+    assert report["exact_pass1_identity"]["status"] == "UNKNOWN"
+    assert "run_id" in report["missing_fields"]
+    assert "artifact_hashes" in report["missing_fields"]
+
+
+def test_packet_proof_manifest_is_not_runtime_source_authority() -> None:
+    artifact = classify_artifact(
+        "out/rte-pkt-02-payload-redaction/RTE-PKT-02_MANIFEST.json"
+    )
+
+    assert artifact["classification"] == "proof_governance_artifact"
+    assert artifact["is_runtime_source_authority"] is False
+    assert (
+        artifact["authority_boundary"]
+        == "runtime source authority outranks generated proof evidence"
+    )
+
+
+def test_no_provider_and_redaction_status_are_carried_into_report() -> None:
+    payload = {
+        "status": "READY_FOR_REVIEW",
+        "provider_calls": {
+            "live_provider_calls_run": False,
+            "batch_submit_poll_retrieve_cancel_run": False,
+        },
+        "live_validation_run": False,
+        "redaction_status": "REDACTED",
+    }
+
+    report = build_conformance_report(
+        payload,
+        artifact_path="out/rte-pkt-02-payload-redaction/RTE-PKT-02_MANIFEST.json",
+    )
+
+    assert report["fields"]["provider_call_status"]["observed_value"] == "NOT_RUN"
+    assert report["fields"]["batch_operation_status"]["observed_value"] == "NOT_RUN"
+    assert report["fields"]["live_validation_status"]["observed_value"] == "NOT_RUN"
+    assert report["fields"]["redaction_status"]["observed_value"] == "REDACTED"
+
+
+def test_proof_contract_helper_requires_no_provider_client() -> None:
+    assert not hasattr(proof_contract, "requests")
+    assert not hasattr(proof_contract, "OpenAI")
+
+    report = build_conformance_report(
+        _full_bundle(),
+        artifact_path="out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json",
+    )
+
+    assert report["overall_status"] == "SATISFIED"
+    assert report["fields"]["provider_call_status"]["observed_value"] == "NOT_RUN"
+    assert report["fields"]["batch_operation_status"]["observed_value"] == "NOT_RUN"
+
+
+def test_not_applicable_fields_require_explicit_caller_declaration() -> None:
+    payload = _full_bundle()
+    payload.pop("handoff_refs")
+
+    report = build_conformance_report(
+        payload,
+        artifact_path="out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json",
+        not_applicable_fields={"handoff_refs"},
+    )
+
+    assert report["overall_status"] == "SATISFIED"
+    assert report["fields"]["handoff_refs"]["status"] == "NOT_APPLICABLE"


### PR DESCRIPTION
## Summary
- add a deterministic proof-contract conformance helper for RTE artifact classification and field-gap reporting
- add focused local tests for run proof vs bundle proof, missing declarations, static-only proof, artifact authority ordering, exact Pass 1 unknowns, redaction/no-provider status, and no-provider-client safety
- add RTE-PKT-10 packet proof outputs under out/rte-pkt-10-proof-contract/

## Validation
- pytest services/repo-truth-extractor/tests/test_proof_contract.py -q
- pytest services/repo-truth-extractor/tests -k 'proof_contract or artifact_authority' -q\n- pytest services/repo-truth-extractor/tests -k 'proof and contract' -q\n- python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/proof_contract.py\n- python -m json.tool out/rte-pkt-10-proof-contract/RTE-PKT-10_MANIFEST.json\n- git diff --check\n- pre-commit run --files <changed RTE-PKT-10 files>\n\n## Boundaries\n- no prompt, promptset, model-map, provider route, provider client, batch protocol, config, compose, or deployment changes\n- no live extraction, provider calls, provider credentials, or batch provider operations\n- exact Pass 1 identity remains UNKNOWN without exact hashes plus run IDs\n\n@codex review\n@gemini\n@copilot\n\nGenerate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated