### PR TITLE
feat(adhd): fuse real activity into assessment

### DIFF
--- a/services/adhd_engine/core/activity_tracker.py
+++ b/services/adhd_engine/core/activity_tracker.py
@@ -115,12 +115,14 @@ class ActivityTracker:
         # Calculate break compliance from Redis break history
         break_history = await self.redis.lrange(f"adhd:breaks:{user_id}", 0, 10)
         break_compliance = self._calculate_break_compliance(break_history)
+        activity_evidence = bool(progress_entries or activity_log or last_break_str or break_history)
 
         result = {
             "completion_rate": completion_rate,
             "context_switches": context_switches,
             "break_compliance": break_compliance,
             "minutes_since_break": minutes_since_break,
+            "activity_evidence": activity_evidence,
             "familiarity_score": round(min(1.0, (completion_rate * 0.7) + 0.3), 2),
             "complexity_avg_30min": self._calculate_average_complexity(progress_entries),
         }

--- a/services/adhd_engine/core/engine.py
+++ b/services/adhd_engine/core/engine.py
@@ -139,6 +139,7 @@ class ADHDAccommodationEngine:
         self.current_energy_levels: Dict[str, EnergyLevel] = {}
         self.current_attention_states: Dict[str, AttentionState] = {}
         self.recent_activity_updates: Dict[str, Dict[str, Any]] = {}
+        self.recent_activity_samples: Dict[str, List[Dict[str, Any]]] = {}
         self.active_accommodations: Dict[str, List[AccommodationRecommendation]] = {}
 
         # Cognitive load monitoring
@@ -476,6 +477,9 @@ class ADHDAccommodationEngine:
     ) -> Dict[str, Any]:
         """Record a bounded activity signal and refresh current ADHD state."""
         metrics = self._sanitize_activity_metrics(activity_data)
+        if self._is_hook_activity(metrics):
+            self._append_activity_sample(user_id, metrics)
+            metrics = self._derive_hook_activity_metrics(user_id)
         self.recent_activity_updates[user_id] = metrics
 
         if user_id not in self.user_profiles:
@@ -511,6 +515,45 @@ class ADHDAccommodationEngine:
             key: value
             for key, value in activity_data.items()
             if key in allowed_fields and value is not None
