### PR TITLE
feat(cli): add dopemux pr-steward command

### DIFF
--- a/docs/ops/pr-steward-cli.md
+++ b/docs/ops/pr-steward-cli.md
@@ -1,0 +1,73 @@
+---
+id: pr-steward-cli
+title: PR Steward CLI
+type: reference
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: Versioned CLI contract for dopemux pr-steward.
+---
+# PR Steward CLI
+
+`dopemux pr-steward` is the versioned operator surface for PR Steward.
+
+## Help
+
+```bash
+python -m dopemux.cli pr-steward --help
+python -m dopemux.cli pr-steward --contract-version
+```
+
+## Intake
+
+```bash
+python -m dopemux.cli pr-steward intake --repo OWNER/REPO --pr 123 --out out/pr/123
+```
+
+This delegates to the existing check-only `tools.pr_steward.intake` engine and
+preserves its exit behavior: `0` for `READY`, `2` for blocked or failed intake.
+
+## Bridge
+
+```bash
+python -m dopemux.cli pr-steward bridge --artifact-dir out/pr/123 --out out/pr/123/bridge
+```
+
+The bridge expects `MERGE_READINESS.json`, `REVIEW_ITEM_LEDGER.json`,
+`THREAD_DISPOSITIONS.json`, and `CI_TRIAGE.json`. It writes
+`ACTION_PLAN.json` and `REPAIR_PACKET.md`.
+
+## Gate
+
+```bash
+python -m dopemux.cli pr-steward gate \
+  --head-sha HEAD \
+  --required-class FINALIZATION \
+  --merge-readiness out/pr/123/MERGE_READINESS.json \
+  --audit-proof proof/TP/PROOF.json \
+  --format json
+```
+
+The gate calls packaged Python `steward_gate` code. Missing artifacts, stale
+timestamps, SHA mismatch, unsupported class, or nonpassing audit status exits
+with code `2`.
+
+## Audit
+
+```bash
+python -m dopemux.cli pr-steward audit --proof proof/TP/PROOF.json --format json
+```
+
+The audit command reads a proof bundle and reports embedded-audit status. It is
+read-only.
+
+## Doctor
+
+```bash
+python -m dopemux.cli pr-steward doctor
+```
+
+`doctor` currently fails closed and points to TP-DMX-STEWARD-DOCTOR-303, where
+scaffold skew and config schema checks are implemented.

--- a/docs/ops/pr-steward.md
+++ b/docs/ops/pr-steward.md
@@ -5,9 +5,9 @@ type: reference
 owner: '@hu3mann'
 author: '@codex'
 date: '2026-05-25'
-last_review: '2026-05-25'
-next_review: '2026-08-23'
-prelude: Check-only PR review intake design scaffold for PR Steward v1.
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: Check-only PR review intake and packaged CLI reference for PR Steward v1.
 ---
 # PR Steward V1
 
@@ -91,6 +91,29 @@ Fixture mode is the offline validation lane and must not require live GitHub:
 ```bash
 python -m tools.pr_steward.intake --fixture-dir tests/fixtures/pr_steward/ready_all_green --repo DDD-Enterprises/dopemux-mvp --pr 704 --out /tmp/pr-steward-ready --strict
 ```
+
+## Packaged Dopemux Command
+
+TP-DMX-STEWARD-PACKAGE-301 adds the packaged operator surface:
+
+```bash
+dopemux pr-steward
+```
+
+The packaged command exposes `intake`, `bridge`, `gate`, `audit`, and a
+fail-closed `doctor` placeholder. It is intentionally a single Dopemux CLI
+surface and does not add new console scripts or scaffold repository files.
+
+`steward_gate` logic ships in Python package code and must not be generated
+into scaffold YAML.
+
+## Packaged Command Boundaries
+
+- No PR mutation is performed by `intake`, `bridge`, `gate`, or `audit`.
+- `doctor` is report-only and currently exits blocked until TP303 implements
+  scaffold/config skew checks.
+- The command wraps existing engines; it does not change PR Steward classifier,
+  Action Bridge compiler, or merge-specialist gate semantics.
 
 ## Review Bundle
 

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/AUDITOR_REPORT.md
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/AUDITOR_REPORT.md
@@ -1,0 +1,31 @@
+# TP-DMX-STEWARD-PACKAGE-301 Bounded Audit
+
+Status: PASS_WITH_LIMITS
+
+## Scope Reviewed
+
+- `dopemux pr-steward` Click pass-through command.
+- Importable `dopemux_pr_steward` package and versioned argparse CLI.
+- Subcommand contract for `intake`, `bridge`, `gate`, `audit`, and `doctor`.
+- Packaged `steward_gate` access through the `gate` subcommand.
+- Documentation updates for PR Steward package usage.
+
+## Findings
+
+- PASS: `dopemux pr-steward --help` delegates to the packaged CLI and lists the versioned subcommand contract.
+- PASS: package import works outside the repository root after lazy-loading repo-local `tools.*` dependencies.
+- PASS: `gate` uses packaged `dopemux_pr_merge_specialist.steward_gate` logic and does not scaffold YAML logic.
+- PASS: `doctor` fails closed and points to TP-DMX-STEWARD-DOCTOR-303.
+- PASS: no new console script was added.
+- PASS: existing PR Steward v1 documentation authority was preserved and extended rather than replaced.
+
+## Limits
+
+- External embedded audit was not run in this local Codex session.
+- `intake` and `bridge` still delegate to repo-local `tools.*` modules, so they are not fully standalone outside repo-root contexts.
+- Live GitHub intake was not executed.
+
+## Residual Risks
+
+- A later package-layout packet may be needed to move PR Steward and Action Bridge engines under `src/` if installed-environment execution outside repo root is required.
+- TP301 is stacked on TP203/#767 while TP102 remains a sibling dependency on #758.

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/CHANGED_FILES.txt
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/CHANGED_FILES.txt
@@ -1,0 +1,14 @@
+docs/ops/pr-steward-cli.md
+docs/ops/pr-steward.md
+proof/TP-DMX-STEWARD-PACKAGE-301/AUDITOR_REPORT.md
+proof/TP-DMX-STEWARD-PACKAGE-301/CHANGED_FILES.txt
+proof/TP-DMX-STEWARD-PACKAGE-301/DIFF_STAT.txt
+proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
+proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
+proof/TP-DMX-STEWARD-PACKAGE-301/VALIDATION_OUTPUT.md
+proof/TP-DMX-STEWARD-PACKAGE-301/review_bundle/README.md
+src/dopemux/cli.py
+src/dopemux_pr_steward/__init__.py
+src/dopemux_pr_steward/cli.py
+task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json
+tests/dopemux_cli/test_pr_steward_cmd.py

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/DIFF_STAT.txt
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/DIFF_STAT.txt
@@ -1,0 +1,15 @@
+ docs/ops/pr-steward-cli.md                         |  73 ++++++++
+ docs/ops/pr-steward.md                             |  29 ++-
+ proof/TP-DMX-STEWARD-PACKAGE-301/AUDITOR_REPORT.md |  31 ++++
+ proof/TP-DMX-STEWARD-PACKAGE-301/CHANGED_FILES.txt |   7 +
+ proof/TP-DMX-STEWARD-PACKAGE-301/DIFF_STAT.txt     |   0
+ proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md      |  17 ++
+ proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json        | 164 +++++++++++++++++
+ .../VALIDATION_OUTPUT.md                           |  95 ++++++++++
+ .../review_bundle/README.md                        |  15 ++
+ src/dopemux/cli.py                                 |  21 +++
+ src/dopemux_pr_steward/__init__.py                 |   5 +
+ src/dopemux_pr_steward/cli.py                      | 195 +++++++++++++++++++++
+ .../generated/TP-DMX-STEWARD-PACKAGE-301.json      |   9 +-
+ tests/dopemux_cli/test_pr_steward_cmd.py           | 107 +++++++++++
+ 14 files changed, 762 insertions(+), 6 deletions(-)

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
@@ -1,24 +1,12 @@
 # Git State
 
 ```
-## codex/tp-dmx-steward-package-301...origin/codex/tp-dmx-merge-finalization-203
- A docs/ops/pr-steward-cli.md
- M docs/ops/pr-steward.md
- A proof/TP-DMX-STEWARD-PACKAGE-301/AUDITOR_REPORT.md
- A proof/TP-DMX-STEWARD-PACKAGE-301/CHANGED_FILES.txt
- A proof/TP-DMX-STEWARD-PACKAGE-301/DIFF_STAT.txt
- A proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
- A proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
- A proof/TP-DMX-STEWARD-PACKAGE-301/VALIDATION_OUTPUT.md
- A proof/TP-DMX-STEWARD-PACKAGE-301/review_bundle/README.md
- M src/dopemux/cli.py
- A src/dopemux_pr_steward/__init__.py
- A src/dopemux_pr_steward/cli.py
- M task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json
- A tests/dopemux_cli/test_pr_steward_cmd.py
+## codex/tp-dmx-steward-package-301...origin/codex/tp-dmx-merge-finalization-203 [ahead 1]
+ M proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
+ M proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
 
 /Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-steward-package-301
-6ad676ce9522806bc658b4b9af1999259f7113ab
+33801d19cbde6654f421f26e2b58730354fc6a71
 codex/tp-dmx-steward-package-301
 https://github.com/DDD-Enterprises/dopemux-mvp.git
 ```

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
@@ -1,0 +1,24 @@
+# Git State
+
+```
+## codex/tp-dmx-steward-package-301...origin/codex/tp-dmx-merge-finalization-203
+ A docs/ops/pr-steward-cli.md
+ M docs/ops/pr-steward.md
+ A proof/TP-DMX-STEWARD-PACKAGE-301/AUDITOR_REPORT.md
+ A proof/TP-DMX-STEWARD-PACKAGE-301/CHANGED_FILES.txt
+ A proof/TP-DMX-STEWARD-PACKAGE-301/DIFF_STAT.txt
+ A proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
+ A proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
+ A proof/TP-DMX-STEWARD-PACKAGE-301/VALIDATION_OUTPUT.md
+ A proof/TP-DMX-STEWARD-PACKAGE-301/review_bundle/README.md
+ M src/dopemux/cli.py
+ A src/dopemux_pr_steward/__init__.py
+ A src/dopemux_pr_steward/cli.py
+ M task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json
+ A tests/dopemux_cli/test_pr_steward_cmd.py
+
+/Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-steward-package-301
+6ad676ce9522806bc658b4b9af1999259f7113ab
+codex/tp-dmx-steward-package-301
+https://github.com/DDD-Enterprises/dopemux-mvp.git
+```

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
@@ -1,12 +1,13 @@
 # Git State
 
 ```
-## codex/tp-dmx-steward-package-301...origin/codex/tp-dmx-merge-finalization-203 [ahead 1]
+## codex/tp-dmx-steward-package-301...origin/codex/tp-dmx-steward-package-301
  M proof/TP-DMX-STEWARD-PACKAGE-301/GIT_STATE.md
  M proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
 
 /Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-steward-package-301
-33801d19cbde6654f421f26e2b58730354fc6a71
+0135173ada62b87e5e2bf881961a720799f4de5d
 codex/tp-dmx-steward-package-301
 https://github.com/DDD-Enterprises/dopemux-mvp.git
+PR_URL https://github.com/DDD-Enterprises/dopemux-mvp/pull/770
 ```

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
@@ -151,7 +151,7 @@
   "codereview_status": "Manual bounded review complete; preserved existing PR Steward v1 docs and fixed package importability outside repo root.",
   "precommit_status": "PASS: pre-commit run on TP301 changed files and git diff --check passed.",
   "commit_sha": "33801d19cbde6654f421f26e2b58730354fc6a71",
