### PR TITLE
fix(rte): expose static economic pricing surfaces

### DIFF
--- a/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_DIFF_SUMMARY.md
+++ b/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_DIFF_SUMMARY.md
@@ -1,0 +1,28 @@
+# RTE-PKT-14 Diff Summary
+
+## OBSERVED
+
+- Added `lib/pricing_surface.py` as the static pricing/economic-surface helper.
+- Restored predecessor route metadata propagation by making `llm_runtime` request metadata use static route identity and by importing `classify_route_identity` in `run_extraction_v5.py`.
+- Added pricing/economic fields to v5 request metadata, route fingerprint metadata, legacy spend tracker cost events, `SpendLedger` rows, pricing coverage rows, and direct-model spend estimates.
+- Added `test_pricing_surface_static_identity.py` for direct xAI, OpenRouter x-ai, matrix coverage, spend row preservation, and no-provider-call safety.
+
+## INFERRED
+
+- Existing pricing rates were preserved. The change affects pricing authority labels and metadata shape, not catalog rates.
+- Existing artifact shape is preserved by additive fields.
+
+## UNKNOWN
+
+- No live billing, retention, ZDR, rate-limit, schema acceptance, returned-model, or upstream OpenRouter x-ai behavior was validated.
+- Dedicated worktree, branch, commit, push, and PR proof are unavailable because `.git` write operations were blocked by sandbox permissions.
+
+## Files Changed
+
+- `services/repo-truth-extractor/benchmarking/direct_model/spend.py`
+- `services/repo-truth-extractor/benchmarking/pricing/coverage.py`
+- `services/repo-truth-extractor/lib/pricing_surface.py`
+- `services/repo-truth-extractor/lib/spend_ledger.py`
+- `services/repo-truth-extractor/llm_runtime.py`
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `services/repo-truth-extractor/tests/test_pricing_surface_static_identity.py`

--- a/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_MANIFEST.json
+++ b/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_MANIFEST.json
@@ -1,0 +1,63 @@
+{
+  "packet_id": "RTE-PKT-14-ECONOMIC-SURFACE-PRICING-VISIBILITY",
+  "generated_at_local": "2026-05-15T16:54:09-07:00",
+  "worktree": "/Users/hue/code/dopemux-mvp",
+  "worktree_note": "Dedicated worktree creation was attempted and blocked by sandbox .git ref lock permissions; edits were made in the primary checkout with scoped files only.",
+  "branch": "main",
+  "base_head": "655c4196ea4c51b7e0898224af9ed15b0451f53f",
+  "changed_code_files": [
+    "services/repo-truth-extractor/benchmarking/direct_model/spend.py",
+    "services/repo-truth-extractor/benchmarking/pricing/coverage.py",
+    "services/repo-truth-extractor/lib/pricing_surface.py",
+    "services/repo-truth-extractor/lib/spend_ledger.py",
+    "services/repo-truth-extractor/llm_runtime.py",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/tests/test_pricing_surface_static_identity.py"
+  ],
+  "proof_outputs": [
+    "out/rte-pkt-14-pricing-visibility/RTE-PKT-14_MANIFEST.json",
+    "out/rte-pkt-14-pricing-visibility/RTE-PKT-14_DIFF_SUMMARY.md",
+    "out/rte-pkt-14-pricing-visibility/RTE-PKT-14_PRICING_SURFACE_MATRIX.md",
+    "out/rte-pkt-14-pricing-visibility/RTE-PKT-14_STATIC_FIXTURE_EXAMPLES.md",
+    "out/rte-pkt-14-pricing-visibility/RTE-PKT-14_TEST_REPORT.md",
+    "out/rte-pkt-14-pricing-visibility/RTE-PKT-14_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-14-pricing-visibility/RTE-PKT-14_REMAINING_UNKNOWNS.md"
+  ],
+  "task_packet_path": "out/rte-pkt-14-pricing-visibility/RTE-PKT-14_TASK_PACKET.json",
+  "validation_summary": {
+    "pytest services/repo-truth-extractor/tests/test_pricing_surface_static_identity.py -q": "PASS exit=0 tests=6",
+    "pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q": "PASS exit=0 tests=6",
+    "pytest services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py -q": "PASS exit=0 tests=5",
+    "pytest services/repo-truth-extractor/tests/test_pricing_catalog.py services/repo-truth-extractor/tests/test_pricing_coverage.py services/repo-truth-extractor/tests/test_profile_review_packets.py -q": "PASS exit=0 tests=5",
+    "pytest services/repo-truth-extractor/tests -k \"pricing or spend or cost\" -q": "PASS exit=0 tests=44 skipped=1",
+    "pytest services/repo-truth-extractor/tests -k \"openrouter and xai\" -q": "PASS exit=0 tests=11",
+    "pytest services/repo-truth-extractor/tests -k \"xai and metadata\" -q": "PASS exit=0 tests=10",
+    "pytest services/repo-truth-extractor/tests -k \"proof_pack or proof or status\" -q": "PASS exit=0 tests=43",
+    "pytest services/repo-truth-extractor/tests -k \"risk and dashboard\" -q": "PASS exit=0 tests=9",
+    "pytest services/repo-truth-extractor/tests -k \"proof_contract or artifact_authority\" -q": "PASS exit=0 tests=10",
+    "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/llm_runtime.py": "PASS exit=0",
+    "python -m json.tool out/rte-pkt-14-pricing-visibility/RTE-PKT-14_MANIFEST.json >/dev/null": "PASS exit=0",
+    "python -m json.tool out/rte-pkt-14-pricing-visibility/RTE-PKT-14_TASK_PACKET.json >/dev/null": "PASS exit=0",
+    "jsonschema validation for out/rte-pkt-14-pricing-visibility/RTE-PKT-14_TASK_PACKET.json": "PASS exit=0",
+    "git diff --check": "PASS exit=0",
+    "git diff --cached --check": "PASS exit=0 no staged files",
+    "pre-commit run --files <changed files>": "PASS exit=0"
+  },
+  "no_provider_call_status": "PASS_STATIC_ONLY_NO_PROVIDER_CALLS",
+  "remaining_unknowns": [
+    "OpenRouter x-ai live upstream metadata remains UNKNOWN.",
+    "OpenRouter x-ai returned-model behavior remains UNKNOWN without live evidence.",
+    "OpenRouter x-ai schema acceptance remains LIVE_VALIDATION_REQUIRED.",
+    "OpenRouter x-ai retention, ZDR, billing, and rate-limit equivalence remain UNKNOWN.",
+    "Direct xAI live safety remains LIVE_VALIDATION_REQUIRED.",
+    "Provider billing equivalence is not inferred from model prefixes."
+  ],
+  "predecessor_packets": [
+    "RTE-PKT-12-OPENROUTER-XAI",
+    "RTE-PKT-13-ROUTE-FINGERPRINT-STATIC-PROOF"
+  ],
+  "predecessor_verdicts": {
+    "RTE-PKT-12": "PASS_WITH_RISKS",
+    "RTE-PKT-13": "PASS_WITH_RISKS"
+  }
+}

