### PR TITLE
feat(adhd): emit native hook activity events

### DIFF
--- a/src/dopemux/claude/native_hooks.py
+++ b/src/dopemux/claude/native_hooks.py
@@ -44,6 +44,67 @@ from dopemux.workflow.service import WorkflowKernel  # noqa: E402
 # Claude Code command hook exit codes
 EXIT_SUCCESS = 0
 EXIT_BLOCK = 2
+DEFAULT_ACTIVITY_STREAM = "dopemux:events"
+NATIVE_HOOK_ACTIVITY_EVENT_TYPE = "native_hook_activity"
+
+
+def _native_hook_activity_events_enabled() -> bool:
+    disabled_values = {"0", "false", "no", "off"}
+    configured = os.environ.get("DOPEMUX_NATIVE_HOOK_EVENTS_ENABLED", "1").strip().lower()
+    return configured not in disabled_values
+
+
+def _open_activity_redis_client():
+    redis_url = (
+        os.environ.get("DOPEMUX_EVENTS_REDIS_URL")
+        or os.environ.get("REDIS_URL")
+        or "redis://localhost:6379/0"
+    )
+    import redis  # type: ignore[import-not-found]
+
+    return redis.Redis.from_url(redis_url, decode_responses=True)
+
+
+def _emit_activity_event(
+    *,
+    hook_event_name: str,
+    status: str,
+    tool_name: Optional[str] = None,
+) -> bool:
+    """Emit a content-free native hook activity event to Redis Streams."""
+    if not _native_hook_activity_events_enabled():
+        return False
+
+    client = None
+    try:
+        client = _open_activity_redis_client()
+        data: Dict[str, Any] = {
+            "hook_event_name": hook_event_name,
+            "status": status,
+        }
+        if tool_name:
+            data["tool_name"] = tool_name
+
+        client.xadd(
+            os.environ.get("DOPEMUX_ACTIVITY_EVENT_STREAM", DEFAULT_ACTIVITY_STREAM),
+            {
+                "event_type": NATIVE_HOOK_ACTIVITY_EVENT_TYPE,
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+                "source": "dopemux.native_hooks",
+                "data": json.dumps(data, sort_keys=True, separators=(",", ":")),
+            },
+            maxlen=10000,
+            approximate=True,
+        )
+        return True
+    except Exception:
+        return False
+    finally:
+        if client is not None and hasattr(client, "close"):
+            try:
+                client.close()
+            except Exception:
+                pass
 
 
 def _truncate(value: Any, limit: int = 400) -> Any:
