### PR TITLE
feat(cli): add dopemux pr-steward doctor skew and config check

### DIFF
--- a/docs/ops/pr-steward-distribution.md
+++ b/docs/ops/pr-steward-distribution.md
@@ -35,5 +35,8 @@ overwrite local workflow or policy edits.
 
 ## Follow-Up
 
-`dopemux pr-steward doctor` remains fail-closed until
-TP-DMX-STEWARD-DOCTOR-303 adds package/scaffold skew and config checks.
+`dopemux pr-steward doctor` is report-only. It validates
+`config/pr_steward/policy.json` against
+`schemas/pr_steward/config.schema.json`, compares the local policy to the
+packaged scaffold policy, and exits blocked on missing config, unknown schema,
+invalid config, or scaffold skew. It does not auto-fix, migrate, or write files.

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/AUDITOR_REPORT.md
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/AUDITOR_REPORT.md
@@ -1,0 +1,20 @@
+# Auditor Report
+
+Status: `SKIPPED`
+
+No external embedded-auditor invocation was available in this Codex session. A
+bounded manual review was performed instead.
+
+## Manual Review
+
+- The doctor command is report-only and exposes no auto-fix or migration option.
+- Tests cover valid matching scaffold policy, invalid config, scaffold skew,
+  unknown schema, help output, and no policy mutation.
+- Unknown or unsupported schema state fails closed as `UNKNOWN_SCHEMA`.
+- Missing or invalid `config/pr_steward/policy.json` fails closed.
+- Scaffold policy drift fails closed for operator review.
+
+## Remaining Risk
+
+- Live downstream repository doctor execution was not run.
+- Intentional local policy customization is reported as scaffold skew in v1.

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/CHANGED_FILES.txt
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/CHANGED_FILES.txt
@@ -1,0 +1,14 @@
+docs/ops/pr-steward-distribution.md
+schemas/pr_steward/config.schema.json
+src/dopemux_pr_steward/cli.py
+src/dopemux_pr_steward/doctor.py
+task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json
+tests/dopemux_cli/test_doctor.py
+proof/TP-DMX-STEWARD-DOCTOR-303/AUDITOR_REPORT.md
+proof/TP-DMX-STEWARD-DOCTOR-303/CHANGED_FILES.txt
+proof/TP-DMX-STEWARD-DOCTOR-303/DIFF_STAT.txt
+proof/TP-DMX-STEWARD-DOCTOR-303/GIT_STATE.md
+proof/TP-DMX-STEWARD-DOCTOR-303/PROOF.json
+proof/TP-DMX-STEWARD-DOCTOR-303/VALIDATION_OUTPUT.md
+proof/TP-DMX-STEWARD-DOCTOR-303/review_bundle/MANIFEST.json
+proof/TP-DMX-STEWARD-DOCTOR-303/review_bundle/SUMMARY.md

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/DIFF_STAT.txt
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/DIFF_STAT.txt
@@ -1,0 +1,7 @@
+ docs/ops/pr-steward-distribution.md                |   7 +-
+ schemas/pr_steward/config.schema.json              |  44 ++++
+ src/dopemux_pr_steward/cli.py                      |  27 ++-
+ src/dopemux_pr_steward/doctor.py                   | 256 +++++++++++++++++++++
+ .../generated/TP-DMX-STEWARD-DOCTOR-303.json       |   8 +-
+ tests/dopemux_cli/test_doctor.py                   | 107 +++++++++
+ 6 files changed, 434 insertions(+), 15 deletions(-)

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/GIT_STATE.md
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/GIT_STATE.md
@@ -1,0 +1,16 @@
+# Git State
+
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-steward-doctor-303`
+- Branch: `codex/tp-dmx-steward-doctor-303`
+- Base ref: `origin/codex/tp-dmx-steward-scaffold-302`
+- Base SHA: `3f4231d5e43df404cf2e8c0847b5a6e4f13bb760`
+- Implementation commit SHA: `ef22118875695c668f364dca3487d22d48509f94`
+- Primary checkout dirty state was not modified.
+
+## Changed Files
+
+See `CHANGED_FILES.txt`.
+
+## Diff Stat
+
+See `DIFF_STAT.txt`.

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/PROOF.json
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/PROOF.json
@@ -1,0 +1,160 @@
+{
+  "tp_id": "TP-DMX-STEWARD-DOCTOR-303",
+  "status": "PASS_WITH_LIMITS",
+  "generated_at": "2026-06-01T00:10:00Z",
+  "worktree_path": "/Users/hue/code/dopemux-mvp/.worktrees/tp-dmx-steward-doctor-303",
+  "branch": "codex/tp-dmx-steward-doctor-303",
+  "base_ref": "origin/codex/tp-dmx-steward-scaffold-302",
+  "base_sha": "3f4231d5e43df404cf2e8c0847b5a6e4f13bb760",
+  "implementation_commit_sha": "ef22118875695c668f364dca3487d22d48509f94",
+  "proof_commit_sha": "PENDING_PROOF_COMMIT",
+  "pr_url": "PENDING_PR_CREATION",
+  "repo_identity": {
+    "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "marker": ".dopetaskroot",
+    "identity_match": true
+  },
+  "stacking": {
+    "reason": "TP303 depends on TP-DMX-STEWARD-SCAFFOLD-302, so the packet and PR base were changed from main to codex/tp-dmx-steward-scaffold-302.",
+    "base_branch": "codex/tp-dmx-steward-scaffold-302",
+    "base_pr": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/772"
+  },
+  "dependency_proofs": [
+    {
+      "tp_id": "TP-DMX-STEWARD-PACKAGE-301",
+      "path": "proof/TP-DMX-STEWARD-PACKAGE-301/PROOF.json",
+      "present": true,
+      "json_valid": true,
+      "status": "PASS_WITH_LIMITS",
+      "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/770"
+    },
+    {
+      "tp_id": "TP-DMX-STEWARD-SCAFFOLD-302",
+      "path": "proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json",
+      "present": true,
+      "json_valid": true,
+      "status": "PASS_WITH_LIMITS",
+      "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/772"
+    }
+  ],
+  "authority_used": [
+    "AGENTS.md",
+    "task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json",
+    "docs/ops/load-plans/load_plan-DMX-AUTOREVIEW-PLATFORM.json",
+    "src/dopemux_pr_steward/cli.py",
+    "src/dopemux/templates/init/config/pr_steward/policy.json",
+    "docs/ops/pr-steward-distribution.md",
+    "proof/TP-DMX-STEWARD-SCAFFOLD-302/PROOF.json"
+  ],
+  "slices_completed": [
+    "Preflight verified the dedicated worktree, origin, branch, .dopetaskroot marker, TP303 schema, and TP301/TP302 dependency proofs.",
+    "RED: added tests/dopemux_cli/test_doctor.py and observed all five tests fail against the placeholder doctor implementation.",
+    "GREEN: added report-only doctor module, config schema, CLI wiring, docs, and packet base metadata.",
+    "Implemented fail-closed behavior for missing/unknown schema, invalid config, and scaffold skew without writing files.",
+    "Refreshed the local editable install to this TP303 worktree so the exact python -m dopemux.cli validation command resolved the new doctor implementation."
+  ],
+  "files_changed": [
+    "docs/ops/pr-steward-distribution.md",
+    "schemas/pr_steward/config.schema.json",
+    "src/dopemux_pr_steward/cli.py",
+    "src/dopemux_pr_steward/doctor.py",
+    "task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json",
+    "tests/dopemux_cli/test_doctor.py",
+    "proof/TP-DMX-STEWARD-DOCTOR-303/**"
+  ],
+  "validations": [
+    {
+      "command": "pytest -q tests/dopemux_cli/test_doctor.py",
+      "exit_code": 1,
+      "status": "RED_PASS",
+      "evidence": "Five tests failed against placeholder doctor behavior."
+    },
+    {
+      "command": "pytest -q tests/dopemux_cli/test_doctor.py",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "5 passed"
+    },
+    {
+      "command": "pytest -q tests/dopemux_cli/test_doctor.py tests/dopemux_cli/test_pr_steward_cmd.py",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "10 passed"
+    },
+    {
+      "command": "python -m pip install -e .",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "Refreshed local editable install from the prior TP302 worktree to this TP303 worktree."
+    },
+    {
+      "command": "python -m dopemux.cli pr-steward doctor --help",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "Help lists --workspace, --schema, and --format; LiteLLM emitted non-fatal botocore warnings."
+    },
+    {
+      "command": "python -m json.tool task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m jsonschema -i task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m json.tool schemas/pr_steward/config.schema.json",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "python -m compileall -q src tests",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "pytest -q tests/dopemux_cli",
+      "exit_code": 0,
+      "status": "PASS",
+      "evidence": "10 passed"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "status": "PASS"
+    },
+    {
+      "command": "pre-commit run --files <TP303 changed files>",
+      "exit_code": 0,
+      "status": "PASS"
+    }
+  ],
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DMX-STEWARD-DOCTOR-303/AUDITOR_REPORT.md",
+    "findings": [],
+    "fixes_applied": [],
+    "remaining_risks": [
+      "External embedded audit was not invoked in this Codex session.",
+      "Doctor validates a deliberately small JSON Schema subset; unsupported schema keywords fail closed as UNKNOWN_SCHEMA."
+    ],
+    "skip_reason": "No supported external embedded-auditor invocation was available in this session; Codex performed bounded manual audit and records this required audit as skipped."
+  },
+  "codereview_status": "Manual bounded review complete; doctor is report-only, no auto-fix path exists, and tests assert no policy mutation.",
+  "precommit_status": "PASS: pre-commit run on TP303 changed files and git diff --check passed.",
+  "residual_risks": [
+    "Doctor compares config/pr_steward/policy.json to the packaged scaffold policy exactly; intentional local policy customization is reported as scaffold skew and requires operator review.",
+    "Live downstream repository doctor execution was not exercised before this proof was written.",
+    "External embedded audit is skipped locally and should be supplied by CI or supervisor review."
+  ],
+  "unknowns": [
+    "Whether downstream projects want configurable allowed drift for PR Steward policy remains UNKNOWN and is deferred outside TP303."
+  ],
+  "cleanup_status": "WORKTREE_ACTIVE_PENDING_PR"
+}

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/PROOF.json
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/PROOF.json
@@ -8,7 +8,7 @@
   "base_sha": "3f4231d5e43df404cf2e8c0847b5a6e4f13bb760",
   "implementation_commit_sha": "ef22118875695c668f364dca3487d22d48509f94",
   "proof_commit_sha": "82f8ba8e28606ad11bde2e593ef98f4c0591d386",
-  "pr_url": "PENDING_PR_CREATION",
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/775",
   "repo_identity": {
     "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
     "marker": ".dopetaskroot",

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/PROOF.json
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/PROOF.json
@@ -7,7 +7,7 @@
   "base_ref": "origin/codex/tp-dmx-steward-scaffold-302",
   "base_sha": "3f4231d5e43df404cf2e8c0847b5a6e4f13bb760",
   "implementation_commit_sha": "ef22118875695c668f364dca3487d22d48509f94",
-  "proof_commit_sha": "PENDING_PROOF_COMMIT",
+  "proof_commit_sha": "82f8ba8e28606ad11bde2e593ef98f4c0591d386",
   "pr_url": "PENDING_PR_CREATION",
   "repo_identity": {
     "origin": "https://github.com/DDD-Enterprises/dopemux-mvp.git",

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/VALIDATION_OUTPUT.md
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/VALIDATION_OUTPUT.md
@@ -1,0 +1,25 @@
+# Validation Output
+
+## PASS
+
+- `pytest -q tests/dopemux_cli/test_doctor.py` exited 0 with `5 passed`.
+- `pytest -q tests/dopemux_cli/test_doctor.py tests/dopemux_cli/test_pr_steward_cmd.py` exited 0 with `10 passed`.
+- `python -m pip install -e .` exited 0 and refreshed the editable install to this TP303 worktree.
+- `python -m dopemux.cli pr-steward doctor --help` exited 0 and listed `--workspace`, `--schema`, and `--format`.
+- `python -m json.tool task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json` exited 0.
+- `python -m jsonschema -i task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` exited 0.
+- `python -m json.tool schemas/pr_steward/config.schema.json` exited 0.
+- `python -m compileall -q src tests` exited 0.
+- `pytest -q tests/dopemux_cli` exited 0 with `10 passed`.
+- `git diff --check` exited 0.
+- `pre-commit run --files <TP303 changed files>` exited 0.
+
+## RED
+
+- `pytest -q tests/dopemux_cli/test_doctor.py` exited 1 before implementation; all five tests failed against placeholder doctor behavior.
+
+## NOT_RUN
+
+- Live downstream repository doctor execution.
+- External embedded audit invocation.
+- Supervisor sign-off.

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/review_bundle/MANIFEST.json
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/review_bundle/MANIFEST.json
@@ -1,0 +1,14 @@
+{
+  "tp_id": "TP-DMX-STEWARD-DOCTOR-303",
+  "bundle_type": "review_bundle",
+  "artifacts": [
+    "../PROOF.json",
+    "../VALIDATION_OUTPUT.md",
+    "../GIT_STATE.md",
+    "../DIFF_STAT.txt",
+    "../CHANGED_FILES.txt",
+    "../AUDITOR_REPORT.md",
+    "SUMMARY.md"
+  ],
+  "excluded": []
+}

--- a/proof/TP-DMX-STEWARD-DOCTOR-303/review_bundle/SUMMARY.md
+++ b/proof/TP-DMX-STEWARD-DOCTOR-303/review_bundle/SUMMARY.md
@@ -1,0 +1,14 @@
+# TP-DMX-STEWARD-DOCTOR-303 Review Bundle
+
+This bundle records the report-only `dopemux pr-steward doctor` implementation.
+
+Implementation commit: `ef22118875695c668f364dca3487d22d48509f94`
+
+Primary validation:
+
+- `pytest -q tests/dopemux_cli/test_doctor.py` -> `5 passed`
+- `pytest -q tests/dopemux_cli` -> `10 passed`
+- `python -m dopemux.cli pr-steward doctor --help` -> exit 0
+- `python -m compileall -q src tests` -> exit 0
+- `git diff --check` -> exit 0
+- `pre-commit run --files <TP303 changed files>` -> exit 0

--- a/schemas/pr_steward/config.schema.json
+++ b/schemas/pr_steward/config.schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.dopemux.dev/pr_steward/config.schema.json",
+  "title": "PR Steward policy config",
+  "description": "Report-only PR Steward v1 policy configuration.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "mode",
+    "mutates_github",
+    "fail_closed_on_unknown",
+    "required_artifacts",
+    "trusted_reviewer_associations"
+  ],
+  "properties": {
+    "mode": {
+      "type": "string",
+      "enum": ["check_only"]
+    },
+    "mutates_github": {
+      "type": "boolean",
+      "enum": [false]
+    },
+    "fail_closed_on_unknown": {
+      "type": "boolean",
+      "enum": [true]
+    },
+    "required_artifacts": {
+      "type": "array",
+      "minItems": 5,
+      "items": {
+        "type": "string"
+      }
+    },
+    "trusted_reviewer_associations": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": ["OWNER", "MEMBER", "COLLABORATOR"]
+      }
+    }
+  }
+}

--- a/src/dopemux_pr_steward/cli.py
+++ b/src/dopemux_pr_steward/cli.py
@@ -9,6 +9,7 @@ from typing import Any, Sequence
 from dopemux_pr_merge_specialist.steward_gate import steward_gate
 
 from . import CONTRACT_VERSION
+from .doctor import format_result, run_doctor
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -62,9 +63,16 @@ def build_parser() -> argparse.ArgumentParser:
 
     doctor = subparsers.add_parser(
         "doctor",
-        help="Report PR Steward package/scaffold health. Full checks land in TP303.",
+        help="Run report-only PR Steward package/scaffold health checks.",
+        description=(
+            "Run report-only PR Steward package/scaffold health checks. "
+            "No files are modified."
+        ),
     )
-    doctor.set_defaults(handler=_run_doctor_placeholder)
+    doctor.add_argument("--workspace", default=".", type=Path)
+    doctor.add_argument("--schema", type=Path)
+    doctor.add_argument("--format", choices=["json", "text"], default="text")
+    doctor.set_defaults(handler=_run_doctor)
     return parser
 
 
@@ -167,13 +175,14 @@ def _run_audit(args: argparse.Namespace) -> int:
     return 0 if status in {"PASS", "PASS_WITH_RISKS"} else 2
 
 
-def _run_doctor_placeholder(args: argparse.Namespace) -> int:
-    print(
-        "pr-steward doctor is report-only and will be implemented by "
-        "TP-DMX-STEWARD-DOCTOR-303.",
-        file=sys.stderr,
-    )
-    return 2
+def _run_doctor(args: argparse.Namespace) -> int:
+    result = run_doctor(workspace=args.workspace, schema_path=args.schema)
+    output = format_result(result, output_format=args.format)
+    if args.format == "json" or result.ok:
+        print(output)
+    else:
+        print(output, file=sys.stderr)
+    return 0 if result.ok else 2
 
 
 def _load_json(path: Path) -> dict[str, Any]:

--- a/src/dopemux_pr_steward/doctor.py
+++ b/src/dopemux_pr_steward/doctor.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from . import CONTRACT_VERSION
+
+
+CONFIG_RELATIVE_PATH = Path("config/pr_steward/policy.json")
+SCHEMA_RELATIVE_PATH = Path("schemas/pr_steward/config.schema.json")
+SCAFFOLD_RELATIVE_PATH = Path(
+    "src/dopemux/templates/init/config/pr_steward/policy.json"
+)
+
+SUPPORTED_SCHEMA_KEYS = {
+    "$id",
+    "$schema",
+    "additionalProperties",
+    "description",
+    "enum",
+    "items",
+    "minItems",
+    "properties",
+    "required",
+    "title",
+    "type",
+}
+
+
+@dataclass(frozen=True)
+class DoctorResult:
+    status: str
+    reason_code: str
+    workspace: str
+    contract_version: str
+    checks: dict[str, dict[str, str]]
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "PASS"
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "workspace": self.workspace,
+            "contract_version": self.contract_version,
+            "checks": self.checks,
+        }
+
+
+def run_doctor(
+    *,
+    workspace: Path,
+    schema_path: Path | None = None,
+    scaffold_path: Path | None = None,
+) -> DoctorResult:
+    """Validate PR Steward config and scaffold skew without mutating files."""
+    workspace = workspace.expanduser().resolve()
+    config_path = workspace / CONFIG_RELATIVE_PATH
+    schema_path = schema_path or _find_repo_file(SCHEMA_RELATIVE_PATH)
+    scaffold_path = scaffold_path or _find_repo_file(SCAFFOLD_RELATIVE_PATH)
+
+    checks: dict[str, dict[str, str]] = {}
+
+    schema = _load_schema(schema_path)
+    if isinstance(schema, str):
+        checks["config_schema"] = {"status": "FAIL", "message": schema}
+        return _blocked("UNKNOWN_SCHEMA", workspace, checks)
+
+    unsupported = _find_unsupported_schema_keys(schema)
+    if unsupported:
+        checks["config_schema"] = {
+            "status": "FAIL",
+            "message": (
+                "Unsupported schema keyword(s): "
+                + ", ".join(sorted(unsupported))
+                + ". Refusing to guess validation semantics."
+            ),
+        }
+        return _blocked("UNKNOWN_SCHEMA", workspace, checks)
+
+    config = _load_json_object(config_path)
+    if isinstance(config, str):
+        checks["config_schema"] = {"status": "FAIL", "message": config}
+        return _blocked("CONFIG_INVALID", workspace, checks)
+
+    errors = _validate_subset(config, schema)
+    if errors:
+        checks["config_schema"] = {
+            "status": "FAIL",
+            "message": "; ".join(errors),
+        }
+        return _blocked("CONFIG_INVALID", workspace, checks)
+
+    checks["config_schema"] = {
+        "status": "PASS",
+        "message": f"{CONFIG_RELATIVE_PATH} validates against {SCHEMA_RELATIVE_PATH}.",
+    }
+
+    scaffold = _load_json_object(scaffold_path)
+    if isinstance(scaffold, str):
+        checks["scaffold_skew"] = {"status": "FAIL", "message": scaffold}
+        return _blocked("SCAFFOLD_UNKNOWN", workspace, checks)
+
+    if _canonical_json(config) != _canonical_json(scaffold):
+        checks["scaffold_skew"] = {
+            "status": "FAIL",
+            "message": (
+                f"{CONFIG_RELATIVE_PATH} differs from packaged scaffold policy; "
+                "review local drift or rerun dopemux init in a controlled branch."
+            ),
+        }
+        return _blocked("SCAFFOLD_SKEW", workspace, checks)
+
+    checks["scaffold_skew"] = {
+        "status": "PASS",
+        "message": f"{CONFIG_RELATIVE_PATH} matches packaged scaffold policy.",
+    }
+    return DoctorResult(
+        status="PASS",
+        reason_code="PASS",
+        workspace=str(workspace),
+        contract_version=CONTRACT_VERSION,
+        checks=checks,
+    )
+
+
+def format_result(result: DoctorResult, *, output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(result.to_payload(), indent=2, sort_keys=True)
+
+    lines = [
+        f"status={result.status}",
+        f"reason_code={result.reason_code}",
+        f"workspace={result.workspace}",
+        f"contract_version={result.contract_version}",
+    ]
+    for name, check in result.checks.items():
+        lines.append(f"{name}: {check['status']} - {check['message']}")
+    if not result.ok:
+        lines.append("TP-DMX-STEWARD-DOCTOR-303 is report-only; no files were changed.")
+    return "\n".join(lines)
+
+
+def _blocked(
+    reason_code: str, workspace: Path, checks: dict[str, dict[str, str]]
+) -> DoctorResult:
+    return DoctorResult(
+        status="BLOCKED",
+        reason_code=reason_code,
+        workspace=str(workspace),
+        contract_version=CONTRACT_VERSION,
+        checks=checks,
+    )
+
+
+def _find_repo_file(relative_path: Path) -> Path:
+    candidates = [Path.cwd(), *Path(__file__).resolve().parents]
+    for candidate in candidates:
+        path = candidate / relative_path
+        if path.exists():
+            return path
+    return Path.cwd() / relative_path
+
+
+def _load_schema(path: Path) -> dict[str, Any] | str:
+    payload = _load_json_object(path)
+    if isinstance(payload, str):
+        return f"Unknown schema at {path}: {payload}"
+    return payload
+
+
+def _load_json_object(path: Path) -> dict[str, Any] | str:
+    if not path.exists():
+        return f"Missing JSON object file: {path}"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return f"Invalid JSON in {path}: {exc.msg}"
+    if not isinstance(payload, dict):
+        return f"{path} must contain a JSON object"
+    return payload
+
+
+def _find_unsupported_schema_keys(schema: Any, *, in_properties: bool = False) -> set[str]:
+    unsupported: set[str] = set()
+    if isinstance(schema, dict):
+        for key, value in schema.items():
+            if not in_properties and key not in SUPPORTED_SCHEMA_KEYS:
+                unsupported.add(key)
+            unsupported.update(
+                _find_unsupported_schema_keys(value, in_properties=(key == "properties"))
+            )
+    elif isinstance(schema, list):
+        for item in schema:
+            unsupported.update(_find_unsupported_schema_keys(item))
+    return unsupported
+
+
+def _validate_subset(payload: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+    errors: list[str] = []
+    expected_type = schema.get("type")
+    if expected_type and not _matches_type(payload, expected_type):
+        return [f"{path} must be {expected_type}"]
+
+    enum = schema.get("enum")
+    if enum is not None and payload not in enum:
+        errors.append(f"{path} must be one of {enum}")
+
+    if isinstance(payload, dict):
+        required = schema.get("required") or []
+        for key in required:
+            if key not in payload:
+                errors.append(f"{path}.{key} is required")
+
+        properties = schema.get("properties") or {}
+        if schema.get("additionalProperties") is False:
+            for key in payload:
+                if key not in properties:
+                    errors.append(f"{path}.{key} is not allowed")
+
+        for key, subschema in properties.items():
+            if key in payload and isinstance(subschema, dict):
+                errors.extend(_validate_subset(payload[key], subschema, f"{path}.{key}"))
+
+    if isinstance(payload, list):
+        min_items = schema.get("minItems")
+        if isinstance(min_items, int) and len(payload) < min_items:
+            errors.append(f"{path} must contain at least {min_items} item(s)")
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(payload):
+                errors.extend(_validate_subset(item, item_schema, f"{path}[{index}]"))
+
+    return errors
+
+
+def _matches_type(payload: Any, expected_type: str) -> bool:
+    if expected_type == "object":
+        return isinstance(payload, dict)
+    if expected_type == "array":
+        return isinstance(payload, list)
+    if expected_type == "string":
+        return isinstance(payload, str)
+    if expected_type == "boolean":
+        return isinstance(payload, bool)
+    if expected_type == "integer":
+        return isinstance(payload, int) and not isinstance(payload, bool)
+    return False
+
+
+def _canonical_json(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))

--- a/task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json
+++ b/task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json
@@ -22,7 +22,7 @@
   ],
   "execution": {
     "agent": "codex",
-    "base_branch": "main",
+    "base_branch": "codex/tp-dmx-steward-scaffold-302",
     "branch": "codex/tp-dmx-steward-doctor-303",
     "stacked_because": "Part of the DMX-AUTOREVIEW-PLATFORM dependency DAG."
   },
@@ -49,7 +49,7 @@
     ]
   },
   "pr": {
-    "base": "main",
+    "base": "codex/tp-dmx-steward-scaffold-302",
     "body": "## Summary\n- Detect engine vs scaffold version skew and validate config/pr_steward against the engine config schema, failing closed with actionable messages. Report-only (no auto-fix) in v1.\n\n## Scope\nTrack: C-distribute. Risk: LOW. Red lane: false.\n\n## Validation\nRun the packet validation commands and capture proof under proof/TP-DMX-STEWARD-DOCTOR-303/PROOF.json.\n\n## NOT_RUN\nList any skipped live, integration, credentialed, or supervisor-gated checks explicitly.",
     "title": "Feat(cli): add dopemux pr-steward doctor skew and config check"
   },
@@ -61,10 +61,10 @@
     "require_identity_match": true
   },
   "series": {
-    "base_branch": "main",
+    "base_branch": "codex/tp-dmx-steward-scaffold-302",
     "final_packet": false,
     "id": "DMX-AUTOREVIEW-PLATFORM",
-    "parent_tp_id": "TP-DMX-STEWARD-PACKAGE-301"
+    "parent_tp_id": "TP-DMX-STEWARD-SCAFFOLD-302"
   },
   "steps": [
     {

--- a/tests/dopemux_cli/test_doctor.py
+++ b/tests/dopemux_cli/test_doctor.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from dopemux_pr_steward.cli import main as steward_main
+
+
+VALID_POLICY = {
+    "mode": "check_only",
+    "mutates_github": False,
+    "fail_closed_on_unknown": True,
+    "required_artifacts": [
+        "MERGE_READINESS.json",
+        "REVIEW_ITEM_LEDGER.json",
+        "THREAD_DISPOSITIONS.json",
+        "CI_TRIAGE.json",
+        "PR_STATE_SNAPSHOT.json",
+    ],
+    "trusted_reviewer_associations": [
+        "OWNER",
+        "MEMBER",
+        "COLLABORATOR",
+    ],
+}
+
+
+def _write_policy(workspace: Path, payload: dict) -> Path:
+    path = workspace / "config" / "pr_steward" / "policy.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def test_doctor_passes_valid_matching_scaffold_policy(tmp_path: Path, capsys) -> None:
+    policy_path = _write_policy(tmp_path, VALID_POLICY)
+    before = policy_path.read_text(encoding="utf-8")
+
+    rc = steward_main(["doctor", "--workspace", str(tmp_path), "--format", "json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 0
+    assert payload["status"] == "PASS"
+    assert payload["checks"]["config_schema"]["status"] == "PASS"
+    assert payload["checks"]["scaffold_skew"]["status"] == "PASS"
+    assert policy_path.read_text(encoding="utf-8") == before
+
+
+def test_doctor_fails_closed_on_invalid_config(tmp_path: Path, capsys) -> None:
+    _write_policy(tmp_path, {"mode": "check_only", "mutates_github": False})
+
+    rc = steward_main(["doctor", "--workspace", str(tmp_path), "--format", "json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 2
+    assert payload["status"] == "BLOCKED"
+    assert payload["checks"]["config_schema"]["status"] == "FAIL"
+    assert "required_artifacts" in payload["checks"]["config_schema"]["message"]
+
+
+def test_doctor_fails_closed_on_scaffold_skew(tmp_path: Path, capsys) -> None:
+    policy = dict(VALID_POLICY)
+    policy["trusted_reviewer_associations"] = ["OWNER", "MEMBER"]
+    _write_policy(tmp_path, policy)
+
+    rc = steward_main(["doctor", "--workspace", str(tmp_path), "--format", "json"])
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 2
+    assert payload["status"] == "BLOCKED"
+    assert payload["checks"]["config_schema"]["status"] == "PASS"
+    assert payload["checks"]["scaffold_skew"]["status"] == "FAIL"
+    assert "config/pr_steward/policy.json differs" in payload["checks"]["scaffold_skew"]["message"]
+
+
+def test_doctor_fails_closed_on_unknown_schema(tmp_path: Path, capsys) -> None:
+    _write_policy(tmp_path, VALID_POLICY)
+
+    rc = steward_main(
+        [
+            "doctor",
+            "--workspace",
+            str(tmp_path),
+            "--schema",
+            str(tmp_path / "missing.schema.json"),
+            "--format",
+            "json",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert rc == 2
+    assert payload["status"] == "BLOCKED"
+    assert payload["reason_code"] == "UNKNOWN_SCHEMA"
+
+
+def test_doctor_help_describes_report_only_contract(capsys) -> None:
+    rc = steward_main(["doctor", "--help"])
+
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "report-only" in captured.out
+    assert "--workspace" in captured.out


### PR DESCRIPTION
## Summary
- Implement report-only `dopemux pr-steward doctor` checks for PR Steward config/schema health.
- Validate `config/pr_steward/policy.json` against `schemas/pr_steward/config.schema.json` using a fail-closed supported-schema subset.
- Detect scaffold policy skew against the packaged init scaffold and return actionable blocked output without mutating repo files.

## Scope
- Stacked on #772 / `codex/tp-dmx-steward-scaffold-302` because TP303 depends on TP302.
- No auto-fix, migration, config write, or GitHub mutation path.

## Validation
- `python -m json.tool task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json`
- `python -m jsonschema -i task-packets/generated/TP-DMX-STEWARD-DOCTOR-303.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `python -m json.tool schemas/pr_steward/config.schema.json`
- `python -m compileall -q src tests`
- `pytest -q tests/dopemux_cli/test_doctor.py` -> 5 passed
- `pytest -q tests/dopemux_cli` -> 10 passed
- `python -m dopemux.cli pr-steward doctor --help` -> exit 0
- `git diff --check`
- `pre-commit run --files <TP303 changed files>`

## NOT_RUN / Risk
- Live downstream repository doctor execution was not run before opening this draft.
- External embedded audit is recorded as SKIPPED in local proof.
- Intentional local PR Steward policy customization is reported as scaffold skew in v1 and needs operator review.

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated.