### PR TITLE
feat(rte): add OpenRouter discovery classifier

### DIFF
--- a/services/repo-truth-extractor/benchmarking/registry/openrouter_discovery.py
+++ b/services/repo-truth-extractor/benchmarking/registry/openrouter_discovery.py
@@ -16,6 +16,7 @@ UNKNOWN = "UNKNOWN"
 SNAPSHOT_SCHEMA_ID = "rte_openrouter_route_metadata_discovery_v1"
 OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
 LIVE_FETCH_ENV = "RTE_OPENROUTER_DISCOVERY_LIVE"
+LIVE_CONSENT_ENV = "DPMX_LIVE_OK"
 
 CLASSIFICATION_LABELS = (
     "DIRECT_OVERLAP_EXCLUDE",
@@ -153,22 +154,20 @@ def _top_provider_context_length(model: dict[str, Any]) -> int | float | str:
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise OpenRouterMetadataError(
             "top_provider.context_length must be a number when present"
-        )
+    )
     return value
 
 
+def _pricing_values(pricing: dict[str, Any]) -> list[Any]:
+    return [value for value in pricing.values() if value is not None]
+
+
 def _is_free(model_id: str, pricing: dict[str, Any] | str) -> bool:
-    if model_id.lower().endswith(":free"):
-        return True
     if not isinstance(pricing, dict):
-        return False
-    price_values = [
-        pricing.get(key)
-        for key in ("prompt", "completion", "request")
-        if key in pricing
-    ]
+        return model_id.lower().endswith(":free")
+    price_values = _pricing_values(pricing)
     if not price_values:
-        return False
+        return model_id.lower().endswith(":free")
     try:
         return all(float(str(value)) == 0.0 for value in price_values)
     except (TypeError, ValueError):
@@ -180,11 +179,7 @@ def _free_or_paid(model_id: str, pricing: dict[str, Any] | str) -> str:
         return "FREE"
     if not isinstance(pricing, dict):
         return UNKNOWN
-    price_values = [
-        pricing.get(key)
-        for key in ("prompt", "completion", "request")
-        if key in pricing
-    ]
+    price_values = _pricing_values(pricing)
     if not price_values:
         return UNKNOWN
     try:
