### PR TITLE
fix(mcp): BETA-INSTALL-01 + BETA-MCP-01 — fix .mcp.json for any-user clone

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -22,7 +22,7 @@
     },
     "task-orchestrator": {
       "type": "stdio",
-      "command": "plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh",
+      "command": "scripts/mcp-wrappers/task-orchestrator-current-stdio.sh",
       "args": [],
       "env": {
         "TASK_ORCHESTRATOR_PROJECT_ROOT": "${TASK_ORCHESTRATOR_PROJECT_ROOT:-}",

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "conport": {
       "type": "sse",
-      "url": "http://localhost:${CONPORT_MCP_PORT}/mcp",
+      "url": "http://localhost:${CONPORT_MCP_PORT:-3005}/mcp",
       "env": {
         "DOPEMUX_WORKSPACE_ID": "${DOPEMUX_WORKSPACE_ID:-}",
         "GEMINI_API_KEY": "${GEMINI_API_KEY:-}",
@@ -13,7 +13,7 @@
     },
     "dope-memory": {
       "type": "sse",
-      "url": "http://localhost:${DOPE_MEMORY_PORT}/mcp",
+      "url": "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp",
       "env": {
         "DOPE_MEMORY_WORKSPACE_ID": "${DOPE_MEMORY_WORKSPACE_ID:-}",
         "DOPE_MEMORY_INSTANCE_ID": "${DOPE_MEMORY_INSTANCE_ID:-}"
@@ -22,7 +22,7 @@
     },
     "task-orchestrator": {
       "type": "stdio",
-      "command": "/Users/hue/plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh",
+      "command": "plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh",
       "args": [],
       "env": {
         "TASK_ORCHESTRATOR_PROJECT_ROOT": "${TASK_ORCHESTRATOR_PROJECT_ROOT:-}",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Dopemux (including the PR Merge Specialist) will be docum
 - CI now includes wrapper-authority coverage, interactive import smoke, and the production `brand_lint.py` gate.
 
 ### Fixed
+- MCP bootstrap now points Task Orchestrator at a tracked launcher wrapper and keeps catalog-rendered SSE URL defaults aligned with checked-in `.mcp.json`.
 - Installer review cleanup now removes dead SQLite test isolation code and makes setup-time `dopemux-network` creation fail closed on unexpected Docker errors.
 - Dependabot uv security-update resolution now has bounded Python support metadata and a patched MCP service floor compatible with current Semgrep/LiteLLM resolution.
 - Repo Truth Extractor full-suite CI now avoids platform-sensitive strict XPASS failures by scoping known prescan xfails to macOS and stabilizing the v4 help assertion environment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Dopemux (including the PR Merge Specialist) will be docum
 - CI now includes wrapper-authority coverage, interactive import smoke, and the production `brand_lint.py` gate.
 
 ### Fixed
+- MCP doctor now runs relative stdio doctor commands from the resolved repo root, so Task Orchestrator wrapper checks work when invoked from repo subdirectories.
 - MCP bootstrap now points Task Orchestrator at a tracked launcher wrapper and keeps catalog-rendered SSE URL defaults aligned with checked-in `.mcp.json`.
 - Installer review cleanup now removes dead SQLite test isolation code and makes setup-time `dopemux-network` creation fail closed on unexpected Docker errors.
 - Dependabot uv security-update resolution now has bounded Python support metadata and a patched MCP service floor compatible with current Semgrep/LiteLLM resolution.

--- a/claudedocs/pr737-review-repair-proof-2026-05-31.md
+++ b/claudedocs/pr737-review-repair-proof-2026-05-31.md
@@ -12,6 +12,7 @@
 
 - Claude Code Review: `REQUEST_CHANGES`
 - Codex review threads: tracked launcher path and catalog URL default sync
+- Codex follow-up review thread: relative stdio doctor command must resolve from the repo root when `dopemux mcp doctor` is run from a subdirectory.
 - Copilot review threads: untracked `plugins/dopemux-mission-control` path in `.mcp.json`, `mcp_catalog.yaml`, and docs
 - User instruction: integrate all Claude review suggestions before merge
 
@@ -22,6 +23,7 @@
 - Updated `.mcp.json`, `mcp_catalog.yaml`, `src/dopemux/mcp/default_catalog.yaml`, and Task Orchestrator reference docs away from untracked plugin paths.
 - Synced catalog SSE defaults to `http://localhost:${CONPORT_MCP_PORT:-3005}/mcp` and `http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp`.
 - Added non-skipped launcher resolution coverage and a catalog-template equality regression for checked-in `.mcp.json`.
+- Anchored stdio doctor subprocesses to the resolved repo root and added regression coverage for a relative wrapper command invoked while the shell is in a repo subdirectory.
 
 ## Validation
 
@@ -33,9 +35,9 @@ PASS:
 - `python -m jsonschema -i task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` exit 0
 - `bash -n scripts/mcp-wrappers/task-orchestrator-current-stdio.sh` exit 0
 - `scripts/mcp-wrappers/task-orchestrator-current-stdio.sh --print-resolution` exit 0
-- `python -m pytest tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py::test_mcp_init_keeps_matching_committed_template_and_writes_envrc tests/unit/test_mcp_commands_catalog.py::test_committed_mcp_json_matches_root_catalog_defaults -q` exit 0
+- `python -m pytest tests/unit/test_mcp_commands_catalog.py::test_doctor_runs_relative_stdio_resolution_from_repo_root tests/unit/test_mcp_commands_catalog.py::test_mcp_init_keeps_matching_committed_template_and_writes_envrc tests/unit/test_mcp_commands_catalog.py::test_committed_mcp_json_matches_root_catalog_defaults tests/unit/test_task_orchestrator_launcher.py -q` exit 0
 - `git diff --check` exit 0
-- `pre-commit run --files .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml scripts/mcp-wrappers/task-orchestrator-current-stdio.sh scripts/mcp-wrappers/task-orchestrator-logback.xml tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json claudedocs/pr737-review-repair-proof-2026-05-31.md` exit 0
+- `pre-commit run --files .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml src/dopemux/commands/mcp_commands.py scripts/mcp-wrappers/task-orchestrator-current-stdio.sh scripts/mcp-wrappers/task-orchestrator-logback.xml tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json claudedocs/pr737-review-repair-proof-2026-05-31.md` exit 0
 
 NOT_RUN:
 

--- a/claudedocs/pr737-review-repair-proof-2026-05-31.md
+++ b/claudedocs/pr737-review-repair-proof-2026-05-31.md
@@ -1,0 +1,42 @@
+# PR 737 Review Repair Proof
+
+## Scope
+
+- PR: #737
+- Local branch: `codex/pr737-review-repair-20260601`
+- Target PR branch: `fix/beta-install-01-mcp-01-mcp-json`
+- Worktree: `/Users/hue/code/dopemux-mvp-wt-pr737-review-repair`
+- Task Packet: `task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json`
+
+## Review Inputs
+
+- Claude Code Review: `REQUEST_CHANGES`
+- Codex review threads: tracked launcher path and catalog URL default sync
+- Copilot review threads: untracked `plugins/dopemux-mission-control` path in `.mcp.json`, `mcp_catalog.yaml`, and docs
+- User instruction: integrate all Claude review suggestions before merge
+
+## Applied Changes
+
+- Added tracked Task Orchestrator launcher wrapper: `scripts/mcp-wrappers/task-orchestrator-current-stdio.sh`
+- Added tracked logback config required by the wrapper: `scripts/mcp-wrappers/task-orchestrator-logback.xml`
+- Updated `.mcp.json`, `mcp_catalog.yaml`, `src/dopemux/mcp/default_catalog.yaml`, and Task Orchestrator reference docs away from untracked plugin paths.
+- Synced catalog SSE defaults to `http://localhost:${CONPORT_MCP_PORT:-3005}/mcp` and `http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp`.
+- Added non-skipped launcher resolution coverage and a catalog-template equality regression for checked-in `.mcp.json`.
+
+## Validation
+
+PASS:
+
+- `python -m json.tool .mcp.json >/dev/null` exit 0
+- YAML parse for `mcp_catalog.yaml` and `src/dopemux/mcp/default_catalog.yaml` exit 0
+- `python -m json.tool task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json >/dev/null` exit 0
+- `python -m jsonschema -i task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` exit 0
+- `bash -n scripts/mcp-wrappers/task-orchestrator-current-stdio.sh` exit 0
+- `scripts/mcp-wrappers/task-orchestrator-current-stdio.sh --print-resolution` exit 0
+- `python -m pytest tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py::test_mcp_init_keeps_matching_committed_template_and_writes_envrc tests/unit/test_mcp_commands_catalog.py::test_committed_mcp_json_matches_root_catalog_defaults -q` exit 0
+- `git diff --check` exit 0
+- `pre-commit run --files .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml scripts/mcp-wrappers/task-orchestrator-current-stdio.sh scripts/mcp-wrappers/task-orchestrator-logback.xml tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json claudedocs/pr737-review-repair-proof-2026-05-31.md` exit 0
+
+NOT_RUN:
+
+- Live Docker Task Orchestrator startup is intentionally `NOT_RUN` because it would start or replace a local container and is outside this review-repair slice.

--- a/docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md
+++ b/docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md
@@ -16,7 +16,7 @@ prelude: System Taskorchestrator (reference) for dopemux documentation and devel
 
 Task Orchestrator is the workflow-coordination service surface for dopemux. In the inspected runtime code it exposes HTTP, WebSocket, and MCP surfaces for workflow idea/epic operations, project workflow views, PM-plane write routing, and cross-plane coordination.
 
-This service must not be confused with the upstream 13-tool stdio MCP Task Orchestrator container used by Codex and `dopemux mcp` local configs. The upstream stdio MCP runtime is launched through `/Users/hue/plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh` and stores repo-scoped SQLite state under the operator's local data directory. The in-repo service described here is the Dopemux FastAPI workflow service.
+This service must not be confused with the upstream 13-tool stdio MCP Task Orchestrator container used by Codex and `dopemux mcp` local configs. The upstream stdio MCP runtime is launched through `plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh` and stores repo-scoped SQLite state under the operator's local data directory. The in-repo service described here is the Dopemux FastAPI workflow service.
 
 Its canonical authority slice is narrow:
 - workflow-significant API behavior and transition routing exposed by `/Users/hue/code/dopemux-mvp/services/task-orchestrator/app/main.py`, `/Users/hue/code/dopemux-mvp/services/task-orchestrator/app/api/project_workflow.py`, and `/Users/hue/code/dopemux-mvp/services/task-orchestrator/app/api/pm_tools.py`
@@ -58,7 +58,7 @@ It does not own durable PM entity truth, chronicle truth, or structured retrieva
 
 - Canonical runtime code: `/Users/hue/code/dopemux-mvp/services/task-orchestrator/app/main.py`
 - Canonical stdio MCP wrapper: `/Users/hue/code/dopemux-mvp/services/task-orchestrator/mcp_stdio.py`
-- Upstream 13-tool stdio MCP launcher for Codex/local MCP clients: `/Users/hue/plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh`
+- Upstream 13-tool stdio MCP launcher for Codex/local MCP clients: `plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh`
 - Unsupported runtime variant: `/Users/hue/code/dopemux-mvp/services/task-orchestrator/task_orchestrator/app.py`
   This file exits immediately and says to use `app/main.py`.
 - Container/runtime packaging surface: `/Users/hue/code/dopemux-mvp/services/task-orchestrator/Dockerfile`
@@ -125,7 +125,7 @@ Storage surfaces:
 - Operational
   `/Users/hue/code/dopemux-mvp/compose.yml`, `/Users/hue/code/dopemux-mvp/docker/compose.core.yml`, and `/Users/hue/code/dopemux-mvp/services/registry.yaml` for current exposed port `8000`.
   `/Users/hue/code/dopemux-mvp/services/task-orchestrator/mcp_stdio.py` for stdio MCP launch.
-  `/Users/hue/plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh` for the upstream 13-tool stdio MCP runtime used by Codex/local MCP config.
+  `plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh` for the upstream 13-tool stdio MCP runtime used by Codex/local MCP config.
 
 - Unknown
   The repo-wide relationship between the in-repo FastAPI workflow service and the upstream 13-tool stdio MCP Task Orchestrator remains a boundary, not a unified runtime contract.

--- a/docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md
+++ b/docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md
@@ -16,7 +16,7 @@ prelude: System Taskorchestrator (reference) for dopemux documentation and devel
 
 Task Orchestrator is the workflow-coordination service surface for dopemux. In the inspected runtime code it exposes HTTP, WebSocket, and MCP surfaces for workflow idea/epic operations, project workflow views, PM-plane write routing, and cross-plane coordination.
 
-This service must not be confused with the upstream 13-tool stdio MCP Task Orchestrator container used by Codex and `dopemux mcp` local configs. The upstream stdio MCP runtime is launched through `plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh` and stores repo-scoped SQLite state under the operator's local data directory. The in-repo service described here is the Dopemux FastAPI workflow service.
+This service must not be confused with the upstream 13-tool stdio MCP Task Orchestrator container used by Codex and `dopemux mcp` local configs. The upstream stdio MCP runtime is launched through the tracked repo wrapper `scripts/mcp-wrappers/task-orchestrator-current-stdio.sh` and stores repo-scoped SQLite state under the operator's local data directory. The in-repo service described here is the Dopemux FastAPI workflow service.
 
 Its canonical authority slice is narrow:
 - workflow-significant API behavior and transition routing exposed by `/Users/hue/code/dopemux-mvp/services/task-orchestrator/app/main.py`, `/Users/hue/code/dopemux-mvp/services/task-orchestrator/app/api/project_workflow.py`, and `/Users/hue/code/dopemux-mvp/services/task-orchestrator/app/api/pm_tools.py`
@@ -58,7 +58,7 @@ It does not own durable PM entity truth, chronicle truth, or structured retrieva
 
 - Canonical runtime code: `/Users/hue/code/dopemux-mvp/services/task-orchestrator/app/main.py`
 - Canonical stdio MCP wrapper: `/Users/hue/code/dopemux-mvp/services/task-orchestrator/mcp_stdio.py`
-- Upstream 13-tool stdio MCP launcher for Codex/local MCP clients: `plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh`
+- Upstream 13-tool stdio MCP launcher for Codex/local MCP clients: `scripts/mcp-wrappers/task-orchestrator-current-stdio.sh`
 - Unsupported runtime variant: `/Users/hue/code/dopemux-mvp/services/task-orchestrator/task_orchestrator/app.py`
   This file exits immediately and says to use `app/main.py`.
 - Container/runtime packaging surface: `/Users/hue/code/dopemux-mvp/services/task-orchestrator/Dockerfile`
@@ -125,7 +125,7 @@ Storage surfaces:
 - Operational
   `/Users/hue/code/dopemux-mvp/compose.yml`, `/Users/hue/code/dopemux-mvp/docker/compose.core.yml`, and `/Users/hue/code/dopemux-mvp/services/registry.yaml` for current exposed port `8000`.
   `/Users/hue/code/dopemux-mvp/services/task-orchestrator/mcp_stdio.py` for stdio MCP launch.
-  `plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh` for the upstream 13-tool stdio MCP runtime used by Codex/local MCP config.
+  `scripts/mcp-wrappers/task-orchestrator-current-stdio.sh` for the upstream 13-tool stdio MCP runtime used by Codex/local MCP config.
 
 - Unknown
   The repo-wide relationship between the in-repo FastAPI workflow service and the upstream 13-tool stdio MCP Task Orchestrator remains a boundary, not a unified runtime contract.

--- a/mcp_catalog.yaml
+++ b/mcp_catalog.yaml
@@ -129,7 +129,7 @@ servers:
     scope: per-worktree
     state_scope: per-repo
     transport: stdio
-    command: /Users/hue/plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh
+    command: plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh
     args: []
     doctor_args: ["--print-resolution"]
     requires_env: ["TASK_ORCHESTRATOR_PROJECT_ROOT"]

--- a/mcp_catalog.yaml
+++ b/mcp_catalog.yaml
@@ -100,7 +100,7 @@ servers:
     transport: sse
     # Port var names match compose.yml conventions so `init` writes env that
     # `docker compose up` reads directly.
-    url_template: "http://localhost:${CONPORT_MCP_PORT}/mcp"
+    url_template: "http://localhost:${CONPORT_MCP_PORT:-3005}/mcp"
     port_var: CONPORT_MCP_PORT
     default_port_base: 3005
     extra_port_vars:
@@ -118,7 +118,7 @@ servers:
   dope-memory:
     scope: per-worktree
     transport: sse
-    url_template: "http://localhost:${DOPE_MEMORY_PORT}/mcp"
+    url_template: "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp"
     port_var: DOPE_MEMORY_PORT
     default_port_base: 3020
     docker_compose_service: dope-memory
@@ -129,7 +129,7 @@ servers:
     scope: per-worktree
     state_scope: per-repo
     transport: stdio
-    command: plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh
+    command: scripts/mcp-wrappers/task-orchestrator-current-stdio.sh
     args: []
     doctor_args: ["--print-resolution"]
     requires_env: ["TASK_ORCHESTRATOR_PROJECT_ROOT"]

--- a/scripts/mcp-wrappers/task-orchestrator-current-stdio.sh
+++ b/scripts/mcp-wrappers/task-orchestrator-current-stdio.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="ghcr.io/jpicklyk/task-orchestrator@sha256:e47ed00aae313a85de0e6340010bfec8bdcd5f8c253d002759a4bb1ef8c122c1"  # v3.8.0 — upgraded 2026-05-27 to activate .taskorchestrator/config.yaml schema support
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+LOGBACK_CONFIG="${SCRIPT_DIR}/task-orchestrator-logback.xml"
+PRINT_RESOLUTION=false
+
+if [[ "${1:-}" == "--print-resolution" ]]; then
+  PRINT_RESOLUTION=true
+  shift
+fi
+
+if [[ "$#" -gt 0 ]]; then
+  printf 'task-orchestrator-current-stdio: unsupported argument: %s\n' "$1" >&2
+  exit 1
+fi
+
+die() {
+  printf 'task-orchestrator-current-stdio: %s\n' "$*" >&2
+  exit 1
+}
+
+require_dir() {
+  local candidate="$1"
+  if [[ -n "${candidate}" && -d "${candidate}" ]]; then
+    cd "${candidate}" >/dev/null 2>&1 && pwd -P
+    return 0
+  fi
+  return 1
+}
+
+git_worktree_root() {
+  local candidate="$1"
+  git -C "${candidate}" rev-parse --show-toplevel 2>/dev/null
+}
+
+git_project_root() {
+  local candidate="$1"
+  local common_dir
+  common_dir="$(git -C "${candidate}" rev-parse --git-common-dir 2>/dev/null)" || return 1
+  if [[ "${common_dir}" != /* ]]; then
+    common_dir="$(cd "${candidate}/${common_dir}" >/dev/null 2>&1 && pwd -P)" || return 1
+  else
+    common_dir="$(cd "${common_dir}" >/dev/null 2>&1 && pwd -P)" || return 1
+  fi
+
+  if [[ "$(basename "${common_dir}")" == ".git" ]]; then
+    dirname "${common_dir}"
+  else
+    printf '%s\n' "${common_dir}"
+  fi
+}
+
+workspace_root=""
+for var_name in TASK_ORCHESTRATOR_WORKSPACE_ROOT DOPEMUX_WORKSPACE_ROOT CODEX_WORKSPACE_ROOT CODEX_PROJECT_ROOT; do
+  var_value="${!var_name:-}"
+  if resolved="$(require_dir "${var_value}")"; then
+    workspace_root="${resolved}"
+    break
+  fi
+done
+
+if [[ -z "${workspace_root}" ]]; then
+  if git_root="$(git_worktree_root "${PWD}")"; then
+    workspace_root="$(cd "${git_root}" && pwd -P)"
+  fi
+fi
+
+if [[ -z "${workspace_root}" ]]; then
+  for var_name in TASK_ORCHESTRATOR_PROJECT_ROOT DOPEMUX_PROJECT_ROOT; do
+    var_value="${!var_name:-}"
+    if resolved="$(require_dir "${var_value}")"; then
+      workspace_root="${resolved}"
+      break
+    fi
+  done
+fi
+
+[[ -n "${workspace_root}" ]] || die "could not derive workspace root from env or current git root"
+[[ -f "${LOGBACK_CONFIG}" ]] || die "missing logback config at ${LOGBACK_CONFIG}"
+
+project_root=""
+if resolved="$(require_dir "${TASK_ORCHESTRATOR_PROJECT_ROOT:-}")"; then
+  project_root="${resolved}"
+elif resolved="$(require_dir "${DOPEMUX_PROJECT_ROOT:-}")"; then
+  project_root="${resolved}"
+elif git_project="$(git_project_root "${workspace_root}")"; then
+  project_root="${git_project}"
+fi
+
+[[ -n "${project_root}" ]] || die "could not derive project root from TASK_ORCHESTRATOR_PROJECT_ROOT, DOPEMUX_PROJECT_ROOT, or git common dir"
+
+hash_input="${project_root}"
+if command -v shasum >/dev/null 2>&1; then
+  workspace_hash="$(printf '%s' "${hash_input}" | shasum -a 256 | awk '{print substr($1, 1, 16)}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+  workspace_hash="$(printf '%s' "${hash_input}" | sha256sum | awk '{print substr($1, 1, 16)}')"
+else
+  workspace_hash="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(sys.stdin.buffer.read()).hexdigest()[:16])' <<<"${hash_input}")"
+fi
+
+workspace_name="$(basename "${project_root}" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+[[ -n "${workspace_name}" ]] || workspace_name="workspace"
+workspace_id="${workspace_name}-${workspace_hash}"
+
+data_root="${XDG_DATA_HOME:-${HOME}/.local/share}/dopemux-mission-control/task-orchestrator"
+data_dir="${data_root}/${workspace_id}"
+
+config_root="${workspace_root}"
+if [[ ! -f "${config_root}/.taskorchestrator/config.yaml" && -f "${project_root}/.taskorchestrator/config.yaml" ]]; then
+  config_root="${project_root}"
+fi
+
+if [[ "${PRINT_RESOLUTION}" == "true" ]]; then
+  printf 'workspace_root=%s\n' "${workspace_root}"
+  printf 'project_root=%s\n' "${project_root}"
+  printf 'state_id=%s\n' "${workspace_id}"
+  printf 'data_dir=%s\n' "${data_dir}"
+  printf 'database_path=%s\n' "${data_dir}/current-tasks.db"
+  printf 'config_root=%s\n' "${config_root}"
+  exit 0
+fi
+
+command -v docker >/dev/null 2>&1 || die "docker is not available on PATH"
+mkdir -p "${data_dir}"
+
+# ─── Singleton enforcement (kill-and-replace) ──────────────────────────
+# Prevents multi-spawn — without this, every wrapper invocation spawned
+# a new docker container against the same SQLite DB, leading to concurrent
+# JVM writers contending on WAL locks. Containers also leaked when Claude
+# Code crashed without cleanly closing the MCP stdio pipe.
+#
+# Strategy: assign a deterministic container name per workspace and remove
+# any existing container with that name OR mounting the same data_dir
+# before starting a fresh one. One container per project at any time.
+#
+# Tradeoff: opening a second Claude session in the same project disconnects
+# the first session's MCP. For typical single-operator-per-project use
+# this matches expectations.
+container_name="task-orchestrator-${workspace_id}"
+
+stale_by_name="$(docker ps -aq --filter "name=^${container_name}$" 2>/dev/null || true)"
+
+stale_by_mount="$(docker ps -q 2>/dev/null | while read -r cid; do
+  [[ -z "${cid}" ]] && continue
+  mount="$(docker inspect --format '{{range .Mounts}}{{if eq .Destination "/app/data"}}{{.Source}}{{end}}{{end}}' "${cid}" 2>/dev/null)"
+  if [[ "${mount}" == "${data_dir}" ]]; then
+    printf '%s\n' "${cid}"
+  fi
+done)"
+
+stale_combined="$(printf '%s\n%s\n' "${stale_by_name}" "${stale_by_mount}" | awk 'NF' | sort -u)"
+
+if [[ -n "${stale_combined}" ]]; then
+  printf 'task-orchestrator-current-stdio: removing %d stale container(s) for %s\n' \
+    "$(echo "${stale_combined}" | wc -l | tr -d ' ')" "${data_dir}" >&2
+  # shellcheck disable=SC2086
+  echo "${stale_combined}" | xargs docker rm -f >/dev/null 2>&1 || true
+fi
+
+docker_args=(
+  run
+  --rm
+  -i
+  --name "${container_name}"
+  --user "$(id -u):$(id -g)"
+  -v "${data_dir}:/app/data"
+  -v "${LOGBACK_CONFIG}:/tmp/logback.xml:ro"
+  -e "DATABASE_PATH=/app/data/current-tasks.db"
+  -e "MCP_TRANSPORT=stdio"
+  -e "USE_FLYWAY=true"
+  -e "AGENT_CONFIG_DIR=/project"
+)
+
+if [[ -f "${config_root}/.taskorchestrator/config.yaml" ]]; then
+  docker_args+=(
+    -v "${config_root}/.taskorchestrator:/project/.taskorchestrator:ro"
+  )
+fi
+
+exec docker "${docker_args[@]}" "${IMAGE}" \
+  java \
+  -Dfile.encoding=UTF-8 \
+  -Djava.awt.headless=true \
+  --enable-native-access=ALL-UNNAMED \
+  -Dlogback.configurationFile=/tmp/logback.xml \
+  -jar orchestrator.jar

--- a/scripts/mcp-wrappers/task-orchestrator-logback.xml
+++ b/scripts/mcp-wrappers/task-orchestrator-logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+  <appender name="STDERR" class="ch.qos.logback.core.ConsoleAppender">
+    <target>System.err</target>
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -- %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="WARN">
+    <appender-ref ref="STDERR" />
+  </root>
+</configuration>

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -775,7 +775,7 @@ def mcp_list_cmd():
             console.logger.info(f"  {name}{marker}")
 
 
-def _run_stdio_doctor(name: str, spec: Dict[str, Any], env: Dict[str, str]) -> List[str]:
+def _run_stdio_doctor(name: str, spec: Dict[str, Any], env: Dict[str, str], cwd: Path) -> List[str]:
     """Run a stdio server's configured non-mutating doctor command."""
     doctor_args = list(spec.get("doctor_args") or [])
     if not doctor_args:
@@ -793,6 +793,7 @@ def _run_stdio_doctor(name: str, spec: Dict[str, Any], env: Dict[str, str]) -> L
             timeout=10,
             check=False,
             env=env,
+            cwd=cwd,
         )
     except FileNotFoundError:
         return [f"`{name}`: doctor command not found: {command}"]
@@ -852,7 +853,7 @@ def mcp_doctor_cmd():
             if not env_source.get(env_key):
                 problems.append(f"`{name}`: required env `{env_key}` is unset.")
         if is_stdio:
-            problems.extend(_run_stdio_doctor(name, spec, doctor_env))
+            problems.extend(_run_stdio_doctor(name, spec, doctor_env, Path(repo)))
             continue
         if spec.get("port_var"):
             port_str = doctor_env.get(spec["port_var"])

--- a/src/dopemux/mcp/default_catalog.yaml
+++ b/src/dopemux/mcp/default_catalog.yaml
@@ -65,7 +65,7 @@ servers:
   conport:
     scope: per-worktree
     transport: sse
-    url_template: "http://localhost:${CONPORT_MCP_PORT}/mcp"
+    url_template: "http://localhost:${CONPORT_MCP_PORT:-3005}/mcp"
     port_var: CONPORT_MCP_PORT
     default_port_base: 3005
     extra_port_vars:
@@ -81,7 +81,7 @@ servers:
   dope-memory:
     scope: per-worktree
     transport: sse
-    url_template: "http://localhost:${DOPE_MEMORY_PORT}/mcp"
+    url_template: "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp"
     port_var: DOPE_MEMORY_PORT
     default_port_base: 3020
     docker_compose_service: dope-memory
@@ -92,7 +92,7 @@ servers:
     scope: per-worktree
     state_scope: per-repo
     transport: stdio
-    command: /Users/hue/plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh
+    command: scripts/mcp-wrappers/task-orchestrator-current-stdio.sh
     args: []
     doctor_args: ["--print-resolution"]
     requires_env: ["TASK_ORCHESTRATOR_PROJECT_ROOT"]

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -99,6 +99,7 @@ A packet is superseded by another packet
 | TP-DMX-COCKPIT-MERGE-EXECUTE-001 | UI Cockpit | Define Ledger-gated Cockpit pack merge execution procedure without authorizing runtime mutation | Blocked Preflight | N/A |
 | TP-DMX-DEPENDABOT-UV-RESOLVER-001 | Dependencies / CI | Repair Dependabot uv security update resolver metadata | Active | N/A |
 | TP-BETA-INSTALL-02-CLAUDE-REVIEW-001 | Installer | Apply Claude review cleanup to BETA-INSTALL-02 network repair | Active | N/A |
+| TP-BETA-INSTALL-01-MCP-01-REVIEW-001 | MCP Config | Repair PR #737 review blockers for portable Task Orchestrator launch | Active | N/A |
 
 ────────────────────────────────────────────────────────────
 🟢 Completed Task Packets

--- a/task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json
+++ b/task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json
@@ -32,6 +32,7 @@
       ".mcp.json",
       "mcp_catalog.yaml",
       "src/dopemux/mcp/default_catalog.yaml",
+      "src/dopemux/commands/mcp_commands.py",
       "scripts/mcp-wrappers/task-orchestrator-current-stdio.sh",
       "scripts/mcp-wrappers/task-orchestrator-logback.xml",
       "tests/unit/test_task_orchestrator_launcher.py",
@@ -50,8 +51,9 @@
       "bash -n scripts/mcp-wrappers/task-orchestrator-current-stdio.sh",
       "scripts/mcp-wrappers/task-orchestrator-current-stdio.sh --print-resolution",
       "python -m pytest tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py::test_mcp_init_keeps_matching_committed_template_and_writes_envrc tests/unit/test_mcp_commands_catalog.py::test_committed_mcp_json_matches_root_catalog_defaults -q",
+      "python -m pytest tests/unit/test_mcp_commands_catalog.py::test_doctor_runs_relative_stdio_resolution_from_repo_root -q",
       "git diff --check",
-      "pre-commit run --files .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml scripts/mcp-wrappers/task-orchestrator-current-stdio.sh scripts/mcp-wrappers/task-orchestrator-logback.xml tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json claudedocs/pr737-review-repair-proof-2026-05-31.md"
+      "pre-commit run --files .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml src/dopemux/commands/mcp_commands.py scripts/mcp-wrappers/task-orchestrator-current-stdio.sh scripts/mcp-wrappers/task-orchestrator-logback.xml tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json claudedocs/pr737-review-repair-proof-2026-05-31.md"
     ]
   },
   "pr": {
@@ -91,12 +93,13 @@
         "Ship the current upstream Task Orchestrator launcher and required logback config at tracked paths.",
         "Point .mcp.json, mcp_catalog.yaml, default_catalog.yaml, and active docs at the tracked path.",
         "Keep conport and dope-memory URL defaults identical between checked-in .mcp.json and catalog-rendered .mcp.json.",
+        "Run relative stdio doctor commands from the resolved repo root, not the shell caller's subdirectory.",
         "Add a launcher test that does not skip when the launcher is absent."
       ],
       "validation": [
         "bash -n scripts/mcp-wrappers/task-orchestrator-current-stdio.sh",
         "scripts/mcp-wrappers/task-orchestrator-current-stdio.sh --print-resolution",
-        "python -m pytest tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py::test_mcp_init_keeps_matching_committed_template_and_writes_envrc tests/unit/test_mcp_commands_catalog.py::test_committed_mcp_json_matches_root_catalog_defaults -q"
+        "python -m pytest tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py::test_mcp_init_keeps_matching_committed_template_and_writes_envrc tests/unit/test_mcp_commands_catalog.py::test_committed_mcp_json_matches_root_catalog_defaults tests/unit/test_mcp_commands_catalog.py::test_doctor_runs_relative_stdio_resolution_from_repo_root -q"
       ]
     },
     {
@@ -111,7 +114,7 @@
         "python -m json.tool task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json >/dev/null",
         "python -m jsonschema -i task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
         "git diff --check",
-        "pre-commit run --files .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml scripts/mcp-wrappers/task-orchestrator-current-stdio.sh scripts/mcp-wrappers/task-orchestrator-logback.xml tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json claudedocs/pr737-review-repair-proof-2026-05-31.md"
+        "pre-commit run --files .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml src/dopemux/commands/mcp_commands.py scripts/mcp-wrappers/task-orchestrator-current-stdio.sh scripts/mcp-wrappers/task-orchestrator-logback.xml tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json claudedocs/pr737-review-repair-proof-2026-05-31.md"
       ]
     }
   ]

--- a/task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json
+++ b/task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json
@@ -1,0 +1,118 @@
+{
+  "id": "TP-BETA-INSTALL-01-MCP-01-REVIEW-001",
+  "project": "dopemux-mvp",
+  "target": "Repair PR #737 review blockers for portable Task Orchestrator launch",
+  "invariants": [
+    "Apply all actionable Claude, Codex, and Copilot review suggestions on PR #737.",
+    "Do not point any fresh-clone MCP config at untracked plugin-local files.",
+    "Keep checked-in .mcp.json and catalog-rendered .mcp.json in sync.",
+    "Do not run live Docker Task Orchestrator startup during validation."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "beta-install-01-mcp-01-review-repair",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/pr737-review-repair-20260601",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(mcp): ship tracked task orchestrator launcher",
+    "allowlist": [
+      ".mcp.json",
+      "mcp_catalog.yaml",
+      "src/dopemux/mcp/default_catalog.yaml",
+      "scripts/mcp-wrappers/task-orchestrator-current-stdio.sh",
+      "scripts/mcp-wrappers/task-orchestrator-logback.xml",
+      "tests/unit/test_task_orchestrator_launcher.py",
+      "tests/unit/test_mcp_commands_catalog.py",
+      "docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md",
+      "CHANGELOG.md",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json",
+      "claudedocs/pr737-review-repair-proof-2026-05-31.md"
+    ],
+    "verify": [
+      "python -m json.tool .mcp.json >/dev/null",
+      "python - <<'PY'\nimport yaml\nfrom pathlib import Path\nyaml.safe_load(Path('mcp_catalog.yaml').read_text())\nyaml.safe_load(Path('src/dopemux/mcp/default_catalog.yaml').read_text())\nPY",
+      "python -m json.tool task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "bash -n scripts/mcp-wrappers/task-orchestrator-current-stdio.sh",
+      "scripts/mcp-wrappers/task-orchestrator-current-stdio.sh --print-resolution",
+      "python -m pytest tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py::test_mcp_init_keeps_matching_committed_template_and_writes_envrc tests/unit/test_mcp_commands_catalog.py::test_committed_mcp_json_matches_root_catalog_defaults -q",
+      "git diff --check",
+      "pre-commit run --files .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml scripts/mcp-wrappers/task-orchestrator-current-stdio.sh scripts/mcp-wrappers/task-orchestrator-logback.xml tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json claudedocs/pr737-review-repair-proof-2026-05-31.md"
+    ]
+  },
+  "pr": {
+    "title": "fix(mcp): BETA-INSTALL-01 + BETA-MCP-01 - fix .mcp.json for any-user clone",
+    "body": "## Review repair\n- Ships a tracked Task Orchestrator launcher wrapper and logback config under scripts/mcp-wrappers.\n- Points checked-in .mcp.json, mcp_catalog.yaml, and default_catalog.yaml at the tracked launcher.\n- Syncs catalog SSE URL defaults with checked-in .mcp.json.\n- Adds a non-skipped launcher resolution regression test.\n\n## Test Plan\n- Validate JSON/YAML and Task Packet schema.\n- Run shell syntax and launcher --print-resolution checks.\n- Run targeted launcher and MCP catalog tests.\n- Run git diff --check and pre-commit on changed files.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "challenge",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "analyze",
+      "task": "Inspect PR #737 review threads and MCP config generation surfaces.",
+      "requirements": [
+        "Identify every unresolved review suggestion.",
+        "Inspect checked-in .mcp.json, root catalog, default catalog, docs, launcher snapshots, and mcp init rendering.",
+        "Distinguish tracked repo assets from home-local plugin assets."
+      ],
+      "validation": [
+        "gh api graphql query for PR #737 reviewThreads",
+        "rg -n 'task-orchestrator-current-stdio|dopemux-mission-control|CONPORT_MCP_PORT|DOPE_MEMORY_PORT' .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml docs scripts tests",
+        "sed -n '375,410p' src/dopemux/commands/mcp_commands.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Replace untracked task-orchestrator launcher references with a tracked wrapper and sync generated config defaults.",
+      "requirements": [
+        "Ship the current upstream Task Orchestrator launcher and required logback config at tracked paths.",
+        "Point .mcp.json, mcp_catalog.yaml, default_catalog.yaml, and active docs at the tracked path.",
+        "Keep conport and dope-memory URL defaults identical between checked-in .mcp.json and catalog-rendered .mcp.json.",
+        "Add a launcher test that does not skip when the launcher is absent."
+      ],
+      "validation": [
+        "bash -n scripts/mcp-wrappers/task-orchestrator-current-stdio.sh",
+        "scripts/mcp-wrappers/task-orchestrator-current-stdio.sh --print-resolution",
+        "python -m pytest tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py::test_mcp_init_keeps_matching_committed_template_and_writes_envrc tests/unit/test_mcp_commands_catalog.py::test_committed_mcp_json_matches_root_catalog_defaults -q"
+      ]
+    },
+    {
+      "id": "precommit",
+      "task": "Validate packet, MCP config, tests, diff scope, and pre-commit before pushing review repair.",
+      "requirements": [
+        "Record validation exit codes in proof.",
+        "Inspect git status and changed-file scope before staging.",
+        "Do not resolve review threads until checks pass on the pushed PR head."
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "git diff --check",
+        "pre-commit run --files .mcp.json mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml scripts/mcp-wrappers/task-orchestrator-current-stdio.sh scripts/mcp-wrappers/task-orchestrator-logback.xml tests/unit/test_task_orchestrator_launcher.py tests/unit/test_mcp_commands_catalog.py docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-INSTALL-01-MCP-01-REVIEW-001.json claudedocs/pr737-review-repair-proof-2026-05-31.md"
+      ]
+    }
+  ]
+}

--- a/tests/unit/test_mcp_commands_catalog.py
+++ b/tests/unit/test_mcp_commands_catalog.py
@@ -335,13 +335,16 @@ def test_doctor_aggregates_problems_and_exits_nonzero(tmp_path, monkeypatch):
     assert "CONPORT_MCP_PORT" in result.output
 
 
-def test_doctor_runs_stdio_resolution_without_port_check(tmp_path, monkeypatch):
-    doctor_script = tmp_path / "doctor.sh"
+def test_doctor_runs_relative_stdio_resolution_from_repo_root(tmp_path, monkeypatch):
+    wrapper_dir = tmp_path / "scripts" / "mcp-wrappers"
+    wrapper_dir.mkdir(parents=True)
+    doctor_script = wrapper_dir / "doctor.sh"
     doctor_script.write_text("#!/usr/bin/env bash\nprintf 'state_id=test-state\\n'\n")
     doctor_script.chmod(0o755)
+    relative_command = "scripts/mcp-wrappers/doctor.sh"
     (tmp_path / mcp_commands.PROJECT_MCP_FILENAME).write_text(json.dumps({
         "mcpServers": {
-            "task-orchestrator": {"type": "stdio", "command": str(doctor_script), "args": []},
+            "task-orchestrator": {"type": "stdio", "command": relative_command, "args": []},
         }
     }, indent=2) + "\n")
     (tmp_path / mcp_commands.ENVRC_FILENAME).write_text("")
@@ -352,7 +355,7 @@ def test_doctor_runs_stdio_resolution_without_port_check(tmp_path, monkeypatch):
                 "scope": "per-worktree",
                 "state_scope": "per-repo",
                 "transport": "stdio",
-                "command": str(doctor_script),
+                "command": relative_command,
                 "doctor_args": ["--print-resolution"],
                 "requires_env": ["TASK_ORCHESTRATOR_PROJECT_ROOT"],
             },
@@ -363,6 +366,9 @@ def test_doctor_runs_stdio_resolution_without_port_check(tmp_path, monkeypatch):
     monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: catalog)
     monkeypatch.setattr(mcp_commands, "resolve_project_identity", lambda **_: _identity(tmp_path))
     monkeypatch.delenv("TASK_ORCHESTRATOR_PROJECT_ROOT", raising=False)
+    subdir = tmp_path / "nested"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
 
     result = CliRunner().invoke(mcp_commands.mcp_doctor_cmd, [])
 

--- a/tests/unit/test_mcp_commands_catalog.py
+++ b/tests/unit/test_mcp_commands_catalog.py
@@ -1,9 +1,11 @@
 import json
 import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import click
 import pytest
+import yaml
 from click.testing import CliRunner
 
 from dopemux.commands import mcp_commands
@@ -55,6 +57,17 @@ def test_mcp_init_keeps_matching_committed_template_and_writes_envrc(tmp_path, m
     assert "export CONPORT_MCP_PORT=" in envrc
     assert "export CONPORT_HTTP_PORT=" in envrc
     assert "export CONPORT_INFO_PORT=" in envrc
+
+
+def test_committed_mcp_json_matches_root_catalog_defaults():
+    repo_root = Path(__file__).resolve().parents[2]
+    catalog = yaml.safe_load((repo_root / "mcp_catalog.yaml").read_text())
+    defaults = catalog.get("defaults", {}).get("per_worktree", [])
+
+    expected = mcp_commands._build_local_mcp_json(defaults, catalog)
+    actual = json.loads((repo_root / ".mcp.json").read_text())
+
+    assert actual == expected
 
 
 def test_mcp_add_appends_primary_and_extra_catalog_ports(tmp_path, monkeypatch):

--- a/tests/unit/test_task_orchestrator_launcher.py
+++ b/tests/unit/test_task_orchestrator_launcher.py
@@ -1,0 +1,40 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TO_LAUNCHER = REPO_ROOT / "scripts/mcp-wrappers/task-orchestrator-current-stdio.sh"
+
+
+def test_task_orchestrator_launcher_is_tracked_executable():
+    assert TO_LAUNCHER.exists()
+    assert os.access(TO_LAUNCHER, os.X_OK)
+
+
+def test_task_orchestrator_launcher_print_resolution_from_non_repo_cwd(tmp_path):
+    env = os.environ.copy()
+    env.update(
+        {
+            "DOPEMUX_PROJECT_ROOT": str(REPO_ROOT),
+            "DOPEMUX_WORKSPACE_ROOT": str(REPO_ROOT),
+            "TASK_ORCHESTRATOR_PROJECT_ROOT": str(REPO_ROOT),
+            "XDG_DATA_HOME": str(tmp_path / "xdg-data"),
+        }
+    )
+
+    result = subprocess.run(
+        [str(TO_LAUNCHER), "--print-resolution"],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"workspace_root={REPO_ROOT}" in result.stdout
+    assert f"project_root={REPO_ROOT}" in result.stdout
+    assert f"config_root={REPO_ROOT}" in result.stdout
+    assert "database_path=" in result.stdout


### PR DESCRIPTION
## Summary

Two bugs in `.mcp.json` that break MCP connectivity on every non-author machine.

### BETA-INSTALL-01 — hardcoded author path (HIGH)

`task-orchestrator.command` was `/Users/hue/plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh` — an absolute path to the author's local filesystem. Every other clone gets a missing-binary error and the task-orchestrator MCP is silently dead.

**Fix:** Changed to `plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh` (repo-relative; Claude Code resolves stdio commands from the project root). Same fix applied to `mcp_catalog.yaml` and the operator reference doc.

### BETA-MCP-01 — SSE port vars with no default (HIGH)

`conport` URL: `http://localhost:${CONPORT_MCP_PORT}/mcp`  
`dope-memory` URL: `http://localhost:${DOPE_MEMORY_PORT}/mcp`

If `dopemux start` hasn't been run, these env vars are unset → URL becomes `http://localhost:/mcp` (invalid port) → SSE connection fails immediately.

**Fix:** Added `:-` defaults matching `compose.yml`:
- `${CONPORT_MCP_PORT:-3005}` (compose.yml:254)
- `${DOPE_MEMORY_PORT:-3020}` (compose.yml:463)

## Files changed
- `.mcp.json` — both fixes
- `mcp_catalog.yaml` — BETA-INSTALL-01 path fix
- `docs/03-reference/systems/task-orchestrator/system-taskorchestrator.md` — path reference updated

## Test plan
- [ ] Fresh clone: `cat .mcp.json | jq .mcpServers["task-orchestrator"].command` → `"plugins/dopemux-mission-control/scripts/task-orchestrator-current-stdio.sh"`
- [ ] With no `CONPORT_MCP_PORT` set: URL resolves to `http://localhost:3005/mcp`
- [ ] With `CONPORT_MCP_PORT=9999`: URL resolves to `http://localhost:9999/mcp`
- [ ] Task orchestrator MCP loads successfully in Claude Code on a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)