### PR TITLE
feat(init): scaffold PR-steward workflows and config

### DIFF
--- a/docs/ops/pr-steward-distribution.md
+++ b/docs/ops/pr-steward-distribution.md
@@ -1,0 +1,39 @@
+---
+id: pr-steward-distribution
+title: PR Steward Distribution
+type: reference
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: Minimal dopemux init scaffold contract for PR Steward distribution.
+---
+# PR Steward Distribution
+
+`dopemux init` copies PR Steward scaffold files from
+`src/dopemux/templates/init/` into a target workspace. The template installer is
+recursive and skips existing files, so normal init and `init --force` do not
+overwrite local workflow or policy edits.
+
+## Scaffolded Files
+
+- `.github/workflows/pr-steward.yml`
+- `.github/workflows/embedded-audit.yml`
+- `config/pr_steward/policy.json`
+- `config/pr_merge_specialist/policy.yaml`
+
+## Boundaries
+
+- The workflows call the packaged `python -m dopemux.cli pr-steward` command.
+- The scaffold does not generate or copy `steward_gate` Python logic.
+- The scaffold does not add a setup subcommand, checksum manifest, or reusable
+  composite action.
+- PR Steward remains check-only; the scaffolded policy records
+  `mutates_github: false`.
+- Merge specialist governed automerge is off by default.
+
+## Follow-Up
+
+`dopemux pr-steward doctor` remains fail-closed until
+TP-DMX-STEWARD-DOCTOR-303 adds package/scaffold skew and config checks.

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/AUDITOR_REPORT.md
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/AUDITOR_REPORT.md
@@ -1,0 +1,24 @@
+# Auditor Report
+
+Status: `SKIPPED`
+
+No external embedded-auditor invocation was available in this Codex session. A
+bounded manual review was performed instead.
+
+## Manual Review
+
+- The implementation is limited to template files, tests, docs, packet metadata,
+  and proof artifacts.
+- `src/dopemux/project_init.py` was inspected and already recursively copies
+  `src/dopemux/templates/init/` while skipping existing destination files.
+- Tests cover normal init scaffolding and `initialize(..., force=True)`
+  no-clobber behavior for existing PR Steward workflow and merge policy files.
+- The scaffolded merge policy keeps governed automerge disabled.
+- The scaffolded PR Steward policy records check-only behavior and
+  `mutates_github: false`.
+
+## Remaining Risk
+
+- The scaffolded workflows were not executed in GitHub Actions.
+- The workflows assume `python -m dopemux.cli` is available in the target CI
+  environment; TP302 explicitly defers heavier setup and reusable action work.

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/CHANGED_FILES.txt
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/CHANGED_FILES.txt
@@ -1,0 +1,15 @@
+docs/ops/pr-steward-distribution.md
+src/dopemux/templates/init/.github/workflows/embedded-audit.yml
+src/dopemux/templates/init/.github/workflows/pr-steward.yml
+src/dopemux/templates/init/config/pr_merge_specialist/policy.yaml
+src/dopemux/templates/init/config/pr_steward/policy.json
+task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json
+tests/dopemux_init/test_pr_steward_scaffold.py
+proof/TP-DMX-STEWARD-SCAFFOLD-302/AUDITOR_REPORT.md
+proof/TP-DMX-STEWARD-SCAFFOLD-302/CHANGED_FILES.txt
+proof/TP-DMX-STEWARD-SCAFFOLD-302/DIFF_STAT.txt
+proof/TP-DMX-STEWARD-SCAFFOLD-302/GIT_STATE.md
+proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json
+proof/TP-DMX-STEWARD-SCAFFOLD-302/VALIDATION_OUTPUT.md
+proof/TP-DMX-STEWARD-SCAFFOLD-302/review_bundle/MANIFEST.json
+proof/TP-DMX-STEWARD-SCAFFOLD-302/review_bundle/SUMMARY.md

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/DIFF_STAT.txt
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/DIFF_STAT.txt
@@ -1,0 +1,8 @@
+ docs/ops/pr-steward-distribution.md                | 39 +++++++++
+ .../init/.github/workflows/embedded-audit.yml      | 50 ++++++++++++
+ .../init/.github/workflows/pr-steward.yml          | 79 +++++++++++++++++++
+ .../init/config/pr_merge_specialist/policy.yaml    | 17 ++++
+ .../templates/init/config/pr_steward/policy.json   | 17 ++++
+ .../generated/TP-DMX-STEWARD-SCAFFOLD-302.json     |  6 +-
+ tests/dopemux_init/test_pr_steward_scaffold.py     | 92 ++++++++++++++++++++++
+ 7 files changed, 297 insertions(+), 3 deletions(-)

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/GIT_STATE.md
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/GIT_STATE.md
@@ -1,0 +1,16 @@
+# Git State
+
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-steward-scaffold-302`
+- Branch: `codex/tp-dmx-steward-scaffold-302`
+- Base ref: `origin/codex/tp-dmx-steward-package-301`
+- Base SHA: `7acb4d9ad43453e3b1c7cfe7b0504dc880007ffe`
+- Implementation commit SHA: `2b8f1c16c25d28c443e6136b2262dc4381ce7158`
+- Primary checkout dirty state was not modified.
+
+## Changed Files
+
+See `CHANGED_FILES.txt`.
+
+## Diff Stat
+
+See `DIFF_STAT.txt`.

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json
@@ -8,7 +8,7 @@
   "base_sha": "7acb4d9ad43453e3b1c7cfe7b0504dc880007ffe",
   "implementation_commit_sha": "2b8f1c16c25d28c443e6136b2262dc4381ce7158",
   "proof_commit_sha": "0a2ea96ae3d40e0fa78e82a4d921958379d516a3",
-  "pr_url": "PENDING_PR_CREATION",
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/772",
   "repo_identity": {
     "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
     "marker": ".dopetaskroot",

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json
@@ -1,0 +1,152 @@
+{
+  "tp_id": "TP-DMX-STEWARD-SCAFFOLD-302",
+  "status": "PASS_WITH_LIMITS",
+  "generated_at": "2026-05-31T23:55:00Z",
+  "worktree_path": "/Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-steward-scaffold-302",
+  "branch": "codex/tp-dmx-steward-scaffold-302",
+  "base_ref": "origin/codex/tp-dmx-steward-package-301",
+  "base_sha": "7acb4d9ad43453e3b1c7cfe7b0504dc880007ffe",
+  "implementation_commit_sha": "2b8f1c16c25d28c443e6136b2262dc4381ce7158",
+  "proof_commit_sha": "PENDING_PROOF_COMMIT",
+  "pr_url": "PENDING_PR_CREATION",
+  "repo_identity": {
+    "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "marker": ".dopetaskroot",
+    "identity_match": true
+  },
+  "stacking": {
+    "reason": "TP302 depends on TP-DMX-STEWARD-PACKAGE-301, so the packet and PR base were changed from main to codex/tp-dmx-steward-package-301.",
+    "base_branch": "codex/tp-dmx-steward-package-301",
+    "base_pr": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/770"
+  },
+  "dependency_proofs": [
+    {
+      "tp_id": "TP-DMX-STEWARD-PACKAGE-301",
+      "path": "proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json",
+      "present": true,
+      "json_valid": true,
+      "status": "PASS_WITH_LIMITS",
+      "head_sha": "33801d19cbde6654f421f26e2b58730354fc6a71",
+      "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/770"
+    }
+  ],
+  "authority_used": [
+    "AGENTS.md",
+    "task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json",
+    "docs/ops/load-plans/load_plan-DMX-AUTOREVIEW-PLATFORM.json",
+    "src/dopemux/project_init.py",
+    "src/dopemux_pr_steward/cli.py",
+    "docs/ops/pr-steward.md",
+    "docs/ops/pr-steward-cli.md",
+    "config/pr_merge_specialist/policy.yaml"
+  ],
+  "slices_completed": [
+    "Preflight verified the dedicated worktree, origin, branch, .dopetaskroot marker, TP302 schema, and TP301 dependency proof.",
+    "RED: pytest -q tests/dopemux_init exited 4 before the test directory existed on the TP301 base.",
+    "RED: added tests/dopemux_init/test_pr_steward_scaffold.py and observed failure because .github/workflows/pr-steward.yml was not scaffolded.",
+    "GREEN: added thin PR Steward and embedded-audit workflow templates plus pr_steward and pr_merge_specialist policy templates.",
+    "Confirmed project_init.py already recursively copies template files and skips existing destination files, including under initialize(..., force=True), so no runtime code change was needed.",
+    "Updated TP302 base and PR metadata to codex/tp-dmx-steward-package-301 to match the dependency stack."
+  ],
+  "files_changed": [
+    "docs/ops/pr-steward-distribution.md",
+    "src/dopemux/templates/init/.github/workflows/embedded-audit.yml",
+    "src/dopemux/templates/init/.github/workflows/pr-steward.yml",
+    "src/dopemux/templates/init/config/pr_merge_specialist/policy.yaml",
+    "src/dopemux/templates/init/config/pr_steward/policy.json",
+    "task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json",
+    "tests/dopemux_init/test_pr_steward_scaffold.py",
+    "proof/TP-DMX-STEWARD-SCAFFOLD-302/**"
+  ],
+  "validations": [
+    {
+      "command": "pytest -q tests/dopemux_init",
+      "exit_code": 4,
+      "status": "BASELINE_ABSENT",
+      "evidence": "ERROR: file or directory not found: tests/dopemux_init"
+    },
+    {
+      "command": "pytest -q tests/dopemux_init/test_pr_steward_scaffold.py",
+      "exit_code": 1,
+      "status": "RED_PASS",
+      "evidence": "AssertionError: .github/workflows/pr-steward.yml did not exist after init."
+    },
+    {
+      "command": "pytest -q tests/dopemux_init/test_pr_steward_scaffold.py",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "2 passed"
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m jsonschema -i task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m compileall -q src tests",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "pytest -q tests/dopemux_init tests/test_project_init_templates.py",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "8 passed"
+    },
+    {
+      "command": "python -c \"import yaml;yaml.safe_load(open('src/dopemux/templates/init/.github/workflows/pr-steward.yml'));yaml.safe_load(open('src/dopemux/templates/init/.github/workflows/embedded-audit.yml'));print('yaml ok')\"",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "yaml ok"
+    },
+    {
+      "command": "pytest -q tests/dopemux_init",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "2 passed"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "pre-commit run --files <TP302 implementation files>",
+      "exit_code": 0,
+      "status": "PASS"
+    }
+  ],
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DMX-STEWARD-SCAFFOLD-302/AUDITOR_REPORT.md",
+    "findings": [],
+    "fixes_applied": [],
+    "remaining_risks": [
+      "External embedded audit was not invoked in this Codex session.",
+      "The scaffolded workflows assume the Dopemux package/command is available in the target repository CI environment; live downstream CI installation behavior was not exercised."
+    ],
+    "skip_reason": "No supported external embedded-auditor invocation was available in this session; Codex performed bounded manual audit and records this required audit as skipped."
+  },
+  "codereview_status": "Manual bounded review complete; project_init.py already provides recursive no-clobber template copying, so the implementation is template-only plus tests/docs/packet metadata.",
+  "precommit_status": "PASS: pre-commit run on TP302 implementation files and git diff --check passed.",
+  "residual_risks": [
+    "The scaffolded GitHub workflows were YAML-parsed and init-copied locally, but they were not executed in GitHub Actions before this proof was written.",
+    "Downstream projects may need a separate installation path for the Dopemux package before python -m dopemux.cli is available in CI; TP302 explicitly avoided heavy setup and reusable action work.",
+    "External embedded audit is skipped locally and should be supplied by CI or supervisor review."
+  ],
+  "unknowns": [
+    "Whether every dopemux-init target repository has a CI environment with Dopemux installed is UNKNOWN.",
+    "Whether downstream branch protection will treat scaffolded PR Steward as advisory or required is UNKNOWN until project-local policy is configured."
+  ],
+  "cleanup_status": "WORKTREE_ACTIVE_PENDING_PR"
+}

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json
@@ -7,7 +7,7 @@
   "base_ref": "origin/codex/tp-dmx-steward-package-301",
   "base_sha": "7acb4d9ad43453e3b1c7cfe7b0504dc880007ffe",
   "implementation_commit_sha": "2b8f1c16c25d28c443e6136b2262dc4381ce7158",
-  "proof_commit_sha": "PENDING_PROOF_COMMIT",
+  "proof_commit_sha": "0a2ea96ae3d40e0fa78e82a4d921958379d516a3",
   "pr_url": "PENDING_PR_CREATION",
   "repo_identity": {
     "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/VALIDATION_OUTPUT.md
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/VALIDATION_OUTPUT.md
@@ -1,0 +1,25 @@
+# Validation Output
+
+## PASS
+
+- `python -m json.tool task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json` exited 0.
+- `python -m jsonschema -i task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` exited 0.
+- `python -m compileall -q src tests` exited 0.
+- `pytest -q tests/dopemux_init/test_pr_steward_scaffold.py` exited 0 with `2 passed`.
+- `pytest -q tests/dopemux_init tests/test_project_init_templates.py` exited 0 with `8 passed`.
+- `python -c "import yaml;yaml.safe_load(open('src/dopemux/templates/init/.github/workflows/pr-steward.yml'));yaml.safe_load(open('src/dopemux/templates/init/.github/workflows/embedded-audit.yml'));print('yaml ok')"` exited 0 with `yaml ok`.
+- `pytest -q tests/dopemux_init` exited 0 with `2 passed`.
+- `git diff --check` exited 0.
+- `pre-commit run --files <TP302 implementation files>` exited 0.
+
+## RED / Baseline
+
+- `pytest -q tests/dopemux_init` exited 4 before the test directory existed on the TP301 base.
+- `pytest -q tests/dopemux_init/test_pr_steward_scaffold.py` exited 1 after adding tests and before adding scaffold templates; the expected failure was missing `.github/workflows/pr-steward.yml`.
+
+## NOT_RUN
+
+- Live GitHub Actions execution of scaffolded workflows.
+- Live downstream `dopemux init` run in a separate repository.
+- External embedded audit invocation.
+- Supervisor sign-off.

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/review_bundle/MANIFEST.json
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/review_bundle/MANIFEST.json
@@ -1,0 +1,14 @@
+{
+  "tp_id": "TP-DMX-STEWARD-SCAFFOLD-302",
+  "bundle_type": "review_bundle",
+  "artifacts": [
+    "../PROOF.json",
+    "../VALIDATION_OUTPUT.md",
+    "../GIT_STATE.md",
+    "../DIFF_STAT.txt",
+    "../CHANGED_FILES.txt",
+    "../AUDITOR_REPORT.md",
+    "SUMMARY.md"
+  ],
+  "excluded": []
+}

--- a/proof/TP-DMX-STEWARD-SCAFFOLD-302/review_bundle/SUMMARY.md
+++ b/proof/TP-DMX-STEWARD-SCAFFOLD-302/review_bundle/SUMMARY.md
@@ -1,0 +1,14 @@
+# TP-DMX-STEWARD-SCAFFOLD-302 Review Bundle
+
+This bundle records the minimal PR Steward distribution scaffold added to
+`dopemux init`.
+
+Implementation commit: `2b8f1c16c25d28c443e6136b2262dc4381ce7158`
+
+Primary validation:
+
+- `pytest -q tests/dopemux_init` -> `2 passed`
+- `pytest -q tests/dopemux_init tests/test_project_init_templates.py` -> `8 passed`
+- `python -m compileall -q src tests` -> exit 0
+- `git diff --check` -> exit 0
+- `pre-commit run --files <TP302 implementation files>` -> exit 0

--- a/src/dopemux/templates/init/.github/workflows/embedded-audit.yml
+++ b/src/dopemux/templates/init/.github/workflows/embedded-audit.yml
@@ -1,0 +1,50 @@
+name: embedded-audit
+
+"on":
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      proof_path:
+        description: Proof bundle path to inspect
+        required: true
+        type: string
+        default: proof/PROOF.json
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+  actions: read
+
+jobs:
+  embedded-audit:
+    name: embedded audit proof check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set proof path
+        id: proof
+        env:
+          INPUT_PROOF_PATH: ${{ inputs.proof_path }}
+        run: |
+          proof_path="${INPUT_PROOF_PATH:-proof/PROOF.json}"
+          printf 'path=%s\n' "$proof_path" >> "$GITHUB_OUTPUT"
+
+      - name: Run embedded audit proof check
+        run: |
+          python -m dopemux.cli pr-steward audit \
+            --proof "${{ steps.proof.outputs.path }}" \
+            --format json
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            printf '## Embedded audit proof check\n\n'
+            printf -- '- proof_path: %s\n' '${{ steps.proof.outputs.path }}'
+            printf -- '- mutation_performed: false\n'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/src/dopemux/templates/init/.github/workflows/pr-steward.yml
+++ b/src/dopemux/templates/init/.github/workflows/pr-steward.yml
@@ -1,0 +1,79 @@
+name: PR Steward
+
+"on":
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to inspect
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  checks: read
+  statuses: read
+  actions: read
+  issues: read
+
+jobs:
+  pr-steward:
+    name: advisory check-only intake
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set PR number
+        id: pr
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            printf 'number=%s\n' "$EVENT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          else
+            printf 'number=%s\n' "$INPUT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run PR Steward
+        id: steward
+        continue-on-error: true
+        run: |
+          set +e
+          python -m dopemux.cli pr-steward intake \
+            --repo "$GITHUB_REPOSITORY" \
+            --pr "${{ steps.pr.outputs.number }}" \
+            --out pr-steward-artifacts \
+            --strict \
+            --format text
+          status=$?
+          printf 'exit_code=%s\n' "$status" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            printf '## PR Steward advisory result\n\n'
+            printf -- '- exit_code: %s\n' '${{ steps.steward.outputs.exit_code }}'
+            printf -- '- mutation_performed: false\n\n'
+            if [ -f pr-steward-artifacts/PR_STEWARD_SUMMARY.md ]; then
+              cat pr-steward-artifacts/PR_STEWARD_SUMMARY.md
+            else
+              printf 'PR Steward did not emit a summary artifact.\n'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload PR Steward artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-steward-${{ steps.pr.outputs.number }}
+          path: pr-steward-artifacts/
+          if-no-files-found: warn

--- a/src/dopemux/templates/init/config/pr_merge_specialist/policy.yaml
+++ b/src/dopemux/templates/init/config/pr_merge_specialist/policy.yaml
@@ -1,0 +1,17 @@
+version: 1
+merge:
+  allow_governed_automerge: false
+  allow_auto_fallback_only_for:
+    - merge_queue_required
+governed_automerge:
+  enabled: false
+steward_gate:
+  artifact_ttl_seconds: 3600
+  allow_global_fix_prs: false
+  remediation_readiness:
+    - NEEDS_IMPLEMENTER
+  finalization_readiness:
+    - READY
+safety:
+  fail_closed_on_incomplete_data: true
+  require_expected_head_oid: true

--- a/src/dopemux/templates/init/config/pr_steward/policy.json
+++ b/src/dopemux/templates/init/config/pr_steward/policy.json
@@ -1,0 +1,17 @@
+{
+  "mode": "check_only",
+  "mutates_github": false,
+  "fail_closed_on_unknown": true,
+  "required_artifacts": [
+    "MERGE_READINESS.json",
+    "REVIEW_ITEM_LEDGER.json",
+    "THREAD_DISPOSITIONS.json",
+    "CI_TRIAGE.json",
+    "PR_STATE_SNAPSHOT.json"
+  ],
+  "trusted_reviewer_associations": [
+    "OWNER",
+    "MEMBER",
+    "COLLABORATOR"
+  ]
+}

--- a/task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json
+++ b/task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json
@@ -24,7 +24,7 @@
   ],
   "execution": {
     "agent": "codex",
-    "base_branch": "main",
+    "base_branch": "codex/tp-dmx-steward-package-301",
     "branch": "codex/tp-dmx-steward-scaffold-302",
     "stacked_because": "Part of the DMX-AUTOREVIEW-PLATFORM dependency DAG."
   },
@@ -51,7 +51,7 @@
     ]
   },
   "pr": {
-    "base": "main",
+    "base": "codex/tp-dmx-steward-package-301",
     "body": "## Summary\n- Add thin .github/workflows/{pr-steward,embedded-audit}.yml + small config/pr_steward/ + config/pr_merge_specialist/policy.yaml (governed_automerge OFF) to src/dopemux/templates/init/; verify dopemux init + init --force provision without clobbering existing files.\n\n## Scope\nTrack: C-distribute. Risk: MEDIUM. Red lane: false.\n\n## Validation\nRun the packet validation commands and capture proof under proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json.\n\n## NOT_RUN\nList any skipped live, integration, credentialed, or supervisor-gated checks explicitly.",
     "title": "Feat(init): scaffold PR-steward workflows and config"
   },
@@ -63,7 +63,7 @@
     "require_identity_match": true
   },
   "series": {
-    "base_branch": "main",
+    "base_branch": "codex/tp-dmx-steward-package-301",
     "final_packet": false,
     "id": "DMX-AUTOREVIEW-PLATFORM",
     "parent_tp_id": "TP-DMX-STEWARD-PACKAGE-301"

--- a/tests/dopemux_init/test_pr_steward_scaffold.py
+++ b/tests/dopemux_init/test_pr_steward_scaffold.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+
+import yaml
+
+from dopemux.profile_manager import DopemuxProfile
+from dopemux.project_init import ProjectInitializer
+
+
+class _ProfileManager:
+    def __init__(self) -> None:
+        self.profile = DopemuxProfile(
+            name="adhd-default",
+            description="Test profile",
+        )
+
+    def list_profiles(self) -> list[DopemuxProfile]:
+        return [self.profile]
+
+    def get_profile(self, name: str) -> DopemuxProfile | None:
+        if name == self.profile.name:
+            return self.profile
+        return None
+
+    def set_active_profile(self, workspace: Path, profile_name: str) -> None:
+        marker = workspace / ".dopemux" / "active_profile"
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.write_text(profile_name, encoding="utf-8")
+
+
+def _initializer(workspace: Path) -> ProjectInitializer:
+    initializer = ProjectInitializer(workspace)
+    initializer.profile_manager = _ProfileManager()
+    return initializer
+
+
+def test_init_scaffolds_pr_steward_workflows_and_policy(tmp_path: Path) -> None:
+    initializer = _initializer(tmp_path)
+
+    assert initializer.initialize(profile_name="adhd-default") is True
+
+    pr_steward_workflow = tmp_path / ".github" / "workflows" / "pr-steward.yml"
+    embedded_audit_workflow = tmp_path / ".github" / "workflows" / "embedded-audit.yml"
+    pr_steward_policy = tmp_path / "config" / "pr_steward" / "policy.json"
+    merge_policy = tmp_path / "config" / "pr_merge_specialist" / "policy.yaml"
+
+    assert pr_steward_workflow.exists()
+    assert embedded_audit_workflow.exists()
+    assert pr_steward_policy.exists()
+    assert merge_policy.exists()
+
+    pr_steward_yaml = yaml.safe_load(pr_steward_workflow.read_text(encoding="utf-8"))
+    embedded_audit_yaml = yaml.safe_load(embedded_audit_workflow.read_text(encoding="utf-8"))
+    pr_steward_config = json.loads(pr_steward_policy.read_text(encoding="utf-8"))
+    merge_config = yaml.safe_load(merge_policy.read_text(encoding="utf-8"))
+
+    pr_steward_runs = [
+        step["run"]
+        for step in pr_steward_yaml["jobs"]["pr-steward"]["steps"]
+        if "run" in step
+    ]
+    embedded_audit_runs = [
+        step["run"]
+        for step in embedded_audit_yaml["jobs"]["embedded-audit"]["steps"]
+        if "run" in step
+    ]
+
+    assert any(
+        "python -m dopemux.cli pr-steward intake" in run for run in pr_steward_runs
+    )
+    assert any(
+        "python -m dopemux.cli pr-steward audit" in run for run in embedded_audit_runs
+    )
+    assert pr_steward_config["mode"] == "check_only"
+    assert pr_steward_config["mutates_github"] is False
+    assert merge_config["governed_automerge"]["enabled"] is False
+
+
+def test_init_force_does_not_clobber_existing_pr_steward_files(tmp_path: Path) -> None:
+    pr_steward_workflow = tmp_path / ".github" / "workflows" / "pr-steward.yml"
+    merge_policy = tmp_path / "config" / "pr_merge_specialist" / "policy.yaml"
+    pr_steward_workflow.parent.mkdir(parents=True)
+    merge_policy.parent.mkdir(parents=True)
+    pr_steward_workflow.write_text("name: custom\n", encoding="utf-8")
+    merge_policy.write_text("custom: true\n", encoding="utf-8")
+
+    initializer = _initializer(tmp_path)
+
+    assert initializer.initialize(profile_name="adhd-default", force=True) is True
+
+    assert pr_steward_workflow.read_text(encoding="utf-8") == "name: custom\n"
+    assert merge_policy.read_text(encoding="utf-8") == "custom: true\n"


### PR DESCRIPTION
## Summary
- Add minimal `dopemux init` scaffold templates for PR Steward and embedded-audit workflows.
- Add `config/pr_steward/policy.json` and `config/pr_merge_specialist/policy.yaml` with governed automerge off by default.
- Add focused init/no-clobber tests, distribution docs, and TP302 proof bundle.

## Scope
- Stacked on #770 / `codex/tp-dmx-steward-package-301` because TP302 depends on TP301.
- No `project_init.py` runtime change: existing recursive template copy and skip-existing behavior already covers this slice.
- Out of scope: heavy setup subcommand, checksum manifest, reusable composite action.

## Validation
- `python -m json.tool task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json`
- `python -m jsonschema -i task-packets/generated/TP-DMX-STEWARD-SCAFFOLD-302.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `python -m compileall -q src tests`
- `pytest -q tests/dopemux_init` -> 2 passed
- `pytest -q tests/dopemux_init tests/test_project_init_templates.py` -> 8 passed
- YAML parse smoke for both scaffolded workflows -> yaml ok
- `git diff --check`
- `pre-commit run --files <TP302 implementation files>`

## NOT_RUN / Risk
- Live GitHub Actions execution of scaffolded workflows was not run before opening this draft.
- External embedded audit is recorded as SKIPPED in local proof.
- Downstream repositories may need a separate installation path for Dopemux before `python -m dopemux.cli` is available in CI; TP302 intentionally defers heavier setup/reusable action work.

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.