### PR TITLE
feat(cli): BETA-CLI-01 — add decisions list/show/query/review/update-outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to Dopemux (including the PR Merge Specialist) will be docum
 - CI now includes wrapper-authority coverage, interactive import smoke, and the production `brand_lint.py` gate.
 
 ### Fixed
+- Decisions CLI review repair now uses the ConPort HTTP REST port, accepts string decision IDs, validates referenced decisions before append-only writes, preserves requested list limits, and covers the new subcommands with focused tests.
 - MCP doctor now runs relative stdio doctor commands from the resolved repo root, so Task Orchestrator wrapper checks work when invoked from repo subdirectories.
 - MCP bootstrap now points Task Orchestrator at a tracked launcher wrapper and keeps catalog-rendered SSE URL defaults aligned with checked-in `.mcp.json`.
 - Installer review cleanup now removes dead SQLite test isolation code and makes setup-time `dopemux-network` creation fail closed on unexpected Docker errors.

--- a/claudedocs/pr740-review-repair-proof-2026-06-01.md
+++ b/claudedocs/pr740-review-repair-proof-2026-06-01.md
@@ -1,0 +1,42 @@
+# PR 740 Review Repair Proof
+
+## Scope
+
+- PR: #740
+- Local branch: `codex/pr740-review-repair-20260601`
+- Target PR branch: `fix/beta-cli-01-decisions-subcommands`
+- Worktree: `/Users/hue/code/dopemux-mvp-wt-pr740-review-repair`
+- Task Packet: `task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json`
+
+## Review Inputs
+
+- Claude Code Review: `REQUEST_CHANGES`
+- Codex review threads: string ConPort IDs and GET decision limit propagation
+- Copilot review threads: ConPort HTTP port, styled table call shape, string IDs, nested POST response ID, registration test update, and limit propagation
+- User instruction: integrate all Claude review suggestions before merge
+
+## Applied Changes
+
+- Changed decisions REST calls to use `CONPORT_URL` or `CONPORT_HTTP_PORT` default `3004`, not `CONPORT_MCP_PORT`.
+- Passed `limit` to `GET /api/decisions` and used a bounded lookup window for `show`, `query`, `review`, and `update-outcome`.
+- Accepted string decision IDs and compared decision IDs as strings.
+- Fixed `styled_table` usage by passing columns positionally.
+- Validated referenced decisions before append-only review/outcome writes.
+- Read created decision IDs from the nested `decision.id` response shape.
+- Updated user-facing wording from graph-link claims to append-only references.
+- Added focused unit coverage for decisions list, show, query, review, update-outcome, ConPort rejection handling, and command registration.
+
+## Validation
+
+PASS:
+
+- `python -m json.tool task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json >/dev/null` exit 0
+- `python -m jsonschema -i task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` exit 0
+- `python -m pytest tests/unit/test_decisions_commands.py tests/unit/test_cli_audit_remediations.py::test_decisions_subcommands_are_registered -q` exit 0
+- `python -m pytest tests/unit/test_cli_audit_remediations.py tests/unit/test_decisions_commands.py -q` exit 0
+- `git diff --check` exit 0
+- `pre-commit run --files src/dopemux/commands/decisions_commands.py tests/unit/test_decisions_commands.py tests/unit/test_cli_audit_remediations.py CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json claudedocs/pr740-review-repair-proof-2026-06-01.md` exit 0
+
+NOT_RUN:
+
+- Live ConPort/Docker runtime validation is intentionally `NOT_RUN`; this review repair uses mocked HTTP calls and does not start local services.

--- a/src/dopemux/commands/decisions_commands.py
+++ b/src/dopemux/commands/decisions_commands.py
@@ -1,43 +1,238 @@
 """
 Decisions Commands
+
+BETA-CLI-01: list / show / query / review / update-outcome subcommands
+were absent.  This module now implements them against the ConPort HTTP
+API (localhost:${CONPORT_MCP_PORT:-3005}).
 """
 
 import os
-import sys
-import subprocess
-import time
-from pathlib import Path
-from subprocess import CalledProcessError
-from typing import Optional, Dict, List, Sequence
+from typing import Optional
 
 import click
