### PR TITLE
feat(repo-truth-extractor): add RTE risk dashboard

### DIFF
--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_DIFF_SUMMARY.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_DIFF_SUMMARY.md
@@ -1,0 +1,20 @@
+# RTE-PKT-11 Diff Summary
+
+## Code Files
+
+- `services/repo-truth-extractor/run_extraction_v5.py`: wires central risk dashboard generation into the existing run dashboard telemetry writer. No extraction, routing, prompt, provider, batch, or live-validation behavior is changed.
+- `services/repo-truth-extractor/lib/proof_contract.py`: carries forward the accepted RTE-PKT-10 proof-contract helper so dashboard generation can consume proof-contract and artifact-authority classification without changing those semantics.
+- `services/repo-truth-extractor/lib/risk_dashboard.py`: adds pure local aggregation, redaction, markdown rendering, and artifact writing for `telemetry/RTE_RISK_DASHBOARD.json` and `telemetry/RTE_RISK_DASHBOARD.md`.
+
+## Test Files
+
+- `services/repo-truth-extractor/tests/test_proof_contract.py`: focused proof-contract helper tests carried forward from RTE-PKT-10 semantics.
+- `services/repo-truth-extractor/tests/test_risk_dashboard.py`: targeted dashboard tests for static/live boundaries, provider lanes, batch JSONL absence, proof-contract partial status, generated artifact authority, prescan/provenance/truth-label summaries, redaction, and no-provider-call behavior.
+
+## Proof Files
+
+- `out/rte-pkt-11-risk-dashboard/`: packet proof bundle and generated dashboard examples.
+
+## Forbidden Paths
+
+No prompt files, promptsets, model maps, provider routes, provider clients, batch protocol files, pricing files, config roots, compose files, or deployment files were changed.

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json
@@ -1,0 +1,119 @@
+{
+  "authority_conflicts": [
+    "AGENTS.md asks for a canonical Task Packet before implementation; active packet non_goals forbid creating additional Task Packets. No new Task Packet was created."
+  ],
+  "changed_files": [
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/lib/proof_contract.py",
+    "services/repo-truth-extractor/lib/risk_dashboard.py",
+    "services/repo-truth-extractor/tests/test_proof_contract.py",
+    "services/repo-truth-extractor/tests/test_risk_dashboard.py",
+    "out/rte-pkt-11-risk-dashboard/"
+  ],
+  "commit_state_at_manifest_generation": "not_committed; scoped files validated and ready to stage",
+  "current_branch_prior_packet_roots_before_output": [
+    "/Users/hue/code/dopemux-mvp/.worktrees/rte-pkt-11-risk-dashboard/out/rte-pkt-11-risk-dashboard"
+  ],
+  "generated_at": "2026-05-15T16:53:21Z",
+  "no_provider_calls": {
+    "batch_provider_operations_performed": false,
+    "external_research_performed": false,
+    "live_extraction_performed": false,
+    "provider_calls_performed": false,
+    "provider_credentials_inspected": false,
+    "provider_credentials_required": false
+  },
+  "packet_id": "RTE-PKT-11-RISK-DASHBOARD",
+  "prior_packet_evidence_roots_read": [
+    "/Users/hue/.codex/worktrees/rte-pkt-01-live-gate/out/rte-pkt-01-live-gate",
+    "/Users/hue/code/dopemux-mvp-rte-pkt-02-payload-redaction/out/rte-pkt-02-payload-redaction",
+    "/Users/hue/.codex/worktrees/73bf/dopemux-mvp/out/rte-pkt-03-prescan-stale",
+    "/Users/hue/.codex/worktrees/0bee/dopemux-mvp/out/rte-pkt-04-prescan-influence",
+    "/Users/hue/.codex/worktrees/0bee/dopemux-mvp/out/rte-pkt-05-provenance-fields",
+    "/Users/hue/.codex/worktrees/0bee/dopemux-mvp/out/rte-pkt-06-truth-labels",
+    "/Users/hue/.codex/worktrees/39a6/dopemux-mvp/out/rte-pkt-07-xai-metadata",
+    "/Users/hue/.codex/worktrees/d17a/dopemux-mvp/out/rte-pkt-08-xai-batch-static",
+    "/Users/hue/.codex/worktrees/227d/dopemux-mvp/out/rte-pkt-09-live-validation-plan",
+    "/Users/hue/.codex/worktrees/e3e0/dopemux-mvp/out/rte-pkt-10-proof-contract",
+    "/Users/hue/.codex/worktrees/0bee/dopemux-mvp/out/rte-pkt-15-failed-sidecars"
+  ],
+  "proof_outputs": [
+    "RTE-PKT-11_MANIFEST.json",
+    "RTE-PKT-11_RISK_DASHBOARD_SCHEMA.md",
+    "RTE-PKT-11_RISK_DASHBOARD_EXAMPLE.json",
+    "RTE-PKT-11_RISK_DASHBOARD_EXAMPLE.md",
+    "RTE-PKT-11_RISK_ITEM_MATRIX.md",
+    "RTE-PKT-11_TEST_REPORT.md",
+    "RTE-PKT-11_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "RTE-PKT-11_DIFF_SUMMARY.md",
+    "RTE-PKT-11_REMAINING_UNKNOWNS.md",
+    "RTE-PKT-11_RESEARCH.md"
+  ],
+  "repo": {
+    "branch": "codex/rte-pkt-11-risk-dashboard",
+    "head": "a4214ca5bf431e1b59791661e2b664a6cd24c1da",
+    "remotes": [
+      "mvp\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)",
+      "mvp\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (push)",
+      "origin\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)",
+      "origin\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (push)"
+    ],
+    "required_markers": {
+      "pyproject.toml": true,
+      "services/repo-truth-extractor/run_extraction_v5.py": true,
+      "services/repo-truth-extractor/tests/": true,
+      "src/dopemux/cli.py": true
+    },
+    "status_at_manifest_generation": [
+      "## codex/rte-pkt-11-risk-dashboard",
+      " M services/repo-truth-extractor/run_extraction_v5.py",
+      "?? out/rte-pkt-11-risk-dashboard/",
+      "?? services/repo-truth-extractor/lib/proof_contract.py",
+      "?? services/repo-truth-extractor/lib/risk_dashboard.py",
+      "?? services/repo-truth-extractor/tests/test_proof_contract.py",
+      "?? services/repo-truth-extractor/tests/test_risk_dashboard.py"
+    ],
+    "worktree_path": "/Users/hue/code/dopemux-mvp/.worktrees/rte-pkt-11-risk-dashboard"
+  },
+  "status": "VALIDATED_TARGETED_STATIC_READY_FOR_REVIEW",
+  "validations": [
+    {
+      "command": "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/risk_dashboard.py services/repo-truth-extractor/lib/proof_contract.py",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest services/repo-truth-extractor/tests -k 'risk and dashboard' -q",
+      "exit_code": 0,
+      "status": "PASS",
+      "summary": "9 passed; pytest config warning about unknown asyncio_mode"
+    },
+    {
+      "command": "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest services/repo-truth-extractor/tests -k 'proof_contract or artifact_authority' -q",
+      "exit_code": 0,
+      "status": "PASS",
+      "summary": "10 passed; pytest config warning about unknown asyncio_mode"
+    },
+    {
+      "command": "python -m json.tool out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json >/dev/null",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m json.tool out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_DASHBOARD_EXAMPLE.json >/dev/null",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "pre-commit run --files <changed packet files>",
+      "exit_code": 0,
+      "status": "PASS",
+      "summary": "Repo pre-commit hooks passed on changed code, tests, and proof outputs."
+    }
+  ]
+}

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json
@@ -10,11 +10,11 @@
     "services/repo-truth-extractor/tests/test_risk_dashboard.py",
     "out/rte-pkt-11-risk-dashboard/"
   ],
-  "commit_state_at_manifest_generation": "not_committed; scoped files validated and ready to stage",
+  "commit_state_at_manifest_generation": "implementation commit observed at 1de11a13131c1bda2708b9baf9610ad7244af11b; manifest refreshed after targeted validation rerun",
   "current_branch_prior_packet_roots_before_output": [
     "/Users/hue/code/dopemux-mvp/.worktrees/rte-pkt-11-risk-dashboard/out/rte-pkt-11-risk-dashboard"
   ],
-  "generated_at": "2026-05-15T16:53:21Z",
+  "generated_at": "2026-05-15T16:58:28Z",
   "no_provider_calls": {
     "batch_provider_operations_performed": false,
     "external_research_performed": false,
@@ -51,7 +51,7 @@
   ],
   "repo": {
     "branch": "codex/rte-pkt-11-risk-dashboard",
-    "head": "a4214ca5bf431e1b59791661e2b664a6cd24c1da",
+    "head": "1de11a13131c1bda2708b9baf9610ad7244af11b",
     "remotes": [
       "mvp\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)",
       "mvp\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (push)",
@@ -65,17 +65,12 @@
       "src/dopemux/cli.py": true
     },
     "status_at_manifest_generation": [
-      "## codex/rte-pkt-11-risk-dashboard",
-      " M services/repo-truth-extractor/run_extraction_v5.py",
-      "?? out/rte-pkt-11-risk-dashboard/",
-      "?? services/repo-truth-extractor/lib/proof_contract.py",
-      "?? services/repo-truth-extractor/lib/risk_dashboard.py",
-      "?? services/repo-truth-extractor/tests/test_proof_contract.py",
-      "?? services/repo-truth-extractor/tests/test_risk_dashboard.py"
+      "## codex/rte-pkt-11-risk-dashboard...origin/codex/rte-pkt-11-risk-dashboard"
     ],
     "worktree_path": "/Users/hue/code/dopemux-mvp/.worktrees/rte-pkt-11-risk-dashboard"
   },
   "status": "VALIDATED_TARGETED_STATIC_READY_FOR_REVIEW",
+  "validation_rerun_at": "2026-05-15T16:58:28Z",
   "validations": [
     {
       "command": "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/risk_dashboard.py services/repo-truth-extractor/lib/proof_contract.py",

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,6 +1,6 @@
 # RTE-PKT-11 No Provider Calls Attestation
 
-Generated: 2026-05-15T16:46:47Z
+Generated: 2026-05-15T16:58:28Z
 
 Attestation: no live extraction, provider calls, provider preflight, provider doctor probes, provider batch submit, provider batch poll, provider batch retrieve, provider batch cancel, remote provider file retrieval, credential inspection, or external web research was performed for this packet.
 

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,11 @@
+# RTE-PKT-11 No Provider Calls Attestation
+
+Generated: 2026-05-15T16:46:47Z
+
+Attestation: no live extraction, provider calls, provider preflight, provider doctor probes, provider batch submit, provider batch poll, provider batch retrieve, provider batch cancel, remote provider file retrieval, credential inspection, or external web research was performed for this packet.
+
+Validation evidence:
+
+- `test_risk_dashboard_generation_requires_no_provider_calls` monkeypatches provider and batch call surfaces to raise if invoked while generating the dashboard through `emit_run_dashboard_snapshot()`.
+- Targeted tests were run with `RTE_DISABLE_LIVE_LLM_IN_TESTS=1`.
+- The dashboard helper imports no provider clients and reads only local runtime/proof inputs supplied by caller or present under a run root.

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_REMAINING_UNKNOWNS.md
@@ -1,0 +1,26 @@
+# RTE-PKT-11 Remaining Unknowns
+
+- Current branch does not contain tracked prior proof roots for RTE-PKT-01 through RTE-PKT-10; local sibling worktree proof roots were readable but are not current-branch source truth.
+- Exact Pass 1 artifact identity remains UNKNOWN because no exact Pass 1 run id plus artifact hash set was present in current local inputs.
+- Live xAI/OpenRouter/OpenAI-compatible/Gemini provider behavior remains LIVE_VALIDATION_REQUIRED.
+- Batch downloaded JSONL remains MISSING in the fixture/current proof example unless local downloaded JSONL artifacts are actually present.
+- Billing truth and ZDR truth remain outside this static packet.
+- AGENTS.md requires creating a canonical task packet, but the active user packet explicitly says not to create additional Task Packets; this work treats the supplied packet as active authority and records this conflict instead of creating a new packet.
+
+## Current-Branch Prior Proof Roots Observed
+
+- `/Users/hue/code/dopemux-mvp/.worktrees/rte-pkt-11-risk-dashboard/out/rte-pkt-11-risk-dashboard`
+
+## Local Sibling Proof Roots Read As Evidence
+
+- `/Users/hue/.codex/worktrees/rte-pkt-01-live-gate/out/rte-pkt-01-live-gate`
+- `/Users/hue/code/dopemux-mvp-rte-pkt-02-payload-redaction/out/rte-pkt-02-payload-redaction`
+- `/Users/hue/.codex/worktrees/73bf/dopemux-mvp/out/rte-pkt-03-prescan-stale`
+- `/Users/hue/.codex/worktrees/0bee/dopemux-mvp/out/rte-pkt-04-prescan-influence`
+- `/Users/hue/.codex/worktrees/0bee/dopemux-mvp/out/rte-pkt-05-provenance-fields`
+- `/Users/hue/.codex/worktrees/0bee/dopemux-mvp/out/rte-pkt-06-truth-labels`
+- `/Users/hue/.codex/worktrees/39a6/dopemux-mvp/out/rte-pkt-07-xai-metadata`
+- `/Users/hue/.codex/worktrees/d17a/dopemux-mvp/out/rte-pkt-08-xai-batch-static`
+- `/Users/hue/.codex/worktrees/227d/dopemux-mvp/out/rte-pkt-09-live-validation-plan`
+- `/Users/hue/.codex/worktrees/e3e0/dopemux-mvp/out/rte-pkt-10-proof-contract`
+- `/Users/hue/.codex/worktrees/0bee/dopemux-mvp/out/rte-pkt-15-failed-sidecars`

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RESEARCH.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RESEARCH.md
@@ -1,0 +1,28 @@
+# RTE-PKT-11 Research
+
+## Evidence Summary
+
+- OBSERVED: Primary checkout `/Users/hue/code/dopemux-mvp` is on `codex/rte-dr00-normalized-baseline` at `a4214ca5bf431e1b59791661e2b664a6cd24c1da` and has unrelated untracked files. It was not modified.
+- OBSERVED: Dedicated worktree `/Users/hue/code/dopemux-mvp/.worktrees/rte-pkt-11-risk-dashboard` is on branch `codex/rte-pkt-11-risk-dashboard` and was initially clean.
+- OBSERVED: Required markers exist in the dedicated worktree: `pyproject.toml`, `src/dopemux/cli.py`, `services/repo-truth-extractor/run_extraction_v5.py`, and `services/repo-truth-extractor/tests/`.
+- OBSERVED: `AGENTS.md` requires worktree isolation, proof, targeted validation, diff review, and precommit.
+- OBSERVED: `PROJECT.md`, `ARCHITECTURE.md`, `SERVICE_CATALOG.md`, and `SYSTEM_RepoTruthExtractor` identify `services/repo-truth-extractor/run_extraction_v5.py` as the strongest RTE runtime authority and generated artifacts as evidence, not source truth.
+- OBSERVED: Existing run dashboard writer is `emit_run_dashboard_snapshot()` in `run_extraction_v5.py`, writing `telemetry/RUN_DASHBOARD.json`.
+- OBSERVED: Current base lacks `services/repo-truth-extractor/lib/proof_contract.py`; accepted RTE-PKT-10 local worktree contains the proof-contract helper used here without semantic changes.
+- OBSERVED: Current branch does not contain prior `out/rte-pkt-01` through `out/rte-pkt-10` proof roots. Local sibling worktrees contain readable prior packet proof roots and were used only as evidence references.
+
+## Risks
+
+- Prior packet proof roots are not all present in this branch, so the runtime dashboard must preserve missing/unknown evidence states.
+- A new telemetry artifact must not call provider, batch, live-validation, or external network paths.
+- Generated dashboard files must not expose secret-shaped values.
+- Generated artifacts must remain lower authority than runtime source.
+
+## Verification Commands
+
+- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/risk_dashboard.py services/repo-truth-extractor/lib/proof_contract.py`
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest services/repo-truth-extractor/tests -k 'risk and dashboard' -q`
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest services/repo-truth-extractor/tests -k 'proof_contract or artifact_authority' -q`
+- `python -m json.tool out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json >/dev/null`
+- `git diff --check`
+- `git status --short --branch`

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_DASHBOARD_EXAMPLE.json
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_DASHBOARD_EXAMPLE.json
@@ -1,0 +1,214 @@
+{
+  "accepted_risks": [
+    "BATCH_STATIC: accepted static proof with residual risk",
+    "FAILED_SIDECARS: accepted static proof with residual risk",
+    "GENERATED_ARTIFACT_AUTHORITY: accepted static proof with residual risk",
+    "PRESCAN_INFLUENCE: accepted static proof with residual risk",
+    "PRESCAN_STALENESS: accepted static proof with residual risk",
+    "PROOF_CONTRACT: accepted static proof with residual risk"
+  ],
+  "artifact_authority_status": "generated_artifacts_are_non_authoritative_evidence",
+  "batch_operation_status": "LIVE_VALIDATION_REQUIRED",
+  "blockers": [
+    "LIVE_VALIDATION_PLAN: live validation execution is not authorized"
+  ],
+  "generated_at": "2026-05-15T00:00:00Z",
+  "git_sha_if_available": "a4214ca5bf431e1b59791661e2b664a6cd24c1da",
+  "live_use_readiness": "READY_FOR_LIMITED_DRY_STATIC_USE",
+  "live_validation_status": "BLOCKED",
+  "next_recommended_actions": [
+    "Review RTE_RISK_DASHBOARD.md before treating static proof as live readiness.",
+    "Run a separately authorized live-validation packet before claiming provider behavior.",
+    "Keep downloaded batch JSONL as MISSING unless local artifacts are actually present.",
+    "Resolve proof-contract partial/missing fields before treating run proof as a full bundle proof."
+  ],
+  "overall_risk_level": "MEDIUM-HIGH",
+  "proof_contract_status": "partial",
+  "provider_call_status": "LIVE_VALIDATION_REQUIRED",
+  "repo_root_if_available": "/Users/hue/code/dopemux-mvp/.worktrees/rte-pkt-11-risk-dashboard",
+  "risk_items": [
+    {
+      "evidence_basis": "local runtime/proof inputs",
+      "id": "LIVE_GATE",
+      "live_use_boundary": "static proof only; production live readiness not claimed",
+      "live_validation_artifacts": [],
+      "live_validation_required_boolean": true,
+      "status": "STATIC_ONLY"
+    },
+    {
+      "coverage": "provider-bound payload/error summaries only; no raw provider payload text",
+      "evidence_basis": "static packet/runtime redaction proof when available",
+      "id": "PROVIDER_PAYLOAD_REDACTION",
+      "remaining_unknowns": [],
+      "status": "PASS_STATIC"
+    },
+    {
+      "comparison_lane_failed_txt_unknown_if_applicable": true,
+      "evidence_basis": "static failed-sidecar redaction proof when available",
+      "id": "FAILED_SIDECARS",
+      "remaining_unknowns": [
+        "comparison-lane .FAILED.txt behavior remains unknown unless separate proof is present"
+      ],
+      "status": "PASS_WITH_RISK"
+    },
+    {
+      "accepted_import_status": "accepted only when identity/freshness evidence is present",
+      "evidence_basis": "prescan receipt/static packet evidence when available",
+      "id": "PRESCAN_STALENESS",
+      "rejected_import_behavior": "stale or malformed imported prescan must be rejected or non-authoritative",
+      "status": "ACCEPTED_WITH_RISK"
+    },
+    {
+      "advisory_model_derived_status": "model-derived prescan signals remain advisory unless accepted by runtime guards",
+      "evidence_basis": "prescan influence labels/static packet evidence when available",
+      "id": "PRESCAN_INFLUENCE",
+      "influence_applied_or_not": "accepted influence must be explicitly labeled",
+      "status": "ACCEPTED_WITH_RISK"
+    },
+    {
+      "evidence_basis": "repair/sidefill provenance static packet evidence when available",
+      "id": "PROVENANCE_FIELDS",
+      "repaired_values_labeled": true,
+      "sidefilled_values_labeled": true,
+      "status": "PASS_STATIC"
+    },
+    {
+      "conflicting_preservation": true,
+      "evidence_basis": "truth-label preservation static packet evidence when available",
+      "id": "TRUTH_LABELS",
+      "status": "PASS_STATIC",
+      "unknown_preservation": true
+    },
+    {
+      "evidence_basis": "static fixture proof only unless live validation artifacts are present",
+      "id": "PROVIDER_METADATA",
+      "live_provider_shapes_required": true,
+      "provider_lanes": {
+        "direct_xai": "LIVE_VALIDATION_REQUIRED",
+        "gemini_compatible": "LIVE_VALIDATION_REQUIRED",
+        "openai_compatible": "LIVE_VALIDATION_REQUIRED",
+        "openrouter_xai": "LIVE_VALIDATION_REQUIRED"
+      },
+      "refusal_incomplete_static": true,
+      "requested_vs_returned_model": "static fixture proven; live provider edge behavior unknown",
+      "status": "LIVE_VALIDATION_REQUIRED"
+    },
+    {
+      "downloaded_jsonl_files": [],
+      "downloaded_jsonl_status": "MISSING",
+      "evidence_basis": "batch static fixture proof when available",
+      "id": "BATCH_STATIC",
+      "live_validation_required": true,
+      "not_live_validated": true,
+      "status": "PASS_WITH_RISK"
+    },
+    {
+      "evidence_basis": "local authorization/live-validation artifact inventory",
+      "execution_not_authorized": true,
+      "id": "LIVE_VALIDATION_PLAN",
+      "live_validation_artifacts": [],
+      "plan_exists": true,
+      "status": "BLOCKED"
+    },
+    {
+      "conformance_status": "partial",
+      "evidence_basis": "RTE-PKT-10 proof-contract helper",
+      "id": "PROOF_CONTRACT",
+      "missing_or_partial_fields": [
+        "artifact_hashes",
+        "authoritative_artifacts",
+        "blockers",
+        "bundle_id",
+        "chain_of_custody",
+        "external_advisory_artifacts",
+        "generated_evidence_artifacts",
+        "handoff_refs",
+        "parent_bundle_refs",
+        "proof_governance_artifacts",
+        "repo_root",
+        "review_order_hint",
+        "runtime_authority_artifacts",
+        "sample_or_uncertain_lineage_artifacts",
+        "source_version",
+        "status",
+        "supporting_artifacts",
+        "validation_state",
+        "warnings"
+      ],
+      "run_proof_vs_bundle_proof": "run_proof_or_packet_evidence_not_full_bundle",
+      "status": "PASS_WITH_RISK"
+    },
+    {
+      "evidence_basis": "proof-contract exact Pass 1 identity classifier",
+      "exact_identity_known_or_unknown": "unknown",
+      "id": "PASS1_IDENTITY",
+      "reason": "only part of run_id, artifact_hashes, and pass1_artifact_identity is present",
+      "status": "UNKNOWN"
+    },
+    {
+      "authority_order": [
+        {
+          "artifact_path": "services/repo-truth-extractor/run_extraction_v5.py",
+          "authority_boundary": "runtime source authority",
+          "authority_rank": 100,
+          "classification": "runtime_authority",
+          "is_generated_evidence": false,
+          "is_runtime_source_authority": true,
+          "live_validation_status": "UNKNOWN",
+          "provider_call_status": "UNKNOWN",
+          "static_only": false
+        },
+        {
+          "artifact_path": "out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json",
+          "authority_boundary": "runtime source authority outranks generated proof evidence",
+          "authority_rank": 60,
+          "classification": "proof_governance_artifact",
+          "is_generated_evidence": true,
+          "is_runtime_source_authority": false,
+          "live_validation_status": "UNKNOWN",
+          "provider_call_status": "UNKNOWN",
+          "static_only": false
+        },
+        {
+          "artifact_path": "telemetry/RUN_DASHBOARD.json",
+          "authority_boundary": "runtime source authority outranks generated proof evidence",
+          "authority_rank": 50,
+          "classification": "runtime_generated_evidence",
+          "is_generated_evidence": true,
+          "is_runtime_source_authority": false,
+          "live_validation_status": "UNKNOWN",
+          "provider_call_status": "UNKNOWN",
+          "static_only": false
+        },
+        {
+          "artifact_path": "telemetry/RTE_RISK_DASHBOARD.json",
+          "authority_boundary": "runtime source authority outranks generated proof evidence",
+          "authority_rank": 0,
+          "classification": "unknown",
+          "is_generated_evidence": false,
+          "is_runtime_source_authority": false,
+          "live_validation_status": "UNKNOWN",
+          "provider_call_status": "UNKNOWN",
+          "static_only": false
+        }
+      ],
+      "evidence_basis": "artifact authority classifier",
+      "id": "GENERATED_ARTIFACT_AUTHORITY",
+      "non_authority_label": "generated artifacts are evidence, not runtime source truth",
+      "status": "ACCEPTED_WITH_RISK"
+    }
+  ],
+  "run_id_if_available": "rte-pkt-11-static-fixture",
+  "static_audit_verdict": "PASS_WITH_RISK",
+  "unknowns": [
+    "PASS1_IDENTITY: UNKNOWN",
+    "PASS1_IDENTITY: exact Pass 1 artifact identity is UNKNOWN"
+  ],
+  "warnings": [
+    "BATCH_STATIC: PASS_WITH_RISK",
+    "BATCH_STATIC: downloaded JSONL inventory is MISSING",
+    "FAILED_SIDECARS: PASS_WITH_RISK",
+    "PROOF_CONTRACT: PASS_WITH_RISK",
+    "PROVIDER_METADATA: LIVE_VALIDATION_REQUIRED"
+  ]
+}

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_DASHBOARD_EXAMPLE.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_DASHBOARD_EXAMPLE.md
@@ -1,0 +1,62 @@
+# RTE Risk Dashboard
+
+- Run ID: rte-pkt-11-static-fixture
+- Generated at: 2026-05-15T00:00:00Z
+- Live-use readiness: READY_FOR_LIMITED_DRY_STATIC_USE
+- Static audit verdict: PASS_WITH_RISK
+- Overall risk level: MEDIUM-HIGH
+- Provider call status: LIVE_VALIDATION_REQUIRED
+- Batch operation status: LIVE_VALIDATION_REQUIRED
+- Live validation status: BLOCKED
+- Proof contract status: partial
+
+## Risk Items
+
+| ID | Status | Evidence | Notes |
+| --- | --- | --- | --- |
+| LIVE_GATE | STATIC_ONLY | local runtime/proof inputs | - |
+| PROVIDER_PAYLOAD_REDACTION | PASS_STATIC | static packet/runtime redaction proof when available | - |
+| FAILED_SIDECARS | PASS_WITH_RISK | static failed-sidecar redaction proof when available | - |
+| PRESCAN_STALENESS | ACCEPTED_WITH_RISK | prescan receipt/static packet evidence when available | - |
+| PRESCAN_INFLUENCE | ACCEPTED_WITH_RISK | prescan influence labels/static packet evidence when available | - |
+| PROVENANCE_FIELDS | PASS_STATIC | repair/sidefill provenance static packet evidence when available | - |
+| TRUTH_LABELS | PASS_STATIC | truth-label preservation static packet evidence when available | - |
+| PROVIDER_METADATA | LIVE_VALIDATION_REQUIRED | static fixture proof only unless live validation artifacts are present | - |
+| BATCH_STATIC | PASS_WITH_RISK | batch static fixture proof when available | downloaded_jsonl_status=MISSING |
+| LIVE_VALIDATION_PLAN | BLOCKED | local authorization/live-validation artifact inventory | - |
+| PROOF_CONTRACT | PASS_WITH_RISK | RTE-PKT-10 proof-contract helper | conformance_status=partial |
+| PASS1_IDENTITY | UNKNOWN | proof-contract exact Pass 1 identity classifier | exact_identity_known_or_unknown=unknown |
+| GENERATED_ARTIFACT_AUTHORITY | ACCEPTED_WITH_RISK | artifact authority classifier | non_authority_label=generated artifacts are evidence, not runtime source truth |
+
+## Blockers
+
+- LIVE_VALIDATION_PLAN: live validation execution is not authorized
+
+## Warnings
+
+- BATCH_STATIC: PASS_WITH_RISK
+- BATCH_STATIC: downloaded JSONL inventory is MISSING
+- FAILED_SIDECARS: PASS_WITH_RISK
+- PROOF_CONTRACT: PASS_WITH_RISK
+- PROVIDER_METADATA: LIVE_VALIDATION_REQUIRED
+
+## Accepted Risks
+
+- BATCH_STATIC: accepted static proof with residual risk
+- FAILED_SIDECARS: accepted static proof with residual risk
+- GENERATED_ARTIFACT_AUTHORITY: accepted static proof with residual risk
+- PRESCAN_INFLUENCE: accepted static proof with residual risk
+- PRESCAN_STALENESS: accepted static proof with residual risk
+- PROOF_CONTRACT: accepted static proof with residual risk
+
+## Unknowns
+
+- PASS1_IDENTITY: UNKNOWN
+- PASS1_IDENTITY: exact Pass 1 artifact identity is UNKNOWN
+
+## Next Recommended Actions
+
+- Review RTE_RISK_DASHBOARD.md before treating static proof as live readiness.
+- Run a separately authorized live-validation packet before claiming provider behavior.
+- Keep downloaded batch JSONL as MISSING unless local artifacts are actually present.
+- Resolve proof-contract partial/missing fields before treating run proof as a full bundle proof.

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_DASHBOARD_SCHEMA.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_DASHBOARD_SCHEMA.md
@@ -1,0 +1,67 @@
+# RTE-PKT-11 Risk Dashboard Schema
+
+Generated: 2026-05-15T16:46:47Z
+
+## Top-Level Fields
+
+Required fields emitted by `lib.risk_dashboard.build_rte_risk_dashboard`:
+
+- `run_id_if_available`: run id when supplied by runtime/proof inputs; otherwise null.
+- `generated_at`: UTC generation timestamp.
+- `repo_root_if_available`: repo root observed by runtime/proof inputs.
+- `git_sha_if_available`: git SHA observed by runtime/proof inputs.
+- `live_use_readiness`: readiness label. Current static packet output uses `READY_FOR_LIMITED_DRY_STATIC_USE` and does not claim production-live readiness.
+- `static_audit_verdict`: static audit verdict status.
+- `overall_risk_level`: operator risk label.
+- `provider_call_status`: aggregate provider status.
+- `batch_operation_status`: aggregate batch status.
+- `live_validation_status`: aggregate live-validation status.
+- `proof_contract_status`: `satisfied`, `partial`, `missing`, `unknown`, or `not_applicable`.
+- `artifact_authority_status`: generated artifact authority statement.
+- `risk_items`: ordered list of required risk items.
+- `blockers`: blocking static/live readiness issues.
+- `warnings`: non-blocking risk warnings.
+- `accepted_risks`: accepted residual static risks.
+- `unknowns`: explicit unknowns.
+- `next_recommended_actions`: operator next actions.
+
+## Status Values
+
+- `PASS_STATIC`
+- `PASS_WITH_RISK`
+- `STATIC_ONLY`
+- `LIVE_VALIDATION_REQUIRED`
+- `MISSING`
+- `UNKNOWN`
+- `BLOCKED`
+- `NOT_APPLICABLE`
+- `ACCEPTED_WITH_RISK`
+
+## Required Risk Items
+
+- `LIVE_GATE`
+- `PROVIDER_PAYLOAD_REDACTION`
+- `FAILED_SIDECARS`
+- `PRESCAN_STALENESS`
+- `PRESCAN_INFLUENCE`
+- `PROVENANCE_FIELDS`
+- `TRUTH_LABELS`
+- `PROVIDER_METADATA`
+- `BATCH_STATIC`
+- `LIVE_VALIDATION_PLAN`
+- `PROOF_CONTRACT`
+- `PASS1_IDENTITY`
+- `GENERATED_ARTIFACT_AUTHORITY`
+
+## Redaction Boundary
+
+Dashboard JSON and markdown are passed through the existing RTE output sanitizer. Secret-shaped strings in values such as tokens, bearer headers, passwords, private keys, and authorization fields are redacted before artifact write.
+
+## Local Input Notes
+
+- `accepted_packet_basis` is an input-side evidence map. Runtime collection sets each risk item to true only when the corresponding `out/rte-pkt-*` proof root exists under the current repo root. Fixture/proof examples can supply accepted packet basis explicitly.
+- Missing prior packet roots must remain `UNKNOWN` or `MISSING`; they are not inferred as passing current-branch evidence.
+
+## Authority Boundary
+
+The dashboard is generated evidence. It does not outrank runtime source code, schemas, tests, configs, or active entrypoints. Generated proof artifacts are labeled as non-authoritative evidence.

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_ITEM_MATRIX.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_ITEM_MATRIX.md
@@ -1,0 +1,35 @@
+# RTE-PKT-11 Risk Item Matrix
+
+| Risk Item | Status | Source Inputs | Notes |
+| --- | --- | --- | --- |
+| `LIVE_GATE` | `STATIC_ONLY` | local runtime/proof inputs | - |
+| `PROVIDER_PAYLOAD_REDACTION` | `PASS_STATIC` | static packet/runtime redaction proof when available | - |
+| `FAILED_SIDECARS` | `PASS_WITH_RISK` | static failed-sidecar redaction proof when available | - |
+| `PRESCAN_STALENESS` | `ACCEPTED_WITH_RISK` | prescan receipt/static packet evidence when available | - |
+| `PRESCAN_INFLUENCE` | `ACCEPTED_WITH_RISK` | prescan influence labels/static packet evidence when available | - |
+| `PROVENANCE_FIELDS` | `PASS_STATIC` | repair/sidefill provenance static packet evidence when available | - |
+| `TRUTH_LABELS` | `PASS_STATIC` | truth-label preservation static packet evidence when available | - |
+| `PROVIDER_METADATA` | `LIVE_VALIDATION_REQUIRED` | static fixture proof only unless live validation artifacts are present | - |
+| `BATCH_STATIC` | `PASS_WITH_RISK` | batch static fixture proof when available | downloaded_jsonl_status=MISSING |
+| `LIVE_VALIDATION_PLAN` | `BLOCKED` | local authorization/live-validation artifact inventory | - |
+| `PROOF_CONTRACT` | `PASS_WITH_RISK` | RTE-PKT-10 proof-contract helper | conformance_status=partial |
+| `PASS1_IDENTITY` | `UNKNOWN` | proof-contract exact Pass 1 identity classifier | exact_identity_known_or_unknown=unknown |
+| `GENERATED_ARTIFACT_AUTHORITY` | `ACCEPTED_WITH_RISK` | artifact authority classifier | non_authority_label=generated artifacts are evidence, not runtime source truth |
+
+## Blockers
+
+- LIVE_VALIDATION_PLAN: live validation execution is not authorized
+
+## Accepted Risks
+
+- BATCH_STATIC: accepted static proof with residual risk
+- FAILED_SIDECARS: accepted static proof with residual risk
+- GENERATED_ARTIFACT_AUTHORITY: accepted static proof with residual risk
+- PRESCAN_INFLUENCE: accepted static proof with residual risk
+- PRESCAN_STALENESS: accepted static proof with residual risk
+- PROOF_CONTRACT: accepted static proof with residual risk
+
+## Unknowns
+
+- PASS1_IDENTITY: UNKNOWN
+- PASS1_IDENTITY: exact Pass 1 artifact identity is UNKNOWN

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_TEST_REPORT.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_TEST_REPORT.md
@@ -1,0 +1,22 @@
+# RTE-PKT-11 Test Report
+
+## PASS
+
+- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/risk_dashboard.py services/repo-truth-extractor/lib/proof_contract.py` -> exit 0.
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest services/repo-truth-extractor/tests -k 'risk and dashboard' -q` -> exit 0, 9 passed, 1 pytest config warning about unknown `asyncio_mode`.
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest services/repo-truth-extractor/tests -k 'proof_contract or artifact_authority' -q` -> exit 0, 10 passed, 1 pytest config warning about unknown `asyncio_mode`.
+- `python -m json.tool out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json >/dev/null` -> exit 0.
+- `python -m json.tool out/rte-pkt-11-risk-dashboard/RTE-PKT-11_RISK_DASHBOARD_EXAMPLE.json >/dev/null` -> exit 0.
+- `git diff --check` -> exit 0.
+- `pre-commit run --files <changed packet files>` -> exit 0.
+
+## NOT_RUN
+
+- Live extraction was not run.
+- Provider preflight/doctor calls were not run.
+- Batch submit/poll/retrieve/cancel operations were not run.
+- Broad full-suite pytest was not run because packet scope is narrow and expected validation requested targeted local tests.
+
+## Warning
+
+Pytest emitted an existing configuration warning: `PytestConfigWarning: Unknown config option: asyncio_mode`.

--- a/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_TEST_REPORT.md
+++ b/out/rte-pkt-11-risk-dashboard/RTE-PKT-11_TEST_REPORT.md
@@ -1,5 +1,7 @@
 # RTE-PKT-11 Test Report
 
+Rerun timestamp: 2026-05-15T16:58:28Z
+
 ## PASS
 
 - `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/risk_dashboard.py services/repo-truth-extractor/lib/proof_contract.py` -> exit 0.

--- a/services/repo-truth-extractor/lib/risk_dashboard.py
+++ b/services/repo-truth-extractor/lib/risk_dashboard.py
@@ -1,0 +1,608 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional, Sequence
+
+from output_safety import sanitize_payload_for_output, sanitize_text_for_output
+
+from lib.proof_contract import (
+    build_conformance_report,
+    classify_artifact_authority_order,
+)
+
+
+RISK_DASHBOARD_JSON_FILENAME = "RTE_RISK_DASHBOARD.json"
+RISK_DASHBOARD_MD_FILENAME = "RTE_RISK_DASHBOARD.md"
+
+STATUS_VALUES = (
+    "PASS_STATIC",
+    "PASS_WITH_RISK",
+    "STATIC_ONLY",
+    "LIVE_VALIDATION_REQUIRED",
+    "MISSING",
+    "UNKNOWN",
+    "BLOCKED",
+    "NOT_APPLICABLE",
+    "ACCEPTED_WITH_RISK",
+)
+
+REQUIRED_RISK_ITEM_IDS = (
+    "LIVE_GATE",
+    "PROVIDER_PAYLOAD_REDACTION",
+    "FAILED_SIDECARS",
+    "PRESCAN_STALENESS",
+    "PRESCAN_INFLUENCE",
+    "PROVENANCE_FIELDS",
+    "TRUTH_LABELS",
+    "PROVIDER_METADATA",
+    "BATCH_STATIC",
+    "LIVE_VALIDATION_PLAN",
+    "PROOF_CONTRACT",
+    "PASS1_IDENTITY",
+    "GENERATED_ARTIFACT_AUTHORITY",
+)
+
+DEFAULT_PROVIDER_LANES = (
+    "direct_xai",
+    "openrouter_xai",
+    "openai_compatible",
+    "gemini_compatible",
+)
+
+PACKET_BASIS_ROOTS = {
+    "LIVE_GATE": ("rte-pkt-01-live-gate",),
+    "PROVIDER_PAYLOAD_REDACTION": ("rte-pkt-02-payload-redaction",),
+    "FAILED_SIDECARS": ("rte-pkt-15-failed-sidecars",),
+    "PRESCAN_STALENESS": ("rte-pkt-03-prescan-stale",),
+    "PRESCAN_INFLUENCE": ("rte-pkt-04-prescan-influence",),
+    "PROVENANCE_FIELDS": ("rte-pkt-05-provenance-fields",),
+    "TRUTH_LABELS": ("rte-pkt-06-truth-labels",),
+    "PROVIDER_METADATA": ("rte-pkt-07-xai-metadata",),
+    "BATCH_STATIC": ("rte-pkt-08-xai-batch-static",),
+    "LIVE_VALIDATION_PLAN": ("rte-pkt-09-live-validation-plan",),
+    "PROOF_CONTRACT": ("rte-pkt-10-proof-contract",),
+}
+
+
+def _now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists() or not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, set):
+        return sorted(value, key=str)
+    return [value]
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _bool_input(inputs: Mapping[str, Any], key: str, default: bool = False) -> bool:
+    value = inputs.get(key)
+    if value is None:
+        return default
+    return bool(value)
+
+
+def _first_string(*values: Any) -> Optional[str]:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _status(value: Any, default: str = "UNKNOWN") -> str:
+    token = str(value or "").strip().upper()
+    if token in STATUS_VALUES:
+        return token
+    return default
+
+
+def _item(item_id: str, status: str, **fields: Any) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {"id": item_id, "status": _status(status)}
+    payload.update(fields)
+    return payload
+
+
+def _risk_items_by_id(items: Sequence[Mapping[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for item in items:
+        item_id = str(item.get("id") or "")
+        if item_id:
+            by_id[item_id] = dict(item)
+    return by_id
+
+
+def _proof_contract_status(report: Mapping[str, Any]) -> tuple[str, str]:
+    overall = str(report.get("overall_status") or "").strip().upper()
+    if overall == "SATISFIED":
+        return "satisfied", "PASS_STATIC"
+    if overall == "PARTIAL":
+        return "partial", "PASS_WITH_RISK"
+    if overall == "MISSING":
+        return "missing", "MISSING"
+    if overall == "NOT_APPLICABLE":
+        return "not_applicable", "NOT_APPLICABLE"
+    return "unknown", "UNKNOWN"
+
+
+def _pass1_status(report: Mapping[str, Any]) -> tuple[str, str]:
+    identity = _as_dict(report.get("exact_pass1_identity"))
+    token = str(identity.get("status") or "").strip().upper()
+    if token == "SATISFIED":
+        return "known", "PASS_STATIC"
+    return "unknown", "UNKNOWN"
+
+
+def _relative_paths(root: Optional[Path], paths: Iterable[Path]) -> list[str]:
+    rows: list[str] = []
+    for path in paths:
+        try:
+            rows.append(str(path.relative_to(root)) if root is not None else str(path))
+        except ValueError:
+            rows.append(str(path))
+    return sorted(rows)
+
+
+def _find_downloaded_jsonl(run_root: Optional[Path]) -> list[str]:
+    if run_root is None or not run_root.exists():
+        return []
+    candidates: list[Path] = []
+    for path in run_root.rglob("*.jsonl"):
+        rel = str(path.relative_to(run_root)).lower()
+        if "download" in rel or "retriev" in rel or "batch" in rel:
+            candidates.append(path)
+    return _relative_paths(run_root, candidates)
+
+
+def _find_live_validation_artifacts(run_root: Optional[Path]) -> list[str]:
+    if run_root is None or not run_root.exists():
+        return []
+    names = {
+        "LIVE_VALIDATION_RESULT.json",
+        "RTE_LIVE_VALIDATION_RESULT.json",
+        "PROVIDER_LIVE_VALIDATION.json",
+        "BATCH_LIVE_VALIDATION.json",
+    }
+    paths = [
+        path
+        for path in run_root.rglob("*.json")
+        if path.name in names or path.name.startswith("LIVE_VALIDATION_")
+    ]
+    return _relative_paths(run_root, paths)
+
+
+def _collect_packet_basis(repo_root: Optional[Path]) -> Dict[str, bool]:
+    if repo_root is None:
+        return {item_id: False for item_id in PACKET_BASIS_ROOTS}
+    out_root = repo_root / "out"
+    return {
+        item_id: any((out_root / dirname).exists() for dirname in dirnames)
+        for item_id, dirnames in PACKET_BASIS_ROOTS.items()
+    }
+
+
+def collect_rte_risk_dashboard_inputs(
+    *,
+    run_id: Optional[str],
+    run_root: Path,
+    repo_root: Optional[Path] = None,
+    git_sha: Optional[str] = None,
+    run_dashboard: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    proof_path = run_root / "PROOF_PACK.json"
+    manifest_path = run_root / "RUN_MANIFEST.json"
+    proof_payload = _load_json(proof_path)
+    manifest_payload = _load_json(manifest_path)
+    proof_source = proof_path if proof_payload else manifest_path
+    proof_contract_payload = proof_payload or manifest_payload
+
+    proof_report = (
+        build_conformance_report(
+            proof_contract_payload,
+            artifact_path=str(proof_source),
+        )
+        if proof_contract_payload
+        else {}
+    )
+
+    downloaded_jsonl = _find_downloaded_jsonl(run_root)
+    live_validation_artifacts = _find_live_validation_artifacts(run_root)
+
+    return {
+        "run_id_if_available": run_id,
+        "repo_root_if_available": str(repo_root.resolve()) if repo_root else None,
+        "git_sha_if_available": git_sha,
+        "run_root_if_available": str(run_root.resolve()),
+        "run_dashboard": dict(run_dashboard or {}),
+        "proof_contract_report": proof_report,
+        "proof_contract_artifact_path": str(proof_source.resolve())
+        if proof_contract_payload
+        else None,
+        "downloaded_jsonl_files": downloaded_jsonl,
+        "live_validation_artifacts": live_validation_artifacts,
+        "accepted_packet_basis": _collect_packet_basis(repo_root),
+        "live_validation_authorized": False,
+        "live_provider_validated": False,
+        "live_batch_validated": False,
+    }
+
+
+def build_rte_risk_dashboard(inputs: Mapping[str, Any]) -> Dict[str, Any]:
+    proof_report = _as_dict(inputs.get("proof_contract_report"))
+    proof_contract_status, proof_risk_status = _proof_contract_status(proof_report)
+    pass1_identity, pass1_risk_status = _pass1_status(proof_report)
+
+    downloaded_jsonl = [
+        str(path) for path in _as_list(inputs.get("downloaded_jsonl_files"))
+    ]
+    downloaded_jsonl_status = "FOUND" if downloaded_jsonl else "MISSING"
+    accepted_packet_basis = _as_dict(inputs.get("accepted_packet_basis"))
+
+    def packet_basis(item_id: str) -> bool:
+        return bool(accepted_packet_basis.get(item_id, False))
+
+    live_validation_artifacts = [
+        str(path) for path in _as_list(inputs.get("live_validation_artifacts"))
+    ]
+    live_validation_authorized = _bool_input(
+        inputs, "live_validation_authorized", default=False
+    )
+    live_validation_plan_exists = _bool_input(
+        inputs,
+        "live_validation_plan_exists",
+        default=packet_basis("LIVE_VALIDATION_PLAN"),
+    )
+    live_provider_validated = _bool_input(inputs, "live_provider_validated", default=False)
+    live_batch_validated = _bool_input(inputs, "live_batch_validated", default=False)
+
+    provider_lanes = _as_dict(inputs.get("provider_lanes"))
+    if not provider_lanes:
+        provider_lanes = {
+            lane: "LIVE_VALIDATION_REQUIRED" for lane in DEFAULT_PROVIDER_LANES
+        }
+    provider_lanes = {
+        str(lane): _status(status, "LIVE_VALIDATION_REQUIRED")
+        for lane, status in provider_lanes.items()
+    }
+
+    provider_call_status = (
+        "PASS_STATIC"
+        if live_provider_validated
+        else (
+            "LIVE_VALIDATION_REQUIRED"
+            if any(status == "LIVE_VALIDATION_REQUIRED" for status in provider_lanes.values())
+            else "UNKNOWN"
+        )
+    )
+    batch_operation_status = (
+        "PASS_STATIC" if live_batch_validated else "LIVE_VALIDATION_REQUIRED"
+    )
+    live_validation_status = (
+        "PASS_STATIC"
+        if live_validation_artifacts and live_validation_authorized
+        else ("BLOCKED" if not live_validation_authorized else "LIVE_VALIDATION_REQUIRED")
+    )
+
+    artifact_authority_rows = classify_artifact_authority_order(
+        [
+            "services/repo-truth-extractor/run_extraction_v5.py",
+            "telemetry/RUN_DASHBOARD.json",
+            "telemetry/RTE_RISK_DASHBOARD.json",
+            "out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json",
+        ]
+    )
+
+    risk_items = [
+        _item(
+            "LIVE_GATE",
+            "STATIC_ONLY",
+            evidence_basis="local runtime/proof inputs",
+            live_validation_required_boolean=True,
+            live_validation_artifacts=live_validation_artifacts,
+            live_use_boundary="static proof only; production live readiness not claimed",
+        ),
+        _item(
+            "PROVIDER_PAYLOAD_REDACTION",
+            "PASS_STATIC" if packet_basis("PROVIDER_PAYLOAD_REDACTION") else "UNKNOWN",
+            evidence_basis="static packet/runtime redaction proof when available",
+            coverage="provider-bound payload/error summaries only; no raw provider payload text",
+            remaining_unknowns=(
+                []
+                if packet_basis("PROVIDER_PAYLOAD_REDACTION")
+                else ["provider payload redaction proof not observed in current inputs"]
+            ),
+        ),
+        _item(
+            "FAILED_SIDECARS",
+            "PASS_WITH_RISK" if packet_basis("FAILED_SIDECARS") else "UNKNOWN",
+            evidence_basis="static failed-sidecar redaction proof when available",
+            comparison_lane_failed_txt_unknown_if_applicable=True,
+            remaining_unknowns=[
+                "comparison-lane .FAILED.txt behavior remains unknown unless separate proof is present"
+            ],
+        ),
+        _item(
+            "PRESCAN_STALENESS",
+            "ACCEPTED_WITH_RISK" if packet_basis("PRESCAN_STALENESS") else "UNKNOWN",
+            evidence_basis="prescan receipt/static packet evidence when available",
+            accepted_import_status="accepted only when identity/freshness evidence is present",
+            rejected_import_behavior="stale or malformed imported prescan must be rejected or non-authoritative",
+        ),
+        _item(
+            "PRESCAN_INFLUENCE",
+            "ACCEPTED_WITH_RISK" if packet_basis("PRESCAN_INFLUENCE") else "UNKNOWN",
+            evidence_basis="prescan influence labels/static packet evidence when available",
+            influence_applied_or_not="accepted influence must be explicitly labeled",
+            advisory_model_derived_status="model-derived prescan signals remain advisory unless accepted by runtime guards",
+        ),
+        _item(
+            "PROVENANCE_FIELDS",
+            "PASS_STATIC" if packet_basis("PROVENANCE_FIELDS") else "UNKNOWN",
+            evidence_basis="repair/sidefill provenance static packet evidence when available",
+            repaired_values_labeled=True,
+            sidefilled_values_labeled=True,
+        ),
+        _item(
+            "TRUTH_LABELS",
+            "PASS_STATIC" if packet_basis("TRUTH_LABELS") else "UNKNOWN",
+            evidence_basis="truth-label preservation static packet evidence when available",
+            unknown_preservation=True,
+            conflicting_preservation=True,
+        ),
+        _item(
+            "PROVIDER_METADATA",
+            "LIVE_VALIDATION_REQUIRED",
+            evidence_basis="static fixture proof only unless live validation artifacts are present",
+            requested_vs_returned_model="static fixture proven; live provider edge behavior unknown",
+            refusal_incomplete_static=True,
+            live_provider_shapes_required=True,
+            provider_lanes=provider_lanes,
+        ),
+        _item(
+            "BATCH_STATIC",
+            "PASS_WITH_RISK" if packet_basis("BATCH_STATIC") else "UNKNOWN",
+            evidence_basis="batch static fixture proof when available",
+            downloaded_jsonl_status=downloaded_jsonl_status,
+            downloaded_jsonl_files=downloaded_jsonl,
+            not_live_validated=not live_batch_validated,
+            live_validation_required=not live_batch_validated,
+        ),
+        _item(
+            "LIVE_VALIDATION_PLAN",
+            "BLOCKED" if not live_validation_authorized else "LIVE_VALIDATION_REQUIRED",
+            evidence_basis="local authorization/live-validation artifact inventory",
+            plan_exists=live_validation_plan_exists,
+            execution_not_authorized=not live_validation_authorized,
+            live_validation_artifacts=live_validation_artifacts,
+        ),
+        _item(
+            "PROOF_CONTRACT",
+            proof_risk_status,
+            evidence_basis="RTE-PKT-10 proof-contract helper",
+            run_proof_vs_bundle_proof=proof_report.get(
+                "proof_posture", "unknown; no proof payload observed"
+            ),
+            missing_or_partial_fields=sorted(
+                set(_as_list(proof_report.get("missing_fields")))
+                | set(_as_list(proof_report.get("partial_fields")))
+            ),
+            conformance_status=proof_contract_status,
+        ),
+        _item(
+            "PASS1_IDENTITY",
+            pass1_risk_status,
+            evidence_basis="proof-contract exact Pass 1 identity classifier",
+            exact_identity_known_or_unknown=pass1_identity,
+            reason=_as_dict(proof_report.get("exact_pass1_identity")).get(
+                "reason",
+                "exact Pass 1 identity evidence is absent from current inputs",
+            ),
+        ),
+        _item(
+            "GENERATED_ARTIFACT_AUTHORITY",
+            "ACCEPTED_WITH_RISK",
+            evidence_basis="artifact authority classifier",
+            non_authority_label="generated artifacts are evidence, not runtime source truth",
+            authority_order=artifact_authority_rows,
+        ),
+    ]
+
+    by_id = _risk_items_by_id(risk_items)
+    blockers = _collect_blockers(by_id)
+    warnings = _collect_warnings(by_id)
+    accepted_risks = _collect_accepted_risks(by_id)
+    unknowns = _collect_unknowns(by_id)
+
+    blockers.extend(str(item) for item in _as_list(inputs.get("blockers")))
+    warnings.extend(str(item) for item in _as_list(inputs.get("warnings")))
+    accepted_risks.extend(str(item) for item in _as_list(inputs.get("accepted_risks")))
+    unknowns.extend(str(item) for item in _as_list(inputs.get("unknowns")))
+
+    dashboard = {
+        "run_id_if_available": _first_string(inputs.get("run_id_if_available")),
+        "generated_at": _first_string(inputs.get("generated_at")) or _now_iso(),
+        "repo_root_if_available": _first_string(inputs.get("repo_root_if_available")),
+        "git_sha_if_available": _first_string(inputs.get("git_sha_if_available")),
+        "live_use_readiness": "READY_FOR_LIMITED_DRY_STATIC_USE",
+        "static_audit_verdict": "PASS_WITH_RISK",
+        "overall_risk_level": "MEDIUM-HIGH",
+        "provider_call_status": provider_call_status,
+        "batch_operation_status": batch_operation_status,
+        "live_validation_status": live_validation_status,
+        "proof_contract_status": proof_contract_status,
+        "artifact_authority_status": "generated_artifacts_are_non_authoritative_evidence",
+        "risk_items": risk_items,
+        "blockers": _dedupe_sorted(blockers),
+        "warnings": _dedupe_sorted(warnings),
+        "accepted_risks": _dedupe_sorted(accepted_risks),
+        "unknowns": _dedupe_sorted(unknowns),
+        "next_recommended_actions": [
+            "Review RTE_RISK_DASHBOARD.md before treating static proof as live readiness.",
+            "Run a separately authorized live-validation packet before claiming provider behavior.",
+            "Keep downloaded batch JSONL as MISSING unless local artifacts are actually present.",
+            "Resolve proof-contract partial/missing fields before treating run proof as a full bundle proof.",
+        ],
+    }
+    return sanitize_payload_for_output(dashboard)
+
+
+def _collect_blockers(by_id: Mapping[str, Mapping[str, Any]]) -> list[str]:
+    rows = []
+    live_plan = by_id.get("LIVE_VALIDATION_PLAN", {})
+    if live_plan.get("execution_not_authorized") is True:
+        rows.append("LIVE_VALIDATION_PLAN: live validation execution is not authorized")
+    return rows
+
+
+def _collect_warnings(by_id: Mapping[str, Mapping[str, Any]]) -> list[str]:
+    rows = []
+    for item_id in REQUIRED_RISK_ITEM_IDS:
+        item = by_id.get(item_id, {})
+        status = item.get("status")
+        if status in {"LIVE_VALIDATION_REQUIRED", "MISSING", "PASS_WITH_RISK"}:
+            rows.append(f"{item_id}: {status}")
+    batch = by_id.get("BATCH_STATIC", {})
+    if batch.get("downloaded_jsonl_status") == "MISSING":
+        rows.append("BATCH_STATIC: downloaded JSONL inventory is MISSING")
+    return rows
+
+
+def _collect_accepted_risks(by_id: Mapping[str, Mapping[str, Any]]) -> list[str]:
+    rows = []
+    for item_id in REQUIRED_RISK_ITEM_IDS:
+        item = by_id.get(item_id, {})
+        if item.get("status") in {"ACCEPTED_WITH_RISK", "PASS_WITH_RISK"}:
+            rows.append(f"{item_id}: accepted static proof with residual risk")
+    return rows
+
+
+def _collect_unknowns(by_id: Mapping[str, Mapping[str, Any]]) -> list[str]:
+    rows = []
+    for item_id in REQUIRED_RISK_ITEM_IDS:
+        item = by_id.get(item_id, {})
+        if item.get("status") == "UNKNOWN":
+            rows.append(f"{item_id}: UNKNOWN")
+    pass1 = by_id.get("PASS1_IDENTITY", {})
+    if pass1.get("exact_identity_known_or_unknown") == "unknown":
+        rows.append("PASS1_IDENTITY: exact Pass 1 artifact identity is UNKNOWN")
+    return rows
+
+
+def _dedupe_sorted(values: Iterable[Any]) -> list[str]:
+    return sorted({sanitize_text_for_output(str(value)) for value in values if str(value)})
+
+
+def render_rte_risk_dashboard_markdown(dashboard: Mapping[str, Any]) -> str:
+    safe = sanitize_payload_for_output(dashboard)
+    lines = [
+        "# RTE Risk Dashboard",
+        "",
+        f"- Run ID: {safe.get('run_id_if_available') or 'UNKNOWN'}",
+        f"- Generated at: {safe.get('generated_at') or 'UNKNOWN'}",
+        f"- Live-use readiness: {safe.get('live_use_readiness') or 'UNKNOWN'}",
+        f"- Static audit verdict: {safe.get('static_audit_verdict') or 'UNKNOWN'}",
+        f"- Overall risk level: {safe.get('overall_risk_level') or 'UNKNOWN'}",
+        f"- Provider call status: {safe.get('provider_call_status') or 'UNKNOWN'}",
+        f"- Batch operation status: {safe.get('batch_operation_status') or 'UNKNOWN'}",
+        f"- Live validation status: {safe.get('live_validation_status') or 'UNKNOWN'}",
+        f"- Proof contract status: {safe.get('proof_contract_status') or 'UNKNOWN'}",
+        "",
+        "## Risk Items",
+        "",
+        "| ID | Status | Evidence | Notes |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in safe.get("risk_items", []):
+        if not isinstance(item, Mapping):
+            continue
+        note_fields = []
+        for key in (
+            "downloaded_jsonl_status",
+            "conformance_status",
+            "exact_identity_known_or_unknown",
+            "non_authority_label",
+        ):
+            value = item.get(key)
+            if value is not None:
+                note_fields.append(f"{key}={value}")
+        notes = "; ".join(note_fields) if note_fields else "-"
+        lines.append(
+            "| {id} | {status} | {evidence} | {notes} |".format(
+                id=_md_cell(item.get("id")),
+                status=_md_cell(item.get("status")),
+                evidence=_md_cell(item.get("evidence_basis", "-")),
+                notes=_md_cell(notes),
+            )
+        )
+
+    for section, key in (
+        ("Blockers", "blockers"),
+        ("Warnings", "warnings"),
+        ("Accepted Risks", "accepted_risks"),
+        ("Unknowns", "unknowns"),
+        ("Next Recommended Actions", "next_recommended_actions"),
+    ):
+        lines.extend(["", f"## {section}", ""])
+        values = safe.get(key, [])
+        if not values:
+            lines.append("- None")
+            continue
+        for value in values:
+            lines.append(f"- {sanitize_text_for_output(str(value))}")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _md_cell(value: Any) -> str:
+    text = sanitize_text_for_output(str(value if value is not None else "UNKNOWN"))
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+def write_rte_risk_dashboard_artifacts(
+    *,
+    run_root: Path,
+    dashboard: Mapping[str, Any],
+    write_json: Optional[Any] = None,
+) -> Dict[str, str]:
+    telemetry_root = run_root / "telemetry"
+    telemetry_root.mkdir(parents=True, exist_ok=True)
+    json_path = telemetry_root / RISK_DASHBOARD_JSON_FILENAME
+    md_path = telemetry_root / RISK_DASHBOARD_MD_FILENAME
+    safe = sanitize_payload_for_output(dict(dashboard))
+    if write_json is not None:
+        write_json(json_path, safe)
+    else:
+        json_path.write_text(
+            json.dumps(safe, indent=2, ensure_ascii=True, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    md_path.write_text(render_rte_risk_dashboard_markdown(safe), encoding="utf-8")
+    return {
+        "risk_dashboard_json": str(json_path.resolve()),
+        "risk_dashboard_markdown": str(md_path.resolve()),
+    }

--- a/services/repo-truth-extractor/lib/risk_dashboard.py
+++ b/services/repo-truth-extractor/lib/risk_dashboard.py
@@ -443,6 +443,13 @@ def build_rte_risk_dashboard(inputs: Mapping[str, Any]) -> Dict[str, Any]:
     accepted_risks.extend(str(item) for item in _as_list(inputs.get("accepted_risks")))
     unknowns.extend(str(item) for item in _as_list(inputs.get("unknowns")))
 
+    final_blockers = _dedupe_sorted(blockers)
+    # These three labels are intentionally static, human-curated assessments of the
+    # codebase's proof state, not derived from runtime blockers.  Runtime blockers
+    # (e.g. live-validation not yet authorized) widen the NOT-READY surface for live
+    # use, but they don't change what this static-proof run was designed to cover.
+    # The "READY_FOR_LIMITED_DRY_STATIC_USE" label explicitly documents that this is
+    # a static-only proof, not a production-readiness signal.
     dashboard = {
         "run_id_if_available": _first_string(inputs.get("run_id_if_available")),
         "generated_at": _first_string(inputs.get("generated_at")) or _now_iso(),
@@ -457,7 +464,7 @@ def build_rte_risk_dashboard(inputs: Mapping[str, Any]) -> Dict[str, Any]:
         "proof_contract_status": proof_contract_status,
         "artifact_authority_status": "generated_artifacts_are_non_authoritative_evidence",
         "risk_items": risk_items,
-        "blockers": _dedupe_sorted(blockers),
+        "blockers": final_blockers,
         "warnings": _dedupe_sorted(warnings),
         "accepted_risks": _dedupe_sorted(accepted_risks),
         "unknowns": _dedupe_sorted(unknowns),

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -240,6 +240,11 @@ from llm_runtime import (
     run_comparison_lane as llm_runtime_run_comparison_lane,
     should_retry as llm_runtime_should_retry,
 )
+from lib.risk_dashboard import (
+    build_rte_risk_dashboard,
+    collect_rte_risk_dashboard_inputs,
+    write_rte_risk_dashboard_artifacts,
+)
 
 # Backward-compatible reporting seam aliases used by targeted tests.
 reporting_write_run_manifest = rte_write_run_manifest
@@ -17166,6 +17171,19 @@ def emit_run_dashboard_snapshot(
 ) -> Dict[str, Any]:
     payload = phase_status_snapshot(run_id, dirs, PHASES)
     write_run_dashboard_snapshot(dirs["root"], payload, source=source)
+    risk_inputs = collect_rte_risk_dashboard_inputs(
+        run_id=run_id,
+        run_root=dirs["root"],
+        repo_root=REPO_ROOT,
+        git_sha=get_git_sha(REPO_ROOT),
+        run_dashboard=payload,
+    )
+    risk_dashboard = build_rte_risk_dashboard(risk_inputs)
+    write_rte_risk_dashboard_artifacts(
+        run_root=dirs["root"],
+        dashboard=risk_dashboard,
+        write_json=write_json,
+    )
     if ui is not None:
         ui.run_dashboard_snapshot(payload, source=source)
     return payload

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -17171,19 +17171,24 @@ def emit_run_dashboard_snapshot(
 ) -> Dict[str, Any]:
     payload = phase_status_snapshot(run_id, dirs, PHASES)
     write_run_dashboard_snapshot(dirs["root"], payload, source=source)
-    risk_inputs = collect_rte_risk_dashboard_inputs(
-        run_id=run_id,
-        run_root=dirs["root"],
-        repo_root=REPO_ROOT,
-        git_sha=get_git_sha(REPO_ROOT),
-        run_dashboard=payload,
-    )
-    risk_dashboard = build_rte_risk_dashboard(risk_inputs)
-    write_rte_risk_dashboard_artifacts(
-        run_root=dirs["root"],
-        dashboard=risk_dashboard,
-        write_json=write_json,
-    )
+    try:
+        risk_inputs = collect_rte_risk_dashboard_inputs(
+            run_id=run_id,
+            run_root=dirs["root"],
+            repo_root=REPO_ROOT,
+            git_sha=get_git_sha(REPO_ROOT),
+            run_dashboard=payload,
+        )
+        risk_dashboard = build_rte_risk_dashboard(risk_inputs)
+        write_rte_risk_dashboard_artifacts(
+            run_root=dirs["root"],
+            dashboard=risk_dashboard,
+            write_json=write_json,
+        )
+    except Exception as _dashboard_exc:
+        logger.warning(
+            "Risk dashboard emission failed (non-fatal): %s", _dashboard_exc
+        )
     if ui is not None:
         ui.run_dashboard_snapshot(payload, source=source)
     return payload

--- a/services/repo-truth-extractor/tests/test_risk_dashboard.py
+++ b/services/repo-truth-extractor/tests/test_risk_dashboard.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+from lib.proof_contract import build_conformance_report
+from lib.risk_dashboard import (
+    REQUIRED_RISK_ITEM_IDS,
+    build_rte_risk_dashboard,
+    render_rte_risk_dashboard_markdown,
+    write_rte_risk_dashboard_artifacts,
+)
+
+
+def _load_runner_module():
+    root = Path(__file__).resolve().parents[3]
+    module_path = root / "services" / "repo-truth-extractor" / "run_extraction_v5.py"
+    spec = importlib.util.spec_from_file_location("run_extraction_v5", module_path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _risk_item(dashboard: dict, item_id: str) -> dict:
+    for item in dashboard["risk_items"]:
+        if item["id"] == item_id:
+            return item
+    raise AssertionError(f"risk item not found: {item_id}")
+
+
+def _partial_proof_contract_report() -> dict:
+    return build_conformance_report(
+        {
+            "run_id": "run-static-001",
+            "git_sha": "abc123",
+            "runner_sha256": "runner-digest",
+            "argv": ["run_extraction_v5.py", "--phase", "D", "--dry-run"],
+            "cwd": "/repo",
+            "updated_at": "2026-05-15T00:00:00Z",
+            "phases": {"D": {"counts": {"raw": 1}}},
+            "linked_artifacts": {"coverage_rollup": "/repo/COVERAGE_ROLLUP.json"},
+        },
+        artifact_path=(
+            "services/repo-truth-extractor/extraction/repo-truth-extractor/"
+            "v5/runs/run/PROOF_PACK.json"
+        ),
+    )
+
+
+def _dashboard(**overrides: object) -> dict:
+    inputs = {
+        "run_id_if_available": "risk-fixture",
+        "generated_at": "2026-05-15T00:00:00Z",
+        "repo_root_if_available": "/repo",
+        "git_sha_if_available": "abc123",
+        "downloaded_jsonl_files": [],
+        "proof_contract_report": _partial_proof_contract_report(),
+        "accepted_packet_basis": {
+            item_id: True for item_id in REQUIRED_RISK_ITEM_IDS
+        },
+        "live_validation_plan_exists": True,
+        "live_validation_authorized": False,
+        "live_provider_validated": False,
+        "live_batch_validated": False,
+    }
+    inputs.update(overrides)
+    return build_rte_risk_dashboard(inputs)
+
+
+def test_risk_dashboard_shows_static_only_live_readiness() -> None:
+    dashboard = _dashboard()
+
+    assert dashboard["live_use_readiness"] == "READY_FOR_LIMITED_DRY_STATIC_USE"
+    assert dashboard["live_validation_status"] == "BLOCKED"
+    assert dashboard["provider_call_status"] == "LIVE_VALIDATION_REQUIRED"
+    assert "production" not in dashboard["live_use_readiness"].lower()
+    assert _risk_item(dashboard, "LIVE_GATE")["status"] == "STATIC_ONLY"
+
+
+def test_risk_dashboard_provider_lanes_remain_live_validation_required() -> None:
+    dashboard = _dashboard()
+    provider_metadata = _risk_item(dashboard, "PROVIDER_METADATA")
+
+    assert provider_metadata["status"] == "LIVE_VALIDATION_REQUIRED"
+    assert provider_metadata["live_provider_shapes_required"] is True
+    assert provider_metadata["provider_lanes"] == {
+        "direct_xai": "LIVE_VALIDATION_REQUIRED",
+        "gemini_compatible": "LIVE_VALIDATION_REQUIRED",
+        "openai_compatible": "LIVE_VALIDATION_REQUIRED",
+        "openrouter_xai": "LIVE_VALIDATION_REQUIRED",
+    }
+
+
+def test_risk_dashboard_batch_static_jsonl_missing_not_live_validated() -> None:
+    dashboard = _dashboard(downloaded_jsonl_files=[])
+    batch_static = _risk_item(dashboard, "BATCH_STATIC")
+
+    assert batch_static["status"] == "PASS_WITH_RISK"
+    assert batch_static["downloaded_jsonl_status"] == "MISSING"
+    assert batch_static["not_live_validated"] is True
+    assert batch_static["live_validation_required"] is True
+
+
+def test_risk_dashboard_proof_contract_partial_status_is_visible() -> None:
+    dashboard = _dashboard()
+    proof_contract = _risk_item(dashboard, "PROOF_CONTRACT")
+    pass1_identity = _risk_item(dashboard, "PASS1_IDENTITY")
+
+    assert dashboard["proof_contract_status"] == "partial"
+    assert proof_contract["status"] == "PASS_WITH_RISK"
+    assert proof_contract["conformance_status"] == "partial"
+    assert "authoritative_artifacts" in proof_contract["missing_or_partial_fields"]
+    assert proof_contract["run_proof_vs_bundle_proof"] == (
+        "run_proof_or_packet_evidence_not_full_bundle"
+    )
+    assert pass1_identity["status"] == "UNKNOWN"
+    assert pass1_identity["exact_identity_known_or_unknown"] == "unknown"
+
+
+def test_risk_dashboard_generated_artifacts_are_non_authoritative() -> None:
+    dashboard = _dashboard()
+    artifact_authority = _risk_item(dashboard, "GENERATED_ARTIFACT_AUTHORITY")
+
+    assert artifact_authority["status"] == "ACCEPTED_WITH_RISK"
+    assert (
+        artifact_authority["non_authority_label"]
+        == "generated artifacts are evidence, not runtime source truth"
+    )
+    assert artifact_authority["authority_order"][0]["classification"] == "runtime_authority"
+
+
+def test_risk_dashboard_prescan_accepted_and_rejected_states_are_summarized() -> None:
+    dashboard = _dashboard()
+    staleness = _risk_item(dashboard, "PRESCAN_STALENESS")
+    influence = _risk_item(dashboard, "PRESCAN_INFLUENCE")
+
+    assert staleness["status"] == "ACCEPTED_WITH_RISK"
+    assert "accepted only" in staleness["accepted_import_status"]
+    assert "stale" in staleness["rejected_import_behavior"]
+    assert influence["influence_applied_or_not"] == (
+        "accepted influence must be explicitly labeled"
+    )
+    assert "advisory" in influence["advisory_model_derived_status"]
+
+
+def test_risk_dashboard_provenance_and_truth_label_states_are_summarized() -> None:
+    dashboard = _dashboard()
+    provenance = _risk_item(dashboard, "PROVENANCE_FIELDS")
+    truth_labels = _risk_item(dashboard, "TRUTH_LABELS")
+
+    assert provenance["repaired_values_labeled"] is True
+    assert provenance["sidefilled_values_labeled"] is True
+    assert truth_labels["unknown_preservation"] is True
+    assert truth_labels["conflicting_preservation"] is True
+
+
+def test_risk_dashboard_redacts_unsafe_fields(tmp_path: Path) -> None:
+    secret_value = "super-" + "secret-value"
+    bearer_value = "hidden-" + "value"
+    dashboard = _dashboard(
+        warnings=[
+            f"provider returned token={secret_value}",
+            {"authorization": f"Bearer {bearer_value}"},
+        ]
+    )
+    written = write_rte_risk_dashboard_artifacts(run_root=tmp_path, dashboard=dashboard)
+    payload_text = Path(written["risk_dashboard_json"]).read_text(encoding="utf-8")
+    markdown = render_rte_risk_dashboard_markdown(dashboard)
+
+    assert secret_value not in payload_text
+    assert bearer_value not in payload_text
+    assert secret_value not in markdown
+    assert bearer_value not in markdown
+    assert "[REDACTED]" in payload_text
+
+
+def test_risk_dashboard_generation_requires_no_provider_calls(
+    tmp_path: Path, monkeypatch
+) -> None:
+    runner = _load_runner_module()
+
+    def forbidden_provider_call(*args, **kwargs):  # pragma: no cover - failure path
+        raise AssertionError("provider or batch call was invoked")
+
+    for name in (
+        "llm_runtime_call_llm",
+        "llm_runtime_call_llm_with_ladder",
+        "run_provider_preflight",
+        "run_provider_doctor_probe",
+        "BatchClient",
+        "XAIBatchClient",
+        "OpenAIBatchClient",
+        "OpenRouterBatchClient",
+        "GeminiBatchClient",
+    ):
+        if hasattr(runner, name):
+            monkeypatch.setattr(runner, name, forbidden_provider_call)
+
+    dirs = {"root": tmp_path}
+    for phase in runner.PHASES:
+        dirs[phase] = tmp_path / phase
+
+    payload = runner.emit_run_dashboard_snapshot(
+        run_id="risk-dashboard-no-provider",
+        dirs=dirs,
+        ui=None,
+        source="test",
+    )
+
+    risk_path = tmp_path / "telemetry" / "RTE_RISK_DASHBOARD.json"
+    assert payload["run_id"] == "risk-dashboard-no-provider"
+    assert risk_path.exists()
+    risk_payload = json.loads(risk_path.read_text(encoding="utf-8"))
+    assert [item["id"] for item in risk_payload["risk_items"]] == list(
+        REQUIRED_RISK_ITEM_IDS
+    )


### PR DESCRIPTION
@codex review
@gemini
@copilot

## Summary
- add a local-only RTE risk dashboard helper and telemetry artifacts
- wire RTE_RISK_DASHBOARD JSON/Markdown generation beside RUN_DASHBOARD snapshots
- carry forward proof-contract/artifact-authority classification and add targeted tests/proof outputs

## Validation
- python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/risk_dashboard.py services/repo-truth-extractor/lib/proof_contract.py
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest services/repo-truth-extractor/tests -k 'risk and dashboard' -q
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 pytest services/repo-truth-extractor/tests -k 'proof_contract or artifact_authority' -q
- python -m json.tool out/rte-pkt-11-risk-dashboard/RTE-PKT-11_MANIFEST.json >/dev/null
- git diff --check
- pre-commit run --files <changed packet files>

## Release Notes
- Repo Truth Extractor now emits a central static risk-state dashboard for operator review.
- No provider calls, live extraction, or batch provider operations were run for this packet.