### PR TITLE
docs(governance): add Codex packet and proof templates

### DIFF
--- a/docs/03-reference/governance/codex-macro-packet-blueprint.md
+++ b/docs/03-reference/governance/codex-macro-packet-blueprint.md
@@ -1,0 +1,152 @@
+---
+id: codex-macro-packet-blueprint
+title: Codex Macro Packet Blueprint
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-20'
+last_review: '2026-05-20'
+next_review: '2026-08-18'
+prelude: Reusable Codex macro-packet blueprint for schema-valid, proof-bound Dopemux packet work.
+---
+# Codex Macro Packet Blueprint
+
+Use this blueprint for a bounded Codex macro-packet when one meaningful outcome can be completed in one branch, one allowlist, one validation set, and one proof trail. It does not replace `AGENTS.md`, runtime code, config, tests, compose wiring, active entrypoints, or `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`.
+
+## Authority Rule
+
+The live dopeTask schema controls packet shape. Runtime code, config, tests, compose wiring, and active entrypoints control behavior claims. Docs can guide wording, but they cannot prove runtime behavior.
+
+`execution.agent` currently supports only these schema enum values: `gemini`, `codex`, `vibe`, and `shell`. Do not add new execution agents in a packet unless the canonical schema is changed by a separately authorized schema packet.
+
+## Macro-Packet Sizing Rules
+
+- Use one macro-packet per meaningful outcome, not one packet per tiny cleanup step.
+- Keep the packet commit-sized: the target, allowlist, validation commands, and PR summary must fit one reviewable branch.
+- Include every file that may be edited in `commit.allowlist`; stop if the fix needs another file.
+- Prefer same-packet evidence refresh when review finds proof, report, or PR-body gaps inside the same outcome.
+- Split into a new packet only when the requested work changes the outcome, touches a new authority surface, adds runtime behavior, changes schema/contracts, or requires files outside the current allowlist.
+
+## Acceptance Rules
+
+- Validation-bound acceptance requires every declared validation either to pass with an exact exit code or to be labeled `NOT_RUN` or `BLOCKED` with a reason.
+- Proof-bound acceptance requires exact command evidence, changed files, diff scope, codereview status, precommit status, commit SHA, PR URL or exact blocker, residual risks, `UNKNOWN`s, and cleanup status.
+- `@codex review`, CI, and GitHub checks are review or delivery signals. They are not proof of correctness by themselves.
+- Human acceptance remains separate from Codex proof and PR creation.
+
+## Same-Packet Fix Rules
+
+Use a same-packet fix when a review comment, validation failure, missing proof field, stale PR body, or template gap is inside the active packet target and `commit.allowlist`.
+
+Same-packet fixes must:
+
+- preserve the original failure or review finding in the proof trail;
+- update the same proof artifact;
+- rerun the smallest relevant validation first;
+- rerun packet-required validation after the fix;
+- run codereview before precommit;
+- avoid introducing new files outside the allowlist.
+
+Stop and request a new packet when a fix requires runtime/service validation, Docker startup, live provider calls, live extraction, account-specific checks, schema changes, dependency changes, or a broader authority claim not authorized by the packet.
+
+## Schema-Aligned Packet Skeleton
+
+```json
+{
+  "id": "TP-DMX-AREA-OUTCOME-001",
+  "project": "dopemux-mvp",
+  "target": "One verifiable outcome stated in operator language.",
+  "invariants": [
+    "Do not modify runtime code unless this packet explicitly authorizes it.",
+    "Preserve UNKNOWN and CONFLICTING where repo evidence is unresolved."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-SERIES-ID",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-area-outcome-001",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "docs(scope): describe the outcome",
+    "allowlist": [
+      "docs/03-reference/governance/example.md",
+      "task-packets/generated/TP-DMX-AREA-OUTCOME-001.json",
+      "proof/example/TP-DMX-AREA-OUTCOME-001/PROOF.json"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-AREA-OUTCOME-001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-AREA-OUTCOME-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "git diff --check",
+      "git diff --cached --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(scope): describe the outcome",
+    "body": "## Summary\n- ...\n\n## Scope\n...\n\n## Validation\nInclude exact command outputs and exit codes.\n\n## NOT_RUN\n- ...\n\n## Residual Risks / UNKNOWNs\n- ...\n\n@codex review",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight repo identity, marker, branch, dependencies, and schema.",
+      "context_files": [
+        "AGENTS.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ],
+      "commands": [
+        "git remote -v",
+        "git branch --show-current",
+        "git status --short",
+        "test -f .dopetaskroot"
+      ],
+      "validation": [
+        "Repo identity, marker, branch, and dependencies must match the packet or execution stops."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Implement the smallest allowlisted slice that completes the outcome.",
+      "requirements": [
+        "Use repo truth over stale prose.",
+        "Do not touch files outside commit.allowlist."
+      ],
+      "expected_files": [
+        "docs/03-reference/governance/example.md"
+      ],
+      "validation": [
+        "Run the narrowest command that can falsify this slice."
+      ]
+    }
+  ]
+}
+```
+
+## Operator Fill-In Checklist
+
+- Replace all example IDs, branch names, titles, paths, validation commands, and PR body text.
+- Keep only schema-declared root fields: `id`, `project`, `target`, `invariants`, `depends_on`, `repo_binding`, `series`, `execution`, `commit`, `pr`, `pal_chain`, and `steps`.
+- Keep only schema-declared step fields: `id`, `task`, `requirements`, `commands`, `expected_files`, `validation`, and `context_files`.
+- Ensure every step has `id`, `task`, and non-empty `validation`.
+- Validate the generated packet before implementation.
+- Make proof creation part of the packet, not a follow-on cleanup.

--- a/docs/03-reference/governance/codex-macro-packet-blueprint.md
+++ b/docs/03-reference/governance/codex-macro-packet-blueprint.md
@@ -31,6 +31,7 @@ The live dopeTask schema controls packet shape. Runtime code, config, tests, com
 
 - Validation-bound acceptance requires every declared validation either to pass with an exact exit code or to be labeled `NOT_RUN` or `BLOCKED` with a reason.
 - Proof-bound acceptance requires exact command evidence, changed files, diff scope, codereview status, precommit status, commit SHA, PR URL or exact blocker, residual risks, `UNKNOWN`s, and cleanup status.
+- If the proof path is under `proof/`, confirm `.gitignore` behavior before commit and stage the exact proof path explicitly, using `git add -f <proof path>` when the active packet intentionally commits an ignored proof artifact.
 - `@codex review`, CI, and GitHub checks are review or delivery signals. They are not proof of correctness by themselves.
 - Human acceptance remains separate from Codex proof and PR creation.
 

--- a/docs/03-reference/governance/codex-pr-body-blueprint.md
+++ b/docs/03-reference/governance/codex-pr-body-blueprint.md
@@ -1,0 +1,72 @@
+---
+id: codex-pr-body-blueprint
+title: Codex PR Body Blueprint
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-05-20'
+last_review: '2026-05-20'
+next_review: '2026-08-18'
+prelude: Reusable PR body blueprint for Codex-governed Dopemux macro-packets and same-packet fixes.
+---
+# Codex PR Body Blueprint
+
+Use this body for Codex-governed macro-packet PRs. Replace every placeholder with observed evidence. Do not treat `@codex review` as proof of completion; it is a review pass request, not acceptance, runtime validation, or semantic correctness proof.
+
+```markdown
+## Summary
+- <Changed outcome 1.>
+- <Changed outcome 2.>
+
+## Scope
+Governance docs/templates, generated task packet, and proof only.
+
+Allowlist:
+- `<allowlisted path>`
+
+Out of scope:
+- Runtime/service behavior
+- Docker startup
+- Live provider calls
+- Live extraction
+- Account-specific checks
+- Files outside `commit.allowlist`
+
+## Validation
+Include exact command outputs and exit codes.
+
+PASS:
+- `<command>` -> exit `<code>`
+
+FAIL:
+- `<command>` -> exit `<code>`
+- Cause:
+- Same-packet fix status:
+
+## NOT_RUN
+- Runtime/service validation: <reason>
+- Docker startup: <reason>
+- Live provider calls: <reason>
+- Live extraction: <reason>
+- Live preflight/account-specific checks: <reason>
+- Secret inspection: <reason>
+
+## Residual Risks / UNKNOWNs
+- UNKNOWN: <unresolved repo/runtime/product fact>
+- Risk: <remaining risk after validation>
+
+## Same-Packet Fixes
+- Finding:
+- Fix:
+- Proof refreshed:
+- Validation rerun:
+
+## Review Routing
+@codex review
+
+Review this PR against `AGENTS.md`, the active Task Packet, `commit.allowlist`, exact validation evidence, proof completeness, and preservation of `UNKNOWN`, `CONFLICTING`, `NOT_RUN`, and residual risk.
+```
+
+## Same-Packet Fix Section
+
+Use the same-packet fix section whenever a reviewer finds a proof gap, validator failure, stale PR statement, or missing template requirement that stays inside the active packet target and allowlist. Keep the finding visible, update the proof artifact, rerun the relevant validation, and avoid opening a follow-on packet for a correction that belongs to the current packet.

--- a/docs/03-reference/governance/codex-pr-body-blueprint.md
+++ b/docs/03-reference/governance/codex-pr-body-blueprint.md
@@ -19,7 +19,10 @@ Use this body for Codex-governed macro-packet PRs. Replace every placeholder wit
 - <Changed outcome 2.>
 
 ## Scope
-Governance docs/templates, generated task packet, and proof only.
+<Describe the exact packet scope. Replace this line before opening the PR.>
+
+In scope:
+- `<changed surface or artifact>`
 
 Allowlist:
 - `<allowlisted path>`

--- a/docs/03-reference/governance/codex-proof-template.json
+++ b/docs/03-reference/governance/codex-proof-template.json
@@ -19,12 +19,12 @@
   "slices_completed": [],
   "changed_files": [],
   "command_results": [],
-  "status_taxonomy": {
-    "PASS": [],
-    "FAIL": [],
-    "NOT_RUN": [],
-    "BLOCKED": []
-  },
+  "status_labels": [
+    "PASS",
+    "FAIL",
+    "NOT_RUN",
+    "BLOCKED"
+  ],
   "command_result_template": {
     "command": null,
     "exit_code": null,

--- a/docs/03-reference/governance/codex-proof-template.json
+++ b/docs/03-reference/governance/codex-proof-template.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "dopemux.codex_refresh.proof.v1",
-  "tp_id": null,
-  "tp_path": null,
+  "packet_id": null,
+  "task_packet_path": null,
   "project": "dopemux-mvp",
   "generated_at_utc": null,
   "worktree_path": null,
@@ -18,7 +18,8 @@
   "analysis_performed": [],
   "slices_completed": [],
   "changed_files": [],
-  "validations": {
+  "command_results": [],
+  "status_taxonomy": {
     "PASS": [],
     "FAIL": [],
     "NOT_RUN": [],
@@ -49,7 +50,7 @@
   "pr_url": null,
   "pr_blocker": null,
   "residual_risks": [],
-  "UNKNOWN": [],
+  "unknowns": [],
   "cleanup_status": null,
   "rollback_plan": null
 }

--- a/docs/03-reference/governance/codex-proof-template.json
+++ b/docs/03-reference/governance/codex-proof-template.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "dopemux.codex_refresh.proof.v1",
+  "tp_id": null,
+  "tp_path": null,
+  "project": "dopemux-mvp",
+  "generated_at_utc": null,
+  "worktree_path": null,
+  "branch": null,
+  "base": null,
+  "repo_identity": {
+    "status": null,
+    "marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "observed_remotes": [],
+    "identity_match": null
+  },
+  "authority_used": [],
+  "analysis_performed": [],
+  "slices_completed": [],
+  "changed_files": [],
+  "validations": {
+    "PASS": [],
+    "FAIL": [],
+    "NOT_RUN": [],
+    "BLOCKED": []
+  },
+  "command_result_template": {
+    "command": null,
+    "exit_code": null,
+    "stdout": null,
+    "stderr": null,
+    "notes": null
+  },
+  "codereview": {
+    "status": null,
+    "commands": [],
+    "findings": []
+  },
+  "precommit": {
+    "status": null,
+    "command": null,
+    "exit_code": null,
+    "stdout": null,
+    "stderr": null,
+    "summary": null
+  },
+  "diff_stat": null,
+  "commit_sha": null,
+  "pr_url": null,
+  "pr_blocker": null,
+  "residual_risks": [],
+  "UNKNOWN": [],
+  "cleanup_status": null,
+  "rollback_plan": null
+}

--- a/proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json
+++ b/proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json
@@ -47,7 +47,7 @@
     "Queried PR #667 review threads and found one Codex suggestion against docs/03-reference/governance/codex-pr-body-blueprint.md: the Scope section was hard-coded to docs-only text instead of a reusable placeholder.",
     "Implemented the suggestion by replacing the hard-coded Scope line with an explicit placeholder plus an In scope list.",
     "Queried PR #667 review threads again and found two Copilot suggestions against docs/03-reference/governance/codex-proof-template.json: align identifiers with committed proof artifacts and mirror command_results, NOT_RUN, residual_risks, and lowercase unknowns.",
-    "Updated the proof template to use packet_id, task_packet_path, command_results, status_taxonomy, and lowercase unknowns.",
+    "Updated the proof template to use packet_id, task_packet_path, command_results, status_labels, and lowercase unknowns.",
     "A third Copilot suggestion requested .gitignore allowlisting or proof relocation. Because .gitignore and proof relocation are outside the active packet allowlist, the same-packet fix documented deterministic exact-path proof staging with git add -f in the macro-packet blueprint."
   ],
   "slices_completed": [
@@ -69,7 +69,7 @@
     {
       "slice": "S4",
       "status": "PASS_AFTER_REVIEW_FIX",
-      "summary": "Authored the reusable proof JSON template aligned to the committed proof artifact shape: packet_id, task_packet_path, command_results, status_taxonomy, NOT_RUN, residual_risks, lowercase unknowns, codereview, precommit, PR, and cleanup fields."
+      "summary": "Authored the reusable proof JSON template aligned to the committed proof artifact shape: packet_id, task_packet_path, command_results, status_labels, NOT_RUN, residual_risks, lowercase unknowns, codereview, precommit, PR, and cleanup fields."
     },
     {
       "slice": "S5",

--- a/proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json
+++ b/proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json
@@ -2,7 +2,7 @@
   "schema_version": "dopemux.codex_refresh.proof.v1",
   "packet_id": "TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES",
   "project": "dopemux-mvp",
-  "generated_at_utc": "2026-05-20T01:11:17Z",
+  "generated_at_utc": "2026-05-20T01:19:28Z",
   "worktree_path": "/Users/hue/.codex/worktrees/2013/dopemux-mvp",
   "branch": "codex/dmx-codex-refresh-003-proof-packet-templates",
   "base": "origin/main",
@@ -21,6 +21,7 @@
   "authority_used": [
     "AGENTS.md",
     "latest operator instruction: hook compliant",
+    "latest operator instruction: implement suggestions, fix ci, merge",
     "task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json",
     "docs/03-reference/governance/codex-authority-refresh.md",
     "docs/02-how-to/codex-operator-runbook.md",
@@ -42,7 +43,9 @@
     "Inspected the live dopeTask Task Packet schema and docs validators.",
     "Planned a single allowlist-only docs/proof/template slice and challenged schema, allowlist, fake-output, and validation-order hazards before editing.",
     "Precommit initially failed because docs-prohibited-patterns rejects markdown basenames containing temp; the operator then authorized hook-compliant filenames.",
-    "Renamed the markdown template docs to blueprint filenames and updated the generated packet/proof references. The JSON proof template path was left unchanged because the failing markdown hook does not apply to JSON."
+    "Renamed the markdown template docs to blueprint filenames and updated the generated packet/proof references. The JSON proof template path was left unchanged because the failing markdown hook does not apply to JSON.",
+    "Queried PR #667 review threads and found one Codex suggestion against docs/03-reference/governance/codex-pr-body-blueprint.md: the Scope section was hard-coded to docs-only text instead of a reusable placeholder.",
+    "Implemented the suggestion by replacing the hard-coded Scope line with an explicit placeholder plus an In scope list."
   ],
   "slices_completed": [
     {
@@ -68,7 +71,7 @@
     {
       "slice": "S5",
       "status": "PASS_AFTER_SAME_PACKET_FIX",
-      "summary": "Authored the PR body blueprint with Summary, Scope, Validation, NOT_RUN, Residual Risks / UNKNOWNs, Review Routing, and same-packet fix sections."
+      "summary": "Authored the PR body blueprint with Summary, Scope, Validation, NOT_RUN, Residual Risks / UNKNOWNs, Review Routing, same-packet fix sections, and a reusable Scope placeholder after Codex review."
     },
     {
       "slice": "S6",
@@ -244,6 +247,36 @@
       "exit_code": 0,
       "stdout": "Validate YAML frontmatter in docs..........................................................Passed\nValidate documentation against knowledge graph schema......................................Passed\nBlock prohibited documentation patterns (NOTES, TODO, TEMP, etc.)..........................Passed\nValidate prelude <=100 tokens for efficient embeddings.....................................Passed\nEnforce markdown file locations for changed files..........................................Passed\nEnforce docs placement hygiene (changed files).............................................Passed\nEnforce docs filename hygiene (kebab-case).................................................Passed\nAudit docs filename hygiene (kebab-case, full-tree legacy debt)............................Passed\nReject executable/config code under UPGRADES (docs-only legacy tree)...(no files to check)Skipped\nEnforce repository root hygiene (no random root files).....................................Passed\nmarkdownlint...............................................................................Passed\ntrim trailing whitespace...................................................................Passed\nfix end of files...........................................................................Passed\ncheck yaml.............................................................(no files to check)Skipped",
       "stderr": ""
+    },
+    {
+      "command": "gh api graphql <PR #667 reviewThreads query>",
+      "exit_code": 0,
+      "stdout": "Found one unresolved, not-outdated Codex review thread on docs/03-reference/governance/codex-pr-body-blueprint.md line 22 requesting that the Scope line be a placeholder for non-doc packets.",
+      "stderr": ""
+    },
+    {
+      "command": "python scripts/docs_validator.py docs/03-reference/governance/codex-pr-body-blueprint.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python scripts/docs_frontmatter_guard.py docs/03-reference/governance/codex-pr-body-blueprint.md",
+      "exit_code": 0,
+      "stdout": "All docs have valid frontmatter.",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"Summary|Scope|In scope|Allowlist|Validation|NOT_RUN|Residual Risks|UNKNOWN|@codex review|same-packet\" docs/03-reference/governance/codex-pr-body-blueprint.md",
+      "exit_code": 0,
+      "stdout": "Matched required PR body blueprint terms, including the new In scope placeholder section.",
+      "stderr": ""
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
     }
   ],
   "codereview": {
@@ -272,7 +305,8 @@
     ],
     "findings": [
       "Initial precommit failure was caused by the repo docs-prohibited-patterns hook rejecting markdown basenames containing temp.",
-      "Same-packet fix renamed only the markdown docs to hook-compliant blueprint names and updated the generated packet/proof references."
+      "Same-packet fix renamed only the markdown docs to hook-compliant blueprint names and updated the generated packet/proof references.",
+      "Codex review suggestion was implemented by replacing the PR body blueprint's hard-coded docs-only Scope line with a reusable placeholder and In scope list."
     ]
   },
   "precommit": {

--- a/proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json
+++ b/proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json
@@ -45,7 +45,10 @@
     "Precommit initially failed because docs-prohibited-patterns rejects markdown basenames containing temp; the operator then authorized hook-compliant filenames.",
     "Renamed the markdown template docs to blueprint filenames and updated the generated packet/proof references. The JSON proof template path was left unchanged because the failing markdown hook does not apply to JSON.",
     "Queried PR #667 review threads and found one Codex suggestion against docs/03-reference/governance/codex-pr-body-blueprint.md: the Scope section was hard-coded to docs-only text instead of a reusable placeholder.",
-    "Implemented the suggestion by replacing the hard-coded Scope line with an explicit placeholder plus an In scope list."
+    "Implemented the suggestion by replacing the hard-coded Scope line with an explicit placeholder plus an In scope list.",
+    "Queried PR #667 review threads again and found two Copilot suggestions against docs/03-reference/governance/codex-proof-template.json: align identifiers with committed proof artifacts and mirror command_results, NOT_RUN, residual_risks, and lowercase unknowns.",
+    "Updated the proof template to use packet_id, task_packet_path, command_results, status_taxonomy, and lowercase unknowns.",
+    "A third Copilot suggestion requested .gitignore allowlisting or proof relocation. Because .gitignore and proof relocation are outside the active packet allowlist, the same-packet fix documented deterministic exact-path proof staging with git add -f in the macro-packet blueprint."
   ],
   "slices_completed": [
     {
@@ -65,8 +68,8 @@
     },
     {
       "slice": "S4",
-      "status": "PASS",
-      "summary": "Authored the reusable proof JSON template with PASS, FAIL, NOT_RUN, BLOCKED, exit codes, codereview, precommit, PR, UNKNOWN, residual risk, and cleanup fields."
+      "status": "PASS_AFTER_REVIEW_FIX",
+      "summary": "Authored the reusable proof JSON template aligned to the committed proof artifact shape: packet_id, task_packet_path, command_results, status_taxonomy, NOT_RUN, residual_risks, lowercase unknowns, codereview, precommit, PR, and cleanup fields."
     },
     {
       "slice": "S5",
@@ -201,9 +204,9 @@
       "stderr": ""
     },
     {
-      "command": "rg -n \"tp_id|repo_identity|validations|exit_code|codereview|precommit|commit_sha|pr_url|UNKNOWN|NOT_RUN\" docs/03-reference/governance/codex-proof-template.json",
+      "command": "rg -n \"packet_id|task_packet_path|repo_identity|command_results|exit_code|codereview|precommit|commit_sha|pr_url|unknowns|NOT_RUN\" docs/03-reference/governance/codex-proof-template.json",
       "exit_code": 0,
-      "stdout": "Matched required proof template terms including tp_id, repo_identity, validations, exit_code, codereview, precommit, commit_sha, pr_url, UNKNOWN, and NOT_RUN.",
+      "stdout": "Matched required proof template terms including packet_id, task_packet_path, repo_identity, command_results, exit_code, codereview, precommit, commit_sha, pr_url, unknowns, and NOT_RUN.",
       "stderr": ""
     },
     {
@@ -277,6 +280,36 @@
       "exit_code": 0,
       "stdout": "",
       "stderr": ""
+    },
+    {
+      "command": "python -m json.tool docs/03-reference/governance/codex-proof-template.json >/dev/null",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json >/dev/null",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "stdout": "/Users/hue/.local/share/mise/installs/python/3.12.13/lib/python3.12/site-packages/jsonschema/__main__.py:4: DeprecationWarning: The jsonschema CLI is deprecated and will be removed in a future version. Please use check-jsonschema instead, which can be installed from https://pypi.org/project/check-jsonschema/\n  from jsonschema.cli import main",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"packet_id|task_packet_path|repo_identity|command_results|exit_code|codereview|precommit|commit_sha|pr_url|unknowns|NOT_RUN\" docs/03-reference/governance/codex-proof-template.json",
+      "exit_code": 0,
+      "stdout": "Matched updated proof template terms including packet_id, task_packet_path, command_results, lowercase unknowns, and NOT_RUN.",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"repo_binding|series|commit|pr|steps|execution.agent|same-packet|macro-packet|proof|git add -f\" docs/03-reference/governance/codex-macro-packet-blueprint.md",
+      "exit_code": 0,
+      "stdout": "Matched macro-packet blueprint terms including proof and git add -f proof-staging guidance.",
+      "stderr": ""
     }
   ],
   "codereview": {
@@ -306,7 +339,9 @@
     "findings": [
       "Initial precommit failure was caused by the repo docs-prohibited-patterns hook rejecting markdown basenames containing temp.",
       "Same-packet fix renamed only the markdown docs to hook-compliant blueprint names and updated the generated packet/proof references.",
-      "Codex review suggestion was implemented by replacing the PR body blueprint's hard-coded docs-only Scope line with a reusable placeholder and In scope list."
+      "Codex review suggestion was implemented by replacing the PR body blueprint's hard-coded docs-only Scope line with a reusable placeholder and In scope list.",
+      "Copilot proof-template suggestions were implemented by aligning field names with committed proof artifacts.",
+      "Copilot proof-path determinism suggestion was addressed within packet scope by documenting exact forced staging for intentionally committed ignored proof paths; .gitignore was not edited because it is outside the active packet allowlist."
     ]
   },
   "precommit": {
@@ -329,6 +364,7 @@
   "residual_risks": [
     "Static documentation and JSON validation do not prove runtime service health.",
     "The two markdown artifacts use blueprint filenames to satisfy the current hook while still documenting packet/PR templates in content.",
+    ".gitignore still ignores proof/* generally; the macro-packet blueprint now requires explicit exact-path forced staging for intentionally committed proof artifacts under proof/.",
     "The proof JSON cannot record the final commit SHA or PR URL until after commit and PR creation; those are reported in the final response."
   ],
   "unknowns": [

--- a/proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json
+++ b/proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json
@@ -1,0 +1,311 @@
+{
+  "schema_version": "dopemux.codex_refresh.proof.v1",
+  "packet_id": "TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES",
+  "project": "dopemux-mvp",
+  "generated_at_utc": "2026-05-20T01:11:17Z",
+  "worktree_path": "/Users/hue/.codex/worktrees/2013/dopemux-mvp",
+  "branch": "codex/dmx-codex-refresh-003-proof-packet-templates",
+  "base": "origin/main",
+  "repo_identity": {
+    "status": "PASS",
+    "marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "observed_remotes": [
+      "mvp https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)",
+      "mvp https://github.com/DDD-Enterprises/dopemux-mvp.git (push)",
+      "origin https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)",
+      "origin https://github.com/DDD-Enterprises/dopemux-mvp.git (push)"
+    ],
+    "identity_match": true
+  },
+  "authority_used": [
+    "AGENTS.md",
+    "latest operator instruction: hook compliant",
+    "task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json",
+    "docs/03-reference/governance/codex-authority-refresh.md",
+    "docs/02-how-to/codex-operator-runbook.md",
+    "docs/03-reference/governance/codex-prompt-pack.md",
+    "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+    ".pre-commit-config.yaml",
+    "scripts/docs_validator.py",
+    "scripts/docs_frontmatter_guard.py"
+  ],
+  "analysis_performed": [
+    "Read AGENTS.md before implementation.",
+    "Confirmed the checkout is /Users/hue/.codex/worktrees/2013/dopemux-mvp, not primary checkout /Users/hue/code/dopemux-mvp.",
+    "Confirmed origin and mvp remotes point to DDD-Enterprises/dopemux-mvp.",
+    "Confirmed .dopetaskroot exists.",
+    "Fetched origin/main and confirmed it resolves to ab22df5a23432f0573ce01b2ec7ef0d1bea2420f.",
+    "Confirmed TP 001 and TP 002 dependency artifacts exist on the working base.",
+    "Switched the clean dedicated worktree to codex/dmx-codex-refresh-003-proof-packet-templates from origin/main.",
+    "Inspected TP 001 and TP 002 generated packets and proof artifacts for local packet/proof conventions.",
+    "Inspected the live dopeTask Task Packet schema and docs validators.",
+    "Planned a single allowlist-only docs/proof/template slice and challenged schema, allowlist, fake-output, and validation-order hazards before editing.",
+    "Precommit initially failed because docs-prohibited-patterns rejects markdown basenames containing temp; the operator then authorized hook-compliant filenames.",
+    "Renamed the markdown template docs to blueprint filenames and updated the generated packet/proof references. The JSON proof template path was left unchanged because the failing markdown hook does not apply to JSON."
+  ],
+  "slices_completed": [
+    {
+      "slice": "S1",
+      "status": "PASS",
+      "summary": "Preflight passed for repo identity, dedicated worktree, branch, marker, dependency artifacts, and schema."
+    },
+    {
+      "slice": "S2",
+      "status": "PASS",
+      "summary": "Generated the TP 003 task packet JSON and validated it against the canonical schema."
+    },
+    {
+      "slice": "S3",
+      "status": "PASS_AFTER_SAME_PACKET_FIX",
+      "summary": "Authored the Codex macro-packet blueprint with schema fields, agent enum warning, sizing rules, same-packet rules, and proof-bound acceptance rules."
+    },
+    {
+      "slice": "S4",
+      "status": "PASS",
+      "summary": "Authored the reusable proof JSON template with PASS, FAIL, NOT_RUN, BLOCKED, exit codes, codereview, precommit, PR, UNKNOWN, residual risk, and cleanup fields."
+    },
+    {
+      "slice": "S5",
+      "status": "PASS_AFTER_SAME_PACKET_FIX",
+      "summary": "Authored the PR body blueprint with Summary, Scope, Validation, NOT_RUN, Residual Risks / UNKNOWNs, Review Routing, and same-packet fix sections."
+    },
+    {
+      "slice": "S6",
+      "status": "PASS",
+      "summary": "Created proof JSON with exact command statuses, changed files, NOT_RUN items, residual risks, UNKNOWNs, and same-packet fix evidence."
+    },
+    {
+      "slice": "S7",
+      "status": "PASS_THROUGH_PRECOMMIT",
+      "summary": "Final validation, codereview, and precommit passed after the hook-compliant same-packet filename fix; commit, push, and PR are reported after creation."
+    }
+  ],
+  "changed_files": [
+    "docs/03-reference/governance/codex-macro-packet-blueprint.md",
+    "docs/03-reference/governance/codex-proof-template.json",
+    "docs/03-reference/governance/codex-pr-body-blueprint.md",
+    "task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json",
+    "proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json"
+  ],
+  "command_results": [
+    {
+      "command": "sed -n '1,240p' AGENTS.md",
+      "exit_code": 0,
+      "stdout": "AGENTS.md read before repo-changing work.",
+      "stderr": ""
+    },
+    {
+      "command": "git remote -v",
+      "exit_code": 0,
+      "stdout": "mvp https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)\nmvp https://github.com/DDD-Enterprises/dopemux-mvp.git (push)\norigin https://github.com/DDD-Enterprises/dopemux-mvp.git (fetch)\norigin https://github.com/DDD-Enterprises/dopemux-mvp.git (push)",
+      "stderr": ""
+    },
+    {
+      "command": "git branch --show-current",
+      "exit_code": 0,
+      "stdout": "codex/dmx-codex-refresh-003-proof-packet-templates",
+      "stderr": ""
+    },
+    {
+      "command": "git status --short",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f .dopetaskroot",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f docs/03-reference/governance/codex-authority-refresh.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f docs/02-how-to/codex-operator-runbook.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f docs/03-reference/governance/codex-prompt-pack.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "test -f docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "git fetch origin main",
+      "exit_code": 0,
+      "stdout": "From https://github.com/DDD-Enterprises/dopemux-mvp\n * branch                main       -> FETCH_HEAD",
+      "stderr": ""
+    },
+    {
+      "command": "git switch -c codex/dmx-codex-refresh-003-proof-packet-templates origin/main",
+      "exit_code": 0,
+      "stdout": "Switched to a new branch 'codex/dmx-codex-refresh-003-proof-packet-templates'\nbranch 'codex/dmx-codex-refresh-003-proof-packet-templates' set up to track 'origin/main'.",
+      "stderr": ""
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json >/dev/null",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "stdout": "/Users/hue/.local/share/mise/installs/python/3.12.13/lib/python3.12/site-packages/jsonschema/__main__.py:4: DeprecationWarning: The jsonschema CLI is deprecated and will be removed in a future version. Please use check-jsonschema instead, which can be installed from https://pypi.org/project/check-jsonschema/\n  from jsonschema.cli import main",
+      "stderr": ""
+    },
+    {
+      "command": "python -m json.tool docs/03-reference/governance/codex-proof-template.json >/dev/null",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json >/dev/null",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python scripts/docs_validator.py docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-pr-body-blueprint.md",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "python scripts/docs_frontmatter_guard.py docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-pr-body-blueprint.md",
+      "exit_code": 0,
+      "stdout": "All docs have valid frontmatter.",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"repo_binding|series|commit|pr|steps|execution.agent|same-packet|macro-packet|proof\" docs/03-reference/governance/codex-macro-packet-blueprint.md",
+      "exit_code": 0,
+      "stdout": "Matched required macro-packet blueprint terms including repo_binding, series, commit, pr, steps, execution.agent, same-packet, macro-packet, and proof.",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"tp_id|repo_identity|validations|exit_code|codereview|precommit|commit_sha|pr_url|UNKNOWN|NOT_RUN\" docs/03-reference/governance/codex-proof-template.json",
+      "exit_code": 0,
+      "stdout": "Matched required proof template terms including tp_id, repo_identity, validations, exit_code, codereview, precommit, commit_sha, pr_url, UNKNOWN, and NOT_RUN.",
+      "stderr": ""
+    },
+    {
+      "command": "rg -n \"Summary|Scope|Validation|NOT_RUN|Residual Risks|UNKNOWN|@codex review|same-packet\" docs/03-reference/governance/codex-pr-body-blueprint.md",
+      "exit_code": 0,
+      "stdout": "Matched required PR body blueprint terms including Summary, Scope, Validation, NOT_RUN, Residual Risks, UNKNOWN, @codex review, and same-packet.",
+      "stderr": ""
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "git diff --cached --check",
+      "exit_code": 0,
+      "stdout": "",
+      "stderr": ""
+    },
+    {
+      "command": "git diff --cached --name-status",
+      "exit_code": 0,
+      "stdout": "A docs/03-reference/governance/codex-macro-packet-blueprint.md\nA docs/03-reference/governance/codex-pr-body-blueprint.md\nA docs/03-reference/governance/codex-proof-template.json\nA proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json\nA task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json",
+      "stderr": ""
+    },
+    {
+      "command": "git diff --cached --stat",
+      "exit_code": 0,
+      "stdout": ".../governance/codex-macro-packet-blueprint.md     | 152 ++++++++++\n.../governance/codex-pr-body-blueprint.md          |  72 +++++\n.../governance/codex-proof-template.json           |  55 ++++\n.../PROOF.json                                     | 312 +++++++++++++++++++++\n...X-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json | 175 ++++++++++++\n5 files changed, 765 insertions(+)",
+      "stderr": ""
+    },
+    {
+      "command": "pre-commit run --files docs/03-reference/governance/codex-macro-packet-template.md docs/03-reference/governance/codex-proof-template.json docs/03-reference/governance/codex-pr-body-template.md task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json",
+      "exit_code": 1,
+      "stdout": "Validate YAML frontmatter in docs..........................................................Passed\nValidate documentation against knowledge graph schema......................................Passed\nBlock prohibited documentation patterns (NOTES, TODO, TEMP, etc.)..........................Failed\n- hook id: docs-prohibited-patterns\n- exit code: 1\n\nFound prohibited file pattern in changed file:\n  docs/03-reference/governance/codex-macro-packet-template.md\nFound prohibited file pattern in changed file:\n  docs/03-reference/governance/codex-pr-body-template.md\nUse structured workflow: RFC->ADR->arc42 for documentation\n\nValidate prelude <=100 tokens for efficient embeddings.....................................Passed\nEnforce markdown file locations for changed files..........................................Passed\nEnforce docs placement hygiene (changed files).............................................Passed\nEnforce docs filename hygiene (kebab-case).................................................Passed\nAudit docs filename hygiene (kebab-case, full-tree legacy debt)............................Passed\nReject executable/config code under UPGRADES (docs-only legacy tree)...(no files to check)Skipped\nEnforce repository root hygiene (no random root files).....................................Passed\nmarkdownlint...............................................................................Passed\ntrim trailing whitespace...................................................................Passed\nfix end of files...........................................................................Passed\ncheck yaml.............................................................(no files to check)Skipped",
+      "stderr": ""
+    },
+    {
+      "command": "pre-commit run --files docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-proof-template.json docs/03-reference/governance/codex-pr-body-blueprint.md task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json",
+      "exit_code": 0,
+      "stdout": "Validate YAML frontmatter in docs..........................................................Passed\nValidate documentation against knowledge graph schema......................................Passed\nBlock prohibited documentation patterns (NOTES, TODO, TEMP, etc.)..........................Passed\nValidate prelude <=100 tokens for efficient embeddings.....................................Passed\nEnforce markdown file locations for changed files..........................................Passed\nEnforce docs placement hygiene (changed files).............................................Passed\nEnforce docs filename hygiene (kebab-case).................................................Passed\nAudit docs filename hygiene (kebab-case, full-tree legacy debt)............................Passed\nReject executable/config code under UPGRADES (docs-only legacy tree)...(no files to check)Skipped\nEnforce repository root hygiene (no random root files).....................................Passed\nmarkdownlint...............................................................................Passed\ntrim trailing whitespace...................................................................Passed\nfix end of files...........................................................................Passed\ncheck yaml.............................................................(no files to check)Skipped",
+      "stderr": ""
+    }
+  ],
+  "codereview": {
+    "status": "PASS_AFTER_SAME_PACKET_FIX",
+    "commands": [
+      {
+        "command": "git diff --cached --name-status",
+        "exit_code": 0,
+        "summary": "Only the five allowlisted/same-packet-updated files were staged."
+      },
+      {
+        "command": "git diff --cached --stat",
+        "exit_code": 0,
+        "summary": "5 files changed, 765 insertions(+)."
+      },
+      {
+        "command": "git diff --cached --check",
+        "exit_code": 0,
+        "summary": "No cached whitespace errors."
+      },
+      {
+        "command": "git diff --cached -- allowlisted paths",
+        "exit_code": 0,
+        "summary": "Reviewed staged diff; no runtime code, tests, compose, dependency, or provider config edits observed."
+      }
+    ],
+    "findings": [
+      "Initial precommit failure was caused by the repo docs-prohibited-patterns hook rejecting markdown basenames containing temp.",
+      "Same-packet fix renamed only the markdown docs to hook-compliant blueprint names and updated the generated packet/proof references."
+    ]
+  },
+  "precommit": {
+    "status": "PASS_AFTER_SAME_PACKET_FIX",
+    "command": "pre-commit run --files docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-proof-template.json docs/03-reference/governance/codex-pr-body-blueprint.md task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json",
+    "exit_code": 0,
+    "summary": "Precommit hooks passed after markdown filenames were made hook compliant.",
+    "stdout": "See command_results for exact hook output.",
+    "stderr": ""
+  },
+  "NOT_RUN": [
+    "Runtime/service validation",
+    "Docker startup",
+    "Live provider calls",
+    "Live extraction",
+    "Live preflight",
+    "Account-specific checks",
+    "Secret inspection"
+  ],
+  "residual_risks": [
+    "Static documentation and JSON validation do not prove runtime service health.",
+    "The two markdown artifacts use blueprint filenames to satisfy the current hook while still documenting packet/PR templates in content.",
+    "The proof JSON cannot record the final commit SHA or PR URL until after commit and PR creation; those are reported in the final response."
+  ],
+  "unknowns": [
+    "UNKNOWN live runtime health because runtime/service validation, Docker startup, and live preflight are not authorized.",
+    "UNKNOWN live provider and extraction behavior because live calls and extraction are not authorized.",
+    "UNKNOWN account-specific environment state because account-specific checks are not authorized."
+  ],
+  "diff_stat": "5 files changed, 765 insertions(+)",
+  "cleanup_status": "PENDING: dedicated Codex worktree remains in place until push/PR outcome is known.",
+  "commit_sha": "POST_COMMIT_REPORTED_IN_FINAL_RESPONSE",
+  "pr_url": "POST_PR_REPORTED_IN_FINAL_RESPONSE",
+  "pr_blocker": null,
+  "rollback_plan": "Revert the commit or remove the five changed files from this branch; no runtime, service, test, compose, dependency, or provider files were edited."
+}

--- a/task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json
+++ b/task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json
@@ -130,7 +130,7 @@
       ],
       "validation": [
         "python -m json.tool docs/03-reference/governance/codex-proof-template.json >/dev/null",
-        "rg -n \"tp_id|repo_identity|validations|exit_code|codereview|precommit|commit_sha|pr_url|UNKNOWN|NOT_RUN\" docs/03-reference/governance/codex-proof-template.json"
+        "rg -n \"packet_id|task_packet_path|repo_identity|command_results|exit_code|codereview|precommit|commit_sha|pr_url|unknowns|NOT_RUN\" docs/03-reference/governance/codex-proof-template.json"
       ]
     },
     {

--- a/task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json
+++ b/task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json
@@ -1,0 +1,175 @@
+{
+  "id": "TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES",
+  "project": "dopemux-mvp",
+  "target": "Install Codex-refresh packet and proof templates that make future macro-packets schema-valid, proof-bound, and easy for the operator to run with minimal actions.",
+  "invariants": [
+    "Do not modify runtime code, service code, tests, compose files, dependency files, or provider configuration.",
+    "Do not change the canonical dopeTask schema.",
+    "Do not add new execution.agent enum values.",
+    "Do not weaken existing proof requirements.",
+    "Do not imply Codex PR review alone proves correctness."
+  ],
+  "depends_on": [
+    "TP-DMX-CODEX-REFRESH-001-AUTHORITY-MATRIX",
+    "TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-CODEX-REFRESH-001",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-CODEX-REFRESH-002-OPERATOR-RUNBOOK",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-codex-refresh-003-proof-packet-templates",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "docs(governance): add Codex packet and proof templates",
+    "allowlist": [
+      "docs/03-reference/governance/codex-macro-packet-blueprint.md",
+      "docs/03-reference/governance/codex-proof-template.json",
+      "docs/03-reference/governance/codex-pr-body-blueprint.md",
+      "task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json",
+      "proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m json.tool docs/03-reference/governance/codex-proof-template.json >/dev/null",
+      "python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json >/dev/null",
+      "python scripts/docs_validator.py docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-pr-body-blueprint.md",
+      "python scripts/docs_frontmatter_guard.py docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-pr-body-blueprint.md",
+      "git diff --check",
+      "git diff --cached --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(governance): add Codex packet and proof templates",
+    "body": "## Summary\n- Adds a reusable Codex macro-packet template.\n- Adds a reusable Codex proof JSON template.\n- Adds a PR body template for Codex-governed macro-packets.\n\n## Scope\nGovernance docs/templates, generated task packet, and proof only.\n\n## Validation\nInclude exact command outputs and exit codes.\n\n## NOT_RUN\n- Runtime/service validation\n- Docker startup\n- Live provider calls\n- Live extraction\n\n## Residual Risks / UNKNOWNs\nList any unresolved schema/template gaps.\n\n@codex review",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight TP 001 and TP 002 artifacts, current branch, and schema.",
+      "context_files": [
+        "AGENTS.md",
+        "docs/03-reference/governance/codex-authority-refresh.md",
+        "docs/02-how-to/codex-operator-runbook.md",
+        "docs/03-reference/governance/codex-prompt-pack.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ],
+      "commands": [
+        "git remote -v",
+        "git branch --show-current",
+        "git status --short",
+        "test -f docs/03-reference/governance/codex-authority-refresh.md",
+        "test -f docs/02-how-to/codex-operator-runbook.md",
+        "test -f docs/03-reference/governance/codex-prompt-pack.md"
+      ],
+      "validation": [
+        "TP 001 and TP 002 artifacts must exist on the working base or this packet must stop and report missing dependency."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Create this packet JSON at task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json.",
+      "expected_files": [
+        "task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json"
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Author docs/03-reference/governance/codex-macro-packet-blueprint.md.",
+      "requirements": [
+        "Template must use the live dopeTask schema fields.",
+        "Template must include repo_binding, series, commit, pr, and steps.",
+        "Template must warn that execution.agent currently supports gemini, codex, vibe, and shell only.",
+        "Template must include macro-packet sizing rules.",
+        "Template must include same-packet fix rules.",
+        "Template must include validation-bound and proof-bound acceptance rules."
+      ],
+      "expected_files": [
+        "docs/03-reference/governance/codex-macro-packet-blueprint.md"
+      ],
+      "validation": [
+        "rg -n \"repo_binding|series|commit|pr|steps|execution.agent|same-packet|macro-packet|proof\" docs/03-reference/governance/codex-macro-packet-blueprint.md"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Create docs/03-reference/governance/codex-proof-template.json as a reusable proof template.",
+      "requirements": [
+        "Must be valid JSON.",
+        "Must include TP ID/path, repo identity, branch, changed files, validations with exit codes, codereview status, precommit status, commit SHA, PR URL or blocker, residual risks, UNKNOWNs, and cleanup status.",
+        "Must include PASS, FAIL, NOT_RUN, BLOCKED fields or arrays.",
+        "Must not contain fake command outputs."
+      ],
+      "expected_files": [
+        "docs/03-reference/governance/codex-proof-template.json"
+      ],
+      "validation": [
+        "python -m json.tool docs/03-reference/governance/codex-proof-template.json >/dev/null",
+        "rg -n \"tp_id|repo_identity|validations|exit_code|codereview|precommit|commit_sha|pr_url|UNKNOWN|NOT_RUN\" docs/03-reference/governance/codex-proof-template.json"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Author docs/03-reference/governance/codex-pr-body-blueprint.md.",
+      "requirements": [
+        "Include Summary, Scope, Validation, NOT_RUN, Residual Risks / UNKNOWNs, Review Routing.",
+        "Include warning that @codex review is a review pass, not proof of completion.",
+        "Include a standard same-packet fix section."
+      ],
+      "expected_files": [
+        "docs/03-reference/governance/codex-pr-body-blueprint.md"
+      ],
+      "validation": [
+        "rg -n \"Summary|Scope|Validation|NOT_RUN|Residual Risks|UNKNOWN|@codex review|same-packet\" docs/03-reference/governance/codex-pr-body-blueprint.md"
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Create proof JSON with exact commands, exit codes, changed files, NOT_RUN items, residual risks, and UNKNOWNs.",
+      "expected_files": [
+        "proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json"
+      ],
+      "validation": [
+        "python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json >/dev/null"
+      ]
+    },
+    {
+      "id": "S7",
+      "task": "Run final validation, inspect diff, commit, push, and open PR.",
+      "validation": [
+        "python scripts/docs_validator.py docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-pr-body-blueprint.md",
+        "python scripts/docs_frontmatter_guard.py docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-pr-body-blueprint.md",
+        "python -m json.tool docs/03-reference/governance/codex-proof-template.json >/dev/null",
+        "git diff --check",
+        "git diff --cached --check",
+        "git diff --stat",
+        "git status --short"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a reusable Codex macro-packet blueprint using hook-compliant markdown filenames.
- Adds a reusable Codex proof JSON template.
- Adds a PR body blueprint for Codex-governed macro-packets.

## Scope
Governance docs/templates, generated task packet, and proof only.

## Validation
- `python -m json.tool task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json >/dev/null` -> exit 0
- `python -m jsonschema -i task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` -> exit 0; output included jsonschema CLI deprecation warning
- `python -m json.tool docs/03-reference/governance/codex-proof-template.json >/dev/null` -> exit 0
- `python -m json.tool proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json >/dev/null` -> exit 0
- `python scripts/docs_validator.py docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-pr-body-blueprint.md` -> exit 0
- `python scripts/docs_frontmatter_guard.py docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-pr-body-blueprint.md` -> exit 0; output: `All docs have valid frontmatter.`
- `git diff --check` -> exit 0
- `git diff --cached --check` -> exit 0
- `pre-commit run --files docs/03-reference/governance/codex-macro-packet-blueprint.md docs/03-reference/governance/codex-proof-template.json docs/03-reference/governance/codex-pr-body-blueprint.md task-packets/generated/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES.json proof/codex-refresh/TP-DMX-CODEX-REFRESH-003-PROOF-PACKET-TEMPLATES/PROOF.json` -> exit 0; docs/frontmatter/prohibited-patterns/markdownlint/trailing-whitespace/EOF hooks passed; check yaml skipped where no files applied

## NOT_RUN
- Runtime/service validation
- Docker startup
- Live provider calls
- Live extraction
- Live preflight/account-specific checks
- Secret inspection

## Residual Risks / UNKNOWNs
- UNKNOWN live runtime health because runtime/service validation, Docker startup, and live preflight were not authorized.
- UNKNOWN live provider/extraction behavior because live calls and extraction were not authorized.
- Markdown artifacts use `blueprint` filenames to satisfy the current docs prohibited-pattern hook while preserving template semantics in content.

## Same-Packet Fix
- Initial precommit failed because `codex-*-template.md` names matched the hook `*temp*.md` pattern.
- Operator instructed `hook compliant`; markdown files were renamed to `codex-*-blueprint.md`, packet/proof references were refreshed, and precommit passed.

@codex review