### PR TITLE
feat(adhd): seed operator profile at startup

### DIFF
--- a/services/adhd_engine/core/engine.py
+++ b/services/adhd_engine/core/engine.py
@@ -19,6 +19,7 @@ import asyncio
 import json
 import logging
 import os
+from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -89,6 +90,13 @@ def _resolve_task_orchestrator_url() -> str:
     if isinstance(configured, str) and configured.strip():
         return configured.strip()
     return os.getenv("TASK_ORCHESTRATOR_URL", "http://task-orchestrator:8000")
+
+
+def _redis_text(value: Any) -> str:
+    """Normalize Redis text responses across decoded and raw-byte clients."""
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode("utf-8")
+    return str(value)
 
 # Machine Learning (IP-005 Days 11-12)
 try:
@@ -260,22 +268,46 @@ class ADHDAccommodationEngine:
             profile_keys = await self.redis_client.keys("adhd:profile:*")
 
             for key in profile_keys:
-                user_id = key.split(":")[-1]
+                key_text = _redis_text(key)
+                user_id = key_text.rsplit(":", 1)[-1]
                 profile_data = await self.redis_client.get(key)
 
                 if profile_data:
-                    profile = ADHDProfile(**json.loads(profile_data))
+                    profile = ADHDProfile(**json.loads(_redis_text(profile_data)))
                     self.user_profiles[user_id] = profile
                     
                     # Initialize ML predictor for user (Phase 10.5)
-                    if ML_AVAILABLE and settings.enable_ml_predictions:
-                        self.energy_predictors[user_id] = EnergyPatternPredictor(user_id)
-                        logger.info(f"🧠 Initialized ML energy predictor for user: {user_id}")
+                    self._ensure_energy_predictor(user_id)
+
+            await self._ensure_operator_profile_seeded()
 
             logger.info(f"📋 Loaded {len(self.user_profiles)} ADHD profiles")
 
         except Exception as e:
             logger.error(f"Failed to load ADHD profiles: {e}")
