### PR TITLE
fix(rte): separate OpenRouter x-ai route metadata

### DIFF
--- a/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_DIFF_SUMMARY.md
+++ b/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_DIFF_SUMMARY.md
@@ -1,0 +1,18 @@
+# RTE-PKT-12 Diff Summary
+
+Changed code and test files:
+
+- `services/repo-truth-extractor/llm_runtime.py`: added static route identity classifier and attached labels to request metadata and ladder attempts.
+- `services/repo-truth-extractor/run_extraction_v5.py`: propagated route identity through `enrich_request_meta` and captured `returned_model_id` as response metadata.
+- `services/repo-truth-extractor/lib/structured_output_contracts.py`: added `provider_schema_variant` labels while preserving existing response-format behavior variants.
+- `services/repo-truth-extractor/lib/prescan/provider_catalog.py`: added route-kind/upstream/economic/live-validation labels to static prescan route rows, readiness matrix rows, and routing-plan rows.
+- `services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py`: added local static tests for direct xAI vs OpenRouter x-ai separation, structured-output labeling, returned-model preservation, and no-provider-call safety.
+
+Forbidden surfaces not changed:
+
+- Prompt files: unchanged.
+- Promptset YAML/model map: unchanged.
+- Provider route selection/model IDs: unchanged.
+- Provider client behavior/live dispatch: unchanged.
+- Pricing calculations: unchanged.
+- Compose/config/deployment files: unchanged.

--- a/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_MANIFEST.json
+++ b/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_MANIFEST.json
@@ -1,0 +1,132 @@
+{
+  "packet_id": "RTE-PKT-12-OPENROUTER-XAI",
+  "generated_at_local": "2026-05-15",
+  "worktree": "/Users/hue/.codex/worktrees/4759/dopemux-mvp",
+  "branch": "codex/rte-pkt-12-openrouter-xai",
+  "base_head": "0179b17b03cf46518aa324bd8f50c805b627631d",
+  "remote": {
+    "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "mvp": "https://github.com/DDD-Enterprises/dopemux-mvp.git"
+  },
+  "status": "STATIC_METADATA_IMPLEMENTED_TARGETED_VALIDATION_PASS",
+  "live_provider_calls": "NOT_RUN",
+  "provider_credentials_required": false,
+  "batch_provider_operations": "NOT_RUN",
+  "active_packet_schema_status": {
+    "status": "CONFLICTING",
+    "detail": "User-supplied packet controlled scope, but local dopetask-canonical-spec.json requires series/commit/pr/steps and no extra fields. No additional task packet was created because the packet non-goals forbid additional task packets."
+  },
+  "changed_code_files": [
+    "services/repo-truth-extractor/llm_runtime.py",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/lib/structured_output_contracts.py",
+    "services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+    "services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py"
+  ],
+  "proof_outputs": [
+    "out/rte-pkt-12-openrouter-xai/RTE-PKT-12_MANIFEST.json",
+    "out/rte-pkt-12-openrouter-xai/RTE-PKT-12_ROUTE_IDENTITY_MATRIX.md",
+    "out/rte-pkt-12-openrouter-xai/RTE-PKT-12_STATIC_FIXTURE_EXAMPLES.md",
+    "out/rte-pkt-12-openrouter-xai/RTE-PKT-12_STRUCTURED_OUTPUT_VARIANT_MATRIX.md",
+    "out/rte-pkt-12-openrouter-xai/RTE-PKT-12_RISK_AND_AUTHORITY_LABELS.md",
+    "out/rte-pkt-12-openrouter-xai/RTE-PKT-12_TEST_REPORT.md",
+    "out/rte-pkt-12-openrouter-xai/RTE-PKT-12_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-12-openrouter-xai/RTE-PKT-12_DIFF_SUMMARY.md",
+    "out/rte-pkt-12-openrouter-xai/RTE-PKT-12_REMAINING_UNKNOWNS.md"
+  ],
+  "validation_summary": [
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "6 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_structured_output_provider_modes.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "3 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_prescan_provider_catalog.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "36 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "12 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k 'openrouter and xai' -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "6 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k 'xai and metadata' -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "2 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k 'structured_output or provider_modes' -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "5 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_pricing_catalog.py services/repo-truth-extractor/tests/test_pricing_coverage.py services/repo-truth-extractor/tests/test_profile_review_packets.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "5 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k 'risk and dashboard' -q",
+      "exit_code": 5,
+      "result": "NOT_RUN_NO_TESTS_SELECTED",
+      "summary": "No matching tests or risk_dashboard helper in this checkout"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k 'proof_contract or artifact_authority' -q",
+      "exit_code": 5,
+      "result": "NOT_RUN_NO_TESTS_SELECTED",
+      "summary": "No matching proof_contract tests or helper in this checkout"
+    },
+    {
+      "command": "python -m py_compile services/repo-truth-extractor/llm_runtime.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/structured_output_contracts.py services/repo-truth-extractor/lib/prescan/provider_catalog.py",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Compilation passed"
+    },
+    {
+      "command": "python -m json.tool out/rte-pkt-12-openrouter-xai/RTE-PKT-12_MANIFEST.json >/dev/null",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Manifest JSON parsed"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "No whitespace errors in tracked diff"
+    },
+    {
+      "command": "git status --short --branch",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Only allowed code/test files and packet proof output root are changed"
+    }
+  ],
+  "no_provider_call_status": "PASS_TARGETED_STATIC_TESTS",
+  "remaining_unknowns": [
+    "OpenRouter live upstream returned model behavior",
+    "OpenRouter x-ai live schema acceptance",
+    "OpenRouter x-ai retention, ZDR, rate limit, and billing guarantees",
+    "Direct xAI live safety",
+    "RTE-PKT-11 risk_dashboard helper not present in this checkout",
+    "RTE-PKT-10 proof_contract helper not present in this checkout"
+  ]
+}

--- a/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,18 @@
+# RTE-PKT-12 No Provider Calls Attestation
+
+Attestation status: PASS for targeted static validation.
+
+Observed:
+
+- No command run in this packet invoked a live extraction.
+- No command run in this packet invoked provider preflight.
+- No command run in this packet submitted, polled, retrieved, or cancelled a provider batch job.
+- No provider credentials were required.
+- The targeted `test_call_llm_openrouter_xai_missing_key_adds_proxy_metadata_without_provider_call` configured all provider client factories to raise if invoked and passed.
+
+Not run:
+
+- Live OpenRouter calls.
+- Live xAI calls.
+- Live OpenAI, Gemini, Anthropic, or other provider calls.
+- Remote provider JSONL retrieval.

--- a/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_REMAINING_UNKNOWNS.md
@@ -1,0 +1,17 @@
+# RTE-PKT-12 Remaining Unknowns
+
+Static route identity improved, but the following remain unresolved:
+
+- OpenRouter x-ai live upstream metadata is UNKNOWN.
+- OpenRouter x-ai returned model behavior is UNKNOWN without live validation.
+- OpenRouter x-ai schema acceptance is LIVE_VALIDATION_REQUIRED.
+- OpenRouter x-ai retention, ZDR, billing, rate-limit, and direct xAI guarantee equivalence are UNKNOWN.
+- Direct xAI live safety remains LIVE_VALIDATION_REQUIRED.
+- RTE-PKT-10 `proof_contract.py` helper is absent from this checkout, so proof-contract consumption could not be implemented or tested here.
+- RTE-PKT-11 `risk_dashboard.py` helper is absent from this checkout, so dashboard consumption could not be implemented or tested here.
+- The active packet JSON supplied in the user request does not conform to the checked-in `dopetask-canonical-spec.json`; this was treated as a governance conflict, not as runtime evidence.
+
+Downstream recommendation:
+
+- RTE-PKT-13 route fingerprint work can consume `requested_provider`, `requested_model_id`, `provider_route_kind`, `upstream_provider`, `economic_surface`, `api_key_env`, `endpoint_effective`, `transport`, and `provider_signature`.
+- RTE-PKT-14 pricing visibility should continue treating OpenRouter x-ai economic surface as `openrouter` unless provider billing artifacts prove otherwise.

--- a/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_RISK_AND_AUTHORITY_LABELS.md
+++ b/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_RISK_AND_AUTHORITY_LABELS.md
@@ -1,0 +1,25 @@
+# RTE-PKT-12 Risk And Authority Labels
+
+Authority observed in this checkout:
+
+- `services/repo-truth-extractor/llm_runtime.py` now emits static route labels in request metadata.
+- `services/repo-truth-extractor/run_extraction_v5.py` now normalizes the same labels through `enrich_request_meta`.
+- `services/repo-truth-extractor/lib/structured_output_contracts.py` now emits a provider-specific schema label separate from behavior.
+- `services/repo-truth-extractor/lib/prescan/provider_catalog.py` now emits route-kind, upstream, economic-surface, and live-validation-required labels in prescan route rows.
+
+Absent surfaces:
+
+- `services/repo-truth-extractor/lib/proof_contract.py` is not present in this checkout.
+- `services/repo-truth-extractor/lib/risk_dashboard.py` is not present in this checkout.
+- The matching selectors for `proof_contract or artifact_authority` and `risk and dashboard` selected no tests and exited with pytest code 5.
+
+OpenRouter x-ai authority boundary:
+
+- Static provider route identity: `openrouter_proxy_xai`.
+- Upstream provider label: `xai`, derived from the `x-ai/` model prefix only.
+- Economic surface: `openrouter`.
+- API key env: `OPENROUTER_API_KEY`.
+- Direct xAI guarantees inherited: `false`.
+- Live validation status: `LIVE_VALIDATION_REQUIRED`.
+
+This packet does not claim OpenRouter x-ai has direct xAI retention, ZDR, billing, rate-limit, schema-acceptance, or returned-model behavior.

--- a/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_ROUTE_IDENTITY_MATRIX.md
+++ b/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_ROUTE_IDENTITY_MATRIX.md
@@ -1,0 +1,15 @@
+# RTE-PKT-12 Route Identity Matrix
+
+Status: OBSERVED static helper behavior after local implementation. No provider calls were made.
+
+| Route | requested_provider | requested_model_id | provider_route_kind | upstream_provider | economic_surface | api_key_env | endpoint/economic authority | live_validation_status |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Direct xAI | `xai` | `grok-fixture` | `direct_provider` | `xai` | `xai_direct` | `XAI_API_KEY` | direct xAI endpoint/key surface | `LIVE_VALIDATION_REQUIRED` |
+| OpenRouter x-ai | `openrouter` | `x-ai/grok-fixture` | `openrouter_proxy_xai` | `xai` | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter endpoint/key/economic surface | `LIVE_VALIDATION_REQUIRED` |
+| OpenRouter OpenAI | `openrouter` | `openai/gpt-fixture` | `openrouter_proxy_other` | `openai` | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter endpoint/key/economic surface | `LIVE_VALIDATION_REQUIRED` |
+| OpenRouter unknown/native | `openrouter` | `fixture-model` | `openrouter_native_or_unknown` | `unknown` | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter endpoint/key/economic surface | `LIVE_VALIDATION_REQUIRED` |
+| Direct OpenAI | `openai` | `gpt-fixture` | `direct_provider` | `openai` | `openai_direct` | `OPENAI_API_KEY` | direct OpenAI endpoint/key surface | `LIVE_VALIDATION_REQUIRED` |
+| Direct Gemini | `gemini` | `gemini-fixture` | `direct_provider` | `gemini` | `gemini_direct` | `GEMINI_API_KEY` | direct Gemini endpoint/key surface | `LIVE_VALIDATION_REQUIRED` |
+| Unknown | `unknown` | `fixture-model` | `unknown` | `unknown` | `unknown` | `UNKNOWN` | no static provider authority | `UNKNOWN` |
+
+Important boundary: `upstream_provider=xai` on OpenRouter x-ai is a static route-name classification only. It is not evidence that live OpenRouter passthrough, returned model metadata, provider guarantees, retention, ZDR, rate limits, or billing match direct xAI.

--- a/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_STATIC_FIXTURE_EXAMPLES.md
+++ b/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_STATIC_FIXTURE_EXAMPLES.md
@@ -1,0 +1,56 @@
+# RTE-PKT-12 Static Fixture Examples
+
+These examples are redacted static metadata shapes exercised by local tests. They are not live provider responses.
+
+Direct xAI request metadata:
+
+```json
+{
+  "requested_provider": "xai",
+  "requested_model_id": "grok-fixture",
+  "provider_route_kind": "direct_provider",
+  "upstream_provider": "xai",
+  "economic_surface": "xai_direct",
+  "api_key_env": "XAI_API_KEY",
+  "endpoint_base_url": "https://api.x.ai/v1",
+  "endpoint_effective": "https://api.x.ai/v1/chat/completions",
+  "transport": "openai_sdk",
+  "structured_output_mode": "json_schema",
+  "provider_schema_variant": "xai_relaxed_direct",
+  "live_validation_status": "LIVE_VALIDATION_REQUIRED"
+}
+```
+OpenRouter x-ai request metadata:
+
+```json
+{
+  "requested_provider": "openrouter",
+  "requested_model_id": "x-ai/grok-fixture",
+  "provider_route_kind": "openrouter_proxy_xai",
+  "upstream_provider": "xai",
+  "economic_surface": "openrouter",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "endpoint_base_url": "https://openrouter.ai/api/v1",
+  "endpoint_effective": "https://openrouter.ai/api/v1/chat/completions",
+  "transport": "openai_sdk",
+  "structured_output_mode": "json_schema",
+  "provider_schema_variant": "openrouter_proxy_xai_relaxed",
+  "live_validation_status": "LIVE_VALIDATION_REQUIRED",
+  "direct_provider_guarantees_inherited": false
+}
+```
+
+Returned model metadata remains response metadata and does not rewrite requested route identity:
+
+```json
+{
+  "requested_provider": "openrouter",
+  "requested_model_id": "x-ai/grok-fixture",
+  "provider": "openrouter",
+  "model_id": "x-ai/grok-fixture",
+  "returned_model_id": "grok-fixture-returned",
+  "provider_route_kind": "openrouter_proxy_xai",
+  "economic_surface": "openrouter",
+  "live_validation_status": "LIVE_VALIDATION_REQUIRED"
+}
+```

--- a/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_STRUCTURED_OUTPUT_VARIANT_MATRIX.md
+++ b/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_STRUCTURED_OUTPUT_VARIANT_MATRIX.md
@@ -1,0 +1,14 @@
+# RTE-PKT-12 Structured Output Variant Matrix
+
+Observed static behavior after implementation:
+
+| Route | response_format behavior variant | provider_schema_variant label | Live schema acceptance claim |
+| --- | --- | --- | --- |
+| Direct xAI | `xai_relaxed` | `xai_relaxed_direct` | `LIVE_VALIDATION_REQUIRED` |
+| OpenRouter x-ai | `xai_relaxed` | `openrouter_proxy_xai_relaxed` | `LIVE_VALIDATION_REQUIRED` |
+| Direct Gemini | `gemini_relaxed` | `gemini_relaxed_direct` | `LIVE_VALIDATION_REQUIRED` |
+| OpenRouter Gemini/Google | `gemini_relaxed` | `openrouter_proxy_gemini_relaxed` | `LIVE_VALIDATION_REQUIRED` |
+| Direct OpenAI | `canonical` | `canonical_direct` | `LIVE_VALIDATION_REQUIRED` |
+| OpenRouter other/unknown | `canonical` | `openrouter_proxy_canonical` | `LIVE_VALIDATION_REQUIRED` |
+
+The implementation preserves the existing `schema_variant` behavior used to adapt response formats. It adds `provider_schema_variant` as a proof/readability label so OpenRouter x-ai can be distinguished from direct xAI without changing `response_format` construction.

