### PR TITLE
fix(ui-dashboard): restore build

### DIFF
--- a/claudedocs/ui-dashboard-build-proof-2026-05-31.md
+++ b/claudedocs/ui-dashboard-build-proof-2026-05-31.md
@@ -24,6 +24,7 @@ After updating the peer-compatible plugin, `npm run build` exposed missing proje
 ## Change
 
 - Updated `eslint-plugin-react-hooks` to `^7.1.1`, which declares peer support for ESLint 10.
+- Regenerated `pnpm-lock.yaml` so pnpm frozen-lockfile installs agree with `package.json`.
 - Added the missing Vite entrypoint files required by the existing `build` script.
 - Added the missing dashboard components imported by `src/App.tsx`.
 - Kept generated `dist/` output untracked.
@@ -37,6 +38,8 @@ PASS:
 - `git diff --check`
 - `cd ui-dashboard && npm install`
   - Result: up to date, audited 395 packages, 0 vulnerabilities.
+- `cd ui-dashboard && npm exec --yes --package=pnpm@10 -- pnpm install --frozen-lockfile --ignore-scripts`
+  - Result: lockfile up to date; install exited 0 using pnpm v10.34.1.
 - `cd ui-dashboard && npm test -- --run`
   - Result: 3 test files passed, 16 tests passed.
 - `cd ui-dashboard && npm run build`
@@ -53,6 +56,7 @@ PASS:
 WARN:
 
 - Vite build logs existing MUI package-level `"use client"` directive warnings but exits 0.
+- `npm run lint` is not a TP validation and currently exits 2 because `ui-dashboard` has no `eslint.config.*` flat config for ESLint 10; GitHub `Code Quality & Linting` passed on the PR head.
 - Browser console logs a React `validateDOMNesting` warning rooted in existing `TaskSequencer`; this is outside the TP build-fix scope.
 - Clipboard copy interaction was blocked by browser permission during smoke validation; the app surfaced the failure as an alert.
 

--- a/claudedocs/ui-dashboard-build-proof-2026-05-31.md
+++ b/claudedocs/ui-dashboard-build-proof-2026-05-31.md
@@ -1,0 +1,67 @@
+# ui-dashboard build proof - 2026-05-31
+
+## Scope
+
+- Task Packet: `task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json`
+- Branch: `fix/ui-dashboard-build`
+- Worktree: `/Users/hue/code/dopemux-mvp-wt-ui-dashboard-build`
+- Base branch: `main`
+- Target: restore `ui-dashboard` `npm install`, tests, and `npm run build` without force or legacy peer dependency flags.
+
+## Observed failure
+
+`npm install` failed in `ui-dashboard` because `eslint-plugin-react-hooks@4.6.2` did not declare peer support for `eslint@10.1.0`.
+
+After updating the peer-compatible plugin, `npm run build` exposed missing project wiring/source files:
+
+- `tsconfig.json`
+- `index.html`
+- `src/main.tsx`
+- `src/components/CognitiveLoadGauge.tsx`
+- `src/components/PredictionPanel.tsx`
+- `src/components/TeamDashboard.tsx`
+
+## Change
+
+- Updated `eslint-plugin-react-hooks` to `^7.1.1`, which declares peer support for ESLint 10.
+- Added the missing Vite entrypoint files required by the existing `build` script.
+- Added the missing dashboard components imported by `src/App.tsx`.
+- Kept generated `dist/` output untracked.
+
+## Validation
+
+PASS:
+
+- `python -m json.tool task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json >/dev/null`
+- `python -m jsonschema -i task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `git diff --check`
+- `cd ui-dashboard && npm install`
+  - Result: up to date, audited 395 packages, 0 vulnerabilities.
+- `cd ui-dashboard && npm test -- --run`
+  - Result: 3 test files passed, 16 tests passed.
+- `cd ui-dashboard && npm run build`
+  - Result: `tsc && vite build` exited 0 and emitted `dist/index.html`, CSS, and JS assets.
+- Browser smoke at `http://127.0.0.1:5174/`
+  - Result: rendered `Dopemux Ultra UI` with `main` content and no Vite error overlay.
+  - Backend was not running, so the dashboard correctly rendered degraded state with `Failed to fetch`.
+  - Alert close interaction removed the visible alert text.
+- PAL codereview with `gpt-5-codex`
+  - Result: no issues found.
+- `pre-commit run --files ui-dashboard/package.json ui-dashboard/package-lock.json ui-dashboard/tsconfig.json ui-dashboard/index.html ui-dashboard/src/main.tsx ui-dashboard/src/components/CognitiveLoadGauge.tsx ui-dashboard/src/components/PredictionPanel.tsx ui-dashboard/src/components/TeamDashboard.tsx task-packets/INDEX.md task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json claudedocs/ui-dashboard-build-proof-2026-05-31.md`
+  - Result: passed.
+
+WARN:
+
+- Vite build logs existing MUI package-level `"use client"` directive warnings but exits 0.
+- Browser console logs a React `validateDOMNesting` warning rooted in existing `TaskSequencer`; this is outside the TP build-fix scope.
+- Clipboard copy interaction was blocked by browser permission during smoke validation; the app surfaced the failure as an alert.
+
+NOT_RUN:
+
+- Full repository test suite.
+- Backend integration with live ADHD engine/API.
+
+## Residual risk
+
+- The added dashboard components are minimal implementations inferred from existing `App.tsx` imports and static accessibility tests.
+- Runtime data behavior remains dependent on the backend API/WebSocket service, which was not started for this build-focused slice.

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -76,6 +76,7 @@ A packet is superseded by another packet
 | TP-DMX-AGENTS-CODEX-ENDTOEND-0001 | Agent Guidance | Make Codex execute TP lifecycle end-to-end by default | Ready | N/A |
 | TP-DMX-ORCH-DOCS-003 | Task Orchestrator | Document read-only/operator-status integration authority boundaries | Active | N/A |
 | TP-DMX-COMPOSE-RESTORE-001 | Infra | Restore canonical Docker Compose authority | Ready | N/A |