-  "pr_url": "PENDING_PR",
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/770",
   "residual_risks": [
     "TP301 is stacked on TP203/#767 while TP102 remains a sibling dependency on PR #758.",
     "The package imports outside repo root, and gate/audit are packaged; intake and bridge require repo-local tools modules until a later package-layout packet moves those engines under src.",

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
@@ -1,0 +1,164 @@
+{
+  "tp_id": "TP-DMX-STEWARD-PACKAGE-301",
+  "status": "PASS_WITH_LIMITS",
+  "generated_at": "2026-05-31T23:35:32Z",
+  "worktree_path": "/Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-steward-package-301",
+  "branch": "codex/tp-dmx-steward-package-301",
+  "base_ref": "origin/codex/tp-dmx-merge-finalization-203",
+  "base_sha": "6ad676ce9522806bc658b4b9af1999259f7113ab",
+  "head_sha": "6ad676ce9522806bc658b4b9af1999259f7113ab",
+  "repo_identity": {
+    "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "marker": ".dopetaskroot",
+    "identity_match": true
+  },
+  "stacking": {
+    "reason": "TP301 is stacked on TP203/#767 to continue the active AUTOREVIEW train. TP-DMX-ACTIONBRIDGE-CLI-102 is a sibling dependency; its proof was verified from origin/codex/tp-dmx-actionbridge-cli-102.",
+    "base_branch": "codex/tp-dmx-merge-finalization-203",
+    "base_pr": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/767"
+  },
+  "dependency_proofs": [
+    {
+      "tp_id": "TP-DMX-ACTIONBRIDGE-CLI-102",
+      "path": "origin/codex/tp-dmx-actionbridge-cli-102:proof/TP-DMX-ACTIONBRIDGE-CLI-102/PROOF.json",
+      "present": true,
+      "json_valid": true,
+      "head_sha": "38c6a3c4f0900a664b8ac6f49e1876bdc9f9352d",
+      "note": "Dependency is on a sibling PR stack, so proof was verified with git show rather than from this worktree."
+    },
+    {
+      "tp_id": "TP-DMX-STEWARD-GATE-201",
+      "path": "proof/TP-DMX-STEWARD-GATE-201/PROOF.json",
+      "present": true,
+      "json_valid": true,
+      "status": "PASS_WITH_LIMITS",
+      "head_sha": "eac0853f521041c5d52f0d40eddb4be84d66b424"
+    }
+  ],
+  "authority_used": [
+    "AGENTS.md",
+    "task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json",
+    "docs/ops/load-plans/load_plan-DMX-AUTOREVIEW-PLATFORM.json",
+    "docs/ops/pr-steward.md",
+    "docs/ops/pr-steward-cli.md",
+    "src/dopemux/cli.py",
+    "tools/pr_steward/intake.py",
+    "tools/pr_action_bridge/compiler.py",
+    "src/dopemux_pr_merge_specialist/steward_gate.py"
+  ],
+  "slices_completed": [
+    "RED: added tests/dopemux_cli/test_pr_steward_cmd.py and observed ModuleNotFoundError for missing dopemux_pr_steward package.",
+    "GREEN: added importable dopemux_pr_steward package with a versioned argparse CLI.",
+    "Added dopemux pr-steward pass-through command without adding a new console script.",
+    "Added gate, audit, bridge, intake, and fail-closed doctor subcommands without changing underlying engine semantics.",
+    "Added outside-repo import regression coverage and lazy-loaded repo-local tools dependencies so the package imports when cwd is not the repo root.",
+    "Updated docs while preserving the existing PR Steward v1 intake contract."
+  ],
+  "files_changed": [
+    "src/dopemux/cli.py",
+    "src/dopemux_pr_steward/__init__.py",
+    "src/dopemux_pr_steward/cli.py",
+    "tests/dopemux_cli/test_pr_steward_cmd.py",
+    "docs/ops/pr-steward.md",
+    "docs/ops/pr-steward-cli.md",
+    "task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json",
+    "proof/TP-DMX-STEWARD-PACKAGE-301/**"
+  ],
+  "validations": [
+    {
+      "command": "pytest -q tests/dopemux_cli/test_pr_steward_cmd.py",
+      "exit_code": 2,
+      "status": "RED_PASS",
+      "evidence": "ModuleNotFoundError: No module named 'dopemux_pr_steward'."
+    },
+    {
+      "command": "pytest -q tests/dopemux_cli/test_pr_steward_cmd.py::test_pr_steward_package_imports_outside_repo_root",
+      "exit_code": 1,
+      "status": "RED_PASS",
+      "evidence": "ModuleNotFoundError: No module named 'tools' before lazy imports."
+    },
+    {
+      "command": "python -m pip install -e .",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "Refreshed stale editable dopemux install from a removed /private/tmp checkout to this TP301 worktree."
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m jsonschema -i task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m compileall -q src tests",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "pytest -q tests/dopemux_cli/test_pr_steward_cmd.py",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "5 passed"
+    },
+    {
+      "command": "pytest -q tests/dopemux_cli",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "5 passed"
+    },
+    {
+      "command": "pytest -q tests/dopemux_cli/test_pr_steward_cmd.py tests/test_cli.py",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "36 passed"
+    },
+    {
+      "command": "python -m dopemux.cli pr-steward --help",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "pre-commit run --files <TP301 changed files>",
+      "exit_code": 0,
+      "status": "PASS"
+    }
+  ],
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DMX-STEWARD-PACKAGE-301/AUDITOR_REPORT.md",
+    "findings": [],
+    "fixes_applied": [],
+    "remaining_risks": [
+      "External embedded audit was not invoked in this Codex session.",
+      "intake and bridge subcommands still delegate to repo-local tools modules; packaging those engines fully is constrained by the TP301 allowlist."
+    ],
+    "skip_reason": "No supported external embedded-auditor invocation was available in this session; Codex performed bounded manual audit and records this required audit as skipped."
+  },
+  "codereview_status": "Manual bounded review complete; preserved existing PR Steward v1 docs and fixed package importability outside repo root.",
+  "precommit_status": "PASS: pre-commit run on TP301 changed files and git diff --check passed.",
+  "commit_sha": "PENDING_COMMIT_METADATA",
+  "pr_url": "PENDING_PR",
+  "residual_risks": [
+    "TP301 is stacked on TP203/#767 while TP102 remains a sibling dependency on PR #758.",
+    "The package imports outside repo root, and gate/audit are packaged; intake and bridge require repo-local tools modules until a later package-layout packet moves those engines under src.",
+    "Local editable install was refreshed to this worktree to validate the exact packet command."
+  ],
+  "unknowns": [
+    "Whether downstream installed environments expect intake and bridge to run outside the repo root remains UNKNOWN."
+  ],
+  "cleanup_status": "WORKTREE_ACTIVE_PENDING_PR"
+}

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
@@ -6,7 +6,7 @@
   "branch": "codex/tp-dmx-steward-package-301",
   "base_ref": "origin/codex/tp-dmx-merge-finalization-203",
   "base_sha": "6ad676ce9522806bc658b4b9af1999259f7113ab",
