### PR TITLE
feat(adhd): derive state from work boundaries

### DIFF
--- a/services/adhd_engine/core/engine.py
+++ b/services/adhd_engine/core/engine.py
@@ -514,16 +514,20 @@ class ADHDAccommodationEngine:
             "status",
             "tool_name",
             "source_event",
+            "boundary_type",
         }
-        return {
+        metrics = {
             key: value
             for key, value in activity_data.items()
             if key in allowed_fields and value is not None
         }
+        if metrics.get("boundary_type") not in {"commit", "test", "build", "file_close"}:
+            metrics.pop("boundary_type", None)
+        return metrics
 
     @staticmethod
     def _is_hook_activity(activity_data: Dict[str, Any]) -> bool:
-        return any(key in activity_data for key in ("hook_event_name", "status", "tool_name"))
+        return any(key in activity_data for key in ("hook_event_name", "status", "tool_name", "boundary_type"))
 
     def _append_activity_sample(self, user_id: str, activity_data: Dict[str, Any]) -> None:
         samples = self.recent_activity_samples.setdefault(user_id, [])
@@ -620,20 +624,41 @@ class ADHDAccommodationEngine:
         attempts = sum(1 for sample in samples if sample.get("status") == "attempt")
         prompt_events = sum(1 for sample in samples if sample.get("hook_event_name") == "UserPromptSubmit")
         tool_events = sum(1 for sample in samples if sample.get("tool_name"))
+        boundary_events = sum(1 for sample in samples if sample.get("boundary_type"))
+        work_boundary_events = sum(
+            1
+            for sample in samples
+            if sample.get("boundary_type") in {"commit", "test", "build"}
+        )
 
-        outcome_count = successes + failures
+        boundary_without_status = sum(
+            1
+            for sample in samples
+            if sample.get("boundary_type") and sample.get("status") not in {"success", "failure"}
+        )
+        outcome_count = successes + failures + boundary_without_status
         completion_rate = successes / outcome_count if outcome_count else 0.5
+        if boundary_without_status and outcome_count:
+            completion_rate = (successes + boundary_without_status) / outcome_count
+
+        context_switches = max(0, prompt_events - boundary_events * 2)
+        minutes_since_break = max(
+            0,
+            min(120, 30 + failures * 10 + attempts * 2) - boundary_events * 10,
+        )
 
         return {
             "completion_rate": completion_rate,
-            "context_switches": prompt_events,
+            "context_switches": context_switches,
             "break_compliance": max(0.0, 1.0 - (failures * 0.2)),
-            "minutes_since_break": min(120, 30 + failures * 10 + attempts * 2),
+            "minutes_since_break": minutes_since_break,
             "tool_failures": failures,
             "tool_successes": successes,
             "tool_attempts": attempts,
             "tool_events": tool_events,
             "prompt_events": prompt_events,
+            "boundary_events": boundary_events,
+            "work_boundary_events": work_boundary_events,
             "activity_evidence": bool(samples),
         }
 

--- a/services/adhd_engine/event_listener.py
+++ b/services/adhd_engine/event_listener.py
@@ -209,6 +209,7 @@ class ADHDEventListener:
             "hook_event_name",
             "status",
             "tool_name",
+            "boundary_type",
         }
         activity_data = {
             key: value
@@ -233,6 +234,12 @@ class ADHDEventListener:
     
     async def _on_file_activity(self, data: Dict[str, Any]):
         """Handle file activity events."""
+        if data.get("action") == "closed":
+            await self._record_activity_signal(
+                {"boundary_type": "file_close"},
+                source_event="file_closed",
+            )
+
         # Add to rolling window
         self._file_activity_window.append({
             "file": data.get("file"),

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001-implementation-notes.md
@@ -1,0 +1,53 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T4 07 Boundary Detection 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-05-31'
+last_review: '2026-05-31'
+next_review: '2026-08-29'
+prelude: Tp Dmx Adhd Cognitive T4 07 Boundary Detection 001 Implementation Notes (explanation)
+  for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001 Implementation Notes
+
+## Scope
+
+- Added content-free `boundary_type` intake for `commit`, `test`, `build`, and `file_close`.
+- Routed `file_closed` listener events into ADHD Engine as `boundary_type=file_close` without forwarding file paths.
+- Derived boundary-aware activity metrics from hook samples:
+  - `boundary_events`
+  - `work_boundary_events`
+  - reduced effective `context_switches`
+  - reduced derived `minutes_since_break`
+- Unknown boundary categories are dropped before retention.
+
+## RED Evidence
+
+- `python -m pytest tests/unit/test_adhd_boundary_detection.py`
+- Result before implementation: `5 failed`
+- Failure modes:
+  - missing `boundary_events` metrics
+  - listener dropped `boundary_type`
+  - `file_closed` did not create an ADHD activity signal
+  - unknown boundary type had no explicit retained metric result
+
+## GREEN Evidence
+
+- `python -m pytest tests/unit/test_adhd_boundary_detection.py`
+- Result after implementation: `5 passed in 1.69s`
+
+## Final Validation
+
+- `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`: PASS
+- `python -m pytest tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py`: PASS, `62 passed in 0.58s`
+- `python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py`: PASS
+- `git diff --check`: PASS
+- `pre-commit run --files services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py tests/unit/test_adhd_boundary_detection.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001-implementation-notes.md`: PASS
+
+## Residual Risk
+
+- This slice validates in-process dispatch and engine derivation only; live Redis/EventBus and installed shell-hook runtime paths were not exercised.
+- Upstream producers must provide content-free `boundary_type` values for commit/test/build. This slice does not parse or persist raw command text.
+- File activity still retains its existing local listener window for procrastination detection; the ADHD Engine activity update receives only `boundary_type=file_close`.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json
@@ -1,0 +1,144 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001",
+  "project": "dopemux-mvp",
+  "target": "ADHD Engine boundary detection uses work breakpoints instead of wall-clock-only activity state",
+  "invariants": [
+    "ADHD Engine remains cognitive-only and must not store prompts, paths, filenames, code content, raw tool arguments, task records, or PM records.",
+    "Boundary detection must use content-free breakpoint categories only: commit, test, build, or file_close.",
+    "Boundary signals must be accepted through the existing activity update path and must drive derived activity metrics.",
+    "File-close events must not forward file paths into ADHD Engine activity state.",
+    "No live Redis, EventBus, provider, notifier, dashboard, or shell-hook validation is authorized in this slice.",
+    "Do not widen into hyperfocus latch, idle/distracted corroboration, dashboard UI, persistent calibration, or native hook raw-command persistence work."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T4-06-BASELINE-CALIBRATION-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-baseline-calibration-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T4-06-BASELINE-CALIBRATION-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-boundary-detection-001",
+    "base_branch": "codex/adhd-baseline-calibration-001",
+    "stacked_because": "Boundary detection consumes the privacy-safe activity loop, real assessment, and per-user baseline paths from preceding T4 slices."
+  },
+  "commit": {
+    "message": "feat(adhd): derive state from work boundaries",
+    "allowlist": [
+      "services/adhd_engine/core/engine.py",
+      "services/adhd_engine/event_listener.py",
+      "tests/unit/test_adhd_boundary_detection.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py",
+      "python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(adhd): derive state from work boundaries",
+    "body": "## Summary\n- accept content-free work boundary categories in ADHD activity signals\n- derive activity metrics from commit/test/build/file-close breakpoints instead of wall-clock-only assumptions\n- route file_closed events into bounded activity updates without forwarding file paths\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py\n- python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py\n- git diff --check",
+    "base": "codex/adhd-baseline-calibration-001"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect ADHD activity intake, native hook activity forwarding, file activity handling, and derived weak-signal metrics before editing.",
+      "requirements": [
+        "Confirm canonical state writer remains ADHDAccommodationEngine.record_activity_update.",
+        "Confirm boundary signal shape remains content-free.",
+        "Do not persist prompt/path/content data or introduce task/PM authority."
+      ],
+      "commands": [
+        "rg -n \"boundary|breakpoint|commit|test|build|file_closed|native_hook_activity|record_activity_update|hook_event_name\" services/adhd_engine src tests -g '*.py'",
+        "nl -ba services/adhd_engine/event_listener.py | sed -n '190,245p'",
+        "nl -ba services/adhd_engine/core/engine.py | sed -n '476,638p;1538,1598p'"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Runtime activity intake and boundary-safe change points are identified before tests or production edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-06-BASELINE-CALIBRATION-001.json",
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/event_listener.py",
+        "tests/unit/test_adhd_activity_loop.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add failing tests, then add content-free boundary categories and make derived activity metrics respond to work breakpoints.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "Accepted boundary types are commit, test, build, and file_close only.",
+        "Boundary events must improve completion signal and reduce stale time-since-break assumptions.",
+        "File-close handling must send only boundary_type/action/source_event, never file path.",
+        "Unknown boundary types must not be retained."
+      ],
+      "commands": [
+        "apply_patch",
+        "python -m pytest tests/unit/test_adhd_boundary_detection.py"
+      ],
+      "expected_files": [
+        "services/adhd_engine/core/engine.py",
+        "services/adhd_engine/event_listener.py",
+        "tests/unit/test_adhd_boundary_detection.py"
+      ],
+      "validation": [
+        "Targeted boundary detection tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, focused tests, syntax, diff scope, and precommit checks for the boundary detection slice.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim live hook/eventbus validation beyond tested in-process dispatch paths."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py",
+        "python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/unit/test_adhd_boundary_detection.py
+++ b/tests/unit/test_adhd_boundary_detection.py
@@ -1,0 +1,164 @@
+from types import SimpleNamespace
+
+import pytest
+
+
+USER_ID = "operator-local-001"
+
+
+@pytest.mark.asyncio
+async def test_boundary_events_drive_activity_metrics_without_wall_clock(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: USER_ID)
+    engine = engine_module.ADHDAccommodationEngine()
+
+    for boundary_type in ("test", "build", "commit"):
+        await engine.record_activity_update(
+            USER_ID,
+            {
+                "hook_event_name": "PostToolUse",
+                "status": "success",
+                "tool_name": "Bash",
+                "boundary_type": boundary_type,
+                "minutes_since_break": 95,
+            },
+        )
+
+    activity = engine.recent_activity_updates[USER_ID]
+
+    assert activity["boundary_events"] == 3
+    assert activity["work_boundary_events"] == 3
+    assert activity["completion_rate"] == 1.0
+    assert activity["minutes_since_break"] < 30
+
+
+@pytest.mark.asyncio
+async def test_boundary_events_stabilize_prompt_switch_state(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+    from services.adhd_engine.core.models import AttentionState
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: USER_ID)
+    engine = engine_module.ADHDAccommodationEngine()
+
+    for _ in range(8):
+        await engine.record_activity_update(
+            USER_ID,
+            {"hook_event_name": "UserPromptSubmit", "status": "attempt"},
+        )
+    for _ in range(4):
+        result = await engine.record_activity_update(
+            USER_ID,
+            {
+                "hook_event_name": "PostToolUse",
+                "status": "success",
+                "tool_name": "Bash",
+                "boundary_type": "test",
+            },
+        )
+
+    activity = engine.recent_activity_updates[USER_ID]
+
+    assert activity["prompt_events"] == 8
+    assert activity["boundary_events"] == 4
+    assert activity["context_switches"] < activity["prompt_events"]
+    assert result["attention_state"] != AttentionState.SCATTERED
+
+
+@pytest.mark.asyncio
+async def test_listener_forwards_boundary_type_but_not_content():
+    from services.adhd_engine.event_listener import ADHDEventListener
+
+    calls = []
+
+    class FakeEngine:
+        async def record_activity_update(self, user_id, activity_data):
+            calls.append((user_id, activity_data))
+            return {"energy_updated": True, "attention_updated": True}
+
+    listener = ADHDEventListener(event_bus=None, adhd_engine=FakeEngine())
+    listener._current_user_id = USER_ID
+
+    event = SimpleNamespace(
+        type="native_hook_activity",
+        data={
+            "hook_event_name": "PostToolUse",
+            "status": "success",
+            "tool_name": "Bash",
+            "boundary_type": "commit",
+            "prompt": "must not be forwarded",
+            "tool_input": {"command": "git commit -m secret"},
+            "path": "/Users/hue/code/dopemux-mvp/secret.py",
+        },
+    )
+
+    await listener._dispatch(event)
+
+    assert calls == [
+        (
+            USER_ID,
+            {
+                "hook_event_name": "PostToolUse",
+                "status": "success",
+                "tool_name": "Bash",
+                "boundary_type": "commit",
+                "source_event": "native_hook_activity",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_listener_turns_file_closed_into_content_free_boundary():
+    from services.adhd_engine.event_listener import ADHDEventListener
+
+    calls = []
+
+    class FakeEngine:
+        async def record_activity_update(self, user_id, activity_data):
+            calls.append((user_id, activity_data))
+            return {"energy_updated": True, "attention_updated": True}
+
+    listener = ADHDEventListener(event_bus=None, adhd_engine=FakeEngine())
+    listener._current_user_id = USER_ID
+
+    event = SimpleNamespace(
+        type="file_closed",
+        data={
+            "file": "/Users/hue/code/dopemux-mvp/private.py",
+            "action": "closed",
+        },
+    )
+
+    await listener._dispatch(event)
+
+    assert calls == [
+        (
+            USER_ID,
+            {
+                "boundary_type": "file_close",
+                "source_event": "file_closed",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_unknown_boundary_type_is_not_retained(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: USER_ID)
+    engine = engine_module.ADHDAccommodationEngine()
+
+    await engine.record_activity_update(
+        USER_ID,
+        {
+            "hook_event_name": "PostToolUse",
+            "status": "success",
+            "tool_name": "Bash",
+            "boundary_type": "raw_command",
+        },
+    )
+
+    assert engine.recent_activity_samples[USER_ID][0].get("boundary_type") is None
+    assert engine.recent_activity_updates[USER_ID]["boundary_events"] == 0


### PR DESCRIPTION
## Summary
- accept content-free work boundary categories in ADHD activity signals
- derive activity metrics from commit/test/build/file-close breakpoints instead of wall-clock-only assumptions
- route file_closed events into bounded activity updates without forwarding file paths

## Release Notes
- ADHD Engine activity derivation now recognizes content-free work boundary categories: `commit`, `test`, `build`, and `file_close`.
- Boundary events can stabilize derived context switching and stale-break metrics without storing prompts, paths, or raw tool arguments.

## Validation
- PASS: `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- PASS: `python -m pytest tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py` (`62 passed in 0.58s`)
- PASS: `python -m py_compile services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py`
- PASS: `git diff --check`
- PASS: `pre-commit run --files services/adhd_engine/core/engine.py services/adhd_engine/event_listener.py tests/unit/test_adhd_boundary_detection.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001-implementation-notes.md`

## Review
@codex review
@gemini
@copilot

## Residual Risk
- Live Redis, EventBus, installed shell-hook, dashboard, and provider paths were not exercised.
- Upstream producers must send content-free `boundary_type` values; this slice does not parse or persist raw command text.