+| TP-UI-DASHBOARD-BUILD-001 | UI Dashboard | Restore ui-dashboard npm install and build | Active | N/A |
 | DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Merged (PR #528) | N/A |
 | TP-DMX-COCKPIT-MERGE-STACK-CONSOLIDATE-001 | UI Cockpit | Audit and prepare Cockpit PR stack 568-571 plus PR 573 evidence for safe consolidation | Active | N/A |
 | TP-DMX-COCKPIT-RUNTIME-RENDER-001 | UI Cockpit | Wire runtime renderer primitives to accepted Cockpit IA package contract | Active | N/A |

--- a/task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json
+++ b/task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json
@@ -31,6 +31,7 @@
     "allowlist": [
       "ui-dashboard/package.json",
       "ui-dashboard/package-lock.json",
+      "ui-dashboard/pnpm-lock.yaml",
       "ui-dashboard/tsconfig.json",
       "ui-dashboard/index.html",
       "ui-dashboard/src/App.tsx",
@@ -50,9 +51,10 @@
       "python -m json.tool task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json >/dev/null",
       "python -m jsonschema -i task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
       "cd ui-dashboard && npm install",
+      "cd ui-dashboard && npm exec --yes --package=pnpm@10 -- pnpm install --frozen-lockfile --ignore-scripts",
       "cd ui-dashboard && npm run build",
       "git diff --check",
-      "pre-commit run --files ui-dashboard/package.json ui-dashboard/package-lock.json ui-dashboard/tsconfig.json ui-dashboard/index.html ui-dashboard/src/App.tsx ui-dashboard/src/components/CognitiveLoadGauge.tsx ui-dashboard/src/components/PredictionPanel.tsx ui-dashboard/src/components/TeamDashboard.tsx ui-dashboard/src/config.ts ui-dashboard/src/index.css ui-dashboard/src/main.tsx ui-dashboard/src/theme.ts ui-dashboard/src/vite-env.d.ts task-packets/INDEX.md task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json claudedocs/ui-dashboard-build-proof-2026-05-31.md"
+      "pre-commit run --files ui-dashboard/package.json ui-dashboard/package-lock.json ui-dashboard/pnpm-lock.yaml ui-dashboard/tsconfig.json ui-dashboard/index.html ui-dashboard/src/App.tsx ui-dashboard/src/components/CognitiveLoadGauge.tsx ui-dashboard/src/components/PredictionPanel.tsx ui-dashboard/src/components/TeamDashboard.tsx ui-dashboard/src/config.ts ui-dashboard/src/index.css ui-dashboard/src/main.tsx ui-dashboard/src/theme.ts ui-dashboard/src/vite-env.d.ts task-packets/INDEX.md task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json claudedocs/ui-dashboard-build-proof-2026-05-31.md"
     ]
   },
   "pr": {
@@ -84,6 +86,7 @@
         "AGENTS.md",
         "ui-dashboard/package.json",
         "ui-dashboard/package-lock.json",
+        "ui-dashboard/pnpm-lock.yaml",
         "ui-dashboard/src/App.tsx"
       ]
     },