-  "head_sha": "6ad676ce9522806bc658b4b9af1999259f7113ab",
+  "head_sha": "33801d19cbde6654f421f26e2b58730354fc6a71",
   "repo_identity": {
     "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
     "marker": ".dopetaskroot",
@@ -150,7 +150,7 @@
   },
   "codereview_status": "Manual bounded review complete; preserved existing PR Steward v1 docs and fixed package importability outside repo root.",
   "precommit_status": "PASS: pre-commit run on TP301 changed files and git diff --check passed.",
-  "commit_sha": "PENDING_COMMIT_METADATA",
+  "commit_sha": "33801d19cbde6654f421f26e2b58730354fc6a71",
   "pr_url": "PENDING_PR",
   "residual_risks": [
     "TP301 is stacked on TP203/#767 while TP102 remains a sibling dependency on PR #758.",

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/VALIDATION_OUTPUT.md
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/VALIDATION_OUTPUT.md
@@ -1,0 +1,95 @@
+# TP-DMX-STEWARD-PACKAGE-301 Validation Output
+
+Generated: 2026-05-31T23:35:32Z
+
+## RED
+
+```text
+$ pytest -q tests/dopemux_cli/test_pr_steward_cmd.py
+ERROR tests/dopemux_cli/test_pr_steward_cmd.py
+ModuleNotFoundError: No module named 'dopemux_pr_steward'
+exit_code=2
+```
+
+```text
+$ pytest -q tests/dopemux_cli/test_pr_steward_cmd.py::test_pr_steward_package_imports_outside_repo_root
+FAILED
+ModuleNotFoundError: No module named 'tools'
+exit_code=1
+```
+
+## PASS
+
+```text
+$ python -m pip install -e .
+Successfully installed dopemux-0.1.0
+exit_code=0
+```
+
+```text
+$ python -m json.tool task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json
+exit_code=0
+```
+
+```text
+$ python -m jsonschema -i task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+exit_code=0
+```
+
+```text
+$ python -m compileall -q src tests
+exit_code=0
+```
+
+```text
+$ pytest -q tests/dopemux_cli/test_pr_steward_cmd.py
+.....                                                                    [100%]
+exit_code=0
+```
+
+```text
+$ pytest -q tests/dopemux_cli
+.....                                                                    [100%]
+exit_code=0
+```
+
+```text
+$ pytest -q tests/dopemux_cli/test_pr_steward_cmd.py tests/test_cli.py
+... [100%]
+exit_code=0
+```
+
+```text
+$ python -m dopemux.cli pr-steward --help
+usage: dopemux-pr-steward [-h] [--contract-version] COMMAND ...
+...
+exit_code=0
+```
+
+```text
+$ git diff --check
+exit_code=0
+```
+
+```text
+$ pre-commit run --files <TP301 changed files>
+Validate YAML frontmatter in docs..........................................................Passed
+Validate documentation against knowledge graph schema......................................Passed
+Block prohibited documentation patterns (NOTES, TODO, TEMP, etc.)..........................Passed
+Validate prelude <=100 tokens for efficient embeddings.....................................Passed
+Enforce markdown file locations for changed files..........................................Passed
+Enforce docs placement hygiene (changed files).............................................Passed
+Enforce docs filename hygiene (kebab-case).................................................Passed
+Audit docs filename hygiene (kebab-case, full-tree legacy debt)............................Passed
+Enforce repository root hygiene (no random root files).....................................Passed
+markdownlint...............................................................................Passed
+trim trailing whitespace...................................................................Passed
+fix end of files...........................................................................Passed
+exit_code=0
+```
+
+## NOT_RUN
+
+- Live GitHub PR Steward intake: NOT_RUN.
+- Live Action Bridge compile against real PR artifacts: NOT_RUN.
+- External embedded audit: NOT_RUN locally.

--- a/proof/TP-DMX-STEWARD-PACKAGE-301/review_bundle/README.md
+++ b/proof/TP-DMX-STEWARD-PACKAGE-301/review_bundle/README.md
@@ -1,0 +1,15 @@
+# TP-DMX-STEWARD-PACKAGE-301 Review Bundle
+
+Single upload unit for reviewer/auditor intake.
+
+Primary artifacts:
+
+- `../PROOF.json`
+- `../VALIDATION_OUTPUT.md`
+- `../AUDITOR_REPORT.md`
+- `../GIT_STATE.md`
+- `../DIFF_STAT.txt`
+- `../CHANGED_FILES.txt`
+
+This bundle records implementation proof only. Live GitHub intake and external
+embedded audit were not run in this local Codex session.

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -2637,6 +2637,27 @@ def pr_merge_command(args):
         sys.exit(e.code)
 
 
+@cli.command(
+    name="pr-steward",
+    context_settings=dict(ignore_unknown_options=True),
+    add_help_option=False,
+)
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def pr_steward_command(args):
+    """
+    🧾 Check-Only Governance: PR Steward
+
+    Exposes the versioned PR Steward command contract:
+    intake, bridge, gate, audit, and doctor.
+    """
+    from dopemux_pr_steward.cli import main as pr_steward_main
+
+    try:
+        raise SystemExit(pr_steward_main(list(args)))
+    except SystemExit as e:
+        sys.exit(e.code)
+
+
 @cli.command()
 @click.option("--attention", "-a", is_flag=True, help="🧠 Cognitive Load: Show attention metrics and focus state.")
 @click.option("--context", "-c", is_flag=True, help="🔬 Mental Model: Show active mental model and context density.")

--- a/src/dopemux_pr_steward/__init__.py
+++ b/src/dopemux_pr_steward/__init__.py
@@ -1,0 +1,5 @@
+"""Importable PR Steward command surface for Dopemux."""
+
+CONTRACT_VERSION = "1.0.0"
+
+__all__ = ["CONTRACT_VERSION"]

--- a/src/dopemux_pr_steward/cli.py
+++ b/src/dopemux_pr_steward/cli.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+from dopemux_pr_merge_specialist.steward_gate import steward_gate
+
+from . import CONTRACT_VERSION
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="dopemux-pr-steward",
+        description="Versioned PR Steward command contract.",
+    )
+    parser.add_argument(
+        "--contract-version",
+        action="version",
+        version=f"dopemux-pr-steward contract-version {CONTRACT_VERSION}",
+    )
+    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+
+    intake = subparsers.add_parser("intake", help="Run check-only PR Steward intake.")
+    intake.add_argument("args", nargs=argparse.REMAINDER)
+    intake.set_defaults(handler=_run_intake)
+
+    bridge = subparsers.add_parser(
+        "bridge",
+        help="Compile PR Steward artifacts into an action plan and repair packet.",
+    )
+    bridge.add_argument("--artifact-dir", required=True, type=Path)
+    bridge.add_argument("--out", required=True, type=Path)
+    bridge.set_defaults(handler=_run_bridge)
+
+    gate = subparsers.add_parser(
+        "gate",
+        help="Evaluate packaged steward_gate over local artifacts.",
+    )
+    gate.add_argument("--head-sha", required=True)
+    gate.add_argument(
+        "--required-class",
+        required=True,
+        choices=["REMEDIATION", "FINALIZATION"],
+    )
+    gate.add_argument("--merge-readiness", required=True, type=Path)
+    gate.add_argument("--audit-proof", required=True, type=Path)
+    gate.add_argument("--ttl-seconds", default=3600, type=int)
+    gate.add_argument("--now")
+    gate.add_argument("--format", choices=["json", "text"], default="text")
+    gate.set_defaults(handler=_run_gate)
+
+    audit = subparsers.add_parser(
+        "audit",
+        help="Inspect embedded audit status in a proof bundle.",
+    )
+    audit.add_argument("--proof", required=True, type=Path)
+    audit.add_argument("--format", choices=["json", "text"], default="text")
+    audit.set_defaults(handler=_run_audit)
+
+    doctor = subparsers.add_parser(
+        "doctor",
+        help="Report PR Steward package/scaffold health. Full checks land in TP303.",
+    )
+    doctor.set_defaults(handler=_run_doctor_placeholder)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    try:
+        args = parser.parse_args(list(argv) if argv is not None else None)
+    except SystemExit as exc:
+        return int(exc.code or 0)
+    handler = getattr(args, "handler", None)
+    if handler is None:
+        parser.print_help()
+        return 0
+    return int(handler(args))
+
+
+def _run_intake(args: argparse.Namespace) -> int:
+    try:
+        from tools.pr_steward.intake import main as intake_main
+    except ModuleNotFoundError as exc:
+        print(f"pr-steward intake unavailable: {exc}", file=sys.stderr)
+        return 2
+    return int(intake_main(list(args.args)))
+
+
+def _run_bridge(args: argparse.Namespace) -> int:
+    artifact_dir = args.artifact_dir
+    out_dir = args.out
+    try:
+        from tools.pr_action_bridge.compiler import compile_action_plan
+
+        merge_readiness = _load_json(artifact_dir / "MERGE_READINESS.json")
+        review_ledger = _load_json(artifact_dir / "REVIEW_ITEM_LEDGER.json")
+        thread_dispositions = _load_json(artifact_dir / "THREAD_DISPOSITIONS.json")
+        ci_triage = _load_json(artifact_dir / "CI_TRIAGE.json")
+        action_plan, repair_packet = compile_action_plan(
+            merge_readiness,
+            review_ledger,
+            thread_dispositions,
+            ci_triage,
+        )
+    except Exception as exc:
+        print(f"pr-steward bridge failed: {exc}", file=sys.stderr)
+        return 2
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "ACTION_PLAN.json").write_text(
+        json.dumps(action_plan, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "REPAIR_PACKET.md").write_text(repair_packet, encoding="utf-8")
+    print(f"Wrote {out_dir / 'ACTION_PLAN.json'}")
+    print(f"Wrote {out_dir / 'REPAIR_PACKET.md'}")
+    return 0
+
+
+def _run_gate(args: argparse.Namespace) -> int:
+    try:
+        result = steward_gate(
+            head_sha=args.head_sha,
+            required_class=args.required_class,
+            merge_readiness_path=args.merge_readiness,
+            audit_proof_path=args.audit_proof,
+            now=_parse_now(args.now),
+            ttl_seconds=args.ttl_seconds,
+        )
+    except Exception as exc:
+        print(f"pr-steward gate failed: {exc}", file=sys.stderr)
+        return 2
+    payload = {
+        "allowed": result.allowed,
+        "reason_code": result.reason_code,
+        "required_class": result.required_class,
+        "evidence": dict(result.evidence),
+        "contract_version": CONTRACT_VERSION,
+    }
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"{payload['reason_code']} allowed={payload['allowed']}")
+    return 0 if result.allowed else 2
+
+
+def _run_audit(args: argparse.Namespace) -> int:
+    try:
+        proof = _load_json(args.proof)
+    except Exception as exc:
+        print(f"pr-steward audit failed: {exc}", file=sys.stderr)
+        return 2
+    audit = proof.get("embedded_audit")
+    status = str(audit.get("status") if isinstance(audit, dict) else "").upper()
+    payload: dict[str, Any] = {
+        "contract_version": CONTRACT_VERSION,
+        "proof": str(args.proof),
+        "embedded_audit_status": status or "UNKNOWN",
+    }
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"embedded_audit_status={payload['embedded_audit_status']}")
+    return 0 if status in {"PASS", "PASS_WITH_RISKS"} else 2
+
+
+def _run_doctor_placeholder(args: argparse.Namespace) -> int:
+    print(
+        "pr-steward doctor is report-only and will be implemented by "
+        "TP-DMX-STEWARD-DOCTOR-303.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return payload
+
+
+def _parse_now(value: str | None):
+    if not value:
+        return None
+    from datetime import datetime
+
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json
+++ b/task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json
@@ -15,6 +15,7 @@
       "python -m json.tool task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json",
       "python -m compileall -q src tests",
       "pytest -q tests/dopemux_cli/test_pr_steward_cmd.py",
+      "python -m dopemux.cli pr-steward --help",
       "git diff --check"
     ]
   },
@@ -24,7 +25,7 @@
   ],
   "execution": {
     "agent": "codex",
-    "base_branch": "main",
+    "base_branch": "codex/tp-dmx-merge-finalization-203",
     "branch": "codex/tp-dmx-steward-package-301",
     "stacked_because": "Part of the DMX-AUTOREVIEW-PLATFORM dependency DAG."
   },
@@ -51,7 +52,7 @@
     ]
   },
   "pr": {
-    "base": "main",
+    "base": "codex/tp-dmx-merge-finalization-203",
     "body": "## Summary\n- Make the Steward/Bridge/gate engine importable; expose `dopemux pr-steward` (intake|bridge|gate|audit|doctor) with a stable versioned CLI contract; steward_gate logic ships in the package, never in scaffolded YAML.\n\n## Scope\nTrack: C-distribute. Risk: MEDIUM. Red lane: false.\n\n## Validation\nRun the packet validation commands and capture proof under proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json.\n\n## NOT_RUN\nList any skipped live, integration, credentialed, or supervisor-gated checks explicitly.",
     "title": "Feat(cli): add dopemux pr-steward console command"
   },
@@ -63,7 +64,7 @@
     "require_identity_match": true
   },
   "series": {
-    "base_branch": "main",
+    "base_branch": "codex/tp-dmx-merge-finalization-203",
     "final_packet": false,
     "id": "DMX-AUTOREVIEW-PLATFORM",
     "parent_tp_id": "TP-DMX-ACTIONBRIDGE-CLI-102"
@@ -129,6 +130,7 @@
         "python -m json.tool task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json",
         "python -m compileall -q src tests",
         "pytest -q tests/dopemux_cli/test_pr_steward_cmd.py",
+        "python -m dopemux.cli pr-steward --help",
         "git diff --check"
       ],
       "id": "S4",
@@ -137,6 +139,7 @@
         "python -m json.tool task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json",
         "python -m compileall -q src tests",
         "pytest -q tests/dopemux_cli/test_pr_steward_cmd.py",
+        "python -m dopemux.cli pr-steward --help",
         "git diff --check"
       ]
     }

--- a/tests/dopemux_cli/test_pr_steward_cmd.py
+++ b/tests/dopemux_cli/test_pr_steward_cmd.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from dopemux.cli import cli
+from dopemux_pr_steward.cli import main as steward_main
+
+
+def _write_json(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_dopemux_pr_steward_help_lists_versioned_subcommands():
+    result = CliRunner().invoke(cli, ["pr-steward", "--help"])
+
+    assert result.exit_code == 0
+    assert "intake" in result.output
+    assert "bridge" in result.output
+    assert "gate" in result.output
+    assert "audit" in result.output
+    assert "doctor" in result.output
+
+
+def test_importable_pr_steward_cli_help_lists_contract(capsys):
+    rc = steward_main(["--help"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "dopemux-pr-steward" in captured.out
+    assert "contract-version" in captured.out
+
+
+def test_gate_subcommand_uses_packaged_steward_gate(tmp_path: Path, capsys):
+    readiness = _write_json(
+        tmp_path / "MERGE_READINESS.json",
+        {
+            "generated_at": "2026-05-31T12:00:00Z",
+            "readiness": "READY",
+            "pr": {"number": 301, "head_sha": "abc123"},
+            "proof": {"proof_head_sha": "abc123"},
+            "embedded_audit": {"status": "PASS"},
+        },
+    )
+    proof = _write_json(
+        tmp_path / "PROOF.json",
+        {
+            "generated_at": "2026-05-31T12:00:00Z",
+            "head_sha": "abc123",
+            "embedded_audit": {"status": "PASS"},
+        },
+    )
+
+    rc = steward_main(
+        [
+            "gate",
+            "--head-sha",
+            "abc123",
+            "--required-class",
+            "FINALIZATION",
+            "--merge-readiness",
+            str(readiness),
+            "--audit-proof",
+            str(proof),
+            "--now",
+            "2026-05-31T12:15:00Z",
+            "--format",
+            "json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 0
+    assert payload["allowed"] is True
+    assert payload["reason_code"] == "ALLOW_FINALIZATION"
+
+
+def test_doctor_placeholder_fails_closed(capsys):
+    rc = steward_main(["doctor"])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "TP-DMX-STEWARD-DOCTOR-303" in captured.err
+
+
+def test_pr_steward_package_imports_outside_repo_root(tmp_path: Path):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from dopemux_pr_steward.cli import main; print(main(['--contract-version']))",
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+    assert result.returncode == 0
+    assert "contract-version 1.0.0" in result.stdout
+    assert result.stdout.strip().endswith("0")


### PR DESCRIPTION
## Summary
- add importable dopemux_pr_steward package with versioned CLI contract
- expose one Dopemux surface: dopemux pr-steward
- provide intake, bridge, gate, audit, and fail-closed doctor subcommands
- keep steward_gate logic in packaged Python code, not scaffolded YAML
- preserve existing PR Steward v1 intake docs and add CLI reference

## Validation
- PASS: python -m json.tool task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json
- PASS: python -m jsonschema -i task-packets/generated/TP-DMX-STEWARD-PACKAGE-301.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: python -m compileall -q src tests
- PASS: pytest -q tests/dopemux_cli/test_pr_steward_cmd.py
- PASS: pytest -q tests/dopemux_cli
- PASS: pytest -q tests/dopemux_cli/test_pr_steward_cmd.py tests/test_cli.py
- PASS: python -m dopemux.cli pr-steward --help
- PASS: git diff --check
- PASS: pre-commit run --files <TP301 changed files>

## Proof
- proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json
- proof/TP-DMX-STEWARD-PACKAGE-301/VALIDATION_OUTPUT.md
- proof/TP-DMX-STEWARD-PACKAGE-301/AUDITOR_REPORT.md

## NOT_RUN
- live GitHub PR Steward intake
- live Action Bridge compile against real PR artifacts
- local external embedded audit; marked SKIPPED in proof

@codex review
@gemini
@copilot