### PR TITLE
fix(adhd): reconcile event backbone APIs

### DIFF
--- a/services/adhd_engine/api/routes.py
+++ b/services/adhd_engine/api/routes.py
@@ -60,15 +60,13 @@ from ..core.models import ADHDProfile, EnergyLevel, AttentionState
 
 # Event emission for implicit triggers (Phase 7)
 try:
-    from event_emitter import emit_claude_prompt, emit_claude_tool, emit_context_saved
-    EVENT_EMISSION_AVAILABLE = True
-except ImportError:
-    EVENT_EMISSION_AVAILABLE = False
-    logger.debug("Event emission not available - hooks won't trigger EventBus")
-
-# Event emission for implicit triggers (Phase 7)
-try:
-    from event_emitter import emit_claude_prompt, emit_claude_tool, emit_context_saved
+    from ..event_emitter import (
+        ADHDEventEmitter,
+        EventTypes,
+        emit_claude_prompt,
+        emit_claude_tool,
+        emit_context_saved,
+    )
     EVENT_EMISSION_AVAILABLE = True
 except ImportError:
     EVENT_EMISSION_AVAILABLE = False
@@ -1917,10 +1915,9 @@ async def log_git_event(
         # Emit to EventBus (Phase 7)
         if EVENT_EMISSION_AVAILABLE:
             try:
-                from event_emitter import ADHDEventEmitter
                 emitter = await ADHDEventEmitter.get_instance()
                 await emitter.emit(
-                    "git_commit" if event_type == "git_commit" else "git_event",
+                    EventTypes.GIT_COMMIT if event_type == "git_commit" else "git_event",
                     data,
                     source="git_hook"
                 )

--- a/services/adhd_engine/event_emitter.py
+++ b/services/adhd_engine/event_emitter.py
@@ -122,24 +122,35 @@ class ADHDEventEmitter:
             data=data,
             source=source
         )
-        
-        # Always log the event
-        logger.debug(f"📤 Emitting event: {event_type} from {source}")
-        
+
+        return await self._publish_event(self.stream_name, event)
+
+    async def publish(self, stream: str, event: Event) -> bool:
+        """Publish a prebuilt Event to a Redis Stream.
+
+        Compatibility bridge for older EventBus-style callers while preserving
+        ADHDEventEmitter as the canonical ADHD event transport.
+        """
+        return await self._publish_event(stream, event)
+
+    async def _publish_event(self, stream: str, event: Event) -> bool:
+        """Publish a structured event to a Redis Stream."""
+        logger.debug(f"📤 Emitting event: {event.type} from {event.source or 'adhd_engine'}")
+
         if not self._connected or not self._redis:
-            logger.debug(f"Event logged (Redis unavailable): {event_type}")
+            logger.debug(f"Event logged (Redis unavailable): {event.type}")
             return False
-        
+
         try:
             # Publish to Redis Stream
             await self._redis.xadd(
-                self.stream_name,
+                stream,
                 event.to_redis_dict(),
                 maxlen=10000  # Keep reasonable stream length
             )
-            logger.debug(f"✅ Event published: {event_type}")
+            logger.debug(f"✅ Event published: {event.type}")
             return True
-            
+
         except Exception as e:
             logger.warning(f"Event publication failed: {e}")
             return False
@@ -247,11 +258,29 @@ class EventTypes:
     # File activity events
     FILE_OPENED = "file_opened"
     FILE_SAVED = "file_saved"
+    FILE_CLOSED = "file_closed"
     FILE_ACTIVITY = "file_activity"
+    FILE_UNCHANGED_30MIN = "file_unchanged_30min"
+
+    # Desktop activity events
+    WINDOW_SWITCHED = "window_switched"
+    APP_FOCUSED = "app_focused"
+    IDLE_DETECTED = "idle_detected"
+    ACTIVITY_RESUMED = "activity_resumed"
+    OVERWHELM_DETECTED = "overwhelm_detected"
     
     # Progress events
     PROGRESS_LOGGED = "progress_logged"
+    TASK_STARTED = "task_started"
     TASK_COMPLETED = "task_completed"
+    TASK_SWITCHED = "task_switched"
+    GIT_COMMIT = "git_commit"
+
+    # Calendar events
+    MEETING_STARTED = "meeting_started"
+    MEETING_ENDED = "meeting_ended"
+    MEETING_APPROACHING = "meeting.approaching"
+    SOCIAL_BATTERY_LOW = "social_battery_low"
     
     # Context events
     CONTEXT_SAVED = "context_saved"

--- a/services/adhd_engine/event_listener.py
+++ b/services/adhd_engine/event_listener.py
@@ -128,6 +128,7 @@ class ADHDEventListener:
             # Claude Code events
             "claude_prompt_received": self._on_claude_prompt,
             "claude_tool_started": self._on_claude_tool,
+            "claude_tool_completed": self._on_claude_tool,
             "claude_session_stopped": self._on_claude_stop,
         }
     

--- a/services/adhd_engine/external_activity.py
+++ b/services/adhd_engine/external_activity.py
@@ -17,6 +17,8 @@ from typing import Any, Dict, List, Optional
 from dataclasses import dataclass, field
 import httpx
 
+from .event_emitter import EventTypes
+
 logger = logging.getLogger(__name__)
 
 
@@ -218,11 +220,9 @@ class DesktopActivityMonitor:
         
         # Emit event
         try:
