### PR TITLE
docs(governance): refresh Codex authority matrix

### DIFF
--- a/docs/03-reference/governance/codex-authority-refresh.md
+++ b/docs/03-reference/governance/codex-authority-refresh.md
@@ -1,0 +1,59 @@
+---
+id: codex-authority-refresh
+title: Codex Authority Refresh
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Codex-facing authority matrix for current dopemux repo work, labels, and proof rules.
+---
+# Codex Authority Refresh
+
+This matrix is a Codex-facing refresh for repo-changing work in this checkout. It does not replace runtime code, config, tests, compose wiring, active entrypoints, or active Task Packets. It records the authority surfaces Codex should inspect before making claims or edits.
+
+## Labels
+
+- `OBSERVED`: current repo files directly support the claim.
+- `CONFLICTING`: current repo files expose more than one authority or path and the conflict must remain visible.
+- `UNKNOWN`: current repo files do not prove the authority, runtime owner, or path.
+- `RECOMMENDED`: operational instruction for future Codex work, not proof of runtime behavior.
+
+## Codex Control Rules
+
+- `OBSERVED`: `AGENTS.md` is the durable Codex and agent-style instruction surface for this repo.
+- `OBSERVED`: the live Task Packet schema is `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`.
+- `OBSERVED`: active Task Packets control execution scope, allowlists, validation obligations, and stop conditions.
+- `OBSERVED`: runtime code, config, compose wiring, tests, and active entrypoints outrank docs for behavior claims.
+- `RECOMMENDED`: validate generated Task Packets against the live schema before implementation.
+- `RECOMMENDED`: Codex should not treat GitHub/CI alone as semantic proof of runtime correctness, authority ownership, or replay safety.
+- `RECOMMENDED`: Codex work must return proof and PR evidence, including commands, exit codes, changed files, residual risks, UNKNOWNs, commit SHA, and PR URL or exact blocker.
+
+## Authority Matrix
+
+| Surface | Status | Codex Authority Boundary | Evidence Paths |
+| --- | --- | --- | --- |
+| `dopemux` | `OBSERVED` | Operator control, CLI, startup, routing, MCP/service coordination. It is not PM, memory, retrieval, or external execution authority. | `AGENTS.md`; `PROJECT.md`; `ARCHITECTURE.md`; `pyproject.toml`; `src/dopemux/cli.py` |
+| `dopetask` | `OBSERVED` | External execution runtime reached through local wrappers. Repo source owns the wrapper/bootstrap path, not the external engine implementation. | `scripts/dopetask`; `.dopetaskroot`; `.dopetask-pin`; `scripts/taskx` |
+| Task Orchestrator | `CONFLICTING` | Workflow-significant transitions and workflow views. `services/task-orchestrator/app/main.py` and the Dockerfile point to the canonical runtime, while `services/task-orchestrator/task_orchestrator/app.py` hard-fails as unsupported. | `services/task-orchestrator/app/main.py`; `services/task-orchestrator/Dockerfile`; `services/task-orchestrator/task_orchestrator/app.py`; `services/task-orchestrator/mcp_stdio.py` |
+| Leantime | `OBSERVED` | Passive PM metadata and project/ticket snapshot authority through dopemux PM adapters and bridge-safe routes. It is not workflow legality authority. | `src/dopemux/pm/writes.py`; `src/dopemux/pm/reads.py`; `compose.yml`; `services/dopecon-bridge/dopecon_bridge/routes.py` |
+| ConPort | `CONFLICTING` | Structured decisions, progress, project context, and custom data. Current PM code proves use, while docs/runtime notes preserve access-contract drift around ConPort-facing ports and clients. | `src/dopemux/pm/writes.py`; `src/dopemux/pm/reads.py`; `services/dopecon-bridge/dopecon_bridge/routes.py`; `PROJECT.md`; `ARCHITECTURE.md` |
+| dope-memory | `CONFLICTING` | Chronicle and evidence-preserving receipts. The strongest observed dope-memory HTTP runtime is under working-memory-assistant, while adjacent memory surfaces remain overlapping. | `services/working-memory-assistant/dope_memory_main.py`; `services/working-memory-assistant/mcp/server.py`; `services/working-memory-assistant/main.py`; `PROJECT.md`; `ARCHITECTURE.md` |
+| dope-context | `OBSERVED` | Code/docs indexing and retrieval. Retrieval output is derived evidence and is not source truth by itself. | `services/dope-context/src/mcp/server.py`; `PROJECT.md`; `ARCHITECTURE.md` |
+| dopecon-bridge | `OBSERVED` | Adapter, proxy, routing, event transport, and compatibility layer. It must not be promoted into canonical task, workflow, decision, progress, PM, chronicle, or retrieval authority. | `services/dopecon-bridge/dopecon_bridge/routes.py`; `services/dopecon-bridge/dopecon_bridge/app.py`; `services/dopecon-bridge/kg_authority.py` |
+| ADHD Engine | `OBSERVED` | Operator-support and cognitive-state service. It supports state, recommendations, hooks, API, MCP, and WebSocket surfaces, but does not own PM, memory, chronicle, ConPort, or retrieval authority. | `services/adhd_engine/main.py`; `services/adhd_engine/mcp_stdio.py`; `PROJECT.md`; `ARCHITECTURE.md` |
+| Repo Truth Extractor | `OBSERVED` | Extraction and audit runtime only. Its outputs are evidence artifacts and do not replace runtime/source truth. Live execution requires explicit consent and is out of scope for docs-only Codex refresh work. | `services/repo-truth-extractor/run_extraction_v5.py`; `AGENTS.md`; `PROJECT.md`; `ARCHITECTURE.md` |
+| agents | `UNKNOWN` | Repo-wide agent runtime authority is unresolved. Multiple agent families exist, and no inspected path proves a single canonical agent execution or coordination owner. | `services/agents/*`; `src/dopemux/agent_orchestrator.py`; `services/task-orchestrator/task_orchestrator/agents/*`; `AGENTS.md` |
+| Cockpit/dopeUI | `CONFLICTING` | Cockpit runtime code is observed as a guarded local UI/runtime-render surface. `dopeUI` was not observed as a current named source/docs authority in the focused search, so Codex must not claim a unified Cockpit/dopeUI authority without new evidence. | `src/dopemux/ui/cockpit/*`; `src/dopemux/commands/cockpit_commands.py`; `tests/unit/dopemux/ui/cockpit/*`; `tests/unit/test_cockpit_cli.py` |
+
+## Current Path Rules
+
+- `OBSERVED`: `compose.yml` presents itself as the canonical Docker Compose entrypoint for normal runtime operation.
+- `CONFLICTING`: root authority docs and tracked `docs/03-reference/*` equivalents do not always share identical paths. Preserve exact paths rather than normalizing root and docs authority into one cleaner story.
+- `CONFLICTING`: TaskX naming remains in `scripts/taskx`, tests, docs, and older packets, but live wrapper evidence shows `scripts/taskx` is a compatibility shim to `scripts/dopetask`.
+- `UNKNOWN`: any authority not backed by runtime code, config, compose wiring, tests, active entrypoints, or the active Task Packet remains unresolved.
+
+## Codex Proof Rule
+
+Codex may cite GitHub checks, CI, PR state, and commits as delivery evidence, but those signals are not enough to prove semantic correctness or authority ownership. For substantial repo work, Codex must return a proof ledger with exact commands, exit codes, changed files, diff scope, validation results, commit SHA, PR URL or exact blocker, residual risks, UNKNOWNs, and cleanup status.

