### PR TITLE
RTE-PKT-15: redact failed sidecar outputs

### DIFF
--- a/out/rte-pkt-15-failed-sidecars/PREFLIGHT.md
+++ b/out/rte-pkt-15-failed-sidecars/PREFLIGHT.md
@@ -1,0 +1,34 @@
+# RTE-PKT-15 Preflight
+
+Generated: 2026-05-19T11:37:22Z
+
+## Observed Repository State
+
+| Check | Result |
+| --- | --- |
+| `pwd` | `/Users/hue/.codex/worktrees/f89f/dopemux-mvp` |
+| Repo root | `/Users/hue/.codex/worktrees/f89f/dopemux-mvp` |
+| Marker | `pyproject.toml` present |
+| RTE runtime marker | `services/repo-truth-extractor/run_extraction_v5.py` present |
+| Remote identity | `origin` and `mvp` point to `https://github.com/DDD-Enterprises/dopemux-mvp.git` |
+| Starting HEAD | `d64d5f15e46e68373e3bed1160fbc3df2807db59` |
+| Starting status | clean detached `HEAD` |
+| Execution branch used | `codex/rte-pkt-15-failed-sidecars-clean` |
+
+## Branch Safety
+
+The packet-requested branch `codex/rte-pkt-15-failed-sidecars` already existed locally at `6c4b46da8125cdb53ded0820e853bc5a533fe919`.
+
+Observed diff from local `main` to that existing branch was far outside this packet allowlist, including broad repository edits and deletions. That branch was preserved untouched. This run used `codex/rte-pkt-15-failed-sidecars-clean` from current local `main` to avoid overwriting prior work.
+
+## Prior Packet Evidence
+
+| Packet | Current-branch evidence | Status used |
+| --- | --- | --- |
+| RTE-PKT-00-SOURCE-CLOSURE | Named proof root absent from this checkout; local sibling search also found no `out/rte-pkt-00-source-closure` directory. | `UNKNOWN`, supplemented by operator grounding in this prompt. |
+| RTE-PKT-01-LIVE-GATE | `out/rte-pkt-01-live-gate/RTE-PKT-01_CLOSEOUT.md` and manifest are present. Closeout states `READY_FOR_REVIEW_CLEAN`. | Accepted for sequencing by operator prompt. |
+| RTE-PKT-02-PAYLOAD-REDACTION | `out/rte-pkt-02-payload-redaction/RTE-PKT-02_MANIFEST.json` is present with `status=READY_FOR_REVIEW`. | Accepted for sequencing by operator prompt. |
+
+## Scope Guard
+
+No live extraction, provider call, provider batch submit, provider batch poll, provider batch retrieve, provider batch cancel, promptset edit, schema edit, model-map edit, route-policy edit, retry-logic edit, repair-semantics edit, or artifact schema redesign was authorized or performed.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_DIFF_SUMMARY.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_DIFF_SUMMARY.md
@@ -3,25 +3,24 @@
 ## Runtime
 
 - `services/repo-truth-extractor/output_safety.py`
-  - Added private-key-block redaction.
-  - Added common provider-token-prefix redaction.
-  - Added `sanitize_failed_sidecar_text` as an explicit wrapper around output text sanitization.
+  - Changed `sanitize_failed_sidecar_text` to use the stronger secret-shape sanitizer path.
+  - Added `sanitize_payload_for_failed_sidecar` for structured failed sidecar payloads.
+  - Preserved safe metadata behavior for environment-name fields and digest-shaped values.
 
 - `services/repo-truth-extractor/run_extraction_v5.py`
-  - Added `_is_failed_text_sidecar_path` and `write_failed_sidecar_text`.
-  - Sanitized deferred `.FAILED.txt` writes when scheduling and again at persistence.
-  - Replaced direct batch-watch `.FAILED.txt` writes with `write_failed_sidecar_text`.
-  - Left JSON writers on existing `write_json` sanitizer path.
+  - Added `_is_failed_json_sidecar_path`.
+  - Routed `.FAILED.json` writes through `sanitize_payload_for_failed_sidecar`.
+  - Preserved existing `.FAILED.txt` writer names, sidecar filenames, failure classes, status codes, and request metadata shape.
 
 ## Tests
 
-- `services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py`
-  - Added local tests for worker exception, parse failure, schema failure, batch provider error, and batch terminal text redaction.
-  - Tests use local fakes/monkeypatches and no provider calls.
-
 - `services/repo-truth-extractor/tests/test_output_safety.py`
-  - Added sanitizer regression coverage for provider-token-shaped text and private-key-block-shaped text while preserving safe SHA text.
+  - Added coverage for generic long secret-shaped failed sidecar text and JSON payload values.
+  - Verified safe environment-name and digest metadata remain visible.
 
-## Scope boundary
+- `services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py`
+  - Added direct `.FAILED.json` writer regression coverage for generic secret-shaped text in non-sensitive failure fields.
 
-No promptsets, model maps, structured-output contract files, provider route configs, compose/deployment files, or docs outside this proof root were changed.
+## Scope Boundary
+
+No promptsets, schemas, model maps, route policies, retry logic, repair semantics, provider clients, provider batch operations, artifact schema redesign, or generated runtime sidecar fixtures were changed.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_MATRIX.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_MATRIX.md
@@ -1,28 +1,20 @@
 # RTE-PKT-15 Failed Sidecar Matrix
 
-## In-scope v5 writers
+This matrix is the summary view of `RTE-PKT-15_FAILED_SIDECAR_WRITER_LEDGER.md`.
 
-| Surface | Source | Coverage | Lineage preserved | Test coverage |
-| --- | --- | --- | --- | --- |
-| Worker exception `.FAILED.txt` | `run_extraction_v5.py` deferred `_op_write_text` and `_apply_write_ops` | CLOSED: `.FAILED.txt` text is sanitized before scheduling and again before persistence. | phase, step_id, partition_id, failure_type, provider, model_id, routing policy, route hop fields | `test_worker_exception_failed_sidecars_redact_secret_text` |
-| Worker exception `.FAILED.json` | `run_extraction_v5.py` `write_json` | CLOSED: structured payload uses `write_json`, which calls `sanitize_payload_for_output`. | failure_type, status_code, request_meta, provider/model metadata | `test_worker_exception_failed_sidecars_redact_secret_text` |
-| Parse failure `.FAILED.txt` | `run_extraction_v5.py` parse failure branch | CLOSED: raw response text flows through failed-sidecar text sanitizer. | phase, step_id, partition_id, status_code, provider/model via request_meta | `test_parse_failure_failed_sidecars_redact_raw_response_text` |
-| Parse failure `.FAILED.json` | `run_extraction_v5.py` parse failure branch | CLOSED: `write_json` sanitizes structured payload. | failure_type, status_code, request_meta | `test_parse_failure_failed_sidecars_redact_raw_response_text` |
-| Schema failure `.FAILED.txt` | `run_extraction_v5.py` schema gate branch | CLOSED: raw response text flows through failed-sidecar text sanitizer. | phase, step_id, partition_id, schema gate context | `test_schema_failure_failed_sidecars_redact_response_and_preserve_context` |
-| Schema failure `.FAILED.json` | `run_extraction_v5.py` schema gate branch | CLOSED: `write_json` sanitizes structured schema context. | failure_type, status_code, schema_gate_context, request_meta | `test_schema_failure_failed_sidecars_redact_response_and_preserve_context` |
-| Payload-unshrinkable `.FAILED.txt` | `run_extraction_v5.py` payload hard-cap branch | CLOSED through central deferred `.FAILED.txt` writer. | failure_type, phase, step_id, partition_id, payload sizing fields | Covered by central writer; no separate fixture generated |
-| Payload-unshrinkable `.FAILED.json` | `run_extraction_v5.py` payload hard-cap branch | CLOSED through `write_json`. | failure_type, provider/model, status_code, sizing fields | Existing JSON sanitizer coverage |
-| Batch missing-row `.FAILED.txt` | `run_extraction_v5.py` `run_batch_watch` | CLOSED: direct write now uses `write_failed_sidecar_text`. | phase, step_id, partition_id, batch job metadata in paired JSON | Static source check; text is local constant |
-| Batch parse/provider `.FAILED.txt` | `run_extraction_v5.py` `run_batch_watch` | CLOSED: provider result text/error now uses `write_failed_sidecar_text`. | phase, step_id, partition_id, provider/model, batch_job_id in paired JSON | `test_batch_watch_failure_sidecars_redact_provider_error_text` |
-| Batch terminal `.FAILED.txt` | `run_extraction_v5.py` `run_batch_watch` | CLOSED: terminal text now uses `write_failed_sidecar_text`. | terminal state text plus paired JSON request_meta | `test_failed_sidecar_text_writer_redacts_batch_terminal_text` |
-| Batch `.FAILED.json` | `run_extraction_v5.py` `run_batch_watch` | CLOSED: direct structured sidecars use `write_json`. | execution_mode, provider, model_id, batch_provider, batch_job_id, failure_type | `test_batch_watch_failure_sidecars_redact_provider_error_text` |
+| Surface | Status | Preserved context |
+| --- | --- | --- |
+| Worker exception `.FAILED.txt` | Sanitized through failed-sidecar text helper. | `phase`, `step_id`, `partition_id`, `failure_type`, provider/model request metadata. |
+| Worker exception `.FAILED.json` | Sanitized through failed-sidecar payload helper. | Structured failure metadata and request metadata. |
+| Parse failure `.FAILED.txt` | Raw response text sanitized before persistence. | Parse failure class, phase, step, partition, status code. |
+| Parse failure `.FAILED.json` | Structured payload sanitized through failed-sidecar JSON path. | Failure class, status code, request metadata. |
+| Schema failure `.FAILED.txt` | Raw schema-failed response text sanitized before persistence. | Schema gate failure label and context. |
+| Schema failure `.FAILED.json` | Structured schema context sanitized through failed-sidecar JSON path. | Schema gate context, request metadata, failure class. |
+| Batch missing-row `.FAILED.txt` | Direct writer uses failed-sidecar text helper. | Missing-row failure label. |
+| Batch provider/parse `.FAILED.txt` | Direct writer uses failed-sidecar text helper. | Batch state, provider/model, batch id in paired JSON. |
+| Batch terminal `.FAILED.txt` | Direct writer uses failed-sidecar text helper. | Terminal-state label. |
+| Batch `.FAILED.json` | Direct writers use failed-sidecar-aware `write_json`. | Batch execution mode, provider/model, batch id, terminal status. |
 
-## Out-of-scope observed writer
+## Out-of-scope observed path
 
-| Surface | Source | Coverage | Status |
-| --- | --- | --- | --- |
-| Comparison-lane `.FAILED.txt` | `services/repo-truth-extractor/llm_runtime.py:1342` | Not patched because packet allowed code paths did not include `llm_runtime.py`. | UNKNOWN / FOLLOW-UP REQUIRED if comparison-lane failed sidecars are in live proof scope |
-
-## Notes
-
-`services/repo-truth-extractor/lib/batch_retriever.py` writes downloaded provider output/error files, not `.FAILED.txt` or `.FAILED.json` sidecars. No provider retrieval operation was run.
+`services/repo-truth-extractor/llm_runtime.py:1625` writes comparison-lane `.FAILED.txt` content directly. It is outside the packet allowlist and remains a follow-up `UNKNOWN`.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_WRITER_LEDGER.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_WRITER_LEDGER.md
@@ -1,0 +1,28 @@
+# RTE-PKT-15 Failed Sidecar Writer Ledger
+
+## In Scope
+
+| Writer surface | Source | Writer type | Sanitizer status | Action |
+| --- | --- | --- | --- | --- |
+| Worker exception text sidecar | `services/repo-truth-extractor/run_extraction_v5.py:13673` via deferred `_op_write_text` | `.FAILED.txt` | Covered by `sanitize_failed_sidecar_text` before scheduling and again at persistence. | Hardened helper now uses the stronger failed-sidecar secret-shape path. |
+| Worker exception JSON sidecar | `services/repo-truth-extractor/run_extraction_v5.py:13674` via deferred `_op_write_json` and `write_json` | `.FAILED.json` | Covered by `write_json`; `.FAILED.json` now uses `sanitize_payload_for_failed_sidecar`. | Hardened. |
+| Payload-unshrinkable text sidecar | `services/repo-truth-extractor/run_extraction_v5.py:14051` via deferred `_op_write_text` | `.FAILED.txt` | Covered by central failed text sanitizer. | Hardened through shared helper. |
+| Payload-unshrinkable JSON sidecar | `services/repo-truth-extractor/run_extraction_v5.py:14056` via deferred `_op_write_json` and `write_json` | `.FAILED.json` | Covered by failed sidecar payload sanitizer. | Hardened through shared helper. |
+| Parse failure text sidecar | `services/repo-truth-extractor/run_extraction_v5.py:16087` via deferred `_op_write_text` | `.FAILED.txt` | Raw response text is sanitized before persistence. | Covered by targeted test. |
+| Parse failure JSON sidecar | `services/repo-truth-extractor/run_extraction_v5.py:16088` via deferred `_op_write_json` and `write_json` | `.FAILED.json` | Structured payload is sanitized through failed sidecar payload sanitizer. | Covered by targeted test. |
+| Schema failure text sidecar | `services/repo-truth-extractor/run_extraction_v5.py:16158` via deferred `_op_write_text` | `.FAILED.txt` | Raw response text is sanitized before persistence. | Covered by targeted test. |
+| Schema failure JSON sidecar | `services/repo-truth-extractor/run_extraction_v5.py:16159` via deferred `_op_write_json` and `write_json` | `.FAILED.json` | Structured schema context is sanitized through failed sidecar payload sanitizer. | Covered by targeted test. |
+| Batch missing-row text sidecar | `services/repo-truth-extractor/run_extraction_v5.py:19174` | `.FAILED.txt` | Direct writer uses `write_failed_sidecar_text`. | Covered by source inspection; text is local constant. |
+| Batch missing-row JSON sidecar | `services/repo-truth-extractor/run_extraction_v5.py:19178` | `.FAILED.json` | Direct writer uses `write_json`, now failed-sidecar-aware. | Covered by source inspection. |
+| Batch provider/parse text sidecar | `services/repo-truth-extractor/run_extraction_v5.py:19222` | `.FAILED.txt` | Direct writer uses `write_failed_sidecar_text`. | Covered by targeted test. |
+| Batch provider/parse JSON sidecar | `services/repo-truth-extractor/run_extraction_v5.py:19226` | `.FAILED.json` | Direct writer uses `write_json`, now failed-sidecar-aware. | Covered by targeted test. |
+| Batch terminal text sidecar | `services/repo-truth-extractor/run_extraction_v5.py:19421` | `.FAILED.txt` | Direct writer uses `write_failed_sidecar_text`. | Covered by targeted helper test. |
+| Batch terminal JSON sidecar | `services/repo-truth-extractor/run_extraction_v5.py:19398` | `.FAILED.json` | Direct writer uses `write_json`, now failed-sidecar-aware. | Covered by source inspection. |
+
+## Out Of Scope / Observed
+
+| Writer surface | Source | Status |
+| --- | --- | --- |
+| Comparison-lane failed text sidecar | `services/repo-truth-extractor/llm_runtime.py:1625` | Out of packet allowlist. It still writes comparison failure text directly and remains a follow-up risk if this lane can carry secret-shaped provider or source text. |
+| Batch retriever output/error files | `services/repo-truth-extractor/lib/batch_retriever.py` | Not `.FAILED.txt` or `.FAILED.json` sidecars. No provider retrieval was run. |
+| Legacy v3 failed sidecar fixtures | `services/repo-truth-extractor/tests/fixtures/run_extraction_v3/` | Evidence fixtures only. Contents were not quoted in proof. |

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FINAL_CLOSEOUT.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FINAL_CLOSEOUT.md
@@ -1,34 +1,35 @@
 # RTE-PKT-15 Final Closeout
 
