### PR TITLE
docs(governance): add Codex operator runbook and prompt pack

### DIFF
--- a/docs/02-how-to/codex-operator-runbook.md
+++ b/docs/02-how-to/codex-operator-runbook.md
@@ -1,0 +1,112 @@
+---
+id: codex-operator-runbook
+title: Codex Operator Runbook
+type: how-to
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Operator runbook for bounded Codex macro-packet execution in Dopemux.
+---
+# Codex Operator Runbook
+
+This runbook controls how to use Codex for Dopemux macro-packet development. It does not replace `AGENTS.md`, active Task Packets, runtime code, config, tests, compose wiring, schemas, or active entrypoints. If this guide conflicts with repo truth, stop and use the stronger authority.
+
+## Authority Boundary
+
+Codex is a bounded implementer and reviewer for scoped repo work. It is not PM authority, memory authority, retrieval authority, bridge authority, workflow authority, runtime authority, or a repo-wide agent authority.
+
+For Dopemux work, Codex must preserve these labels:
+
+| Label | Meaning |
+| --- | --- |
+| `OBSERVED` | Direct repo evidence supports the claim. |
+| `CONFLICTING` | Repo evidence shows multiple unresolved paths or owners. |
+| `UNKNOWN` | Repo evidence does not prove the claim. |
+| `NOT_RUN` | A requested or relevant check was intentionally not executed. |
+
+## Codex Cloud Setup Checklist
+
+Use this checklist before assigning a Task Packet in a Codex cloud environment:
+
+1. Connect the environment to `DDD-Enterprises/dopemux-mvp` through the current official Codex/GitHub setup path.
+2. Select the intended repository and base branch for the packet.
+3. Ensure the environment can read `AGENTS.md`, `.dopetaskroot`, `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`, and the active Task Packet.
+4. Keep no secrets in prompts, setup scripts, checked-in files, proof artifacts, logs, or PR text.
+5. Use the setup script only for dependency installation or deterministic local tool preparation required by the packet.
+6. Keep internet off during the agent phase unless the Task Packet explicitly authorizes network access and names the reason.
+7. Do not add provider credentials, account tokens, or private operator material to make a packet easier to run.
+8. Confirm the packet branch, proof path, and commit allowlist before starting.
+
+Official Codex product behavior and environment controls can change. Treat the current official Codex documentation and UI as product authority, and treat this repo as authority only for Dopemux packet gates.
+
+Product references checked for this runbook:
+
+- [Using Codex with your ChatGPT plan](https://help.openai.com/en/articles/11369540/)
+- [Enterprise admin getting started guide for Codex](https://help.openai.com/en/articles/11390924)
+- [Codex changelog](https://help.openai.com/en/articles/11428266-codex-changelog)
+
+## Minimal Operator Workflow
+
+Use one macro-packet per meaningful outcome.
+
+1. Assign one active Task Packet to Codex.
+2. Include the packet JSON or a link to the tracked packet, plus the hard rules from `AGENTS.md`.
+3. Wait for the PR and proof return. Do not start a follow-on cleanup packet while the same packet can absorb corrections.
+4. Paste Codex proof to the supervisor/reviewer exactly enough to preserve commands, exit codes, changed files, diff stat, commit SHA, PR URL or blocker, residual risks, and `UNKNOWN`s.
+5. Request same-packet fixes only when review finds gaps inside the existing packet scope.
+6. Merge only after human acceptance, not merely because Codex opened a PR or checks passed.
+
+## Branch, PR, And Proof Requirements
+
+Every repo-changing Codex packet must:
+
+- work from a dedicated branch named by the Task Packet
+- confirm `.dopetaskroot` before editing
+- confirm remotes identify `DDD-Enterprises/dopemux-mvp`
+- validate the generated Task Packet against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- edit only files listed in `commit.allowlist`
+- run the packet-declared validation commands
+- run codereview before precommit
+- run `git diff --check` and `git diff --cached --check`
+- commit only allowlisted files
+- push and open a PR when authenticated
+- return proof with exact commands, exit codes, changed files, diff stat, commit SHA, PR URL or exact blocker, residual risks, `UNKNOWN`s, and cleanup status
+
+## Prohibited Without Explicit Packet Authorization
+
+Codex must not run or claim:
+
+- runtime or service validation
+- Docker startup
+- live provider calls
+- live extraction
+- live preflight against account-specific systems
+- secret inspection
+- runtime, service, compose, dependency, test, or provider-configuration edits
+
+If a packet explicitly authorizes one of these actions, Codex must still preserve least privilege, avoid printing secret values, and mark any skipped or blocked check as `NOT_RUN`.
+
+## Same-Packet Fix Rule
+
+Review comments, missing proof, validator failures, and documentation gaps stay in the same packet when the requested correction is inside the packet target and allowlist. Open a new packet only when the requested work changes the outcome, touches a new authority surface, or requires files outside the current allowlist.
+
+Same-packet fixes must refresh the proof artifact and PR evidence. Do not hide the earlier failure; record it as a failed command or resolved review finding.
+
+## Stop Conditions
+
+Stop and report evidence when:
+
+- repo identity, branch, marker, or dependency preflight fails
+- the Task Packet is missing, malformed, or fails schema validation
+- a requested edit is outside `commit.allowlist`
+- runtime authority conflicts with docs
+- validation fails and the cause is not understood
+- proof cannot be produced truthfully
+- the operator asks Codex to merge or accept its own work
+- a fix would require live provider calls, live extraction, Docker startup, or account-specific checks not authorized by the packet
+
+## Merge Discipline
+
+Codex may prepare a PR and request review. Codex must not treat its own proof as acceptance, and must not merge unless a human operator explicitly authorizes that merge after reviewing proof and residual risk.

--- a/docs/03-reference/governance/codex-prompt-pack.md
+++ b/docs/03-reference/governance/codex-prompt-pack.md
@@ -1,0 +1,194 @@
+---
+id: codex-prompt-pack
+title: Codex Prompt Pack
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-19'
+last_review: '2026-05-19'
+next_review: '2026-08-17'
+prelude: Reusable Codex prompts for bounded Dopemux Task Packet execution, review, fixes, and proof return.
+---
+# Codex Prompt Pack
+
+This prompt pack is reusable operator copy for Dopemux macro-packet development. It does not replace `AGENTS.md`, active Task Packets, runtime code, config, tests, compose wiring, schemas, or active entrypoints.
+
+Codex is a bounded implementer/reviewer. Codex is not PM authority, memory authority, retrieval authority, bridge authority, repo-wide agent authority, or runtime authority.
+
+## Master Codex Packet Execution Prompt
+
+```text
+You are Codex running in a dedicated worktree for DDD-Enterprises/dopemux-mvp.
+
+Execute exactly the Task Packet below.
+
+Hard rules:
+- Read AGENTS.md first.
+- Confirm you are inside the intended worktree, not the primary checkout.
+- Confirm repo remote is DDD-Enterprises/dopemux-mvp.
+- Confirm .dopetaskroot exists.
+- Treat runtime code, config, tests, compose, schemas, and active entrypoints as stronger than docs.
+- Preserve OBSERVED, CONFLICTING, UNKNOWN, and NOT_RUN.
+- Do not modify files outside commit.allowlist.
+- Do not run live provider calls, live extraction, live preflight, Docker startup, account-specific checks, or secret inspection unless the Task Packet explicitly authorizes them.
+- Validate the generated packet against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json.
+- Work in commit-sized slices.
+- Run codereview before precommit.
+- Always run git diff --check and git diff --cached --check.
+- Commit allowed files only.
+- Push the branch and open a PR if authenticated.
+- Return proof with commands, exit codes, changed files, diff stat, commit SHA, PR URL or exact blocker, residual risks, UNKNOWNs, and cleanup status.
+
+If any preflight check fails, STOP and report evidence. Do not improvise.
+
+Task Packet:
+<paste packet JSON here>
+```
+
+## Codex PR Review Comment Prompt
+
+Use this as a GitHub PR comment when a Codex review is wanted:
+
+```text
+@codex review
+
+Review this PR against:
+- AGENTS.md
+- the active Task Packet and commit.allowlist
+- runtime code/config/tests/compose/schemas/active entrypoints over docs
+- proof completeness
+- validation commands and exit codes
+- preservation of OBSERVED, CONFLICTING, UNKNOWN, and NOT_RUN
+
+Prioritize correctness, determinism, replayability, auditability, proof gaps, and unauthorized scope.
+Do not request cosmetic refactors unless they block the packet.
+```
+
+## Same-Packet Fix Prompt
+
+```text
+Continue the same Task Packet. Do not create a new packet.
+
+Fix only the reviewed gap below, and only inside the existing commit.allowlist.
+Refresh proof in the same proof artifact.
+Preserve the original failure or review finding in the proof trail.
+Rerun the smallest relevant validation first, then rerun packet-required validation.
+Run codereview before precommit.
+
+Reviewed gap:
+<paste exact review finding or failed command here>
+
+STOP if the fix requires files outside commit.allowlist, runtime/provider/live extraction/Docker/account-specific checks not authorized by the packet, or a new outcome.
+```
+
+## Proof-Return Template
+
+````text
+proof-return
+
+Task Packet:
+- id:
+- path:
+
+Repo:
+- worktree:
+- branch:
+- remote identity:
+- .dopetaskroot:
+
+Change Summary:
+- <summary>
+
+Authority Used:
+- AGENTS.md:
+- Task Packet:
+- runtime/config/tests/compose/schemas checked:
+- docs/reference checked:
+
+Analysis Performed:
+- <analysis>
+
+Validation Performed:
+PASS:
+- command:
+  exit_code:
+  output:
+
+FAIL:
+- command:
+  exit_code:
+  output:
+
+NOT_RUN:
+- runtime/service validation:
+- Docker startup:
+- live provider calls:
+- live extraction:
+- account-specific checks:
+- secret inspection:
+
+Changed Files:
+- <path>
+
+Diff Stat:
+```text
+<paste git diff --stat or git diff --cached --stat>
+```
+
+Codereview:
+- status:
+- evidence:
+
+Precommit:
+- status:
+- evidence:
+
+Commit:
+- sha:
+- message:
+
+PR:
+- url or exact blocker:
+
+Residual Risks / UNKNOWNs:
+- <risk or UNKNOWN>
+
+Cleanup Status:
+- <status>
+
+Rollback Plan:
+- <plan>
+````
+
+## STOP Conditions
+
+Codex must STOP when:
+
+- repo identity, branch, marker, or dependency preflight fails
+- the Task Packet fails schema validation
+- the requested edit is outside `commit.allowlist`
+- a command would inspect or print secret values
+- a command would run live provider calls, live extraction, live preflight, Docker startup, or account-specific checks without packet authorization
+- runtime truth conflicts with docs and the packet does not authorize resolving the conflict
+- validation fails and the cause is unknown
+- proof would require inventing commands, files, commits, PRs, runtime behavior, or test results
+- the operator asks Codex to accept or merge its own work without explicit human acceptance
+
+Report exact evidence and leave the worktree unchanged beyond already-authorized packet artifacts.
+
+## Independent Review Triggers
+
+Request independent review before merge when a packet touches or claims:
+
+- schemas, manifests, migrations, serializers, APIs, MCP tools, or queue/checkpoint payloads
+- workflow transitions, approvals, retries, replay, projections, or idempotency
+- runtime authority, canonical writers, PM truth, memory truth, retrieval truth, bridge authority, or agent authority
+- provider credentials, account-specific checks, network permissions, or secret handling
+- broad docs canon changes that could weaken `AGENTS.md` or active Task Packet authority
+- same-packet fixes after a failed validation whose cause was not obvious
+
+Docs-only packets can still require independent review when they change authority language or proof gates.
+
+## Macro-Packet Rule
+
+Use one macro-packet per meaningful outcome. Do not create permanent three-agent theater as the default workflow. Planner/reviewer/testgen style roles are useful only when the packet risk justifies them and the handoff preserves the same packet, same allowlist, and same proof trail.

--- a/proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json
+++ b/proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json
@@ -1,0 +1,277 @@
+{
+  "schema_version": "dopemux.codex_refresh.proof.v1",
+  "packet_id": "TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK",
+  "project": "dopemux-mvp",
+  "generated_at_utc": "2026-05-20T00:37:29Z",
+  "worktree_path": "/Users/hue/.codex/worktrees/0b56/dopemux-mvp",
+  "branch": "codex/dmx-codex-refresh-002-operator-runbook",
+  "base": "origin/main",
+  "repo_identity": {
+    "status": "PASS",
+    "marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "observed_remotes": [
+      "mvp https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)",
+      "mvp https://github.com/DDD-Enterprises/dopemux-mvp.git (push)",
+      "origin https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)",
+      "origin https://github.com/DDD-Enterprises/dopemux-mvp.git (push)"
+    ]
+  },
+  "authority_used": [
+    "AGENTS.md",
+    "task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json",
+    "docs/03-reference/governance/codex-authority-refresh.md",
+    "docs/03-reference/governance/codex-refresh-gap-register.md",
+    "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+    "scripts/docs_validator.py",
+    "scripts/docs_frontmatter_guard.py",
+    "Official OpenAI Codex Help Center and developer pages for product-boundary checks only"
+  ],
+  "analysis_performed": [
+    "Read AGENTS.md before implementation.",
+    "Confirmed the current checkout is /Users/hue/.codex/worktrees/0b56/dopemux-mvp, not primary checkout /Users/hue/code/dopemux-mvp.",
+    "Confirmed origin and mvp remotes point to DDD-Enterprises/dopemux-mvp.",
+    "Confirmed .dopetaskroot exists.",
+    "Fetched origin/main through git pull attempt; pull did not update detached HEAD because histories diverged and Git required an explicit reconcile strategy.",
+    "Verified TP 001 dependency files exist on origin/main.",
+    "Switched the clean dedicated worktree to codex/dmx-codex-refresh-002-operator-runbook from origin/main.",
+    "Inspected TP 001 authority refresh and gap register before authoring TP 002 docs.",
+    "Inspected the live dopetask Task Packet schema and docs validators.",
+    "Inspected nearby operator workflow, agent workflow, TP 001 packet, and TP 001 proof conventions.",
+    "Checked official OpenAI Codex docs/search results to avoid inventing Codex product behavior."
+  ],
+  "slices_completed": [
+    {
+      "slice": "S1",
+      "status": "PASS",
+      "summary": "Preflight passed after origin/main refresh and dedicated branch switch."
+    },
+    {
+      "slice": "S2",
+      "status": "PASS",
+      "summary": "Generated task packet JSON at the allowlisted path."
+    },
+    {
+      "slice": "S3",
+      "status": "PASS",
+      "summary": "Authored Codex operator runbook with setup checklist, minimal workflow, branch/PR/proof gates, same-packet repair, stop conditions, and live-action prohibitions."
+    },
+    {
+      "slice": "S4",
+      "status": "PASS",
+      "summary": "Authored reusable Codex prompt pack with packet execution, PR review, same-packet fix, proof-return, stop conditions, independent-review triggers, and bounded-authority language."
+    },
+    {
+      "slice": "S5",
+      "status": "PASS",
+      "summary": "Created proof JSON draft for validation and final refresh."
+    },
+    {
+      "slice": "S6",
+      "status": "PASS_THROUGH_PRECOMMIT",
+      "summary": "Final validation, codereview, and precommit passed; commit, push, and PR are reported in the final response because the commit SHA and PR URL cannot be known before committing the proof artifact."
+    }
+  ],
+  "changed_files": [
+    "docs/02-how-to/codex-operator-runbook.md",
+    "docs/03-reference/governance/codex-prompt-pack.md",
+    "task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json",
+    "proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json"
+  ],
+  "command_results": [
+    {
+      "command": "git pull origin main",
+      "exit_code": 128,
+      "stdout": "From https://github.com/DDD-Enterprises/dopemux-mvp\n * branch                main       -> FETCH_HEAD\n   df6c967d7..f94b07d4e  main       -> origin/main",
+      "stderr": "hint: You have divergent branches and need to specify how to reconcile them.\nfatal: Need to specify how to reconcile divergent branches."
+    },
+    {
+      "command": "git cat-file -e origin/main:docs/03-reference/governance/codex-authority-refresh.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "git cat-file -e origin/main:docs/03-reference/governance/codex-refresh-gap-register.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "git switch -c codex/dmx-codex-refresh-002-operator-runbook origin/main",
+      "exit_code": 0,
+      "stdout": "Previous HEAD position was d64d5f15e Add RTE UX valuation proof pack\nSwitched to a new branch 'codex/dmx-codex-refresh-002-operator-runbook'\nbranch 'codex/dmx-codex-refresh-002-operator-runbook' set up to track 'origin/main'.",
+      "stderr": ""
+    },
+    {
+      "command": "git remote -v",
+      "exit_code": 0,
+      "stdout": "mvp https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)\nmvp https://github.com/DDD-Enterprises/dopemux-mvp.git (push)\norigin https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)\norigin https://github.com/DDD-Enterprises/dopemux-mvp.git (push)",
+      "stderr": ""
+    },
+    {
+      "command": "git branch --show-current",
+      "exit_code": 0,
+      "stdout": "codex/dmx-codex-refresh-002-operator-runbook",
+      "stderr": ""
+    },
+    {
+      "command": "test -f .dopetaskroot",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f docs/03-reference/governance/codex-authority-refresh.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f docs/03-reference/governance/codex-refresh-gap-register.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json >/dev/null",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "stdout": "/Users/hue/.local/share/mise/installs/python/3.12.13/lib/python3.12/site-packages/jsonschema/__main__.py:4: DeprecationWarning: The jsonschema CLI is deprecated and will be removed in a future version. Please use check-jsonschema instead, which can be installed from https://pypi.org/project/check-jsonschema/\n  from jsonschema.cli import main",
+      "stderr": ""
+    },
+    {
+      "command": "python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json >/dev/null",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"Codex cloud|AGENTS.md|proof|Task Packet|same-packet|UNKNOWN|no secrets|live extraction\" docs/02-how-to/codex-operator-runbook.md",
+      "exit_code": 0,
+      "stdout": "14:This runbook controls how to use Codex for Dopemux macro-packet development. It does not replace `AGENTS.md`, active Task Packets, runtime code, config, tests, compose wiring, schemas, or active entrypoints. If this guide conflicts with repo truth, stop and use the stronger authority.\n26:| `UNKNOWN` | Repo evidence does not prove the claim. |\n31:Use this checklist before assigning a Task Packet in a Codex cloud environment:\n35:3. Ensure the environment can read `AGENTS.md`, `.dopetaskroot`, `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`, and the active Task Packet.\n36:4. Keep no secrets in prompts, setup scripts, checked-in files, proof artifacts, logs, or PR text.\n38:6. Keep internet off during the agent phase unless the Task Packet explicitly authorizes network access and names the reason.\n40:8. Confirm the packet branch, proof path, and commit allowlist before starting.\n54:1. Assign one active Task Packet to Codex.\n55:2. Include the packet JSON or a link to the tracked packet, plus the hard rules from `AGENTS.md`.\n56:3. Wait for the PR and proof return. Do not start a follow-on cleanup packet while the same packet can absorb corrections.\n57:4. Paste Codex proof to the supervisor/reviewer exactly enough to preserve commands, exit codes, changed files, diff stat, commit SHA, PR URL or blocker, residual risks, and `UNKNOWN`s.\n58:5. Request same-packet fixes only when review finds gaps inside the existing packet scope.\n65:- work from a dedicated branch named by the Task Packet\n68:- validate the generated Task Packet against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`\n75:- return proof with exact commands, exit codes, changed files, diff stat, commit SHA, PR URL or exact blocker, residual risks, `UNKNOWN`s, and cleanup status\n84:- live extraction\n93:Review comments, missing proof, validator failures, and documentation gaps stay in the same packet when the requested correction is inside the packet target and allowlist. Open a new packet only when the requested work changes the outcome, touches a new authority surface, or requires files outside the current allowlist.\n95:Same-packet fixes must refresh the proof artifact and PR evidence. Do not hide the earlier failure; record it as a failed command or resolved review finding.\n102:- the Task Packet is missing, malformed, or fails schema validation\n106:- proof cannot be produced truthfully\n108:- a fix would require live provider calls, live extraction, Docker startup, or account-specific checks not authorized by the packet\n112:Codex may prepare a PR and request review. Codex must not treat its own proof as acceptance, and must not merge unless a human operator explicitly authorizes that merge after reviewing proof and residual risk.",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"@codex review|same-packet|proof-return|STOP|bounded implementer|authority\" docs/03-reference/governance/codex-prompt-pack.md",
+      "exit_code": 0,
+      "stdout": "16:Codex is a bounded implementer/reviewer. Codex is not PM authority, memory authority, retrieval authority, bridge authority, repo-wide agent authority, or runtime authority.\n42:If any preflight check fails, STOP and report evidence. Do not improvise.\n53:@codex review\n81:STOP if the fix requires files outside commit.allowlist, runtime/provider/live extraction/Docker/account-specific checks not authorized by the packet, or a new outcome.\n87:proof-return\n163:## STOP Conditions\n165:Codex must STOP when:\n185:- runtime authority, canonical writers, PM truth, memory truth, retrieval truth, bridge authority, or agent authority\n187:- broad docs canon changes that could weaken `AGENTS.md` or active Task Packet authority\n188:- same-packet fixes after a failed validation whose cause was not obvious\n190:Docs-only packets can still require independent review when they change authority language or proof gates.",
+      "stderr": ""
+    },
+    {
+      "command": "python scripts/docs_validator.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python scripts/docs_frontmatter_guard.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md",
+      "exit_code": 0,
+      "stdout": "All docs have valid frontmatter.",
+      "stderr": ""
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "git check-ignore -v proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json",
+      "exit_code": 0,
+      "stdout": ".gitignore:358:proof/*\tproof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json",
+      "stderr": ""
+    }
+  ],
+  "codereview": {
+    "status": "PASS_AFTER_SAME_PACKET_FIX",
+    "commands": [
+      {
+        "command": "git diff --cached --name-status",
+        "exit_code": 0,
+        "stdout": "A\tdocs/02-how-to/codex-operator-runbook.md\nA\tdocs/03-reference/governance/codex-prompt-pack.md\nA\tproof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json\nA\ttask-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json",
+        "stderr": ""
+      },
+      {
+        "command": "git diff --cached --stat",
+        "exit_code": 0,
+        "stdout": " docs/02-how-to/codex-operator-runbook.md           | 112 ++++++++++\n docs/03-reference/governance/codex-prompt-pack.md  | 194 +++++++++++++++++\n .../PROOF.json                                     | 232 +++++++++++++++++++++\n .../TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json | 156 ++++++++++++++\n 4 files changed, 694 insertions(+)",
+        "stderr": ""
+      },
+      {
+        "command": "git diff --cached --check",
+        "exit_code": 2,
+        "stdout": "docs/03-reference/governance/codex-prompt-pack.md:100: trailing whitespace.\n+- \ndocs/03-reference/governance/codex-prompt-pack.md:109: trailing whitespace.\n+- \ndocs/03-reference/governance/codex-prompt-pack.md:131: trailing whitespace.\n+- \ndocs/03-reference/governance/codex-prompt-pack.md:154: trailing whitespace.\n+- \ndocs/03-reference/governance/codex-prompt-pack.md:157: trailing whitespace.\n+- \ndocs/03-reference/governance/codex-prompt-pack.md:160: trailing whitespace.\n+- ",
+        "stderr": ""
+      },
+      {
+        "command": "git diff --check",
+        "exit_code": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      {
+        "command": "python scripts/docs_validator.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md",
+        "exit_code": 0,
+        "stdout": "",
+        "stderr": ""
+      },
+      {
+        "command": "python scripts/docs_frontmatter_guard.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md",
+        "exit_code": 0,
+        "stdout": "All docs have valid frontmatter.",
+        "stderr": ""
+      },
+      {
+        "command": "git diff --cached --check",
+        "exit_code": 0,
+        "stdout": "",
+        "stderr": ""
+      }
+    ]
+  },
+  "precommit": {
+    "status": "PASS",
+    "command": "pre-commit run --files docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json",
+    "exit_code": 0,
+    "stdout": "Validate YAML frontmatter in docs..........................................................Passed\nValidate documentation against knowledge graph schema......................................Passed\nBlock prohibited documentation patterns (NOTES, TODO, TEMP, etc.)..........................Passed\nValidate prelude ≤100 tokens for efficient embeddings......................................Passed\nEnforce markdown file locations for changed files..........................................Passed\nEnforce docs placement hygiene (changed files).............................................Passed\nEnforce docs filename hygiene (kebab-case).................................................Passed\nAudit docs filename hygiene (kebab-case, full-tree legacy debt)............................Passed\nReject executable/config code under UPGRADES (docs-only legacy tree)...(no files to check)Skipped\nEnforce repository root hygiene (no random root files).....................................Passed\nmarkdownlint...............................................................................Passed\ntrim trailing whitespace...................................................................Passed\nfix end of files...........................................................................Passed\ncheck yaml.............................................................(no files to check)Skipped",
+    "stderr": "",
+    "summary": "Precommit hooks passed on the four allowlisted files."
+  },
+  "NOT_RUN": [
+    "Runtime/service validation",
+    "Docker startup",
+    "Live provider calls",
+    "Live extraction",
+    "Live preflight",
+    "Account-specific checks",
+    "Secret inspection"
+  ],
+  "residual_risks": [
+    "Static documentation validation does not prove runtime service health.",
+    "Codex product UI and environment controls can drift after this runbook; current official product docs remain the product authority.",
+    "Repo-wide agent runtime authority remains UNKNOWN per TP 001.",
+    "Task-orchestrator and several memory/authority surfaces remain CONFLICTING per TP 001."
+  ],
+  "unknowns": [
+    "UNKNOWN live runtime health because Docker startup and service validation are not authorized.",
+    "UNKNOWN live provider and extraction behavior because live calls and extraction are not authorized.",
+    "UNKNOWN account-specific Codex environment settings because account-specific checks are not authorized.",
+    "UNKNOWN repo-wide agent runtime authority across observed duplicated agent surfaces."
+  ],
+  "diff_stat": "docs/02-how-to/codex-operator-runbook.md           | 112 ++++++++++\ndocs/03-reference/governance/codex-prompt-pack.md  | 194 +++++++++++++++++\n.../PROOF.json                                     | 232 +++++++++++++++++++++\n.../TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json | 156 ++++++++++++++\n4 files changed, 694 insertions(+)",
+  "cleanup_status": "PENDING: dedicated Codex worktree remains in place until push/PR outcome is known.",
+  "commit_sha": "POST_COMMIT_REPORTED_IN_FINAL_RESPONSE",
+  "pr_url": "POST_PR_REPORTED_IN_FINAL_RESPONSE"
+}

--- a/task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json
+++ b/task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json
@@ -1,0 +1,156 @@
+{
+  "id": "TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK",
+  "project": "dopemux-mvp",
+  "target": "Install a Codex operator runbook and reusable Codex prompt pack for Dopemux macro-packet development with minimal operator actions and explicit proof gates.",
+  "invariants": [
+    "Do not modify runtime code, service code, tests, compose files, dependency files, or provider configuration.",
+    "Do not duplicate or weaken AGENTS.md authority.",
+    "Do not invent Codex behavior beyond official docs or observed repo behavior.",
+    "Preserve one macro-packet per meaningful outcome.",
+    "Do not add permanent three-agent theater as default workflow."
+  ],
+  "depends_on": [
+    "TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-CODEX-REFRESH-001",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-codex-refresh-002-operator-runbook",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "docs(governance): add Codex operator runbook and prompt pack",
+    "allowlist": [
+      "docs/02-how-to/codex-operator-runbook.md",
+      "docs/03-reference/governance/codex-prompt-pack.md",
+      "task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json",
+      "proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json >/dev/null",
+      "python scripts/docs_validator.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md",
+      "python scripts/docs_frontmatter_guard.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md",
+      "git diff --check",
+      "git diff --cached --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(governance): add Codex operator runbook and prompt pack",
+    "body": "## Summary\n- Adds a Dopemux Codex operator runbook.\n- Adds reusable Codex prompts for packet execution, PR review, same-packet fix, and proof return.\n- Keeps Codex as bounded implementer/reviewer, not authority.\n\n## Scope\nDocumentation, generated task packet, and proof only.\n\n## Validation\nInclude exact command outputs and exit codes.\n\n## NOT_RUN\n- Runtime/service validation\n- Docker startup\n- Live provider calls\n- Live extraction\n\n## Residual Risks / UNKNOWNs\nList unresolved setup assumptions.\n\n@codex review",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight TP 001 state, authority docs, and current branch.",
+      "context_files": [
+        "AGENTS.md",
+        "docs/03-reference/governance/codex-authority-refresh.md",
+        "docs/03-reference/governance/codex-refresh-gap-register.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ],
+      "commands": [
+        "git remote -v",
+        "git branch --show-current",
+        "git status --short",
+        "test -f docs/03-reference/governance/codex-authority-refresh.md",
+        "test -f docs/03-reference/governance/codex-refresh-gap-register.md"
+      ],
+      "validation": [
+        "TP 001 files must exist on the working base or the packet must stop and report missing dependency.",
+        "Working branch must be dedicated to TP 002."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Create this packet JSON at task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json.",
+      "expected_files": [
+        "task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json"
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Author docs/02-how-to/codex-operator-runbook.md.",
+      "requirements": [
+        "Include setup checklist for Codex cloud environment.",
+        "Include minimal operator workflow: assign TP, wait for PR/proof, paste proof to supervisor, same-packet fixes only, merge only after acceptance.",
+        "Include environment guidance: no secrets, internet off during agent phase unless explicit task needs it, setup script only for dependency install.",
+        "Include branch/PR/proof requirements.",
+        "Include prohibition on runtime/provider/live extraction without explicit TP authorization."
+      ],
+      "expected_files": [
+        "docs/02-how-to/codex-operator-runbook.md"
+      ],
+      "validation": [
+        "rg -n \"Codex cloud|AGENTS.md|proof|Task Packet|same-packet|UNKNOWN|no secrets|live extraction\" docs/02-how-to/codex-operator-runbook.md"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Author docs/03-reference/governance/codex-prompt-pack.md.",
+      "requirements": [
+        "Include master Codex packet execution prompt.",
+        "Include Codex PR review comment prompt using @codex review.",
+        "Include same-packet fix prompt.",
+        "Include proof-return template.",
+        "Include stop conditions.",
+        "Include risk triggers for independent review.",
+        "State that Codex is bounded implementer/reviewer, not PM/memory/retrieval/bridge/agent authority."
+      ],
+      "expected_files": [
+        "docs/03-reference/governance/codex-prompt-pack.md"
+      ],
+      "validation": [
+        "rg -n \"@codex review|same-packet|proof-return|STOP|bounded implementer|authority\" docs/03-reference/governance/codex-prompt-pack.md"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Create proof JSON with exact commands, exit codes, changed files, NOT_RUN items, residual risks, and UNKNOWNs.",
+      "expected_files": [
+        "proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json"
+      ],
+      "validation": [
+        "python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json >/dev/null"
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Run final validation, inspect diff, commit, push, and open PR.",
+      "validation": [
+        "python scripts/docs_validator.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md",
+        "python scripts/docs_frontmatter_guard.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md",
+        "git diff --check",
+        "git diff --cached --check",
+        "git diff --stat",
+        "git status --short"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a Dopemux Codex operator runbook.
- Adds reusable Codex prompts for packet execution, PR review, same-packet fix, and proof return.
- Keeps Codex as bounded implementer/reviewer, not authority.

## Scope
Documentation, generated task packet, and proof only.

## Validation
- `python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json >/dev/null` -> exit 0, stdout empty.
- `python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` -> exit 0, stdout: jsonschema CLI deprecation warning only.
- `python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json >/dev/null` -> exit 0, stdout empty.
- `python scripts/docs_validator.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md` -> exit 0, stdout empty.
- `python scripts/docs_frontmatter_guard.py docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md` -> exit 0, stdout: `All docs have valid frontmatter.`
- `git diff --check` -> exit 0, stdout empty.
- `git diff --cached --check` -> exit 0, stdout empty before commit.
- `pre-commit run --files docs/02-how-to/codex-operator-runbook.md docs/03-reference/governance/codex-prompt-pack.md task-packets/generated/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json proof/codex-refresh/TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK/PROOF.json` -> exit 0; docs/frontmatter/placement/root hygiene/markdownlint/trailing whitespace/EOF hooks passed; UPGRADES and YAML hooks skipped where no files applied.

## Diff Stat
```text
 docs/02-how-to/codex-operator-runbook.md           | 112 +++++++++
 docs/03-reference/governance/codex-prompt-pack.md  | 194 +++++++++++++++
 .../PROOF.json                                     | 277 +++++++++++++++++++++
 .../TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK.json | 156 ++++++++++++
 4 files changed, 739 insertions(+)
```

## NOT_RUN
- Runtime/service validation
- Docker startup
- Live provider calls
- Live extraction
- Live preflight
- Account-specific checks
- Secret inspection

## Residual Risks / UNKNOWNs
- Static docs validation does not prove runtime service health.
- Codex product UI and environment controls can drift; current official Codex docs/UI remain product authority.
- Repo-wide agent runtime authority remains UNKNOWN per TP 001.
- Task-orchestrator and several memory/authority surfaces remain CONFLICTING per TP 001.

@codex review