### PR TITLE
fix(rte): harden secret redaction and env variant excludes

### DIFF
--- a/services/repo-truth-extractor/lib/prescan/models.py
+++ b/services/repo-truth-extractor/lib/prescan/models.py
@@ -80,8 +80,12 @@ DEFAULT_OPERATOR_LOCAL_EXCLUDE_GLOBS = (
 DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS = (
     ".env",
     ".env.*",
+    ".env-*",
+    ".env_*",
     "**/.env",
     "**/.env.*",
+    "**/.env-*",
+    "**/.env_*",
     "*.pem",
     "**/*.pem",
     "*.key",

--- a/services/repo-truth-extractor/output_safety.py
+++ b/services/repo-truth-extractor/output_safety.py
@@ -7,7 +7,7 @@ from typing import Any, Mapping, Sequence
 
 _SECRET_QUERY_RE = re.compile(r"([?&](?:key|api[_-]?key|token|access[_-]?token|secret)=)[^&\s]+", re.IGNORECASE)
 _SECRET_ASSIGN_RE = re.compile(
-    r"(?i)((?:[\"']?\b(?:api[_-]?key|bearer|token|secret|password|private[_-]?key|webhook[_-]?secret)\b[\"']?\s*[:=]\s*)[\"']?)([^\"',\s\]}]+)([\"']?)"
+    r"(?i)((?:[\"']?([A-Za-z_][A-Za-z0-9_-]*)[\"']?\s*[:=]\s*)[\"']?)([^\"',\s\]\}\[]+)([\"']?)"
 )
 _BEARER_INLINE_RE = re.compile(r"(?i)(\bBearer\s+)([^\s,;]+)")
 _AUTH_HEADER_RE = re.compile(
@@ -89,10 +89,16 @@ def sanitize_text_for_output(text: str) -> str:
     value = _PRIVATE_KEY_BLOCK_RE.sub("[REDACTED PRIVATE KEY]", value)
     value = _SECRET_QUERY_RE.sub(r"\1REDACTED", value)
     value = _AUTH_HEADER_RE.sub(r"\1[REDACTED]\3", value)
-    value = _SECRET_ASSIGN_RE.sub(r"\1[REDACTED]\3", value)
+    value = _SECRET_ASSIGN_RE.sub(_redact_secret_assignment, value)
     value = _BEARER_INLINE_RE.sub(r"\1[REDACTED]", value)
     value = _PROVIDER_TOKEN_RE.sub("[REDACTED]", value)
     return value
+
+
+def _redact_secret_assignment(match: re.Match[str]) -> str:
+    if not _is_sensitive_key(match.group(2)):
+        return match.group(0)
+    return f"{match.group(1)}[REDACTED]{match.group(4)}"
 
 
 def sanitize_failed_sidecar_text(text: str) -> str:

--- a/services/repo-truth-extractor/output_safety.py
+++ b/services/repo-truth-extractor/output_safety.py
@@ -5,9 +5,11 @@ import re
 from pathlib import Path
 from typing import Any, Mapping, Sequence
 
-_SECRET_QUERY_RE = re.compile(r"([?&](?:key|api[_-]?key|token|access[_-]?token|secret)=)[^&\s]+", re.IGNORECASE)
+_SECRET_QUERY_RE = re.compile(
+    r"([?&](?:key|api[_-]?key|token|access[_-]?token|secret)=)[^&\s]+", re.IGNORECASE
+)
 _SECRET_ASSIGN_RE = re.compile(
-    r"(?i)((?:[\"']?([A-Za-z_][A-Za-z0-9_-]*)[\"']?\s*[:=]\s*)[\"']?)([^\"',\s\]\}\[]+)([\"']?)"
+    r"(?i)((?:[\"']?([A-Za-z_][A-Za-z0-9_-]*)[\"']?\s*[:=]\s*)[\"']?)([^\"',\s\]\}]+)([\"']?)"
 )
 _BEARER_INLINE_RE = re.compile(r"(?i)(\bBearer\s+)([^\s,;]+)")
 _AUTH_HEADER_RE = re.compile(
@@ -64,18 +66,51 @@ _SAFE_SENSITIVE_KEYS = {
 
 
 def _is_sensitive_key(key: Any) -> bool:
-    token = str(key or "").strip().lower()
+    token = str(key or "").strip().lower().replace("-", "_")
     if not token or token in _SAFE_SENSITIVE_KEYS:
         return False
-    if token.endswith(("_env", "_envs", "_env_name", "_env_requested", "_env_resolved", "_present", "_set", "_sha256", "_signature", "_bytes", "_count", "_counts", "_seconds", "_ms", "_tokens", "_token_limit")):
+    if token.endswith(
+        (
+            "_env",
+            "_envs",
+            "_env_name",
+            "_env_requested",
+            "_env_resolved",
+            "_present",
+            "_set",
+            "_sha256",
+            "_signature",
+            "_bytes",
+            "_count",
+            "_counts",
+            "_seconds",
+            "_ms",
+            "_tokens",
+            "_token_limit",
+        )
+    ):
         return False
-    if token.startswith(("missing_", "required_", "configured_", "fallback_")) and "api_key" in token:
+    if (
+        token.startswith(("missing_", "required_", "configured_", "fallback_"))
+        and "api_key" in token
+    ):
         return False
-    if any(fragment in token for fragment in ("authorization", "bearer", "secret", "password", "private_key", "private-key", "webhook_secret")):
+    if any(
+        fragment in token
+        for fragment in (
+            "authorization",
+            "bearer",
+            "secret",
+            "password",
+            "private_key",
+            "private-key",
+            "webhook_secret",
+        )
+    ):
         return True
     if token == "key":
         return True
-    if "api_key" in token and "env" not in token:
+    if (token == "apikey" or "api_key" in token) and "env" not in token:
         return True
     if "token" in token and "tokens" not in token and "token_limit" not in token:
         return True
@@ -97,6 +132,8 @@ def sanitize_text_for_output(text: str) -> str:
 
 def _redact_secret_assignment(match: re.Match[str]) -> str:
     if not _is_sensitive_key(match.group(2)):
+        return match.group(0)
+    if match.group(3).startswith("[REDACTED"):
         return match.group(0)
     return f"{match.group(1)}[REDACTED]{match.group(4)}"
 
@@ -151,12 +188,16 @@ def sanitize_payload_for_output(payload: Any, *, field_name: str | None = None) 
             str(key): sanitize_payload_for_output(value, field_name=str(key))
             for key, value in payload.items()
         }
-    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+    if isinstance(payload, Sequence) and not isinstance(
+        payload, (str, bytes, bytearray)
+    ):
         return [sanitize_payload_for_output(item) for item in payload]
     return payload
 
 
-def sanitize_payload_for_provider(payload: Any, *, field_name: str | None = None) -> Any:
+def sanitize_payload_for_provider(
+    payload: Any, *, field_name: str | None = None
+) -> Any:
     if isinstance(payload, Path):
         return sanitize_text_for_provider_payload(str(payload))
     if field_name is not None and _is_sensitive_key(field_name):
@@ -172,12 +213,16 @@ def sanitize_payload_for_provider(payload: Any, *, field_name: str | None = None
             str(key): sanitize_payload_for_provider(value, field_name=str(key))
             for key, value in payload.items()
         }
-    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+    if isinstance(payload, Sequence) and not isinstance(
+        payload, (str, bytes, bytearray)
+    ):
         return [sanitize_payload_for_provider(item) for item in payload]
     return payload
 
 
-def sanitize_payload_for_failed_sidecar(payload: Any, *, field_name: str | None = None) -> Any:
+def sanitize_payload_for_failed_sidecar(
+    payload: Any, *, field_name: str | None = None
+) -> Any:
     if isinstance(payload, Path):
         return sanitize_failed_sidecar_text(str(payload))
     if field_name is not None and _is_sensitive_key(field_name):
@@ -193,7 +238,9 @@ def sanitize_payload_for_failed_sidecar(payload: Any, *, field_name: str | None 
             str(key): sanitize_payload_for_failed_sidecar(value, field_name=str(key))
             for key, value in payload.items()
         }
-    if isinstance(payload, Sequence) and not isinstance(payload, (str, bytes, bytearray)):
+    if isinstance(payload, Sequence) and not isinstance(
+        payload, (str, bytes, bytearray)
+    ):
         return [sanitize_payload_for_failed_sidecar(item) for item in payload]
     return payload
 

--- a/services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_1_secret_assign_regex.py
+++ b/services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_1_secret_assign_regex.py
@@ -14,6 +14,7 @@ Documented in:
 The test asserts the BROKEN behavior currently exists (xfail), so when
 the regex is fixed, the test passes automatically.
 """
+
 from __future__ import annotations
 
 import sys
@@ -65,6 +66,10 @@ SURROUNDED_LEAKS = [
     "DATABASE_PASSWORD=hunter2-prod-secret-xyz",
     "INTERNAL_TOKEN=abcdefghij1234567890",
     "CUSTOMER_SECRET_KEY=leaked-value-here",
+    "apikey=leaked-value-here",
+    "api-key=leaked-value-here",
+    '"api-key": "leaked-value-here"',
+    "TOKEN=[leaked-value-here]",
 ]
 
 

--- a/services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_1_secret_assign_regex.py
+++ b/services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_1_secret_assign_regex.py
@@ -57,10 +57,8 @@ def test_known_secret_patterns_are_redacted(label: str, raw: str) -> None:
     assert "REDACTED" in out, f"{label}: expected REDACTED in {out!r}"
 
 
-# --- Patterns that are CURRENTLY MISSED (FA-4-HIGH-1) ---
-# These are env-var-style names where the keyword is surrounded by underscores,
-# so \b doesn't trigger. We mark these xfail; they flip to pass when the
-# regex is fixed.
+# --- Patterns fixed by FA-4-HIGH-1 ---
+# These are env-var-style names where the keyword is surrounded by underscores.
 SURROUNDED_LEAKS = [
     "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
     "aws_secret_access_key=abc-leak-value",
@@ -70,12 +68,9 @@ SURROUNDED_LEAKS = [
 ]
 
 
-@pytest.mark.xfail(
-    reason="FA-4-HIGH-1: _SECRET_ASSIGN_RE \\b boundary fails when keyword is surrounded by underscores. Fix the regex (replace \\b with [^A-Za-z0-9] grouping) and this test passes."
-)
 @pytest.mark.parametrize("raw", SURROUNDED_LEAKS)
 def test_underscored_env_names_should_be_redacted(raw: str) -> None:
-    """xfail until FA-4-HIGH-1 fixes the \\b boundary issue."""
+    """FA-4-HIGH-1 regression: underscored env-name secrets must redact."""
     out = sanitize_text_for_output(raw)
     assert "REDACTED" in out, (
         f"Expected redaction of underscored env-name secret: input={raw!r} output={out!r}"

--- a/services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_2_walker_env_variants.py
+++ b/services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_2_walker_env_variants.py
@@ -67,10 +67,7 @@ def test_dot_suffix_env_variants_excluded(filename: str, tmp_path: Path) -> None
     )
 
 
-# --- xfail regression: hyphen/underscore variants — should ALSO be excluded ---
-@pytest.mark.xfail(
-    reason="FA-4-HIGH-2: DEFAULT_SECRET_BEARING_EXCLUDE_GLOBS does NOT cover .env-* / .env_* hyphenated/underscored variants. Add .env-* and .env_* patterns to close."
-)
+# --- FA-4-HIGH-2 regression: hyphen/underscore variants should also be excluded ---
 @pytest.mark.parametrize(
     "filename",
     [
@@ -84,7 +81,7 @@ def test_dot_suffix_env_variants_excluded(filename: str, tmp_path: Path) -> None
 def test_hyphen_underscore_env_variants_should_be_excluded(
     filename: str, tmp_path: Path
 ) -> None:
-    """xfail until FA-4-HIGH-2 adds hyphen/underscore .env variants."""
+    """Hyphen/underscore .env variants must be excluded."""
     (tmp_path / filename).write_text(
         "STAGING_SECRET=fake-staging-secret-xyz\n", encoding="utf-8"
     )

--- a/services/repo-truth-extractor/tests/test_output_safety.py
+++ b/services/repo-truth-extractor/tests/test_output_safety.py
@@ -28,8 +28,12 @@ def _load_runner_module():
 
 def _load_gate_module():
     root = Path(__file__).resolve().parents[3]
-    module_path = root / "services" / "repo-truth-extractor" / "validate_pre_live_gate_v25.py"
-    spec = importlib.util.spec_from_file_location("validate_pre_live_gate_v25", module_path)
+    module_path = (
+        root / "services" / "repo-truth-extractor" / "validate_pre_live_gate_v25.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "validate_pre_live_gate_v25", module_path
+    )
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -70,6 +74,22 @@ def test_sanitize_payload_redacts_secret_fields_but_preserves_env_metadata() -> 
     assert sanitized["sha256"] == "abcdef1234567890"
 
 
+def test_assignment_redaction_covers_api_key_aliases_and_bracket_values() -> None:
+    output_safety = _load_output_safety_module()
+    samples = [
+        "apikey=raw-secret-value",
+        "api-key=raw-secret-value",
+        '"api-key": "raw-secret-value"',
+        "TOKEN=[abc123]",
+    ]
+
+    for sample in samples:
+        sanitized = output_safety.sanitize_text_for_output(sample)
+        assert "raw-secret-value" not in sanitized
+        assert "abc123" not in sanitized
+        assert "[REDACTED]" in sanitized
+
+
 def test_failed_sidecar_text_redacts_provider_tokens_and_private_key_blocks() -> None:
     output_safety = _load_output_safety_module()
     provider_token = "sk-" + "RTEPKT15" + ("B" * 32)
@@ -95,7 +115,9 @@ def test_failed_sidecar_text_redacts_provider_tokens_and_private_key_blocks() ->
     assert f"safe_sha256={safe_digest}" in sanitized
 
 
-def test_failed_sidecar_payload_redacts_generic_secret_shapes_but_preserves_env_metadata() -> None:
+def test_failed_sidecar_payload_redacts_generic_secret_shapes_but_preserves_env_metadata() -> (
+    None
+):
     output_safety = _load_output_safety_module()
     opaque_token = "RtE" + ("cD4" * 14)
     safe_digest = "b" * 64
@@ -144,7 +166,11 @@ def test_ui_events_redact_secret_like_fields(tmp_path: Path) -> None:
         },
     )
 
-    rows = [json.loads(line) for line in (tmp_path / "events.jsonl").read_text(encoding="utf-8").splitlines() if line.strip()]
+    rows = [
+        json.loads(line)
+        for line in (tmp_path / "events.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
     event = next(row for row in rows if row.get("type") == "llm_request_completed")
     assert event["authorization"] == "[REDACTED]"
     assert event["api_key"] == "[REDACTED]"
@@ -190,30 +216,69 @@ def test_s_int_outputs_redact_secret_fields(tmp_path: Path) -> None:
     module = _load_run_s_int()
     repo_root = tmp_path / "repo"
     (repo_root / "services" / "alpha").mkdir(parents=True, exist_ok=True)
-    (repo_root / "services" / "alpha" / "main.py").write_text("# webhook\n", encoding="utf-8")
-    (repo_root / "docker" / "mcp-servers-source" / "demo").mkdir(parents=True, exist_ok=True)
-    (repo_root / "docker" / "mcp-servers-source" / "demo" / "server.py").write_text("mcp = True\n", encoding="utf-8")
+    (repo_root / "services" / "alpha" / "main.py").write_text(
+        "# webhook\n", encoding="utf-8"
+    )
+    (repo_root / "docker" / "mcp-servers-source" / "demo").mkdir(
+        parents=True, exist_ok=True
+    )
+    (repo_root / "docker" / "mcp-servers-source" / "demo" / "server.py").write_text(
+        "mcp = True\n", encoding="utf-8"
+    )
     out_root = tmp_path / "proof" / "s_int"
 
     def fake_executor(step, rendered_prompt, schema, prior_outputs):  # type: ignore[no-untyped-def]
         del rendered_prompt, schema, prior_outputs
         if step.step_id == "S16":
-            payload = {"status": "OK", "findings": [{"server_id": "mcp.demo", "status": "OK", "notes": []}], "missing_evidence": []}
+            payload = {
+                "status": "OK",
+                "findings": [{"server_id": "mcp.demo", "status": "OK", "notes": []}],
+                "missing_evidence": [],
+            }
         elif step.step_id == "S17":
-            payload = {"status": "OK", "hooks": [{"path": "services/alpha/main.py", "term": "webhook", "line": 1}], "missing_evidence": []}
+            payload = {
+                "status": "OK",
+                "hooks": [
+                    {"path": "services/alpha/main.py", "term": "webhook", "line": 1}
+                ],
+                "missing_evidence": [],
+            }
         elif step.step_id == "S18":
-            payload = {"status": "OK", "contracts": [{"contract_id": "TRINITY", "coverage": "partial"}], "missing_evidence": []}
+            payload = {
+                "status": "OK",
+                "contracts": [{"contract_id": "TRINITY", "coverage": "partial"}],
+                "missing_evidence": [],
+            }
         elif step.step_id == "S19":
-            payload = {"status": "OK", "categories": [{"category": "operator", "grade": "B", "notes": []}], "missing_evidence": []}
+            payload = {
+                "status": "OK",
+                "categories": [{"category": "operator", "grade": "B", "notes": []}],
+                "missing_evidence": [],
+            }
         else:
-            payload = {"status": "OK", "milestones": [{"milestone_id": step.step_id, "title": "Ship"}], "risks": [], "missing_evidence": []}
+            payload = {
+                "status": "OK",
+                "milestones": [{"milestone_id": step.step_id, "title": "Ship"}],
+                "risks": [],
+                "missing_evidence": [],
+            }
         payload["api_key"] = "raw-secret"
         payload["api_key_env"] = "OPENAI_API_KEY"
         return {"payload": payload}
 
-    summary = module.run_s_int(repo_root, "sint_run", dry_run=False, out_root=out_root, prompt_executor=fake_executor)
+    summary = module.run_s_int(
+        repo_root,
+        "sint_run",
+        dry_run=False,
+        out_root=out_root,
+        prompt_executor=fake_executor,
+    )
     assert summary["status"] == "OK"
-    written = next(path for path in sorted((out_root / "sint_run").glob("*.json")) if path.name != "S_INT_MACHINE_SUMMARY.json")
+    written = next(
+        path
+        for path in sorted((out_root / "sint_run").glob("*.json"))
+        if path.name != "S_INT_MACHINE_SUMMARY.json"
+    )
     parsed = json.loads(written.read_text(encoding="utf-8"))
     assert parsed["api_key"] == "[REDACTED]"
     assert parsed["api_key_env"] == "OPENAI_API_KEY"


### PR DESCRIPTION
Implements TP-RTE-FINAL-AUDIT-SECRETS-002.

## Summary
- Fixes underscored env-name assignment redaction for RTE output/provider/payload sanitization.
- Adds adjacent `.env-*` / `.env_*` walker exclusions, including nested variants.
- Converts the fixed FA-4-HIGH-1 and FA-4-HIGH-2 focused regression cases from xfail to normal pass cases.

## Validation
- `PYTHONPATH=services/repo-truth-extractor python -m pytest -q -p no:cacheprovider services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_1_secret_assign_regex.py services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_2_walker_env_variants.py` -> 28 passed, 1 warning.
- `PYTHONPATH=services/repo-truth-extractor python -m pytest -q -p no:cacheprovider services/repo-truth-extractor/tests/test_output_safety.py services/repo-truth-extractor/tests/test_provider_payload_redaction.py` -> 17 passed, 1 warning.
- `git diff --check` -> pass.
- `pre-commit run --files services/repo-truth-extractor/output_safety.py services/repo-truth-extractor/lib/prescan/models.py services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_1_secret_assign_regex.py services/repo-truth-extractor/tests/regression/audit_2026_05_22/test_fa_4_high_2_walker_env_variants.py` -> pass.

## Scope Notes
- No live provider calls or live extraction were run.
- Existing untracked generated report directories were not staged, deleted, or modified.
- No schema coverage, prompt delimiter, home-scan consent, model refresh, Flex plumbing, benchmark spend guard, docs sweep, or broad walker refactor work is included.

## Review Routing
@codex review
@gemini
@copilot
