### PR TITLE
fix(adhd): enforce content-free privacy guards

### DIFF
--- a/services/adhd_engine/api/routes.py
+++ b/services/adhd_engine/api/routes.py
@@ -1,8 +1,8 @@
 """
 FastAPI routes for ADHD Accommodation Engine.
 
-Provides 6 API endpoints (/api/v1/*) for ADHD-optimized task management:
-- POST /assess-task - Task suitability assessment
+Provides API endpoints (/api/v1/*) for ADHD cognitive state and accommodations:
+- POST /assess-task - Cognitive suitability assessment
 - GET /energy-level/{user_id} - Current energy level
 - GET /attention-state/{user_id} - Current attention state
 - POST /recommend-break - Personalized break recommendations
@@ -27,6 +27,25 @@ import importlib
 import asyncio
 
 logger = logging.getLogger(__name__)
+
+CONTENT_BEARING_HOOK_KEYS = {
+    "arg",
+    "args",
+    "argument",
+    "arguments",
+    "code",
+    "content",
+    "file",
+    "file_path",
+    "filename",
+    "files",
+    "path",
+    "paths",
+    "prompt",
+    "prompt_hint",
+    "prompt_summary",
+    "raw_args",
+}
 
 from services.shared.brand_voice import (
     StatusChip,
@@ -103,6 +122,46 @@ def _brand_error_payload(message: str, chip: StatusChip = StatusChip.BLOCKER) ->
         "error": brand_error(message, chip=chip),
         **_brand_meta(chip),
     }
+
+
+def _has_nonempty_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, (list, tuple, set, dict)):
+        return bool(value)
+    return True
+
+
+def _find_content_bearing_key(value: Any, *, path: str = "") -> str | None:
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            key_text = str(key)
+            key_path = f"{path}.{key_text}" if path else key_text
+            if key_text.lower() in CONTENT_BEARING_HOOK_KEYS and _has_nonempty_value(nested_value):
+                return key_path
+            nested_match = _find_content_bearing_key(nested_value, path=key_path)
+            if nested_match:
+                return nested_match
+    elif isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            nested_match = _find_content_bearing_key(item, path=f"{path}[{index}]")
+            if nested_match:
+                return nested_match
+    return None
+
+
+def _reject_content_bearing_hook_payload(payload: dict) -> None:
+    matched_key = _find_content_bearing_key(payload)
+    if matched_key:
+        raise HTTPException(
+            status_code=400,
+            detail=brand_error(
+                f"Content-bearing hook payload rejected at '{matched_key}'. "
+                "ADHD Engine accepts content-free signals only."
+            ),
+        )
 
 
 class _InMemoryCache:
@@ -842,22 +901,13 @@ async def get_tasks_for_user(
     engine = Depends(get_engine),
     api_key: str = Security(verify_api_key)
 ):
-    """Get aggregated task completion metrics for user."""
-    try:
-        completed = await engine.get_tasks_completed(user_id)
-        total = await engine.get_total_tasks(user_id)
-        rate = completed / total if total > 0 else 0.0
-
-        return {
-            "completed": completed,
-            "total": total,
-            "rate": round(rate, 2),
-            "user_id": user_id,
-            "timestamp": datetime.now(timezone.utc)
-        }
-    except Exception as e:
-        logger.error(brand_log(f"Tasks metrics retrieval failed: {e}"))
-        raise HTTPException(status_code=500, detail=brand_error(str(e)))
+    """Fail closed; ADHD Engine is not task/PM authority."""
+    raise HTTPException(
+        status_code=410,
+        detail=brand_error(
+            "ADHD Engine task metrics endpoint is disabled. Use canonical PM/task authority."
+        ),
+    )
 
 
 @router.get("/tasks", response_model=schemas.TasksResponse)
@@ -1550,7 +1600,7 @@ async def log_user_intent(
     - timestamp: ISO timestamp
     """
     try:
