### PR TITLE
fix(governance): handle resolved threads and proof freshness

### DIFF
--- a/docs/ops/embedded-audit.md
+++ b/docs/ops/embedded-audit.md
@@ -55,3 +55,5 @@ Loose `/tmp` artifacts must be copied into the review bundle or explicitly liste
 - `FAIL`: blocking issue found.
 - `NEEDS_SUPERVISOR`: unresolved authority, security, schema, or process issue needs higher review.
 - `SKIPPED`: no supported auditor executable or invocation could be proven; final packet status cannot be READY.
+
+`PASS_WITH_RISKS` is acceptable to downstream gates when the risks are recorded and no blocking findings remain. It is advisory, not a license to ignore unresolved implementation blockers elsewhere.

--- a/docs/ops/pr-acceptance.md
+++ b/docs/ops/pr-acceptance.md
@@ -25,6 +25,7 @@ A PR is eligible for normal closeout only when all of these are true:
 - every review item, issue comment, review comment, review thread, and CI check is classified
 - no unknown or untrusted reviewer or bot remains unclassified
 - no blocking thread, failed required check, stale proof, or unresolved audit finding remains
+- proof freshness may be satisfied by an explicit supervisor-accepted self-reference exception when the proof records proof-only changed-file evidence and the embedded audit is nonblocking
 
 ## Skip-Second-GPT-5.5 Rule
 
@@ -35,7 +36,7 @@ Skip the second GPT-5.5 Pro supervisor review only when both gates are READY:
 
 If either gate is missing, skipped, stale, failed, or unknown, the PR requires supervisor review or human escalation.
 
-No second GPT-5.5 Pro prompt can be skipped unless PR Steward emits `READY` and embedded audit is `PASS` or nonblocking `PASS_WITH_RISKS`. Unknown or untrusted reviewers and bots and unresolved review threads both block `READY`.
+No second GPT-5.5 Pro prompt can be skipped unless PR Steward emits `READY` and embedded audit is `PASS` or nonblocking `PASS_WITH_RISKS`. Unknown or untrusted reviewers and bots and unresolved review threads both block `READY`. Resolved or outdated threads must not be left behind as active blockers.
 
 Explicit known reviewer logins are trusted. GitHub `authorAssociation` values `OWNER`, `MEMBER`, and `COLLABORATOR` are trusted unless a future policy overrides this rule. External unknown actors and unclassified bots block `READY`.
 

--- a/docs/ops/pr-steward.md
+++ b/docs/ops/pr-steward.md
@@ -62,7 +62,7 @@ Return `NOT_READY` or `NEEDS_SUPERVISOR` when:
 - any reviewer, bot, review item, or check cannot be classified
 - any blocking review thread is unresolved
 - required CI failed, was cancelled, or is missing
-- proof does not match PR head SHA
+- proof is stale, missing, or lacks a valid supervisor-accepted self-reference exception
 - embedded audit is absent, skipped, failed, or stale
 - GitHub auth or API state cannot be proven
 - any requested action would mutate GitHub state
@@ -70,6 +70,10 @@ Return `NOT_READY` or `NEEDS_SUPERVISOR` when:
 Return `BLOCKED` when the harvest is incomplete, the PR is draft, or the PR is closed without explicit `--allow-closed`. Return `NEEDS_IMPLEMENTER` when concrete implementation work is required, such as unresolved threads or failed checks. Unknown or untrusted reviewers and bots always block `READY`.
 
 Explicit known reviewer logins are trusted. GitHub `authorAssociation` values `OWNER`, `MEMBER`, and `COLLABORATOR` are also trusted unless a future policy overrides that rule. External unknown actors and unclassified bots block `READY`.
+
+Resolved and outdated review threads are historical evidence, not active blockers. When a raw review comment is linked to a resolved or outdated thread, PR Steward clears the stale `MUST_FIX` classification instead of keeping a false active blocker behind.
+
+Proof freshness is fail-closed by default. A proof may be treated as current either by exact PR head match or by an explicit `CURRENT_WITH_SELF_REFERENCE_EXCEPTION` record that includes supervisor acceptance and proof-only changed-file evidence under `proof/`.
 
 ## CLI
 

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_OUTPUT.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_OUTPUT.json
@@ -1,0 +1,113 @@
+{
+  "audited_files": [
+    "tools/pr_steward/classifier.py",
+    "tools/pr_steward/collector.py",
+    "tests/pr_steward/test_intake.py",
+    "schemas/pr_steward/merge_readiness.schema.json",
+    "schemas/pr_steward/pr_state_snapshot.schema.json",
+    "docs/ops/pr-steward.md",
+    "docs/ops/pr-acceptance.md",
+    "docs/ops/embedded-audit.md"
+  ],
+  "confirmed_pass": [
+    {
+      "area": "PASS_WITH_RISKS",
+      "evidence": "PASS_WITH_RISKS is in PASSING_AUDITS, not in BLOCKING_AUDITS, and the schema allows READY with PASS_WITH_RISKS. Covered by focused tests.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "resolved thread clears review comment blocker",
+      "evidence": "Resolved review threads map linked comments to AUTO_APPLIED and nonblocking dispositions; tests confirm readiness is READY.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "resolved outdated thread nonblocking",
+      "evidence": "Resolved outdated threads are AUTO_APPLIED and nonblocking; fixture smoke confirms unresolved_blocking_count=0.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "unresolved thread blocks",
+      "evidence": "Unresolved threads contribute MUST_FIX and UNRESOLVED_REVIEW_THREAD blockers; fixture smoke confirms failure closed.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "raw review comment without thread still blocks",
+      "evidence": "Comments without thread linkage fall back to body disposition and block on P1 bodies.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "proof freshness CURRENT exact head",
+      "evidence": "Exact head SHA match produces proof_freshness.status=CURRENT and matches_pr_head=true.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "proof freshness self-reference exception gating",
+      "evidence": "CURRENT_WITH_SELF_REFERENCE_EXCEPTION requires supervisor acceptance, the required allowed_when set, and proof-only changed files.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "self-reference exception rejects runtime changes",
+      "evidence": "A runtime file in changed_files causes _proof_is_current to fail and the readiness state remains supervisor-blocked.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "check-only boundary enforcement",
+      "evidence": "mutation_performed stays false, forbidden mutator flags are absent, and docs keep PR Steward check-only.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "schema allOf READY invariants",
+      "evidence": "Schemas accept READY only with exact-head or explicit self-reference exception semantics and no blockers.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "collector two-phase proof state",
+      "evidence": "The collector now derives proof freshness from the live PR head, not only the raw proof blob.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "embedded-audit.md verdict rules alignment",
+      "evidence": "PASS_WITH_RISKS remains acceptable downstream when no blocking findings remain.",
+      "verdict": "PASS"
+    }
+  ],
+  "findings": [
+    {
+      "area": "resolved/outdated thread handling",
+      "description": "The thread classifier treats unresolved-outdated review threads as blocking MUST_FIX, while the comment classifier treats the linked raw review comment as AUTO_APPLIED and nonblocking. The net system still fails closed because the thread classifier contributes the blocker, but the audit trail is contradictory and the divergent state is not covered by a fixture.",
+      "doc_intent": "pr-steward.md describes resolved and outdated review threads as historical evidence, which is consistent with the comment classifier but not with the thread classifier in the unresolved-outdated case.",
+      "id": "F1",
+      "impact": "Latent and nonblocking. The blocker still survives, but the audit trail is inconsistent if this state occurs.",
+      "location": "classifier.py:_classify_threads:351 vs _classify_comments:291-298",
+      "severity": "MEDIUM",
+      "status": "NOT_BLOCKING",
+      "title": "Thread and comment classifiers diverge on isOutdated=true, isResolved=false"
+    },
+    {
+      "area": "test coverage",
+      "description": "All new outdated-thread fixtures set isResolved=true. No fixture exercises the unresolved-outdated divergence identified in F1.",
+      "id": "F2",
+      "impact": "Coverage gap only.",
+      "location": "tests/pr_steward/test_intake.py",
+      "severity": "LOW",
+      "status": "NOT_BLOCKING",
+      "title": "isOutdated=true+isResolved=false thread case is untested"
+    },
+    {
+      "area": "test coverage",
+      "description": "The fallback branch for embedded audit statuses outside PASS/PASS_WITH_RISKS is not exercised by a fixture.",
+      "id": "F3",
+      "impact": "Coverage gap only; the logic is straightforward and fail-closed.",
+      "location": "tools/pr_steward/classifier.py:124-126",
+      "severity": "LOW",
+      "status": "NOT_BLOCKING",
+      "title": "EMBEDDED_AUDIT_UNKNOWN blocker path is untested"
+    }
+  ],
+  "notes": [
+    "The phrase \u201cresolved and outdated review threads are historical evidence\u201d is ambiguous in the docs. The comment classifier treats either resolved or outdated as nonblocking; the thread classifier still treats unresolved-outdated as blocking. That is conservative overall, but the audit trail is inconsistent and should be clarified in a follow-up packet.",
+    "proof_freshness is intentionally optional in the schemas so older proofs still validate. The classifier synthesizes CURRENT freshness from matching SHAs when the field is absent.",
+    "The collector and classifier both define _proof_freshness with different inputs. They are separate module-local helpers and do not collide."
+  ],
+  "verdict": "PASS_WITH_RISKS"
+}

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_REPORT.md
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_REPORT.md
@@ -1,0 +1,40 @@
+# Auditor Report - TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001
+
+## Auditor
+
+- auditor_tool: claude-code-direct
+- auditor_model: claude-sonnet-4-6
+- invocation: `claude -p --model sonnet --effort low --permission-mode plan --tools Read --add-dir /Users/hue/.codex/worktrees/693f/dopemux-mvp --output-format json --no-session-persistence ...`
+- verdict: PASS_WITH_RISKS
+- audit_output: `proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_OUTPUT.json`
+
+## Scope Reviewed
+
+- tools/pr_steward/classifier.py
+- tools/pr_steward/collector.py
+- schemas/pr_steward/merge_readiness.schema.json
+- schemas/pr_steward/pr_state_snapshot.schema.json
+- tests/pr_steward/test_intake.py
+- tests/fixtures/pr_steward/**
+- docs/ops/pr-steward.md
+- docs/ops/pr-acceptance.md
+- docs/ops/embedded-audit.md
+- task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json
+
+## Findings
+
+| Severity | Finding | Evidence | Required Action |
+|---|---|---|---|
+| MEDIUM | Thread/comment classifier diverge on unresolved-outdated threads | classifier.py:_classify_threads:351 vs _classify_comments:291-298 | Clarify semantics or align the two paths in a follow-up packet. |
+| LOW | Unresolved-outdated thread state is untested | tests/pr_steward/test_intake.py | Add a fixture if the state should be explicitly represented. |
+| LOW | EMBEDDED_AUDIT_UNKNOWN path is untested | classifier.py:124-126 | Add a fixture only if this path needs direct regression coverage. |
+
+## Nonblocking Risks
+
+- The unresolved-outdated thread state is conservative but audit-trail inconsistent.
+- The proof freshness self-reference exception remains intentionally narrow.
+- The local audit lane completed through authenticated Claude Code, not through PAL bridge MCP.
+
+## Conclusion
+
+The implementation is governance-safe and ready to commit with risks recorded. The remaining issue is coverage/consistency, not a blocking correctness defect.

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/CHANGED_FILES.txt
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/CHANGED_FILES.txt
@@ -1,0 +1,8 @@
+docs/ops/embedded-audit.md
+docs/ops/pr-acceptance.md
+docs/ops/pr-steward.md
+schemas/pr_steward/merge_readiness.schema.json
+schemas/pr_steward/pr_state_snapshot.schema.json
+tests/pr_steward/test_intake.py
+tools/pr_steward/classifier.py
+tools/pr_steward/collector.py

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/DIFF_STAT.txt
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/DIFF_STAT.txt
@@ -1,0 +1,9 @@
+ docs/ops/embedded-audit.md                       |   2 +
+ docs/ops/pr-acceptance.md                        |   3 +-
+ docs/ops/pr-steward.md                           |   6 +-
+ schemas/pr_steward/merge_readiness.schema.json   | 132 +++++++++++++++---
+ schemas/pr_steward/pr_state_snapshot.schema.json |  72 ++++++++++
+ tests/pr_steward/test_intake.py                  | 136 +++++++++++++++++++
+ tools/pr_steward/classifier.py                   | 164 ++++++++++++++++++++++-
+ tools/pr_steward/collector.py                    |  61 +++++++++
+ 8 files changed, 556 insertions(+), 20 deletions(-)

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/GIT_STATE.md
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/GIT_STATE.md
@@ -1,0 +1,30 @@
+# Git State
+
+- branch: codex/pr-steward-resolved-thread-proof-semantics-001
+- head: 898310bd01cf48b2703a166b429d4b330ec9f84e
+- remote: https://github.com/DDD-Enterprises/dopemux-mvp.git
+- worktree_status: dirty
+- repo_marker: .dopetaskroot (present)
+
+## Status
+
+```text
+ M docs/ops/embedded-audit.md
+ M docs/ops/pr-acceptance.md
+ M docs/ops/pr-steward.md
+ M schemas/pr_steward/merge_readiness.schema.json
+ M schemas/pr_steward/pr_state_snapshot.schema.json
+ M tests/pr_steward/test_intake.py
+ M tools/pr_steward/classifier.py
+ M tools/pr_steward/collector.py
+?? task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json
+?? tests/fixtures/pr_steward/embedded_audit_pass_with_risks_nonblocking/
+?? tests/fixtures/pr_steward/outdated_resolved_thread_nonblocking/
+?? tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit/
+?? tests/fixtures/pr_steward/proof_current_exact_head_ready/
+?? tests/fixtures/pr_steward/proof_self_reference_exception_ready_or_needs_supervisor/
+?? tests/fixtures/pr_steward/proof_self_reference_exception_rejects_runtime_changes/
+?? tests/fixtures/pr_steward/raw_review_comment_without_thread_still_blocks/
+?? tests/fixtures/pr_steward/resolved_thread_clears_review_item/
+?? tests/fixtures/pr_steward/unresolved_thread_still_blocks/
+```

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/PROOF.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/PROOF.json
@@ -1,0 +1,131 @@
+{
+  "authoritative_artifacts": [
+    "task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json",
+    "tools/pr_steward/classifier.py",
+    "tools/pr_steward/collector.py",
+    "tests/pr_steward/test_intake.py",
+    "schemas/pr_steward/merge_readiness.schema.json",
+    "schemas/pr_steward/pr_state_snapshot.schema.json",
+    "docs/ops/pr-steward.md",
+    "docs/ops/pr-acceptance.md",
+    "docs/ops/embedded-audit.md"
+  ],
+  "base_sha": "898310bd01cf48b2703a166b429d4b330ec9f84e",
+  "branch": "codex/pr-steward-resolved-thread-proof-semantics-001",
+  "bundle_id": "TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001",
+  "chain_of_custody": [
+    {
+      "evidence": "Updated PR Steward runtime, schemas, tests, fixtures, and docs to support resolved-thread and proof-freshness semantics.",
+      "step": "implementation"
+    },
+    {
+      "evidence": "Focused validation passed; see command_outputs and VALIDATION_OUTPUT.md.",
+      "step": "validation"
+    },
+    {
+      "evidence": "Local authenticated Claude Code audit returned PASS_WITH_RISKS with one medium nonblocking divergence and two low coverage gaps.",
+      "step": "audit"
+    }
+  ],
+  "command_outputs": [
+    {
+      "command": "python -m compileall -q tools tests",
+      "exit_code": 0,
+      "output": "PASS"
+    },
+    {
+      "command": "pytest -q tests/pr_steward",
+      "exit_code": 0,
+      "output": "21 passed"
+    },
+    {
+      "command": "python -m tools.pr_steward.intake --fixture-dir tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit --repo DDD-Enterprises/dopemux-mvp --pr 704 --out /tmp/pr-steward-pr713-like --strict",
+      "exit_code": 0,
+      "output": "/tmp/pr-steward-pr713-like generated with readiness READY"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "output": "PASS"
+    },
+    {
+      "command": "local direct Claude audit",
+      "exit_code": 0,
+      "output": "PASS_WITH_RISKS"
+    }
+  ],
+  "created_at": "2026-05-27T00:55:19.209497Z",
+  "files_changed": [
+    "docs/ops/embedded-audit.md",
+    "docs/ops/pr-acceptance.md",
+    "docs/ops/pr-steward.md",
+    "schemas/pr_steward/merge_readiness.schema.json",
+    "schemas/pr_steward/pr_state_snapshot.schema.json",
+    "tests/pr_steward/test_intake.py",
+    "tools/pr_steward/classifier.py",
+    "tools/pr_steward/collector.py"
+  ],
+  "git_status_after": " M docs/ops/embedded-audit.md\n M docs/ops/pr-acceptance.md\n M docs/ops/pr-steward.md\n M schemas/pr_steward/merge_readiness.schema.json\n M schemas/pr_steward/pr_state_snapshot.schema.json\n M tests/pr_steward/test_intake.py\n M tools/pr_steward/classifier.py\n M tools/pr_steward/collector.py\n?? task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json\n?? tests/fixtures/pr_steward/embedded_audit_pass_with_risks_nonblocking/\n?? tests/fixtures/pr_steward/outdated_resolved_thread_nonblocking/\n?? tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit/\n?? tests/fixtures/pr_steward/proof_current_exact_head_ready/\n?? tests/fixtures/pr_steward/proof_self_reference_exception_ready_or_needs_supervisor/\n?? tests/fixtures/pr_steward/proof_self_reference_exception_rejects_runtime_changes/\n?? tests/fixtures/pr_steward/raw_review_comment_without_thread_still_blocks/\n?? tests/fixtures/pr_steward/resolved_thread_clears_review_item/\n?? tests/fixtures/pr_steward/unresolved_thread_still_blocks/\n",
+  "git_status_before": "",
+  "handoff_refs": [
+    "docs/ops/pr-steward.md",
+    "docs/ops/pr-acceptance.md",
+    "docs/ops/embedded-audit.md"
+  ],
+  "head_sha": "898310bd01cf48b2703a166b429d4b330ec9f84e",
+  "repo_identity": {
+    "branch": "codex/pr-steward-resolved-thread-proof-semantics-001",
+    "identity_match": true,
+    "path": "/Users/hue/.codex/worktrees/693f/dopemux-mvp",
+    "remote": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "repo_marker": ".dopetaskroot"
+  },
+  "review_bundle": {
+    "contains_all_review_required_artifacts": true,
+    "manifest": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/MANIFEST.json",
+    "path": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle",
+    "upload_unit": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle"
+  },
+  "review_order_hint": [
+    "Verify resolved/outdated review-thread semantics and proof freshness logic in tools/pr_steward.",
+    "Review the schemas for additive proof_freshness support.",
+    "Review the fixture coverage and proof bundle artifacts."
+  ],
+  "run_id": "2026-05-27T00:55:19.209497Z",
+  "skill": "pr-steward-check-only-runtime",
+  "status": "PASS_WITH_RISKS",
+  "supporting_artifacts": [
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/MANIFEST.json",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/SUMMARY.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/PROOF.json",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/AUDITOR_REPORT.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/VALIDATION_OUTPUT.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/GIT_STATE.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/DIFF_STAT.txt",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/CHANGED_FILES.txt",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/ARTIFACT_INDEX.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_OUTPUT.json",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_REPORT.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/VALIDATION_OUTPUT.md"
+  ],
+  "validation_state": {
+    "failed_or_blocked": [],
+    "not_run": [
+      "commit",
+      "push",
+      "PR creation"
+    ],
+    "overall": "PASS_WITH_RISKS",
+    "passed": [
+      "task packet JSON parse",
+      "PR Steward schemas JSON parse",
+      "compileall tools/tests",
+      "pytest tests/pr_steward",
+      "fixture smoke pr713_like_resolved_threads_with_pass_with_risks_audit",
+      "fixture smoke JSON artifacts parse",
+      "git diff --check",
+      "local direct Claude audit PASS_WITH_RISKS"
+    ],
+    "reason": "Local direct Claude audit returned PASS_WITH_RISKS; one medium nonblocking divergence between thread and comment classifiers remains untested but conservative."
+  }
+}

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/PROOF.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/PROOF.json
@@ -10,7 +10,7 @@
     "docs/ops/pr-acceptance.md",
     "docs/ops/embedded-audit.md"
   ],
-  "base_sha": "898310bd01cf48b2703a166b429d4b330ec9f84e",
+  "base_sha": "ef0c30bf4",
   "branch": "codex/pr-steward-resolved-thread-proof-semantics-001",
   "bundle_id": "TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001",
   "chain_of_custody": [
@@ -72,7 +72,7 @@
     "docs/ops/pr-acceptance.md",
     "docs/ops/embedded-audit.md"
   ],
-  "head_sha": "898310bd01cf48b2703a166b429d4b330ec9f84e",
+  "head_sha": "a34995e34",
   "repo_identity": {
     "branch": "codex/pr-steward-resolved-thread-proof-semantics-001",
     "identity_match": true,

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/VALIDATION_OUTPUT.md
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/VALIDATION_OUTPUT.md
@@ -1,0 +1,27 @@
+# Validation Output
+
+## Passed
+
+- `python -m json.tool task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json`
+- `python -m json.tool schemas/pr_steward/merge_readiness.schema.json`
+- `python -m json.tool schemas/pr_steward/pr_state_snapshot.schema.json`
+- `python -m compileall -q tools tests`
+- `pytest -q tests/pr_steward`
+- `python -m tools.pr_steward.intake --fixture-dir tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit --repo DDD-Enterprises/dopemux-mvp --pr 704 --out /tmp/pr-steward-pr713-like --strict`
+- `python -m json.tool /tmp/pr-steward-pr713-like/MERGE_READINESS.json`
+- `python -m json.tool /tmp/pr-steward-pr713-like/PR_STATE_SNAPSHOT.json`
+- `python -m json.tool /tmp/pr-steward-pr713-like/REVIEW_ITEM_LEDGER.json`
+- `python -m json.tool /tmp/pr-steward-pr713-like/THREAD_DISPOSITIONS.json`
+- `python -m json.tool /tmp/pr-steward-pr713-like/CI_TRIAGE.json`
+- `git diff --check`
+- direct local Claude audit: PASS_WITH_RISKS
+
+## Failures
+
+- none
+
+## Not Run
+
+- commit
+- push
+- PR creation

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/ARTIFACT_INDEX.md
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/ARTIFACT_INDEX.md
@@ -1,0 +1,9 @@
+# Artifact Index
+
+- `artifacts/AUDITOR_OUTPUT.json`: raw local Claude audit JSON
+- `artifacts/MERGE_READINESS.json`: fixture smoke merge-readiness artifact
+- `artifacts/PR_STATE_SNAPSHOT.json`: fixture smoke snapshot artifact
+- `artifacts/REVIEW_ITEM_LEDGER.json`: fixture smoke review-item ledger
+- `artifacts/THREAD_DISPOSITIONS.json`: fixture smoke thread dispositions
+- `artifacts/CI_TRIAGE.json`: fixture smoke CI triage artifact
+- `artifacts/PR_STEWARD_SUMMARY.md`: fixture smoke summary output

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/AUDITOR_REPORT.md
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/AUDITOR_REPORT.md
@@ -1,0 +1,40 @@
+# Auditor Report - TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001
+
+## Auditor
+
+- auditor_tool: claude-code-direct
+- auditor_model: claude-sonnet-4-6
+- invocation: `claude -p --model sonnet --effort low --permission-mode plan --tools Read --add-dir /Users/hue/.codex/worktrees/693f/dopemux-mvp --output-format json --no-session-persistence ...`
+- verdict: PASS_WITH_RISKS
+- audit_output: `proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_OUTPUT.json`
+
+## Scope Reviewed
+
+- tools/pr_steward/classifier.py
+- tools/pr_steward/collector.py
+- schemas/pr_steward/merge_readiness.schema.json
+- schemas/pr_steward/pr_state_snapshot.schema.json
+- tests/pr_steward/test_intake.py
+- tests/fixtures/pr_steward/**
+- docs/ops/pr-steward.md
+- docs/ops/pr-acceptance.md
+- docs/ops/embedded-audit.md
+- task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json
+
+## Findings
+
+| Severity | Finding | Evidence | Required Action |
+|---|---|---|---|
+| MEDIUM | Thread/comment classifier diverge on unresolved-outdated threads | classifier.py:_classify_threads:351 vs _classify_comments:291-298 | Clarify semantics or align the two paths in a follow-up packet. |
+| LOW | Unresolved-outdated thread state is untested | tests/pr_steward/test_intake.py | Add a fixture if the state should be explicitly represented. |
+| LOW | EMBEDDED_AUDIT_UNKNOWN path is untested | classifier.py:124-126 | Add a fixture only if this path needs direct regression coverage. |
+
+## Nonblocking Risks
+
+- The unresolved-outdated thread state is conservative but audit-trail inconsistent.
+- The proof freshness self-reference exception remains intentionally narrow.
+- The local audit lane completed through authenticated Claude Code, not through PAL bridge MCP.
+
+## Conclusion
+
+The implementation is governance-safe and ready to commit with risks recorded. The remaining issue is coverage/consistency, not a blocking correctness defect.

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/CHANGED_FILES.txt
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/CHANGED_FILES.txt
@@ -1,0 +1,8 @@
+docs/ops/embedded-audit.md
+docs/ops/pr-acceptance.md
+docs/ops/pr-steward.md
+schemas/pr_steward/merge_readiness.schema.json
+schemas/pr_steward/pr_state_snapshot.schema.json
+tests/pr_steward/test_intake.py
+tools/pr_steward/classifier.py
+tools/pr_steward/collector.py

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/DIFF_STAT.txt
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/DIFF_STAT.txt
@@ -1,0 +1,9 @@
+ docs/ops/embedded-audit.md                       |   2 +
+ docs/ops/pr-acceptance.md                        |   3 +-
+ docs/ops/pr-steward.md                           |   6 +-
+ schemas/pr_steward/merge_readiness.schema.json   | 132 +++++++++++++++---
+ schemas/pr_steward/pr_state_snapshot.schema.json |  72 ++++++++++
+ tests/pr_steward/test_intake.py                  | 136 +++++++++++++++++++
+ tools/pr_steward/classifier.py                   | 164 ++++++++++++++++++++++-
+ tools/pr_steward/collector.py                    |  61 +++++++++
+ 8 files changed, 556 insertions(+), 20 deletions(-)

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/GIT_STATE.md
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/GIT_STATE.md
@@ -1,0 +1,30 @@
+# Git State
+
+- branch: codex/pr-steward-resolved-thread-proof-semantics-001
+- head: 898310bd01cf48b2703a166b429d4b330ec9f84e
+- remote: https://github.com/DDD-Enterprises/dopemux-mvp.git
+- worktree_status: dirty
+- repo_marker: .dopetaskroot (present)
+
+## Status
+
+```text
+ M docs/ops/embedded-audit.md
+ M docs/ops/pr-acceptance.md
+ M docs/ops/pr-steward.md
+ M schemas/pr_steward/merge_readiness.schema.json
+ M schemas/pr_steward/pr_state_snapshot.schema.json
+ M tests/pr_steward/test_intake.py
+ M tools/pr_steward/classifier.py
+ M tools/pr_steward/collector.py
+?? task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json
+?? tests/fixtures/pr_steward/embedded_audit_pass_with_risks_nonblocking/
+?? tests/fixtures/pr_steward/outdated_resolved_thread_nonblocking/
+?? tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit/
+?? tests/fixtures/pr_steward/proof_current_exact_head_ready/
+?? tests/fixtures/pr_steward/proof_self_reference_exception_ready_or_needs_supervisor/
+?? tests/fixtures/pr_steward/proof_self_reference_exception_rejects_runtime_changes/
+?? tests/fixtures/pr_steward/raw_review_comment_without_thread_still_blocks/
+?? tests/fixtures/pr_steward/resolved_thread_clears_review_item/
+?? tests/fixtures/pr_steward/unresolved_thread_still_blocks/
+```

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/MANIFEST.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/MANIFEST.json
@@ -1,0 +1,21 @@
+{
+  "artifacts": [
+    "review_bundle/AUDITOR_REPORT.md",
+    "review_bundle/VALIDATION_OUTPUT.md",
+    "review_bundle/GIT_STATE.md",
+    "review_bundle/DIFF_STAT.txt",
+    "review_bundle/CHANGED_FILES.txt",
+    "review_bundle/PROOF.json",
+    "review_bundle/artifacts/AUDITOR_OUTPUT.json",
+    "review_bundle/artifacts/CI_TRIAGE.json",
+    "review_bundle/artifacts/MERGE_READINESS.json",
+    "review_bundle/artifacts/PR_STATE_SNAPSHOT.json",
+    "review_bundle/artifacts/REVIEW_ITEM_LEDGER.json",
+    "review_bundle/artifacts/THREAD_DISPOSITIONS.json",
+    "review_bundle/artifacts/PR_STEWARD_SUMMARY.md"
+  ],
+  "bundle_id": "TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001",
+  "created_at": "2026-05-27T00:55:19.209497Z",
+  "review_bundle": "/Users/hue/.codex/worktrees/693f/dopemux-mvp/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle",
+  "summary": "Proof bundle for PR Steward resolved-thread and proof-freshness semantics repair."
+}

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/PROOF.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/PROOF.json
@@ -1,0 +1,131 @@
+{
+  "authoritative_artifacts": [
+    "task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json",
+    "tools/pr_steward/classifier.py",
+    "tools/pr_steward/collector.py",
+    "tests/pr_steward/test_intake.py",
+    "schemas/pr_steward/merge_readiness.schema.json",
+    "schemas/pr_steward/pr_state_snapshot.schema.json",
+    "docs/ops/pr-steward.md",
+    "docs/ops/pr-acceptance.md",
+    "docs/ops/embedded-audit.md"
+  ],
+  "base_sha": "898310bd01cf48b2703a166b429d4b330ec9f84e",
+  "branch": "codex/pr-steward-resolved-thread-proof-semantics-001",
+  "bundle_id": "TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001",
+  "chain_of_custody": [
+    {
+      "evidence": "Updated PR Steward runtime, schemas, tests, fixtures, and docs to support resolved-thread and proof-freshness semantics.",
+      "step": "implementation"
+    },
+    {
+      "evidence": "Focused validation passed; see command_outputs and VALIDATION_OUTPUT.md.",
+      "step": "validation"
+    },
+    {
+      "evidence": "Local authenticated Claude Code audit returned PASS_WITH_RISKS with one medium nonblocking divergence and two low coverage gaps.",
+      "step": "audit"
+    }
+  ],
+  "command_outputs": [
+    {
+      "command": "python -m compileall -q tools tests",
+      "exit_code": 0,
+      "output": "PASS"
+    },
+    {
+      "command": "pytest -q tests/pr_steward",
+      "exit_code": 0,
+      "output": "21 passed"
+    },
+    {
+      "command": "python -m tools.pr_steward.intake --fixture-dir tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit --repo DDD-Enterprises/dopemux-mvp --pr 704 --out /tmp/pr-steward-pr713-like --strict",
+      "exit_code": 0,
+      "output": "/tmp/pr-steward-pr713-like generated with readiness READY"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "output": "PASS"
+    },
+    {
+      "command": "local direct Claude audit",
+      "exit_code": 0,
+      "output": "PASS_WITH_RISKS"
+    }
+  ],
+  "created_at": "2026-05-27T00:55:19.209497Z",
+  "files_changed": [
+    "docs/ops/embedded-audit.md",
+    "docs/ops/pr-acceptance.md",
+    "docs/ops/pr-steward.md",
+    "schemas/pr_steward/merge_readiness.schema.json",
+    "schemas/pr_steward/pr_state_snapshot.schema.json",
+    "tests/pr_steward/test_intake.py",
+    "tools/pr_steward/classifier.py",
+    "tools/pr_steward/collector.py"
+  ],
+  "git_status_after": " M docs/ops/embedded-audit.md\n M docs/ops/pr-acceptance.md\n M docs/ops/pr-steward.md\n M schemas/pr_steward/merge_readiness.schema.json\n M schemas/pr_steward/pr_state_snapshot.schema.json\n M tests/pr_steward/test_intake.py\n M tools/pr_steward/classifier.py\n M tools/pr_steward/collector.py\n?? task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json\n?? tests/fixtures/pr_steward/embedded_audit_pass_with_risks_nonblocking/\n?? tests/fixtures/pr_steward/outdated_resolved_thread_nonblocking/\n?? tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit/\n?? tests/fixtures/pr_steward/proof_current_exact_head_ready/\n?? tests/fixtures/pr_steward/proof_self_reference_exception_ready_or_needs_supervisor/\n?? tests/fixtures/pr_steward/proof_self_reference_exception_rejects_runtime_changes/\n?? tests/fixtures/pr_steward/raw_review_comment_without_thread_still_blocks/\n?? tests/fixtures/pr_steward/resolved_thread_clears_review_item/\n?? tests/fixtures/pr_steward/unresolved_thread_still_blocks/\n",
+  "git_status_before": "",
+  "handoff_refs": [
+    "docs/ops/pr-steward.md",
+    "docs/ops/pr-acceptance.md",
+    "docs/ops/embedded-audit.md"
+  ],
+  "head_sha": "898310bd01cf48b2703a166b429d4b330ec9f84e",
+  "repo_identity": {
+    "branch": "codex/pr-steward-resolved-thread-proof-semantics-001",
+    "identity_match": true,
+    "path": "/Users/hue/.codex/worktrees/693f/dopemux-mvp",
+    "remote": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "repo_marker": ".dopetaskroot"
+  },
+  "review_bundle": {
+    "contains_all_review_required_artifacts": true,
+    "manifest": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/MANIFEST.json",
+    "path": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle",
+    "upload_unit": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle"
+  },
+  "review_order_hint": [
+    "Verify resolved/outdated review-thread semantics and proof freshness logic in tools/pr_steward.",
+    "Review the schemas for additive proof_freshness support.",
+    "Review the fixture coverage and proof bundle artifacts."
+  ],
+  "run_id": "2026-05-27T00:55:19.209497Z",
+  "skill": "pr-steward-check-only-runtime",
+  "status": "PASS_WITH_RISKS",
+  "supporting_artifacts": [
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/MANIFEST.json",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/SUMMARY.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/PROOF.json",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/AUDITOR_REPORT.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/VALIDATION_OUTPUT.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/GIT_STATE.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/DIFF_STAT.txt",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/CHANGED_FILES.txt",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/ARTIFACT_INDEX.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_OUTPUT.json",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_REPORT.md",
+    "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/VALIDATION_OUTPUT.md"
+  ],
+  "validation_state": {
+    "failed_or_blocked": [],
+    "not_run": [
+      "commit",
+      "push",
+      "PR creation"
+    ],
+    "overall": "PASS_WITH_RISKS",
+    "passed": [
+      "task packet JSON parse",
+      "PR Steward schemas JSON parse",
+      "compileall tools/tests",
+      "pytest tests/pr_steward",
+      "fixture smoke pr713_like_resolved_threads_with_pass_with_risks_audit",
+      "fixture smoke JSON artifacts parse",
+      "git diff --check",
+      "local direct Claude audit PASS_WITH_RISKS"
+    ],
+    "reason": "Local direct Claude audit returned PASS_WITH_RISKS; one medium nonblocking divergence between thread and comment classifiers remains untested but conservative."
+  }
+}

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/SUMMARY.md
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/SUMMARY.md
@@ -1,0 +1,7 @@
+# Summary
+
+- Packet: TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001
+- Verdict: PASS_WITH_RISKS
+- Audit: local authenticated Claude Code direct audit
+- Nonblocking risk: unresolved-outdated thread state is conservative but audit-trail inconsistent and untested
+- Validation: compileall, pytest tests/pr_steward, JSON schema parsing, fixture smoke, git diff --check

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/VALIDATION_OUTPUT.md
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/VALIDATION_OUTPUT.md
@@ -1,0 +1,27 @@
+# Validation Output
+
+## Passed
+
+- `python -m json.tool task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json`
+- `python -m json.tool schemas/pr_steward/merge_readiness.schema.json`
+- `python -m json.tool schemas/pr_steward/pr_state_snapshot.schema.json`
+- `python -m compileall -q tools tests`
+- `pytest -q tests/pr_steward`
+- `python -m tools.pr_steward.intake --fixture-dir tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit --repo DDD-Enterprises/dopemux-mvp --pr 704 --out /tmp/pr-steward-pr713-like --strict`
+- `python -m json.tool /tmp/pr-steward-pr713-like/MERGE_READINESS.json`
+- `python -m json.tool /tmp/pr-steward-pr713-like/PR_STATE_SNAPSHOT.json`
+- `python -m json.tool /tmp/pr-steward-pr713-like/REVIEW_ITEM_LEDGER.json`
+- `python -m json.tool /tmp/pr-steward-pr713-like/THREAD_DISPOSITIONS.json`
+- `python -m json.tool /tmp/pr-steward-pr713-like/CI_TRIAGE.json`
+- `git diff --check`
+- direct local Claude audit: PASS_WITH_RISKS
+
+## Failures
+
+- none
+
+## Not Run
+
+- commit
+- push
+- PR creation

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/AUDITOR_OUTPUT.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/AUDITOR_OUTPUT.json
@@ -1,0 +1,113 @@
+{
+  "audited_files": [
+    "tools/pr_steward/classifier.py",
+    "tools/pr_steward/collector.py",
+    "tests/pr_steward/test_intake.py",
+    "schemas/pr_steward/merge_readiness.schema.json",
+    "schemas/pr_steward/pr_state_snapshot.schema.json",
+    "docs/ops/pr-steward.md",
+    "docs/ops/pr-acceptance.md",
+    "docs/ops/embedded-audit.md"
+  ],
+  "confirmed_pass": [
+    {
+      "area": "PASS_WITH_RISKS",
+      "evidence": "PASS_WITH_RISKS is in PASSING_AUDITS, not in BLOCKING_AUDITS, and the schema allows READY with PASS_WITH_RISKS. Covered by focused tests.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "resolved thread clears review comment blocker",
+      "evidence": "Resolved review threads map linked comments to AUTO_APPLIED and nonblocking dispositions; tests confirm readiness is READY.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "resolved outdated thread nonblocking",
+      "evidence": "Resolved outdated threads are AUTO_APPLIED and nonblocking; fixture smoke confirms unresolved_blocking_count=0.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "unresolved thread blocks",
+      "evidence": "Unresolved threads contribute MUST_FIX and UNRESOLVED_REVIEW_THREAD blockers; fixture smoke confirms failure closed.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "raw review comment without thread still blocks",
+      "evidence": "Comments without thread linkage fall back to body disposition and block on P1 bodies.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "proof freshness CURRENT exact head",
+      "evidence": "Exact head SHA match produces proof_freshness.status=CURRENT and matches_pr_head=true.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "proof freshness self-reference exception gating",
+      "evidence": "CURRENT_WITH_SELF_REFERENCE_EXCEPTION requires supervisor acceptance, the required allowed_when set, and proof-only changed files.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "self-reference exception rejects runtime changes",
+      "evidence": "A runtime file in changed_files causes _proof_is_current to fail and the readiness state remains supervisor-blocked.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "check-only boundary enforcement",
+      "evidence": "mutation_performed stays false, forbidden mutator flags are absent, and docs keep PR Steward check-only.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "schema allOf READY invariants",
+      "evidence": "Schemas accept READY only with exact-head or explicit self-reference exception semantics and no blockers.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "collector two-phase proof state",
+      "evidence": "The collector now derives proof freshness from the live PR head, not only the raw proof blob.",
+      "verdict": "PASS"
+    },
+    {
+      "area": "embedded-audit.md verdict rules alignment",
+      "evidence": "PASS_WITH_RISKS remains acceptable downstream when no blocking findings remain.",
+      "verdict": "PASS"
+    }
+  ],
+  "findings": [
+    {
+      "area": "resolved/outdated thread handling",
+      "description": "The thread classifier treats unresolved-outdated review threads as blocking MUST_FIX, while the comment classifier treats the linked raw review comment as AUTO_APPLIED and nonblocking. The net system still fails closed because the thread classifier contributes the blocker, but the audit trail is contradictory and the divergent state is not covered by a fixture.",
+      "doc_intent": "pr-steward.md describes resolved and outdated review threads as historical evidence, which is consistent with the comment classifier but not with the thread classifier in the unresolved-outdated case.",
+      "id": "F1",
+      "impact": "Latent and nonblocking. The blocker still survives, but the audit trail is inconsistent if this state occurs.",
+      "location": "classifier.py:_classify_threads:351 vs _classify_comments:291-298",
+      "severity": "MEDIUM",
+      "status": "NOT_BLOCKING",
+      "title": "Thread and comment classifiers diverge on isOutdated=true, isResolved=false"
+    },
+    {
+      "area": "test coverage",
+      "description": "All new outdated-thread fixtures set isResolved=true. No fixture exercises the unresolved-outdated divergence identified in F1.",
+      "id": "F2",
+      "impact": "Coverage gap only.",
+      "location": "tests/pr_steward/test_intake.py",
+      "severity": "LOW",
+      "status": "NOT_BLOCKING",
+      "title": "isOutdated=true+isResolved=false thread case is untested"
+    },
+    {
+      "area": "test coverage",
+      "description": "The fallback branch for embedded audit statuses outside PASS/PASS_WITH_RISKS is not exercised by a fixture.",
+      "id": "F3",
+      "impact": "Coverage gap only; the logic is straightforward and fail-closed.",
+      "location": "tools/pr_steward/classifier.py:124-126",
+      "severity": "LOW",
+      "status": "NOT_BLOCKING",
+      "title": "EMBEDDED_AUDIT_UNKNOWN blocker path is untested"
+    }
+  ],
+  "notes": [
+    "The phrase \u201cresolved and outdated review threads are historical evidence\u201d is ambiguous in the docs. The comment classifier treats either resolved or outdated as nonblocking; the thread classifier still treats unresolved-outdated as blocking. That is conservative overall, but the audit trail is inconsistent and should be clarified in a follow-up packet.",
+    "proof_freshness is intentionally optional in the schemas so older proofs still validate. The classifier synthesizes CURRENT freshness from matching SHAs when the field is absent.",
+    "The collector and classifier both define _proof_freshness with different inputs. They are separate module-local helpers and do not collide."
+  ],
+  "verdict": "PASS_WITH_RISKS"
+}

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/CI_TRIAGE.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/CI_TRIAGE.json
@@ -1,0 +1,23 @@
+{
+  "checks": [
+    {
+      "blocking": false,
+      "conclusion": "success",
+      "head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+      "name": "unit",
+      "rationale": "Check is nonblocking or successful.",
+      "required": true,
+      "status": "completed",
+      "url": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1"
+    }
+  ],
+  "failed_required_count": 0,
+  "generated_at": "2026-05-27T00:53:35.445208Z",
+  "head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+  "mutation_performed": false,
+  "pending_required_count": 0,
+  "pr_number": 704,
+  "required_check_count": 1,
+  "schema_version": "1.0.0",
+  "unknown_required_count": 0
+}

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/MERGE_READINESS.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/MERGE_READINESS.json
@@ -1,0 +1,41 @@
+{
+  "blockers": [],
+  "ci_triage_path": "CI_TRIAGE.json",
+  "embedded_audit": {
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md",
+    "status": "PASS_WITH_RISKS"
+  },
+  "generated_at": "2026-05-27T00:53:35.445208Z",
+  "mutation_performed": false,
+  "pr": {
+    "base_ref": "main",
+    "changed_files": [
+      "tools/pr_steward/intake.py"
+    ],
+    "commits": [
+      "f67888696de4e9d0082fe320eef3e6f995ef17ba"
+    ],
+    "head_ref": "codex/tp-dmx-auditor-router-pal-clink-002",
+    "head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+    "number": 713,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/713"
+  },
+  "proof": {
+    "matches_pr_head": true,
+    "proof_freshness": {
+      "matches_pr_head": true,
+      "pr_head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+      "proof_recorded_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+      "reason": "Proof head SHA matches PR head SHA.",
+      "self_reference_exception": null,
+      "status": "CURRENT"
+    },
+    "proof_head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json"
+  },
+  "readiness": "READY",
+  "review_item_ledger_path": "REVIEW_ITEM_LEDGER.json",
+  "schema_version": "1.0.0",
+  "thread_dispositions_path": "THREAD_DISPOSITIONS.json",
+  "unknowns": []
+}

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/PR_STATE_SNAPSHOT.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/PR_STATE_SNAPSHOT.json
@@ -1,0 +1,138 @@
+{
+  "changed_files": [
+    {
+      "additions": 120,
+      "deletions": 0,
+      "path": "tools/pr_steward/intake.py",
+      "status": "added"
+    }
+  ],
+  "checks": [
+    {
+      "blocking": false,
+      "conclusion": "success",
+      "head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+      "name": "unit",
+      "rationale": "Check is nonblocking or successful.",
+      "required": true,
+      "status": "completed",
+      "url": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1"
+    }
+  ],
+  "commits": [
+    {
+      "message": "chore(proof): capture pal clink audit verdict",
+      "sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba"
+    }
+  ],
+  "embedded_audit": {
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md",
+    "status": "PASS_WITH_RISKS"
+  },
+  "generated_at": "2026-05-27T00:53:35.445208Z",
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "issue_comments": [],
+  "mutation_performed": false,
+  "pr": {
+    "author": "hu3mann",
+    "base_ref": "main",
+    "base_sha": "base000000000000000000000000000000000000",
+    "created_at": "2026-05-26T01:00:00Z",
+    "draft": false,
+    "head_ref": "codex/tp-dmx-auditor-router-pal-clink-002",
+    "head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+    "merge_state_status": "BLOCKED",
+    "mergeable": "MERGEABLE",
+    "number": 713,
+    "review_decision": "COMMENTED",
+    "state": "OPEN",
+    "updated_at": "2026-05-26T02:00:00Z",
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/713"
+  },
+  "pr_number": 704,
+  "proof": {
+    "matches_pr_head": true,
+    "proof_freshness": {
+      "matches_pr_head": true,
+      "pr_head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+      "proof_recorded_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+      "reason": "Proof head SHA matches PR head SHA.",
+      "self_reference_exception": null,
+      "status": "CURRENT"
+    },
+    "proof_head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json"
+  },
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "review_comments": [
+    {
+      "author": {
+        "login": "chatgpt-codex-connector"
+      },
+      "authorAssociation": "MEMBER",
+      "body": "P1: address this before merge.",
+      "createdAt": "2026-05-26T02:01:00Z",
+      "id": "RTC_713_1",
+      "line": 42,
+      "path": "tools/pr_steward/intake.py"
+    },
+    {
+      "author": {
+        "login": "chatgpt-codex-connector"
+      },
+      "authorAssociation": "MEMBER",
+      "body": "P2: already addressed.",
+      "createdAt": "2026-05-26T02:02:00Z",
+      "id": "RTC_713_2",
+      "line": 43,
+      "path": "tools/pr_steward/intake.py"
+    }
+  ],
+  "review_threads": [
+    {
+      "comments": [
+        {
+          "author": {
+            "login": "chatgpt-codex-connector"
+          },
+          "authorAssociation": "MEMBER",
+          "body": "P1: address this before merge.",
+          "createdAt": "2026-05-26T02:01:00Z",
+          "id": "RTC_713_1",
+          "line": 42,
+          "path": "tools/pr_steward/intake.py"
+        }
+      ],
+      "id": "RT_713_1",
+      "isOutdated": false,
+      "isResolved": true,
+      "line": 42,
+      "path": "tools/pr_steward/intake.py",
+      "startLine": 40
+    },
+    {
+      "comments": [
+        {
+          "author": {
+            "login": "chatgpt-codex-connector"
+          },
+          "authorAssociation": "MEMBER",
+          "body": "P2: already addressed.",
+          "createdAt": "2026-05-26T02:02:00Z",
+          "id": "RTC_713_2",
+          "line": 43,
+          "path": "tools/pr_steward/intake.py"
+        }
+      ],
+      "id": "RT_713_2",
+      "isOutdated": true,
+      "isResolved": true,
+      "line": 43,
+      "path": "tools/pr_steward/intake.py",
+      "startLine": 41
+    }
+  ],
+  "reviews": [],
+  "schema_version": "1.0.0"
+}

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/PR_STEWARD_SUMMARY.md
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/PR_STEWARD_SUMMARY.md
@@ -1,0 +1,13 @@
+# PR Steward Summary
+
+- PR: 713
+- readiness: READY
+- mutation_performed: false
+
+## Blockers
+
+- none
+
+## UNKNOWN
+
+- none

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/REVIEW_ITEM_LEDGER.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/REVIEW_ITEM_LEDGER.json
@@ -1,0 +1,49 @@
+{
+  "generated_at": "2026-05-27T00:53:35.445208Z",
+  "items": [
+    {
+      "author": "chatgpt-codex-connector",
+      "author_association": "MEMBER",
+      "blocking": false,
+      "body_excerpt": "P1: address this before merge.",
+      "disposition": "AUTO_APPLIED",
+      "id": "RTC_713_1",
+      "rationale": "Resolved review thread clears original raw review comment blocker.",
+      "source": "review_comment"
+    },
+    {
+      "author": "chatgpt-codex-connector",
+      "author_association": "MEMBER",
+      "blocking": false,
+      "body_excerpt": "P2: already addressed.",
+      "disposition": "AUTO_APPLIED",
+      "id": "RTC_713_2",
+      "rationale": "Resolved review thread clears original raw review comment blocker.",
+      "source": "review_comment"
+    },
+    {
+      "author": "chatgpt-codex-connector",
+      "author_association": "MEMBER",
+      "blocking": false,
+      "body_excerpt": "P1: address this before merge.",
+      "disposition": "OPTIONAL_DEFERRED",
+      "id": "RTC_713_1",
+      "rationale": "Resolved thread has no active blocker.",
+      "source": "review_thread"
+    },
+    {
+      "author": "chatgpt-codex-connector",
+      "author_association": "MEMBER",
+      "blocking": false,
+      "body_excerpt": "P2: already addressed.",
+      "disposition": "AUTO_APPLIED",
+      "id": "RTC_713_2",
+      "rationale": "Resolved outdated thread is historical evidence only.",
+      "source": "review_thread"
+    }
+  ],
+  "mutation_performed": false,
+  "pr_number": 704,
+  "schema_version": "1.0.0",
+  "unclassified_count": 0
+}

--- a/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/THREAD_DISPOSITIONS.json
+++ b/proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle/artifacts/THREAD_DISPOSITIONS.json
@@ -1,0 +1,29 @@
+{
+  "generated_at": "2026-05-27T00:53:35.445208Z",
+  "mutation_performed": false,
+  "pr_number": 704,
+  "schema_version": "1.0.0",
+  "threads": [
+    {
+      "blocking": false,
+      "disposition": "OPTIONAL_DEFERRED",
+      "is_resolved": true,
+      "rationale": "Resolved review thread is nonblocking.",
+      "review_item_ids": [
+        "RTC_713_1"
+      ],
+      "thread_id": "RT_713_1"
+    },
+    {
+      "blocking": false,
+      "disposition": "AUTO_APPLIED",
+      "is_resolved": true,
+      "rationale": "Resolved outdated thread is nonblocking evidence.",
+      "review_item_ids": [
+        "RTC_713_2"
+      ],
+      "thread_id": "RT_713_2"
+    }
+  ],
+  "unresolved_blocking_count": 0
+}

--- a/schemas/pr_steward/merge_readiness.schema.json
+++ b/schemas/pr_steward/merge_readiness.schema.json
@@ -91,6 +91,78 @@
         },
         "matches_pr_head": {
           "type": "boolean"
+        },
+        "proof_freshness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "matches_pr_head",
+            "reason",
+            "proof_recorded_sha",
+            "pr_head_sha",
+            "self_reference_exception"
+          ],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "CURRENT",
+                "CURRENT_WITH_SELF_REFERENCE_EXCEPTION",
+                "STALE",
+                "MISSING",
+                "UNKNOWN"
+              ]
+            },
+            "matches_pr_head": {
+              "type": "boolean"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "proof_recorded_sha": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pr_head_sha": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "self_reference_exception": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "supervisor_accepted": {
+                  "type": "boolean"
+                },
+                "allowed_when": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "changed_files": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "note": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -138,21 +210,51 @@
               "status"
             ]
           },
-          "proof": {
-            "properties": {
-              "proof_head_sha": {
-                "type": "string",
-                "minLength": 1
-              },
-              "matches_pr_head": {
-                "const": true
-              }
-            },
-            "required": [
-              "proof_head_sha",
-              "matches_pr_head"
-            ]
-          },
+                    "proof": {
+                        "anyOf": [
+                            {
+                                "properties": {
+                                    "proof_head_sha": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "matches_pr_head": {
+                                        "const": true
+                                    }
+                                },
+                                "required": [
+                                    "proof_head_sha",
+                                    "matches_pr_head"
+                                ]
+                            },
+                            {
+                                "properties": {
+                                    "proof_head_sha": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "matches_pr_head": {
+                                        "const": false
+                                    },
+                                    "proof_freshness": {
+                                        "properties": {
+                                            "status": {
+                                                "const": "CURRENT_WITH_SELF_REFERENCE_EXCEPTION"
+                                            }
+                                        },
+                                        "required": [
+                                            "status"
+                                        ]
+                                    }
+                                },
+                                "required": [
+                                    "proof_head_sha",
+                                    "matches_pr_head",
+                                    "proof_freshness"
+                                ]
+                            }
+                        ]
+                    },
           "blockers": {
             "maxItems": 0
           },

--- a/schemas/pr_steward/merge_readiness.schema.json
+++ b/schemas/pr_steward/merge_readiness.schema.json
@@ -237,15 +237,27 @@
                                         "const": false
                                     },
                                     "proof_freshness": {
-                                        "properties": {
-                                            "status": {
-                                                "const": "CURRENT_WITH_SELF_REFERENCE_EXCEPTION"
-                                            }
-                                        },
-                                        "required": [
-                                            "status"
-                                        ]
-                                    }
+                                         "properties": {
+                                             "status": {
+                                                 "const": "CURRENT_WITH_SELF_REFERENCE_EXCEPTION"
+                                             },
+                                             "self_reference_exception": {
+                                                 "type": "object",
+                                                 "properties": {
+                                                     "supervisor_accepted": {
+                                                         "const": true
+                                                     }
+                                                 },
+                                                 "required": [
+                                                     "supervisor_accepted"
+                                                 ]
+                                             }
+                                         },
+                                         "required": [
+                                             "status",
+                                             "self_reference_exception"
+                                         ]
+                                     }
                                 },
                                 "required": [
                                     "proof_head_sha",

--- a/schemas/pr_steward/pr_state_snapshot.schema.json
+++ b/schemas/pr_steward/pr_state_snapshot.schema.json
@@ -336,6 +336,78 @@
         },
         "matches_pr_head": {
           "type": "boolean"
+        },
+        "proof_freshness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "matches_pr_head",
+            "reason",
+            "proof_recorded_sha",
+            "pr_head_sha",
+            "self_reference_exception"
+          ],
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": [
+                "CURRENT",
+                "CURRENT_WITH_SELF_REFERENCE_EXCEPTION",
+                "STALE",
+                "MISSING",
+                "UNKNOWN"
+              ]
+            },
+            "matches_pr_head": {
+              "type": "boolean"
+            },
+            "reason": {
+              "type": "string"
+            },
+            "proof_recorded_sha": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "pr_head_sha": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "self_reference_exception": {
+              "type": [
+                "object",
+                "null"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "supervisor_accepted": {
+                  "type": "boolean"
+                },
+                "allowed_when": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "changed_files": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "note": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json
+++ b/task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json
@@ -1,0 +1,186 @@
+{
+  "commit": {
+    "allowlist": [
+      "tools/pr_steward/collector.py",
+      "tools/pr_steward/classifier.py",
+      "tests/pr_steward/test_intake.py",
+      "tests/fixtures/pr_steward/resolved_thread_clears_review_item/harvest.json",
+      "tests/fixtures/pr_steward/outdated_resolved_thread_nonblocking/harvest.json",
+      "tests/fixtures/pr_steward/raw_review_comment_without_thread_still_blocks/harvest.json",
+      "tests/fixtures/pr_steward/unresolved_thread_still_blocks/harvest.json",
+      "tests/fixtures/pr_steward/proof_current_exact_head_ready/harvest.json",
+      "tests/fixtures/pr_steward/proof_self_reference_exception_ready_or_needs_supervisor/harvest.json",
+      "tests/fixtures/pr_steward/proof_self_reference_exception_rejects_runtime_changes/harvest.json",
+      "tests/fixtures/pr_steward/embedded_audit_pass_with_risks_nonblocking/harvest.json",
+      "tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit/harvest.json",
+      "schemas/pr_steward/merge_readiness.schema.json",
+      "schemas/pr_steward/pr_state_snapshot.schema.json",
+      "docs/ops/pr-steward.md",
+      "docs/ops/pr-acceptance.md",
+      "docs/ops/embedded-audit.md",
+      "task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json"
+    ],
+    "message": "fix(governance): handle resolved threads and proof freshness",
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json",
+      "python -m json.tool schemas/pr_steward/merge_readiness.schema.json",
+      "python -m json.tool schemas/pr_steward/pr_state_snapshot.schema.json",
+      "python -m compileall -q tools tests",
+      "pytest -q tests/pr_steward",
+      "python -m tools.pr_steward.intake --fixture-dir tests/fixtures/pr_steward/resolved_thread_clears_review_item --repo DDD-Enterprises/dopemux-mvp --pr 704 --out /tmp/pr-steward-resolved-thread --strict",
+      "python -m tools.pr_steward.intake --fixture-dir tests/fixtures/pr_steward/proof_self_reference_exception_ready_or_needs_supervisor --repo DDD-Enterprises/dopemux-mvp --pr 704 --out /tmp/pr-steward-proof-exception --strict",
+      "python -m json.tool /tmp/pr-steward-resolved-thread/MERGE_READINESS.json",
+      "python -m json.tool /tmp/pr-steward-proof-exception/MERGE_READINESS.json",
+      "git diff --check"
+    ]
+  },
+  "depends_on": [
+    "TP-DMX-PR-STEWARD-001"
+  ],
+  "embedded_audit": {
+    "auditor_model": "claude-sonnet-4-6",
+    "auditor_tool": "claude-code-direct",
+    "evidence_bundle": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001",
+    "final_recommendation": "ACCEPT_WITH_RISKS",
+    "notes": [
+      "Local authenticated Claude Code direct audit completed successfully.",
+      "One medium nonblocking divergence remains untested for unresolved-outdated threads."
+    ],
+    "output_path": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_OUTPUT.json",
+    "report_path": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/AUDITOR_REPORT.md",
+    "verdict": "PASS_WITH_RISKS"
+  },
+  "execution": {
+    "agent": "codex",
+    "base_branch": "main",
+    "branch": "codex/pr-steward-resolved-thread-proof-semantics-001"
+  },
+  "id": "TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001",
+  "invariants": [
+    "Do not mutate GitHub state.",
+    "Do not resolve review threads.",
+    "Do not approve PRs.",
+    "Do not auto-merge or mutate merge queues.",
+    "Do not store secrets.",
+    "Fail closed when reviewers, threads, checks, or proof freshness cannot be proven.",
+    "Treat AUTO_APPLIED as a disposition value only unless a future packet explicitly authorizes edit behavior."
+  ],
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "pr": {
+    "base": "main",
+    "body": "## Summary\n- Repairs PR Steward semantics so review comments tied to resolved or outdated review threads stop blocking readiness.\n- Adds explicit proof freshness support for exact-head and supervisor-accepted self-reference exception semantics.\n- Keeps PR Steward check-only and fail-closed on unresolved current threads, stale proof, or unknown reviewers.\n\n## Scope\nCheck-only review-intake semantics only. No GitHub mutation, no thread resolution, no merge queue mutation, and no changes to PR #713 runtime code.\n\n## Validation\nRun schema parsing, focused PR Steward tests, fixture smoke tests, compileall, and git diff --check.\n\n## NOT_RUN\nNo live GitHub mutation and no merge operations by design.",
+    "title": "fix(governance): handle resolved threads and proof freshness"
+  },
+  "project": "dopemux-mvp",
+  "proof_bundle": {
+    "commit_policy": "Commit only after validation passes and proof bundle is complete.",
+    "path": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001",
+    "pr_policy": "PR creation or update only after commit and validation pass.",
+    "required_artifacts": [
+      "AUDITOR_REPORT.md",
+      "AUDITOR_OUTPUT.json",
+      "PROOF.json",
+      "VALIDATION_OUTPUT.md",
+      "GIT_STATE.md",
+      "DIFF_STAT.txt",
+      "CHANGED_FILES.txt",
+      "review_bundle/MANIFEST.json",
+      "review_bundle/SUMMARY.md",
+      "review_bundle/PROOF.json",
+      "review_bundle/AUDITOR_REPORT.md",
+      "review_bundle/VALIDATION_OUTPUT.md",
+      "review_bundle/GIT_STATE.md",
+      "review_bundle/DIFF_STAT.txt",
+      "review_bundle/CHANGED_FILES.txt",
+      "review_bundle/ARTIFACT_INDEX.md",
+      "review_bundle/artifacts/AUDITOR_OUTPUT.json",
+      "review_bundle/artifacts/CI_TRIAGE.json",
+      "review_bundle/artifacts/MERGE_READINESS.json",
+      "review_bundle/artifacts/PR_STATE_SNAPSHOT.json",
+      "review_bundle/artifacts/REVIEW_ITEM_LEDGER.json",
+      "review_bundle/artifacts/THREAD_DISPOSITIONS.json",
+      "review_bundle/artifacts/PR_STEWARD_SUMMARY.md"
+    ],
+    "review_bundle": "proof/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001/review_bundle"
+  },
+  "repo_binding": {
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "require_identity_match": true
+  },
+  "series": {
+    "base_branch": "main",
+    "final_packet": false,
+    "id": "DMX-PR-STEWARD",
+    "parent_tp_id": "TP-DMX-PR-STEWARD-001"
+  },
+  "status": "PASS_WITH_RISKS",
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Inspect PR Steward runtime, schemas, fixtures, and docs to determine where resolved-thread and proof freshness semantics are enforced.",
+      "validation": [
+        "Identify the canonical collector/classifier flow.",
+        "Identify the proof freshness and thread disposition surfaces.",
+        "Preserve check-only boundaries."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Implement deterministic resolved-thread linkage and proof freshness classification without GitHub mutation.",
+      "validation": [
+        "Resolved and outdated threads clear corresponding raw review-comment blockers.",
+        "Proof freshness supports exact-head and explicit self-reference exception semantics.",
+        "Current unresolved threads still block readiness."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Update fixtures, schemas, and docs to match runtime semantics.",
+      "validation": [
+        "Fixture scenarios cover resolved-thread, unresolved-thread, and proof freshness cases.",
+        "Schema validation stays additive.",
+        "Docs state the new semantics plainly."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Run focused validation and build proof artifacts.",
+      "validation": [
+        "python -m compileall -q tools tests",
+        "pytest -q tests/pr_steward",
+        "python -m json.tool task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json",
+        "git diff --check"
+      ]
+    }
+  ],
+  "target": "Repair PR Steward readiness semantics so resolved and outdated review threads clear corresponding raw review-comment blockers, and proof freshness supports exact-head or supervisor-accepted self-reference exception semantics without mutating GitHub state.",
+  "validation": {
+    "audit_lane": "local authenticated Claude Code direct audit",
+    "audit_risk": "Unresolved-outdated thread state is conservative but audit-trail inconsistent and not fixture-covered.",
+    "audit_verdict": "PASS_WITH_RISKS",
+    "commands": [
+      "python -m json.tool task-packets/generated/TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001.json",
+      "python -m json.tool schemas/pr_steward/merge_readiness.schema.json",
+      "python -m json.tool schemas/pr_steward/pr_state_snapshot.schema.json",
+      "python -m compileall -q tools tests",
+      "pytest -q tests/pr_steward",
+      "python -m tools.pr_steward.intake --fixture-dir tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit --repo DDD-Enterprises/dopemux-mvp --pr 704 --out /tmp/pr-steward-pr713-like --strict",
+      "git diff --check"
+    ]
+  }
+}

--- a/tests/fixtures/pr_steward/embedded_audit_pass_with_risks_nonblocking/harvest.json
+++ b/tests/fixtures/pr_steward/embedded_audit_pass_with_risks_nonblocking/harvest.json
@@ -1,0 +1,49 @@
+{
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "pr": {
+    "number": 704,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/704",
+    "state": "OPEN",
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "reviewDecision": "APPROVED",
+    "baseRefName": "main",
+    "baseRefOid": "base000000000000000000000000000000000000",
+    "headRefName": "codex/tp-dmx-pr-steward-001",
+    "headRefOid": "head000000000000000000000000000000000000",
+    "author": {"login": "hu3mann"},
+    "createdAt": "2026-05-26T01:00:00Z",
+    "updatedAt": "2026-05-26T02:00:00Z"
+  },
+  "changed_files": [
+    {"path": "tools/pr_steward/intake.py", "additions": 120, "deletions": 0, "status": "added"}
+  ],
+  "commits": [
+    {"oid": "head000000000000000000000000000000000000", "messageHeadline": "feat(governance): add check-only PR steward intake"}
+  ],
+  "reviews": [],
+  "review_comments": [],
+  "review_threads": [],
+  "issue_comments": [],
+  "checks": [
+    {
+      "name": "unit",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1",
+      "isRequired": true,
+      "headSha": "head000000000000000000000000000000000000"
+    }
+  ],
+  "embedded_audit": {
+    "status": "PASS_WITH_RISKS",
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md"
+  },
+  "proof": {
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+    "proof_head_sha": "head000000000000000000000000000000000000",
+    "matches_pr_head": true
+  }
+}

--- a/tests/fixtures/pr_steward/outdated_resolved_thread_nonblocking/harvest.json
+++ b/tests/fixtures/pr_steward/outdated_resolved_thread_nonblocking/harvest.json
@@ -1,0 +1,79 @@
+{
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "pr": {
+    "number": 704,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/704",
+    "state": "OPEN",
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "reviewDecision": "APPROVED",
+    "baseRefName": "main",
+    "baseRefOid": "base000000000000000000000000000000000000",
+    "headRefName": "codex/tp-dmx-pr-steward-001",
+    "headRefOid": "head000000000000000000000000000000000000",
+    "author": {"login": "hu3mann"},
+    "createdAt": "2026-05-26T01:00:00Z",
+    "updatedAt": "2026-05-26T02:00:00Z"
+  },
+  "changed_files": [
+    {"path": "tools/pr_steward/intake.py", "additions": 120, "deletions": 0, "status": "added"}
+  ],
+  "commits": [
+    {"oid": "head000000000000000000000000000000000000", "messageHeadline": "feat(governance): add check-only PR steward intake"}
+  ],
+  "reviews": [],
+  "review_comments": [
+    {
+      "id": "RTC_OUTDATED",
+      "author": {"login": "chatgpt-codex-connector"},
+      "authorAssociation": "MEMBER",
+      "body": "P2: historical comment already addressed.",
+      "path": "tools/pr_steward/intake.py",
+      "line": 42,
+      "createdAt": "2026-05-26T02:01:00Z"
+    }
+  ],
+  "review_threads": [
+    {
+      "id": "RT_OUTDATED",
+      "isResolved": true,
+      "isOutdated": true,
+      "path": "tools/pr_steward/intake.py",
+      "line": 42,
+      "startLine": 40,
+      "comments": [
+        {
+          "id": "RTC_OUTDATED",
+          "author": {"login": "chatgpt-codex-connector"},
+          "authorAssociation": "MEMBER",
+          "body": "P2: historical comment already addressed.",
+          "path": "tools/pr_steward/intake.py",
+          "line": 42,
+          "createdAt": "2026-05-26T02:01:00Z"
+        }
+      ]
+    }
+  ],
+  "issue_comments": [],
+  "checks": [
+    {
+      "name": "unit",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1",
+      "isRequired": true,
+      "headSha": "head000000000000000000000000000000000000"
+    }
+  ],
+  "embedded_audit": {
+    "status": "PASS",
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md"
+  },
+  "proof": {
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+    "proof_head_sha": "head000000000000000000000000000000000000",
+    "matches_pr_head": true
+  }
+}

--- a/tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit/harvest.json
+++ b/tests/fixtures/pr_steward/pr713_like_resolved_threads_with_pass_with_risks_audit/harvest.json
@@ -1,0 +1,107 @@
+{
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "pr": {
+    "number": 713,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/713",
+    "state": "OPEN",
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "BLOCKED",
+    "reviewDecision": "COMMENTED",
+    "baseRefName": "main",
+    "baseRefOid": "base000000000000000000000000000000000000",
+    "headRefName": "codex/tp-dmx-auditor-router-pal-clink-002",
+    "headRefOid": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+    "author": {"login": "hu3mann"},
+    "createdAt": "2026-05-26T01:00:00Z",
+    "updatedAt": "2026-05-26T02:00:00Z"
+  },
+  "changed_files": [
+    {"path": "tools/pr_steward/intake.py", "additions": 120, "deletions": 0, "status": "added"}
+  ],
+  "commits": [
+    {"oid": "f67888696de4e9d0082fe320eef3e6f995ef17ba", "messageHeadline": "chore(proof): capture pal clink audit verdict"}
+  ],
+  "reviews": [],
+  "review_comments": [
+    {
+      "id": "RTC_713_1",
+      "author": {"login": "chatgpt-codex-connector"},
+      "authorAssociation": "MEMBER",
+      "body": "P1: address this before merge.",
+      "path": "tools/pr_steward/intake.py",
+      "line": 42,
+      "createdAt": "2026-05-26T02:01:00Z"
+    },
+    {
+      "id": "RTC_713_2",
+      "author": {"login": "chatgpt-codex-connector"},
+      "authorAssociation": "MEMBER",
+      "body": "P2: already addressed.",
+      "path": "tools/pr_steward/intake.py",
+      "line": 43,
+      "createdAt": "2026-05-26T02:02:00Z"
+    }
+  ],
+  "review_threads": [
+    {
+      "id": "RT_713_1",
+      "isResolved": true,
+      "isOutdated": false,
+      "path": "tools/pr_steward/intake.py",
+      "line": 42,
+      "startLine": 40,
+      "comments": [
+        {
+          "id": "RTC_713_1",
+          "author": {"login": "chatgpt-codex-connector"},
+          "authorAssociation": "MEMBER",
+          "body": "P1: address this before merge.",
+          "path": "tools/pr_steward/intake.py",
+          "line": 42,
+          "createdAt": "2026-05-26T02:01:00Z"
+        }
+      ]
+    },
+    {
+      "id": "RT_713_2",
+      "isResolved": true,
+      "isOutdated": true,
+      "path": "tools/pr_steward/intake.py",
+      "line": 43,
+      "startLine": 41,
+      "comments": [
+        {
+          "id": "RTC_713_2",
+          "author": {"login": "chatgpt-codex-connector"},
+          "authorAssociation": "MEMBER",
+          "body": "P2: already addressed.",
+          "path": "tools/pr_steward/intake.py",
+          "line": 43,
+          "createdAt": "2026-05-26T02:02:00Z"
+        }
+      ]
+    }
+  ],
+  "issue_comments": [],
+  "checks": [
+    {
+      "name": "unit",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1",
+      "isRequired": true,
+      "headSha": "f67888696de4e9d0082fe320eef3e6f995ef17ba"
+    }
+  ],
+  "embedded_audit": {
+    "status": "PASS_WITH_RISKS",
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md"
+  },
+  "proof": {
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+    "proof_head_sha": "f67888696de4e9d0082fe320eef3e6f995ef17ba",
+    "matches_pr_head": true
+  }
+}

--- a/tests/fixtures/pr_steward/proof_current_exact_head_ready/harvest.json
+++ b/tests/fixtures/pr_steward/proof_current_exact_head_ready/harvest.json
@@ -1,0 +1,49 @@
+{
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "pr": {
+    "number": 704,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/704",
+    "state": "OPEN",
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "reviewDecision": "APPROVED",
+    "baseRefName": "main",
+    "baseRefOid": "base000000000000000000000000000000000000",
+    "headRefName": "codex/tp-dmx-pr-steward-001",
+    "headRefOid": "head000000000000000000000000000000000000",
+    "author": {"login": "hu3mann"},
+    "createdAt": "2026-05-26T01:00:00Z",
+    "updatedAt": "2026-05-26T02:00:00Z"
+  },
+  "changed_files": [
+    {"path": "tools/pr_steward/intake.py", "additions": 120, "deletions": 0, "status": "added"}
+  ],
+  "commits": [
+    {"oid": "head000000000000000000000000000000000000", "messageHeadline": "feat(governance): add check-only PR steward intake"}
+  ],
+  "reviews": [],
+  "review_comments": [],
+  "review_threads": [],
+  "issue_comments": [],
+  "checks": [
+    {
+      "name": "unit",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1",
+      "isRequired": true,
+      "headSha": "head000000000000000000000000000000000000"
+    }
+  ],
+  "embedded_audit": {
+    "status": "PASS",
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md"
+  },
+  "proof": {
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+    "proof_head_sha": "head000000000000000000000000000000000000",
+    "matches_pr_head": true
+  }
+}

--- a/tests/fixtures/pr_steward/proof_self_reference_exception_ready_or_needs_supervisor/harvest.json
+++ b/tests/fixtures/pr_steward/proof_self_reference_exception_ready_or_needs_supervisor/harvest.json
@@ -1,0 +1,73 @@
+{
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "pr": {
+    "number": 704,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/704",
+    "state": "OPEN",
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "reviewDecision": "APPROVED",
+    "baseRefName": "main",
+    "baseRefOid": "base000000000000000000000000000000000000",
+    "headRefName": "codex/tp-dmx-pr-steward-001",
+    "headRefOid": "head000000000000000000000000000000000000",
+    "author": {"login": "hu3mann"},
+    "createdAt": "2026-05-26T01:00:00Z",
+    "updatedAt": "2026-05-26T02:00:00Z"
+  },
+  "changed_files": [
+    {"path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md", "additions": 1, "deletions": 0, "status": "modified"},
+    {"path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json", "additions": 1, "deletions": 0, "status": "modified"},
+    {"path": "proof/TP-DMX-PR-STEWARD-001/review_bundle/MANIFEST.json", "additions": 1, "deletions": 0, "status": "modified"}
+  ],
+  "commits": [
+    {"oid": "proof00000000000000000000000000000000000", "messageHeadline": "chore(proof): capture current head with self-reference exception"}
+  ],
+  "reviews": [],
+  "review_comments": [],
+  "review_threads": [],
+  "issue_comments": [],
+  "checks": [
+    {
+      "name": "unit",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1",
+      "isRequired": true,
+      "headSha": "head000000000000000000000000000000000000"
+    }
+  ],
+  "embedded_audit": {
+    "status": "PASS_WITH_RISKS",
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md"
+  },
+  "proof": {
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+    "proof_head_sha": "proof000000000000000000000000000000000000",
+    "matches_pr_head": false,
+    "proof_freshness": {
+      "status": "CURRENT_WITH_SELF_REFERENCE_EXCEPTION",
+      "matches_pr_head": false,
+      "reason": "Final proof commit cannot contain its own final SHA without changing SHA again.",
+      "proof_recorded_sha": "proof000000000000000000000000000000000000",
+      "pr_head_sha": "head000000000000000000000000000000000000",
+      "self_reference_exception": {
+        "supervisor_accepted": true,
+        "allowed_when": [
+          "proof-only final commit",
+          "no runtime/source/test/schema changes after validated head",
+          "embedded audit is PASS or PASS_WITH_RISKS",
+          "supervisor acceptance recorded"
+        ],
+        "changed_files": [
+          "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md",
+          "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+          "proof/TP-DMX-PR-STEWARD-001/review_bundle/MANIFEST.json"
+        ],
+        "note": "Supervisor accepted proof-only final commit."
+      }
+    }
+  }
+}

--- a/tests/fixtures/pr_steward/proof_self_reference_exception_rejects_runtime_changes/harvest.json
+++ b/tests/fixtures/pr_steward/proof_self_reference_exception_rejects_runtime_changes/harvest.json
@@ -1,0 +1,71 @@
+{
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "pr": {
+    "number": 704,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/704",
+    "state": "OPEN",
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "reviewDecision": "APPROVED",
+    "baseRefName": "main",
+    "baseRefOid": "base000000000000000000000000000000000000",
+    "headRefName": "codex/tp-dmx-pr-steward-001",
+    "headRefOid": "head000000000000000000000000000000000000",
+    "author": {"login": "hu3mann"},
+    "createdAt": "2026-05-26T01:00:00Z",
+    "updatedAt": "2026-05-26T02:00:00Z"
+  },
+  "changed_files": [
+    {"path": "src/runtime.py", "additions": 12, "deletions": 0, "status": "modified"},
+    {"path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json", "additions": 1, "deletions": 0, "status": "modified"}
+  ],
+  "commits": [
+    {"oid": "proof11111111111111111111111111111111111", "messageHeadline": "chore(proof): incorrect self-reference exception"}
+  ],
+  "reviews": [],
+  "review_comments": [],
+  "review_threads": [],
+  "issue_comments": [],
+  "checks": [
+    {
+      "name": "unit",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1",
+      "isRequired": true,
+      "headSha": "head000000000000000000000000000000000000"
+    }
+  ],
+  "embedded_audit": {
+    "status": "PASS_WITH_RISKS",
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md"
+  },
+  "proof": {
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+    "proof_head_sha": "proof11111111111111111111111111111111111",
+    "matches_pr_head": false,
+    "proof_freshness": {
+      "status": "CURRENT_WITH_SELF_REFERENCE_EXCEPTION",
+      "matches_pr_head": false,
+      "reason": "Final proof commit cannot contain its own final SHA without changing SHA again.",
+      "proof_recorded_sha": "proof11111111111111111111111111111111111",
+      "pr_head_sha": "head000000000000000000000000000000000000",
+      "self_reference_exception": {
+        "supervisor_accepted": true,
+        "allowed_when": [
+          "proof-only final commit",
+          "no runtime/source/test/schema changes after validated head",
+          "embedded audit is PASS or PASS_WITH_RISKS",
+          "supervisor acceptance recorded"
+        ],
+        "changed_files": [
+          "src/runtime.py",
+          "proof/TP-DMX-PR-STEWARD-001/PROOF.json"
+        ],
+        "note": "Supervisor accepted proof-only final commit."
+      }
+    }
+  }
+}

--- a/tests/fixtures/pr_steward/raw_review_comment_without_thread_still_blocks/harvest.json
+++ b/tests/fixtures/pr_steward/raw_review_comment_without_thread_still_blocks/harvest.json
@@ -1,0 +1,59 @@
+{
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "pr": {
+    "number": 704,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/704",
+    "state": "OPEN",
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "reviewDecision": "COMMENTED",
+    "baseRefName": "main",
+    "baseRefOid": "base000000000000000000000000000000000000",
+    "headRefName": "codex/tp-dmx-pr-steward-001",
+    "headRefOid": "head000000000000000000000000000000000000",
+    "author": {"login": "hu3mann"},
+    "createdAt": "2026-05-26T01:00:00Z",
+    "updatedAt": "2026-05-26T02:00:00Z"
+  },
+  "changed_files": [
+    {"path": "tools/pr_steward/intake.py", "additions": 120, "deletions": 0, "status": "added"}
+  ],
+  "commits": [
+    {"oid": "head000000000000000000000000000000000000", "messageHeadline": "feat(governance): add check-only PR steward intake"}
+  ],
+  "reviews": [],
+  "review_comments": [
+    {
+      "id": "RTC_RAW_BLOCK",
+      "author": {"login": "chatgpt-codex-connector"},
+      "authorAssociation": "MEMBER",
+      "body": "P1: this should fail closed.",
+      "path": "tools/pr_steward/intake.py",
+      "line": 42,
+      "createdAt": "2026-05-26T02:01:00Z"
+    }
+  ],
+  "review_threads": [],
+  "issue_comments": [],
+  "checks": [
+    {
+      "name": "unit",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1",
+      "isRequired": true,
+      "headSha": "head000000000000000000000000000000000000"
+    }
+  ],
+  "embedded_audit": {
+    "status": "PASS",
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md"
+  },
+  "proof": {
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+    "proof_head_sha": "head000000000000000000000000000000000000",
+    "matches_pr_head": true
+  }
+}

--- a/tests/fixtures/pr_steward/resolved_thread_clears_review_item/harvest.json
+++ b/tests/fixtures/pr_steward/resolved_thread_clears_review_item/harvest.json
@@ -1,0 +1,79 @@
+{
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "pr": {
+    "number": 704,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/704",
+    "state": "OPEN",
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "reviewDecision": "APPROVED",
+    "baseRefName": "main",
+    "baseRefOid": "base000000000000000000000000000000000000",
+    "headRefName": "codex/tp-dmx-pr-steward-001",
+    "headRefOid": "head000000000000000000000000000000000000",
+    "author": {"login": "hu3mann"},
+    "createdAt": "2026-05-26T01:00:00Z",
+    "updatedAt": "2026-05-26T02:00:00Z"
+  },
+  "changed_files": [
+    {"path": "tools/pr_steward/intake.py", "additions": 120, "deletions": 0, "status": "added"}
+  ],
+  "commits": [
+    {"oid": "head000000000000000000000000000000000000", "messageHeadline": "feat(governance): add check-only PR steward intake"}
+  ],
+  "reviews": [],
+  "review_comments": [
+    {
+      "id": "RTC_RESOLVED",
+      "author": {"login": "chatgpt-codex-connector"},
+      "authorAssociation": "MEMBER",
+      "body": "P2: historical comment already addressed.",
+      "path": "tools/pr_steward/intake.py",
+      "line": 42,
+      "createdAt": "2026-05-26T02:01:00Z"
+    }
+  ],
+  "review_threads": [
+    {
+      "id": "RT_RESOLVED",
+      "isResolved": true,
+      "isOutdated": false,
+      "path": "tools/pr_steward/intake.py",
+      "line": 42,
+      "startLine": 40,
+      "comments": [
+        {
+          "id": "RTC_RESOLVED",
+          "author": {"login": "chatgpt-codex-connector"},
+          "authorAssociation": "MEMBER",
+          "body": "P2: historical comment already addressed.",
+          "path": "tools/pr_steward/intake.py",
+          "line": 42,
+          "createdAt": "2026-05-26T02:01:00Z"
+        }
+      ]
+    }
+  ],
+  "issue_comments": [],
+  "checks": [
+    {
+      "name": "unit",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1",
+      "isRequired": true,
+      "headSha": "head000000000000000000000000000000000000"
+    }
+  ],
+  "embedded_audit": {
+    "status": "PASS",
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md"
+  },
+  "proof": {
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+    "proof_head_sha": "head000000000000000000000000000000000000",
+    "matches_pr_head": true
+  }
+}

--- a/tests/fixtures/pr_steward/unresolved_thread_still_blocks/harvest.json
+++ b/tests/fixtures/pr_steward/unresolved_thread_still_blocks/harvest.json
@@ -1,0 +1,79 @@
+{
+  "harvest_complete": true,
+  "harvest_errors": [],
+  "pr": {
+    "number": 704,
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/704",
+    "state": "OPEN",
+    "isDraft": false,
+    "mergeable": "MERGEABLE",
+    "mergeStateStatus": "CLEAN",
+    "reviewDecision": "COMMENTED",
+    "baseRefName": "main",
+    "baseRefOid": "base000000000000000000000000000000000000",
+    "headRefName": "codex/tp-dmx-pr-steward-001",
+    "headRefOid": "head000000000000000000000000000000000000",
+    "author": {"login": "hu3mann"},
+    "createdAt": "2026-05-26T01:00:00Z",
+    "updatedAt": "2026-05-26T02:00:00Z"
+  },
+  "changed_files": [
+    {"path": "tools/pr_steward/intake.py", "additions": 120, "deletions": 0, "status": "added"}
+  ],
+  "commits": [
+    {"oid": "head000000000000000000000000000000000000", "messageHeadline": "feat(governance): add check-only PR steward intake"}
+  ],
+  "reviews": [],
+  "review_comments": [
+    {
+      "id": "RTC_UNRESOLVED",
+      "author": {"login": "chatgpt-codex-connector"},
+      "authorAssociation": "MEMBER",
+      "body": "P1: this should fail closed.",
+      "path": "tools/pr_steward/intake.py",
+      "line": 42,
+      "createdAt": "2026-05-26T02:01:00Z"
+    }
+  ],
+  "review_threads": [
+    {
+      "id": "RT_UNRESOLVED",
+      "isResolved": false,
+      "isOutdated": false,
+      "path": "tools/pr_steward/intake.py",
+      "line": 42,
+      "startLine": 40,
+      "comments": [
+        {
+          "id": "RTC_UNRESOLVED",
+          "author": {"login": "chatgpt-codex-connector"},
+          "authorAssociation": "MEMBER",
+          "body": "P1: this should fail closed.",
+          "path": "tools/pr_steward/intake.py",
+          "line": 42,
+          "createdAt": "2026-05-26T02:01:00Z"
+        }
+      ]
+    }
+  ],
+  "issue_comments": [],
+  "checks": [
+    {
+      "name": "unit",
+      "status": "COMPLETED",
+      "conclusion": "SUCCESS",
+      "detailsUrl": "https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/1",
+      "isRequired": true,
+      "headSha": "head000000000000000000000000000000000000"
+    }
+  ],
+  "embedded_audit": {
+    "status": "PASS",
+    "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md"
+  },
+  "proof": {
+    "proof_path": "proof/TP-DMX-PR-STEWARD-001/PROOF.json",
+    "proof_head_sha": "head000000000000000000000000000000000000",
+    "matches_pr_head": true
+  }
+}

--- a/tests/pr_steward/test_intake.py
+++ b/tests/pr_steward/test_intake.py
@@ -93,6 +93,141 @@ def test_ready_with_resolved_outdated_thread_records_nonblocking_evidence(
     assert threads["threads"][0]["blocking"] is False
 
 
+def test_resolved_thread_clears_review_comment_block(
+    tmp_path: Path,
+) -> None:
+    result = run_intake("resolved_thread_clears_review_item", tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    validate_artifacts(tmp_path)
+    readiness = load_json(tmp_path / "MERGE_READINESS.json")
+    ledger = load_json(tmp_path / "REVIEW_ITEM_LEDGER.json")
+    threads = load_json(tmp_path / "THREAD_DISPOSITIONS.json")
+    review_comment_items = [
+        item for item in ledger["items"] if item["source"] == "review_comment"
+    ]
+    assert readiness["readiness"] == "READY"
+    assert "REVIEW_ITEM_MUST_FIX" not in readiness["blockers"]
+    assert "UNRESOLVED_REVIEW_THREAD" not in readiness["blockers"]
+    assert review_comment_items[0]["disposition"] == "AUTO_APPLIED"
+    assert review_comment_items[0]["blocking"] is False
+    assert threads["threads"][0]["disposition"] == "OPTIONAL_DEFERRED"
+
+
+def test_outdated_resolved_thread_nonblocking(
+    tmp_path: Path,
+) -> None:
+    result = run_intake("outdated_resolved_thread_nonblocking", tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    validate_artifacts(tmp_path)
+    readiness = load_json(tmp_path / "MERGE_READINESS.json")
+    ledger = load_json(tmp_path / "REVIEW_ITEM_LEDGER.json")
+    threads = load_json(tmp_path / "THREAD_DISPOSITIONS.json")
+    review_comment_items = [
+        item for item in ledger["items"] if item["source"] == "review_comment"
+    ]
+    assert readiness["readiness"] == "READY"
+    assert threads["threads"][0]["disposition"] == "AUTO_APPLIED"
+    assert review_comment_items[0]["disposition"] == "AUTO_APPLIED"
+    assert review_comment_items[0]["blocking"] is False
+
+
+def test_raw_review_comment_without_thread_still_blocks(
+    tmp_path: Path,
+) -> None:
+    result = run_intake("raw_review_comment_without_thread_still_blocks", tmp_path)
+
+    assert result.returncode == 2, result.stderr
+    validate_artifacts(tmp_path)
+    readiness = load_json(tmp_path / "MERGE_READINESS.json")
+    ledger = load_json(tmp_path / "REVIEW_ITEM_LEDGER.json")
+    assert readiness["readiness"] == "NEEDS_IMPLEMENTER"
+    assert "REVIEW_ITEM_MUST_FIX" in readiness["blockers"]
+    assert ledger["items"][0]["disposition"] == "MUST_FIX"
+    assert ledger["items"][0]["blocking"] is True
+
+
+def test_unresolved_thread_still_blocks(
+    tmp_path: Path,
+) -> None:
+    result = run_intake("unresolved_thread_still_blocks", tmp_path)
+
+    assert result.returncode == 2, result.stderr
+    validate_artifacts(tmp_path)
+    readiness = load_json(tmp_path / "MERGE_READINESS.json")
+    threads = load_json(tmp_path / "THREAD_DISPOSITIONS.json")
+    assert readiness["readiness"] == "NEEDS_IMPLEMENTER"
+    assert "UNRESOLVED_REVIEW_THREAD" in readiness["blockers"]
+    assert threads["threads"][0]["disposition"] == "MUST_FIX"
+
+
+def test_proof_current_exact_head_ready(tmp_path: Path) -> None:
+    result = run_intake("proof_current_exact_head_ready", tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    validate_artifacts(tmp_path)
+    readiness = load_json(tmp_path / "MERGE_READINESS.json")
+    assert readiness["readiness"] == "READY"
+    assert readiness["proof"]["proof_freshness"]["status"] == "CURRENT"
+    assert readiness["proof"]["matches_pr_head"] is True
+
+
+def test_proof_self_reference_exception_ready(tmp_path: Path) -> None:
+    result = run_intake("proof_self_reference_exception_ready_or_needs_supervisor", tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    validate_artifacts(tmp_path)
+    readiness = load_json(tmp_path / "MERGE_READINESS.json")
+    assert readiness["readiness"] == "READY"
+    assert (
+        readiness["proof"]["proof_freshness"]["status"]
+        == "CURRENT_WITH_SELF_REFERENCE_EXCEPTION"
+    )
+    assert readiness["proof"]["matches_pr_head"] is False
+
+
+def test_proof_self_reference_exception_rejects_runtime_changes(
+    tmp_path: Path,
+) -> None:
+    result = run_intake(
+        "proof_self_reference_exception_rejects_runtime_changes",
+        tmp_path,
+    )
+
+    assert result.returncode == 2, result.stderr
+    validate_artifacts(tmp_path)
+    readiness = load_json(tmp_path / "MERGE_READINESS.json")
+    assert readiness["readiness"] == "NEEDS_SUPERVISOR"
+    assert "PROOF_STALE_OR_MISSING" in readiness["blockers"]
+
+
+def test_embedded_audit_pass_with_risks_nonblocking(tmp_path: Path) -> None:
+    result = run_intake("embedded_audit_pass_with_risks_nonblocking", tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    validate_artifacts(tmp_path)
+    readiness = load_json(tmp_path / "MERGE_READINESS.json")
+    assert readiness["readiness"] == "READY"
+    assert readiness["embedded_audit"]["status"] == "PASS_WITH_RISKS"
+
+
+def test_pr713_like_resolved_threads_with_pass_with_risks_audit(
+    tmp_path: Path,
+) -> None:
+    result = run_intake(
+        "pr713_like_resolved_threads_with_pass_with_risks_audit",
+        tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr
+    validate_artifacts(tmp_path)
+    readiness = load_json(tmp_path / "MERGE_READINESS.json")
+    assert readiness["readiness"] == "READY"
+    assert "REVIEW_ITEM_MUST_FIX" not in readiness["blockers"]
+    assert "UNRESOLVED_REVIEW_THREAD" not in readiness["blockers"]
+
+
 def test_forbidden_mutation_args_are_not_supported(tmp_path: Path) -> None:
     help_result = subprocess.run(
         [sys.executable, "-m", "tools.pr_steward.intake", "--help"],
@@ -259,6 +394,7 @@ def test_live_collection_uses_proof_path_for_ready_state(
     assert readiness["embedded_audit"]["status"] == "PASS_WITH_RISKS"
     assert readiness["proof"]["proof_head_sha"] == pr_head
     assert readiness["proof"]["matches_pr_head"] is True
+    assert readiness["proof"]["proof_freshness"]["status"] == "CURRENT"
 
 
 def test_trusted_author_association_is_nonblocking() -> None:

--- a/tools/pr_steward/classifier.py
+++ b/tools/pr_steward/classifier.py
@@ -348,19 +348,19 @@ def _classify_threads(
                 rationale = "Thread author is not in known reviewer config."
                 _append_once(blockers, "UNKNOWN_REVIEWER_NEEDS_CLASSIFICATION")
                 _append_once(unknowns, f"Unknown review_thread author: {author}")
-            elif not is_resolved:
+            elif is_resolved or is_outdated:
+                disposition = "AUTO_APPLIED"
+                blocking = False
+                rationale = (
+                    "Resolved review thread clears blocker."
+                    if is_resolved
+                    else "Outdated review thread is historical evidence only."
+                )
+            else:
                 disposition = "MUST_FIX"
                 blocking = True
                 rationale = "Active unresolved review thread blocks readiness."
                 _append_once(blockers, "UNRESOLVED_REVIEW_THREAD")
-            elif is_outdated:
-                disposition = "AUTO_APPLIED"
-                blocking = False
-                rationale = "Resolved outdated thread is historical evidence only."
-            else:
-                disposition = "OPTIONAL_DEFERRED"
-                blocking = False
-                rationale = "Resolved thread has no active blocker."
             items.append(
                 _review_item(
                     item_id=item_id,

--- a/tools/pr_steward/classifier.py
+++ b/tools/pr_steward/classifier.py
@@ -81,12 +81,14 @@ def build_artifacts(
             unknowns=unknowns,
         )
     )
+    thread_lookup = _thread_comment_lookup(harvest.get("review_threads") or [])
     review_items.extend(
         _classify_comments(
             harvest.get("review_comments") or [],
             source="review_comment",
             known_reviewers=known_reviewers,
             trusted_associations=trusted_associations,
+            thread_lookup=thread_lookup,
             blockers=blockers,
             unknowns=unknowns,
         )
@@ -97,6 +99,7 @@ def build_artifacts(
             source="issue_comment",
             known_reviewers=known_reviewers,
             trusted_associations=trusted_associations,
+            thread_lookup=None,
             blockers=blockers,
             unknowns=unknowns,
         )
@@ -123,7 +126,7 @@ def build_artifacts(
         _append_once(unknowns, f"Unknown embedded audit status: {audit_status}")
 
     proof = _proof(harvest)
-    if not proof["matches_pr_head"]:
+    if not _proof_is_current(proof, pr["head_sha"]):
         _append_once(blockers, "PROOF_STALE_OR_MISSING")
     if not proof["proof_head_sha"]:
         _append_once(unknowns, "Proof head SHA missing")
@@ -264,6 +267,7 @@ def _classify_comments(
     source: str,
     known_reviewers: set[str],
     trusted_associations: set[str],
+    thread_lookup: dict[str, dict[str, Any]] | None,
     blockers: list[str],
     unknowns: list[str],
 ) -> list[dict[str, Any]]:
@@ -273,12 +277,26 @@ def _classify_comments(
         association = _association(comment)
         body = str(comment.get("body") or "")
         item_id = str(comment.get("id") or f"{source}-{index}")
+        thread = (thread_lookup or {}).get(item_id)
         if not _known_author(author, association, known_reviewers, trusted_associations):
             disposition = "UNKNOWN_REVIEWER_NEEDS_CLASSIFICATION"
             blocking = True
             rationale = "Comment author is not in known reviewer config."
             _append_once(blockers, "UNKNOWN_REVIEWER_NEEDS_CLASSIFICATION")
             _append_once(unknowns, f"Unknown {source} author: {author}")
+        elif thread and thread.get("is_resolved"):
+            disposition = "AUTO_APPLIED"
+            blocking = False
+            rationale = "Resolved review thread clears original raw review comment blocker."
+        elif thread and thread.get("is_outdated"):
+            disposition = "AUTO_APPLIED"
+            blocking = False
+            rationale = "Outdated review thread is historical evidence only."
+        elif thread and not thread.get("is_resolved"):
+            disposition = "MUST_FIX"
+            blocking = True
+            rationale = "Linked unresolved review thread blocks readiness."
+            _append_once(blockers, "UNRESOLVED_REVIEW_THREAD")
         else:
             disposition, blocking, rationale = _body_disposition(body)
             if blocking:
@@ -558,11 +576,151 @@ def _embedded_audit(harvest: dict[str, Any]) -> dict[str, str]:
 
 def _proof(harvest: dict[str, Any]) -> dict[str, Any]:
     raw = harvest.get("proof") or {}
+    proof_head_sha = raw.get("proof_head_sha")
+    pr_head_sha = _harvest_pr_head_sha(harvest.get("pr") or {})
+    freshness = _proof_freshness(raw, proof_head_sha, pr_head_sha)
+    raw_matches = raw.get("matches_pr_head")
     return {
         "proof_path": str(raw.get("proof_path") or ""),
-        "proof_head_sha": raw.get("proof_head_sha"),
-        "matches_pr_head": bool(raw.get("matches_pr_head", False)),
+        "proof_head_sha": proof_head_sha,
+        "matches_pr_head": bool(
+            freshness["matches_pr_head"] if raw_matches is None else raw_matches
+        ),
+        "proof_freshness": freshness,
     }
+
+
+def _harvest_pr_head_sha(pr: dict[str, Any]) -> str:
+    for key in ("head_sha", "headRefOid", "head_ref_oid"):
+        value = pr.get(key)
+        if value:
+            return str(value)
+    return ""
+
+
+def _proof_freshness(
+    raw: dict[str, Any], proof_head_sha: Any, pr_head_sha: str
+) -> dict[str, Any]:
+    proof_freshness = raw.get("proof_freshness")
+    if isinstance(proof_freshness, dict):
+        status = str(proof_freshness.get("status") or "UNKNOWN")
+        freshness = {
+            "status": status,
+            "matches_pr_head": bool(
+                proof_freshness.get("matches_pr_head", bool(proof_head_sha and pr_head_sha and str(proof_head_sha) == pr_head_sha))
+            ),
+            "reason": str(proof_freshness.get("reason") or ""),
+            "proof_recorded_sha": _maybe_string(proof_freshness.get("proof_recorded_sha"))
+            or _maybe_string(proof_head_sha),
+            "pr_head_sha": _maybe_string(
+                proof_freshness.get("pr_head_sha")
+            )
+            or (pr_head_sha or None),
+            "self_reference_exception": proof_freshness.get(
+                "self_reference_exception"
+            )
+            if isinstance(proof_freshness.get("self_reference_exception"), dict)
+            else None,
+        }
+        return freshness
+
+    if not proof_head_sha:
+        return {
+            "status": "MISSING",
+            "matches_pr_head": False,
+            "reason": "Proof head SHA missing.",
+            "proof_recorded_sha": None,
+            "pr_head_sha": pr_head_sha or None,
+            "self_reference_exception": None,
+        }
+    if pr_head_sha and str(proof_head_sha) == pr_head_sha:
+        return {
+            "status": "CURRENT",
+            "matches_pr_head": True,
+            "reason": "Proof head SHA matches PR head SHA.",
+            "proof_recorded_sha": str(proof_head_sha),
+            "pr_head_sha": pr_head_sha,
+            "self_reference_exception": None,
+        }
+    return {
+        "status": "STALE",
+        "matches_pr_head": False,
+        "reason": "Proof head SHA does not match PR head SHA.",
+        "proof_recorded_sha": str(proof_head_sha),
+        "pr_head_sha": pr_head_sha or None,
+        "self_reference_exception": None,
+    }
+
+
+def _proof_is_current(proof: dict[str, Any], pr_head_sha: str) -> bool:
+    freshness = proof.get("proof_freshness") or {}
+    status = str(freshness.get("status") or "UNKNOWN")
+    proof_head_sha = proof.get("proof_head_sha")
+    if status == "CURRENT":
+        return bool(proof_head_sha) and bool(freshness.get("matches_pr_head", False))
+    if status != "CURRENT_WITH_SELF_REFERENCE_EXCEPTION":
+        return False
+    if not proof_head_sha:
+        return False
+    if str(freshness.get("pr_head_sha") or "") != pr_head_sha:
+        return False
+    exception = freshness.get("self_reference_exception") or {}
+    if not isinstance(exception, dict):
+        return False
+    if exception.get("supervisor_accepted") is not True:
+        return False
+    allowed_when = {
+        str(item)
+        for item in exception.get("allowed_when") or []
+        if str(item).strip()
+    }
+    required = {
+        "proof-only final commit",
+        "no runtime/source/test/schema changes after validated head",
+        "embedded audit is PASS or PASS_WITH_RISKS",
+        "supervisor acceptance recorded",
+    }
+    if not required.issubset(allowed_when):
+        return False
+    changed_files = exception.get("changed_files") or []
+    if not isinstance(changed_files, list) or not changed_files:
+        return False
+    for path in changed_files:
+        path_str = str(path or "").strip()
+        if not path_str.startswith("proof/"):
+            return False
+    return True
+
+
+def _maybe_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    value = str(value)
+    return value if value else None
+
+
+def _thread_comment_lookup(threads: list[Any]) -> dict[str, dict[str, Any]]:
+    lookup: dict[str, dict[str, Any]] = {}
+    for thread_index, thread in enumerate(threads):
+        thread_id = str(thread.get("id") or f"thread-{thread_index}")
+        is_resolved = bool(thread.get("isResolved", False))
+        is_outdated = bool(thread.get("isOutdated", False))
+        path = str(thread.get("path") or "")
+        line = thread.get("line")
+        start_line = thread.get("startLine")
+        for comment_index, comment in enumerate(thread.get("comments") or []):
+            comment_id = str(
+                comment.get("id") or f"{thread_id}-comment-{comment_index}"
+            )
+            lookup[comment_id] = {
+                "thread_id": thread_id,
+                "is_resolved": is_resolved,
+                "is_outdated": is_outdated,
+                "path": path,
+                "line": line,
+                "start_line": start_line,
+            }
+    return lookup
 
 
 def _body_disposition(body: str) -> tuple[str, bool, str]:

--- a/tools/pr_steward/classifier.py
+++ b/tools/pr_steward/classifier.py
@@ -657,7 +657,11 @@ def _proof_is_current(proof: dict[str, Any], pr_head_sha: str) -> bool:
     status = str(freshness.get("status") or "UNKNOWN")
     proof_head_sha = proof.get("proof_head_sha")
     if status == "CURRENT":
-        return bool(proof_head_sha) and bool(freshness.get("matches_pr_head", False))
+        if not proof_head_sha or str(proof_head_sha) != pr_head_sha:
+            return False
+        if not freshness.get("matches_pr_head", False):
+            return False
+        return True
     if status != "CURRENT_WITH_SELF_REFERENCE_EXCEPTION":
         return False
     if not proof_head_sha:

--- a/tools/pr_steward/collector.py
+++ b/tools/pr_steward/collector.py
@@ -270,6 +270,7 @@ def _proof_state(
     if not isinstance(embedded, dict):
         embedded = {}
     proof_head_sha = _proof_head_sha(payload)
+    proof_freshness = _proof_freshness(payload, proof_head_sha, pr_head_sha)
     return {
         "embedded_audit": {
             "status": str(embedded.get("status") or "SKIPPED"),
@@ -284,6 +285,7 @@ def _proof_state(
             "matches_pr_head": bool(
                 proof_head_sha and pr_head_sha and proof_head_sha == pr_head_sha
             ),
+            "proof_freshness": proof_freshness,
         },
     }, []
 
@@ -298,7 +300,66 @@ def _missing_proof_state(proof_path: Path | None) -> dict[str, Any]:
             "proof_path": proof_path.as_posix() if proof_path else "",
             "proof_head_sha": None,
             "matches_pr_head": False,
+            "proof_freshness": {
+                "status": "MISSING",
+                "matches_pr_head": False,
+                "reason": "Proof file was not provided.",
+                "proof_recorded_sha": None,
+                "pr_head_sha": None,
+                "self_reference_exception": None,
+            },
         },
+    }
+
+
+def _proof_freshness(
+    payload: dict[str, Any], proof_head_sha: str | None, pr_head_sha: str | None
+) -> dict[str, Any]:
+    raw = payload.get("proof_freshness")
+    if isinstance(raw, dict):
+        exception = raw.get("self_reference_exception")
+        return {
+            "status": str(raw.get("status") or "UNKNOWN"),
+            "matches_pr_head": bool(
+                raw.get("matches_pr_head", bool(proof_head_sha and pr_head_sha and proof_head_sha == pr_head_sha))
+            ),
+            "reason": str(raw.get("reason") or ""),
+            "proof_recorded_sha": str(raw.get("proof_recorded_sha") or proof_head_sha)
+            if proof_head_sha
+            else None,
+            "pr_head_sha": str(raw.get("pr_head_sha") or pr_head_sha)
+            if (raw.get("pr_head_sha") or pr_head_sha)
+            else None,
+            "self_reference_exception": exception
+            if isinstance(exception, dict)
+            else None,
+        }
+
+    if not proof_head_sha:
+        return {
+            "status": "MISSING",
+            "matches_pr_head": False,
+            "reason": "Proof head SHA missing.",
+            "proof_recorded_sha": None,
+            "pr_head_sha": pr_head_sha,
+            "self_reference_exception": None,
+        }
+    if pr_head_sha and proof_head_sha == pr_head_sha:
+        return {
+            "status": "CURRENT",
+            "matches_pr_head": True,
+            "reason": "Proof head SHA matches PR head SHA.",
+            "proof_recorded_sha": proof_head_sha,
+            "pr_head_sha": pr_head_sha,
+            "self_reference_exception": None,
+        }
+    return {
+        "status": "STALE",
+        "matches_pr_head": False,
+        "reason": "Proof head SHA does not match PR head SHA.",
+        "proof_recorded_sha": proof_head_sha,
+        "pr_head_sha": pr_head_sha,
+        "self_reference_exception": None,
     }
 
 


### PR DESCRIPTION
# Summary

- Packet: TP-DMX-PR-STEWARD-RESOLVED-THREAD-PROOF-SEMANTICS-001
- Verdict: PASS_WITH_RISKS
- Audit: local authenticated Claude Code direct audit
- Nonblocking risk: unresolved-outdated thread state is conservative but audit-trail inconsistent and untested
- Validation: compileall, pytest tests/pr_steward, JSON schema parsing, fixture smoke, git diff --check
