### PR TITLE
Fix RTE Claude safety proof replay metadata

### DIFF
--- a/out/rte-ux-claude-rte-safety-guidance/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001_AUDIT_NOTE.md
+++ b/out/rte-ux-claude-rte-safety-guidance/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001_AUDIT_NOTE.md
@@ -116,3 +116,41 @@ account, or validation behavior.
 - PASS: no follow-on packet ids found outside excluded valuation, current
   task-packet, audit, and proof contexts
 - PASS: `pre-commit run --files ...` on all touched files
+
+## Proof Replay Cleanup (post-merge patch)
+
+After PR #643 was squash-merged to `main` as
+`0083f50a58ffa5e9d34eb3c9c620bf28076541e5`, an audit identified two replayability
+issues in the original artifacts. A proof-only follow-up on branch
+`codex/rte-claude-safety-proof-replay-cleanup` (from `origin/main`) patched
+the following without changing runtime guidance:
+
+- `proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json`
+  `validation_commands[1]` originally referenced an absent path
+  (`schemas/task-packet-payload.schema.json`) with `Draft202012Validator`. It
+  has been replaced with the canonical
+  `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` path validated
+  by `Draft7Validator`, matching the embedded task-packet `verify[1]` form and
+  the schema's `$schema: draft-07/schema#`. The replay command now executes
+  successfully against the merged tree.
+- `proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json`
+  `rollback_plan` originally contained a pre-merge `<commit-sha>` placeholder.
+  It now records that PR #643 is merged as squash commit
+  `0083f50a58ffa5e9d34eb3c9c620bf28076541e5` and documents the concrete
+  post-merge revert command.
+- `task-packets/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001.md` Rollback Plan
+  prose was updated to the same post-merge phrasing. The embedded task-packet
+  JSON payload was not touched and still validates against the canonical
+  schema.
+- A `proof_replay_cleanup` block was added to `PROOF.json` recording the
+  cleanup branch, the merged SHA, the patches applied, and the no-runtime,
+  no-provider, no-live-extraction attestations.
+
+The pre-squash local-branch HEAD `aa3f205072fb3ee5b935a0da72d83a56ffd8a56a`
+referenced in some external notes is not present in this proof, audit, or
+packet artifact text. No other artifact rollback text required correction.
+
+This cleanup was proof and audit only. It did not change runtime, dispatch,
+provider, promptset, schema, routing, pricing, live-extraction, validator,
+or guidance semantics. No provider calls, live extraction, live preflight, or
+network/provider validation were run.

--- a/out/rte-ux-claude-rte-safety-guidance/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001_AUDIT_NOTE.md
+++ b/out/rte-ux-claude-rte-safety-guidance/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001_AUDIT_NOTE.md
@@ -145,9 +145,9 @@ the following without changing runtime guidance:
   cleanup branch, the merged SHA, the patches applied, and the no-runtime,
   no-provider, no-live-extraction attestations.
 
-The pre-squash local-branch HEAD `aa3f205072fb3ee5b935a0da72d83a56ffd8a56a`
-referenced in some external notes is not present in this proof, audit, or
-packet artifact text. No other artifact rollback text required correction.
+A pre-squash local-branch HEAD referenced in external review notes is not
+present in this proof, audit, or packet artifact text. No other artifact
+rollback text required correction.
 
 This cleanup was proof and audit only. It did not change runtime, dispatch,
 provider, promptset, schema, routing, pricing, live-extraction, validator,

--- a/out/rte-ux-claude-rte-safety-guidance/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001_AUDIT_NOTE.md
+++ b/out/rte-ux-claude-rte-safety-guidance/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001_AUDIT_NOTE.md
@@ -126,13 +126,12 @@ issues in the original artifacts. A proof-only follow-up on branch
 the following without changing runtime guidance:
 
 - `proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json`
-  `validation_commands[1]` originally referenced an absent path
-  (`schemas/task-packet-payload.schema.json`) with `Draft202012Validator`. It
-  has been replaced with the canonical
-  `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` path validated
-  by `Draft7Validator`, matching the embedded task-packet `verify[1]` form and
-  the schema's `$schema: draft-07/schema#`. The replay command now executes
-  successfully against the merged tree.
+  `validation_commands[1]` originally invoked the absent legacy schema
+  reference with `Draft202012Validator`. It has been replaced with the
+  canonical `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+  path validated by `Draft7Validator`, matching the embedded task-packet
+  `verify[1]` form and the schema's `$schema: draft-07/schema#`. The replay
+  command now executes successfully against the merged tree.
 - `proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json`
   `rollback_plan` originally contained a pre-merge `<commit-sha>` placeholder.
   It now records that PR #643 is merged as squash commit

--- a/proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json
+++ b/proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json
@@ -184,7 +184,7 @@
     "patches": [
       {
         "field": "validation_commands[1]",
-        "reason": "Original command referenced absent path schemas/task-packet-payload.schema.json with Draft202012Validator. Replaced with the canonical docs/03-reference/spec/dopetask/dopetask-canonical-spec.json path validated by Draft7Validator (matching the schema's $schema draft-07/schema# and the embedded task-packet verify[1] form). The replay command now executes successfully against the merged tree."
+        "reason": "Original command referenced the absent legacy schema reference with Draft202012Validator. Replaced with the canonical docs/03-reference/spec/dopetask/dopetask-canonical-spec.json path validated by Draft7Validator (matching the schema's $schema draft-07/schema# and the embedded task-packet verify[1] form). The replay command now executes successfully against the merged tree."
       },
       {
         "field": "rollback_plan",

--- a/proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json
+++ b/proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json
@@ -195,6 +195,24 @@
     "no_provider_calls_run": true,
     "no_live_extraction_run": true,
     "forbidden_paths_touched": [],
-    "scope": "proof and audit replayability cleanup only"
+    "scope": "proof and audit replayability cleanup only",
+    "replay_validation_results": {
+      "status": "PASS",
+      "note": "The historical validation_results.results array is preserved unchanged because it records what was actually executed during the original packet. This block records that the patched validation_commands[1] (canonical Draft7 form) was executed against the merged tree during proof-only cleanup and returned PASS.",
+      "results": [
+        {
+          "command": "python -m json.tool proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json",
+          "exit_code": 0,
+          "result": "PASS",
+          "evidence": "Patched PROOF.json parses as JSON."
+        },
+        {
+          "command": "validation_commands[1] (Draft7Validator + docs/03-reference/spec/dopetask/dopetask-canonical-spec.json) extracted from PROOF.json and executed inline",
+          "exit_code": 0,
+          "result": "PASS",
+          "evidence": "Heredoc body printed 'PASS task packet payload schema validation' against the merged tree."
+        }
+      ]
+    }
   }
 }

--- a/proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json
+++ b/proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json
@@ -92,7 +92,7 @@
   ],
   "validation_commands": [
     "python -m json.tool proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json",
-    "python - <<'PY'\nimport json\nfrom pathlib import Path\n\nfrom jsonschema import Draft202012Validator\n\npacket_text = Path('task-packets/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001.md').read_text()\nschema = json.loads(Path('schemas/task-packet-payload.schema.json').read_text())\npayload = json.loads(packet_text.split('```json', 1)[1].split('```', 1)[0])\nDraft202012Validator(schema).validate(payload)\nprint('PASS task packet payload schema validation')\nPY",
+    "python - <<'PY'\nimport json, re\nfrom pathlib import Path\nfrom jsonschema import Draft7Validator\npacket = Path('task-packets/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001.md').read_text()\nmatch = re.search(r'```json\\n(.*?)\\n```', packet, re.S)\nassert match, 'missing fenced json payload'\npayload = json.loads(match.group(1))\nschema = json.loads(Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text())\nerrors = sorted(Draft7Validator(schema).iter_errors(payload), key=lambda e: list(e.path))\nif errors:\n    raise SystemExit('\\n'.join('%s: %s' % (('/'.join(map(str, e.path)) or '<root>'), e.message) for e in errors))\nprint('PASS task packet payload schema validation')\nPY",
     "git diff --check",
     "git status --short",
     "git diff --name-only",
@@ -172,8 +172,29 @@
     "push_or_pr": "NOT_REQUESTED"
   },
   "rollback_plan": [
-    "Before commit, remove the newly created task packet, audit note, and proof file, then restore AGENTS.md and .claude/PROJECT_INSTRUCTIONS.md from HEAD in the dedicated worktree.",
-    "After commit, revert the local commit from /Users/hue/code/dopemux-mvp-rte-claude-safety-guidance with git revert <commit-sha>.",
+    "Pre-commit local rollback (no longer reachable; packet is merged): would have removed the newly created task packet, audit note, and proof file, then restored AGENTS.md and .claude/PROJECT_INSTRUCTIONS.md from HEAD in the dedicated worktree.",
+    "Post-merge rollback (current state): PR #643 was squash-merged to main as 0083f50a58ffa5e9d34eb3c9c620bf28076541e5. From a fresh worktree off origin/main, revert with `git revert 0083f50a58ffa5e9d34eb3c9c620bf28076541e5` and open a follow-up PR.",
     "Do not mutate the dirty primary checkout at /Users/hue/code/dopemux-mvp."
-  ]
+  ],
+  "proof_replay_cleanup": {
+    "cleanup_packet": "proof-only cleanup applied on branch codex/rte-claude-safety-proof-replay-cleanup from origin/main",
+    "pr_643_state": "MERGED",
+    "pr_643_merge_commit": "0083f50a58ffa5e9d34eb3c9c620bf28076541e5",
+    "pr_643_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/643",
+    "patches": [
+      {
+        "field": "validation_commands[1]",
+        "reason": "Original command referenced absent path schemas/task-packet-payload.schema.json with Draft202012Validator. Replaced with the canonical docs/03-reference/spec/dopetask/dopetask-canonical-spec.json path validated by Draft7Validator (matching the schema's $schema draft-07/schema# and the embedded task-packet verify[1] form). The replay command now executes successfully against the merged tree."
+      },
+      {
+        "field": "rollback_plan",
+        "reason": "Original entry used a pre-merge `<commit-sha>` placeholder. Updated to record that PR #643 is now merged as squash commit 0083f50a58ffa5e9d34eb3c9c620bf28076541e5 and to document the concrete post-merge revert command. The earlier local-branch HEAD aa3f205072fb3ee5b935a0da72d83a56ffd8a56a (pre-squash) is not present anywhere in this proof, audit, or packet artifact text."
+      }
+    ],
+    "no_runtime_changes": true,
+    "no_provider_calls_run": true,
+    "no_live_extraction_run": true,
+    "forbidden_paths_touched": [],
+    "scope": "proof and audit replayability cleanup only"
+  }
 }

--- a/proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json
+++ b/proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json
@@ -188,7 +188,7 @@
       },
       {
         "field": "rollback_plan",
-        "reason": "Original entry used a pre-merge `<commit-sha>` placeholder. Updated to record that PR #643 is now merged as squash commit 0083f50a58ffa5e9d34eb3c9c620bf28076541e5 and to document the concrete post-merge revert command. The earlier local-branch HEAD aa3f205072fb3ee5b935a0da72d83a56ffd8a56a (pre-squash) is not present anywhere in this proof, audit, or packet artifact text."
+        "reason": "Original entry used a pre-merge `<commit-sha>` placeholder. Updated to record that PR #643 is now merged as squash commit 0083f50a58ffa5e9d34eb3c9c620bf28076541e5 and to document the concrete post-merge revert command. A pre-squash local-branch HEAD referenced in external review notes is not present anywhere in this proof, audit, or packet artifact text."
       }
     ],
     "no_runtime_changes": true,

--- a/task-packets/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001.md
+++ b/task-packets/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001.md
@@ -333,8 +333,12 @@ restored guidance files from `HEAD` in the dedicated packet worktree.
 
 Post-merge rollback (current state): PR #643 was squash-merged to main as
 `0083f50a58ffa5e9d34eb3c9c620bf28076541e5`. From a fresh worktree off
-`origin/main`, revert with `git revert
-0083f50a58ffa5e9d34eb3c9c620bf28076541e5` and open a follow-up PR.
+`origin/main`, run the following from the repo root, then open a follow-up
+PR:
+
+```sh
+git revert 0083f50a58ffa5e9d34eb3c9c620bf28076541e5
+```
 
 Do not mutate the dirty primary checkout at `/Users/hue/code/dopemux-mvp`.
 

--- a/task-packets/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001.md
+++ b/task-packets/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001.md
@@ -327,10 +327,16 @@ Do not push or open a PR unless explicitly requested after local commit closeout
 
 ## Rollback Plan
 
-Before commit, remove the newly created task packet, audit note, and proof file,
-then restore guidance files from `HEAD`. After commit, run
-`git revert <commit-sha>` from the dedicated packet worktree. Do not mutate the
-dirty primary checkout.
+Pre-commit local rollback (no longer reachable; packet is merged): would have
+removed the newly created task packet, audit note, and proof file, then
+restored guidance files from `HEAD` in the dedicated packet worktree.
+
+Post-merge rollback (current state): PR #643 was squash-merged to main as
+`0083f50a58ffa5e9d34eb3c9c620bf28076541e5`. From a fresh worktree off
+`origin/main`, revert with `git revert
+0083f50a58ffa5e9d34eb3c9c620bf28076541e5` and open a follow-up PR.
+
+Do not mutate the dirty primary checkout at `/Users/hue/code/dopemux-mvp`.
 
 ## No Runtime Behavior Statement
 


### PR DESCRIPTION
This PR is proof-only cleanup for the already-merged `RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001`.

It fixes the review findings from PR #643:

1. Updates the proof replay validation command from the absent schema path:
   `schemas/task-packet-payload.schema.json`

   to the canonical schema path:
   `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`

2. Updates rollback metadata for the squash-merged main state to use:
   `git revert 0083f50a58ffa5e9d34eb3c9c620bf28076541e5`

Scope:
- Proof/audit/task-packet metadata only.
- No runtime changes.
- No source changes.
- No provider calls.
- No live extraction.
- No packet 3 work.

Validation reported:
- Proof JSON parses.
- Embedded task packet payload validates against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`.
- `git diff --check` passes.
- Scope guard passes.
- `pre-commit run --files <touched files>` passes.

Touched files:
- `proof/rte-ux/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001/PROOF.json`
- `out/rte-ux-claude-rte-safety-guidance/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001_AUDIT_NOTE.md`
- `task-packets/RTE-UX-PKT-CLAUDE-RTE-SAFETY-GUIDANCE-001.md`

Rollback:
Close this PR without merge, or revert commit:
`c3a880a5daf2555890dde3a0657be14e72ce4a13`

After this PR is accepted or merged, packet 3 may start:
`RTE-UX-PKT-CLI-TONE-EMOJI-CLEANUP-001`