### PR TITLE
feat(adhd): close activity signal loop

### DIFF
--- a/services/adhd_engine/api/routes.py
+++ b/services/adhd_engine/api/routes.py
@@ -61,17 +61,10 @@ from ..operator_identity import resolve_operator_user_id
 
 # Event emission for implicit triggers (Phase 7)
 try:
-    from event_emitter import emit_claude_prompt, emit_claude_tool, emit_context_saved
+    from ..event_emitter import ADHDEventEmitter, emit_claude_prompt, emit_claude_tool, emit_context_saved
     EVENT_EMISSION_AVAILABLE = True
 except ImportError:
-    EVENT_EMISSION_AVAILABLE = False
-    logger.debug("Event emission not available - hooks won't trigger EventBus")
-
-# Event emission for implicit triggers (Phase 7)
-try:
-    from event_emitter import emit_claude_prompt, emit_claude_tool, emit_context_saved
-    EVENT_EMISSION_AVAILABLE = True
-except ImportError:
+    ADHDEventEmitter = None
     EVENT_EMISSION_AVAILABLE = False
     logger.debug("Event emission not available - hooks won't trigger EventBus")
 
@@ -637,19 +630,14 @@ async def update_activity(
     """
     try:
         cache = await get_cache_instance()
-        # Check cache first (though POST, cache recent activity summary)
         cache_key = _make_cache_key("activity", user_id)
-        cached_data = await cache.get(cache_key)
 
-        if cached_data:
-            logger.debug(f"Cache hit for activity update: {user_id}")
-            return schemas.ActivityUpdateResponse.model_validate_json(cached_data)
-
-        # Cache miss - record current event and append to rolling activity history.
+        # Record current event and append to rolling activity history.
+        activity_metrics = request.model_dump(exclude_none=True, exclude={"user_id"})
         activity_event = {
             "user_id": user_id,
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "metrics": request.model_dump(exclude_none=True),
+            "metrics": activity_metrics,
         }
         latest_key = f"adhd:activity:{user_id}:latest"
         history_key = f"adhd:activity:{user_id}:history"
@@ -665,14 +653,23 @@ async def update_activity(
         history = history[-200:]  # keep recent bounded history
         await cache.set(history_key, json.dumps(history), ttl=86400)
 
-        # Trigger reassessment if engine has this user
-        energy_updated = False
-        attention_updated = False
+        update_result = await engine.record_activity_update(user_id, activity_metrics)
+        energy_updated = bool(update_result.get("energy_updated"))
+        attention_updated = bool(update_result.get("attention_updated"))
 
-        if user_id in engine.user_profiles:
-            # Would trigger immediate assessment here
-            energy_updated = True
-            attention_updated = True
+        if EVENT_EMISSION_AVAILABLE and ADHDEventEmitter is not None:
+            try:
+                emitter = await ADHDEventEmitter.get_instance()
+                await emitter.emit(
+                    "activity_updated",
+                    {
+                        "user_id": user_id,
+                        "metrics": activity_metrics,
+                    },
+                    source="adhd_activity_api",
+                )
+            except Exception as e:
+                logger.warning(brand_log(f"Activity event emission failed: {e}", chip=StatusChip.BLOCKER))
 
         # Get ML prediction if available (predict activity impact)
         ml_prediction = None

--- a/services/adhd_engine/core/engine.py
+++ b/services/adhd_engine/core/engine.py
@@ -138,6 +138,7 @@ class ADHDAccommodationEngine:
         self.user_profiles: Dict[str, ADHDProfile] = {}
         self.current_energy_levels: Dict[str, EnergyLevel] = {}
         self.current_attention_states: Dict[str, AttentionState] = {}
+        self.recent_activity_updates: Dict[str, Dict[str, Any]] = {}
         self.active_accommodations: Dict[str, List[AccommodationRecommendation]] = {}
 
         # Cognitive load monitoring
@@ -357,7 +358,8 @@ class ADHDAccommodationEngine:
             hyperfocus_guard=self.hyperfocus_guard,
             overwhelm_detector=self.overwhelm_detector,
             procrastination_detector=self.procrastination_detector,
-            activity_tracker=self.activity_tracker
+            activity_tracker=self.activity_tracker,
+            adhd_engine=self,
         )
 
     async def _start_event_listener(self) -> None:
@@ -466,6 +468,50 @@ class ADHDAccommodationEngine:
         except Exception as e:
             logger.error(f"Task suitability assessment failed: {e}")
             return {"error": str(e)}
+
+    async def record_activity_update(
+        self,
+        user_id: str,
+        activity_data: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Record a bounded activity signal and refresh current ADHD state."""
+        metrics = self._sanitize_activity_metrics(activity_data)
+        self.recent_activity_updates[user_id] = metrics
+
+        if user_id not in self.user_profiles:
+            self.user_profiles[user_id] = ADHDProfile(user_id=user_id)
+
+        energy_level = await self._assess_current_energy_level(user_id)
+        attention_state = await self._assess_attention_state(user_id)
+
+        self.current_energy_levels[user_id] = energy_level
+        self.current_attention_states[user_id] = attention_state
+
+        return {
+            "energy_level": energy_level,
+            "attention_state": attention_state,
+            "energy_updated": True,
+            "attention_updated": True,
+        }
+
+    @staticmethod
+    def _sanitize_activity_metrics(activity_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Keep only content-free numeric/status activity fields."""
+        allowed_fields = {
+            "completion_rate",
+            "context_switches",
+            "break_compliance",
+            "minutes_since_break",
+            "hook_event_name",
+            "status",
+            "tool_name",
+            "source_event",
+        }
+        return {
+            key: value
+            for key, value in activity_data.items()
+            if key in allowed_fields and value is not None
+        }
 
     def _calculate_task_cognitive_load(
         self,
@@ -1333,6 +1379,8 @@ Format: {{
         Queries real data via ActivityTracker for accurate ADHD assessments.
         """
         try:
+            if user_id in self.recent_activity_updates:
+                return self.recent_activity_updates[user_id]
             if self.activity_tracker:
                 return await self.activity_tracker.get_recent_activity(user_id)
             else:
@@ -1360,6 +1408,14 @@ Format: {{
         Analyzes real activity log data for accurate attention state detection.
         """
         try:
+            if user_id in self.recent_activity_updates:
+                activity = self.recent_activity_updates[user_id]
+                return {
+                    "context_switches_per_hour": activity.get("context_switches", 0),
+                    "abandoned_tasks": 0,
+                    "average_focus_duration": 25,
+                    "distraction_events": 0,
+                }
             if self.activity_tracker:
                 return await self.activity_tracker.get_attention_indicators(user_id)
             else:

--- a/services/adhd_engine/event_listener.py
+++ b/services/adhd_engine/event_listener.py
@@ -59,6 +59,7 @@ class ADHDEventListener:
         working_memory_support=None,
         context_preserver=None,
         activity_tracker=None,
+        adhd_engine=None,
         output_channels: Optional[List] = None
     ):
         """
@@ -72,9 +73,11 @@ class ADHDEventListener:
             working_memory_support: WorkingMemorySupport instance
             context_preserver: ContextPreserver instance
             activity_tracker: ActivityTracker instance
+            adhd_engine: ADHDAccommodationEngine instance for state refreshes
             output_channels: List of output channel handlers
         """
         self.event_bus = event_bus
+        self.adhd_engine = adhd_engine
         self.hyperfocus_guard = hyperfocus_guard
         self.overwhelm_detector = overwhelm_detector
         self.procrastination_detector = procrastination_detector
@@ -100,6 +103,8 @@ class ADHDEventListener:
             "file_saved": self._on_file_activity,
             "file_closed": self._on_file_activity,
             "file_activity": self._on_file_activity,
+            "activity_updated": self._on_activity_updated,
+            "native_hook_activity": self._on_native_hook_activity,
             "window_switched": self._on_window_switch,
             "app_focused": self._on_app_focus,
             "idle_detected": self._on_idle,
@@ -128,6 +133,7 @@ class ADHDEventListener:
             # Claude Code events
             "claude_prompt_received": self._on_claude_prompt,
             "claude_tool_started": self._on_claude_tool,
+            "claude_tool_completed": self._on_claude_tool,
             "claude_session_stopped": self._on_claude_stop,
         }
     
@@ -180,6 +186,50 @@ class ADHDEventListener:
     # ─────────────────────────────────────────────────────────────
     # Activity Event Handlers
     # ─────────────────────────────────────────────────────────────
+
+    async def _record_activity_signal(
+        self,
+        data: Dict[str, Any],
+        *,
+        source_event: str,
+    ) -> None:
+        """Refresh engine state from a content-free activity signal."""
+        if not self.adhd_engine or not hasattr(self.adhd_engine, "record_activity_update"):
+            return
+
+        user_id = data.get("user_id") or self._current_user_id
+        if not user_id:
+            return
+
+        allowed_fields = {
+            "completion_rate",
+            "context_switches",
+            "break_compliance",
+            "minutes_since_break",
+            "hook_event_name",
+            "status",
+            "tool_name",
+        }
+        activity_data = {
+            key: value
+            for key, value in data.items()
+            if key in allowed_fields and value is not None
+        }
+        activity_data["source_event"] = source_event
+        await self.adhd_engine.record_activity_update(user_id, activity_data)
+
+    async def _on_activity_updated(self, data: Dict[str, Any]):
+        """Handle activity updates emitted by the local /activity endpoint."""
+        metrics = data.get("metrics") if isinstance(data.get("metrics"), dict) else {}
+        activity_data = {
+            "user_id": data.get("user_id"),
+            **metrics,
+        }
+        await self._record_activity_signal(activity_data, source_event="activity_updated")
+
+    async def _on_native_hook_activity(self, data: Dict[str, Any]):
+        """Handle content-free native hook activity emitted by Dopemux hooks."""
+        await self._record_activity_signal(data, source_event="native_hook_activity")
     
     async def _on_file_activity(self, data: Dict[str, Any]):
         """Handle file activity events."""
@@ -528,5 +578,6 @@ def create_adhd_event_listener(
         working_memory_support=getattr(engine, 'working_memory_support', None),
         context_preserver=getattr(engine, 'context_preserver', None),
         activity_tracker=getattr(engine, 'activity_tracker', None),
+        adhd_engine=engine,
         output_channels=output_channels or [],
     )

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001-implementation-notes.md
@@ -1,0 +1,60 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T4 03B Activity Loop 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: Tp Dmx Adhd Cognitive T4 03B Activity Loop 001 Implementation Notes (explanation)
+  for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T4-03B Activity Loop Implementation Notes
+
+## Authority
+
+- Active Task Packet: `TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001`
+- Parent dependency: `TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001`
+- Runtime authority: `services/adhd_engine/core/engine.py`
+- Listener authority: `services/adhd_engine/event_listener.py`
+- `/activity` route authority: `services/adhd_engine/api/routes.py`
+
+## Change
+
+- Added `ADHDAccommodationEngine.record_activity_update()` to sanitize bounded activity metrics, refresh energy and attention assessments, and write `current_energy_levels` and `current_attention_states`.
+- Made immediate activity updates take precedence over `ActivityTracker` reads during reassessment.
+- Injected the active engine into `ADHDEventListener`.
+- Added listener handling for `native_hook_activity` and `activity_updated` events.
+- Changed `/activity` to process every update, write current state, and best-effort emit a content-free `activity_updated` event.
+- Removed the stale early cache-hit return from `/activity` so state-changing calls are not skipped.
+
+## TDD Evidence
+
+- RED: `python -m pytest tests/unit/test_adhd_activity_loop.py`
+  - Exit 1 before implementation.
+  - Missing `record_activity_update`, missing listener `adhd_engine` injection, and missing route `ADHDEventEmitter` import.
+- RED: `python -m pytest tests/unit/test_adhd_activity_loop.py`
+  - Exit 1 after adding immediate-update precedence regression.
+  - `_get_recent_activity()` returned stale `ActivityTracker` data instead of the just-recorded update.
+- RED: `python -m pytest tests/unit/test_adhd_activity_loop.py`
+  - Exit 1 after adding cache-bypass regression.
+  - `/activity` returned a cached response and skipped the update path.
+- GREEN: `python -m pytest tests/unit/test_adhd_activity_loop.py`
+  - Exit 0 after implementation.
+  - `5 passed in 1.65s`.
+
+## Validation
+
+- PASS: `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- PASS: `python -m pytest tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py`
+  - `20 passed in 1.48s`.
+- PASS: `python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py services/adhd_engine/api/routes.py`
+- PASS: `git diff --check`
+- PASS: `python -m pre_commit run --files services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py services/adhd_engine/api/routes.py tests/unit/test_adhd_activity_loop.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001-implementation-notes.md`
+
+## Residual Risk
+
+- Live Redis stream consumption was not exercised in this slice.
+- Native hook producer code lives in the parallel T4-02a branch; full producer-to-consumer validation remains pending until dependency branches are merged together.
+- The attention indicator mapping from activity metrics is intentionally minimal; richer weak-signal fusion remains the next T4 item.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json
@@ -1,0 +1,152 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001",
+  "project": "dopemux-mvp",
+  "target": "ADHD Engine listener and /activity endpoint close the activity signal loop into current state",
+  "invariants": [
+    "The active FastAPI runtime imports services.adhd_engine.core.engine; the legacy services/adhd_engine/engine.py sibling is not the authority for this slice.",
+    "Activity loop updates must remain content-free and must not persist prompts, paths, usernames, hostnames, file contents, code contents, or raw tool arguments.",
+    "Listener activity handling must call an engine assessment/update path and write current_energy_levels and current_attention_states for the active operator.",
+    "/activity must perform a real engine state update and emit a bounded activity event instead of only returning stub booleans.",
+    "Native hook producer code remains in TP-DMX-ADHD-COGNITIVE-T4-02A; this slice consumes the native_hook_activity event type but does not modify native hook files.",
+    "ADHD Engine remains cognitive-only under AGENTS.md section 6."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T4-00-OPERATOR-IDENTITY-001",
+    "TP-DMX-ADHD-COGNITIVE-T4-02A-NATIVE-HOOKS-EVENTS-001",
+    "TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-profile-seed-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-activity-loop-001",
+    "base_branch": "codex/adhd-profile-seed-001",
+    "stacked_because": "Activity loop closure depends on the stable operator identity and startup operator profile seed; native hook producer changes are a parallel dependency with no shared files."
+  },
+  "commit": {
+    "message": "feat(adhd): close activity signal loop",
+    "allowlist": [
+      "services/adhd_engine/core/engine.py",
+      "services/adhd_engine/event_listener.py",
+      "services/adhd_engine/api/routes.py",
+      "tests/unit/test_adhd_activity_loop.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py",
+      "python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py services/adhd_engine/api/routes.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(adhd): close activity signal loop",
+    "body": "## Summary\n- add a bounded engine activity update path that writes current energy and attention state\n- have the listener consume content-free native_hook_activity and activity_updated events through that path\n- make /activity update engine state and emit a content-free activity_updated event instead of only returning stub booleans\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py\n- python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py services/adhd_engine/api/routes.py\n- git diff --check",
+    "base": "codex/adhd-profile-seed-001"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect active listener dispatch, native hook event shape, /activity route behavior, engine assessment writers, and profile seed dependency before editing.",
+      "requirements": [
+        "Distinguish active services.adhd_engine.core.engine runtime from legacy services/adhd_engine/engine.py.",
+        "Confirm native_hook_activity payload remains content-free.",
+        "Do not modify native hook producer files in this slice.",
+        "Do not replace the real assessment algorithms; only wire activity signals into the existing assessment/update path."
+      ],
+      "commands": [
+        "rg -n \"native_hook_activity|_dispatch|_on_activity|update_activity|_assess_current_energy_level|_assess_attention_state|current_energy_levels|current_attention_states\" services/adhd_engine src tests -g '*.py'",
+        "sed -n '1,620p' services/adhd_engine/event_listener.py",
+        "sed -n '620,720p' services/adhd_engine/api/routes.py",
+        "sed -n '880,1050p' services/adhd_engine/core/engine.py"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Runtime authority and activity loop change points are identified before tests or production edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-03A-OPERATOR-PROFILE-SEED-001.json",
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/event_listener.py",
+        "services/adhd_engine/api/routes.py",
+        "services/adhd_engine/event_emitter.py",
+        "src/dopemux/claude/native_hooks.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add tests then wire content-free activity events and /activity updates into a shared engine state update path.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "Listener must handle native_hook_activity and activity_updated events.",
+        "Listener must use the current listener user id unless an explicit event user_id is present.",
+        "Engine update path must write current_energy_levels and current_attention_states from assessment results.",
+        "/activity must update engine state and best-effort emit activity_updated without exposing raw content.",
+        "Do not persist prompts, paths, file names, raw code, or raw tool arguments in emitted event data."
+      ],
+      "commands": [
+        "apply_patch"
+      ],
+      "expected_files": [
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/event_listener.py",
+        "services/adhd_engine/api/routes.py",
+        "tests/unit/test_adhd_activity_loop.py"
+      ],
+      "validation": [
+        "Targeted activity-loop tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, targeted tests, syntax, diff scope, and precommit checks for the bounded T4-03b slice.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim full native hook to engine integration until both producer and consumer branches are merged together and exercised."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py",
+        "python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py services/adhd_engine/api/routes.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/unit/test_adhd_activity_loop.py
+++ b/tests/unit/test_adhd_activity_loop.py
@@ -1,0 +1,241 @@
+from types import SimpleNamespace
+
+import pytest
+
+
+class FakeCache:
+    def __init__(self):
+        self.values = {}
+
+    async def get(self, key, default=None):
+        return self.values.get(key, default)
+
+    async def set(self, key, value, ttl=None):
+        self.values[key] = value
+        return True
+
+
+@pytest.mark.asyncio
+async def test_engine_activity_update_writes_current_state(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+    from services.adhd_engine.core.models import AttentionState, EnergyLevel
+
+    async def fake_energy(self, user_id):
+        assert user_id == "operator-local-001"
+        return EnergyLevel.LOW
+
+    async def fake_attention(self, user_id):
+        assert user_id == "operator-local-001"
+        return AttentionState.SCATTERED
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: "operator-local-001")
+    monkeypatch.setattr(engine_module.ADHDAccommodationEngine, "_assess_current_energy_level", fake_energy)
+    monkeypatch.setattr(engine_module.ADHDAccommodationEngine, "_assess_attention_state", fake_attention)
+
+    engine = engine_module.ADHDAccommodationEngine()
+
+    result = await engine.record_activity_update(
+        "operator-local-001",
+        {"completion_rate": 0.25, "context_switches": 12, "prompt": "must not be retained"},
+    )
+
+    assert result["energy_level"] == EnergyLevel.LOW
+    assert result["attention_state"] == AttentionState.SCATTERED
+    assert result["energy_updated"] is True
+    assert result["attention_updated"] is True
+    assert engine.current_energy_levels["operator-local-001"] == EnergyLevel.LOW
+    assert engine.current_attention_states["operator-local-001"] == AttentionState.SCATTERED
+    assert "prompt" not in engine.recent_activity_updates["operator-local-001"]
+
+
+@pytest.mark.asyncio
+async def test_recent_activity_update_takes_precedence_for_immediate_assessment(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+
+    class StaleActivityTracker:
+        async def get_recent_activity(self, user_id):
+            return {"completion_rate": 1.0, "context_switches": 0}
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: "operator-local-001")
+    engine = engine_module.ADHDAccommodationEngine()
+    engine.activity_tracker = StaleActivityTracker()
+    engine.recent_activity_updates["operator-local-001"] = {
+        "completion_rate": 0.2,
+        "context_switches": 14,
+    }
+
+    assert await engine._get_recent_activity("operator-local-001") == {
+        "completion_rate": 0.2,
+        "context_switches": 14,
+    }
+
+
+@pytest.mark.asyncio
+async def test_listener_native_hook_activity_updates_engine_state():
+    from services.adhd_engine.core.models import AttentionState, EnergyLevel
+    from services.adhd_engine.event_listener import ADHDEventListener
+
+    calls = []
+
+    class FakeEngine:
+        def __init__(self):
+            self.current_energy_levels = {}
+            self.current_attention_states = {}
+
+        async def record_activity_update(self, user_id, activity_data):
+            calls.append((user_id, activity_data))
+            self.current_energy_levels[user_id] = EnergyLevel.MEDIUM
+            self.current_attention_states[user_id] = AttentionState.FOCUSED
+            return {
+                "energy_level": EnergyLevel.MEDIUM,
+                "attention_state": AttentionState.FOCUSED,
+                "energy_updated": True,
+                "attention_updated": True,
+            }
+
+    engine = FakeEngine()
+    listener = ADHDEventListener(event_bus=None, adhd_engine=engine)
+    listener._current_user_id = "operator-local-001"
+
+    event = SimpleNamespace(
+        type="native_hook_activity",
+        data={
+            "hook_event_name": "PostToolUse",
+            "status": "success",
+            "tool_name": "Edit",
+            "prompt": "must not be forwarded",
+        },
+    )
+
+    await listener._dispatch(event)
+
+    assert calls == [
+        (
+            "operator-local-001",
+            {
+                "hook_event_name": "PostToolUse",
+                "status": "success",
+                "tool_name": "Edit",
+                "source_event": "native_hook_activity",
+            },
+        )
+    ]
+    assert engine.current_energy_levels["operator-local-001"] == EnergyLevel.MEDIUM
+    assert engine.current_attention_states["operator-local-001"] == AttentionState.FOCUSED
+
+
+@pytest.mark.asyncio
+async def test_activity_route_updates_engine_and_emits_bounded_event(monkeypatch):
+    from services.adhd_engine.api import routes
+    from services.adhd_engine.api.schemas import ActivityUpdateRequest
+    from services.adhd_engine.core.models import AttentionState, EnergyLevel
+
+    emitted = []
+
+    class FakeEmitter:
+        @classmethod
+        async def get_instance(cls):
+            return cls()
+
+        async def emit(self, event_type, data, source):
+            emitted.append((event_type, data, source))
+            return True
+
+    class FakeEngine:
+        def __init__(self):
+            self.user_profiles = {"operator-local-001": object()}
+            self.current_energy_levels = {}
+            self.current_attention_states = {}
+            self.predictive_engine = None
+
+        async def record_activity_update(self, user_id, activity_data):
+            self.current_energy_levels[user_id] = EnergyLevel.HIGH
+            self.current_attention_states[user_id] = AttentionState.FOCUSED
+            return {
+                "energy_level": EnergyLevel.HIGH,
+                "attention_state": AttentionState.FOCUSED,
+                "energy_updated": True,
+                "attention_updated": True,
+            }
+
+    cache = FakeCache()
+
+    async def fake_cache_instance():
+        return cache
+
+    monkeypatch.setattr(routes, "get_cache_instance", fake_cache_instance)
+    monkeypatch.setattr(routes, "EVENT_EMISSION_AVAILABLE", True)
+    monkeypatch.setattr(routes, "ADHDEventEmitter", FakeEmitter)
+
+    response = await routes.update_activity(
+        user_id="operator-local-001",
+        request=ActivityUpdateRequest(
+            user_id="operator-local-001",
+            completion_rate=0.9,
+            context_switches=2,
+            minutes_since_break=12,
+        ),
+        engine=FakeEngine(),
+    )
+
+    assert response.recorded is True
+    assert response.energy_updated is True
+    assert response.attention_updated is True
+    assert emitted == [
+        (
+            "activity_updated",
+            {
+                "user_id": "operator-local-001",
+                "metrics": {
+                    "completion_rate": 0.9,
+                    "context_switches": 2,
+                    "minutes_since_break": 12,
+                },
+            },
+            "adhd_activity_api",
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_activity_route_processes_update_even_when_response_cache_exists(monkeypatch):
+    from services.adhd_engine.api import routes
+    from services.adhd_engine.api.schemas import ActivityUpdateRequest
+
+    calls = []
+
+    class FakeEngine:
+        user_profiles = {"operator-local-001": object()}
+        current_energy_levels = {}
+        current_attention_states = {}
+        predictive_engine = None
+
+        async def record_activity_update(self, user_id, activity_data):
+            calls.append((user_id, activity_data))
+            return {
+                "energy_updated": True,
+                "attention_updated": True,
+            }
+
+    cache = FakeCache()
+    cache.values[routes._make_cache_key("activity", "operator-local-001")] = (
+        '{"recorded":true,"energy_updated":false,"attention_updated":false,"message":"cached"}'
+    )
+
+    async def fake_cache_instance():
+        return cache
+
+    monkeypatch.setattr(routes, "get_cache_instance", fake_cache_instance)
+    monkeypatch.setattr(routes, "EVENT_EMISSION_AVAILABLE", False)
+
+    response = await routes.update_activity(
+        user_id="operator-local-001",
+        request=ActivityUpdateRequest(
+            user_id="operator-local-001",
+            completion_rate=0.4,
+        ),
+        engine=FakeEngine(),
+    )
+
+    assert response.energy_updated is True
+    assert calls == [("operator-local-001", {"completion_rate": 0.4})]


### PR DESCRIPTION
## Summary
- add a bounded engine activity update path that writes current energy and attention state
- have the listener consume content-free native_hook_activity and activity_updated events through that path
- make /activity update engine state and emit a content-free activity_updated event instead of returning stub booleans
- remove the stale early cache-hit return from /activity so state-changing calls are always processed

## Validation
- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- python -m pytest tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py
- python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py services/adhd_engine/api/routes.py
- git diff --check
- python -m pre_commit run --files services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py services/adhd_engine/api/routes.py tests/unit/test_adhd_activity_loop.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001-implementation-notes.md

## Residual risk
- live Redis stream consumption was not exercised
- native hook producer branch must land with this consumer before full producer-to-consumer validation is claimed

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated