### PR TITLE
feat(dx): rewrite /dx:implement to use task-orchestrator (TP-CS-041)

### DIFF
--- a/.claude/commands/dx/implement.md
+++ b/.claude/commands/dx/implement.md
@@ -1,325 +1,303 @@
 ---
-description: "ADHD-optimized 25-minute implementation session with task assessment"
-arguments: "[task_id]"
+description: "ADHD-optimized 25-minute implementation session driven by task-orchestrator"
+arguments: "[<item-id>]"
 allowed-tools: [
   "Bash", "Read", "Write", "Edit", "Grep", "Glob", "TodoWrite",
-  "mcp__conport__*",
-  "mcp__serena__*",
-  "mcp__pal__apilookup",
-  "mcp__zen__thinkdeep", "mcp__zen__debug", "mcp__zen__codereview"
+  "mcp__task-orchestrator__get_next_item",
+  "mcp__task-orchestrator__advance_item",
+  "mcp__task-orchestrator__get_context",
+  "mcp__task-orchestrator__manage_notes",
+  "mcp__conport__update_active_context",
+  "mcp__pal__thinkdeep", "mcp__pal__debug", "mcp__pal__codereview",
+  "mcp__pal__apilookup"
 ]
-model: "claude-sonnet-4-5-20250929"
+model: "claude-sonnet-4-5"
 ---
 
-# /dx:implement - ADHD Implementation Session
+# /dx:implement — ADHD Implementation Session
 
-Start an ADHD-optimized 25-minute focused implementation session with intelligent task assessment and break management.
+Start an ADHD-optimized 25-minute focused implementation session. Drives task selection, session
+lifecycle, and completion gate surfacing through the task-orchestrator.
 
-**Purpose**: Provide structured, supportive implementation sessions that respect ADHD needs for focus, breaks, and progress tracking.
-
----
-
-## Phase 1: Task Selection & ADHD Assessment
-
-### Step 1.1: Get Task
-
-**If task_id provided in $ARGUMENTS**:
-
-- Query ConPort for specific task:
-
-  ```bash
-  Use mcp__conport__get_progress with workspace_id "/Users/hue/code/dopemux-mvp" and limit 100
-  ```
-
-- Find task matching provided ID or description substring
-
-**If no task_id provided**:
-
-- Query ConPort for TODO tasks:
-
-  ```bash
-  Use mcp__conport__get_progress with:
-    workspace_id: "/Users/hue/code/dopemux-mvp"
-    status_filter: "TODO"
-    limit: 10
-  ```
-
-- Show available tasks with brief descriptions
-
-### Step 1.2: Assess Task Suitability (ADHD Engine Integration)
-
-For the selected task:
-
-1. **Estimate task complexity** (0.0-1.0 scale):
-   - Simple refactor/docs: 0.3
-   - Standard feature: 0.5-0.6
-   - Complex architecture/debugging: 0.8
-   - Use your judgment based on description
-
-2. **Call ADHD Engine for assessment**:
-
-   ```bash
-   Use Bash tool:
-   curl -s -X POST http://localhost:8095/api/v1/assess-task \
-     -H "Content-Type: application/json" \
-     -d '{
-       "user_id": "current_user",
-       "task_id": "TASK_ID",
-       "task_data": {
-         "complexity_score": ESTIMATED_COMPLEXITY,
-         "estimated_minutes": 25,
-         "description": "TASK_DESCRIPTION",
-         "dependencies": []
-       }
-     }' | python -m json.tool
-   ```
-
-3. **Display ADHD Assessment Results**:
-
-   ```
-   ═══════════════════════════════════════════
-   ADHD Task Assessment
-   ═══════════════════════════════════════════
-
-   ⚡ Energy Match: [suitability_score as percentage]
-   🧠 Cognitive Load: [cognitive_load_level]
-   ✅ Suitability: [energy_match as percentage]
-
-   Recommendations:
-   [Loop through recommendations array and display each]
-   💡 [message]
-      → [suggested_actions as bullet points]
-
-   ═══════════════════════════════════════════
-   ```
-
-4. **Decision Point**:
-   - If suitability_score < 0.6:
-     - Show: "⚠️ This task may be challenging right now"
-     - Ask: "Continue anyway? (y/n) Or select different task?"
-   - If user selects "n": Go back to Step 1.1
-   - If suitability >= 0.6 or user confirms: Proceed
-
-**Error Handling**: If ADHD Engine unavailable:
-
-- Show: "⚠️ ADHD assessment unavailable (is adhd-engine running?)"
-- Show: "Proceeding with standard 25-minute session"
-- Continue to Phase 2
+> **Authority**: task-orchestrator MCP per `AGENTS.md §6` + ADR
+> `docs/90-adr/adr-task-orchestrator-as-workflow-authority.md`.
 
 ---
 
-## Phase 2: Session Start
+## Phase 1: Argument Parsing + Task Selection
 
-### Step 2.1: Update ConPort Task Status
+Parse `$ARGUMENTS`:
 
-```bash
-Use mcp__conport__update_progress with:
-  workspace_id: "/Users/hue/code/dopemux-mvp"
-  progress_id: TASK_ID
-  status: "IN_PROGRESS"
-  description: "ORIGINAL_DESCRIPTION (session started)"
+- **`<item-id>` provided** — treat as orchestrator work-item UUID. Call
+  `get_context(itemId=<item-id>)` to confirm the item exists and read its current role, title,
+  ancestors, and gate status. Skip the selection prompt.
+- **No argument** — call `get_next_item(limit=3, includeAncestors=true, includeDetails=true)` to
+  get the top 3 ADHD-ranked queue items, then display them and ask the user to pick one (max 3
+  options — ADHD-safe).
+
+**Selection display** (no-arg path):
+
+```
+── Next Up ──────────────────────────────────────────
+  1. [ab12cd34] Sprint Goal › Task Title
+     priority: high · complexity: 5
+
+  2. [ef56gh78] Sprint Goal › Other Task
+     priority: medium · complexity: 3
+
+  3. [ij90kl12] Sprint Goal › Yet Another
+     priority: medium · complexity: 6
+─────────────────────────────────────────────────────
+Which task? (1/2/3 or paste UUID)
 ```
 
-### Step 2.2: Update Active Context
+Show the full UUID once (in parentheses) after the short prefix.
+
+### Step 1.2: ADHD Engine Assessment (Optional)
+
+Derive complexity (0.0–1.0) from the item's `complexity` field (divide by 10), then:
 
 ```bash
-Use mcp__conport__update_active_context with:
+curl -s -X POST http://localhost:8095/api/v1/assess-task \
+  -H "Content-Type: application/json" \
+  -d '{
+    "user_id": "current_user",
+    "task_id": "ITEM_UUID",
+    "task_data": {
+      "complexity_score": COMPLEXITY,
+      "estimated_minutes": 25,
+      "description": "ITEM_TITLE",
+      "dependencies": []
+    }
+  }' | python -m json.tool
+```
+
+Display results compactly:
+
+```
+⚡ Energy Match: XX%    🧠 Cognitive Load: LOW/MED/HIGH    ✅ Suitability: XX%
+💡 <recommendation>
+```
+
+If suitability < 0.6, warn and offer to select a different task. If the ADHD Engine is
+unavailable, show `⚠️ ADHD assessment unavailable — proceeding with standard session` and
+continue.
+
+---
+
+## Phase 2: Session Start (Safety & Confirmation)
+
+### Step 2.1: Preflight Read
+
+Call `get_context(itemId=CHOSEN_UUID)` before any transition:
+
+- **role = queue** → proceed to Step 2.2
+- **role = work** → item already in progress; skip transition, log "Re-entering active session"
+- **role = review or terminal** → warn user; do not start a new session on a closed item
+
+### Step 2.2: Start Transition (queue only)
+
+```
+advance_item(transitions=[{
+  itemId: CHOSEN_UUID,
+  trigger: "start",
+  summary: "Session start via /dx:implement"
+}])
+```
+
+### Step 2.3: Update Session Context
+
+```
+mcp__conport__update_active_context:
   workspace_id: "/Users/hue/code/dopemux-mvp"
   patch_content: {
-    "current_task": "TASK_ID",
-    "session_start": "CURRENT_TIMESTAMP",
+    "current_task": "CHOSEN_UUID",
+    "session_start": "ISO_TIMESTAMP",
     "session_type": "implement",
     "target_duration": 25
   }
 ```
 
-### Step 2.3: Display Session Start
-
-Show to user:
+### Step 2.4: Session Banner
 
 ```
 🚀 Implementation Session Started
-═══════════════════════════════════════════
+═══════════════════════════════════════════════
 
-📋 Task: [TASK_DESCRIPTION]
-⏱️ Duration: 25 minutes
+📋 Task: [ITEM_TITLE]
+🆔 ID:   [ab12cd34]  (full UUID shown once)
+▸ Role:  work
+⏱️  Duration: 25 minutes
 🎯 Focus: Stay on this task, minimize context switches
 
-ADHD Support Active:
-✅ Progress tracked in ConPort
-✅ Break reminder at 25 minutes
-✅ Energy-optimized task selection
-
-Let's build! 💪
-═══════════════════════════════════════════
+Orchestrator tracking active. Let's build! 💪
+═══════════════════════════════════════════════
 ```
 
 ---
 
 ## Phase 3: Implementation Work
 
-**Instructions for Implementation Phase**:
-
-You are now in focused implementation mode. Follow these ADHD-supportive guidelines:
+You are now in focused implementation mode.
 
 ### Work Guidelines
 
-- **Stay Focused**: Work on this one task only
-- **Save Frequently**: After each meaningful change, save your work
-- **Track Progress**: Update your mental progress estimate
-- **Minimize Switches**: If you need to look something up, keep it brief and return to task
+- **Stay Focused** — work on this one task only
+- **Save Frequently** — after each meaningful change, save work
+- **Minimize Switches** — keep lookups brief, return to task
 
 ### ADHD Accommodations
 
-**If Feeling Stuck**:
-
-- Break the current step into even smaller pieces
-- Start with the easiest part
-- It's okay to make progress incrementally
-
-**If Distracted**:
-
-- Acknowledge the distraction
-- Gently return focus to the task
-- No judgment - this is normal
-
-**If Overwhelmed**:
-
-- Pause and reassess
-- Consider if task complexity was underestimated
-- It's okay to break early and adjust approach
+- **If stuck**: break the current step into smaller pieces; start with the easiest part
+- **If distracted**: acknowledge, gently return focus — no judgment
+- **If overwhelmed**: pause, reassess; it's okay to break early and adjust approach
 
 ### Progress Checkpoints
 
-After each major step (file created, test passing, feature working):
+After each major step (file created, test passing, feature working), optionally file a running
+note:
 
-- Briefly note progress
-- Optionally save to ConPort with progress note
-- Celebrate small wins internally
+```
+manage_notes(operation="upsert", notes=[{
+  itemId: CHOSEN_UUID,
+  key: "implementation-evidence",
+  role: "work",
+  body: "Progress: <what was done, any exit codes>"
+}])
+```
 
 ---
 
 ## Phase 4: Session Completion
 
-**After 25 minutes of work OR when task reaches natural checkpoint**:
-
-### Step 4.1: Check Completion Status
-
-Ask user:
+After 25 minutes or when the task reaches a natural checkpoint, ask:
 
 ```
 Session checkpoint reached!
 
-Task status:
-- ✅ DONE (task completed)
-- 🔄 IN_PROGRESS (still working, good progress)
-- ⏸️ BLOCKED (encountered blocker)
-- 🔀 CONTEXT_SWITCH (need to switch tasks)
-
-What's the status?
+1. ✅ DONE          — task complete, ready to close
+2. 🔄 IN_PROGRESS   — still working, good progress
+3. ⛔ BLOCKED        — hit a blocker
+4. 🔀 CONTEXT_SWITCH — switching tasks
 ```
 
-### Step 4.2: Update ConPort
+### DONE Path
 
-```bash
-Use mcp__conport__update_progress with:
+Call `get_context(itemId=CHOSEN_UUID)` and inspect `gateStatus.canAdvance` + `gateStatus.missingNotes`:
+
+**If `gateStatus.canAdvance: false`** (gates pending):
+
+```
+⚠️ Gates pending before you can complete:
+
+Missing notes:
+  • proof-bundle (review) — REQUIRED
+  • <other keys from gateStatus.missingNotes>
+
+Run: /dx:note CHOSEN_UUID proof-bundle
+Then: /dx:complete CHOSEN_UUID
+```
+
+**If `gateStatus.canAdvance: true`** (all gates clear):
+
+```
+✅ ✅ ✅ Gates are clear!
+Run: /dx:complete CHOSEN_UUID
+```
+
+Do **not** call `advance_item(trigger="complete")` from this command — delegate to `/dx:complete`.
+
+### BLOCKED Path
+
+Ask the user for a brief reason, then:
+
+```
+advance_item(transitions=[{
+  itemId: CHOSEN_UUID,
+  trigger: "block",
+  summary: "USER_REASON"
+}])
+```
+
+### IN_PROGRESS / CONTEXT_SWITCH
+
+No orchestrator transition — item stays in `work`. Update session context only (Step 4.1 below).
+
+### All Paths: Close Session Context
+
+```
+mcp__conport__update_active_context:
   workspace_id: "/Users/hue/code/dopemux-mvp"
-  progress_id: TASK_ID
-  status: USER_SELECTED_STATUS
-  description: "DESCRIPTION (+ brief progress note)"
+  patch_content: {
+    "last_session_end": "ISO_TIMESTAMP",
+    "last_task_status": "DONE|BLOCKED|IN_PROGRESS|CONTEXT_SWITCH",
+    "session_completed": true
+  }
 ```
 
-### Step 4.3: Break Reminder
-
-Show break recommendation:
+### Break Reminder
 
 ```
 ☕ Time for a 5-Minute Break!
-═══════════════════════════════════════════
+═══════════════════════════════════════════════
+You've been focused for 25 minutes — great work!
 
-You've been focused for 25 minutes - great work!
+• Walk  · Hydrate  · Stretch  · Deep breathing  · 20-20-20
 
-Break Suggestions:
-• 5-minute walk (get blood flowing)
-• Hydrate (water break)
-• Stretch (release tension)
-• Deep breathing (3-5 breaths)
-• Look away from screen (20-20-20 rule)
-
-Set a 5-minute timer and step away.
 You've earned this break! 💙
-
-═══════════════════════════════════════════
-```
-
-### Step 4.4: Celebration (if DONE)
-
-If status is DONE:
-
-```
-✅ ✅ ✅ AWESOME! TASK COMPLETE! ✅ ✅ ✅
-
-[TASK_DESCRIPTION]
-
-🎉 You crushed it!
-
-Next steps:
-- Take that well-deserved break
-- Then: /dx:implement for next task
-- Or: /dx:stats to see your progress
-
-Keep up the great work!
-```
-
-### Step 4.5: Update Active Context
-
-```bash
-Use mcp__conport__update_active_context with:
-  workspace_id: "/Users/hue/code/dopemux-mvp"
-  patch_content: {
-    "last_session_end": "CURRENT_TIMESTAMP",
-    "last_task_status": "USER_STATUS",
-    "session_completed": true
-  }
+═══════════════════════════════════════════════
 ```
 
 ---
 
 ## Error Handling
 
-**If ConPort MCP unavailable**:
+**task-orchestrator unavailable** — if `get_next_item` or `advance_item` fail:
+- Show `⚠️ task-orchestrator unavailable — workflow state won't be updated`
+- Offer to continue the session without state tracking
+- Suggest running `get_context()` health-check when available
 
