### PR TITLE
feat(governance): add repo preflight workflow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,3 +5,4 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 if [[ -x "$REPO_ROOT/scripts/repo_preflight.sh" ]]; then
   ALLOW_DIRTY=1 "$REPO_ROOT/scripts/repo_preflight.sh" "dopemux-mvp" >/dev/null
 fi
+PREFLIGHT_SKIP_GIT_CLEAN=1 RUN_MODE=enforce "$REPO_ROOT/scripts/preflight.sh"

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,31 @@
+name: preflight
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Run preflight
+        run: |
+          chmod +x ./scripts/preflight.sh
+          RUN_MODE=enforce \
+          TP_ID=CI-PREFLIGHT \
+          ./scripts/preflight.sh

--- a/.gitignore
+++ b/.gitignore
@@ -218,6 +218,9 @@ backup/
 processing_inputs/
 
 # ===================================================================
+
+# Local preflight run manifests
+.runs/
 # Dopemux: Multi-Project Documentation Architecture
 # ===================================================================
 

--- a/config/preflight/ledger.json
+++ b/config/preflight/ledger.json
@@ -1,0 +1,5 @@
+{
+  "ledger_version": "1.0",
+  "repo": "dopemux-mvp",
+  "status": "ACTIVE"
+}

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_ID="${RUN_ID:-run-$(date -u +'%Y%m%d-%H%M%S')}"
+RUN_MODE="${RUN_MODE:-dry-run}"
+TP_ID="${TP_ID:-UNKNOWN-TP}"
+PREFLIGHT_SKIP_GIT_CLEAN="${PREFLIGHT_SKIP_GIT_CLEAN:-0}"
+PREFLIGHT_LEDGER_PATH="${PREFLIGHT_LEDGER_PATH:-config/preflight/ledger.json}"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$REPO_ROOT"
+
+FAILURES=()
+SKIPPED=()
+
+log() {
+  printf '[preflight] %s\n' "$*"
+}
+
+record_failure() {
+  FAILURES+=("$1")
+}
+
+record_skip() {
+  SKIPPED+=("$1")
+}
+
+json_array() {
+  if [[ "$#" -eq 0 ]]; then
+    printf '[]'
+  else
+    printf '%s\n' "$@" | jq -R . | jq -s .
+  fi
+}
+
+next_manifest_path() {
+  local candidate=".runs/${1}.manifest.json"
+  local idx=1
+  while [[ -e "$candidate" ]]; do
+    candidate=".runs/${1}.${idx}.manifest.json"
+    idx=$((idx + 1))
+  done
+  printf '%s\n' "$candidate"
+}
+
+python_syntax_check() {
+  python - <<'PY'
+from pathlib import Path
+import ast
+
+paths = []
+for base in ("src", "tests"):
+    root = Path(base)
+    if root.exists():
+        paths.extend(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+
+for path in sorted(paths):
+    ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+print(f"syntax-ok files={len(paths)}")
+PY
+}
+
+run_smoke_tests() {
+  local pytest_args=(tests/unit/test_extract_local_smoke.py)
+  if [[ -d tests/smoke ]]; then
+    pytest_args=(tests/smoke)
+  fi
+
+  if command -v uv >/dev/null 2>&1; then
+    uv run --frozen --extra test pytest -q --no-cov "${pytest_args[@]}" || return 1
+    uv run --frozen --extra test python - <<'PY'
+from pathlib import Path
+import ast
+
+paths = []
+for base in ("src", "tests"):
+    root = Path(base)
+    if root.exists():
+        paths.extend(p for p in root.rglob("*.py") if "__pycache__" not in p.parts)
+
+for path in sorted(paths):
+    ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+print(f"syntax-ok files={len(paths)}")
+PY
+    return $?
+  fi
+
+  if command -v python >/dev/null 2>&1; then
+    python -m pytest -q --no-cov "${pytest_args[@]}" || return 1
+    python_syntax_check
+    return $?
+  fi
+
+  return 1
+}
+
+mkdir -p .runs
+MANIFEST_PATH="$(next_manifest_path "$RUN_ID")"
+
+log "check: run-mode"
+case "$RUN_MODE" in
+  dry-run|enforce)
+    log "OK: run mode ${RUN_MODE}"
+    ;;
+  *)
+    log "FAIL: invalid RUN_MODE=${RUN_MODE}"
+    record_failure "run-mode"
+    ;;
+esac
+
+log "check: jq-present"
+if command -v jq >/dev/null 2>&1; then
+  log "OK: jq present"
+else
+  log "FAIL: jq missing"
+  record_failure "jq-present"
+fi
+
+log "check: git-clean"
+if [[ "$PREFLIGHT_SKIP_GIT_CLEAN" == "1" ]]; then
+  log "SKIP: git clean disabled for hook context"
+  record_skip "git-clean"
+elif [[ -n "$(git status --porcelain)" ]]; then
+  log "FAIL: worktree not clean"
+  record_failure "git-clean"
+else
+  log "OK: worktree clean"
+fi
+
+log "check: ledger-present"
+if [[ -f "$PREFLIGHT_LEDGER_PATH" ]]; then
+  log "OK: ledger present"
+else
+  log "FAIL: missing ${PREFLIGHT_LEDGER_PATH}"
+  record_failure "ledger-present"
+fi
+
+log "check: ledger-json"
+if [[ -f "$PREFLIGHT_LEDGER_PATH" ]]; then
+  if jq -e . "$PREFLIGHT_LEDGER_PATH" >/dev/null; then
+    log "OK: ledger JSON valid"
+  else
+    log "FAIL: ledger JSON invalid"
+    record_failure "ledger-json"
+  fi
+else
+  log "SKIP: ledger JSON validation requires ${PREFLIGHT_LEDGER_PATH}"
+  record_skip "ledger-json"
+fi
+
+log "check: diff-whitespace"
+if git diff --check && git diff --cached --check; then
+  log "OK: diff whitespace clean"
+else
+  log "FAIL: diff whitespace check failed"
+  record_failure "diff-whitespace"
+fi
+
+log "check: smoke-tests"
+if run_smoke_tests; then
+  log "OK: smoke checks passed"
+else
+  log "FAIL: smoke checks failed"
+  record_failure "smoke-tests"
+fi
+
+STATUS="PASS"
+if [[ "${#FAILURES[@]}" -gt 0 ]]; then
+  STATUS="FAIL"
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  log "manifest not written: jq missing"
+  if [[ "$RUN_MODE" == "enforce" ]]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+failures_json="$(json_array "${FAILURES[@]}")"
+skipped_json="$(json_array "${SKIPPED[@]}")"
+repo_url="$(git config --get remote.origin.url || true)"
+repo_url="${repo_url:-UNKNOWN}"
+branch="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+branch="${branch:-UNKNOWN}"
+commit="$(git rev-parse HEAD 2>/dev/null || true)"
+commit="${commit:-UNKNOWN}"
+
+jq -n \
+  --arg manifest_version "1.0" \
+  --arg run_id "$RUN_ID" \
+  --arg tp_id "$TP_ID" \
+  --arg run_mode "$RUN_MODE" \
+  --arg status "$STATUS" \
+  --argjson failures "$failures_json" \
+  --argjson skipped "$skipped_json" \
+  --arg repo "$repo_url" \
+  --arg branch "$branch" \
+  --arg commit "$commit" \
+  --arg manifest_path "$MANIFEST_PATH" \
+  --arg timestamp_utc "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  '{
+    manifest_version: $manifest_version,
+    run_id: $run_id,
+    tp_id: $tp_id,
+    run_mode: $run_mode,
+    status: $status,
+    failures: $failures,
+    skipped: $skipped,
+    repo: $repo,
+    branch: $branch,
+    commit: $commit,
+    manifest_path: $manifest_path,
+    timestamp_utc: $timestamp_utc
+  }' > "$MANIFEST_PATH"
+
+log "manifest written: ${MANIFEST_PATH}"
+
+if [[ "${#FAILURES[@]}" -gt 0 ]] && [[ "$RUN_MODE" == "enforce" ]]; then
+  exit 1
+fi

--- a/task-packets/TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001.md
+++ b/task-packets/TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001.md
@@ -1,0 +1,118 @@
+---
+id: TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001
+title: Preflight Governance Adoption
+type: explanation
+owner: '@hu3mann'
+author: Codex
+date: '2026-05-23'
+prelude: Task packet for adopting the local preflight hook, CI workflow, ledger,
+  and ignored run manifest path as one bounded governance slice.
+last_review: '2026-05-23'
+next_review: '2026-08-21'
+---
+# Task Packet: TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001 · Governance · Preflight Adoption
+
+## Objective
+
+Adopt the existing uncommitted preflight bundle as a bounded governance/CI slice, preserving deterministic local checks and CI evidence without mutating unrelated repo state.
+
+## Scope
+
+IN:
+
+* Add `scripts/preflight.sh` as the local/CI preflight runner.
+* Add `config/preflight/ledger.json` as the minimal preflight ledger required by the runner.
+* Add `.github/workflows/preflight.yml` to run preflight on pull requests and manual dispatch.
+* Update `.githooks/pre-commit` to invoke preflight in hook-safe mode.
+* Update `.gitignore` to ignore generated `.runs/` manifests.
+* Validate the runner syntax, ledger JSON, ignore behavior, smoke path, and diff hygiene.
+
+OUT:
+
+* No changes to runtime services, Docker wiring, provider credentials, MCP servers, or generated research outputs.
+* No broad test-suite rewrite.
+* No deletion or mutation of the primary checkout dirty state.
+
+## Invariants (Must Remain True)
+
+* Preflight manifests must be generated under `.runs/` and remain ignored.
+* Hook execution must not require a clean worktree because hooks run while files are staged.
+* CI execution must fail closed on missing ledger, invalid ledger JSON, diff whitespace errors, and smoke-test failures.
+* The runner must not print or capture secrets.
+* The primary checkout remains untouched except for the user-existing dirty bundle already classified.
+
+If an invariant appears impossible, stop and report.
+
+## Plan (Numbered)
+
+1. Isolate the existing dirty bundle in a dedicated worktree and create this task packet.
+1. Inspect the preflight runner, hook, workflow, ledger, and ignore entry.
+1. Make only minimal correctness fixes required by validation.
+1. Run syntax, ledger, ignore, dry-run/enforce preflight, diff, and pre-commit validations.
+1. Commit and push the bounded governance slice, then open a PR if validation passes.
+
+## Files to Touch
+
+* `.githooks/pre-commit`
+* `.github/workflows/preflight.yml`
+* `.gitignore`
+* `config/preflight/ledger.json`
+* `scripts/preflight.sh`
+* `task-packets/TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001.md`
+
+If additional files are needed, stop and request approval.
+
+## Exact Commands to Run
+
+* `bash -n scripts/preflight.sh`
+* `jq -e . config/preflight/ledger.json`
+* `git check-ignore -v .runs/example.manifest.json`
+* `PREFLIGHT_SKIP_GIT_CLEAN=1 RUN_MODE=dry-run TP_ID=TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001 ./scripts/preflight.sh`
+* `PREFLIGHT_SKIP_GIT_CLEAN=1 RUN_MODE=enforce TP_ID=TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001 ./scripts/preflight.sh`
+* `git diff --check`
+* `pre-commit run --files .githooks/pre-commit .github/workflows/preflight.yml .gitignore config/preflight/ledger.json scripts/preflight.sh task-packets/TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001.md`
+* `git status --short`
+
+## Output Capture Rules (Verbatim)
+
+Implementer must return:
+
+* `git diff --stat`
+* `git diff`
+* Command outputs verbatim
+* Exit codes
+* Any generated `.runs/` manifest paths
+* Any blockers or skipped validations
+
+## Acceptance Criteria
+
+* The preflight runner passes shell syntax validation.
+* `config/preflight/ledger.json` is valid JSON.
+* `.runs/` is ignored.
+* Preflight dry-run and enforce modes pass with `PREFLIGHT_SKIP_GIT_CLEAN=1`.
+* Targeted pre-commit checks pass for the touched files.
+* Diff scope is limited to the task packet allowlist.
+
+## Rollback Steps
+
+* Delete `.github/workflows/preflight.yml`.
+* Delete `config/preflight/ledger.json`.
+* Delete `scripts/preflight.sh`.
+* Delete `task-packets/TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001.md`.
+* Revert `.githooks/pre-commit`.
+* Revert `.gitignore`.
+
+## STOP CONDITIONS
+
+Stop immediately if:
+
+* Preflight requires live provider credentials or network/provider validation.
+* The smoke path requires broad unrelated source changes.
+* Hook execution cannot be made deterministic without expanding scope.
+* Secrets appear in generated manifests or command output.
+
+If stopped, return:
+
+* What you attempted
+* Evidence collected
+* What output is needed next


### PR DESCRIPTION
## Summary
- add a bounded repo preflight runner for local hook and CI use
- add a preflight workflow, config-scoped ledger, ignored .runs manifests, and task packet
- update the local pre-commit hook to run preflight in hook-safe mode

## Validation
- bash -n scripts/preflight.sh
- jq -e . config/preflight/ledger.json
- git check-ignore -v .runs/example.manifest.json
- PREFLIGHT_SKIP_GIT_CLEAN=1 RUN_MODE=dry-run TP_ID=TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001 ./scripts/preflight.sh
- PREFLIGHT_SKIP_GIT_CLEAN=1 RUN_MODE=enforce TP_ID=TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001 ./scripts/preflight.sh
- git diff --check
- pre-commit run --files .githooks/pre-commit .github/workflows/preflight.yml .gitignore config/preflight/ledger.json scripts/preflight.sh task-packets/TP-DMX-PREFLIGHT-GOVERNANCE-ADOPTION-001.md
- git commit hook preflight run passed

## Notes
- Moved the original dirty 00/LEDGER.json concept to config/preflight/ledger.json to satisfy root hygiene.
- Generated .runs manifests and .venv are ignored.
- Existing Dependabot vulnerabilities on default branch are outside this PR.

@codex review
@gemini
@copilot