--- a/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,0 +1,15 @@
+# RTE-PKT-14 No Provider Calls Attestation
+
+Status: PASS_STATIC_ONLY_NO_PROVIDER_CALLS
+
+## OBSERVED
+
+- No live extraction was run.
+- No provider preflight was run.
+- No OpenRouter, xAI, OpenAI, Gemini, Anthropic, or other provider API call was made by this implementation.
+- Static tests install provider-client factories that raise if invoked.
+- The new pricing-surface test uses static route fixtures and local spend ledger writes only.
+
+## Scope
+
+This attestation covers the local implementation and validation commands recorded in `RTE-PKT-14_TEST_REPORT.md`. It does not claim anything about live provider billing, retention, ZDR, rate limits, schema acceptance, returned-model behavior, or upstream metadata.

--- a/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_PRICING_SURFACE_MATRIX.md
+++ b/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_PRICING_SURFACE_MATRIX.md
@@ -1,0 +1,17 @@
+# RTE-PKT-14 Pricing Surface Matrix
+
+| Case | provider_route_kind | upstream_provider | economic_surface | pricing_surface | api_key_env | billing authority | live validation status | direct provider billing inherited |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Direct xAI | direct_provider | xai | xai_direct | xai_direct | XAI_API_KEY | direct_provider_catalog_or_unknown | LIVE_VALIDATION_REQUIRED | null |
+| OpenRouter x-ai | openrouter_proxy_xai | xai | openrouter | openrouter | OPENROUTER_API_KEY | openrouter_catalog_or_unknown | LIVE_VALIDATION_REQUIRED | false |
+| OpenRouter OpenAI | openrouter_proxy_other | openai | openrouter | openrouter | OPENROUTER_API_KEY | openrouter_catalog_or_unknown | LIVE_VALIDATION_REQUIRED | false |
+| OpenRouter unknown/native | openrouter_native_or_unknown | unknown | openrouter | openrouter | OPENROUTER_API_KEY | openrouter_catalog_or_unknown | LIVE_VALIDATION_REQUIRED | false |
+| Direct OpenAI | direct_provider | openai | openai_direct | openai_direct | OPENAI_API_KEY | direct_provider_catalog_or_unknown | LIVE_VALIDATION_REQUIRED | null |
+| Direct Gemini | direct_provider | gemini | gemini_direct | gemini_direct | GEMINI_API_KEY | direct_provider_catalog_or_unknown | LIVE_VALIDATION_REQUIRED | null |
+| Unknown provider | unknown | unknown | unknown | unknown | null | unknown | UNKNOWN | null |
+
+## Authority Notes
+
+- OpenRouter x-ai uses `pricing_surface=openrouter` even when `upstream_provider=xai`.
+- Direct provider billing is not inherited through OpenRouter proxy routes.
+- No row claims live provider billing equivalence.

--- a/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_REMAINING_UNKNOWNS.md
@@ -1,0 +1,21 @@
+# RTE-PKT-14 Remaining Unknowns
+
+## UNKNOWN
+
+- OpenRouter x-ai live upstream metadata remains UNKNOWN.
+- OpenRouter x-ai returned-model behavior remains UNKNOWN unless live evidence exists.
+- OpenRouter x-ai schema acceptance remains LIVE_VALIDATION_REQUIRED.
+- OpenRouter x-ai retention, ZDR, billing, and rate-limit equivalence remain UNKNOWN.
+- Direct xAI live safety remains LIVE_VALIDATION_REQUIRED.
+- OpenRouter x-ai direct-provider billing inheritance remains false in static metadata unless provider billing artifacts prove otherwise.
+- Missing provider billing artifacts remain UNKNOWN.
+
+## OBSERVED
+
+- `services/repo-truth-extractor/lib/proof_contract.py` exists in this checkout.
+- `services/repo-truth-extractor/lib/risk_dashboard.py` exists in this checkout.
+- Static pricing metadata uses `pricing_surface=openrouter` for OpenRouter x-ai and `pricing_surface=xai_direct` for direct xAI.
+
+## Not Claimed
+
+- No live provider billing, retention, ZDR, rate-limit, schema, or returned-model guarantee is claimed from an OpenRouter `x-ai/...` prefix.

--- a/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_STATIC_FIXTURE_EXAMPLES.md
+++ b/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_STATIC_FIXTURE_EXAMPLES.md
@@ -1,0 +1,53 @@
+# RTE-PKT-14 Static Fixture Examples
+
+## Direct xAI
+
+```json
+{
+  "requested_provider": "xai",
+  "requested_model_id": "grok-fixture",
+  "provider_route_kind": "direct_provider",
+  "upstream_provider": "xai",
+  "economic_surface": "xai_direct",
+  "pricing_surface": "xai_direct",
+  "api_key_env": "XAI_API_KEY",
+  "pricing_authority": "direct_provider_catalog_or_unknown",
+  "pricing_live_validation_status": "LIVE_VALIDATION_REQUIRED",
+  "direct_provider_billing_inherited": null
+}
+```
+
+## OpenRouter x-ai
+
+```json
+{
+  "requested_provider": "openrouter",
+  "requested_model_id": "x-ai/grok-fixture",
+  "provider_route_kind": "openrouter_proxy_xai",
+  "upstream_provider": "xai",
+  "economic_surface": "openrouter",
+  "pricing_surface": "openrouter",
+  "api_key_env": "OPENROUTER_API_KEY",
+  "pricing_authority": "openrouter_catalog_or_unknown",
+  "pricing_live_validation_status": "LIVE_VALIDATION_REQUIRED",
+  "direct_provider_billing_inherited": false
+}
+```
+
+## Spend Row Preservation
+
+```json
+{
+  "provider": "openrouter",
+  "model_id": "x-ai/grok-4.1-fast",
+  "pricing_key": "openrouter/x-ai/grok-4.1-fast",
+  "upstream_provider": "xai",
+  "economic_surface": "openrouter",
+  "pricing_surface": "openrouter",
+  "direct_provider_billing_inherited": false
+}
+```
+
+## No Live Claim
+
+OpenRouter x-ai examples are static request-route fixtures only. They do not prove provider billing equivalence, retention, ZDR, rate limits, schema acceptance, returned-model behavior, or upstream response metadata.

--- a/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_TEST_REPORT.md
+++ b/out/rte-pkt-14-pricing-visibility/RTE-PKT-14_TEST_REPORT.md
@@ -1,0 +1,37 @@
+# RTE-PKT-14 Test Report
+
+## Required Validation
+
+| Command | Result |
+| --- | --- |
+| `pytest services/repo-truth-extractor/tests/test_pricing_surface_static_identity.py -q` | PASS exit=0, 6 passed |
+| `pytest services/repo-truth-extractor/tests/test_openrouter_xai_route_identity.py -q` | PASS exit=0, 6 passed |
+| `pytest services/repo-truth-extractor/tests/test_route_fingerprint_static_identity.py -q` | PASS exit=0, 5 passed |
+| `pytest services/repo-truth-extractor/tests/test_pricing_catalog.py services/repo-truth-extractor/tests/test_pricing_coverage.py services/repo-truth-extractor/tests/test_profile_review_packets.py -q` | PASS exit=0, 5 passed |
+| `pytest services/repo-truth-extractor/tests -k "pricing or spend or cost" -q` | PASS exit=0, 44 passed, 1 skipped |
+| `pytest services/repo-truth-extractor/tests -k "openrouter and xai" -q` | PASS exit=0, 11 passed |
+| `pytest services/repo-truth-extractor/tests -k "xai and metadata" -q` | PASS exit=0, 10 passed |
+| `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/llm_runtime.py` | PASS exit=0 |
+
+## Optional Validation
+
+| Command | Result |
+| --- | --- |
+| `pytest services/repo-truth-extractor/tests -k "proof_pack or proof or status" -q` | PASS exit=0, 43 passed |
+| `pytest services/repo-truth-extractor/tests -k "risk and dashboard" -q` | PASS exit=0, 9 passed |
+| `pytest services/repo-truth-extractor/tests -k "proof_contract or artifact_authority" -q` | PASS exit=0, 10 passed |
+
+## Shared Test Warning
+
+All pytest runs emitted the existing warning `Unknown config option: asyncio_mode`. The broad pricing/spend/cost selector skipped one unrelated CLI test because `dopemux` was not importable in that test context.
+
+## Final Hygiene
+
+| Command | Result |
+| --- | --- |
+| `python -m json.tool out/rte-pkt-14-pricing-visibility/RTE-PKT-14_MANIFEST.json >/dev/null` | PASS exit=0 |
+| `python -m json.tool out/rte-pkt-14-pricing-visibility/RTE-PKT-14_TASK_PACKET.json >/dev/null` | PASS exit=0 |
+| `jsonschema validation for out/rte-pkt-14-pricing-visibility/RTE-PKT-14_TASK_PACKET.json` | PASS exit=0 |
+| `git diff --check` | PASS exit=0 |
+| `git diff --cached --check` | PASS exit=0, no staged files |
+| `pre-commit run --files <changed files>` | PASS exit=0 |

--- a/services/repo-truth-extractor/benchmarking/direct_model/spend.py
+++ b/services/repo-truth-extractor/benchmarking/direct_model/spend.py
@@ -31,6 +31,21 @@ class SpendEstimate:
     pricing_confidence: str
     pricing_currency: str
     surface_scope: str
+    requested_provider: str
+    requested_model_id: str
+    provider_route_kind: str
+    upstream_provider: str
+    economic_surface: str
+    api_key_env: str | None
+    endpoint_effective: str | None
+    transport: str | None
+    provider_signature: str | None
+    route_fingerprint_hash: str | None
+    pricing_authority: str
+    pricing_surface: str
+    pricing_surface_source: str
+    pricing_live_validation_status: str
+    direct_provider_billing_inherited: bool | None
     pricing_version: str
     pricing_match_type: str
     unknown_model: bool
@@ -52,6 +67,21 @@ class SpendEstimate:
             "pricing_confidence": self.pricing_confidence,
             "pricing_currency": self.pricing_currency,
             "surface_scope": self.surface_scope,
+            "requested_provider": self.requested_provider,
+            "requested_model_id": self.requested_model_id,
+            "provider_route_kind": self.provider_route_kind,
+            "upstream_provider": self.upstream_provider,
+            "economic_surface": self.economic_surface,
+            "api_key_env": self.api_key_env,
+            "endpoint_effective": self.endpoint_effective,
+            "transport": self.transport,
+            "provider_signature": self.provider_signature,
+            "route_fingerprint_hash": self.route_fingerprint_hash,
+            "pricing_authority": self.pricing_authority,
+            "pricing_surface": self.pricing_surface,
+            "pricing_surface_source": self.pricing_surface_source,
+            "pricing_live_validation_status": self.pricing_live_validation_status,
+            "direct_provider_billing_inherited": self.direct_provider_billing_inherited,
             "pricing_version": self.pricing_version,
             "pricing_match_type": self.pricing_match_type,
             "unknown_model": self.unknown_model,
@@ -98,6 +128,45 @@ class SpendGuard:
             pricing_confidence=str(rate.get("pricing_confidence") or "UNKNOWN"),
             pricing_currency=str(rate.get("pricing_currency") or "USD"),
             surface_scope=str(rate.get("surface_scope") or "unknown"),
+            requested_provider=str(rate.get("requested_provider") or provider),
+            requested_model_id=str(rate.get("requested_model_id") or model_id),
+            provider_route_kind=str(rate.get("provider_route_kind") or "unknown"),
+            upstream_provider=str(rate.get("upstream_provider") or "unknown"),
+            economic_surface=str(rate.get("economic_surface") or "unknown"),
+            api_key_env=(
+                str(rate.get("api_key_env"))
+                if rate.get("api_key_env") is not None
+                else None
+            ),
+            endpoint_effective=(
+                str(rate.get("endpoint_effective"))
+                if rate.get("endpoint_effective") is not None
+                else None
+            ),
+            transport=(
+                str(rate.get("transport")) if rate.get("transport") is not None else None
+            ),
+            provider_signature=(
+                str(rate.get("provider_signature"))
+                if rate.get("provider_signature") is not None
+                else None
+            ),
+            route_fingerprint_hash=(
+                str(rate.get("route_fingerprint_hash"))
+                if rate.get("route_fingerprint_hash") is not None
+                else None
+            ),
+            pricing_authority=str(rate.get("pricing_authority") or "unknown"),
+            pricing_surface=str(rate.get("pricing_surface") or "unknown"),
+            pricing_surface_source=str(
+                rate.get("pricing_surface_source") or "static_request_route_metadata"
+            ),
+            pricing_live_validation_status=str(
+                rate.get("pricing_live_validation_status") or "UNKNOWN"
+            ),
+            direct_provider_billing_inherited=rate.get(
+                "direct_provider_billing_inherited"
+            ),
             pricing_version=str(rate.get("pricing_version") or "unknown"),
             pricing_match_type=str(rate.get("match_type") or "unknown"),
             unknown_model=unknown_model,

--- a/services/repo-truth-extractor/benchmarking/pricing/coverage.py
+++ b/services/repo-truth-extractor/benchmarking/pricing/coverage.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from collections import Counter
 from typing import Any
 
+from lib.pricing_surface import normalize_provider_model, pricing_surface_metadata
+
 from .catalog import ACTIVE_BENCHMARK_UNIVERSE, PricingCatalog, load_pricing_catalog
 
 
@@ -29,6 +31,8 @@ def build_pricing_coverage_report(
 
     for model_key in universe:
         normalized_key = str(model_key).strip().lower()
+        provider, model_id = normalize_provider_model(None, normalized_key)
+        surface = pricing_surface_metadata(provider=provider, model_id=model_id)
         entry = active_catalog.models.get(normalized_key)
         if entry is None:
             row = {
@@ -42,6 +46,7 @@ def build_pricing_coverage_report(
                 "input_cost_per_m": None,
                 "output_cost_per_m": None,
                 "pricing_caveat": "No catalog entry present for active benchmark candidate.",
+                **surface,
             }
         else:
             row = {
@@ -59,6 +64,7 @@ def build_pricing_coverage_report(
                     None if entry["output_cost_per_m"] is None else float(entry["output_cost_per_m"])
                 ),
                 "pricing_caveat": str(entry.get("pricing_caveat") or ""),
+                **surface,
             }
         counts[row["coverage_class"]] += 1
         rows.append(row)

--- a/services/repo-truth-extractor/lib/pricing_surface.py
+++ b/services/repo-truth-extractor/lib/pricing_surface.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+
+STATIC_PRICING_SURFACE_AUTHORITY = "static_request_route_metadata"
+
+PROVIDER_API_KEY_ENV: Dict[str, str] = {
+    "openai": "OPENAI_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "xai": "XAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+
+def _api_key_env_or_default(
+    value: Optional[str],
+    provider: str,
+) -> Optional[str]:
+    token = str(value or "").strip()
+    if token in {"***redacted***", "[REDACTED]", "REDACTED"}:
+        token = ""
+    return token or PROVIDER_API_KEY_ENV.get(provider) or None
+
+
+def normalize_provider_model(
+    provider: Optional[str],
+    model_id: Optional[str],
+    route: Optional[str] = None,
+) -> Tuple[str, str]:
+    route_token = str(route or "").strip()
+    provider_token = str(provider or "").strip().lower()
+    model_token = str(model_id or "").strip()
+    if route_token and (not provider_token or not model_token):
+        if "/" in route_token:
+            route_provider, route_model_id = route_token.split("/", 1)
+            provider_token = provider_token or route_provider.strip().lower()
+            model_token = model_token or route_model_id.strip()
+    if not provider_token and "/" in model_token:
+        first, rest = model_token.split("/", 1)
+        if first:
+            return first.strip().lower(), rest.strip()
+    return provider_token, model_token
+
+
+def classify_static_route_identity(
+    *,
+    provider: Optional[str],
+    model_id: Optional[str],
+    api_key_env: Optional[str] = None,
+    route: Optional[str] = None,
+) -> Dict[str, Any]:
+    normalized_provider, requested_model_id = normalize_provider_model(
+        provider, model_id, route
+    )
+    normalized_model_id = requested_model_id.lower()
+    upstream_provider = normalized_provider if normalized_provider else "unknown"
+    provider_route_kind = "unknown"
+    economic_surface = "unknown"
+
+    if normalized_provider == "openrouter":
+        prefix, sep, _rest = normalized_model_id.partition("/")
+        normalized_prefix = {"x-ai": "xai", "google": "gemini"}.get(prefix, prefix)
+        economic_surface = "openrouter"
+        if sep and normalized_prefix == "xai":
+            provider_route_kind = "openrouter_proxy_xai"
+            upstream_provider = "xai"
+        elif sep and normalized_prefix in {"openai", "gemini", "anthropic"}:
+            provider_route_kind = "openrouter_proxy_other"
+            upstream_provider = normalized_prefix
+        else:
+            provider_route_kind = "openrouter_native_or_unknown"
+            upstream_provider = "unknown"
+    elif normalized_provider in {"xai", "openai", "gemini"}:
+        provider_route_kind = "direct_provider"
+        upstream_provider = normalized_provider
+        economic_surface = {
+            "xai": "xai_direct",
+            "openai": "openai_direct",
+            "gemini": "gemini_direct",
+        }[normalized_provider]
+
+    resolved_api_key_env = _api_key_env_or_default(
+        api_key_env,
+        normalized_provider,
+    )
+    identity: Dict[str, Any] = {
+        "requested_provider": normalized_provider or "unknown",
+        "requested_model_id": requested_model_id,
+        "provider_route_kind": provider_route_kind,
+        "upstream_provider": upstream_provider or "unknown",
+        "economic_surface": economic_surface,
+        "api_key_env": resolved_api_key_env,
+        "live_validation_status": (
+            "LIVE_VALIDATION_REQUIRED"
+            if normalized_provider in {"xai", "openai", "gemini", "openrouter"}
+            else "UNKNOWN"
+        ),
+        "route_identity_authority": STATIC_PRICING_SURFACE_AUTHORITY,
+        "direct_provider_guarantees_inherited": (
+            False if normalized_provider == "openrouter" else None
+        ),
+    }
+    return {key: value for key, value in identity.items() if value is not None}
+
+
+def pricing_surface_metadata(
+    *,
+    provider: Optional[str] = None,
+    model_id: Optional[str] = None,
+    route: Optional[str] = None,
+    api_key_env: Optional[str] = None,
+    route_identity: Optional[Dict[str, Any]] = None,
+    endpoint_effective: Optional[str] = None,
+    transport: Optional[str] = None,
+    provider_signature: Optional[str] = None,
+    route_fingerprint_hash: Optional[str] = None,
+) -> Dict[str, Any]:
+    identity = dict(route_identity or {})
+    if not identity:
+        identity = classify_static_route_identity(
+            provider=provider,
+            model_id=model_id,
+            api_key_env=api_key_env,
+            route=route,
+        )
+
+    requested_provider = str(
+        identity.get("requested_provider") or provider or "unknown"
+    ).strip().lower()
+    requested_model_id = str(
+        identity.get("requested_model_id") or model_id or ""
+    ).strip()
+    provider_route_kind = str(identity.get("provider_route_kind") or "unknown")
+    upstream_provider = str(identity.get("upstream_provider") or "unknown")
+    economic_surface = str(identity.get("economic_surface") or "unknown")
+    resolved_api_key_env = _api_key_env_or_default(
+        str(identity.get("api_key_env") or api_key_env or ""),
+        requested_provider,
+    )
+
+    pricing_surface = economic_surface if economic_surface else "unknown"
+    if pricing_surface == "openrouter":
+        pricing_authority = "openrouter_catalog_or_unknown"
+        direct_provider_billing_inherited: Optional[bool] = False
+    elif provider_route_kind == "direct_provider" and upstream_provider in {
+        "xai",
+        "openai",
+        "gemini",
+    }:
+        pricing_authority = "direct_provider_catalog_or_unknown"
+        direct_provider_billing_inherited = None
+    else:
+        pricing_authority = "unknown"
+        direct_provider_billing_inherited = None
+
+    return {
+        "requested_provider": requested_provider or "unknown",
+        "requested_model_id": requested_model_id,
+        "provider_route_kind": provider_route_kind,
+        "upstream_provider": upstream_provider,
+        "economic_surface": economic_surface or "unknown",
+        "api_key_env": resolved_api_key_env,
+        "endpoint_effective": endpoint_effective
+        if endpoint_effective is not None
+        else identity.get("endpoint_effective"),
+        "transport": transport if transport is not None else identity.get("transport"),
+        "provider_signature": provider_signature
+        if provider_signature is not None
+        else identity.get("provider_signature"),
+        "route_fingerprint_hash": route_fingerprint_hash
+        if route_fingerprint_hash is not None
+        else identity.get("route_fingerprint_hash"),
+        "pricing_authority": pricing_authority,
+        "pricing_surface": pricing_surface or "unknown",
+        "pricing_surface_source": STATIC_PRICING_SURFACE_AUTHORITY,
+        "pricing_live_validation_status": str(
+            identity.get("live_validation_status") or "UNKNOWN"
+        ),
+        "direct_provider_billing_inherited": direct_provider_billing_inherited,
+    }
+
+
+def pricing_surface_matrix_rows() -> list[Dict[str, Any]]:
+    fixtures = (
+        ("Direct xAI", "xai", "grok-fixture", "XAI_API_KEY"),
+        ("OpenRouter x-ai", "openrouter", "x-ai/grok-fixture", "OPENROUTER_API_KEY"),
+        ("OpenRouter OpenAI", "openrouter", "openai/gpt-fixture", "OPENROUTER_API_KEY"),
+        ("OpenRouter unknown/native", "openrouter", "native-fixture", "OPENROUTER_API_KEY"),
+        ("Direct OpenAI", "openai", "gpt-fixture", "OPENAI_API_KEY"),
+        ("Direct Gemini", "gemini", "gemini-fixture", "GEMINI_API_KEY"),
+        ("Unknown provider", "unknown", "model-fixture", None),
+    )
+    rows: list[Dict[str, Any]] = []
+    for label, provider, model_id, api_key_env in fixtures:
+        metadata = pricing_surface_metadata(
+            provider=provider,
+            model_id=model_id,
+            api_key_env=api_key_env,
+        )
+        rows.append(
+            {
+                "label": label,
+                **metadata,
+                "billing_authority": metadata["pricing_authority"],
+            }
+        )
+    return rows

--- a/services/repo-truth-extractor/lib/spend_ledger.py
+++ b/services/repo-truth-extractor/lib/spend_ledger.py
@@ -20,6 +20,21 @@ try:
 except ImportError:  # pragma: no cover - fallback only when imported out of tree
     load_pricing_catalog = None
 
+try:
+    from lib.pricing_surface import pricing_surface_metadata
+except ImportError:  # pragma: no cover - direct file imports in legacy tests
+    import importlib.util
+
+    _pricing_surface_path = Path(__file__).with_name("pricing_surface.py")
+    _pricing_surface_spec = importlib.util.spec_from_file_location(
+        "repo_truth_pricing_surface", _pricing_surface_path
+    )
+    if _pricing_surface_spec is None or _pricing_surface_spec.loader is None:
+        raise
+    _pricing_surface_module = importlib.util.module_from_spec(_pricing_surface_spec)
+    _pricing_surface_spec.loader.exec_module(_pricing_surface_module)
+    pricing_surface_metadata = _pricing_surface_module.pricing_surface_metadata
+
 
 def _baseline_rate(pricing_source: str = "route_registry_baseline") -> Dict[str, Any]:
     return {
@@ -96,6 +111,21 @@ class ModelSpend:
     model_id: str
     pricing_key: str
     pricing_source: str
+    requested_provider: str = "unknown"
+    requested_model_id: str = ""
+    provider_route_kind: str = "unknown"
+    upstream_provider: str = "unknown"
+    economic_surface: str = "unknown"
+    api_key_env: str | None = None
+    endpoint_effective: str | None = None
+    transport: str | None = None
+    provider_signature: str | None = None
+    route_fingerprint_hash: str | None = None
+    pricing_authority: str = "unknown"
+    pricing_surface: str = "unknown"
+    pricing_surface_source: str = "static_request_route_metadata"
+    pricing_live_validation_status: str = "UNKNOWN"
+    direct_provider_billing_inherited: bool | None = None
     pricing_version: str = PRICING_VERSION
     unknown_model: bool = False
     usage_count: int = 0
@@ -142,6 +172,33 @@ def _safe_float(value: Any) -> float:
         return float(value or 0.0)
     except Exception:
         return 0.0
+
+
+MODEL_SURFACE_FIELDS = (
+    "requested_provider",
+    "requested_model_id",
+    "provider_route_kind",
+    "upstream_provider",
+    "economic_surface",
+    "api_key_env",
+    "endpoint_effective",
+    "transport",
+    "provider_signature",
+    "route_fingerprint_hash",
+    "pricing_authority",
+    "pricing_surface",
+    "pricing_surface_source",
+    "pricing_live_validation_status",
+    "direct_provider_billing_inherited",
+)
+
+
+def _model_surface_from_payload(model_data: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        key: model_data.get(key)
+        for key in MODEL_SURFACE_FIELDS
+        if key in model_data
+    }
 
 
 def _normalize_provider_model(
@@ -207,6 +264,11 @@ def get_model_cost_rate(
     route: Optional[str] = None,
 ) -> Dict[str, Any]:
     provider_token, model_token = _normalize_provider_model(provider, model_id, route)
+    surface = pricing_surface_metadata(
+        provider=provider_token,
+        model_id=model_token,
+        route=route,
+    )
     for index, candidate in enumerate(_pricing_candidates(provider_token, model_token)):
         if candidate in MODEL_COST_RATES:
             rate = MODEL_COST_RATES[candidate]
@@ -218,6 +280,7 @@ def get_model_cost_rate(
                 "pricing_source": str(
                     rate.get("pricing_source") or "route_registry_baseline"
                 ),
+                **surface,
                 "pricing_source_type": str(rate.get("pricing_source_type") or "legacy_baseline"),
                 "pricing_status": str(rate.get("pricing_status") or "PRICED_WITH_CAVEAT"),
                 "pricing_confidence": str(rate.get("pricing_confidence") or "LOW"),
@@ -247,6 +310,7 @@ def get_model_cost_rate(
         "pricing_key": fallback_key,
         "pricing_version": PRICING_VERSION,
         "pricing_source": str(fallback["pricing_source"]),
+        **surface,
         "pricing_source_type": "inferred_estimated_fallback",
         "pricing_status": "UNPRICED_UNKNOWN",
         "pricing_confidence": "UNKNOWN",
@@ -295,6 +359,7 @@ class SpendLedger:
                     model_id=str(model_data.get("model_id") or ""),
                     pricing_key=str(model_data.get("pricing_key") or model_key),
                     pricing_source=str(model_data.get("pricing_source") or "legacy_load"),
+                    **_model_surface_from_payload(model_data),
                     pricing_version=str(
                         model_data.get("pricing_version") or self.record.pricing_version
                     ),
@@ -336,6 +401,7 @@ class SpendLedger:
                 model_id=str(model_data.get("model_id") or ""),
                 pricing_key=str(model_data.get("pricing_key") or model_key),
                 pricing_source=str(model_data.get("pricing_source") or "legacy_load"),
+                **_model_surface_from_payload(model_data),
                 pricing_version=str(
                     model_data.get("pricing_version") or self.record.pricing_version
                 ),
@@ -464,6 +530,7 @@ class SpendLedger:
                     model_id=str(priced["model_id"]),
                     pricing_key=model_key,
                     pricing_source=str(priced["pricing_source"]),
+                    **_model_surface_from_payload(priced),
                     pricing_version=str(priced["pricing_version"]),
                     unknown_model=bool(priced["unknown_model"]),
                     input_cost_per_1m_usd=_safe_float(priced["input_cost_per_1m_usd"]),
@@ -492,6 +559,7 @@ class SpendLedger:
                     model_id=str(priced["model_id"]),
                     pricing_key=model_key,
                     pricing_source=str(priced["pricing_source"]),
+                    **_model_surface_from_payload(priced),
                     pricing_version=str(priced["pricing_version"]),
                     unknown_model=bool(priced["unknown_model"]),
                     input_cost_per_1m_usd=_safe_float(priced["input_cost_per_1m_usd"]),

--- a/services/repo-truth-extractor/llm_runtime.py
+++ b/services/repo-truth-extractor/llm_runtime.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import requests
 
+from lib.pricing_surface import classify_static_route_identity
 from output_safety import sanitize_text_for_provider_payload
 
 logger = logging.getLogger(__name__)
@@ -146,11 +147,11 @@ def _normalize_route_tuple(
 
 
 def _provider_route_kind(provider: str, model_id: str) -> str:
-    provider_token = str(provider or "").strip().lower()
-    model_token = str(model_id or "").strip().lower()
-    if provider_token == "openrouter" and model_token.startswith("x-ai/"):
-        return "openrouter_proxy_xai"
-    return "direct_provider"
+    return str(
+        classify_static_route_identity(provider=provider, model_id=model_id).get(
+            "provider_route_kind", "unknown"
+        )
+    )
 
 
 def _request_route_metadata(
@@ -158,12 +159,11 @@ def _request_route_metadata(
     model_id: str,
     api_key_env: str,
 ) -> Dict[str, Any]:
-    return {
-        "requested_provider": provider,
-        "requested_model_id": model_id,
-        "api_key_env": api_key_env,
-        "provider_route_kind": _provider_route_kind(provider, model_id),
-    }
+    return classify_static_route_identity(
+        provider=provider,
+        model_id=model_id,
+        api_key_env=api_key_env,
+    )
 
 
 def _structured_output_request_metadata(
@@ -309,60 +309,29 @@ def classify_route_identity(
 ) -> Dict[str, Any]:
     normalized_provider = str(provider or "").strip().lower()
     requested_model_id = str(model_id or "").strip()
-    normalized_model_id = requested_model_id.lower()
-    upstream_provider = normalized_provider if normalized_provider else "unknown"
-    provider_route_kind = "unknown"
-    economic_surface = "unknown"
-
-    if normalized_provider == "openrouter":
-        prefix, sep, _rest = normalized_model_id.partition("/")
-        normalized_prefix = {"x-ai": "xai"}.get(prefix, prefix)
-        economic_surface = "openrouter"
-        if sep and normalized_prefix == "xai":
-            provider_route_kind = "openrouter_proxy_xai"
-            upstream_provider = "xai"
-        elif sep and normalized_prefix in {"openai", "gemini", "anthropic"}:
-            provider_route_kind = "openrouter_proxy_other"
-            upstream_provider = normalized_prefix
-        else:
-            provider_route_kind = "openrouter_native_or_unknown"
-            upstream_provider = "unknown"
-    elif normalized_provider in {"xai", "openai", "gemini"}:
-        provider_route_kind = "direct_provider"
-        upstream_provider = normalized_provider
-        economic_surface = {
-            "xai": "xai_direct",
-            "openai": "openai_direct",
-            "gemini": "gemini_direct",
-        }[normalized_provider]
-
-    identity: Dict[str, Any] = {
-        "requested_provider": normalized_provider or "unknown",
-        "requested_model_id": requested_model_id,
-        "provider_route_kind": provider_route_kind,
-        "upstream_provider": upstream_provider or "unknown",
-        "economic_surface": economic_surface,
-        "api_key_env": str(api_key_env or "").strip() or None,
-        "endpoint_base_url": endpoint_base_url,
-        "endpoint_effective": endpoint_effective,
-        "transport": transport,
-        "provider_signature": provider_signature,
-        "structured_output_mode": _structured_output_mode_from_meta(structured_output),
-        "provider_schema_variant": provider_schema_variant_label(
-            normalized_provider,
-            requested_model_id,
-        ),
-        "live_validation_status": (
-            "LIVE_VALIDATION_REQUIRED"
-            if normalized_provider in {"xai", "openai", "gemini", "openrouter"}
-            else "UNKNOWN"
-        ),
-        "route_identity_authority": "static_request_route_metadata",
-        "direct_provider_guarantees_inherited": (
-            False if normalized_provider == "openrouter" else None
-        ),
-    }
+    identity: Dict[str, Any] = classify_static_route_identity(
+        provider=provider,
+        model_id=model_id,
+        api_key_env=api_key_env,
+    )
+    identity.update(
+        {
+            "endpoint_base_url": endpoint_base_url,
+            "endpoint_effective": endpoint_effective,
+            "transport": transport,
+            "provider_signature": provider_signature,
+            "structured_output_mode": _structured_output_mode_from_meta(
+                structured_output
+            ),
+            "provider_schema_variant": provider_schema_variant_label(
+                normalized_provider,
+                requested_model_id,
+            ),
+            "route_identity_authority": "static_request_route_metadata",
+        }
+    )
     return {key: value for key, value in identity.items() if value is not None}
+
 
 def call_llm(
     deps: LLMRuntimeDeps,

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -229,6 +229,7 @@ from llm_runtime import (
     backoff_seconds as llm_runtime_backoff_seconds,
     call_llm as llm_runtime_call_llm,
     call_llm_with_ladder as llm_runtime_call_llm_with_ladder,
+    classify_route_identity as llm_runtime_classify_route_identity,
     coerce_artifacts_from_response as llm_runtime_coerce_artifacts_from_response,
     comparison_artifact_dir as llm_runtime_comparison_artifact_dir,
     compute_comparison_resume_decision as llm_runtime_compute_comparison_resume_decision,
@@ -240,6 +241,7 @@ from llm_runtime import (
     run_comparison_lane as llm_runtime_run_comparison_lane,
     should_retry as llm_runtime_should_retry,
 )
+from lib.pricing_surface import pricing_surface_metadata
 from lib.risk_dashboard import (
     build_rte_risk_dashboard,
     collect_rte_risk_dashboard_inputs,
@@ -3653,6 +3655,40 @@ def record_request_cost(
             pricing_registry=state.pricing_registry,
         )
         state.total_cost_usd = _quantize_usd(state.total_cost_usd + cost_usd)
+        pricing_meta = pricing_surface_metadata(
+            provider=provider,
+            model_id=model_id,
+            api_key_env=(
+                str(
+                    meta.get("api_key_env")
+                    or meta.get("api_key_env_resolved")
+                    or meta.get("api_key_env_requested")
+                    or ""
+                )
+                or None
+            ),
+            route_identity=meta,
+            endpoint_effective=(
+                str(meta.get("endpoint_effective"))
+                if meta.get("endpoint_effective") is not None
+                else None
+            ),
+            transport=(
+                str(meta.get("transport"))
+                if meta.get("transport") is not None
+                else None
+            ),
+            provider_signature=(
+                str(meta.get("provider_signature"))
+                if meta.get("provider_signature") is not None
+                else None
+            ),
+            route_fingerprint_hash=(
+                str(meta.get("route_fingerprint_hash"))
+                if meta.get("route_fingerprint_hash") is not None
+                else None
+            ),
+        )
         event = {
             "sequence": len(state.entries) + 1,
             "recorded_at": now_iso(),
@@ -3666,6 +3702,7 @@ def record_request_cost(
             "total_tokens": int(usage.get("total_tokens", 0) or 0),
             "cost_usd": float(cost_usd),
             "total_cost_usd_after_event": float(_quantize_usd(state.total_cost_usd)),
+            **pricing_meta,
         }
         state.entries.append(event)
         if state.total_cost_usd > state.max_cost_usd:
@@ -9209,6 +9246,15 @@ def build_static_route_fingerprint_metadata(
     material = static_route_fingerprint_material(route_meta)
     route_meta["route_fingerprint_material"] = material
     route_meta["route_fingerprint_hash"] = static_route_fingerprint_hash(material)
+    route_meta.update(
+        pricing_surface_metadata(
+            route_identity=route_meta,
+            endpoint_effective=route_meta.get("endpoint_effective"),
+            transport=route_meta.get("transport"),
+            provider_signature=route_meta.get("provider_signature"),
+            route_fingerprint_hash=route_meta.get("route_fingerprint_hash"),
+        )
+    )
     return route_meta
 
 
@@ -9874,9 +9920,28 @@ def _build_cost_abort_state(
         "cost_abort_recovery_rule": recovery_rule,
     }
     if isinstance(pricing, dict):
-        payload["pricing_key"] = pricing.get("pricing_key")
-        payload["pricing_source"] = pricing.get("pricing_source")
-        payload["pricing_version"] = pricing.get("pricing_version")
+        for key in (
+            "pricing_key",
+            "pricing_source",
+            "pricing_version",
+            "requested_provider",
+            "requested_model_id",
+            "provider_route_kind",
+            "upstream_provider",
+            "economic_surface",
+            "api_key_env",
+            "endpoint_effective",
+            "transport",
+            "provider_signature",
+            "route_fingerprint_hash",
+            "pricing_authority",
+            "pricing_surface",
+            "pricing_surface_source",
+            "pricing_live_validation_status",
+            "direct_provider_billing_inherited",
+        ):
+            if key in pricing:
+                payload[key] = pricing.get(key)
         payload["unknown_model"] = bool(pricing.get("unknown_model", False))
         payload["projected_additional_cost_usd"] = pricing.get("estimated_cost_usd")
         payload["input_tokens"] = pricing.get("input_tokens")
@@ -10559,6 +10624,10 @@ def enrich_request_meta(
         "provider_failure",
         failure_type in {"provider", "rate_limit", "quota_or_billing", "timeout"},
     )
+    if "endpoint_effective" not in enriched:
+        enriched["endpoint_effective"] = endpoint_effective(
+            f"{endpoint_base}/chat/completions"
+        )
     if "provider_signature" not in enriched:
         enriched["provider_signature"] = provider_signature(
             provider,
@@ -10569,6 +10638,52 @@ def enrich_request_meta(
             ),
             auth_effective if provider == "gemini" else None,
         )
+    route_identity = llm_runtime_classify_route_identity(
+        provider=str(enriched.get("provider") or provider),
+        model_id=str(enriched.get("model_id") or model_id),
+        api_key_env=str(enriched.get("api_key_env") or api_key_env or ""),
+        endpoint_base_url=str(enriched.get("endpoint_base_url") or endpoint_base),
+        endpoint_effective=str(enriched.get("endpoint_effective") or ""),
+        transport=(
+            str(enriched.get("transport"))
+            if enriched.get("transport") is not None
+            else None
+        ),
+        provider_signature=str(enriched.get("provider_signature") or ""),
+        structured_output=structured_output,
+    )
+    for key, value in route_identity.items():
+        enriched.setdefault(key, value)
+    enriched.setdefault("direct_provider_guarantees_inherited", None)
+    if "route_fingerprint_hash" not in enriched:
+        route_material = static_route_fingerprint_material(enriched)
+        enriched.setdefault("route_fingerprint_material", route_material)
+        enriched["route_fingerprint_hash"] = static_route_fingerprint_hash(route_material)
+    pricing_identity = pricing_surface_metadata(
+        route_identity=enriched,
+        endpoint_effective=(
+            str(enriched.get("endpoint_effective"))
+            if enriched.get("endpoint_effective") is not None
+            else None
+        ),
+        transport=(
+            str(enriched.get("transport"))
+            if enriched.get("transport") is not None
+            else None
+        ),
+        provider_signature=(
+            str(enriched.get("provider_signature"))
+            if enriched.get("provider_signature") is not None
+            else None
+        ),
+        route_fingerprint_hash=(
+            str(enriched.get("route_fingerprint_hash"))
+            if enriched.get("route_fingerprint_hash") is not None
+            else None
+        ),
+    )
+    for key, value in pricing_identity.items():
+        enriched.setdefault(key, value)
     enriched["routing_signature"] = routing_signature(
         phase,
         step_id,
@@ -17508,6 +17623,7 @@ def _pricing_preview_record(
         if provider and model_id
         else "unknown"
     )
+    pricing_meta = pricing_surface_metadata(provider=provider, model_id=model_id)
     estimated_cost_usd = (
         (max(0, int(input_tokens)) / 1_000_000.0) * BASELINE_INPUT_COST_PER_1M_USD
         + (max(0, int(output_tokens)) / 1_000_000.0) * BASELINE_OUTPUT_COST_PER_1M_USD
@@ -17519,6 +17635,7 @@ def _pricing_preview_record(
         "pricing_source": f"unknown_model:{UNKNOWN_MODEL_POLICY}",
         "pricing_version": PRICING_VERSION,
         "unknown_model": True,
+        **pricing_meta,
         "input_cost_per_1m_usd": BASELINE_INPUT_COST_PER_1M_USD,
         "output_cost_per_1m_usd": BASELINE_OUTPUT_COST_PER_1M_USD,
         "input_tokens": max(0, int(input_tokens)),

--- a/services/repo-truth-extractor/tests/test_pricing_surface_static_identity.py
+++ b/services/repo-truth-extractor/tests/test_pricing_surface_static_identity.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from _v5_smoke_helpers import load_runner_module
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from lib.pricing_surface import pricing_surface_matrix_rows, pricing_surface_metadata
+from lib.spend_ledger import SpendLedger
+
+
+def _no_provider_call(*_args: Any, **_kwargs: Any) -> Any:
+    raise AssertionError("pricing-surface static tests must not invoke provider clients")
+
+
+def _static_route(provider: str, model_id: str, api_key_env: str) -> dict[str, Any]:
+    runner = load_runner_module()
+    endpoint_base = (
+        "https://openrouter.ai/api/v1"
+        if provider == "openrouter"
+        else (
+            "https://api.x.ai/v1"
+            if provider == "xai"
+            else f"https://api.{provider}.example/v1"
+        )
+    )
+    return runner.build_static_route_fingerprint_metadata(
+        provider=provider,
+        model_id=model_id,
+        api_key_env=api_key_env,
+        endpoint_base_url=endpoint_base,
+        endpoint_url=f"{endpoint_base}/chat/completions",
+        transport="openai_sdk",
+        structured_output_mode="json_schema",
+    )
+
+
+def test_direct_xai_pricing_surface_is_xai_direct() -> None:
+    route = _static_route("xai", "grok-fixture", "XAI_API_KEY")
+
+    assert route["provider_route_kind"] == "direct_provider"
+    assert route["upstream_provider"] == "xai"
+    assert route["economic_surface"] == "xai_direct"
+    assert route["pricing_surface"] == "xai_direct"
+    assert route["pricing_authority"] == "direct_provider_catalog_or_unknown"
+    assert route["api_key_env"] == "XAI_API_KEY"
+    assert route["direct_provider_billing_inherited"] is None
+    assert route["pricing_live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+
+
+def test_openrouter_xai_pricing_surface_is_openrouter_not_xai_direct() -> None:
+    route = _static_route("openrouter", "x-ai/grok-fixture", "OPENROUTER_API_KEY")
+
+    assert route["provider_route_kind"] == "openrouter_proxy_xai"
+    assert route["upstream_provider"] == "xai"
+    assert route["economic_surface"] == "openrouter"
+    assert route["pricing_surface"] == "openrouter"
+    assert route["pricing_authority"] == "openrouter_catalog_or_unknown"
+    assert route["api_key_env"] == "OPENROUTER_API_KEY"
+    assert route["direct_provider_billing_inherited"] is False
+    assert route["pricing_live_validation_status"] == "LIVE_VALIDATION_REQUIRED"
+    assert route["pricing_surface"] != "xai_direct"
+
+
+def test_openrouter_xai_pricing_proof_differs_from_direct_xai() -> None:
+    direct = _static_route("xai", "grok-fixture", "XAI_API_KEY")
+    proxied = _static_route("openrouter", "x-ai/grok-fixture", "OPENROUTER_API_KEY")
+
+    assert direct["upstream_provider"] == proxied["upstream_provider"] == "xai"
+    assert direct["pricing_surface"] != proxied["pricing_surface"]
+    assert direct["economic_surface"] != proxied["economic_surface"]
+    assert direct["api_key_env"] != proxied["api_key_env"]
+    assert direct["provider_route_kind"] != proxied["provider_route_kind"]
+    assert direct["provider_signature"] != proxied["provider_signature"]
+    assert direct["route_fingerprint_hash"] != proxied["route_fingerprint_hash"]
+
+
+def test_spend_ledger_rows_preserve_pricing_surface(tmp_path: Path) -> None:
+    ledger = SpendLedger(tmp_path, "pricing_surface_static")
+
+    openrouter_spend = ledger.accumulate(
+        "A",
+        100,
+        50,
+        provider="openrouter",
+        model_id="x-ai/grok-4.1-fast",
+        route="openrouter/x-ai/grok-4.1-fast",
+    )
+    direct_xai_spend = ledger.accumulate(
+        "A",
+        100,
+        50,
+        provider="xai",
+        model_id="grok-4.20",
+        route="xai/grok-4.20",
+    )
+
+    assert openrouter_spend["economic_surface"] == "openrouter"
+    assert openrouter_spend["pricing_surface"] == "openrouter"
+    assert openrouter_spend["direct_provider_billing_inherited"] is False
+    assert direct_xai_spend["economic_surface"] == "xai_direct"
+    assert direct_xai_spend["pricing_surface"] == "xai_direct"
+    assert direct_xai_spend["direct_provider_billing_inherited"] is None
+
+    payload = json.loads((tmp_path / "spend_ledger.json").read_text(encoding="utf-8"))
+    openrouter_row = payload["models"]["openrouter/x-ai/grok-4.1-fast"]
+    direct_xai_row = payload["models"]["xai/grok-4.20"]
+    assert openrouter_row["pricing_surface"] == "openrouter"
+    assert openrouter_row["economic_surface"] == "openrouter"
+    assert openrouter_row["upstream_provider"] == "xai"
+    assert openrouter_row["direct_provider_billing_inherited"] is False
+    assert direct_xai_row["pricing_surface"] == "xai_direct"
+    assert direct_xai_row["economic_surface"] == "xai_direct"
+
+
+def test_pricing_surface_matrix_covers_required_static_cases() -> None:
+    rows = pricing_surface_matrix_rows()
+    by_label = {row["label"]: row for row in rows}
+
+    assert set(by_label) == {
+        "Direct xAI",
+        "OpenRouter x-ai",
+        "OpenRouter OpenAI",
+        "OpenRouter unknown/native",
+        "Direct OpenAI",
+        "Direct Gemini",
+        "Unknown provider",
+    }
+    assert by_label["Direct xAI"]["pricing_surface"] == "xai_direct"
+    assert by_label["OpenRouter x-ai"]["pricing_surface"] == "openrouter"
+    assert by_label["OpenRouter x-ai"]["direct_provider_billing_inherited"] is False
+    assert by_label["OpenRouter OpenAI"]["upstream_provider"] == "openai"
+    assert by_label["OpenRouter OpenAI"]["billing_authority"] == "openrouter_catalog_or_unknown"
+    assert by_label["OpenRouter unknown/native"]["provider_route_kind"] == (
+        "openrouter_native_or_unknown"
+    )
+    assert by_label["OpenRouter unknown/native"]["pricing_surface"] == "openrouter"
+    assert by_label["Direct OpenAI"]["pricing_surface"] == "openai_direct"
+    assert by_label["Direct Gemini"]["pricing_surface"] == "gemini_direct"
+    assert by_label["Unknown provider"]["pricing_surface"] == "unknown"
+    assert by_label["Unknown provider"]["billing_authority"] == "unknown"
+
+
+def test_static_pricing_visibility_does_not_call_provider_clients(
+    monkeypatch: Any,
+) -> None:
+    runner = load_runner_module()
+    for attr in (
+        "get_http_session",
+        "get_gemini_client",
+        "get_xai_client",
+        "get_openrouter_client",
+        "get_openai_client",
+    ):
+        monkeypatch.setattr(runner, attr, _no_provider_call, raising=False)
+
+    route = runner.build_static_route_fingerprint_metadata(
+        provider="openrouter",
+        model_id="x-ai/grok-fixture",
+        api_key_env="OPENROUTER_API_KEY",
+        endpoint_base_url="https://openrouter.ai/api/v1",
+        endpoint_url="https://openrouter.ai/api/v1/chat/completions",
+        transport="openai_sdk",
+        structured_output_mode="json_schema",
+    )
+    pricing = pricing_surface_metadata(route_identity=route)
+
+    assert pricing["pricing_surface"] == "openrouter"
+    assert pricing["direct_provider_billing_inherited"] is False


### PR DESCRIPTION
## Summary
- Adds static economic/pricing-surface visibility for direct xAI vs OpenRouter x-ai routes.
- Preserves OpenRouter x-ai as `economic_surface=openrouter` and `pricing_surface=openrouter`.
- Preserves direct xAI as `pricing_surface=xai_direct`.
- Adds pricing-surface proof artifacts under `out/rte-pkt-14-pricing-visibility/`.

## Boundary
No live extraction, provider preflight, provider credential use, provider batch operation, or live provider API calls were run.

OpenRouter x-ai live upstream metadata, returned-model behavior, schema acceptance, retention/ZDR, billing, and rate-limit equivalence remain UNKNOWN / LIVE_VALIDATION_REQUIRED.

## Validation
See `out/rte-pkt-14-pricing-visibility/RTE-PKT-14_MANIFEST.json`.

## Known caveat
Implementation was completed in a sandbox where `.git` writes were blocked, so staging/commit/push/PR were performed afterward from a git-write-capable environment.