--- a/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_TEST_REPORT.md
+++ b/out/rte-pkt-12-openrouter-xai/RTE-PKT-12_TEST_REPORT.md
@@ -1,0 +1,22 @@
+# RTE-PKT-12 Test Report
+
+All executed tests were local/static. No live extraction, provider preflight, provider batch operation, or provider credential access was run.
+
+| Command | Exit | Result |
+| --- | ---: | --- |
+| `pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q` | 0 | PASS, 6 passed |
+| `pytest services/repo-truth-extractor/tests/test_structured_output_provider_modes.py -q` | 0 | PASS, 3 passed |
+| `pytest services/repo-truth-extractor/tests/test_prescan_provider_catalog.py -q` | 0 | PASS, 36 passed |
+| `pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q` | 0 | PASS, 12 passed |
+| `pytest services/repo-truth-extractor/tests -k 'openrouter and xai' -q` | 0 | PASS, 6 passed |
+| `pytest services/repo-truth-extractor/tests -k 'xai and metadata' -q` | 0 | PASS, 2 passed |
+| `pytest services/repo-truth-extractor/tests -k 'structured_output or provider_modes' -q` | 0 | PASS, 5 passed |
+| `pytest services/repo-truth-extractor/tests/test_pricing_catalog.py services/repo-truth-extractor/tests/test_pricing_coverage.py services/repo-truth-extractor/tests/test_profile_review_packets.py -q` | 0 | PASS, 5 passed |
+| `pytest services/repo-truth-extractor/tests -k 'risk and dashboard' -q` | 5 | NOT_RUN_NO_TESTS_SELECTED |
+| `pytest services/repo-truth-extractor/tests -k 'proof_contract or artifact_authority' -q` | 5 | NOT_RUN_NO_TESTS_SELECTED |
+| `python -m py_compile services/repo-truth-extractor/llm_runtime.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/structured_output_contracts.py services/repo-truth-extractor/lib/prescan/provider_catalog.py` | 0 | PASS |
+| `python -m json.tool out/rte-pkt-12-openrouter-xai/RTE-PKT-12_MANIFEST.json >/dev/null` | 0 | PASS |
+| `git diff --check` | 0 | PASS |
+| `git status --short --branch` | 0 | PASS, only allowed code/test files and packet proof output root changed |
+
+Common warning: pytest reported `PytestConfigWarning: Unknown config option: asyncio_mode`. This appears pre-existing and did not fail the targeted tests.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_DIFF_SUMMARY.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_DIFF_SUMMARY.md
@@ -1,0 +1,28 @@
+# RTE-PKT-13 Diff Summary
+
+## OBSERVED code changes
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+  - Added static route fingerprint authority constants and required fingerprint input fields.
+  - Added deterministic static route fingerprint material/hash helpers.
+  - Enriched `RUN_ROUTING_FINGERPRINT.json` phase rows with requested route identity, endpoint/economic authority, transport, provider signature, structured-output mode, provider schema variant, live-validation boundary, static authority, and provider-behavior proof boundary.
+  - Enriched representative `effective_model_routing` rows in the run routing fingerprint artifact when a `RunnerConfig` is available.
+  - Preserved existing row fields including `provider`, `model_id`, `api_key_env`, `ladder`, `transport`, `endpoint_base_url`, `endpoint_effective`, and `routing_signature`.
+- `services/repo-truth-extractor/llm_runtime.py`
+  - Aligned `route_identity_authority` with the packet-required static request route metadata authority label.
+- `services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py`
+  - Added targeted static tests for direct xAI, OpenRouter x-ai, fingerprint separation, returned-model identity preservation, and no-provider-call artifact generation safety.
+
+## INFERRED compatibility impact
+
+- Existing consumers of older route fingerprint fields should continue to read those fields because no existing `RUN_ROUTING_FINGERPRINT.json` keys were removed.
+- Consumers that compare full artifact JSON may observe additive fields in `phases[*]` rows and in `effective_model_routing` rows emitted by `write_run_routing_fingerprint`.
+
+## Non-goals preserved
+
+- No prompt files changed.
+- No promptset YAML or model-map route IDs changed.
+- No provider dispatch behavior changed.
+- No provider client behavior changed.
+- No pricing logic changed.
+- No live extraction, provider preflight, or batch provider operation was run.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json
@@ -1,0 +1,127 @@
+{
+  "packet_id": "RTE-PKT-13-ROUTE-FINGERPRINT-STATIC-PROOF",
+  "generated_at_local": "2026-05-15T11:18:29-0700",
+  "worktree": "/Users/hue/.codex/worktrees/536d/dopemux-mvp",
+  "branch": "codex/rte-pkt-13-route-fingerprint",
+  "base_head": "fac81ac877b61ea5762f4fc84a3c4e73f061c9b8",
+  "predecessor_packet": "RTE-PKT-12-OPENROUTER-XAI",
+  "predecessor_verdict": "PASS_WITH_RISKS",
+  "predecessor_verdict_source": "active_packet_instruction",
+  "predecessor_local_manifest_status_observed": "STATIC_METADATA_IMPLEMENTED_TARGETED_VALIDATION_PASS",
+  "changed_code_files": [
+    "services/repo-truth-extractor/llm_runtime.py",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py"
+  ],
+  "proof_outputs": [
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_DIFF_SUMMARY.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_ROUTE_FINGERPRINT_MATRIX.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_STATIC_FIXTURE_EXAMPLES.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_TEST_REPORT.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_REMAINING_UNKNOWNS.md"
+  ],
+  "validation_summary": [
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "5 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "6 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"routing_fingerprint or route_fingerprint or fingerprint\" -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "8 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"openrouter and xai\" -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "8 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"xai and metadata\" -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "2 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_structured_output_provider_modes.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "3 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "12 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_v5_golden_fixture_smoke.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "1 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"proof_pack or proof or status\" -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "25 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"risk and dashboard\" -q",
+      "exit_code": 5,
+      "result": "NOT_RUN_NO_TESTS_SELECTED",
+      "summary": "No tests selected"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"proof_contract or artifact_authority\" -q",
+      "exit_code": 5,
+      "result": "NOT_RUN_NO_TESTS_SELECTED",
+      "summary": "No tests selected"
+    },
+    {
+      "command": "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/llm_runtime.py",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Compilation passed"
+    },
+    {
+      "command": "python -m json.tool out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json >/dev/null",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Manifest JSON parsed"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "No whitespace errors in unstaged diff"
+    },
+    {
+      "command": "pre-commit run --files services/repo-truth-extractor/llm_runtime.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json out/rte-pkt-13-route-fingerprint/RTE-PKT-13_DIFF_SUMMARY.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_ROUTE_FINGERPRINT_MATRIX.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_STATIC_FIXTURE_EXAMPLES.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_TEST_REPORT.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_NO_PROVIDER_CALLS_ATTESTATION.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_REMAINING_UNKNOWNS.md",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Configured pre-commit hooks passed for changed files"
+    }
+  ],
+  "no_provider_call_status": "PASS_TARGETED_STATIC_TESTS",
+  "remaining_unknowns": [
+    "OpenRouter x-ai live upstream metadata UNKNOWN",
+    "OpenRouter x-ai returned model behavior UNKNOWN unless live evidence exists",
+    "OpenRouter x-ai schema acceptance LIVE_VALIDATION_REQUIRED",
+    "OpenRouter x-ai retention/ZDR/billing/rate-limit equivalence UNKNOWN",
+    "Direct xAI live safety LIVE_VALIDATION_REQUIRED",
+    "proof_contract.py surface MISSING/UNKNOWN in services/repo-truth-extractor",
+    "risk_dashboard.py surface MISSING/UNKNOWN in services/repo-truth-extractor"
+  ]
+}

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,21 @@
+# RTE-PKT-13 No Provider Calls Attestation
+
+## OBSERVED
+
+- No live extraction command was run.
+- No provider preflight command was run.
+- No provider batch submit, poll, retrieve, or cancel command was run.
+- No provider credentials were required for the targeted tests.
+- `test_route_fingerprint_static_identity.py` monkeypatches provider client factories to raise if the run routing fingerprint artifact path invokes provider clients.
+- The tested route fingerprint path writes static metadata from request route configuration and local endpoint/transport helpers.
+
+## NOT_RUN
+
+- OpenRouter live call validation.
+- Direct xAI live call validation.
+- OpenAI, Gemini, Anthropic, or other provider live call validation.
+- Provider retention, ZDR, billing, rate-limit, schema-acceptance, or returned-model behavior validation.
+
+## Boundary
+
+This packet proves static request route fingerprinting only. It does not prove OpenRouter x-ai live equivalence to direct xAI.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_REMAINING_UNKNOWNS.md
@@ -1,0 +1,19 @@
+# RTE-PKT-13 Remaining Unknowns
+
+## UNKNOWN / LIVE_VALIDATION_REQUIRED
+
+- OpenRouter x-ai live upstream metadata remains UNKNOWN.
+- OpenRouter x-ai returned model behavior remains UNKNOWN unless future live evidence exists.
+- OpenRouter x-ai schema acceptance remains LIVE_VALIDATION_REQUIRED.
+- OpenRouter x-ai retention, ZDR, billing, and rate-limit equivalence remain UNKNOWN.
+- Direct xAI live safety remains LIVE_VALIDATION_REQUIRED.
+
+## MISSING / UNKNOWN surfaces
+
+- `proof_contract.py` was not found under `services/repo-truth-extractor`; this surface remains MISSING/UNKNOWN for this packet.
+- `risk_dashboard.py` was not found under `services/repo-truth-extractor`; this surface remains MISSING/UNKNOWN for this packet.
+
+## Residual risk
+
+- Additive `RUN_ROUTING_FINGERPRINT.json` fields may affect consumers that compare full JSON objects instead of selecting known keys.
+- This static proof does not validate live provider schema acceptance, returned-model metadata, billing authority, or retention behavior.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_ROUTE_FINGERPRINT_MATRIX.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_ROUTE_FINGERPRINT_MATRIX.md
@@ -1,0 +1,19 @@
+# RTE-PKT-13 Route Fingerprint Matrix
+
+| Route | requested_provider | requested_model_id | provider_route_kind | upstream_provider | economic_surface | api_key_env | endpoint/economic authority | structured_output_mode | provider_schema_variant | live_validation_status | direct_provider_guarantees_inherited | live_provider_behavior_proven |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Direct xAI | `xai` | `grok-fixture` | `direct_provider` | `xai` | `xai_direct` | `XAI_API_KEY` | direct xAI endpoint/key/economic surface | `json_schema` | `xai_relaxed_direct` | `LIVE_VALIDATION_REQUIRED` | `null` | `false` |
+| OpenRouter x-ai | `openrouter` | `x-ai/grok-fixture` | `openrouter_proxy_xai` | `xai` | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter endpoint/key/economic surface | `json_schema` | `openrouter_proxy_xai_relaxed` | `LIVE_VALIDATION_REQUIRED` | `false` | `false` |
+| OpenRouter OpenAI | `openrouter` | `openai/gpt-fixture` | `openrouter_proxy_other` | `openai` | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter endpoint/key/economic surface | `json_schema` | `openrouter_proxy_canonical` | `LIVE_VALIDATION_REQUIRED` | `false` | `false` |
+| OpenRouter unknown/native | `openrouter` | `native-fixture` | `openrouter_native_or_unknown` | `unknown` | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter endpoint/key/economic surface | `json_schema` | `openrouter_proxy_canonical` | `LIVE_VALIDATION_REQUIRED` | `false` | `false` |
+| Direct OpenAI | `openai` | `gpt-fixture` | `direct_provider` | `openai` | `openai_direct` | `OPENAI_API_KEY` | direct OpenAI endpoint/key/economic surface | `json_schema` | `canonical_direct` | `LIVE_VALIDATION_REQUIRED` | `null` | `false` |
+| Direct Gemini | `gemini` | `gemini-fixture` | `direct_provider` | `gemini` | `gemini_direct` | `GEMINI_API_KEY` | direct Gemini endpoint/key/economic surface | `json_schema` | `gemini_relaxed_direct` | `LIVE_VALIDATION_REQUIRED` | `null` | `false` |
+| Unknown provider | `unknown` | `unknown-fixture` | `unknown` | `unknown` | `unknown` | `UNKNOWN` | UNKNOWN | `none` | `unknown` | `UNKNOWN` | `null` | `false` |
+
+## OBSERVED fingerprint inputs
+
+The deterministic route fingerprint material is limited to:
+
+`requested_provider`, `requested_model_id`, `provider_route_kind`, `upstream_provider`, `economic_surface`, `api_key_env`, `endpoint_effective`, `transport`, `provider_signature`, `structured_output_mode`, `provider_schema_variant`, `live_validation_status`.
+
+`returned_model_id` is response metadata only and is intentionally excluded from the static fingerprint material.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_STATIC_FIXTURE_EXAMPLES.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_STATIC_FIXTURE_EXAMPLES.md
@@ -1,0 +1,46 @@
+# RTE-PKT-13 Static Fixture Examples
+
+## Direct xAI
+
+```json
+{
+  "requested_provider": "xai",
+  "requested_model_id": "grok-fixture",
+  "provider_route_kind": "direct_provider",
+  "upstream_provider": "xai",
+  "economic_surface": "xai_direct",
+  "api_key_env": "XAI_API_KEY",
+  "endpoint_base_url": "https://api.x.ai/v1",
+  "endpoint_effective": "https://api.x.ai/v1/chat/completions",
+  "transport": "openai_sdk",
+  "provider_schema_variant": "xai_relaxed_direct",
+  "live_validation_status": "LIVE_VALIDATION_REQUIRED",
+  "fingerprint_authority": "static_request_route_metadata",
+  "live_provider_behavior_proven": false
+}
+```
+
+## OpenRouter x-ai
+
+```json
+{
+  "requested_provider": "openrouter",
+  "requested_model_id": "x-ai/grok-fixture",
+  "provider_route_kind": "openrouter_proxy_xai",
+  "upstream_provider": "xai",
+  "economic_surface": "openrouter",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "endpoint_base_url": "https://openrouter.ai/api/v1",
+  "endpoint_effective": "https://openrouter.ai/api/v1/chat/completions",
+  "transport": "openai_sdk",
+  "provider_schema_variant": "openrouter_proxy_xai_relaxed",
+  "direct_provider_guarantees_inherited": false,
+  "live_validation_status": "LIVE_VALIDATION_REQUIRED",
+  "fingerprint_authority": "static_request_route_metadata",
+  "live_provider_behavior_proven": false
+}
+```
+
+## Returned model metadata boundary
+
+`returned_model_id`, when present in response metadata, remains separate from requested route identity. It is not part of `route_fingerprint_material` and does not rewrite `requested_provider`, `requested_model_id`, `provider_route_kind`, or `economic_surface`.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_TEST_REPORT.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_TEST_REPORT.md
@@ -1,0 +1,21 @@
+# RTE-PKT-13 Test Report
+
+| Command | Exit | Result | Summary |
+| --- | ---: | --- | --- |
+| `pytest services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py -q` | 0 | PASS | 5 passed |
+| `pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q` | 0 | PASS | 6 passed |
+| `pytest services/repo-truth-extractor/tests -k "routing_fingerprint or route_fingerprint or fingerprint" -q` | 0 | PASS | 8 passed |
+| `pytest services/repo-truth-extractor/tests -k "openrouter and xai" -q` | 0 | PASS | 8 passed |
+| `pytest services/repo-truth-extractor/tests -k "xai and metadata" -q` | 0 | PASS | 2 passed |
+| `pytest services/repo-truth-extractor/tests/test_structured_output_provider_modes.py -q` | 0 | PASS | 3 passed |
+| `pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q` | 0 | PASS | 12 passed |
+| `pytest services/repo-truth-extractor/tests/test_v5_golden_fixture_smoke.py -q` | 0 | PASS | 1 passed |
+| `pytest services/repo-truth-extractor/tests -k "proof_pack or proof or status" -q` | 0 | PASS | 25 passed |
+| `pytest services/repo-truth-extractor/tests -k "risk and dashboard" -q` | 5 | NOT_RUN_NO_TESTS_SELECTED | No tests selected |
+| `pytest services/repo-truth-extractor/tests -k "proof_contract or artifact_authority" -q` | 5 | NOT_RUN_NO_TESTS_SELECTED | No tests selected |
+| `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/llm_runtime.py` | 0 | PASS | Compilation passed |
+| `python -m json.tool out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json >/dev/null` | 0 | PASS | Manifest JSON parsed |
+| `git diff --check` | 0 | PASS | No whitespace errors in unstaged diff |
+| `pre-commit run --files <changed files>` | 0 | PASS | Configured hooks passed for changed files |
+
+All pytest runs emitted the existing pytest configuration warning for unknown `asyncio_mode`.