@@ -97,10 +100,12 @@
       "expected_files": [
         "ui-dashboard/package.json",
         "ui-dashboard/package-lock.json",
+        "ui-dashboard/pnpm-lock.yaml",
         "claudedocs/ui-dashboard-build-proof-2026-05-31.md"
       ],
       "validation": [
         "cd ui-dashboard && npm install",
+        "cd ui-dashboard && npm exec --yes --package=pnpm@10 -- pnpm install --frozen-lockfile --ignore-scripts",
         "cd ui-dashboard && npm run build"
       ]
     },
@@ -115,7 +120,7 @@
         "python -m json.tool task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json >/dev/null",
         "python -m jsonschema -i task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
         "git diff --check",
-        "pre-commit run --files ui-dashboard/package.json ui-dashboard/package-lock.json ui-dashboard/tsconfig.json ui-dashboard/index.html ui-dashboard/src/main.tsx ui-dashboard/src/components/CognitiveLoadGauge.tsx ui-dashboard/src/components/PredictionPanel.tsx ui-dashboard/src/components/TeamDashboard.tsx task-packets/INDEX.md task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json claudedocs/ui-dashboard-build-proof-2026-05-31.md"
+        "pre-commit run --files ui-dashboard/package.json ui-dashboard/package-lock.json ui-dashboard/pnpm-lock.yaml ui-dashboard/tsconfig.json ui-dashboard/index.html ui-dashboard/src/main.tsx ui-dashboard/src/components/CognitiveLoadGauge.tsx ui-dashboard/src/components/PredictionPanel.tsx ui-dashboard/src/components/TeamDashboard.tsx task-packets/INDEX.md task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json claudedocs/ui-dashboard-build-proof-2026-05-31.md"
       ]
     }
   ]

--- a/task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json
+++ b/task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json
@@ -1,0 +1,122 @@
+{
+  "id": "TP-UI-DASHBOARD-BUILD-001",
+  "project": "dopemux-mvp",
+  "target": "ui-dashboard npm install and build failure",
+  "invariants": [
+    "Make the smallest change needed for ui-dashboard npm install and npm run build to pass.",
+    "Do not change dashboard user-facing logic or UI unless the compiler requires a source correction.",
+    "Do not use legacy-peer-deps or force flags as the fix.",
+    "Commit package-lock.json when npm install changes dependency resolution."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "beta-remaining-ui-dashboard",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "fix/ui-dashboard-build",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(ui-dashboard): RV-13 - restore build",
+    "allowlist": [
+      "ui-dashboard/package.json",
+      "ui-dashboard/package-lock.json",
+      "ui-dashboard/tsconfig.json",
+      "ui-dashboard/index.html",
+      "ui-dashboard/src/App.tsx",
+      "ui-dashboard/src/components/CognitiveLoadGauge.tsx",
+      "ui-dashboard/src/components/PredictionPanel.tsx",
+      "ui-dashboard/src/components/TeamDashboard.tsx",
+      "ui-dashboard/src/config.ts",
+      "ui-dashboard/src/index.css",
+      "ui-dashboard/src/main.tsx",
+      "ui-dashboard/src/theme.ts",
+      "ui-dashboard/src/vite-env.d.ts",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json",
+      "claudedocs/ui-dashboard-build-proof-2026-05-31.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "cd ui-dashboard && npm install",
+      "cd ui-dashboard && npm run build",
+      "git diff --check",
+      "pre-commit run --files ui-dashboard/package.json ui-dashboard/package-lock.json ui-dashboard/tsconfig.json ui-dashboard/index.html ui-dashboard/src/App.tsx ui-dashboard/src/components/CognitiveLoadGauge.tsx ui-dashboard/src/components/PredictionPanel.tsx ui-dashboard/src/components/TeamDashboard.tsx ui-dashboard/src/config.ts ui-dashboard/src/index.css ui-dashboard/src/main.tsx ui-dashboard/src/theme.ts ui-dashboard/src/vite-env.d.ts task-packets/INDEX.md task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json claudedocs/ui-dashboard-build-proof-2026-05-31.md"
+    ]
+  },
+  "pr": {
+    "title": "fix(ui-dashboard): restore build",
+    "body": "## Problem\\nui-dashboard fails during npm install/build.\\n\\n## Fix\\nApply the smallest dependency/source/build wiring changes needed for npm install and npm run build to pass.\\n\\n## Test Plan\\n- Validate Task Packet JSON and schema.\\n- Run npm install and npm run build in ui-dashboard.\\n- Run git diff --check and pre-commit on changed files.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect ui-dashboard package metadata, lockfile state, and reproduce npm install/build failure.",
+      "requirements": [
+        "Use npm because the task specifies npm install and npm run build.",
+        "Record exact failure output before changing dependencies."
+      ],
+      "validation": [
+        "cd ui-dashboard && npm install && npm run build 2>&1 | tail -30"
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "ui-dashboard/package.json",
+        "ui-dashboard/package-lock.json",
+        "ui-dashboard/src/App.tsx"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Fix npm dependency/build failures without UI behavior changes.",
+      "requirements": [
+        "Prefer updating the incompatible package over using npm force or legacy peer dependency flags.",
+        "Only add build config or source fixes if npm run build exposes them after install succeeds."
+      ],
+      "expected_files": [
+        "ui-dashboard/package.json",
+        "ui-dashboard/package-lock.json",
+        "claudedocs/ui-dashboard-build-proof-2026-05-31.md"
+      ],
+      "validation": [
+        "cd ui-dashboard && npm install",
+        "cd ui-dashboard && npm run build"
+      ]
+    },
+    {
+      "id": "precommit",
+      "task": "Run focused validation, codereview, pre-commit, commit, push, and open the PR.",
+      "requirements": [
+        "Inspect diff scope before staging.",
+        "Report rendered Browser validation as NOT_RUN if the change is build-only and no dev server is started."
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "git diff --check",
+        "pre-commit run --files ui-dashboard/package.json ui-dashboard/package-lock.json ui-dashboard/tsconfig.json ui-dashboard/index.html ui-dashboard/src/main.tsx ui-dashboard/src/components/CognitiveLoadGauge.tsx ui-dashboard/src/components/PredictionPanel.tsx ui-dashboard/src/components/TeamDashboard.tsx task-packets/INDEX.md task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json claudedocs/ui-dashboard-build-proof-2026-05-31.md"
+      ]
+    }
+  ]
+}

--- a/ui-dashboard/index.html
+++ b/ui-dashboard/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Dopemux Ultra UI</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui-dashboard/package-lock.json
+++ b/ui-dashboard/package-lock.json
@@ -28,7 +28,7 @@
         "@typescript-eslint/parser": "^8.57.2",
         "@vitejs/plugin-react": "^4.2.1",
         "eslint": "^10.1.0",
-        "eslint-plugin-react-hooks": "^4.6.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.6",
         "jsdom": "^28.1.0",
         "typescript": "^5.2.2",
@@ -3563,16 +3563,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
-      "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
@@ -3922,6 +3929,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -5894,6 +5918,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/ui-dashboard/package.json
+++ b/ui-dashboard/package.json
@@ -31,7 +31,7 @@
     "@typescript-eslint/parser": "^8.57.2",
     "@vitejs/plugin-react": "^4.2.1",
     "eslint": "^10.1.0",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.6",
     "jsdom": "^28.1.0",
     "typescript": "^5.2.2",