+
+    def _ensure_energy_predictor(self, user_id: str) -> None:
+        """Initialize the optional ML predictor for a loaded or seeded profile."""
+        if ML_AVAILABLE and settings.enable_ml_predictions and user_id not in self.energy_predictors:
+            self.energy_predictors[user_id] = EnergyPatternPredictor(user_id)
+            logger.info(f"🧠 Initialized ML energy predictor for user: {user_id}")
+
+    async def _ensure_operator_profile_seeded(self) -> None:
+        """Seed and persist a default profile for the stable local operator."""
+        operator_user_id = self.operator_user_id or resolve_operator_user_id()
+        self.operator_user_id = operator_user_id
+
+        if operator_user_id in self.user_profiles:
+            self._ensure_energy_predictor(operator_user_id)
+            return
+
+        profile = ADHDProfile(user_id=operator_user_id)
+        self.user_profiles[operator_user_id] = profile
+        self._ensure_energy_predictor(operator_user_id)
+
+        profile_key = f"adhd:profile:{operator_user_id}"
+        await self.redis_client.set(profile_key, json.dumps(asdict(profile), default=str))
+        logger.info(f"📋 Seeded default ADHD profile for operator: {operator_user_id}")
 
     async def _start_accommodation_monitoring(self) -> None:
         """Start background monitoring tasks."""

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001-implementation-notes.md
@@ -1,0 +1,53 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T4 03A Operator Profile Seed 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: Tp Dmx Adhd Cognitive T4 03A Operator Profile Seed 001 Implementation Notes
+  (explanation) for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T4-03A Operator Profile Seed Implementation Notes
+
+## Authority
+
+- Active Task Packet: `TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001`
+- Parent dependency: `TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001`
+- Runtime authority: `services/adhd_engine/core/engine.py`
+- Profile schema authority: `services/adhd_engine/core/models.py`
+- Existing persistence shape: `services/adhd_engine/api/routes.py` uses `json.dumps(asdict(profile), default=str)` for `adhd:profile:<user_id>`.
+
+## Change
+
+- `_load_user_profiles()` now normalizes Redis text keys and values so decoded-string and raw-byte Redis clients both work.
+- Startup now seeds a default `ADHDProfile` for the resolved stable operator id when no operator profile was loaded.
+- Existing operator profiles are preserved and are not overwritten.
+- Seeded operator profiles are persisted under `adhd:profile:<operator_user_id>` using the existing profile JSON shape.
+
+## TDD Evidence
+
+- RED: `python -m pytest tests/unit/test_adhd_operator_profile_seed.py`
+  - Exit 1 before implementation.
+  - Empty Redis startup left `engine.user_profiles["operator-local-001"]` missing.
+  - Byte Redis keys raised a loader error and left existing byte-key profiles unloaded.
+- GREEN: `python -m pytest tests/unit/test_adhd_operator_profile_seed.py`
+  - Exit 0 after implementation.
+  - `3 passed in 1.40s`.
+
+## Validation
+
+- PASS: `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- PASS: `python -m pytest tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py`
+  - `15 passed in 1.54s`.
+- PASS: `python -m py_compile services/adhd_engine/core/engine.py`
+- PASS: `git diff --check`
+- PASS: `python -m pre_commit run --files services/adhd_engine/core/engine.py tests/unit/test_adhd_operator_profile_seed.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001-implementation-notes.md`
+
+## Residual Risk
+
+- Live Redis/container startup was not exercised in this slice.
+- This does not close native hook ingestion or activity-loop gaps; it only proves the active profile load path seeds the operator profile.
+- This branch is intentionally stacked on `codex/adhd-operator-identity-001`.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json
@@ -1,0 +1,144 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001",
+  "project": "dopemux-mvp",
+  "target": "ADHD Engine startup seeds a default profile for the stable operator identity",
+  "invariants": [
+    "The active FastAPI runtime imports services.adhd_engine.core.engine; the legacy services/adhd_engine/engine.py sibling is not the authority for this slice.",
+    "Operator profile identity must come from resolve_operator_user_id and must not derive from workspace paths, prompts, hostnames, usernames, machine identifiers, or content.",
+    "Startup profile seeding must keep user_profiles non-empty for the operator when Redis has no profiles.",
+    "Existing persisted profiles must be preserved and an existing operator profile must not be overwritten.",
+    "ADHD Engine remains cognitive-only under AGENTS.md section 6."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-operator-identity-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-profile-seed-001",
+    "base_branch": "codex/adhd-operator-identity-001",
+    "stacked_because": "Default profile seeding depends on the stable operator identity resolver introduced by T4-00."
+  },
+  "commit": {
+    "message": "feat(adhd): seed operator profile at startup",
+    "allowlist": [
+      "services/adhd_engine/core/engine.py",
+      "tests/unit/test_adhd_operator_profile_seed.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py",
+      "python -m py_compile services/adhd_engine/core/engine.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(adhd): seed operator profile at startup",
+    "body": "## Summary\n- seed a default ADHDProfile for the stable operator identity during active engine profile loading\n- persist only newly missing operator profiles under the existing adhd:profile:<user_id> Redis key contract\n- preserve existing Redis profiles and avoid workspace/path-derived user ids\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py\n- python -m py_compile services/adhd_engine/core/engine.py\n- git diff --check",
+    "base": "codex/adhd-operator-identity-001"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect the active engine profile load path, ADHDProfile schema, persistence readers, and existing operator identity tests before editing.",
+      "requirements": [
+        "Distinguish active services.adhd_engine.core.engine runtime from legacy services/adhd_engine/engine.py.",
+        "Confirm Redis profile key and JSON shape before persistence changes.",
+        "Do not widen into native hook ingestion, activity loops, or API profile update behavior."
+      ],
+      "commands": [
+        "rg -n \"ADHDProfile|adhd:profile|user_profiles|_load_user_profiles\" tests services/adhd_engine -g '*.py'",
+        "sed -n '1,240p' services/adhd_engine/core/models.py",
+        "sed -n '240,290p' services/adhd_engine/core/engine.py",
+        "sed -n '580,635p' services/adhd_engine/api/routes.py"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Runtime authority and persistence contract are identified before tests or production edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001.json",
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/core/models.py",
+        "services/adhd_engine/api/routes.py",
+        "services/adhd_engine/adhd_config_service.py",
+        "tests/unit/test_adhd_operator_identity.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add a startup seed path that creates and persists a default operator ADHDProfile only when the operator profile is absent after Redis profile loading.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "The seeded user id must be exactly resolve_operator_user_id output.",
+        "Persist under adhd:profile:<operator_user_id> with the same asdict JSON shape used by the profile API.",
+        "Do not overwrite an existing operator profile.",
+        "Preserve existing non-operator profiles.",
+        "Decode Redis byte keys and values deterministically if encountered."
+      ],
+      "commands": [
+        "apply_patch"
+      ],
+      "expected_files": [
+        "services/adhd_engine/core/engine.py",
+        "tests/unit/test_adhd_operator_profile_seed.py"
+      ],
+      "validation": [
+        "Targeted startup profile seed tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, targeted tests, syntax, diff scope, and precommit checks for the bounded T4-03a slice.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim native hook activity ingestion or monitor behavior beyond the profile load path exercised by tests."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py",
+        "python -m py_compile services/adhd_engine/core/engine.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/unit/test_adhd_operator_profile_seed.py
+++ b/tests/unit/test_adhd_operator_profile_seed.py
@@ -1,0 +1,87 @@
+import json
+
+import pytest
+
+
+class FakeRedisProfiles:
+    def __init__(self, profiles=None):
+        self.profiles = dict(profiles or {})
+        self.set_calls = []
+
+    async def keys(self, pattern):
+        assert pattern == "adhd:profile:*"
+        return list(self.profiles.keys())
+
+    async def get(self, key):
+        return self.profiles.get(key)
+
+    async def set(self, key, value):
+        self.set_calls.append((key, value))
+        self.profiles[key] = value
+        return True
+
+
+@pytest.mark.asyncio
+async def test_load_user_profiles_seeds_default_operator_profile_when_redis_is_empty(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+    from services.adhd_engine.core.models import ADHDProfile
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: "operator-local-001")
+
+    engine = engine_module.ADHDAccommodationEngine()
+    engine.redis_client = FakeRedisProfiles()
+
+    await engine._load_user_profiles()
+
+    profile = engine.user_profiles["operator-local-001"]
+    assert isinstance(profile, ADHDProfile)
+    assert profile.user_id == "operator-local-001"
+    assert "adhd:profile:/Users/hue/code/dopemux-mvp" not in engine.redis_client.profiles
+
+    assert len(engine.redis_client.set_calls) == 1
+    key, payload = engine.redis_client.set_calls[0]
+    assert key == "adhd:profile:operator-local-001"
+    assert json.loads(payload)["user_id"] == "operator-local-001"
+
+
+@pytest.mark.asyncio
+async def test_load_user_profiles_preserves_existing_operator_profile(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: "operator-local-001")
+    existing_profile = {
+        "user_id": "operator-local-001",
+        "optimal_task_duration": 45,
+        "peak_hours": [11, 15],
+        "crash_indicators": ["late_day_drift"],
+    }
+
+    engine = engine_module.ADHDAccommodationEngine()
+    engine.redis_client = FakeRedisProfiles(
+        {"adhd:profile:operator-local-001": json.dumps(existing_profile)}
+    )
+
+    await engine._load_user_profiles()
+
+    assert engine.user_profiles["operator-local-001"].optimal_task_duration == 45
+    assert engine.user_profiles["operator-local-001"].peak_hours == [11, 15]
+    assert engine.redis_client.set_calls == []
+
+
+@pytest.mark.asyncio
+async def test_load_user_profiles_decodes_redis_byte_keys_and_seeds_operator(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: "operator-local-001")
+    existing_profile = {"user_id": "other-user", "optimal_task_duration": 30}
+
+    engine = engine_module.ADHDAccommodationEngine()
+    engine.redis_client = FakeRedisProfiles(
+        {b"adhd:profile:other-user": json.dumps(existing_profile).encode("utf-8")}
+    )
+
+    await engine._load_user_profiles()
+
+    assert engine.user_profiles["other-user"].optimal_task_duration == 30
+    assert engine.user_profiles["operator-local-001"].user_id == "operator-local-001"
+    assert engine.redis_client.set_calls[0][0] == "adhd:profile:operator-local-001"


### PR DESCRIPTION
## Summary
- seed a default ADHDProfile for the stable operator identity during active engine profile loading
- persist only newly missing operator profiles under the existing adhd:profile:<user_id> Redis key contract
- preserve existing Redis profiles and avoid workspace/path-derived user ids

## Validation
- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- python -m pytest tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py
- python -m py_compile services/adhd_engine/core/engine.py
- git diff --check
- python -m pre_commit run --files services/adhd_engine/core/engine.py tests/unit/test_adhd_operator_profile_seed.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001-implementation-notes.md

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated