### PR TITLE
docs: add architecture governance operations handoff docs

### DIFF
--- a/docs/00-MASTER-INDEX.md
+++ b/docs/00-MASTER-INDEX.md
@@ -25,6 +25,8 @@ Status: [LOGGED] Topology Complete
 - **[Quick Start Guide](../QUICK_START.md)** - Get up and running in 5 minutes
 - **[Dopemux Quickstart Tutorial](01-tutorials/quickstart.md)** - Compose-backed startup and first checks
 - **[Developer Onboarding](02-how-to/developer-onboarding.md)** - Contributor setup, Task Packet discipline, and docs validation
+- **[Project Overview](04-explanation/overview/project-overview.md)** - Repo-grounded project shape and authority split
+- **[System Map](04-explanation/overview/system-map.md)** - High-level map of systems and non-authority links
 - **[Installation](01-tutorials/start-here.md)** - Comprehensive setup guide
 - **[README](../README.md)** - Project overview and features
 
@@ -56,6 +58,7 @@ Status: [LOGGED] Topology Complete
 - [PR Merge Flight Dashboard Quickstart](02-how-to/pr-merge-flight-dashboard.md)
 - [CI Remediation Specialist Reference](03-reference/ci-remediation-specialist.md)
 - [Internal Workflow Kit](02-how-to/internal-workflow-kit.md)
+- [Operator Workflows](02-how-to/operator-workflows.md)
 - [Workflow Idea to Epic Lifecycle](02-how-to/operations/workflow-idea-epic-lifecycle.md)
 - [Serena V2 Deployment](02-how-to/serena-v2-production-deployment.md)
 - [Repo Truth Extractor CLI Runbook](02-how-to/extraction/run-v4-from-dopemux-cli.md) - canonical command namespace: `dopemux rte ...` (`upgrades` is a legacy compatibility alias; `extractor` is a hidden legacy/refusal surface)
@@ -103,6 +106,9 @@ Status: [LOGGED] Topology Complete
 
 ### Core Architecture
 - [Architecture Overview](04-explanation/architecture/dopemux-architecture-overview.md) - Complete system architecture
+- [Dopemux Architecture](04-explanation/architecture/dopemux-architecture.md) - Split-authority architecture explanation grounded in current repo evidence
+- [Data and Control Flow](04-explanation/architecture/data-and-control-flow.md) - Operator, PM, bridge, retrieval, memory, and extraction flows
+- [Problem Statement](04-explanation/overview/problem-statement.md) - Documentation and operator-control problem framing
 - [Full Codebase Explainer](04-explanation/architecture/dopemux-mvp-full-codebase-explainer.md) - Repo-truth explainer for the active Dopemux control surfaces, service boundaries, and authority split
 - [System Bible](04-explanation/architecture/system-bible.md) - Consolidated knowledge base
 - [Three-Layer Integration](90-adr/adr-207-architecture-3-0-three-layer-integration.md)
@@ -196,10 +202,14 @@ Status: [LOGGED] Topology Complete
 
 ### Governance
 - [Authority Map](03-reference/governance/authority-map.md)
+- [Authority Boundaries](03-reference/governance/authority-boundaries.md)
+- [Governance Model](03-reference/governance/governance-model.md)
 - [Conflict Ledger](03-reference/governance/conflict-ledger.md)
 - [Documentation Source Map](03-reference/governance/dopemux-documentation-source-map.md)
 - [Documentation Gap Register](03-reference/governance/documentation-gap-register.md)
 - [Documentation Trust Map](03-reference/governance/doc-trust-map.md)
+- [AI Agent Handoff Guide](03-reference/instructions/ai-agent-handoff-guide.md)
+- [Component Catalog](03-reference/systems/component-catalog.md)
 - Additional governance contracts are tracked in the active backlog and linked from the Authority Map.
 
 ### Technical Deep Dives

--- a/docs/02-how-to/operator-workflows.md
+++ b/docs/02-how-to/operator-workflows.md
@@ -1,0 +1,104 @@
+---
+id: operator-workflows
+title: Operator Workflows
+type: how-to
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Operator workflows for Dopemux startup, PM routing, documentation packets, and proof.
+---
+# Operator Workflows
+
+This guide gives practical operator paths without changing authority boundaries.
+
+## Start From Repo Preflight
+
+```bash
+git status -sb
+git branch --show-current
+git rev-parse --show-toplevel
+test -f pyproject.toml
+test -f AGENTS.md
+```
+
+For service work, also inspect:
+
+```bash
+docker compose -f compose.yml config >/dev/null
+python scripts/check_root_hygiene.py
+```
+
+## Operator Startup
+
+Use `dopemux start` for the operator CLI/cockpit path:
+
+```bash
+dopemux start
+```
+
+Use explicit compose startup when you need the compose service stack:
+
+```bash
+docker network inspect dopemux-network >/dev/null 2>&1 \
+  || docker network create dopemux-network
+docker compose -f compose.yml up -d --build
+```
+
+Packet 003 did not run live compose startup. Mark live health as `NOT_RUN`
+unless you actually run the checks.
+
+## PM Write Routing
+
+Classify the PM write before choosing a tool:
+
+| PM write | Canonical writer | Rule |
+| --- | --- | --- |
+| title, description, assignee, passive metadata | Leantime | Do not route workflow changes through metadata writes. |
+| status, phase, blocker, queue, next action | task-orchestrator | Use workflow transition surfaces. |
+| decision, progress, project context | ConPort | Mirror to dope-memory only as receipt/history. |
+| historical receipt | dope-memory | Do not treat receipt as current PM state. |
+
+dopecon-bridge can proxy selected PM or KG-like calls. It is not the canonical
+writer. Name the upstream authority in proof.
+
+## Documentation Packet Flow
+
+1. Confirm parent packet is terminal.
+2. Start the next Task Packet in Task Orchestrator.
+3. Create the generated packet JSON first.
+4. Validate packet JSON against the canonical schema.
+5. Edit only allowlisted files.
+6. Run targeted validators after each meaningful slice.
+7. Run required packet validators.
+8. Commit only allowlisted files.
+9. Open a draft PR.
+10. Record proof and residual risks.
+
+Use a dedicated branch or worktree. Do not start a child packet until the parent
+packet is accepted with proof.
+
+## Runtime And Retrieval Workflow
+
+When using dope-context or ConPort retrieval:
+
+1. Treat the result as derived context.
+2. Open the source files or runtime code it points to.
+3. Verify the claim against source, tests, compose, or active entrypoints.
+4. Mark unresolved behavior as `UNKNOWN` or `NEEDS_REPO_VERIFICATION`.
+
+## Proof Workflow
+
+Proof should include:
+
+- files changed
+- validations with exit codes
+- remote CI status when available
+- full-repo validator failures, even when outside scope
+- `UNKNOWN`s and residual risks
+- runtime checks as `PASS`, `FAIL`, or `NOT_RUN`
+- rollback plan
+
+Do not invent results. Do not treat green docs checks as proof of runtime
+correctness.

--- a/docs/03-reference/governance/authority-boundaries.md
+++ b/docs/03-reference/governance/authority-boundaries.md
@@ -1,0 +1,63 @@
+---
+id: authority-boundaries
+title: Authority Boundaries
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Reference matrix for Dopemux canonical writers, derived views, and non-authority surfaces.
+---
+# Authority Boundaries
+
+Use this reference before writing docs, routing PM updates, or interpreting
+retrieval/extraction output. Authority is per domain.
+
+## Boundary Matrix
+
+| Domain | Canonical or strongest observed authority | Derived/supporting surfaces | Must Not Own |
+| --- | --- | --- | --- |
+| Operator control | `dopemux` CLI | compose, registry, local configs | PM truth, external execution after handoff |
+| Execution after handoff | external `dopetask` through `scripts/dopetask` | `scripts/taskx` shim | PM metadata, workflow legality, memory |
+| PM metadata | Leantime | leantime-bridge, bridge-safe PM routing | workflow legality, decisions, progress context |
+| Workflow transitions | Task Orchestrator | bridge custom-data persistence, Leantime status mirrors | all PM state, ConPort authority, dope-memory chronicle |
+| Decisions/progress/context | ConPort | dopecon-bridge `/kg/*` proxy views, PM adapters | passive PM metadata, workflow legality |
+| Historical receipts | dope-memory | PM mirror receipts, event projections | current PM state, all memory |
+| Code/docs retrieval | dope-context | ConPort retrieval where applicable | source truth for retrieved files |
+| Bridge/proxy/event transport | dopecon-bridge | Redis event bus, upstream adapters | canonical task, workflow, PM, decision, progress, memory, retrieval |
+| Operator support | ADHD Engine | bridge and ConPort projections | PM truth, ConPort authority, dope-memory authority |
+| Extraction/audit | Repo Truth Extractor | generated reports and proof artifacts | runtime truth or service authority |
+| Agents | `UNKNOWN` | `services/agents`, `src/dopemux/agent_orchestrator.py`, task-orchestrator agents | PM truth or repo-wide authority without proof |
+
+## Rules
+
+- Name the canonical writer before making a write.
+- Treat a mirror as a receipt only when the canonical writer is named.
+- Treat retrieval output as derived evidence.
+- Treat dopecon-bridge routes as operational paths, not source truth.
+- Treat Repo Truth Extractor artifacts as evidence, not stronger than runtime.
+- Preserve `UNKNOWN` when ownership is not proven.
+
+## Examples
+
+| Question | Authority path |
+| --- | --- |
+| Change a task title or assignee | Leantime metadata path |
+| Move a work item through workflow | task-orchestrator transition path |
+| Record a project decision | ConPort decision/progress path |
+| Preserve historical context | dope-memory chronicle path |
+| Find code/docs context | dope-context retrieval, then inspect source |
+| Route a compatibility call | dopecon-bridge, with upstream authority named |
+| Audit repo architecture | Repo Truth Extractor, with runtime truth still stronger |
+
+## Required Labels
+
+Use these labels in proof and docs when authority is not direct:
+
+- `canonical`: direct owner for this domain slice.
+- `mirror`: receipt or reflection from a canonical writer.
+- `proxy`: transport or adapter path.
+- `derived`: retrieval, report, index, summary, or projection.
+- `UNKNOWN`: unresolved ownership or runtime authority.
+- `NEEDS_REPO_VERIFICATION`: plausible but not exercised in runtime validation.

--- a/docs/03-reference/governance/governance-model.md
+++ b/docs/03-reference/governance/governance-model.md
@@ -1,0 +1,113 @@
+---
+id: governance-model
+title: Governance Model
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Governance rules for Task Packet execution, truth hierarchy, proof, and docs validation.
+---
+# Governance Model
+
+This model summarizes current repo governance for documentation and
+repo-changing work. It does not replace `AGENTS.md` or
+`docs/03-reference/governance/rules.md`.
+
+## Truth Hierarchy
+
+Use this truth hierarchy when sources conflict:
+
+1. Active Task Packet for scope, allowlist, validation, and stop conditions.
+2. Runtime code, config, compose wiring, tests, and active entrypoints.
+3. Tracked truth/reference docs under `docs/03-reference/truth/` and current
+   system docs.
+4. Current governance/reference docs such as `PROJECT.md`, `ARCHITECTURE.md`,
+   `PM_PLANE.md`, `SERVICE_CATALOG.md`, and system references.
+5. Historical, generated, archived, uploaded, exploratory, or design docs.
+6. Assumptions, explicitly labeled `UNKNOWN` or `NEEDS_REPO_VERIFICATION`.
+
+Task Packets control scoped execution. They do not make unsupported runtime
+claims true.
+
+## Task Packet Requirements
+
+Non-trivial repo-changing work requires a generated Task Packet before
+implementation. The packet must be validated against
+`docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` when the schema
+is available.
+
+Each packet must declare:
+
+- repo binding and marker
+- series identity and dependency order
+- branch and commit plan
+- allowlisted files
+- validations
+- expected files
+- proof obligations
+
+Do not edit outside the packet allowlist unless a later operator instruction
+explicitly changes scope.
+
+## Worktree And Branch Discipline
+
+Before edits:
+
+```bash
+git status -sb
+git branch --show-current
+git rev-parse --show-toplevel
+git remote -v
+```
+
+Use a dedicated branch or worktree. Preserve unrelated dirty files. Do not
+reset, clean, or overwrite user work without explicit authorization.
+
+## Proof Rules
+
+Proof must include:
+
+- Task Packet ID and path
+- branch and commit SHA
+- PR URL or exact blocker
+- files changed
+- validations with exit codes
+- known failures
+- `UNKNOWN`s
+- residual risks
+- runtime checks marked `PASS`, `FAIL`, or `NOT_RUN`
+- rollback plan
+
+Proof is evidence for review. It is not a substitute for missing validation.
+
+## Docs Validation Gates
+
+For documentation-heavy packets, use changed-file checks before broad checks:
+
+```bash
+python scripts/docs_validator.py <changed-docs>
+python scripts/docs_frontmatter_guard.py <changed-docs>
+python scripts/check_root_hygiene.py
+git diff --check
+pre-commit run --files <changed-files>
+```
+
+When a packet requires full-repo validators, run them and record failures. If
+they fail on files outside the packet allowlist, preserve that as residual docs
+hygiene debt instead of silently expanding the packet.
+
+## Completion Language
+
+Use precise states:
+
+- `PASS`: directly validated.
+- `FAIL`: command or check failed.
+- `NOT_RUN`: not executed.
+- `UNKNOWN`: not proven by inspected evidence.
+- `NEEDS_REPO_VERIFICATION`: plausible from docs/code but not exercised live.
+
+Do not claim runtime drift is closed unless runtime validation actually proves
+it. Do not claim a packet is accepted until proof is recorded and the operator
+or reviewer accepts it.