-        prompt_summary = request.get("prompt_summary", "")
+        _reject_content_bearing_hook_payload(request)
         signals = request.get("signals", {})
         adhd_state = request.get("adhd_state", {})
         timestamp = request.get("timestamp")
@@ -1562,7 +1612,6 @@ async def log_user_intent(
                     category="claude_intents",
                     key=f"intent_{timestamp}",
                     value={
-                        "prompt_hint": prompt_summary[:50],  # Even more truncated for privacy
                         "signals": signals,
                         "energy": adhd_state.get("energy"),
                         "attention": adhd_state.get("attention"),
@@ -1607,7 +1656,7 @@ async def log_user_intent(
         if EVENT_EMISSION_AVAILABLE:
             try:
                 await emit_claude_prompt(
-                    prompt_summary=prompt_summary,
+                    prompt_summary="",
                     signals=signals,
                     adhd_state=adhd_state
                 )
@@ -1620,6 +1669,8 @@ async def log_user_intent(
             "buffer_size": len(engine._intent_buffer)
         }
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(brand_log(f"Intent logging failed: {e}"))
         return {"recorded": False, "error": str(e)}
@@ -1641,10 +1692,9 @@ async def save_context_for_hook(
     Triggers WorkingMemorySupport and ContextPreserver.
     """
     try:
+        _reject_content_bearing_hook_payload(request)
         reason = request.get("reason", "unknown")
-        prompt_hint = request.get("prompt_hint", "")
-        files = request.get("files", [])
-        
+
         context_saved = False
         breadcrumb_saved = False
         
@@ -1654,7 +1704,7 @@ async def save_context_for_hook(
                 await engine.context_preserver.save_context(
                     user_id=user_id,
                     reason=reason,
-                    additional_context={"files": files, "prompt_hint": prompt_hint}
+                    additional_context={}
                 )
                 context_saved = True
             except Exception as e:
@@ -1665,7 +1715,7 @@ async def save_context_for_hook(
             try:
                 await engine.working_memory_support.save_breadcrumb(
                     user_id=user_id,
-                    description=f"[{reason}] {prompt_hint}"[:100]
+                    description=f"[{reason}]"[:100]
                 )
                 breadcrumb_saved = True
             except Exception as e:
@@ -1678,8 +1728,6 @@ async def save_context_for_hook(
             
             engine._context_snapshots[user_id] = {
                 "reason": reason,
-                "prompt_hint": prompt_hint,
-                "files": files,
                 "timestamp": datetime.now(timezone.utc).isoformat()
             }
             context_saved = True
@@ -1690,7 +1738,7 @@ async def save_context_for_hook(
                 await emit_context_saved(
                     user_id=user_id,
                     reason=reason,
-                    prompt_hint=prompt_hint
+                    prompt_hint=""
                 )
             except Exception as e:
                 logger.debug(f"Event emission failed: {e}")
@@ -1702,6 +1750,8 @@ async def save_context_for_hook(
             "reason": reason
         }
         
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(brand_log(f"Context save failed: {e}"))
         return {"saved": False, "error": str(e)}
@@ -1713,67 +1763,14 @@ async def get_unfinished_work(
     engine = Depends(get_engine)
 ):
     """
-    Get count and list of unfinished work items.
-    
-    Used by prompt_analyzer.py to warn when starting new features
-    with many unfinished items.
-    
-    Sources:
-    - ConPort progress entries with status != DONE
-    - Serena UntrackedWorkDetector if available
-    - Local abandoned tasks
+    Fail closed; ADHD Engine is not task, PM, or unfinished-work authority.
     """
-    try:
-        unfinished_items = []
-        
-        # Get from ConPort if available
-        if hasattr(engine, 'conport') and engine.conport:
-            try:
-                progress_entries = await engine.conport.get_progress(
-                    status="IN_PROGRESS",
-                    limit=50
-                )
-                for entry in progress_entries:
-                    unfinished_items.append({
-                        "id": entry.get("id"),
-                        "title": entry.get("title", "Unknown"),
-                        "status": entry.get("status"),
-                        "last_updated": entry.get("updated_at")
-                    })
-            except Exception as e:
-                logger.warning(brand_log(f"Failed to get ConPort progress: {e}"))
-        
-        # Get from UntrackedWorkDetector if available
-        if hasattr(engine, 'untracked_detector') and engine.untracked_detector:
-            try:
-                untracked = await engine.untracked_detector.detect()
-                for item in untracked.get("items", []):
-                    unfinished_items.append({
-                        "id": f"untracked_{item.get('path', 'unknown')}",
-                        "title": item.get("path", "Untracked work"),
-                        "status": "untracked",
-                        "confidence": item.get("confidence")
-                    })
-            except Exception as e:
-                logger.warning(brand_log(f"Failed to get untracked work: {e}"))
-        
-        # Deduplicate by id
-        seen_ids = set()
-        unique_items = []
-        for item in unfinished_items:
-            if item.get("id") not in seen_ids:
-                seen_ids.add(item.get("id"))
-                unique_items.append(item)
-        
-        return {
-            "count": len(unique_items),
-            "items": unique_items[:10],  # Return top 10 for display
-            "total_available": len(unique_items)
-        }
-        
-    except Exception as e:
-        logger.error(brand_log(f"Unfinished work retrieval failed: {e}"))
-        return {"count": 0, "items": [], "error": str(e)}
+    raise HTTPException(
+        status_code=410,
+        detail=brand_error(
+            "ADHD Engine unfinished-work endpoint is disabled. Use canonical PM/task authority."
+        ),
+    )
 
 
 @router.post("/record-progress")

--- a/services/adhd_engine/core/engine.py
+++ b/services/adhd_engine/core/engine.py
@@ -1543,22 +1543,10 @@ Format: {{
         total_load = await self._calculate_system_cognitive_load()
         logger.warning(f"⚠️ COGNITIVE OVERLOAD DETECTED: {total_load:.2f}")
 
-        # Week 3: Create break recommendation in ConPort
-        if self.conport and total_load > 0.8:  # Overload threshold
-            try:
-                # Create high-priority break task
-                entry_id = self.conport.log_progress_entry(
-                    status="TODO",
-                    description=f"🧠 BREAK RECOMMENDED - System cognitive load: {total_load:.1%}. "
-                                f"Consider taking a 5-10 minute break to prevent burnout."
-                )
-
-                if entry_id:
-                    logger.info(f"✅ Created break recommendation #{entry_id} in ConPort")
-                    self.accommodation_stats["breaks_suggested"] += 1
-
-            except Exception as e:
-                logger.error(f"Failed to create break recommendation in ConPort: {e}")
+        if total_load > 0.8:
+            logger.info(
+                "Cognitive overload detected; ADHD Engine does not create task or PM records"
+            )
 
     async def _adjust_task_recommendations_for_protection(self, user_id: str) -> None:
         """

--- a/services/adhd_engine/event_emitter.py
+++ b/services/adhd_engine/event_emitter.py
@@ -269,7 +269,6 @@ async def emit_claude_prompt(
     return await emitter.emit(
         EventTypes.CLAUDE_PROMPT_RECEIVED,
         {
-            "prompt_summary": prompt_summary[:100],  # Truncate for privacy
             "signals": signals,
             "adhd_state": adhd_state,
         },
@@ -307,7 +306,6 @@ async def emit_context_saved(
         {
             "user_id": user_id,
             "reason": reason,
-            "prompt_hint": prompt_hint[:50]
         },
         source="save_context_hook"
     )

--- a/services/adhd_engine/tests/test_api.py
+++ b/services/adhd_engine/tests/test_api.py
@@ -252,136 +252,36 @@ class TestUserProfile:
 
 
 class TestTasksEndpoints:
-    """Test task completion metrics endpoints."""
+    """Test task/PM metrics endpoints fail closed."""
 
-    def test_get_tasks_for_specific_user(self, client, mock_initialized_engine):
-        """Should return task completion metrics for specific user."""
-        # Mock the activity tracker with sample data
-        mock_activity_tracker = AsyncMock()
-        mock_activity_tracker.get_daily_stats = AsyncMock(return_value={
-            "completed": 5,
-            "total": 10
-        })
-        mock_initialized_engine.activity_tracker = mock_activity_tracker
-        mock_initialized_engine.get_tasks_completed = AsyncMock(return_value=5)
-        mock_initialized_engine.get_total_tasks = AsyncMock(return_value=10)
-
-        with patch('adhd_engine.main.engine', mock_initialized_engine):
-            response = client.get("/api/v1/tasks/test_user")
-
-            assert response.status_code == 200
-            data = response.json()
-
-            assert data["completed"] == 5
-            assert data["total"] == 10
-            assert data["rate"] == 0.5
-            assert data["user_id"] == "test_user"
-            assert "timestamp" in data
-
-    def test_get_tasks_default_user(self, client, mock_initialized_engine):
-        """Should return task completion metrics for default user."""
-        # Mock the activity tracker with sample data
-        mock_activity_tracker = AsyncMock()
-        mock_activity_tracker.get_daily_stats = AsyncMock(return_value={
-            "completed": 3,
-            "total": 7
-        })
-        mock_initialized_engine.activity_tracker = mock_activity_tracker
-        mock_initialized_engine.get_tasks_completed = AsyncMock(return_value=3)
-        mock_initialized_engine.get_total_tasks = AsyncMock(return_value=7)
-
-        with patch('adhd_engine.main.engine', mock_initialized_engine):
-            response = client.get("/api/v1/tasks")
-
-            assert response.status_code == 200
-            data = response.json()
-
-            assert data["completed"] == 3
-            assert data["total"] == 7
-            assert data["rate"] == 0.43
-            assert data["user_id"] == "default_user"
-            assert "timestamp" in data
-
-    def test_get_tasks_zero_total(self, client, mock_initialized_engine):
-        """Should handle zero total tasks (division by zero)."""
-        # Mock the activity tracker with zero tasks
-        mock_activity_tracker = AsyncMock()
-        mock_activity_tracker.get_daily_stats = AsyncMock(return_value={
-            "completed": 0,
-            "total": 0
-        })
-        mock_initialized_engine.activity_tracker = mock_activity_tracker
-        mock_initialized_engine.get_tasks_completed = AsyncMock(return_value=0)
-        mock_initialized_engine.get_total_tasks = AsyncMock(return_value=0)
-
-        with patch('adhd_engine.main.engine', mock_initialized_engine):
-            response = client.get("/api/v1/tasks/test_user")
-
-            assert response.status_code == 200
-            data = response.json()
-
-            assert data["completed"] == 0
-            assert data["total"] == 0
-            assert data["rate"] == 0.0
-            assert data["user_id"] == "test_user"
-
-    def test_get_tasks_all_completed(self, client, mock_initialized_engine):
-        """Should handle 100% completion rate."""
-        # Mock the activity tracker with all tasks completed
-        mock_activity_tracker = AsyncMock()
-        mock_activity_tracker.get_daily_stats = AsyncMock(return_value={
-            "completed": 8,
-            "total": 8
-        })
-        mock_initialized_engine.activity_tracker = mock_activity_tracker
-        mock_initialized_engine.get_tasks_completed = AsyncMock(return_value=8)
-        mock_initialized_engine.get_total_tasks = AsyncMock(return_value=8)
-
-        with patch('adhd_engine.main.engine', mock_initialized_engine):
-            response = client.get("/api/v1/tasks/test_user")
-
-            assert response.status_code == 200
-            data = response.json()
-
-            assert data["completed"] == 8
-            assert data["total"] == 8
-            assert data["rate"] == 1.0
-            assert data["user_id"] == "test_user"
-
-    def test_get_tasks_engine_error(self, client, mock_initialized_engine):
-        """Should handle engine errors gracefully."""
-        # Mock the activity tracker to raise an exception
+    def test_get_tasks_for_specific_user_fails_closed(self, client, mock_initialized_engine):
+        """ADHD Engine should not expose task completion metrics."""
         mock_initialized_engine.get_tasks_completed = AsyncMock(
-            side_effect=Exception("Activity tracker unavailable")
+            side_effect=AssertionError("must not read task metrics")
+        )
+        mock_initialized_engine.get_total_tasks = AsyncMock(
+            side_effect=AssertionError("must not read task metrics")
         )
 
         with patch('adhd_engine.main.engine', mock_initialized_engine):
             response = client.get("/api/v1/tasks/test_user")
 
-            assert response.status_code == 500
+            assert response.status_code == 410
             data = response.json()
-            assert "detail" in data
+            assert "canonical PM/task authority" in str(data["detail"])
 
-    def test_get_tasks_partial_completion(self, client, mock_initialized_engine):
-        """Should correctly calculate partial completion rate."""
-        # Mock the activity tracker with partial completion
-        mock_activity_tracker = AsyncMock()
-        mock_activity_tracker.get_daily_stats = AsyncMock(return_value={
-            "completed": 2,
-            "total": 3
-        })
-        mock_initialized_engine.activity_tracker = mock_activity_tracker
-        mock_initialized_engine.get_tasks_completed = AsyncMock(return_value=2)
-        mock_initialized_engine.get_total_tasks = AsyncMock(return_value=3)
+    def test_get_tasks_default_user_fails_closed(self, client, mock_initialized_engine):
+        """Default task metrics route should use the same fail-closed contract."""
+        mock_initialized_engine.get_tasks_completed = AsyncMock(
+            side_effect=AssertionError("must not read task metrics")
+        )
+        mock_initialized_engine.get_total_tasks = AsyncMock(
+            side_effect=AssertionError("must not read task metrics")
+        )
 
         with patch('adhd_engine.main.engine', mock_initialized_engine):
-            response = client.get("/api/v1/tasks/test_user")
+            response = client.get("/api/v1/tasks")
 
-            assert response.status_code == 200
+            assert response.status_code == 410
             data = response.json()
-
-            assert data["completed"] == 2
-            assert data["total"] == 3
-            # Rate should be rounded to 2 decimal places
-            assert data["rate"] == 0.67
-            assert data["user_id"] == "test_user"
+            assert "canonical PM/task authority" in str(data["detail"])

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001-implementation-notes.md
@@ -1,0 +1,56 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T4 05 Privacy Guard 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: Tp Dmx Adhd Cognitive T4 05 Privacy Guard 001 Implementation Notes
+  (explanation) for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T4-05 Privacy Guard Implementation Notes
+
+## Authority
+
+- Active Task Packet: `TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001`
+- Parent dependency: `TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001`
+- Runtime route authority: `services/adhd_engine/api/routes.py`
+- Runtime engine authority: `services/adhd_engine/core/engine.py`
+- Event payload authority: `services/adhd_engine/event_emitter.py`
+
+## Change
+
+- Added a recursive content-bearing hook payload guard for prompt, path, file, code, raw-argument, and arbitrary content fields.
+- Made `/save-context` and `/log-intent` reject content-bearing payloads before persistence or event emission.
+- Removed prompt summaries and prompt hints from emitted Claude prompt/context events.
+- Made `/tasks`, `/tasks/{user_id}`, and `/unfinished-work` fail closed with HTTP 410 instead of exposing task, PM, path, or unfinished-work data.
+- Removed the ConPort progress-entry write from cognitive overload handling.
+- Updated stale ADHD API task tests to assert the new fail-closed contract.
+
+## TDD Evidence
+
+- RED: `python -m pytest tests/unit/test_adhd_privacy_guard.py`
+  - Exit 1 before implementation.
+  - `5 failed`: routes accepted prompt/path content, event helpers emitted prompt fields, task/unfinished routes did not fail closed, and cognitive overload wrote ConPort progress.
+- GREEN: `python -m pytest tests/unit/test_adhd_privacy_guard.py`
+  - Exit 0 after implementation.
+  - `5 passed in 1.11s`.
+- GREEN: `python -m pytest tests/unit/test_adhd_privacy_guard.py services/adhd_engine/tests/test_api.py`
+  - Exit 0 after updating stale task API expectations.
+  - `16 passed in 0.23s`.
+
+## Validation
+
+- PASS: `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- PASS: `python -m pytest tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py`
+  - `53 passed`.
+- PASS: `python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/api/routes.py services/adhd_engine/event_emitter.py`
+- PASS: `git diff --check`
+
+## Residual Risk
+
+- Live Redis, live EventBus, and real hook shell scripts were not exercised in this slice.
+- The guard is route/event-path coverage, not a full repository-wide privacy scanner.
+- This branch is intentionally stacked on `codex/adhd-real-assessment-001`.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001.json
@@ -1,0 +1,150 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001",
+  "project": "dopemux-mvp",
+  "target": "ADHD Engine section 6 compliance and privacy schema guard",
+  "invariants": [
+    "ADHD Engine is cognitive-only and must not act as task, PM, work-item, source-code, prompt, path, or content authority.",
+    "Local hook routes must reject prompt text, prompt summaries, file paths, filenames, code content, raw tool arguments, and arbitrary content fields.",
+    "Recommendation and hook events must remain content-free and bounded to state, reason codes, counters, booleans, and allowlisted tool/status labels.",
+    "ADHD Engine must not create ConPort progress entries, task records, PM records, or unfinished-work projections.",
+    "Routes that previously exposed task/PM work data must fail closed rather than returning task or path details.",
+    "This slice must not widen into notifier UX, calibration, dashboard rendering, or live Redis/event-stream validation."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001",
+    "TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-real-assessment-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-privacy-guard-001",
+    "base_branch": "codex/adhd-real-assessment-001",
+    "stacked_because": "Privacy guards must cover the newest real-assessment activity sample path from T4-04."
+  },
+  "commit": {
+    "message": "fix(adhd): enforce content-free privacy guards",
+    "allowlist": [
+      "services/adhd_engine/core/engine.py",
+      "services/adhd_engine/api/routes.py",
+      "services/adhd_engine/event_emitter.py",
+      "tests/unit/test_adhd_privacy_guard.py",
+      "services/adhd_engine/tests/test_api.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py",
+      "python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/api/routes.py services/adhd_engine/event_emitter.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(adhd): enforce content-free privacy guards",
+    "body": "## Summary\n- reject prompt/path/content-bearing local hook payloads before persistence or event emission\n- fail closed on ADHD task/unfinished-work routes so task and PM authority does not leak through ADHD Engine\n- stop cognitive-overload handling from creating ConPort progress tasks\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py\n- python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/api/routes.py services/adhd_engine/event_emitter.py\n- git diff --check",
+    "base": "codex/adhd-real-assessment-001"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect ADHD Engine route, event, and persistence paths that accept prompts, paths, task records, or PM/work projections.",
+      "requirements": [
+        "Distinguish active services.adhd_engine.core.engine runtime from legacy sibling modules.",
+        "Identify canonical writers and reject ADHD Engine ownership of task, PM, or work-item truth.",
+        "Do not touch notifier, dashboard, calibration, or live transport behavior."
+      ],
+      "commands": [
+        "rg -n \"tasks|unfinished-work|save-context|log-intent|prompt_hint|prompt_summary|files|log_progress_entry|emit_context_saved|emit_claude_prompt\" services/adhd_engine tests -g '*.py'",
+        "nl -ba services/adhd_engine/api/routes.py | sed -n '830,875p;1535,1776p'",
+        "nl -ba services/adhd_engine/core/engine.py | sed -n '1536,1563p'",
+        "nl -ba services/adhd_engine/event_emitter.py | sed -n '261,313p'"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Unsafe prompt/path/task/PM surfaces are identified before tests or production edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-03B-ACTIVITY-LOOP-001.json",
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-04-REAL-ASSESSMENT-001.json",
+        "services/adhd_engine/api/routes.py",
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/event_emitter.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add failing privacy tests, then make ADHD Engine reject content-bearing hook payloads, emit content-free events, and fail closed on task/PM routes.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "`/save-context` and `/log-intent` must reject prompt/path/content-bearing payloads before persistence.",
+        "`emit_claude_prompt` and `emit_context_saved` must not include prompt summaries or prompt hints in emitted data.",
+        "`/tasks` and `/unfinished-work` must not expose task, PM, path, or unfinished-work details.",
+        "Cognitive overload handling must not create ConPort progress entries."
+      ],
+      "commands": [
+        "apply_patch"
+      ],
+      "expected_files": [
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/api/routes.py",
+        "services/adhd_engine/event_emitter.py",
+        "tests/unit/test_adhd_privacy_guard.py",
+        "services/adhd_engine/tests/test_api.py"
+      ],
+      "validation": [
+        "Targeted privacy guard tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, focused tests, syntax, diff scope, and precommit checks for the privacy guard slice.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim full live privacy enforcement beyond the tested route/event/persistence paths."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py",
+        "python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/api/routes.py services/adhd_engine/event_emitter.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/unit/test_adhd_privacy_guard.py
+++ b/tests/unit/test_adhd_privacy_guard.py
@@ -1,0 +1,180 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+
+class ForbiddenConPort:
+    def __init__(self):
+        self.progress_called = False
+
+    def log_progress_entry(self, **kwargs):
+        self.progress_called = True
+        return "forbidden-progress-entry"
+
+
+class ForbiddenContextPreserver:
+    async def save_context(self, **kwargs):
+        raise AssertionError("context preserver must not receive prompt or path content")
+
+
+class ForbiddenWorkingMemory:
+    async def save_breadcrumb(self, **kwargs):
+        raise AssertionError("working memory must not receive prompt content")
+
+
+@pytest.mark.asyncio
+async def test_save_context_rejects_prompt_and_file_content_before_persistence(monkeypatch):
+    from services.adhd_engine.api import routes
+
+    emitted = []
+
+    async def fake_emit_context_saved(**kwargs):
+        emitted.append(kwargs)
+        return True
+
+    engine = SimpleNamespace(
+        context_preserver=ForbiddenContextPreserver(),
+        working_memory_support=ForbiddenWorkingMemory(),
+    )
+
+    monkeypatch.setattr(routes, "EVENT_EMISSION_AVAILABLE", True)
+    monkeypatch.setattr(routes, "emit_context_saved", fake_emit_context_saved)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await routes.save_context_for_hook(
+            {
+                "reason": "context_switch",
+                "prompt_hint": "raw prompt must not persist",
+                "files": ["/Users/hue/code/dopemux-mvp/services/adhd_engine/api/routes.py"],
+            },
+            user_id="operator-local-001",
+            engine=engine,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert emitted == []
+    assert not hasattr(engine, "_context_snapshots")
+
+
+@pytest.mark.asyncio
+async def test_log_intent_rejects_prompt_summary_before_conport_or_event(monkeypatch):
+    from services.adhd_engine.api import routes
+
+    class ForbiddenIntentConPort:
+        async def log_custom_data(self, **kwargs):
+            raise AssertionError("ConPort must not receive prompt summaries")
+
+    emitted = []
+
+    async def fake_emit_claude_prompt(**kwargs):
+        emitted.append(kwargs)
+        return True
+
+    engine = SimpleNamespace(conport=ForbiddenIntentConPort())
+
+    monkeypatch.setattr(routes, "EVENT_EMISSION_AVAILABLE", True)
+    monkeypatch.setattr(routes, "emit_claude_prompt", fake_emit_claude_prompt)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await routes.log_user_intent(
+            {
+                "prompt_summary": "build the secret thing in /tmp/private.py",
+                "signals": {"is_context_switch": True},
+                "adhd_state": {"energy": "low"},
+                "timestamp": "2026-05-31T00:00:00Z",
+            },
+            engine=engine,
+        )
+
+    assert exc_info.value.status_code == 400
+    assert emitted == []
+    assert not hasattr(engine, "_intent_buffer")
+
+
+@pytest.mark.asyncio
+async def test_event_helpers_emit_content_free_payloads(monkeypatch):
+    from services.adhd_engine import event_emitter
+
+    emitted = []
+
+    class FakeEmitter:
+        async def emit(self, event_type, data, source):
+            emitted.append((event_type, data, source))
+            return True
+
+    async def fake_get_instance():
+        return FakeEmitter()
+
+    monkeypatch.setattr(event_emitter.ADHDEventEmitter, "get_instance", fake_get_instance)
+
+    assert await event_emitter.emit_claude_prompt(
+        "raw prompt content",
+        {"is_context_switch": True},
+        {"energy": "low", "attention": "scattered"},
+    )
+    assert await event_emitter.emit_context_saved(
+        "operator-local-001",
+        "context_switch",
+        "raw prompt hint",
+    )
+
+    assert emitted == [
+        (
+            event_emitter.EventTypes.CLAUDE_PROMPT_RECEIVED,
+            {
+                "signals": {"is_context_switch": True},
+                "adhd_state": {"energy": "low", "attention": "scattered"},
+            },
+            "prompt_analyzer_hook",
+        ),
+        (
+            event_emitter.EventTypes.CONTEXT_SAVED,
+            {
+                "user_id": "operator-local-001",
+                "reason": "context_switch",
+            },
+            "save_context_hook",
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_task_and_unfinished_work_routes_fail_closed_without_engine_reads():
+    from services.adhd_engine.api import routes
+
+    class ForbiddenEngine:
+        async def get_tasks_completed(self, user_id):
+            raise AssertionError("ADHD Engine must not expose task metrics")
+
+        async def get_total_tasks(self, user_id):
+            raise AssertionError("ADHD Engine must not expose task metrics")
+
+    with pytest.raises(HTTPException) as task_exc:
+        await routes.get_tasks_for_user("operator-local-001", ForbiddenEngine(), api_key="test")
+
+    with pytest.raises(HTTPException) as unfinished_exc:
+        await routes.get_unfinished_work("operator-local-001", ForbiddenEngine())
+
+    assert task_exc.value.status_code == 410
+    assert unfinished_exc.value.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_cognitive_overload_does_not_create_conport_progress_task(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: "operator-local-001")
+    engine = engine_module.ADHDAccommodationEngine()
+    conport = ForbiddenConPort()
+    engine.conport = conport
+
+    async def overload():
+        return 0.95
+
+    monkeypatch.setattr(engine, "_calculate_system_cognitive_load", overload)
+
+    await engine._handle_cognitive_overload()
+
+    assert conport.progress_called is False
+    assert engine.accommodation_stats["breaks_suggested"] == 0


### PR DESCRIPTION
## Summary
- reject prompt/path/content-bearing local hook payloads before persistence or event emission
- fail closed on ADHD task and unfinished-work routes so task/PM authority does not leak through ADHD Engine
- stop cognitive-overload handling from creating ConPort progress tasks
- update stale ADHD API task tests to the new fail-closed contract

## Validation
- PASS: python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: python -m pytest tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py
- PASS: python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/api/routes.py services/adhd_engine/event_emitter.py
- PASS: git diff --check
- PASS: python -m pre_commit run --files services/adhd_engine/core/engine.py services/adhd_engine/api/routes.py services/adhd_engine/event_emitter.py tests/unit/test_adhd_privacy_guard.py services/adhd_engine/tests/test_api.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-05-PRIVACY-GUARD-001-implementation-notes.md

## Residual risk
- Live Redis, live EventBus, and real hook shell scripts were not exercised in this slice.
- This is route/event-path coverage, not a full repository-wide privacy scanner.
- This PR is stacked on #778 / codex/adhd-real-assessment-001.

@codex review
@gemini
@copilot

Generate release notes, ensure all documentation referencing all code changes is updated, all tests pass, and release notes, changelog, and feature lists are updated