### PR TITLE
fix(adhd-engine): isolate Redis keys by instance

### DIFF
--- a/claudedocs/beta-mcp-03-adhd-redis-isolation-proof-2026-05-31.md
+++ b/claudedocs/beta-mcp-03-adhd-redis-isolation-proof-2026-05-31.md
@@ -1,0 +1,150 @@
+# BETA-MCP-03 ADHD Redis Isolation Proof
+
+## Status
+
+VERIFIED_TARGETED for local acceptance validation. Commit SHA and PR URL are recorded in the final response after Git/GitHub mutation.
+
+## Task Packet
+
+- ID: `TP-BETA-MCP-03-ADHD-REDIS-ISOLATION`
+- Path: `task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json`
+- Worktree: `/Users/hue/code/dopemux-mvp-wt-beta-mcp-03`
+- Branch: `fix/beta-mcp-03-adhd-engine-redis-isolation`
+- Base commit: `69f17d066945a323f817557fc1d7a1e7d41a5a21`
+
+## Authority Used
+
+- Latest user instruction: `go`, following sequential remaining-work prompt execution.
+- `AGENTS.md`
+- `.claude/claude.md`
+- `.claude/modules/shared/governance-principles.md`
+- `claudedocs/codex-remaining-work-prompt-2026-05-30.md`
+- `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- Runtime/config truth: `compose.yml`, `src/dopemux/mcp/instance_overlay.py`, `services/adhd_engine/**`
+
+## Analysis Performed
+
+Observed:
+
+- `compose.yml` exposes `DOPEMUX_INSTANCE_ID` for some MCP services but had no `ADHD_ENGINE_INSTANCE_ID` or `ADHD_ENGINE_REDIS_PREFIX` for `adhd-engine`.
+- `src/dopemux/mcp/instance_overlay.py` writes `DOPEMUX_INSTANCE_ID` into per-instance env files but does not define an ADHD Redis prefix.
+- ADHD Engine Redis state/cache keys were constructed as shared `adhd:*` keys in:
+  - `services/adhd_engine/adhd_config_service.py`
+  - `services/adhd_engine/api/routes.py`
+  - `services/adhd_engine/core/activity_tracker.py`
+  - `services/adhd_engine/core/engine.py`
+  - `services/adhd_engine/core/feature_flags.py`
+  - `services/adhd_engine/engine.py`
+
+Chosen approach:
+
+- Add a small deterministic helper in `services/adhd_engine/redis_keys.py`.
+- Prefix keys from `ADHD_ENGINE_REDIS_PREFIX`, then `ADHD_ENGINE_INSTANCE_ID`, then `DOPEMUX_INSTANCE_ID`.
+- Preserve historical unprefixed key behavior when none of those env vars is configured outside compose.
+- Expose `ADHD_ENGINE_REDIS_PREFIX` in compose as `${ADHD_ENGINE_REDIS_PREFIX:-${DOPEMUX_INSTANCE_ID:-default}}`.
+
+Rejected alternatives:
+
+- Separate Redis databases: not selected because compose topology and Redis URL behavior would change more broadly.
+- New compose overlay: rejected because `compose.yml` says normal runtime should not add overlay files.
+
+## Change Summary
+
+- Added `services/adhd_engine/redis_keys.py`.
+- Scoped ADHD Engine attention, energy, profile, break, activity, notification, feature-flag, cache, and Pub/Sub state-change keys.
+- Added `ADHD_ENGINE_REDIS_PREFIX` to the `adhd-engine` compose environment.
+- Added focused tests for key prefix fallback, precedence, and config-service state reads.
+- Registered the Task Packet in `task-packets/INDEX.md`.
+
+## Validation Performed
+
+PASS:
+
+```text
+python -m json.tool task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json >/dev/null
+exit: 0
+```
+
+```text
+python -m jsonschema -i task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+exit: 0
+note: jsonschema CLI emitted a deprecation warning only.
+```
+
+```text
+python -m pytest services/adhd_engine/tests/test_redis_keys.py services/adhd_engine/tests/test_adhd_config_service.py -q
+34 passed
+exit: 0
+```
+
+```text
+PYTHONPATH=services python -m pytest services/adhd_engine/tests/test_activity_tracker.py -q
+13 passed
+exit: 0
+```
+
+```text
+python -m compileall services/adhd_engine
+exit: 0
+```
+
+```text
+docker compose -f compose.yml config --quiet
+exit: 0
+note: compose emitted unset environment variable warnings for ANTHROPIC_API_KEY, HOST_CODE_PARENT_DIR, HOST_PROJECT_RELATIVE_PATH, and LEANTIME_TOKEN.
+```
+
+```text
+git diff --check
+exit: 0
+```
+
+FAIL:
+
+```text
+python -m pytest services/adhd_engine/tests/test_feature_flags.py services/adhd_engine/tests/test_api_caching.py services/adhd_engine/tests/test_activity_tracker.py -q
+exit: 2
+reason: test_feature_flags.py collection failed with ModuleNotFoundError: No module named 'adhd_engine.feature_flags'.
+```
+
+```text
+PYTHONPATH=services python -m pytest services/adhd_engine/tests/test_api_caching.py services/adhd_engine/tests/test_activity_tracker.py -q
+exit: 1
+reason: test_api_caching.py returned eight 503 response failures; activity tracker tests passed in the same run.
+```
+
+NOT_RUN:
+
+- `docker compose up` / live service startup: not required for this packet and would mutate local runtime state.
+- Live Redis collision test with two worktrees: not run because it requires live services.
+- Full repository test suite: outside this packet's narrow validation scope.
+
+## Codereview Status
+
+PASS: self-review of the diff found no Redis topology changes, no dependency additions, and no changes outside the packet allowlist.
+
+## Precommit Status
+
+PASS:
+
+```text
+pre-commit run --files compose.yml services/adhd_engine/redis_keys.py services/adhd_engine/adhd_config_service.py services/adhd_engine/api/routes.py services/adhd_engine/core/activity_tracker.py services/adhd_engine/core/engine.py services/adhd_engine/core/feature_flags.py services/adhd_engine/engine.py services/adhd_engine/tests/test_redis_keys.py task-packets/INDEX.md task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json claudedocs/beta-mcp-03-adhd-redis-isolation-proof-2026-05-31.md
+exit: 0
+```
+
+Hooks reported PASS for documentation validators, markdownlint, trailing whitespace, end-of-file checks, and root hygiene.
+
+## Commit / PR
+
+- Commit SHA: recorded in final response after commit creation.
+- PR URL: recorded in final response after PR creation.
+
+## Remaining Uncertainty / Risk
+
+- Runtime isolation is validated by key construction and compose rendering, not by a live two-worktree Redis collision test.
+- Existing `test_api_caching.py` harness failures remain unresolved in this packet.
+- Existing `test_feature_flags.py` import-path failure remains unresolved in this packet.
+
+## Rollback Plan
+
+Revert the single commit for this branch, removing the compose env var, `redis_keys.py`, key helper callsites, focused tests, Task Packet/index entry, and this proof note.

--- a/compose.yml
+++ b/compose.yml
@@ -436,6 +436,8 @@ services:
       - HOST=0.0.0.0
       - ADHD_ENGINE_API_KEY=${ADHD_ENGINE_API_KEY:-dev-key-123}
       - REDIS_URL=redis://redis-primary:6379
+      # Scope ADHD state/cache keys per worktree instance while preserving explicit overrides.
+      - ADHD_ENGINE_REDIS_PREFIX=${ADHD_ENGINE_REDIS_PREFIX:-${DOPEMUX_INSTANCE_ID:-default}}
       - CONPORT_URL=http://conport:3005
       - DOPECON_BRIDGE_URL=http://dopecon-bridge:3016
       - DOPECON_BRIDGE_SOURCE_PLANE=cognitive_plane

--- a/services/adhd_engine/adhd_config_service.py
+++ b/services/adhd_engine/adhd_config_service.py
@@ -30,8 +30,10 @@ from redis.exceptions import RedisError
 
 try:
     from .inmemory_redis import InMemoryRedis
+    from .redis_keys import redis_key
 except ImportError:
     from inmemory_redis import InMemoryRedis
+    from redis_keys import redis_key
 
 logger = logging.getLogger(__name__)
 
@@ -222,7 +224,7 @@ class ADHDConfigService:
                       and maintain sustainable productivity.
         """
         # Check time since last break
-        last_break_key = f"adhd:last_break:{user_id}"
+        last_break_key = redis_key(f"adhd:last_break:{user_id}")
         last_break_str = await self.redis_client.get(last_break_key)
 
         if last_break_str:
@@ -285,8 +287,8 @@ class ADHDConfigService:
             return cached_value
 
         # Query ADHD Engine Redis
-        redis_key = f"adhd:attention_state:{user_id}"
-        state = await self.redis_client.get(redis_key)
+        attention_key = redis_key(f"adhd:attention_state:{user_id}")
+        state = await self.redis_client.get(attention_key)
 
         if not state:
             state = "transitioning"  # Safe default if ADHD Engine hasn't assessed yet
@@ -313,8 +315,8 @@ class ADHDConfigService:
             return cached_value
 
         # Query ADHD Engine Redis
-        redis_key = f"adhd:energy_level:{user_id}"
-        level = await self.redis_client.get(redis_key)
+        energy_key = redis_key(f"adhd:energy_level:{user_id}")
+        level = await self.redis_client.get(energy_key)
 
         if not level:
             level = "medium"  # Safe default
@@ -346,8 +348,8 @@ class ADHDConfigService:
             return cached_value
 
         # Query ADHD Engine Redis
-        redis_key = f"adhd:profile:{user_id}"
-        profile_json = await self.redis_client.get(redis_key)
+        profile_key = redis_key(f"adhd:profile:{user_id}")
+        profile_json = await self.redis_client.get(profile_key)
 
         if not profile_json:
             logger.debug(f"No ADHD profile found for {user_id}, using defaults")

--- a/services/adhd_engine/api/routes.py
+++ b/services/adhd_engine/api/routes.py
@@ -57,6 +57,7 @@ except ImportError:
 
 from . import schemas
 from ..core.models import ADHDProfile, EnergyLevel, AttentionState
+from ..redis_keys import redis_key
 
 # Event emission for implicit triggers (Phase 7)
 try:
@@ -224,7 +225,7 @@ def _make_cache_key(endpoint: str, user_id: str, **params) -> str:
     for k, v in sorted(params.items()):
         if v is not None:
             key_parts.append(f"{k}:{v}")
-    return ":".join(key_parts)
+    return redis_key(":".join(key_parts))
 
 async def _invalidate_user_caches(user_id: str):
     """Invalidate all cached responses for a user (used when profile updates)."""
@@ -608,7 +609,7 @@ async def create_or_update_profile(
 
         # Persist profile snapshot in shared cache for cross-process reuse.
         cache = await get_cache_instance()
-        profile_key = f"adhd:profile:{request.user_id}"
+        profile_key = redis_key(f"adhd:profile:{request.user_id}")
         await cache.set(profile_key, json.dumps(asdict(profile), default=str), ttl=86400)
 
         return schemas.UserProfileResponse(
@@ -650,8 +651,8 @@ async def update_activity(
             "timestamp": datetime.now(timezone.utc).isoformat(),
             "metrics": request.model_dump(exclude_none=True),
         }
-        latest_key = f"adhd:activity:{user_id}:latest"
-        history_key = f"adhd:activity:{user_id}:history"
+        latest_key = redis_key(f"adhd:activity:{user_id}:latest")
+        history_key = redis_key(f"adhd:activity:{user_id}:history")
         await cache.set(latest_key, json.dumps(activity_event), ttl=86400)
         history_raw = await cache.get(history_key, "[]")
         try:

--- a/services/adhd_engine/core/activity_tracker.py
+++ b/services/adhd_engine/core/activity_tracker.py
@@ -18,6 +18,7 @@ from datetime import datetime, timezone
 
 from ..config import settings
 from ..bridge_integration import ConPortBridgeAdapter
+from ..redis_keys import redis_key
 
 logger = logging.getLogger(__name__)
 
@@ -109,11 +110,11 @@ class ActivityTracker:
         context_switches = activity_log.get('context_switches', 0) if activity_log else 0
 
         # Get last break from Redis
-        last_break_str = await self.redis.get(f"adhd:last_break:{user_id}")
+        last_break_str = await self.redis.get(redis_key(f"adhd:last_break:{user_id}"))
         minutes_since_break = self._calculate_minutes_since(last_break_str)
 
         # Calculate break compliance from Redis break history
-        break_history = await self.redis.lrange(f"adhd:breaks:{user_id}", 0, 10)
+        break_history = await self.redis.lrange(redis_key(f"adhd:breaks:{user_id}"), 0, 10)
         break_compliance = self._calculate_break_compliance(break_history)
 
         result = {

--- a/services/adhd_engine/core/engine.py
+++ b/services/adhd_engine/core/engine.py
@@ -37,6 +37,7 @@ from .activity_tracker import ActivityTracker
 from ..conport_mcp_client import ConPortMCPClient  # Relative import
 from ..bridge_integration import ConPortBridgeAdapter  # Relative import
 from ..pal_client import ADHDPALClient  # Relative import
+from ..redis_keys import redis_key, redis_pattern
 
 # Domain Imports - Attention
 from ..domains.attention.attention_calibrator import AttentionCalibrator
@@ -255,7 +256,7 @@ class ADHDAccommodationEngine:
         """Load ADHD profiles from persistent storage."""
         try:
             # Load profiles from Redis
-            profile_keys = await self.redis_client.keys("adhd:profile:*")
+            profile_keys = await self.redis_client.keys(redis_pattern("adhd:profile:*"))
 
             for key in profile_keys:
                 user_id = key.split(":")[-1]
@@ -1071,7 +1072,7 @@ Format: {{
         """Check if user needs break recommendation."""
         try:
             # Get last break time
-            last_break_key = f"adhd:last_break:{user_id}"
+            last_break_key = redis_key(f"adhd:last_break:{user_id}")
             last_break_str = await self.redis_client.get(last_break_key)
 
             if last_break_str:
@@ -1158,13 +1159,13 @@ Format: {{
             }
 
             await self.redis_client.lpush(
-                f"adhd:break_recommendations:{self.workspace_id}",
+                redis_key(f"adhd:break_recommendations:{self.workspace_id}"),
                 json.dumps(break_data)
             )
 
             # Trim to keep recent recommendations
             await self.redis_client.ltrim(
-                f"adhd:break_recommendations:{self.workspace_id}",
+                redis_key(f"adhd:break_recommendations:{self.workspace_id}"),
                 0, 9  # Keep 10 most recent
             )
 
@@ -1214,7 +1215,7 @@ Format: {{
         """Apply hyperfocus protection measures."""
         try:
             # Get hyperfocus session duration
-            session_start_key = f"adhd:hyperfocus_start:{user_id}"
+            session_start_key = redis_key(f"adhd:hyperfocus_start:{user_id}")
             session_start_str = await self.redis_client.get(session_start_key)
 
             if session_start_str:
@@ -1249,7 +1250,7 @@ Format: {{
                 }
 
                 await self.redis_client.lpush(
-                    f"adhd:hyperfocus_warnings:{self.workspace_id}",
+                    redis_key(f"adhd:hyperfocus_warnings:{self.workspace_id}"),
                     json.dumps(warning_data)
                 )
 
@@ -1583,12 +1584,12 @@ Format: {{
         # Store notification in Redis for tracking
         try:
             await self.redis_client.lpush(
-                f"adhd:notifications:{self.workspace_id}",
+                redis_key(f"adhd:notifications:{self.workspace_id}"),
                 json.dumps(notification)
             )
             # Keep only recent notifications
             await self.redis_client.ltrim(
-                f"adhd:notifications:{self.workspace_id}",
+                redis_key(f"adhd:notifications:{self.workspace_id}"),
                 0, 49  # Keep 50 most recent
             )
         except Exception as e:
@@ -1647,7 +1648,7 @@ Format: {{
         """Get current session duration in minutes."""
         try:
             # Check if we have a session start time in Redis
-            session_start_str = await self.redis_client.get(f"adhd:session_start:{user_id}")
+            session_start_str = await self.redis_client.get(redis_key(f"adhd:session_start:{user_id}"))
             if session_start_str:
                 session_start = datetime.fromisoformat(session_start_str)
                 # Ensure session_start is timezone-aware (assume stored times are in UTC if naive)
@@ -1737,7 +1738,7 @@ Format: {{
             # Publish to Redis Pub/Sub for other services (Phase 10.6)
             if self.redis_client:
                 try:
-                    channel = f"adhd:state_changes:{user_id}"
+                    channel = redis_key(f"adhd:state_changes:{user_id}")
                     await self.redis_client.publish(channel, json.dumps(message))
                     logger.debug(f"📢 Published state update to Redis channel: {channel}")
                 except Exception as e:

--- a/services/adhd_engine/core/feature_flags.py
+++ b/services/adhd_engine/core/feature_flags.py
@@ -27,6 +27,8 @@ from typing import Optional, Dict, Any
 
 import redis.asyncio as redis
 
+from ..redis_keys import redis_key, redis_pattern
+
 logger = logging.getLogger(__name__)
 
 
@@ -75,7 +77,7 @@ class ADHDFeatureFlags:
         """
         # Priority 1: Check user override
         if user_id:
-            user_key = f"adhd:feature_flags:{feature}:user:{user_id}"
+            user_key = redis_key(f"adhd:feature_flags:{feature}:user:{user_id}")
             user_flag = await self.redis.get(user_key)
             if user_flag is not None:
                 enabled = user_flag.lower() in ("true", "1", "yes")
@@ -83,7 +85,7 @@ class ADHDFeatureFlags:
                 return enabled
 
         # Priority 2: Check service flag
-        service_key = f"adhd:feature_flags:{feature}:service:{service}"
+        service_key = redis_key(f"adhd:feature_flags:{feature}:service:{service}")
         service_flag = await self.redis.get(service_key)
         if service_flag is not None:
             enabled = service_flag.lower() in ("true", "1", "yes")
@@ -91,7 +93,7 @@ class ADHDFeatureFlags:
             return enabled
 
         # Priority 3: Check global flag
-        global_key = f"adhd:feature_flags:{feature}:global"
+        global_key = redis_key(f"adhd:feature_flags:{feature}:global")
         global_flag = await self.redis.get(global_key)
         if global_flag is not None:
             enabled = global_flag.lower() in ("true", "1", "yes")
@@ -112,13 +114,13 @@ class ADHDFeatureFlags:
             feature: Feature flag name
             service: Service name to enable for
         """
-        key = f"adhd:feature_flags:{feature}:service:{service}"
+        key = redis_key(f"adhd:feature_flags:{feature}:service:{service}")
         await self.redis.set(key, "true")
         logger.info(f"✅ Enabled {feature} for service {service}")
 
     async def disable_for_service(self, feature: str, service: str) -> None:
         """Disable feature for specific service."""
-        key = f"adhd:feature_flags:{feature}:service:{service}"
+        key = redis_key(f"adhd:feature_flags:{feature}:service:{service}")
         await self.redis.delete(key)
         logger.info(f"❌ Disabled {feature} for service {service}")
 
@@ -132,13 +134,13 @@ class ADHDFeatureFlags:
             feature: Feature flag name
             user_id: User ID to enable for
         """
-        key = f"adhd:feature_flags:{feature}:user:{user_id}"
+        key = redis_key(f"adhd:feature_flags:{feature}:user:{user_id}")
         await self.redis.set(key, "true")
         logger.info(f"✅ Enabled {feature} for user {user_id}")
 
     async def disable_for_user(self, feature: str, user_id: str) -> None:
         """Disable feature for specific user."""
-        key = f"adhd:feature_flags:{feature}:user:{user_id}"
+        key = redis_key(f"adhd:feature_flags:{feature}:user:{user_id}")
         await self.redis.delete(key)
         logger.info(f"❌ Disabled {feature} for user {user_id}")
 
@@ -151,7 +153,7 @@ class ADHDFeatureFlags:
         Args:
             feature: Feature flag name
         """
-        key = f"adhd:feature_flags:{feature}:global"
+        key = redis_key(f"adhd:feature_flags:{feature}:global")
         await self.redis.set(key, "true")
         logger.info(f"🌐 Enabled {feature} globally")
 
@@ -161,7 +163,7 @@ class ADHDFeatureFlags:
 
         All services immediately revert to legacy behavior.
         """
-        key = f"adhd:feature_flags:{feature}:global"
+        key = redis_key(f"adhd:feature_flags:{feature}:global")
         await self.redis.delete(key)
         logger.info(f"🚨 Disabled {feature} globally (rollback)")
 
@@ -185,12 +187,12 @@ class ADHDFeatureFlags:
         }
 
         # Check global
-        global_key = f"adhd:feature_flags:{feature}:global"
+        global_key = redis_key(f"adhd:feature_flags:{feature}:global")
         global_flag = await self.redis.get(global_key)
         status["global"] = bool(global_flag and global_flag.lower() in ("true", "1", "yes"))
 
         # Get all service flags
-        pattern = f"adhd:feature_flags:{feature}:service:*"
+        pattern = redis_pattern(f"adhd:feature_flags:{feature}:service:*")
         service_keys = await self.redis.keys(pattern)
         for key in service_keys:
             service_name = key.split(":")[-1]
@@ -198,7 +200,7 @@ class ADHDFeatureFlags:
             status["services"][service_name] = flag_value.lower() in ("true", "1", "yes")
 
         # Get all user flags
-        pattern = f"adhd:feature_flags:{feature}:user:*"
+        pattern = redis_pattern(f"adhd:feature_flags:{feature}:user:*")
         user_keys = await self.redis.keys(pattern)
         for key in user_keys:
             user_id = key.split(":")[-1]

--- a/services/adhd_engine/core/feature_flags.py
+++ b/services/adhd_engine/core/feature_flags.py
@@ -27,7 +27,10 @@ from typing import Optional, Dict, Any
 
 import redis.asyncio as redis
 
-from ..redis_keys import redis_key, redis_pattern
+try:
+    from ..redis_keys import redis_key, redis_pattern
+except ImportError:
+    from redis_keys import redis_key, redis_pattern
 
 logger = logging.getLogger(__name__)
 

--- a/services/adhd_engine/engine.py
+++ b/services/adhd_engine/engine.py
@@ -37,6 +37,7 @@ from .activity_tracker import ActivityTracker
 from .conport_mcp_client import ConPortMCPClient
 from .bridge_integration import ConPortBridgeAdapter
 from .pal_client import ADHDPALClient
+from .redis_keys import redis_key, redis_pattern
 
 # ADHD Detectors (Phase 7: Full I/O Wiring)
 from .hyperfocus_guard import HyperfocusGuard
@@ -243,7 +244,7 @@ class ADHDAccommodationEngine:
         """Load ADHD profiles from persistent storage."""
         try:
             # Load profiles from Redis
-            profile_keys = await self.redis_client.keys("adhd:profile:*")
+            profile_keys = await self.redis_client.keys(redis_pattern("adhd:profile:*"))
 
             for key in profile_keys:
                 user_id = key.split(":")[-1]
@@ -1075,7 +1076,7 @@ Format: {{
         """Check if user needs break recommendation."""
         try:
             # Get last break time
-            last_break_key = f"adhd:last_break:{user_id}"
+            last_break_key = redis_key(f"adhd:last_break:{user_id}")
             last_break_str = await self.redis_client.get(last_break_key)
 
             if last_break_str:
@@ -1162,13 +1163,13 @@ Format: {{
             }
 
             await self.redis_client.lpush(
-                f"adhd:break_recommendations:{self.workspace_id}",
+                redis_key(f"adhd:break_recommendations:{self.workspace_id}"),
                 json.dumps(break_data)
             )
 
             # Trim to keep recent recommendations
             await self.redis_client.ltrim(
-                f"adhd:break_recommendations:{self.workspace_id}",
+                redis_key(f"adhd:break_recommendations:{self.workspace_id}"),
                 0, 9  # Keep 10 most recent
             )
 
@@ -1218,7 +1219,7 @@ Format: {{
         """Apply hyperfocus protection measures."""
         try:
             # Get hyperfocus session duration
-            session_start_key = f"adhd:hyperfocus_start:{user_id}"
+            session_start_key = redis_key(f"adhd:hyperfocus_start:{user_id}")
             session_start_str = await self.redis_client.get(session_start_key)
 
             if session_start_str:
@@ -1253,7 +1254,7 @@ Format: {{
                 }
 
                 await self.redis_client.lpush(
-                    f"adhd:hyperfocus_warnings:{self.workspace_id}",
+                    redis_key(f"adhd:hyperfocus_warnings:{self.workspace_id}"),
                     json.dumps(warning_data)
                 )
 
@@ -1597,12 +1598,12 @@ Format: {{
         # Store notification in Redis for tracking
         try:
             await self.redis_client.lpush(
-                f"adhd:notifications:{self.workspace_id}",
+                redis_key(f"adhd:notifications:{self.workspace_id}"),
                 json.dumps(notification)
             )
             # Keep only recent notifications
             await self.redis_client.ltrim(
-                f"adhd:notifications:{self.workspace_id}",
+                redis_key(f"adhd:notifications:{self.workspace_id}"),
                 0, 49  # Keep 50 most recent
             )
         except Exception as e:
@@ -1647,7 +1648,7 @@ Format: {{
         """Get current session duration in minutes."""
         try:
             # Check if we have a session start time in Redis
-            session_start_str = await self.redis_client.get(f"adhd:session_start:{user_id}")
+            session_start_str = await self.redis_client.get(redis_key(f"adhd:session_start:{user_id}"))
             if session_start_str:
                 session_start = datetime.fromisoformat(session_start_str)
                 delta = datetime.now(timezone.utc) - session_start

--- a/services/adhd_engine/redis_keys.py
+++ b/services/adhd_engine/redis_keys.py
@@ -1,0 +1,27 @@
+"""Redis key namespacing helpers for ADHD Engine state."""
+from __future__ import annotations
+
+import os
+
+
+def redis_key_prefix() -> str:
+    """Return the configured ADHD Engine Redis namespace prefix, if any."""
+    raw_prefix = (
+        os.getenv("ADHD_ENGINE_REDIS_PREFIX")
+        or os.getenv("ADHD_ENGINE_INSTANCE_ID")
+        or os.getenv("DOPEMUX_INSTANCE_ID")
+        or ""
+    )
+    return raw_prefix.strip().strip(":")
+
+
+def redis_key(key: str) -> str:
+    """Prefix a concrete Redis key when an ADHD Engine instance id is configured."""
+    prefix = redis_key_prefix()
+    normalized_key = key.strip(":")
+    return f"{prefix}:{normalized_key}" if prefix else normalized_key
+
+
+def redis_pattern(pattern: str) -> str:
+    """Prefix a Redis key pattern using the same namespace as concrete keys."""
+    return redis_key(pattern)

--- a/services/adhd_engine/tests/test_redis_keys.py
+++ b/services/adhd_engine/tests/test_redis_keys.py
@@ -1,0 +1,48 @@
+"""Tests for ADHD Engine Redis key instance namespacing."""
+
+import json
+
+import pytest
+
+from ..adhd_config_service import ADHDConfigService
+from ..redis_keys import redis_key, redis_key_prefix, redis_pattern
+
+
+def test_redis_key_preserves_legacy_key_without_prefix(monkeypatch):
+    monkeypatch.delenv("ADHD_ENGINE_REDIS_PREFIX", raising=False)
+    monkeypatch.delenv("ADHD_ENGINE_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("DOPEMUX_INSTANCE_ID", raising=False)
+
+    assert redis_key_prefix() == ""
+    assert redis_key("adhd:energy_level:user1") == "adhd:energy_level:user1"
+    assert redis_pattern("adhd:profile:*") == "adhd:profile:*"
+
+
+def test_redis_key_uses_explicit_prefix_before_instance_ids(monkeypatch):
+    monkeypatch.setenv("ADHD_ENGINE_REDIS_PREFIX", "explicit")
+    monkeypatch.setenv("ADHD_ENGINE_INSTANCE_ID", "adhd-instance")
+    monkeypatch.setenv("DOPEMUX_INSTANCE_ID", "dopemux-instance")
+
+    assert redis_key_prefix() == "explicit"
+    assert redis_key("adhd:attention_state:user1") == "explicit:adhd:attention_state:user1"
+    assert redis_pattern("adhd:profile:*") == "explicit:adhd:profile:*"
+
+
+@pytest.mark.asyncio
+async def test_config_service_reads_prefixed_attention_energy_and_profile(monkeypatch, redis_client):
+    monkeypatch.setenv("ADHD_ENGINE_REDIS_PREFIX", "worktree-a")
+    service = ADHDConfigService(redis_url="redis://localhost:6379/5", workspace_id="/tmp/worktree-a")
+    service.redis_client = redis_client
+
+    await redis_client.set("adhd:attention_state:user1", "overwhelmed")
+    await redis_client.set("worktree-a:adhd:attention_state:user1", "focused")
+    await redis_client.set("worktree-a:adhd:energy_level:user1", "high")
+    await redis_client.set(
+        "worktree-a:adhd:profile:user1",
+        json.dumps({"optimal_task_duration": 25, "max_task_duration": 90}),
+    )
+
+    assert await service.get_max_results("user1") == 15
+    assert await service.get_complexity_threshold("user1") == 0.9
+    summary = await service.get_current_state_summary("user1")
+    assert summary["profile"]["max_task_duration"] == 90

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -76,6 +76,7 @@ A packet is superseded by another packet
 | TP-DMX-AGENTS-CODEX-ENDTOEND-0001 | Agent Guidance | Make Codex execute TP lifecycle end-to-end by default | Ready | N/A |
 | TP-DMX-ORCH-DOCS-003 | Task Orchestrator | Document read-only/operator-status integration authority boundaries | Active | N/A |
 | TP-DMX-COMPOSE-RESTORE-001 | Infra | Restore canonical Docker Compose authority | Ready | N/A |
+| TP-BETA-MCP-03-ADHD-REDIS-ISOLATION | ADHD Engine | Isolate ADHD Engine Redis keys by instance | Active | N/A |
 | DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Merged (PR #528) | N/A |
 | TP-DMX-COCKPIT-MERGE-STACK-CONSOLIDATE-001 | UI Cockpit | Audit and prepare Cockpit PR stack 568-571 plus PR 573 evidence for safe consolidation | Active | N/A |
 | TP-DMX-COCKPIT-RUNTIME-RENDER-001 | UI Cockpit | Wire runtime renderer primitives to accepted Cockpit IA package contract | Active | N/A |

--- a/task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json
+++ b/task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json
@@ -1,0 +1,147 @@
+{
+  "id": "TP-BETA-MCP-03-ADHD-REDIS-ISOLATION",
+  "project": "dopemux-mvp",
+  "target": "Isolate ADHD Engine Redis state by instance so parallel worktrees do not collide on user-scoped attention, energy, break, profile, cache, and notification keys.",
+  "invariants": [
+    "Do not change Redis server topology, ports, volumes, or compose service names.",
+    "Do not introduce new dependencies.",
+    "Preserve unprefixed Redis keys when no ADHD Engine Redis prefix or instance id is configured outside compose.",
+    "Expose compose runtime isolation through DOPEMUX_INSTANCE_ID-derived ADHD_ENGINE_REDIS_PREFIX.",
+    "Keep Redis key serialization deterministic and explicit."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "BETA-MCP",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "fix/beta-mcp-03-adhd-engine-redis-isolation",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(adhd-engine): BETA-MCP-03 isolate Redis keys by instance",
+    "allowlist": [
+      "compose.yml",
+      "services/adhd_engine/redis_keys.py",
+      "services/adhd_engine/adhd_config_service.py",
+      "services/adhd_engine/api/routes.py",
+      "services/adhd_engine/core/activity_tracker.py",
+      "services/adhd_engine/core/engine.py",
+      "services/adhd_engine/core/feature_flags.py",
+      "services/adhd_engine/engine.py",
+      "services/adhd_engine/tests/test_redis_keys.py",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json",
+      "claudedocs/beta-mcp-03-adhd-redis-isolation-proof-2026-05-31.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest services/adhd_engine/tests/test_redis_keys.py services/adhd_engine/tests/test_adhd_config_service.py -q",
+      "python -m compileall services/adhd_engine",
+      "docker compose -f compose.yml config --quiet",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(adhd-engine): isolate Redis keys by instance",
+    "body": "## Summary\n- Adds deterministic ADHD Engine Redis key prefixing from ADHD_ENGINE_REDIS_PREFIX, ADHD_ENGINE_INSTANCE_ID, or DOPEMUX_INSTANCE_ID.\n- Exposes ADHD_ENGINE_REDIS_PREFIX in compose via DOPEMUX_INSTANCE_ID.\n- Applies the prefix to ADHD state/cache/profile/break/notification keys while preserving unprefixed behavior when no prefix is configured outside compose.\n\n## Test Plan\n- python -m json.tool task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json >/dev/null\n- python -m jsonschema -i task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest services/adhd_engine/tests/test_redis_keys.py services/adhd_engine/tests/test_adhd_config_service.py -q\n- python -m compileall services/adhd_engine\n- docker compose -f compose.yml config --quiet\n- git diff --check\n\n## NOT_RUN\n- docker compose up / live service startup: not required by packet and may mutate local runtime state.\n\n@codex review\n@gemini\n@copilot",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight repo identity, branch, marker, worktree isolation, dirty state, and required authority files.",
+      "context_files": [
+        "AGENTS.md",
+        ".claude/claude.md",
+        ".claude/modules/shared/governance-principles.md",
+        "claudedocs/codex-remaining-work-prompt-2026-05-30.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ],
+      "validation": [
+        "Repo root is /Users/hue/code/dopemux-mvp-wt-beta-mcp-03.",
+        "Branch is fix/beta-mcp-03-adhd-engine-redis-isolation.",
+        "Remote identifies DDD-Enterprises/dopemux-mvp.",
+        ".dopetaskroot exists."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Trace ADHD Engine Redis key construction and existing instance-overlay behavior.",
+      "context_files": [
+        "compose.yml",
+        "src/dopemux/mcp/instance_overlay.py",
+        "services/adhd_engine/adhd_config_service.py",
+        "services/adhd_engine/api/routes.py",
+        "services/adhd_engine/core/activity_tracker.py",
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/core/feature_flags.py",
+        "services/adhd_engine/engine.py"
+      ],
+      "validation": [
+        "Current compose environment is checked for ADHD_ENGINE_INSTANCE_ID and ADHD_ENGINE_REDIS_PREFIX.",
+        "Redis keys for attention, energy, breaks, profiles, activity, feature flags, and notifications are identified.",
+        "Existing instance overlay DOPEMUX_INSTANCE_ID behavior is recorded."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Add deterministic Redis key prefixing and expose it in compose.",
+      "expected_files": [
+        "compose.yml",
+        "services/adhd_engine/redis_keys.py",
+        "services/adhd_engine/adhd_config_service.py",
+        "services/adhd_engine/api/routes.py",
+        "services/adhd_engine/core/activity_tracker.py",
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/core/feature_flags.py",
+        "services/adhd_engine/engine.py"
+      ],
+      "validation": [
+        "compose.yml sets ADHD_ENGINE_REDIS_PREFIX from ADHD_ENGINE_REDIS_PREFIX or DOPEMUX_INSTANCE_ID.",
+        "No configured prefix preserves historical unprefixed key behavior.",
+        "Configured prefix scopes ADHD Engine Redis keys deterministically."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Add focused tests and run targeted validation plus precommit.",
+      "expected_files": [
+        "services/adhd_engine/tests/test_redis_keys.py",
+        "claudedocs/beta-mcp-03-adhd-redis-isolation-proof-2026-05-31.md"
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest services/adhd_engine/tests/test_redis_keys.py services/adhd_engine/tests/test_adhd_config_service.py -q",
+        "python -m compileall services/adhd_engine",
+        "docker compose -f compose.yml config --quiet",
+        "git diff --check"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds deterministic ADHD Engine Redis key prefixing from `ADHD_ENGINE_REDIS_PREFIX`, `ADHD_ENGINE_INSTANCE_ID`, or `DOPEMUX_INSTANCE_ID`.
- Exposes `ADHD_ENGINE_REDIS_PREFIX` in compose using the worktree instance id with explicit override support.
- Applies namespacing to ADHD state/cache/profile/break/activity/notification/feature-flag keys while preserving legacy unprefixed behavior when no prefix is configured outside compose.
- Adds focused tests for key fallback, precedence, and config-service prefixed reads.

## Test Plan
- `python -m json.tool task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json >/dev/null`
- `python -m jsonschema -i task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `python -m pytest services/adhd_engine/tests/test_redis_keys.py services/adhd_engine/tests/test_adhd_config_service.py -q`
- `PYTHONPATH=services python -m pytest services/adhd_engine/tests/test_activity_tracker.py -q`
- `python -m compileall services/adhd_engine`
- `docker compose -f compose.yml config --quiet`
- `git diff --check`
- `pre-commit run --files compose.yml services/adhd_engine/redis_keys.py services/adhd_engine/adhd_config_service.py services/adhd_engine/api/routes.py services/adhd_engine/core/activity_tracker.py services/adhd_engine/core/engine.py services/adhd_engine/core/feature_flags.py services/adhd_engine/engine.py services/adhd_engine/tests/test_redis_keys.py task-packets/INDEX.md task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json claudedocs/beta-mcp-03-adhd-redis-isolation-proof-2026-05-31.md`

## Known Failed Exploratory Checks
- `python -m pytest services/adhd_engine/tests/test_feature_flags.py services/adhd_engine/tests/test_api_caching.py services/adhd_engine/tests/test_activity_tracker.py -q` fails at collection because `adhd_engine.feature_flags` is not importable in the current package layout.
- `PYTHONPATH=services python -m pytest services/adhd_engine/tests/test_api_caching.py services/adhd_engine/tests/test_activity_tracker.py -q` returns eight 503 failures from `test_api_caching.py`; activity tracker tests pass.

## NOT_RUN
- `docker compose up` / live service startup: not required for this packet and may mutate local runtime state.
- Live two-worktree Redis collision test: requires live services.

## Proof
- Task Packet: `task-packets/generated/TP-BETA-MCP-03-ADHD-REDIS-ISOLATION.json`
- Proof note: `claudedocs/beta-mcp-03-adhd-redis-isolation-proof-2026-05-31.md`

@codex review
@gemini
@copilot