@@ -212,6 +273,7 @@ class NativeHookAdapter:
         )
 
     def _on_user_prompt(self, data: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+        _emit_activity_event(hook_event_name="UserPromptSubmit", status="observed")
         state = self._active_state()
         if not state:
             return self._allow()
@@ -228,11 +290,15 @@ class NativeHookAdapter:
         )
 
     def _on_pre_tool_use(self, data: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+        tool_name = str(data.get("tool_name") or "unknown")
+        _emit_activity_event(
+            hook_event_name="PreToolUse",
+            status="attempt",
+            tool_name=tool_name,
+        )
         state = self._active_state()
         if not state:
             return self._allow()
-
-        tool_name = str(data.get("tool_name") or "unknown")
 
         if state.max_iterations == 0 and "wf-limit" in state.workflow_id:
             return self._deny_tool("Workflow iteration limit reached (0/0).", _workflow_context_lines(state, include_gates=True))
@@ -281,6 +347,11 @@ class NativeHookAdapter:
 
     def _on_post_tool_use(self, data: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
         tool_name = str(data.get("tool_name") or "unknown")
+        _emit_activity_event(
+            hook_event_name="PostToolUse",
+            status="success",
+            tool_name=tool_name,
+        )
         tool_input = data.get("tool_input") or {}
         tool_response = data.get("tool_response")
 
@@ -323,6 +394,12 @@ class NativeHookAdapter:
         return self._allow()
 
     def _on_post_tool_use_failure(self, data: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+        tool_name = str(data.get("tool_name") or "unknown")
+        _emit_activity_event(
+            hook_event_name="PostToolUseFailure",
+            status="failure",
+            tool_name=tool_name,
+        )
         state = self._active_state()
         if not state:
             return self._allow()
@@ -330,7 +407,7 @@ class NativeHookAdapter:
         self.kernel.record_tool_event(
             state,
             event_name="posttoolusefailure",
-            tool_name=str(data.get("tool_name") or "unknown"),
+            tool_name=tool_name,
             status="failure",
             payload={
                 "tool_input": _truncate(data.get("tool_input")),

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001-implementation-notes.md
@@ -1,0 +1,59 @@
+---
+title: T4-02a Native Hooks Events Implementation Notes
+status: draft
+id: TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001-implementation-notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: T4-02a Native Hooks Events Implementation Notes (explanation) for dopemux
+  documentation and developer workflows.
+---
+# T4-02a Native Hooks Events Implementation Notes
+
+## Scope
+
+Native hook activity now emits best-effort Redis Stream events for:
+
+- `UserPromptSubmit`
+- `PreToolUse`
+- `PostToolUse`
+- `PostToolUseFailure`
+
+The emitted event intentionally excludes prompt text, tool input, tool response, errors, cwd, paths, and session IDs.
+
+## Event Shape
+
+Each event is written with `xadd` to `dopemux:events` by default:
+
+```json
+{
+  "event_type": "native_hook_activity",
+  "timestamp": "<utc iso timestamp>",
+  "source": "dopemux.native_hooks",
+  "data": "{\"hook_event_name\":\"PreToolUse\",\"status\":\"attempt\",\"tool_name\":\"Read\"}"
+}
+```
+
+## TDD Evidence
+
+RED:
+
+```text
+python -m pytest tests/test_native_hooks_workflow.py
+1 failed, 4 passed
+```
+
+GREEN:
+
+```text
+python -m pytest tests/test_native_hooks_workflow.py
+5 passed
+```
+
+## Deferred / Out Of Scope
+
+- No live Redis integration run was performed in this slice.
+- No changes were made to Claude settings registration or shell hook scripts.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001.json
@@ -1,0 +1,123 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001",
+  "project": "dopemux-mvp",
+  "target": "Emit content-free native hook activity events to dopemux:events",
+  "invariants": [
+    "Native hook event payloads must not include prompt text, tool input, tool response, errors, file paths, or cwd.",
+    "Redis publication failures must not change Claude hook allow/block behavior.",
+    "Events must use Redis XADD to dopemux:events with stable event_type, timestamp, source, and JSON data fields."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "feat/autoreview-platform-series",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T4-01-EVENT-BACKBONE-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-native-hooks-events-001",
+    "base_branch": "feat/autoreview-platform-series"
+  },
+  "commit": {
+    "message": "feat(adhd): emit native hook activity events",
+    "allowlist": [
+      "src/dopemux/claude/native_hooks.py",
+      "tests/test_native_hooks_workflow.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/test_native_hooks_workflow.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(adhd): emit native hook activity events",
+    "body": "## Summary\n- emit content-free native hook activity events for prompt, pre-tool, post-tool, and tool-failure hooks through Redis XADD to dopemux:events\n- keep Redis unavailable/failure paths non-blocking for Claude hook allow/block behavior\n- add unit coverage proving activity events exclude prompt text, tool inputs, tool responses, errors, cwd, and file/path payloads\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/test_native_hooks_workflow.py\n- git diff --check\n\n@codex review\n@gemini\n@copilot\n\nGenerate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated",
+    "base": "feat/autoreview-platform-series"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Trace native hook dispatch, existing workflow side effects, and event stream conventions.",
+      "requirements": [
+        "Identify exactly which hook events are in scope.",
+        "Verify content-bearing fields that must not reach Redis event data."
+      ],
+      "expected_files": [
+        "src/dopemux/claude/native_hooks.py",
+        "tests/test_native_hooks_workflow.py"
+      ],
+      "validation": [
+        "rg -n \"UserPromptSubmit|PreToolUse|PostToolUse|PostToolUseFailure|xadd|dopemux:events\" src/dopemux/claude/native_hooks.py tests/test_native_hooks_workflow.py"
+      ]
+    },
+    {
+      "id": "test",
+      "task": "Add failing tests proving native hooks emit content-free Redis stream events.",
+      "requirements": [
+        "Use an injected fake Redis client; do not require live Redis.",
+        "Assert no prompt text, tool_input, tool_response, error, cwd, file, or path content is serialized."
+      ],
+      "expected_files": [
+        "tests/test_native_hooks_workflow.py"
+      ],
+      "validation": [
+        "python -m pytest tests/test_native_hooks_workflow.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add minimal best-effort Redis XADD emission in native_hooks.py for prompt, pre-tool, post-tool, and tool-failure hooks.",
+      "requirements": [
+        "Default stream must be dopemux:events.",
+        "Redis errors must be swallowed inside the event emitter helper.",
+        "Existing hook allow/block semantics must remain unchanged."
+      ],
+      "expected_files": [
+        "src/dopemux/claude/native_hooks.py"
+      ],
+      "validation": [
+        "python -m pytest tests/test_native_hooks_workflow.py"
+      ]
+    },
+    {
+      "id": "precommit",
+      "task": "Run schema, targeted tests, diff checks, PAL codereview, and pre-commit for allowlisted files.",
+      "requirements": [
+        "Report PASS, FAIL, and NOT_RUN explicitly.",
+        "Do not claim live Redis integration unless a live Redis run is performed."
+      ],
+      "validation": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/test_native_hooks_workflow.py",
+        "git diff --check",
+        "pre-commit run --files src/dopemux/claude/native_hooks.py tests/test_native_hooks_workflow.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001-implementation-notes.md"
+      ]
+    }
+  ]
+}

--- a/tests/test_native_hooks_workflow.py
+++ b/tests/test_native_hooks_workflow.py
@@ -1,5 +1,36 @@
+import json
+
+from dopemux.claude import native_hooks
 from dopemux.claude.native_hooks import handle_event
 from dopemux.workflow import WorkflowKernel, WorkflowStatus
+
+
+class FakeRedisClient:
+    def __init__(self):
+        self.xadd_calls = []
+        self.closed = False
+
+    def xadd(self, stream, fields, maxlen=None, approximate=True):
+        self.xadd_calls.append(
+            {
+                "stream": stream,
+                "fields": fields,
+                "maxlen": maxlen,
+                "approximate": approximate,
+            }
+        )
+        return "1-0"
+
+    def close(self):
+        self.closed = True
+
+
+class FailingRedisClient:
+    def xadd(self, *_args, **_kwargs):
+        raise RuntimeError("redis unavailable")
+
+    def close(self):
+        return None
 
 
 def test_session_start_returns_strict_response_shape(tmp_path, monkeypatch):
@@ -81,3 +112,107 @@ def test_stop_hook_requires_checkpoint_or_completion_token(tmp_path, monkeypatch
         {"cwd": str(tmp_path), "env": {"DOPEMUX_INSTANCE_ID": "main"}},
     )
     assert allowed.get("decision") != "block"
+
+
+def test_native_hooks_emit_content_free_activity_events(tmp_path, monkeypatch):
+    fake_redis = FakeRedisClient()
+    monkeypatch.setattr(native_hooks, "_open_activity_redis_client", lambda: fake_redis, raising=False)
+
+    handle_event(
+        "UserPromptSubmit",
+        {
+            "cwd": str(tmp_path),
+            "session_id": "session-secret",
+            "prompt": "secret prompt text",
+            "env": {"DOPEMUX_INSTANCE_ID": "main"},
+        },
+    )
+    handle_event(
+        "PreToolUse",
+        {
+            "cwd": str(tmp_path),
+            "session_id": "session-secret",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/private/path/secret.py"},
+            "env": {"DOPEMUX_INSTANCE_ID": "main"},
+        },
+    )
+    handle_event(
+        "PostToolUse",
+        {
+            "cwd": str(tmp_path),
+            "session_id": "session-secret",
+            "tool_name": "Write",
+            "tool_response": {"content": "secret response"},
+            "env": {"DOPEMUX_INSTANCE_ID": "main"},
+        },
+    )
+    handle_event(
+        "PostToolUseFailure",
+        {
+            "cwd": str(tmp_path),
+            "session_id": "session-secret",
+            "tool_name": "Bash",
+            "error": "secret failure",
+            "env": {"DOPEMUX_INSTANCE_ID": "main"},
+        },
+    )
+
+    assert [call["stream"] for call in fake_redis.xadd_calls] == [
+        "dopemux:events",
+        "dopemux:events",
+        "dopemux:events",
+        "dopemux:events",
+    ]
+
+    event_data = [json.loads(call["fields"]["data"]) for call in fake_redis.xadd_calls]
+    assert [event["hook_event_name"] for event in event_data] == [
+        "UserPromptSubmit",
+        "PreToolUse",
+        "PostToolUse",
+        "PostToolUseFailure",
+    ]
+    assert [event["status"] for event in event_data] == [
+        "observed",
+        "attempt",
+        "success",
+        "failure",
+    ]
+    assert event_data[1]["tool_name"] == "Read"
+    assert fake_redis.closed is True
+
+    serialized = json.dumps(fake_redis.xadd_calls, sort_keys=True)
+    forbidden_fragments = [
+        "secret prompt text",
+        "tool_input",
+        "file_path",
+        "/private/path/secret.py",
+        "tool_response",
+        "secret response",
+        "secret failure",
+        str(tmp_path),
+        "session-secret",
+    ]
+    for fragment in forbidden_fragments:
+        assert fragment not in serialized
+
+
+def test_native_hook_activity_emit_failure_does_not_block_hook(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        native_hooks,
+        "_open_activity_redis_client",
+        lambda: FailingRedisClient(),
+        raising=False,
+    )
+
+    response = handle_event(
+        "PreToolUse",
+        {
+            "cwd": str(tmp_path),
+            "tool_name": "Read",
+            "tool_input": {"file_path": "/private/path/secret.py"},
+            "env": {"DOPEMUX_INSTANCE_ID": "main"},
+        },
+    )
+
+    assert response.get("decision") != "block"


### PR DESCRIPTION
## Summary
- emit content-free native hook activity events for prompt, pre-tool, post-tool, and tool-failure hooks through Redis XADD to dopemux:events
- keep Redis unavailable/failure paths non-blocking for Claude hook allow/block behavior
- add unit coverage proving activity events exclude prompt text, tool inputs, tool responses, errors, cwd, paths, and session IDs

## Validation
- PASS: python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: python -m pytest tests/test_native_hooks_workflow.py
- PASS: python -m py_compile src/dopemux/claude/native_hooks.py tests/test_native_hooks_workflow.py
- PASS: git diff --check
- PASS: git diff --cached --check
- PASS: pre-commit run --files src/dopemux/claude/native_hooks.py tests/test_native_hooks_workflow.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001-implementation-notes.md
- PASS: PAL codereview, internal, gpt-5-codex, issues_found=0, continuation_id=6149197b-e60e-4643-a343-01296499de46

## Not Run
- live Redis integration
- Claude Code live hook invocation

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated