### PR TITLE
Docs: install mobile-first tmux Cockpit UX spec

### DIFF
--- a/docs/03-reference/systems/dopemux/mobile-tmux-cockpit-ux-spec.md
+++ b/docs/03-reference/systems/dopemux/mobile-tmux-cockpit-ux-spec.md
@@ -1,0 +1,473 @@
+---
+id: mobile-tmux-cockpit-ux-spec
+title: Mobile Tmux Cockpit UX Spec
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Docs-only mobile-first tmux Cockpit UX addendum for Dopemux authority-safe terminal operation.
+---
+
+# Mobile Tmux Cockpit UX Spec
+
+Packet: `TP-DMX-MOBILE-TUI-SPEC-001`
+
+Status: docs/spec addendum only. No runtime, source, config, dependency, or
+tmux behavior is changed by this document.
+
+## 1. Purpose And Non-Goals
+
+Purpose: define a mobile-first tmux Cockpit UX architecture for Blink/SSH/Mosh
+clients while preserving the repo's split authority model and proof discipline.
+
+Non-goals:
+
+- Do not implement runtime behavior.
+- Do not add or change Python code.
+- Do not mutate `.tmux.conf` or `config/mobile/tmux.mobile.conf`.
+- Do not promote Cockpit, dopecon-bridge, dope-context retrieval, generated
+  reports, adapters, mirrors, or UI summaries into canonical truth.
+- Do not replace the existing TUI design system. This is a mobile addendum and
+  future prototype contract.
+
+## 2. Authority Boundary Model
+
+Repo evidence used:
+
+- `PROJECT.md`
+- `ARCHITECTURE.md`
+- `PM_PLANE.md`
+- `SERVICE_CATALOG.md`
+- `docs/03-reference/systems/system-boundaries.md`
+- `docs/03-reference/systems/dopemux/system-dopemux.md`
+- `docs/03-reference/systems/dopetask/system-dopetask.md`
+- `docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md`
+- `docs/03-reference/systems/dopecon-bridge/system-dopeconbridge.md`
+- `docs/03-reference/systems/dope-context/system-dopecontext.md`
+
+Authority boundaries for this UX:
+
+| Surface | Authority boundary |
+| --- | --- |
+| dopemux | Operator control, CLI, startup, routing, MCP/service coordination. Not PM truth, memory truth, retrieval truth, or execution truth after handoff. |
+| dopetask | External execution runtime reached through `scripts/dopetask`. Not PM, memory, retrieval, or Cockpit authority. |
+| task-orchestrator | Workflow transitions and workflow views. Runtime packaging and some storage boundaries remain drifted. |
+| Leantime | Passive PM metadata and project/ticket snapshots. |
+| ConPort | Structured decisions, progress, context, and custom data. |
+| dope-memory | Chronicle and evidence-preserving memory/receipt history. |
+| dope-context | Code/docs retrieval and indexing only. Search results are derived views. |
+| dopecon-bridge | Proxy, routing, compatibility, auth, and event transport only. It is not task, workflow, decision, progress, PM, chronicle, or retrieval truth. |
+| ADHD Engine | Operator support and cognitive-state cues only. It does not gate PM or prove execution success. |
+| Repo Truth Extractor | Extraction/audit only. Outputs are evidence artifacts, not runtime truth. |
+
+Rule: every data row or action surface names its canonical writer. If the writer
+is unresolved, render `UNKNOWN` and block mutation.
+
+## 3. Mobile-First Constraints
+
+- The mobile client is a replaceable viewport. Remote state and proof stay on
+  the host.
+- tmux is the reconnect/resume chassis, not business logic.
+- SSH is the common transport. Mosh is optional for roaming links and cannot be
+  assumed for tunnels, bastions, scrollback, or all terminal features.
+- Touch and mouse are optional conveniences. Keyboard navigation is the primary
+  accessibility and reliability contract.
+- Clipboard behavior is convenience only. It is not proof transport.
+- Permanent multi-pane density is unsafe on phone-sized terminals.
+- Full-screen overlays are safer than cramped popups on mobile.
+
+## 4. Viewport Rules
+
+| Viewport | Contract |
+| --- | --- |
+| Under 70 columns | Proposed mobile-first fallback: single-column, one active region, one-line status, full-screen drill-down overlays. CONFLICTING with current runtime/design-system blocker below `80x24`; not implemented by this packet. |
+| `80x24` | Current minimum supported runtime viewport. One primary region plus minimal chrome. Bridge/retrieval/proxy details collapse into inspector/detail. |
+| `100x30` or `100x32` | One dominant region plus one secondary region. Prefer stacked or strongly asymmetric split. |
+| `120x40+` | Restrained desktop tmux layout with optional third region for provenance, proof, or segregated bridge detail. |
+
+Observed runtime conflict: `src/dopemux/ui/cockpit/render.py` and the Cockpit
+design-system acceptance currently require a blocker below `80x24`. Future
+prototype work must explicitly decide whether and how to implement the
+under-70-column fallback without silently weakening existing tests.
+
+## 5. Global Navigation Model
+
+Primary mobile homes:
+
+- Home / Cockpit
+- Task Packet Queue
+- Execution Monitor
+- PM Plane View
+- Memory / Chronicle View
+- Retrieval / Search View
+
+Secondary routed views:
+
+- System Health
+- Proof / Evidence Viewer
+- Settings / Terminal Diagnostics
+- Unknown / Drift Queue
+- Blocked Reason
+
+Global overlays:
+
+- Command Palette
+- Safe Action Gate
+- Help
+
+Rules:
+
+- On mobile, top-level navigation must fit without horizontal scrolling.
+- Numeric shortcuts are optional accelerators; all flows must be reachable by
+  arrows, Tab, Enter, Back/Esc equivalent, and Command Palette.
+- Global overlays take over the full active tmux pane or app surface.
+
+## 6. Screen Inventory
+
+### Home / Cockpit
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Operator summary and safe launch point. |
+| Primary data sources | dopemux status/health/doctor outputs, service summaries, packet summaries, proof pointers. |
+| Authority boundary | dopemux owns chrome/control only; tile data names upstream authority. |
+| Mobile layout | Single-column stack: Now, Risk, Next, Source. |
+| Desktop tmux layout | Summary, queue/execution snapshot, authority/drift strip. |
+| Keybindings | `1`, `h`, `q`, `x`, `:`, `?`, Enter, Back/Esc equivalent. |
+| Empty state | No active work; show Queue, Palette, and last proof path if available. |
+| Error state | Failed tile renders `UNKNOWN` with source name. |
+| Forbidden actions | Direct mutation, fake unified PM row, bridge or retrieval result shown as canonical. |
+
+### System Health
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Service status, logs, operator diagnostics, and authority warnings. |
+| Primary data sources | dopemux health/status, service registry, runtime authority docs, logs. |
+| Authority boundary | dopemux hosts the view; each service row keeps its own authority. |
+| Mobile layout | Service list plus selected-service detail and diagnostics footer. |
+| Desktop tmux layout | Service list, health/log body, authority manifest/resources. |
+| Keybindings | `h`, `r`, `l`, `s`, `d`, Enter, Back/Esc equivalent. |
+| Empty state | No services configured for this workspace. |
+| Error state | Unreachable health source is `UNKNOWN`, not healthy. |
+| Forbidden actions | Inline start/stop without gate, hiding conflicts, treating reachability as correctness. |
+
+### Task Packet Queue
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Workflow queue and packet readiness view. |
+| Primary data sources | task-orchestrator workflow views, task packet metadata, packet index. |
+| Authority boundary | task-orchestrator owns workflow transitions; packet files are artifacts; execution remains downstream. |
+| Mobile layout | Packet list with sticky detail footer for selected packet. |
+| Desktop tmux layout | Queue, packet detail, linked proof/provenance. |
+| Keybindings | `2`, `q`, arrows, `j/k`, Enter, `p`, `x`, Back/Esc equivalent. |
+| Empty state | No queued or active packets. |
+| Error state | Queue fetch failure names source and renders `UNKNOWN`, not empty. |
+| Forbidden actions | Reorder/status/promote without canonical writer and Safe Action Gate. |
+
+### Execution Monitor
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Bounded execution view for active or recent packet runs. |
+| Primary data sources | dopetask handoff state, runner identity, validation logs, proof path. |
+| Authority boundary | dopetask owns execution after handoff; stdout is not proof. |
+| Mobile layout | Metadata header, log body, bottom action rail. |
+| Desktop tmux layout | Log main, event/proof inspector, queue strip. |
+| Keybindings | `3`, `x`, `c`, `p`, `o`, tmux `prefix z`, Back/Esc equivalent. |
+| Empty state | No active run; show last proof path if known. |
+| Error state | Runner unreachable, proof missing, and stale validation are distinct states. |
+| Forbidden actions | Hidden rerun, implicit cancel, treating started/confirmed as completed. |
+
+### Proof / Evidence Viewer
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Inspect proof bundles, receipts, paths, hashes, diffs, logs, and validation summaries. |
+| Primary data sources | File-backed proof bundles, receipts, validation logs, artifact manifests. |
+| Authority boundary | Viewer owns nothing; every artifact declares canonical writer and provenance. |
+| Mobile layout | Metadata header, artifact selector, artifact body. |
+| Desktop tmux layout | Artifact list, preview, provenance/receipts. |
+| Keybindings | `e`, `p`, arrows, `j/k`, Enter, `o`, `y`, Back/Esc equivalent. |
+| Empty state | Proof pending; show expected proof requirement. |
+| Error state | Missing artifact, stale proof, parse error, and receipt mismatch are separate. |
+| Forbidden actions | Editing proof, collapsing absence into success, hiding request IDs, accepting confirmation as proof. |
+
+### PM Plane View
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Workflow triage and PM readiness without unified PM truth. |
+| Primary data sources | Leantime metadata, task-orchestrator workflow, ConPort decisions/progress/context, dope-memory receipts. |
+| Authority boundary | Split by slice; dopemux and Cockpit are not PM systems of record. |
+| Mobile layout | Work-item list, full-screen detail with Leantime, Workflow, ConPort, Receipts sections. |
+| Desktop tmux layout | List, selected item, decisions/receipts pane. |
+| Keybindings | `4`, `p`, `w`, `d`, `m`, `r`, Enter, Back/Esc equivalent. |
+| Empty state | No PM items matching scope. |
+| Error state | Missing slice remains visible as `UNKNOWN`; no silent backfill from another system. |
+| Forbidden actions | Fake single PM record, inline admin mutation, hiding which owner is written. |
+
+### Memory / Chronicle View
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Chronicle and event/receipt inspection. |
+| Primary data sources | dope-memory chronicle, receipt artifacts, upstream event producers. |
+| Authority boundary | dope-memory is receipt/history authority, not current PM truth. |
+| Mobile layout | Timeline list plus selected receipt detail. |
+| Desktop tmux layout | Timeline, selected event body, linked source/proof. |
+| Keybindings | `5`, `m`, `f`, `p`, `o`, Enter, Back/Esc equivalent. |
+| Empty state | No chronicle entries in current filter. |
+| Error state | Ledger unavailable, stale mirror, or parse failure named separately. |
+| Forbidden actions | Treating receipts as current state, mutating PM from chronicle, hiding mirror status. |
+
+### Retrieval / Search View
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Search code/docs and route results back to source authorities. |
+| Primary data sources | dope-context code/docs retrieval, optional ConPort search results when explicitly labeled. |
+| Authority boundary | dope-context owns retrieval/index behavior only; hits are derived leads. |
+| Mobile layout | Query line, result list, selected result preview. |
+| Desktop tmux layout | Query/results, preview, provenance/detail. |
+| Keybindings | `6`, `/`, `s`, `f`, Enter, `o`, Back/Esc equivalent. |
+| Empty state | No results; show active filters. |
+| Error state | Index unavailable, stale index, and upstream fetch failure named separately. |
+| Forbidden actions | Treating retrieval output as truth, hiding source path, writing through search result. |
+
+### Command Palette
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Global broker for discover, inspect, preview, and route. |
+| Primary data sources | Command catalog, safe-action catalog, authority map, current route. |
+| Authority boundary | Palette is broker only; it never executes or confirms. |
+| Mobile layout | Full-screen input, result list, preview/route footer. |
+| Desktop tmux layout | Center overlay with preview; still not a side drawer on narrow panes. |
+| Keybindings | `:`, `ctrl+k` where available, arrows, Enter, Back/Esc equivalent. |
+| Empty state | No commands matching filter. |
+| Error state | Unknown command, unresolved params, or unknown writer routes to Unknown/Drift. |
+| Forbidden actions | Execute, auto-confirm, silently reroute, hide authority or proof requirement. |
+
+### Safe Action Gate
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Refuse, confirm intent, execute supervised actions only when authorized, and demand proof. |
+| Primary data sources | Action request, canonical writer, tier policy, proof requirement, rollback/abort plan. |
+| Authority boundary | Gate is control/checkpoint only; canonical writer owns mutation. |
+| Mobile layout | Full-screen review: action, writer, tier, proof, risks, confirm/refuse. |
+| Desktop tmux layout | Full-screen or dominant overlay; no cramped modal for T4/T5/TU. |
+| Keybindings | `g`, Enter to inspect/confirm when allowed, typed confirmation for high tiers, Back/Esc abort. |
+| Empty state | No pending action. |
+| Error state | Missing writer, missing proof path, stale request, or unknown side effect refuses closed. |
+| Forbidden actions | Confirmation-only success, hidden side effects, bridge-owned canonical write, destructive action without typed confirmation and proof path. |
+
+### Settings / Terminal Diagnostics
+
+| Field | Contract |
+| --- | --- |
+| Purpose | Inspect terminal capabilities, tmux state, profile, and proposed settings. |
+| Primary data sources | tmux environment, terminal size, feature probes, config paths, dopemux settings. |
+| Authority boundary | dopemux owns settings chrome; tmux config remains external until a separate mutation packet authorizes changes. |
+| Mobile layout | Diagnostics list plus selected detail/proposed command. |
+| Desktop tmux layout | Diagnostics, feature matrix, proposed config preview. |
+| Keybindings | `d`, `t`, `r`, `c`, Enter, Back/Esc equivalent. |
+| Empty state | No diagnostics run yet. |
+| Error state | Probe unavailable or capability UNKNOWN; do not assume support. |
+| Forbidden actions | Mutating tmux config, enabling terminal features without probe, treating clipboard/mouse/glyph support as guaranteed. |
+
+## 7. Command Palette Model
+
+The palette accepts free text and structured filters:
+
+- `auth:`
+- `writer:`
+- `class:`
+- `place:`
+- `proof:`
+- `status:`
+- `coverage:`
+- `src:`
+- `tp:`
+- `svc:`
+
+Each result shows:
+
+- command or route
+- authority domain
+- canonical writer or `UNKNOWN`
+- safety tier
+- proof requirement
+- expected destination: inspect, copy command, Safe Action Gate, blocked reason,
+  Unknown/Drift, or settings/diagnostics
+
+The palette cannot execute actions directly.
+
+## 8. Breadcrumb Model
+
+Breadcrumbs describe route and authority:
+
+```text
+<screen> / <entity> / <subview> / AUTH=<canonical-writer-or-UNKNOWN>
+```
+
+Examples:
+
+```text
+Queue / TP-055 / detail / AUTH=task-orchestrator
+Execution / TP-055 / proof / AUTH=dopetask
+PM / LT-412 / decisions / AUTH=ConPort
+Search / query:runner-timeout / AUTH=dope-context-derived
+```
+
+## 9. Search And Filter Model
+
+- The filter row shows one line on mobile.
+- Expanded filters open as a full-screen overlay.
+- Result rows carry source path, source system, derived/canonical label, and
+  stale/fresh status when known.
+- Retrieved code/docs/results remain leads back to the source file or upstream
+  system.
+
+## 10. Focus Model
+
+- Narrow mode: one active region only.
+- `80x24`: one primary region and minimal chrome.
+- `100x30` or `100x32`: one primary region plus one secondary region.
+- `120x40+`: optional third region for provenance, proof, or segregated bridge
+  detail.
+- Focus order is deterministic: primary list, detail, action rail, chrome.
+- There is always one obvious Back/Esc equivalent.
+
+## 11. Modal And Overlay Behavior
+
+- Command Palette, Safe Action Gate, and Help are full-screen overlays on
+  mobile.
+- Do not stack overlays.
+- T4, T5, and TU actions always use full-screen review.
+- Popups and tmux menus are optional desktop conveniences, never required
+  mobile controls.
+
+## 12. Help Overlay
+
+Help is context-sensitive and full-screen on mobile. It shows:
+
+- current screen purpose
+- authority boundary
+- keybindings available from the current route
+- proof expectation for actions
+- how to leave the screen
+- current unresolved UNKNOWNs, if any
+
+Help text must not imply that Cockpit owns upstream truth.
+
+## 13. Safe Action Gate Tiers
+
+These tier names are a mobile UX taxonomy. Runtime mapping to the current
+`runtime_contract.py` constants is `UNKNOWN` until a runtime packet implements
+or rejects the mapping.
+
+Confirmation is intent evidence only. It is not completion proof.
+
+| Tier | Allowed examples | Forbidden examples | Canonical writer requirement | Confirmation requirement | Proof requirement | Receipt requirement | Refusal behavior | Mobile UX rule |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| `T0_READ_ONLY` | View status, open proof, inspect source path. | Any mutation, write, execution, or generated command that changes state. | Writer may be `none`; source authority still labeled. | None. | Source path or read timestamp when relevant. | Optional read receipt. | Refuse mutation request. | Inline view allowed; no modal required. |
+| `T1_INSPECT` | Run bounded diagnostics, query health, validate packet schema. | State changes, service start/stop, writes, destructive operations. | Target inspected system named or `UNKNOWN`. | Explicit invoke. | Inspect output, timestamp, command, exit code when command runs. | Inspect receipt recommended. | If target or side effect unknown, downgrade/refuse. | Full-screen output on narrow viewports. |
+| `T2_GENERATE_COMMAND` | Generate a command for operator copy/review. | Execute generated command, hide risk, omit cwd. | Proposed writer and cwd named or `UNKNOWN`. | Explicit copy/accept intent only. | Generated command text and rationale. | Command-generation receipt. | If writer/cwd unresolved, route to Unknown/Drift. | Show command, cwd, writer, and proof expectation together. |
+| `T3_SUPERVISED_EXECUTION` | Run approved non-mutating or low-risk command with visible output. | Background hidden execution, implicit retries, missing proof path. | Writer or inspected authority named. | Explicit confirmation. | Exit code, output summary/path, command, cwd. | Execution receipt. | Abort on stale request, changed cwd, or unknown side effect. | Full-screen running state with cancel/abort visible. |
+| `T4_STATE_MUTATION` | Write PM metadata to Leantime, log decision to ConPort, update workflow through task-orchestrator. | Cross-authority save-all, bridge-owned canonical write, silent mirror writes. | Canonical writer required and must not be bridge/retrieval/Cockpit unless repo evidence proves it. | Explicit confirmation; typed field/action for sensitive writes. | File-backed or upstream receipt-backed proof. | Required canonical writer receipt plus mirror receipt when mirrors exist. | Refuse if writer, rollback, proof, or side effects are unknown. | Full-screen gate. Writer and proof path must stay visible. |
+| `T5_DESTRUCTIVE` | Delete/archive/prune only when separately authorized. | Destructive action from palette, implied cleanup, broad deletion. | Canonical writer and rollback/restore path required. | Typed confirmation plus exact target. | Pre/post evidence, receipt, and rollback/restore record. | Required destructive receipt. | Default deny. | Full-screen gate with exact target and irreversible warning. |
+| `TU_UNKNOWN_RISK` | Inspect unknown action, copy recommended packet prompt. | Execute, mutate, auto-classify as safe. | Writer unknown by definition. | None for execution; inspect only. | Blocked reason and unknown ledger. | Unknown/refusal receipt. | Fail closed. | Full-screen blocked reason with next evidence needed. |
+
+## 14. Proof / Receipt Display Pattern
+
+Every proof view or action result shows:
+
+- action/request ID when available
+- canonical writer
+- authority domain
+- safety tier
+- confirmation record if any
+- proof artifact path
+- validation command and exit code
+- timestamp
+- upstream receipt ID or file hash when available
+- mirror receipt ID when mirrors exist
+- stale/fresh status
+- missing proof as explicit `UNKNOWN` or `PENDING`, never success
+
+Proof must be file-backed and replayable. Clipboard, color, UI toast, and
+confirmation button state are not proof.
+
+## 15. Mobile Layout Fallbacks
+
+- Prefer truncation with inspect/drill-down over wrapping dense rows.
+- Collapse bridge/proxy/retrieval detail before canonical state.
+- Collapse decorative chrome before proof, writer, tier, and error state.
+- If text cannot fit, route to full-screen detail.
+- Keep one-line current filter; expand filters on demand.
+- Use ASCII fallback for glyph-sensitive operator surfaces.
+
+## 16. Anti-Patterns
+
+- Cockpit as a fake unified brain.
+- dopecon-bridge as PM/workflow/decision/progress authority.
+- dope-context retrieval result as source truth.
+- Safe action confirmation as completion proof.
+- Clipboard as proof transport.
+- Mouse-required or hover-required controls.
+- F-key-only navigation.
+- Permanent multi-pane layout under narrow viewports.
+- Cross-authority save-all.
+- Hidden retries, silent fallbacks, or implicit coercions.
+- Generated reports promoted above runtime/source truth.
+
+## 17. Open UNKNOWNs
+
+- Whether the under-70-column fallback should replace or coexist with the
+  current below-`80x24` blocker.
+- Exact runtime mapping between `T0_READ_ONLY` style names and current
+  `runtime_contract.py` tier constants.
+- Canonical writers for future Cockpit actions not yet represented in the
+  runtime action catalog.
+- Terminal capability probes for Blink + tmux + SSH + Mosh.
+- Whether mobile tmux mouse, OSC 52, extended keys, glyphs, and true color are
+  reliable enough for anything beyond optional convenience.
+- Proof schema for mobile UI action receipts.
+- Relationship between in-repo task-orchestrator service and the upstream local
+  13-tool MCP Task Orchestrator remains a boundary, not one unified runtime.
+
+## 18. Prototype Acceptance Contract
+
+A future prototype packet should be read-only first and must satisfy:
+
+- No runtime writes or upstream mutations.
+- Deterministic render snapshots for `80x24`, `100x32`, and `120x40`.
+- Explicit decision on under-70-column fallback vs current blocker.
+- Authority label visible on every data screen.
+- Bridge and retrieval outputs visibly derived/proxy.
+- Command Palette broker-only behavior.
+- Safe Action Gate refuses `TU_UNKNOWN_RISK`.
+- Proof viewer distinguishes pending, missing, stale, and passing proof.
+- Mobile navigation works without mouse, hover, or F-keys.
+- Terminal diagnostics report unknown capabilities as `UNKNOWN`, not supported.
+- Tests cover viewport degradation and forbidden authority claims.
+
+## 19. Cross-References
+
+- Research manifest:
+  `docs/06-research/mobile-tmux-tui/source-manifest.md`
+- Mobile constraints:
+  `docs/06-research/mobile-tmux-tui/01-mobile-blink-ssh-constraints.md`
+- Framework architecture:
+  `docs/06-research/mobile-tmux-tui/02-tui-framework-architecture.md`
+- UX research:
+  `docs/06-research/mobile-tmux-tui/03-dopemux-cockpit-ux-spec.md`
+- Existing TUI spec:
+  `docs/03-reference/systems/dopemux/tui-spec-v2-0a.md`
+- Existing Cockpit safety overlay:
+  `docs/03-reference/Dopemux Cockpit TUI Design System/ARCHITECTURE_SAFETY_OVERLAY.md`

--- a/docs/06-research/mobile-tmux-tui/01-mobile-blink-ssh-constraints.md
+++ b/docs/06-research/mobile-tmux-tui/01-mobile-blink-ssh-constraints.md
@@ -1,0 +1,86 @@
+---
+id: mobile-blink-ssh-constraints
+title: Mobile Blink SSH Constraints
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+prelude: Normalized research summary for mobile Blink, SSH, Mosh, tmux, and narrow
+  viewport constraints.
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+---
+# Mobile Blink SSH Constraints
+
+Source: `/Users/hue/Downloads/deep-research-report 15.md`
+
+SHA256:
+`15ebfbe00f8a6a968a64d2c8de5a53af9e4289b7bab2250ad25e82dc66a30432`
+
+Classification: research input. This document is not repo truth.
+
+## OBSERVED
+
+- Mobile terminal state must live on the remote host, not in the phone client.
+  tmux detach/attach semantics and Mosh roaming support make the client a
+  replaceable viewport.
+- Blink Shell supports SSH and Mosh workflows, hardware keyboard shortcuts,
+  modifier remapping, Smart Keys, gestures, and terminal resizing.
+- iOS can suspend long-running network activity. Blink-specific mitigations may
+  help, but the product should not assume a stable raw SSH connection.
+- Mosh is useful for roaming and intermittent connectivity, but UDP, tunnels,
+  bastions, scrollback limitations, and terminal feature differences make it an
+  optional transport rather than a required foundation.
+- tmux menus, popups, mouse behavior, clipboard behavior, and terminal feature
+  negotiation depend on terminal capabilities. They must be probed or treated
+  as optional.
+
+## INFERRED
+
+- iPhone portrait should be treated as a single-focus control surface for
+  status, queue review, logs, approval, and rapid triage.
+- iPad landscape and external keyboards can support limited editor/operator
+  work, but should still inherit the narrow-mode safety model.
+- Window-centric navigation is safer than dense pane-centric navigation on
+  mobile.
+- High-frequency status churn and animation are poor fits for mobile SSH.
+  Coarse refresh intervals and stable render snapshots are preferable.
+- Mouse and touch can be conveniences, but keyboard navigation must remain the
+  primary contract.
+
+## CONFLICTING
+
+- The current repo mobile tmux config at `config/mobile/tmux.mobile.conf`
+  enables mouse support, OSC 52 clipboard support, prefixless function-key
+  jumps, and bottom status. The research recommends treating mouse, clipboard,
+  and function-key access as optional on mobile and using a more conservative
+  primary key model.
+- Existing Cockpit runtime and design-system docs block below `80x24`.
+  The research recommends a usable single-column fallback below 70 columns.
+  This packet documents that as a future prototype contract only; it does not
+  change runtime behavior.
+
+## UNKNOWN
+
+- Exact usable column counts by device, orientation, font, keyboard, and Blink
+  profile are not established by repo evidence.
+- Blink touch-to-terminal-mouse behavior is not proven as a stable product
+  dependency.
+- OSC 52 clipboard behavior across Blink, SSH, Mosh, tmux, and remote apps is
+  not proven enough to carry proof or receipt transport.
+- Exact terminal feature support for extended keys, true color, glyphs, and
+  focus events is not proven across all mobile clients.
+
+## Mobile Rules To Carry Forward
+
+- tmux is the reconnect/resume chassis, not business logic.
+- Use a dedicated mobile tmux session or socket for mobile operation.
+- Do not let mobile clients resize or damage desktop work sessions by default.
+- Treat under-70-column layouts as single-column and drill-down only.
+- At `80x24`, use one primary region plus minimal chrome.
+- At `100x30` or `100x32`, allow one dominant region and one secondary region.
+- At `120x40+`, allow restrained multi-pane desktop-style layouts.
+- Full-screen overlays are safer than narrow popups for Command Palette, help,
+  and Safe Action Gate.
+- Proof must be file-backed and path-addressable; clipboard success is not
+  proof.

--- a/docs/06-research/mobile-tmux-tui/02-tui-framework-architecture.md
+++ b/docs/06-research/mobile-tmux-tui/02-tui-framework-architecture.md
@@ -1,0 +1,84 @@
+---
+id: tui-framework-architecture
+title: TUI Framework Architecture
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+prelude: Normalized research summary for a tmux-first Dopemux Cockpit framework architecture.
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+---
+# TUI Framework Architecture
+
+Source: `/Users/hue/Downloads/deep-research-report 14.md`
+
+SHA256:
+`5757d34173f9931aeda6e33db8c3d0f89a984fca3f77c123bebed7843105dc6d`
+
+Classification: research input. This document is not repo truth.
+
+## OBSERVED
+
+- The repo already has a Cockpit command surface that can render deterministic
+  plain/audit output or launch a thin Textual shell.
+- `src/dopemux/ui/cockpit/render.py` is the deterministic render layer. It
+  declares `80x24` as the minimum supported viewport and produces ANSI-free,
+  stable text for tests.
+- `src/dopemux/ui/cockpit/app.py` is a thin Textual surface over the renderer.
+- `src/dopemux/commands/cockpit_commands.py` exposes `120x40`, `100x32`, and
+  `80x24` presets.
+- Existing tests verify deterministic rendering, split authority labels,
+  forbidden phrase exclusions, bridge collapse at `80x24`, and blocker behavior
+  below minimum size.
+- The repo already contains `docs/03-reference/python-tmux-research.md`, which
+  records prior direction around libtmux plus Textual architecture.
+
+## INFERRED
+
+- The best architecture is a hybrid Python CLI plus deterministic renderer plus
+  optional Textual shell plus tmux orchestration.
+- Textual is a suitable richer shell because it fits the current Python runtime
+  and test structure, but it must not become the source of truth.
+- Rich is useful for presentation, not as the primary app framework.
+- prompt_toolkit or plain deterministic text is the correct fallback for
+  constrained mobile terminals.
+- Bubble Tea, Lip Gloss, and Ratatui are credible terminal frameworks, but a Go
+  or Rust cockpit rewrite would broaden the repo blast radius and duplicate
+  current Python renderer work.
+- Pure tmux scripting should remain orchestration only. Domain logic, proof
+  display, adapters, and action contracts should not migrate into tmux snippets.
+
+## CONFLICTING
+
+- Current runtime blocks below `80x24`. The mobile-first research recommends
+  a degraded under-70-column mode. That is a future runtime/prototype question,
+  not a docs packet implementation change.
+- Current design-system docs are `120x40` first. Mobile-first use requires
+  inverting the layout priority for phone-sized clients while preserving the
+  existing desktop contract.
+
+## UNKNOWN
+
+- There is no repo validation proving Textual, prompt_toolkit, Bubble Tea, and
+  Ratatui behavior side by side inside Blink on iPhone portrait.
+- Exact Unicode, glyph, terminal feature, and color behavior across Blink, tmux,
+  SSH, Mosh, Textual, and fallback renderers remains unproven.
+- The future runtime mapping between current safe-action tiers in
+  `runtime_contract.py` and the more descriptive tier names documented in the
+  mobile spec remains unresolved.
+
+## Architecture Contract To Carry Forward
+
+- Headless domain/adapters own state and actions.
+- Deterministic renderer owns stable, testable snapshots.
+- Textual owns optional richer interaction only.
+- Plain/audit output must remain a guaranteed fallback.
+- tmux owns session persistence, attach/detach, pane/window orchestration, and
+  reconnect ergonomics.
+- Adapters return immutable snapshot payloads plus proof/provenance metadata,
+  never framework widgets.
+- Bounded polling is preferred for mobile status. Stream only log-like data.
+- Runtime validation should include deterministic renderer tests, Textual
+  headless tests at `80x24`, `100x32`, and `120x40`, and isolated tmux
+  integration only when runtime work is actually authorized.

--- a/docs/06-research/mobile-tmux-tui/03-dopemux-cockpit-ux-spec.md
+++ b/docs/06-research/mobile-tmux-tui/03-dopemux-cockpit-ux-spec.md
@@ -1,0 +1,80 @@
+---
+id: dopemux-cockpit-ux-spec-research
+title: Dopemux Cockpit UX Spec Research
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+prelude: Normalized research summary for a mobile-first tmux Cockpit UX specification.
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+---
+# Dopemux Cockpit UX Spec Research
+
+Source: `/Users/hue/Downloads/deep-research-report 13.md`
+
+SHA256:
+`e7550446b250eef4995dc605432342dc1c3c6a9010164479823e7e6105c809f2`
+
+Classification: research input. This document is not repo truth.
+
+## OBSERVED
+
+- The repo authority model is already explicit: `dopemux` is operator control,
+  `dopetask` is execution after handoff, task-orchestrator owns workflow
+  transitions, Leantime owns PM metadata, ConPort owns decisions/progress,
+  dope-memory owns chronicle receipts, dope-context owns retrieval, and
+  dopecon-bridge is proxy/routing/event transport only.
+- Existing Cockpit docs already require authority labels, pane declarations,
+  bridge segregation, provenance labels, forbidden phrases, and blocker behavior
+  below `80x24`.
+- Existing Cockpit runtime already implements a deterministic static PM shell
+  and tests architecture-safety constraints.
+- Existing Command Palette, Settings/Admin/Runtime, Safe Action Gate, and
+  Unknown/Drift surfaces are secondary surfaces, not top-level authority modes.
+
+## INFERRED
+
+- The mobile Cockpit should retain the authority contracts but invert layout
+  priority: single-focus first, multi-pane only when viewport supports it.
+- Command Palette and Safe Action Gate should be full-screen overlays on mobile.
+- Breadcrumbs should show both route and authority, for example
+  `Queue / TP-055 / detail / AUTH=task-orchestrator`.
+- Search and filters should use shared prefixes across search and palette:
+  `auth:`, `writer:`, `class:`, `place:`, `proof:`, `status:`, `coverage:`,
+  `src:`, `tp:`, and `svc:`.
+- Proof and evidence viewing must show artifact paths, validation status,
+  receipt IDs, request correlation, and canonical writer. Absence of proof is
+  visible state, not success.
+
+## CONFLICTING
+
+- Research recommends degrading below `80x24`; current runtime and design-system
+  acceptance require a `[BLOCKER]` below `80x24`. The new repo-facing spec
+  preserves this as a conflict and documents the mobile-first behavior as a
+  future acceptance contract only.
+- Research recommends avoiding F-key-only navigation and mouse-required
+  controls. Existing mobile tmux config currently exposes F-key jumps and mouse
+  support. The repo-facing spec treats these as optional conveniences, not core
+  input contracts.
+
+## UNKNOWN
+
+- Canonical writers for several future actions are not proven until a concrete
+  runtime action catalog exists.
+- The exact safe-action tier mapping to current runtime tier constants is
+  unresolved.
+- Future proof bundle schemas for mobile UI actions are not implemented by this
+  docs packet.
+- Terminal diagnostics capability probing is not yet implemented.
+
+## UX Rules To Carry Forward
+
+- The Cockpit is a viewport over authoritative systems, not a canonical system.
+- Every write/action names the upstream canonical writer or blocks as UNKNOWN.
+- Bridge and retrieval outputs are visibly labeled derived/proxy output.
+- Confirmation is intent evidence only. It is not completion proof.
+- Proof must be file-backed and replayable.
+- Dangerous or unknown actions fail closed.
+- On mobile, overlays beat cramped multi-pane layout.
+- Empty states and error states must name the authority or source they depend on.

--- a/docs/06-research/mobile-tmux-tui/source-manifest.md
+++ b/docs/06-research/mobile-tmux-tui/source-manifest.md
@@ -36,11 +36,10 @@ the requested categories directly:
 - TUI framework and architecture
 - Dopemux Cockpit UX specification
 
-Files such as `/Users/hue/Downloads/ssh.pub` and
-`/Users/hue/Downloads/zilliz-cloud-Dopemux-username-password.txt` appeared in
-the broad filename inventory but were not inspected or ingested as research
-inputs because they are not relevant to this packet and may contain credential
-or key material.
+The broad filename inventory also surfaced credential-like or key-material
+filenames. Those files were not inspected, named in detail, or ingested as
+research inputs because they are not relevant to this packet and may contain
+sensitive material.
 
 ## Repo Authority Inputs
 

--- a/docs/06-research/mobile-tmux-tui/source-manifest.md
+++ b/docs/06-research/mobile-tmux-tui/source-manifest.md
@@ -1,0 +1,79 @@
+---
+id: mobile-tmux-tui-source-manifest
+title: Mobile Tmux TUI Research Source Manifest
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+prelude: Source manifest for TP-DMX-MOBILE-TUI-SPEC-001 research intake from Downloads.
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+---
+# Source Manifest
+
+This manifest records the local research inputs used by
+`TP-DMX-MOBILE-TUI-SPEC-001`. These files are research inputs and derived
+guidance only. They do not outrank runtime code, config, schema, tests, active
+entrypoints, or repo-truth authority docs.
+
+## Intake Result
+
+| Normalized artifact | Original file | SHA256 | Size | Method | External citations | Redaction / conversion warning | Classification |
+| --- | --- | --- | ---: | --- | --- | --- | --- |
+| `01-mobile-blink-ssh-constraints.md` | `/Users/hue/Downloads/deep-research-report 15.md` | `15ebfbe00f8a6a968a64d2c8de5a53af9e4289b7bab2250ad25e82dc66a30432` | 22568 bytes | Markdown source summarized and normalized to repo-neutral ASCII. | Yes, source contains citation placeholders. | Secret-pattern scan found no credential material in selected source. | research_input |
+| `02-tui-framework-architecture.md` | `/Users/hue/Downloads/deep-research-report 14.md` | `5757d34173f9931aeda6e33db8c3d0f89a984fca3f77c123bebed7843105dc6d` | 22735 bytes | Markdown source summarized and normalized to repo-neutral ASCII. | Yes, source contains citation placeholders. | Secret-pattern scan found no credential material in selected source. | research_input |
+| `03-dopemux-cockpit-ux-spec.md` | `/Users/hue/Downloads/deep-research-report 13.md` | `e7550446b250eef4995dc605432342dc1c3c6a9010164479823e7e6105c809f2` | 37037 bytes | Markdown source summarized and reconciled against repo truth. | Yes, source contains citation placeholders. | Secret-pattern scan found no credential material in selected source. | research_input |
+
+## Candidate Notes
+
+The Downloads inventory also surfaced older or unrelated files, including
+`Mobile-First Tmux for Dopemux.txt`, `tui-spec-v2.0a.md`, Cockpit design ZIPs,
+and multiple older Deep Research reports. They were not ingested as the three
+expected reports because content inspection showed the May 19 files above match
+the requested categories directly:
+
+- mobile / Blink / SSH constraints
+- TUI framework and architecture
+- Dopemux Cockpit UX specification
+
+Files such as `/Users/hue/Downloads/ssh.pub` and
+`/Users/hue/Downloads/zilliz-cloud-Dopemux-username-password.txt` appeared in
+the broad filename inventory but were not inspected or ingested as research
+inputs because they are not relevant to this packet and may contain credential
+or key material.
+
+## Repo Authority Inputs
+
+The research was reconciled against these repo-truth and Cockpit/TUI surfaces:
+
+- `AGENTS.md`
+- `PROJECT.md`
+- `ARCHITECTURE.md`
+- `PM_PLANE.md`
+- `SERVICE_CATALOG.md`
+- `docs/03-reference/systems/system-boundaries.md`
+- `docs/03-reference/systems/dopemux/system-dopemux.md`
+- `docs/03-reference/systems/dopetask/system-dopetask.md`
+- `docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md`
+- `docs/03-reference/systems/dopecon-bridge/system-dopeconbridge.md`
+- `docs/03-reference/systems/dope-context/system-dopecontext.md`
+- `docs/03-reference/systems/dopemux/tui-spec-v2-0a.md`
+- `docs/03-reference/Dopemux Cockpit TUI Design System/ARCHITECTURE_SAFETY_OVERLAY.md`
+- `docs/03-reference/Dopemux Cockpit TUI Design System/PM_IMPLEMENTER_COCKPIT_REDIRECTION.md`
+- `docs/03-reference/Dopemux Cockpit TUI Design System/acceptance.md`
+- `docs/03-reference/python-tmux-research.md`
+- `docs/03-reference/systems/dashboard/tmux-dashboard-design.md`
+- `config/mobile/tmux.mobile.conf`
+- `.tmux.conf`
+- `src/dopemux/ui/cockpit/render.py`
+- `src/dopemux/ui/cockpit/app.py`
+- `src/dopemux/ui/cockpit/runtime_contract.py`
+- `src/dopemux/commands/cockpit_commands.py`
+- `tests/unit/dopemux/ui/cockpit/test_cockpit_render.py`
+- `tests/unit/dopemux/ui/cockpit/test_cockpit_command.py`
+
+## Authority Note
+
+If this manifest conflicts with runtime code, config, schema, tests, or active
+repo-truth docs, the higher authority wins and this manifest should be treated
+as stale derived guidance.