+        }
+
+    @staticmethod
+    def _is_hook_activity(activity_data: Dict[str, Any]) -> bool:
+        return any(key in activity_data for key in ("hook_event_name", "status", "tool_name"))
+
+    def _append_activity_sample(self, user_id: str, activity_data: Dict[str, Any]) -> None:
+        samples = self.recent_activity_samples.setdefault(user_id, [])
+        samples.append(dict(activity_data))
+        self.recent_activity_samples[user_id] = samples[-50:]
+
+    def _derive_hook_activity_metrics(self, user_id: str) -> Dict[str, Any]:
+        """Derive bounded activity metrics from content-free hook events."""
+        samples = self.recent_activity_samples.get(user_id, [])
+        failures = sum(
+            1
+            for sample in samples
+            if sample.get("status") == "failure"
+            or sample.get("hook_event_name") == "PostToolUseFailure"
+        )
+        successes = sum(1 for sample in samples if sample.get("status") == "success")
+        attempts = sum(1 for sample in samples if sample.get("status") == "attempt")
+        prompt_events = sum(1 for sample in samples if sample.get("hook_event_name") == "UserPromptSubmit")
+        tool_events = sum(1 for sample in samples if sample.get("tool_name"))
+
+        outcome_count = successes + failures
+        completion_rate = successes / outcome_count if outcome_count else 0.5
+
+        return {
+            "completion_rate": completion_rate,
+            "context_switches": prompt_events,
+            "break_compliance": max(0.0, 1.0 - (failures * 0.2)),
+            "minutes_since_break": min(120, 30 + failures * 10 + attempts * 2),
+            "tool_failures": failures,
+            "tool_successes": successes,
+            "tool_attempts": attempts,
+            "tool_events": tool_events,
+            "prompt_events": prompt_events,
+            "activity_evidence": bool(samples),
         }
 
     def _calculate_task_cognitive_load(
@@ -1410,12 +1453,7 @@ Format: {{
         try:
             if user_id in self.recent_activity_updates:
                 activity = self.recent_activity_updates[user_id]
-                return {
-                    "context_switches_per_hour": activity.get("context_switches", 0),
-                    "abandoned_tasks": 0,
-                    "average_focus_duration": 25,
-                    "distraction_events": 0,
-                }
+                return self._attention_indicators_from_activity(activity)
             if self.activity_tracker:
                 return await self.activity_tracker.get_attention_indicators(user_id)
             else:
@@ -1434,6 +1472,28 @@ Format: {{
                 "average_focus_duration": 25,
                 "distraction_events": 2
             }
+
+    @staticmethod
+    def _attention_indicators_from_activity(activity: Dict[str, Any]) -> Dict[str, Any]:
+        """Map bounded activity metrics into attention indicators."""
+        context_switches = int(activity.get("context_switches", 0) or 0)
+        prompt_events = int(activity.get("prompt_events", 0) or 0)
+        tool_failures = int(activity.get("tool_failures", 0) or 0)
+        context_switches_per_hour = max(context_switches, prompt_events)
+
+        if context_switches_per_hour >= 10:
+            average_focus_duration = 8
+        elif context_switches_per_hour >= 6:
+            average_focus_duration = 12
+        else:
+            average_focus_duration = max(10, 25 - tool_failures * 3)
+
+        return {
+            "context_switches_per_hour": context_switches_per_hour,
+            "abandoned_tasks": tool_failures,
+            "average_focus_duration": average_focus_duration,
+            "distraction_events": (tool_failures * 3) + max(0, context_switches_per_hour - 15),
+        }
 
     async def _calculate_system_cognitive_load(self) -> float:
         """

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001-implementation-notes.md
@@ -1,0 +1,54 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T4 04 Real Assessment 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: Tp Dmx Adhd Cognitive T4 04 Real Assessment 001 Implementation Notes
+  (explanation) for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T4-04 Real Assessment Implementation Notes
+
+## Authority
+
+- Active Task Packet: `TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001`
+- Parent dependency: `TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001`
+- Runtime authority: `services/adhd_engine/core/engine.py`
+- Activity evidence authority: `services/adhd_engine/core/activity_tracker.py`
+- Existing activity-loop tests: `tests/unit/test_adhd_activity_loop.py`
+
+## Change
+
+- Added bounded recent hook activity samples in `ADHDAccommodationEngine` and derived content-free aggregate metrics from those samples.
+- Made recent activity metrics drive attention indicators instead of returning fixed focused defaults.
+- Kept raw prompt content out of `recent_activity_updates`; only allowlisted numeric/string counters survive sanitization.
+- Added `activity_evidence` to `ActivityTracker.get_recent_activity()` so downstream assessment can distinguish observed activity from fallback/default data.
+- Added focused regression coverage for high context switching, repeated hook failures, and ActivityTracker evidence flags.
+
+## TDD Evidence
+
+- RED: `python -m pytest tests/unit/test_adhd_real_assessment.py`
+  - Exit 1 before implementation.
+  - High context-switch activity returned `AttentionState.FOCUSED` instead of `SCATTERED`.
+  - Repeated hook failures left energy at `EnergyLevel.MEDIUM`.
+  - `ActivityTracker.get_recent_activity()` did not expose `activity_evidence`.
+- GREEN: `python -m pytest tests/unit/test_adhd_real_assessment.py`
+  - Exit 0 after implementation.
+  - `4 passed in 1.45s`.
+
+## Validation
+
+- PASS: `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- PASS: `python -m pytest tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py`
+  - `37 passed in 0.27s`.
+- PASS: `python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/core/activity_tracker.py`
+- PASS: `git diff --check`
+
+## Residual Risk
+
+- Live Redis and live event-stream ingestion were not exercised in this slice.
+- The weak-signal scoring remains intentionally conservative and bounded; richer privacy-schema hardening remains the separate section 6 guard item.
+- This branch is intentionally stacked on `codex/adhd-activity-loop-001`.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json
@@ -1,0 +1,145 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001",
+  "project": "dopemux-mvp",
+  "target": "ADHD Engine assessment uses real activity and weak signals instead of neutral defaults",
+  "invariants": [
+    "The active FastAPI runtime imports services.adhd_engine.core.engine; the legacy services/adhd_engine/engine.py sibling is not the authority for this slice.",
+    "Assessment fusion must remain content-free and must not persist prompts, paths, usernames, hostnames, file contents, code contents, or raw tool arguments.",
+    "Recent activity updates from T4-03B must drive energy and attention state before fallback defaults are used.",
+    "Content-free native hook signals must influence attention and energy through bounded aggregate counters, not raw content.",
+    "ActivityTracker must distinguish observed activity evidence from fallback/default data.",
+    "ADHD Engine remains cognitive-only under AGENTS.md section 6."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-activity-loop-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-real-assessment-001",
+    "base_branch": "codex/adhd-activity-loop-001",
+    "stacked_because": "Real assessment fusion depends on the activity-loop state update path introduced by T4-03B."
+  },
+  "commit": {
+    "message": "feat(adhd): fuse real activity into assessment",
+    "allowlist": [
+      "services/adhd_engine/core/engine.py",
+      "services/adhd_engine/core/activity_tracker.py",
+      "tests/unit/test_adhd_real_assessment.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py",
+      "python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/core/activity_tracker.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(adhd): fuse real activity into assessment",
+    "body": "## Summary\n- derive bounded weak-signal metrics from recent activity updates before falling back to neutral defaults\n- make high context switching and hook failures affect attention state instead of returning focused by default\n- mark ActivityTracker results with whether observed activity evidence existed\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py\n- python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/core/activity_tracker.py\n- git diff --check",
+    "base": "codex/adhd-activity-loop-001"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect active energy assessment, attention assessment, recent activity update storage, and ActivityTracker fallback behavior before editing.",
+      "requirements": [
+        "Distinguish active services.adhd_engine.core.engine runtime from legacy services/adhd_engine/engine.py.",
+        "Confirm existing tests around activity-loop state updates and ActivityTracker defaults.",
+        "Do not widen into privacy hardening endpoints; that is a separate T4 item."
+      ],
+      "commands": [
+        "rg -n \"_assess_current_energy_level|_assess_attention_state|_get_recent_activity|_get_attention_indicators|recent_activity_updates|completion_rate|context_switches\" tests services/adhd_engine -g '*.py'",
+        "nl -ba services/adhd_engine/core/engine.py | sed -n '930,1090p;1370,1435p'",
+        "nl -ba services/adhd_engine/core/activity_tracker.py | sed -n '65,225p'",
+        "sed -n '1,280p' tests/unit/test_adhd_activity_loop.py"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Runtime authority and fallback/default behavior are identified before tests or production edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json",
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/core/activity_tracker.py",
+        "tests/unit/test_adhd_activity_loop.py",
+        "services/adhd_engine/tests/test_activity_tracker.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add failing tests then make recent numeric activity and hook weak signals drive energy and attention state before fallback defaults.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "High context switching from recent activity must produce scattered/overwhelmed attention, not focused-by-default.",
+        "Repeated hook failures must reduce energy and increase distraction indicators without storing raw content.",
+        "ActivityTracker results must expose whether activity evidence existed.",
+        "Keep the weak-signal window bounded and deterministic."
+      ],
+      "commands": [
+        "apply_patch"
+      ],
+      "expected_files": [
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/core/activity_tracker.py",
+        "tests/unit/test_adhd_real_assessment.py"
+      ],
+      "validation": [
+        "Targeted real-assessment tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, targeted tests, syntax, diff scope, and precommit checks for the bounded T4-04 slice.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim full privacy schema hardening; that remains the separate §6 guard item."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py",
+        "python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/core/activity_tracker.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/unit/test_adhd_real_assessment.py
+++ b/tests/unit/test_adhd_real_assessment.py
@@ -1,0 +1,101 @@
+import pytest
+
+
+class FakeRedis:
+    async def get(self, key):
+        return None
+
+    async def lrange(self, key, start, end):
+        return []
+
+
+class FakeConPort:
+    def __init__(self, progress_entries=None, activity_log=None):
+        self.progress_entries = list(progress_entries or [])
+        self.activity_log = activity_log
+
+    def get_progress_entries(self, **kwargs):
+        return self.progress_entries
+
+    def get_custom_data(self, **kwargs):
+        return self.activity_log
+
+
+@pytest.mark.asyncio
+async def test_high_context_switch_activity_drives_scattered_attention(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+    from services.adhd_engine.core.models import AttentionState, EnergyLevel
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: "operator-local-001")
+    engine = engine_module.ADHDAccommodationEngine()
+
+    result = await engine.record_activity_update(
+        "operator-local-001",
+        {
+            "completion_rate": 0.25,
+            "context_switches": 14,
+            "break_compliance": 0.4,
+            "minutes_since_break": 95,
+        },
+    )
+
+    assert result["energy_level"] in {EnergyLevel.LOW, EnergyLevel.VERY_LOW}
+    assert result["attention_state"] == AttentionState.SCATTERED
+    assert engine.current_attention_states["operator-local-001"] == AttentionState.SCATTERED
+
+
+@pytest.mark.asyncio
+async def test_repeated_native_hook_failures_drive_low_energy_and_overwhelmed_attention(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+    from services.adhd_engine.core.models import AttentionState, EnergyLevel
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: "operator-local-001")
+    engine = engine_module.ADHDAccommodationEngine()
+
+    for _ in range(4):
+        result = await engine.record_activity_update(
+            "operator-local-001",
+            {
+                "hook_event_name": "PostToolUseFailure",
+                "status": "failure",
+                "tool_name": "Edit",
+                "prompt": "must not be retained",
+            },
+        )
+
+    assert result["energy_level"] in {EnergyLevel.LOW, EnergyLevel.VERY_LOW}
+    assert result["attention_state"] == AttentionState.OVERWHELMED
+    assert "prompt" not in engine.recent_activity_updates["operator-local-001"]
+    assert engine.recent_activity_updates["operator-local-001"]["tool_failures"] == 4
+
+
+@pytest.mark.asyncio
+async def test_activity_tracker_marks_fallback_data_as_no_observed_evidence():
+    from services.adhd_engine.core.activity_tracker import ActivityTracker
+
+    tracker = ActivityTracker(redis_client=FakeRedis(), conport_db_path="/fake/path.db")
+    tracker.conport = FakeConPort(progress_entries=[], activity_log=None)
+
+    result = await tracker.get_recent_activity("operator-local-001")
+
+    assert result["activity_evidence"] is False
+
+
+@pytest.mark.asyncio
+async def test_activity_tracker_marks_real_activity_data_as_observed_evidence():
+    from services.adhd_engine.core.activity_tracker import ActivityTracker
+
+    tracker = ActivityTracker(redis_client=FakeRedis(), conport_db_path="/fake/path.db")
+    tracker.conport = FakeConPort(
+        progress_entries=[
+            {"status": "DONE"},
+            {"status": "IN_PROGRESS"},
+        ],
+        activity_log={"context_switches": 3},
+    )
+
+    result = await tracker.get_recent_activity("operator-local-001")
+
+    assert result["activity_evidence"] is True
+    assert result["completion_rate"] == 0.5
+    assert result["context_switches"] == 3


### PR DESCRIPTION
## Summary
- derive bounded weak-signal metrics from recent activity updates before falling back to neutral defaults
- make high context switching and hook failures affect attention state instead of returning focused by default
- mark ActivityTracker results with whether observed activity evidence existed

## Validation
- PASS: python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: python -m pytest tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py
- PASS: python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/core/activity_tracker.py
- PASS: git diff --check
- PASS: python -m pre_commit run --files services/adhd_engine/core/engine.py services/adhd_engine/core/activity_tracker.py tests/unit/test_adhd_real_assessment.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001-implementation-notes.md

## Residual risk
- Live Redis and live event-stream ingestion were not exercised in this slice.
- Privacy schema hardening remains the separate section 6 guard item.
- This PR is stacked on #777 / codex/adhd-activity-loop-001.

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated