### PR TITLE
[codex] docs(rte): add opus uiux audit bundle

### DIFF
--- a/config/docs_hygiene/docs_placement_policy.yaml
+++ b/config/docs_hygiene/docs_placement_policy.yaml
@@ -10,6 +10,7 @@ canonical_roots:
   - 04-explanation
   - 05-audit-reports
   - 06-research
+  - audit
   - research
   - 90-adr
   - 91-rfc

--- a/docs/audit/rte-opus-uiux-claude-design-audit/FINDINGS_LEDGER.json
+++ b/docs/audit/rte-opus-uiux-claude-design-audit/FINDINGS_LEDGER.json
@@ -1,0 +1,431 @@
+{
+  "audit_id": "RTE-OPUS-UIUX-CLAUDE-DESIGN-AUDIT-001",
+  "head_sha": "a234f798947d51915b2adea3e0bc5a2917ac595b",
+  "branch": "claude/youthful-neumann-b94cc0",
+  "date": "2026-05-16",
+  "mode": "fresh-independent-pass",
+  "authority_order": [
+    "runtime_code_cli_tests_configs",
+    "rte_proof_status_runtime_writers",
+    "AGENTS_md_and_governance",
+    "TRUTH_and_SYSTEM_docs",
+    "rte_docs_design_claude_guidance",
+    "historical_generated_artifacts",
+    "external_assumptions_not_authority"
+  ],
+  "allowed_labels": ["OBSERVED", "INFERRED", "UNKNOWN", "CONFLICTING", "CLAIMED", "RECOMMENDED"],
+  "id_scheme": "F-OPUS-{SEV}-{N}",
+  "findings": [
+    {
+      "id": "F-OPUS-CRIT-1",
+      "severity": "CRIT",
+      "title": "CLI surface broadly violates brand-voice §2A 'no hype, no mascot, no visionary framing'",
+      "label": "OBSERVED",
+      "authority_tier": "runtime_plus_governance",
+      "evidence": [
+        "src/dopemux/cli.py:5075",
+        "src/dopemux/cli.py:5186",
+        "src/dopemux/cli.py:5219",
+        "src/dopemux/cli.py:5253",
+        "src/dopemux/cli.py:5418",
+        "src/dopemux/cli.py:4938",
+        ".claude/brand-voice-guidelines.md:55-62",
+        ".claude/brand-voice-guidelines.md:332-341",
+        ".claude/brand-voice-guidelines.md:347"
+      ],
+      "recommendation_ref": "R-OPUS-1"
+    },
+    {
+      "id": "F-OPUS-CRIT-2",
+      "severity": "CRIT",
+      "title": "Truth-order documents disagree on what wins",
+      "label": "CONFLICTING",
+      "authority_tier": "governance",
+      "evidence": [
+        "AGENTS.md:9-19",
+        "README.md:64-72",
+        ".claude/brand-voice-guidelines.md:372-381",
+        "audit_packet_authority_order (in this audit's own task packet)"
+      ],
+      "recommendation_ref": "R-OPUS-2"
+    },
+    {
+      "id": "F-OPUS-CRIT-3",
+      "severity": "CRIT",
+      "title": "No Claude/agent-facing file teaches Claude how to operate RTE safely",
+      "label": "OBSERVED",
+      "authority_tier": "claude_guidance",
+      "evidence": [
+        ".claude/CLAUDE.md (zero RTE-specific content)",
+        "services/.claude/CLAUDE.md:38-44 (Key Services table omits RTE)",
+        "src/.claude/CLAUDE.md (no RTE consent guidance)",
+        "CLAUDE_AUTOMATION_INSTRUCTIONS.md (prompt-rewrite harness, not operator guidance)",
+        "AGENTS.md:81 (scopes RTE outputs but does not teach RTE operation)"
+      ],
+      "recommendation_ref": "R-OPUS-3"
+    },
+    {
+      "id": "F-OPUS-HIGH-1",
+      "severity": "HIGH",
+      "title": "CLI emoji use exceeds the 6-emoji whitelist by ~4×",
+      "label": "OBSERVED",
+      "authority_tier": "runtime_plus_governance",
+      "evidence": [
+        ".claude/brand-voice-guidelines.md:268-270",
+        "docs/04-explanation/branding/cli-ux-design-spec.md:153-156",
+        "src/dopemux/cli.py:4874-4882 (📊 🆔 🧠 📦 ⚡ 🔬 📂 ⏪)",
+        "src/dopemux/cli.py:5022-5034 (🔄 ⏩ 📥 📡 🛡️ 💸)",
+        "src/dopemux/cli.py:5075 (🚀)",
+        "src/dopemux/cli.py:5169-5174 (🆔 🔧 🔬 📊)",
+        "src/dopemux/cli.py:5186 (🏥)",
+        "src/dopemux/cli.py:5253 (🛫)",
+        "src/dopemux/cli.py:5418 (⚖️)",
+        "src/dopemux/cli.py:5469 (🌊)",
+        "src/dopemux/cli.py:5491 (👁️)",
+        "src/dopemux/cli.py:5546 (🎭)",
+        "src/dopemux/commands/extractor_commands.py:155 (🗺️)",
+        "src/dopemux/commands/extractor_commands.py:163 (🔥)",
+        "src/dopemux/commands/extractor_commands.py:87 (💰)"
+      ],
+      "recommendation_ref": "R-OPUS-4"
+    },
+    {
+      "id": "F-OPUS-HIGH-2",
+      "severity": "HIGH",
+      "title": "Two UX style documents describe incompatible visual languages",
+      "label": "CONFLICTING",
+      "authority_tier": "docs",
+      "evidence": [
+        "docs/ux/ux-style-guide.md:22-29",
+        "docs/04-explanation/branding/cli-ux-design-spec.md:75-83",
+        "docs/04-explanation/branding/cli-ux-design-spec.md:161-164",
+        "docs/ux/ux-style-guide.md:14-15 (self-demotion line)"
+      ],
+      "recommendation_ref": "R-OPUS-5"
+    },
+    {
+      "id": "F-OPUS-HIGH-3",
+      "severity": "HIGH",
+      "title": "docs/ux/terminal-rendering-guide.md is an empty stub",
+      "label": "OBSERVED",
+      "authority_tier": "docs",
+      "evidence": [
+        "docs/ux/terminal-rendering-guide.md:1-13 (296 bytes, frontmatter only)",
+        ".claude/brand-voice-guidelines.md:318-319 (references render modes)",
+        "docs/04-explanation/branding/cli-ux-design-spec.md:196-207 (defines RICH/PLAIN/COMPACT/AUDIT)"
+      ],
+      "recommendation_ref": "R-OPUS-6"
+    },
+    {
+      "id": "F-OPUS-HIGH-4",
+      "severity": "HIGH",
+      "title": "dopemux rte promptset audit is v4-only despite v5 being canonical",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "src/dopemux/cli.py:5430-5437",
+        "src/dopemux/cli.py:5534",
+        "README.md:33",
+        "README.md:60",
+        "AGENTS.md:81",
+        "services/repo-truth-extractor/README.md:18",
+        "services/repo-truth-extractor/README.md:100-103"
+      ],
+      "recommendation_ref": "R-OPUS-7"
+    },
+    {
+      "id": "F-OPUS-HIGH-5",
+      "severity": "HIGH",
+      "title": "Pre-live validator NO_GO uses RuntimeError string, not error_panel(problem, why, fix)",
+      "label": "OBSERVED",
+      "authority_tier": "runtime_plus_governance",
+      "evidence": [
+        "services/repo-truth-extractor/run_extraction_v5.py:3067-3070",
+        ".claude/brand-voice-guidelines.md:295-300"
+      ],
+      "recommendation_ref": "R-OPUS-8"
+    },
+    {
+      "id": "F-OPUS-HIGH-6",
+      "severity": "HIGH",
+      "title": "dopemux rte run --help has 30+ options with no progressive disclosure",
+      "label": "OBSERVED",
+      "authority_tier": "runtime_plus_governance",
+      "evidence": [
+        "src/dopemux/cli.py:4968-5163",
+        "docs/04-explanation/branding/cli-ux-design-spec.md:182-183",
+        "docs/04-explanation/branding/cli-ux-design-spec.md:25"
+      ],
+      "recommendation_ref": "R-OPUS-9"
+    },
+    {
+      "id": "F-OPUS-MED-1",
+      "severity": "MED",
+      "title": "ARCHITECTURE.md §5.5 still presents dopemux upgrades as the operator path",
+      "label": "OBSERVED",
+      "authority_tier": "governance",
+      "evidence": ["ARCHITECTURE.md:150", "README.md:60-62"],
+      "recommendation_ref": "R-OPUS-10"
+    },
+    {
+      "id": "F-OPUS-MED-2",
+      "severity": "MED",
+      "title": "Canonical RTE commands are defined as @upgrades.command and aliased into rte",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "src/dopemux/cli.py:4934",
+        "src/dopemux/cli.py:4968",
+        "src/dopemux/cli.py:5167",
+        "src/dopemux/cli.py:5207",
+        "src/dopemux/cli.py:5234",
+        "src/dopemux/cli.py:5277",
+        "src/dopemux/cli.py:5401",
+        "src/dopemux/cli.py:5440",
+        "src/dopemux/cli.py:5509-5538"
+      ],
+      "recommendation_ref": "R-OPUS-11"
+    },
+    {
+      "id": "F-OPUS-MED-3",
+      "severity": "MED",
+      "title": "dopemux extractor status is a dual-mode surface with no operator hint",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": ["src/dopemux/commands/extractor_commands.py:299-345"],
+      "recommendation_ref": "R-OPUS-12"
+    },
+    {
+      "id": "F-OPUS-MED-4",
+      "severity": "MED",
+      "title": "dopemux rte wizard is registered but undocumented",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "src/dopemux/cli.py:5516",
+        "README.md:54-62 (no wizard mention)",
+        "services/repo-truth-extractor/README.md (no wizard mention)"
+      ],
+      "recommendation_ref": "R-OPUS-13"
+    },
+    {
+      "id": "F-OPUS-MED-5",
+      "severity": "MED",
+      "title": "services/.claude/CLAUDE.md Key Services table omits repo-truth-extractor",
+      "label": "OBSERVED",
+      "authority_tier": "claude_guidance",
+      "evidence": ["services/.claude/CLAUDE.md:38-44"],
+      "recommendation_ref": "R-OPUS-14"
+    },
+    {
+      "id": "F-OPUS-MED-6",
+      "severity": "MED",
+      "title": "No --help text or epilog tells operators about DPMX_LIVE_OK=1",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "src/dopemux/cli.py:4968-5163",
+        "services/repo-truth-extractor/README.md:145",
+        "services/repo-truth-extractor/run_extraction_v5.py:3016-3019"
+      ],
+      "recommendation_ref": "R-OPUS-15"
+    },
+    {
+      "id": "F-OPUS-MED-7",
+      "severity": "MED",
+      "title": "Cockpit audit reports' 'do not implement' caveat is prose, not a structured flag",
+      "label": "OBSERVED",
+      "authority_tier": "docs",
+      "evidence": [
+        "docs/05-audit-reports/cockpit-pm-implementer-processing-pack-2026-04-24.md:17",
+        "rg returns zero matches for READY_FOR_CLAUDE_DESIGN or safe_for_claude_design repo-wide"
+      ],
+      "recommendation_ref": "R-OPUS-16"
+    },
+    {
+      "id": "F-OPUS-LOW-1",
+      "severity": "LOW",
+      "title": "validate-live stage caps shown without explicit USD unit in --help",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "src/dopemux/cli.py:5317",
+        "src/dopemux/cli.py:5321",
+        "src/dopemux/cli.py:5326",
+        "src/dopemux/cli.py:5328"
+      ],
+      "recommendation_ref": "R-OPUS-17"
+    },
+    {
+      "id": "F-OPUS-LOW-2",
+      "severity": "LOW",
+      "title": "Brand-voice required closer compliance in RTE error/status output is unverified",
+      "label": "UNKNOWN",
+      "authority_tier": "runtime_plus_governance",
+      "evidence": [
+        ".claude/brand-voice-guidelines.md:181-183",
+        "services/repo-truth-extractor/run_extraction_v5.py:3015-3019 (parser.error without explicit NEXT:)"
+      ],
+      "recommendation_ref": "R-OPUS-18"
+    },
+    {
+      "id": "F-OPUS-LOW-3",
+      "severity": "LOW",
+      "title": "cli.py truth-command deprecation message omits DPMX_LIVE_OK=1",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": ["src/dopemux/cli.py:5495-5500"],
+      "recommendation_ref": "R-OPUS-19"
+    },
+    {
+      "id": "F-OPUS-OBS-1",
+      "severity": "OBS",
+      "title": "Phase 1 audit-survey produced fabricated string references",
+      "label": "OBSERVED",
+      "authority_tier": "audit_meta",
+      "evidence": ["repo-wide rg for READY_FOR_CLAUDE_DESIGN and safe_for_claude_design returns zero matches"],
+      "polarity": "neutral_meta"
+    },
+    {
+      "id": "F-OPUS-OBS-2",
+      "severity": "OBS",
+      "title": "Risk dashboard self-tags honestly with hard-coded static labels",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": ["services/repo-truth-extractor/lib/risk_dashboard.py:446-460"],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-3",
+      "severity": "OBS",
+      "title": "Spend ledger is honest about pricing fallback",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "services/repo-truth-extractor/lib/spend_ledger.py:11-16",
+        "services/repo-truth-extractor/lib/spend_ledger.py:245-258"
+      ],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-4",
+      "severity": "OBS",
+      "title": "Consent gates are belt-and-suspenders",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "src/dopemux/cli.py:4909-4918",
+        "services/repo-truth-extractor/run_extraction_v5.py:2992-3020",
+        "services/repo-truth-extractor/run_extraction_v5.py:3023-3076"
+      ],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-5",
+      "severity": "OBS",
+      "title": "Output safety redaction is comprehensive and defense-in-depth",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "services/repo-truth-extractor/output_safety.py:7-37",
+        "services/repo-truth-extractor/output_safety.py:85-130",
+        "services/repo-truth-extractor/output_safety.py:40-63"
+      ],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-6",
+      "severity": "OBS",
+      "title": "README cost-incident anchor is exemplary operator UX",
+      "label": "OBSERVED",
+      "authority_tier": "docs",
+      "evidence": ["services/repo-truth-extractor/README.md:262-264"],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-7",
+      "severity": "OBS",
+      "title": "lib/proof_contract.py enforces a tight authority-rank model",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "services/repo-truth-extractor/lib/proof_contract.py:119-127",
+        "services/repo-truth-extractor/lib/proof_contract.py:286-358",
+        "services/repo-truth-extractor/lib/proof_contract.py:354"
+      ],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-8",
+      "severity": "OBS",
+      "title": "is_read_only_introspection_mode cleanly enumerates safe introspection paths",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": [
+        "services/repo-truth-extractor/run_extraction_v5.py:2880-2895",
+        "services/repo-truth-extractor/run_extraction_v5.py:2849-2870"
+      ],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-9",
+      "severity": "OBS",
+      "title": "dopemux truth deprecation message redirects to canonical surface and dry-runs",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": ["src/dopemux/cli.py:5495-5500"],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-10",
+      "severity": "OBS",
+      "title": "extractor group invocation prints a one-line redirect echo (mixed)",
+      "label": "OBSERVED",
+      "authority_tier": "runtime",
+      "evidence": ["src/dopemux/commands/extractor_commands.py:38-43"],
+      "polarity": "mixed"
+    },
+    {
+      "id": "F-OPUS-OBS-11",
+      "severity": "OBS",
+      "title": "RTE README first-live preset codifies conservative defaults",
+      "label": "OBSERVED",
+      "authority_tier": "docs",
+      "evidence": ["services/repo-truth-extractor/README.md:147-169"],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-12",
+      "severity": "OBS",
+      "title": "Comparison lane is explicitly non-blocking and uses separate output trees",
+      "label": "OBSERVED",
+      "authority_tier": "docs_plus_runtime",
+      "evidence": ["services/repo-truth-extractor/README.md:304-385"],
+      "polarity": "positive"
+    },
+    {
+      "id": "F-OPUS-OBS-13",
+      "severity": "OBS",
+      "title": "Six cockpit audit reports exist but none are RTE-specific",
+      "label": "OBSERVED",
+      "authority_tier": "docs",
+      "evidence": [
+        "docs/05-audit-reports/cockpit-pm-implementer-processing-pack-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-design-input-merged-brief-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-pm-implementer-callable-inventory-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-pm-implementer-design-brief-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-archive-intent-pack-2026-04-24.md",
+        "docs/05-audit-reports/cockpit-adhd-lifestyle-feature-map-2026-04-24.md"
+      ],
+      "polarity": "neutral_observation"
+    }
+  ],
+  "counts": {
+    "CRIT": 3,
+    "HIGH": 6,
+    "MED": 7,
+    "LOW": 3,
+    "OBS": 13,
+    "total": 32
+  }
+}

--- a/docs/audit/rte-opus-uiux-claude-design-audit/claude-design-compatibility.md
+++ b/docs/audit/rte-opus-uiux-claude-design-audit/claude-design-compatibility.md
@@ -1,0 +1,116 @@
+---
+id: CLAUDE_DESIGN_COMPATIBILITY
+title: Claude Design Compatibility
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-17'
+last_review: '2026-05-17'
+next_review: '2026-08-15'
+prelude: Claude Design Compatibility (explanation) for dopemux documentation and developer
+  workflows.
+---
+# CLAUDE_DESIGN_COMPATIBILITY.md
+
+Per-file compatibility ledger for every Claude/design-adjacent artifact that affects how humans or LLM agents interact with RTE.
+
+**Columns**
+- **Path** — file location relative to repo root.
+- **Declared authority** — what the file claims to be (frontmatter `type:`, in-file prose, or implicit by location).
+- **Observed authority tier** — where it lands under the audit's authority order (1=runtime, 2=runtime writers, 3=AGENTS/governance, 4=TRUTH/SYSTEM, 5=docs/design/Claude, 6=historical).
+- **Drift** — is what the file declares consistent with what runtime/governance actually says?
+- **Claude-Design safety** — is this file safe to feed to Claude Design or an automation agent as authoritative? Values: `runtime-safe`, `governance-safe`, `evidence-only`, `not-for-implementation`, `non-authoritative`, `stub`.
+- **Risk class** — `low` / `medium` / `high` based on operator/agent confusion potential.
+- **Finding refs** — IDs from FINDINGS_LEDGER.md.
+
+---
+
+| Path | Declared authority | Observed tier | Drift | Claude-Design safety | Risk class | Finding refs |
+|------|---------------------|---------------|-------|----------------------|------------|--------------|
+| `AGENTS.md` | governance / agent runtime guidance | 3 | self-consistent; truth order at §2 differs from README.md and brand-voice-guidelines.md | governance-safe (within its own scope) | high | F-OPUS-CRIT-2 |
+| `README.md` | governance / project overview | 3 | truth order at §5 omits Task Packets that AGENTS.md §2 puts first | governance-safe (operator-facing); not authoritative against runtime | high | F-OPUS-CRIT-2 |
+| `ARCHITECTURE.md` | governance / observed-runtime architecture | 3 | §5.5 still names `dopemux upgrades` as operator path; deprecated by README.md §4 | governance-safe with caveat | medium | F-OPUS-MED-1 |
+| `.claude/CLAUDE.md` (root) | Claude operating guidance (5) | 5 | self-consistent for general Dopemux; **silent on RTE consent/`DPMX_LIVE_OK`/spend caps** | not-for-RTE-implementation | high | F-OPUS-CRIT-3 |
+| `.claude/claude.md` (lowercase variant, same file on case-insensitive filesystem) | same as above | 5 | same | same | high | F-OPUS-CRIT-3 |
+| `services/.claude/CLAUDE.md` | Claude services-tree guidance (5) | 5 | Key Services table omits `repo-truth-extractor`; service tree omits it | not-for-RTE-implementation | high | F-OPUS-CRIT-3, F-OPUS-MED-5 |
+| `src/.claude/CLAUDE.md` | Claude source-code guidance (5) | 5 | mentions `extractor_commands.py` exports but not RTE consent invariants | not-for-RTE-implementation | medium | F-OPUS-CRIT-3 |
+| `.claude/brand-voice-guidelines.md` | reference / lint-enforced brand voice (5 escalating to runtime via `brand_lint.py`) | 5 + runtime-enforced subset | self-consistent; §9 decision ladder differs from AGENTS.md §2 and README.md §5 | governance-safe; lint-enforced for code, advisory for prose | medium | F-OPUS-CRIT-1, F-OPUS-CRIT-2, F-OPUS-HIGH-1, F-OPUS-HIGH-5 |
+| `CLAUDE_AUTOMATION_INSTRUCTIONS.md` | reference / batch-prompt-rewrite harness instructions | 5 | not RTE operator guidance despite name suggesting Claude+RTE alignment | not-for-implementation | low | — |
+| `docs/ux/ux-style-guide.md` | explanation / self-demoted | 5 | body prescribes a palette ("Spaceage Operationalism", green/red/yellow/blue chips) directly contradicting `cli-ux-design-spec.md` ("Neon Mint", mint/pink/violet) | non-authoritative (explicitly demoted) | high | F-OPUS-HIGH-2 |
+| `docs/ux/terminal-rendering-guide.md` | explanation | 5 | empty stub (296 bytes, frontmatter only); referenced indirectly by brand-voice §4 | stub | medium | F-OPUS-HIGH-3 |
+| `docs/04-explanation/branding/cli-ux-design-spec.md` | explanation; marked "single source of truth for all CLI/TUI output styling" | 5 (claims runtime-spec but not runtime-enforced beyond `theme.py`) | self-consistent within its own scope; aligned with `brand-voice-guidelines.md` §4 | governance-safe (visual layer) | low | F-OPUS-HIGH-1, F-OPUS-HIGH-2, F-OPUS-HIGH-6 |
+| `docs/03-reference/brand-compliance-checklist.md` | reference / release gate | 5 | (not deeply inspected here; brand-voice §9.6 places it at tier 6 of its own decision ladder, after `BRAND_SYSTEM.md`/`BRAND_VOICE_BIBLE.md`/`brand-resource-pack.md`) | governance-safe (pre-PR checklist) | low | — |
+| `docs/05-audit-reports/cockpit-pm-implementer-processing-pack-2026-04-24.md` | reference / audit report | 6 | verdict at line 17 says "evidence pack only, do not implement"; PM-cockpit-scoped, not RTE | evidence-only | medium | F-OPUS-MED-7, F-OPUS-OBS-1, F-OPUS-OBS-13 |
+| `docs/05-audit-reports/cockpit-design-input-merged-brief-2026-04-24.md` | reference / design brief | 6 | input synthesis for cockpit redesign; not RTE | evidence-only | low | F-OPUS-OBS-13 |
+| `docs/05-audit-reports/cockpit-pm-implementer-callable-inventory-2026-04-24.md` | reference / inventory snapshot | 6 | snapshot of MCP/HTTP/CLI surfaces at 2026-04-24 | evidence-only | low | F-OPUS-OBS-13 |
+| `docs/05-audit-reports/cockpit-pm-implementer-design-brief-2026-04-24.md` | reference / design brief | 6 | PM cockpit, not RTE | evidence-only | low | F-OPUS-OBS-13 |
+| `docs/05-audit-reports/cockpit-archive-intent-pack-2026-04-24.md` | reference / archive intent | 6 | not RTE | evidence-only | low | F-OPUS-OBS-13 |
+| `docs/05-audit-reports/cockpit-adhd-lifestyle-feature-map-2026-04-24.md` | reference / feature map | 6 | not RTE | evidence-only | low | F-OPUS-OBS-13 |
+| `docs/05-audit-reports/rte-state-of-work-audit-20260410.md` | reference / RTE audit history | 6 | not re-validated against current HEAD; treat as historical | evidence-only | low | — |
+| `docs/05-audit-reports/rte-live-certification-gates.md` | reference / RTE gates documentation | 6 | not re-validated against current HEAD | evidence-only | low | — |
+| `docs/05-audit-reports/rte-production-certification-audit-20260414.md` | reference / RTE production-cert audit | 6 | historical certification snapshot | evidence-only | low | — |
+| `docs/05-audit-reports/rte-prelive-audit-pack-2026-04-23.md` | reference / RTE pre-live pack | 6 | historical | evidence-only | low | — |
+| `docs/05-audit-reports/rte-canonical-entrypoint-implementation-2026-04-23.md` | reference / RTE entrypoint history | 6 | historical | evidence-only | low | — |
+| `docs/05-audit-reports/rte-gemini-deep-pal-audit-2026-04-23.md` | reference / RTE Gemini audit | 6 | historical | evidence-only | low | — |
+| `docs/05-audit-reports/rte-branch-integration-audit-2026-04-23.md` | reference / RTE branch-integration audit | 6 | historical | evidence-only | low | — |
+| `proof/` (TP-RTE-\* and rte-\* `.proof.json`) | runtime-emitted proof artifacts | 2 | proof bundles correctly self-classify against `lib/proof_contract.py` authority ranks | runtime-safe-evidence | low | F-OPUS-OBS-7 |
+| `services/repo-truth-extractor/README.md` | reference / service documentation | 5 (effectively runtime-companion since it documents canonical CLI) | self-consistent; includes the `$10 March 2026` incident anchor and the `COST_ABORTED` no-resume rule | governance-safe operator doc | low | F-OPUS-OBS-6, F-OPUS-OBS-11, F-OPUS-OBS-12 |
+| `services/repo-truth-extractor/run_extraction_v5.py` | runtime (1) | 1 | strongest authority for RTE behavior | runtime-safe | low | F-OPUS-OBS-4, F-OPUS-OBS-8, F-OPUS-HIGH-5, F-OPUS-MED-6 |
+| `services/repo-truth-extractor/output_safety.py` | runtime (1) | 1 | strongest authority for redaction | runtime-safe | low | F-OPUS-OBS-5 |
+| `services/repo-truth-extractor/rte_config.py` | runtime (1) | 1 | constants for paths, env vars, preset caps | runtime-safe | low | — |
+| `services/repo-truth-extractor/lib/proof_contract.py` | runtime (1) | 1 | authoritative authority-rank classifier for proof bundles | runtime-safe | low | F-OPUS-OBS-7 |
+| `services/repo-truth-extractor/lib/risk_dashboard.py` | runtime (1) | 1 | runtime writer for risk dashboard | runtime-safe | low | F-OPUS-OBS-2 |
+| `services/repo-truth-extractor/lib/spend_ledger.py` | runtime (1) | 1 | runtime writer for spend ledger | runtime-safe | low | F-OPUS-OBS-3 |
+| `services/repo-truth-extractor/validate_pre_live_gate_v25.py` | runtime (1) | 1 | fail-closed pre-live validator subprocess | runtime-safe | low | — |
+| `services/repo-truth-extractor/reporting.py` | runtime (1) | 1 | runtime writer for step metrics, failure index, run dashboard | runtime-safe | low | — |
+| `src/dopemux/cli.py` (RTE region 4859–5539) | runtime (1) | 1 | strongest authority for CLI surface | runtime-safe (but violates brand-voice in help text) | medium | F-OPUS-CRIT-1, F-OPUS-HIGH-1, F-OPUS-HIGH-4, F-OPUS-HIGH-6, F-OPUS-MED-2, F-OPUS-MED-4, F-OPUS-MED-6, F-OPUS-LOW-1, F-OPUS-LOW-3 |
+| `src/dopemux/commands/extractor_commands.py` | runtime (1) | 1 | legacy promptset/prescan tooling with deprecation echo | runtime-safe | low | F-OPUS-MED-3, F-OPUS-OBS-10 |
+| `task-packets/` (authored) | reference / work-instruction | 5 | per AGENTS.md §2.1, *active* Task Packets are tier-1 for the slice they cover; inactive Task Packets are tier-5 evidence | varies | medium | F-OPUS-CRIT-2 |
+| `task-packets/generated/` | generated artifacts | 6 | generated, not authored | evidence-only | medium | F-OPUS-CRIT-2 |
+| `docs/03-reference/Dopemux Cockpit TUI Design System/` (HTML/CSS spec) | design system spec | 5 | not deeply inspected; treat as design-intent only | governance-safe (visual layer) | low | — |
+| `docs/flight_deck/operator-signoff-rules.md` | governance / tactical approval | 3 | (not deeply inspected) | governance-safe | low | — |
+| `docs/governance/handoff-contract.md` | governance / PM transition authority | 3 | (not deeply inspected) | governance-safe | low | — |
+| `docs/pr_prep/operator-contract.md` | governance / PR operator rules | 3 | (not deeply inspected) | governance-safe | low | — |
+| `docs/pr_prep/high-risk-handoff-rules.md` | governance / risk escalation | 3 | (not deeply inspected) | governance-safe | low | — |
+| `docs/rollout/operator-onboarding.md` | operator doc | 5 | (not deeply inspected) | governance-safe | low | — |
+| `docs/arbitration/operator-supervision-guide.md` | operator doc | 5 | (not deeply inspected) | governance-safe | low | — |
+| `docs/arbitration/operator-review-checklist.md` | operator doc | 5 | (not deeply inspected) | governance-safe | low | — |
+
+---
+
+## Drift summary by class
+
+**Authority-tier conflicts (high-risk):**
+- Truth-order conflict across `AGENTS.md`, `README.md`, `brand-voice-guidelines.md` §9, and this audit packet. (`F-OPUS-CRIT-2`)
+- `dopemux upgrades` named as operator path in `ARCHITECTURE.md` despite README.md deprecating it. (`F-OPUS-MED-1`)
+- `docs/ux/ux-style-guide.md` self-demotes but body prescribes incompatible palette. (`F-OPUS-HIGH-2`)
+
+**RTE-specific guidance gaps (high-risk for agents):**
+- Zero RTE consent/spend/redaction guidance in any `.claude/CLAUDE.md` variant. (`F-OPUS-CRIT-3`)
+- `services/.claude/CLAUDE.md` Key Services table omits RTE. (`F-OPUS-MED-5`)
+- No cockpit audit report scopes RTE specifically. (`F-OPUS-OBS-13`)
+
+**Stub or empty content (medium-risk):**
+- `docs/ux/terminal-rendering-guide.md` is frontmatter-only. (`F-OPUS-HIGH-3`)
+
+**Positive observations (do not change):**
+- `lib/proof_contract.py` carries the authority-rank model into the proof bundle itself. (`F-OPUS-OBS-7`)
+- `risk_dashboard.py` self-tags `READY_FOR_LIMITED_DRY_STATIC_USE` honestly. (`F-OPUS-OBS-2`)
+- `spend_ledger.py` is honest about pricing fallback. (`F-OPUS-OBS-3`)
+- `output_safety.py` redaction patterns are comprehensive. (`F-OPUS-OBS-5`)
+- `services/repo-truth-extractor/README.md` "$10 March 2026" incident anchor is exemplary. (`F-OPUS-OBS-6`)
+- Comparison lane never overwrites canonical outputs. (`F-OPUS-OBS-12`)
+
+---
+
+## What this means for Claude/agents
+
+For an LLM agent (Claude, Codex, or otherwise) being asked to *work on* RTE:
+
+1. **Runtime authority wins.** `services/repo-truth-extractor/run_extraction_v5.py` and adjacent runtime files are tier 1. Anything else is evidence, not law.
+2. **No `.claude/CLAUDE.md` variant teaches RTE invariants.** Agents must read AGENTS.md §6 (line 81 — "Repo Truth Extractor audits and extracts repo truth only; its outputs are evidence artifacts, not runtime truth") and the runtime consent gates in `run_extraction_v5.py:2880-3076` directly.
+3. **Three different truth orders exist.** Until reconciled (F-OPUS-CRIT-2), agents should prefer the order most specific to their task: brand work → `brand-voice-guidelines.md` §9; PM/architecture work → `AGENTS.md` §2; operator-doc work → `README.md` §5.
+4. **Cockpit audit reports are evidence packets, not specifications.** All six 2026-04-24 cockpit reports cover PM cockpit, not RTE. Their "do not implement from this packet" caveat is prose at the head of each file, not a structured frontmatter flag.
+5. **Generated `.proof.json` artifacts never outrank runtime.** This is operationalised in `lib/proof_contract.py:119-127` as `_AUTHORITY_RANK`. Agents using proof bundles as evidence should preserve the `authority_boundary` field unchanged.
+
+End of CLAUDE_DESIGN_COMPATIBILITY.md.

--- a/docs/audit/rte-opus-uiux-claude-design-audit/findings-ledger.md
+++ b/docs/audit/rte-opus-uiux-claude-design-audit/findings-ledger.md
@@ -1,0 +1,309 @@
+---
+id: FINDINGS_LEDGER
+title: Findings Ledger
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-17'
+last_review: '2026-05-17'
+next_review: '2026-08-15'
+prelude: Findings Ledger (explanation) for dopemux documentation and developer workflows.
+---
+# FINDINGS_LEDGER.md — RTE-OPUS-UIUX-CLAUDE-DESIGN-AUDIT-001
+
+**Audit run.** Repo HEAD: `a234f798947d51915b2adea3e0bc5a2917ac595b` (branch `claude/youthful-neumann-b94cc0`, worktree of `dopemux-mvp`).
+**Date:** 2026-05-16. **Mode:** fresh independent pass. **Authority order:** runtime > runtime artifact writers > AGENTS.md > TRUTH_*/SYSTEM_* > docs > generated. Labels: `OBSERVED` / `INFERRED` / `UNKNOWN` / `CONFLICTING` / `CLAIMED` / `RECOMMENDED`.
+
+Severity scheme: `CRIT` blocking, `HIGH` high-priority, `MED` medium, `LOW` low, `OBS` observation. Finding IDs are independent of P0–P5 (`F-OPUS-{SEV}-{N}`).
+
+---
+
+## CRIT — Blocking, must address before recommending RTE for unattended operator use
+
+### F-OPUS-CRIT-1 — CLI surface broadly violates brand-voice §2A "no hype, no mascot, no visionary framing"
+
+- **Label:** `OBSERVED`.
+- **Authority tier:** runtime + governance. `src/dopemux/cli.py` is runtime; `brand-voice-guidelines.md` is documented in §6 as lint-enforced via `scripts/brand_lint.py` and `VOICE_GATES.yaml` → `voice.validate_output()` (`brand-voice-guidelines.md:332-341`).
+- **Evidence:**
+  - `src/dopemux/cli.py:5075` — `"""🚀 Ignite Pipeline: Run the Repo Truth Extractor (resumable) // Engages the high-fidelity extraction engines to process the codebase according to the active ritual promptset and routing policies."""`
+  - `src/dopemux/cli.py:5186` — `"""🏥 Extraction Apothecary: Run diagnostics and deterministic re-process planning // Performs a high-fidelity audit of an extraction session, identifying structural hazards and proposing a deterministic re-synchronization plan for failed partitions."""`
+  - `src/dopemux/cli.py:5219` — `"""📊 Ritual Status: Show status of an extraction run // Retrieves current cockpit telemetry for a specific extraction session..."""`
+  - `src/dopemux/cli.py:5253` — `"""🛫 Pre-Ignition Check: Run pre-flight diagnostics for an extraction run // Executes a comprehensive sensor audit before starting an extraction ritual..."""`
+  - `src/dopemux/cli.py:5418` — `"""⚖️ Ritual Integrity: Audit promptset contract compliance // Performs a deep-tissue audit of the promptset to ensure compliance with ritual contracts..."""`
+  - `src/dopemux/cli.py:4938` — `"""📋 Catalog Phases: List ritual phases and effective pipeline order..."""`
+  - Brand-voice gate: `brand-voice-guidelines.md:55-62` — *"Operator-first … Terse, procedural … Calm, specific, unsentimental. **No hype, no mascot, no visionary framing.** Receipts over vibes …"* with explicit ❌ examples including `❌ "Your workflow is now supercharged."` (analogue of *"Engages the high-fidelity extraction engines"*).
+  - `brand-voice-guidelines.md:347` — *"As of 2026-04-22 the branch passes with 0 errors, 0 warnings. Don't regress."* `brand_lint.py` is the runtime gate but the Click docstrings/help text appear to fall outside the audited file set listed at `brand-voice-guidelines.md:350-352` (`STRICT_LOG_FILES`, `STRICT_HTTPException` files, etc.).
+- **Why it matters:** The brand-voice spec is the production tone authority for operator-facing surfaces (`brand-voice-guidelines.md:53`). Every operator running `dopemux rte run --help` sees the prose "Engages the high-fidelity extraction engines to process the codebase according to the active ritual promptset and routing policies" — exactly the *visionary framing* §2A bans. For a system whose core safety guarantee is *terse, evidence-backed, "label `unknown` rather than invent" CLI output*, the help-text surface materially undercuts the bar the runtime sets for itself. Operators (especially new ones) are taught to expect hype where the brand-voice contract promises terse procedure.
+- **Recommendation (separated in RECOMMENDATIONS.md):** see `R-OPUS-1`.
+
+### F-OPUS-CRIT-2 — Truth-order documents disagree on what wins
+
+- **Label:** `CONFLICTING`.
+- **Authority tier:** governance vs governance vs governance.
+- **Evidence:**
+  - `AGENTS.md:9-19` lists truth order as: 1) Active Task Packet, 2) Runtime code/config/tests, 3) `TRUTH_*.md`, 4) `RULES.md`/`PROJECT.md`/`ARCHITECTURE.md`/`SYSTEM_BOUNDARIES.md`/`PM_PLANE.md`/`SERVICE_CATALOG.md`/`SYSTEM_*.md`, 5) historical/generated.
+  - `README.md:64-72` lists truth order as: 1) Runtime code/config/tests, 2) `TRUTH_*.md`, 3) `ARCHITECTURE.md`/`PM_PLANE.md`/`SYSTEM_BOUNDARIES.md`/`PROJECT.md`/`BRAND_SYSTEM.md`, 4) `SYSTEM_*.md` and `SERVICE_CATALOG.md` under `docs/03-reference/`. **No mention of Task Packets.**
+  - `brand-voice-guidelines.md:372-381` ("Decision Ladder") lists a *third* order specifically for voice: 1) Runtime code, 2) `cli-ux-design-spec.md`, 3) `BRAND_SYSTEM.md`, 4) `BRAND_VOICE_BIBLE.md` + `VOICE_GATES.yaml`, 5) `brand-resource-pack.md`, 6) `brand-compliance-checklist.md`, 7) `dopemux-brand-system.md`.
+  - This audit's task packet introduces a *fourth* ordering: runtime > RTE proof/status writers > AGENTS.md > `TRUTH_*`/`SYSTEM_*` > RTE docs/Claude guidance > historical.
+- **Why it matters:** Operators and agents reading any one of these files form different mental models of which document wins when claims diverge. A Claude agent applied to fix a brand drift between `cli.py` and `BRAND_SYSTEM.md` will resolve it differently depending on whether it loaded AGENTS.md (Task Packet first) or `brand-voice-guidelines.md` §9 (Runtime > cli-ux-design-spec > BRAND_SYSTEM). The audit packet's authority order is *yet another* answer, never reconciled. This is the single largest source of governance drift risk for RTE work.
+- **Recommendation:** `R-OPUS-2`.
+
+### F-OPUS-CRIT-3 — No Claude/agent-facing file teaches Claude how to operate RTE safely
+
+- **Label:** `OBSERVED`.
+- **Authority tier:** Claude guidance (governance-adjacent).
+- **Evidence:**
+  - `.claude/CLAUDE.md` (root, lowercase `.claude/claude.md`): 7,658 bytes of guidance covering Dopemux platform philosophy, ConPort, SuperClaude, Serena, ADHD principles. Zero mentions of `DPMX_LIVE_OK`, `--execute`, RTE consent gates, `dopemux rte` commands, spend caps, redaction obligations, or any RTE-specific operating constraint.
+  - `services/.claude/CLAUDE.md`: 2,033 bytes of "Services Development Context." Key Services table at lines 38-44 lists `conport`, `dopecon-bridge`, `task-orchestrator`, `adhd-engine` — **omits `repo-truth-extractor`** despite RTE being a top-level service with the largest provider-billing risk surface in the repo.
+  - `src/.claude/CLAUDE.md`: covers Pydantic/FastAPI conventions, `dopemux.cli:main`, mentions `extractor_commands.py` exports `_run_extractor_runner` — but nothing about how Claude should reason about adding/changing CLI surfaces that affect RTE consent or spend.
+  - `CLAUDE_AUTOMATION_INSTRUCTIONS.md` is an extraction-prompt-rewrite harness, not RTE operator guidance.
+  - `AGENTS.md:81` does scope RTE: *"Repo Truth Extractor audits and extracts repo truth only; its outputs are evidence artifacts, not runtime truth."* This is correct authority-bounding for RTE outputs, but it doesn't teach Claude how to drive RTE day-to-day.
+- **Why it matters:** Per `AGENTS.md` and `brand-voice-guidelines.md`, Claude/Codex agents are expected to perform repo-changing work end-to-end. RTE is the one subsystem where a wrong agent action ($10 accidental live run per `services/repo-truth-extractor/README.md:262-264`) has real-money consequences. Yet the four Claude-targeted files describing how Claude should work in this repo never mention RTE consent gates or the operator-safety contract. A Claude agent following the existing `.claude/CLAUDE.md` and `services/.claude/CLAUDE.md` has *no in-context preparation* for RTE's safety invariants. The safety lives in code (which agents do read) — but the Claude guidance surface treats RTE as if it were a generic service, which it is not.
+- **Recommendation:** `R-OPUS-3`.
+
+---
+
+## HIGH — Strongly recommended fixes; not strictly blocking but materially degrade operator UX
+
+### F-OPUS-HIGH-1 — CLI emoji use exceeds the 6-emoji whitelist by ~4×
+
+- **Label:** `OBSERVED`.
+- **Evidence:**
+  - Whitelist: `brand-voice-guidelines.md:268-270` and `docs/04-explanation/branding/cli-ux-design-spec.md:153-156` — exactly six approved emojis: `💊 🧪 🧠 ⚡ 💧 🔬`. Spec says "all other emoji should migrate to nerd font glyphs."
+  - Actual usage in `src/dopemux/cli.py` for `dopemux rte` and adjacent surfaces (sample, not exhaustive): 📊 (4874, 4938, 5210, 5223), 🆔 (4876, 5169, 5209, 5236), 🧠 (4877, 4994, 5478 — *on whitelist*), 📦 (4878), ⚡ (4879, 5022, 5034, 5467 — *on whitelist*), 🔬 (4880, 5173 — *on whitelist*), 📂 (4881), ⏪ (4882), 🚀 (5075, 5556), 🏥 (5186), 🛫 (5253), ⚖️ (5418), 🌊 (5469), 🔧 (5170), 🧪 (4938 — *on whitelist*), 💸 (5034), 📋 (4938), ⏩ (5030), 📥 (5031), 📡 (5032), 🛡️ (5033), 🔄 (5028), 👁️ (5491), 💰 (5087 in extractor_commands.py), 🎭 (5546), 🗺️ (extractor_commands.py:155), 🔥 (extractor_commands.py:163).
+  - Net: at least 18 emojis outside the whitelist, in operator-visible Click help text and command docstrings.
+- **Why it matters:** ADHD-oriented spec rule from `cli-ux-design-spec.md:28` *("max 5 simultaneous colors per screen, glanceable status, consistent icon-chip-message flow")* is undermined by 23+ emoji idioms competing for visual attention. The same spec mandates "consistent icon-chip-message flow" — that is the *opposite* of decorating every flag with a unique theatrical emoji.
+- **Recommendation:** `R-OPUS-4`.
+
+### F-OPUS-HIGH-2 — Two UX style documents describe incompatible visual languages
+
+- **Label:** `CONFLICTING`.
+- **Evidence:**
+  - `docs/ux/ux-style-guide.md:22-29` — "Spaceage Operationalism": status chips `[READY]` (Green) / `[BLOCKED]` (Red) / `[DEFERRED]` (Yellow) / `[SUPERVISED]` (Blue).
+  - `docs/04-explanation/branding/cli-ux-design-spec.md:75-83, 161-164` — "Neon Mint": Success=`serum.mint #94FADB`, Error=`gremlin.pink #FF8BD1`, Warning=`gilt.edge #F5F26D`, Info=`ritual.cyan #7DFBF6`, Debug=`aftercare.violet #9B78FF`. Status chips: `[LIVE]` cyan, `[BLOCKER]` pink, `[OVERRIDE]` gold, `[LOGGED]` mint, `[AFTERCARE]` violet, `[EDGE]` cyan.
+  - `docs/ux/ux-style-guide.md:14-15` self-demotes: *"This copy is retained for compatibility, but the production authority is `../04-explanation/branding/cli-ux-design-spec.md`. If this file drifts from the CLI UX spec or runtime voice gates, treat this file as non-authoritative."*
+- **Why it matters:** Even with the self-demotion note, two materially different visual languages co-exist under `docs/ux/`. A contributor or Claude agent who lands in `docs/ux/ux-style-guide.md` first reads "[READY] Green / [BLOCKED] Red" — entirely incompatible with the runtime `[LIVE] [BLOCKER] [OVERRIDE] [LOGGED] [AFTERCARE] [EDGE]` chip set and the mint/pink/violet semantics. The self-demotion line is one sentence; the *body* of the file (16 substantive lines) continues prescribing the deprecated palette in declarative imperative tone ("Use bracketed badges for primary states"). Self-demotion does not erase the prescription operators read.
+- **Recommendation:** `R-OPUS-5`.
+
+### F-OPUS-HIGH-3 — `docs/ux/terminal-rendering-guide.md` is an empty stub
+
+- **Label:** `OBSERVED`.
+- **Evidence:** File is 13 lines of which 12 are YAML frontmatter; line 13 closes the frontmatter and the body is empty. Total bytes: 296. (`docs/ux/terminal-rendering-guide.md:1-13`).
+- **Why it matters:** `brand-voice-guidelines.md:318-319` references "Render modes (via `DOPEMUX_RENDER_MODE` or `NO_COLOR`)" and `cli-ux-design-spec.md:196-207` documents `RICH` / `PLAIN` / `COMPACT` / `AUDIT` modes. Operators looking for the file titled "Terminal Rendering Guide" find nothing actionable. The file is also indexed via `next_review: '2026-06-15'` — the documentation system regards it as live.
+- **Recommendation:** `R-OPUS-6`.
+
+### F-OPUS-HIGH-4 — `dopemux rte promptset audit` is v4-only despite v5 being canonical
+
+- **Label:** `OBSERVED`.
+- **Evidence:**
+  - `src/dopemux/cli.py:5430-5437`: only v4 path implemented; any other version raises `click.ClickException("Promptset audit is implemented for v4 only.")`.
+  - `README.md:33, 60` and `AGENTS.md:81` and `services/repo-truth-extractor/README.md:18, 100-103` all name v5 as the canonical engine.
+  - `rte_promptset_group.add_command(extractor_promptset_audit, "audit")` wires this exception path into the canonical `dopemux rte promptset audit` (`cli.py:5534`).
+- **Why it matters:** Operators reading the canonical guide and running `dopemux rte promptset audit` on a v5 promptset get a ClickException with no v5 workaround offered. The audit command is one of the small set of safe pre-flight read-only commands operators *should* run before live execution. Telling them the canonical command refuses on the canonical engine creates exactly the operator confusion the rest of the system tries to prevent.
+- **Recommendation:** `R-OPUS-7`.
+
+### F-OPUS-HIGH-5 — Pre-live validator NO_GO raises `RuntimeError(...)` with concatenated string, not `error_panel(problem, why, fix)`
+
+- **Label:** `OBSERVED`.
+- **Evidence:**
+  - `services/repo-truth-extractor/run_extraction_v5.py:3067-3070` — `raise RuntimeError("Pre-live validator blocked live execution: " f"verdict={verdict} reason_codes={detail} output_dir={output_dir}.{stderr_suffix}")`.
+  - Brand-voice contract `brand-voice-guidelines.md:295-300`: *"Error messages MUST: 1. Use `error_panel(problem, why, fix)` or wrap in `styled_panel(border_style="error")`. 2. Use 3-part Problem / Why / Fix structure. 3. Include an actionable step. 4. Use `[BLOCKER]` chip."*
+- **Why it matters:** This is the single most consequential error path in RTE — when the pre-live validator blocks a live run, the operator needs to know (a) what failed, (b) why it failed, (c) what to do next. The current path concatenates reason codes and a path into one line, no separation of problem/why/fix, no `[BLOCKER]` chip, no actionable next step beyond reading `output_dir`. The brand-voice rule is explicit that this is a violation.
+- **Recommendation:** `R-OPUS-8`.
+
+### F-OPUS-HIGH-6 — `dopemux rte run --help` has 30+ options with no progressive disclosure
+
+- **Label:** `OBSERVED`.
+- **Evidence:**
+  - `src/dopemux/cli.py:4968-5163` — `extractor_run` declares ~33 Click options on one command.
+  - Spec: `cli-ux-design-spec.md:182-183` — *"Progressive disclosure: Level 1 (default summary), Level 2 (`--verbose`), Level 3 (`--debug`)."*
+  - Spec: `cli-ux-design-spec.md:25` — *"3-second scan rule: any CLI output must be scannable in 3 seconds."*
+- **Why it matters:** The flagship operator command shows everything at once. Operators trying to figure out which knob does what scroll through 33 options. This is functionally the opposite of progressive disclosure and breaks the 3-second scan rule the spec mandates.
+- **Recommendation:** `R-OPUS-9`.
+
+---
+
+## MED — Notable; fix when convenient
+
+### F-OPUS-MED-1 — `ARCHITECTURE.md §5.5` still presents `dopemux upgrades` as the operator path
+
+- **Label:** `OBSERVED`.
+- **Evidence:** `ARCHITECTURE.md:150` — *"operator invocation comes through `dopemux upgrades ...` or direct runner execution"*. README.md:60-62 deprecates `dopemux upgrades` ("do not use it as the canonical RTE path in new operator guidance").
+- **Why it matters:** ARCHITECTURE.md is a tier-4 governance doc per AGENTS.md §2. Stale operator command names in architectural prose teach the wrong canonical path to Claude agents and human contributors.
+- **Recommendation:** `R-OPUS-10`.
+
+### F-OPUS-MED-2 — Canonical RTE commands are defined as `@upgrades.command(...)` and aliased into `rte`
+
+- **Label:** `OBSERVED`.
+- **Evidence:**
+  - `src/dopemux/cli.py:4934, 4968, 5167, 5207, 5234, 5277, 5401, 5440` — every primary RTE command is decorated `@upgrades.command(...)` (or `@upgrades.group(...)`).
+  - `src/dopemux/cli.py:5509-5538` — these are then aliased into the `rte` group via `rte.add_command(...)`.
+- **Why it matters:** README.md says `dopemux rte` is canonical and `dopemux upgrades` is legacy. The runtime keeps the upgrades surface as the *identity* of these commands and the rte surface as the alias. This works (both invocation paths produce the same behavior) but conveys the opposite hierarchy — the canonical name is grafted on top of the legacy name. A future refactor that removes `upgrades` will need to migrate identity, not just aliasing.
+- **Recommendation:** `R-OPUS-11`.
+
+### F-OPUS-MED-3 — `dopemux extractor status` is a dual-mode surface with no operator hint
+
+- **Label:** `OBSERVED`.
+- **Evidence:** `src/dopemux/commands/extractor_commands.py:299-345` — without flags it reads a `SYNC_MANIFEST.json` from a promptset directory; with `--pipeline-version` / `--run-id` / `--json` it raises `ClickException("Legacy runtime status disabled. Use 'dopemux rte status' instead.")`.
+- **Why it matters:** One command, two completely different jobs, gated by flag presence. Operators using `dopemux extractor status --run-id X` get a deprecation; operators using bare `dopemux extractor status` get a real (but legacy) report. The docstring at line 329-336 partially explains this, but the dual-mode behavior is unusual and surprise-prone.
+- **Recommendation:** `R-OPUS-12`.
+
+### F-OPUS-MED-4 — `dopemux rte wizard` is registered but undocumented
+
+- **Label:** `OBSERVED`.
+- **Evidence:** `src/dopemux/cli.py:5516` — `rte.add_command(audit.commands["wizard"], "wizard")`. The `wizard` is sourced from a different Click group (`audit`). Neither `README.md:54-62` nor `services/repo-truth-extractor/README.md` documents `dopemux rte wizard`.
+- **Why it matters:** Operators running `dopemux rte --help` will see `wizard` as a top-level RTE subcommand with no idea what it does. Discoverable but undocumented surfaces invite operators to invoke unfamiliar commands.
+- **Recommendation:** `R-OPUS-13`.
+
+### F-OPUS-MED-5 — `services/.claude/CLAUDE.md` Key Services table omits `repo-truth-extractor`
+
+- **Label:** `OBSERVED`.
+- **Evidence:** `services/.claude/CLAUDE.md` lines 38-44 list `conport / dopecon-bridge / task-orchestrator / adhd-engine`. The bottom-of-file ASCII service tree (line 63-70 area) also omits `repo-truth-extractor` despite it being the highest-risk service.
+- **Why it matters:** Same root cause as `F-OPUS-CRIT-3`: Claude-targeted documentation systematically under-represents RTE. Adding a row here is small but addresses the structural omission.
+- **Recommendation:** `R-OPUS-14`.
+
+### F-OPUS-MED-6 — No `--help` text or epilog tells operators about `DPMX_LIVE_OK=1`
+
+- **Label:** `OBSERVED`.
+- **Evidence:**
+  - `src/dopemux/cli.py:4968-5163` (`extractor_run`) — the canonical live-execution command has no Click epilog and no help-text reference to `DPMX_LIVE_OK`.
+  - The env var is documented in `services/repo-truth-extractor/README.md:145` and inside the consent-gate error message in `run_extraction_v5.py:3016-3019` (only after the operator has *tried* to run live and been refused).
+- **Why it matters:** `DPMX_LIVE_OK=1` is the single most important environment variable for safe RTE operation. Operators discover its existence only by reading the README or by being refused by the consent gate. The Click help surface — the canonical operator self-service path — is silent.
+- **Recommendation:** `R-OPUS-15`.
+
+### F-OPUS-MED-7 — Cockpit audit reports' "do not implement" caveat is prose, not a structured flag
+
+- **Label:** `OBSERVED`.
+- **Evidence:**
+  - `docs/05-audit-reports/cockpit-pm-implementer-processing-pack-2026-04-24.md:17` — *"verdict: Proceed to GPT-5.5 Pro synthesis and Claude Design only as an evidence pack. Do not implement UI/runtime/service changes from this packet."*
+  - Searching the entire repo for `READY_FOR_CLAUDE_DESIGN` or `safe_for_claude_design` returns **zero matches** (`rg` repo-wide). No structured machine-readable flag exists.
+- **Why it matters:** A Claude agent looking up the cockpit packet for design guidance can read the verdict line and respect it — but only if it reads the body. A structured frontmatter field such as `claude_implementation_authority: none` / `claude_design_evidence_only: true` would make the constraint machine-checkable. The prose form is honest but parsing-fragile.
+- **Note on Phase 1 audit-survey hygiene:** the audit's own Phase 1 exploration *fabricated* references to `READY_FOR_CLAUDE_DESIGN: not approved` and `safe_for_claude_design: NO`. Those exact strings do not exist in any file. The genuine caveat is prose-only. Recorded under `F-OPUS-OBS-1` so the audit chain is not poisoned downstream.
+- **Recommendation:** `R-OPUS-16`.
+
+---
+
+## LOW — Minor; do when touching adjacent code
+
+### F-OPUS-LOW-1 — `validate-live` stage caps shown without explicit `USD` unit in `--help`
+
+- **Label:** `OBSERVED`.
+- **Evidence:** `src/dopemux/cli.py:5317, 5321, 5326, 5328` — `--provider-probe-max-usd`, `--batch-pilot-max-usd`, `--phase-slice-max-usd`, `--full-max-usd` show default floats (`0.10`, `1.0`, `5.0`, `75.0`) in `--help` with no `USD` annotation in the description. Operators must infer dollars from the flag name.
+- **Why it matters:** A flag named `--provider-probe-max-usd` is reasonably self-describing, but the help text for budget controls should be unambiguous about units. Compounded by `--provider-probe-max-minutes` (also numeric), a tired operator could misread.
+- **Recommendation:** `R-OPUS-17`.
+
+### F-OPUS-LOW-2 — Brand-voice required closer (`NEXT:` / `Receipt:` / `PROGRESS`) compliance in RTE error/status output is unverified by static reading
+
+- **Label:** `UNKNOWN`.
+- **Evidence:** `brand-voice-guidelines.md:181-183` (§3.5) requires every agent/CLI output to end with `NEXT:`, `Next:`, `Receipt:`, or `PROGRESS`. Static grep across `services/repo-truth-extractor/run_extraction_v5.py` for these tokens shows them present in some emitters but not consistently in error paths like `enforce_live_operation_consent` (cli.py:5495-5500's deprecated `truth` command does end with three example commands, which is a functional `NEXT:` equivalent; `parser.error(...)` at run_extraction_v5.py:3015-3019 does not).
+- **Why it matters:** Per the brand-voice contract this is lint-checkable but the audit's read-only inspection cannot fully exercise the runtime emitters to verify.
+- **Recommendation:** `R-OPUS-18`.
+
+### F-OPUS-LOW-3 — `cli.py` truth-command deprecation message points operators to commands but doesn't show `DPMX_LIVE_OK=1` env var
+
+- **Label:** `OBSERVED`.
+- **Evidence:** `src/dopemux/cli.py:5495-5500` — `dopemux truth` deprecation message points to `dopemux rte run --pipeline-version v5 --phase ALL --dry-run`, which is correctly dry-run-defaulted. But it doesn't carry forward the `DPMX_LIVE_OK=1` requirement that an operator stepping up to `--execute` will hit.
+- **Why it matters:** The transition message is correct for the dry-run case but under-prepares the operator for the live case. Adjacent to `F-OPUS-MED-6`.
+- **Recommendation:** `R-OPUS-19`.
+
+---
+
+## OBS — Observations worth recording (not all are issues; several are positive)
+
+### F-OPUS-OBS-1 — Phase 1 audit-survey produced fabricated string references
+
+- **Label:** `OBSERVED` (about the audit process itself).
+- **Evidence:** Phase 1 Explore agent reported `READY_FOR_CLAUDE_DESIGN: not approved` and `safe_for_claude_design: NO` flags in cockpit audit reports. Repo-wide `rg` for these literal strings returns zero matches at HEAD `a234f7989`. The actual caveat is prose at `cockpit-pm-implementer-processing-pack-2026-04-24.md:17`.
+- **Why it matters:** A finding that doesn't exist in source is worse than a missed finding. Recording this here protects downstream consumers of the audit from inheriting the fabrication.
+- **Authority impact:** none — the audit's actual claims are grounded in the prose verdict. But the lesson is: cross-check Explore/Plan agent reports against `rg`/`grep` before promoting their claims into findings.
+
+### F-OPUS-OBS-2 — Risk dashboard self-tags honestly with hard-coded static labels
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:** `services/repo-truth-extractor/lib/risk_dashboard.py:446-460` — `live_use_readiness: "READY_FOR_LIMITED_DRY_STATIC_USE"`, `static_audit_verdict: "PASS_WITH_RISK"`, `overall_risk_level: "MEDIUM-HIGH"` are hard-coded with an in-file comment explaining the choice: *"These three labels are intentionally static, human-curated assessments of the codebase's proof state, not derived from runtime blockers."*
+- **Why it matters:** This is exactly the operator honesty the audit framework wants. The dashboard doesn't pretend to compute live-use readiness from runtime state; it honestly says "this is a static proof, not a production-readiness signal."
+
+### F-OPUS-OBS-3 — Spend ledger is honest about pricing fallback
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:** `services/repo-truth-extractor/lib/spend_ledger.py:11-16` — *"Repo-local pricing authority is incomplete in this checkout. Keep the registry explicit and deterministic, and make the fallback policy visible in the ledger instead of inventing provider-billing truth."* Unknown-model events use `_fallback_cost_rate()` which is the max-of-known input/output rate (line 245-258) — conservative.
+- **Why it matters:** Operators see `pricing_status: UNPRICED_UNKNOWN`, `pricing_confidence: UNKNOWN`, `unknown_model: true`, and `unknown_model_events` counters. They are not lied to about cost. This is the model the rest of the operator UX should hold itself to.
+
+### F-OPUS-OBS-4 — Consent gates are belt-and-suspenders
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:**
+  - `src/dopemux/cli.py:4909-4915` — `rte scan` requires `--allow-legacy-v3-scan`.
+  - Defense-in-depth comment at `cli.py:4916-4918` says `run_repscan.py` independently requires the same flag.
+  - `run_extraction_v5.py:2992-3020` — `enforce_live_operation_consent` requires BOTH `--execute` AND `DPMX_LIVE_OK=1` for any live-capable op (provider preflight, auth doctor, doctor, gemini model list, batch watch/retrieve, async submit, online prescan, sync phase execution).
+  - `run_extraction_v5.py:3023-3076` — `enforce_pre_live_validator_for_execution` runs the v25 validator subprocess and raises on `NO_GO`, returning `SKIPPED_NO_CONSENT` when env var unset.
+- **Why it matters:** The runtime fail-closed posture for live execution is rigorous. Click guard + argparse classification + env-var requirement + validator subprocess — four independent layers. This is the right shape for $-cost surfaces.
+
+### F-OPUS-OBS-5 — Output safety redaction is comprehensive and defense-in-depth
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:** `services/repo-truth-extractor/output_safety.py:7-37, 85-130` — patterns cover OAuth bearers, AWS access keys, JWT tokens, Google API keys, GitHub PATs (`gh[pousr]_*`), GitLab PATs (`glpat-*`), generic API-key assignments via regex, `Authorization` / `x-goog-api-key` headers, `-----BEGIN ... PRIVATE KEY-----` blocks. `sanitize_text_for_provider_payload` adds extra long-token candidate redaction (`_LONG_TOKEN_CANDIDATE_RE`, line 35-37) — defense in depth before provider POST. `_SAFE_SENSITIVE_KEYS` allowlist (line 40-63) curates env-name fields that should *not* be redacted.
+- **Why it matters:** This is one of the strongest redaction surfaces in the repo. The allowlist for `*_env`/`*_env_name`/`*_present` fields prevents over-redaction of audit metadata while still catching real secrets.
+
+### F-OPUS-OBS-6 — README cost-incident anchor is exemplary operator UX
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:** `services/repo-truth-extractor/README.md:262-264` — *"⚠️ Cost warning: Each run invokes provider APIs and may incur significant charges. A single accidental run cost $10 in March 2026. Never run without explicit authorization."*
+- **Why it matters:** Operator UX for risky systems is dramatically improved by *concrete* prior-incident anchors. "$10 in March 2026" is short, specific, and unforgettable — far more effective than generic "may be expensive" warnings. The pattern is worth propagating to the consent-gate error messages.
+
+### F-OPUS-OBS-7 — `lib/proof_contract.py` enforces a tight authority-rank model
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:** `services/repo-truth-extractor/lib/proof_contract.py:119-127` — explicit `_AUTHORITY_RANK`: `runtime_authority=100`, `proof_governance_artifact=60`, `runtime_generated_evidence=50`, `generated_audit_context=40`, `external_advisory_context=30`, `sample_artifact_uncertain_lineage=20`, `unknown=0`. The classifier (`classify_artifact`, line 286-358) hard-codes `services/repo-truth-extractor/run_extraction_v5.py` as `runtime_authority` and `out/rte-pkt-*` / `proof/TP-RTE-*` as `proof_governance_artifact`.
+- **Why it matters:** The authority hierarchy required by AGENTS.md §2 and re-asserted by the audit packet is *operationalised in code* — proof bundles emit `authority_boundary: "runtime source authority outranks generated proof evidence"` (line 354) as a literal string field. Generated artifacts cannot be confused for runtime truth because the bundle itself carries the rank.
+
+### F-OPUS-OBS-8 — `is_read_only_introspection_mode` cleanly enumerates safe introspection paths
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:** `services/repo-truth-extractor/run_extraction_v5.py:2880-2895` — explicit list of 11 read-only flags (`coverage_report`, `status`, `status_json`, `tail_run_log`, `show_provider_usage`, `print_config`, `print_run_order`, `print_phase_routing`, `print_phase_prompts`, `print_promptpack`, `promptgen_scan`, `verify_phase_output`). This classification is reused by `should_enforce_pre_live_validator` (line 2849-2870) to correctly skip validator overhead on read-only paths.
+- **Why it matters:** The clean separation between read-only and dispatching modes is the right shape for an operator CLI with safety-critical execution paths. The same flags appear in both helpers, ensuring consistency.
+
+### F-OPUS-OBS-9 — `dopemux truth` deprecation message redirects to the canonical surface and dry-runs
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:** `src/dopemux/cli.py:5495-5500` — `truth_command` raises `ClickException` with explicit three-line guidance: `dopemux rte run --pipeline-version v5 --phase ALL --dry-run` / `dopemux rte preflight ...` / `dopemux rte validate-live ...`. All three redirect targets are dry-run / read-only.
+- **Why it matters:** A deprecated surface that points operators to the right *safer* path is doing its job well. Worth propagating the pattern.
+
+### F-OPUS-OBS-10 — `extractor` group invocation prints a one-line redirect echo
+
+- **Label:** `OBSERVED` (mixed).
+- **Evidence:** `src/dopemux/commands/extractor_commands.py:38-43` — when any `dopemux extractor <subcommand>` is invoked, a Click callback echoes *"`dopemux extractor` is legacy promptset tooling. Use `dopemux rte run` for canonical v5 execution."* *before* running the subcommand.
+- **Why it matters:** Helpful reminder, but the echo runs *every time* the legacy group is used (including for `init` and `validate` which are still operational). The redirect chatter can become noise for operators who use those still-supported legacy commands frequently.
+
+### F-OPUS-OBS-11 — RTE README's `first-live` preset codifies conservative defaults
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:** `services/repo-truth-extractor/README.md:147-169` — `--preset first-live` defaults `--routing-policy cost`, `--max-cost-usd 5.0`, `--partition-workers 1`, `--no-batch`, `--batch-wait-timeout-seconds 1800`. Live preset execution runs the validator first unless `--skip-pre-live-validator` is set.
+- **Why it matters:** This is the right shape for staged go-live: an operator-friendly preset name (`first-live`) bundles the conservative-default set in one flag. It pairs well with the README's $10-incident anchor (F-OPUS-OBS-6).
+
+### F-OPUS-OBS-12 — Comparison lane is explicitly non-blocking and uses separate output trees
+
+- **Label:** `OBSERVED` (positive).
+- **Evidence:** `services/repo-truth-extractor/README.md:304-385` — comparison-lane outputs are written to `raw/comparison/...` and never overwrite canonical files; comparison failures do not abort the canonical run. Resume behavior is independent.
+- **Why it matters:** A feature that *adds* dual-model evidence without weakening canonical output safety. The operator UX is clean: canonical run results are unchanged by the presence of comparison runs.
+
+### F-OPUS-OBS-13 — Six cockpit audit reports exist but none are RTE-specific
+
+- **Label:** `OBSERVED`.
+- **Evidence:** `docs/05-audit-reports/cockpit-*.md` are six files covering PM/Implementer cockpit, callable inventory, design brief, processing pack, archive intent, and ADHD lifestyle feature map — all dated 2026-04-24. They focus on the *PM* cockpit, not RTE. RTE-specific audit reports live separately under names like `rte-state-of-work-audit-20260410.md`, `rte-live-certification-gates.md`, `rte-production-certification-audit-20260414.md`, `rte-prelive-audit-pack-2026-04-23.md`, `rte-canonical-entrypoint-implementation-2026-04-23.md`, `rte-gemini-deep-pal-audit-2026-04-23.md`, `rte-branch-integration-audit-2026-04-23.md`.
+- **Why it matters:** No cockpit audit pack treats RTE as a cockpit surface. RTE has runtime telemetry (`RUN_DASHBOARD.json`, `TERMINAL_TIMELINE.jsonl`, `STEP_METRICS.json`) but the existing cockpit design work treats "cockpit" as the PM cockpit, not the RTE operator cockpit. There's no operator-cockpit ergonomic baseline for RTE specifically. Whether that gap should be filled is out of scope for this audit, but worth flagging.
+
+---
+
+## Verification on this ledger
+
+Run from repo root:
+
+```bash
+rg -c "^### F-OPUS-" out/rte-opus-uiux-claude-design-audit/FINDINGS_LEDGER.md
+# Expected: count == total findings (CRIT + HIGH + MED + LOW + OBS)
+rg -n "^- \*\*Label:\*\* " out/rte-opus-uiux-claude-design-audit/FINDINGS_LEDGER.md | rg -v "OBSERVED|INFERRED|UNKNOWN|CONFLICTING|CLAIMED|RECOMMENDED"
+# Expected: zero output (no label outside the allowed taxonomy)
+```
+
+End of FINDINGS_LEDGER.md.

--- a/docs/audit/rte-opus-uiux-claude-design-audit/methodology.md
+++ b/docs/audit/rte-opus-uiux-claude-design-audit/methodology.md
@@ -1,0 +1,156 @@
+---
+id: METHODOLOGY
+title: Methodology
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-17'
+last_review: '2026-05-17'
+next_review: '2026-08-15'
+prelude: Methodology (explanation) for dopemux documentation and developer workflows.
+---
+# METHODOLOGY.md
+
+How this audit was conducted, what was read, and the decision rules used to label evidence.
+
+## Audit identity
+
+- **ID:** `RTE-OPUS-UIUX-CLAUDE-DESIGN-AUDIT-001`
+- **HEAD:** `a234f798947d51915b2adea3e0bc5a2917ac595b` on branch `claude/youthful-neumann-b94cc0` (worktree of `dopemux-mvp`).
+- **Date:** 2026-05-16.
+- **Model:** Claude Opus (executed by Claude Code harness with Plan-mode planning followed by ACT execution).
+- **Mode chosen by user:** fresh independent pass with balanced weighting across five evaluation sections; durable output under `out/rte-opus-uiux-claude-design-audit/`.
+
+## Authority order applied to every claim
+
+From the audit packet, applied verbatim:
+
+1. Runtime code, CLI wiring, checked-in tests, configs, active entrypoints.
+2. RTE proof/status/runtime artifact writers.
+3. AGENTS.md and repo governance files.
+4. `TRUTH_*` and `SYSTEM_*` docs.
+5. RTE docs, design docs, Claude/agent guidance, generated proof bundles.
+6. Historical/generated exploratory docs.
+7. External assumptions are not authority.
+
+Generated artifacts never outrank the runtime they describe. `UNKNOWN` was never upgraded to `OBSERVED` by inference.
+
+## Allowed labels
+
+`OBSERVED`, `INFERRED`, `UNKNOWN`, `CONFLICTING`, `CLAIMED`, `RECOMMENDED` — used verbatim from the audit packet.
+
+## Severity scheme
+
+`CRIT`, `HIGH`, `MED`, `LOW`, `OBS`. Matches prior P0–P5 convention so the output is legible to anyone who's read those, but finding IDs are independent (`F-OPUS-{SEV}-{N}`) per the user's "fresh independent pass" decision.
+
+## Five evaluation sections (balanced ~20% each)
+
+1. **Operator CLI surfaces** — every `dopemux rte` subcommand, `extractor` deprecated surfaces, hidden argparse introspection flags, consent gates, default-safe semantics.
+2. **Proof/dashboard/risk surfaces** — `RUN_DASHBOARD.json`, `STEP_METRICS.json`, `FAILURE_INDEX.json`, `SPEND_LEDGER.json`, `PROOF_PACK.json`, `RTE_RISK_DASHBOARD.json`, `TERMINAL_TIMELINE.jsonl`, `RUN_ROUTING_FINGERPRINT.json`; writers in `reporting.py`, `lib/proof_contract.py`, `lib/risk_dashboard.py`, `lib/spend_ledger.py`; redaction in `output_safety.py`; consent in `run_extraction_v5.py:2880-3076`.
+3. **Claude/design adjacency** — `AGENTS.md`, all four `CLAUDE.md` variants, `brand-voice-guidelines.md`, `ux-style-guide.md`, `cli-ux-design-spec.md`, `terminal-rendering-guide.md`, cockpit audit reports, `proof/` artifacts, task packets, governance docs.
+4. **Terminal ergonomics** — Click help text quality, JSON-vs-human output, `--watch` / `--tail-run-log`, voice consistency, status chips, render modes, ADHD optimisations.
+5. **Error states** — `ClickException` paths, `enforce_live_operation_consent`, `enforce_pre_live_validator_for_execution`, `validate_pre_live_gate_v25.py` reason codes, failed sidecar redaction, hygiene/dry-run violations.
+
+## Files inspected (read-only)
+
+### Tier 1 — runtime (full reads or targeted ranges)
+
+| File | Lines | Coverage |
+|------|------:|----------|
+| `src/dopemux/cli.py` | 6250 | 4830–5570 (RTE region) |
+| `src/dopemux/commands/extractor_commands.py` | 523 | full |
+| `services/repo-truth-extractor/run_extraction_v5.py` | 22547 | targeted (lines ~2780–3130 consent/sidecar/validator; grep on add_argument and key handlers) |
+| `services/repo-truth-extractor/output_safety.py` | 206 | full |
+| `services/repo-truth-extractor/rte_config.py` | 141 | full |
+| `services/repo-truth-extractor/lib/proof_contract.py` | 549 | full |
+| `services/repo-truth-extractor/lib/risk_dashboard.py` | 615 | full |
+| `services/repo-truth-extractor/lib/spend_ledger.py` | 602 | partial (1–602 dataclasses and accumulators) |
+| `services/repo-truth-extractor/reporting.py` | 1093 | partial (1–200) |
+| `services/repo-truth-extractor/validate_pre_live_gate_v25.py` | 1375 | partial (1–300) |
+
+### Tier 3 — governance
+
+| File | Coverage |
+|------|----------|
+| `AGENTS.md` | full |
+| `README.md` | full |
+| `ARCHITECTURE.md` | full |
+
+### Tier 5 — docs / Claude / design
+
+| File | Coverage |
+|------|----------|
+| `.claude/CLAUDE.md` (root) | full (via system-reminder injection plus targeted Read) |
+| `.claude/claude.md` (case variant) | full |
+| `services/.claude/CLAUDE.md` | full (via system-reminder injection) |
+| `src/.claude/CLAUDE.md` | full (via system-reminder injection) |
+| `.claude/brand-voice-guidelines.md` | full |
+| `docs/ux/ux-style-guide.md` | full |
+| `docs/ux/terminal-rendering-guide.md` | full |
+| `docs/04-explanation/branding/cli-ux-design-spec.md` | full |
+| `docs/05-audit-reports/cockpit-pm-implementer-processing-pack-2026-04-24.md` | first 120 lines |
+| `services/repo-truth-extractor/README.md` | full |
+
+### Tier 6 — historical / generated audit reports
+
+Surveyed by `ls` and grep; not read in depth:
+
+- `docs/05-audit-reports/cockpit-*-2026-04-24.md` (6 files)
+- `docs/05-audit-reports/rte-*.md` (7 files)
+- `docs/05-audit-reports/supervisor-*.md` (4 files)
+- `docs/05-audit-reports/repo-*.md` (8 files)
+
+## Search commands used
+
+```bash
+git rev-parse HEAD
+git status --short --branch
+wc -l <runtime files>
+ls <governance/design files>
+find docs/04-explanation -iname '*cli-ux*'
+rg -n "READY_FOR_CLAUDE|safe_for_claude|claude_design" .
+rg -n "def main\(|def enforce_live|def enforce_pre|class SpendTracker" services/repo-truth-extractor/run_extraction_v5.py
+grep -n "READY_FOR_CLAUDE\|safe_for_claude\|claude_design\|not approved" docs/05-audit-reports/*.md
+ls docs/05-audit-reports/
+```
+
+No tests were executed. No provider calls were made. No code was changed. `git status` at the end of the audit confirms only files under `out/rte-opus-uiux-claude-design-audit/` are new.
+
+## Decision rules used during the audit
+
+1. **Generated artifacts never outrank runtime.** A claim in `*.proof.json` that disagrees with `run_extraction_v5.py` is `CONFLICTING`, never `OBSERVED` as if the proof bundle were authoritative.
+2. **UNKNOWN is preserved, not promoted.** If runtime emit paths could not be exhaustively verified from static reading, the audit records `UNKNOWN` (see `F-OPUS-LOW-2`).
+3. **Self-demoted documents still count.** A file that says "I am not authoritative" but continues to prescribe behavior is still teaching the reader something. The audit treats self-demotion as a partial mitigation, not full erasure (see `F-OPUS-HIGH-2`).
+4. **Truth-order conflicts are surfaced, not resolved.** When `AGENTS.md`, `README.md`, and `brand-voice-guidelines.md` disagree, the audit records the conflict and lets reconciliation happen elsewhere (see `F-OPUS-CRIT-2`).
+5. **Phase 1 agent reports are not authority.** When the Phase 1 Explore agent claimed `READY_FOR_CLAUDE_DESIGN: not approved` flags existed, a `grep` showed they did not. The audit corrected the record and recorded the meta-finding (`F-OPUS-OBS-1`).
+6. **Severity reflects operator impact, not aesthetic preference.** A brand-voice violation in help text is `CRIT` not because the prose is bad in isolation, but because it teaches operators to expect hype from a system whose other safety properties depend on terse evidence-based output.
+
+## What this audit did NOT do
+
+- Did not run `dopemux rte run` or any RTE command.
+- Did not run any `pytest` suite.
+- Did not call any LLM provider.
+- Did not submit, poll, retrieve, or cancel any batch job.
+- Did not require provider credentials.
+- Did not edit any source file outside `out/rte-opus-uiux-claude-design-audit/`.
+- Did not merge, rebase, push, or open PRs.
+- Did not claim live provider behavior.
+- Did not collapse RTE into broader Dopemux authority.
+- Did not cross-reference `F1-*` through `F5-*` finding IDs from prior P0–P5 audits (per user's "fresh independent pass" decision).
+- Did not implement, mockup, or design UI changes.
+
+## Reproducibility
+
+To reproduce this audit at the same HEAD:
+
+```bash
+cd <repo-or-worktree>
+git checkout a234f798947d51915b2adea3e0bc5a2917ac595b
+# Read the files listed in METHODOLOGY.md §Files inspected.
+# Apply the decision rules in §Decision rules used.
+# Produce the seven output files under out/rte-opus-uiux-claude-design-audit/.
+```
+
+The output files are intended to be self-contained — a reader should be able to verify any finding by following the cited `file:line` references at the current HEAD.
+
+End of METHODOLOGY.md.

--- a/docs/audit/rte-opus-uiux-claude-design-audit/recommendations.md
+++ b/docs/audit/rte-opus-uiux-claude-design-audit/recommendations.md
@@ -1,0 +1,241 @@
+---
+id: RECOMMENDATIONS
+title: Recommendations
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-17'
+last_review: '2026-05-17'
+next_review: '2026-08-15'
+prelude: Recommendations (explanation) for dopemux documentation and developer workflows.
+---
+# RECOMMENDATIONS.md
+
+All recommendations are labeled `RECOMMENDED`. They are intentionally separated from observed findings (per the audit packet's hard requirement). Recommendations cite the finding they address and propose a specific change; they do **not** implement anything.
+
+Each recommendation:
+- **Addresses** — finding ID(s) it resolves.
+- **Action** — concrete proposed change in one sentence.
+- **Authority** — which doc/file should change first to keep authority order intact.
+- **Verification** — how a future maintainer can check that the recommendation landed.
+- **Cost class** — `S` (single-file/small), `M` (multi-file or careful), `L` (cross-cutting change).
+
+---
+
+## CRIT-tier recommendations
+
+### R-OPUS-1 — Re-tone the RTE Click help text against `brand-voice-guidelines.md §2A`
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-CRIT-1`.
+- **Action:** Rewrite the docstrings of `rte_scan`, `extractor_list`, `extractor_run`, `extractor_doctor`, `extractor_status`, `extractor_preflight`, `extractor_validate_live`, `extractor_promptset_audit`, `extractor_trace`, and `truth_command` in `src/dopemux/cli.py` to match the §2A operator-production register: terse, procedural, lead with the result, end with `NEXT:` where an operator action is needed. Replace "Ignite Pipeline" / "Ritual Apothecary" / "Catalog Phases" / "Pre-Ignition Check" / "Ritual Status" / "Ritual Integrity" with plain action verbs ("Run", "Diagnose", "List", "Preflight", "Show status", "Audit").
+- **Authority:** Runtime first; `brand-voice-guidelines.md` already covers the rule, no doc change needed.
+- **Verification:** `rg -n "Ignite|Ritual|Catalog Phases|Pre-Ignition|Apothecary|Cognitive Routing|cockpit telemetry" src/dopemux/cli.py` returns zero matches; sample help text matches §2A "✅ Right" examples.
+- **Cost class:** S.
+
+### R-OPUS-2 — Reconcile truth-order across `AGENTS.md`, `README.md`, and `brand-voice-guidelines.md §9`
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-CRIT-2`.
+- **Action:** Pick *one* canonical truth-order document (recommend `AGENTS.md §2`) and replace the divergent orderings in `README.md §5` and `brand-voice-guidelines.md §9` with explicit references back to AGENTS.md (`"See AGENTS.md §2 for repo-wide truth order. The list below is scoped to <X> only and does not override repo truth order."`). Keep brand-voice's *scoped* decision ladder if useful — but mark it as a sub-order, not a competing repo-wide order.
+- **Authority:** Governance (`AGENTS.md`) wins; downstream docs adapt.
+- **Verification:** `rg -n "Truth Order|truth order|Decision Ladder|decision ladder" AGENTS.md README.md .claude/brand-voice-guidelines.md` shows one normative source; the other two reference it.
+- **Cost class:** M (multi-doc but small per-doc).
+
+### R-OPUS-3 — Add an RTE-specific section to `.claude/CLAUDE.md` (or a sibling `.claude/RTE.md`)
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-CRIT-3` and indirectly `F-OPUS-MED-5`.
+- **Action:** Write a short section/file teaching Claude/agents the RTE invariants:
+  1. `DPMX_LIVE_OK=1` requirement for any live operation.
+  2. `--dry-run` is the default for `dopemux rte run`; never weaken this default.
+  3. Consent gate paths in `run_extraction_v5.py:2992-3076` are the source of truth for live-capable classification.
+  4. The `first-live` preset (`services/repo-truth-extractor/README.md:147-169`) is the conservative onboarding path.
+  5. `$10` accidental-run anchor — quote it.
+  6. Generated `.proof.json` and `out/rte-pkt-*` artifacts never outrank runtime per `lib/proof_contract.py:119-127`.
+  7. AGENTS.md §6 line 81 is the authority bound: "RTE outputs are evidence artifacts, not runtime truth."
+- **Authority:** Claude guidance (tier 5), but writes the bridge to runtime invariants.
+- **Verification:** A new contributor (or Claude agent) reading the file can answer: "What's the env var for live execution?" and "What's the safest first command to try?" without reading runtime code.
+- **Cost class:** S.
+
+## HIGH-tier recommendations
+
+### R-OPUS-4 — Bring CLI emoji usage onto the 6-emoji whitelist (or migrate to nerd-font glyphs)
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-HIGH-1`.
+- **Action:** In `src/dopemux/cli.py` and `src/dopemux/commands/extractor_commands.py`, replace off-whitelist emojis (📊 🆔 📦 📂 ⏪ 🔧 🌊 🚀 ⏯️ 🎭 💸 ⚖️ ⏩ 📥 📡 🛫 🏥 👁️ 💰 🛡️ ✅ 🔄 🗺️ 🔥) with the nerd-font status glyphs documented at `cli-ux-design-spec.md §4` and `brand-voice-guidelines.md §4.6`, or remove them. Keep the six allowed emojis where they appear (`💊 🧪 🧠 ⚡ 💧 🔬`).
+- **Authority:** Runtime first; spec is already aligned.
+- **Verification:** `rg -n "[^[:print:][:space:]]" src/dopemux/cli.py src/dopemux/commands/extractor_commands.py` then filter against the whitelist; expect ≤6 unique emoji characters.
+- **Cost class:** S–M (mechanical).
+
+### R-OPUS-5 — Replace `docs/ux/ux-style-guide.md` body with a one-line redirect
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-HIGH-2`.
+- **Action:** Replace lines 18–42 of `docs/ux/ux-style-guide.md` with a single forwarding paragraph: "This file is non-authoritative. The CLI/TUI UX authority is `../04-explanation/branding/cli-ux-design-spec.md`. The runtime brand voice is `.claude/brand-voice-guidelines.md`. Do not prescribe palette or chip semantics here." Preserve the frontmatter for indexing.
+- **Authority:** Docs only.
+- **Verification:** `wc -l docs/ux/ux-style-guide.md` is small; `rg -n "READY|BLOCKED|DEFERRED|SUPERVISED|Spaceage" docs/ux/ux-style-guide.md` returns zero matches.
+- **Cost class:** S.
+
+### R-OPUS-6 — Either delete `docs/ux/terminal-rendering-guide.md` or fill its body
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-HIGH-3`.
+- **Action:** Decide intent. If still desired, fill the body with content covering the `DOPEMUX_RENDER_MODE` and `NO_COLOR` semantics from `cli-ux-design-spec.md §7` plus actual terminal color-space/unicode-fallback behavior. If not desired, delete the file and remove its `_manifest.yaml` entry.
+- **Authority:** Docs only.
+- **Verification:** `wc -c docs/ux/terminal-rendering-guide.md` is either zero (deleted) or substantially larger (filled). If filled, it cross-references `cli-ux-design-spec.md §7` rather than restating it.
+- **Cost class:** S.
+
+### R-OPUS-7 — Either implement v5 promptset audit or rename the command to clarify v4-only scope
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-HIGH-4`.
+- **Action:** Two viable paths. (a) Implement a v5 promptset audit (preferred — operators on the canonical engine deserve a canonical audit). (b) Rename the command to `dopemux rte promptset audit-v4` and have `dopemux rte promptset audit` either alias to v4 with a deprecation note or refuse with a message that says "v5 promptset audit is not yet implemented; v4-only is available at `dopemux rte promptset audit-v4`."
+- **Authority:** Runtime first.
+- **Verification:** `dopemux rte promptset audit --pipeline-version v5` either succeeds or returns a message that explicitly states the v5-audit gap and offers the v4 fallback.
+- **Cost class:** M (option a) or S (option b).
+
+### R-OPUS-8 — Reshape pre-live validator NO_GO error to `error_panel(problem, why, fix)` shape
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-HIGH-5`.
+- **Action:** In `run_extraction_v5.py:3067-3070`, replace the `RuntimeError("Pre-live validator blocked live execution: " f"verdict={verdict} reason_codes={detail} output_dir={output_dir}.{stderr_suffix}")` raise with a structured error that includes:
+  - **Problem:** "Pre-live validator returned NO_GO."
+  - **Why:** Each reason code on its own line, optionally with the human-readable label from `validate_pre_live_gate_v25.py:101-113` (`CRITICAL_TEST_FAILURE`, `TARGET_TRUTH_SPLIT_MISMATCH`, etc.).
+  - **Fix:** "Read `<output_dir>/VALIDATION_REPORT.json` for details. If a `CRITICAL_TEST_FAILURE`, run the failing test (`pytest <path>`) and re-validate. Do not waive without operator sign-off."
+  - Use `[BLOCKER]` chip if rendering via `dopemux.console` is available; otherwise format as three labeled lines.
+- **Authority:** Runtime + brand-voice spec §5.
+- **Verification:** A simulated NO_GO produces a three-section message; `rg -n "Problem:|Why:|Fix:" services/repo-truth-extractor/run_extraction_v5.py` shows the structure.
+- **Cost class:** S.
+
+### R-OPUS-9 — Add progressive disclosure to `dopemux rte run --help`
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-HIGH-6`.
+- **Action:** Split the 30+ options into groups using Click's option-group features (or split into a small set of essential options at the top and the rest under `--help-extended` or a dedicated `dopemux rte run --advanced-help` subcommand). At minimum, the help text should lead with: phase, pipeline version, dry-run/execute, routing-policy, run-id, promptset-root. Move batch, ui, prescan, escalation, and worker options under an "Advanced" header.
+- **Authority:** Runtime first.
+- **Verification:** `dopemux rte run --help` first screen (24 lines) shows ≤8 options; remaining options appear under a clearly named group or sub-help.
+- **Cost class:** S–M.
+
+## MED-tier recommendations
+
+### R-OPUS-10 — Update `ARCHITECTURE.md §5.5` to name `dopemux rte` as the canonical operator path
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-MED-1`.
+- **Action:** Replace the prose at `ARCHITECTURE.md:150` so it reads "operator invocation comes through `dopemux rte ...` or direct runner execution; `dopemux upgrades ...` remains as a legacy compatibility alias and is not the canonical operator path."
+- **Authority:** Governance doc, downstream of runtime.
+- **Verification:** `rg -n "dopemux upgrades" ARCHITECTURE.md` either returns zero (preferred) or returns a line that is explicitly a legacy reference.
+- **Cost class:** S.
+
+### R-OPUS-11 — Plan a re-identification of canonical RTE commands from `upgrades` to `rte`
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-MED-2`.
+- **Action:** Schedule a refactor (not in this audit) to make `@rte.command(...)` the canonical decorator for `rte_run`/`rte_doctor`/`rte_status`/etc., with `@upgrades.command(...)` reduced to an alias adapter. Until then, document the inversion in `services/repo-truth-extractor/README.md` ("Note: the canonical command identity currently lives under the `upgrades` Click group as a historical artifact; both `dopemux rte X` and `dopemux upgrades X` resolve to the same handler.").
+- **Authority:** Runtime change is the eventual fix; doc note is the interim.
+- **Verification:** `rg -n "@upgrades.command|@rte.command" src/dopemux/cli.py` count: post-refactor, `@rte.command` should outnumber `@upgrades.command` for RTE-canonical commands.
+- **Cost class:** M (refactor).
+
+### R-OPUS-12 — Disambiguate `dopemux extractor status` dual mode
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-MED-3`.
+- **Action:** Split into two commands: `dopemux extractor status` (always reads SYNC_MANIFEST.json from a promptset directory) and remove the flag-based branch into runtime status. Operators wanting runtime status use `dopemux rte status`. Alternative: emit a single-line preamble such as `"Mode: promptset-sync-manifest"` / `"Mode: runtime-status (deprecated, use dopemux rte status)"` so the operator knows which job they got.
+- **Authority:** Runtime.
+- **Verification:** `rg -n "if pipeline_version is not None" src/dopemux/commands/extractor_commands.py` returns zero (split) or the dual-mode is explicitly framed in the output.
+- **Cost class:** S.
+
+### R-OPUS-13 — Document `dopemux rte wizard`
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-MED-4`.
+- **Action:** Add a one-paragraph section to `services/repo-truth-extractor/README.md` and `README.md §4` describing what `dopemux rte wizard` does, when to use it, and what safety posture it adopts. If the wizard is internal-only or unfinished, mark its `--help` text with `[INTERNAL]` or remove it from the `rte` group alias at `cli.py:5516`.
+- **Authority:** Docs first; runtime second if the command should be hidden.
+- **Verification:** `rg -n "rte wizard|rte.add_command\\(audit.commands" src/dopemux/cli.py README.md services/repo-truth-extractor/README.md` shows aligned references.
+- **Cost class:** S.
+
+### R-OPUS-14 — Add `repo-truth-extractor` to `services/.claude/CLAUDE.md` Key Services table
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-MED-5` (paired with `F-OPUS-CRIT-3`).
+- **Action:** Add a row to the table at `services/.claude/CLAUDE.md:38-44`: `| repo-truth-extractor | (CLI, no HTTP port) | Repo truth extraction; uses DPMX_LIVE_OK gate, $-cost surface |`. Add it to the ASCII service tree (~line 67).
+- **Authority:** Claude guidance.
+- **Verification:** `rg -n "repo-truth-extractor" services/.claude/CLAUDE.md` returns at least two lines (table row + tree entry).
+- **Cost class:** S.
+
+### R-OPUS-15 — Add `DPMX_LIVE_OK=1` to the `--help` epilog of every live-capable command
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-MED-6` (paired with `R-UX-1`).
+- **Action:** Use Click's `epilog=...` on `extractor_run`, `extractor_validate_live`, `extractor_preflight` (when `--auth-doctor` is set), and `rte_scan` to include a short note: `"Live execution requires DPMX_LIVE_OK=1 in the environment in addition to --execute (or stage-specific flags). See services/repo-truth-extractor/README.md §Live batch safety."`
+- **Authority:** Runtime.
+- **Verification:** `rg -n "DPMX_LIVE_OK" src/dopemux/cli.py` returns at least four matches (one per command); manual `dopemux rte run --help` shows the epilog.
+- **Cost class:** S.
+
+### R-OPUS-16 — Add a structured frontmatter flag to cockpit audit reports
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-MED-7`.
+- **Action:** Add a frontmatter field such as `implementation_authority: none` and/or `claude_design_evidence_only: true` to every `docs/05-audit-reports/cockpit-*-2026-04-24.md` file. Optionally introduce a canonical vocabulary documented in `AGENTS.md` (e.g., values `none`, `advisory`, `runtime_spec`).
+- **Authority:** Docs + governance (AGENTS.md gains a sub-section on the vocabulary).
+- **Verification:** `rg -n "implementation_authority|claude_design_evidence_only" docs/05-audit-reports/cockpit-*.md` returns one match per file.
+- **Cost class:** S.
+
+## LOW-tier recommendations
+
+### R-OPUS-17 — Annotate `validate-live` USD options with explicit unit in `--help`
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-LOW-1`.
+- **Action:** Add `help="USD spend cap for the provider probe stage. Default $0.10 USD."` and equivalents on the four `*-max-usd` options at `cli.py:5317, 5321, 5326, 5328`.
+- **Authority:** Runtime.
+- **Verification:** `rg -n "USD" src/dopemux/cli.py` shows entries on each of the four flags.
+- **Cost class:** S.
+
+### R-OPUS-18 — Add a brand-voice closer audit to RTE runtime emitters
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-LOW-2`.
+- **Action:** Either (a) extend `scripts/brand_lint.py` to audit RTE runtime emitter sites for `NEXT:` / `Receipt:` / `PROGRESS` closers, or (b) add a one-time pass over `run_extraction_v5.py` adding closers to user-visible emit paths and document a maintainer rule. Closer rule is at `brand-voice-guidelines.md:181-183`.
+- **Authority:** Lint extension is governance; runtime change is runtime.
+- **Verification:** `python scripts/brand_lint.py` reports zero closer-rule violations for any RTE runtime file.
+- **Cost class:** M.
+
+### R-OPUS-19 — Carry `DPMX_LIVE_OK=1` into the `dopemux truth` deprecation message
+
+- **Label:** `RECOMMENDED`.
+- **Addresses:** `F-OPUS-LOW-3` (paired with `R-OPUS-15`).
+- **Action:** Append a line to the deprecation message at `cli.py:5495-5500`: `"Note: live execution also requires DPMX_LIVE_OK=1 in the environment."` Keep the three dry-run-safe redirects.
+- **Authority:** Runtime.
+- **Verification:** `rg -n "DPMX_LIVE_OK" src/dopemux/cli.py` includes a match in the `truth_command` function body.
+- **Cost class:** S.
+
+---
+
+## Recommendation rollup
+
+| Tier | Count | IDs |
+|------|------:|-----|
+| CRIT | 3 | R-OPUS-1, R-OPUS-2, R-OPUS-3 |
+| HIGH | 6 | R-OPUS-4 through R-OPUS-9 |
+| MED  | 7 | R-OPUS-10 through R-OPUS-16 |
+| LOW  | 3 | R-OPUS-17, R-OPUS-18, R-OPUS-19 |
+
+**Suggested execution order if implementing in one campaign:**
+
+1. R-OPUS-2 (truth-order reconciliation) — unblocks every other governance change.
+2. R-OPUS-3 + R-OPUS-14 (Claude-guidance for RTE) — protects agent operations.
+3. R-OPUS-1 + R-OPUS-4 (CLI tone + emoji whitelist) — most operator-visible.
+4. R-OPUS-8 (validator error shape) — most consequential error path.
+5. R-OPUS-9 (progressive disclosure) — improves the most-used help surface.
+6. R-OPUS-5 + R-OPUS-6 (UX doc cleanup) — eliminates two drift surfaces.
+7. R-OPUS-10 + R-OPUS-11 (ARCH/upgrades reconciliation) — long-term cleanliness.
+8. R-OPUS-7 (v5 promptset audit) — closes a real operator gap.
+9. R-OPUS-15 + R-OPUS-19 (DPMX_LIVE_OK in help/deprecation) — small safety wins.
+10. Remaining (R-OPUS-12, 13, 16, 17, 18) — opportunistic.
+
+This sequencing is suggestive only; the audit packet's hard non-goal forbids implementing any of these.
+
+End of RECOMMENDATIONS.md.

--- a/docs/audit/rte-opus-uiux-claude-design-audit/report.md
+++ b/docs/audit/rte-opus-uiux-claude-design-audit/report.md
@@ -1,0 +1,117 @@
+---
+id: REPORT
+title: Report
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-17'
+last_review: '2026-05-17'
+next_review: '2026-08-15'
+prelude: Report (explanation) for dopemux documentation and developer workflows.
+---
+# REPORT.md — RTE-OPUS-UIUX-CLAUDE-DESIGN-AUDIT-001
+
+**Executive summary, scope, evidence map, verdict.**
+
+## 1. What this is
+
+A read-only, source-grounded UI/UX + Claude/design audit of the Repo Truth Extractor (RTE), conducted at HEAD `a234f798947d51915b2adea3e0bc5a2917ac595b` on branch `claude/youthful-neumann-b94cc0` of `dopemux-mvp`. The audit is *not* a remediation packet; it does not edit source, prompts, schemas, or any Claude/governance file. It produces seven deliverables under `out/rte-opus-uiux-claude-design-audit/`.
+
+This audit was scoped by the user as a **fresh independent pass** (no cross-referencing of prior P0–P5 finding IDs) with **balanced weighting** across five evaluation areas: operator CLI, proof/dashboard/risk surfaces, Claude/design adjacency, terminal ergonomics, and error states.
+
+## 2. The two questions
+
+The audit's primary and secondary questions, with one-line answers:
+
+- **Primary — Does RTE expose a coherent, safe, understandable, low-friction operator experience across CLI commands, doctor/preflight/status/reporting, proof artifacts, error states, and agent-facing design/Claude guidance?**
+  **Answer:** Partly. The *runtime* is rigorous (belt-and-suspenders consent gates, honest pricing fallback, comprehensive redaction, hard-coded honest risk-dashboard labels, runtime-enforced authority ranks in `lib/proof_contract.py`). The *operator-facing surface around the runtime* — Click help text, voice register, emoji density, error message shape, Claude-targeted guidance, conflicting truth orders — undercuts the safety contract the runtime works to keep.
+- **Secondary — Do Claude/design-related files accurately support RTE operation without overclaiming authority, encouraging unsafe automation, or muddying the line between runtime truth, generated proof, design intent, and live provider behavior?**
+  **Answer:** Generally yes on the *authority bounding* (AGENTS.md §6 line 81 correctly scopes RTE outputs as evidence, `lib/proof_contract.py` operationalises authority ranks, generated artifacts carry an `authority_boundary` field). The gap is on *coverage*: no Claude-targeted file teaches RTE-specific safety invariants, and three competing truth-order documents make it ambiguous which one wins for a given task.
+
+## 3. Top findings (3 CRIT, 6 HIGH)
+
+The CRIT-tier findings are the audit's core takeaway:
+
+- **`F-OPUS-CRIT-1` — CLI surface broadly violates `brand-voice-guidelines.md §2A`.** Click docstrings across `rte run/doctor/status/preflight/scan/promptset/list/trace` use thematic prose ("Ignite Pipeline", "Ritual Apothecary", "Catalog Phases", "Pre-Ignition Check", "Ritual Integrity", "Engages the high-fidelity extraction engines") that maps directly to the §2A ❌ examples ("Your workflow is now supercharged"). The brand-voice contract is the *production* spec for operator-facing surfaces and is lint-enforced for a subset of files — but Click help text appears to be outside that subset.
+- **`F-OPUS-CRIT-2` — Three truth-order documents disagree.** `AGENTS.md §2` ranks Task Packets first; `README.md §5` doesn't mention Task Packets and groups governance docs at tier 3; `brand-voice-guidelines.md §9` has a third order specifically for voice. The audit packet itself introduces a fourth. Operators and Claude agents reading any single source form different mental models of which wins.
+- **`F-OPUS-CRIT-3` — No `.claude/CLAUDE.md` variant teaches Claude how to operate RTE safely.** Four `CLAUDE.md` files exist (root, `.claude/`, `services/.claude/`, `src/.claude/`), all generic Dopemux platform guidance. Zero mention `DPMX_LIVE_OK`, `--execute`, RTE consent gates, spend caps, redaction obligations, or the `first-live` preset. `services/.claude/CLAUDE.md`'s Key Services table even omits `repo-truth-extractor` entirely.
+
+The six HIGH-tier findings address: emoji whitelist overrun, conflicting `docs/ux/` style guides, empty `terminal-rendering-guide.md` stub, `dopemux rte promptset audit` being v4-only, pre-live validator NO_GO error shape, and 30+-option `--help` with no progressive disclosure. See `FINDINGS_LEDGER.md` for full evidence.
+
+## 4. What the audit affirms (positive observations)
+
+The audit found multiple positive signals that should not be regressed:
+
+- **Belt-and-suspenders consent gates** (`F-OPUS-OBS-4`). `dopemux rte scan` requires `--allow-legacy-v3-scan` AND `--execute` AND `DPMX_LIVE_OK=1`. `enforce_live_operation_consent` checks for both `--execute` AND env var. `enforce_pre_live_validator_for_execution` then runs a subprocess validator. Four independent fail-closed layers.
+- **Honest pricing fallback** (`F-OPUS-OBS-3`). `lib/spend_ledger.py:11-16` is explicit that pricing authority is incomplete; the fallback uses MAX-of-known rates and records `pricing_status: UNPRICED_UNKNOWN`. Operators are never lied to about cost.
+- **Honest risk-dashboard self-labeling** (`F-OPUS-OBS-2`). `live_use_readiness: "READY_FOR_LIMITED_DRY_STATIC_USE"` is hard-coded with an in-file comment explaining the choice — the dashboard does not pretend to compute live readiness from runtime state.
+- **Authority ranks operationalised in code** (`F-OPUS-OBS-7`). `lib/proof_contract.py:119-127` carries `_AUTHORITY_RANK` into the proof bundle as a literal string field — generated artifacts cannot be confused with runtime truth because they carry their own non-authority label.
+- **Comprehensive output redaction** (`F-OPUS-OBS-5`). `output_safety.py` covers OAuth bearers, JWT, AWS keys, GitHub/GitLab PATs, Google API keys, private-key blocks, plus defense-in-depth long-token-candidate redaction in `sanitize_text_for_provider_payload`.
+- **README cost-incident anchor** (`F-OPUS-OBS-6`). `services/repo-truth-extractor/README.md:262-264` quotes a specific incident — "$10 in March 2026" — that is exactly the operator-anchored warning style the audit framework values.
+- **`is_read_only_introspection_mode` cleanly enumerates safe paths** (`F-OPUS-OBS-8`). 11 introspection flags listed in one place; `should_enforce_pre_live_validator` reuses the same list.
+- **Comparison lane is non-blocking** (`F-OPUS-OBS-12`). Outputs go to a separate tree; canonical run is unaffected by comparison failures.
+- **`first-live` preset codifies conservative defaults** (`F-OPUS-OBS-11`). `--routing-policy cost`, `--max-cost-usd 5.0`, `--partition-workers 1`, `--no-batch`.
+
+## 5. Evidence map (where to verify each claim)
+
+| Section | Key files |
+|---------|-----------|
+| Section 1 (CLI) | `src/dopemux/cli.py:4830-5570`, `src/dopemux/commands/extractor_commands.py:1-523` |
+| Section 2 (proof/risk/spend) | `services/repo-truth-extractor/lib/proof_contract.py`, `lib/risk_dashboard.py`, `lib/spend_ledger.py`, `output_safety.py`, `reporting.py`, `run_extraction_v5.py:2780-3130` |
+| Section 3 (Claude/design) | `AGENTS.md`, `.claude/CLAUDE.md`, `services/.claude/CLAUDE.md`, `src/.claude/CLAUDE.md`, `.claude/brand-voice-guidelines.md`, `docs/ux/ux-style-guide.md`, `docs/ux/terminal-rendering-guide.md`, `docs/04-explanation/branding/cli-ux-design-spec.md`, `docs/05-audit-reports/cockpit-*.md`, `services/repo-truth-extractor/README.md`, `README.md`, `ARCHITECTURE.md` |
+| Section 4 (terminal ergonomics) | derived from Section 1 (help-text scan) + Section 3 (brand-voice/style cross-check) |
+| Section 5 (error states) | `src/dopemux/cli.py:4909-4931, 5495-5500`, `src/dopemux/commands/extractor_commands.py:111-118, 291-293, 339-341`, `services/repo-truth-extractor/run_extraction_v5.py:2992-3076`, `services/repo-truth-extractor/validate_pre_live_gate_v25.py:101-162`, `output_safety.py:98` |
+
+## 6. Verdict
+
+**For operator daily use of the runtime:** the safety surface is in good shape. The consent gates, redaction, validator subprocess, spend ledger, risk dashboard, and proof contract are rigorous, honest, and consistent with each other. An operator following the `services/repo-truth-extractor/README.md` and using `--preset first-live` has a coherent safe-onboarding path. This audit does not recommend gating RTE runtime use behind any of the findings below.
+
+**For operator-experience around the runtime:** there is meaningful drift. CLI help text reads like marketing copy in a brand-voice contract that explicitly bans marketing copy. The visual UX layer has two competing prescriptions in `docs/ux/`. The pre-live validator NO_GO error — the most consequential error path — does not match the prescribed `error_panel(problem, why, fix)` shape. Operators get the *behavior* the runtime promises but the *framing* the runtime would otherwise reject.
+
+**For Claude/agent-assisted RTE work:** there is a coverage gap. Four `CLAUDE.md` files exist and none of them mentions `DPMX_LIVE_OK`, `--execute`, or the consent-gate code paths. An agent acting on RTE must derive these invariants from runtime code; that derivation works for a careful agent and breaks for an impatient one. Closing this gap (`R-OPUS-3`) is the single most impactful change available.
+
+**For Claude/design authority hygiene:** the runtime authority bound is solid (AGENTS.md §6 line 81, `lib/proof_contract.py:119-127`). The cross-document truth-order conflict (CRIT-2) is the largest *latent* risk — it has not produced a known incident, but it will the first time two valid documents disagree on a decision that matters.
+
+## 7. Counts
+
+| Severity | Count |
+|----------|------:|
+| CRIT     | 3 |
+| HIGH     | 6 |
+| MED      | 7 |
+| LOW      | 3 |
+| OBS      | 13 (including 1 negative meta-finding about audit hygiene and 12 substantive observations of which 9 are positive) |
+| **Total** | **32** |
+
+Plus 19 recommendations across CRIT/HIGH/MED/LOW tiers in `RECOMMENDATIONS.md`.
+
+## 8. Deliverable index
+
+| File | Purpose |
+|------|---------|
+| [`REPORT.md`](report.md) | This file. Executive summary, scope, evidence map, verdict. |
+| [`FINDINGS_LEDGER.md`](findings-ledger.md) | Every finding with ID, severity, label, evidence (`file:line`), authority tier, recommendation reference. |
+| [`FINDINGS_LEDGER.json`](FINDINGS_LEDGER.json) | Machine-readable mirror of the ledger. |
+| [`CLAUDE_DESIGN_COMPATIBILITY.md`](claude-design-compatibility.md) | Per-file compatibility ledger for every Claude/design-adjacent artifact. |
+| [`UX_RISK_LEDGER.md`](ux-risk-ledger.md) | 14 prioritized operator-UX risks (separate from findings). |
+| [`RECOMMENDATIONS.md`](recommendations.md) | 19 `RECOMMENDED` items, ordered. Strictly separated from observed findings. |
+| [`METHODOLOGY.md`](methodology.md) | How the audit was conducted, files inspected, decision rules, reproducibility. |
+
+## 9. What this audit did not do (reaffirming the hard non-goals)
+
+- No edits to source, prompts, promptsets, schemas, or `CLAUDE.md`.
+- No implementation packets, no code patches, no UI mockups.
+- No live extraction. No provider preflight. No provider API calls. No batch operations.
+- No PRs / merges / pushes.
+- No claims about live provider behavior.
+- No collapsing RTE into broader Dopemux authority.
+- No cross-referencing of P0–P5 finding IDs.
+
+## 10. Reading order for consumers
+
+- **Operators who just want to use RTE safely:** read `services/repo-truth-extractor/README.md` first; this audit's findings do not change the runtime behavior they rely on.
+- **A maintainer prioritizing fixes:** start with `RECOMMENDATIONS.md` §"Suggested execution order"; the first four items (R-OPUS-2, 3, 14, 1, 4, 8) cover the highest-impact paths.
+- **A Claude/Codex agent assigned an RTE task:** read `CLAUDE_DESIGN_COMPATIBILITY.md` §"What this means for Claude/agents" first; then read the runtime files cited there.
+- **An auditor verifying these findings:** read `METHODOLOGY.md` and re-check `FINDINGS_LEDGER.md` against current HEAD.
+
+End of REPORT.md.

--- a/docs/audit/rte-opus-uiux-claude-design-audit/ux-risk-ledger.md
+++ b/docs/audit/rte-opus-uiux-claude-design-audit/ux-risk-ledger.md
@@ -1,0 +1,146 @@
+---
+id: UX_RISK_LEDGER
+title: Ux Risk Ledger
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-17'
+last_review: '2026-05-17'
+next_review: '2026-08-15'
+prelude: Ux Risk Ledger (explanation) for dopemux documentation and developer workflows.
+---
+# UX_RISK_LEDGER.md
+
+Prioritized operator-experience risk ledger. Risks are operator-impact-ordered. Each row names the trigger condition, the operator harm, the mitigation already in place (if any), and the residual gap.
+
+Risks are not the same as findings — a risk can exist *because* a finding exists, but several risks predate any specific finding (e.g., the inherent risk of a 22,547-line runtime). The ledger answers "where does an operator most likely get hurt?" not "what is broken."
+
+---
+
+## R-UX-1 — Operator runs RTE live without realizing `DPMX_LIVE_OK=1` exists
+
+- **Trigger:** Operator reads `dopemux rte run --help`, sees `--execute` flag, runs `dopemux rte run --execute`.
+- **Harm:** Consent gate refuses with `parser.error(...)` listing `DPMX_LIVE_OK=1` as missing. Operator either (a) sets the env var and re-runs without reading further safety material, or (b) gives up confused.
+- **Mitigation in place:** Hard gate at `run_extraction_v5.py:3008-3019` refuses to dispatch. Error message names the missing consent.
+- **Residual gap:** The `--help` text for `dopemux rte run` does not mention `DPMX_LIVE_OK=1`. Operators discover the env var only by hitting the wall. (`F-OPUS-MED-6`)
+- **Operator-harm tier:** **high** — concerns the most expensive surface.
+
+## R-UX-2 — Operator reads "Spaceage Operationalism" style guide and ships UI with `[READY]`/`[BLOCKED]`/`[DEFERRED]`/`[SUPERVISED]` chips
+
+- **Trigger:** Contributor or Claude agent searching for UX guidance lands in `docs/ux/ux-style-guide.md` (it's the obvious file by name and path).
+- **Harm:** They follow the prescribed status chip set + green/red/yellow/blue palette, which is incompatible with the runtime `[LIVE]/[BLOCKER]/[OVERRIDE]/[LOGGED]/[AFTERCARE]/[EDGE]` chips and the mint/pink/violet palette. Result: drift between the new surface and the runtime brand.
+- **Mitigation in place:** A single self-demotion line at `docs/ux/ux-style-guide.md:14-15` redirects to `cli-ux-design-spec.md`.
+- **Residual gap:** The body of the file (16 substantive lines) keeps prescribing the deprecated palette in imperative tone. Self-demotion + opposing prescription is fragile. (`F-OPUS-HIGH-2`)
+- **Operator-harm tier:** **medium-high** — visible in every new contributor's first design-pass and likely to compound.
+
+## R-UX-3 — Operator copies CLI help-text prose into operator runbooks
+
+- **Trigger:** Operator writes a runbook for a teammate, copy-pastes `dopemux rte run --help` output.
+- **Harm:** Runbook now contains brand-voice violations (`Ignite Pipeline`, `Engages the high-fidelity extraction engines`, `Ritual Apothecary`, `ritual session`, `cockpit telemetry`). New teammate either (a) learns to expect this register everywhere, or (b) becomes confused about whether RTE is a serious operations tool. (`F-OPUS-CRIT-1`)
+- **Mitigation in place:** `brand-voice-guidelines.md` §2A is the production spec, and `brand_lint.py` enforces it for some files.
+- **Residual gap:** Click docstrings/help text appear to be outside the lint surface. The hype-voice gets through.
+- **Operator-harm tier:** **medium-high**.
+
+## R-UX-4 — Claude agent runs RTE without internalizing safety invariants
+
+- **Trigger:** A Claude or Codex agent is asked to "extend the RTE preflight command" and loads `.claude/CLAUDE.md` for project context.
+- **Harm:** None of the four `CLAUDE.md` files in the repo (`.claude/`, `services/.claude/`, `src/.claude/`, and the lowercase variant) mention `DPMX_LIVE_OK`, consent gates, or spend caps. The agent must derive these invariants from runtime code. If the agent doesn't read `run_extraction_v5.py:2992-3076` carefully, it may propose changes that weaken consent. (`F-OPUS-CRIT-3`)
+- **Mitigation in place:** AGENTS.md §6 line 81 scopes RTE outputs; the runtime code is comprehensive and grep-discoverable.
+- **Residual gap:** Nothing in the Claude-facing material teaches the safety contract proactively.
+- **Operator-harm tier:** **high** — agents acting on RTE without context is the single largest *new* risk surface introduced by Claude/agent integration.
+
+## R-UX-5 — Operator runs `dopemux rte promptset audit` on canonical v5 promptset and is refused
+
+- **Trigger:** Operator follows the canonical command guide, runs `dopemux rte promptset audit` on a v5 promptset.
+- **Harm:** `ClickException("Promptset audit is implemented for v4 only.")`. Operator either tries `--pipeline-version v4` (wrong engine) or gives up. The pre-flight audit they wanted is unavailable. (`F-OPUS-HIGH-4`)
+- **Mitigation in place:** Error message names "v4 only."
+- **Residual gap:** No fallback to a v5-equivalent audit; no doc that says "v5 promptsets are audited differently — try X."
+- **Operator-harm tier:** **medium**.
+
+## R-UX-6 — Pre-live validator NO_GO produces an unstructured stderr line
+
+- **Trigger:** Operator runs `dopemux rte run --execute` after setting `DPMX_LIVE_OK=1`; the v25 validator returns NO_GO.
+- **Harm:** A `RuntimeError("Pre-live validator blocked live execution: verdict=NO_GO_CODE reason_codes=CRITICAL_TEST_FAILURE output_dir=/path/...")` propagates. No problem/why/fix structure, no `[BLOCKER]` chip, no actionable next step beyond "read the output_dir." Operator has to open the output directory and find `VALIDATION_REPORT.json` to know what to fix. (`F-OPUS-HIGH-5`)
+- **Mitigation in place:** The validator does write a structured `VALIDATION_REPORT.json`; the error message includes the path.
+- **Residual gap:** The error message is not in the `error_panel(problem, why, fix)` shape the brand-voice spec mandates. The reason codes are stringified into one line rather than separated by purpose. The next-step is implicit.
+- **Operator-harm tier:** **medium-high** — this is the *most consequential* error path in RTE.
+
+## R-UX-7 — Operator scans 33-flag help text and misses a critical option
+
+- **Trigger:** Operator runs `dopemux rte run --help`.
+- **Harm:** ~33 Click options dumped in flat list. Critical safety options (`--max-cost-usd` not present in the rte run signature itself, `--allow-multi-phase-live-batch`, `--prescan-online`, `--allow-online-llm`) sit alongside cosmetic flags (`--ui`, `--pretty`, `--quiet`). Operators scan and miss the one they need. (`F-OPUS-HIGH-6`)
+- **Mitigation in place:** Click does its standard help formatting.
+- **Residual gap:** No progressive disclosure (`--verbose`/`--debug` for extended help), no grouping by safety vs cosmetic vs routing, no scan-friendly summary at the top.
+- **Operator-harm tier:** **medium**.
+
+## R-UX-8 — Operator discovers `dopemux rte wizard` and invokes it without context
+
+- **Trigger:** Operator runs `dopemux rte --help`, sees `wizard` in the subcommand list, runs `dopemux rte wizard` curiously.
+- **Harm:** Behavior is the `audit.commands["wizard"]` registered at `cli.py:5516` — undocumented in README.md or AGENTS.md. Operator has no idea what they're starting. (`F-OPUS-MED-4`)
+- **Mitigation in place:** The wizard sub-app may have its own help text (not inspected here).
+- **Residual gap:** Documentation gap.
+- **Operator-harm tier:** **low-medium**.
+
+## R-UX-9 — Operator confuses `dopemux upgrades run` and `dopemux rte run` as different commands
+
+- **Trigger:** Operator reads ARCHITECTURE.md §5.5 (still mentions `dopemux upgrades`), runs `dopemux upgrades run`, then later reads README.md §4 saying use `dopemux rte run`.
+- **Harm:** Two command paths, same behavior. Operator may try one, see something they don't recognize, try the other, get the same thing, and become uncertain about whether they're using the canonical path. Documentation drift compounds the confusion. (`F-OPUS-MED-1`, `F-OPUS-MED-2`)
+- **Mitigation in place:** Both paths produce identical behavior (canonical commands aliased into both Click groups).
+- **Residual gap:** ARCHITECTURE.md needs the deprecation note; eventual `upgrades` removal needs a plan.
+- **Operator-harm tier:** **low-medium**.
+
+## R-UX-10 — Operator uses `dopemux extractor status` in either mode without realizing it has two
+
+- **Trigger:** Operator runs `dopemux extractor status` (no flags) hoping for runtime status.
+- **Harm:** Gets a `SYNC_MANIFEST.json` reading from a generated promptset, not the run status they wanted. With flags they get a deprecation pointing to `dopemux rte status`. Either way the behavior is not what an operator hoping for "show me what's happening with my run" expects. (`F-OPUS-MED-3`)
+- **Mitigation in place:** Docstring partially explains.
+- **Residual gap:** Dual-mode commands need explicit framing.
+- **Operator-harm tier:** **low**.
+
+## R-UX-11 — Operator misreads spend cap floats as something other than USD
+
+- **Trigger:** Operator runs `dopemux rte validate-live --help`, sees `--provider-probe-max-usd 0.10` defaults.
+- **Harm:** A tired or non-English-first operator may briefly misread the float-without-unit. Compounded by adjacent `--provider-probe-max-minutes` (also a float, also unit-bearing-via-name). (`F-OPUS-LOW-1`)
+- **Mitigation in place:** Flag name has `-usd` suffix.
+- **Residual gap:** Help description doesn't restate the unit.
+- **Operator-harm tier:** **low**.
+
+## R-UX-12 — Empty terminal-rendering-guide.md misleads operators looking for it
+
+- **Trigger:** Operator searches `docs/ux/` for terminal-rendering reference, finds `terminal-rendering-guide.md`, opens it.
+- **Harm:** File has only frontmatter; no body content. Operator wastes time, then must find the actual rendering specifics elsewhere (`cli-ux-design-spec.md §7 Render Modes`). (`F-OPUS-HIGH-3`)
+- **Mitigation in place:** None.
+- **Residual gap:** Either delete the stub or write the content.
+- **Operator-harm tier:** **low**.
+
+## R-UX-13 — Cockpit audit reports look like specifications
+
+- **Trigger:** A contributor or Claude agent searches `docs/05-audit-reports/` for cockpit design and finds six 2026-04-24 cockpit-pm-implementer-* reports.
+- **Harm:** Files are long, structured, headed with "Authority map" / "Callable Surface Inventory" — they read like specs. The "evidence pack only, do not implement" caveat is prose at the head, not a structured frontmatter flag. An impatient reader (or an agent that summarizes rather than reads) could miss it. (`F-OPUS-MED-7`)
+- **Mitigation in place:** Verdict prose at top of each file.
+- **Residual gap:** Structured frontmatter flag would make the caveat machine-checkable.
+- **Operator-harm tier:** **medium**.
+
+## R-UX-14 — Brand-voice conformance for runtime emitters is partially unverifiable from static reading alone
+
+- **Trigger:** Audit tries to confirm that every CLI/agent emit ends with `NEXT:` / `Receipt:` / `PROGRESS` per `brand-voice-guidelines.md` §3.5.
+- **Harm:** Static reading shows the rule but cannot exhaustively verify every emit path. Some are obviously compliant (the truth-deprecation message ends with three example commands functioning as a NEXT). Others are not (the consent-gate `parser.error(...)` at run_extraction_v5.py:3015-3019). (`F-OPUS-LOW-2`)
+- **Mitigation in place:** `brand_lint.py` audits a defined set of files; runtime wrapper `validate_or_fallback()` exists.
+- **Residual gap:** Audit cannot say from static reading whether the closer rule is consistently met across all RTE runtime emitters. Recorded as `UNKNOWN`.
+- **Operator-harm tier:** **low** (audit-completeness risk, not operator-harm).
+
+---
+
+## Risk-tier rollup
+
+| Tier | Count | Risk IDs |
+|------|------:|----------|
+| high | 2 | R-UX-1, R-UX-4 |
+| medium-high | 3 | R-UX-2, R-UX-3, R-UX-6 |
+| medium | 4 | R-UX-5, R-UX-7, R-UX-13, (R-UX-2 also slots here) |
+| low-medium | 2 | R-UX-8, R-UX-9 |
+| low | 4 | R-UX-10, R-UX-11, R-UX-12, R-UX-14 |
+
+The two `high` risks (`R-UX-1`, `R-UX-4`) deserve attention first because they concern the most consequential operator/agent paths — live execution discovery and Claude-agent safety priming.
+
+End of UX_RISK_LEDGER.md.

--- a/proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json
+++ b/proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json
@@ -1,0 +1,136 @@
+{
+  "packet_id": "TP-DMX-RTEOPUS-AUDIT-DOCS-001",
+  "generated_at_local": "2026-05-17T16:16:00-07:00",
+  "repo": {
+    "name": "dopemux-mvp",
+    "remote": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "worktree": "/Users/hue/.codex/worktrees/rte-opus-audit-docs/dopemux-mvp",
+    "branch": "codex/rte-opus-audit-docs",
+    "base_ref": "origin/main",
+    "base_sha": "3bdb146813ad34de44078d86900c3fdbb971ef25"
+  },
+  "source_bundle": {
+    "path": "/Users/hue/code/dopemux-mvp/.claude/worktrees/youthful-neumann-b94cc0/out/rte-opus-uiux-claude-design-audit",
+    "source_worktree_branch": "claude/youthful-neumann-b94cc0",
+    "source_worktree_head_sha": "a234f798947d51915b2adea3e0bc5a2917ac595b",
+    "source_worktree_status": "source bundle was untracked in the source Claude worktree",
+    "audit_id": "RTE-OPUS-UIUX-CLAUDE-DESIGN-AUDIT-001"
+  },
+  "destination_bundle": {
+    "path": "docs/audit/rte-opus-uiux-claude-design-audit",
+    "path_decision": "latest user instruction selected docs/audit; existing repo convention also contains docs/05-audit-reports, so the path choice is explicit rather than inferred"
+  },
+  "artifact_files": [
+    {
+      "source_file": "CLAUDE_DESIGN_COMPATIBILITY.md",
+      "destination_file": "claude-design-compatibility.md",
+      "source_sha256": "bd636a1296c367221f76f7d66f8f46c158db4865e19da92d972760dd66beee22",
+      "destination_sha256": "f23a67250713d083fcda57ed446b9cb1ee19155b8eab145d9bbacbaa2a92b723",
+      "hash_relation": "different_after_docs_frontmatter_filename_and_markdownlint_normalization"
+    },
+    {
+      "source_file": "FINDINGS_LEDGER.json",
+      "destination_file": "FINDINGS_LEDGER.json",
+      "source_sha256": "e48e833b1972b11af1aacfa10192c87479070924557cd33d890de91a1e67927e",
+      "destination_sha256": "e48e833b1972b11af1aacfa10192c87479070924557cd33d890de91a1e67927e",
+      "hash_relation": "identical"
+    },
+    {
+      "source_file": "FINDINGS_LEDGER.md",
+      "destination_file": "findings-ledger.md",
+      "source_sha256": "bc8bc4a7f9b8b01b73c15a2bb30558a6e60a7ffcbda055ce8162a268f3177df0",
+      "destination_sha256": "9217364bb8a51931e25fc6bf81b4b2d1fd532873c5a2bf2efb46048cf679418d",
+      "hash_relation": "different_after_docs_frontmatter_and_filename_normalization"
+    },
+    {
+      "source_file": "METHODOLOGY.md",
+      "destination_file": "methodology.md",
+      "source_sha256": "b1b260eaa8871f5094dfc38cce6d25c8fd3d046234a72cfdeb90f5f010884b14",
+      "destination_sha256": "dafa4c2d2885658299b261864f42b7230dac616d21202144d737f98c2a5901c3",
+      "hash_relation": "different_after_docs_frontmatter_and_filename_normalization"
+    },
+    {
+      "source_file": "RECOMMENDATIONS.md",
+      "destination_file": "recommendations.md",
+      "source_sha256": "0e07bd8a0c08c8697be264df77b38fd039077a8848a58cb0818f3bc49f74f47b",
+      "destination_sha256": "aae3030de8333befbc780e35384df9a8ee740a3d405c4fa1d94f1f60bb1de1af",
+      "hash_relation": "different_after_docs_frontmatter_and_filename_normalization"
+    },
+    {
+      "source_file": "REPORT.md",
+      "destination_file": "report.md",
+      "source_sha256": "6e4677b4abe1fb9eaee9acb4975f2d201ffc775d22a4a6455f6daf9e6c946ed3",
+      "destination_sha256": "943e1be2dfdccb620074609b83f3c927c9e8c0393116e79e17e03dcf4587e907",
+      "hash_relation": "different_after_docs_frontmatter_filename_and_link_normalization"
+    },
+    {
+      "source_file": "UX_RISK_LEDGER.md",
+      "destination_file": "ux-risk-ledger.md",
+      "source_sha256": "5538580455ec4a6275cef091abd9584e5642dde1aa3961ebea69a6399f9f9148",
+      "destination_sha256": "e58f00827f1dfa3f364f30a0ec14d29f89d2664f6a3692ef9c16b97a0e9da7c4",
+      "hash_relation": "different_after_docs_frontmatter_and_filename_normalization"
+    }
+  ],
+  "copy_verification": {
+    "status": "PASS_WITH_DOCS_NORMALIZATION",
+    "method": "source file hashes recorded, destination file hashes recorded, destination file count preserved, Markdown normalized for repo docs frontmatter and filename hygiene",
+    "file_count": 7,
+    "destination_files": [
+      "FINDINGS_LEDGER.json",
+      "claude-design-compatibility.md",
+      "findings-ledger.md",
+      "methodology.md",
+      "recommendations.md",
+      "report.md",
+      "ux-risk-ledger.md"
+    ]
+  },
+  "scope_attestation": {
+    "runtime_files_changed": false,
+    "service_files_changed": false,
+    "prompt_files_changed": false,
+    "schema_files_changed": false,
+    "provider_calls_run": false,
+    "live_extraction_run": false,
+    "repo_docs_hygiene_policy_changed": true,
+    "markdown_frontmatter_added": true,
+    "markdown_filenames_normalized": true,
+    "observed_findings_or_recommendations_rewritten": false
+  },
+  "validation_results": [
+    {
+      "command": "python -m json.tool task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json",
+      "exit_code": 0,
+      "result": "PASS",
+      "evidence": "Task packet JSON parsed successfully before artifact copy."
+    },
+    {
+      "command": "python - <<'PY' ... dopetask-canonical-spec validation ... PY",
+      "exit_code": 0,
+      "result": "PASS",
+      "evidence": "Task packet validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+    },
+    {
+      "command": "python - <<'PY' ... compare source and destination hashes ... PY",
+      "exit_code": 0,
+      "result": "PASS",
+      "evidence": "Source and destination file mappings were recorded; JSON remained byte-identical and Markdown destination hashes changed only after docs hygiene normalization."
+    },
+    {
+      "command": "git diff --check -- docs/audit/rte-opus-uiux-claude-design-audit config/docs_hygiene/docs_placement_policy.yaml proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json task-packets/INDEX.md",
+      "exit_code": 0,
+      "result": "PASS",
+      "evidence": "No whitespace errors reported for the changed paths."
+    },
+    {
+      "command": "pre-commit run --files docs/audit/rte-opus-uiux-claude-design-audit/claude-design-compatibility.md docs/audit/rte-opus-uiux-claude-design-audit/FINDINGS_LEDGER.json docs/audit/rte-opus-uiux-claude-design-audit/findings-ledger.md docs/audit/rte-opus-uiux-claude-design-audit/methodology.md docs/audit/rte-opus-uiux-claude-design-audit/recommendations.md docs/audit/rte-opus-uiux-claude-design-audit/report.md docs/audit/rte-opus-uiux-claude-design-audit/ux-risk-ledger.md config/docs_hygiene/docs_placement_policy.yaml proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json task-packets/INDEX.md",
+      "exit_code": 0,
+      "result": "PASS",
+      "evidence": "Docs frontmatter, docs graph validation, prohibited pattern check, prelude length, markdown location, docs placement hygiene, docs filename hygiene, full-tree docs filename audit, root hygiene, markdownlint, trailing whitespace, EOF fixer, and YAML checks passed."
+    }
+  ],
+  "remaining_unknowns": [
+    "The source bundle was untracked in the Claude worktree, so this PR preserves the recovered files and checksums but cannot prove prior Git history for the bundle.",
+    "The copied audit's internal findings remain evidence artifacts from source HEAD a234f798947d51915b2adea3e0bc5a2917ac595b, not claims about current runtime state."
+  ]
+}

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -52,6 +52,7 @@ A packet is superseded by another packet
 | TP-DMX-REPOHYG-008 | Repo Hygiene | Remove Genetic Agent and Taskmaster active surfaces | Ready | N/A |
 | TP-DMX-RTEAUDIT-001 | Repo Truth Extractor | Assemble pre-live audit pack for GPT-5.4 Pro | Ready | N/A |
 | TP-DMX-RTE-55PRO-AUDIT-ASSEMBLY-001 | Repo Truth Extractor | Assemble GPT-5.5 Pro multi-pass audit pack | Active | N/A |
+| TP-DMX-RTEOPUS-AUDIT-DOCS-001 | Repo Truth Extractor | Add recovered Opus UI/UX Claude design audit bundle to docs/audit | Active | N/A |
 | TP-DMX-RTEINT-001 | Repo Truth Extractor | Integrate current RTE branch deltas into staging audit branch | Ready | N/A |
 | TP-DMX-RTECANON-001 | Repo Truth Extractor | Establish `dopemux rte` as the canonical operator entrypoint | Ready | N/A |
 | TP-RTE-V3-CONSENT-004 | Repo Truth Extractor | Gate legacy v3 execution and fail closed on unknown pipeline versions | Active | N/A |

--- a/task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json
+++ b/task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json
@@ -1,0 +1,175 @@
+{
+  "id": "TP-DMX-RTEOPUS-AUDIT-DOCS-001",
+  "project": "dopemux-mvp",
+  "target": "Add the recovered RTE Opus UI/UX Claude design audit bundle to the project under docs/audit for durable review and PR traceability, while updating docs hygiene policy to recognize that user-selected audit root.",
+  "invariants": [
+    "Do not modify runtime code, service code, prompt content, schemas, or production configuration.",
+    "Preserve the recovered audit evidence content while applying repo-required docs frontmatter and filename hygiene.",
+    "Keep the historical source audit claims as evidence artifacts, not runtime truth.",
+    "Record source and destination checksums so the copy is auditable.",
+    "Latest user instruction selects docs/audit even though existing repo docs commonly use docs/05-audit-reports; preserve that conflict explicitly instead of silently normalizing paths."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-RTE-AUDIT-SERIES-001",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/rte-opus-audit-docs",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(rte): add opus uiux audit bundle",
+    "allowlist": [
+      "docs/audit/rte-opus-uiux-claude-design-audit/claude-design-compatibility.md",
+      "docs/audit/rte-opus-uiux-claude-design-audit/FINDINGS_LEDGER.json",
+      "docs/audit/rte-opus-uiux-claude-design-audit/findings-ledger.md",
+      "docs/audit/rte-opus-uiux-claude-design-audit/methodology.md",
+      "docs/audit/rte-opus-uiux-claude-design-audit/recommendations.md",
+      "docs/audit/rte-opus-uiux-claude-design-audit/report.md",
+      "docs/audit/rte-opus-uiux-claude-design-audit/ux-risk-ledger.md",
+      "config/docs_hygiene/docs_placement_policy.yaml",
+      "proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json",
+      "task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json",
+      "task-packets/INDEX.md"
+    ],
+    "verify": [
+      "git rev-parse --show-toplevel",
+      "test -f .dopetaskroot",
+      "git remote -v",
+      "git branch --show-current",
+      "git status --short --branch",
+      "python -m json.tool task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json",
+      "python -m json.tool proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json",
+      "python - <<'PY'\nimport json\nfrom pathlib import Path\nfrom jsonschema import Draft7Validator\nschema = json.loads(Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text())\npayload = json.loads(Path('task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json').read_text())\nerrors = sorted(Draft7Validator(schema).iter_errors(payload), key=lambda e: list(e.path))\nif errors:\n    raise SystemExit('\\n'.join('%s: %s' % (('/'.join(map(str, e.path)) or '<root>'), e.message) for e in errors))\nprint('PASS task packet schema validation')\nPY",
+      "shasum -a 256 docs/audit/rte-opus-uiux-claude-design-audit/*",
+      "git diff --check -- docs/audit/rte-opus-uiux-claude-design-audit config/docs_hygiene/docs_placement_policy.yaml proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json task-packets/INDEX.md"
+    ]
+  },
+  "pr": {
+    "title": "docs(rte): add opus uiux audit bundle",
+    "body": "## Summary\n- add the recovered RTE Opus UI/UX Claude design audit bundle under docs/audit/rte-opus-uiux-claude-design-audit\n- update docs placement policy so docs/audit is an explicit active docs root\n- add a task packet and proof JSON with source and destination checksum evidence\n- keep the bundle as audit evidence only; no runtime, prompt, schema, or service files change\n\n## Scope\n- documentation audit artifacts only\n- docs hygiene policy recognition for docs/audit\n- task packet and proof for repo traceability\n- no generated artifact rewrites outside repo-required docs normalization\n\n## Validation\n- task packet JSON parses and validates against dopetask-canonical-spec.json\n- proof JSON parses\n- source and destination SHA-256 hashes are recorded after docs normalization\n- git diff --check passes for the changed paths\n- pre-commit passes for the changed files",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Verify repo identity, source bundle identity, and the requested docs/audit destination before copying artifacts.",
+      "requirements": [
+        "Confirm worktree is a clean dedicated worktree on codex/rte-opus-audit-docs.",
+        "Confirm origin remote matches dopemux-mvp.",
+        "Confirm the recovered source bundle exists in the Claude worktree.",
+        "Confirm docs/audit is the latest user-selected destination even though existing repo audit reports commonly use docs/05-audit-reports.",
+        "Confirm docs/audit is represented in docs hygiene policy before final validation."
+      ],
+      "commands": [
+        "git rev-parse --show-toplevel",
+        "test -f .dopetaskroot",
+        "git remote -v",
+        "git branch --show-current",
+        "git status --short --branch",
+        "find /Users/hue/code/dopemux-mvp/.claude/worktrees/youthful-neumann-b94cc0/out/rte-opus-uiux-claude-design-audit -type f -maxdepth 1 -print | sort"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json"
+      ],
+      "validation": [
+        "Repo identity and source bundle identity are recorded before artifact copy.",
+        "Destination path decision is explicitly tied to the latest user instruction."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docs/INDEX.md",
+        "docs/docs_index.yaml",
+        "docs/03-reference/filesystem-guide.md",
+        "docs/03-reference/governance/manifest-and-index-rules.md",
+        "config/docs_hygiene/docs_placement_policy.yaml"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Copy the seven recovered audit artifacts into docs/audit/rte-opus-uiux-claude-design-audit and normalize Markdown files to repo docs hygiene.",
+      "requirements": [
+        "Create docs/audit/rte-opus-uiux-claude-design-audit if absent.",
+        "Copy exactly the seven recovered files from the source bundle.",
+        "Allow repo docs hooks to add frontmatter and enforce kebab-case Markdown filenames.",
+        "Do not rewrite observed findings or recommendations beyond mechanical docs hygiene.",
+        "Generate checksum proof after copy and normalization."
+      ],
+      "commands": [
+        "shasum -a 256 /Users/hue/code/dopemux-mvp/.claude/worktrees/youthful-neumann-b94cc0/out/rte-opus-uiux-claude-design-audit/*",
+        "shasum -a 256 docs/audit/rte-opus-uiux-claude-design-audit/*"
+      ],
+      "expected_files": [
+        "docs/audit/rte-opus-uiux-claude-design-audit/claude-design-compatibility.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/FINDINGS_LEDGER.json",
+        "docs/audit/rte-opus-uiux-claude-design-audit/findings-ledger.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/methodology.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/recommendations.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/report.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/ux-risk-ledger.md",
+        "proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json"
+      ],
+      "validation": [
+        "Destination file list matches source file list.",
+        "Source and destination SHA-256 hashes are recorded after docs normalization.",
+        "Copied files remain evidence artifacts only."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Validate, stage only allowlisted files, commit, push, and open a draft PR.",
+      "requirements": [
+        "Validate task packet schema.",
+        "Validate proof JSON.",
+        "Run git diff --check on changed paths.",
+        "Run configured pre-commit hooks for the changed files if safe.",
+        "Review diff scope before staging and before commit.",
+        "Open a draft PR against main."
+      ],
+      "commands": [
+        "python -m json.tool task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json",
+        "python -m json.tool proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json",
+        "python - <<'PY'\nimport json\nfrom pathlib import Path\nfrom jsonschema import Draft7Validator\nschema = json.loads(Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text())\npayload = json.loads(Path('task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json').read_text())\nerrors = sorted(Draft7Validator(schema).iter_errors(payload), key=lambda e: list(e.path))\nif errors:\n    raise SystemExit('\\n'.join('%s: %s' % (('/'.join(map(str, e.path)) or '<root>'), e.message) for e in errors))\nprint('PASS task packet schema validation')\nPY",
+        "git diff --check -- docs/audit/rte-opus-uiux-claude-design-audit config/docs_hygiene/docs_placement_policy.yaml proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json task-packets/INDEX.md",
+        "pre-commit run --files docs/audit/rte-opus-uiux-claude-design-audit/claude-design-compatibility.md docs/audit/rte-opus-uiux-claude-design-audit/FINDINGS_LEDGER.json docs/audit/rte-opus-uiux-claude-design-audit/findings-ledger.md docs/audit/rte-opus-uiux-claude-design-audit/methodology.md docs/audit/rte-opus-uiux-claude-design-audit/recommendations.md docs/audit/rte-opus-uiux-claude-design-audit/report.md docs/audit/rte-opus-uiux-claude-design-audit/ux-risk-ledger.md config/docs_hygiene/docs_placement_policy.yaml proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json task-packets/INDEX.md"
+      ],
+      "expected_files": [
+        "docs/audit/rte-opus-uiux-claude-design-audit/claude-design-compatibility.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/FINDINGS_LEDGER.json",
+        "docs/audit/rte-opus-uiux-claude-design-audit/findings-ledger.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/methodology.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/recommendations.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/report.md",
+        "docs/audit/rte-opus-uiux-claude-design-audit/ux-risk-ledger.md",
+        "config/docs_hygiene/docs_placement_policy.yaml",
+        "proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json",
+        "task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "All changed files are allowlisted.",
+        "Validation commands pass or failures are reported with exact blocker.",
+        "PR is opened as draft unless explicitly requested otherwise."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add the recovered RTE Opus UI/UX Claude design audit bundle under `docs/audit/rte-opus-uiux-claude-design-audit/`.
- Add `docs/audit` to docs placement policy so the requested audit root is explicit and passes repo hygiene checks.
- Add task packet `TP-DMX-RTEOPUS-AUDIT-DOCS-001` and checksum proof for source/destination traceability.

## Scope
- Documentation audit artifacts only.
- No runtime, service, prompt, schema, or production config changes.
- Markdown artifacts were normalized for repo docs frontmatter and kebab-case filename hygiene; the source checksums and destination checksums are recorded in proof.

## Validation
- `python -m json.tool task-packets/TP-DMX-RTEOPUS-AUDIT-DOCS-001.json`
- `python -m json.tool proof/rte-opus-uiux-claude-design-audit-2026-05-17.proof.json`
- task packet schema validation against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `git diff --check`
- `pre-commit run --files ...` for all changed files

## Release Notes
- Docs-only audit bundle addition; no changelog or runtime feature list updates required.

@codex review
@gemini
@copilot