### PR TITLE
feat(adhd): resolve stable operator identity

### DIFF
--- a/services/adhd_engine/api/routes.py
+++ b/services/adhd_engine/api/routes.py
@@ -57,6 +57,7 @@ except ImportError:
 
 from . import schemas
 from ..core.models import ADHDProfile, EnergyLevel, AttentionState
+from ..operator_identity import resolve_operator_user_id
 
 # Event emission for implicit triggers (Phase 7)
 try:
@@ -1486,7 +1487,7 @@ async def adjust_automation_level(
 
 @router.get("/state")
 async def get_adhd_state(
-    user_id: str = "default",
+    user_id: str | None = None,
     engine = Depends(get_engine)
 ):
     """
@@ -1500,6 +1501,7 @@ async def get_adhd_state(
     Returns simplified state without API key requirement for local hooks.
     """
     try:
+        user_id = user_id or resolve_operator_user_id()
         # Get energy level
         energy_level = engine.current_energy_levels.get(user_id, EnergyLevel.MEDIUM)
         energy_str = energy_level.value if hasattr(energy_level, 'value') else str(energy_level).lower()
@@ -1524,6 +1526,7 @@ async def get_adhd_state(
         
     except Exception as e:
         logger.error(brand_log(f"ADHD state retrieval failed: {e}"))
+        user_id = user_id or "unknown"
         return {
             "energy": "medium",
             "attention": "focused",

--- a/services/adhd_engine/config.py
+++ b/services/adhd_engine/config.py
@@ -36,6 +36,10 @@ class Settings:
     conport_url: str = os.getenv("CONPORT_URL", "http://localhost:3010")
     pal_url: str = os.getenv("PAL_URL", os.getenv("ZEN_URL", "http://localhost:3003"))  # Backward compat with ZEN_URL
     workspace_id: str = os.getenv("ADHD_WORKSPACE_ID", os.getcwd())
+    operator_id_path: str = os.getenv(
+        "ADHD_OPERATOR_ID_PATH",
+        os.path.expanduser("~/.dopemux/operator_id"),
+    )
     dopecon_bridge_url: str = os.getenv("DOPECON_BRIDGE_URL", os.getenv("CONPORT_BRIDGE_URL", "http://localhost:3016"))
     dopecon_bridge_token: Optional[str] = os.getenv("DOPECON_BRIDGE_TOKEN")
     dopecon_bridge_source_plane: str = os.getenv("DOPECON_BRIDGE_SOURCE_PLANE", "cognitive_plane")

--- a/services/adhd_engine/core/engine.py
+++ b/services/adhd_engine/core/engine.py
@@ -33,6 +33,7 @@ from .models import (
     AccommodationRecommendation
 )
 from ..config import settings  # Relative import
+from ..operator_identity import resolve_operator_user_id
 from .activity_tracker import ActivityTracker
 from ..conport_mcp_client import ConPortMCPClient  # Relative import
 from ..bridge_integration import ConPortBridgeAdapter  # Relative import
@@ -65,7 +66,7 @@ from ..event_listener import ADHDEventListener
 try:
     from ..event_emitter import ADHDEventEmitter
 except ImportError:
-    pass
+    ADHDEventEmitter = None
 
 # ConPort-KG Integration (optional)
 try:
@@ -116,6 +117,7 @@ class ADHDAccommodationEngine:
         """Initialize ADHD accommodation engine with settings-based configuration."""
         self.redis_url = settings.redis_url
         self.workspace_id = settings.workspace_id
+        self.operator_user_id = resolve_operator_user_id()
 
         # Redis connection for state persistence (now using shared pool)
         self.redis_client: Optional[redis.Redis] = None
@@ -294,12 +296,13 @@ class ADHDAccommodationEngine:
         """Initialize DDD domain components."""
         # Attention Domain
         self.hyperfocus_guard = HyperfocusGuard()
-        self.attention_calibrator = AttentionCalibrator(user_id=settings.workspace_id)  # Using workspace_id as default user
+        self.operator_user_id = resolve_operator_user_id()
+        self.attention_calibrator = AttentionCalibrator(user_id=self.operator_user_id)
         self.procrastination_detector = ProcrastinationDetector()
         self.overwhelm_detector = OverwhelmDetector()
         
         # Wellbeing Domain
-        self.social_battery_monitor = SocialBatteryMonitor(user_id=settings.workspace_id, bridge_client=self.conport)
+        self.social_battery_monitor = SocialBatteryMonitor(user_id=self.operator_user_id, bridge_client=self.conport)
         
         # Task Enablement Domain
         self.task_decomposer = TaskDecompositionAssistant()
@@ -311,17 +314,10 @@ class ADHDAccommodationEngine:
         self.voice_assistant = VoiceAssistant(adhd_engine=self)
         
         # Event Listener
-        from ..event_listener import ADHDEventListener
-        # We need an EventBus - usually this would be injected or imported
-        # For now, we will create a dummy event bus if not available or assume it's part of the engine
-        # But wait, event_listener expects 'event_bus'.
-        # Assuming engine has access to event bus, or we need to create one.
-        # Let's import the event bus if available.
-        try:
-            from ..event_emitter import ADHDEventEmitter
+        if ADHDEventEmitter is not None:
             # Event emitter expects a Redis URL, not a bridge adapter object.
             self.event_bus = ADHDEventEmitter(settings.redis_url)
-        except ImportError:
+        else:
             self.event_bus = None
             
         self.event_listener = ADHDEventListener(
@@ -335,7 +331,8 @@ class ADHDAccommodationEngine:
     async def _start_event_listener(self) -> None:
         """Start the central event listener."""
         if self.event_listener:
-            await self.event_listener.start(user_id=settings.workspace_id)
+            self.operator_user_id = resolve_operator_user_id()
+            await self.event_listener.start(user_id=self.operator_user_id)
 
     # Core Accommodation Methods
 

--- a/services/adhd_engine/main.py
+++ b/services/adhd_engine/main.py
@@ -38,6 +38,7 @@ except Exception:  # pragma: no cover - fallback path for isolated service image
 from .core.engine import ADHDAccommodationEngine
 from .api import routes
 from .config import settings
+from .operator_identity import resolve_operator_user_id
 from .middleware.rate_limit import RateLimitMiddleware
 from .core.error_handling import with_error_handling
 try:
@@ -60,10 +61,12 @@ except ImportError:  # pragma: no cover - optional dependency for local test env
 mcp = FastMCP("ADHD-Engine")
 
 @mcp.tool()
-async def get_cognitive_state(user_id: str = "default") -> dict:
+async def get_cognitive_state(user_id: str | None = None) -> dict:
     """Get current cognitive state (energy, attention, load)."""
     if not engine:
         return {"error": "Engine not initialized"}
+
+    user_id = user_id or resolve_operator_user_id()
 
     # We call the engine directly for speed
     energy = await engine.get_energy_level(user_id)
@@ -368,7 +371,7 @@ async def lifespan(app: FastAPI):
 
                 # Start event listener as background task
                 event_listener_task = asyncio.create_task(
-                    event_listener.start(user_id="default"),
+                    event_listener.start(user_id=resolve_operator_user_id()),
                     name="adhd_event_listener"
                 )
 

--- a/services/adhd_engine/operator_identity.py
+++ b/services/adhd_engine/operator_identity.py
@@ -1,0 +1,75 @@
+"""Content-free operator identity resolution for local ADHD engine state."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+
+_OVERRIDE_ENV_KEYS = ("DOPEMUX_ADHD_USER_ID", "ADHD_OPERATOR_USER_ID")
+_DEFAULT_ID_PATH = Path("~/.dopemux/operator_id").expanduser()
+
+
+def _validate_content_free_operator_id(value: str, *, source: str) -> str:
+    operator_id = value.strip()
+    if not operator_id:
+        raise ValueError(f"ADHD operator identity from {source} is empty")
+    if "/" in operator_id or "\\" in operator_id or operator_id in {".", ".."}:
+        raise ValueError(
+            f"ADHD operator identity from {source} must be content-free, not path-like"
+        )
+    if len(operator_id) > 128:
+        raise ValueError(f"ADHD operator identity from {source} is too long")
+    return operator_id
+
+
+def _configured_override() -> str | None:
+    for key in _OVERRIDE_ENV_KEYS:
+        raw_value = os.getenv(key)
+        if raw_value is not None:
+            return _validate_content_free_operator_id(raw_value, source=key)
+    return None
+
+
+def _default_identity_path() -> Path:
+    return Path(os.getenv("ADHD_OPERATOR_ID_PATH", str(_DEFAULT_ID_PATH))).expanduser()
+
+
+def resolve_operator_user_id(identity_path: str | os.PathLike[str] | None = None) -> str:
+    """Return the local operator id without deriving it from machine/user content.
+
+    The normal path is a persisted random UUID stored at ``~/.dopemux/operator_id``.
+    Environment overrides are intentionally explicit and never persisted.
+    """
+
+    override = _configured_override()
+    if override is not None:
+        return override
+
+    path = (
+        Path(identity_path).expanduser()
+        if identity_path is not None
+        else _default_identity_path()
+    )
+    if path.exists():
+        return _validate_content_free_operator_id(
+            path.read_text(encoding="utf-8"),
+            source=str(path),
+        )
+
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    generated = str(uuid.uuid4())
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    try:
+        fd = os.open(path, flags, 0o600)
+    except FileExistsError:
+        return _validate_content_free_operator_id(
+            path.read_text(encoding="utf-8"),
+            source=str(path),
+        )
+
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(f"{generated}\n")
+    os.chmod(path, 0o600)
+    return generated

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001-implementation-notes.md
@@ -1,0 +1,71 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T4 00 Operator Identity 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: Tp Dmx Adhd Cognitive T4 00 Operator Identity 001 Implementation Notes (explanation)
+  for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001 Implementation Notes
+
+## Scope
+
+Implemented the T4-00 operator identity gate only.
+
+In scope:
+- Add content-free operator identity resolver.
+- Persist a random UUID at `~/.dopemux/operator_id` with `0600` permissions.
+- Allow explicit content-free environment override without writing the persisted file.
+- Thread the resolved operator id through active ADHD engine domain component startup, event listener startup, MCP cognitive-state default, and `/api/v1/state` default.
+
+Out of scope:
+- Profile seeding (`T4-03a`).
+- Activity input-loop closure (`T4-03b`).
+- Event API reconciliation (`T4-01`).
+- Assessment algorithm changes (`T4-04`).
+
+## Analysis Performed
+
+Observed runtime authority:
+- `services/adhd_engine/main.py` imports `services.adhd_engine.core.engine.ADHDAccommodationEngine`.
+- `services/adhd_engine/core/engine.py` used `settings.workspace_id` for `AttentionCalibrator`, `SocialBatteryMonitor`, and `event_listener.start`.
+- `services/adhd_engine/api/routes.py` defaulted local `/state` to `"default"`.
+- `services/adhd_engine/main.py` defaulted MCP `get_cognitive_state` and lifespan event listener startup to `"default"`.
+
+Challenge notes:
+- Do not hash workspace, machine id, hostname, username, repo path, or prompt/file content; those would create fingerprinting or content leakage risk.
+- Do not seed `engine.user_profiles` in this slice; the loaded DAG has separate T4-03a profile seeding.
+- Do not edit the legacy sibling `services/adhd_engine/engine.py`; the active app path imports `core.engine`.
+
+## Validation Evidence
+
+RED:
+- `python -m pytest tests/unit/test_adhd_operator_identity.py`
+- Result: `6 failed`.
+- Expected failures: missing `services.adhd_engine.operator_identity`, missing `settings.operator_id_path`, missing resolver imports/threading in `core.engine` and `api.routes`.
+
+GREEN:
+- `python -m pytest tests/unit/test_adhd_operator_identity.py`
+- Result: `6 passed in 1.47s`.
+
+Targeted regression:
+- `python -m pytest tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py`
+- Result: `12 passed in 1.42s`.
+
+Packet schema:
+- `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- Result: exit code 0. The jsonschema CLI emitted only its deprecation warning.
+
+Diff hygiene:
+- `git diff --check`
+- Result: exit code 0.
+
+## Remaining Risk
+
+- Existing operator identity files with invalid/path-like content now fail closed at resolver time.
+- `/api/v1/state` now resolves the operator id by default, but state dictionaries will still return fallback energy/attention until T4-03a/T4-03b/T4-04 land.
+- Runtime integration with a live ADHD engine process was not exercised in this slice.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json
@@ -1,0 +1,144 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001",
+  "project": "dopemux-mvp",
+  "target": "ADHD Engine operator identity gate for the cognitive signal pipeline",
+  "invariants": [
+    "Operator identity must be content-free and must not derive from machine identifiers, paths, usernames, hostnames, prompts, file contents, or code contents.",
+    "The active FastAPI runtime imports services.adhd_engine.core.engine; the legacy services/adhd_engine/engine.py sibling is not the authority for this slice.",
+    "T4-00 must not seed default profiles or close the activity input loop; those remain T4-03a/T4-03b work.",
+    "ADHD Engine remains cognitive-only under AGENTS.md section 6."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "feat/autoreview-platform-series",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-operator-identity-001",
+    "base_branch": "feat/autoreview-platform-series",
+    "stacked_because": "Primary checkout is dirty and the loaded ADHD remediation plan is uncommitted there."
+  },
+  "commit": {
+    "message": "feat(adhd): resolve stable operator identity",
+    "allowlist": [
+      "services/adhd_engine/operator_identity.py",
+      "services/adhd_engine/config.py",
+      "services/adhd_engine/core/engine.py",
+      "services/adhd_engine/api/routes.py",
+      "services/adhd_engine/main.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001-implementation-notes.md",
+      "tests/unit/test_adhd_operator_identity.py"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(adhd): resolve stable operator identity",
+    "body": "## Summary\n- add a content-free persisted random operator identity resolver for ADHD engine user threading\n- stop using workspace_id and hard-coded default user ids for active ADHD engine startup/state defaults\n- add targeted regression tests for persistence, permissions, override behavior, and runtime threading\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py\n- git diff --check",
+    "base": "feat/autoreview-platform-series"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect active ADHD engine imports, identity defaults, route defaults, settings, and existing ADHD tests before editing.",
+      "requirements": [
+        "Distinguish active services.adhd_engine.core.engine runtime from legacy services/adhd_engine/engine.py.",
+        "Do not widen into T4-01 event API or T4-03 profile seeding work."
+      ],
+      "commands": [
+        "rg -n \"workspace_id|user_id|default_user|operator_id|AttentionCalibrator|event_listener.start|/state\" services/adhd_engine src tests -g '*.py'",
+        "nl -ba services/adhd_engine/core/engine.py | sed -n '1,420p'",
+        "nl -ba services/adhd_engine/api/routes.py | sed -n '220,260p;1460,1510p'"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Runtime authority and change points are identified before tests or production edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/adhd-cognitive-remediation-plan-2026-05-31.md",
+        "docs/ops/load-plans/load_plan-DMX-ADHD-COGNITIVE-REMEDIATION.json",
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/api/routes.py",
+        "services/adhd_engine/main.py",
+        "services/adhd_engine/config.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add a persisted random operator identity resolver and thread it through active engine startup, event listener startup, MCP cognitive-state default, and local /state hook default.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "Persisted identity file must be created with 0600 permissions where supported.",
+        "Generated identity must be random UUID text and stable across resolver calls.",
+        "Explicit environment override is allowed only as an operator-provided content-free id and must not write the persisted identity file.",
+        "No machine fingerprinting, path hashing, hostname use, prompt/content capture, profile seeding, or task authority changes."
+      ],
+      "commands": [
+        "apply_patch"
+      ],
+      "expected_files": [
+        "services/adhd_engine/operator_identity.py",
+        "services/adhd_engine/config.py",
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/api/routes.py",
+        "services/adhd_engine/main.py",
+        "tests/unit/test_adhd_operator_identity.py"
+      ],
+      "validation": [
+        "Targeted identity tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, targeted tests, diff scope, and precommit checks for the bounded T4-00 slice.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim T4-01/T4-03 activity pipeline behavior."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/unit/test_adhd_operator_identity.py
+++ b/tests/unit/test_adhd_operator_identity.py
@@ -1,0 +1,137 @@
+import importlib
+import stat
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_operator_identity_is_random_persisted_uuid_with_private_permissions(tmp_path, monkeypatch):
+    from services.adhd_engine.operator_identity import resolve_operator_user_id
+
+    identity_path = tmp_path / ".dopemux" / "operator_id"
+    monkeypatch.delenv("DOPEMUX_ADHD_USER_ID", raising=False)
+    monkeypatch.delenv("ADHD_OPERATOR_USER_ID", raising=False)
+
+    first = resolve_operator_user_id(identity_path=identity_path)
+    second = resolve_operator_user_id(identity_path=identity_path)
+
+    assert first == second
+    assert uuid.UUID(first).version == 4
+    assert identity_path.read_text(encoding="utf-8").strip() == first
+    assert stat.S_IMODE(identity_path.stat().st_mode) == 0o600
+
+
+def test_operator_identity_env_override_is_content_free_and_does_not_write_file(tmp_path, monkeypatch):
+    from services.adhd_engine.operator_identity import resolve_operator_user_id
+
+    identity_path = tmp_path / ".dopemux" / "operator_id"
+    monkeypatch.setenv("DOPEMUX_ADHD_USER_ID", "operator-local-001")
+
+    assert resolve_operator_user_id(identity_path=identity_path) == "operator-local-001"
+    assert not identity_path.exists()
+
+
+def test_operator_identity_rejects_pathlike_or_empty_overrides(tmp_path, monkeypatch):
+    from services.adhd_engine.operator_identity import resolve_operator_user_id
+
+    identity_path = tmp_path / ".dopemux" / "operator_id"
+    monkeypatch.setenv("DOPEMUX_ADHD_USER_ID", "/Users/hue/code/dopemux-mvp")
+
+    with pytest.raises(ValueError, match="content-free"):
+        resolve_operator_user_id(identity_path=identity_path)
+
+    monkeypatch.setenv("DOPEMUX_ADHD_USER_ID", "   ")
+    with pytest.raises(ValueError, match="empty"):
+        resolve_operator_user_id(identity_path=identity_path)
+
+
+def test_adhd_settings_exposes_operator_identity_path(monkeypatch, tmp_path):
+    managed_keys = ["ADHD_OPERATOR_ID_PATH", "DOPEMUX_ADHD_USER_ID", "ADHD_OPERATOR_USER_ID"]
+    for key in managed_keys:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("ADHD_OPERATOR_ID_PATH", str(tmp_path / "operator-id"))
+
+    config = importlib.import_module("services.adhd_engine.config")
+    config = importlib.reload(config)
+
+    assert config.settings.operator_id_path == str(tmp_path / "operator-id")
+
+
+@pytest.mark.asyncio
+async def test_core_engine_threads_operator_identity_to_domain_components_and_listener(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+
+    started = {}
+
+    class FakeAttentionCalibrator:
+        def __init__(self, user_id, storage_path=".calibration_data"):
+            self.user_id = user_id
+            self.storage_path = storage_path
+
+    class FakeSocialBatteryMonitor:
+        def __init__(self, user_id, bridge_client=None):
+            self.user_id = user_id
+            self.bridge_client = bridge_client
+
+    class FakeNoArg:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class FakeVoiceAssistant:
+        def __init__(self, adhd_engine):
+            self.adhd_engine = adhd_engine
+
+    class FakeCoordinator:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    class FakeEventEmitter:
+        def __init__(self, redis_url):
+            self.redis_url = redis_url
+
+    class FakeEventListener:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        async def start(self, user_id):
+            started["user_id"] = user_id
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: "operator-local-001")
+    monkeypatch.setattr(engine_module, "AttentionCalibrator", FakeAttentionCalibrator)
+    monkeypatch.setattr(engine_module, "SocialBatteryMonitor", FakeSocialBatteryMonitor)
+    monkeypatch.setattr(engine_module, "HyperfocusGuard", FakeNoArg)
+    monkeypatch.setattr(engine_module, "ProcrastinationDetector", FakeNoArg)
+    monkeypatch.setattr(engine_module, "OverwhelmDetector", FakeNoArg)
+    monkeypatch.setattr(engine_module, "TaskDecompositionAssistant", FakeNoArg)
+    monkeypatch.setattr(engine_module, "VoiceAssistant", FakeVoiceAssistant)
+    monkeypatch.setattr(engine_module, "DecompositionCoordinator", FakeCoordinator)
+    monkeypatch.setattr(engine_module, "ADHDEventEmitter", FakeEventEmitter)
+    monkeypatch.setattr(engine_module, "ADHDEventListener", FakeEventListener)
+
+    engine = engine_module.ADHDAccommodationEngine()
+    engine._initialize_domain_components()
+    await engine._start_event_listener()
+
+    assert engine.operator_user_id == "operator-local-001"
+    assert engine.attention_calibrator.user_id == "operator-local-001"
+    assert engine.social_battery_monitor.user_id == "operator-local-001"
+    assert started["user_id"] == "operator-local-001"
+
+
+@pytest.mark.asyncio
+async def test_state_route_defaults_to_resolved_operator_identity(monkeypatch):
+    from services.adhd_engine.api import routes
+    from services.adhd_engine.core.models import AttentionState, EnergyLevel
+
+    monkeypatch.setattr(routes, "resolve_operator_user_id", lambda: "operator-local-001")
+    engine = SimpleNamespace(
+        current_energy_levels={"operator-local-001": EnergyLevel.HIGH},
+        current_attention_states={"operator-local-001": AttentionState.SCATTERED},
+    )
+
+    state = await routes.get_adhd_state(engine=engine)
+
+    assert state["user_id"] == "operator-local-001"
+    assert state["energy"] == "high"
+    assert state["attention"] == "scattered"


### PR DESCRIPTION
## Summary
- add a content-free persisted random operator identity resolver for ADHD engine user threading
- stop using workspace_id and hard-coded default user ids for active ADHD engine startup/state defaults
- add targeted regression tests for persistence, permissions, override behavior, and runtime threading

## Validation
- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- python -m pytest tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py
- pre-commit run --files services/adhd_engine/operator_identity.py services/adhd_engine/config.py services/adhd_engine/core/engine.py services/adhd_engine/api/routes.py services/adhd_engine/main.py tests/unit/test_adhd_operator_identity.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001-implementation-notes.md
- git diff --check

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated