### PR TITLE
fix(rte): add static route fingerprint proof

### DIFF
--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_DIFF_SUMMARY.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_DIFF_SUMMARY.md
@@ -1,0 +1,28 @@
+# RTE-PKT-13 Diff Summary
+
+## OBSERVED code changes
+
+- `services/repo-truth-extractor/run_extraction_v5.py`
+  - Added static route fingerprint authority constants and required fingerprint input fields.
+  - Added deterministic static route fingerprint material/hash helpers.
+  - Enriched `RUN_ROUTING_FINGERPRINT.json` phase rows with requested route identity, endpoint/economic authority, transport, provider signature, structured-output mode, provider schema variant, live-validation boundary, static authority, and provider-behavior proof boundary.
+  - Enriched representative `effective_model_routing` rows in the run routing fingerprint artifact when a `RunnerConfig` is available.
+  - Preserved existing row fields including `provider`, `model_id`, `api_key_env`, `ladder`, `transport`, `endpoint_base_url`, `endpoint_effective`, and `routing_signature`.
+- `services/repo-truth-extractor/llm_runtime.py`
+  - Aligned `route_identity_authority` with the packet-required static request route metadata authority label.
+- `services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py`
+  - Added targeted static tests for direct xAI, OpenRouter x-ai, fingerprint separation, returned-model identity preservation, and no-provider-call artifact generation safety.
+
+## INFERRED compatibility impact
+
+- Existing consumers of older route fingerprint fields should continue to read those fields because no existing `RUN_ROUTING_FINGERPRINT.json` keys were removed.
+- Consumers that compare full artifact JSON may observe additive fields in `phases[*]` rows and in `effective_model_routing` rows emitted by `write_run_routing_fingerprint`.
+
+## Non-goals preserved
+
+- No prompt files changed.
+- No promptset YAML or model-map route IDs changed.
+- No provider dispatch behavior changed.
+- No provider client behavior changed.
+- No pricing logic changed.
+- No live extraction, provider preflight, or batch provider operation was run.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json
@@ -1,0 +1,127 @@
+{
+  "packet_id": "RTE-PKT-13-ROUTE-FINGERPRINT-STATIC-PROOF",
+  "generated_at_local": "2026-05-15T11:18:29-0700",
+  "worktree": "/Users/hue/.codex/worktrees/536d/dopemux-mvp",
+  "branch": "codex/rte-pkt-13-route-fingerprint",
+  "base_head": "fac81ac877b61ea5762f4fc84a3c4e73f061c9b8",
+  "predecessor_packet": "RTE-PKT-12-OPENROUTER-XAI",
+  "predecessor_verdict": "PASS_WITH_RISKS",
+  "predecessor_verdict_source": "active_packet_instruction",
+  "predecessor_local_manifest_status_observed": "STATIC_METADATA_IMPLEMENTED_TARGETED_VALIDATION_PASS",
+  "changed_code_files": [
+    "services/repo-truth-extractor/llm_runtime.py",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py"
+  ],
+  "proof_outputs": [
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_DIFF_SUMMARY.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_ROUTE_FINGERPRINT_MATRIX.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_STATIC_FIXTURE_EXAMPLES.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_TEST_REPORT.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-13-route-fingerprint/RTE-PKT-13_REMAINING_UNKNOWNS.md"
+  ],
+  "validation_summary": [
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "5 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "6 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"routing_fingerprint or route_fingerprint or fingerprint\" -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "8 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"openrouter and xai\" -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "8 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"xai and metadata\" -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "2 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_structured_output_provider_modes.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "3 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "12 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_v5_golden_fixture_smoke.py -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "1 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"proof_pack or proof or status\" -q",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "25 passed"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"risk and dashboard\" -q",
+      "exit_code": 5,
+      "result": "NOT_RUN_NO_TESTS_SELECTED",
+      "summary": "No tests selected"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests -k \"proof_contract or artifact_authority\" -q",
+      "exit_code": 5,
+      "result": "NOT_RUN_NO_TESTS_SELECTED",
+      "summary": "No tests selected"
+    },
+    {
+      "command": "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/llm_runtime.py",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Compilation passed"
+    },
+    {
+      "command": "python -m json.tool out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json >/dev/null",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Manifest JSON parsed"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "No whitespace errors in unstaged diff"
+    },
+    {
+      "command": "pre-commit run --files services/repo-truth-extractor/llm_runtime.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json out/rte-pkt-13-route-fingerprint/RTE-PKT-13_DIFF_SUMMARY.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_ROUTE_FINGERPRINT_MATRIX.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_STATIC_FIXTURE_EXAMPLES.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_TEST_REPORT.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_NO_PROVIDER_CALLS_ATTESTATION.md out/rte-pkt-13-route-fingerprint/RTE-PKT-13_REMAINING_UNKNOWNS.md",
+      "exit_code": 0,
+      "result": "PASS",
+      "summary": "Configured pre-commit hooks passed for changed files"
+    }
+  ],
+  "no_provider_call_status": "PASS_TARGETED_STATIC_TESTS",
+  "remaining_unknowns": [
+    "OpenRouter x-ai live upstream metadata UNKNOWN",
+    "OpenRouter x-ai returned model behavior UNKNOWN unless live evidence exists",
+    "OpenRouter x-ai schema acceptance LIVE_VALIDATION_REQUIRED",
+    "OpenRouter x-ai retention/ZDR/billing/rate-limit equivalence UNKNOWN",
+    "Direct xAI live safety LIVE_VALIDATION_REQUIRED",
+    "proof_contract.py surface MISSING/UNKNOWN in services/repo-truth-extractor",
+    "risk_dashboard.py surface MISSING/UNKNOWN in services/repo-truth-extractor"
+  ]
+}

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,21 @@
+# RTE-PKT-13 No Provider Calls Attestation
+
+## OBSERVED
+
+- No live extraction command was run.
+- No provider preflight command was run.
+- No provider batch submit, poll, retrieve, or cancel command was run.
+- No provider credentials were required for the targeted tests.
+- `test_route_fingerprint_static_identity.py` monkeypatches provider client factories to raise if the run routing fingerprint artifact path invokes provider clients.
+- The tested route fingerprint path writes static metadata from request route configuration and local endpoint/transport helpers.
+
+## NOT_RUN
+
+- OpenRouter live call validation.
+- Direct xAI live call validation.
+- OpenAI, Gemini, Anthropic, or other provider live call validation.
+- Provider retention, ZDR, billing, rate-limit, schema-acceptance, or returned-model behavior validation.
+
+## Boundary
+
+This packet proves static request route fingerprinting only. It does not prove OpenRouter x-ai live equivalence to direct xAI.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_REMAINING_UNKNOWNS.md
@@ -1,0 +1,19 @@
+# RTE-PKT-13 Remaining Unknowns
+
+## UNKNOWN / LIVE_VALIDATION_REQUIRED
+
+- OpenRouter x-ai live upstream metadata remains UNKNOWN.
+- OpenRouter x-ai returned model behavior remains UNKNOWN unless future live evidence exists.
+- OpenRouter x-ai schema acceptance remains LIVE_VALIDATION_REQUIRED.
+- OpenRouter x-ai retention, ZDR, billing, and rate-limit equivalence remain UNKNOWN.
+- Direct xAI live safety remains LIVE_VALIDATION_REQUIRED.
+
+## MISSING / UNKNOWN surfaces
+
+- `proof_contract.py` was not found under `services/repo-truth-extractor`; this surface remains MISSING/UNKNOWN for this packet.
+- `risk_dashboard.py` was not found under `services/repo-truth-extractor`; this surface remains MISSING/UNKNOWN for this packet.
+
+## Residual risk
+
+- Additive `RUN_ROUTING_FINGERPRINT.json` fields may affect consumers that compare full JSON objects instead of selecting known keys.
+- This static proof does not validate live provider schema acceptance, returned-model metadata, billing authority, or retention behavior.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_ROUTE_FINGERPRINT_MATRIX.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_ROUTE_FINGERPRINT_MATRIX.md
@@ -1,0 +1,19 @@
+# RTE-PKT-13 Route Fingerprint Matrix
+
+| Route | requested_provider | requested_model_id | provider_route_kind | upstream_provider | economic_surface | api_key_env | endpoint/economic authority | structured_output_mode | provider_schema_variant | live_validation_status | direct_provider_guarantees_inherited | live_provider_behavior_proven |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Direct xAI | `xai` | `grok-fixture` | `direct_provider` | `xai` | `xai_direct` | `XAI_API_KEY` | direct xAI endpoint/key/economic surface | `json_schema` | `xai_relaxed_direct` | `LIVE_VALIDATION_REQUIRED` | `null` | `false` |
+| OpenRouter x-ai | `openrouter` | `x-ai/grok-fixture` | `openrouter_proxy_xai` | `xai` | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter endpoint/key/economic surface | `json_schema` | `openrouter_proxy_xai_relaxed` | `LIVE_VALIDATION_REQUIRED` | `false` | `false` |
+| OpenRouter OpenAI | `openrouter` | `openai/gpt-fixture` | `openrouter_proxy_other` | `openai` | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter endpoint/key/economic surface | `json_schema` | `openrouter_proxy_canonical` | `LIVE_VALIDATION_REQUIRED` | `false` | `false` |
+| OpenRouter unknown/native | `openrouter` | `native-fixture` | `openrouter_native_or_unknown` | `unknown` | `openrouter` | `OPENROUTER_API_KEY` | OpenRouter endpoint/key/economic surface | `json_schema` | `openrouter_proxy_canonical` | `LIVE_VALIDATION_REQUIRED` | `false` | `false` |
+| Direct OpenAI | `openai` | `gpt-fixture` | `direct_provider` | `openai` | `openai_direct` | `OPENAI_API_KEY` | direct OpenAI endpoint/key/economic surface | `json_schema` | `canonical_direct` | `LIVE_VALIDATION_REQUIRED` | `null` | `false` |
+| Direct Gemini | `gemini` | `gemini-fixture` | `direct_provider` | `gemini` | `gemini_direct` | `GEMINI_API_KEY` | direct Gemini endpoint/key/economic surface | `json_schema` | `gemini_relaxed_direct` | `LIVE_VALIDATION_REQUIRED` | `null` | `false` |
+| Unknown provider | `unknown` | `unknown-fixture` | `unknown` | `unknown` | `unknown` | `UNKNOWN` | UNKNOWN | `none` | `unknown` | `UNKNOWN` | `null` | `false` |
+
+## OBSERVED fingerprint inputs
+
+The deterministic route fingerprint material is limited to:
+
+`requested_provider`, `requested_model_id`, `provider_route_kind`, `upstream_provider`, `economic_surface`, `api_key_env`, `endpoint_effective`, `transport`, `provider_signature`, `structured_output_mode`, `provider_schema_variant`, `live_validation_status`.
+
+`returned_model_id` is response metadata only and is intentionally excluded from the static fingerprint material.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_STATIC_FIXTURE_EXAMPLES.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_STATIC_FIXTURE_EXAMPLES.md
@@ -1,0 +1,46 @@
+# RTE-PKT-13 Static Fixture Examples
+
+## Direct xAI
+
+```json
+{
+  "requested_provider": "xai",
+  "requested_model_id": "grok-fixture",
+  "provider_route_kind": "direct_provider",
+  "upstream_provider": "xai",
+  "economic_surface": "xai_direct",
+  "api_key_env": "XAI_API_KEY",
+  "endpoint_base_url": "https://api.x.ai/v1",
+  "endpoint_effective": "https://api.x.ai/v1/chat/completions",
+  "transport": "openai_sdk",
+  "provider_schema_variant": "xai_relaxed_direct",
+  "live_validation_status": "LIVE_VALIDATION_REQUIRED",
+  "fingerprint_authority": "static_request_route_metadata",
+  "live_provider_behavior_proven": false
+}
+```
+
+## OpenRouter x-ai
+
+```json
+{
+  "requested_provider": "openrouter",
+  "requested_model_id": "x-ai/grok-fixture",
+  "provider_route_kind": "openrouter_proxy_xai",
+  "upstream_provider": "xai",
+  "economic_surface": "openrouter",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "endpoint_base_url": "https://openrouter.ai/api/v1",
+  "endpoint_effective": "https://openrouter.ai/api/v1/chat/completions",
+  "transport": "openai_sdk",
+  "provider_schema_variant": "openrouter_proxy_xai_relaxed",
+  "direct_provider_guarantees_inherited": false,
+  "live_validation_status": "LIVE_VALIDATION_REQUIRED",
+  "fingerprint_authority": "static_request_route_metadata",
+  "live_provider_behavior_proven": false
+}
+```
+
+## Returned model metadata boundary
+
+`returned_model_id`, when present in response metadata, remains separate from requested route identity. It is not part of `route_fingerprint_material` and does not rewrite `requested_provider`, `requested_model_id`, `provider_route_kind`, or `economic_surface`.

--- a/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_TEST_REPORT.md
+++ b/out/rte-pkt-13-route-fingerprint/RTE-PKT-13_TEST_REPORT.md
@@ -1,0 +1,21 @@
+# RTE-PKT-13 Test Report
+
+| Command | Exit | Result | Summary |
+| --- | ---: | --- | --- |
+| `pytest services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py -q` | 0 | PASS | 5 passed |
+| `pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q` | 0 | PASS | 6 passed |
+| `pytest services/repo-truth-extractor/tests -k "routing_fingerprint or route_fingerprint or fingerprint" -q` | 0 | PASS | 8 passed |
+| `pytest services/repo-truth-extractor/tests -k "openrouter and xai" -q` | 0 | PASS | 8 passed |
+| `pytest services/repo-truth-extractor/tests -k "xai and metadata" -q` | 0 | PASS | 2 passed |
+| `pytest services/repo-truth-extractor/tests/test_structured_output_provider_modes.py -q` | 0 | PASS | 3 passed |
+| `pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q` | 0 | PASS | 12 passed |
+| `pytest services/repo-truth-extractor/tests/test_v5_golden_fixture_smoke.py -q` | 0 | PASS | 1 passed |
+| `pytest services/repo-truth-extractor/tests -k "proof_pack or proof or status" -q` | 0 | PASS | 25 passed |
+| `pytest services/repo-truth-extractor/tests -k "risk and dashboard" -q` | 5 | NOT_RUN_NO_TESTS_SELECTED | No tests selected |
+| `pytest services/repo-truth-extractor/tests -k "proof_contract or artifact_authority" -q` | 5 | NOT_RUN_NO_TESTS_SELECTED | No tests selected |
+| `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/llm_runtime.py` | 0 | PASS | Compilation passed |
+| `python -m json.tool out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json >/dev/null` | 0 | PASS | Manifest JSON parsed |
+| `git diff --check` | 0 | PASS | No whitespace errors in unstaged diff |
+| `pre-commit run --files <changed files>` | 0 | PASS | Configured hooks passed for changed files |
+
+All pytest runs emitted the existing pytest configuration warning for unknown `asyncio_mode`.

--- a/services/repo-truth-extractor/llm_runtime.py
+++ b/services/repo-truth-extractor/llm_runtime.py
@@ -250,7 +250,7 @@ def classify_route_identity(
             if normalized_provider in {"xai", "openai", "gemini", "openrouter"}
             else "UNKNOWN"
         ),
-        "route_identity_authority": "static_request_metadata",
+        "route_identity_authority": "static_request_route_metadata",
         "direct_provider_guarantees_inherited": (
             False if normalized_provider == "openrouter" else None
         ),

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -1360,6 +1360,21 @@ PROVIDER_API_KEY_ENV: Dict[str, str] = {
     "xai": "XAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
 }
+STATIC_ROUTE_FINGERPRINT_AUTHORITY = "static_request_route_metadata"
+ROUTE_FINGERPRINT_INPUT_FIELDS: Tuple[str, ...] = (
+    "requested_provider",
+    "requested_model_id",
+    "provider_route_kind",
+    "upstream_provider",
+    "economic_surface",
+    "api_key_env",
+    "endpoint_effective",
+    "transport",
+    "provider_signature",
+    "structured_output_mode",
+    "provider_schema_variant",
+    "live_validation_status",
+)
 
 
 # --- Setup Logging ---
@@ -5737,16 +5752,71 @@ def routing_ladders_payload() -> Dict[str, Dict[str, List[Dict[str, str]]]]:
     return payload
 
 
-def effective_model_routing_payload() -> Dict[str, Dict[str, str]]:
-    payload: Dict[str, Dict[str, str]] = {}
+def _structured_output_mode_for_static_route(
+    phase: str,
+    step_id: str,
+    provider: str,
+    model_id: str,
+    api_key_env: str,
+) -> str:
+    contract = _step_contract_for(phase, step_id)
+    route_entry = route_entry_by_identity(
+        route_entries_for_stage(contract, "primary"),
+        provider=provider,
+        model_id=model_id,
+        api_key_env=api_key_env,
+    )
+    if route_entry is not None:
+        return str(route_entry.get("structured_output_mode") or "none")
+    if is_json_managed_step(contract):
+        return "json_schema"
+    return "none"
+
+
+def effective_model_routing_payload(
+    cfg: Optional[RunnerConfig] = None,
+) -> Dict[str, Dict[str, Any]]:
+    payload: Dict[str, Dict[str, Any]] = {}
     for phase in PHASES:
         provider, model_id, api_key_env = MODEL_ROUTING.get(phase, ("", "", ""))
-        payload[phase] = {
+        row: Dict[str, Any] = {
             "provider": provider,
             "model_id": model_id,
             "api_key_env": api_key_env,
             "scope": "representative_phase_default_not_step_authoritative",
         }
+        if cfg is not None and provider and model_id:
+            step_id = _representative_step_id_for_phase(phase)
+            endpoint_base = llm_base_url(provider, cfg)
+            auth_sequence = (
+                _gemini_auth_mode_sequence(cfg.gemini_auth_mode, endpoint_base)
+                if provider == "gemini"
+                else ["sdk_bearer"]
+            )
+            endpoint_url = transport_endpoint_url(
+                provider, model_id, cfg, "REDACTED", auth_sequence[0]
+            )
+            row.update(
+                build_static_route_fingerprint_metadata(
+                    provider=provider,
+                    model_id=model_id,
+                    api_key_env=api_key_env,
+                    endpoint_base_url=endpoint_base,
+                    endpoint_url=endpoint_url,
+                    transport=transport_for_provider(provider, cfg),
+                    structured_output_mode=_structured_output_mode_for_static_route(
+                        phase,
+                        step_id,
+                        provider,
+                        model_id,
+                        api_key_env,
+                    ),
+                    gemini_auth_mode_effective=(
+                        auth_sequence[0] if provider == "gemini" else None
+                    ),
+                )
+            )
+        payload[phase] = row
     return payload
 
 
@@ -6157,6 +6227,25 @@ def write_run_routing_fingerprint(
             endpoint_url = transport_endpoint_url(
                 provider, model_id, cfg, "REDACTED", default_sequence[0]
             )
+            transport = transport_for_provider(provider, cfg)
+            route_fingerprint = build_static_route_fingerprint_metadata(
+                provider=provider,
+                model_id=model_id,
+                api_key_env=api_key_env,
+                endpoint_base_url=endpoint_base,
+                endpoint_url=endpoint_url,
+                transport=transport,
+                structured_output_mode=_structured_output_mode_for_static_route(
+                    phase,
+                    prompt.step_id,
+                    provider,
+                    model_id,
+                    api_key_env,
+                ),
+                gemini_auth_mode_effective=(
+                    default_sequence[0] if provider == "gemini" else None
+                ),
+            )
             entries.append(
                 {
                     "step_id": prompt.step_id,
@@ -6174,7 +6263,7 @@ def write_run_routing_fingerprint(
                         }
                         for route_provider, route_model, route_key_env in ladder
                     ],
-                    "transport": transport_for_provider(provider, cfg),
+                    "transport": transport,
                     "endpoint_base_url": endpoint_base,
                     "endpoint_effective": endpoint_effective(endpoint_url),
                     "gemini_endpoint_family": (
@@ -6192,6 +6281,7 @@ def write_run_routing_fingerprint(
                         endpoint_base,
                         default_sequence[0] if provider == "gemini" else None,
                     ),
+                    **route_fingerprint,
                 }
             )
         phase_entries[phase] = entries
@@ -6199,6 +6289,13 @@ def write_run_routing_fingerprint(
     payload = {
         "run_id": run_id,
         "created_at": now_iso(),
+        "fingerprint_authority": STATIC_ROUTE_FINGERPRINT_AUTHORITY,
+        "live_provider_behavior_proven": False,
+        "live_validation_status": "LIVE_VALIDATION_REQUIRED",
+        "route_fingerprint_input_fields": list(ROUTE_FINGERPRINT_INPUT_FIELDS),
+        "returned_model_identity_policy": (
+            "returned_model_id_is_response_metadata_only_and_does_not_rewrite_requested_route_identity"
+        ),
         "config": {
             "routing_policy": cfg.routing_policy,
             "routing_policy_version": ROUTING_POLICY_VERSION,
@@ -6235,7 +6332,7 @@ def write_run_routing_fingerprint(
             "wait_timeout_seconds": cfg.batch_wait_timeout_seconds,
             "max_requests_per_job": cfg.batch_max_requests_per_job,
         },
-        "effective_model_routing": effective_model_routing_payload(),
+        "effective_model_routing": effective_model_routing_payload(cfg),
         "benchmark_route_ownership": benchmark_route_ownership_payload(validate=False),
         "phases": phase_entries,
     }
@@ -9051,6 +9148,60 @@ def routing_signature(
         canonical, ensure_ascii=True, sort_keys=True, separators=(",", ":")
     )
     return hashlib.blake2b(encoded, digest_size=32).hexdigest()
+
+
+def static_route_fingerprint_material(route_meta: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        field: route_meta.get(field)
+        for field in ROUTE_FINGERPRINT_INPUT_FIELDS
+    }
+
+
+def static_route_fingerprint_hash(material: Dict[str, Any]) -> str:
+    encoded = sanitized_json_bytes(
+        material, ensure_ascii=True, sort_keys=True, separators=(",", ":")
+    )
+    return hashlib.blake2b(encoded, digest_size=32).hexdigest()
+
+
+def build_static_route_fingerprint_metadata(
+    *,
+    provider: str,
+    model_id: str,
+    api_key_env: str,
+    endpoint_base_url: str,
+    endpoint_url: str,
+    transport: str,
+    structured_output_mode: str,
+    gemini_auth_mode_effective: Optional[str] = None,
+) -> Dict[str, Any]:
+    endpoint_url_effective = endpoint_effective(endpoint_url)
+    route_signature = provider_signature(
+        provider,
+        model_id,
+        endpoint_url,
+        gemini_auth_mode_effective if provider == "gemini" else None,
+    )
+    route_meta = llm_runtime_classify_route_identity(
+        provider=provider,
+        model_id=model_id,
+        api_key_env=api_key_env,
+        endpoint_base_url=endpoint_base_url,
+        endpoint_effective=endpoint_url_effective,
+        transport=transport,
+        provider_signature=route_signature,
+        structured_output={
+            "structured_output_mode_effective": structured_output_mode,
+        },
+    )
+    route_meta["route_identity_authority"] = STATIC_ROUTE_FINGERPRINT_AUTHORITY
+    route_meta.setdefault("direct_provider_guarantees_inherited", None)
+    route_meta["fingerprint_authority"] = STATIC_ROUTE_FINGERPRINT_AUTHORITY
+    route_meta["live_provider_behavior_proven"] = False
+    material = static_route_fingerprint_material(route_meta)
+    route_meta["route_fingerprint_material"] = material
+    route_meta["route_fingerprint_hash"] = static_route_fingerprint_hash(material)
+    return route_meta
 
 
 def build_auth_present_flags(

--- a/services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py
+++ b/services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _v5_smoke_helpers import load_runner_module, make_cfg
+
+
+def _no_provider_call(*_args: Any, **_kwargs: Any) -> Any:
+    raise AssertionError("route fingerprint tests must not invoke provider clients")
+
+
+def _direct_xai_fingerprint() -> dict[str, Any]:
+    runner = load_runner_module()
+    return runner.build_static_route_fingerprint_metadata(
+        provider="xai",
+        model_id="grok-fixture",
+        api_key_env="XAI_API_KEY",
+        endpoint_base_url="https://api.x.ai/v1",
+        endpoint_url="https://api.x.ai/v1/chat/completions",
+        transport="openai_sdk",
+        structured_output_mode="json_schema",
+    )
+
+
+def _openrouter_xai_fingerprint() -> dict[str, Any]:
+    runner = load_runner_module()
+    return runner.build_static_route_fingerprint_metadata(
+        provider="openrouter",
+        model_id="x-ai/grok-fixture",
+        api_key_env="OPENROUTER_API_KEY",
+        endpoint_base_url="https://openrouter.ai/api/v1",
+        endpoint_url="https://openrouter.ai/api/v1/chat/completions",
+        transport="openai_sdk",
+        structured_output_mode="json_schema",
+    )
+
+
+def test_direct_xai_route_fingerprint_records_direct_identity() -> None:
+    route = _direct_xai_fingerprint()
+
+    assert route["requested_provider"] == "xai"
+    assert route["requested_model_id"] == "grok-fixture"
+    assert route["provider_route_kind"] == "direct_provider"
+    assert route["upstream_provider"] == "xai"
+    assert route["economic_surface"] == "xai_direct"
+    assert route["api_key_env"] == "XAI_API_KEY"
+    assert route["endpoint_base_url"] == "https://api.x.ai/v1"
+    assert route["endpoint_effective"] == "https://api.x.ai/v1/chat/completions"
+    assert route["transport"] == "openai_sdk"
+    assert route["structured_output_mode"] == "json_schema"
+    assert route["provider_schema_variant"] == "xai_relaxed_direct"
+    assert route["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+    assert route["fingerprint_authority"] == "static_request_route_metadata"
+    assert route["live_provider_behavior_proven"] is False
+    assert route["route_fingerprint_material"]["economic_surface"] == "xai_direct"
+
+
+def test_openrouter_xai_route_fingerprint_records_proxy_identity() -> None:
+    route = _openrouter_xai_fingerprint()
+
+    assert route["requested_provider"] == "openrouter"
+    assert route["requested_model_id"] == "x-ai/grok-fixture"
+    assert route["provider_route_kind"] == "openrouter_proxy_xai"
+    assert route["upstream_provider"] == "xai"
+    assert route["economic_surface"] == "openrouter"
+    assert route["api_key_env"] == "OPENROUTER_API_KEY"
+    assert route["endpoint_base_url"] == "https://openrouter.ai/api/v1"
+    assert route["endpoint_effective"] == "https://openrouter.ai/api/v1/chat/completions"
+    assert route["transport"] == "openai_sdk"
+    assert route["structured_output_mode"] == "json_schema"
+    assert route["provider_schema_variant"] == "openrouter_proxy_xai_relaxed"
+    assert route["direct_provider_guarantees_inherited"] is False
+    assert route["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+    assert route["fingerprint_authority"] == "static_request_route_metadata"
+    assert route["live_provider_behavior_proven"] is False
+    assert route["route_fingerprint_material"]["economic_surface"] == "openrouter"
+
+
+def test_openrouter_xai_fingerprint_differs_from_direct_xai() -> None:
+    direct = _direct_xai_fingerprint()
+    proxied = _openrouter_xai_fingerprint()
+
+    assert direct["upstream_provider"] == proxied["upstream_provider"] == "xai"
+    assert direct["route_fingerprint_hash"] != proxied["route_fingerprint_hash"]
+    assert direct["route_fingerprint_material"] != proxied["route_fingerprint_material"]
+
+
+def test_returned_model_metadata_does_not_rewrite_requested_route_identity() -> None:
+    runner = load_runner_module()
+    enriched = runner.enrich_request_meta(
+        {
+            "provider": "openrouter",
+            "model_id": "x-ai/grok-fixture",
+            "api_key_env_resolved": "OPENROUTER_API_KEY",
+            "endpoint_base_url": "https://openrouter.ai/api/v1",
+            "endpoint_effective": "https://openrouter.ai/api/v1/chat/completions",
+            "transport": "openai_sdk",
+            "response_summary": {"returned_model_id": "grok-returned-fixture"},
+            "structured_output": {"structured_output_mode_effective": "json_schema"},
+        },
+        run_id="run-static",
+        phase="A",
+        step_id="A1",
+        partition_id="A_P0001",
+        provider="openrouter",
+        model_id="x-ai/grok-fixture",
+    )
+
+    assert enriched["returned_model_id"] == "grok-returned-fixture"
+    assert enriched["requested_provider"] == "openrouter"
+    assert enriched["requested_model_id"] == "x-ai/grok-fixture"
+    assert enriched["provider_route_kind"] == "openrouter_proxy_xai"
+    assert enriched["economic_surface"] == "openrouter"
+
+    material = runner.static_route_fingerprint_material(enriched)
+    assert "returned_model_id" not in material
+    assert material["requested_provider"] == "openrouter"
+    assert material["requested_model_id"] == "x-ai/grok-fixture"
+
+
+def test_run_routing_fingerprint_static_artifact_preserves_existing_shape(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    runner = load_runner_module()
+    for attr in (
+        "get_http_session",
+        "get_gemini_client",
+        "get_xai_client",
+        "get_openrouter_client",
+        "get_openai_client",
+    ):
+        monkeypatch.setattr(runner, attr, _no_provider_call, raising=False)
+
+    run_root = tmp_path / "run"
+    run_root.mkdir()
+    runner.write_run_routing_fingerprint(run_root, "run-static", make_cfg(runner), ["D"])
+
+    payload = json.loads((run_root / "RUN_ROUTING_FINGERPRINT.json").read_text())
+    row = payload["phases"]["D"][0]
+
+    assert payload["fingerprint_authority"] == "static_request_route_metadata"
+    assert payload["live_provider_behavior_proven"] is False
+    assert payload["live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+    assert payload["route_fingerprint_input_fields"] == list(
+        runner.ROUTE_FINGERPRINT_INPUT_FIELDS
+    )
+    assert row["provider"]
+    assert row["model_id"]
+    assert row["api_key_env"]
+    assert row["routing_signature"]
+    assert row["requested_provider"] == row["provider"]
+    assert row["requested_model_id"] == row["model_id"]
+    assert row["provider_route_kind"]
+    assert row["economic_surface"]
+    assert row["endpoint_effective"]
+    assert row["provider_signature"]
+    assert row["structured_output_mode"]
+    assert row["provider_schema_variant"]
+    assert row["route_fingerprint_material"]
+    assert row["route_fingerprint_hash"]


### PR DESCRIPTION
## Summary
- add static route fingerprint material/hash fields to RUN_ROUTING_FINGERPRINT rows
- preserve requested route identity separately from returned model metadata
- add RTE-PKT-13 proof artifacts and targeted static tests

## Validation
- pytest services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py -q
- pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q
- pytest services/repo-truth-extractor/tests -k "routing_fingerprint or route_fingerprint or fingerprint" -q
- pytest services/repo-truth-extractor/tests -k "openrouter and xai" -q
- pytest services/repo-truth-extractor/tests -k "xai and metadata" -q
- pytest services/repo-truth-extractor/tests/test_structured_output_provider_modes.py -q
- pytest services/repo-truth-extractor/tests/test_llm_runtime_seam.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q
- pytest services/repo-truth-extractor/tests/test_v5_golden_fixture_smoke.py -q
- pytest services/repo-truth-extractor/tests -k "proof_pack or proof or status" -q
- python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/llm_runtime.py
- python -m json.tool out/rte-pkt-13-route-fingerprint/RTE-PKT-13_MANIFEST.json >/dev/null
- git diff --check
- git diff --cached --check
- pre-commit run --files <changed files>

## Boundary
No live extraction, provider preflight, provider credential requirement, or provider batch operation was run. OpenRouter x-ai live equivalence to direct xAI remains UNKNOWN / LIVE_VALIDATION_REQUIRED.

@codex review
@gemini
@copilot