--- a/services/repo-truth-extractor/lib/prescan/provider_catalog.py
+++ b/services/repo-truth-extractor/lib/prescan/provider_catalog.py
@@ -133,16 +133,34 @@ def _route_identity(provider: str, model_id: str) -> dict[str, Any]:
     normalized_provider = str(provider).strip().lower()
     normalized_model = str(model_id).strip()
     upstream_provider = normalized_provider
+    provider_route_kind = "unknown"
     if normalized_provider == "openrouter":
         prefix, sep, _rest = normalized_model.partition("/")
         normalized_prefix = {"x-ai": "xai"}.get(prefix.lower(), prefix.lower())
-        if sep and normalized_prefix in {"openai", "gemini", "xai", "anthropic"}:
+        if sep and normalized_prefix == "xai":
+            upstream_provider = "xai"
+            provider_route_kind = "openrouter_proxy_xai"
+        elif sep and normalized_prefix in {"openai", "gemini", "anthropic"}:
             upstream_provider = normalized_prefix
+            provider_route_kind = "openrouter_proxy_other"
+        else:
+            upstream_provider = "unknown"
+            provider_route_kind = "openrouter_native_or_unknown"
+    elif normalized_provider in {"openai", "gemini", "xai"}:
+        provider_route_kind = "direct_provider"
     dependency_class = "proxy" if normalized_provider == "openrouter" else "first_party"
     if normalized_provider in {"ollama", "lmstudio", "vllm", "mock", "local"}:
         dependency_class = "local"
-    economic_surface = normalized_provider if normalized_provider else "unknown"
+    economic_surface = {
+        "xai": "xai_direct",
+        "openai": "openai_direct",
+        "gemini": "gemini_direct",
+        "openrouter": "openrouter",
+    }.get(normalized_provider, "unknown")
     return {
+        "requested_provider": normalized_provider or "unknown",
+        "requested_model_id": normalized_model,
+        "provider_route_kind": provider_route_kind,
         "dependency_class": dependency_class,
         "economic_surface": economic_surface,
         "upstream_provider": upstream_provider,
@@ -150,6 +168,11 @@ def _route_identity(provider: str, model_id: str) -> dict[str, Any]:
             normalized_provider == "openrouter" and upstream_provider != normalized_provider
         ),
         "execution_transport": _route_transport(normalized_provider),
+        "live_validation_status": (
+            "LIVE_VALIDATION_REQUIRED"
+            if normalized_provider in {"openai", "gemini", "xai", "openrouter"}
+            else "UNKNOWN"
+        ),
     }
 
 
@@ -327,9 +350,12 @@ def build_provider_readiness_matrix(
                 "provider": str(route.get("provider") or ""),
                 "model_id": str(route.get("model_id") or ""),
                 "api_key_env": str(route.get("api_key_env") or ""),
+                "provider_route_kind": str(route.get("provider_route_kind") or ""),
+                "upstream_provider": str(route.get("upstream_provider") or ""),
                 "dependency_class": str(route.get("dependency_class") or ""),
                 "economic_surface": str(route.get("economic_surface") or ""),
                 "execution_transport": str(route.get("execution_transport") or ""),
+                "live_validation_status": str(route.get("live_validation_status") or ""),
                 "route_admissible": bool(route.get("route_admissible")),
                 "ready": bool(provider_probe.get("ready")),
                 "provider_probe": provider_probe,
@@ -532,9 +558,12 @@ def build_prescan_routing_plan(
                 "model_id": str(route.get("model_id") or ""),
                 "api_key_env": str(route.get("api_key_env") or ""),
                 "prescan_tier": str(route.get("prescan_tier") or ""),
+                "provider_route_kind": str(route.get("provider_route_kind") or ""),
+                "upstream_provider": str(route.get("upstream_provider") or ""),
                 "dependency_class": str(route.get("dependency_class") or ""),
                 "economic_surface": str(route.get("economic_surface") or ""),
                 "execution_transport": str(route.get("execution_transport") or ""),
+                "live_validation_status": str(route.get("live_validation_status") or ""),
                 "pricing": dict(route.get("pricing") or {}),
                 "structured_output_mode": str(route.get("structured_output_mode") or "none"),
                 "strict_json_schema": bool(route.get("strict_json_schema", False)),
@@ -551,8 +580,11 @@ def build_prescan_routing_plan(
             "api_key_env": str(selected.get("api_key_env")),
             "structured_output_mode": str(selected.get("structured_output_mode") or "none"),
             "strict_json_schema": bool(selected.get("strict_json_schema", False)),
+            "provider_route_kind": str(selected.get("provider_route_kind") or ""),
+            "upstream_provider": str(selected.get("upstream_provider") or ""),
             "dependency_class": str(selected.get("dependency_class") or ""),
             "economic_surface": str(selected.get("economic_surface") or ""),
+            "live_validation_status": str(selected.get("live_validation_status") or ""),
             "selection_basis": "lowest_estimated_cost_within_allowed_tier_band_after_readiness",
             "pricing": dict(selected.get("pricing") or {}),
             "legacy_route_changed": bool(

--- a/services/repo-truth-extractor/lib/structured_output_contracts.py
+++ b/services/repo-truth-extractor/lib/structured_output_contracts.py
@@ -512,10 +512,35 @@ def provider_schema_variant(
     if normalized_provider == "openrouter":
         if normalized_model_id.startswith("x-ai/"):
             return "xai_relaxed"
-        if normalized_model_id.startswith("google/") or normalized_model_id.startswith("gemini"):
+        if normalized_model_id.startswith("google/") or normalized_model_id.startswith(
+            "gemini"
+        ):
             return "gemini_relaxed"
         return "canonical"
     return "canonical"
+
+
+def provider_schema_variant_label(
+    provider: str,
+    model_id: str,
+) -> str:
+    normalized_provider = str(provider or "").strip().lower()
+    normalized_model_id = str(model_id or "").strip().lower()
+    if normalized_provider == "xai":
+        return "xai_relaxed_direct"
+    if normalized_provider == "gemini":
+        return "gemini_relaxed_direct"
+    if normalized_provider == "openrouter":
+        if normalized_model_id.startswith("x-ai/"):
+            return "openrouter_proxy_xai_relaxed"
+        if normalized_model_id.startswith("google/") or normalized_model_id.startswith(
+            "gemini"
+        ):
+            return "openrouter_proxy_gemini_relaxed"
+        return "openrouter_proxy_canonical"
+    if normalized_provider == "openai":
+        return "canonical_direct"
+    return "unknown"
 
 
 def adapt_canonical_schema_for_variant(
@@ -559,6 +584,7 @@ def build_provider_structured_output(
     )
     provider = str((route or {}).get("provider") or "").strip().lower()
     model_id = str((route or {}).get("model_id") or "").strip()
+    variant_label = provider_schema_variant_label(provider, model_id)
     if effective_mode == STRUCTURED_OUTPUT_MODE_NONE:
         return None, {
             "enabled": False,
@@ -568,6 +594,7 @@ def build_provider_structured_output(
             "schema_name": None,
             "schema_version": None,
             "schema_variant": None,
+            "provider_schema_variant": variant_label,
             "strict": bool(strict),
             "contract_lane": contract_lane_name,
             "transport_mode": None,
@@ -581,6 +608,7 @@ def build_provider_structured_output(
             "schema_name": None,
             "schema_version": None,
             "schema_variant": None,
+            "provider_schema_variant": variant_label,
             "strict": False,
             "contract_lane": contract_lane_name,
             "transport_mode": (
@@ -612,6 +640,8 @@ def build_provider_structured_output(
             "structured_output_mode_requested": effective_mode,
             "structured_output_mode_effective": effective_mode,
             "schema_variant": variant,
+            "schema_variant_behavior": variant,
+            "provider_schema_variant": variant_label,
             "transport_mode": (
                 "response_json_schema"
                 if provider == "gemini" and str(transport or "").strip().lower() != "openai_compat_http"

--- a/services/repo-truth-extractor/llm_runtime.py
+++ b/services/repo-truth-extractor/llm_runtime.py
@@ -357,7 +357,7 @@ def classify_route_identity(
             if normalized_provider in {"xai", "openai", "gemini", "openrouter"}
             else "UNKNOWN"
         ),
-        "route_identity_authority": "static_request_metadata",
+        "route_identity_authority": "static_request_route_metadata",
         "direct_provider_guarantees_inherited": (
             False if normalized_provider == "openrouter" else None
         ),

--- a/services/repo-truth-extractor/llm_runtime.py
+++ b/services/repo-truth-extractor/llm_runtime.py
@@ -250,6 +250,120 @@ def _retry_attempted(retry_trace: Sequence[Dict[str, Any]]) -> bool:
     )
 
 
+
+def provider_schema_variant_label(provider: str, model_id: str) -> str:
+    normalized_provider = str(provider or "").strip().lower()
+    normalized_model_id = str(model_id or "").strip().lower()
+    if normalized_provider == "xai":
+        return "xai_relaxed_direct"
+    if normalized_provider == "gemini":
+        return "gemini_relaxed_direct"
+    if normalized_provider == "openrouter":
+        if normalized_model_id.startswith("x-ai/"):
+            return "openrouter_proxy_xai_relaxed"
+        if normalized_model_id.startswith("google/") or normalized_model_id.startswith(
+            "gemini"
+        ):
+            return "openrouter_proxy_gemini_relaxed"
+        return "openrouter_proxy_canonical"
+    if normalized_provider == "openai":
+        return "canonical_direct"
+    return "unknown"
+
+
+def _structured_output_mode_from_meta(
+    structured_output: Optional[Dict[str, Any]],
+) -> str:
+    if not isinstance(structured_output, dict):
+        return "none"
+    for key in (
+        "structured_output_mode_effective",
+        "structured_output_mode_requested",
+    ):
+        token = str(structured_output.get(key) or "").strip()
+        if token:
+            return token
+    if not bool(structured_output.get("enabled")):
+        return "none"
+    transport_mode = str(structured_output.get("transport_mode") or "").strip()
+    if "json_schema" in transport_mode:
+        return "json_schema"
+    if (
+        "json_object" in transport_mode
+        or structured_output.get("mime_type") == "application/json"
+    ):
+        return "json_object"
+    return "unknown"
+
+
+def classify_route_identity(
+    *,
+    provider: str,
+    model_id: str,
+    api_key_env: Optional[str] = None,
+    endpoint_base_url: Optional[str] = None,
+    endpoint_effective: Optional[str] = None,
+    transport: Optional[str] = None,
+    provider_signature: Optional[str] = None,
+    structured_output: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    normalized_provider = str(provider or "").strip().lower()
+    requested_model_id = str(model_id or "").strip()
+    normalized_model_id = requested_model_id.lower()
+    upstream_provider = normalized_provider if normalized_provider else "unknown"
+    provider_route_kind = "unknown"
+    economic_surface = "unknown"
+
+    if normalized_provider == "openrouter":
+        prefix, sep, _rest = normalized_model_id.partition("/")
+        normalized_prefix = {"x-ai": "xai"}.get(prefix, prefix)
+        economic_surface = "openrouter"
+        if sep and normalized_prefix == "xai":
+            provider_route_kind = "openrouter_proxy_xai"
+            upstream_provider = "xai"
+        elif sep and normalized_prefix in {"openai", "gemini", "anthropic"}:
+            provider_route_kind = "openrouter_proxy_other"
+            upstream_provider = normalized_prefix
+        else:
+            provider_route_kind = "openrouter_native_or_unknown"
+            upstream_provider = "unknown"
+    elif normalized_provider in {"xai", "openai", "gemini"}:
+        provider_route_kind = "direct_provider"
+        upstream_provider = normalized_provider
+        economic_surface = {
+            "xai": "xai_direct",
+            "openai": "openai_direct",
+            "gemini": "gemini_direct",
+        }[normalized_provider]
+
+    identity: Dict[str, Any] = {
+        "requested_provider": normalized_provider or "unknown",
+        "requested_model_id": requested_model_id,
+        "provider_route_kind": provider_route_kind,
+        "upstream_provider": upstream_provider or "unknown",
+        "economic_surface": economic_surface,
+        "api_key_env": str(api_key_env or "").strip() or None,
+        "endpoint_base_url": endpoint_base_url,
+        "endpoint_effective": endpoint_effective,
+        "transport": transport,
+        "provider_signature": provider_signature,
+        "structured_output_mode": _structured_output_mode_from_meta(structured_output),
+        "provider_schema_variant": provider_schema_variant_label(
+            normalized_provider,
+            requested_model_id,
+        ),
+        "live_validation_status": (
+            "LIVE_VALIDATION_REQUIRED"
+            if normalized_provider in {"xai", "openai", "gemini", "openrouter"}
+            else "UNKNOWN"
+        ),
+        "route_identity_authority": "static_request_metadata",
+        "direct_provider_guarantees_inherited": (
+            False if normalized_provider == "openrouter" else None
+        ),
+    }
+    return {key: value for key, value in identity.items() if value is not None}
+
 def call_llm(
     deps: LLMRuntimeDeps,
     provider: str,

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -1368,6 +1368,21 @@ PROVIDER_API_KEY_ENV: Dict[str, str] = {
     "xai": "XAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
 }
+STATIC_ROUTE_FINGERPRINT_AUTHORITY = "static_request_route_metadata"
+ROUTE_FINGERPRINT_INPUT_FIELDS: Tuple[str, ...] = (
+    "requested_provider",
+    "requested_model_id",
+    "provider_route_kind",
+    "upstream_provider",
+    "economic_surface",
+    "api_key_env",
+    "endpoint_effective",
+    "transport",
+    "provider_signature",
+    "structured_output_mode",
+    "provider_schema_variant",
+    "live_validation_status",
+)
 
 
 # --- Setup Logging ---
@@ -5745,16 +5760,71 @@ def routing_ladders_payload() -> Dict[str, Dict[str, List[Dict[str, str]]]]:
     return payload
 
 
-def effective_model_routing_payload() -> Dict[str, Dict[str, str]]:
-    payload: Dict[str, Dict[str, str]] = {}
+def _structured_output_mode_for_static_route(
+    phase: str,
+    step_id: str,
+    provider: str,
+    model_id: str,
+    api_key_env: str,
+) -> str:
+    contract = _step_contract_for(phase, step_id)
+    route_entry = route_entry_by_identity(
+        route_entries_for_stage(contract, "primary"),
+        provider=provider,
+        model_id=model_id,
+        api_key_env=api_key_env,
+    )
+    if route_entry is not None:
+        return str(route_entry.get("structured_output_mode") or "none")
+    if is_json_managed_step(contract):
+        return "json_schema"
+    return "none"
+
+
+def effective_model_routing_payload(
+    cfg: Optional[RunnerConfig] = None,
+) -> Dict[str, Dict[str, Any]]:
+    payload: Dict[str, Dict[str, Any]] = {}
     for phase in PHASES:
         provider, model_id, api_key_env = MODEL_ROUTING.get(phase, ("", "", ""))
-        payload[phase] = {
+        row: Dict[str, Any] = {
             "provider": provider,
             "model_id": model_id,
             "api_key_env": api_key_env,
             "scope": "representative_phase_default_not_step_authoritative",
         }
+        if cfg is not None and provider and model_id:
+            step_id = _representative_step_id_for_phase(phase)
+            endpoint_base = llm_base_url(provider, cfg)
+            auth_sequence = (
+                _gemini_auth_mode_sequence(cfg.gemini_auth_mode, endpoint_base)
+                if provider == "gemini"
+                else ["sdk_bearer"]
+            )
+            endpoint_url = transport_endpoint_url(
+                provider, model_id, cfg, "REDACTED", auth_sequence[0]
+            )
+            row.update(
+                build_static_route_fingerprint_metadata(
+                    provider=provider,
+                    model_id=model_id,
+                    api_key_env=api_key_env,
+                    endpoint_base_url=endpoint_base,
+                    endpoint_url=endpoint_url,
+                    transport=transport_for_provider(provider, cfg),
+                    structured_output_mode=_structured_output_mode_for_static_route(
+                        phase,
+                        step_id,
+                        provider,
+                        model_id,
+                        api_key_env,
+                    ),
+                    gemini_auth_mode_effective=(
+                        auth_sequence[0] if provider == "gemini" else None
+                    ),
+                )
+            )
+        payload[phase] = row
     return payload
 
 
@@ -6165,6 +6235,25 @@ def write_run_routing_fingerprint(
             endpoint_url = transport_endpoint_url(
                 provider, model_id, cfg, "REDACTED", default_sequence[0]
             )
+            transport = transport_for_provider(provider, cfg)
+            route_fingerprint = build_static_route_fingerprint_metadata(
+                provider=provider,
+                model_id=model_id,
+                api_key_env=api_key_env,
+                endpoint_base_url=endpoint_base,
+                endpoint_url=endpoint_url,
+                transport=transport,
+                structured_output_mode=_structured_output_mode_for_static_route(
+                    phase,
+                    prompt.step_id,
+                    provider,
+                    model_id,
+                    api_key_env,
+                ),
+                gemini_auth_mode_effective=(
+                    default_sequence[0] if provider == "gemini" else None
+                ),
+            )
             entries.append(
                 {
                     "step_id": prompt.step_id,
@@ -6182,7 +6271,7 @@ def write_run_routing_fingerprint(
                         }
                         for route_provider, route_model, route_key_env in ladder
                     ],
-                    "transport": transport_for_provider(provider, cfg),
+                    "transport": transport,
                     "endpoint_base_url": endpoint_base,
                     "endpoint_effective": endpoint_effective(endpoint_url),
                     "gemini_endpoint_family": (
@@ -6200,6 +6289,7 @@ def write_run_routing_fingerprint(
                         endpoint_base,
                         default_sequence[0] if provider == "gemini" else None,
                     ),
+                    **route_fingerprint,
                 }
             )
         phase_entries[phase] = entries
@@ -6207,6 +6297,13 @@ def write_run_routing_fingerprint(
     payload = {
         "run_id": run_id,
         "created_at": now_iso(),
+        "fingerprint_authority": STATIC_ROUTE_FINGERPRINT_AUTHORITY,
+        "live_provider_behavior_proven": False,
+        "live_validation_status": "LIVE_VALIDATION_REQUIRED",
+        "route_fingerprint_input_fields": list(ROUTE_FINGERPRINT_INPUT_FIELDS),
+        "returned_model_identity_policy": (
+            "returned_model_id_is_response_metadata_only_and_does_not_rewrite_requested_route_identity"
+        ),
         "config": {
             "routing_policy": cfg.routing_policy,
             "routing_policy_version": ROUTING_POLICY_VERSION,
@@ -6243,7 +6340,7 @@ def write_run_routing_fingerprint(
             "wait_timeout_seconds": cfg.batch_wait_timeout_seconds,
             "max_requests_per_job": cfg.batch_max_requests_per_job,
         },
-        "effective_model_routing": effective_model_routing_payload(),
+        "effective_model_routing": effective_model_routing_payload(cfg),
         "benchmark_route_ownership": benchmark_route_ownership_payload(validate=False),
         "phases": phase_entries,
     }
@@ -9059,6 +9156,60 @@ def routing_signature(
         canonical, ensure_ascii=True, sort_keys=True, separators=(",", ":")
     )
     return hashlib.blake2b(encoded, digest_size=32).hexdigest()
+
+
+def static_route_fingerprint_material(route_meta: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        field: route_meta.get(field)
+        for field in ROUTE_FINGERPRINT_INPUT_FIELDS
+    }
+
+
+def static_route_fingerprint_hash(material: Dict[str, Any]) -> str:
+    encoded = sanitized_json_bytes(
+        material, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.blake2b(encoded, digest_size=32).hexdigest()
+
+
+def build_static_route_fingerprint_metadata(
+    *,
+    provider: str,
+    model_id: str,
+    api_key_env: str,
+    endpoint_base_url: str,
+    endpoint_url: str,
+    transport: str,
+    structured_output_mode: str,
+    gemini_auth_mode_effective: Optional[str] = None,
+) -> Dict[str, Any]:
+    endpoint_url_effective = endpoint_effective(endpoint_url)
+    route_signature = provider_signature(
+        provider,
+        model_id,
+        endpoint_url,
+        gemini_auth_mode_effective if provider == "gemini" else None,
+    )
+    route_meta = llm_runtime_classify_route_identity(
+        provider=provider,
+        model_id=model_id,
+        api_key_env=api_key_env,
+        endpoint_base_url=endpoint_base_url,
+        endpoint_effective=endpoint_url_effective,
+        transport=transport,
+        provider_signature=route_signature,
+        structured_output={
+            "structured_output_mode_effective": structured_output_mode,
+        },
+    )
+    route_meta["route_identity_authority"] = STATIC_ROUTE_FINGERPRINT_AUTHORITY
+    route_meta.setdefault("direct_provider_guarantees_inherited", None)
+    route_meta["fingerprint_authority"] = STATIC_ROUTE_FINGERPRINT_AUTHORITY
+    route_meta["live_provider_behavior_proven"] = False
+    material = static_route_fingerprint_material(route_meta)
+    route_meta["route_fingerprint_material"] = material
+    route_meta["route_fingerprint_hash"] = static_route_fingerprint_hash(material)
+    return route_meta
 
 
 def build_auth_present_flags(

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -9155,7 +9155,7 @@ def routing_signature(
     encoded = sanitized_json_bytes(
         canonical, ensure_ascii=True, sort_keys=True, separators=(",", ":")
     )
-    return hashlib.blake2b(encoded, digest_size=32).hexdigest()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def static_route_fingerprint_material(route_meta: Dict[str, Any]) -> Dict[str, Any]:
@@ -10593,8 +10593,8 @@ def enrich_request_meta(
     endpoint_sig = json.dumps(
         endpoint_sig_src, ensure_ascii=True, separators=(",", ":"), sort_keys=True
     )
-    enriched["endpoint_transport_signature"] = hashlib.blake2b(
-        endpoint_sig.encode("utf-8"), digest_size=32
+    enriched["endpoint_transport_signature"] = hashlib.sha256(
+        endpoint_sig.encode("utf-8")
     ).hexdigest()
     enriched.setdefault("routing_tier", None)
     enriched.setdefault("routing_policy", None)

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -9169,7 +9169,7 @@ def static_route_fingerprint_hash(material: Dict[str, Any]) -> str:
     encoded = sanitized_json_bytes(
         material, ensure_ascii=True, sort_keys=True, separators=(",", ":")
     )
-    return hashlib.blake2b(encoded, digest_size=32).hexdigest()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def build_static_route_fingerprint_metadata(

--- a/services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py
+++ b/services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+import llm_runtime
+from _v5_smoke_helpers import load_runner_module
+from lib.prescan.provider_catalog import _route_identity
+from lib.structured_output_contracts import build_provider_step_contract_output
+
+
+def _no_provider_call(*_args: Any, **_kwargs: Any) -> Any:
+    raise AssertionError("provider client must not be invoked by static route tests")
+
+
+def _fake_deps() -> llm_runtime.LLMRuntimeDeps:
+    return llm_runtime.LLMRuntimeDeps(
+        live_llm_calls_blocked_for_tests=lambda: False,
+        live_llm_tests_env="RTE_TEST_LIVE_OK",
+        llm_base_url=lambda provider, _cfg: (
+            "https://openrouter.ai/api/v1"
+            if provider == "openrouter"
+            else "https://api.x.ai/v1"
+        ),
+        transport_for_provider=lambda _provider, _cfg: "openai_sdk",
+        resolve_api_key=lambda _provider, api_key_env: ("", api_key_env),
+        build_chat_payload=lambda _provider, model_id, system_prompt, user_content, **_kwargs: {
+            "model": model_id,
+            "messages": [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_content},
+            ],
+        },
+        serialize_payload_body=lambda payload: json.dumps(payload, sort_keys=True),
+        measure_payload_bytes_from_body=len,
+        gemini_auth_mode_sequence=lambda _mode, _base_url: ["sdk_bearer"],
+        make_url=lambda _provider, base_url, _cfg, _api_key, _mode: base_url + "/chat/completions",
+        make_headers=lambda *_args: {},
+        sdk_auth_present_flags=lambda _provider, present: {"sdk_api_key_present": present},
+        build_auth_present_flags=lambda _headers, _query_key: {},
+        endpoint_effective=lambda url: url,
+        endpoint_fingerprint=lambda url: {"endpoint_host": "fixture.test", "endpoint_path": url},
+        provider_signature=lambda provider, model_id, endpoint_url, _mode: (
+            f"provider={provider};model={model_id};endpoint={endpoint_url}"
+        ),
+        get_http_session=_no_provider_call,
+        get_gemini_client=_no_provider_call,
+        extract_text_from_gemini_response=lambda _response: "",
+        get_xai_client=_no_provider_call,
+        get_openrouter_client=_no_provider_call,
+        get_openai_client=_no_provider_call,
+        extract_text_from_chat_completion=lambda _response: "",
+        summarize_llm_response=lambda **_kwargs: {},
+        exception_status_code=lambda _exc: None,
+        exception_response_text=lambda _exc: "",
+        classify_failure_type=lambda _status, _body, _text: "unknown",
+        extract_provider_error_reason=lambda _body: None,
+        sanitize_error_text=lambda text: text,
+        capture_exception_metadata=lambda _exc: {},
+        new_trace_id=lambda: "trace-static",
+        new_span_id=lambda: "span-static",
+        cost_abort_failure_meta=lambda **kwargs: dict(kwargs),
+        should_retry=lambda _status, _failure, _exc, _policy: False,
+        backoff_seconds=lambda _attempt, _base, _max: 0.0,
+        is_spend_aborted=lambda: False,
+        sha256_text=lambda _path: "sha256-fixture",
+        runner_script=Path("run_extraction_v5.py"),
+        is_auth_classified_failure=lambda _failure: False,
+        classify_escalation_class=lambda **_kwargs: "none",
+        is_break_glass_opus_route=lambda _route: False,
+        provider_api_key_env={"openrouter": "OPENROUTER_API_KEY", "xai": "XAI_API_KEY"},
+        max_files_for_phase=lambda _phase, _cfg: 1,
+        estimate_text_tokens=lambda system, user: len(system) + len(user),
+        project_output_tokens=lambda input_tokens: input_tokens,
+        check_projected_cost_limit=lambda **_kwargs: None,
+        accumulate_runtime_spend=lambda **_kwargs: None,
+        cost_limit_exceeded_error=RuntimeError,
+        now_iso=lambda: "2026-05-15T00:00:00+00:00",
+        strip_outer_json_fence=lambda _text: None,
+        extract_first_fenced_json_block=lambda _text: None,
+        extract_first_json_object=lambda _text: None,
+        is_semantic_eof_eligible=lambda _exc, _text: False,
+        try_repair_json_truncation=lambda _text, _exc: None,
+    )
+
+
+def _step_contract() -> dict[str, Any]:
+    return {
+        "phase": "A",
+        "step_id": "A1",
+        "scope": {"json_managed": True},
+        "expected_artifacts": ["STATIC_ROUTE_FIXTURE.json"],
+        "artifact_order": ["STATIC_ROUTE_FIXTURE.json"],
+        "lane": {"lane_class": "BULK_DOCS_STRICT"},
+        "artifacts": {
+            "STATIC_ROUTE_FIXTURE.json": {
+                "canonical_schema_id": "STATIC_ROUTE_FIXTURE@v1",
+                "required_fields": ["id", "path", "line_range"],
+                "prompt_required_item_fields": [],
+                "allow_empty_array_fields": [],
+            }
+        },
+    }
+
+
+def test_direct_xai_route_identity_is_direct_provider_with_xai_surface() -> None:
+    identity = llm_runtime.classify_route_identity(
+        provider="xai",
+        model_id="grok-fixture",
+        api_key_env="XAI_API_KEY",
+        endpoint_base_url="https://api.x.ai/v1",
+        endpoint_effective="https://api.x.ai/v1/chat/completions",
+        transport="openai_sdk",
+        provider_signature="provider=xai;model=grok-fixture",
+        structured_output={"structured_output_mode_effective": "json_schema"},
+    )
+
+    assert identity["requested_provider"] == "xai"
+    assert identity["requested_model_id"] == "grok-fixture"
+    assert identity["provider_route_kind"] == "direct_provider"
+    assert identity["upstream_provider"] == "xai"
+    assert identity["economic_surface"] == "xai_direct"
+    assert identity["api_key_env"] == "XAI_API_KEY"
+    assert identity["provider_schema_variant"] == "xai_relaxed_direct"
+
+
+def test_openrouter_xai_route_identity_is_proxy_with_openrouter_surface() -> None:
+    identity = llm_runtime.classify_route_identity(
+        provider="openrouter",
+        model_id="x-ai/grok-fixture",
+        api_key_env="OPENROUTER_API_KEY",
+        endpoint_base_url="https://openrouter.ai/api/v1",
+        endpoint_effective="https://openrouter.ai/api/v1/chat/completions",
+        transport="openai_sdk",
+        provider_signature="provider=openrouter;model=x-ai/grok-fixture",
+        structured_output={"structured_output_mode_effective": "json_schema"},
+    )
+
+    assert identity["requested_provider"] == "openrouter"
+    assert identity["requested_model_id"] == "x-ai/grok-fixture"
+    assert identity["provider_route_kind"] == "openrouter_proxy_xai"
+    assert identity["upstream_provider"] == "xai"
+    assert identity["economic_surface"] == "openrouter"
+    assert identity["api_key_env"] == "OPENROUTER_API_KEY"
+    assert identity["provider_schema_variant"] == "openrouter_proxy_xai_relaxed"
+    assert identity["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+    assert identity["direct_provider_guarantees_inherited"] is False
+
+
+def test_call_llm_openrouter_xai_missing_key_adds_proxy_metadata_without_provider_call() -> None:
+    result = llm_runtime.call_llm(
+        _fake_deps(),
+        provider="openrouter",
+        model_id="x-ai/grok-fixture",
+        api_key_env="OPENROUTER_API_KEY",
+        system_prompt="Return JSON.",
+        user_content="{}",
+        cfg=SimpleNamespace(gemini_auth_mode="auto"),
+        structured_output_override={
+            "structured_output_mode_requested": "json_schema",
+            "structured_output_mode_effective": "json_schema",
+            "provider_schema_variant": "openrouter_proxy_xai_relaxed",
+        },
+    )
+
+    assert result["ok"] is False
+    meta = result["meta"]
+    assert meta["failure_type"] == "auth_missing"
+    assert meta["requested_provider"] == "openrouter"
+    assert meta["provider_route_kind"] == "openrouter_proxy_xai"
+    assert meta["upstream_provider"] == "xai"
+    assert meta["economic_surface"] == "openrouter"
+    assert meta["api_key_env"] == "OPENROUTER_API_KEY"
+    assert meta["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+
+
+def test_returned_model_metadata_does_not_rewrite_openrouter_xai_route_kind() -> None:
+    runner = load_runner_module()
+
+    meta = runner.enrich_request_meta(
+        {
+            "provider": "openrouter",
+            "model_id": "x-ai/grok-fixture",
+            "api_key_env_resolved": "OPENROUTER_API_KEY",
+            "endpoint_base_url": "https://openrouter.ai/api/v1",
+            "endpoint_effective": "https://openrouter.ai/api/v1/chat/completions",
+            "transport": "openai_sdk",
+            "response_summary": {"returned_model_id": "grok-fixture-returned"},
+            "structured_output": {"structured_output_mode_effective": "json_schema"},
+        },
+        run_id="run-static",
+        phase="A",
+        step_id="A1",
+        partition_id="A_P0001",
+        provider="openrouter",
+        model_id="x-ai/grok-fixture",
+    )
+
+    assert meta["returned_model_id"] == "grok-fixture-returned"
+    assert meta["requested_provider"] == "openrouter"
+    assert meta["requested_model_id"] == "x-ai/grok-fixture"
+    assert meta["provider"] == "openrouter"
+    assert meta["model_id"] == "x-ai/grok-fixture"
+    assert meta["provider_route_kind"] == "openrouter_proxy_xai"
+    assert meta["economic_surface"] == "openrouter"
+    assert meta["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+
+
+def test_openrouter_xai_structured_output_label_preserves_xai_relaxed_behavior() -> None:
+    response_format, response_meta = build_provider_step_contract_output(
+        route={
+            "provider": "openrouter",
+            "model_id": "x-ai/grok-fixture",
+            "api_key_env": "OPENROUTER_API_KEY",
+            "structured_output_mode": "json_schema",
+            "strict_json_schema": False,
+        },
+        transport="openai_sdk",
+        step_contract=_step_contract(),
+        artifact_names=("STATIC_ROUTE_FIXTURE.json",),
+    )
+
+    assert response_format["type"] == "json_schema"
+    assert response_meta["schema_variant"] == "xai_relaxed"
+    assert response_meta["schema_variant_behavior"] == "xai_relaxed"
+    assert response_meta["provider_schema_variant"] == "openrouter_proxy_xai_relaxed"
+    assert response_meta["structured_output_mode_effective"] == "json_schema"
+
+
+def test_prescan_route_identity_labels_openrouter_xai_proxy_static_risk() -> None:
+    identity = _route_identity("openrouter", "x-ai/grok-fixture")
+
+    assert identity["requested_provider"] == "openrouter"
+    assert identity["requested_model_id"] == "x-ai/grok-fixture"
+    assert identity["provider_route_kind"] == "openrouter_proxy_xai"
+    assert identity["upstream_provider"] == "xai"
+    assert identity["economic_surface"] == "openrouter"
+    assert identity["billing_independent_from_upstream"] is True
+    assert identity["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"

--- a/services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py
+++ b/services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _v5_smoke_helpers import load_runner_module, make_cfg
+
+
+def _no_provider_call(*_args: Any, **_kwargs: Any) -> Any:
+    raise AssertionError("route fingerprint tests must not invoke provider clients")
+
+
+def _direct_xai_fingerprint() -> dict[str, Any]:
+    runner = load_runner_module()
+    return runner.build_static_route_fingerprint_metadata(
+        provider="xai",
+        model_id="grok-fixture",
+        api_key_env="XAI_API_KEY",
+        endpoint_base_url="https://api.x.ai/v1",
+        endpoint_url="https://api.x.ai/v1/chat/completions",
+        transport="openai_sdk",
+        structured_output_mode="json_schema",
+    )
+
+
+def _openrouter_xai_fingerprint() -> dict[str, Any]:
+    runner = load_runner_module()
+    return runner.build_static_route_fingerprint_metadata(
+        provider="openrouter",
+        model_id="x-ai/grok-fixture",
+        api_key_env="OPENROUTER_API_KEY",
+        endpoint_base_url="https://openrouter.ai/api/v1",
+        endpoint_url="https://openrouter.ai/api/v1/chat/completions",
+        transport="openai_sdk",
+        structured_output_mode="json_schema",
+    )
+
+
+def test_direct_xai_route_fingerprint_records_direct_identity() -> None:
+    route = _direct_xai_fingerprint()
+
+    assert route["requested_provider"] == "xai"
+    assert route["requested_model_id"] == "grok-fixture"
+    assert route["provider_route_kind"] == "direct_provider"
+    assert route["upstream_provider"] == "xai"
+    assert route["economic_surface"] == "xai_direct"
+    assert route["api_key_env"] == "XAI_API_KEY"
+    assert route["endpoint_base_url"] == "https://api.x.ai/v1"
+    assert route["endpoint_effective"] == "https://api.x.ai/v1/chat/completions"
+    assert route["transport"] == "openai_sdk"
+    assert route["structured_output_mode"] == "json_schema"
+    assert route["provider_schema_variant"] == "xai_relaxed_direct"
+    assert route["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+    assert route["fingerprint_authority"] == "static_request_route_metadata"
+    assert route["live_provider_behavior_proven"] is False
+    assert route["route_fingerprint_material"]["economic_surface"] == "xai_direct"
+
+
+def test_openrouter_xai_route_fingerprint_records_proxy_identity() -> None:
+    route = _openrouter_xai_fingerprint()
+
+    assert route["requested_provider"] == "openrouter"
+    assert route["requested_model_id"] == "x-ai/grok-fixture"
+    assert route["provider_route_kind"] == "openrouter_proxy_xai"
+    assert route["upstream_provider"] == "xai"
+    assert route["economic_surface"] == "openrouter"
+    assert route["api_key_env"] == "OPENROUTER_API_KEY"
+    assert route["endpoint_base_url"] == "https://openrouter.ai/api/v1"
+    assert route["endpoint_effective"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert route["transport"] == "openai_sdk"
+    assert route["structured_output_mode"] == "json_schema"
+    assert route["provider_schema_variant"] == "openrouter_proxy_xai_relaxed"
+    assert route["direct_provider_guarantees_inherited"] is False
+    assert route["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+    assert route["fingerprint_authority"] == "static_request_route_metadata"
+    assert route["live_provider_behavior_proven"] is False
+    assert route["route_fingerprint_material"]["economic_surface"] == "openrouter"
+
+
+def test_openrouter_xai_fingerprint_differs_from_direct_xai() -> None:
+    direct = _direct_xai_fingerprint()
+    proxied = _openrouter_xai_fingerprint()
+
+    assert direct["upstream_provider"] == proxied["upstream_provider"] == "xai"
+    assert direct["route_fingerprint_hash"] != proxied["route_fingerprint_hash"]
+    assert direct["route_fingerprint_material"] != proxied["route_fingerprint_material"]
+
+
+def test_returned_model_metadata_does_not_rewrite_requested_route_identity() -> None:
+    runner = load_runner_module()
+    enriched = runner.enrich_request_meta(
+        {
+            "provider": "openrouter",
+            "model_id": "x-ai/grok-fixture",
+            "api_key_env_resolved": "OPENROUTER_API_KEY",
+            "endpoint_base_url": "https://openrouter.ai/api/v1",
+            "endpoint_effective": "https://openrouter.ai/api/v1/chat/completions",
+            "transport": "openai_sdk",
+            "response_summary": {"returned_model_id": "grok-returned-fixture"},
+            "structured_output": {"structured_output_mode_effective": "json_schema"},
+        },
+        run_id="run-static",
+        phase="A",
+        step_id="A1",
+        partition_id="A_P0001",
+        provider="openrouter",
+        model_id="x-ai/grok-fixture",
+    )
+
+    assert enriched["returned_model_id"] == "grok-returned-fixture"
+    assert enriched["requested_provider"] == "openrouter"
+    assert enriched["requested_model_id"] == "x-ai/grok-fixture"
+    assert enriched["provider_route_kind"] == "openrouter_proxy_xai"
+    assert enriched["economic_surface"] == "openrouter"
+
+    material = runner.static_route_fingerprint_material(enriched)
+    assert "returned_model_id" not in material
+    assert material["requested_provider"] == "openrouter"
+    assert material["requested_model_id"] == "x-ai/grok-fixture"
+
+
+def test_run_routing_fingerprint_static_artifact_preserves_existing_shape(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    runner = load_runner_module()
+    for attr in (
+        "get_http_session",
+        "get_gemini_client",
+        "get_xai_client",
+        "get_openrouter_client",
+        "get_openai_client",
+    ):
+        monkeypatch.setattr(runner, attr, _no_provider_call, raising=False)
+
+    run_root = tmp_path / "run"
+    run_root.mkdir()
+    runner.write_run_routing_fingerprint(run_root, "run-static", make_cfg(runner), ["D"])
+
+    payload = json.loads((run_root / "RUN_ROUTING_FINGERPRINT.json").read_text())
+    row = payload["phases"]["D"][0]
+
+    assert payload["fingerprint_authority"] == "static_request_route_metadata"
+    assert payload["live_provider_behavior_proven"] is False
+    assert payload["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+    assert payload["route_fingerprint_input_fields"] == list(
+        runner.ROUTE_FINGERPRINT_INPUT_FIELDS
+    )
+    assert row["provider"]
+    assert row["model_id"]
+    assert row["api_key_env"]
+    assert row["routing_signature"]
+    assert row["requested_provider"] == row["provider"]
+    assert row["requested_model_id"] == row["model_id"]
+    assert row["provider_route_kind"]
+    assert row["economic_surface"]
+    assert row["endpoint_effective"]
+    assert row["provider_signature"]
+    assert row["structured_output_mode"]
+    assert row["provider_schema_variant"]
+    assert row["route_fingerprint_material"]
+    assert row["route_fingerprint_hash"]


### PR DESCRIPTION
## Summary
- Adds static route identity metadata for direct xAI vs OpenRouter `x-ai/...` proxy routes.
- Propagates route kind, upstream provider, economic surface, API key env, schema variant label, and live-validation-required status into request/proof-visible metadata.
- Adds targeted static tests and RTE-PKT-12 proof artifacts under `out/rte-pkt-12-openrouter-xai/`.

## Validation
- `pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q`
- `pytest services/repo-truth-extractor/tests/test_structured_output_provider_modes.py -q`
- `pytest services/repo-truth-extractor/tests/test_prescan_provider_catalog.py -q`
- `pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q`
- `pytest services/repo-truth-extractor/tests -k 'openrouter and xai' -q`
- `pytest services/repo-truth-extractor/tests -k 'xai and metadata' -q`
- `pytest services/repo-truth-extractor/tests -k 'structured_output or provider_modes' -q`
- `pytest services/repo-truth-extractor/tests/test_pricing_catalog.py services/repo-truth-extractor/tests/test_pricing_coverage.py services/repo-truth-extractor/tests/test_profile_review_packets.py -q`
- `python -m py_compile services/repo-truth-extractor/llm_runtime.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/lib/structured_output_contracts.py services/repo-truth-extractor/lib/prescan/provider_catalog.py`
- `python -m json.tool out/rte-pkt-12-openrouter-xai/RTE-PKT-12_MANIFEST.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`
- `pre-commit run --files ...`

## Not Run / Unknown
- No live provider calls, live extraction, provider preflight, or batch provider operations were run.
- `pytest -k 'risk and dashboard'` and `pytest -k 'proof_contract or artifact_authority'` selected no tests in this checkout; corresponding helper files were not present.
- OpenRouter x-ai live upstream metadata, schema acceptance, retention/ZDR, rate-limit, and billing equivalence remain live-validation-required/unknown.

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.
