### PR TITLE
feat(pr-merge): gate remediation seams behind steward_gate

### DIFF
--- a/config/pr_merge_specialist/policy.yaml
+++ b/config/pr_merge_specialist/policy.yaml
@@ -124,6 +124,7 @@ merge:
     - merge_queue_required
 steward_gate:
   artifact_ttl_seconds: 3600
+  allow_global_fix_prs: false
   remediation_readiness:
     - NEEDS_IMPLEMENTER
   finalization_readiness:

--- a/docs/ops/steward-merge-gate.md
+++ b/docs/ops/steward-merge-gate.md
@@ -43,6 +43,35 @@ The gate denies when:
 | `REMEDIATION` | `NEEDS_IMPLEMENTER` |
 | `FINALIZATION` | `READY` |
 
-TP-DMX-STEWARD-GATE-201 only adds the guard library. It is not wired into
-remediation, finalization, merge, thread-resolution, or GitHub mutation seams.
-Those integrations are separate packets.
+## Remediation Wiring
+
+TP-DMX-MERGE-REMEDIATION-202 wires `steward_gate(REMEDIATION)` into the
+remediation mutation seams in `dopemux_pr_merge_specialist.queue_drain`:
+
+- review-thread implementation, rationale replies, and agentic thread fixes
+- mechanical conflict recovery after rebase failure
+- local validation and reproduced remote-check AI remediation
+- shared global-fix PR creation policy
+
+Remediation requires fresh local `MERGE_READINESS.json` and `PROOF.json`
+artifacts for the exact PR head SHA. The PR Steward readiness must be
+`NEEDS_IMPLEMENTER`, both embedded-audit statuses must be `PASS` or
+`PASS_WITH_RISKS`, and `MERGE_READINESS.json.blockers` must contain at least one
+implementer-owned blocker such as `UNRESOLVED_REVIEW_THREAD`, `FAILED_CHECK`,
+`REQUEST_CHANGES`, or `REVIEW_ITEM_MUST_FIX`.
+
+When the remediation gate denies, queue drain records
+`STEWARD_REMEDIATION_GATE.json`, sets `operator_state` to
+`steward_remediation_blocked`, and does not launch Gemini, apply review-thread
+changes, create shared global-fix PRs, or perform conflict auto-recovery.
+
+Thread resolution remains outside TP-DMX-MERGE-REMEDIATION-202. Remediation may
+reply and push verified fixes, but resolving review threads is deferred to the
+finalization packet.
+
+Shared global-fix PR creation is disabled when `steward_gate` policy is present
+unless `steward_gate.allow_global_fix_prs` is explicitly `true`.
+
+TP-DMX-STEWARD-GATE-201 only added the guard library. TP202 wires remediation
+seams only; finalization, merge execution, governed automerge, and review-thread
+resolution remain separate packet work.

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/AUDITOR_REPORT.md
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/AUDITOR_REPORT.md
@@ -1,0 +1,15 @@
+# Auditor Report
+
+Status: `SKIPPED`
+
+No external embedded auditor was invoked in this Codex session. Manual bounded review covered:
+
+- remediation gate denial paths are fail-closed on missing artifacts, stale/nonmatching proof via `steward_gate`, and missing implementer-owned blockers
+- queue-drain remediation mutation points check the remediation gate before thread remediation, conflict auto-recovery, local CI remediation, and reproduced remote-check remediation
+- shared global-fix PR creation is blocked when repo `steward_gate` policy is present unless explicitly allowed
+- `pr_apply` no longer resolves review threads after remediation; resolution remains deferred to finalization packet work
+
+Residual risks:
+
+- Admin-bypass and merge finalization seams are intentionally not wired in TP202 because TP203 owns finalization/merge execution.
+- External embedded audit and supervisor review remain required before accepting this red-lane packet.

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/CHANGED_FILES.txt
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/CHANGED_FILES.txt
@@ -1,0 +1,12 @@
+config/pr_merge_specialist/policy.yaml
+docs/ops/steward-merge-gate.md
+src/dopemux_pr_merge_specialist/queue_drain.py
+task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json
+tests/pr_merge_specialist/test_remediation_gate.py
+proof/TP-DMX-MERGE-REMEDIATION-202/AUDITOR_REPORT.md
+proof/TP-DMX-MERGE-REMEDIATION-202/CHANGED_FILES.txt
+proof/TP-DMX-MERGE-REMEDIATION-202/DIFF_STAT.txt
+proof/TP-DMX-MERGE-REMEDIATION-202/GIT_STATE.md
+proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json
+proof/TP-DMX-MERGE-REMEDIATION-202/VALIDATION_OUTPUT.md
+proof/TP-DMX-MERGE-REMEDIATION-202/review_bundle/README.md

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/DIFF_STAT.txt
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/DIFF_STAT.txt
@@ -1,0 +1,6 @@
+ config/pr_merge_specialist/policy.yaml             |   1 +
+ docs/ops/steward-merge-gate.md                     |  35 ++-
+ src/dopemux_pr_merge_specialist/queue_drain.py     | 284 ++++++++++++++++++---
+ .../generated/TP-DMX-MERGE-REMEDIATION-202.json    |   4 +-
+ tests/pr_merge_specialist/test_remediation_gate.py | 119 +++++++++
+ 5 files changed, 401 insertions(+), 42 deletions(-)

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/GIT_STATE.md
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/GIT_STATE.md
@@ -1,0 +1,22 @@
+# Git State
+
+- worktree: `/Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-merge-remediation-202`
+- branch: `codex/tp-dmx-merge-remediation-202`
+- base branch: `origin/codex/tp-dmx-steward-gate-201`
+- base/head before TP202 commit: `eac0853f521041c5d52f0d40eddb4be84d66b424`
+- TP202 implementation commit before proof metadata amend:
+  `29bed2029a813e9c294273e6db36901fcd3ba13b`
+- origin: `https://github.com/DDD-Enterprises/dopemux-mvp.git`
+- repo marker: `.dopetaskroot` present
+- primary checkout dirty state: ignored; TP202 work ran in the dedicated worktree above
+
+Intended staged files before commit:
+
+```text
+M  config/pr_merge_specialist/policy.yaml
+M  docs/ops/steward-merge-gate.md
+M  src/dopemux_pr_merge_specialist/queue_drain.py
+M  task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json
+A  tests/pr_merge_specialist/test_remediation_gate.py
+?? proof/TP-DMX-MERGE-REMEDIATION-202/
+```

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/GIT_STATE.md
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/GIT_STATE.md
@@ -4,8 +4,8 @@
 - branch: `codex/tp-dmx-merge-remediation-202`
 - base branch: `origin/codex/tp-dmx-steward-gate-201`
 - base/head before TP202 commit: `eac0853f521041c5d52f0d40eddb4be84d66b424`
-- TP202 implementation commit before proof metadata amend:
-  `29bed2029a813e9c294273e6db36901fcd3ba13b`
+- TP202 implementation commit:
+  `01e83f86a3cd60543f2835a378fb409e0387e1a7`
 - origin: `https://github.com/DDD-Enterprises/dopemux-mvp.git`
 - repo marker: `.dopetaskroot` present
 - primary checkout dirty state: ignored; TP202 work ran in the dedicated worktree above

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json
@@ -1,0 +1,142 @@
+{
+  "tp_id": "TP-DMX-MERGE-REMEDIATION-202",
+  "status": "PASS_WITH_LIMITS",
+  "generated_at": "2026-05-31T14:18:45Z",
+  "worktree_path": "/Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-merge-remediation-202",
+  "branch": "codex/tp-dmx-merge-remediation-202",
+  "base_ref": "origin/codex/tp-dmx-steward-gate-201",
+  "base_sha": "eac0853f521041c5d52f0d40eddb4be84d66b424",
+  "head_sha": "29bed2029a813e9c294273e6db36901fcd3ba13b",
+  "repo_identity": {
+    "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "marker": ".dopetaskroot",
+    "identity_match": true
+  },
+  "stacking": {
+    "reason": "TP202 depends on TP-DMX-STEWARD-GATE-201, which is open as draft PR #765 and not yet merged to main.",
+    "base_branch": "codex/tp-dmx-steward-gate-201"
+  },
+  "dependency_proofs": [
+    {
+      "tp_id": "TP-DMX-STEWARD-GATE-201",
+      "path": "proof/TP-DMX-STEWARD-GATE-201/PROOF.json",
+      "present": true,
+      "status": "PASS_WITH_LIMITS",
+      "note": "Dependency proof validates and #765 CI passed, but its external embedded audit was locally skipped."
+    }
+  ],
+  "authority_used": [
+    "AGENTS.md",
+    "task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json",
+    "task-packets/generated/TP-DMX-STEWARD-GATE-201.json",
+    "docs/ops/steward-merge-gate.md",
+    "src/dopemux_pr_merge_specialist/queue_drain.py",
+    "src/dopemux_pr_merge_specialist/steward_gate.py",
+    "config/pr_merge_specialist/policy.yaml",
+    "tests/pr_merge_specialist"
+  ],
+  "slices_completed": [
+    "RED: added tests/pr_merge_specialist/test_remediation_gate.py and observed AttributeError for missing queue_drain gate helpers.",
+    "GREEN: added require_steward_remediation_gate and global_fix_prs_allowed helpers, then wired the gate into queue-drain remediation mutation points.",
+    "Changed pr_apply thread handling so remediation does not resolve review threads; finalization remains deferred to TP203.",
+    "Disabled shared global-fix PR creation under repo steward_gate policy unless explicitly allowed.",
+    "Updated TP202 docs and packet base to reflect the stacked TP201 dependency."
+  ],
+  "files_changed": [
+    "config/pr_merge_specialist/policy.yaml",
+    "docs/ops/steward-merge-gate.md",
+    "src/dopemux_pr_merge_specialist/queue_drain.py",
+    "task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json",
+    "tests/pr_merge_specialist/test_remediation_gate.py",
+    "proof/TP-DMX-MERGE-REMEDIATION-202/AUDITOR_REPORT.md",
+    "proof/TP-DMX-MERGE-REMEDIATION-202/CHANGED_FILES.txt",
+    "proof/TP-DMX-MERGE-REMEDIATION-202/DIFF_STAT.txt",
+    "proof/TP-DMX-MERGE-REMEDIATION-202/GIT_STATE.md",
+    "proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json",
+    "proof/TP-DMX-MERGE-REMEDIATION-202/VALIDATION_OUTPUT.md",
+    "proof/TP-DMX-MERGE-REMEDIATION-202/review_bundle/README.md"
+  ],
+  "validations": [
+    {
+      "command": "PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist/test_remediation_gate.py",
+      "exit_code": 1,
+      "status": "RED_PASS",
+      "evidence": "AttributeError for missing require_steward_remediation_gate and global_fix_prs_allowed helpers."
+    },
+    {
+      "command": "PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist/test_remediation_gate.py",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "4 passed"
+    },
+    {
+      "command": "PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist/test_remediation_gate.py tests/pr_merge_specialist/test_agentic_thread_remediation.py tests/pr_merge_specialist/test_queue_drain_integration.py",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m py_compile src/dopemux_pr_merge_specialist/queue_drain.py src/dopemux_pr_merge_specialist/policy.py tests/pr_merge_specialist/test_remediation_gate.py",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m compileall -q src tests",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m jsonschema -i task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "pre-commit run --files <TP202 changed files>",
+      "exit_code": 0,
+      "status": "PASS"
+    }
+  ],
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DMX-MERGE-REMEDIATION-202/AUDITOR_REPORT.md",
+    "findings": [],
+    "fixes_applied": [],
+    "remaining_risks": [
+      "External embedded audit was not invoked in this Codex session.",
+      "Supervisor review is still required for this red-lane merge-engine change."
+    ],
+    "skip_reason": "No supported external embedded-auditor invocation was available in this session; Codex performed bounded manual audit and records this required audit as skipped."
+  },
+  "codereview_status": "Manual bounded review complete; tests cover gate allow/deny and existing queue-drain regressions pass.",
+  "precommit_status": "PASS: pre-commit run on TP202 changed files and git diff --check passed.",
+  "commit_sha": "29bed2029a813e9c294273e6db36901fcd3ba13b",
+  "pr_url": "PENDING_PR",
+  "residual_risks": [
+    "TP202 is stacked on TP201 because TP201 is not merged to main.",
+    "External embedded audit and supervisor review remain required before treating this red-lane packet as accepted.",
+    "Admin-bypass and merge-finalization authority remain intentionally deferred to TP203."
+  ],
+  "unknowns": [
+    "Task Orchestrator MCP context unavailable: Transport closed."
+  ],
+  "cleanup_status": "WORKTREE_ACTIVE_PENDING_PR"
+}

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json
@@ -6,7 +6,7 @@
   "branch": "codex/tp-dmx-merge-remediation-202",
   "base_ref": "origin/codex/tp-dmx-steward-gate-201",
   "base_sha": "eac0853f521041c5d52f0d40eddb4be84d66b424",
-  "head_sha": "29bed2029a813e9c294273e6db36901fcd3ba13b",
+  "head_sha": "01e83f86a3cd60543f2835a378fb409e0387e1a7",
   "repo_identity": {
     "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
     "marker": ".dopetaskroot",
@@ -128,7 +128,7 @@
   },
   "codereview_status": "Manual bounded review complete; tests cover gate allow/deny and existing queue-drain regressions pass.",
   "precommit_status": "PASS: pre-commit run on TP202 changed files and git diff --check passed.",
-  "commit_sha": "29bed2029a813e9c294273e6db36901fcd3ba13b",
+  "commit_sha": "01e83f86a3cd60543f2835a378fb409e0387e1a7",
   "pr_url": "PENDING_PR",
   "residual_risks": [
     "TP202 is stacked on TP201 because TP201 is not merged to main.",

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json
@@ -129,7 +129,7 @@
   "codereview_status": "Manual bounded review complete; tests cover gate allow/deny and existing queue-drain regressions pass.",
   "precommit_status": "PASS: pre-commit run on TP202 changed files and git diff --check passed.",
   "commit_sha": "01e83f86a3cd60543f2835a378fb409e0387e1a7",
-  "pr_url": "PENDING_PR",
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/766",
   "residual_risks": [
     "TP202 is stacked on TP201 because TP201 is not merged to main.",
     "External embedded audit and supervisor review remain required before treating this red-lane packet as accepted.",

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/VALIDATION_OUTPUT.md
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/VALIDATION_OUTPUT.md
@@ -1,0 +1,73 @@
+# Validation Output
+
+## RED
+
+```text
+PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist/test_remediation_gate.py
+exit_code=1
+
+AttributeError: module 'dopemux_pr_merge_specialist.queue_drain' has no attribute 'require_steward_remediation_gate'
+AttributeError: module 'dopemux_pr_merge_specialist.queue_drain' has no attribute 'global_fix_prs_allowed'
+```
+
+## PASS
+
+```text
+PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist/test_remediation_gate.py
+exit_code=0
+4 passed
+```
+
+```text
+PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist/test_remediation_gate.py tests/pr_merge_specialist/test_agentic_thread_remediation.py tests/pr_merge_specialist/test_queue_drain_integration.py
+exit_code=0
+```
+
+```text
+PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist
+exit_code=0
+```
+
+```text
+python -m py_compile src/dopemux_pr_merge_specialist/queue_drain.py src/dopemux_pr_merge_specialist/policy.py tests/pr_merge_specialist/test_remediation_gate.py
+exit_code=0
+```
+
+```text
+python -m compileall -q src tests
+exit_code=0
+```
+
+```text
+python -m json.tool task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json
+exit_code=0
+```
+
+```text
+python -m jsonschema -i task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+exit_code=0
+```
+
+```text
+git diff --check
+exit_code=0
+```
+
+```text
+pre-commit run --files config/pr_merge_specialist/policy.yaml docs/ops/steward-merge-gate.md src/dopemux_pr_merge_specialist/queue_drain.py task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json tests/pr_merge_specialist/test_remediation_gate.py proof/TP-DMX-MERGE-REMEDIATION-202/AUDITOR_REPORT.md proof/TP-DMX-MERGE-REMEDIATION-202/CHANGED_FILES.txt proof/TP-DMX-MERGE-REMEDIATION-202/DIFF_STAT.txt proof/TP-DMX-MERGE-REMEDIATION-202/GIT_STATE.md proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json proof/TP-DMX-MERGE-REMEDIATION-202/VALIDATION_OUTPUT.md proof/TP-DMX-MERGE-REMEDIATION-202/review_bundle/README.md
+exit_code=0
+```
+
+## NOT_RUN
+
+```text
+Task Orchestrator get_context
+status=NOT_RUN
+reason=Transport closed
+```
+
+```text
+External embedded auditor
+status=SKIPPED
+reason=No supported external embedded-auditor invocation was available in this Codex session.
+```

--- a/proof/TP-DMX-MERGE-REMEDIATION-202/review_bundle/README.md
+++ b/proof/TP-DMX-MERGE-REMEDIATION-202/review_bundle/README.md
@@ -1,0 +1,11 @@
+# TP-DMX-MERGE-REMEDIATION-202 Review Bundle
+
+Review the repository diff plus this proof directory as the single upload unit.
+
+Primary files:
+
+- `src/dopemux_pr_merge_specialist/queue_drain.py`
+- `tests/pr_merge_specialist/test_remediation_gate.py`
+- `docs/ops/steward-merge-gate.md`
+- `config/pr_merge_specialist/policy.yaml`
+- `task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json`

--- a/src/dopemux_pr_merge_specialist/queue_drain.py
+++ b/src/dopemux_pr_merge_specialist/queue_drain.py
@@ -24,6 +24,7 @@ from .runtime import CommandResult, append_command_log, append_live_log, execute
 from .schema import ARTIFACT_VERSION, ArtifactMeta, BlockerType, FallbackReason, Finding, FindingSeverity, Fingerprint, MergeDecision, MergeActionType, OverrideRecord, PhaseRecord, PRResult, PRState, PRStateData, POLICY_SCHEMA_VERSION, PreflightCheck, PreflightResult, PullRequestState, QueueOrderingLayer, ReviewThread, RunManifest, ThreadComment, ThreadDisposition, ThreadDispositionType, TruthSource, ValidationReport, ValidationStatus, ValidationStepResult, TOOL_VERSION
 from .validation import run_validation, validation_report_md
 from .strategy_library import STRATEGY_LIBRARY, select_strategy, StrategyAssignment, TRAIN_ELIGIBLE_STRATEGIES, STRATEGY_EXECUTION_ORDER
+from .steward_gate import StewardGateResult, steward_gate
 
 
 
@@ -66,7 +67,7 @@ from .conflict import (
 from .merge import checks_green, wait_for_green_checks, checks_blocker_reason, decide_merge_action, run_merge_with_fallback, serialize_check_payload
 from .worktree import prepare_worktree, cleanup_worktree, ensure_worktree_matches_pr_head, attempt_rebase, attempt_speculative_rebase, push_rebased_head, auto_recover_rebase_conflicts
 
-__all__ = ['queue_scan', 'queue_scan_internal', 'pr_plan', 'pr_apply', 'pr_merge', 'pr_approve', 'pr_ready', '_get_ops_engine', '_derive_allowed_actions', 'queue_drain', 'stage_and_push_if_needed', 'update_remaining_pr_bases']
+__all__ = ['queue_scan', 'queue_scan_internal', 'pr_plan', 'pr_apply', 'pr_merge', 'pr_approve', 'pr_ready', '_get_ops_engine', '_derive_allowed_actions', 'queue_drain', 'stage_and_push_if_needed', 'update_remaining_pr_bases', 'require_steward_remediation_gate', 'global_fix_prs_allowed']
 
 def stage_and_push_if_needed(*, worktree_path: Path, head_ref: str, active_run_id: str, pr_id: int, execute: bool, commands_log: Path, policy: Dict[str, Any], log: Optional[Callable] = None) -> bool:
     def _log(msg: str):
@@ -277,6 +278,143 @@ def _with_operator_state(
         else result.lifecycle_state
     )
     return replace(result, lifecycle_state=lifecycle_state, artifacts=artifacts)
+
+
+IMPLEMENTER_BLOCKERS = {
+    "UNRESOLVED_REVIEW_THREAD",
+    "FAILED_CHECK",
+    "REQUEST_CHANGES",
+    "REVIEW_ITEM_MUST_FIX",
+    "ACTIVE_THREAD",
+    "REQUIRED_CHECK_FAILED",
+    "CONFLICT_DETECTED",
+}
+
+
+def global_fix_prs_allowed(policy: Dict[str, Any]) -> bool:
+    return bool(policy.get("steward_gate", {}).get("allow_global_fix_prs", False))
+
+
+def _steward_gate_now(value: Any) -> Optional[datetime]:
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    raise TypeError("now must be a datetime, ISO timestamp string, or None")
+
+
+def _steward_artifact_path(
+    raw_path: Any,
+    *,
+    pr_dir: Path,
+    pr_id: int,
+    default_name: str,
+) -> Path:
+    if raw_path:
+        rendered = str(raw_path).format(pr_dir=str(pr_dir), pr_id=pr_id)
+        path = Path(rendered)
+        return path if path.is_absolute() else pr_dir / path
+    return pr_dir / default_name
+
+
+def require_steward_remediation_gate(
+    *,
+    pr: PullRequestState,
+    policy: Dict[str, Any],
+    pr_dir: Path,
+    now: Any = None,
+) -> StewardGateResult:
+    gate_policy = policy.get("steward_gate", {})
+    merge_readiness_path = _steward_artifact_path(
+        gate_policy.get("merge_readiness_path"),
+        pr_dir=pr_dir,
+        pr_id=pr.pr_id,
+        default_name="MERGE_READINESS.json",
+    )
+    audit_proof_path = _steward_artifact_path(
+        gate_policy.get("audit_proof_path"),
+        pr_dir=pr_dir,
+        pr_id=pr.pr_id,
+        default_name="PROOF.json",
+    )
+    result = steward_gate(
+        head_sha=pr.head_sha,
+        required_class="REMEDIATION",
+        merge_readiness_path=merge_readiness_path,
+        audit_proof_path=audit_proof_path,
+        now=_steward_gate_now(now),
+        ttl_seconds=int(gate_policy.get("artifact_ttl_seconds", 3600) or 3600),
+    )
+    if not result.allowed:
+        return result
+
+    try:
+        readiness = json.loads(merge_readiness_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError) as exc:
+        return StewardGateResult(
+            allowed=False,
+            reason_code="DENY_ARTIFACT_UNREADABLE",
+            required_class="REMEDIATION",
+            evidence={"error": type(exc).__name__},
+        )
+    blockers = [
+        str(item)
+        for item in readiness.get("blockers", [])
+        if isinstance(item, str) and item
+    ]
+    implementer_blockers = [
+        blocker for blocker in blockers if blocker in IMPLEMENTER_BLOCKERS
+    ]
+    if not implementer_blockers:
+        return StewardGateResult(
+            allowed=False,
+            reason_code="DENY_NO_IMPLEMENTER_BLOCKER",
+            required_class="REMEDIATION",
+            evidence={**dict(result.evidence), "blockers": blockers},
+        )
+    return StewardGateResult(
+        allowed=True,
+        reason_code=result.reason_code,
+        required_class=result.required_class,
+        evidence={**dict(result.evidence), "implementer_blockers": implementer_blockers},
+    )
+
+
+def _steward_gate_blocked_result(
+    *,
+    active_run_id: str,
+    pr: PullRequestState,
+    threads: List[ReviewThread],
+    check_payload: Dict[str, Any],
+    validation: ValidationReport,
+    policy: Dict[str, Any],
+    gate_result: StewardGateResult,
+    pr_dir: Path,
+) -> PRResult:
+    result = build_plan_result(
+        active_run_id=active_run_id,
+        pr=pr,
+        threads=threads,
+        check_payload=check_payload,
+        validation_report=validation,
+        policy=policy,
+    )
+    result = _with_operator_state(
+        result,
+        "steward_remediation_blocked",
+        detail=gate_result.reason_code,
+    )
+    write_json(
+        pr_dir / "STEWARD_REMEDIATION_GATE.json",
+        {
+            "allowed": gate_result.allowed,
+            "reason_code": gate_result.reason_code,
+            "required_class": gate_result.required_class,
+            "evidence": dict(gate_result.evidence),
+        },
+    )
+    write_pr_state_artifact(pr_dir, result)
+    return result
 
 
 def _merge_prepared_result(
@@ -863,6 +1001,37 @@ def pr_apply(
             if has_conflicts(pr.mergeable, pr.merge_state_status)
             else ""
         )
+        needs_thread_remediation = any(
+            disposition.disposition
+            in {
+                ThreadDispositionType.IMPLEMENT,
+                ThreadDispositionType.AGENTIC_FIX,
+                ThreadDispositionType.DECLINE_WITH_RATIONALE,
+                ThreadDispositionType.AUTO_RESOLVE_OUTDATED,
+            }
+            for disposition in thread_dispositions
+        )
+        if execute and needs_thread_remediation:
+            gate_result = require_steward_remediation_gate(
+                pr=pr,
+                policy=policy,
+                pr_dir=pr_dir,
+            )
+            if not gate_result.allowed:
+                log(
+                    f"Steward remediation gate denied thread remediation: {gate_result.reason_code}",
+                    "ERROR",
+                )
+                return _steward_gate_blocked_result(
+                    active_run_id=active_run_id,
+                    pr=pr,
+                    threads=threads,
+                    check_payload=check_payload,
+                    validation=validation,
+                    policy=policy,
+                    gate_result=gate_result,
+                    pr_dir=pr_dir,
+                )
         if conflict_state in {"manual_conflict_required", "semantic_conflict_blocked"}:
             analysis_path = pr_dir / "CONFLICT_ANALYSIS.md"
             write_text(
@@ -997,6 +1166,27 @@ def pr_apply(
                 ),
             )
             if conflict_state == "eligible":
+                if execute:
+                    gate_result = require_steward_remediation_gate(
+                        pr=pr,
+                        policy=policy,
+                        pr_dir=pr_dir,
+                    )
+                    if not gate_result.allowed:
+                        log(
+                            f"Steward remediation gate denied conflict remediation: {gate_result.reason_code}",
+                            "ERROR",
+                        )
+                        return _steward_gate_blocked_result(
+                            active_run_id=active_run_id,
+                            pr=pr,
+                            threads=threads,
+                            check_payload=check_payload,
+                            validation=validation,
+                            policy=policy,
+                            gate_result=gate_result,
+                            pr_dir=pr_dir,
+                        )
                 log("Attempting automated mechanical conflict recovery...")
                 recovered, recovery_state, _recovery_meta = auto_recover_rebase_conflicts(
                     pr=pr,
@@ -1063,30 +1253,41 @@ def pr_apply(
         )
         
         if not validation.passed and execute:
-            log("Validation failed, attempting AI remediation...")
-            if remediate_ci_failure(worktree_path, validation, log):
-                log("Re-running validation suite after AI fix...", "START")
-                validation = run_validation(
-                    repo_root=repo_root,
-                    worktree_path=worktree_path,
-                    policy=policy,
-                    execute=execute,
-                    commands_log=commands_log,
-                    pr_id=pr.pr_id,
-                    head_sha=pr.head_sha,
-                    base_sha=pr.base_sha,
-                    policy_fingerprint=policy_fingerprint(policy),
-                    lifecycle_state=(
-                        pr.lifecycle_state.value
-                        if hasattr(pr.lifecycle_state, "value")
-                        else str(pr.lifecycle_state)
-                    ),
-                    progress_callback=progress_callback
+            gate_result = require_steward_remediation_gate(
+                pr=pr,
+                policy=policy,
+                pr_dir=pr_dir,
+            )
+            if not gate_result.allowed:
+                log(
+                    f"Steward remediation gate denied CI remediation: {gate_result.reason_code}",
+                    "ERROR",
                 )
-                if validation.passed:
-                    log("Committing AI remediation fix...")
-                    if stage_and_push_if_needed(worktree_path=worktree_path, head_ref=pr.head_ref, active_run_id=active_run_id, pr_id=pr.pr_id, execute=execute, commands_log=commands_log, policy=policy, log=log):
-                        _refresh_client_state(client, pr.pr_id)        
+            else:
+                log("Validation failed, attempting AI remediation...")
+                if remediate_ci_failure(worktree_path, validation, log):
+                    log("Re-running validation suite after AI fix...", "START")
+                    validation = run_validation(
+                        repo_root=repo_root,
+                        worktree_path=worktree_path,
+                        policy=policy,
+                        execute=execute,
+                        commands_log=commands_log,
+                        pr_id=pr.pr_id,
+                        head_sha=pr.head_sha,
+                        base_sha=pr.base_sha,
+                        policy_fingerprint=policy_fingerprint(policy),
+                        lifecycle_state=(
+                            pr.lifecycle_state.value
+                            if hasattr(pr.lifecycle_state, "value")
+                            else str(pr.lifecycle_state)
+                        ),
+                        progress_callback=progress_callback
+                    )
+                    if validation.passed:
+                        log("Committing AI remediation fix...")
+                        if stage_and_push_if_needed(worktree_path=worktree_path, head_ref=pr.head_ref, active_run_id=active_run_id, pr_id=pr.pr_id, execute=execute, commands_log=commands_log, policy=policy, log=log):
+                            _refresh_client_state(client, pr.pr_id)
         if validation.passed:
             log("Validation PASSED", "SUCCESS")
         else:
@@ -1105,10 +1306,21 @@ def pr_apply(
                 log=log,
             )
             if remote_validation is not None and not remote_validation.passed:
-                log(
-                    f"Remote required check '{reproduced_check}' failed locally; attempting AI remediation..."
+                gate_result = require_steward_remediation_gate(
+                    pr=pr,
+                    policy=policy,
+                    pr_dir=pr_dir,
                 )
-                if remediate_ci_failure(worktree_path, remote_validation, log):
+                if not gate_result.allowed:
+                    log(
+                        f"Steward remediation gate denied remote-check remediation: {gate_result.reason_code}",
+                        "ERROR",
+                    )
+                else:
+                    log(
+                        f"Remote required check '{reproduced_check}' failed locally; attempting AI remediation..."
+                    )
+                if gate_result.allowed and remediate_ci_failure(worktree_path, remote_validation, log):
                     reproduced_check, remote_validation = reproduce_remote_required_check_failure(
                         worktree_path=worktree_path,
                         commands_log=commands_log,
@@ -1145,15 +1357,6 @@ def pr_apply(
                         else:
                             log("Full validation still failed after remote-check remediation.", "ERROR")
 
-        if validation.passed:
-            resolve_verified_threads(
-                dispositions=applied_threads,
-                execute=execute,
-                commands_log=commands_log,
-                repo_root=repo_root,
-                policy=policy
-            )
-
         result = build_plan_result(
             active_run_id=active_run_id,
             pr=refreshed_pr,
@@ -1161,7 +1364,7 @@ def pr_apply(
             check_payload=refreshed_checks,
             validation_report=validation,
             policy=policy,
-            threads_resolved_locally=validation.passed and any(d.applied for d in applied_threads)
+            threads_resolved_locally=False
         )
         if operator_state:
             result = _with_operator_state(result, operator_state)
@@ -1871,6 +2074,13 @@ def _handle_global_ci_blockers(
             for r, _failed_step in blocked_prs:
                 blocked_map[r.pr_state.pr_id] = pr_number
         else:
+            if "steward_gate" in client.policy and not global_fix_prs_allowed(client.policy):
+                _log(
+                    f"Global CI blocker fingerprint {fingerprint} requires supervisor; "
+                    "shared global-fix PR creation is disabled by steward_gate policy.",
+                    "WARNING",
+                )
+                continue
             # New global blocker. Create a global fix PR.
             _log(
                 f"New global CI blocker detected for fingerprint {fingerprint}; triggering shared remediation for {len(blocked_prs)} PRs.",

--- a/task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json
+++ b/task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json
@@ -23,7 +23,7 @@
   ],
   "execution": {
     "agent": "codex",
-    "base_branch": "main",
+    "base_branch": "codex/tp-dmx-steward-gate-201",
     "branch": "codex/tp-dmx-merge-remediation-202",
     "stacked_because": "Part of the DMX-AUTOREVIEW-PLATFORM dependency DAG."
   },
@@ -53,7 +53,7 @@
     ]
   },
   "pr": {
-    "base": "main",
+    "base": "codex/tp-dmx-steward-gate-201",
     "body": "## Summary\n- Wire steward_gate into pr_apply / apply_thread_dispositions (reply-only) / conflict+CI remediation, gated on NEEDS_IMPLEMENTER + implementer-role blocker; demote thread RESOLVE to finalization; route global-fix-PR/admin-bypass/fork-force-push to supervisor (blocked by default).\n\n## Scope\nTrack: B-govern-merge. Risk: HIGH. Red lane: true.\n\n## Validation\nRun the packet validation commands and capture proof under proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json.\n\n## NOT_RUN\nList any skipped live, integration, credentialed, or supervisor-gated checks explicitly.",
     "title": "Feat(pr-merge): gate remediation seams behind steward_gate"
   },

--- a/tests/pr_merge_specialist/test_remediation_gate.py
+++ b/tests/pr_merge_specialist/test_remediation_gate.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dopemux_pr_merge_specialist.schema import PullRequestState
+from dopemux_pr_merge_specialist import queue_drain
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _pr_state() -> PullRequestState:
+    return PullRequestState(
+        pr_id=765,
+        title="needs implementation",
+        author="dev",
+        state="OPEN",
+        base_ref="main",
+        head_ref="feature/steward",
+        ci_status="FAILURE",
+        mergeable="MERGEABLE",
+        merge_state_status="CLEAN",
+        review_decision="",
+        head_sha="abc123",
+        base_sha="base123",
+    )
+
+
+def _merge_readiness(*, blockers: list[str] | None = None) -> dict:
+    return {
+        "generated_at": "2026-05-31T12:00:00Z",
+        "readiness": "NEEDS_IMPLEMENTER",
+        "blockers": blockers or ["FAILED_CHECK"],
+        "pr": {
+            "number": 765,
+            "head_sha": "abc123",
+            "head_ref": "feature/steward",
+        },
+        "proof": {
+            "proof_head_sha": "abc123",
+            "proof_path": "proof/TP/PROOF.json",
+        },
+        "embedded_audit": {
+            "status": "PASS",
+            "source": "independent",
+        },
+    }
+
+
+def _audit_proof() -> dict:
+    return {
+        "generated_at": "2026-05-31T12:00:00Z",
+        "head_sha": "abc123",
+        "embedded_audit": {
+            "status": "PASS",
+            "source": "independent",
+        },
+    }
+
+
+def test_remediation_gate_allows_needs_implementer_with_implementer_blocker(tmp_path: Path):
+    pr_dir = tmp_path / "pr" / "765"
+    _write_json(pr_dir / "MERGE_READINESS.json", _merge_readiness(blockers=["UNRESOLVED_REVIEW_THREAD"]))
+    _write_json(pr_dir / "PROOF.json", _audit_proof())
+
+    result = queue_drain.require_steward_remediation_gate(
+        pr=_pr_state(),
+        policy={"steward_gate": {"artifact_ttl_seconds": 3600}},
+        pr_dir=pr_dir,
+        now="2026-05-31T12:30:00Z",
+    )
+
+    assert result.allowed is True
+    assert result.reason_code == "ALLOW_REMEDIATION"
+    assert result.evidence["implementer_blockers"] == ["UNRESOLVED_REVIEW_THREAD"]
+
+
+def test_remediation_gate_denies_missing_implementer_blocker(tmp_path: Path):
+    pr_dir = tmp_path / "pr" / "765"
+    _write_json(pr_dir / "MERGE_READINESS.json", _merge_readiness(blockers=["PROOF_STALE"]))
+    _write_json(pr_dir / "PROOF.json", _audit_proof())
+
+    result = queue_drain.require_steward_remediation_gate(
+        pr=_pr_state(),
+        policy={"steward_gate": {"artifact_ttl_seconds": 3600}},
+        pr_dir=pr_dir,
+        now="2026-05-31T12:30:00Z",
+    )
+
+    assert result.allowed is False
+    assert result.reason_code == "DENY_NO_IMPLEMENTER_BLOCKER"
+    assert result.evidence["blockers"] == ["PROOF_STALE"]
+
+
+def test_remediation_gate_denies_missing_artifacts(tmp_path: Path):
+    result = queue_drain.require_steward_remediation_gate(
+        pr=_pr_state(),
+        policy={"steward_gate": {"artifact_ttl_seconds": 3600}},
+        pr_dir=tmp_path / "missing",
+        now="2026-05-31T12:30:00Z",
+    )
+
+    assert result.allowed is False
+    assert result.reason_code == "DENY_ARTIFACT_UNREADABLE"
+
+
+def test_global_fix_pr_creation_requires_explicit_policy_opt_in():
+    assert queue_drain.global_fix_prs_allowed({}) is False
+    assert queue_drain.global_fix_prs_allowed({"steward_gate": {}}) is False
+    assert (
+        queue_drain.global_fix_prs_allowed(
+            {"steward_gate": {"allow_global_fix_prs": True}}
+        )
+        is True
+    )


### PR DESCRIPTION
## Summary
- wire `steward_gate(REMEDIATION)` into queue-drain remediation mutation seams
- require fresh PR Steward `NEEDS_IMPLEMENTER` artifacts plus implementer-owned blockers before thread, conflict, local CI, or reproduced remote-check remediation
- keep remediation reply-only by deferring review-thread resolution to TP203
- disable shared global-fix PR creation under repo steward policy unless explicitly enabled

## Scope
Stacked on #765 / `codex/tp-dmx-steward-gate-201` because TP202 depends on TP201. Does not wire finalization, merge execution, governed automerge, admin-bypass, or thread resolution.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist/test_remediation_gate.py`
- `PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist/test_remediation_gate.py tests/pr_merge_specialist/test_agentic_thread_remediation.py tests/pr_merge_specialist/test_queue_drain_integration.py`
- `PYTHONDONTWRITEBYTECODE=1 pytest -q -s -p no:cacheprovider tests/pr_merge_specialist`
- `python -m compileall -q src tests`
- `python -m jsonschema -i task-packets/generated/TP-DMX-MERGE-REMEDIATION-202.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `python scripts/audit/validate_audit_proof.py proof/TP-DMX-MERGE-REMEDIATION-202/PROOF.json`
- `pre-commit run --files <TP202 changed files>`
- `git diff --check`

## Review
@codex review
@gemini
@copilot