--- a/docs/03-reference/governance/codex-refresh-gap-register.md
+++ b/docs/03-reference/governance/codex-refresh-gap-register.md
@@ -1,0 +1,33 @@
+---
+id: codex-refresh-gap-register
+title: Codex Refresh Gap Register
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Gap register for unresolved Codex authority refresh risks in dopemux repo work.
+---
+# Codex Refresh Gap Register
+
+This register lists Codex-refresh gaps that must remain unresolved until proved by runtime code, config, tests, compose wiring, or active entrypoints. It is intentionally not a cleanup story.
+
+## Gaps
+
+| ID | Status | Gap | Evidence Boundary | Codex Handling |
+| --- | --- | --- | --- | --- |
+| CG-001 | `CONFLICTING` | Root-vs-docs authority path drift remains. Root files such as `AGENTS.md`, `PROJECT.md`, and `ARCHITECTURE.md` coexist with tracked docs under `docs/03-reference/*`, and some historical requested paths are absent or moved. | `AGENTS.md`; `PROJECT.md`; `ARCHITECTURE.md`; `docs/03-reference/governance/rules.md`; `docs/03-reference/systems/system-boundaries.md` | Cite exact paths used. Do not normalize root and docs authority into one source. |
+| CG-002 | `CONFLICTING` | TaskX vs dopetask naming drift remains. `scripts/taskx` exists, but it is a compatibility shim to `scripts/dopetask`; older docs, tests, and packets may still say TaskX. | `scripts/taskx`; `scripts/dopetask`; `PROJECT.md`; `ARCHITECTURE.md` | For execution claims, trace the live wrapper path: `dopemux` to `scripts/taskx` to `scripts/dopetask` to external `dopetask`. |
+| CG-003 | `CONFLICTING` | task-orchestrator runtime/package drift remains. The canonical observed runtime is `services/task-orchestrator/app/main.py`, Docker runs `app.main:app`, and legacy `task_orchestrator/app.py` hard-fails. | `services/task-orchestrator/app/main.py`; `services/task-orchestrator/Dockerfile`; `services/task-orchestrator/task_orchestrator/app.py`; `compose.yml` | Use the observed runtime path for behavior claims. Preserve the package/path conflict in docs and proof. |
+| CG-004 | `UNKNOWN` | Agent authority UNKNOWN remains. The repo has multiple agent families and no inspected runtime path proves a single repo-wide agent authority. | `services/agents/*`; `src/dopemux/agent_orchestrator.py`; `services/task-orchestrator/task_orchestrator/agents/*`; `AGENTS.md` | Do not claim a unified agent runtime. Treat agent ownership as UNKNOWN unless a packet proves a specific runtime path. |
+| CG-005 | `OBSERVED_RISK` | dopecon-bridge authority confusion risk remains. Bridge routes, proxies, adapts, and transports events, but broad PM/KG/ConPort surfaces can look canonical. | `services/dopecon-bridge/dopecon_bridge/routes.py`; `services/dopecon-bridge/kg_authority.py`; `PROJECT.md`; `ARCHITECTURE.md` | State the upstream canonical writer before any bridge-mediated write or claim. Never treat bridge proxy output as source truth by itself. |
+| CG-006 | `OBSERVED_RISK` | Proof/CI insufficiency risk remains. CI, GitHub checks, commits, and PR state prove delivery signals, not semantic correctness, authority ownership, replay safety, or runtime health. | `AGENTS.md`; `docs/03-reference/governance/rules.md`; active Task Packet validation obligations | Return exact validation commands, exit codes, diff scope, PR evidence, residual risks, and UNKNOWNs. Do not say CI alone proves correctness. |
+| CG-007 | `CONFLICTING` | ConPort access-contract drift remains. PM reads/writes use ConPort surfaces, while authority docs preserve split HTTP/MCP or port assumptions. | `src/dopemux/pm/writes.py`; `src/dopemux/pm/reads.py`; `services/dopecon-bridge/dopecon_bridge/routes.py`; `PROJECT.md`; `ARCHITECTURE.md` | Classify ConPort as structured decisions/progress/context authority, but keep access/port details path-specific. |
+| CG-008 | `CONFLICTING` | dope-memory and working-memory-assistant naming/runtime overlap remains. The observed dope-memory HTTP runtime lives under `services/working-memory-assistant`, with adjacent memory surfaces beside it. | `services/working-memory-assistant/dope_memory_main.py`; `services/working-memory-assistant/main.py`; `services/working-memory-assistant/mcp/server.py` | Treat dope-memory as chronicle/receipt authority only where the runtime path proves it. Preserve broader memory ownership UNKNOWN. |
+| CG-009 | `CONFLICTING` | Cockpit/dopeUI authority remains split or absent. Cockpit runtime-render code and tests are present; the focused source/docs search did not observe a current named `dopeUI` authority path. | `src/dopemux/ui/cockpit/*`; `src/dopemux/commands/cockpit_commands.py`; `tests/unit/dopemux/ui/cockpit/*`; focused `rg` search for `dopeUI|dope-ui|dopeui` | Do not claim Cockpit and dopeUI are one system. Mark dopeUI UNKNOWN until a live source path is proved. |
+| CG-010 | `UNKNOWN` | Live-provider, live extraction, live preflight, Docker startup, and account-specific runtime state are not exercised in docs-only Codex refresh work. | Packet invariants and validation scope | Mark these as NOT_RUN in proof. Do not infer service health from static inspection. |
+
+## Closeout Rule
+
+These gaps close only when a later packet provides direct runtime/code/config/test evidence and validates the affected path. Until then, Codex must preserve `UNKNOWN` and `CONFLICTING` labels in analysis, proof, PR text, and handoff notes.

--- a/proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json
+++ b/proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json
@@ -1,0 +1,210 @@
+{
+  "schema_version": "dopemux.codex_refresh.proof.v1",
+  "packet_id": "TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX",
+  "project": "dopemux-mvp",
+  "generated_at_utc": "2026-05-19T23:35:00Z",
+  "worktree_path": "/Users/hue/.codex/worktrees/4274/dopemux-mvp",
+  "branch": "codex/dmx-codex-refresh-001-authority-matrix",
+  "base": "origin/main",
+  "repo_identity": {
+    "status": "PASS",
+    "marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "observed_remotes": [
+      "mvp https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)",
+      "mvp https://github.com/DDD-Enterprises/dopemux-mvp.git (push)",
+      "origin https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)",
+      "origin https://github.com/DDD-Enterprises/dopemux-mvp.git (push)"
+    ]
+  },
+  "authority_used": [
+    "AGENTS.md",
+    "docs/03-reference/governance/rules.md",
+    "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+    "PROJECT.md",
+    "ARCHITECTURE.md",
+    "runtime/config evidence paths cited in docs/03-reference/governance/codex-authority-refresh.md"
+  ],
+  "analysis_performed": [
+    "Read live AGENTS.md on the packet branch after switching from detached HEAD.",
+    "Verified repo remote, branch, clean status, .dopetaskroot marker, and live task packet schema presence.",
+    "Inspected runtime/config evidence for dopemux CLI entrypoint, scripts/taskx, scripts/dopetask, compose.yml, task-orchestrator runtime paths, PM read/write routing, dopecon-bridge routing, dope-memory, dope-context, ADHD Engine, Repo Truth Extractor, agents, and Cockpit.",
+    "Preserved CONFLICTING and UNKNOWN labels where runtime/config/docs did not collapse authority."
+  ],
+  "slices_completed": [
+    {
+      "slice": "S1",
+      "status": "PASS",
+      "summary": "Preflight repo identity, branch, marker, schema, and authority files."
+    },
+    {
+      "slice": "S2",
+      "status": "PASS",
+      "summary": "Generated task packet JSON and validated it against the live schema."
+    },
+    {
+      "slice": "S3",
+      "status": "PASS",
+      "summary": "Authored Codex-facing authority matrix with OBSERVED, CONFLICTING, UNKNOWN, and RECOMMENDED labels."
+    },
+    {
+      "slice": "S4",
+      "status": "PASS",
+      "summary": "Authored gap register preserving root/docs path drift, TaskX/dopetask naming drift, task-orchestrator drift, agent UNKNOWN, bridge authority risk, and proof/CI insufficiency risk."
+    },
+    {
+      "slice": "S5",
+      "status": "PASS",
+      "summary": "Created proof JSON with commands, exit codes, changed files, NOT_RUN items, residual risks, and UNKNOWNs."
+    }
+  ],
+  "changed_files": [
+    "docs/03-reference/governance/codex-authority-refresh.md",
+    "docs/03-reference/governance/codex-refresh-gap-register.md",
+    "task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json",
+    "proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json"
+  ],
+  "command_results": [
+    {
+      "command": "git switch -c codex/dmx-codex-refresh-001-authority-matrix origin/main",
+      "exit_code": 0,
+      "stdout": "Previous HEAD position was d64d5f15e Add RTE UX valuation proof pack\nSwitched to a new branch 'codex/dmx-codex-refresh-001-authority-matrix'\nbranch 'codex/dmx-codex-refresh-001-authority-matrix' set up to track 'origin/main'.",
+      "stderr": ""
+    },
+    {
+      "command": "git remote -v",
+      "exit_code": 0,
+      "stdout": "mvp\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)\nmvp\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (push)\norigin\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)\norigin\thttps://github.com/DDD-Enterprises/dopemux-mvp.git (push)",
+      "stderr": ""
+    },
+    {
+      "command": "git branch --show-current",
+      "exit_code": 0,
+      "stdout": "codex/dmx-codex-refresh-001-authority-matrix",
+      "stderr": ""
+    },
+    {
+      "command": "git status --short",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f AGENTS.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f .dopetaskroot",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json >/dev/null",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "stdout": "/Users/hue/.local/share/mise/installs/python/3.12.13/lib/python3.12/site-packages/jsonschema/__main__.py:4: DeprecationWarning: The jsonschema CLI is deprecated and will be removed in a future version. Please use check-jsonschema instead, which can be installed from https://pypi.org/project/check-jsonschema/\n  from jsonschema.cli import main",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"OBSERVED|CONFLICTING|UNKNOWN|RECOMMENDED\" docs/03-reference/governance/codex-authority-refresh.md",
+      "exit_code": 0,
+      "stdout": "Matched authority labels in docs/03-reference/governance/codex-authority-refresh.md.",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"docs/03-reference/spec/dopetask/dopetask-canonical-spec.json|AGENTS.md|dopecon-bridge|scripts/dopetask|Task Orchestrator|ConPort|dope-memory|dope-context\" docs/03-reference/governance/codex-authority-refresh.md",
+      "exit_code": 0,
+      "stdout": "Matched live schema path, AGENTS.md, scripts/dopetask, Task Orchestrator, ConPort, dope-memory, dope-context, and dopecon-bridge references.",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"TaskX|dopetask|agent authority|UNKNOWN|dopecon-bridge|task-orchestrator|CI\" docs/03-reference/governance/codex-refresh-gap-register.md",
+      "exit_code": 0,
+      "stdout": "Matched TaskX, dopetask, agent authority, UNKNOWN, dopecon-bridge, task-orchestrator, and CI references.",
+      "stderr": ""
+    },
+    {
+      "command": "python scripts/docs_validator.py docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python scripts/docs_frontmatter_guard.py docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md",
+      "exit_code": 0,
+      "stdout": "All docs have valid frontmatter.",
+      "stderr": ""
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    }
+  ],
+  "codereview": {
+    "status": "PASS",
+    "commands": [
+      {
+        "command": "git diff --cached --name-status",
+        "exit_code": 0,
+        "summary": "Only the four allowlisted files were staged."
+      },
+      {
+        "command": "git diff --cached --stat",
+        "exit_code": 0,
+        "summary": "4 files changed, 442 insertions(+)."
+      },
+      {
+        "command": "git diff --cached --check",
+        "exit_code": 0,
+        "summary": "No cached whitespace errors."
+      }
+    ]
+  },
+  "precommit": {
+    "status": "PASS",
+    "command": "pre-commit run --files docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json",
+    "exit_code": 0,
+    "summary": "Docs frontmatter, docs graph validator, prohibited patterns, prelude token count, markdown location, docs placement, docs filename, root hygiene, markdownlint, trailing whitespace, EOF, and YAML hooks passed; UPGRADES and YAML hooks skipped where no files applied."
+  },
+  "NOT_RUN": [
+    "Live provider calls",
+    "Live extraction",
+    "Live preflight",
+    "Docker startup",
+    "Runtime service health checks",
+    "Account-specific checks",
+    "Secret inspection"
+  ],
+  "residual_risks": [
+    "Static inspection does not prove runtime service health.",
+    "dopeUI remains UNKNOWN because the focused source/docs search did not observe a current named authority path.",
+    "task-orchestrator runtime/package drift remains CONFLICTING across canonical app/main.py, Docker wiring, and unsupported legacy task_orchestrator/app.py.",
+    "ConPort access contracts remain path-specific and partially CONFLICTING.",
+    "GitHub/CI delivery evidence remains insufficient as semantic runtime proof."
+  ],
+  "unknowns": [
+    "UNKNOWN repo-wide agent runtime authority across services/agents, src/dopemux/agent_orchestrator.py, and services/task-orchestrator/task_orchestrator/agents.",
+    "UNKNOWN dopeUI authority path in current focused source/docs search.",
+    "UNKNOWN live runtime health because Docker startup and service health checks were not authorized.",
+    "UNKNOWN live provider/extraction behavior because live calls and extraction were not authorized."
+  ],
+  "cleanup_status": "PENDING: dedicated Codex worktree remains in place until push/PR outcome is known.",
+  "commit_sha": "POST_COMMIT_REPORTED_IN_FINAL_RESPONSE",
+  "pr_url": "POST_PR_REPORTED_IN_FINAL_RESPONSE"
+}