-            from event_bus import Event, EventType
-            
-            event = Event(
-                type=EventType.WINDOW_SWITCHED,
-                data={
+            await self.event_bus.emit(
+                EventTypes.WINDOW_SWITCHED,
+                {
                     "from_app": from_app,
                     "to_app": to_app,
                     "from_window": from_window,
@@ -233,25 +233,22 @@ class DesktopActivityMonitor:
                     "switches_this_hour": self.switch_count_last_hour,
                     "rapid_switching": self.switch_count_last_hour > self.rapid_switch_threshold
                 },
-                source="desktop_activity_monitor"
+                source="desktop_activity_monitor",
             )
-            
-            await self.event_bus.publish("dopemux:events", event)
-            
+
             logger.debug(f"Window switch: {from_app} → {to_app}")
             
             # Emit overwhelm warning if rapid switching
             if self.switch_count_last_hour > self.rapid_switch_threshold:
-                overwhelm_event = Event(
-                    type=EventType.OVERWHELM_DETECTED,
-                    data={
+                await self.event_bus.emit(
+                    EventTypes.OVERWHELM_DETECTED,
+                    {
                         "trigger": "rapid_window_switching",
                         "switches_per_hour": self.switch_count_last_hour,
                         "threshold": self.rapid_switch_threshold
                     },
-                    source="desktop_activity_monitor"
+                    source="desktop_activity_monitor",
                 )
-                await self.event_bus.publish("dopemux:events", overwhelm_event)
                 
         except Exception as e:
             logger.warning(f"Failed to emit window switch event: {e}")
@@ -262,20 +259,16 @@ class DesktopActivityMonitor:
             return
         
         try:
-            from event_bus import Event, EventType
-            
-            event = Event(
-                type=EventType.IDLE_DETECTED,
-                data={
+            await self.event_bus.emit(
+                EventTypes.IDLE_DETECTED,
+                {
                     "idle_seconds": idle_seconds,
                     "idle_minutes": idle_seconds / 60,
                     "last_active_app": self.current_app,
                     "is_break": idle_seconds > 300  # 5+ min = break
                 },
-                source="desktop_activity_monitor"
+                source="desktop_activity_monitor",
             )
-            
-            await self.event_bus.publish("dopemux:events", event)
             
         except Exception as e:
             logger.warning(f"Failed to emit idle event: {e}")
@@ -488,11 +481,9 @@ class CalendarIntegration:
         self.meetings_today += 1
         
         try:
-            from event_bus import Event, EventType
-            
-            event = Event(
-                type=EventType.MEETING_STARTED,
-                data={
+            await self.event_bus.emit(
+                EventTypes.MEETING_STARTED,
+                {
                     "title": meeting.title,
                     "meeting_type": meeting.meeting_type,
                     "attendees": meeting.attendees,
@@ -500,10 +491,8 @@ class CalendarIntegration:
                     "social_battery_before": self.social_battery,
                     "meetings_today": self.meetings_today
                 },
-                source="calendar_integration"
+                source="calendar_integration",
             )
-            
-            await self.event_bus.publish("dopemux:events", event)
             logger.info(f"📅 Meeting started: {meeting.title}")
             
         except Exception as e:
@@ -519,8 +508,6 @@ class CalendarIntegration:
         self.meeting_hours_today += duration_minutes / 60
         
         try:
-            from event_bus import Event, EventType
-            
             # Determine recovery suggestion based on social battery
             if self.social_battery < 20:
                 recovery_suggestion = "Take a 15-minute solo break - social battery critically low"
@@ -528,34 +515,31 @@ class CalendarIntegration:
                 recovery_suggestion = "Consider a 5-minute break before next task"
             else:
                 recovery_suggestion = None
-            
-            event = Event(
-                type=EventType.MEETING_ENDED,
-                data={
+
+            await self.event_bus.emit(
+                EventTypes.MEETING_ENDED,
+                {
                     "title": meeting.title,
                     "duration_minutes": duration_minutes,
                     "social_battery_after": self.social_battery,
                     "meeting_hours_today": self.meeting_hours_today,
                     "recovery_suggestion": recovery_suggestion
                 },
-                source="calendar_integration"
+                source="calendar_integration",
             )
-            
-            await self.event_bus.publish("dopemux:events", event)
             logger.info(f"📅 Meeting ended: {meeting.title}")
             
             # Emit social battery warning if low
             if self.social_battery < 30:
-                battery_event = Event(
-                    type=EventType.SOCIAL_BATTERY_LOW,
-                    data={
+                await self.event_bus.emit(
+                    EventTypes.SOCIAL_BATTERY_LOW,
+                    {
                         "social_battery": self.social_battery,
                         "meeting_hours_today": self.meeting_hours_today,
                         "recovery_time_needed_minutes": (50 - self.social_battery) * 6
                     },
-                    source="calendar_integration"
+                    source="calendar_integration",
                 )
-                await self.event_bus.publish("dopemux:events", battery_event)
                 
         except Exception as e:
             logger.warning(f"Failed to emit meeting end event: {e}")
@@ -566,8 +550,6 @@ class CalendarIntegration:
             return
         
         try:
-            from event_bus import Event
-            
             # Determine preparation suggestion based on current state
             if self.social_battery < 30:
                 prep_suggestion = "Low social battery - consider declining or shortening this meeting"
@@ -575,19 +557,17 @@ class CalendarIntegration:
                 prep_suggestion = "Meeting starting soon - save your work"
             else:
                 prep_suggestion = f"Meeting in {int(minutes_until)} minutes"
-            
-            event = Event(
-                type="meeting.approaching",  # Custom event
-                data={
+
+            await self.event_bus.emit(
+                EventTypes.MEETING_APPROACHING,
+                {
                     "title": meeting.title,
                     "minutes_until": minutes_until,
                     "social_battery": self.social_battery,
                     "preparation_suggestion": prep_suggestion
                 },
-                source="calendar_integration"
+                source="calendar_integration",
             )
-            
-            await self.event_bus.publish("dopemux:events", event)
             
         except Exception as e:
             logger.warning(f"Failed to emit meeting approaching event: {e}")

--- a/services/adhd_engine/workspace_watcher.py
+++ b/services/adhd_engine/workspace_watcher.py
@@ -28,6 +28,8 @@ from pathlib import Path
 from typing import Dict, Any, List, Optional, Set
 from dataclasses import dataclass, field
 
+from .event_emitter import EventTypes
+
 logger = logging.getLogger(__name__)
 
 # Try to import watchdog for efficient monitoring
@@ -124,35 +126,33 @@ class WorkspaceEventEmitter:
         
         try:
             # Determine event type
-            from event_bus import Event, EventType
-            
             if action == "saved":
-                event_type = EventType.FILE_SAVED
+                event_type = EventTypes.FILE_SAVED
             elif action == "opened":
-                event_type = EventType.FILE_OPENED
+                event_type = EventTypes.FILE_OPENED
+            elif action == "closed":
+                event_type = EventTypes.FILE_CLOSED
             else:
-                event_type = getattr(EventType, 'FILE_ACTIVITY', 'file_activity')
+                event_type = EventTypes.FILE_ACTIVITY
             
             # Get relative path for cleaner logging
             try:
                 rel_path = Path(file_path).relative_to(self.workspace_path)
             except ValueError:
                 rel_path = file_path
-            
-            event = Event(
-                type=event_type,
-                data={
+
+            await self.event_bus.emit(
+                event_type,
+                {
                     "file": str(file_path),
                     "relative_path": str(rel_path),
                     "action": action,
                     "timestamp": datetime.now().isoformat(),
-                    "extension": Path(file_path).suffix
+                    "extension": Path(file_path).suffix,
                 },
-                source="workspace_watcher"
+                source="workspace_watcher",
             )
-            
-            await self.event_bus.publish("dopemux:events", event)
-            
+
             # Track activity
             async with self._activity_lock:
                 self.last_modified[file_path] = datetime.now()
@@ -167,8 +167,6 @@ class WorkspaceEventEmitter:
             
             logger.debug(f"📁 File {action}: {rel_path}")
             
-        except ImportError:
-            logger.warning(brand_log("EventBus not available - file event not emitted", chip=StatusChip.AFTERCARE))
         except Exception as e:
             logger.error(brand_log(f"Failed to emit file event: {e}", chip=StatusChip.BLOCKER))
     
@@ -181,19 +179,15 @@ class WorkspaceEventEmitter:
             for file_path, last_mod in list(self.last_modified.items()):
                 if now - last_mod > unchanged_threshold:
                     # File unchanged for >30 min - possible hyperfocus
-                    from event_bus import Event, EventType
-                    
-                    event = Event(
-                        type=getattr(EventType, 'FILE_UNCHANGED_30MIN', 'file_unchanged'),
-                        data={
+                    await self.event_bus.emit(
+                        EventTypes.FILE_UNCHANGED_30MIN,
+                        {
                             "file": file_path,
                             "unchanged_minutes": int((now - last_mod).total_seconds() / 60),
-                            "timestamp": now.isoformat()
+                            "timestamp": now.isoformat(),
                         },
                         source="workspace_watcher"
                     )
-                    
-                    await self.event_bus.publish("dopemux:events", event)
                     logger.info(brand_log(f"🔥 Possible hyperfocus: {file_path} unchanged for 30+ min", chip=StatusChip.LIVE))
                     
                     # Remove from tracking to avoid repeated alerts

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001-implementation-notes.md
@@ -1,0 +1,52 @@
+---
+title: T4-01 Event Backbone Implementation Notes
+status: draft
+id: TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001-implementation-notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: T4-01 Event Backbone Implementation Notes (explanation) for dopemux documentation
+  and developer workflows.
+---
+# T4-01 Event Backbone Implementation Notes
+
+## Scope
+
+Observed runtime defects:
+
+- `WorkspaceEventEmitter` and `DesktopActivityMonitor`/`CalendarIntegration` imported a nonexistent top-level `event_bus` module and attempted to call a `publish()` API while startup passes `ADHDEventEmitter`.
+- `services.adhd_engine.api.routes` imported top-level `event_emitter`, so package imports left `EVENT_EMISSION_AVAILABLE = False`.
+- `emit_claude_tool()` emits `claude_tool_completed`, but `ADHDEventListener` only handled `claude_tool_started`.
+- `ADHDEventListener._surface_finding()` called `event_bus.publish(...)`, but `ADHDEventEmitter` did not expose a publish-compatible bridge.
+
+## Implementation
+
+- Kept `ADHDEventEmitter` as the canonical ADHD event transport.
+- Added `ADHDEventEmitter.publish(stream, event)` as a compatibility bridge for prebuilt `Event` objects while preserving `emit(event_type, data, source)` as the primary producer API.
+- Routed workspace and external activity producers through `event_bus.emit(...)`.
+- Switched route hook imports to package-relative `..event_emitter`.
+- Added `claude_tool_completed` listener mapping to the existing Claude tool handler.
+
+## TDD Evidence
+
+RED:
+
+```text
+python -m pytest tests/unit/test_adhd_event_backbone.py
+6 failed
+```
+
+GREEN:
+
+```text
+python -m pytest tests/unit/test_adhd_event_backbone.py
+6 passed
+```
+
+## Deferred / Out Of Scope
+
+- No live Redis, Desktop Commander, Calendar, or FastAPI startup integration run was performed in this implementation slice.
+- No privacy payload narrowing was attempted beyond preserving the existing structured payloads; broader content minimization remains separate remediation work.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001.json
@@ -1,0 +1,135 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001",
+  "project": "dopemux-mvp",
+  "target": "Reconcile ADHD engine event APIs onto ADHDEventEmitter",
+  "invariants": [
+    "ADHDEventEmitter remains the canonical ADHD event transport for Redis Stream events.",
+    "Event emission must remain bounded to structured event type, source, timestamp, and JSON payload fields.",
+    "Missing Redis availability must not be reported as successful publication."
+  ],
+  "depends_on": [
+    "DMX-ADHD-COGNITIVE-T4-01"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "feat/autoreview-platform-series",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-event-backbone-001",
+    "base_branch": "feat/autoreview-platform-series"
+  },
+  "commit": {
+    "message": "fix(adhd): reconcile event backbone APIs",
+    "allowlist": [
+      "services/adhd_engine/event_emitter.py",
+      "services/adhd_engine/event_listener.py",
+      "services/adhd_engine/workspace_watcher.py",
+      "services/adhd_engine/external_activity.py",
+      "services/adhd_engine/api/routes.py",
+      "tests/unit/test_adhd_event_backbone.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_adhd_event_backbone.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(adhd): reconcile event backbone APIs",
+    "body": "## Summary\n- reconcile ADHD workspace, external activity, listener finding, and route hook event calls onto ADHDEventEmitter\n- add unit coverage for canonical publish/emit compatibility, package-relative route imports, and handled Claude tool completion events\n- keep Redis-unavailable publication fail-closed while preserving structured event payloads\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_adhd_event_backbone.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py\n- git diff --check\n\n@codex review\n@gemini\n@copilot\n\nGenerate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated",
+    "base": "feat/autoreview-platform-series"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Trace existing ADHD event emitters, listeners, routes, and startup wiring before changing runtime code.",
+      "requirements": [
+        "Identify canonical writer and consumer paths for dopemux:events.",
+        "Call out unsupported or stale event_bus imports as observed defects."
+      ],
+      "expected_files": [
+        "services/adhd_engine/event_emitter.py",
+        "services/adhd_engine/event_listener.py",
+        "services/adhd_engine/workspace_watcher.py",
+        "services/adhd_engine/external_activity.py",
+        "services/adhd_engine/api/routes.py"
+      ],
+      "validation": [
+        "rg -n \"EventType|EventTypes|ADHDEventEmitter|event_bus|publish|emit_claude_tool\" services/adhd_engine tests -g '*.py'"
+      ]
+    },
+    {
+      "id": "test",
+      "task": "Add focused failing tests for the observed T4-01 event API mismatches.",
+      "requirements": [
+        "Cover package-relative route imports enabling event hooks.",
+        "Cover WorkspaceEventEmitter and ExternalActivityManager emission through the canonical emitter API.",
+        "Cover listener handling for claude_tool_completed."
+      ],
+      "expected_files": [
+        "tests/unit/test_adhd_event_backbone.py"
+      ],
+      "validation": [
+        "python -m pytest tests/unit/test_adhd_event_backbone.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Make the smallest runtime changes needed to reconcile event producers and consumers onto ADHDEventEmitter.",
+      "requirements": [
+        "Use relative imports inside services.adhd_engine package surfaces.",
+        "Preserve Redis Stream replay semantics through xadd plus consumer groups.",
+        "Do not introduce provider calls, live extraction, or new external dependencies."
+      ],
+      "expected_files": [
+        "services/adhd_engine/event_emitter.py",
+        "services/adhd_engine/event_listener.py",
+        "services/adhd_engine/workspace_watcher.py",
+        "services/adhd_engine/external_activity.py",
+        "services/adhd_engine/api/routes.py"
+      ],
+      "validation": [
+        "python -m pytest tests/unit/test_adhd_event_backbone.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py"
+      ]
+    },
+    {
+      "id": "precommit",
+      "task": "Run schema, targeted tests, diff, and configured pre-commit checks for the allowlisted paths.",
+      "requirements": [
+        "Report PASS, FAIL, and NOT_RUN explicitly.",
+        "Do not claim integration behavior beyond the commands run."
+      ],
+      "validation": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_adhd_event_backbone.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py",
+        "git diff --check",
+        "pre-commit run --files services/adhd_engine/event_emitter.py services/adhd_engine/event_listener.py services/adhd_engine/workspace_watcher.py services/adhd_engine/external_activity.py services/adhd_engine/api/routes.py tests/unit/test_adhd_event_backbone.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001-implementation-notes.md"
+      ]
+    }
+  ]
+}

--- a/tests/unit/test_adhd_event_backbone.py
+++ b/tests/unit/test_adhd_event_backbone.py
@@ -1,0 +1,145 @@
+import importlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.adhd_engine.event_emitter import ADHDEventEmitter, Event, EventTypes
+from services.adhd_engine.event_listener import ADHDEventListener
+from services.adhd_engine.external_activity import DesktopActivityMonitor, MeetingEvent, CalendarIntegration
+from services.adhd_engine.workspace_watcher import WorkspaceEventEmitter
+
+
+class FakeCanonicalEmitter:
+    def __init__(self):
+        self.calls = []
+
+    async def emit(self, event_type, data, source="adhd_engine_api"):
+        self.calls.append(
+            {
+                "event_type": event_type,
+                "data": data,
+                "source": source,
+            }
+        )
+        return True
+
+
+class FakeRedis:
+    def __init__(self):
+        self.xadd_calls = []
+
+    async def xadd(self, stream, fields, maxlen=None):
+        self.xadd_calls.append(
+            {
+                "stream": stream,
+                "fields": fields,
+                "maxlen": maxlen,
+            }
+        )
+        return b"1-0"
+
+
+@pytest.mark.asyncio
+async def test_adhd_event_emitter_publish_bridges_event_objects_to_redis_stream():
+    emitter = ADHDEventEmitter("redis://unit-test")
+    emitter._redis = FakeRedis()
+    emitter._connected = True
+
+    event = Event(
+        type=EventTypes.FILE_SAVED,
+        data={"relative_path": "src/app.py", "action": "saved"},
+        source="workspace_watcher",
+    )
+
+    assert await emitter.publish("dopemux:events", event) is True
+    assert emitter._redis.xadd_calls == [
+        {
+            "stream": "dopemux:events",
+            "fields": event.to_redis_dict(),
+            "maxlen": 10000,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_workspace_watcher_uses_canonical_emitter_for_file_activity(tmp_path):
+    source_file = tmp_path / "src" / "app.py"
+    source_file.parent.mkdir()
+    source_file.write_text("print('ok')\n")
+    emitter = FakeCanonicalEmitter()
+    watcher = WorkspaceEventEmitter(emitter, str(tmp_path))
+
+    await watcher.emit_file_event(str(source_file), "saved")
+
+    assert emitter.calls == [
+        {
+            "event_type": EventTypes.FILE_SAVED,
+            "data": {
+                "file": str(source_file),
+                "relative_path": "src/app.py",
+                "action": "saved",
+                "timestamp": emitter.calls[0]["data"]["timestamp"],
+                "extension": ".py",
+            },
+            "source": "workspace_watcher",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_desktop_activity_uses_canonical_emitter_for_window_events():
+    emitter = FakeCanonicalEmitter()
+    monitor = DesktopActivityMonitor(emitter)
+
+    await monitor._on_window_switch(
+        from_app="Code",
+        to_app="Slack",
+        from_window="repo.py",
+        to_window="DM",
+    )
+
+    assert emitter.calls[0]["event_type"] == EventTypes.WINDOW_SWITCHED
+    assert emitter.calls[0]["source"] == "desktop_activity_monitor"
+    assert emitter.calls[0]["data"]["is_distraction"] is True
+    assert emitter.calls[0]["data"]["is_leaving_work"] is True
+
+
+@pytest.mark.asyncio
+async def test_calendar_activity_uses_canonical_emitter_for_meeting_events():
+    emitter = FakeCanonicalEmitter()
+    calendar = CalendarIntegration(emitter)
+    now = datetime.now(timezone.utc)
+    meeting = MeetingEvent(
+        title="Planning",
+        start_time=now,
+        end_time=now + timedelta(hours=1),
+        attendees=3,
+    )
+
+    await calendar._on_meeting_started(meeting)
+
+    assert emitter.calls[0]["event_type"] == EventTypes.MEETING_STARTED
+    assert emitter.calls[0]["source"] == "calendar_integration"
+    assert emitter.calls[0]["data"]["meeting_type"] == "video"
+
+
+@pytest.mark.asyncio
+async def test_listener_handles_claude_tool_completed_events():
+    listener = ADHDEventListener(event_bus=FakeCanonicalEmitter())
+
+    assert EventTypes.CLAUDE_TOOL_COMPLETED in listener._handlers
+
+    await listener._dispatch(
+        Event(
+            type=EventTypes.CLAUDE_TOOL_COMPLETED,
+            data={"tool": "Edit", "success": True, "user_id": "operator"},
+            source="log_progress_hook",
+        )
+    )
+
+
+def test_routes_enable_event_emission_with_package_relative_imports():
+    routes = importlib.import_module("services.adhd_engine.api.routes")
+    routes = importlib.reload(routes)
+
+    assert routes.EVENT_EMISSION_AVAILABLE is True


### PR DESCRIPTION
## Summary
- reconcile ADHD workspace, external activity, listener finding, and route hook event calls onto ADHDEventEmitter
- add unit coverage for canonical publish/emit compatibility, package-relative route imports, and handled Claude tool completion events
- keep Redis-unavailable publication fail-closed while preserving structured event payloads

## Validation
- PASS: python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: python -m pytest tests/unit/test_adhd_event_backbone.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py
- PASS: python -m py_compile services/adhd_engine/event_emitter.py services/adhd_engine/event_listener.py services/adhd_engine/workspace_watcher.py services/adhd_engine/external_activity.py services/adhd_engine/api/routes.py tests/unit/test_adhd_event_backbone.py
- PASS: git diff --check
- PASS: git diff --cached --check
- PASS: pre-commit run --files services/adhd_engine/event_emitter.py services/adhd_engine/event_listener.py services/adhd_engine/workspace_watcher.py services/adhd_engine/external_activity.py services/adhd_engine/api/routes.py tests/unit/test_adhd_event_backbone.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001-implementation-notes.md
- PASS: PAL codereview, internal, gpt-5-codex, issues_found=0, continuation_id=0b734cf1-c141-410f-9f72-959eda87e940

## Not Run
- live Redis stream integration
- FastAPI lifespan startup
- Desktop Commander or Calendar integration against live services

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated