### PR TITLE
fix(security): externalize LiteLLM key and restrict compose ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,9 @@ QDRANT_API_KEY=your_qdrant_api_key_here
 # API Keys
 ADHD_ENGINE_API_KEY=your_secure_adhd_engine_key_here
 TASK_ORCHESTRATOR_API_KEY=your_secure_task_orchestrator_key_here
+# REQUIRED: generate with: openssl rand -hex 32
+# Used by LiteLLM and its compose healthcheck; never commit a real value.
+LITELLM_MASTER_KEY=CHANGE_ME_generate_with_openssl_rand_hex_32_placeholder
 OPENAI_API_KEY=your_openai_api_key_here
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
 OPENROUTER_API_KEY=

--- a/claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md
+++ b/claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md
@@ -1,0 +1,96 @@
+# Security Compose LiteLLM + Localhost Proof - 2026-05-31
+
+## Scope
+
+- Task Packet: `TP-SEC-COMPOSE-LITELLM-LOCALHOST-001`
+- Worktree: `/Users/hue/code/dopemux-mvp-wt-security-compose`
+- Branch: `fix/security-litellm-key-compose`
+- Base commit: `69f17d066945a323f817557fc1d7a1e7d41a5a21`
+- Repo remote: `https://github.com/DDD-Enterprises/dopemux-mvp.git`
+
+## Authority Used
+
+- Latest user prompt: implement remaining beta work sequentially; combine items 3 and 4 if cleaner.
+- `AGENTS.md`: Task Packet, proof bundle, worktree, validation, and truthful finality requirements.
+- `.claude/claude.md` and `.claude/modules/shared/governance-principles.md`: inspect-first and validation bucket doctrine.
+- Runtime/config evidence: `compose.yml`, `.env.example`, `install.sh`, service entrypoints under `services/` and `docker/`.
+
+## Observed Evidence
+
+- `grep -n "LITELLM_MASTER_KEY\|Authorization.*Bearer" compose.yml` on the base showed a redacted hardcoded bearer placeholder in the LiteLLM healthcheck, not an unredacted secret value.
+- `grep -n "0\.0\.0\.0" compose.yml` showed `MCP_SERVER_HOST`, `HOST`, and `WEBHOOK_RECEIVER_HOST` values using `0.0.0.0`.
+- Runtime inspection showed Docker-published container services generally must listen on the container interface. Changing those container-internal binds to `127.0.0.1` risks making host-published ports unreachable.
+
+## Changes
+
+- `compose.yml`
+  - Added `LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}` to the LiteLLM environment.
+  - Replaced the hardcoded LiteLLM healthcheck bearer with `Authorization: Bearer $${LITELLM_MASTER_KEY}`.
+  - Restricted `adhd-engine`, `leantime-bridge`, and `webhook-receiver` host port publication to `127.0.0.1`.
+  - Documented retained container-internal `0.0.0.0` binds as intentional Docker reachability requirements.
+- `.env.example`
+  - Added `LITELLM_MASTER_KEY` with a non-real placeholder and generation comment.
+- `install.sh`
+  - Added `LITELLM_MASTER_KEY` to full-stack env collection.
+  - Marked it sensitive and local-defaultable.
+  - Generates a 32-byte hex secret via Python `secrets.token_hex(32)` when using the installer default.
+- `task-packets/INDEX.md`
+  - Added the active Task Packet entry.
+- `task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json`
+  - Added the scoped Task Packet for this slice.
+
+## Validation
+
+### PASS
+
+- `python -m json.tool task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json >/dev/null`
+- `python -m jsonschema -i task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `grep -n "LITELLM_MASTER_KEY\|Authorization.*Bearer" compose.yml .env.example install.sh`
+- `grep -n "0\.0\.0\.0" compose.yml`
+- PyYAML compose security assertions:
+  - LiteLLM healthcheck uses `$${LITELLM_MASTER_KEY}`.
+  - `dope-context`, `adhd-engine`, `leantime-bridge`, and `webhook-receiver` published ports start with `127.0.0.1:`.
+- `bash -n install.sh`
+- `docker compose -f compose.yml config --quiet`
+- `git diff --check`
+- PAL codereview (`mcp__pal.codereview`, model `gpt-5-codex`, internal validation): no issues reported.
+- `pre-commit run --files .env.example compose.yml install.sh task-packets/INDEX.md task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md`
+
+### NOT_RUN
+
+- `docker compose up` / live service boot: not required by prompt, and live Docker runtime validation was out of scope for this commit-sized security slice.
+- End-to-end webhook delivery: not required and would require external provider/webhook setup.
+
+## Prompt Conflict / Challenge Result
+
+The audit prompt said the actual LiteLLM key was present in `compose.yml`; current repo truth on the verified base showed a redacted placeholder. The fix still removes the hardcoded bearer value from source and routes it through `LITELLM_MASTER_KEY`.
+
+The audit prompt also described env-var `0.0.0.0` binds as the exposure. Runtime inspection showed those binds are container-internal for Docker-published services. This slice therefore restricts host-facing publication to `127.0.0.1` and documents retained container-internal binds instead of changing them to a value that could break Docker reachability.
+
+## Precommit Status
+
+- PASS: `git diff --check`
+- PASS: PAL codereview (`gpt-5-codex`, internal validation)
+- PASS: `pre-commit run --files ...`
+
+## Commit / PR
+
+- Commit SHA: pending
+- PR URL: pending
+
+## Residual Risk / Unknowns
+
+- Docker runtime startup was not exercised, so actual service boot behavior remains `NOT_RUN`.
+- The remaining weak defaults in `.env.example` are intentionally left for the separate security weak-defaults item.
+- Existing public host publications outside the four audited lines were not remediated in this slice.
+
+## Rollback
+
+Revert this branch commit or restore the touched files from `origin/main`:
+
+- `.env.example`
+- `compose.yml`
+- `install.sh`
+- `task-packets/INDEX.md`
+- `task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json`
+- `claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md`

--- a/compose.yml
+++ b/compose.yml
@@ -304,12 +304,13 @@ services:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - DATABASE_URL=${LITELLM_DATABASE_URL:-postgresql://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/litellm}
+      - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}
     ports:
       - "${LITELLM_PORT:-4000}:4000"
     depends_on:
       - postgres
     healthcheck:
-      test: [ "CMD-SHELL", "curl -f -H 'Authorization: Bearer <REDACTED_LITELLM_MASTER_KEY>' http://localhost:4000/health || exit 1" ]
+      test: [ "CMD-SHELL", "curl -f -H \"Authorization: Bearer $${LITELLM_MASTER_KEY}\" http://localhost:4000/health || exit 1" ]
       timeout: 10s
       retries: 3
       interval: 30s
@@ -326,6 +327,7 @@ services:
 
     environment:
       - MCP_SERVER_PORT=${DOPE_CONTEXT_PORT:-3010}
+      # Docker-published services must listen on the container interface; host publication is loopback-only below.
       - MCP_SERVER_HOST=0.0.0.0
       - VOYAGE_API_KEY=${VOYAGE_API_KEY}
       - VOYAGEAI_API_KEY=${VOYAGE_API_KEY}
@@ -433,6 +435,7 @@ services:
 
     environment:
       - API_PORT=8095
+      # Dockerfile starts uvicorn on 0.0.0.0; host publication is restricted to loopback below.
       - HOST=0.0.0.0
       - ADHD_ENGINE_API_KEY=${ADHD_ENGINE_API_KEY:-dev-key-123}
       - REDIS_URL=redis://redis-primary:6379
@@ -441,7 +444,7 @@ services:
       - DOPECON_BRIDGE_SOURCE_PLANE=cognitive_plane
       - ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8097,http://adhd-dashboard:8097
     ports:
-      - "${ADHD_ENGINE_PORT:-3025}:8095"
+      - "127.0.0.1:${ADHD_ENGINE_PORT:-3025}:8095"
     depends_on:
       - redis-primary
     healthcheck:
@@ -589,8 +592,9 @@ services:
     networks:
       - dopemux-network
     ports:
-      - "${LEANTIME_BRIDGE_PORT:-3015}:3015"
+      - "127.0.0.1:${LEANTIME_BRIDGE_PORT:-3015}:3015"
     environment:
+      # Container-internal bind required for Docker port publication; host port is loopback-only.
       - MCP_SERVER_HOST=0.0.0.0
       - MCP_SERVER_PORT=${LEANTIME_BRIDGE_PORT:-3015}
       - LEANTIME_API_URL=${LEANTIME_API_URL:-${LEANTIME_URL:-http://leantime:80}}
@@ -615,8 +619,9 @@ services:
     networks:
       - dopemux-network
     ports:
-      - "${WEBHOOK_RECEIVER_HOST_PORT:-8790}:8790"
+      - "127.0.0.1:${WEBHOOK_RECEIVER_HOST_PORT:-8790}:8790"
     environment:
+      # Container-internal bind required for Docker port publication; host port is loopback-only.
       - WEBHOOK_RECEIVER_HOST=0.0.0.0
       - WEBHOOK_RECEIVER_PORT=8790
       # Default to SQLite at WEBHOOK_DB_PATH; set WEBHOOK_DB_URL to use PostgreSQL instead.

--- a/install.sh
+++ b/install.sh
@@ -238,7 +238,7 @@ env_prompt() {
         LEANTIME_TOKEN) echo "Leantime API token" ;;
         TASK_ORCHESTRATOR_API_KEY) echo "Task Orchestrator API key" ;;
         ADHD_ENGINE_API_KEY) echo "ADHD Engine API key" ;;
-        LITELLM_MASTER_KEY) echo "LiteLLM master key (generate with: openssl rand -hex 32)" ;;
+        LITELLM_MASTER_KEY) echo "LiteLLM master key (generate with: printf 'sk-%s\\n' \"$(openssl rand -hex 32)\")" ;;
         LITELLM_DATABASE_URL) echo "LiteLLM database URL (PostgreSQL DSN)" ;;
         OPENAI_WEBHOOK_SECRET) echo "OpenAI webhook secret (optional receiver verification)" ;;
         *) echo "$1" ;;
@@ -251,7 +251,7 @@ env_default() {
         LEANTIME_URL) echo "http://localhost:8097" ;;
         TASK_ORCHESTRATOR_API_KEY) echo "dev-key-456" ;;
         ADHD_ENGINE_API_KEY) echo "dev-key-123" ;;
-        LITELLM_MASTER_KEY) python3 -c 'import secrets; print(secrets.token_hex(32))' ;;
+        LITELLM_MASTER_KEY) python3 -c 'import secrets; print("sk-" + secrets.token_hex(32))' ;;
         LITELLM_DATABASE_URL) echo "postgresql://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/litellm" ;;
         *) echo "" ;;
     esac

--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,7 @@ FULL_STACK_ENV_VARS=(
     LEANTIME_TOKEN
     TASK_ORCHESTRATOR_API_KEY
     ADHD_ENGINE_API_KEY
+    LITELLM_MASTER_KEY
     LITELLM_DATABASE_URL
     TAVILY_API_KEY
     EXA_API_KEY
@@ -237,6 +238,7 @@ env_prompt() {
         LEANTIME_TOKEN) echo "Leantime API token" ;;
         TASK_ORCHESTRATOR_API_KEY) echo "Task Orchestrator API key" ;;
         ADHD_ENGINE_API_KEY) echo "ADHD Engine API key" ;;
+        LITELLM_MASTER_KEY) echo "LiteLLM master key (generate with: openssl rand -hex 32)" ;;
         LITELLM_DATABASE_URL) echo "LiteLLM database URL (PostgreSQL DSN)" ;;
         OPENAI_WEBHOOK_SECRET) echo "OpenAI webhook secret (optional receiver verification)" ;;
         *) echo "$1" ;;
@@ -249,6 +251,7 @@ env_default() {
         LEANTIME_URL) echo "http://localhost:8097" ;;
         TASK_ORCHESTRATOR_API_KEY) echo "dev-key-456" ;;
         ADHD_ENGINE_API_KEY) echo "dev-key-123" ;;
+        LITELLM_MASTER_KEY) python3 -c 'import secrets; print(secrets.token_hex(32))' ;;
         LITELLM_DATABASE_URL) echo "postgresql://dopemux_age:dopemux_age_dev_password@dopemux-postgres-age:5432/litellm" ;;
         *) echo "" ;;
     esac
@@ -256,7 +259,7 @@ env_default() {
 
 env_is_sensitive() {
     case "$1" in
-        AGE_PASSWORD|ANTHROPIC_API_KEY|OPENAI_API_KEY|OPENROUTER_API_KEY|GEMINI_API_KEY|XAI_API_KEY|VOYAGE_API_KEY|TAVILY_API_KEY|EXA_API_KEY|LEANTIME_TOKEN|TASK_ORCHESTRATOR_API_KEY|ADHD_ENGINE_API_KEY|LITELLM_DATABASE_URL|OPENAI_WEBHOOK_SECRET)
+        AGE_PASSWORD|ANTHROPIC_API_KEY|OPENAI_API_KEY|OPENROUTER_API_KEY|GEMINI_API_KEY|XAI_API_KEY|VOYAGE_API_KEY|TAVILY_API_KEY|EXA_API_KEY|LEANTIME_TOKEN|TASK_ORCHESTRATOR_API_KEY|ADHD_ENGINE_API_KEY|LITELLM_MASTER_KEY|LITELLM_DATABASE_URL|OPENAI_WEBHOOK_SECRET)
             return 0
             ;;
         *)
@@ -275,7 +278,7 @@ env_is_sensitive() {
 #   mode when a provider-optional value is missing.
 env_policy() {
     case "$1" in
-        AGE_PASSWORD|LEANTIME_URL|TASK_ORCHESTRATOR_API_KEY|ADHD_ENGINE_API_KEY|LITELLM_DATABASE_URL)
+        AGE_PASSWORD|LEANTIME_URL|TASK_ORCHESTRATOR_API_KEY|ADHD_ENGINE_API_KEY|LITELLM_MASTER_KEY|LITELLM_DATABASE_URL)
             echo "local-defaultable"
             ;;
         ANTHROPIC_API_KEY|OPENAI_API_KEY|OPENROUTER_API_KEY|GEMINI_API_KEY|XAI_API_KEY|VOYAGE_API_KEY|TAVILY_API_KEY|EXA_API_KEY|LEANTIME_TOKEN|OPENAI_WEBHOOK_SECRET)
@@ -302,6 +305,7 @@ capability_label() {
         LEANTIME_TOKEN) echo "Leantime sync" ;;
         TASK_ORCHESTRATOR_API_KEY) echo "Task Orchestrator auth" ;;
         ADHD_ENGINE_API_KEY) echo "ADHD Engine auth" ;;
+        LITELLM_MASTER_KEY) echo "LiteLLM master key" ;;
         LITELLM_DATABASE_URL) echo "LiteLLM database URL" ;;
         OPENAI_WEBHOOK_SECRET) echo "OpenAI webhook verification" ;;
         *) echo "$1" ;;

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -76,6 +76,7 @@ A packet is superseded by another packet
 | TP-DMX-AGENTS-CODEX-ENDTOEND-0001 | Agent Guidance | Make Codex execute TP lifecycle end-to-end by default | Ready | N/A |
 | TP-DMX-ORCH-DOCS-003 | Task Orchestrator | Document read-only/operator-status integration authority boundaries | Active | N/A |
 | TP-DMX-COMPOSE-RESTORE-001 | Infra | Restore canonical Docker Compose authority | Ready | N/A |
+| TP-SEC-COMPOSE-LITELLM-LOCALHOST-001 | Security | Externalize LiteLLM healthcheck key and localize compose service ports | Active | N/A |
 | DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Merged (PR #528) | N/A |
 | TP-DMX-COCKPIT-MERGE-STACK-CONSOLIDATE-001 | UI Cockpit | Audit and prepare Cockpit PR stack 568-571 plus PR 573 evidence for safe consolidation | Active | N/A |
 | TP-DMX-COCKPIT-RUNTIME-RENDER-001 | UI Cockpit | Wire runtime renderer primitives to accepted Cockpit IA package contract | Active | N/A |

--- a/task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json
+++ b/task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json
@@ -1,0 +1,127 @@
+{
+  "id": "TP-SEC-COMPOSE-LITELLM-LOCALHOST-001",
+  "project": "dopemux-mvp",
+  "target": "compose LiteLLM secret handling and localhost-only host publication for internal services",
+  "invariants": [
+    "Do not repeat or expose committed secret values in proofs or output.",
+    "Preserve Docker container reachability; internal container binds may remain 0.0.0.0 only when required for Docker port publication.",
+    "Restrict externally published internal service ports to 127.0.0.1 unless runtime evidence proves public access is intentional.",
+    "Report observed prompt/runtime conflicts as UNKNOWN or documented exceptions rather than silently forcing the prompt."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "beta-remaining-security-compose",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "fix/security-litellm-key-compose",
+    "base_branch": "main",
+    "stacked_because": "Items 3 and 4 both touch compose.yml and are safer as one compose security PR."
+  },
+  "commit": {
+    "message": "fix(security): SEC - externalize LiteLLM healthcheck key and localize service ports",
+    "allowlist": [
+      ".env.example",
+      "compose.yml",
+      "install.sh",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json",
+      "claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python - <<'PY'\\nimport yaml\\nfrom pathlib import Path\\ncompose = yaml.safe_load(Path('compose.yml').read_text())\\nservices = compose['services']\\nassert '${LITELLM_MASTER_KEY}' in str(services['litellm']['healthcheck']['test'])\\nfor service in ['adhd-engine', 'leantime-bridge', 'webhook-receiver']:\\n    ports = services[service]['ports']\\n    assert all(str(port).startswith('127.0.0.1:') for port in ports), (service, ports)\\nPY",
+      "bash -n install.sh",
+      "docker compose -f compose.yml config --quiet",
+      "git diff --check",
+      "pre-commit run --files .env.example compose.yml install.sh task-packets/INDEX.md task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md"
+    ]
+  },
+  "pr": {
+    "title": "fix(security): externalize LiteLLM key and restrict compose ports",
+    "body": "## Problem\\n- LiteLLM healthcheck carried a hardcoded bearer value in compose.yml instead of an environment reference.\\n- Several internal compose services published host ports on all interfaces, while Docker runtime evidence shows container-internal 0.0.0.0 binds may be required for published ports to remain reachable.\\n\\n## Fix\\n- Move the LiteLLM healthcheck bearer to LITELLM_MASTER_KEY.\\n- Add LITELLM_MASTER_KEY to .env.example and installer full-stack env handling.\\n- Restrict internal service host port publication to 127.0.0.1 and document intentional container-internal binds where needed.\\n\\n## Test Plan\\n- Validate Task Packet JSON and schema.\\n- Parse and assert compose security invariants with PyYAML.\\n- Run bash -n install.sh.\\n- Run docker compose config.\\n- Run git diff --check and pre-commit on changed files.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect compose, service entrypoints, installer env handling, and authority docs before editing.",
+      "requirements": [
+        "Differentiate current repo truth from the audit prompt when the redacted LiteLLM placeholder differs from the claimed committed secret.",
+        "Identify whether changing container bind hosts would break Docker reachability."
+      ],
+      "validation": [
+        "grep -n \"LITELLM_MASTER_KEY\\|Authorization.*Bearer\" compose.yml",
+        "grep -n \"0\\\\.0\\\\.0\\\\.0\" compose.yml",
+        "rg -n \"MCP_SERVER_HOST|WEBHOOK_RECEIVER_HOST|HOST|uvicorn\" services docker src"
+      ],
+      "context_files": [
+        "AGENTS.md",
+        ".claude/claude.md",
+        ".claude/modules/shared/governance-principles.md",
+        "compose.yml",
+        "install.sh",
+        ".env.example"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Externalize the LiteLLM healthcheck bearer and restrict host-published internal service ports to localhost.",
+      "requirements": [
+        "Use LITELLM_MASTER_KEY in compose healthcheck instead of a hardcoded bearer value.",
+        "Add LITELLM_MASTER_KEY to .env.example and installer full-stack env handling.",
+        "Restrict adhd-engine, leantime-bridge, and webhook-receiver host port publication to 127.0.0.1.",
+        "Document any retained container-internal 0.0.0.0 binds as Docker reachability requirements."
+      ],
+      "expected_files": [
+        ".env.example",
+        "compose.yml",
+        "install.sh",
+        "claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md"
+      ],
+      "validation": [
+        "python - <<'PY'\\nimport yaml\\nfrom pathlib import Path\\ncompose = yaml.safe_load(Path('compose.yml').read_text())\\nservices = compose['services']\\nassert '${LITELLM_MASTER_KEY}' in str(services['litellm']['healthcheck']['test'])\\nfor service in ['adhd-engine', 'leantime-bridge', 'webhook-receiver']:\\n    ports = services[service]['ports']\\n    assert all(str(port).startswith('127.0.0.1:') for port in ports), (service, ports)\\nPY",
+        "bash -n install.sh",
+        "docker compose -f compose.yml config --quiet"
+      ]
+    },
+    {
+      "id": "precommit",
+      "task": "Run diff, focused validation, pre-commit, commit, push, and open the PR with proof.",
+      "requirements": [
+        "Inspect git diff before staging.",
+        "Do not claim Docker runtime start was exercised unless it was actually run."
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "git diff --check",
+        "pre-commit run --files .env.example compose.yml install.sh task-packets/INDEX.md task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Problem
- LiteLLM healthcheck carried a hardcoded bearer value in `compose.yml` instead of an environment reference.
- Several internal compose services published host ports on all interfaces.
- Runtime inspection showed changing container-internal binds from `0.0.0.0` to `127.0.0.1` could break Docker-published port reachability, so this PR restricts host publication instead and documents retained internal binds.

## Fix
- Move the LiteLLM healthcheck bearer to `LITELLM_MASTER_KEY` via container env and escaped `CMD-SHELL` expansion.
- Add `LITELLM_MASTER_KEY` to `.env.example` and full-stack installer env handling.
- Generate a local LiteLLM master key default in `install.sh` with Python `secrets.token_hex(32)`.
- Restrict `adhd-engine`, `leantime-bridge`, and `webhook-receiver` host port mappings to `127.0.0.1`.
- Add Task Packet and proof bundle:
  - `task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json`
  - `claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md`

## Validation
PASS:
- `python -m json.tool task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json >/dev/null`
- `python -m jsonschema -i task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- PyYAML compose assertions for LiteLLM healthcheck env use and loopback host port mappings
- `bash -n install.sh`
- `docker compose -f compose.yml config --quiet`
- `git diff --check`
- PAL codereview (`gpt-5-codex`, internal validation): no issues reported
- `pre-commit run --files .env.example compose.yml install.sh task-packets/INDEX.md task-packets/generated/TP-SEC-COMPOSE-LITELLM-LOCALHOST-001.json claudedocs/security-compose-litellm-localhost-proof-2026-05-31.md`

NOT_RUN:
- `docker compose up` / live service boot: out of scope for this commit-sized security slice.
- End-to-end webhook delivery: requires external provider/webhook setup.

## Review
@codex review
@gemini
@copilot
