### PR TITLE
🎨 Palette: Predictive Task Finish Times

### DIFF
--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -231,6 +231,7 @@ from llm_runtime import (
     call_llm_with_ladder as llm_runtime_call_llm_with_ladder,
     coerce_artifacts_from_response as llm_runtime_coerce_artifacts_from_response,
     comparison_artifact_dir as llm_runtime_comparison_artifact_dir,
+    classify_route_identity as llm_runtime_classify_route_identity,
     compute_comparison_resume_decision as llm_runtime_compute_comparison_resume_decision,
     is_auth_classified_failure as llm_runtime_is_auth_classified_failure,
     is_retryable_exception as llm_runtime_is_retryable_exception,

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -260,6 +260,22 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
     return `Finish at ${hh}:${mm}`;
   }, [totalRemainingMinutes]);
 
+  const taskFinishTimes = useMemo(() => {
+    let cumulative = 0;
+    return optimizedTasks.reduce((acc, task) => {
+      const isCurrent = task.id === currentTaskId;
+      const taskRemainingMinutes = isCurrent
+        ? Math.max(0, task.estimatedMinutes - taskTimer / 60)
+        : task.estimatedMinutes;
+      cumulative += taskRemainingMinutes;
+      const finishDate = new Date(Date.now() + cumulative * 60000);
+      const hh = finishDate.getHours().toString().padStart(2, '0');
+      const mm = finishDate.getMinutes().toString().padStart(2, '0');
+      acc[task.id] = `${hh}:${mm}`;
+      return acc;
+    }, {} as Record<string, string>);
+  }, [optimizedTasks, currentTaskId, taskTimer]);
+
   return (
     <Paper
       sx={{
@@ -746,6 +762,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 0.5 }}>
                       <Typography variant="caption">
                         {task.estimatedMinutes} min • {task.energyRequired} energy
+                        {!isCompleted && taskFinishTimes[task.id] && ` • Ends at ${taskFinishTimes[task.id]}`}
                       </Typography>
                       <Typography variant="caption">#{index + 1}</Typography>
                     </Box>

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -271,27 +271,47 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
   }, [totalRemainingMinutes]);
 
   const taskFinishTimes = useMemo(() => {
+    const acc: Record<string, string> = {};
+    if (optimizedTasks.length === 0 && !currentTaskId) return acc;
+
+    // Anchor at wall-clock now; heartbeat + taskTimer are deps so the memo
+    // recomputes every second while the timer runs and every 30s while paused.
+    const nowMs = Date.now();
+    const today = new Date(nowMs).getDate();
+
+    // The active task may be filtered out of optimizedTasks (e.g. critical
+    // cognitive load excludes complexity > 0.5), but its remaining time still
+    // anchors every downstream task. Pull it from the raw task list.
+    const currentTaskObj = tasks.find(
+      (t) => t.id === currentTaskId && t.status !== 'completed'
+    );
+    const currentRemainingMinutes = currentTaskObj
+      ? Math.max(0, currentTaskObj.estimatedMinutes - taskTimer / 60)
+      : 0;
+
+    // Execution order: current task first, then the rest of optimizedTasks in
+    // their displayed order. This fixes accumulating against complexity-sorted
+    // index instead of execution order.
+    const orderedRest = optimizedTasks.filter((t) => t.id !== currentTaskId);
+    const executionOrder: Task[] = currentTaskObj
+      ? [currentTaskObj, ...orderedRest]
+      : orderedRest;
+
     let cumulative = 0;
-    const now = new Date(heartbeat);
-    const today = now.getDate();
-
-    return optimizedTasks.reduce((acc, task) => {
+    for (const task of executionOrder) {
       const isCurrent = task.id === currentTaskId;
-      const taskRemainingMinutes = isCurrent
-        ? Math.max(0, task.estimatedMinutes - taskTimer / 60)
-        : task.estimatedMinutes;
-      cumulative += taskRemainingMinutes;
+      cumulative += isCurrent ? currentRemainingMinutes : task.estimatedMinutes;
 
-      // Note: Date.now() / heartbeat is read here but driven by taskTimer/heartbeat deps
-      const finishDate = new Date(heartbeat + cumulative * 60000);
+      const finishDate = new Date(nowMs + cumulative * 60000);
       const hh = finishDate.getHours().toString().padStart(2, '0');
       const mm = finishDate.getMinutes().toString().padStart(2, '0');
       const dayPrefix = finishDate.getDate() !== today ? 'Tomorrow at ' : '';
 
       acc[task.id] = `${dayPrefix}${hh}:${mm}`;
-      return acc;
-    }, {} as Record<string, string>);
-  }, [optimizedTasks, currentTaskId, taskTimer, heartbeat]);
+    }
+
+    return acc;
+  }, [optimizedTasks, currentTaskId, taskTimer, heartbeat, tasks]);
 
   return (
     <Paper
@@ -779,7 +799,7 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 0.5 }}>
                       <Typography variant="caption">
                         {task.estimatedMinutes} min • {task.energyRequired} energy
-                        {!isCompleted && taskFinishTimes[task.id] && ` • Ends at ${taskFinishTimes[task.id]}`}
+                        {taskFinishTimes[task.id] && ` • Ends at ${taskFinishTimes[task.id]}`}
                       </Typography>
                       <Typography variant="caption">#{index + 1}</Typography>
                     </Box>

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -272,7 +272,12 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
 
   const taskFinishTimes = useMemo(() => {
     const nowMs = Date.now();
-    const today = new Date(nowMs).getDate();
+    // Use a calendar-date key (yyyymmdd in local time) for prefix decisions so
+    // month/year rollovers and 2+-day spans are handled correctly. Using
+    // getDate() alone collides on same-day-of-month across months.
+    const localDateKey = (d: Date) =>
+      d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
+    const todayKey = localDateKey(new Date(nowMs));
 
     const activeTask = tasks.find((t) => t.id === currentTaskId);
     const activeTaskRemaining = activeTask
@@ -300,7 +305,25 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
       const finishDate = new Date(nowMs + cumulative * 60000);
       const hh = finishDate.getHours().toString().padStart(2, '0');
       const mm = finishDate.getMinutes().toString().padStart(2, '0');
-      const dayPrefix = finishDate.getDate() !== today ? 'Tomorrow at ' : '';
+      const finishKey = localDateKey(finishDate);
+      const dayOffset = finishKey - todayKey;
+      let dayPrefix = '';
+      if (dayOffset !== 0) {
+        // For tasks finishing more than a day out, fall back to a short date
+        // ("MMM D at HH:MM"). Same-day finishes get no prefix, next-day gets
+        // the friendlier "Tomorrow at" shorthand.
+        const oneDayMs = 24 * 60 * 60 * 1000;
+        const nextDayKey = localDateKey(new Date(nowMs + oneDayMs));
+        if (finishKey === nextDayKey) {
+          dayPrefix = 'Tomorrow at ';
+        } else {
+          const shortDate = finishDate.toLocaleDateString(undefined, {
+            month: 'short',
+            day: 'numeric',
+          });
+          dayPrefix = `${shortDate} at `;
+        }
+      }
 
       result[task.id] = `${dayPrefix}${hh}:${mm}`;
     });

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -271,47 +271,42 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
   }, [totalRemainingMinutes]);
 
   const taskFinishTimes = useMemo(() => {
-    const acc: Record<string, string> = {};
-    if (optimizedTasks.length === 0 && !currentTaskId) return acc;
-
-    // Anchor at wall-clock now; heartbeat + taskTimer are deps so the memo
-    // recomputes every second while the timer runs and every 30s while paused.
     const nowMs = Date.now();
     const today = new Date(nowMs).getDate();
 
-    // The active task may be filtered out of optimizedTasks (e.g. critical
-    // cognitive load excludes complexity > 0.5), but its remaining time still
-    // anchors every downstream task. Pull it from the raw task list.
-    const currentTaskObj = tasks.find(
-      (t) => t.id === currentTaskId && t.status !== 'completed'
-    );
-    const currentRemainingMinutes = currentTaskObj
-      ? Math.max(0, currentTaskObj.estimatedMinutes - taskTimer / 60)
+    const activeTask = tasks.find((t) => t.id === currentTaskId);
+    const activeTaskRemaining = activeTask
+      ? Math.max(0, activeTask.estimatedMinutes - taskTimer / 60)
       : 0;
 
-    // Execution order: current task first, then the rest of optimizedTasks in
-    // their displayed order. This fixes accumulating against complexity-sorted
-    // index instead of execution order.
-    const orderedRest = optimizedTasks.filter((t) => t.id !== currentTaskId);
-    const executionOrder: Task[] = currentTaskObj
-      ? [currentTaskObj, ...orderedRest]
-      : orderedRest;
+    const result: Record<string, string> = {};
+    let cumulative = activeTaskRemaining;
 
-    let cumulative = 0;
-    for (const task of executionOrder) {
+    // Sequence: current task first, then others in optimized order.
+    // We source activeTask from raw tasks to ensure it anchors downstream math
+    // even if filtered out of the visible list (e.g. by cognitive load threshold).
+    const sequence: Task[] = activeTask ? [activeTask] : [];
+    optimizedTasks.forEach((t) => {
+      if (t.id !== currentTaskId) sequence.push(t);
+    });
+
+    sequence.forEach((task) => {
       const isCurrent = task.id === currentTaskId;
-      cumulative += isCurrent ? currentRemainingMinutes : task.estimatedMinutes;
+      if (!isCurrent) {
+        cumulative += task.estimatedMinutes;
+      }
 
+      // Note: Date.now() is read fresh but driven by heartbeat/taskTimer deps
       const finishDate = new Date(nowMs + cumulative * 60000);
       const hh = finishDate.getHours().toString().padStart(2, '0');
       const mm = finishDate.getMinutes().toString().padStart(2, '0');
       const dayPrefix = finishDate.getDate() !== today ? 'Tomorrow at ' : '';
 
-      acc[task.id] = `${dayPrefix}${hh}:${mm}`;
-    }
+      result[task.id] = `${dayPrefix}${hh}:${mm}`;
+    });
 
-    return acc;
-  }, [optimizedTasks, currentTaskId, taskTimer, heartbeat, tasks]);
+    return result;
+  }, [tasks, optimizedTasks, currentTaskId, taskTimer, heartbeat]);
 
   return (
     <Paper

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -272,12 +272,8 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
 
   const taskFinishTimes = useMemo(() => {
     const nowMs = Date.now();
-    // Use a calendar-date key (yyyymmdd in local time) for prefix decisions so
-    // month/year rollovers and 2+-day spans are handled correctly. Using
-    // getDate() alone collides on same-day-of-month across months.
-    const localDateKey = (d: Date) =>
-      d.getFullYear() * 10000 + (d.getMonth() + 1) * 100 + d.getDate();
-    const todayKey = localDateKey(new Date(nowMs));
+    const now = new Date(nowMs);
+    const todayKey = `${now.getFullYear()}${now.getMonth()}${now.getDate()}`;
 
     const activeTask = tasks.find((t) => t.id === currentTaskId);
     const activeTaskRemaining = activeTask
@@ -305,23 +301,20 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
       const finishDate = new Date(nowMs + cumulative * 60000);
       const hh = finishDate.getHours().toString().padStart(2, '0');
       const mm = finishDate.getMinutes().toString().padStart(2, '0');
-      const finishKey = localDateKey(finishDate);
-      const dayOffset = finishKey - todayKey;
+
+      const finishDateKey = `${finishDate.getFullYear()}${finishDate.getMonth()}${finishDate.getDate()}`;
       let dayPrefix = '';
-      if (dayOffset !== 0) {
-        // For tasks finishing more than a day out, fall back to a short date
-        // ("MMM D at HH:MM"). Same-day finishes get no prefix, next-day gets
-        // the friendlier "Tomorrow at" shorthand.
-        const oneDayMs = 24 * 60 * 60 * 1000;
-        const nextDayKey = localDateKey(new Date(nowMs + oneDayMs));
-        if (finishKey === nextDayKey) {
+
+      if (finishDateKey !== todayKey) {
+        const diffMs =
+          new Date(finishDate.getFullYear(), finishDate.getMonth(), finishDate.getDate()).getTime() -
+          new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+        const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+        if (diffDays === 1) {
           dayPrefix = 'Tomorrow at ';
         } else {
-          const shortDate = finishDate.toLocaleDateString(undefined, {
-            month: 'short',
-            day: 'numeric',
-          });
-          dayPrefix = `${shortDate} at `;
+          dayPrefix = `${finishDate.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} at `;
         }
       }
 

--- a/ui-dashboard/src/components/TaskSequencer.tsx
+++ b/ui-dashboard/src/components/TaskSequencer.tsx
@@ -85,6 +85,8 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
   const [currentTaskId, setCurrentTaskId] = useState<string | null>('1');
   const [taskTimer, setTaskTimer] = useState<number>(0);
   const [isTimerRunning, setIsTimerRunning] = useState(false);
+  // Heartbeat to keep "Ends at" times fresh even when taskTimer is paused
+  const [heartbeat, setHeartbeat] = useState<number>(Date.now());
   const [isResetConfirming, setIsResetConfirming] = useState(false);
   const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -97,6 +99,14 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
     }
     return () => clearInterval(interval);
   }, [isTimerRunning]);
+
+  useEffect(() => {
+    // 30s heartbeat to ensure absolute time anchors stay relevant during pauses
+    const interval = setInterval(() => {
+      setHeartbeat(Date.now());
+    }, 30000);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     setTaskTimer(0);
@@ -262,19 +272,26 @@ const TaskSequencer: React.FC<TaskSequencerProps> = ({ cognitiveState }) => {
 
   const taskFinishTimes = useMemo(() => {
     let cumulative = 0;
+    const now = new Date(heartbeat);
+    const today = now.getDate();
+
     return optimizedTasks.reduce((acc, task) => {
       const isCurrent = task.id === currentTaskId;
       const taskRemainingMinutes = isCurrent
         ? Math.max(0, task.estimatedMinutes - taskTimer / 60)
         : task.estimatedMinutes;
       cumulative += taskRemainingMinutes;
-      const finishDate = new Date(Date.now() + cumulative * 60000);
+
+      // Note: Date.now() / heartbeat is read here but driven by taskTimer/heartbeat deps
+      const finishDate = new Date(heartbeat + cumulative * 60000);
       const hh = finishDate.getHours().toString().padStart(2, '0');
       const mm = finishDate.getMinutes().toString().padStart(2, '0');
-      acc[task.id] = `${hh}:${mm}`;
+      const dayPrefix = finishDate.getDate() !== today ? 'Tomorrow at ' : '';
+
+      acc[task.id] = `${dayPrefix}${hh}:${mm}`;
       return acc;
     }, {} as Record<string, string>);
-  }, [optimizedTasks, currentTaskId, taskTimer]);
+  }, [optimizedTasks, currentTaskId, taskTimer, heartbeat]);
 
   return (
     <Paper

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -88,8 +88,7 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('ref={headerRef}');
   expect(content).toContain('tabIndex={-1}');
   expect(content).toContain('headerRef.current?.focus();');
-  // Predictive task finish times. The !isCompleted guard was dropped because
-  // optimizedTasks already filters completed tasks out of the render list.
+  // Predictive task finish times
   expect(content).toMatch(/\{taskFinishTimes\[task\.id\] && ` • Ends at \$\{taskFinishTimes\[task\.id\]\}`\}/);
 });
 

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -88,6 +88,8 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('ref={headerRef}');
   expect(content).toContain('tabIndex={-1}');
   expect(content).toContain('headerRef.current?.focus();');
+  // Predictive task finish times
+  expect(content).toMatch(/\{!isCompleted && taskFinishTimes\[task\.id\] && ` • Ends at \$\{taskFinishTimes\[task\.id\]\}`\}/);
 });
 
 test('TaskSequencer.tsx implements overtime visual cues', () => {

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.ts
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.ts
@@ -88,8 +88,9 @@ test('TaskSequencer.tsx has contextual aria-labels and current step indicator', 
   expect(content).toContain('ref={headerRef}');
   expect(content).toContain('tabIndex={-1}');
   expect(content).toContain('headerRef.current?.focus();');
-  // Predictive task finish times
-  expect(content).toMatch(/\{!isCompleted && taskFinishTimes\[task\.id\] && ` • Ends at \$\{taskFinishTimes\[task\.id\]\}`\}/);
+  // Predictive task finish times. The !isCompleted guard was dropped because
+  // optimizedTasks already filters completed tasks out of the render list.
+  expect(content).toMatch(/\{taskFinishTimes\[task\.id\] && ` • Ends at \$\{taskFinishTimes\[task\.id\]\}`\}/);
 });
 
 test('TaskSequencer.tsx implements overtime visual cues', () => {


### PR DESCRIPTION
🎨 Palette: Predictive Task Finish Times

💡 What:
Added estimated completion times (e.g., "Ends at 14:30") to each task in the `TaskSequencer` list.

🎯 Why:
Relative durations (e.g., "45m remaining") can be abstract for users with ADHD who experience "time blindness." Absolute wall-clock anchors provide a concrete reference point, making the ritual progress feel more tangible and manageable.

♿ Accessibility:
- Included the "Ends at" time in the `ListItemText` secondary content, making it available to screen readers.
- Added a new test case in `Accessibility.test.ts` to ensure the pattern is preserved in the source code.

📸 UX Details:
- Uses a `useMemo` hook to calculate cumulative finish times based on the current `taskTimer` and estimated task durations.
- Only displays for incomplete tasks to maintain a clean UI for finished items.

---
*PR created automatically by Jules for task [4600135995636968912](https://jules.google.com/task/4600135995636968912) started by @hu3mann*