-## Status
+Status before push: `READY_FOR_REVIEW_SCOPE_CLEAN_PENDING_PUSH`
 
-`READY_FOR_REVIEW_CLEAN_PENDING_COMMIT`
+PR: `https://github.com/DDD-Enterprises/dopemux-mvp/pull/654`
 
-## Closeout result
+## Completed Slices
 
-RTE-PKT-15 failed-sidecar redaction changes are review-ready. REG-001 was triaged against a detached clean-base worktree and classified `BASELINE_FAILURE`.
+- Preflight and authority inspection.
+- Failed sidecar writer mapping.
+- Minimal runtime hardening for failed text and failed JSON sidecar sanitization.
+- Targeted test additions for generic secret-shaped failed sidecar values.
+- Packet-adjacent local regression validation.
+- Proof artifact refresh without quoting legacy failed sidecar fixture contents.
+- PR scope cleanup: rebased onto current `origin/main` and removed `out/rte-ux-valuation-opus-audit/**` from the PR diff.
 
-## Validation summary
+## Residual Risks
 
-- PASS: `pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q`
-- PASS: `pytest services/repo-truth-extractor/tests/test_output_safety.py -q`
-- PASS: `pytest services/repo-truth-extractor/tests -k 'failed and redaction' -q`
-- PASS: `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py`
-- PASS: `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
-- PASS: `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py::test_classify_request_failure_distinguishes_batch_terminal_and_parse_failures -q`
-- PASS: `git diff --check`
-- BASELINE_FAILURE: broader prelive hardening plus concurrency command failed identically on implementation branch and clean base.
+- Packet 00 proof root is absent from this checkout.
+- Comparison-lane `.FAILED.txt` writer in `llm_runtime.py` remains outside the packet allowlist.
+- Legacy v3 failed sidecar fixtures remain evidence surfaces and were not modified.
+- Requested branch name was occupied by broad unrelated local drift; clean branch used instead.
+- `after_commit_sha` cannot be embedded with its final value in the same commit; final SHA is reported in the Codex closeout response.
 
-## Commit status
+## Final Changed Files Against `origin/main`
 
-Commit was pending when this proof file was written. The final response records the commit SHA after commit creation because embedding a commit's own SHA inside the same committed file would change the commit identity.
+- `services/repo-truth-extractor/output_safety.py`
+- `services/repo-truth-extractor/run_extraction_v5.py`
+- `services/repo-truth-extractor/tests/test_output_safety.py`
+- `services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py`
+- `out/rte-pkt-15-failed-sidecars/**`
 
-## Residual risks
+## Closeout Gate
 
-- `services/repo-truth-extractor/llm_runtime.py:1342` comparison-lane `.FAILED.txt` direct writer remains `UNKNOWN` and out of scope.
-- Legacy v3 failed sidecar fixtures remain out of scope.
-- Sanitizer coverage is pattern-based and should be expanded if new credential formats are discovered.
-
-## Provider boundary
-
-No provider calls, live extraction, provider batch submit, provider batch poll, provider batch retrieve, or provider batch cancel operation occurred during closeout.
+Final commit SHA, pushed branch status, and final git status are reported in the final Codex response.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json
@@ -1,12 +1,19 @@
 {
   "packet_id": "RTE-PKT-15-FAILED-SIDECARS",
-  "generated_at_utc": "2026-05-15T03:37:44Z",
-  "repo_root": "/Users/hue/.codex/worktrees/a8da/dopemux-mvp",
-  "branch": "codex/rte-pkt-15-failed-sidecars",
-  "before_commit_sha": "a4214ca5bf431e1b59791661e2b664a6cd24c1da",
-  "after_commit_sha": "REPORTED_IN_FINAL_RESPONSE_AFTER_COMMIT",
+  "generated_at_utc": "2026-05-19T11:37:22Z",
+  "updated_at_utc": "2026-05-19T13:08:40Z",
+  "repo_root": "/Users/hue/.codex/worktrees/f89f/dopemux-mvp",
+  "branch": "codex/rte-pkt-15-failed-sidecars-clean",
+  "requested_branch": "codex/rte-pkt-15-failed-sidecars",
+  "requested_branch_status": "local branch existed with broad unrelated drift; preserved untouched",
+  "base_branch_observed": "origin/main",
+  "base_branch_sha_after_scope_cleanup": "027465e31",
+  "before_commit_sha": "d64d5f15e46e68373e3bed1160fbc3df2807db59",
+  "after_commit_sha": "REPORTED_IN_FINAL_RESPONSE_AFTER_REBASE_PUSH",
+  "after_commit_sha_note": "The final commit cannot embed its own SHA without another commit; final SHA is reported in the closeout response.",
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/654",
   "remote": "origin and mvp point to https://github.com/DDD-Enterprises/dopemux-mvp.git",
-  "validation_status": "READY_FOR_REVIEW_BASELINE_FAILURE_TRIAGED_PENDING_COMMIT",
+  "validation_status": "READY_FOR_REVIEW_SCOPE_CLEAN_PENDING_PUSH",
   "provider_calls_performed": false,
   "batch_provider_operations_performed": false,
   "live_extraction_performed": false,
@@ -19,63 +26,95 @@
     "services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py",
     "services/repo-truth-extractor/tests/test_output_safety.py"
   ],
-  "proof_files": [
-    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json",
+  "final_changed_file_list_against_origin_main": [
+    "out/rte-pkt-15-failed-sidecars/PREFLIGHT.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_DIFF_SUMMARY.md",
     "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_MATRIX.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_WRITER_LEDGER.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FINAL_CLOSEOUT.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_NO_PROVIDER_CALLS_ATTESTATION.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REDACTION_MATRIX.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REGRESSION_TRIAGE_CLOSEOUT.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_RISKS.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_UNKNOWNS.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_SECRET_FIXTURE_REDACTION_PROOF.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TASK_PACKET.json",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TEST_REPORT.md",
+    "out/rte-pkt-15-failed-sidecars/implementation-notes.md",
+    "services/repo-truth-extractor/output_safety.py",
+    "services/repo-truth-extractor/run_extraction_v5.py",
+    "services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py",
+    "services/repo-truth-extractor/tests/test_output_safety.py"
+  ],
+  "scope_cleanup": {
+    "unrelated_path_removed_from_pr_diff": "out/rte-ux-valuation-opus-audit/**",
+    "cleanup_method": "rebased PR branch onto current origin/main and dropped the unrelated UX proof-pack commit from PR ancestry",
+    "final_pr_allowlist_check": "PASS",
+    "comparison_lane_status": "out_of_scope"
+  },
+  "proof_files": [
+    "out/rte-pkt-15-failed-sidecars/PREFLIGHT.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TASK_PACKET.json",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_WRITER_LEDGER.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_MATRIX.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REDACTION_MATRIX.md",
     "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TEST_REPORT.md",
     "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_NO_PROVIDER_CALLS_ATTESTATION.md",
     "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_SECRET_FIXTURE_REDACTION_PROOF.md",
     "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_DIFF_SUMMARY.md",
     "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_UNKNOWNS.md",
+    "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_RISKS.md",
     "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REGRESSION_TRIAGE_CLOSEOUT.md",
     "out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FINAL_CLOSEOUT.md",
     "out/rte-pkt-15-failed-sidecars/implementation-notes.md"
   ],
-  "regression_triage": {
-    "id": "REG-001",
-    "classification": "BASELINE_FAILURE",
-    "implementation_command": "pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q",
-    "implementation_result": "FAIL: 1 failed, 23 passed; test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback observed escalation_trigger provider_failure",
-    "clean_base_worktree": "/Users/hue/.codex/worktrees/rte-pkt-15a-clean-base",
-    "clean_base_sha": "a4214ca5bf431e1b59791661e2b664a6cd24c1da",
-    "clean_base_result": "FAIL: 1 failed, 23 passed; same test, same assertion, same observed escalation_trigger provider_failure",
-    "acceptance_impact": "Does not block closeout commit under RTE-PKT-15A policy because the broader failure is baseline behavior."
-  },
-  "tests": [
+  "validations": [
     {
-      "command": "pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q",
-      "result": "PASS",
-      "observed": "5 passed; PytestConfigWarning for unknown asyncio_mode"
-    },
-    {
-      "command": "pytest services/repo-truth-extractor/tests/test_output_safety.py -q",
-      "result": "PASS",
-      "observed": "6 passed; PytestConfigWarning for unknown asyncio_mode"
-    },
-    {
-      "command": "pytest services/repo-truth-extractor/tests -k 'failed and redaction' -q",
-      "result": "PASS",
-      "observed": "5 passed; PytestConfigWarning for unknown asyncio_mode"
-    },
-    {
-      "command": "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py",
+      "command": "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py",
       "result": "PASS",
       "observed": "exit code 0"
     },
     {
-      "command": "pytest services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q",
+      "command": "pytest services/repo-truth-extractor/tests/test_output_safety.py -q",
       "result": "PASS",
-      "observed": "2 passed; PytestConfigWarning for unknown asyncio_mode"
+      "observed": "7 passed; warning for unknown asyncio_mode"
     },
     {
-      "command": "pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py::test_classify_request_failure_distinguishes_batch_terminal_and_parse_failures -q",
+      "command": "pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q",
       "result": "PASS",
-      "observed": "1 passed; PytestConfigWarning for unknown asyncio_mode"
+      "observed": "6 passed; warning for unknown asyncio_mode"
     },
     {
-      "command": "pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q",
-      "result": "FAIL",
-      "observed": "1 failed, 23 passed; failing assertion expected request_meta.escalation_trigger is None but observed provider_failure"
+      "command": "pytest services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q",
+      "result": "PASS",
+      "observed": "4 passed; warning for unknown asyncio_mode"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_run_extraction_v5_live_gate_terminality.py -q",
+      "result": "PASS",
+      "observed": "39 passed; warning for unknown asyncio_mode"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_batch_clients.py -q",
+      "result": "NOT_RUN",
+      "observed": "file absent on this base; direct command returned pytest exit code 4"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_batch_clients_integration.py -q",
+      "result": "PASS",
+      "observed": "7 passed; warning for unknown asyncio_mode"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_strict_passthrough.py -q",
+      "result": "NOT_RUN",
+      "observed": "file absent on this base; direct command returned pytest exit code 4"
+    },
+    {
+      "command": "pytest services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py -q",
+      "result": "PASS",
+      "observed": "5 passed; warning for unknown asyncio_mode"
     },
     {
       "command": "git diff --check",
@@ -83,25 +122,28 @@
       "observed": "exit code 0"
     },
     {
-      "command": "pre-commit run --files services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FAILED_SIDECAR_MATRIX.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TEST_REPORT.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_NO_PROVIDER_CALLS_ATTESTATION.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_SECRET_FIXTURE_REDACTION_PROOF.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_DIFF_SUMMARY.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_UNKNOWNS.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REGRESSION_TRIAGE_CLOSEOUT.md out/rte-pkt-15-failed-sidecars/RTE-PKT-15_FINAL_CLOSEOUT.md out/rte-pkt-15-failed-sidecars/implementation-notes.md",
-      "result": "PASS",
-      "observed": "exit code 0; docs/location/root-hygiene hooks passed or skipped where no files applied"
+      "command": "safe path/count secret-shape scan over RTE runtime, tests, and proof root",
+      "result": "REVIEWED",
+      "observed": "broad scan found expected positives in sanitizer literals, synthetic tests, and legacy fixtures; matched contents were not copied"
     },
     {
-      "command": "python -m json.tool out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json >/dev/null",
-      "result": "PASS",
-      "observed": "exit code 0"
+      "command": "safe path/count secret-shape scan over touched files",
+      "result": "REVIEWED",
+      "observed": "runtime runner and failed-sidecar test had 0 matches; sanitizer and output-safety test each had one deliberate private-key-pattern literal"
     },
     {
-      "command": "python -c 'from pathlib import Path; pats=[\"RTE\"+\"PKT15\",\"s\"+\"k-\",\"A\"*4,\"B\"*4,\"C\"*4,\"PRIVATE \"+\"KEY-----\",\"Bearer \"+\"X\"]; text=\"\\n\".join(p.read_text(encoding=\"utf-8\") for p in Path(\"out/rte-pkt-15-failed-sidecars\").glob(\"**/*\") if p.is_file()); hits=[p for p in pats if p in text]; raise SystemExit(1 if hits else 0)'",
+      "command": "pre-commit run --files services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py out/rte-pkt-15-failed-sidecars/*",
       "result": "PASS",
-      "observed": "no matches"
+      "observed": "exit code 0; configured hooks passed or skipped where not applicable"
+    },
+    {
+      "command": "git diff --name-only origin/main...HEAD allowlist check",
+      "result": "PASS",
+      "observed": "only RTE-PKT-15 allowlisted files remain in the PR diff; out/rte-ux-valuation-opus-audit is absent"
     }
   ],
-  "missing_declared_regression_tests": [
-    "services/repo-truth-extractor/tests/test_provider_payload_redaction.py"
-  ],
   "remaining_unknowns": [
+    "RTE-PKT-00 named proof root is absent from this checkout.",
     "services/repo-truth-extractor/llm_runtime.py comparison-lane .FAILED.txt writer is outside packet allowlist and still writes failure_reason directly.",
     "Legacy v3 failed sidecar fixtures were not modified by this packet."
   ]

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_NO_PROVIDER_CALLS_ATTESTATION.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_NO_PROVIDER_CALLS_ATTESTATION.md
@@ -1,13 +1,11 @@
-# RTE-PKT-15 No Provider Calls Attestation
+# RTE-PKT-15 No Live Calls Attestation
 
 No live extraction was run.
 
-No xAI, OpenAI, OpenRouter, Gemini, Anthropic, or other provider call was run.
+No provider call was run.
 
 No provider batch submit, poll, retrieve, or cancel operation was run.
 
-The failed-sidecar tests use local monkeypatches and fake batch clients. The batch-watch test constructs local batch index/input files and replaces `build_batch_client`, `resolve_api_key`, `get_phase_prompts`, and `maybe_send_batch_webhook` with local test doubles.
+The failed-sidecar tests use local monkeypatches, temporary files, and fake batch clients. The batch-watch test replaces provider-facing construction and webhook behavior with local test doubles.
 
-No provider credentials were required or inspected.
-
-Closeout update: regression triage used only local pytest commands in the implementation worktree and a detached clean-base worktree. No provider credentials, live extraction, provider batch submit, provider batch poll, provider batch retrieve, provider batch cancel, or external research occurred during closeout.
+No provider credentials were required, read, or inspected.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REDACTION_MATRIX.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REDACTION_MATRIX.md
@@ -1,0 +1,16 @@
+# RTE-PKT-15 Redaction Matrix
+
+| Surface | Secret-shaped input class | Expected output behavior | Validation |
+| --- | --- | --- | --- |
+| Failed text helper | Provider-token-shaped text, bearer header text, private-key-block-shaped text, generic long mixed token text | Secret-shaped value absent; redaction marker present; safe digest text preserved. | `test_failed_sidecar_text_redacts_provider_tokens_and_private_key_blocks` |
+| Failed JSON helper | Generic long mixed token in non-sensitive failure field | Secret-shaped value absent; redaction marker present; `api_key_env` and digest metadata preserved. | `test_failed_sidecar_payload_redacts_generic_secret_shapes_but_preserves_env_metadata` |
+| Worker exception sidecars | Exception text containing generated secret-shaped content | `.FAILED.txt` and `.FAILED.json` omit secret-shaped value; failure class and partition metadata remain. | `test_worker_exception_failed_sidecars_redact_secret_text` |
+| Parse failure sidecars | Raw provider response text containing generated secret-shaped content | `.FAILED.txt` and `.FAILED.json` omit secret-shaped value; parse failure metadata remains. | `test_parse_failure_failed_sidecars_redact_raw_response_text` |
+| Schema failure sidecars | Schema-failed response payload containing generated secret-shaped content | `.FAILED.txt` and `.FAILED.json` omit secret-shaped value; schema gate context remains. | `test_schema_failure_failed_sidecars_redact_response_and_preserve_context` |
+| Batch provider sidecars | Batch result error containing generated secret-shaped content | `.FAILED.txt` and `.FAILED.json` omit secret-shaped value; provider, model, and batch id remain. | `test_batch_watch_failure_sidecars_redact_provider_error_text` |
+| Batch terminal text helper | Terminal-state text containing generated secret-shaped content | `.FAILED.txt` omits secret-shaped value; terminal class text remains. | `test_failed_sidecar_text_writer_redacts_batch_terminal_text` |
+| Failed JSON direct writer | `.FAILED.json` payload with generic long mixed token | Token absent from persisted JSON; safe env and digest metadata preserved. | `test_failed_sidecar_json_writer_redacts_generic_secret_shape` |
+
+## Boundary
+
+RTE-PKT-15 handles post-failure artifact redaction. RTE-PKT-02 provider-bound payload redaction remains separate and was not changed.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REGRESSION_TRIAGE_CLOSEOUT.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REGRESSION_TRIAGE_CLOSEOUT.md
@@ -1,39 +1,19 @@
 # RTE-PKT-15 Regression Triage Closeout
 
-## REG-001 command
+## Packet-Adjacent Tests
 
-`pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
+All present packet-adjacent tests passed.
 
-## Implementation branch result
+Two packet-declared filenames are absent on this base:
 
-- Worktree: `/Users/hue/.codex/worktrees/a8da/dopemux-mvp`
-- Branch: `codex/rte-pkt-15-failed-sidecars`
-- HEAD: `a4214ca5bf431e1b59791661e2b664a6cd24c1da`
-- Result: FAIL
-- Summary: 1 failed, 23 passed.
-- Failing test: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback`
-- Assertion: expected `payload["request_meta"]["escalation_trigger"] is None`
-- Observed value: `provider_failure`
+- `services/repo-truth-extractor/tests/test_batch_clients.py`
+- `services/repo-truth-extractor/tests/test_strict_passthrough.py`
 
-## Clean base result
+Nearest observed substitutions were run and passed:
 
-- Worktree: `/Users/hue/.codex/worktrees/rte-pkt-15a-clean-base`
-- Branch: detached HEAD
-- HEAD: `a4214ca5bf431e1b59791661e2b664a6cd24c1da`
-- Result: FAIL
-- Summary: 1 failed, 23 passed.
-- Failing test: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback`
-- Assertion: expected `payload["request_meta"]["escalation_trigger"] is None`
-- Observed value: `provider_failure`
+- `services/repo-truth-extractor/tests/test_batch_clients_integration.py`
+- `services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py`
 
-## Classification
+## Scope Assessment
 
-`BASELINE_FAILURE`
-
-The implementation branch and clean base fail the same command on the same test with the same assertion and observed value. The line number differs because the implementation branch adds sidecar-redaction code above the logged runtime line, but the tested behavior and assertion are identical.
-
-## Acceptance impact
-
-This failure does not block committing RTE-PKT-15 closeout under the packet policy because it is proven baseline behavior, not a new regression from failed-sidecar redaction.
-
-The failure remains outside this packet's implementation scope. No provider escalation semantics or broader prelive hardening test expectations were changed.
+The diff changes only failed sidecar output safety and targeted tests/proof. No retry logic, repair semantics, provider routing, model-map, promptset, or schema behavior was changed.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_RISKS.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_RISKS.md
@@ -1,0 +1,9 @@
+# RTE-PKT-15 Remaining Risks
+
+| Risk | Classification | Why it remains |
+| --- | --- | --- |
+| Comparison-lane `.FAILED.txt` direct writer | `UNKNOWN / FOLLOW-UP` | `services/repo-truth-extractor/llm_runtime.py` is outside the packet allowlist and still writes `failure_reason` directly. |
+| Legacy v3 failed sidecar fixtures | `ACCEPTED_RESIDUAL` | Fixtures are evidence surfaces, not current v5 writer paths. They were not modified and their contents were not quoted. |
+| Packet-00 named proof files absent | `UNKNOWN` | The current branch does not contain `out/rte-pkt-00-source-closure/`; operator grounding supplied the packet-00 failed-sidecar risk context. |
+| Existing local branch name collision | `PROCESS_DRIFT` | The requested branch already existed with broad unrelated drift. This run used a clean branch and preserved the old branch untouched. |
+| Broad test-tree grep positives | `EXPECTED_POSITIVES` | The broad packet grep reports deliberate sanitizer patterns, synthetic test literals, and legacy fixture paths. Proof records only path/count evidence, not matched contents. |

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_UNKNOWNS.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_REMAINING_UNKNOWNS.md
@@ -1,21 +1,19 @@
 # RTE-PKT-15 Remaining Unknowns
 
+## UNKNOWN: Packet 00 proof root
+
+The current branch does not contain the named `out/rte-pkt-00-source-closure/` proof root, and a local sibling worktree search did not find it. The operator prompt supplied the packet-00 failed-sidecar risk context.
+
 ## UNKNOWN: comparison-lane failed text sidecar
 
-`services/repo-truth-extractor/llm_runtime.py:1342` writes comparison-lane `.FAILED.txt` content directly from `failure_reason`.
+`services/repo-truth-extractor/llm_runtime.py:1625` writes comparison-lane `.FAILED.txt` content directly from `failure_reason`.
 
-This file is outside the packet allowlist, so it was not patched. If comparison-lane failed sidecars are in the live proof-storage boundary, a follow-up packet should either add `llm_runtime.py` to scope or prove comparison-lane failure text cannot contain provider/source/error secret-shaped content.
+This file is outside the packet allowlist, so it was not patched. If comparison-lane failed sidecars are in the live proof-storage boundary, a follow-up packet should either add `llm_runtime.py` to scope or prove comparison-lane failure text cannot contain provider, source, or exception secret-shaped content.
 
-## UNKNOWN: legacy v3 failed sidecar fixtures
+## ACCEPTED RESIDUAL: legacy v3 failed sidecar fixtures
 
-Legacy v3 fixture sidecars were not modified. This packet focused on RTE v5 runtime failed sidecar safety. Existing fixture contents were not quoted in proof.
+Legacy v3 fixture sidecars were not modified. This packet focused on current v5 runtime failed sidecar safety. Existing fixture contents were not quoted in proof.
 
-## NOT PRESENT: provider payload redaction regression file
+## PROCESS DRIFT: requested branch name collision
 
-The packet named `services/repo-truth-extractor/tests/test_provider_payload_redaction.py` as a conditional regression command. That file was not present in this checkout.
-
-## Drift: broader prelive hardening validation
-
-The broader command `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q` failed one provider escalation assertion unrelated to changed sidecar-redaction lines.
-
-Closeout comparison against `/Users/hue/.codex/worktrees/rte-pkt-15a-clean-base` at `a4214ca5bf431e1b59791661e2b664a6cd24c1da` reproduced the same failing test, assertion, and observed `provider_failure` value. Classification: `BASELINE_FAILURE`.
+The requested branch already existed locally with broad unrelated drift against current `main`. This run used a clean branch and preserved the old branch untouched.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_SECRET_FIXTURE_REDACTION_PROOF.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_SECRET_FIXTURE_REDACTION_PROOF.md
@@ -1,20 +1,14 @@
 # RTE-PKT-15 Secret Fixture Redaction Proof
 
-Generated tests construct secret-shaped values at runtime and assert absence from persisted `.FAILED.txt` and `.FAILED.json` outputs.
+Tests construct synthetic secret-shaped values at runtime. No real Packet 00 failed sidecar fixture content was copied into tests, logs, comments, or proof.
 
-The raw generated fixture values are not quoted in this proof.
+Validated surfaces:
 
-Covered assertions:
+- Worker exception text is absent from persisted failed sidecars while worker failure context remains.
+- Parse failure response text is absent from persisted failed sidecars while parse failure context remains.
+- Schema failure response text is absent from persisted failed sidecars while schema gate context remains.
+- Batch provider error text is absent from persisted failed sidecars while provider, model, and batch id context remains.
+- Batch terminal text sidecar output preserves the terminal failure label.
+- Failed JSON direct writer redacts generic long secret-shaped values in non-sensitive failure fields while preserving safe metadata.
 
-- Worker exception text: generated secret-shaped exception content is absent from `.FAILED.txt` and paired `.FAILED.json`; redaction markers remain.
-- Parse failure response text: generated secret-shaped model response content is absent from `.FAILED.txt` and paired `.FAILED.json`; `failure_type`, `status_code`, phase, step, and partition remain.
-- Schema failure response text: generated secret-shaped response content is absent from `.FAILED.txt` and paired `.FAILED.json`; schema context remains visible.
-- Batch provider error text: generated secret-shaped provider error content is absent from `.FAILED.txt` and paired `.FAILED.json`; provider, model, and batch ID remain.
-- Batch terminal text helper: generated secret-shaped terminal text is absent from `.FAILED.txt`; terminal failure class text remains.
-- Output safety helper: provider-token-shaped text and private-key-block-shaped text are removed; safe SHA text remains.
-
-Observed redaction markers:
-
-- `[REDACTED]`
-- `[REDACTED PRIVATE KEY]`
-- `REDACTED` for query parameter values
+Legacy v3 failed sidecar fixtures remain unmodified evidence surfaces and are not quoted here.

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TASK_PACKET.json
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TASK_PACKET.json
@@ -1,0 +1,123 @@
+{
+  "id": "RTE-PKT-15-FAILED-SIDECARS",
+  "project": "dopemux-rte",
+  "target": "Repo Truth Extractor failed sidecar redaction",
+  "invariants": [
+    "No live extraction.",
+    "No provider calls.",
+    "No batch submit, poll, retrieve, or cancel.",
+    "No promptset edits.",
+    "No schema edits.",
+    "No model-map edits.",
+    "No route-policy edits.",
+    "No retry-logic changes.",
+    "No repair-semantics changes.",
+    "No artifact schema redesign.",
+    "Runtime-generated artifacts remain evidence surfaces, not source truth.",
+    "Secrets and secret-shaped values must not be quoted in proof outputs.",
+    "Preserve deterministic ordering and existing failure classification semantics."
+  ],
+  "depends_on": [
+    "RTE-PKT-00-SOURCE-CLOSURE",
+    "RTE-PKT-01-LIVE-GATE",
+    "RTE-PKT-02-PAYLOAD-REDACTION"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "pyproject.toml",
+    "require_identity_match": true,
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git"
+  },
+  "series": {
+    "id": "RTE-REMEDIATION-SERIES",
+    "base_branch": "main",
+    "parent_tp_id": "RTE-PKT-02-PAYLOAD-REDACTION",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/rte-pkt-15-failed-sidecars-clean"
+  },
+  "commit": {
+    "message": "fix(rte): redact failed sidecar outputs",
+    "allowlist": [
+      "services/repo-truth-extractor/run_extraction_v5.py",
+      "services/repo-truth-extractor/output_safety.py",
+      "services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py",
+      "services/repo-truth-extractor/tests/test_output_safety.py",
+      "services/repo-truth-extractor/tests/fixtures/**",
+      "out/rte-pkt-15-failed-sidecars/**"
+    ],
+    "verify": [
+      "git diff --check",
+      "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py",
+      "pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q",
+      "pytest services/repo-truth-extractor/tests/test_output_safety.py -q"
+    ]
+  },
+  "pr": {
+    "title": "RTE-PKT-15: redact failed sidecar outputs",
+    "body": "Implements RTE-PKT-15-FAILED-SIDECARS. Scope is limited to failed sidecar redaction and tests. No provider calls, live extraction, batch provider operations, promptset edits, schema edits, model-map edits, route-policy edits, retry-semantics changes, or repair-semantics changes are authorized.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "01-preflight-and-baseline",
+      "task": "Verify repo identity, branch/worktree safety, dependencies, and prior packet evidence before editing.",
+      "validation": [
+        "Repo identity and branch deviation are recorded in PREFLIGHT.md."
+      ]
+    },
+    {
+      "id": "02-map-failed-sidecar-writers",
+      "task": "Map current failed sidecar writer paths and classify scope.",
+      "validation": [
+        "Failed sidecar writer ledger lists in-scope and out-of-scope writers."
+      ]
+    },
+    {
+      "id": "03-apply-sidecar-redaction",
+      "task": "Apply output-safety redaction to failed text and JSON sidecars.",
+      "validation": [
+        "Failed text and JSON sidecars use failed-sidecar sanitizer coverage."
+      ]
+    },
+    {
+      "id": "04-add-redaction-tests",
+      "task": "Add targeted failed sidecar redaction tests.",
+      "validation": [
+        "Focused output safety and failed sidecar tests pass."
+      ]
+    },
+    {
+      "id": "05-regression-guard-existing-surfaces",
+      "task": "Run packet-adjacent local regression tests.",
+      "validation": [
+        "Adjacent local regressions pass or substitutions are recorded."
+      ]
+    },
+    {
+      "id": "06-proof-and-secret-scan",
+      "task": "Generate proof artifacts and run secret-shape scan.",
+      "validation": [
+        "Proof artifacts avoid quoting secret-shaped fixture contents."
+      ]
+    },
+    {
+      "id": "07-review-and-closeout",
+      "task": "Inspect final diff, validate scope, and prepare commit/PR closeout.",
+      "validation": [
+        "Final diff remains within allowlist."
+      ]
+    }
+  ]
+}

--- a/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TEST_REPORT.md
+++ b/out/rte-pkt-15-failed-sidecars/RTE-PKT-15_TEST_REPORT.md
@@ -2,63 +2,32 @@
 
 ## PASS
 
-- `pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q`
-  - Result: PASS, 5 passed.
-  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
-- `pytest services/repo-truth-extractor/tests/test_output_safety.py -q`
-  - Result: PASS, 6 passed.
-  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
-- `pytest services/repo-truth-extractor/tests -k 'failed and redaction' -q`
-  - Result: PASS, 5 passed.
-  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
-- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py`
-  - Result: PASS, exit code 0.
-- `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
-  - Result: PASS, 2 passed.
-  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
-- `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py::test_classify_request_failure_distinguishes_batch_terminal_and_parse_failures -q`
-  - Result: PASS, 1 passed.
-  - Warning: `PytestConfigWarning` for unknown `asyncio_mode`.
-- `git diff --check`
-  - Result: PASS, exit code 0.
-- `pre-commit run --files ...`
-  - Result: PASS, exit code 0.
-  - Observed: docs/location/root-hygiene hooks passed or skipped where no files applied.
-- `python -m json.tool out/rte-pkt-15-failed-sidecars/RTE-PKT-15_MANIFEST.json >/dev/null`
-  - Result: PASS, exit code 0.
-- `python -c 'from pathlib import Path; pats=["RTE"+"PKT15","s"+"k-","A"*4,"B"*4,"C"*4,"PRIVATE "+"KEY-----","Bearer "+"X"]; text="\n".join(p.read_text(encoding="utf-8") for p in Path("out/rte-pkt-15-failed-sidecars").glob("**/*") if p.is_file()); hits=[p for p in pats if p in text]; raise SystemExit(1 if hits else 0)'`
-  - Result: PASS, no matches.
+| Command | Result |
+| --- | --- |
+| `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py` | PASS, exit code 0 |
+| `pytest services/repo-truth-extractor/tests/test_output_safety.py -q` | PASS, 7 passed; warning for unknown `asyncio_mode` |
+| `pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q` | PASS, 6 passed; warning for unknown `asyncio_mode` |
+| `pytest services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q` | PASS, 4 passed; warning for unknown `asyncio_mode` |
+| `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_live_gate_terminality.py -q` | PASS, 39 passed; warning for unknown `asyncio_mode` |
+| `pytest services/repo-truth-extractor/tests/test_batch_clients_integration.py -q` | PASS, 7 passed; warning for unknown `asyncio_mode` |
+| `pytest services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py -q` | PASS, 5 passed; warning for unknown `asyncio_mode` |
+| `git diff --check` | PASS, exit code 0 |
+| `git diff --name-only origin/main...HEAD` allowlist check | PASS, only RTE-PKT-15 allowlisted files remain |
+| `pre-commit run --files ...` | PASS, exit code 0; configured hooks passed or skipped where not applicable |
 
-## FAIL
+## NOT_RUN / Substituted
 
-- `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
-  - Result: FAIL, 1 failed and 23 passed.
-  - Failing assertion: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback` expected `request_meta["escalation_trigger"] is None`; observed `provider_failure`.
-  - Scope assessment: the changed lines do not modify provider-failure escalation semantics. This packet did not broaden into that failure.
+| Packet command | Observed status | Substitution |
+| --- | --- | --- |
+| `pytest services/repo-truth-extractor/tests/test_batch_clients.py -q` | File absent; direct command returned pytest exit code 4. | `pytest services/repo-truth-extractor/tests/test_batch_clients_integration.py -q` passed. |
+| `pytest services/repo-truth-extractor/tests/test_strict_passthrough.py -q` | File absent; direct command returned pytest exit code 4. | `pytest services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py -q` passed. |
+| Live extraction / provider calls / provider batch operations | Forbidden by packet. | Not run. |
 
-## REGRESSION TRIAGE
+## Secret-Shape Scan
 
-- Implementation branch command:
-  - `pytest services/repo-truth-extractor/tests/test_run_extraction_v5_prelive_hardening.py services/repo-truth-extractor/tests/test_run_extraction_v5_concurrency.py -q`
-  - Result: FAIL, 1 failed and 23 passed.
-  - Failing test: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback`.
-  - Observed value: `provider_failure`.
-- Clean base worktree:
-  - Path: `/Users/hue/.codex/worktrees/rte-pkt-15a-clean-base`
-  - SHA: `a4214ca5bf431e1b59791661e2b664a6cd24c1da`
-  - Result: FAIL, 1 failed and 23 passed.
-  - Failing test: `test_current_partition_execution_preserves_provider_failure_semantics_before_parse_fallback`.
-  - Observed value: `provider_failure`.
-- Classification: `BASELINE_FAILURE`.
-- Acceptance impact: not a new regression from RTE-PKT-15 sidecar redaction.
+- Literal packet grep over the broad RTE test tree reports expected positives in sanitizer literals, synthetic test literals, and legacy fixture paths. Matched contents were not copied into proof.
+- Safe path/count scan over touched files found no matches in `run_extraction_v5.py` or `test_failed_sidecar_redaction.py`; `output_safety.py` and `test_output_safety.py` each contain one deliberate private-key-pattern literal used by the sanitizer/test.
 