-import yaml
-from dopemux.ui.progress import branded_progress
-from dopemux.ui.progress import branded_progress
-from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from ..console import console
 from ..ui.theme import styled_panel, styled_table, error_panel, Glyphs, StatusChip
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _conport_url() -> str:
+    port = os.environ.get("CONPORT_MCP_PORT", "3005")
+    return f"http://localhost:{port}"
+
+
+def _workspace_id() -> str:
+    return os.environ.get(
+        "DOPEMUX_WORKSPACE_ID",
+        os.environ.get("TASK_ORCHESTRATOR_PROJECT_ROOT", os.getcwd()),
+    )
+
+
+def _get_decisions(workspace_id: str) -> list:
+    """Fetch all decisions from ConPort. Returns [] on error."""
+    try:
+        import requests
+        r = requests.get(
+            f"{_conport_url()}/api/decisions",
+            params={"workspace_id": workspace_id},
+            timeout=10,
+        )
+        r.raise_for_status()
+        return r.json().get("decisions", [])
+    except Exception as exc:
+        console.logger.warning(f"[yellow]ConPort unavailable: {exc}[/yellow]")
+        return []
+
+
+def _print_decision_table(decisions: list) -> None:
+    if not decisions:
+        console.logger.info("[text.dim]No decisions found.[/text.dim]")
+        return
+    table = styled_table(
+        "Decisions",
+        columns=["ID", "Summary", "Date"],
+        show_lines=True,
+    )
+    for d in decisions:
+        table.add_row(
+            str(d.get("id", "—")),
+            d.get("summary", "")[:80],
+            str(d.get("created_at", d.get("timestamp", "—")))[:19],
+        )
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# decisions group
+# ---------------------------------------------------------------------------
 
 @click.group()
 def decisions():
     """
     📊 Decision Governance: Track and analyze cockpit conclusions
 
-    Orchestrates the logging and analysis of ritual decisions within the 
-    persistent knowledge graph. Synchronizes ADHD-optimized visualizations 
+    Orchestrates the logging and analysis of ritual decisions within the
+    persistent knowledge graph. Synchronizes ADHD-optimized visualizations
     with review workflows to ensure high-fidelity cognitive alignment.
     """
     pass
 
+
+# ---------------------------------------------------------------------------
+# decisions list
+# ---------------------------------------------------------------------------
+
+@decisions.command("list")
+@click.option("--workspace", "-w", default=None, help="Workspace ID (defaults to DOPEMUX_WORKSPACE_ID or cwd)")
+@click.option("--limit", "-n", default=20, show_default=True, help="Max decisions to show")
+def decisions_list(workspace: Optional[str], limit: int):
+    """List recent decisions from ConPort."""
+    wid = workspace or _workspace_id()
+    items = _get_decisions(wid)
+    _print_decision_table(items[:limit])
+
+
+# ---------------------------------------------------------------------------
+# decisions show
+# ---------------------------------------------------------------------------
+
+@decisions.command("show")
+@click.argument("decision_id", type=int)
+@click.option("--workspace", "-w", default=None)
+def decisions_show(decision_id: int, workspace: Optional[str]):
+    """Show full detail for a single decision by ID."""
+    wid = workspace or _workspace_id()
+    items = _get_decisions(wid)
+    match = next((d for d in items if d.get("id") == decision_id), None)
+    if not match:
+        console.logger.error(f"[red]Decision {decision_id} not found.[/red]")
+        raise SystemExit(1)
+    panel = styled_panel(
+        "\n".join([
+            f"[bold]Summary:[/bold]    {match.get('summary', '—')}",
+            f"[bold]Rationale:[/bold]  {match.get('rationale', '—')}",
+            f"[bold]Alternatives:[/bold] {', '.join(match.get('alternatives', [])) or '—'}",
+            f"[bold]Date:[/bold]       {match.get('created_at', match.get('timestamp', '—'))}",
+            f"[bold]Tags:[/bold]       {', '.join(match.get('tags', [])) or '—'}",
+        ]),
+        title=f"Decision #{decision_id}",
+    )
+    console.print(panel)
+
+
+# ---------------------------------------------------------------------------
+# decisions query
+# ---------------------------------------------------------------------------
+
+@decisions.command("query")
+@click.argument("term")
+@click.option("--workspace", "-w", default=None)
+@click.option("--limit", "-n", default=20, show_default=True)
+def decisions_query(term: str, workspace: Optional[str], limit: int):
+    """Search decisions whose summary or rationale contains TERM."""
+    wid = workspace or _workspace_id()
+    items = _get_decisions(wid)
+    term_lower = term.lower()
+    matches = [
+        d for d in items
+        if term_lower in d.get("summary", "").lower()
+        or term_lower in d.get("rationale", "").lower()
+    ]
+    if not matches:
+        console.logger.info(f"[text.dim]No decisions matching {term!r}.[/text.dim]")
+        return
+    _print_decision_table(matches[:limit])
+
+
+# ---------------------------------------------------------------------------
+# decisions review  (add a review note to an existing decision)
+# ---------------------------------------------------------------------------
+
+@decisions.command("review")
+@click.argument("decision_id", type=int)
+@click.option("--note", "-m", required=True, help="Review note to attach")
+@click.option("--workspace", "-w", default=None)
+def decisions_review(decision_id: int, note: str, workspace: Optional[str]):
+    """
+    Attach a review note to a decision by logging a linked follow-up entry.
+
+    ConPort does not support in-place mutation, so review notes are stored as
+    a new decision whose summary references the original ID.
+    """
+    wid = workspace or _workspace_id()
+    try:
+        import requests
+        r = requests.post(
+            f"{_conport_url()}/api/decisions",
+            json={
+                "workspace_id": wid,
+                "summary": f"[Review of #{decision_id}] {note}",
+                "rationale": f"Follow-up review note for decision #{decision_id}.",
+                "alternatives": [],
+            },
+            timeout=10,
+        )
+        r.raise_for_status()
+        result = r.json()
+        new_id = result.get("id", "?")
+        console.logger.info(f"[green]Review note logged as decision #{new_id}.[/green]")
+    except Exception as exc:
+        console.logger.error(f"[red]Failed to log review: {exc}[/red]")
+        raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# decisions update-outcome
+# ---------------------------------------------------------------------------
+
+@decisions.command("update-outcome")
+@click.argument("decision_id", type=int)
+@click.option("--outcome", "-o", required=True, help="Outcome description (what actually happened)")
+@click.option("--workspace", "-w", default=None)
+def decisions_update_outcome(decision_id: int, outcome: str, workspace: Optional[str]):
+    """
+    Record the real-world outcome of a decision.
+
+    Logged as a new ConPort entry linked to the original decision ID so the
+    history is append-only and auditable.
+    """
+    wid = workspace or _workspace_id()
+    try:
+        import requests
+        r = requests.post(
+            f"{_conport_url()}/api/decisions",
+            json={
+                "workspace_id": wid,
+                "summary": f"[Outcome of #{decision_id}] {outcome}",
+                "rationale": f"Real-world outcome recorded for decision #{decision_id}.",
+                "alternatives": [],
+            },
+            timeout=10,
+        )
+        r.raise_for_status()
+        result = r.json()
+        new_id = result.get("id", "?")
+        console.logger.info(
+            f"[green]Outcome logged as decision #{new_id} (linked to #{decision_id}).[/green]"
+        )
+    except Exception as exc:
+        console.logger.error(f"[red]Failed to log outcome: {exc}[/red]")
+        raise SystemExit(1)
+
+
+# ---------------------------------------------------------------------------
+# Existing sub-groups (kept unchanged)
+# ---------------------------------------------------------------------------
 
 @decisions.group()
 def energy():
     """
     ⚡ Vitality Telemetry: Track ritual energy levels
 
-    Synchronizes ADHD-optimized energy tracking rituals. Monitors cognitive 
-    vitality patterns throughout the temporal cycle to optimize 
+    Synchronizes ADHD-optimized energy tracking rituals. Monitors cognitive
+    vitality patterns throughout the temporal cycle to optimize
     decision-making timing and ritual efficiency.
     """
     pass