@@ -500,6 +495,10 @@ def fetch_openrouter_models_live(timeout_seconds: float = 30.0) -> dict[str, Any
     if os.environ.get(LIVE_FETCH_ENV) != "1":
         raise OpenRouterMetadataError(
             f"live OpenRouter discovery requires {LIVE_FETCH_ENV}=1"
+        )
+    if os.environ.get(LIVE_CONSENT_ENV) != "1":
+        raise OpenRouterMetadataError(
+            f"live OpenRouter discovery requires {LIVE_CONSENT_ENV}=1"
         )
     headers = {"Accept": "application/json"}
     api_key = _api_key_from_env()

--- a/services/repo-truth-extractor/benchmarking/registry/openrouter_discovery.py
+++ b/services/repo-truth-extractor/benchmarking/registry/openrouter_discovery.py
@@ -1,0 +1,596 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import tempfile
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+UNKNOWN = "UNKNOWN"
+SNAPSHOT_SCHEMA_ID = "rte_openrouter_route_metadata_discovery_v1"
+OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models"
+LIVE_FETCH_ENV = "RTE_OPENROUTER_DISCOVERY_LIVE"
+
+CLASSIFICATION_LABELS = (
+    "DIRECT_OVERLAP_EXCLUDE",
+    "DIRECT_OVERLAP_EXCEPTION",
+    "OPENROUTER_VALUE_CANDIDATE",
+    "FREE_EXPERIMENTAL",
+    "BENCHMARK_ONLY",
+    "DO_NOT_RECOMMEND",
+)
+
+_SECRET_PATTERNS = (
+    re.compile(r"Authorization:\s*Bearer\s+[A-Za-z0-9_\-.]{10,}", re.IGNORECASE),
+    re.compile(r"Bearer\s+[A-Za-z0-9_\-.]{10,}", re.IGNORECASE),
+    re.compile(r"\bsk" r"-or-[A-Za-z0-9_\-.]{8,}\b", re.IGNORECASE),
+    re.compile(r"\bOPENROUTER_API_KEY\s*=\s*\S+", re.IGNORECASE),
+    re.compile(r"\bV5_OPENROUTER_API_KEY\s*=\s*\S+", re.IGNORECASE),
+)
+
+_DIRECT_OVERLAP_VENDORS = {
+    "anthropic",
+    "google_gemini",
+    "mistral_flagship",
+    "openai",
+    "xai",
+}
+_EXPLICIT_EXCEPTION_VENDORS = {
+    "anthropic",
+    "deepseek",
+    "stepfun",
+    "zai",
+}
+_DIRECT_PLATFORM_BENCHMARK_VENDORS = {
+    "cohere",
+    "ibm_granite",
+    "meta_llama",
+}
+_HOSTED_OPEN_WEIGHT_VENDORS = {
+    "arcee",
+    "gemma",
+    "nvidia",
+    "prime_intellect",
+    "qwen",
+    "reka",
+}
+_BENCHMARKABLE_OR_ADVANTAGE_MARKERS = (
+    "pinned free",
+    ":free",
+    "hosted open-weight",
+    "structured output",
+    "require_parameters",
+    "max_price",
+    "data_collection",
+    "zdr",
+    "provider fallback",
+    "route telemetry",
+    "schema reliability",
+)
+
+
+class OpenRouterMetadataError(ValueError):
+    """Raised when OpenRouter metadata cannot be normalized safely."""
+
+
+def stable_snapshot_json(payload: Any) -> str:
+    return json.dumps(payload, ensure_ascii=True, sort_keys=True, separators=(",", ":"))
+
+
+def _redact_string(value: str) -> str:
+    redacted = value
+    for pattern in _SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    return redacted
+
+
+def _safe_string(value: Any, *, field: str, required: bool = False) -> str:
+    if value is None:
+        if required:
+            raise OpenRouterMetadataError(f"missing required field: {field}")
+        return UNKNOWN
+    if not isinstance(value, str):
+        raise OpenRouterMetadataError(f"{field} must be a string")
+    normalized = value.strip()
+    if not normalized and required:
+        raise OpenRouterMetadataError(f"missing required field: {field}")
+    if any(pattern.search(normalized) for pattern in _SECRET_PATTERNS):
+        if field == "id":
+            raise OpenRouterMetadataError("model id contains sensitive token pattern")
+        return _redact_string(normalized)
+    return normalized or UNKNOWN
+
+
+def _optional_number(model: dict[str, Any], field: str) -> int | float | str:
+    if field not in model or model[field] is None:
+        return UNKNOWN
+    value = model[field]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise OpenRouterMetadataError(f"{field} must be a number when present")
+    return value
+
+
+def _supported_parameters(model: dict[str, Any]) -> list[str] | str:
+    if "supported_parameters" not in model or model["supported_parameters"] is None:
+        return UNKNOWN
+    params = model["supported_parameters"]
+    if not isinstance(params, list) or not all(isinstance(item, str) for item in params):
+        raise OpenRouterMetadataError("supported_parameters must be a string array")
+    return sorted({item.strip() for item in params if item.strip()})
+
+
+def _pricing(model: dict[str, Any]) -> dict[str, Any] | str:
+    if "pricing" not in model or model["pricing"] is None:
+        return UNKNOWN
+    pricing = model["pricing"]
+    if not isinstance(pricing, dict):
+        raise OpenRouterMetadataError("pricing must be an object when present")
+    normalized: dict[str, Any] = {}
+    for key, value in sorted(pricing.items()):
+        if isinstance(value, bool) or (
+            not isinstance(value, (str, int, float)) and value is not None
+        ):
+            raise OpenRouterMetadataError("pricing values must be scalar when present")
+        normalized[str(key)] = _redact_string(value) if isinstance(value, str) else value
+    return normalized
+
+
+def _top_provider_context_length(model: dict[str, Any]) -> int | float | str:
+    if "top_provider" not in model or model["top_provider"] is None:
+        return UNKNOWN
+    top_provider = model["top_provider"]
+    if not isinstance(top_provider, dict):
+        raise OpenRouterMetadataError("top_provider must be an object when present")
+    value = top_provider.get("context_length")
+    if value is None:
+        return UNKNOWN
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise OpenRouterMetadataError(
+            "top_provider.context_length must be a number when present"
+        )
+    return value
+
+
+def _is_free(model_id: str, pricing: dict[str, Any] | str) -> bool:
+    if model_id.lower().endswith(":free"):
+        return True
+    if not isinstance(pricing, dict):
+        return False
+    price_values = [
+        pricing.get(key)
+        for key in ("prompt", "completion", "request")
+        if key in pricing
+    ]
+    if not price_values:
+        return False
+    try:
+        return all(float(str(value)) == 0.0 for value in price_values)
+    except (TypeError, ValueError):
+        return False
+
+
+def _free_or_paid(model_id: str, pricing: dict[str, Any] | str) -> str:
+    if _is_free(model_id, pricing):
+        return "FREE"
+    if not isinstance(pricing, dict):
+        return UNKNOWN
+    price_values = [
+        pricing.get(key)
+        for key in ("prompt", "completion", "request")
+        if key in pricing
+    ]
+    if not price_values:
+        return UNKNOWN
+    try:
+        if any(float(str(value)) > 0.0 for value in price_values):
+            return "PAID"
+    except (TypeError, ValueError):
+        return UNKNOWN
+    return "FREE"
+
+
+def _structured_output_support(supported_parameters: list[str] | str) -> str:
+    if supported_parameters == UNKNOWN:
+        return UNKNOWN
+    params = {item.lower() for item in supported_parameters}
+    if "structured_outputs" in params:
+        return "SUPPORTED"
+    if "response_format" in params:
+        return "RESPONSE_FORMAT_DECLARED"
+    return "NOT_DECLARED"
+
+
+def _vendor_key(model_id: str) -> str:
+    token = model_id.lower()
+    prefix, _sep, slug = token.partition("/")
+    if prefix == "openai":
+        return "openai"
+    if prefix == "google" and "gemini" in slug:
+        return "google_gemini"
+    if prefix == "google" and "gemma" in slug:
+        return "gemma"
+    if prefix == "anthropic" or "claude" in slug:
+        return "anthropic"
+    if prefix == "x-ai" or "grok" in slug:
+        return "xai"
+    if prefix == "mistralai" and slug.startswith(("mistral-large", "mistral-medium")):
+        return "mistral_flagship"
+    if prefix == "moonshotai" and "kimi-k2" in slug:
+        return "kimi_k2"
+    if prefix == "cohere":
+        return "cohere"
+    if prefix == "meta-llama":
+        return "meta_llama"
+    if prefix in {"ibm", "ibm-granite"} or "granite" in slug:
+        return "ibm_granite"
+    if prefix == "qwen":
+        return "qwen"
+    if prefix.startswith("arcee"):
+        return "arcee"
+    if prefix in {"primeintellect", "prime-intellect"}:
+        return "prime_intellect"
+    if prefix == "nvidia":
+        return "nvidia"
+    if prefix == "rekaai" or prefix == "reka":
+        return "reka"
+    if prefix == "deepseek":
+        return "deepseek"
+    if prefix in {"z-ai", "zai"} or "glm" in slug:
+        return "zai"
+    if prefix.startswith("stepfun"):
+        return "stepfun"
+    if prefix == "openrouter":
+        return "openrouter_native"
+    return "unknown"
+
+
+def _vendor_family(vendor_key: str) -> tuple[str, str]:
+    mapping = {
+        "anthropic": ("Anthropic", "Claude"),
+        "arcee": ("Arcee", "Open-weight hosted"),
+        "cohere": ("Cohere", "Command"),
+        "deepseek": ("DeepSeek", "DeepSeek"),
+        "gemma": ("Google Gemma", "Gemma"),
+        "google_gemini": ("Google Gemini", "Gemini"),
+        "ibm_granite": ("IBM Granite", "Granite"),
+        "kimi_k2": ("Moonshot AI", "Kimi K2"),
+        "meta_llama": ("Meta Llama", "Llama"),
+        "mistral_flagship": ("Mistral", "Mistral flagship"),
+        "nvidia": ("NVIDIA", "Hosted open-weight"),
+        "openai": ("OpenAI", "GPT"),
+        "openrouter_native": ("OpenRouter", "OpenRouter-native"),
+        "prime_intellect": ("Prime Intellect", "Hosted open-weight"),
+        "qwen": ("Qwen", "Qwen"),
+        "reka": ("Reka", "Reka"),
+        "stepfun": ("StepFun", "StepFun"),
+        "xai": ("xAI", "Grok"),
+        "zai": ("Z.ai", "GLM"),
+    }
+    return mapping.get(vendor_key, (UNKNOWN, UNKNOWN))
+
+
+def _privacy_warning(model: dict[str, Any], vendor_key: str) -> str:
+    description = str(model.get("description") or "").lower()
+    if vendor_key == "openrouter_native" and (
+        "prompt" in description and "output" in description and "logged" in description
+    ):
+        return "PROVIDER_LOGGING_INDICATED"
+    if "provider logging" in description or "data collection" in description:
+        return "PROVIDER_LOGGING_INDICATED"
+    return UNKNOWN
+
+
+def _benchmark_priority(label: str, structured_output_support: str) -> str:
+    if label == "DIRECT_OVERLAP_EXCLUDE":
+        return "LOW"
+    if label == "DIRECT_OVERLAP_EXCEPTION":
+        return "HIGH"
+    if label == "OPENROUTER_VALUE_CANDIDATE":
+        return "HIGH" if structured_output_support == "SUPPORTED" else "MEDIUM"
+    if label == "FREE_EXPERIMENTAL":
+        return "MEDIUM"
+    if label == "DO_NOT_RECOMMEND":
+        return "LOW"
+    return "MEDIUM"
+
+
+def _is_benchmarkable_exception_reason(reason: str) -> bool:
+    normalized = reason.lower()
+    return "benchmark" in normalized and any(
+        marker in normalized for marker in _BENCHMARKABLE_OR_ADVANTAGE_MARKERS
+    )
+
+
+def _direct_overlap_status(vendor_key: str, label: str) -> str:
+    if label == "DIRECT_OVERLAP_EXCEPTION":
+        return "DIRECT_OVERLAP_EXCEPTION"
+    if vendor_key in _DIRECT_OVERLAP_VENDORS:
+        return "DIRECT_OVERLAP"
+    if vendor_key in _EXPLICIT_EXCEPTION_VENDORS:
+        return "DIRECT_OVERLAP_EXCEPTION_REQUIRES_OR_ADVANTAGE"
+    if vendor_key in _DIRECT_PLATFORM_BENCHMARK_VENDORS:
+        return "DIRECT_PLATFORM_ROUTE"
+    if vendor_key == "unknown":
+        return UNKNOWN
+    return "NOT_DIRECT_OVERLAP"
+
+
+def _classify_label_and_reasons(
+    *,
+    model_id: str,
+    vendor_key: str,
+    free_or_paid: str,
+    privacy_warning: str,
+    structured_output_support: str,
+    or_advantage_reasons: dict[str, str],
+) -> tuple[str, list[str]]:
+    lower_id = model_id.lower()
+    explicit_reason = or_advantage_reasons.get(model_id) or or_advantage_reasons.get(
+        lower_id
+    )
+    reasons: list[str] = []
+
+    if free_or_paid == "FREE" and (
+        lower_id.endswith(":free") or vendor_key == "openrouter_native"
+    ):
+        reasons.append("OpenRouter free route is experimental and not production-routed.")
+        if lower_id.endswith(":free"):
+            reasons.append("Pinned :free variant is OpenRouter-only value.")
+        if vendor_key == "openrouter_native":
+            reasons.append("OpenRouter-native free route.")
+        if privacy_warning != UNKNOWN:
+            reasons.append("Provider logging/privacy warning is indicated.")
+        return "FREE_EXPERIMENTAL", reasons
+
+    if explicit_reason and vendor_key in _EXPLICIT_EXCEPTION_VENDORS:
+        if not _is_benchmarkable_exception_reason(explicit_reason):
+            reasons.append(
+                "Explicit exception reason lacks a benchmarkable OpenRouter advantage."
+            )
+            return "BENCHMARK_ONLY", reasons
+        reasons.append("Explicit repo-needed OpenRouter exception supplied.")
+        reasons.append(_redact_string(explicit_reason))
+        if structured_output_support == "SUPPORTED":
+            reasons.append("Structured output support is declared by metadata.")
+        return "DIRECT_OVERLAP_EXCEPTION", reasons
+
+    if vendor_key in _DIRECT_OVERLAP_VENDORS:
+        reasons.append(
+            "Closed direct-provider duplicate route; OpenRouter-only advantage is not established."
+        )
+        return "DIRECT_OVERLAP_EXCLUDE", reasons
+
+    if vendor_key == "kimi_k2":
+        reasons.append("Kimi K2.x remains benchmark-only in first implementation.")
+        return "BENCHMARK_ONLY", reasons
+
+    if vendor_key in _DIRECT_PLATFORM_BENCHMARK_VENDORS:
+        reasons.append(
+            "Direct-platform route requires benchmark evidence before recommendation."
+        )
+        return "BENCHMARK_ONLY", reasons
+
+    if vendor_key in _HOSTED_OPEN_WEIGHT_VENDORS:
+        reasons.append("Hosted open-weight/non-direct route has OpenRouter-only value.")
+        if structured_output_support == "SUPPORTED":
+            reasons.append("Structured output support is declared by metadata.")
+        return "OPENROUTER_VALUE_CANDIDATE", reasons
+
+    if vendor_key in _EXPLICIT_EXCEPTION_VENDORS:
+        reasons.append(
+            "Potential direct-overlap exception lacks explicit measurable OpenRouter advantage."
+        )
+        return "BENCHMARK_ONLY", reasons
+
+    reasons.append("Model family is not classified by the first OpenRouter snapshot rules.")
+    return "BENCHMARK_ONLY", reasons
+
+
+def classify_openrouter_model(
+    model: dict[str, Any],
+    *,
+    or_advantage_reasons: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(model, dict):
+        raise OpenRouterMetadataError("model entry must be an object")
+
+    model_id = _safe_string(model.get("id"), field="id", required=True)
+    name = _safe_string(model.get("name"), field="name")
+    vendor_key = _vendor_key(model_id)
+    vendor, family = _vendor_family(vendor_key)
+    supported_parameters = _supported_parameters(model)
+    pricing = _pricing(model)
+    context_length = _optional_number(model, "context_length")
+    top_provider_context_length = _top_provider_context_length(model)
+    free_or_paid = _free_or_paid(model_id, pricing)
+    structured_output_support = _structured_output_support(supported_parameters)
+    privacy_warning = _privacy_warning(model, vendor_key)
+    label, reasons = _classify_label_and_reasons(
+        model_id=model_id,
+        vendor_key=vendor_key,
+        free_or_paid=free_or_paid,
+        privacy_warning=privacy_warning,
+        structured_output_support=structured_output_support,
+        or_advantage_reasons=or_advantage_reasons or {},
+    )
+    if label not in CLASSIFICATION_LABELS:
+        raise OpenRouterMetadataError(f"unsupported classification label: {label}")
+
+    return {
+        "id": model_id,
+        "name": name,
+        "vendor": vendor,
+        "family": family,
+        "classification_label": label,
+        "classification_reasons": reasons,
+        "free_or_paid": free_or_paid,
+        "structured_output_support": structured_output_support,
+        "supported_parameters": supported_parameters,
+        "context_length": context_length,
+        "top_provider_context_length": top_provider_context_length,
+        "pricing": pricing,
+        "direct_overlap_status": _direct_overlap_status(vendor_key, label),
+        "benchmark_priority": _benchmark_priority(label, structured_output_support),
+        "privacy_warning": privacy_warning,
+    }
+
+
+def _validate_models_payload(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict):
+        raise OpenRouterMetadataError("OpenRouter payload must be an object")
+    models = payload.get("data")
+    if not isinstance(models, list):
+        raise OpenRouterMetadataError("OpenRouter payload missing data array")
+    if not all(isinstance(item, dict) for item in models):
+        raise OpenRouterMetadataError("OpenRouter data entries must be objects")
+    return models
+
+
+def build_openrouter_discovery_snapshot(
+    payload: dict[str, Any],
+    *,
+    source_ref: str = "openrouter_models_api",
+    generated_at: str = UNKNOWN,
+    live_fetch: bool = False,
+    or_advantage_reasons: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    models = [
+        classify_openrouter_model(
+            item,
+            or_advantage_reasons=or_advantage_reasons,
+        )
+        for item in _validate_models_payload(payload)
+    ]
+    models.sort(key=lambda item: item["id"])
+    counts = {label: 0 for label in CLASSIFICATION_LABELS}
+    for item in models:
+        counts[item["classification_label"]] += 1
+    counts = {label: count for label, count in counts.items() if count}
+    return {
+        "snapshot_schema_id": SNAPSHOT_SCHEMA_ID,
+        "source_ref": _redact_string(source_ref),
+        "generated_at": generated_at,
+        "live_fetch": bool(live_fetch),
+        "model_count": len(models),
+        "classification_counts": counts,
+        "models": models,
+        "notes": [
+            "Classification is advisory metadata for RTE benchmarking and route-profile follow-up only.",
+            "No production route is enabled by this snapshot.",
+            "UNKNOWN marks absent or unproven metadata instead of inferred facts.",
+        ],
+    }
+
+
+def _api_key_from_env() -> str | None:
+    return (
+        os.environ.get("OPENROUTER_API_KEY", "").strip()
+        or os.environ.get("V5_OPENROUTER_API_KEY", "").strip()
+        or None
+    )
+
+
+def fetch_openrouter_models_live(timeout_seconds: float = 30.0) -> dict[str, Any]:
+    if os.environ.get(LIVE_FETCH_ENV) != "1":
+        raise OpenRouterMetadataError(
+            f"live OpenRouter discovery requires {LIVE_FETCH_ENV}=1"
+        )
+    headers = {"Accept": "application/json"}
+    api_key = _api_key_from_env()
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(OPENROUTER_MODELS_URL, headers=headers)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise OpenRouterMetadataError(
+            f"OpenRouter models fetch failed with HTTP {exc.code}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise OpenRouterMetadataError("OpenRouter models fetch failed") from exc
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise OpenRouterMetadataError("OpenRouter models response was not JSON") from exc
+    _validate_models_payload(payload)
+    return payload
+
+
+def write_openrouter_discovery_snapshot(
+    *,
+    input_payload: dict[str, Any] | None = None,
+    output_path: Path | None = None,
+    live_fetch: bool = False,
+    or_advantage_reasons: dict[str, str] | None = None,
+) -> Path:
+    if live_fetch:
+        payload = fetch_openrouter_models_live()
+        generated_at = datetime.now(timezone.utc).isoformat()
+        if output_path is None:
+            output_path = (
+                Path(tempfile.gettempdir())
+                / "rte_openrouter_discovery_snapshot.json"
+            )
+    else:
+        if input_payload is None:
+            raise OpenRouterMetadataError("input_payload is required without live_fetch")
+        payload = input_payload
+        generated_at = UNKNOWN
+        if output_path is None:
+            raise OpenRouterMetadataError("output_path is required for snapshot writes")
+
+    snapshot = build_openrouter_discovery_snapshot(
+        payload,
+        generated_at=generated_at,
+        live_fetch=live_fetch,
+        or_advantage_reasons=or_advantage_reasons,
+    )
+    assert output_path is not None
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(stable_snapshot_json(snapshot) + "\n", encoding="utf-8")
+    return output_path
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise OpenRouterMetadataError(f"input JSON is malformed: {path}") from exc
+    if not isinstance(payload, dict):
+        raise OpenRouterMetadataError("input JSON root must be an object")
+    return payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Build an RTE OpenRouter route metadata discovery snapshot."
+    )
+    parser.add_argument("--input-json", type=Path)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--live", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.live:
+        write_openrouter_discovery_snapshot(
+            output_path=args.output_json,
+            live_fetch=True,
+        )
+        return 0
+    if args.input_json is None:
+        raise OpenRouterMetadataError("--input-json is required without --live")
+    write_openrouter_discovery_snapshot(
+        input_payload=_load_json(args.input_json),
+        output_path=args.output_json,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/repo-truth-extractor/tests/fixtures/openrouter_models_sample.json
+++ b/services/repo-truth-extractor/tests/fixtures/openrouter_models_sample.json
@@ -1,0 +1,208 @@
+{
+  "data": [
+    {
+      "id": "anthropic/claude-sonnet-4.5",
+      "name": "Claude Sonnet 4.5",
+      "created": 1760000000,
+      "description": "Closed Anthropic route fixture.",
+      "context_length": 200000,
+      "architecture": {
+        "input_modalities": ["text"],
+        "output_modalities": ["text"],
+        "tokenizer": "Claude",
+        "instruct_type": null
+      },
+      "pricing": {
+        "prompt": "0.000003",
+        "completion": "0.000015",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 200000,
+        "max_completion_tokens": 64000,
+        "is_moderated": true
+      },
+      "supported_parameters": ["max_tokens", "response_format", "structured_outputs"]
+    },
+    {
+      "id": "deepseek/deepseek-chat",
+      "name": "DeepSeek Chat",
+      "created": 1760000001,
+      "description": "Direct-overlap exception fixture.",
+      "context_length": 64000,
+      "pricing": {
+        "prompt": "0.00000027",
+        "completion": "0.0000011",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 64000,
+        "max_completion_tokens": 8192,
+        "is_moderated": false
+      },
+      "supported_parameters": ["max_tokens", "response_format", "structured_outputs"]
+    },
+    {
+      "id": "google/gemini-2.5-pro",
+      "name": "Gemini 2.5 Pro",
+      "created": 1760000002,
+      "description": "Closed Google route fixture.",
+      "context_length": 1048576,
+      "pricing": {
+        "prompt": "0.00000125",
+        "completion": "0.000010",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 1048576,
+        "max_completion_tokens": 65536,
+        "is_moderated": true
+      },
+      "supported_parameters": ["max_tokens", "response_format", "structured_outputs"]
+    },
+    {
+      "id": "meta-llama/llama-3.3-70b-instruct",
+      "name": "Llama 3.3 70B Instruct",
+      "created": 1760000003,
+      "description": "Direct-platform route fixture.",
+      "context_length": 131072,
+      "pricing": {
+        "prompt": "0.00000012",
+        "completion": "0.00000030",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 131072,
+        "max_completion_tokens": 8192,
+        "is_moderated": false
+      },
+      "supported_parameters": ["max_tokens", "response_format"]
+    },
+    {
+      "id": "mistralai/mistral-large",
+      "name": "Mistral Large",
+      "created": 1760000004,
+      "description": "Flagship Mistral route fixture.",
+      "context_length": 128000,
+      "pricing": {
+        "prompt": "0.000002",
+        "completion": "0.000006",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 128000,
+        "max_completion_tokens": 8192,
+        "is_moderated": true
+      },
+      "supported_parameters": ["max_tokens", "response_format", "structured_outputs"]
+    },
+    {
+      "id": "moonshotai/kimi-k2",
+      "name": "Kimi K2",
+      "created": 1760000005,
+      "description": "Kimi fixture.",
+      "context_length": 128000,
+      "pricing": {
+        "prompt": "0.00000055",
+        "completion": "0.0000022",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 128000,
+        "max_completion_tokens": 8192,
+        "is_moderated": false
+      },
+      "supported_parameters": ["max_tokens", "response_format"]
+    },
+    {
+      "id": "openai/gpt-4o-mini",
+      "name": "GPT-4o Mini",
+      "created": 1760000006,
+      "description": "Closed OpenAI route fixture.",
+      "context_length": 128000,
+      "pricing": {
+        "prompt": "0.00000015",
+        "completion": "0.00000060",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 128000,
+        "max_completion_tokens": 16384,
+        "is_moderated": true
+      },
+      "supported_parameters": ["max_tokens", "response_format", "structured_outputs"]
+    },
+    {
+      "id": "openrouter/owl-alpha",
+      "name": "Owl Alpha",
+      "created": 1760000007,
+      "description": "OpenRouter-native free route. Prompts and outputs are logged to improve the provider model.",
+      "context_length": 32768,
+      "pricing": {
+        "prompt": "0",
+        "completion": "0",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 32768,
+        "max_completion_tokens": 4096,
+        "is_moderated": false
+      },
+      "supported_parameters": ["max_tokens", "response_format", "structured_outputs"]
+    },
+    {
+      "id": "qwen/qwen3-coder:free",
+      "name": "Qwen3 Coder Free",
+      "created": 1760000008,
+      "description": "Pinned free route fixture.",
+      "context_length": 262144,
+      "pricing": {
+        "prompt": "0",
+        "completion": "0",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 262144,
+        "max_completion_tokens": 32768,
+        "is_moderated": false
+      },
+      "supported_parameters": ["max_tokens", "response_format", "structured_outputs"]
+    },
+    {
+      "id": "qwen/qwen3-coder",
+      "name": "Qwen3 Coder",
+      "created": 1760000009,
+      "description": "Hosted open-weight candidate fixture.",
+      "context_length": 262144,
+      "pricing": {
+        "prompt": "0.00000020",
+        "completion": "0.00000080",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 262144,
+        "max_completion_tokens": 32768,
+        "is_moderated": false
+      },
+      "supported_parameters": ["max_tokens", "response_format", "structured_outputs"]
+    },
+    {
+      "id": "x-ai/grok-4",
+      "name": "Grok 4",
+      "created": 1760000010,
+      "description": "Closed xAI route fixture.",
+      "context_length": 256000,
+      "pricing": {
+        "prompt": "0.000003",
+        "completion": "0.000015",
+        "request": "0"
+      },
+      "top_provider": {
+        "context_length": 256000,
+        "max_completion_tokens": 32768,
+        "is_moderated": false
+      },
+      "supported_parameters": ["max_tokens", "response_format", "structured_outputs"]
+    }
+  ]
+}

--- a/services/repo-truth-extractor/tests/test_openrouter_discovery.py
+++ b/services/repo-truth-extractor/tests/test_openrouter_discovery.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SERVICE_ROOT = Path(__file__).resolve().parents[1]
+if str(SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(SERVICE_ROOT))
+
+from benchmarking.registry.openrouter_discovery import (
+    LIVE_FETCH_ENV,
+    OpenRouterMetadataError,
+    build_openrouter_discovery_snapshot,
+    classify_openrouter_model,
+    fetch_openrouter_models_live,
+    stable_snapshot_json,
+)
+
+
+FIXTURE_PATH = (
+    Path(__file__).resolve().parent / "fixtures" / "openrouter_models_sample.json"
+)
+
+
+def _fixture_payload() -> dict:
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_direct_overlap_models_are_excluded() -> None:
+    rows = {
+        "openai": classify_openrouter_model({"id": "openai/gpt-4o-mini"}),
+        "gemini": classify_openrouter_model({"id": "google/gemini-2.5-pro"}),
+        "anthropic": classify_openrouter_model({"id": "anthropic/claude-sonnet-4.5"}),
+        "xai": classify_openrouter_model({"id": "x-ai/grok-4"}),
+        "mistral": classify_openrouter_model({"id": "mistralai/mistral-large"}),
+    }
+
+    assert {row["classification_label"] for row in rows.values()} == {
+        "DIRECT_OVERLAP_EXCLUDE"
+    }
+    assert rows["openai"]["direct_overlap_status"] == "DIRECT_OVERLAP"
+    assert rows["gemini"]["vendor"] == "Google Gemini"
+    assert rows["anthropic"]["benchmark_priority"] == "LOW"
+
+
+def test_direct_overlap_exception_requires_explicit_or_advantage_reason() -> None:
+    default_row = classify_openrouter_model({"id": "deepseek/deepseek-chat"})
+    weak_exception_row = classify_openrouter_model(
+        {"id": "deepseek/deepseek-chat"},
+        or_advantage_reasons={"deepseek/deepseek-chat": "repo preference only"},
+    )
+    exception_row = classify_openrouter_model(
+        {"id": "deepseek/deepseek-chat"},
+        or_advantage_reasons={
+            "deepseek/deepseek-chat": "OpenRouter provider fallback and route telemetry must be benchmarked before route-profile admission."
+        },
+    )
+
+    assert default_row["classification_label"] == "BENCHMARK_ONLY"
+    assert weak_exception_row["classification_label"] == "BENCHMARK_ONLY"
+    assert exception_row["classification_label"] == "DIRECT_OVERLAP_EXCEPTION"
+    assert exception_row["direct_overlap_status"] == "DIRECT_OVERLAP_EXCEPTION"
+    assert any(
+        "provider fallback and route telemetry" in reason
+        for reason in exception_row["classification_reasons"]
+    )
+
+
+def test_free_routes_are_experimental_and_preserve_privacy_warning() -> None:
+    pinned_free = classify_openrouter_model({"id": "qwen/qwen3-coder:free"})
+    native_free = classify_openrouter_model(
+        {
+            "id": "openrouter/owl-alpha",
+            "description": "Prompts and outputs are logged by the provider.",
+            "pricing": {"prompt": "0", "completion": "0", "request": "0"},
+        }
+    )
+
+    assert pinned_free["classification_label"] == "FREE_EXPERIMENTAL"
+    assert pinned_free["free_or_paid"] == "FREE"
+    assert native_free["classification_label"] == "FREE_EXPERIMENTAL"
+    assert native_free["privacy_warning"] == "PROVIDER_LOGGING_INDICATED"
+
+
+def test_hosted_open_weight_candidate_is_admitted_for_benchmarking() -> None:
+    row = classify_openrouter_model(
+        {
+            "id": "qwen/qwen3-coder",
+            "supported_parameters": ["max_tokens", "structured_outputs"],
+            "context_length": 262144,
+            "top_provider": {"context_length": 262144},
+        }
+    )
+
+    assert row["classification_label"] == "OPENROUTER_VALUE_CANDIDATE"
+    assert row["structured_output_support"] == "SUPPORTED"
+    assert row["benchmark_priority"] == "HIGH"
+    assert row["top_provider_context_length"] == 262144
+
+
+def test_unknown_and_malformed_metadata_fail_closed() -> None:
+    unknown = classify_openrouter_model({"id": "unknown-lab/unknown-model"})
+
+    assert unknown["classification_label"] == "BENCHMARK_ONLY"
+    assert unknown["context_length"] == "UNKNOWN"
+    assert unknown["supported_parameters"] == "UNKNOWN"
+    assert unknown["structured_output_support"] == "UNKNOWN"
+
+    with pytest.raises(OpenRouterMetadataError):
+        classify_openrouter_model({"name": "missing id"})
+
+    with pytest.raises(OpenRouterMetadataError):
+        build_openrouter_discovery_snapshot({"data": [{"id": "bad", "pricing": []}]})
+
+    with pytest.raises(OpenRouterMetadataError):
+        build_openrouter_discovery_snapshot(
+            {"data": [{"id": "bad", "pricing": {"prompt": []}}]}
+        )
+
+
+def test_no_secret_or_auth_header_appears_in_output() -> None:
+    fake_secret = "sk" + "-or-v1-" + "secretvalue0123456789"
+    fake_bearer = "Bearer " + fake_secret
+    row = classify_openrouter_model(
+        {
+            "id": "qwen/qwen3-coder",
+            "name": fake_bearer,
+            "headers": {"Authorization": fake_bearer},
+            "pricing": {"prompt": "0.1", "completion": "0.2"},
+            "supported_parameters": ["structured_outputs"],
+        }
+    )
+    encoded = stable_snapshot_json({"models": [row]})
+
+    assert "sk" + "-or-" not in encoded
+    assert "Authorization" not in encoded
+    assert "Bearer " not in encoded
+    assert "[REDACTED]" in encoded
+
+
+def test_live_fetch_requires_explicit_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(LIVE_FETCH_ENV, raising=False)
+
+    with pytest.raises(OpenRouterMetadataError, match=LIVE_FETCH_ENV):
+        fetch_openrouter_models_live(timeout_seconds=0.001)
+
+
+def test_fixture_metadata_produces_deterministic_sorted_output() -> None:
+    snapshot_one = build_openrouter_discovery_snapshot(
+        _fixture_payload(),
+        source_ref="fixture:openrouter_models_sample.json",
+        generated_at="UNKNOWN",
+        or_advantage_reasons={
+            "deepseek/deepseek-chat": "OpenRouter provider fallback and route telemetry must be benchmarked before route-profile admission."
+        },
+    )
+    snapshot_two = build_openrouter_discovery_snapshot(
+        _fixture_payload(),
+        source_ref="fixture:openrouter_models_sample.json",
+        generated_at="UNKNOWN",
+        or_advantage_reasons={
+            "deepseek/deepseek-chat": "OpenRouter provider fallback and route telemetry must be benchmarked before route-profile admission."
+        },
+    )
+
+    assert stable_snapshot_json(snapshot_one) == stable_snapshot_json(snapshot_two)
+    model_ids = [row["id"] for row in snapshot_one["models"]]
+    assert model_ids == sorted(model_ids)
+    assert snapshot_one["classification_counts"] == {
+        "BENCHMARK_ONLY": 2,
+        "DIRECT_OVERLAP_EXCEPTION": 1,
+        "DIRECT_OVERLAP_EXCLUDE": 5,
+        "FREE_EXPERIMENTAL": 2,
+        "OPENROUTER_VALUE_CANDIDATE": 1,
+    }

--- a/services/repo-truth-extractor/tests/test_openrouter_discovery.py
+++ b/services/repo-truth-extractor/tests/test_openrouter_discovery.py
@@ -86,6 +86,22 @@ def test_free_routes_are_experimental_and_preserve_privacy_warning() -> None:
     assert native_free["privacy_warning"] == "PROVIDER_LOGGING_INDICATED"
 
 
+def test_pricing_with_extra_billable_dimension_is_not_marked_free() -> None:
+    row = classify_openrouter_model(
+        {
+            "id": "qwen/qwen3-coder:free",
+            "pricing": {
+                "prompt": "0",
+                "completion": "0",
+                "request": "0",
+                "image": "0.0001",
+            },
+        }
+    )
+
+    assert row["free_or_paid"] == "PAID"
+
+
 def test_hosted_open_weight_candidate_is_admitted_for_benchmarking() -> None:
     row = classify_openrouter_model(
         {
@@ -146,6 +162,16 @@ def test_live_fetch_requires_explicit_opt_in(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.delenv(LIVE_FETCH_ENV, raising=False)
 
     with pytest.raises(OpenRouterMetadataError, match=LIVE_FETCH_ENV):
+        fetch_openrouter_models_live(timeout_seconds=0.001)
+
+
+def test_live_fetch_requires_repo_live_consent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(LIVE_FETCH_ENV, "1")
+    monkeypatch.delenv("DPMX_LIVE_OK", raising=False)
+
+    with pytest.raises(OpenRouterMetadataError, match="DPMX_LIVE_OK"):
         fetch_openrouter_models_live(timeout_seconds=0.001)
 
 


### PR DESCRIPTION
@codex review
@gemini
@copilot

## Summary
- Add an RTE-local OpenRouter metadata discovery/classification module for benchmark/profile follow-up only.
- Add a fixture-safe OpenRouter models sample and tests for direct overlap, explicit exceptions, free routes, hosted open-weight candidates, malformed metadata, redaction, deterministic sorting, and live-fetch opt-in.
- No production route table, model_map, pricing config, generated extraction artifact, task-packet, PM, memory, retrieval, bridge, or task-orchestrator changes.

## Release Notes
- Repo Truth Extractor can now generate an advisory OpenRouter metadata snapshot without changing default extraction behavior.

## Validation
- PASS: `python -m pytest -q services/repo-truth-extractor/tests/test_openrouter_discovery.py` (8 passed)
- PASS: `python -m compileall -q services/repo-truth-extractor`
- PASS: `python -m json.tool services/repo-truth-extractor/tests/fixtures/openrouter_models_sample.json`
- PASS: generated `/tmp/rte_openrouter_discovery_snapshot.json` parsed with `python -m json.tool`
- PASS: changed-file secret scan returned no matches
- NOTE: required broad secret scan finds existing unrelated fixture/test strings outside this PR
- PASS: `git diff --cached --check`
- PASS: `python -m pre_commit run --files ...`

## Residual Risk
- Classifier family matching is advisory and may need updates as OpenRouter model IDs evolve.

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.