### PR TITLE
fix(rte,mcp,install): remediate distributed audit findings (TP-1/1b/2/3/4/5)

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,7 +51,7 @@ That's it! The installer handles everything automatically.
 - `--stack core|full` – Preselect which service profile to run within canonical `compose.yml` (useful for CI or scripted installs)
 - `--env-file /path/to/.env` – Override where API keys/secrets are read/written (defaults to repo-root `.env`)
 - `--yes` – Auto-confirm every prompt (implied by `--quick` and `--full`)
-- `INSTALLER_TEST_MODE=1 ./install.sh ...` – CI-friendly dry-run that skips Docker/pip/shell side effects (used by automated tests)
+- `INSTALLER_TEST_MODE=1 ./install.sh ...` – CI-friendly dry-run used by automated tests. It exercises control flow, arg parsing, prompts, and env-file handling **only**. It does **not** cover (and cannot catch regressions in): Docker network creation, image pull/build, `docker compose up`, Python venv + `pip install`, shell-integration/rc edits, system-resource preflight, or post-install verification. Validate those via a full (non-test-mode) install on a throwaway host.
 
 ### Verify Installation
 ```bash

--- a/KNOWN_GAPS.md
+++ b/KNOWN_GAPS.md
@@ -1,0 +1,107 @@
+# Known Gaps
+
+This file documents explicitly deferred or stub implementations — features partially
+wired but not fully operational.  Each entry records *what* is incomplete, *why* it
+was deferred (scope, risk, or dependency), and *what* a future implementer must do.
+
+Entries are added as stubs are discovered and audited; they are NOT bugs unless marked
+`[BUG]`.  Completing an entry means: implement the missing behavior, add/extend tests,
+update or remove this entry, and record the decision in ConPort.
+
+---
+
+## RTE — Repo Truth Extractor
+
+### KG-RTE-01 — S7: truth-split per-step comparison not wired
+**Status:** Deferred  
+**File:** `services/repo-truth-extractor/validate_pre_live_gate_v25.py`  
+**Function:** `collect_truth_split`  
+**Description:** `collect_truth_split` fail-closes with a waivable P1 blocker
+(`TRUTH_SPLIT_NOT_IMPLEMENTED`) rather than performing the real per-step
+source-vs-extraction comparison.  The downstream `classify_truth_split_row` wiring
+and diff generation are not implemented.  
+**Why deferred:** Requires access to both the prescan output and the live extraction
+result in the same validation pass; runtime plumbing not yet available.  
+**To implement:** Wire `classify_truth_split_row` to compare prescan vs extraction
+at each pipeline step; emit per-row pass/fail into the gate report; remove the
+`TRUTH_SPLIT_NOT_IMPLEMENTED` stub and the associated waiver path.
+
+---
+
+### KG-RTE-02 — S8-002: extraction_hygiene policy YAML unwired
+**Status:** Deferred  
+**File:** `services/repo-truth-extractor/extraction_hygiene.py`  
+**Description:** The extraction hygiene policy is hardcoded inside the module.
+The canonical `config/extraction_hygiene/*.yaml` configuration files are documented
+but not loaded at runtime; changes to hygiene rules require code edits rather than
+config changes.  
+**Why deferred:** Config-loading plumbing not prioritised in the current sprint.  
+**To implement:** Load the YAML config at startup (or lazily on first use); merge with
+or replace the hardcoded defaults; add a schema / validation pass for the YAML shape.
+
+---
+
+### KG-RTE-03 — S2: `required_prompt_sections` declared but unenforced
+**Status:** Deferred  
+**File:** `services/repo-truth-extractor/run_extraction_v4.py` (`load_promptset`)  
+**Description:** `required_prompt_sections` is declared in the promptset schema and
+the "Legacy Context" guardrail is documented, but neither is enforced at runtime.
+A promptset missing required sections is loaded without error.  
+**Why deferred:** Enforcement adds complexity to the promptset loader; deferred to
+a dedicated promptset-validation task.  
+**To implement:** Validate loaded promptsets against `required_prompt_sections`;
+raise a clear error (or structured warning) when a section is absent; add tests.
+
+---
+
+## MCP / Integration Bridge
+
+### KG-MCP-01 — MCP2-05: `str(e)` info disclosure in HTTP error details
+**Status:** Deferred (low severity — no secrets exposed in current paths)  
+**Files:** ~9 sites in `services/mcp-integration-bridge/main.py` that include
+`str(e)` or `repr(e)` in HTTP 4xx/5xx response bodies.  
+**Description:** Exception messages forwarded to HTTP clients can leak internal
+path names, module names, or partial stack traces.  In current code paths no
+credentials or secrets appear in exception strings, making this an info-disclosure
+risk rather than a credential-exposure risk.  
+**Why deferred:** Fixing requires auditing all ~9 sites and deciding on a
+sanitisation strategy (generic message vs structured error code); deferred to a
+dedicated security hardening task.  
+**To implement:** Replace `str(e)` in HTTP response bodies with a generic user-facing
+message; log the full exception server-side at ERROR level; assign error codes to
+allow clients to react programmatically without needing the raw message.
+
+---
+
+### KG-MCP-02 — Broker `request_escalation` has no transport
+**Status:** Deferred  
+**File:** `src/dopemux/mcp/broker.py` (`request_escalation`)  
+**Description:** `request_escalation` constructs an `EscalationRequest` and returns
+`approval_required=True` in the response, but there is no mechanism to actually
+notify an operator or record the pending approval anywhere (no webhook, no ConPort
+entry, no queue message).  Callers receive `approval_required=True` and must poll
+or retry indefinitely with no signal that the approval was handled.  
+**Why deferred:** Transport layer (webhook URL, ConPort hook, or Redis queue) not
+yet decided.  
+**To implement:** Choose a transport; implement `notify_approver(escalation_request)`;
+persist the pending escalation (e.g. ConPort `log_custom_data` with category
+`"pending_escalations"`); add a complementary `approve_escalation` / `deny_escalation`
+MCP tool or REST endpoint; add expiry / timeout logic.
+
+---
+
+## RTE — Phases
+
+### KG-RTE-04 — Orphan phase "M" documented but not wired or removed
+**Status:** Deferred  
+**File:** `services/repo-truth-extractor/phases.py`  
+**Description:** Phase "M" (merge / consolidation pass) is described in the module
+docstring and phase registry but has no implementation.  It is never scheduled by
+the phase runner.  This creates documentation drift — operators reading `phases.py`
+expect a merge pass that does not execute.  
+**Why deferred:** Scope for the merge pass is undefined; removal vs implementation
+decision deferred.  
+**To implement:** Either (a) implement the merge pass and wire it into the phase
+runner, or (b) remove the phase "M" registry entry and documentation reference and
+add a comment explaining why it was removed.  Either way, update `phases.py` and
+any docs that reference it.

--- a/claudedocs/pr725-proof-bundle-2026-05-30.md
+++ b/claudedocs/pr725-proof-bundle-2026-05-30.md
@@ -1,0 +1,194 @@
+# Proof Bundle — PR #725
+
+**Title:** `fix(rte,mcp,install): remediate distributed audit findings (TP-1/1b/2/3/4/5)`  
+**PR:** https://github.com/DDD-Enterprises/dopemux-mvp/pull/725  
+**Branch:** `claude/rte-remediation-2026-05-29` → `main`  
+**Date:** 2026-05-30  
+**Prepared per:** AGENTS.md §8
+
+---
+
+## Task Packet Reference
+
+| TP ID | Description |
+|-------|-------------|
+| TP-RTE-001 (TP-1) | RTE fail-closed gate truth-split, prescan correctness, orphan-phase doc |
+| TP-RTE-001b (TP-1b) | SP exec-time fail-close, loud S-prompt swap, canonical run_status, hygiene/promptset docs |
+| TP-MCP-002 (TP-2) | MCP internal lockdown — scoped child env, escalation, gate fail-closed, session sanitize |
+| TP-MCP-003 (TP-3) | MCP services lockdown — debug secret leak, localhost bind, KG deny-by-default, capture validation, CORS |
+| TP-INSTALL-004 (TP-4) | Install hardening — canonical dopemux-network, pipefail, .env chmod 600, healthcheck |
+| TP-CLI-005 (TP-5) | CLI v3 engine deprecation warning + canonical command migration banner |
+| CODE-REVIEW-P0 | Restore gate strict/warn enforcement + remove dead conport block (lost in salvage) |
+| CODE-REVIEW-P1P2 | Five P1 regressions + three P2 hardening gaps found during post-PR code review |
+
+---
+
+## Worktree & Branch
+
+```
+Repo root:  /Users/hue/code/dopemux-mvp
+Worktree:   /Users/hue/code/dopemux-mvp/.worktrees/rte-remediation
+Branch:     claude/rte-remediation-2026-05-29
+Base (main merge-base): d38e138730f2abf20c56207df9887b579765efa9
+HEAD:       7fc1da21568508940791f0a4f3b4599e5fa69811
+```
+
+---
+
+## Commits (oldest → newest)
+
+```
+fb836be19  fix(rte): TP-1 core — fail-closed gate truth-split, prescan correctness, orphan-phase doc
+d5bd554f2  fix(install): TP-4 hardening — canonical dopemux-network, pipefail, .env chmod 600, healthcheck, test-mode docs
+a3b0ec3ea  fix(rte): TP-1b — SP exec-time fail-close, loud S-prompt swap, canonical run_status, hygiene/promptset docs
+f23fa0999  fix(mcp): TP-2 internal lockdown — scoped child env, escalation fix, gate fail-closed, session 0700+sanitize
+8f7ca3893  fix(mcp): TP-3 services lockdown — debug secret leak, localhost bind, KG deny-by-default, capture validation, CORS
+2d9637db6  fix(cli,docs): TP-5 — v3 engine deprecation warning + canonical command migration banner
+ba5f43f33  fix(mcp): P0-1 — restore gate strict/warn enforcement lost in salvage (MCP1-02)
+25a9dbcff  fix(mcp): P0-2 — remove dead conport dual-spelling block; correct false claim (MCP1-10)
+7fc1da215  fix(mcp,rte,install): P1+P2 — code-review regressions and hardening
+```
+
+---
+
+## Files Changed (41 total, +1621/−70 across the PR)
+
+### Security / MCP layer
+- `src/dopemux/mcp/gate.py` — strict-mode enforcement restored; dead conport block removed
+- `src/dopemux/mcp/server_manager.py` — scoped child env; proxy/CA vars added to allow-list
+- `src/dopemux/mcp/session_manager.py` — path-sanitize fixed (encode not reject); 0700 perms
+- `src/dopemux/mcp/broker.py` — escalation fix
+
+### Capture / Integration Bridge
+- `services/mcp-capture/server.py` — localhost-only bind; capture validation; event type alias fix
+- `services/mcp-integration-bridge/main.py` — CORS restricted; localhost bind; KG deny-by-default; CORS port defaults
+- `services/mcp-integration-bridge/kg_authority.py` — deny-by-default route guard
+
+### RTE service
+- `services/repo-truth-extractor/lib/prescan/engine.py` — prescan correctness; compression key aligned
+- `services/repo-truth-extractor/lib/intelligence_router.py` — compress_map lookup (AttributeError guard)
+- `services/repo-truth-extractor/validate_pre_live_gate_v25.py` — fail-closed S7
+- `services/repo-truth-extractor/run_extraction_v4.py` — promptset docs
+- `services/repo-truth-extractor/run_extraction_v5.py` — SP exec-time fail-close, run_status
+- `services/repo-truth-extractor/extraction_hygiene.py` — hygiene docs
+- `services/repo-truth-extractor/rte_promptset.py` — S-prompt swap
+- `services/repo-truth-extractor/rte_constants.py` — canonical constants
+- `services/repo-truth-extractor/reporting.py` — run_status canonical
+- `services/repo-truth-extractor/phases.py` — orphan-phase doc
+
+### Install / scripts
+- `install.sh` — canonical dopemux-network; .env chmod 600; healthcheck; test-mode
+- `scripts/setup.sh` — pipefail; pipefail SIGPIPE fixes (submodule/health)
+- `scripts/install-docker-mcp-servers.sh` — master-branch fallback
+- `scripts/deploy/deployment/stack_up_all.sh` — network rename complete
+
+### Docs
+- `INSTALL.md` — network name
+- `docs/02-how-to/install.md` — network name; added MCP management doc
+- `docs/02-how-to/universal-extractor-usage.md` — usage guide
+- `docs/02-how-to/manage-mcp-servers.md` — new
+
+### Tests added/extended
+- `tests/mcp/test_discovery_gate_strict.py` — 6 new real-assertion tests for gate strict/warn
+- `tests/mcp/test_mcp_internal_lockdown.py` — extended: session encoding + traversal rejection
+- `tests/unit/pm/test_pm_route_contracts.py` — contract tests
+- `tests/unit/test_task_orchestrator_launcher.py` — launcher tests
+- `services/repo-truth-extractor/tests/test_pre_live_gate_v25.py` — pre-live gate tests
+
+### Governance
+- `KNOWN_GAPS.md` — 6 deferred shells documented (KG-RTE-01..04, KG-MCP-01..02)
+- `claudedocs/pr725-proof-bundle-2026-05-30.md` — this file
+
+---
+
+## Validations
+
+| Suite | Result | Detail |
+|-------|--------|--------|
+| `tests/mcp/` | **PASS** | 41 passed, 2 skipped |
+| `services/repo-truth-extractor/tests/` | **PASS** | 1115 passed, 1 skipped, 8 xfailed |
+| FastAPI TestClient (bridge) | **NOT_RUN** | `fastapi` not installed in venv |
+| `_build_child_env` unit test | **NOT_RUN** | `websockets` not installed in venv |
+| Live extraction / service start | **NOT_RUN** | Per AGENTS.md §7 — requires Docker + secrets |
+
+---
+
+## Code Review Status
+
+Code review performed against PR head `96a331aab` (pre-repair), recorded in
+`claudedocs/code-review-pr725-2026-05-29.md`. Findings:
+
+| Finding | Severity | Status |
+|---------|----------|--------|
+| gate.py strict_optional dead code | HIGH | ✅ Fixed (P0-1, `ba5f43f33`) |
+| gate.py conport fallback no-op | MED | ✅ Fixed (P0-2, `25a9dbcff`) |
+| mcp-capture event type alias rejected | MED-HIGH | ✅ Fixed (P1-1, `7fc1da215`) |
+| installer dropped master fallback | MED | ✅ Fixed (P1-2, `7fc1da215`) |
+| session_id sanitizer silently loses persistence | MED | ✅ Fixed (P1-3, `7fc1da215`) |
+| compression key mismatch (engine vs router) | MED | ✅ Fixed (P1-4, `7fc1da215`) |
+| network rename incomplete | MED | ✅ Fixed (P1-5, `7fc1da215`) |
+| child env missing proxy/CA vars | MED-LOW | ✅ Fixed (P2, `7fc1da215`) |
+| CORS default missing ports | LOW-MED | ✅ Fixed (P2, `7fc1da215`) |
+| setup.sh pipefail SIGPIPE | LOW | ✅ Fixed (P2, `7fc1da215`) |
+| bridge host 127.0.0.1 default | LOW (note) | ✅ Noted in code; no change needed |
+
+---
+
+## Precommit Status
+
+- `git diff --check` clean on all commits (no whitespace errors)
+- No unintended files staged (verified with `git diff --stat HEAD` before each commit)
+- No changes to `proof/`, `docs/archive/`, or migration scripts
+
+---
+
+## Deferred Shells
+
+All 6 pre-existing stub implementations documented in `KNOWN_GAPS.md`:
+
+| ID | Shell | Disposition |
+|----|-------|-------------|
+| KG-RTE-01 | S7 truth-split per-step wiring | Documented; deferred — runtime plumbing not available |
+| KG-RTE-02 | S8-002 extraction_hygiene YAML unwired | Documented; deferred — config-loading sprint |
+| KG-RTE-03 | S2 `required_prompt_sections` unenforced | Documented; deferred — promptset-validation task |
+| KG-MCP-01 | MCP2-05 `str(e)` info disclosure (~9 sites) | Documented; deferred — no secrets exposed, security hardening task |
+| KG-MCP-02 | Broker `request_escalation` no transport | Documented; deferred — transport layer not decided |
+| KG-RTE-04 | Orphan phase "M" | Documented; deferred — scope undefined |
+
+---
+
+## Residual Risks
+
+1. **P1-3 session encoding forward-compatibility** — Sessions saved before this fix used
+   the strict `[A-Za-z0-9_-]` check, so no existing session files have colon/dot IDs
+   (they were silently dropped, not persisted). Sessions created after the fix encode
+   such chars; no double-encoding risk on re-load since the decode path matches.
+
+2. **P1-4 bare-string compression hints** — The key rename wires the offline prescan path
+   into the router, but bare-string entries (what the engine currently emits) still yield
+   no active compression hint — `send_summary_instead` is absent on bare strings. Functional
+   improvement deferred to KG-RTE-* (emit richer objects from the engine). This is
+   pre-existing behaviour, not a regression.
+
+3. **Deferred shells** — S7/S8-002/S2/MCP2-05/broker-escalation/phase-M remain as stubs.
+   All are pre-existing; all are now documented in `KNOWN_GAPS.md`.
+
+4. **NOT_RUN live tests** — FastAPI/websockets test paths not exercised. Changes to those
+   surfaces are minimal and consistent with house patterns.
+
+---
+
+## UNKNOWNs
+
+- Whether any production session files exist with non-safe-filename characters in the session
+  ID (pre-fix they were silently dropped, so the answer is almost certainly "no live files",
+  but we cannot confirm from static analysis).
+- Whether any master-only MCP upstreams are used in production (installer fix is defensive).
+
+---
+
+## Cleanup
+
+- Worktree `/Users/hue/code/dopemux-mvp/.worktrees/rte-remediation` should be removed
+  after PR merge: `git worktree remove .worktrees/rte-remediation`
+- No temporary files, debug scripts, or test fixtures left behind.

--- a/config/repo_hygiene/root_hygiene_policy.json
+++ b/config/repo_hygiene/root_hygiene_policy.json
@@ -177,7 +177,8 @@
     "mcp-proxy-config*.yaml",
     "CHECKLIST.md",
     ".dockerignore",
-    ".python-version"
+    ".python-version",
+    "KNOWN_GAPS.md"
   ],
   "legacy_root_files": [
     "ARCHITECTURE.md",

--- a/docs/02-how-to/install.md
+++ b/docs/02-how-to/install.md
@@ -80,7 +80,7 @@ That's it! The installer handles everything automatically.
 
 The canonical `compose.yml` file at the repository root is the single source of truth for runtime orchestration. Legacy compose files are deprecated.
 
-During interactive runs the installer now previews each bundle (services + estimated runtime) so you know exactly what will be launched. Passing `--stack` skips the prompt but still prints the summary. Full installs automatically create the required Docker networks (`mcp-network`, `dopemux-unified-network`, `leantime-net`).
+During interactive runs the installer now previews each bundle (services + estimated runtime) so you know exactly what will be launched. Passing `--stack` skips the prompt but still prints the summary. Full installs automatically create the required Docker networks (`mcp-network`, `dopemux-network`, `leantime-net`).
 
 ### Environment Variables & `.env`
 

--- a/docs/02-how-to/install.md
+++ b/docs/02-how-to/install.md
@@ -62,7 +62,7 @@ That's it! The installer handles everything automatically.
 - `--stack core|full` – Preselect which service profile to run within canonical `compose.yml` (useful for CI or scripted installs)
 - `--env-file /path/to/.env` – Override where API keys/secrets are read/written (defaults to repo-root `.env`)
 - `--yes` – Auto-confirm every prompt (implied by `--quick` and `--full`)
-- `INSTALLER_TEST_MODE=1 ./install.sh ...` – CI-friendly dry-run that skips Docker/pip/shell side effects (used by automated tests)
+- `INSTALLER_TEST_MODE=1 ./install.sh ...` – CI-friendly dry-run used by automated tests. It exercises control flow, arg parsing, prompts, and env-file handling **only**. It does **not** cover (and cannot catch regressions in): Docker network creation, image pull/build, `docker compose up`, Python venv + `pip install`, shell-integration/rc edits, system-resource preflight, or post-install verification. Validate those via a full (non-test-mode) install on a throwaway host.
 
 ### Verify Installation
 ```bash

--- a/docs/02-how-to/universal-extractor-usage.md
+++ b/docs/02-how-to/universal-extractor-usage.md
@@ -17,6 +17,20 @@ next_review: '2026-06-04'
 ---
 # How to: Use the Universal Repo-Truth-Extractor
 
+> **⚠️ Command migration (audit USAGE-INV):** the `dopemux extractor <subcommand>` surface
+> shown in some examples below is **deprecated and disabled** — invoking it prints a refusal
+> that points at the canonical command. Use the `dopemux rte …` commands instead:
+>
+> | Deprecated (shadowed) | Canonical |
+> |---|---|
+> | `dopemux extractor init …` | `dopemux rte promptset sync …` |
+> | `dopemux extractor validate …` | `dopemux rte promptset validate …` |
+> | `dopemux extractor status …` | `dopemux rte status …` |
+> | `dopemux extractor run …` | `dopemux rte run …` |
+> | `dopemux extractor prescan …` | `dopemux rte run …` (prescan is integrated) |
+>
+> Flags are unchanged — the canonical commands reuse the same underlying implementations.
+
 ## Prerequisites
 
 - Python 3.11+ with dopemux installed (`pip install -e .`)

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,21 @@ SELECTED_STACK="core"  # core | research | full
 SELECTED_COMPOSE_FILE="$DOCKER_COMPOSE_CORE"
 ENV_FILE="${ENV_FILE:-.env}"
 STACK_SELECTED_FROM_FLAG=false
+# ============================================================================
+# INSTALLER_TEST_MODE — CI/dry-run guard (set to "1" by automated installer tests).
+#
+# When enabled, every side-effecting step is SHORT-CIRCUITED. This mode validates
+# control flow, arg parsing, prompts, and env-file handling ONLY. It deliberately
+# does NOT exercise (and therefore CANNOT catch regressions in):
+#   - Docker network creation        (ensure_docker_networks)
+#   - Docker image pull / build      (install_docker_services)
+#   - `docker compose ... up -d`     (install_docker_services)
+#   - Python venv + `pip install -e` (install_dopemux_core)
+#   - Shell integration / rc edits   (configure_shell_integration)
+#   - System resource preflight      (check_system_resources / preflight_checks / check_docker)
+#   - Post-install verification       (verify_installation)
+# Validate those paths manually or in a full (non-test-mode) install on a throwaway host.
+# ============================================================================
 INSTALLER_TEST_MODE="${INSTALLER_TEST_MODE:-0}"
 STARTED_CAPABILITIES=()
 DEFERRED_CAPABILITIES=()

--- a/scripts/deploy/deployment/stack_up_all.sh
+++ b/scripts/deploy/deployment/stack_up_all.sh
@@ -37,7 +37,7 @@ echo "== Dopemux: Bringing up all stacks (cached images preferred) =="
 
 # Core shared networks
 ensure_network mcp-network
-ensure_network dopemux-unified-network
+ensure_network dopemux-network
 ensure_network leantime-net
 
 # Event Bus (optional)

--- a/scripts/install-docker-mcp-servers.sh
+++ b/scripts/install-docker-mcp-servers.sh
@@ -33,6 +33,26 @@ validate_env_var() {
     fi
 }
 
+# P1-2: checkout helper with master fallback — when the default ref is "main"
+# and the remote has no "main" branch (master-only upstream), fall back to
+# "master" before giving up.  Under set -e a bare `git checkout main` on such
+# a repo would abort the entire installer.
+_checkout_with_master_fallback() {
+    local ref="$1"
+    local server_name="$2"
+    if git checkout "$ref" 2>/dev/null; then
+        return 0
+    fi
+    # Only attempt the fallback when the caller didn't pin an explicit ref.
+    if [ "$ref" = "main" ] || [ -z "$ref" ]; then
+        echo "⚠️  $server_name: branch 'main' not found, trying 'master'..."
+        git checkout master
+    else
+        # Non-default ref: let the original failure propagate.
+        git checkout "$ref"
+    fi
+}
+
 # Function to install a Docker MCP server
 install_docker_mcp_server() {
     local server_name="$1"
@@ -57,13 +77,13 @@ install_docker_mcp_server() {
     if [ -d ".git" ]; then
         echo "🔄 Updating existing $server_name repository (ref: $ref)..."
         git fetch --all --tags
-        git checkout "$ref"
+        _checkout_with_master_fallback "$ref" "$server_name"
         # Only fast-forward when tracking a branch; tags/SHAs have no upstream to pull.
         git pull --ff-only 2>/dev/null || true
     else
         echo "📥 Cloning $server_name repository (ref: $ref)..."
         git clone "$repo_url" .
-        git checkout "$ref"
+        _checkout_with_master_fallback "$ref" "$server_name"
     fi
 
     if [ "$ref" = "main" ] || [ "$ref" = "master" ]; then

--- a/scripts/install-docker-mcp-servers.sh
+++ b/scripts/install-docker-mcp-servers.sh
@@ -39,6 +39,11 @@ install_docker_mcp_server() {
     local repo_url="$2"
     local provider="$3"
     local model="$4"
+    # Optional git ref (branch, tag, or SHA) to pin the checkout. Defaults to "main".
+    # SECURITY/SUPPLY-CHAIN TODO: "main" is a moving branch HEAD — pin a verified tag or
+    # commit SHA here (or pass it as $5 / a $REF env var) once a known-good revision of the
+    # upstream repo has been audited, so installs become reproducible and tamper-evident.
+    local ref="${5:-${MCP_SERVER_REF:-main}}"
 
     echo "📦 Installing $server_name..."
 
@@ -50,11 +55,20 @@ install_docker_mcp_server() {
 
     # Clone or update repository
     if [ -d ".git" ]; then
-        echo "🔄 Updating existing $server_name repository..."
-        git pull origin main || git pull origin master
+        echo "🔄 Updating existing $server_name repository (ref: $ref)..."
+        git fetch --all --tags
+        git checkout "$ref"
+        # Only fast-forward when tracking a branch; tags/SHAs have no upstream to pull.
+        git pull --ff-only 2>/dev/null || true
     else
-        echo "📥 Cloning $server_name repository..."
+        echo "📥 Cloning $server_name repository (ref: $ref)..."
         git clone "$repo_url" .
+        git checkout "$ref"
+    fi
+
+    if [ "$ref" = "main" ] || [ "$ref" = "master" ]; then
+        echo "⚠️  WARNING: $server_name is pinned to moving branch '$ref' (unpinned HEAD)."
+        echo "    Builds are NOT reproducible. Pin a tag/SHA via MCP_SERVER_REF to harden."
     fi
 
     # Create environment configuration
@@ -82,6 +96,9 @@ MAX_THINKING_STEPS=10
 # === Docker Configuration ===
 MCP_SERVER_PORT=3001
 EOF
+
+    # Restrict the .env (contains API keys/tokens) to the owner only — it was world-readable.
+    chmod 600 .env
 
     # Fix Dockerfile if needed (for src/ layout)
     if [ -f "Dockerfile" ] && grep -q "COPY main.py" Dockerfile; then

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -153,11 +153,15 @@ fi
 echo
 echo -e "${CYAN}🔧 Step 6/8: Initializing git submodules...${NC}"
 
-if git submodule update --init --recursive 2>&1 | grep -q "Submodule"; then
+# P2: `set -o pipefail` + `grep -q` closes the pipe early → SIGPIPE → non-zero
+# exit → pipefail fires.  Capture output first, then test.
+_submodule_out=$(git submodule update --init --recursive 2>&1)
+if echo "$_submodule_out" | grep -q "Submodule"; then
     echo -e "${GREEN}   ✅ Submodules initialized${NC}"
 else
     echo -e "${YELLOW}   ⏭️  No submodules configured yet${NC}"
 fi
+unset _submodule_out
 
 # ============================================================================
 # Step 7: Docker Setup (Optional)
@@ -214,11 +218,18 @@ echo -e "${CYAN}🏥 Step 8/8: Verifying installation...${NC}"
 if command -v dopemux &> /dev/null; then
     if [ "$SKIP_DOCKER" = false ]; then
         echo -e "${CYAN}   Running health check...${NC}"
-        if dopemux health 2>&1 | head -10; then
+        # P2: `set -o pipefail` + `head` closes the pipe early → SIGPIPE on the
+        # producer → non-zero pipeline exit even when dopemux health succeeds.
+        # Capture output + exit code separately to avoid the SIGPIPE.
+        _health_out=$(dopemux health 2>&1)
+        _health_rc=$?
+        echo "$_health_out" | head -10
+        if [ $_health_rc -eq 0 ]; then
             echo -e "${GREEN}   ✅ Health check passed${NC}"
         else
             echo -e "${YELLOW}   ⚠️  Some services may not be ready yet${NC}"
         fi
+        unset _health_out _health_rc
     else
         echo -e "${YELLOW}   ⏭️  Skipping health check (Docker not started)${NC}"
     fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,6 +11,7 @@
 #
 
 set -e  # Exit on error
+set -o pipefail  # Fail a pipeline if any stage fails (so `cmd | tail` reflects cmd's exit)
 
 # Colors for output
 RED='\033[0;31m'
@@ -166,22 +167,30 @@ if [ "$SKIP_DOCKER" = false ]; then
     echo
     echo -e "${CYAN}🐳 Step 7/8: Setting up Docker services...${NC}"
 
-    # Create Docker network
     # BETA-INSTALL-02: create "dopemux-network" — the name compose.yml declares
     # as external.  The old "dopemux-unified-network" was never joined by any
     # container since compose.yml was updated.
-    if docker network ls --format '{{.Name}}' | grep -q "^dopemux-network$"; then
+    # Use an existence pre-check instead of piping `docker network create` into grep:
+    # `docker network create` exits non-zero when the network exists, which under
+    # `set -o pipefail` would make the pipeline fail and misreport the result.
+    if docker network inspect dopemux-network >/dev/null 2>&1; then
         echo -e "${YELLOW}   ⏭️  Network already exists: dopemux-network${NC}"
     else
-        docker network create dopemux-network
+        docker network create dopemux-network >/dev/null
+
         echo -e "${GREEN}   ✅ Created network: dopemux-network${NC}"
     fi
 
     # Start MCP services
+    # Capture output to a var so the compose exit status drives the if/else
+    # (piping straight into `tail` would evaluate tail's exit code, always 0,
+    # making the failure branch dead even with pipefail).
     echo -e "${CYAN}   🐳 Starting MCP services...${NC}"
-    if docker compose -f compose.yml up -d 2>&1 | tail -5; then
+    if compose_output=$(docker compose -f compose.yml up -d 2>&1); then
+        echo "$compose_output" | tail -5
         echo -e "${GREEN}   ✅ MCP services started${NC}"
     else
+        echo "$compose_output" | tail -5
         echo -e "${RED}   ❌ Docker startup failed${NC}"
         exit 1
     fi

--- a/services/dope-context/Dockerfile
+++ b/services/dope-context/Dockerfile
@@ -33,8 +33,10 @@ ENV PYTHONPATH=/app/src
 RUN mkdir -p /app/data /app/logs
 
 # Health check - verify MCP server is responding
+# `|| exit 1` ensures a failed/unreachable /health marks the container unhealthy.
+# (`|| exit 0` previously masked failures and the container could never report unhealthy.)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=45s --retries=3 \
-    CMD curl -f http://localhost:3010/health || exit 0
+    CMD curl -f http://localhost:3010/health || exit 1
 
 # Labels
 LABEL mcp.role="search"

--- a/services/mcp-capture/server.py
+++ b/services/mcp-capture/server.py
@@ -103,6 +103,23 @@ class CaptureMCPServer:
                 lane = arguments.get("lane")
                 repo_root_str = arguments.get("repo_root")
 
+                # MCP2-03 (audit): validate the untrusted event envelope before forwarding
+                # to Chronicle ingestion -- the MCP runtime does not enforce the declared
+                # inputSchema. Fail closed (the except below returns a structured error) on
+                # a malformed event or out-of-enum mode rather than ingesting unchecked.
+                if not isinstance(event, dict):
+                    raise ValueError("'event' must be an object")
+                event_type = event.get("event_type")
+                if not isinstance(event_type, str) or not event_type.strip():
+                    raise ValueError(
+                        "'event.event_type' is required and must be a non-empty string"
+                    )
+                allowed_modes = {"plugin", "cli", "mcp", "auto"}
+                if mode not in allowed_modes:
+                    raise ValueError(
+                        f"'mode' must be one of {sorted(allowed_modes)}; got {mode!r}"
+                    )
+
                 repo_root = Path(repo_root_str) if repo_root_str else None
 
                 # Call emit_capture_event

--- a/services/mcp-capture/server.py
+++ b/services/mcp-capture/server.py
@@ -109,10 +109,13 @@ class CaptureMCPServer:
                 # a malformed event or out-of-enum mode rather than ingesting unchecked.
                 if not isinstance(event, dict):
                     raise ValueError("'event' must be an object")
-                event_type = event.get("event_type")
+                # P1-1: accept "type" alias — emit_capture_event supports both
+                # "event_type" and "type"; the guard must match so aliased clients
+                # aren't silently dropped with a structured error.
+                event_type = event.get("event_type") or event.get("type")
                 if not isinstance(event_type, str) or not event_type.strip():
                     raise ValueError(
-                        "'event.event_type' is required and must be a non-empty string"
+                        "'event.event_type' (or alias 'event.type') is required and must be a non-empty string"
                     )
                 allowed_modes = {"plugin", "cli", "mcp", "auto"}
                 if mode not in allowed_modes:

--- a/services/mcp-integration-bridge/kg_authority.py
+++ b/services/mcp-integration-bridge/kg_authority.py
@@ -59,8 +59,10 @@ class KGAuthorityMiddleware(BaseHTTPMiddleware):
         method = request.method
 
         # Find matching authority rule
+        matched_rule = False
         for path_prefix, rules in self.AUTHORITY_RULES.items():
             if path.startswith(path_prefix):
+                matched_rule = True
                 # Check plane authorization
                 allowed_planes = rules["allowed_planes"]
                 if allowed_planes and source_plane not in allowed_planes:
@@ -87,6 +89,18 @@ class KGAuthorityMiddleware(BaseHTTPMiddleware):
 
                 logger.info(f"✅ KG request authorized: {source_plane} {method} {path}")
                 break
+
+        # MCP2-01 (audit): deny-by-default. A /kg/* path matching NO authority rule was
+        # previously passed straight through (fail-open). Refuse it instead, so a newly
+        # added or mistyped /kg/* route cannot bypass the Two-Plane boundary by omission.
+        if not matched_rule:
+            logger.warning(
+                f"❌ No KG authority rule for path={path}; denying (deny-by-default)"
+            )
+            raise HTTPException(
+                status_code=403,
+                detail=f"No authority rule defined for {path}",
+            )
 
         # Request authorized, continue
         response = await call_next(request)

--- a/services/mcp-integration-bridge/main.py
+++ b/services/mcp-integration-bridge/main.py
@@ -1197,9 +1197,18 @@ app = FastAPI(
     description=f"Task management coordination for Dopemux instance: {INSTANCE_NAME}",
 )
 
+# MCP2-07 (audit): wildcard origins on a service exposing task/KG data is unsafe (and is
+# an invalid combo with allow_credentials=True). Restrict to a configured allow-list
+# (comma-separated MCP_INTEGRATION_CORS_ORIGINS), defaulting to localhost. Override
+# explicitly for an intentional networked deployment.
+_cors_origins = [
+    origin.strip()
+    for origin in os.getenv("MCP_INTEGRATION_CORS_ORIGINS", "").split(",")
+    if origin.strip()
+] or ["http://localhost", "http://127.0.0.1"]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -1690,15 +1699,20 @@ async def debug_instance_info():
             "task_orchestrator": TASK_ORCHESTRATOR_URL,
             "leantime_bridge": LEANTIME_BRIDGE_URL,
         },
-        "database_url": POSTGRES_URL,
-        "redis_url": REDIS_URL,
+        # MCP2-06 (audit): never return the DB/Redis connection strings -- they embed
+        # credentials. Report only whether they are configured.
+        "database_configured": bool(POSTGRES_URL),
+        "redis_configured": bool(REDIS_URL),
     }
 
 
 if __name__ == "__main__":
+    # MCP2-06 (audit): bind localhost by default so the bridge (which exposes task/KG data
+    # and a debug endpoint) is not reachable off-host unless explicitly opted in.
+    host = os.getenv("MCP_INTEGRATION_HOST", "127.0.0.1")
     uvicorn.run(
         "main:app",
-        host="0.0.0.0",
+        host=host,
         port=MCP_INTEGRATION_PORT,
         reload=False,  # Disable reload in production
     )

--- a/services/mcp-integration-bridge/main.py
+++ b/services/mcp-integration-bridge/main.py
@@ -1201,11 +1201,24 @@ app = FastAPI(
 # an invalid combo with allow_credentials=True). Restrict to a configured allow-list
 # (comma-separated MCP_INTEGRATION_CORS_ORIGINS), defaulting to localhost. Override
 # explicitly for an intentional networked deployment.
+# P2: CORS matches scheme+host+port exactly; bare "http://localhost" blocks any
+# browser client at localhost:3000 etc.  Include the common local dev ports in
+# the default so the Dopemux dashboard works out of the box.  Operators who need
+# a different set should set MCP_INTEGRATION_CORS_ORIGINS explicitly.
 _cors_origins = [
     origin.strip()
     for origin in os.getenv("MCP_INTEGRATION_CORS_ORIGINS", "").split(",")
     if origin.strip()
-] or ["http://localhost", "http://127.0.0.1"]
+] or [
+    "http://localhost",
+    "http://localhost:3000",
+    "http://localhost:3001",
+    "http://localhost:8080",
+    "http://127.0.0.1",
+    "http://127.0.0.1:3000",
+    "http://127.0.0.1:3001",
+    "http://127.0.0.1:8080",
+]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,

--- a/services/repo-truth-extractor/extraction_hygiene.py
+++ b/services/repo-truth-extractor/extraction_hygiene.py
@@ -35,7 +35,17 @@ from typing import Any, Dict, List, Optional
 # Policy paths
 # ---------------------------------------------------------------------------
 _SCRIPT_DIR = Path(__file__).resolve().parent
+# S8-001 (audit) is STALE: parents[1] correctly resolves to the repo root
+# (parents[0] = services/, parents[1] = repo root) -- no change needed here.
 _REPO_ROOT_DEFAULT = _SCRIPT_DIR.parents[1]
+# S8-002 (audit): these point at the canonical hygiene config, but the policy used by this
+# module is currently HARDCODED below and is NOT loaded from these YAML files -- so the YAML
+# under config/extraction_hygiene/ may diverge from runtime behavior. Wiring a yaml loader
+# that merges these files over the hardcoded defaults is deferred to a dedicated follow-up:
+# it requires reconciling the YAML schema against the hardcoded policy first, since this
+# module performs destructive quarantine moves and silently switching the policy source
+# could change what gets quarantined/cleaned. Until then the hardcoded policy is
+# authoritative and these paths document where the canonical config is intended to live.
 _POLICY_PATH = _REPO_ROOT_DEFAULT / "config" / "extraction_hygiene" / "hygiene_policy.yaml"
 _TIERS_PATH = _REPO_ROOT_DEFAULT / "config" / "extraction_hygiene" / "authority_tiers.yaml"
 

--- a/services/repo-truth-extractor/lib/intelligence_router.py
+++ b/services/repo-truth-extractor/lib/intelligence_router.py
@@ -451,17 +451,17 @@ class IntelligenceRouter:
         return None
 
     def get_compression_hint_source(self, rel_path: str) -> Optional[str]:
+        # P1-4: use self.compress_map (normalised at __init__, bare strings safe)
+        # instead of iterating hints directly — bare string entries from the
+        # engine have no .get() method and would raise AttributeError.
         path_keys = set(self._path_keys(rel_path))
         for chain_id, members in self.intel.get("version_chains", {}).items():
             paths = {str(m.get("path") or "") for m in members if isinstance(m, dict)}
             if not path_keys.intersection(paths):
                 continue
-            for candidate in self.hints.get("compress_candidates", []):
-                if (
-                    candidate.get("chain_id") == chain_id
-                    and candidate.get("send_summary_instead")
-                ):
-                    return "prescan.extraction_hints.compress_candidates"
+            entry = self.compress_map.get(chain_id, {})
+            if entry.get("send_summary_instead"):
+                return "prescan.extraction_hints.compress_candidates"
         return None
 
     def get_model_routing_hint_details(self, rel_path: str) -> Optional[Dict[str, Any]]:
@@ -716,13 +716,14 @@ class IntelligenceRouter:
 
     def get_compression_hint(self, rel_path: str) -> Optional[str]:
         """Return a summary hint if this file is part of a compressed version chain."""
+        # P1-4: use compress_map (see get_compression_hint_source for same rationale).
         path_keys = set(self._path_keys(rel_path))
         for chain_id, members in self.intel.get("version_chains", {}).items():
             paths = {str(m.get("path") or "") for m in members if isinstance(m, dict)}
             if path_keys.intersection(paths):
-                for cc in self.hints.get("compress_candidates", []):
-                    if cc.get("chain_id") == chain_id and cc.get("send_summary_instead"):
-                        return cc.get("summary_hint", "Superseded by newer version.")
+                entry = self.compress_map.get(chain_id, {})
+                if entry.get("send_summary_instead"):
+                    return entry.get("summary_hint", "Superseded by newer version.")
         return None
 
     def get_routing_priority(self, rel_path: str) -> int:

--- a/services/repo-truth-extractor/lib/intelligence_router.py
+++ b/services/repo-truth-extractor/lib/intelligence_router.py
@@ -258,7 +258,16 @@ class IntelligenceRouter:
         # Pre-processed lookups
         self._base_skip_list = set(self.hints.get("skip_duplicates", []))
         self.skip_list = set(self._base_skip_list)
-        self.compress_map = {c["chain_id"]: c for c in self.hints.get("compress_candidates", [])}
+        # S3-07: compress_candidates schema permits bare strings OR objects. Index
+        # objects by chain_id; normalize bare strings to a minimal record so an
+        # imported, schema-valid prescan can't crash router construction with a
+        # TypeError. Malformed members are skipped rather than fatal.
+        self.compress_map = {}
+        for c in self.hints.get("compress_candidates", []):
+            if isinstance(c, dict) and "chain_id" in c:
+                self.compress_map[c["chain_id"]] = c
+            elif isinstance(c, str):
+                self.compress_map[c] = {"chain_id": c}
 
         # Load topological order if available
         self.topological_order = self.code_intel.get("topological_order", [])
@@ -748,7 +757,13 @@ class IntelligenceRouter:
         for hint in self._model_routing:
             pattern = hint.get("partition_pattern", "")
             if any(_fnmatch.fnmatch(path_key, pattern) for path_key in path_keys):
-                return hint.get("recommended_model", "standard")
+                # S3-03: the LLM-emitted recommended_model is free text. Only the three
+                # tier tokens are honored downstream; anything else (e.g. a raw model
+                # name) was previously returned verbatim and then silently dropped while
+                # still being labeled applied=True. Coerce to the valid tier set here so
+                # the value the engine consumes and the influence label always agree.
+                recommended = hint.get("recommended_model", "standard")
+                return recommended if recommended in ("premium", "standard", "economy") else "standard"
 
         # Check code intelligence
         if self.code_report:

--- a/services/repo-truth-extractor/lib/prescan/engine.py
+++ b/services/repo-truth-extractor/lib/prescan/engine.py
@@ -722,7 +722,10 @@ class PrescanEngine:
                 "ghost_files": len(ghosts),
                 "by_class": by_class,
                 "by_extension": by_ext,
-                "total_size_bytes": sum(entry.size_bytes for entry in included),
+                # S3-06: canonical key is total_included_size_bytes (matches schemas.py
+                # and IntelligenceRouter.estimate_token_savings). Emitting total_size_bytes
+                # here made the router read 0 and report 0% savings unconditionally.
+                "total_included_size_bytes": sum(entry.size_bytes for entry in included),
                 "corpus_health_score": 100,
             },
             "lifecycle_distribution": self._get_lifecycle_dist(entries),

--- a/services/repo-truth-extractor/lib/prescan/engine.py
+++ b/services/repo-truth-extractor/lib/prescan/engine.py
@@ -747,7 +747,11 @@ class PrescanEngine:
             "version_chain_count": version_chain_count,
             "extraction_hints": {
                 "skip_duplicates": sorted(entry.rel_path for entry in entries if entry.is_duplicate),
-                "compression_candidates": sorted(
+                # P1-4: align key with intelligence_router ("compress_candidates").
+                # The old key "compression_candidates" was read nowhere — the router
+                # only populates compress_map / iterates hints["compress_candidates"],
+                # so offline prescan hints were silently ignored.
+                "compress_candidates": sorted(
                     entry.rel_path
                     for entry in entries
                     if entry.is_duplicate or (entry.version_chain_id and not entry.is_latest_version)

--- a/services/repo-truth-extractor/phases.py
+++ b/services/repo-truth-extractor/phases.py
@@ -196,6 +196,12 @@ REQUIRED_PROMPT_STEP_IDS: Dict[str, Set[str]] = {
     "Z": {"Z0", "Z1", "Z2", "Z9"},
     "S": set(PHASE_S_BASE_STEPS),
     "SP": set(PHASE_SP_BASE_STEPS),
+    # S4-MED-1: "M" is an orphan phase id. It has required prompt-step ids here and is
+    # referenced in v5 routing sets (PREMIUM_SYNTHESIS_PHASES / OPTIMAL_NO_CODE_PHASES),
+    # but there is NO PhaseId.M, no PhaseDefinition, no dir_name, and no dispatch path, so
+    # it can never be selected or executed. Coverage/verify tooling that enumerates these
+    # ids will count M0-M6 as "required" for a phase that cannot run. Retained (not removed)
+    # to avoid touching the routing sets; treat as reserved/inert until a real M phase lands.
     "M": {"M0", "M1", "M2", "M3", "M4", "M5", "M6"},
 }
 

--- a/services/repo-truth-extractor/reporting.py
+++ b/services/repo-truth-extractor/reporting.py
@@ -19,6 +19,7 @@ from rte_config import (
     RUN_DASHBOARD_FILENAME,
     STEP_METRICS_FILENAME,
 )
+from rte_constants import RUN_STATUS_BLOCKED, RUN_STATUS_OK
 
 
 @dataclass(frozen=True)
@@ -166,9 +167,12 @@ def write_run_dashboard_snapshot(
 
 def _normalize_gate_status(value: Optional[str]) -> str:
     token = str(value or "").strip().upper()
-    if token in {"PASS", "PASSED", "READY", "OK"}:
+    if token in {"PASS", "PASSED", "READY", "OK", "CLEAR"}:
         return "PASS"
-    if token in {"FAIL", "FAILED", "BLOCKED", "NO_GO"}:
+    # S6-OBS-1 (audit): COST_ABORTED previously fell through to UNKNOWN. Map it to FAIL so a
+    # cost-aborted run status, if ever routed through this normalizer, fails closed rather
+    # than reading as UNKNOWN.
+    if token in {"FAIL", "FAILED", "BLOCKED", "NO_GO", "COST_ABORTED"}:
         return "FAIL"
     return "UNKNOWN"
 
@@ -584,7 +588,7 @@ def write_run_manifest(
         "prompt_failures": prompt_report.get("prompt_failures", []),
         "prompt_failures_count": int(prompt_report.get("prompt_failures_count", 0)),
         "promptset_sha256": prompt_report["promptset_sha256"],
-        "run_status": "BLOCKED" if run_blocked else "OK",
+        "run_status": RUN_STATUS_BLOCKED if run_blocked else RUN_STATUS_OK,
         "phase_status": "blocked_promptset" if run_blocked else "ready",
         "blocked_promptset": run_blocked,
         "routing_policy": routing_policy,

--- a/services/repo-truth-extractor/rte_constants.py
+++ b/services/repo-truth-extractor/rte_constants.py
@@ -1,0 +1,23 @@
+"""Canonical status-string constants for the Repo Truth Extractor.
+
+Audit finding S6-MED-1: the RUN_MANIFEST.run_status field is written by two separate
+producers -- reporting.write_run_manifest (initial) and
+run_extraction_v5.compute_run_status / update_run_manifest_status (final) -- with
+independently hardcoded string literals, risking divergence. Centralize the vocabulary
+here so both producers reference the same constants.
+
+Values are intentionally identical to the historical literals ("OK"/"BLOCKED"/
+"COST_ABORTED") so existing RUN_MANIFEST.json consumers and characterization tests are
+unaffected. This module is a leaf (no imports) to keep it cycle-safe for any importer.
+"""
+from __future__ import annotations
+
+# Terminal RUN_MANIFEST.run_status states. compute_run_status() in run_extraction_v5 is the
+# authoritative producer; reporting.write_run_manifest seeds the initial value.
+RUN_STATUS_OK = "OK"
+RUN_STATUS_BLOCKED = "BLOCKED"
+RUN_STATUS_COST_ABORTED = "COST_ABORTED"
+
+RUN_STATUS_VALUES = frozenset(
+    {RUN_STATUS_OK, RUN_STATUS_BLOCKED, RUN_STATUS_COST_ABORTED}
+)

--- a/services/repo-truth-extractor/rte_promptset.py
+++ b/services/repo-truth-extractor/rte_promptset.py
@@ -311,6 +311,16 @@ def resolve_phase_s_prompts(
     if normalized_mode == legacy_mode:
         return legacy_phase_prompt_specs("S")
 
+    # S4-CRIT-1 (audit): non-legacy modes swap the Phase-S step set from the default
+    # S0-S12 to the SP0-SP12 registry steps (still written under the S_synthesis dir).
+    # Make that explicit and loud so it cannot be activated silently via DOPEMUX_S_PROMPTS.
+    logger.warning(
+        "Phase S prompts mode=%r resolves the SP registry step set (SP0-SP12) under phase "
+        "'S' -- NOT the default legacy S0-S12 set. Set DOPEMUX_S_PROMPTS=legacy to restore "
+        "default behavior.",
+        normalized_mode,
+    )
+
     try:
         registry = load_phase_s_registry()
     except Exception as exc:

--- a/services/repo-truth-extractor/run_extraction_v4.py
+++ b/services/repo-truth-extractor/run_extraction_v4.py
@@ -101,6 +101,13 @@ def read_yaml(path: Path) -> Dict[str, Any]:
 
 
 def load_promptset() -> Dict[str, Any]:
+    # S2 (audit), documented: promptset.yaml declares `required_prompt_sections`, but no
+    # runtime code enforces those sections against the prompt bodies (grep: zero readers).
+    # Relatedly, the "Legacy Context (for intent only; never as evidence)" line in the prompt
+    # templates is a defensive guardrail -- the runtime injects no block named "Legacy
+    # Context", so the guardrail is harmless-but-inert. Both are known gaps left as-is:
+    # enforcing sections is a behavior change, and stripping the guardrail would touch ~105
+    # prompt files (shifting many promptset hashes) for no functional gain.
     return read_yaml(PROMPTSET_PATH)
 
 

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -223,6 +223,11 @@ from rte_reports import (
     write_step_metrics_snapshot as rte_write_step_metrics_snapshot,
 )
 from reporting import build_run_id_resolution_precedence
+from rte_constants import (
+    RUN_STATUS_BLOCKED,
+    RUN_STATUS_COST_ABORTED,
+    RUN_STATUS_OK,
+)
 from llm_runtime import (
     LLMRuntimeDeps,
     _RESPONSE_SUMMARY_PASSTHROUGH_KEYS,
@@ -3603,16 +3608,16 @@ def compute_run_status(
     cost_abort_triggered: bool = False,
 ) -> str:
     if cost_abort_triggered:
-        return "COST_ABORTED"
+        return RUN_STATUS_COST_ABORTED
     if blocked_promptset:
-        return "BLOCKED"
+        return RUN_STATUS_BLOCKED
     if missing_required_artifacts_total > 0:
-        return "BLOCKED"
+        return RUN_STATUS_BLOCKED
     if phase_statuses:
         for status in phase_statuses.values():
             if status == "FAIL":
-                return "BLOCKED"
-    return "OK"
+                return RUN_STATUS_BLOCKED
+    return RUN_STATUS_OK
 
 
 def update_run_manifest_status(
@@ -13947,6 +13952,26 @@ def execute_step_for_partitions(
         if json_managed_step and contract_artifacts
         else prompt_spec.output_artifacts
     )
+    # S4-CRIT-2 (audit): fail closed at EXECUTION time when a phase-SP step would emit a
+    # JSON artifact but has no phase contract. Phase 'SP' is absent from
+    # reports/repo_truth_map.json, so step_contract is None for every SP step and its JSON
+    # output would be written with no schema / required-field enforcement. The guard lives
+    # here (live execution only, dry-run excluded) rather than at prompt resolution, which
+    # read-only paths exercise (phase listing, the CostProfile validator, dry-run /
+    # post-review preview) -- a resolution-time raise would break those.
+    if (
+        str(phase).strip().upper() == "SP"
+        and not cfg.dry_run
+        and step_contract is None
+        and any(str(artifact).lower().endswith(".json") for artifact in output_artifacts)
+    ):
+        raise RuntimeError(
+            f"Phase SP step {step_id} would emit JSON artifact(s) "
+            f"{tuple(output_artifacts)} with no phase contract (phase 'SP' is not declared "
+            f"in reports/repo_truth_map.json). Refusing to run an uncontracted synthesis "
+            f"step live. Register phase SP in the truth map (with required_fields/schema) "
+            f"to re-enable, or preview with --dry-run."
+        )
     contract_lane = resolve_contract_lane(step_contract)
     contract_repair_mode = resolve_contract_repair_mode(step_contract)
     contract_sidefill_enabled = resolve_contract_sidefill_enabled(step_contract)

--- a/services/repo-truth-extractor/tests/test_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/tests/test_pre_live_gate_v25.py
@@ -61,6 +61,18 @@ def test_truth_split_prefers_specific_classification() -> None:
     )
 
 
+def test_collect_truth_split_fails_closed_until_implemented() -> None:
+    # S7 (audit): the runner/promptset/model-map drift audit is unimplemented. It must
+    # fail closed with a waivable P1 blocker, never a fake PASS.
+    gate = _load_gate_module()
+    payload, blockers, findings = gate.collect_truth_split(None, None)
+    assert payload["status"] == "NOT_IMPLEMENTED"
+    assert len(blockers) == 1
+    assert blockers[0].reason_code == gate.TRUTH_SPLIT_NOT_IMPLEMENTED
+    assert blockers[0].severity == "P1"
+    assert findings == []
+
+
 def test_pal_validation_is_conditional_when_missing_for_active_route(tmp_path: Path) -> None:
     gate = _load_gate_module()
     config = gate.GateConfig(

--- a/services/repo-truth-extractor/validate_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/validate_pre_live_gate_v25.py
@@ -101,6 +101,7 @@ CONTRACT_MAP_VOLATILE_KEYS = {
 IMPORT_OR_CLI_FAILURE = "IMPORT_OR_CLI_FAILURE"
 TARGET_PROMPT_INTEGRITY_FAILURE = "TARGET_PROMPT_INTEGRITY_FAILURE"
 TARGET_TRUTH_SPLIT_MISMATCH = "TARGET_TRUTH_SPLIT_MISMATCH"
+TRUTH_SPLIT_NOT_IMPLEMENTED = "TRUTH_SPLIT_NOT_IMPLEMENTED"
 CONTRACT_MAP_NONDETERMINISTIC = "CONTRACT_MAP_NONDETERMINISTIC"
 ROUTE_DERIVATION_FAILURE = "ROUTE_DERIVATION_FAILURE"
 REQUIRED_API_KEY_MISSING = "REQUIRED_API_KEY_MISSING"
@@ -474,8 +475,34 @@ def evaluate_prompt_integrity(runner: Any, config: GateConfig) -> Tuple[Dict[str
 
 
 def collect_truth_split(runner: Any, config: GateConfig) -> Tuple[Dict[str, Any], List[Blocker], List[Dict[str, Any]]]:
-    # Placeholder for truth split logic
-    return {"layer": "truth_split_audit", "status": "PASS", "target_phase_mismatch_count": 0, "repo_wide_mismatch_count": 0, "rows": []}, [], []
+    # FAIL-CLOSED (audit finding S7): the runner/promptset/model-map drift audit is not
+    # implemented. This previously returned a hardcoded PASS, which silently asserted
+    # "no drift" without running any check -- giving false go-live confidence. Until
+    # classify_truth_split_row (above) is wired into a real per-step comparison, we must
+    # not claim PASS. Emit a waivable P1 blocker so the gate fails closed; an operator who
+    # accepts the gap may proceed with `--waiver-code TRUTH_SPLIT_NOT_IMPLEMENTED`.
+    blocker = Blocker(
+        reason_code=TRUTH_SPLIT_NOT_IMPLEMENTED,
+        layer="truth_split_audit",
+        severity="P1",
+        message=(
+            "Truth-split drift audit is not implemented; cannot assert runner/promptset/"
+            "model-map alignment. Failing closed. Waive with "
+            "--waiver-code TRUTH_SPLIT_NOT_IMPLEMENTED to proceed without this check."
+        ),
+        details={"implemented": False},
+    )
+    return (
+        {
+            "layer": "truth_split_audit",
+            "status": "NOT_IMPLEMENTED",
+            "target_phase_mismatch_count": 0,
+            "repo_wide_mismatch_count": 0,
+            "rows": [],
+        },
+        [blocker],
+        [],
+    )
 
 
 def evaluate_contract_map(

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -4926,9 +4926,17 @@ def _pipeline_version_options(command_fn: Callable) -> Callable:
 def _resolved_pipeline_version(
     pipeline_version: str, engine_version_legacy: Optional[str]
 ) -> str:
-    if engine_version_legacy:
-        return engine_version_legacy
-    return pipeline_version
+    resolved = engine_version_legacy if engine_version_legacy else pipeline_version
+    # v3-warn (audit): v3 is the legacy/shadow engine, still operator-reachable via the
+    # hidden --engine-version flag or --pipeline-version v3. Keep it working but warn
+    # loudly so operators don't silently run the unsupported engine. v5 is canonical.
+    if str(resolved).strip().lower() == "v3":
+        console.logger.warning(
+            "[warning]⚠️  Pipeline engine v3 is DEPRECATED[/warning] — it is the legacy/"
+            "shadow engine and v5 is canonical. Prefer --pipeline-version v5. v3 remains "
+            "available but is unsupported and may be removed."
+        )
+    return resolved
 
 
 def _run_truth_v5_alias(

--- a/src/dopemux/mcp/broker.py
+++ b/src/dopemux/mcp/broker.py
@@ -564,11 +564,16 @@ class MetaMCPBroker:
                     f"Escalation type '{escalation_type}' not allowed for role '{session.role}'"
                 )
 
+            # `escalation_triggers` values are `EscalationRule` dataclass instances
+            # (see roles.py), not dicts — use attribute access (TP-2 fix; `.get()`
+            # raised AttributeError).
             escalation_config = role_config.escalation_triggers[escalation_type]
 
-            # Check if approval is required
-            if escalation_config.get("approval_required", False):
-                # In a real implementation, this would trigger an approval workflow
+            # Check if approval is required.
+            # NOTE: the approval dispatch path is currently unwired — this returns
+            # an "approval_required" status but no transport actually requests or
+            # records approval (observation only; no transport added here).
+            if escalation_config.approval_required:
                 logger.info(
                     f"Escalation approval required for {session_id}: {escalation_type}"
                 )
@@ -580,13 +585,13 @@ class MetaMCPBroker:
                 }
 
             # Mount additional tools
-            additional_tools = set(escalation_config.get("additional_tools", []))
+            additional_tools = set(escalation_config.additional_tools or [])
             if additional_tools:
                 await self._mount_tools(session_id, additional_tools)
                 session.mounted_tools.update(additional_tools)
 
             # Set escalation expiry
-            duration = escalation_config.get("max_duration", 1800)  # Default 30 minutes
+            duration = escalation_config.max_duration  # seconds (dataclass default 1800)
             session.escalation_active = True
             session.escalation_expires = datetime.now() + timedelta(seconds=duration)
 

--- a/src/dopemux/mcp/gate.py
+++ b/src/dopemux/mcp/gate.py
@@ -84,14 +84,6 @@ class DiscoveryGate:
                 missing_globs = []
                 for glob in required_globs:
                     matches = fnmatch.filter(discovered_tools, glob)
-                    
-                    # Special case for ConPort: handle both spellings if one fails
-                    if not matches and (glob.startswith("conport_") or glob.startswith("conport_")):
-                        if "conport_" in glob:
-                            alt_glob = glob.replace("conport_", "conport_")
-                        else:
-                            alt_glob = glob.replace("conport_", "conport_")
-                        matches = fnmatch.filter(discovered_tools, alt_glob)
 
                     if not matches and not handshake_required:
                         missing_globs.append(glob)

--- a/src/dopemux/mcp/gate.py
+++ b/src/dopemux/mcp/gate.py
@@ -100,10 +100,27 @@ class DiscoveryGate:
                     self.report["missing_required_tools"][name] = missing_globs
                     if is_mandatory:
                         passed = False
+                    else:
+                        # Non-mandatory (env_var / global_fallback): ALWAYS WARN; escalate
+                        # to a hard BLOCK only under strict_optional (fail-closed opt-in).
+                        self.report["warnings"].append(
+                            f"Non-mandatory server '{name}' is missing required tool(s): "
+                            f"{', '.join(missing_globs)}"
+                        )
+                        if self.strict_optional:
+                            passed = False
             else:
                 self.report["unreachable_transport"].append(name)
                 if is_mandatory:
                     passed = False
+                else:
+                    # Non-mandatory (env_var / global_fallback): ALWAYS WARN; escalate
+                    # to a hard BLOCK only under strict_optional (fail-closed opt-in).
+                    self.report["warnings"].append(
+                        f"Non-mandatory server '{name}' is unreachable (transport failed)"
+                    )
+                    if self.strict_optional:
+                        passed = False
 
         self.report["status"] = "PASS" if passed else "BLOCK"
         self._save_report()

--- a/src/dopemux/mcp/gate.py
+++ b/src/dopemux/mcp/gate.py
@@ -1,5 +1,6 @@
 import json
 import fnmatch
+import os
 from pathlib import Path
 from typing import Optional
 from .resolver import InstanceResolver
@@ -12,19 +13,41 @@ class DiscoveryGate:
     - Runs Tool Discovery (JSON-RPC POST tools/list)
     - Validates required tool globs are satisfied
     - Fails closed with structured report
+
+    Provenance-aware failure policy (TP-2 / MCP1-02):
+    - repo_profile servers are ALWAYS mandatory: unreachable or missing-glob -> BLOCK.
+    - env_var / global_fallback servers are non-mandatory. Previously their failures
+      were silently fail-open. They now ALWAYS emit a clearly-labeled WARNING in the
+      report. With ``strict_optional=True`` (or env DOPEMUX_MCP_GATE_STRICT=1) those
+      warnings additionally escalate to a hard BLOCK (fail-closed opt-in).
     """
-    def __init__(self, project_root: Optional[Path] = None, run_id: str = "latest"):
+    def __init__(
+        self,
+        project_root: Optional[Path] = None,
+        run_id: str = "latest",
+        strict_optional: Optional[bool] = None,
+    ):
         self.project_root = project_root or Path.cwd()
         self.run_id = run_id
         self.resolver = InstanceResolver(self.project_root)
         self.discovery = ToolDiscoveryClient()
         self.proof_dir = self.project_root / "proof" / run_id
+        # Opt-in fail-closed for non-mandatory servers. Default is loud-warn (safe,
+        # non-breaking for existing optional-server setups). Env var lets operators
+        # turn on strict mode without code changes.
+        if strict_optional is None:
+            strict_optional = os.environ.get(
+                "DOPEMUX_MCP_GATE_STRICT", ""
+            ).strip().lower() in ("1", "true", "yes", "on")
+        self.strict_optional = strict_optional
         self.report = {
             "status": "INIT",
             "reachable_transport": [],
             "unreachable_transport": [],
             "tools_discoverable": {},
             "missing_required_tools": {},
+            "warnings": [],
+            "strict_optional": self.strict_optional,
             "resolved_endpoints": {},
             "provenance": {}
         }

--- a/src/dopemux/mcp/server_manager.py
+++ b/src/dopemux/mcp/server_manager.py
@@ -24,6 +24,7 @@ Integration Points:
 import asyncio
 import json
 import logging
+import os
 import subprocess
 import time
 from dataclasses import dataclass, field
@@ -36,6 +37,73 @@ import websockets
 import yaml
 
 logger = logging.getLogger(__name__)
+
+# Security (TP-2 / MCP1-04): child MCP processes must NOT inherit the full host
+# environment, which would leak every secret (API keys, tokens) to every server.
+# We forward only a conservative base of non-secret operational variables, plus
+# any secrets the server has explicitly declared via `requires_env`/`optional_env`,
+# plus the per-server `environment` dict. Secrets are forwarded by *name* only when
+# the server declares it needs them — never blanket-copied.
+_CHILD_ENV_BASE_ALLOWLIST: tuple[str, ...] = (
+    # Process/runtime essentials
+    "PATH",
+    "HOME",
+    "USER",
+    "LOGNAME",
+    "SHELL",
+    "TMPDIR",
+    "TERM",
+    # Locale (also matched by LC_* prefix below)
+    "LANG",
+    "LC_ALL",
+    # Python launcher vars (spawned interpreters break without these)
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PYTHONUNBUFFERED",
+    "VIRTUAL_ENV",
+    # Node launcher vars (some stdio servers are node-based)
+    "NODE_PATH",
+    "NVM_DIR",
+)
+
+
+def _build_child_env(config: Dict[str, Any]) -> Dict[str, str]:
+    """Build a fail-closed environment for a spawned (stdio) MCP child process.
+
+    Precedence (lowest to highest): base operational allow-list (from host) <
+    declared secrets named in ``requires_env``/``optional_env`` (from host, if set) <
+    explicit per-server ``environment`` dict (from config).
+
+    Crucially this does NOT copy the entire host environment, so unrelated host
+    secrets never reach the child. A server only receives a secret if it has
+    explicitly declared a need for it by name.
+    """
+    child_env: Dict[str, str] = {}
+
+    # 1. Base operational allow-list + any LC_* locale vars present on the host.
+    for key, value in os.environ.items():
+        if key in _CHILD_ENV_BASE_ALLOWLIST or key.startswith("LC_"):
+            child_env[key] = value
+
+    # 2. Explicitly declared secrets, forwarded by name only when present on host.
+    declared_env_names: List[str] = []
+    for decl_key in ("requires_env", "optional_env"):
+        declared = config.get(decl_key) or []
+        if isinstance(declared, (list, tuple)):
+            declared_env_names.extend(str(name) for name in declared)
+    for name in declared_env_names:
+        host_value = os.environ.get(name)
+        if host_value is not None:
+            child_env[name] = host_value
+
+    # 3. Per-server environment dict wins over everything above.
+    explicit_env = config.get("environment", {})
+    if isinstance(explicit_env, dict):
+        for key, value in explicit_env.items():
+            if value is not None:
+                child_env[str(key)] = str(value)
+
+    return child_env
 
 
 class ServerTransport(Enum):
@@ -434,7 +502,6 @@ class MCPServerManager:
         config = connection.config
         command = config.get("command", [])
         working_dir = config.get("working_directory", ".")
-        env = config.get("environment", {})
 
         if not command:
             raise ValueError(
@@ -442,11 +509,11 @@ class MCPServerManager:
             )
 
         try:
-            # Prepare environment
-            import os
-
-            full_env = os.environ.copy()
-            full_env.update(env)
+            # Prepare environment (TP-2 / MCP1-04): fail-closed allow-list instead
+            # of copying the full host environment, which would leak every host
+            # secret to every child MCP process. `_build_child_env` forwards only
+            # base operational vars + declared secrets + the per-server env dict.
+            child_env = _build_child_env(config)
 
             # Start process
             connection.process = subprocess.Popen(
@@ -455,7 +522,7 @@ class MCPServerManager:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 cwd=working_dir,
-                env=full_env,
+                env=child_env,
                 text=True,
                 bufsize=0,
             )

--- a/src/dopemux/mcp/server_manager.py
+++ b/src/dopemux/mcp/server_manager.py
@@ -64,6 +64,19 @@ _CHILD_ENV_BASE_ALLOWLIST: tuple[str, ...] = (
     # Node launcher vars (some stdio servers are node-based)
     "NODE_PATH",
     "NVM_DIR",
+    # P2: outbound proxy / TLS trust — non-secret operational vars that
+    # stdio children need when the host is behind a corporate proxy or uses
+    # a custom CA bundle.  Without these, spawned children silently lose TLS
+    # connectivity.  These are NOT secret and carry no credentials.
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
 )
 
 

--- a/src/dopemux/mcp/session_manager.py
+++ b/src/dopemux/mcp/session_manager.py
@@ -733,15 +733,20 @@ class SessionManager:
 
     @staticmethod
     def _safe_session_filename(session_id: str) -> str:
-        # MCP1-05 (audit): session_id flows into a filesystem path (f"{session_id}.json").
-        # Reject separators / parent refs / unexpected chars so a crafted id (e.g.
-        # "../../etc/passwd") cannot escape the session storage directory.
+        # MCP1-05 (audit): session_id flows into a filesystem path.  Block the
+        # path-traversal chars that can escape the storage directory ("/", null,
+        # "..") then percent-encode everything else so that clients using
+        # colon-style ids ("agent:primary", ISO timestamps) are not silently
+        # dropped — the ValueError was caught by a broad `except Exception` and
+        # swallowed, making persistence silently fail.
         sid = str(session_id)
-        if not re.fullmatch(r"[A-Za-z0-9_-]+", sid):
+        if not sid or "/" in sid or "\x00" in sid or sid in (".", ".."):
             raise ValueError(
-                f"Invalid session_id (must match [A-Za-z0-9_-]+): {session_id!r}"
+                f"Invalid session_id (contains path-traversal characters): {session_id!r}"
             )
-        return f"{sid}.json"
+        # Percent-encode chars that are not filesystem-safe on any platform.
+        safe = re.sub(r"[^A-Za-z0-9_\-]", lambda m: f"%{ord(m.group()):02X}", sid)
+        return f"{safe}.json"
 
     async def _save_session_state(self, session: SessionState) -> None:
         """Save session state to disk"""

--- a/src/dopemux/mcp/session_manager.py
+++ b/src/dopemux/mcp/session_manager.py
@@ -25,6 +25,7 @@ Design Principles:
 import asyncio
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
@@ -204,7 +205,13 @@ class SessionManager:
 
         # Session storage
         self.session_storage_path = Path("/tmp/metamcp_sessions")
-        self.session_storage_path.mkdir(exist_ok=True)
+        # MCP1-05 (audit): /tmp is world-accessible and these files hold session context.
+        # Restrict to owner-only; mkdir's mode is masked by umask, so chmod explicitly.
+        self.session_storage_path.mkdir(mode=0o700, exist_ok=True)
+        try:
+            self.session_storage_path.chmod(0o700)
+        except OSError:
+            pass
 
         logger.info("SessionManager initialized with ADHD accommodations")
 
@@ -724,10 +731,22 @@ class SessionManager:
         except Exception as e:
             logger.error(f"Session monitoring error for {session_id}: {e}")
 
+    @staticmethod
+    def _safe_session_filename(session_id: str) -> str:
+        # MCP1-05 (audit): session_id flows into a filesystem path (f"{session_id}.json").
+        # Reject separators / parent refs / unexpected chars so a crafted id (e.g.
+        # "../../etc/passwd") cannot escape the session storage directory.
+        sid = str(session_id)
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", sid):
+            raise ValueError(
+                f"Invalid session_id (must match [A-Za-z0-9_-]+): {session_id!r}"
+            )
+        return f"{sid}.json"
+
     async def _save_session_state(self, session: SessionState) -> None:
         """Save session state to disk"""
         try:
-            session_file = self.session_storage_path / f"{session.session_id}.json"
+            session_file = self.session_storage_path / self._safe_session_filename(session.session_id)
 
             # Convert to serializable format
             session_data = {
@@ -785,7 +804,7 @@ class SessionManager:
     async def _load_session_state(self, session_id: str) -> Optional[SessionState]:
         """Load session state from disk"""
         try:
-            session_file = self.session_storage_path / f"{session_id}.json"
+            session_file = self.session_storage_path / self._safe_session_filename(session_id)
 
             if not session_file.exists():
                 return None

--- a/tests/mcp/test_discovery_gate_strict.py
+++ b/tests/mcp/test_discovery_gate_strict.py
@@ -1,0 +1,149 @@
+"""Regression tests for DiscoveryGate provenance-aware failure policy.
+
+Context (PR #725 review): the TP-2 commit claimed to make non-mandatory
+(env_var / global_fallback) server failures ALWAYS emit a WARNING, and to
+escalate them to a hard BLOCK under ``strict_optional`` / DOPEMUX_MCP_GATE_STRICT.
+The ``__init__`` wiring landed but the ``run()``-side enforcement was lost in a
+salvage, so the behaviour was never delivered. The shipped
+``test_discovery_gate`` only prints (no assertions), so it passed vacuously and
+did not catch the regression.
+
+These tests assert the contract directly by injecting controlled resolver +
+discovery results, so they fail closed against the regressed code and stay green
+once the ``run()`` logic is restored.
+"""
+
+import pytest
+
+from dopemux.mcp.gate import DiscoveryGate
+
+
+def _make_gate(tmp_path, *, servers, provenance, discovery_servers, strict_optional=None):
+    """Build a DiscoveryGate with the resolver + discovery layers stubbed.
+
+    ``servers``/``provenance`` mimic InstanceResolver.resolve(); ``discovery_servers``
+    mimics ToolDiscoveryClient.discover()["servers"]. This keeps the test
+    deterministic and offline while exercising the real run() logic.
+    """
+    gate = DiscoveryGate(tmp_path, run_id="test", strict_optional=strict_optional)
+
+    def fake_resolve(profile_name="default"):
+        return {"servers": servers, "provenance": provenance, "transports": {}}
+
+    async def fake_discover(resolved_servers):
+        return {
+            "servers": discovery_servers,
+            "reachable": all(s.get("reachable") for s in discovery_servers),
+        }
+
+    gate.resolver.resolve = fake_resolve
+    gate.discovery.discover = fake_discover
+    return gate
+
+
+@pytest.mark.asyncio
+async def test_nonmandatory_unreachable_warns_but_passes(tmp_path):
+    """An env_var (non-mandatory) server that is unreachable must WARN, not block."""
+    gate = _make_gate(
+        tmp_path,
+        servers={"opt": {"required_tool_globs": []}},
+        provenance={"opt": "env_var"},
+        discovery_servers=[
+            {"name": "opt", "reachable": False, "status": "unreachable", "tools": []}
+        ],
+    )
+    passed = await gate.run()
+    assert passed is True
+    assert gate.report["status"] == "PASS"
+    assert any("opt" in w for w in gate.report["warnings"]), gate.report["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_nonmandatory_unreachable_blocks_under_strict(tmp_path):
+    """Under strict_optional, the same non-mandatory failure escalates to BLOCK."""
+    gate = _make_gate(
+        tmp_path,
+        servers={"opt": {"required_tool_globs": []}},
+        provenance={"opt": "env_var"},
+        discovery_servers=[
+            {"name": "opt", "reachable": False, "status": "unreachable", "tools": []}
+        ],
+        strict_optional=True,
+    )
+    passed = await gate.run()
+    assert passed is False
+    assert gate.report["status"] == "BLOCK"
+    assert any("opt" in w for w in gate.report["warnings"]), gate.report["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_mandatory_unreachable_always_blocks(tmp_path):
+    """A repo_profile (mandatory) server that is unreachable must always BLOCK."""
+    gate = _make_gate(
+        tmp_path,
+        servers={"repo": {"required_tool_globs": []}},
+        provenance={"repo": "repo_profile"},
+        discovery_servers=[
+            {"name": "repo", "reachable": False, "status": "unreachable", "tools": []}
+        ],
+    )
+    passed = await gate.run()
+    assert passed is False
+    assert gate.report["status"] == "BLOCK"
+
+
+@pytest.mark.asyncio
+async def test_nonmandatory_missing_glob_warns_passes_then_strict_blocks(tmp_path):
+    """A reachable non-mandatory server missing a required glob warns (PASS), and
+    BLOCKs under strict_optional. Exercises the missing-globs branch of run()."""
+    servers = {"opt": {"required_tool_globs": ["needed_*"]}}
+    provenance = {"opt": "env_var"}
+    discovery_servers = [
+        {"name": "opt", "reachable": True, "status": "ok", "tools": ["other_tool"]}
+    ]
+
+    gate = _make_gate(
+        tmp_path,
+        servers=servers,
+        provenance=provenance,
+        discovery_servers=discovery_servers,
+    )
+    passed = await gate.run()
+    assert passed is True
+    assert gate.report["status"] == "PASS"
+    assert "opt" in gate.report["missing_required_tools"]
+    assert any("opt" in w for w in gate.report["warnings"]), gate.report["warnings"]
+
+    gate_strict = _make_gate(
+        tmp_path,
+        servers=servers,
+        provenance=provenance,
+        discovery_servers=discovery_servers,
+        strict_optional=True,
+    )
+    passed_strict = await gate_strict.run()
+    assert passed_strict is False
+    assert gate_strict.report["status"] == "BLOCK"
+
+
+@pytest.mark.asyncio
+async def test_mandatory_reachable_with_all_globs_passes(tmp_path):
+    """Control: a mandatory server that is reachable with all globs satisfied PASSES
+    with no warnings."""
+    gate = _make_gate(
+        tmp_path,
+        servers={"repo": {"required_tool_globs": ["conport_*"]}},
+        provenance={"repo": "repo_profile"},
+        discovery_servers=[
+            {
+                "name": "repo",
+                "reachable": True,
+                "status": "ok",
+                "tools": ["conport_decisions_add", "conport_graph_query"],
+            }
+        ],
+    )
+    passed = await gate.run()
+    assert passed is True
+    assert gate.report["status"] == "PASS"
+    assert gate.report["warnings"] == []

--- a/tests/mcp/test_mcp_internal_lockdown.py
+++ b/tests/mcp/test_mcp_internal_lockdown.py
@@ -1,0 +1,60 @@
+"""TP-2 (MCP-internal lockdown) regression tests.
+
+Covers the audit fixes:
+- MCP1-04: spawned child MCP processes must not inherit undeclared host secrets.
+- MCP1-05: session_id must be sanitized before it is used in a filesystem path.
+"""
+from __future__ import annotations
+
+import pytest
+
+from dopemux.mcp.session_manager import SessionManager
+
+
+def _load_build_child_env():
+    # server_manager imports `websockets` at module top; skip (NOT_RUN) where it isn't
+    # installed rather than failing collection.
+    pytest.importorskip("websockets")
+    from dopemux.mcp.server_manager import _build_child_env
+
+    return _build_child_env
+
+
+def test_build_child_env_does_not_leak_undeclared_secrets(monkeypatch):
+    # MCP1-04: only base operational vars + declared secrets + per-server env reach a child.
+    build_child_env = _load_build_child_env()
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("FOO_DECLARED_KEY", "declared-secret")
+    monkeypatch.setenv("UNDECLARED_SECRET_KEY", "should-not-leak")
+    config = {"requires_env": ["FOO_DECLARED_KEY"], "environment": {"EXTRA": "x"}}
+
+    env = build_child_env(config)
+
+    assert env.get("PATH") == "/usr/bin"                     # base operational var
+    assert env.get("FOO_DECLARED_KEY") == "declared-secret"  # declared secret forwarded
+    assert env.get("EXTRA") == "x"                           # per-server env forwarded
+    assert "UNDECLARED_SECRET_KEY" not in env                # undeclared secret NOT leaked
+
+
+def test_build_child_env_per_server_env_overrides_host(monkeypatch):
+    build_child_env = _load_build_child_env()
+    monkeypatch.setenv("FOO_DECLARED_KEY", "host-value")
+    config = {
+        "requires_env": ["FOO_DECLARED_KEY"],
+        "environment": {"FOO_DECLARED_KEY": "override"},
+    }
+    assert build_child_env(config)["FOO_DECLARED_KEY"] == "override"
+
+
+def test_safe_session_filename_accepts_valid():
+    assert SessionManager._safe_session_filename("abc-123_X") == "abc-123_X.json"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    ["../etc/passwd", "a/b", "..", "", "a.b", "a b", "a/../b", "/abs"],
+)
+def test_safe_session_filename_rejects_traversal(bad):
+    # MCP1-05: reject path separators / parent refs / unexpected chars.
+    with pytest.raises(ValueError):
+        SessionManager._safe_session_filename(bad)

--- a/tests/mcp/test_mcp_internal_lockdown.py
+++ b/tests/mcp/test_mcp_internal_lockdown.py
@@ -52,9 +52,31 @@ def test_safe_session_filename_accepts_valid():
 
 @pytest.mark.parametrize(
     "bad",
-    ["../etc/passwd", "a/b", "..", "", "a.b", "a b", "a/../b", "/abs"],
+    # MCP1-05 / P1-3: reject real path-traversal sequences (/, .., null, empty).
+    # Dots and spaces/colons in non-traversal ids are now percent-encoded rather
+    # than rejected so that legitimate client-supplied ids (e.g. "agent:primary",
+    # "v1.0.0") don't silently lose persistence state.
+    ["../etc/passwd", "a/b", "..", "", "a/../b", "/abs", "\x00bad"],
 )
 def test_safe_session_filename_rejects_traversal(bad):
-    # MCP1-05: reject path separators / parent refs / unexpected chars.
     with pytest.raises(ValueError):
         SessionManager._safe_session_filename(bad)
+
+
+@pytest.mark.parametrize(
+    "sid, expected",
+    [
+        # Plain alphanumeric — unchanged
+        ("abc-123_X", "abc-123_X.json"),
+        # Colon-style lane ids — encoded
+        ("agent:primary", "agent%3Aprimary.json"),
+        # Dots (version strings, timestamps) — encoded
+        ("v1.0.0", "v1%2E0%2E0.json"),
+        # Spaces — encoded
+        ("a b", "a%20b.json"),
+    ],
+)
+def test_safe_session_filename_encodes_non_traversal(sid, expected):
+    # P1-3: non-traversal ids that contain chars outside [A-Za-z0-9_-] are now
+    # percent-encoded rather than rejected.
+    assert SessionManager._safe_session_filename(sid) == expected


### PR DESCRIPTION
## Summary

Remediates verified findings from the distributed RTE/CLI/install/docs/MCP audit
(`claudedocs/rte-distributed-audit-2026-05-29.md`). **Full program, all surfaces**, with the
**conservative / fail-closed / non-breaking** option on every architectural fork (fail-close
SP, lockdown MCP, deprecate-warn v3). 6 commits, one per Task-Packet slice; the slices touch
disjoint files and can be split into per-TP PRs on request.

A read-only verification pass **recalibrated several findings before any edit** (recorded
inline): `MCP2-04` git-history secret leak → REFUTED (no real keys in history); `S8-001`
repo-root off-by-one → STALE (the code is correct); the MCP broker RBAC → fail-*closed* but
unwired dead code (real bug was a dataclass/dict crash in escalation).

## What changed (per slice)

- **TP-1 core** (`74ba64dc7`) — S7: the pre-live gate's `collect_truth_split` returned a
  hardcoded `PASS` (silent "no drift" with no check) → now fails closed with a **waivable P1
  blocker** (`--waiver-code TRUTH_SPLIT_NOT_IMPLEMENTED`). S3-06/07/03 prescan correctness;
  S4-MED-1 orphan-phase doc.
- **TP-1b** (`73999a384`) — **S4-CRIT-2 SP fail-close at *execution* time** (refuses an
  uncontracted JSON-emitting SP step on a live run; dry-run / resolution / listing /
  CostProfile / post-review-preview unaffected — a resolution-time raise broke 12 CostProfile
  tests + the post-review preset). S4-CRIT-1 loud `DOPEMUX_S_PROMPTS` swap warning. S6 canonical
  `run_status` (`rte_constants.py`). S8-002 documented divergence (deferred YAML wiring — the
  tool does destructive moves). S2 documented declared-but-unenforced sections.
- **TP-2 MCP-internal** (`37f92b0d4`) — MCP1-04 child processes get a scoped env allow-list
  (no full `os.environ` → no secret leak to every server); broker escalation dataclass-access
  fix; MCP1-02 gate fail-closed/loud-warn (`DOPEMUX_MCP_GATE_STRICT`); MCP1-10 conport no-op
  fix; MCP1-05 session storage `0700` + `session_id` path-traversal sanitization.
- **TP-3 MCP-services** (`f3010b7ff`) — MCP2-06 `/api/debug/instance-info` no longer returns
  the Postgres/Redis URLs (credentials) + binds `127.0.0.1` by default; MCP2-01 KG authority
  middleware **deny-by-default**; MCP2-07 CORS allow-list (no wildcard); MCP2-03 capture-server
  input validation.
- **TP-4 install** (`003a2bbba`) — canonical `dopemux-network` (compose declares it
  `external: true`; INST-01 was real); `setup.sh` `pipefail` + un-masked compose/network
  failure; `.env` `chmod 600` + pinnable clone ref; `dope-context` healthcheck `|| exit 1`;
  `INSTALLER_TEST_MODE` coverage documented.
- **TP-5 docs+v3** (`96a331aab`) — v3 engine deprecation warning (kept working); migration
  banner mapping the disabled `dopemux extractor <subcmd>` surface to canonical `dopemux rte …`
  commands.

## ⚠️ Intended behavior changes
- The **pre-live gate now returns NO-GO** at the truth-split layer until someone wires real
  drift detection or passes `--waiver-code TRUTH_SPLIT_NOT_IMPLEMENTED` (the old `PASS` was
  fake — this is the fix).
- **Live phase-SP execution now refuses** when SP steps are uncontracted (SP is absent from
  `repo_truth_map.json`). Default `legacy` S-prompts and dry-run/preview are unaffected.
- **MCP integration-bridge binds `127.0.0.1`** and **CORS is no longer wildcard** by default
  (override via `MCP_INTEGRATION_HOST` / `MCP_INTEGRATION_CORS_ORIGINS` for networked deploy).

## Validation
- **PASS** — full `services/repo-truth-extractor/tests/` (sans live, AGENTS.md §7); MCP
  gate/registry/provision/resolver + session-sanitization; v3-warning exercised; all 20 py
  files compile; `git diff --check` clean.
- **NOT_RUN** — `_build_child_env` tests (`websockets` not installed); FastAPI TestClient for
  TP-3 (`fastapi` not installed + §7 no running services); any live extraction/provider.
  Logic is static-audited + file:line-anchored.
- **DEFERRED** — MCP2-05 (`str(e)` in HTTP error detail, MED info-disclosure, ~9 sites — no
  secrets; the secret leak is closed by MCP2-06). Follow-ups: wire `classify_truth_split_row`
  into the S7 gate; register phase SP in `repo_truth_map.json` if post-review SP must run live.

## Recommended next step
Run `/code-review ultra` on this PR for an independent multi-agent audit (PAL codereview was
NOT_RUN this session due to infra instability).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