--- a/out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json
+++ b/out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json
@@ -8,7 +8,16 @@
     "base_branch": "main",
     "start_head": "f87816b2a906bcf6a174ba384c401be16f542213",
     "end_head": "5c4977f26bc1a6830f5839968755dd6a5d1780c6",
+    "end_head_semantics": "Original docs/spec packet execution commit before proof-only review repair and branch-update commits. This field is not the live self-referential PR head; use Git/GitHub PR metadata for the current branch head.",
     "origin_head": "refs/remotes/origin/main"
+  },
+  "revision_chain": {
+    "self_reference_note": "A committed proof file cannot embed the hash of the commit that contains it without a follow-up commit changing that hash. Current PR head evidence is therefore authoritative in Git/GitHub metadata, while this JSON records the packet evidence chain.",
+    "packet_base_head": "f87816b2a906bcf6a174ba384c401be16f542213",
+    "initial_packet_commit": "5c4977f26bc1a6830f5839968755dd6a5d1780c6",
+    "proof_head_repair_commit": "ce12e1b5ba785d58152316af72729ef96b98cb9b",
+    "branch_update_merge_commit": "a26ac2a8e0ae74d2c55d44a0a530e59965908c4f",
+    "current_pr_head_source": "Verify with gh pr view 665 --json headRefOid and git rev-parse HEAD after fetching the PR branch."
   },
   "primary_checkout_preflight": {
     "root": "/Users/hue/.codex/worktrees/7e70/dopemux-mvp",

--- a/out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json
+++ b/out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json
@@ -7,7 +7,7 @@
     "branch": "codex/tp-dmx-mobile-tui-spec-001",
     "base_branch": "main",
     "start_head": "f87816b2a906bcf6a174ba384c401be16f542213",
-    "end_head": "f87816b2a906bcf6a174ba384c401be16f542213",
+    "end_head": "5c4977f26bc1a6830f5839968755dd6a5d1780c6",
     "origin_head": "refs/remotes/origin/main"
   },
   "primary_checkout_preflight": {

--- a/out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json
+++ b/out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json
@@ -1,0 +1,274 @@
+{
+  "tp_id": "TP-DMX-MOBILE-TUI-SPEC-001",
+  "status": "PASS_WITH_RISKS",
+  "repo": {
+    "root": "/Users/hue/.codex/worktrees/tp-dmx-mobile-tui-spec-001",
+    "remote": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "branch": "codex/tp-dmx-mobile-tui-spec-001",
+    "base_branch": "main",
+    "start_head": "f87816b2a906bcf6a174ba384c401be16f542213",
+    "end_head": "f87816b2a906bcf6a174ba384c401be16f542213",
+    "origin_head": "refs/remotes/origin/main"
+  },
+  "primary_checkout_preflight": {
+    "root": "/Users/hue/.codex/worktrees/7e70/dopemux-mvp",
+    "start_head": "d64d5f15e46e68373e3bed1160fbc3df2807db59",
+    "branch": "HEAD detached",
+    "remote_match": true,
+    "markers_observed": [
+      ".git",
+      ".dopetaskroot",
+      ".dopemux",
+      "pyproject.toml"
+    ],
+    "post_correction_status": "clean"
+  },
+  "research_sources": [
+    {
+      "path": "/Users/hue/Downloads/deep-research-report 15.md",
+      "sha256": "15ebfbe00f8a6a968a64d2c8de5a53af9e4289b7bab2250ad25e82dc66a30432",
+      "size_bytes": 22568,
+      "classification": "research_input",
+      "content_classification": "mobile_blink_ssh_constraints",
+      "ingested_as": "docs/06-research/mobile-tmux-tui/01-mobile-blink-ssh-constraints.md",
+      "external_citations_present": true,
+      "conversion_method": "Markdown source summarized and normalized to repo-neutral ASCII",
+      "redaction_or_conversion_warning": "No credential-pattern findings in selected source; source citation placeholders were summarized rather than copied verbatim."
+    },
+    {
+      "path": "/Users/hue/Downloads/deep-research-report 14.md",
+      "sha256": "5757d34173f9931aeda6e33db8c3d0f89a984fca3f77c123bebed7843105dc6d",
+      "size_bytes": 22735,
+      "classification": "research_input",
+      "content_classification": "tui_framework_architecture",
+      "ingested_as": "docs/06-research/mobile-tmux-tui/02-tui-framework-architecture.md",
+      "external_citations_present": true,
+      "conversion_method": "Markdown source summarized and normalized to repo-neutral ASCII",
+      "redaction_or_conversion_warning": "No credential-pattern findings in selected source; source citation placeholders were summarized rather than copied verbatim."
+    },
+    {
+      "path": "/Users/hue/Downloads/deep-research-report 13.md",
+      "sha256": "e7550446b250eef4995dc605432342dc1c3c6a9010164479823e7e6105c809f2",
+      "size_bytes": 37037,
+      "classification": "research_input",
+      "content_classification": "dopemux_cockpit_ux_spec",
+      "ingested_as": "docs/06-research/mobile-tmux-tui/03-dopemux-cockpit-ux-spec.md",
+      "external_citations_present": true,
+      "conversion_method": "Markdown source summarized and reconciled against repo truth",
+      "redaction_or_conversion_warning": "No credential-pattern findings in selected source; source citation placeholders were summarized rather than copied verbatim."
+    }
+  ],
+  "repo_sources_inspected": [
+    "AGENTS.md",
+    "PROJECT.md",
+    "ARCHITECTURE.md",
+    "PM_PLANE.md",
+    "SERVICE_CATALOG.md",
+    "task-packets/INDEX.md",
+    "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+    "docs/03-reference/systems/system-boundaries.md",
+    "docs/03-reference/systems/dopemux/system-dopemux.md",
+    "docs/03-reference/systems/dopetask/system-dopetask.md",
+    "docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md",
+    "docs/03-reference/systems/dopecon-bridge/system-dopeconbridge.md",
+    "docs/03-reference/systems/dope-context/system-dopecontext.md",
+    "docs/03-reference/systems/dopemux/tui-spec-v2-0a.md",
+    "docs/03-reference/Dopemux Cockpit TUI Design System/ARCHITECTURE_SAFETY_OVERLAY.md",
+    "docs/03-reference/Dopemux Cockpit TUI Design System/PM_IMPLEMENTER_COCKPIT_REDIRECTION.md",
+    "docs/03-reference/Dopemux Cockpit TUI Design System/acceptance.md",
+    "docs/03-reference/python-tmux-research.md",
+    "docs/03-reference/systems/dashboard/tmux-dashboard-design.md",
+    "config/mobile/tmux.mobile.conf",
+    ".tmux.conf",
+    "src/dopemux/ui/cockpit/render.py",
+    "src/dopemux/ui/cockpit/app.py",
+    "src/dopemux/ui/cockpit/runtime_contract.py",
+    "src/dopemux/commands/cockpit_commands.py",
+    "tests/unit/dopemux/ui/cockpit/test_cockpit_render.py",
+    "tests/unit/dopemux/ui/cockpit/test_cockpit_command.py",
+    "scripts/dopetask",
+    "scripts/taskx",
+    ".pre-commit-config.yaml",
+    "config/docs_hygiene/docs_placement_policy.yaml"
+  ],
+  "existing_cockpit_tui_surfaces_observed": [
+    "src/dopemux/ui/cockpit/",
+    "src/dopemux/commands/cockpit_commands.py",
+    "tests/unit/dopemux/ui/cockpit/",
+    "docs/03-reference/systems/dopemux/tui-spec-v2-0a.md",
+    "docs/03-reference/Dopemux Cockpit TUI Design System/",
+    "docs/03-reference/python-tmux-research.md",
+    "docs/03-reference/systems/dashboard/tmux-dashboard-design.md",
+    "config/mobile/tmux.mobile.conf",
+    ".tmux.conf"
+  ],
+  "files_changed": [
+    "task-packets/generated/TP-DMX-MOBILE-TUI-SPEC-001.json",
+    "task-packets/INDEX.md",
+    "docs/06-research/mobile-tmux-tui/source-manifest.md",
+    "docs/06-research/mobile-tmux-tui/01-mobile-blink-ssh-constraints.md",
+    "docs/06-research/mobile-tmux-tui/02-tui-framework-architecture.md",
+    "docs/06-research/mobile-tmux-tui/03-dopemux-cockpit-ux-spec.md",
+    "docs/03-reference/systems/dopemux/mobile-tmux-cockpit-ux-spec.md",
+    "out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json"
+  ],
+  "validations": [
+    {
+      "command": "pwd && git rev-parse --show-toplevel && git remote -v && git status --short --branch && git branch --show-current && git rev-parse HEAD && (git symbolic-ref refs/remotes/origin/HEAD || true)",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "Primary checkout and dedicated worktree identity commands ran; remote matched DDD-Enterprises/dopemux-mvp."
+    },
+    {
+      "command": "find \"$HOME/Downloads\" -maxdepth 1 -type f (...) -print0 | xargs -0 ls -lh",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "Downloads inventory completed; selected three matching May 19 Markdown reports by content."
+    },
+    {
+      "command": "shasum -a 256 \"$HOME/Downloads/deep-research-report 13.md\" \"$HOME/Downloads/deep-research-report 14.md\" \"$HOME/Downloads/deep-research-report 15.md\"",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "rg -n -i \"(api[_ -]?key|token|password|secret|credential|BEGIN .*PRIVATE|sk-[A-Za-z0-9]|ghp_[A-Za-z0-9]|xox[baprs]-|AKIA[0-9A-Z]{16})\" selected research files || true",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "No credential-bearing findings in selected source files; ordinary prose hits only."
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-MOBILE-TUI-SPEC-001.json >/dev/null",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "python - <<'PY' ... jsonschema.validate(packet, schema) ... PY",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "Validated against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "git status --short",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "Dedicated worktree showed only packet allowlist files changed before proof was added."
+    },
+    {
+      "command": "git status --short",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "Initial checkout /Users/hue/.codex/worktrees/7e70/dopemux-mvp is clean after corrective cleanup."
+    },
+    {
+      "command": "pre-commit run --files docs/03-reference/systems/dopemux/mobile-tmux-cockpit-ux-spec.md docs/06-research/mobile-tmux-tui/01-mobile-blink-ssh-constraints.md docs/06-research/mobile-tmux-tui/02-tui-framework-architecture.md docs/06-research/mobile-tmux-tui/03-dopemux-cockpit-ux-spec.md docs/06-research/mobile-tmux-tui/SOURCE_MANIFEST.md out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json task-packets/INDEX.md task-packets/generated/TP-DMX-MOBILE-TUI-SPEC-001.json",
+      "exit_code": 1,
+      "result": "FAIL",
+      "notes": "docs-frontmatter-guard modified four markdown files and docs-filename-hygiene rejected SOURCE_MANIFEST.md, requiring kebab-case source-manifest.md."
+    },
+    {
+      "command": "pre-commit run --files docs/03-reference/systems/dopemux/mobile-tmux-cockpit-ux-spec.md docs/06-research/mobile-tmux-tui/01-mobile-blink-ssh-constraints.md docs/06-research/mobile-tmux-tui/02-tui-framework-architecture.md docs/06-research/mobile-tmux-tui/03-dopemux-cockpit-ux-spec.md docs/06-research/mobile-tmux-tui/source-manifest.md out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json task-packets/INDEX.md task-packets/generated/TP-DMX-MOBILE-TUI-SPEC-001.json",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "All configured hooks passed after accepting frontmatter guard changes and kebab-case manifest filename."
+    },
+    {
+      "command": "python -m json.tool out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json >/dev/null",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "git diff --cached --check",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "git diff --cached --name-only",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "Cached diff contains only the packet allowlist docs/spec/proof/index paths."
+    },
+    {
+      "command": "git diff --cached --stat",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "Cached diff is documentation/spec/proof only."
+    },
+    {
+      "command": "git diff --cached -- task-packets/generated/TP-DMX-MOBILE-TUI-SPEC-001.json docs/06-research/mobile-tmux-tui/ docs/03-reference/systems/dopemux/ docs/03-reference/systems/dashboard/ task-packets/INDEX.md out/proof/TP-DMX-MOBILE-TUI-SPEC-001/",
+      "exit_code": 0,
+      "result": "PASS",
+      "notes": "Scoped cached diff was inspected; it contained only the intended packet files."
+    }
+  ],
+  "not_run": [
+    {
+      "command": "./scripts/dopetask --help",
+      "result": "NOT_RUN",
+      "reason": "scripts/dopetask creates .dopetask_venv and installs pinned dopetask when venv is absent; packet forbids dependency installation."
+    },
+    {
+      "command": "./scripts/dopetask tp --help",
+      "result": "NOT_RUN",
+      "reason": "Same dependency-install side effect as ./scripts/dopetask --help."
+    },
+    {
+      "command": "broad runtime or unit test suites",
+      "result": "NOT_RUN",
+      "reason": "Docs/spec/proof-only packet did not modify runtime/source/test files."
+    }
+  ],
+  "authority_findings": {
+    "preserved_boundaries": true,
+    "unknowns": [
+      "Whether under-70-column mobile fallback should replace or coexist with the current below-80x24 blocker.",
+      "Exact runtime mapping between T0_READ_ONLY style tier names and current runtime_contract.py tier constants.",
+      "Canonical writers for future Cockpit actions not represented in the current runtime action catalog.",
+      "Terminal capability probes for Blink plus tmux plus SSH plus Mosh.",
+      "Reliability of mobile tmux mouse, OSC 52, extended keys, glyphs, and true color across supported clients.",
+      "Proof schema for future mobile UI action receipts.",
+      "Repo-wide relationship between in-repo task-orchestrator service and upstream local 13-tool MCP Task Orchestrator remains a boundary, not a unified runtime."
+    ],
+    "conflicts": [
+      "Existing Cockpit runtime and design-system acceptance block below 80x24; mobile research recommends an under-70-column single-column fallback.",
+      "Existing config/mobile/tmux.mobile.conf enables mouse, OSC 52, bottom status, and prefixless F-key jumps; mobile research recommends these as optional conveniences rather than primary requirements.",
+      "Prompt requested SOURCE_MANIFEST.md, but active docs filename hygiene requires kebab-case for non-exempt docs files; committed manifest path is docs/06-research/mobile-tmux-tui/source-manifest.md."
+    ],
+    "risks": [
+      "Docs-only spec may be misread as implemented runtime unless readers honor the status and non-goals sections.",
+      "Prompt requested SOURCE_MANIFEST.md, but repo hook policy required source-manifest.md; the filename was adjusted to pass pre-commit without changing config.",
+      "Current runtime still blocks below 80x24; mobile fallback is only a future prototype acceptance contract."
+    ]
+  },
+  "scope_check": {
+    "runtime_changed": false,
+    "source_changed": false,
+    "config_changed": false,
+    "tmux_config_changed": false,
+    "dependency_changed": false,
+    "docs_only": true
+  },
+  "corrective_actions": [
+    {
+      "issue": "Initial apply_patch landed in the initial checkout instead of the dedicated worktree.",
+      "action": "Removed only the added files and index line created by this packet from /Users/hue/.codex/worktrees/7e70/dopemux-mvp, removed the empty created directory, verified git status clean, and reapplied the same changes to the dedicated worktree with absolute paths.",
+      "result": "Initial checkout restored to clean status before continuing."
+    }
+  ],
+  "codereview": {
+    "status": "PASS_WITH_RISKS",
+    "notes": "Manual diff and cached diff review found only docs/spec/proof/index changes. Residual risk is limited to docs being misread as runtime implementation and the recorded manifest filename adjustment."
+  },
+  "precommit": {
+    "status": "PASS",
+    "notes": "pre-commit is installed and configured; initial run failed on prompt-requested SOURCE_MANIFEST.md filename and docs-frontmatter-guard modified four markdown files. Manifest was renamed to source-manifest.md to honor active docs filename hygiene without changing config; rerun passed."
+  },
+  "next_recommended_packet": {
+    "id": "TP-DMX-MOBILE-TUI-PROTOTYPE-002",
+    "purpose": "Prototype read-only mobile-first Cockpit shell using existing deterministic renderer and no write actions."
+  }
+}

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -71,6 +71,7 @@ A packet is superseded by another packet
 | TP-DMX-COCKPIT-INVENTORY-REGEN-001 | UI Cockpit | Regenerate current-head Cockpit command/surface inventory artifacts | Active | N/A |
 | TP-DMX-COCKPIT-RUNTIME-CONTRACT-FIDELITY-001 | UI Cockpit | Repair Cockpit runtime contract-fidelity gaps | Active | N/A |
 | TP-DMX-COCKPIT-DESIGN-PICKUP-001 | UI Cockpit | Create current-state Cockpit design pickup brief after pack-to-main consolidation | Active | N/A |
+| TP-DMX-MOBILE-TUI-SPEC-001 | UI Cockpit | Install mobile-first tmux Cockpit UX specification without runtime changes | Active | N/A |
 | PACKET_031 | Memory | Dual Capture Adapters, Single Ledger | Executing | ADR-213 |
 | PACKET_032 | Memory | Chronicle Promotion Guards | Pending Audit | ADR-214 |
 | DMX-COCKPIT-PMIMPL-PACK-001 | Cockpit / PM Plane | PM/Implementer cockpit processing pack | Ready | N/A |

--- a/task-packets/generated/TP-DMX-MOBILE-TUI-SPEC-001.json
+++ b/task-packets/generated/TP-DMX-MOBILE-TUI-SPEC-001.json
@@ -1,0 +1,99 @@
+{
+  "id": "TP-DMX-MOBILE-TUI-SPEC-001",
+  "project": "dopemux-mvp",
+  "target": "Dopemux mobile-first tmux Cockpit UX specification",
+  "invariants": [
+    "No runtime/source/config behavior changes.",
+    "Dopemux remains the operator control surface only.",
+    "dopetask remains the external execution runtime.",
+    "PM authority remains split across Leantime, task-orchestrator, ConPort, and dope-memory mirror receipts.",
+    "dopecon-bridge remains proxy/routing/event transport only, not canonical truth.",
+    "dope-context retrieval output remains derived and never source truth.",
+    "Confirmation is not proof.",
+    "Every proposed write/action must name the canonical writer or mark writer UNKNOWN."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".git",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MOBILE-TMUX-TUI",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/tp-dmx-mobile-tui-spec-001"
+  },
+  "commit": {
+    "message": "docs: install mobile tmux cockpit UX spec",
+    "allowlist": [
+      "task-packets/generated/TP-DMX-MOBILE-TUI-SPEC-001.json",
+      "task-packets/INDEX.md",
+      "docs/06-research/mobile-tmux-tui/",
+      "docs/03-reference/systems/dopemux/",
+      "docs/03-reference/systems/dashboard/",
+      "out/proof/TP-DMX-MOBILE-TUI-SPEC-001/"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-MOBILE-TUI-SPEC-001.json",
+      "python -m json.tool out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "Docs: install mobile-first tmux Cockpit UX spec",
+    "body": "Installs the mobile-first tmux Cockpit UX specification from Deep Research inputs, preserving Dopemux authority boundaries and proof requirements. Runtime behavior is unchanged.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Inventory repo truth, existing Cockpit/TUI docs, and Downloads research files.",
+      "validation": [
+        "Record inspected files, research filenames, hashes, and authority notes in proof."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Create stable research docs under docs/06-research/mobile-tmux-tui/.",
+      "validation": [
+        "Docs exist, preserve source provenance, and label OBSERVED, INFERRED, UNKNOWN, and CONFLICTING where needed."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Install a mobile-first Cockpit UX spec addendum under the Dopemux docs path.",
+      "validation": [
+        "Spec preserves authority boundaries, mobile/SSH constraints, Safe Action Gate rules, and proof/receipt display contract."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Update task packet index/governance references if the repo convention requires it.",
+      "validation": [
+        "Index update is minimal and traceable to TP-DMX-MOBILE-TUI-SPEC-001."
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Create proof JSON and run validation.",
+      "validation": [
+        "Proof JSON parses, packet JSON parses, git diff is scoped, and git diff --check passes."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Installs TP-DMX-MOBILE-TUI-SPEC-001 as a docs/spec-only update for the mobile-first tmux Dopemux Cockpit UX.

## Scope

- Imports Deep Research files from ~/Downloads into stable repo docs
- Adds/updates mobile-first tmux Cockpit UX specification
- Preserves Dopemux authority boundaries
- Adds task packet and proof artifact
- No runtime/source/config behavior changes

## Validation

See `out/proof/TP-DMX-MOBILE-TUI-SPEC-001/PROOF.json`.

## Risks / UNKNOWNs

See proof artifact.