-## NOT_RUN
-
-- `pytest services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q`
-  - Reason: file is not present in this checkout.
-- Live/provider/batch network validation.
-  - Reason: forbidden by packet.
-
-## Provider boundary
+## Provider Boundary
 
 No validation command used provider credentials, submitted provider batch jobs, polled provider batch jobs, retrieved provider batch jobs, cancelled provider batch jobs, or ran live extraction.

--- a/out/rte-pkt-15-failed-sidecars/implementation-notes.md
+++ b/out/rte-pkt-15-failed-sidecars/implementation-notes.md
@@ -2,23 +2,29 @@
 
 Packet: `RTE-PKT-15-FAILED-SIDECARS`
 
-Worktree: `/Users/hue/.codex/worktrees/a8da/dopemux-mvp`
+Worktree: `/Users/hue/.codex/worktrees/f89f/dopemux-mvp`
 
-Branch: `codex/rte-pkt-15-failed-sidecars`
+Branch: `codex/rte-pkt-15-failed-sidecars-clean`
 
-Base SHA: `a4214ca5bf431e1b59791661e2b664a6cd24c1da`
+Original local base SHA: `d64d5f15e46e68373e3bed1160fbc3df2807db59`
+
+Rebased PR base: `origin/main@027465e31`
 
 ## Implemented
 
-- Added explicit failed-sidecar text sanitization in `output_safety.py`.
-- Routed in-scope v5 `.FAILED.txt` persistence through `write_failed_sidecar_text`.
-- Kept `.FAILED.json` artifacts on `write_json`, preserving existing structured payload redaction.
-- Added targeted local tests for failed sidecar redaction and lineage preservation.
+- Strengthened failed sidecar text redaction by using the secret-shape sanitizer path.
+- Added structured failed sidecar payload sanitization for `.FAILED.json` writes.
+- Kept filenames, failure classes, status-code fields, and metadata shape intact.
+- Added targeted regression tests for generic secret-shaped content in failed text and JSON sidecars.
 
 ## Validation
 
-Targeted packet tests passed. Compile and diff checks passed. One broader prelive hardening command failed on existing provider-failure escalation semantics outside this packet's edit scope.
+Focused packet tests passed. Packet-adjacent local regression tests passed with two filename substitutions recorded in `RTE-PKT-15_TEST_REPORT.md`.
+
+## PR Scope Cleanup
+
+`out/rte-ux-valuation-opus-audit/**` was removed from the PR diff by rebasing onto current `origin/main` and dropping the unrelated UX proof-pack commit from PR ancestry.
 
 ## Status
 
-Implementation is ready for review with the documented out-of-scope comparison-lane unknown and broader validation drift.
+Ready for review pending final push.

--- a/services/repo-truth-extractor/output_safety.py
+++ b/services/repo-truth-extractor/output_safety.py
@@ -96,7 +96,7 @@ def sanitize_text_for_output(text: str) -> str:
 
 
 def sanitize_failed_sidecar_text(text: str) -> str:
-    return sanitize_text_for_output(text)
+    return sanitize_text_for_provider_payload(text)
 
 
 def _looks_like_hex_digest(value: str) -> bool:
@@ -168,6 +168,27 @@ def sanitize_payload_for_provider(payload: Any, *, field_name: str | None = None
         }
     if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
         return [sanitize_payload_for_provider(item) for item in payload]
