### PR TITLE
docs(onboarding): refresh first-touch start here

### DIFF
--- a/claudedocs/docs-first-touch-product-name-proof-2026-05-31.md
+++ b/claudedocs/docs-first-touch-product-name-proof-2026-05-31.md
@@ -1,0 +1,60 @@
+# docs first-touch product-name proof - 2026-05-31
+
+## Scope
+
+- Task Packet: `task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json`
+- Branch: `fix/docs-first-touch-product-name`
+- Worktree: `/Users/hue/code/dopemux-mvp-wt-docs-first-touch`
+- Base branch: `main`
+- Target: replace stale active Start Here onboarding content with the actual Dopemux first-touch flow.
+
+## Observed State
+
+- `docs/01-tutorials/start-here.md`, `start-here-2.md`, and `start-here-3.md` were byte-identical stale audit-branch guides.
+- The stale Start Here files referenced `code-audit`, audit success summaries, and non-existent first-touch files such as `README-AUDIT-COMPLETE.md`.
+- `docs/01-tutorials/quickstart.md`, root `QUICK_START.md`, and `README.md` already documented Dopemux install/start boundaries.
+- The prescribed `chatx` grep still finds `ChatX` only in `docs/archive/...` historical material, not in active first-touch onboarding docs.
+
+## Change
+
+- Replaced the active Start Here variants with a Dopemux onboarding path:
+  - clone repo
+  - run `./install.sh`
+  - run `dopemux start`
+  - open Claude Code from the checkout and inspect `/mcp`
+- Preserved explicit runtime authority language and directed compose-backed smoke checks to `QUICK_START.md`.
+- Added a Task Packet and index row for replayability.
+
+## Validation
+
+PASS:
+
+- `python -m json.tool task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json >/dev/null`
+- `python -m jsonschema -i task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `grep -rn "chatx\\|chat-x\\|ChatX" README.md INSTALL.md docs/01-tutorials 2>/dev/null; test $? -eq 1`
+  - Result: no active first-touch matches.
+- `rg -n "code-audit|README-AUDIT|ULTIMATE-AUDIT|production-ready|START HERE - Complete Audit" docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md; test $? -eq 1`
+  - Result: no stale audit-branch matches.
+- `python scripts/docs_validator.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md`
+- `python scripts/docs_frontmatter_guard.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md`
+  - Result: all docs have valid frontmatter.
+- PAL codereview with `gpt-5-codex`
+  - Result: no issues found.
+- `pre-commit run --files docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md task-packets/INDEX.md task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json claudedocs/docs-first-touch-product-name-proof-2026-05-31.md`
+  - Result: passed.
+
+WARN:
+
+- `grep -rn "chatx\\|chat-x\\|ChatX" docs/ README.md INSTALL.md 2>/dev/null | head -20` still reports archive/history-only matches under `docs/archive/...`.
+- This slice did not validate a live `./install.sh` or `dopemux start` runtime session.
+
+NOT_RUN:
+
+- Full docs lint suite.
+- Full repository test suite.
+- Live installer/startup run.
+
+## Residual Risk
+
+- The repo has duplicated `start-here` variants with the same frontmatter `id`; this slice refreshed all three because they were identical active tutorial files, but did not resolve duplicate-doc architecture.
+- Archive/historical `ChatX` references remain because they are not active onboarding surfaces and were not read deeply enough to rewrite safely.

--- a/docs/01-tutorials/start-here-2.md
+++ b/docs/01-tutorials/start-here-2.md
@@ -50,7 +50,11 @@ specific options, see [INSTALL.md](../../INSTALL.md).
 Load the shell integration that the installer wrote, or open a new terminal:
 
 ```bash
+# zsh
 source ~/.zshrc
+
+# bash
+source ~/.bashrc
 ```
 
 Start the operator CLI:

--- a/docs/01-tutorials/start-here-2.md
+++ b/docs/01-tutorials/start-here-2.md
@@ -47,6 +47,12 @@ Run the installer:
 The installer is the repo's first-touch setup path. For unattended or stack
 specific options, see [INSTALL.md](../../INSTALL.md).
 
+Load the shell integration that the installer wrote, or open a new terminal:
+
+```bash
+source ~/.zshrc
+```
+
 Start the operator CLI:
 
 ```bash

--- a/docs/01-tutorials/start-here-2.md
+++ b/docs/01-tutorials/start-here-2.md
@@ -3,257 +3,110 @@ id: START-HERE
 title: Start Here
 type: tutorial
 owner: '@hu3mann'
-last_review: '2025-11-10'
-next_review: '2026-02-08'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
 author: '@hu3mann'
 date: '2026-02-05'
 prelude: Start Here (tutorial) for dopemux documentation and developer workflows.
 ---
-# 🚀 START HERE - Complete Audit Success
+# Start Here
 
-**Status**: ✅ **PRODUCTION-READY**
-**Branch**: `code-audit` (ready to push/merge)
-**Time**: 12 hours (saved 81 hours!)
-**Quality**: 9.3/10 overall ⭐⭐⭐⭐⭐
+Use this page as the first-touch path for a local Dopemux checkout. It is a
+short orientation, not a replacement for runtime truth: code, compose wiring,
+tests, and active entrypoints still outrank this document.
 
----
+Dopemux is an operator control workspace for split-authority development
+systems. It coordinates startup, routing, MCP/service surfaces, execution
+handoff, PM metadata, structured context, chronicle memory, retrieval, bridge
+transport, operator support, and repo audit without claiming one system owns
+all of those lanes.
 
-## What Happened
+## First Local Run
 
-We completed a **comprehensive security audit** that:
-1. Found and **FIXED all 10 critical vulnerabilities**
-1. **Completed the DopeconBridge** (was 80% done with stubs)
-1. Achieved **perfect security (10/10)** and **perfect architecture (10/10)**
-1. Created **52 comprehensive reports** documenting everything
-1. Validated **95% documentation accuracy**
+Prerequisites:
 
-**All in 12 hours** instead of the original 93-hour plan!
+- Python 3.11 or newer.
+- Docker with `docker compose`.
+- `uv` for Python dependency management.
+- Claude Code installed and available to open from this repository checkout.
+- Provider API keys for any provider-backed services you choose to run.
 
----
-
-## Security Fixes Applied ✅
-
-**Before**: 4/10 (multiple critical issues)
-**After**: **10/10** ⭐⭐⭐⭐⭐
-
-1. ✅ CORS wildcards (4 services) → Environment whitelists
-1. ✅ Hardcoded credentials (2 files) → Environment variables
-1. ✅ No authentication (7 endpoints) → API key required
-1. ✅ Missing imports → Fixed
-1. ✅ DopeconBridge stubs → Fully implemented
-
-**Impact**: All production-critical vulnerabilities eliminated
-
----
-
-## DopeconBridge - COMPLETE ✅
-
-**Before**: 80% done (custom_data endpoints were stubs)
-**After**: **100% complete** ⭐⭐⭐⭐⭐
-
-**What We Built**:
-- `mcp_client.py` (209 lines) - PostgreSQL integration
-- Wired `save_custom_data()` - Actually saves to database
-- Wired `get_custom_data()` - Actually retrieves data
-- Created `bridge_client.py` - HTTP client for services
-- Migrated ADHD Engine - Uses bridge (not direct SQLite)
-
-**Result**: **ZERO architecture violations** remaining!
-
----
-
-## Documentation - Comprehensive ✅
-
-**52 Reports Created**:
-- Complete audit findings (Phases 1-4)
-- Security analysis and fixes
-- Service reviews (all 12)
-- DopeconBridge completion
-- Deployment guides
-- Performance assessments
-- ADR-206 (formal record)
-
-**Accuracy**: 95% (validated with automated tests)
-
----
-
-## How to Deploy (3 Options)
-
-### Option A: Create PR → Merge → Deploy (Recommended)
+Clone and enter the repo:
 
 ```bash
-# 1. Push branch
-git push origin code-audit
-
-# 2. Create PR with this template:
+git clone https://github.com/DDD-Enterprises/dopemux-mvp
+cd dopemux-mvp
 ```
 
-**PR Title**: Security fixes + DopeconBridge completion + Comprehensive audit
-
-**PR Description**:
-```markdown
-Complete code audit delivering production-ready security + architecture compliance.
-
-## Summary
-- 10 security vulnerabilities fixed
-- DopeconBridge 100% complete
-- Full architecture compliance (ZERO violations)
-- 95% documentation accuracy validated
-
-## Scores
-- Security: 4/10 → 10/10 ⭐⭐⭐⭐⭐
-- Architecture: 6/10 → 10/10 ⭐⭐⭐⭐⭐
-- Overall: 9.3/10 ⭐⭐⭐⭐⭐
-
-## Changes
-- 28 commits
-- 56 files (code + docs)
-- 8,600+ lines (comprehensive improvements)
-
-## Testing
-✅ Security fixes validated
-✅ DopeconBridge tested
-✅ Performance profiled
-✅ Code examples: 100% pass rate
-
-## Deployment
-Ready for immediate production deployment.
-See: DEPLOYMENT-WORKTREE-INSTRUCTIONS.md
-
-## Documentation
-Complete audit trail: 52 reports in claudedocs/
-Key file: ULTIMATE-AUDIT-SUCCESS.md
-```
+Run the installer:
 
 ```bash
-# 3. After PR merged
-cd /Users/hue/code/dopemux-mvp  # Main worktree
-git pull
-# Deploy using DEPLOYMENT-INSTRUCTIONS.md
+./install.sh
 ```
 
----
+The installer is the repo's first-touch setup path. For unattended or stack
+specific options, see [INSTALL.md](../../INSTALL.md).
 
-### Option B: Direct Merge in Main Worktree
+Start the operator CLI:
 
 ```bash
-# Switch to main worktree
-cd /Users/hue/code/dopemux-mvp
-
-# Merge code-audit branch
-git merge code-audit --no-edit
-
-# Push to remote
-git push origin main
-
-# Deploy
-# Use DEPLOYMENT-INSTRUCTIONS.md
+dopemux start
 ```
 
----
+`dopemux start` is the operator cockpit entrypoint. It handles the local
+startup path for Dopemux operator work; use the explicit compose flow in
+[Quick Start](../../QUICK_START.md) when you need to start and inspect the
+compose-backed service stack directly.
 
-### Option C: Deploy from Code-Audit Worktree
+Open Claude Code from this checkout after startup so it reads the repository
+Claude/MCP configuration for the current working directory. In Claude Code, use
+`/mcp` to inspect which MCP servers are visible for the active session.
+
+## Optional Smoke Checks
+
+If you started the compose-backed services, check the observed default health
+ports:
 
 ```bash
-# Already in code-audit worktree
-cp .env.example .env
-nano .env  # Set production values
-
-# Deploy services directly
-cd services/adhd_engine && python main.py &
-cd services/mcp-dopecon-bridge && python main.py &
-# etc.
+curl -fsS http://localhost:3016/health  # dopecon-bridge
+curl -fsS http://localhost:3004/health  # ConPort HTTP
+curl -fsS http://localhost:3010/health  # dope-context
+curl -fsS http://localhost:3020/health  # dope-memory
+curl -fsS http://localhost:8000/health  # task-orchestrator
+curl -fsS http://localhost:3025/health  # ADHD Engine
 ```
 
----
+These ports are defaults from the tracked compose and registry configuration.
+Local `.env` overrides can change them.
 
-## Configuration Required
+## Authority Notes
 
-**Create `.env` file**:
-```bash
-cp .env.example .env
-```
+- `dopemux` owns operator startup, routing, and coordination.
+- `dopetask` owns execution after handoff through `scripts/dopetask`.
+- Leantime owns passive PM metadata.
+- task-orchestrator owns workflow-significant transitions.
+- ConPort owns structured decisions, progress, and context.
+- dope-memory owns chronicle receipts.
+- dope-context owns derived code/docs retrieval.
+- dopecon-bridge is bridge/proxy/event transport only.
+- ADHD Engine is operator support only.
+- Repo Truth Extractor emits evidence artifacts; runtime/source truth still
+  wins.
 
-**Set these values**:
-```
-ALLOWED_ORIGINS=https://yourdomain.com
-ADHD_ENGINE_API_KEY=$(openssl rand -hex 32)
-SERENA_DB_PASSWORD=your-password
-USE_DOPECON_BRIDGE=true
-```
+## If You Get Stuck
 
-**Time**: 5 minutes
+- Installer failure: run `./install.sh --verify` and read the reported blocker.
+- Missing Docker network: follow [Quick Start](../../QUICK_START.md) to create
+  `dopemux-network`.
+- Port conflict: inspect `.env`, existing containers, and local processes
+  before changing docs or code.
+- MCP missing in Claude Code: confirm Claude Code was opened from this checkout
+  and run `/mcp`.
 
----
+## Next Reading
 
-## Validation Tests
-
-**After deployment**:
-
-```bash
-# 1. Health checks
-curl http://localhost:8000/health
-curl http://localhost:3016/kg/health
-
-# 2. Security test
-curl -H "X-API-Key: your-key" http://localhost:8000/api/v1/energy-level/test
-# Should work ✅
-
-curl http://localhost:8000/api/v1/energy-level/test
-# Should fail (no key) ✅
-
-# 3. DopeconBridge test
-curl -X POST http://localhost:3016/custom_data \
-  -H "X-Source-Plane: cognitive_plane" \
-  -d '{"workspace_id":"/test","category":"test","key":"k","value":{"v":1}}'
-# Should save ✅
-```
-
----
-
-## Key Documents
-
-**Must Read**:
-1. `README-AUDIT-COMPLETE.md` ← This file
-1. `ULTIMATE-AUDIT-SUCCESS.md` ← Comprehensive summary
-1. `DEPLOYMENT-WORKTREE-INSTRUCTIONS.md` ← How to deploy
-
-**Reference**:
-1. `claudedocs/` ← All 52 audit reports
-1. `.env.example` ← Configuration template
-1. `LAUNCH-PLAN.md` ← Deployment options
-
----
-
-## What You Have Now
-
-✅ **Production-ready codebase** (10/10 security, 10/10 architecture)
-✅ **Comprehensive documentation** (52 reports, 95% accurate)
-✅ **Clear deployment path** (3 options, all validated)
-✅ **No blockers** (all critical work complete)
-
----
-
-## Recommended Next Steps
-
-**TODAY**:
-1. Review: `ULTIMATE-AUDIT-SUCCESS.md` (5 min)
-1. Push: `git push origin code-audit` (1 min)
-1. PR: Create on GitHub with template above (5 min)
-
-**THIS WEEK**:
-1. Merge: After review (or immediately if solo)
-1. Deploy: Follow `DEPLOYMENT-INSTRUCTIONS.md` (30 min)
-1. Monitor: First 24 hours
-
-**SUCCESS**: Production deployment with perfect security + architecture!
-
----
-
-**EVERYTHING IS READY** 🎉
-
-You can deploy with complete confidence!
-
----
-
-*Audit completed using MCP-enhanced methodology: Dope-Context (semantic search), Zen (AI validation), Serena-v2 (code navigation). Result: 87% time savings with production-grade quality.*
+- [Quick Start](../../QUICK_START.md)
+- [Tutorial Quickstart](quickstart.md)
+- [Developer Onboarding](../02-how-to/developer-onboarding.md)
+- [Architecture](../../ARCHITECTURE.md)
+- [System Boundaries](../03-reference/systems/system-boundaries.md)

--- a/docs/01-tutorials/start-here-3.md
+++ b/docs/01-tutorials/start-here-3.md
@@ -50,7 +50,11 @@ specific options, see [INSTALL.md](../../INSTALL.md).
 Load the shell integration that the installer wrote, or open a new terminal:
 
 ```bash
+# zsh
 source ~/.zshrc
+
+# bash
+source ~/.bashrc
 ```
 
 Start the operator CLI:

--- a/docs/01-tutorials/start-here-3.md
+++ b/docs/01-tutorials/start-here-3.md
@@ -47,6 +47,12 @@ Run the installer:
 The installer is the repo's first-touch setup path. For unattended or stack
 specific options, see [INSTALL.md](../../INSTALL.md).
 
+Load the shell integration that the installer wrote, or open a new terminal:
+
+```bash
+source ~/.zshrc
+```
+
 Start the operator CLI:
 
 ```bash

--- a/docs/01-tutorials/start-here-3.md
+++ b/docs/01-tutorials/start-here-3.md
@@ -3,257 +3,110 @@ id: START-HERE
 title: Start Here
 type: tutorial
 owner: '@hu3mann'
-last_review: '2025-11-10'
-next_review: '2026-02-08'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
 author: '@hu3mann'
 date: '2026-02-05'
 prelude: Start Here (tutorial) for dopemux documentation and developer workflows.
 ---
-# 🚀 START HERE - Complete Audit Success
+# Start Here
 
-**Status**: ✅ **PRODUCTION-READY**
-**Branch**: `code-audit` (ready to push/merge)
-**Time**: 12 hours (saved 81 hours!)
-**Quality**: 9.3/10 overall ⭐⭐⭐⭐⭐
+Use this page as the first-touch path for a local Dopemux checkout. It is a
+short orientation, not a replacement for runtime truth: code, compose wiring,
+tests, and active entrypoints still outrank this document.
 
----
+Dopemux is an operator control workspace for split-authority development
+systems. It coordinates startup, routing, MCP/service surfaces, execution
+handoff, PM metadata, structured context, chronicle memory, retrieval, bridge
+transport, operator support, and repo audit without claiming one system owns
+all of those lanes.
 
-## What Happened
+## First Local Run
 
-We completed a **comprehensive security audit** that:
-1. Found and **FIXED all 10 critical vulnerabilities**
-1. **Completed the DopeconBridge** (was 80% done with stubs)
-1. Achieved **perfect security (10/10)** and **perfect architecture (10/10)**
-1. Created **52 comprehensive reports** documenting everything
-1. Validated **95% documentation accuracy**
+Prerequisites:
 
-**All in 12 hours** instead of the original 93-hour plan!
+- Python 3.11 or newer.
+- Docker with `docker compose`.
+- `uv` for Python dependency management.
+- Claude Code installed and available to open from this repository checkout.
+- Provider API keys for any provider-backed services you choose to run.
 
----
-
-## Security Fixes Applied ✅
-
-**Before**: 4/10 (multiple critical issues)
-**After**: **10/10** ⭐⭐⭐⭐⭐
-
-1. ✅ CORS wildcards (4 services) → Environment whitelists
-1. ✅ Hardcoded credentials (2 files) → Environment variables
-1. ✅ No authentication (7 endpoints) → API key required
-1. ✅ Missing imports → Fixed
-1. ✅ DopeconBridge stubs → Fully implemented
-
-**Impact**: All production-critical vulnerabilities eliminated
-
----
-
-## DopeconBridge - COMPLETE ✅
-
-**Before**: 80% done (custom_data endpoints were stubs)
-**After**: **100% complete** ⭐⭐⭐⭐⭐
-
-**What We Built**:
-- `mcp_client.py` (209 lines) - PostgreSQL integration
-- Wired `save_custom_data()` - Actually saves to database
-- Wired `get_custom_data()` - Actually retrieves data
-- Created `bridge_client.py` - HTTP client for services
-- Migrated ADHD Engine - Uses bridge (not direct SQLite)
-
-**Result**: **ZERO architecture violations** remaining!
-
----
-
-## Documentation - Comprehensive ✅
-
-**52 Reports Created**:
-- Complete audit findings (Phases 1-4)
-- Security analysis and fixes
-- Service reviews (all 12)
-- DopeconBridge completion
-- Deployment guides
-- Performance assessments
-- ADR-206 (formal record)
-
-**Accuracy**: 95% (validated with automated tests)
-
----
-
-## How to Deploy (3 Options)
-
-### Option A: Create PR → Merge → Deploy (Recommended)
+Clone and enter the repo:
 
 ```bash
-# 1. Push branch
-git push origin code-audit
-
-# 2. Create PR with this template:
+git clone https://github.com/DDD-Enterprises/dopemux-mvp
+cd dopemux-mvp
 ```
 
-**PR Title**: Security fixes + DopeconBridge completion + Comprehensive audit
-
-**PR Description**:
-```markdown
-Complete code audit delivering production-ready security + architecture compliance.
-
-## Summary
-- 10 security vulnerabilities fixed
-- DopeconBridge 100% complete
-- Full architecture compliance (ZERO violations)
-- 95% documentation accuracy validated
-
-## Scores
-- Security: 4/10 → 10/10 ⭐⭐⭐⭐⭐
-- Architecture: 6/10 → 10/10 ⭐⭐⭐⭐⭐
-- Overall: 9.3/10 ⭐⭐⭐⭐⭐
-
-## Changes
-- 28 commits
-- 56 files (code + docs)
-- 8,600+ lines (comprehensive improvements)
-
-## Testing
-✅ Security fixes validated
-✅ DopeconBridge tested
-✅ Performance profiled
-✅ Code examples: 100% pass rate
-
-## Deployment
-Ready for immediate production deployment.
-See: DEPLOYMENT-WORKTREE-INSTRUCTIONS.md
-
-## Documentation
-Complete audit trail: 52 reports in claudedocs/
-Key file: ULTIMATE-AUDIT-SUCCESS.md
-```
+Run the installer:
 
 ```bash
-# 3. After PR merged
-cd /Users/hue/code/dopemux-mvp  # Main worktree
-git pull
-# Deploy using DEPLOYMENT-INSTRUCTIONS.md
+./install.sh
 ```
 
----
+The installer is the repo's first-touch setup path. For unattended or stack
+specific options, see [INSTALL.md](../../INSTALL.md).
 
-### Option B: Direct Merge in Main Worktree
+Start the operator CLI:
 
 ```bash
-# Switch to main worktree
-cd /Users/hue/code/dopemux-mvp
-
-# Merge code-audit branch
-git merge code-audit --no-edit
-
-# Push to remote
-git push origin main
-
-# Deploy
-# Use DEPLOYMENT-INSTRUCTIONS.md
+dopemux start
 ```
 
----
+`dopemux start` is the operator cockpit entrypoint. It handles the local
+startup path for Dopemux operator work; use the explicit compose flow in
+[Quick Start](../../QUICK_START.md) when you need to start and inspect the
+compose-backed service stack directly.
 
-### Option C: Deploy from Code-Audit Worktree
+Open Claude Code from this checkout after startup so it reads the repository
+Claude/MCP configuration for the current working directory. In Claude Code, use
+`/mcp` to inspect which MCP servers are visible for the active session.
+
+## Optional Smoke Checks
+
+If you started the compose-backed services, check the observed default health
+ports:
 
 ```bash
-# Already in code-audit worktree
-cp .env.example .env
-nano .env  # Set production values
-
-# Deploy services directly
-cd services/adhd_engine && python main.py &
-cd services/mcp-dopecon-bridge && python main.py &
-# etc.
+curl -fsS http://localhost:3016/health  # dopecon-bridge
+curl -fsS http://localhost:3004/health  # ConPort HTTP
+curl -fsS http://localhost:3010/health  # dope-context
+curl -fsS http://localhost:3020/health  # dope-memory
+curl -fsS http://localhost:8000/health  # task-orchestrator
+curl -fsS http://localhost:3025/health  # ADHD Engine
 ```
 
----
+These ports are defaults from the tracked compose and registry configuration.
+Local `.env` overrides can change them.
 
-## Configuration Required
+## Authority Notes
 
-**Create `.env` file**:
-```bash
-cp .env.example .env
-```
+- `dopemux` owns operator startup, routing, and coordination.
+- `dopetask` owns execution after handoff through `scripts/dopetask`.
+- Leantime owns passive PM metadata.
+- task-orchestrator owns workflow-significant transitions.
+- ConPort owns structured decisions, progress, and context.
+- dope-memory owns chronicle receipts.
+- dope-context owns derived code/docs retrieval.
+- dopecon-bridge is bridge/proxy/event transport only.
+- ADHD Engine is operator support only.
+- Repo Truth Extractor emits evidence artifacts; runtime/source truth still
+  wins.
 
-**Set these values**:
-```
-ALLOWED_ORIGINS=https://yourdomain.com
-ADHD_ENGINE_API_KEY=$(openssl rand -hex 32)
-SERENA_DB_PASSWORD=your-password
-USE_DOPECON_BRIDGE=true
-```
+## If You Get Stuck
 
-**Time**: 5 minutes
+- Installer failure: run `./install.sh --verify` and read the reported blocker.
+- Missing Docker network: follow [Quick Start](../../QUICK_START.md) to create
+  `dopemux-network`.
+- Port conflict: inspect `.env`, existing containers, and local processes
+  before changing docs or code.
+- MCP missing in Claude Code: confirm Claude Code was opened from this checkout
+  and run `/mcp`.
 
----
+## Next Reading
 
-## Validation Tests
-
-**After deployment**:
-
-```bash
-# 1. Health checks
-curl http://localhost:8000/health
-curl http://localhost:3016/kg/health
-
-# 2. Security test
-curl -H "X-API-Key: your-key" http://localhost:8000/api/v1/energy-level/test
-# Should work ✅
-
-curl http://localhost:8000/api/v1/energy-level/test
-# Should fail (no key) ✅
-
-# 3. DopeconBridge test
-curl -X POST http://localhost:3016/custom_data \
-  -H "X-Source-Plane: cognitive_plane" \
-  -d '{"workspace_id":"/test","category":"test","key":"k","value":{"v":1}}'
-# Should save ✅
-```
-
----
-
-## Key Documents
-
-**Must Read**:
-1. `README-AUDIT-COMPLETE.md` ← This file
-1. `ULTIMATE-AUDIT-SUCCESS.md` ← Comprehensive summary
-1. `DEPLOYMENT-WORKTREE-INSTRUCTIONS.md` ← How to deploy
-
-**Reference**:
-1. `claudedocs/` ← All 52 audit reports
-1. `.env.example` ← Configuration template
-1. `LAUNCH-PLAN.md` ← Deployment options
-
----
-
-## What You Have Now
-
-✅ **Production-ready codebase** (10/10 security, 10/10 architecture)
-✅ **Comprehensive documentation** (52 reports, 95% accurate)
-✅ **Clear deployment path** (3 options, all validated)
-✅ **No blockers** (all critical work complete)
-
----
-
-## Recommended Next Steps
-
-**TODAY**:
-1. Review: `ULTIMATE-AUDIT-SUCCESS.md` (5 min)
-1. Push: `git push origin code-audit` (1 min)
-1. PR: Create on GitHub with template above (5 min)
-
-**THIS WEEK**:
-1. Merge: After review (or immediately if solo)
-1. Deploy: Follow `DEPLOYMENT-INSTRUCTIONS.md` (30 min)
-1. Monitor: First 24 hours
-
-**SUCCESS**: Production deployment with perfect security + architecture!
-
----
-
-**EVERYTHING IS READY** 🎉
-
-You can deploy with complete confidence!
-
----
-
-*Audit completed using MCP-enhanced methodology: Dope-Context (semantic search), Zen (AI validation), Serena-v2 (code navigation). Result: 87% time savings with production-grade quality.*
+- [Quick Start](../../QUICK_START.md)
+- [Tutorial Quickstart](quickstart.md)
+- [Developer Onboarding](../02-how-to/developer-onboarding.md)
+- [Architecture](../../ARCHITECTURE.md)
+- [System Boundaries](../03-reference/systems/system-boundaries.md)

--- a/docs/01-tutorials/start-here.md
+++ b/docs/01-tutorials/start-here.md
@@ -50,7 +50,11 @@ specific options, see [INSTALL.md](../../INSTALL.md).
 Load the shell integration that the installer wrote, or open a new terminal:
 
 ```bash
+# zsh
 source ~/.zshrc
+
+# bash
+source ~/.bashrc
 ```
 
 Start the operator CLI:

--- a/docs/01-tutorials/start-here.md
+++ b/docs/01-tutorials/start-here.md
@@ -47,6 +47,12 @@ Run the installer:
 The installer is the repo's first-touch setup path. For unattended or stack
 specific options, see [INSTALL.md](../../INSTALL.md).
 
+Load the shell integration that the installer wrote, or open a new terminal:
+
+```bash
+source ~/.zshrc
+```
+
 Start the operator CLI:
 
 ```bash

--- a/docs/01-tutorials/start-here.md
+++ b/docs/01-tutorials/start-here.md
@@ -3,257 +3,110 @@ id: START-HERE
 title: Start Here
 type: tutorial
 owner: '@hu3mann'
-last_review: '2025-11-10'
-next_review: '2026-02-08'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
 author: '@hu3mann'
 date: '2026-02-05'
 prelude: Start Here (tutorial) for dopemux documentation and developer workflows.
 ---
-# 🚀 START HERE - Complete Audit Success
+# Start Here
 
-**Status**: ✅ **PRODUCTION-READY**
-**Branch**: `code-audit` (ready to push/merge)
-**Time**: 12 hours (saved 81 hours!)
-**Quality**: 9.3/10 overall ⭐⭐⭐⭐⭐
+Use this page as the first-touch path for a local Dopemux checkout. It is a
+short orientation, not a replacement for runtime truth: code, compose wiring,
+tests, and active entrypoints still outrank this document.
 
----
+Dopemux is an operator control workspace for split-authority development
+systems. It coordinates startup, routing, MCP/service surfaces, execution
+handoff, PM metadata, structured context, chronicle memory, retrieval, bridge
+transport, operator support, and repo audit without claiming one system owns
+all of those lanes.
 
-## What Happened
+## First Local Run
 
-We completed a **comprehensive security audit** that:
-1. Found and **FIXED all 10 critical vulnerabilities**
-1. **Completed the DopeconBridge** (was 80% done with stubs)
-1. Achieved **perfect security (10/10)** and **perfect architecture (10/10)**
-1. Created **52 comprehensive reports** documenting everything
-1. Validated **95% documentation accuracy**
+Prerequisites:
 
-**All in 12 hours** instead of the original 93-hour plan!
+- Python 3.11 or newer.
+- Docker with `docker compose`.
+- `uv` for Python dependency management.
+- Claude Code installed and available to open from this repository checkout.
+- Provider API keys for any provider-backed services you choose to run.
 
----
-
-## Security Fixes Applied ✅
-
-**Before**: 4/10 (multiple critical issues)
-**After**: **10/10** ⭐⭐⭐⭐⭐
-
-1. ✅ CORS wildcards (4 services) → Environment whitelists
-1. ✅ Hardcoded credentials (2 files) → Environment variables
-1. ✅ No authentication (7 endpoints) → API key required
-1. ✅ Missing imports → Fixed
-1. ✅ DopeconBridge stubs → Fully implemented
-
-**Impact**: All production-critical vulnerabilities eliminated
-
----
-
-## DopeconBridge - COMPLETE ✅
-
-**Before**: 80% done (custom_data endpoints were stubs)
-**After**: **100% complete** ⭐⭐⭐⭐⭐
-
-**What We Built**:
-- `mcp_client.py` (209 lines) - PostgreSQL integration
-- Wired `save_custom_data()` - Actually saves to database
-- Wired `get_custom_data()` - Actually retrieves data
-- Created `bridge_client.py` - HTTP client for services
-- Migrated ADHD Engine - Uses bridge (not direct SQLite)
-
-**Result**: **ZERO architecture violations** remaining!
-
----
-
-## Documentation - Comprehensive ✅
-
-**52 Reports Created**:
-- Complete audit findings (Phases 1-4)
-- Security analysis and fixes
-- Service reviews (all 12)
-- DopeconBridge completion
-- Deployment guides
-- Performance assessments
-- ADR-206 (formal record)
-
-**Accuracy**: 95% (validated with automated tests)
-
----
-
-## How to Deploy (3 Options)
-
-### Option A: Create PR → Merge → Deploy (Recommended)
+Clone and enter the repo:
 
 ```bash
-# 1. Push branch
-git push origin code-audit
-
-# 2. Create PR with this template:
+git clone https://github.com/DDD-Enterprises/dopemux-mvp
+cd dopemux-mvp
 ```
 
-**PR Title**: Security fixes + DopeconBridge completion + Comprehensive audit
-
-**PR Description**:
-```markdown
-Complete code audit delivering production-ready security + architecture compliance.
-
-## Summary
-- 10 security vulnerabilities fixed
-- DopeconBridge 100% complete
-- Full architecture compliance (ZERO violations)
-- 95% documentation accuracy validated
-
-## Scores
-- Security: 4/10 → 10/10 ⭐⭐⭐⭐⭐
-- Architecture: 6/10 → 10/10 ⭐⭐⭐⭐⭐
-- Overall: 9.3/10 ⭐⭐⭐⭐⭐
-
-## Changes
-- 28 commits
-- 56 files (code + docs)
-- 8,600+ lines (comprehensive improvements)
-
-## Testing
-✅ Security fixes validated
-✅ DopeconBridge tested
-✅ Performance profiled
-✅ Code examples: 100% pass rate
-
-## Deployment
-Ready for immediate production deployment.
-See: DEPLOYMENT-WORKTREE-INSTRUCTIONS.md
-
-## Documentation
-Complete audit trail: 52 reports in claudedocs/
-Key file: ULTIMATE-AUDIT-SUCCESS.md
-```
+Run the installer:
 
 ```bash
-# 3. After PR merged
-cd /Users/hue/code/dopemux-mvp  # Main worktree
-git pull
-# Deploy using DEPLOYMENT-INSTRUCTIONS.md
+./install.sh
 ```
 
----
+The installer is the repo's first-touch setup path. For unattended or stack
+specific options, see [INSTALL.md](../../INSTALL.md).
 
-### Option B: Direct Merge in Main Worktree
+Start the operator CLI:
 
 ```bash
-# Switch to main worktree
-cd /Users/hue/code/dopemux-mvp
-
-# Merge code-audit branch
-git merge code-audit --no-edit
-
-# Push to remote
-git push origin main
-
-# Deploy
-# Use DEPLOYMENT-INSTRUCTIONS.md
+dopemux start
 ```
 
----
+`dopemux start` is the operator cockpit entrypoint. It handles the local
+startup path for Dopemux operator work; use the explicit compose flow in
+[Quick Start](../../QUICK_START.md) when you need to start and inspect the
+compose-backed service stack directly.
 
-### Option C: Deploy from Code-Audit Worktree
+Open Claude Code from this checkout after startup so it reads the repository
+Claude/MCP configuration for the current working directory. In Claude Code, use
+`/mcp` to inspect which MCP servers are visible for the active session.
+
+## Optional Smoke Checks
+
+If you started the compose-backed services, check the observed default health
+ports:
 
 ```bash
-# Already in code-audit worktree
-cp .env.example .env
-nano .env  # Set production values
-
-# Deploy services directly
-cd services/adhd_engine && python main.py &
-cd services/mcp-dopecon-bridge && python main.py &
-# etc.
+curl -fsS http://localhost:3016/health  # dopecon-bridge
+curl -fsS http://localhost:3004/health  # ConPort HTTP
+curl -fsS http://localhost:3010/health  # dope-context
+curl -fsS http://localhost:3020/health  # dope-memory
+curl -fsS http://localhost:8000/health  # task-orchestrator
+curl -fsS http://localhost:3025/health  # ADHD Engine
 ```
 
----
+These ports are defaults from the tracked compose and registry configuration.
+Local `.env` overrides can change them.
 
-## Configuration Required
+## Authority Notes
 
-**Create `.env` file**:
-```bash
-cp .env.example .env
-```
+- `dopemux` owns operator startup, routing, and coordination.
+- `dopetask` owns execution after handoff through `scripts/dopetask`.
+- Leantime owns passive PM metadata.
+- task-orchestrator owns workflow-significant transitions.
+- ConPort owns structured decisions, progress, and context.
+- dope-memory owns chronicle receipts.
+- dope-context owns derived code/docs retrieval.
+- dopecon-bridge is bridge/proxy/event transport only.
+- ADHD Engine is operator support only.
+- Repo Truth Extractor emits evidence artifacts; runtime/source truth still
+  wins.
 
-**Set these values**:
-```
-ALLOWED_ORIGINS=https://yourdomain.com
-ADHD_ENGINE_API_KEY=$(openssl rand -hex 32)
-SERENA_DB_PASSWORD=your-password
-USE_DOPECON_BRIDGE=true
-```
+## If You Get Stuck
 
-**Time**: 5 minutes
+- Installer failure: run `./install.sh --verify` and read the reported blocker.
+- Missing Docker network: follow [Quick Start](../../QUICK_START.md) to create
+  `dopemux-network`.
+- Port conflict: inspect `.env`, existing containers, and local processes
+  before changing docs or code.
+- MCP missing in Claude Code: confirm Claude Code was opened from this checkout
+  and run `/mcp`.
 
----
+## Next Reading
 
-## Validation Tests
-
-**After deployment**:
-
-```bash
-# 1. Health checks
-curl http://localhost:8000/health
-curl http://localhost:3016/kg/health
-
-# 2. Security test
-curl -H "X-API-Key: your-key" http://localhost:8000/api/v1/energy-level/test
-# Should work ✅
-
-curl http://localhost:8000/api/v1/energy-level/test
-# Should fail (no key) ✅
-
-# 3. DopeconBridge test
-curl -X POST http://localhost:3016/custom_data \
-  -H "X-Source-Plane: cognitive_plane" \
-  -d '{"workspace_id":"/test","category":"test","key":"k","value":{"v":1}}'
-# Should save ✅
-```
-
----
-
-## Key Documents
-
-**Must Read**:
-1. `README-AUDIT-COMPLETE.md` ← This file
-1. `ULTIMATE-AUDIT-SUCCESS.md` ← Comprehensive summary
-1. `DEPLOYMENT-WORKTREE-INSTRUCTIONS.md` ← How to deploy
-
-**Reference**:
-1. `claudedocs/` ← All 52 audit reports
-1. `.env.example` ← Configuration template
-1. `LAUNCH-PLAN.md` ← Deployment options
-
----
-
-## What You Have Now
-
-✅ **Production-ready codebase** (10/10 security, 10/10 architecture)
-✅ **Comprehensive documentation** (52 reports, 95% accurate)
-✅ **Clear deployment path** (3 options, all validated)
-✅ **No blockers** (all critical work complete)
-
----
-
-## Recommended Next Steps
-
-**TODAY**:
-1. Review: `ULTIMATE-AUDIT-SUCCESS.md` (5 min)
-1. Push: `git push origin code-audit` (1 min)
-1. PR: Create on GitHub with template above (5 min)
-
-**THIS WEEK**:
-1. Merge: After review (or immediately if solo)
-1. Deploy: Follow `DEPLOYMENT-INSTRUCTIONS.md` (30 min)
-1. Monitor: First 24 hours
-
-**SUCCESS**: Production deployment with perfect security + architecture!
-
----
-
-**EVERYTHING IS READY** 🎉
-
-You can deploy with complete confidence!
-
----
-
-*Audit completed using MCP-enhanced methodology: Dope-Context (semantic search), Zen (AI validation), Serena-v2 (code navigation). Result: 87% time savings with production-grade quality.*
+- [Quick Start](../../QUICK_START.md)
+- [Tutorial Quickstart](quickstart.md)
+- [Developer Onboarding](../02-how-to/developer-onboarding.md)
+- [Architecture](../../ARCHITECTURE.md)
+- [System Boundaries](../03-reference/systems/system-boundaries.md)

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -76,6 +76,7 @@ A packet is superseded by another packet
 | TP-DMX-AGENTS-CODEX-ENDTOEND-0001 | Agent Guidance | Make Codex execute TP lifecycle end-to-end by default | Ready | N/A |
 | TP-DMX-ORCH-DOCS-003 | Task Orchestrator | Document read-only/operator-status integration authority boundaries | Active | N/A |
 | TP-DMX-COMPOSE-RESTORE-001 | Infra | Restore canonical Docker Compose authority | Ready | N/A |
+| TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001 | Docs | Refresh active Start Here onboarding and product naming | Active | N/A |
 | DMX-COCKPIT-STATIC-002 | UI Cockpit | Expose deterministic static cockpit renderer through guarded CLI wrapper | Merged (PR #528) | N/A |
 | TP-DMX-COCKPIT-MERGE-STACK-CONSOLIDATE-001 | UI Cockpit | Audit and prepare Cockpit PR stack 568-571 plus PR 573 evidence for safe consolidation | Active | N/A |
 | TP-DMX-COCKPIT-RUNTIME-RENDER-001 | UI Cockpit | Wire runtime renderer primitives to accepted Cockpit IA package contract | Active | N/A |

--- a/task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json
+++ b/task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json
@@ -1,0 +1,107 @@
+{
+  "id": "TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001",
+  "project": "dopemux-mvp",
+  "target": "first-touch docs product name and onboarding drift",
+  "invariants": [
+    "Fix only confirmed stale first-touch onboarding content.",
+    "Preserve repo truth labels where runtime startup behavior is not validated.",
+    "Do not rewrite archived or historical docs unless they are active onboarding surfaces.",
+    "Document remaining archive-only chatx references as out of scope."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "beta-remaining-docs-first-touch",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "fix/docs-first-touch-product-name",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "docs(onboarding): refresh first-touch start here",
+    "allowlist": [
+      "docs/01-tutorials/start-here.md",
+      "docs/01-tutorials/start-here-2.md",
+      "docs/01-tutorials/start-here-3.md",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json",
+      "claudedocs/docs-first-touch-product-name-proof-2026-05-31.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "grep -rn \"chatx\\|chat-x\\|ChatX\" README.md INSTALL.md docs/01-tutorials 2>/dev/null",
+      "python scripts/docs_validator.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md",
+      "python scripts/docs_frontmatter_guard.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md",
+      "git diff --check",
+      "pre-commit run --files docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md task-packets/INDEX.md task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json claudedocs/docs-first-touch-product-name-proof-2026-05-31.md"
+    ]
+  },
+  "pr": {
+    "title": "docs(onboarding): refresh first-touch start here",
+    "body": "## Problem\\nThe active Start Here tutorial describes a stale code-audit branch rather than Dopemux onboarding.\\n\\n## Fix\\nReplace the active Start Here variants with a repo-grounded Dopemux first-touch flow.\\n\\n## Test Plan\\n- Validate Task Packet JSON and schema.\\n- Check active first-touch docs for chatx references.\\n- Run docs validator/frontmatter guard, git diff --check, and pre-commit on changed files.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect active first-touch docs and product-name references before editing.",
+      "requirements": [
+        "Run the prescribed chatx grep.",
+        "Read active tutorial start/quickstart surfaces.",
+        "Distinguish active onboarding docs from archived historical docs."
+      ],
+      "validation": [
+        "grep -rn \"chatx\\|chat-x\\|ChatX\" docs/ README.md INSTALL.md 2>/dev/null | head -20",
+        "sed -n '1,180p' docs/01-tutorials/start-here.md",
+        "sed -n '1,180p' docs/01-tutorials/quickstart.md"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Replace confirmed stale Start Here content with the actual Dopemux first-touch flow.",
+      "requirements": [
+        "Reflect clone/install, ./install.sh, dopemux start, and opening Claude Code.",
+        "Preserve explicit uncertainty for live startup behavior not validated in this slice.",
+        "Keep archived chatx references out of scope unless active onboarding docs reference them."
+      ],
+      "validation": [
+        "grep -rn \"chatx\\|chat-x\\|ChatX\" README.md INSTALL.md docs/01-tutorials 2>/dev/null"
+      ]
+    },
+    {
+      "id": "precommit",
+      "task": "Validate docs, codereview, pre-commit, commit, push, and open the PR.",
+      "requirements": [
+        "Inspect diff scope before staging.",
+        "Report archive-only chatx references as remaining risk, not active onboarding failures."
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python scripts/docs_validator.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md",
+        "python scripts/docs_frontmatter_guard.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md",
+        "git diff --check",
+        "pre-commit run --files docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md task-packets/INDEX.md task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json claudedocs/docs-first-touch-product-name-proof-2026-05-31.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json
+++ b/task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json
@@ -39,7 +39,7 @@
     "verify": [
       "python -m json.tool task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json >/dev/null",
       "python -m jsonschema -i task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
-      "grep -rn \"chatx\\|chat-x\\|ChatX\" README.md INSTALL.md docs/01-tutorials 2>/dev/null",
+      "grep -rn \"chatx\\|chat-x\\|ChatX\" README.md INSTALL.md docs/01-tutorials 2>/dev/null; test $? -eq 1",
       "python scripts/docs_validator.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md",
       "python scripts/docs_frontmatter_guard.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md",
       "git diff --check",
@@ -70,7 +70,7 @@
         "Distinguish active onboarding docs from archived historical docs."
       ],
       "validation": [
-        "grep -rn \"chatx\\|chat-x\\|ChatX\" docs/ README.md INSTALL.md 2>/dev/null | head -20",
+        "grep -rn \"chatx\\|chat-x\\|ChatX\" docs/ README.md INSTALL.md 2>/dev/null; test $? -eq 1",
         "sed -n '1,180p' docs/01-tutorials/start-here.md",
         "sed -n '1,180p' docs/01-tutorials/quickstart.md"
       ]
@@ -84,7 +84,7 @@
         "Keep archived chatx references out of scope unless active onboarding docs reference them."
       ],
       "validation": [
-        "grep -rn \"chatx\\|chat-x\\|ChatX\" README.md INSTALL.md docs/01-tutorials 2>/dev/null"
+        "grep -rn \"chatx\\|chat-x\\|ChatX\" README.md INSTALL.md docs/01-tutorials 2>/dev/null; test $? -eq 1"
       ]
     },
     {


### PR DESCRIPTION
## Problem

The active `docs/01-tutorials/start-here*.md` files described a stale `code-audit` branch/audit-success workflow instead of a new user's Dopemux onboarding path.

The prescribed `chatx` grep still finds `ChatX` only under `docs/archive/...` historical material. Those files are not active first-touch docs and were left unchanged because this slice only rewrites docs that were read and confirmed as active onboarding surfaces.

## Fix

- Replace `start-here.md`, `start-here-2.md`, and `start-here-3.md` with a repo-grounded Dopemux first-touch flow:
  - clone repo
  - run `./install.sh`
  - run `dopemux start`
  - open Claude Code from the checkout and inspect `/mcp`
- Preserve authority notes and runtime-truth caveats.
- Add Task Packet and proof artifact.

## Validation

PASS:
- `python -m json.tool task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json >/dev/null`
- `python -m jsonschema -i task-packets/generated/TP-DOCS-FIRST-TOUCH-PRODUCT-NAME-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `grep -rn "chatx\|chat-x\|ChatX" README.md INSTALL.md docs/01-tutorials 2>/dev/null; test $? -eq 1`
- `rg -n "code-audit|README-AUDIT|ULTIMATE-AUDIT|production-ready|START HERE - Complete Audit" docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md; test $? -eq 1`
- `python scripts/docs_validator.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md`
- `python scripts/docs_frontmatter_guard.py docs/01-tutorials/start-here.md docs/01-tutorials/start-here-2.md docs/01-tutorials/start-here-3.md`
- `git diff --check`
- PAL codereview with `gpt-5-codex` -> no issues found
- `pre-commit run --files ...` on changed files -> passed

WARN:
- Archive/history-only `ChatX` references remain under `docs/archive/...`.
- Live `./install.sh` and `dopemux start` were not run in this docs-only slice.

@codex review
@gemini
@copilot