-- Show: "⚠️ ConPort unavailable - progress won't be saved"
-- Continue session anyway (user's choice)
-- Suggest: "Save work manually and retry later"
+**ADHD Engine unavailable** — handled in Phase 1; session continues without assessment.
 
-**If ADHD Engine unavailable**:
+**Invalid UUID** — if `get_context(itemId=X)` returns not-found:
+- Show `⚠️ Item X not found in orchestrator`
+- Fall back to no-arg selection path
 
-- Already handled in Phase 1
-- Session continues without assessment
-
-**If user interrupts mid-session**:
-
-- That's okay! ADHD-friendly design
-- Work is saved if user used Write/Edit tools
-- Can resume with /dx:session resume
+**User interrupts mid-session** — ADHD-friendly; work is preserved in edited files.
+Resume any time with `/dx:implement <uuid>`.
 
 ---
 
 ## Success Criteria
 
-- ✅ Task selected (with or without ADHD assessment)
-- ✅ Session started (ConPort updated to IN_PROGRESS)
+- ✅ Task selected from orchestrator queue or confirmed by UUID
+- ✅ `advance_item(trigger="start")` called, or re-entry logged (role=work)
+- ✅ ConPort `active_context` updated with session metadata
 - ✅ User completed focused work
-- ✅ Progress tracked in ConPort
+- ✅ Completion gate status surfaced (DONE path)
 - ✅ Break reminder shown
-- ✅ Supportive, encouraging tone maintained throughout
+- ✅ Encouraging, ADHD-supportive tone maintained throughout
+- ✅ Scannable at a glance in <10s
 
 ---
 
 ## Notes for Claude
 
-**Tone**: Be warm, encouraging, and supportive. Celebrate progress.
-**Visuals**: Use progress bars, boxes, emojis for visual engagement.
-**Flexibility**: If user wants to deviate from 25min, that's fine - adjust.
-**ADHD First**: Always prioritize user wellbeing over rigid process.
+**This is a write command.** Always preflight-read with `get_context(itemId)` before any
+`advance_item` call (Phase 2.1). Never transition blind.
+
+**DONE path delegates** — do not call `advance_item(trigger="complete")` here. The proof-bundle
+gate will reject it until the note is filled. Surface the gate and direct the user to `/dx:note`
+then `/dx:complete`.
+
+**Actor-attribution gap** — the deployed `advance_item` schema has no `actor` parameter. Embed
+attribution in `summary` if needed (e.g. "Session start via /dx:implement [worktree-dopemux-mvp-…]").
+
+**Role re-entry** — an item already in `work` is a re-entrant session; skip `advance_item(start)`,
+don't double-advance.
+
+**Tone** — warm, encouraging, celebratory. Emojis welcome. Adapt flexibly if the user wants a
+different session length; 25 min is the default, not a hard rule.
+
+**Next actions**: `/dx:note` to file notes · `/dx:complete` to close · `/dx:blocked` to check
+queue blockers · `/dx:next` for next task recommendation.


### PR DESCRIPTION
## Summary

- Replaces ConPort workflow-state calls in `/dx:implement` with task-orchestrator MCP: `get_next_item` for ADHD-ranked selection, `advance_item(trigger=start)` for session start (with preflight role-guard), `get_context` for gate surfacing, and `advance_item(trigger=block)` for blocked path
- DONE path no longer attempts inline completion — surfaces `gateStatus.canAdvance` / missing notes and delegates to `/dx:complete`
- Keeps `mcp__conport__update_active_context` for session metadata (not workflow state)
- Updates allowed-tools: removes `mcp__conport__*` wildcard and `mcp__zen__*`, adds explicit orchestrator tools, renames zen→pal, updates model slug

## Test plan

- [ ] `/dx:implement` with no arg: `get_next_item` returns 3 ADHD-ranked items, selection display renders correctly
- [ ] `/dx:implement <uuid>`: `get_context` confirms item, session start transitions queue→work
- [ ] Re-entry (item already in work): skip transition, log "Re-entering active session"
- [ ] DONE path: `gateStatus.canAdvance: false` shows missing notes + directions to `/dx:note` + `/dx:complete`
- [ ] DONE path: `gateStatus.canAdvance: true` directs straight to `/dx:complete`
- [ ] BLOCKED path: `advance_item(trigger=block)` called with user-provided reason
- [ ] ADHD Engine unavailable: graceful fallback message, session continues

Part of DMX-ORCH-CLAUDE-SURFACE series (TP-CS-041).

🤖 Generated with [Claude Code](https://claude.com/claude-code)