--- a/docs/03-reference/instructions/ai-agent-handoff-guide.md
+++ b/docs/03-reference/instructions/ai-agent-handoff-guide.md
@@ -1,0 +1,97 @@
+---
+id: ai-agent-handoff-guide
+title: AI Agent Handoff Guide
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Handoff guidance for AI agents working in Dopemux without becoming authority owners.
+---
+# AI Agent Handoff Guide
+
+This guide is for AI agents contributing to Dopemux. Agents are workflow
+participants, not source-truth owners.
+
+## Ground Rules
+
+- Do not invent repo facts, tests, files, commits, PRs, or runtime behavior.
+- Do not expose hidden chain-of-thought. Provide concise reasoning summaries,
+  evidence, commands, and outcomes instead.
+- Do not treat prompts, generated artifacts, retrieval output, or older docs as
+  stronger than runtime/source truth.
+- Do not promote dopecon-bridge to PM, workflow, decision, progress, memory, or
+  retrieval authority.
+- Do not treat dope-memory as all memory.
+- Do not treat dope-context retrieval as source truth.
+- Do not treat Repo Truth Extractor artifacts as higher authority than runtime.
+- Preserve `UNKNOWN` when agent authority or runtime ownership is unresolved.
+
+## Required Handoff Fields
+
+A handoff should include:
+
+- active Task Packet ID
+- branch and commit SHA
+- PR URL or blocker
+- changed files
+- validations and exit codes
+- `PASS`, `FAIL`, and `NOT_RUN` sections
+- residual risks
+- unresolved `UNKNOWN`s
+- rollback path
+- next requested action
+
+## Authority Reminder
+
+Use the truth hierarchy from `docs/03-reference/governance/governance-model.md`:
+
+1. Active Task Packet for execution scope.
+2. Runtime code, config, compose wiring, tests, and active entrypoints.
+3. Current truth/reference docs.
+4. Governance and system docs.
+5. Historical or generated docs.
+6. Explicit assumptions only when marked.
+
+## PM Handoff Classification
+
+When handing off PM work, name the writer:
+
+- Leantime for passive metadata.
+- task-orchestrator for workflow transitions.
+- ConPort for decisions, progress, project context, and custom data.
+- dope-memory for historical receipt/chronicle.
+
+If a bridge route was used, state the upstream authority behind the route.
+
+## Agent Authority Warning
+
+Repo-wide agent runtime authority is `UNKNOWN`. Evidence exists across multiple
+families, including `services/agents`, `src/dopemux/agent_orchestrator.py`, and
+task-orchestrator agent surfaces. Do not claim a single canonical agent runtime
+unless a later packet verifies it.
+
+## Handoff Template
+
+```text
+Task Packet:
+Branch:
+Commit:
+PR:
+Files Changed:
+Validation PASS:
+Validation FAIL:
+Validation NOT_RUN:
+Residual Risks:
+UNKNOWNs:
+Rollback:
+Requested Next Step:
+```
+
+## Completion Bar
+
+An agent handoff is acceptable only when a reviewer can reproduce what happened
+from repo evidence. If validation did not run, say `NOT_RUN`. If evidence is
+missing, say `UNKNOWN`. If a command failed outside scope, record it instead of
+expanding scope silently.

--- a/docs/03-reference/systems/component-catalog.md
+++ b/docs/03-reference/systems/component-catalog.md
@@ -1,0 +1,61 @@
+---
+id: component-catalog
+title: Component Catalog
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Compact component catalog for Dopemux systems, authorities, and drift markers.
+---
+# Component Catalog
+
+This catalog is a compact operator reference. `SERVICE_CATALOG.md` and the
+system docs remain the richer source for tiering and detailed evidence.
+
+| Component | Role | Authority | Drift / UNKNOWN |
+| --- | --- | --- | --- |
+| `dopemux` | Operator CLI and control surface | startup, routing, MCP/server coordination | Does not own downstream PM, memory, retrieval, or execution truth. |
+| `dopetask` | External execution runtime | execution after `scripts/dopetask` handoff | TaskX naming remains in some code/tests as compatibility drift. |
+| Leantime | PM application | passive metadata and project/ticket snapshots | Mostly accessed through adapters/bridge tooling. |
+| Task Orchestrator | Workflow service | workflow transitions, queue, blockers | Runtime path and historical port assumptions remain drift-prone. |
+| ConPort | Structured context system | decisions, progress, context, custom data | Access is split across `3004`, `3005`, and caller assumptions. |
+| dope-memory | Chronicle service | historical receipts and chronicle ledger | Lives under working-memory-assistant tree; do not treat as all memory. |
+| working-memory-assistant | Memory support surface | snapshot/recovery support where implemented | Non-ledger persistence authority remains `UNKNOWN`. |
+| dope-context | Code/docs retrieval | derived indexing and search | Retrieval output is derived, not source truth. |
+| dopecon-bridge | Adapter/proxy/event layer | proxying, compatibility routing, event transport | Must not own PM, workflow, decision, progress, memory, or retrieval. |
+| ADHD Engine | Operator-support service | cognitive-state and recommendation surfaces | Persistence backends for some surfaces remain `UNKNOWN`. |
+| Repo Truth Extractor | Audit/extraction runtime | repo-truth evidence artifacts | Artifacts do not outrank runtime code/config/tests. |
+| Serena | Code-intelligence support | operational support only | Deployment/runtime authority remains `UNKNOWN`. |
+| LiteLLM | Model routing support | routing proxy infrastructure | Support component, not a repo truth authority. |
+| leantime-bridge | PM adapter | proxy to Leantime | Not PM authority itself. |
+| agent families | Agent implementations | `UNKNOWN` | Multiple families exist; no single repo-wide agent authority is proven. |
+
+## Port Orientation
+
+Observed compose/registry defaults:
+
+| Service | Host port |
+| --- | ---: |
+| dopecon-bridge | `3016` |
+| ConPort HTTP | `3004` |
+| ConPort MCP/SSE | `3005` |
+| dope-context | `3010` |
+| dope-memory | `3020` |
+| task-orchestrator | `8000` |
+| ADHD Engine | `3025` |
+| Leantime | `8080` |
+
+Local `.env` overrides can change these. Packet 003 did not run a live compose
+startup, so live service health is `NOT_RUN`.
+
+## Use Rule
+
+Before depending on a component, classify whether you need:
+
+- authority: a canonical writer or owner
+- proxy: an operational route to another authority
+- derived context: retrieval/report output
+- support: useful runtime help with no domain authority
+- unresolved ownership: `UNKNOWN`

--- a/docs/04-explanation/architecture/data-and-control-flow.md
+++ b/docs/04-explanation/architecture/data-and-control-flow.md
@@ -1,0 +1,141 @@
+---
+id: data-and-control-flow
+title: Data And Control Flow
+type: explanation
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Evidence-backed data and control flow summary for Dopemux systems.
+---
+# Data And Control Flow
+
+This document summarizes observed control and data flows. It does not prove
+live runtime health; packet 003 did not start services.
+
+## Operator Startup Flow
+
+```text
+operator -> dopemux CLI -> routing/MCP/workspace coordination -> downstream systems
+```
+
+Observed evidence:
+
+- `pyproject.toml` registers `dopemux = "dopemux.cli:main"`.
+- `src/dopemux/cli.py` contains `dopemux start` and command registration.
+- `compose.yml` and `services/registry.yaml` describe the default service stack.
+
+Control authority stays with `dopemux` only for the operator-control slice.
+
+## Execution Handoff Flow
+
+```text
+dopemux kernel path -> scripts/taskx -> scripts/dopetask -> external dopetask
+```
+
+`scripts/taskx` is a compatibility shim. `scripts/dopetask` creates or reuses a
+local `.dopetask_venv`, installs the version from `.dopetask-pin`, and executes
+the external `dopetask` binary. The external runtime is not implemented as repo
+source here.
+
+## PM Write Flow
+
+```text
+metadata -> Leantime
+workflow transition -> task-orchestrator
+decision/progress/context -> ConPort
+historical receipt mirror -> dope-memory
+```
+
+Observed evidence:
+
+- `src/dopemux/pm/writes.py` classifies PM actions and returns canonical
+  receipts naming `leantime`, `task-orchestrator`, or `conport`.
+- dope-memory appears as a mirror receipt sink for PM progress/decision activity.
+
+This flow is intentionally split. A bridge route or mirror receipt does not
+change the canonical writer.
+
+## Workflow Persistence Flow
+
+```text
+task-orchestrator workflow service -> DopeconBridge custom-data client -> bridge-backed storage path
+```
+
+Observed evidence:
+
+- task-orchestrator workflow APIs live under `services/task-orchestrator/app/*`.
+- workflow store code writes categories such as `workflow_ideas`,
+  `workflow_epics`, and `workflow_audit` through a bridge client.
+
+This means Task Orchestrator serves workflow authority while its persistence path
+is bridge-mediated. The bridge still does not become workflow authority.
+
+## Chronicle Flow
+
+```text
+PM or operator event -> dope-memory /tools routes -> chronicle ledger
+```
+
+Observed evidence:
+
+- `services/working-memory-assistant/dope_memory_main.py` identifies itself as
+  the canonical dope-memory HTTP entrypoint on `3020`.
+- chronicle store and schema files define the durable ledger behavior.
+
+dope-memory is historical receipt authority. It is not the current PM state
+writer.
+
+## Retrieval Flow
+
+```text
+caller -> dope-context or ConPort retrieval -> ranked derived output -> operator evidence
+```
+
+Observed evidence:
+
+- `services/dope-context/src/mcp/server.py` exposes indexing and search tools.
+- ConPort exposes structured context, decision, progress, custom-data, and
+  relationship query surfaces.
+
+Retrieval output is derived. Use it to find source evidence; do not let it
+override runtime files, schemas, tests, compose wiring, or active entrypoints.
+
+## Bridge Proxy Flow
+
+```text
+caller -> dopecon-bridge route -> upstream service or event bus
+```
+
+Observed evidence:
+
+- `services/dopecon-bridge/dopecon_bridge/routes.py` explicitly states the
+  bridge is adapter/proxy only.
+- The same file policy-checks workflow-significant PM mutations and routes safe
+  PM and KG-like calls to upstream systems.
+
+Bridge outputs must be labeled proxy, compatibility, or derived unless the
+upstream system is named.
+
+## Repo Truth Extractor Flow
+
+```text
+dopemux rte -> extractor command wrapper -> run_extraction_v5.py -> extraction artifacts
+```
+
+Observed evidence:
+
+- `src/dopemux/cli.py` registers `dopemux rte` as the canonical operator command
+  family.
+- `services/repo-truth-extractor/run_extraction_v5.py` is the strongest v5
+  runner authority.
+
+Extractor artifacts are evidence artifacts. Runtime truth still wins.
+
+## UNKNOWN And Drift
+
+- `UNKNOWN`: one canonical repo-wide agent runtime.
+- `UNKNOWN`: exact deployed authority for some Serena and support surfaces.
+- `NEEDS_REPO_VERIFICATION`: live startup and health for the full compose stack
+  in the current environment.

--- a/docs/04-explanation/architecture/dopemux-architecture.md
+++ b/docs/04-explanation/architecture/dopemux-architecture.md
@@ -1,0 +1,110 @@
+---
+id: dopemux-architecture
+title: Dopemux Architecture
+type: explanation
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Architecture explanation for Dopemux split-authority service and control planes.
+---
+# Dopemux Architecture
+
+Dopemux is a split-authority operator workspace. The architecture is not a
+single service and not a single assistant. It is a set of cooperating systems
+with domain-specific authority and known drift.
+
+## Planes
+
+| Plane | Primary systems | Authority shape |
+| --- | --- | --- |
+| Operator/control | `dopemux` | CLI, startup coordination, routing, MCP/server coordination |
+| Execution | `dopetask` via `scripts/dopetask` | External execution after handoff |
+| PM metadata | Leantime | Passive work-item metadata and project/ticket snapshots |
+| Workflow | Task Orchestrator | Workflow transitions, queue, blockers |
+| Structured context | ConPort | Decisions, progress, project context, custom data |
+| Chronicle memory | dope-memory | Historical receipts and evidence-preserving ledger |
+| Retrieval | dope-context and ConPort retrieval | Derived search/retrieval over code/docs and structured records |
+| Bridge/adapter | dopecon-bridge | Proxying, compatibility routing, event transport |
+| Operator support | ADHD Engine | Cognitive-state and support surfaces |
+| Extraction/audit | Repo Truth Extractor | Evidence artifacts about the repo |
+
+## Runtime Spine
+
+`pyproject.toml` exposes `dopemux = "dopemux.cli:main"`, so `src/dopemux/cli.py`
+is the operator CLI entrypoint. The `dopemux start` path handles cockpit,
+routing, validation, and coordination behavior. It should not be documented as
+owning every downstream domain.
+
+Execution handoff flows through:
+
+```text
+dopemux -> scripts/taskx -> scripts/dopetask -> external dopetask binary
+```
+
+`scripts/taskx` is a compatibility shim. `scripts/dopetask` enforces
+`.dopetaskroot`, reads `.dopetask-pin`, installs the pinned external
+`dopetask`, and executes it.
+
+## PM Architecture
+
+`src/dopemux/pm/writes.py` is the clearest PM write-boundary evidence:
+
+- metadata updates go to Leantime
+- workflow transitions go to task-orchestrator
+- progress and decision logs go to ConPort
+- historical receipt mirrors go to dope-memory
+
+Task Orchestrator is therefore workflow authority, not all PM authority.
+Leantime is metadata authority, not workflow legality authority. ConPort is
+decision/progress/context authority, not passive PM metadata authority.
+dope-memory is a receipt/chronicle sink, not current PM state authority.
+
+## Bridge Architecture
+
+`services/dopecon-bridge/dopecon_bridge/routes.py` states the bridge is an
+adapter and proxy layer only. It exposes PM, KG, decision, progress, and event
+routes, but those routes do not make it source truth.
+
+Bridge-mediated writes must name the upstream canonical writer. Bridge-mediated
+reads must be labeled as proxy or derived views.
+
+## Retrieval And Extraction
+
+dope-context indexes and retrieves code/docs. ConPort also supports structured
+and semantic retrieval. These outputs are derived and can help an operator find
+evidence, but the retrieved source file, runtime code, or config remains the
+actual authority.
+
+Repo Truth Extractor runs repo analysis and emits artifacts. Its outputs are
+evidence artifacts, not runtime truth. The current canonical operator command
+family is `dopemux rte`; `dopemux upgrades` is compatibility, and older
+`dopemux truth` style paths are drift/refusal surfaces.
+
+## Known Architecture Drift
+
+- Task Orchestrator has historical conflict across runtime app paths and port
+  references. Current compose and registry use `8000`; legacy references to
+  `3014` remain in older surfaces.
+- ConPort is split across HTTP `3004`, MCP/SSE `3005`, and info `4004`.
+- dope-memory runs as the canonical chronicle service under the
+  working-memory-assistant tree, while other working-memory-assistant surfaces
+  remain adjacent support surfaces.
+- Serena and agent systems remain unresolved or drifted in this packet's
+  evidence set.
+
+## Must Not Own
+
+| System | Must Not Own |
+| --- | --- |
+| dopemux | Canonical PM entity truth, chronicle truth, dope-context retrieval truth, external execution after handoff |
+| Task Orchestrator | Passive PM metadata, all PM state, ConPort structured authority, dope-memory chronicle |
+| ConPort | All memory, passive PM metadata, workflow legality, dope-context source truth |
+| dope-memory | Current PM state, workflow legality, all memory |
+| dope-context | Source truth for code/docs, PM truth, chronicle truth |
+| dopecon-bridge | Canonical PM, workflow, decision, progress, memory, or retrieval authority |
+| ADHD Engine | PM truth, ConPort authority, dope-memory authority |
+| Repo Truth Extractor | Runtime truth, PM authority, memory authority, retrieval authority |
+
+Where ownership is not proven, preserve `UNKNOWN`.

--- a/docs/04-explanation/overview/problem-statement.md
+++ b/docs/04-explanation/overview/problem-statement.md
@@ -1,0 +1,56 @@
+---
+id: problem-statement
+title: Problem Statement
+type: explanation
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Problem statement for Dopemux documentation and split-authority operations.
+---
+# Problem Statement
+
+Dopemux solves an operator problem: development work spans execution, PM,
+context, memory, retrieval, service startup, and audit trails, but those domains
+do not have one trustworthy owner in this repository. The system needs a control
+surface that can route work across those domains while preserving which service
+is authoritative for each slice.
+
+The main documentation risk is false unification. If docs describe Dopemux as a
+single assistant, a single PM platform, a bridge-owned control plane, or a
+unified memory layer, operators can send writes to the wrong surface and treat
+derived views as truth.
+
+## Observed Tensions
+
+| Tension | Repo-grounded impact |
+| --- | --- |
+| PM is split | Metadata, workflow transitions, decision/progress context, and historical receipts have different writers. |
+| Memory is split | ConPort structured context and dope-memory chronology are adjacent but not interchangeable. |
+| Retrieval is derived | dope-context and ConPort retrieval output can support investigation but cannot override source files. |
+| Bridge routes look authoritative | dopecon-bridge exposes PM/KG-like routes while its runtime states it is adapter/proxy only. |
+| Runtime packaging drift remains | task-orchestrator and some MCP surfaces have old port/path assumptions beside newer compose defaults. |
+| Agent ownership is unresolved | Multiple agent families exist, and no single runtime authority is proven. |
+
+## Desired Operator Outcome
+
+An operator should be able to:
+
+1. Identify the source of truth for the action they are taking.
+2. Start from `dopemux` for operator control without making `dopemux` the owner
+   of every domain.
+3. Route PM writes to the correct canonical writer.
+4. Treat retrieval and extraction outputs as evidence instead of final truth.
+5. Preserve `UNKNOWN` and drift until validation closes it.
+6. Produce proof that names changed files, validations, residual risks, and
+   exact blockers.
+
+## Non-Goals
+
+- Do not flatten Dopemux into a monolithic assistant.
+- Do not promote dopecon-bridge into PM, workflow, decision, progress, or
+  memory authority.
+- Do not treat dope-context retrieval or Repo Truth Extractor artifacts as
+  stronger than runtime code.
+- Do not claim runtime drift is closed from docs-only work.

--- a/docs/04-explanation/overview/project-overview.md
+++ b/docs/04-explanation/overview/project-overview.md
@@ -1,0 +1,88 @@
+---
+id: project-overview
+title: Project Overview
+type: explanation
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Repo-grounded overview of Dopemux as a split-authority operator workspace.
+---
+# Project Overview
+
+Dopemux is a composed operator workspace for development-control workflows. It
+is centered on the `dopemux` CLI, but the repository is not only a CLI package.
+It contains operator tooling, service runtimes, bridge/proxy layers, PM
+adapters, memory and retrieval systems, compose wiring, and repo-truth
+extraction tooling.
+
+The strongest repo-grounded interpretation is that Dopemux coordinates
+multiple systems without collapsing their authority:
+
+- `dopemux` owns operator control, startup coordination, routing, and MCP/server
+  coordination.
+- `dopetask` owns execution after handoff through `scripts/dopetask`; `scripts/taskx`
+  is only a compatibility shim.
+- Leantime owns passive PM metadata and project/ticket snapshots.
+- task-orchestrator owns workflow-significant transitions, queue state, and
+  blockers.
+- ConPort owns structured decisions, progress, project context, and custom-data
+  context.
+- dope-memory owns chronicle receipts and historical memory.
+- dope-context owns code/docs indexing and derived retrieval.
+- dopecon-bridge owns proxying, compatibility routing, and event transport.
+- ADHD Engine owns operator-support and cognitive-state surfaces.
+- Repo Truth Extractor owns extraction and audit artifacts about the repo.
+
+This is not a monolithic assistant, not one PM system, not one memory system,
+and not one agent authority. Repo-wide agent ownership remains `UNKNOWN` across
+the inspected agent families.
+
+## Source Basis
+
+This overview is grounded in:
+
+- `PROJECT.md`
+- `ARCHITECTURE.md`
+- `PM_PLANE.md`
+- `SERVICE_CATALOG.md`
+- `docs/03-reference/systems/system-boundaries.md`
+- `docs/03-reference/governance/dopemux-documentation-source-map.md`
+- `src/dopemux/pm/writes.py`
+- `compose.yml`
+- `services/registry.yaml`
+
+Runtime code, config, compose wiring, tests, and active entrypoints still outrank
+this document.
+
+## Operating Shape
+
+The operator enters through `dopemux`. From there, the repo can coordinate
+routing, workspace context, local service configuration, and selected command
+families such as Repo Truth Extractor. Execution handoff flows through
+`scripts/taskx` into `scripts/dopetask`, which installs and runs the pinned
+external `dopetask` runtime.
+
+PM behavior is split by concern. Metadata belongs with Leantime, workflow
+transitions with task-orchestrator, decision/progress context with ConPort, and
+historical receipt mirroring with dope-memory. dopecon-bridge can route or proxy
+some PM-adjacent operations, but it is not the PM authority.
+
+Memory and retrieval are also split. ConPort stores structured context and
+decisions. dope-memory preserves chronicle receipts. dope-context indexes and
+retrieves code/docs. Retrieval results are useful evidence, but source files and
+runtime code remain source truth.
+
+## Current Limits
+
+- task-orchestrator runtime packaging has known drift between app code, older
+  module paths, and port references.
+- ConPort access patterns are split across HTTP and MCP/SSE surfaces.
+- dope-memory and working-memory-assistant share a tree and can be confused.
+- dopecon-bridge exposes broad routes that can look authoritative but are not.
+- Repo Truth Extractor outputs evidence artifacts; they do not replace runtime.
+- Agent authority is `UNKNOWN`.
+
+These limits are not closed by documentation. They require targeted runtime
+validation or separate implementation work.

--- a/docs/04-explanation/overview/system-map.md
+++ b/docs/04-explanation/overview/system-map.md
@@ -1,0 +1,82 @@
+---
+id: system-map
+title: System Map
+type: explanation
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: High-level system map for Dopemux authority slices and non-authority links.
+---
+# System Map
+
+This map shows the current repo-grounded system relationships. It is a
+documentation map, not a runtime topology proof. Runtime code, compose wiring,
+tests, and active entrypoints remain stronger than this diagram.
+
+```mermaid
+flowchart TD
+  operator["Operator"]
+  dopemux["dopemux CLI\noperator control"]
+  dopetask["dopetask\nexternal execution"]
+  leantime["Leantime\nPM metadata"]
+  orchestrator["task-orchestrator\nworkflow transitions"]
+  conport["ConPort\nstructured context decisions progress"]
+  memory["dope-memory\nchronicle receipts"]
+  context["dope-context\nderived code/docs retrieval"]
+  bridge["dopecon-bridge\nproxy event transport"]
+  adhd["ADHD Engine\noperator support"]
+  rte["Repo Truth Extractor\naudit artifacts"]
+
+  operator --> dopemux
+  dopemux --> dopetask
+  dopemux --> orchestrator
+  dopemux --> conport
+  dopemux --> context
+  dopemux --> rte
+
+  orchestrator --> bridge
+  bridge --> leantime
+  bridge --> conport
+  bridge --> memory
+
+  conport --> memory
+  adhd --> bridge
+  adhd --> conport
+  context -. "derived retrieval only" .-> dopemux
+  rte -. "evidence artifacts only" .-> dopemux
+```
+
+## Authority Reading
+
+- Solid arrows show observed operational or integration paths.
+- Dotted arrows mark evidence or retrieval outputs that must not become source
+  truth.
+- dopecon-bridge appears in the middle because many systems route through it,
+  but that does not make it the canonical writer for the domains it touches.
+- ADHD Engine participates in the operator-support plane and can project data
+  through integrations, but it does not own PM or memory truth.
+
+## Key Boundaries
+
+| System | Owns | Must not own |
+| --- | --- | --- |
+| dopemux | Operator startup, routing, CLI coordination | PM truth, memory truth, retrieval truth, external execution after handoff |
+| dopetask | Execution after wrapper handoff | PM metadata, workflow legality, memory, retrieval |
+| task-orchestrator | Workflow transitions, queue, blockers | Passive PM metadata, ConPort decisions/progress, dope-memory chronicle |
+| Leantime | Passive PM metadata and project/ticket snapshots | Workflow legality and decision/progress context |
+| ConPort | Structured decisions, progress, context, custom data | All PM, chronicle history, dope-context retrieval |
+| dope-memory | Chronicle receipts and historical ledger | Current PM status, workflow legality |
+| dope-context | Derived code/docs retrieval | Source truth for the files it retrieves |
+| dopecon-bridge | Proxy, adapter, compatibility routing, event transport | Canonical task, workflow, PM, decision, progress, memory, retrieval |
+| ADHD Engine | Operator support and cognitive-state surfaces | PM truth, ConPort authority, dope-memory authority |
+| Repo Truth Extractor | Repo audit/extraction artifacts | Runtime truth or PM/memory/retrieval authority |
+
+## Unresolved Areas
+
+- `UNKNOWN`: one canonical agent runtime.
+- `UNKNOWN`: exact persistence model for some ADHD and working-memory-assistant
+  support surfaces.
+- `NEEDS_REPO_VERIFICATION`: live compose startup and service health for any
+  local profile not explicitly exercised.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -32,6 +32,11 @@ Use this file as the root pointer for active documentation navigation and mainte
 - [Root Quick Start](../QUICK_START.md)
 - [Dopemux Quickstart](01-tutorials/quickstart.md)
 - [Developer Onboarding](02-how-to/developer-onboarding.md)
+- [Project Overview](04-explanation/overview/project-overview.md)
+- [Problem Statement](04-explanation/overview/problem-statement.md)
+- [System Map](04-explanation/overview/system-map.md)
+- [Dopemux Architecture](04-explanation/architecture/dopemux-architecture.md)
+- [Data and Control Flow](04-explanation/architecture/data-and-control-flow.md)
 - [Repo Truth Extractor v5 First Live Run](02-how-to/extraction/repo-truth-extractor-v5-first-live-run.md)
 - [Extraction Pipeline Reliability](03-reference/extraction/pipeline-reliability.md)
 - [V5 Extraction Pipeline Upgrade Design](04-explanation/architecture/v5-extraction-pipeline-upgrade-design.md)
@@ -46,6 +51,11 @@ Use this file as the root pointer for active documentation navigation and mainte
 - [Dopemux Documentation Source Map](03-reference/governance/dopemux-documentation-source-map.md)
 - [Documentation Gap Register](03-reference/governance/documentation-gap-register.md)
 - [Documentation Trust Map](03-reference/governance/doc-trust-map.md)
+- [Authority Boundaries](03-reference/governance/authority-boundaries.md)
+- [Governance Model](03-reference/governance/governance-model.md)
+- [Component Catalog](03-reference/systems/component-catalog.md)
+- [Operator Workflows](02-how-to/operator-workflows.md)
+- [AI Agent Handoff Guide](03-reference/instructions/ai-agent-handoff-guide.md)
 
 ## Skill Templates for Documentation Sync
 

--- a/task-packets/generated/TP-DMX-DOCS-FORGE-003-ARCH-GOV-OPS-HANDOFF.json
+++ b/task-packets/generated/TP-DMX-DOCS-FORGE-003-ARCH-GOV-OPS-HANDOFF.json
@@ -1,0 +1,201 @@
+{
+  "id": "TP-DMX-DOCS-FORGE-003-ARCH-GOV-OPS-HANDOFF",
+  "project": "dopemux-mvp",
+  "target": "documentation/architecture-governance-operations-handoff",
+  "invariants": [
+    "Documentation-only work: do not edit runtime code, service code, Docker files, dependency files, tests, or generated extraction outputs unless explicitly allowed by this packet.",
+    "Preserve Dopemux split-authority architecture: dopemux controls operator routing/startup, dopetask executes after handoff, task-orchestrator owns workflow transitions, Leantime owns PM metadata, ConPort owns structured decisions/progress/context, dope-memory owns chronicle receipts, dope-context owns retrieval, dopecon-bridge remains proxy/event transport only, ADHD Engine remains operator support only, Repo Truth Extractor produces evidence artifacts only.",
+    "Every claim in new docs must be grounded in inspected repo files or marked UNKNOWN, INFERRED, or NEEDS_REPO_VERIFICATION.",
+    "Do not normalize known drift into a cleaner story; preserve contradictions and unresolved canonicality explicitly.",
+    "Each step must leave commit/proof evidence: changed files, validation output, exit codes, residual risks, and exact follow-up if blocked."
+  ],
+  "depends_on": [
+    "TP-DMX-DOCS-FORGE-002-README-QUICKSTART"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "pyproject.toml",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-DOCS-FORGE-001",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-DOCS-FORGE-002-README-QUICKSTART",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "docs/dmx-docs-forge-003-arch-gov-ops"
+  },
+  "commit": {
+    "message": "docs: add architecture governance operations handoff docs",
+    "allowlist": [
+      "task-packets/generated/TP-DMX-DOCS-FORGE-003-ARCH-GOV-OPS-HANDOFF.json",
+      "docs/04-explanation/overview/project-overview.md",
+      "docs/04-explanation/overview/problem-statement.md",
+      "docs/04-explanation/overview/system-map.md",
+      "docs/04-explanation/architecture/dopemux-architecture.md",
+      "docs/04-explanation/architecture/data-and-control-flow.md",
+      "docs/03-reference/governance/authority-boundaries.md",
+      "docs/03-reference/governance/governance-model.md",
+      "docs/03-reference/systems/component-catalog.md",
+      "docs/02-how-to/operator-workflows.md",
+      "docs/03-reference/instructions/ai-agent-handoff-guide.md",
+      "docs/INDEX.md",
+      "docs/00-MASTER-INDEX.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-DOCS-FORGE-003-ARCH-GOV-OPS-HANDOFF.json >/dev/null",
+      "bash scripts/lint-docs.sh",
+      "python scripts/docs_validator.py",
+      "python scripts/docs_frontmatter_guard.py",
+      "python scripts/check_root_hygiene.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs: add architecture governance operations handoff docs",
+    "body": "Add repo-grounded overview, architecture, authority, operations, governance, and AI handoff docs using existing docs hygiene roots. Documentation-only change.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "challenge",
+      "implement",
+      "docgen",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "step-1-overview-system-map",
+      "task": "Create overview docs under existing docs policy roots instead of inventing unregistered top-level docs roots. Commit-plan note: overview/system-map is slice 1.",
+      "requirements": [
+        "Use docs/04-explanation/overview/ unless docs policy proves a better canonical path.",
+        "Include Mermaid map only if it reflects inspected system boundaries."
+      ],
+      "commands": [
+        "mkdir -p docs/04-explanation/overview",
+        "cat > docs/04-explanation/overview/project-overview.md <<'EOF'\n# Project Overview\n\nTODO: fill from repo evidence.\nEOF",
+        "cat > docs/04-explanation/overview/problem-statement.md <<'EOF'\n# Problem Statement\n\nTODO: fill from repo evidence.\nEOF",
+        "cat > docs/04-explanation/overview/system-map.md <<'EOF'\n# System Map\n\nTODO: fill from repo evidence.\nEOF"
+      ],
+      "expected_files": [
+        "docs/04-explanation/overview/project-overview.md",
+        "docs/04-explanation/overview/problem-statement.md",
+        "docs/04-explanation/overview/system-map.md"
+      ],
+      "validation": [
+        "test -s docs/04-explanation/overview/project-overview.md",
+        "test -s docs/04-explanation/overview/system-map.md",
+        "rg -n \"dopemux|dopetask|task-orchestrator|ConPort|dope-memory|dope-context|dopecon-bridge|ADHD Engine|Repo Truth Extractor\" docs/04-explanation/overview/*.md"
+      ],
+      "context_files": [
+        "PROJECT.md",
+        "ARCHITECTURE.md",
+        "docs/03-reference/systems/system-boundaries.md",
+        "SERVICE_CATALOG.md"
+      ]
+    },
+    {
+      "id": "step-2-architecture-authority-flow-component-docs",
+      "task": "Create architecture, authority boundaries, data/control flow, and component catalog docs. Commit-plan note: architecture/reference docs are slice 2 and must preserve known drift.",
+      "requirements": [
+        "Authority boundaries must explicitly state dopecon-bridge is not canonical authority and retrieval outputs are derived.",
+        "Data/control flow must include dopemux startup, dopetask handoff, PM writes, dope-memory chronicle, dope-context retrieval, bridge proxy, and RTE flow."
+      ],
+      "commands": [
+        "mkdir -p docs/04-explanation/architecture docs/03-reference/governance docs/03-reference/systems",
+        "touch docs/04-explanation/architecture/dopemux-architecture.md docs/04-explanation/architecture/data-and-control-flow.md docs/03-reference/governance/authority-boundaries.md docs/03-reference/systems/component-catalog.md"
+      ],
+      "expected_files": [
+        "docs/04-explanation/architecture/dopemux-architecture.md",
+        "docs/04-explanation/architecture/data-and-control-flow.md",
+        "docs/03-reference/governance/authority-boundaries.md",
+        "docs/03-reference/systems/component-catalog.md"
+      ],
+      "validation": [
+        "rg -n \"Must Not Own|dopecon-bridge|derived|UNKNOWN|Task Orchestrator|ConPort|dope-memory|dope-context\" docs/04-explanation/architecture/*.md docs/03-reference/governance/authority-boundaries.md docs/03-reference/systems/component-catalog.md"
+      ],
+      "context_files": [
+        "ARCHITECTURE.md",
+        "PM_PLANE.md",
+        "docs/03-reference/systems/system-boundaries.md",
+        "docs/03-reference/truth/truth-data-events.md",
+        "docs/03-reference/truth/truth-canonicals.md",
+        "docs/03-reference/truth/truth-gaps.md",
+        "docs/03-reference/systems/*/system-*.md"
+      ]
+    },
+    {
+      "id": "step-3-operations-governance-agent-handoff",
+      "task": "Create operator workflows, governance model, and AI agent handoff guide. Commit-plan note: operations/governance/handoff docs are slice 3 and must be indexed.",
+      "requirements": [
+        "Operator workflows must classify PM writes by canonical writer.",
+        "Governance model must include truth order, completion language, proof rules, docs validation gates, and task packet requirements.",
+        "AI handoff guide must instruct agents not to expose hidden chain-of-thought and not to invent repo facts."
+      ],
+      "commands": [
+        "mkdir -p docs/02-how-to docs/03-reference/governance docs/03-reference/instructions",
+        "touch docs/02-how-to/operator-workflows.md docs/03-reference/governance/governance-model.md docs/03-reference/instructions/ai-agent-handoff-guide.md"
+      ],
+      "expected_files": [
+        "docs/02-how-to/operator-workflows.md",
+        "docs/03-reference/governance/governance-model.md",
+        "docs/03-reference/instructions/ai-agent-handoff-guide.md"
+      ],
+      "validation": [
+        "rg -n \"truth hierarchy|proof|Task Packet|worktree|hidden chain-of-thought|Do not invent|Leantime|task-orchestrator|ConPort|dope-memory\" docs/02-how-to/operator-workflows.md docs/03-reference/governance/governance-model.md docs/03-reference/instructions/ai-agent-handoff-guide.md"
+      ],
+      "context_files": [
+        "RULES.md",
+        "AGENTS.md",
+        "PAL_EXECUTION_RULES.md",
+        "PAL_CHAINING_DOCTRINE.md",
+        "PAL_PACKET_TEMPLATE.md",
+        "docs/03-reference/governance/proof-contract.md",
+        "docs/03-reference/governance/proof-bundle-schema.md",
+        "docs/03-reference/governance/handoff-contract.md"
+      ]
+    },
+    {
+      "id": "step-4-index-validate-proof",
+      "task": "Update docs indexes and run validators. Commit-plan note: stage only architecture/operations/governance/handoff docs, packet, and index files allowed by this TP.",
+      "requirements": [
+        "Proof must include docs paths chosen, docs policy compliance, validation output, and residual drift."
+      ],
+      "commands": [
+        "bash scripts/lint-docs.sh",
+        "python scripts/docs_validator.py",
+        "python scripts/docs_frontmatter_guard.py",
+        "python scripts/check_root_hygiene.py",
+        "git diff --check",
+        "git diff --stat",
+        "git status --short"
+      ],
+      "expected_files": [
+        "docs/04-explanation/overview/project-overview.md",
+        "docs/04-explanation/architecture/dopemux-architecture.md",
+        "docs/03-reference/governance/authority-boundaries.md",
+        "docs/02-how-to/operator-workflows.md",
+        "docs/03-reference/instructions/ai-agent-handoff-guide.md"
+      ],
+      "validation": [
+        "git diff --check",
+        "test -s docs/03-reference/governance/governance-model.md",
+        "test -s docs/03-reference/instructions/ai-agent-handoff-guide.md"
+      ],
+      "context_files": [
+        "docs/INDEX.md",
+        "docs/00-MASTER-INDEX.md",
+        "config/docs_hygiene/docs_placement_policy.yaml"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds packet 003 generated Task Packet JSON for `TP-DMX-DOCS-FORGE-003-ARCH-GOV-OPS-HANDOFF`.
- Adds repo-grounded overview, architecture, data/control flow, authority-boundary, governance, component catalog, operator workflow, and AI handoff docs.
- Updates docs index files for packet 003 docs.

## Workflow Notes
- Series: `DMX-DOCS-FORGE-001`
- Packet: `TP-DMX-DOCS-FORGE-003-ARCH-GOV-OPS-HANDOFF`
- Base branch deviation: PR is stacked on `docs/dmx-docs-forge-002-readme-quickstart` because packet 002 is accepted but not merged. This preserves strict packet dependency order and keeps the packet 003 diff isolated.
- Runtime files were inspected for authority but not modified.

## Validation
PASS:
- `python -m json.tool task-packets/generated/TP-DMX-DOCS-FORGE-003-ARCH-GOV-OPS-HANDOFF.json` exited 0.
- `python - <<'PY' ... jsonschema.validate(...) ... PY` against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` exited 0.
- Targeted content checks for overview, architecture/authority, operations/governance/handoff docs exited 0.
- `python scripts/docs_validator.py <packet 003 files>` exited 0.
- `python scripts/docs_frontmatter_guard.py <packet 003 files>` exited 0.
- `python scripts/check_root_hygiene.py` exited 0.
- `git diff --check` and `git diff --cached --check` exited 0.
- `pre-commit run --files <packet 003 files>` exited 0.

FAIL, pre-existing full-repo docs debt outside packet allowlist:
- `bash scripts/lint-docs.sh` exited 1: loose `.bak` files, duplicate suffix files, uppercase active-doc filenames, oversized history/sourceFiles directory, and many active docs missing frontmatter.
- `python scripts/docs_validator.py` exited 1: seven pre-existing archived MCP docs missing YAML frontmatter plus ADR/RFC warnings.
- `python scripts/docs_frontmatter_guard.py` exited 1: same seven pre-existing archived MCP docs need frontmatter.

NOT_RUN:
- Runtime/service validation; packet is documentation-only and no runtime files were changed.

## Residual Risks / UNKNOWNs
- Root authority files `RULES.md`, `PAL_EXECUTION_RULES.md`, `PAL_CHAINING_DOCTRINE.md`, and `PAL_PACKET_TEMPLATE.md` were not present in the worktree; tracked docs equivalents were used where available.
- Full-repo docs hygiene remains blocked by pre-existing files outside the packet allowlist.
- Runtime drift is not declared closed because no runtime validation was authorized or run.

@codex review
@gemini
@copilot