+    return payload
+
+
+def sanitize_payload_for_failed_sidecar(payload: Any, *, field_name: str | None = None) -> Any:
+    if isinstance(payload, Path):
+        return sanitize_failed_sidecar_text(str(payload))
+    if field_name is not None and _is_sensitive_key(field_name):
+        if payload is None or isinstance(payload, bool):
+            return payload
+        if isinstance(payload, (int, float)):
+            return payload
+        return "[REDACTED]"
+    if isinstance(payload, str):
+        return sanitize_failed_sidecar_text(payload)
+    if isinstance(payload, Mapping):
+        return {
+            str(key): sanitize_payload_for_failed_sidecar(value, field_name=str(key))
+            for key, value in payload.items()
+        }
+    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+        return [sanitize_payload_for_failed_sidecar(item) for item in payload]
     return payload
 
 

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -44,6 +44,7 @@ if str(RUNNER_SERVICE_DIR) not in sys.path:
 
 from output_safety import (
     sanitize_failed_sidecar_text,
+    sanitize_payload_for_failed_sidecar,
     sanitize_payload_for_output,
     sanitize_text_for_output,
     sanitize_text_for_provider_payload,
@@ -2770,8 +2771,15 @@ def get_run_dirs(root: Path, run_id: str, readonly: bool = False) -> Dict[str, P
     )
 
 
+def _is_failed_json_sidecar_path(path: Path) -> bool:
+    return path.name.endswith(".FAILED.json")
+
+
 def write_json(path: Path, payload: Any) -> None:
-    sanitized_payload = sanitize_payload_for_output(payload)
+    if _is_failed_json_sidecar_path(path):
+        sanitized_payload = sanitize_payload_for_failed_sidecar(payload)
+    else:
+        sanitized_payload = sanitize_payload_for_output(payload)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         json.dumps(

--- a/services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py
+++ b/services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py
@@ -90,6 +90,10 @@ def _secret_value() -> str:
     return "sk-" + "RTEPKT15" + ("A" * 32)
 
 
+def _opaque_secret_value() -> str:
+    return "RtE" + ("dE5" * 14)
+
+
 def _prompt_spec(runner: types.ModuleType, tmp_path: Path, *, step_id: str = "A0") -> Any:
     prompt_path = tmp_path / f"PROMPT_{step_id}_TEST.md"
     prompt_path.write_text("Return OUT.json\n", encoding="utf-8")
@@ -354,3 +358,30 @@ def test_failed_sidecar_text_writer_redacts_batch_terminal_text(tmp_path: Path) 
     failed_text = failed_path.read_text(encoding="utf-8")
     _assert_secret_redacted(failed_text, secret)
     assert "batch_terminal_state:failed" in failed_text
+
+
+def test_failed_sidecar_json_writer_redacts_generic_secret_shape(tmp_path: Path) -> None:
+    runner = _load_runner_module()
+    secret = _opaque_secret_value()
+    safe_digest = "c" * 64
+    failed_json_path = tmp_path / "raw" / "A0__A_P0001.FAILED.json"
+
+    runner.write_json(
+        failed_json_path,
+        {
+            "failure_type": "provider",
+            "api_key_env": "OPENAI_API_KEY",
+            "request_meta": {
+                "provider_error_reason": f"opaque failure marker {secret}",
+                "sha256": safe_digest,
+            },
+        },
+    )
+
+    failed_json = json.loads(failed_json_path.read_text(encoding="utf-8"))
+    rendered = json.dumps(failed_json, sort_keys=True)
+    assert secret not in rendered
+    assert "[REDACTED]" in rendered
+    assert failed_json["failure_type"] == "provider"
+    assert failed_json["api_key_env"] == "OPENAI_API_KEY"
+    assert failed_json["request_meta"]["sha256"] == safe_digest

--- a/services/repo-truth-extractor/tests/test_output_safety.py
+++ b/services/repo-truth-extractor/tests/test_output_safety.py
@@ -73,22 +73,49 @@ def test_sanitize_payload_redacts_secret_fields_but_preserves_env_metadata() -> 
 def test_failed_sidecar_text_redacts_provider_tokens_and_private_key_blocks() -> None:
     output_safety = _load_output_safety_module()
     provider_token = "sk-" + "RTEPKT15" + ("B" * 32)
+    opaque_token = "RtE" + ("aB3" * 14)
     private_key_body = "MII" + ("C" * 48)
+    safe_digest = "a" * 64
     text = (
         f"provider_error_reason={provider_token}\n"
+        f"opaque failure marker {opaque_token}\n"
         "-----BEGIN PRIVATE KEY-----\n"
         f"{private_key_body}\n"
         "-----END PRIVATE KEY-----\n"
-        "safe_sha256=abcdef1234567890\n"
+        f"safe_sha256={safe_digest}\n"
     )
 
     sanitized = output_safety.sanitize_failed_sidecar_text(text)
 
     assert provider_token not in sanitized
+    assert opaque_token not in sanitized
     assert private_key_body not in sanitized
     assert "[REDACTED]" in sanitized
     assert "[REDACTED PRIVATE KEY]" in sanitized
-    assert "safe_sha256=abcdef1234567890" in sanitized
+    assert f"safe_sha256={safe_digest}" in sanitized
+
+
+def test_failed_sidecar_payload_redacts_generic_secret_shapes_but_preserves_env_metadata() -> None:
+    output_safety = _load_output_safety_module()
+    opaque_token = "RtE" + ("cD4" * 14)
+    safe_digest = "b" * 64
+
+    sanitized = output_safety.sanitize_payload_for_failed_sidecar(
+        {
+            "failure_type": "provider",
+            "api_key_env": "OPENAI_API_KEY",
+            "request_meta": {
+                "provider_error_reason": f"opaque failure marker {opaque_token}",
+                "sha256": safe_digest,
+            },
+        }
+    )
+
+    rendered = json.dumps(sanitized, sort_keys=True)
+    assert opaque_token not in rendered
+    assert "[REDACTED]" in rendered
+    assert sanitized["api_key_env"] == "OPENAI_API_KEY"
+    assert sanitized["request_meta"]["sha256"] == safe_digest
 
 
 def test_ui_events_redact_secret_like_fields(tmp_path: Path) -> None:


### PR DESCRIPTION
Implements RTE-PKT-15-FAILED-SIDECARS. Scope is limited to failed sidecar redaction and tests.

Summary:
- Strengthens failed text sidecar redaction by using the secret-shape sanitizer path.
- Routes .FAILED.json writes through a failed-sidecar payload sanitizer.
- Adds targeted tests for generic secret-shaped failed text and JSON sidecar content.
- Refreshes proof artifacts under out/rte-pkt-15-failed-sidecars/.

Validation:
- PASS: python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/output_safety.py
- PASS: pytest services/repo-truth-extractor/tests/test_output_safety.py -q
- PASS: pytest services/repo-truth-extractor/tests/test_failed_sidecar_redaction.py -q
- PASS: pytest services/repo-truth-extractor/tests/test_provider_payload_redaction.py -q
- PASS: pytest services/repo-truth-extractor/tests/test_run_extraction_v5_live_gate_terminality.py -q
- PASS: pytest services/repo-truth-extractor/tests/test_batch_clients_integration.py -q
- PASS: pytest services/repo-truth-extractor/tests/test_strict_passthrough_attestations.py -q
- PASS: git diff --check
- PASS: pre-commit run --files packet files

Not run / substituted:
- test_batch_clients.py and test_strict_passthrough.py are absent on this base; nearest observed equivalents were run and passed.
- No live extraction, provider calls, provider batch submit/poll/retrieve/cancel, promptset edits, schema edits, model-map edits, route-policy edits, retry changes, repair changes, or artifact schema redesign.

Residual risks:
- Requested branch codex/rte-pkt-15-failed-sidecars already existed locally with broad unrelated drift, so this PR uses codex/rte-pkt-15-failed-sidecars-clean.
- RTE-PKT-00 named proof root is absent from this checkout; operator prompt supplied the Packet 00 risk context.
- Comparison-lane failed text sidecar writer in llm_runtime.py remains outside this packet allowlist.

@codex review
@gemini
@copilot