--- a/task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json
+++ b/task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json
@@ -1,0 +1,158 @@
+{
+  "id": "TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX",
+  "project": "dopemux-mvp",
+  "target": "Refresh the Codex-facing repo authority matrix so future Codex work uses live AGENTS.md, live task packet schema, current authority paths, and explicit UNKNOWN/CONFLICTING evidence.",
+  "invariants": [
+    "Do not modify runtime code, service code, tests, compose files, dependency files, or provider configuration.",
+    "Do not claim missing files exist.",
+    "Do not normalize uploaded/root authority docs and live docs into one cleaner story.",
+    "Preserve Dopemux split authority boundaries.",
+    "No live provider calls, live extraction, live preflight, Docker startup, or account-specific checks."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-CODEX-REFRESH-001",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-codex-refresh-001-authority-matrix",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "docs(governance): refresh Codex authority matrix",
+    "allowlist": [
+      "docs/03-reference/governance/codex-authority-refresh.md",
+      "docs/03-reference/governance/codex-refresh-gap-register.md",
+      "task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json",
+      "proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json >/dev/null",
+      "python scripts/docs_validator.py docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md",
+      "python scripts/docs_frontmatter_guard.py docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md",
+      "git diff --check",
+      "git diff --cached --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(governance): refresh Codex authority matrix",
+    "body": "## Summary\n- Adds a Codex-facing authority refresh matrix grounded in live repo paths.\n- Adds a Codex refresh gap register preserving UNKNOWN and CONFLICTING authority/path evidence.\n- Adds packet/proof artifacts for this refresh slice.\n\n## Scope\nDocs/governance, task packet, and proof only. No runtime, tests, compose, dependencies, provider config, live extraction, or Docker startup.\n\n## Validation\nInclude exact command outputs and exit codes.\n\n## NOT_RUN\n- Live provider calls\n- Live extraction\n- Live preflight\n- Docker startup\n- Runtime service health checks\n\n## Residual Risks / UNKNOWNs\nList unresolved authority/path conflicts.\n\n@codex review",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight repo identity, current branch/base, clean status, and required authority files.",
+      "context_files": [
+        "AGENTS.md",
+        "docs/03-reference/governance/rules.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "PROJECT.md",
+        "ARCHITECTURE.md"
+      ],
+      "commands": [
+        "git remote -v",
+        "git branch --show-current",
+        "git status --short",
+        "test -f AGENTS.md",
+        "test -f docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ],
+      "validation": [
+        "Repo remote must identify DDD-Enterprises/dopemux-mvp.",
+        "Base branch must be main or a branch created from main.",
+        "Required authority files must be present or explicitly marked UNKNOWN."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Create the task packet JSON at the generated task-packet path using this exact packet content, adjusted only for formatting if needed.",
+      "expected_files": [
+        "task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json"
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Author docs/03-reference/governance/codex-authority-refresh.md with a concise live authority matrix for Codex work.",
+      "requirements": [
+        "Include OBSERVED, CONFLICTING, UNKNOWN labels.",
+        "Include live task schema path.",
+        "Include current AGENTS.md role.",
+        "Include authority boundaries for dopemux, dopetask, task-orchestrator, Leantime, ConPort, dope-memory, dope-context, dopecon-bridge, ADHD Engine, Repo Truth Extractor, agents, and Cockpit/dopeUI.",
+        "State that Codex should not treat GitHub/CI alone as semantic proof.",
+        "State that Codex work must return proof and PR evidence."
+      ],
+      "expected_files": [
+        "docs/03-reference/governance/codex-authority-refresh.md"
+      ],
+      "validation": [
+        "rg -n \"OBSERVED|CONFLICTING|UNKNOWN|RECOMMENDED\" docs/03-reference/governance/codex-authority-refresh.md",
+        "rg -n \"docs/03-reference/spec/dopetask/dopetask-canonical-spec.json|AGENTS.md|dopecon-bridge|scripts/dopetask|Task Orchestrator|ConPort|dope-memory|dope-context\" docs/03-reference/governance/codex-authority-refresh.md"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Author docs/03-reference/governance/codex-refresh-gap-register.md listing the Codex-refresh gaps that must remain unresolved until proved by runtime/code/config/tests.",
+      "requirements": [
+        "Include root-vs-docs authority path drift.",
+        "Include TaskX vs dopetask naming drift.",
+        "Include task-orchestrator runtime/package drift.",
+        "Include agent authority UNKNOWN.",
+        "Include bridge authority confusion risk.",
+        "Include proof/CI insufficiency risk."
+      ],
+      "expected_files": [
+        "docs/03-reference/governance/codex-refresh-gap-register.md"
+      ],
+      "validation": [
+        "rg -n \"TaskX|dopetask|agent authority|UNKNOWN|dopecon-bridge|task-orchestrator|CI\" docs/03-reference/governance/codex-refresh-gap-register.md"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Create proof JSON with exact commands, exit codes, changed files, NOT_RUN items, residual risks, and UNKNOWNs.",
+      "expected_files": [
+        "proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json"
+      ],
+      "validation": [
+        "python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json >/dev/null",
+        "rg -n \"NOT_RUN|UNKNOWN|residual\" proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json"
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Run final docs/proof validation, inspect diff, commit, push, and open PR.",
+      "validation": [
+        "python scripts/docs_validator.py docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md",
+        "python scripts/docs_frontmatter_guard.py docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md",
+        "git diff --check",
+        "git diff --cached --check",
+        "git diff --stat",
+        "git status --short"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a Codex-facing authority refresh matrix grounded in live repo paths.
- Adds a Codex refresh gap register preserving UNKNOWN and CONFLICTING authority/path evidence.
- Adds packet/proof artifacts for this refresh slice.

## Scope
Docs/governance, task packet, and proof only. No runtime, tests, compose, dependencies, provider config, live extraction, or Docker startup.

## Validation
Exact command outputs and exit codes:

```text
$ python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json >/dev/null
exit 0
stdout: <empty>
stderr: <empty>

$ python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
exit 0
stdout/stderr:
/Users/hue/.local/share/mise/installs/python/3.12.13/lib/python3.12/site-packages/jsonschema/__main__.py:4: DeprecationWarning: The jsonschema CLI is deprecated and will be removed in a future version. Please use check-jsonschema instead, which can be installed from https://pypi.org/project/check-jsonschema/
  from jsonschema.cli import main

$ python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json >/dev/null
exit 0
stdout: <empty>
stderr: <empty>

$ python scripts/docs_validator.py docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md
exit 0
stdout: <empty>
stderr: <empty>

$ python scripts/docs_frontmatter_guard.py docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md
exit 0
stdout:
All docs have valid frontmatter.

$ git diff --check
exit 0
stdout: <empty>
stderr: <empty>

$ git diff --cached --check
exit 0
stdout: <empty>
stderr: <empty>

$ pre-commit run --files docs/03-reference/governance/codex-authority-refresh.md docs/03-reference/governance/codex-refresh-gap-register.md task-packets/generated/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json proof/codex-refresh/TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX/PROOF.json
exit 0
stdout:
Validate YAML frontmatter in docs..........................................................Passed
Validate documentation against knowledge graph schema......................................Passed
Block prohibited documentation patterns (NOTES, TODO, TEMP, etc.)..........................Passed
Validate prelude <=100 tokens for efficient embeddings.....................................Passed
Enforce markdown file locations for changed files..........................................Passed
Enforce docs placement hygiene (changed files).............................................Passed
Enforce docs filename hygiene (kebab-case).................................................Passed
Audit docs filename hygiene (kebab-case, full-tree legacy debt)............................Passed
Reject executable/config code under UPGRADES (docs-only legacy tree)...(no files to check)Skipped
Enforce repository root hygiene (no random root files).....................................Passed
markdownlint...............................................................................Passed
trim trailing whitespace...................................................................Passed
fix end of files...........................................................................Passed
check yaml.............................................................(no files to check)Skipped

$ git diff --stat HEAD~1..HEAD
exit 0
stdout:
 .../governance/codex-authority-refresh.md          |  59 ++++++
 .../governance/codex-refresh-gap-register.md       |  33 ++++
 .../PROOF.json                                     | 210 +++++++++++++++++++++
 .../TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX.json | 158 ++++++++++++++++
 4 files changed, 460 insertions(+)
```

## NOT_RUN
- Live provider calls
- Live extraction
- Live preflight
- Docker startup
- Runtime service health checks
- Account-specific checks
- Secret inspection

## Residual Risks / UNKNOWNs
- Static inspection does not prove runtime service health.
- `dopeUI` remains UNKNOWN because the focused source/docs search did not observe a current named authority path.
- task-orchestrator runtime/package drift remains CONFLICTING across canonical `app/main.py`, Docker wiring, and unsupported legacy `task_orchestrator/app.py`.
- ConPort access contracts remain path-specific and partially CONFLICTING.
- GitHub/CI delivery evidence remains insufficient as semantic runtime proof.
- Repo-wide agent runtime authority remains UNKNOWN across `services/agents`, `src/dopemux/agent_orchestrator.py`, and `services/task-orchestrator/task_orchestrator/agents`.

## Commit
- `ee1e6fa2b1d292045d33a4391069d89646126fee`

@codex review