@@ -48,17 +243,11 @@ def patterns():
     """
     🔍 Cognitive Synthesis: Pattern detection and learning
 
-    Engages the pattern detection engine to synthesize insights from 
-    decision history. Automatically clusters ritual tags, identifies 
+    Engages the pattern detection engine to synthesize insights from
+    decision history. Automatically clusters ritual tags, identifies
     sequential chains, and correlates energy telemetry with ritual quality.
     """
     pass
-
-# No concrete decision-management callbacks are present in this module today.
-# Keep the runtime surface limited to the real groups above instead of swallowing
-# a self-import failure and implying hidden subcommands exist.
-
-
 
 
 # ============================================================================

--- a/src/dopemux/commands/decisions_commands.py
+++ b/src/dopemux/commands/decisions_commands.py
@@ -3,23 +3,31 @@ Decisions Commands
 
 BETA-CLI-01: list / show / query / review / update-outcome subcommands
 were absent.  This module now implements them against the ConPort HTTP
-API (localhost:${CONPORT_MCP_PORT:-3005}).
+API (localhost:${CONPORT_HTTP_PORT:-3004} or CONPORT_URL).
 """
 
 import os
-from typing import Optional
+import sys
+from typing import Any, Optional
 
 import click
+import requests
 
 from ..console import console
-from ..ui.theme import styled_panel, styled_table, error_panel, Glyphs, StatusChip
+from ..ui.theme import styled_panel, styled_table
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
+DEFAULT_DECISION_LOOKUP_LIMIT = 1000
+WORKSPACE_HELP = "Workspace ID (defaults to DOPEMUX_WORKSPACE_ID or cwd)"
+
+
 def _conport_url() -> str:
-    port = os.environ.get("CONPORT_MCP_PORT", "3005")
+    if url := os.environ.get("CONPORT_URL"):
+        return url.rstrip("/")
+    port = os.environ.get("CONPORT_HTTP_PORT", "3004")
     return f"http://localhost:{port}"
 
 
@@ -30,29 +38,49 @@ def _workspace_id() -> str:
     )
 
 
-def _get_decisions(workspace_id: str) -> list:
+def _get_decisions(workspace_id: str, limit: int = 20) -> list[dict[str, Any]]:
     """Fetch all decisions from ConPort. Returns [] on error."""
     try:
-        import requests
         r = requests.get(
             f"{_conport_url()}/api/decisions",
-            params={"workspace_id": workspace_id},
+            params={"workspace_id": workspace_id, "limit": limit},
             timeout=10,
         )
         r.raise_for_status()
         return r.json().get("decisions", [])
-    except Exception as exc:
+    except (requests.ConnectionError, requests.Timeout) as exc:
         console.logger.warning(f"[yellow]ConPort unavailable: {exc}[/yellow]")
+        return []
+    except requests.HTTPError as exc:
+        response = exc.response
+        status = response.status_code if response is not None else "unknown"
+        console.logger.warning(f"[yellow]ConPort rejected decisions request: HTTP {status}[/yellow]")
+        return []
+    except requests.RequestException as exc:
+        console.logger.warning(f"[yellow]ConPort request failed: {exc}[/yellow]")
         return []
 
 
-def _print_decision_table(decisions: list) -> None:
+def _find_decision(decisions: list[dict[str, Any]], decision_id: str) -> dict[str, Any] | None:
+    return next((d for d in decisions if str(d.get("id")) == decision_id), None)
+
+
+def _created_decision_id(result: dict[str, Any]) -> str:
+    decision = result.get("decision")
+    if isinstance(decision, dict):
+        return str(decision.get("id", "?"))
+    return str(result.get("id", "?"))
+
+
+def _print_decision_table(decisions: list[dict[str, Any]]) -> None:
     if not decisions:
         console.logger.info("[text.dim]No decisions found.[/text.dim]")
         return
     table = styled_table(
         "Decisions",
-        columns=["ID", "Summary", "Date"],
+        "ID",
+        "Summary",
+        "Date",
         show_lines=True,
     )
     for d in decisions:
@@ -85,12 +113,12 @@ def decisions():
 # ---------------------------------------------------------------------------
 
 @decisions.command("list")
-@click.option("--workspace", "-w", default=None, help="Workspace ID (defaults to DOPEMUX_WORKSPACE_ID or cwd)")
+@click.option("--workspace", "-w", default=None, help=WORKSPACE_HELP)
 @click.option("--limit", "-n", default=20, show_default=True, help="Max decisions to show")
 def decisions_list(workspace: Optional[str], limit: int):
     """List recent decisions from ConPort."""
     wid = workspace or _workspace_id()
-    items = _get_decisions(wid)
+    items = _get_decisions(wid, limit=limit)
     _print_decision_table(items[:limit])
 
 
@@ -99,16 +127,16 @@ def decisions_list(workspace: Optional[str], limit: int):
 # ---------------------------------------------------------------------------
 
 @decisions.command("show")
-@click.argument("decision_id", type=int)
-@click.option("--workspace", "-w", default=None)
-def decisions_show(decision_id: int, workspace: Optional[str]):
+@click.argument("decision_id")
+@click.option("--workspace", "-w", default=None, help=WORKSPACE_HELP)
+def decisions_show(decision_id: str, workspace: Optional[str]):
     """Show full detail for a single decision by ID."""
     wid = workspace or _workspace_id()
-    items = _get_decisions(wid)
-    match = next((d for d in items if d.get("id") == decision_id), None)
+    items = _get_decisions(wid, limit=DEFAULT_DECISION_LOOKUP_LIMIT)
+    match = _find_decision(items, decision_id)
     if not match:
         console.logger.error(f"[red]Decision {decision_id} not found.[/red]")
-        raise SystemExit(1)
+        sys.exit(1)
     panel = styled_panel(
         "\n".join([
             f"[bold]Summary:[/bold]    {match.get('summary', '—')}",
@@ -117,7 +145,7 @@ def decisions_show(decision_id: int, workspace: Optional[str]):
             f"[bold]Date:[/bold]       {match.get('created_at', match.get('timestamp', '—'))}",
             f"[bold]Tags:[/bold]       {', '.join(match.get('tags', [])) or '—'}",
         ]),
-        title=f"Decision #{decision_id}",
+        title=f"Decision {decision_id}",
     )
     console.print(panel)
 
@@ -128,12 +156,12 @@ def decisions_show(decision_id: int, workspace: Optional[str]):
 
 @decisions.command("query")
 @click.argument("term")
-@click.option("--workspace", "-w", default=None)
-@click.option("--limit", "-n", default=20, show_default=True)
+@click.option("--workspace", "-w", default=None, help=WORKSPACE_HELP)
+@click.option("--limit", "-n", default=20, show_default=True, help="Max matching decisions to show")
 def decisions_query(term: str, workspace: Optional[str], limit: int):
     """Search decisions whose summary or rationale contains TERM."""
     wid = workspace or _workspace_id()
-    items = _get_decisions(wid)
+    items = _get_decisions(wid, limit=max(limit, DEFAULT_DECISION_LOOKUP_LIMIT))
     term_lower = term.lower()
     matches = [
         d for d in items
@@ -151,36 +179,38 @@ def decisions_query(term: str, workspace: Optional[str], limit: int):
 # ---------------------------------------------------------------------------
 
 @decisions.command("review")
-@click.argument("decision_id", type=int)
+@click.argument("decision_id")
 @click.option("--note", "-m", required=True, help="Review note to attach")
-@click.option("--workspace", "-w", default=None)
-def decisions_review(decision_id: int, note: str, workspace: Optional[str]):
+@click.option("--workspace", "-w", default=None, help=WORKSPACE_HELP)
+def decisions_review(decision_id: str, note: str, workspace: Optional[str]):
     """
-    Attach a review note to a decision by logging a linked follow-up entry.
+    Attach a review note to a decision by logging a referencing follow-up entry.
 
     ConPort does not support in-place mutation, so review notes are stored as
     a new decision whose summary references the original ID.
     """
     wid = workspace or _workspace_id()
+    if not _find_decision(_get_decisions(wid, limit=DEFAULT_DECISION_LOOKUP_LIMIT), decision_id):
+        console.logger.error(f"[red]Decision {decision_id} not found; review not logged.[/red]")
+        sys.exit(1)
     try:
-        import requests
         r = requests.post(
             f"{_conport_url()}/api/decisions",
             json={
                 "workspace_id": wid,
-                "summary": f"[Review of #{decision_id}] {note}",
-                "rationale": f"Follow-up review note for decision #{decision_id}.",
+                "summary": f"[Review of {decision_id}] {note}",
+                "rationale": f"Follow-up review note for decision {decision_id}.",
                 "alternatives": [],
             },
             timeout=10,
         )
         r.raise_for_status()
         result = r.json()
-        new_id = result.get("id", "?")
+        new_id = _created_decision_id(result)
         console.logger.info(f"[green]Review note logged as decision #{new_id}.[/green]")
-    except Exception as exc:
+    except requests.RequestException as exc:
         console.logger.error(f"[red]Failed to log review: {exc}[/red]")
-        raise SystemExit(1)
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------
@@ -188,38 +218,40 @@ def decisions_review(decision_id: int, note: str, workspace: Optional[str]):
 # ---------------------------------------------------------------------------
 
 @decisions.command("update-outcome")
-@click.argument("decision_id", type=int)
+@click.argument("decision_id")
 @click.option("--outcome", "-o", required=True, help="Outcome description (what actually happened)")
-@click.option("--workspace", "-w", default=None)
-def decisions_update_outcome(decision_id: int, outcome: str, workspace: Optional[str]):
+@click.option("--workspace", "-w", default=None, help=WORKSPACE_HELP)
+def decisions_update_outcome(decision_id: str, outcome: str, workspace: Optional[str]):
     """
     Record the real-world outcome of a decision.
 
-    Logged as a new ConPort entry linked to the original decision ID so the
+    Logged as a new ConPort entry referencing the original decision ID so the
     history is append-only and auditable.
     """
     wid = workspace or _workspace_id()
+    if not _find_decision(_get_decisions(wid, limit=DEFAULT_DECISION_LOOKUP_LIMIT), decision_id):
+        console.logger.error(f"[red]Decision {decision_id} not found; outcome not logged.[/red]")
+        sys.exit(1)
     try:
-        import requests
         r = requests.post(
             f"{_conport_url()}/api/decisions",
             json={
                 "workspace_id": wid,
-                "summary": f"[Outcome of #{decision_id}] {outcome}",
-                "rationale": f"Real-world outcome recorded for decision #{decision_id}.",
+                "summary": f"[Outcome of {decision_id}] {outcome}",
+                "rationale": f"Real-world outcome recorded for decision {decision_id}.",
                 "alternatives": [],
             },
             timeout=10,
         )
         r.raise_for_status()
         result = r.json()
-        new_id = result.get("id", "?")
+        new_id = _created_decision_id(result)
         console.logger.info(
-            f"[green]Outcome logged as decision #{new_id} (linked to #{decision_id}).[/green]"
+            f"[green]Outcome logged as decision #{new_id} (references {decision_id}).[/green]"
         )
-    except Exception as exc:
+    except requests.RequestException as exc:
         console.logger.error(f"[red]Failed to log outcome: {exc}[/red]")
-        raise SystemExit(1)
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -100,6 +100,7 @@ A packet is superseded by another packet
 | TP-DMX-DEPENDABOT-UV-RESOLVER-001 | Dependencies / CI | Repair Dependabot uv security update resolver metadata | Active | N/A |
 | TP-BETA-INSTALL-02-CLAUDE-REVIEW-001 | Installer | Apply Claude review cleanup to BETA-INSTALL-02 network repair | Active | N/A |
 | TP-BETA-INSTALL-01-MCP-01-REVIEW-001 | MCP Config | Repair PR #737 review blockers for portable Task Orchestrator launch | Active | N/A |
+| TP-BETA-CLI-01-DECISIONS-REVIEW-001 | CLI Decisions | Repair PR #740 review blockers for decisions CLI subcommands | Active | N/A |
 
 ────────────────────────────────────────────────────────────
 🟢 Completed Task Packets

--- a/task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json
+++ b/task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json
@@ -1,0 +1,110 @@
+{
+  "id": "TP-BETA-CLI-01-DECISIONS-REVIEW-001",
+  "project": "dopemux-mvp",
+  "target": "Repair PR #740 review blockers for decisions CLI subcommands",
+  "invariants": [
+    "Apply all actionable Claude, Codex, and Copilot review suggestions on PR #740.",
+    "Keep decisions CLI writes append-only and fail closed when the referenced decision is absent.",
+    "Use the ConPort HTTP REST API endpoint, not the MCP/SSE port, for /api/decisions.",
+    "Do not run live ConPort or Docker services during validation."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "beta-cli-01-decisions-review-repair",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/pr740-review-repair-20260601",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(cli): repair decisions command review blockers",
+    "allowlist": [
+      "src/dopemux/commands/decisions_commands.py",
+      "tests/unit/test_decisions_commands.py",
+      "tests/unit/test_cli_audit_remediations.py",
+      "CHANGELOG.md",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json",
+      "claudedocs/pr740-review-repair-proof-2026-06-01.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_decisions_commands.py tests/unit/test_cli_audit_remediations.py::test_decisions_subcommands_are_registered -q",
+      "git diff --check",
+      "pre-commit run --files src/dopemux/commands/decisions_commands.py tests/unit/test_decisions_commands.py tests/unit/test_cli_audit_remediations.py CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json claudedocs/pr740-review-repair-proof-2026-06-01.md"
+    ]
+  },
+  "pr": {
+    "title": "feat(cli): BETA-CLI-01 - add decisions list/show/query/review/update-outcome",
+    "body": "## Review repair\n- Uses ConPort HTTP REST port defaults for decisions API calls.\n- Accepts string decision IDs and compares IDs as strings.\n- Threads requested limits through GET /api/decisions and uses a bounded lookup window for search/show/write validation.\n- Fixes styled_table invocation, nested POST response ID parsing, and append-only reference wording.\n- Validates referenced decisions before review/outcome writes.\n- Adds focused unit coverage for all new command paths and updates the command-registration snapshot.\n\n## Test Plan\n- Validate Task Packet JSON/schema.\n- Run focused decisions command tests and command registration snapshot.\n- Run git diff --check and pre-commit on changed files.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "challenge",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "analyze",
+      "task": "Inspect PR #740 review threads, decisions CLI implementation, ConPort HTTP contract, and existing command tests.",
+      "requirements": [
+        "Identify every unresolved Claude, Codex, and Copilot review suggestion.",
+        "Inspect ConPort REST endpoint ports, ID shapes, response envelopes, and list limits.",
+        "Inspect styled_table signature and current decisions registration tests."
+      ],
+      "validation": [
+        "gh api graphql query for PR #740 reviewThreads",
+        "sed -n '1,280p' src/dopemux/commands/decisions_commands.py",
+        "rg -n 'CONPORT_HTTP_PORT|CONPORT_MCP_PORT|/api/decisions|decision_id' src docker repo-truth-pack compose.yml"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Repair decisions CLI runtime behavior and add focused regression coverage.",
+      "requirements": [
+        "Use CONPORT_URL or CONPORT_HTTP_PORT default 3004 for decisions REST calls.",
+        "Accept string decision IDs and compare IDs as strings.",
+        "Pass requested limits to ConPort and use a bounded lookup limit for lookup/search/write validation.",
+        "Validate review and update-outcome target IDs before POST writes.",
+        "Read created IDs from the nested decision response object.",
+        "Use positional styled_table columns and complete workspace help text.",
+        "Use append-only reference wording instead of claiming graph links."
+      ],
+      "validation": [
+        "python -m pytest tests/unit/test_decisions_commands.py tests/unit/test_cli_audit_remediations.py::test_decisions_subcommands_are_registered -q"
+      ]
+    },
+    {
+      "id": "precommit",
+      "task": "Validate packet, tests, diff scope, and pre-commit before pushing PR #740 review repair.",
+      "requirements": [
+        "Record validation exit codes in proof.",
+        "Inspect git status and changed-file scope before staging.",
+        "Do not resolve review threads until checks pass on the pushed PR head."
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "git diff --check",
+        "pre-commit run --files src/dopemux/commands/decisions_commands.py tests/unit/test_decisions_commands.py tests/unit/test_cli_audit_remediations.py CHANGELOG.md task-packets/INDEX.md task-packets/generated/TP-BETA-CLI-01-DECISIONS-REVIEW-001.json claudedocs/pr740-review-repair-proof-2026-06-01.md"
+      ]
+    }
+  ]
+}

--- a/tests/unit/test_cli_audit_remediations.py
+++ b/tests/unit/test_cli_audit_remediations.py
@@ -100,12 +100,18 @@ def test_routing_mode_update_fails_closed_on_invalid_yaml(tmp_path: Path):
     assert config_path.read_text(encoding="utf-8") == original
 
 
-def test_decisions_runtime_does_not_advertise_missing_subcommands():
+def test_decisions_subcommands_are_registered():
     decisions = cli.commands["decisions"]
 
-    assert set(decisions.commands) == {"energy", "patterns"}
-    assert "review" not in decisions.commands
-    assert "list" not in decisions.commands
+    assert set(decisions.commands) == {
+        "energy",
+        "patterns",
+        "list",
+        "show",
+        "query",
+        "review",
+        "update-outcome",
+    }
 
 
 def test_removed_genetic_code_commands_are_not_registered():

--- a/tests/unit/test_decisions_commands.py
+++ b/tests/unit/test_decisions_commands.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import requests
+from click.testing import CliRunner
+
+from dopemux.commands import decisions_commands
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            exc = requests.HTTPError(f"HTTP {self.status_code}")
+            exc.response = self
+            raise exc
+
+
+def test_decisions_list_uses_conport_http_port_and_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorded: dict[str, Any] = {}
+
+    def fake_get(url: str, *, params: dict[str, Any], timeout: int) -> FakeResponse:
+        recorded.update({"url": url, "params": params, "timeout": timeout})
+        return FakeResponse({
+            "decisions": [
+                {
+                    "id": "decision-1",
+                    "summary": "Choose tracked wrapper",
+                    "rationale": "Fresh clones need tracked files",
+                    "created_at": "2026-06-01T00:00:00Z",
+                }
+            ]
+        })
+
+    monkeypatch.delenv("CONPORT_URL", raising=False)
+    monkeypatch.setenv("CONPORT_HTTP_PORT", "3999")
+    monkeypatch.setenv("DOPEMUX_WORKSPACE_ID", "workspace-a")
+    monkeypatch.setattr(decisions_commands.requests, "get", fake_get)
+
+    result = CliRunner().invoke(decisions_commands.decisions, ["list", "--limit", "50"])
+
+    assert result.exit_code == 0, result.output
+    assert recorded == {
+        "url": "http://localhost:3999/api/decisions",
+        "params": {"workspace_id": "workspace-a", "limit": 50},
+        "timeout": 10,
+    }
+
+
+def test_decisions_show_accepts_string_decision_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        decisions_commands,
+        "_get_decisions",
+        lambda workspace_id, limit=20: [
+            {
+                "id": "f8f12c3e-8421-46b9-b7c7-4a9128f21355",
+                "summary": "Keep append-only decisions",
+                "rationale": "Auditability",
+                "alternatives": [],
+                "tags": [],
+                "created_at": "2026-06-01T00:00:00Z",
+            }
+        ],
+    )
+
+    result = CliRunner().invoke(
+        decisions_commands.decisions,
+        ["show", "f8f12c3e-8421-46b9-b7c7-4a9128f21355"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Keep append-only decisions" in result.output
+
+
+def test_decisions_query_fetches_lookup_window_and_limits_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, int]] = []
+
+    def fake_get_decisions(workspace_id: str, limit: int = 20) -> list[dict[str, Any]]:
+        calls.append((workspace_id, limit))
+        return [
+            {"id": "decision-1", "summary": "alpha choice", "rationale": "", "created_at": "now"},
+            {"id": "decision-2", "summary": "beta choice", "rationale": "alpha detail", "created_at": "now"},
+        ]
+
+    monkeypatch.setenv("DOPEMUX_WORKSPACE_ID", "workspace-a")
+    monkeypatch.setattr(decisions_commands, "_get_decisions", fake_get_decisions)
+
+    result = CliRunner().invoke(decisions_commands.decisions, ["query", "alpha", "--limit", "1"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [("workspace-a", decisions_commands.DEFAULT_DECISION_LOOKUP_LIMIT)]
+
+
+def test_decisions_review_validates_target_and_reads_nested_response_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, Any] = {}
+
+    monkeypatch.setenv("DOPEMUX_WORKSPACE_ID", "workspace-a")
+    monkeypatch.setattr(
+        decisions_commands,
+        "_get_decisions",
+        lambda workspace_id, limit=20: [{"id": "decision-1", "summary": "Original"}],
+    )
+
+    def fake_post(url: str, *, json: dict[str, Any], timeout: int) -> FakeResponse:
+        recorded.update({"url": url, "json": json, "timeout": timeout})
+        return FakeResponse({"status": "logged", "decision": {"id": "decision-review"}})
+
+    monkeypatch.setattr(decisions_commands.requests, "post", fake_post)
+
+    result = CliRunner().invoke(
+        decisions_commands.decisions,
+        ["review", "decision-1", "--note", "Still valid"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert recorded["json"]["summary"] == "[Review of decision-1] Still valid"
+    assert "decision-review" in result.output
+
+
+def test_decisions_review_rejects_missing_target_before_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(decisions_commands, "_get_decisions", lambda workspace_id, limit=20: [])
+    monkeypatch.setattr(
+        decisions_commands.requests,
+        "post",
+        lambda *args, **kwargs: pytest.fail("review must not write without target decision"),
+    )
+
+    result = CliRunner().invoke(
+        decisions_commands.decisions,
+        ["review", "missing-id", "--note", "Do not write"],
+    )
+
+    assert result.exit_code == 1
+
+
+def test_decisions_update_outcome_references_target_and_reads_nested_response_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: dict[str, Any] = {}
+
+    monkeypatch.setattr(
+        decisions_commands,
+        "_get_decisions",
+        lambda workspace_id, limit=20: [{"id": "decision-1", "summary": "Original"}],
+    )
+
+    def fake_post(url: str, *, json: dict[str, Any], timeout: int) -> FakeResponse:
+        recorded.update({"url": url, "json": json, "timeout": timeout})
+        return FakeResponse({"status": "logged", "decision": {"id": "decision-outcome"}})
+
+    monkeypatch.setattr(decisions_commands.requests, "post", fake_post)
+
+    result = CliRunner().invoke(
+        decisions_commands.decisions,
+        ["update-outcome", "decision-1", "--outcome", "It worked"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert recorded["json"]["summary"] == "[Outcome of decision-1] It worked"
+    assert "references decision-1" in result.output
+    assert "decision-outcome" in result.output
+
+
+def test_get_decisions_distinguishes_conport_rejection(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_get(url: str, *, params: dict[str, Any], timeout: int) -> FakeResponse:
+        return FakeResponse({"error": "bad workspace"}, status_code=403)
+
+    monkeypatch.setattr(decisions_commands.requests, "get", fake_get)
+
+    assert decisions_commands._get_decisions("blocked-workspace", limit=5) == []


### PR DESCRIPTION
## Summary

`dopemux decisions` shipped only empty `energy` and `patterns` sub-groups — five documented subcommands were missing (BETA-CLI-01, HIGH).

## New commands

```
dopemux decisions list                List recent decisions (--limit N, -w workspace)
dopemux decisions show <id>           Full detail for one decision by ConPort ID
dopemux decisions query <term>        Filter decisions by summary/rationale text
dopemux decisions review <id> -m MSG  Attach a review note (append-only new entry)
dopemux decisions update-outcome <id> -o OUTCOME  Record real-world outcome
```

## Design decisions

- **ConPort is append-only** — `review` and `update-outcome` log new linked entries (summary prefixed `[Review of #N]` / `[Outcome of #N]`) rather than mutating existing records. Audit trail stays intact.
- **Graceful degradation** — if ConPort is unreachable, `list`/`show`/`query` warn and return empty rather than crashing. `review`/`update-outcome` fail loudly since they're write ops.
- **Workspace resolution** — `DOPEMUX_WORKSPACE_ID` → `TASK_ORCHESTRATOR_PROJECT_ROOT` → `cwd`, matching existing CLI conventions.
- **Port** — `${CONPORT_MCP_PORT:-3005}`, consistent with compose.yml and the BETA-MCP-01 fix in PR #737.

## Test plan

- [ ] `dopemux decisions list` → table of decisions (or "No decisions" when ConPort empty)
- [ ] `dopemux decisions show 1` → panel with full fields for decision #1
- [ ] `dopemux decisions query auth` → filtered list
- [ ] `dopemux decisions review 1 -m "outcome was correct"` → new decision logged
- [ ] `dopemux decisions update-outcome 1 -o "shipped, no issues"` → new decision logged
- [ ] All commands exit 0 when ConPort unreachable (list/show/query warn; review/update-outcome exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)