--- a/ui-dashboard/pnpm-lock.yaml
+++ b/ui-dashboard/pnpm-lock.yaml
@@ -64,8 +64,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0
       eslint-plugin-react-hooks:
-        specifier: ^4.6.0
-        version: 4.6.2(eslint@10.1.0)
+        specifier: ^7.1.1
+        version: 7.1.1(eslint@10.1.0)
       eslint-plugin-react-refresh:
         specifier: ^0.4.6
         version: 0.4.26(eslint@10.1.0)
@@ -664,66 +664,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -1224,11 +1237,11 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-plugin-react-hooks@4.6.2:
-    resolution: {integrity: sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==}
-    engines: {node: '>=10'}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
+    engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react-refresh@0.4.26:
     resolution: {integrity: sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==}
@@ -1357,6 +1370,12 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  hermes-estree@0.25.1:
+    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
+
+  hermes-parser@0.25.1:
+    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
@@ -1518,24 +1537,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2041,6 +2064,15 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod-validation-error@4.0.2:
+    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -3145,9 +3177,16 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-plugin-react-hooks@4.6.2(eslint@10.1.0):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.1.0):
     dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.0
       eslint: 10.1.0
+      hermes-parser: 0.25.1
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react-refresh@0.4.26(eslint@10.1.0):
     dependencies:
@@ -3282,6 +3321,12 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  hermes-estree@0.25.1: {}
+
+  hermes-parser@0.25.1:
+    dependencies:
+      hermes-estree: 0.25.1
 
   hoist-non-react-statics@3.3.2:
     dependencies:
@@ -3930,3 +3975,9 @@ snapshots:
   yaml@1.10.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod-validation-error@4.0.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/ui-dashboard/src/components/CognitiveLoadGauge.tsx
+++ b/ui-dashboard/src/components/CognitiveLoadGauge.tsx
@@ -1,0 +1,62 @@
+import { Box, LinearProgress, Paper, Tooltip, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+
+import { brandTokens, statusStyles } from '../theme';
+
+interface CognitiveLoadGaugeProps {
+  load: number;
+  status: keyof typeof statusStyles;
+  recommendation: string;
+}
+
+export default function CognitiveLoadGauge({
+  load,
+  status,
+  recommendation,
+}: CognitiveLoadGaugeProps) {
+  const statusMeta = statusStyles[status];
+  const normalizedLoad = Math.max(0, Math.min(100, Math.round(load * 100)));
+
+  return (
+    <Paper
+      aria-label={`Cognitive load ${normalizedLoad} percent, ${statusMeta.label}`}
+      sx={{
+        p: 3,
+        minHeight: 300,
+        borderRadius: 3,
+        background: brandTokens.gradients.focusCard,
+        border: `1px solid ${statusMeta.border}`,
+      }}
+    >
+      <Typography variant="overline" color="text.secondary">
+        Cognitive Load
+      </Typography>
+      <Typography variant="h2" sx={{ color: statusMeta.color, my: 1 }}>
+        {normalizedLoad}%
+      </Typography>
+      <Box aria-hidden="true" sx={{ width: 28, height: 2, bgcolor: statusMeta.color, mb: 1 }} />
+      <LinearProgress
+        aria-label="Cognitive Load Percentage"
+        aria-valuetext={`${normalizedLoad}%`}
+        variant="determinate"
+        value={normalizedLoad}
+        sx={{
+          height: 10,
+          borderRadius: 6,
+          backgroundColor: alpha(statusMeta.color, 0.14),
+          '& .MuiLinearProgress-bar': {
+            backgroundColor: statusMeta.color,
+          },
+        }}
+      />
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="h6">{statusMeta.label}</Typography>
+        <Tooltip title={`Recommendation: ${recommendation}`} arrow>
+          <Typography variant="body2" color="text.secondary" tabIndex={0}>
+            {recommendation}
+          </Typography>
+        </Tooltip>
+      </Box>
+    </Paper>
+  );
+}

--- a/ui-dashboard/src/components/PredictionPanel.tsx
+++ b/ui-dashboard/src/components/PredictionPanel.tsx
@@ -1,0 +1,63 @@
+import { Box, LinearProgress, Paper, Tooltip, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+
+import { brandTokens } from '../theme';
+
+interface PredictionPanelProps {
+  prediction?: number;
+}
+
+export default function PredictionPanel({ prediction }: PredictionPanelProps) {
+  const hasPrediction = typeof prediction === 'number';
+  const value = hasPrediction ? Math.max(0, Math.min(100, Math.round(prediction * 100))) : 0;
+
+  return (
+    <Paper
+      aria-label={hasPrediction ? `Fifteen minute prediction ${value} percent` : 'No prediction available'}
+      sx={{
+        p: 3,
+        minHeight: 300,
+        borderRadius: 3,
+        background: brandTokens.gradients.focusCard,
+      }}
+    >
+      <Typography variant="overline" color="text.secondary">
+        15-minute forecast
+      </Typography>
+      <Typography variant="h3" sx={{ color: brandTokens.colors.giltEdge, my: 1 }}>
+        {hasPrediction ? `${value}%` : 'N/A'}
+      </Typography>
+      <Box aria-hidden="true" sx={{ width: 28, height: 2, bgcolor: brandTokens.colors.giltEdge, mb: 1 }} />
+      <Tooltip title="Predictive LSTM model running on edge device" arrow>
+        <LinearProgress
+          aria-label="15-Minute Load Prediction Percentage"
+          aria-valuetext={hasPrediction ? `${value}%` : 'Prediction Loading...'}
+          variant={hasPrediction ? 'determinate' : 'indeterminate'}
+          value={value}
+          sx={{
+            height: 8,
+            borderRadius: 6,
+            backgroundColor: alpha(brandTokens.colors.giltEdge, 0.14),
+            '& .MuiLinearProgress-bar': {
+              backgroundColor: brandTokens.colors.giltEdge,
+            },
+          }}
+        />
+      </Tooltip>
+      {!hasPrediction && (
+        <LinearProgress
+          aria-label="Loading prediction data"
+          aria-valuetext="Prediction Loading..."
+          sx={{ mt: 1 }}
+        />
+      )}
+      <Box sx={{ mt: 3 }}>
+        <Typography variant="body2" color="text.secondary">
+          {hasPrediction
+            ? 'Forecast panel uses the backend projected cognitive load when available.'
+            : 'Prediction Loading...'}
+        </Typography>
+      </Box>
+    </Paper>
+  );
+}

--- a/ui-dashboard/src/components/TeamDashboard.tsx
+++ b/ui-dashboard/src/components/TeamDashboard.tsx
@@ -1,0 +1,104 @@
+import { Avatar, Box, Chip, LinearProgress, Paper, Tooltip, Typography } from '@mui/material';
+import { alpha } from '@mui/material/styles';
+
+import { brandTokens, statusStyles } from '../theme';
+
+const teamMembers = [
+  { name: 'Operator', load: 42, energy: 78, attention: 82, status: 'optimal' },
+  { name: 'Implementer', load: 55, energy: 68, attention: 74, status: 'high' },
+  { name: 'Reviewer', load: 34, energy: 72, attention: 80, status: 'low' },
+] as const;
+
+const teamSignals = [
+  { label: 'Queue', value: 'Stable', color: brandTokens.colors.serumMint },
+  { label: 'Handoff', value: 'Clear', color: brandTokens.colors.saintGold },
+];
+
+export default function TeamDashboard() {
+  const teamAverageLoad = Math.round(
+    teamMembers.reduce((total, member) => total + member.load, 0) / teamMembers.length
+  );
+
+  return (
+    <Paper
+      aria-label="Team dashboard signal summary"
+      sx={{
+        p: 3,
+        borderRadius: 3,
+        background: brandTokens.gradients.focusCard,
+      }}
+    >
+      <Typography variant="h6" sx={{ mb: 2 }}>
+        Team Signal Board
+      </Typography>
+      <Tooltip title="Average cognitive load across all team members" arrow>
+        <LinearProgress
+          aria-label="Team Average Cognitive Load Percentage"
+          aria-valuetext={`${teamAverageLoad}%`}
+          variant="determinate"
+          value={teamAverageLoad}
+          sx={{ mb: 2, height: 8, borderRadius: 6 }}
+        />
+      </Tooltip>
+      <Box sx={{ display: 'grid', gap: 1.5, mb: 2 }}>
+        {teamMembers.map((member) => (
+          <Box
+            key={member.name}
+            tabIndex={0}
+            sx={{
+              display: 'grid',
+              gap: 1,
+              p: 1.5,
+              borderRadius: 2,
+              border: `1px solid ${alpha(statusStyles[member.status].color, 0.4)}`,
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Avatar aria-label={`Profile picture of ${member.name}`} sx={{ width: 28, height: 28 }}>
+                {member.name[0]}
+              </Avatar>
+              <Typography variant="body2">{member.name}</Typography>
+              <Tooltip title={statusStyles[member.status].label} arrow>
+                <Chip size="small" label={statusStyles[member.status].label} />
+              </Tooltip>
+              <Box aria-hidden="true" sx={{ ml: 'auto', width: 6, height: 6, borderRadius: '50%', bgcolor: statusStyles[member.status].color }} />
+            </Box>
+            <LinearProgress
+              aria-label={`${member.name}'s Cognitive Load Percentage`}
+              aria-valuetext={`${member.load}%`}
+              variant="determinate"
+              value={member.load}
+            />
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+              <Tooltip title="Current energy level" arrow>
+                <Chip size="small" tabIndex={0} label={`Energy ${member.energy}%`} />
+              </Tooltip>
+              <Tooltip title="Current attention focus" arrow>
+                <Chip size="small" tabIndex={0} label={`Attention ${member.attention}%`} />
+              </Tooltip>
+            </Box>
+          </Box>
+        ))}
+      </Box>
+      <Tooltip title="AI-generated team coordination insights" arrow>
+        <Typography variant="body2" color="text.secondary" tabIndex={0} sx={{ mb: 2 }}>
+          Sequence handoffs while average load is below escalation threshold.
+        </Typography>
+      </Tooltip>
+      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
+        {teamSignals.map((signal) => (
+          <Chip
+            key={signal.label}
+            label={`${signal.label}: ${signal.value}`}
+            sx={{
+              color: signal.color,
+              border: `1px solid ${alpha(signal.color, 0.55)}`,
+              backgroundColor: alpha(signal.color, 0.08),
+            }}
+            variant="outlined"
+          />
+        ))}
+      </Box>
+    </Paper>
+  );
+}

--- a/ui-dashboard/src/main.tsx
+++ b/ui-dashboard/src/main.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ui-dashboard/tsconfig.json
+++ b/ui-dashboard/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": []
+}


### PR DESCRIPTION
## Problem

`ui-dashboard` failed during `npm install` because `eslint-plugin-react-hooks@4.6.2` did not declare peer support for `eslint@10.1.0`. After dependency resolution was fixed, `npm run build` exposed missing Vite/React entrypoint wiring and missing dashboard components imported by `src/App.tsx`.

## Fix

- Update `eslint-plugin-react-hooks` to `^7.1.1`, which declares ESLint 10 peer support.
- Add the missing Vite entrypoint files: `index.html`, `src/main.tsx`, and `tsconfig.json`.
- Add minimal implementations for the existing `App.tsx` imports: `CognitiveLoadGauge`, `PredictionPanel`, and `TeamDashboard`.
- Add Task Packet and proof artifact for replayable validation.

## Validation

PASS:
- `python -m json.tool task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json >/dev/null`
- `python -m jsonschema -i task-packets/generated/TP-UI-DASHBOARD-BUILD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `git diff --check`
- `cd ui-dashboard && npm install` -> 0 vulnerabilities
- `cd ui-dashboard && npm test -- --run` -> 3 files / 16 tests passed
- `cd ui-dashboard && npm run build` -> exited 0
- Browser smoke at `http://127.0.0.1:5174/` -> rendered dashboard, no Vite error overlay
- PAL codereview with `gpt-5-codex` -> no issues found
- `pre-commit run --files ...` on changed files -> passed

WARN:
- Vite build logs existing MUI package-level `"use client"` directive warnings but exits 0.
- Browser console logs a React `validateDOMNesting` warning rooted in existing `TaskSequencer`; this is outside this build-fix slice.
- Backend was not running in browser smoke, so degraded `Failed to fetch` state was expected.

@codex review
@gemini
@copilot
