### PR TITLE
feat(adhd): latch hyperfocus until corroborated exit

### DIFF
--- a/services/adhd_engine/core/engine.py
+++ b/services/adhd_engine/core/engine.py
@@ -515,6 +515,9 @@ class ADHDAccommodationEngine:
             "tool_name",
             "source_event",
             "boundary_type",
+            "tool_failures",
+            "idle_detected",
+            "idle_minutes",
         }
         metrics = {
             key: value
@@ -1214,6 +1217,14 @@ Format: {{
             short_focus = focus_duration < thresholds["low_focus_duration"]
             long_focus = focus_duration > thresholds["high_focus_duration"]
             low_distraction = distraction_events < max(2, thresholds["high_distraction_events"] / 2)
+            boundary_seen = (
+                indicators.get("boundary_events", 0) > 0
+                or indicators.get("work_boundary_events", 0) > 0
+            )
+            idle_seen = (
+                bool(indicators.get("idle_detected"))
+                or indicators.get("idle_minutes", 0) > 0
+            )
 
             # Assess attention state
             if excessive_abandonment or excessive_distractions:
@@ -1229,6 +1240,18 @@ Format: {{
 
             # Update tracking
             previous_state = self.current_attention_states.get(user_id)
+            if previous_state == AttentionState.HYPERFOCUSED and not boundary_seen:
+                exit_signal_count = sum(
+                    1
+                    for signal_seen in (
+                        rapid_switching,
+                        excessive_abandonment or excessive_distractions,
+                        idle_seen,
+                    )
+                    if signal_seen
+                )
+                if exit_signal_count < 2:
+                    attention_state = AttentionState.HYPERFOCUSED
             self.current_attention_states[user_id] = attention_state
 
             # Log state change
@@ -1596,6 +1619,13 @@ Format: {{
         prompt_events = int(activity.get("prompt_events", 0) or 0)
         tool_failures = int(activity.get("tool_failures", 0) or 0)
         context_switches_per_hour = max(context_switches, prompt_events)
+        idle_minutes = float(activity.get("idle_minutes", 0) or 0.0)
+        boundary_events = int(activity.get("boundary_events", 0) or 0)
+        work_boundary_events = int(activity.get("work_boundary_events", 0) or 0)
+        if activity.get("boundary_type"):
+            boundary_events = max(boundary_events, 1)
+            if activity.get("boundary_type") in {"commit", "test", "build"}:
+                work_boundary_events = max(work_boundary_events, 1)
 
         if context_switches_per_hour >= 10:
             average_focus_duration = 8
@@ -1609,6 +1639,10 @@ Format: {{
             "abandoned_tasks": tool_failures,
             "average_focus_duration": average_focus_duration,
             "distraction_events": (tool_failures * 3) + max(0, context_switches_per_hour - 15),
+            "boundary_events": boundary_events,
+            "work_boundary_events": work_boundary_events,
+            "idle_detected": bool(activity.get("idle_detected")) or idle_minutes > 0,
+            "idle_minutes": idle_minutes,
         }
 
     async def _calculate_system_cognitive_load(self) -> float:

--- a/src/dopemux/adhd/attention_monitor.py
+++ b/src/dopemux/adhd/attention_monitor.py
@@ -303,8 +303,21 @@ class AttentionMonitor:
         focus_score: float,
     ) -> str:
         """Classify current attention state."""
-        # Check for distraction (long pause)
-        if pause_duration > 600:  # 10 minutes
+        long_pause = pause_duration > 600
+        pressure_signals = sum(
+            1
+            for signal_seen in (
+                context_switches > self.context_switch_threshold,
+                error_rate >= 2,
+            )
+            if signal_seen
+        )
+
+        if self._current_state == AttentionState.HYPERFOCUS and pressure_signals < 2:
+            return AttentionState.HYPERFOCUS
+
+        # Check for distraction (long pause with corroborating pressure)
+        if long_pause and pressure_signals >= 2:
             return AttentionState.DISTRACTED
 
         # Check for hyperfocus (sustained high activity)

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001-implementation-notes.md
@@ -1,0 +1,63 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T4 08 Hyperfocus Latch 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-02'
+last_review: '2026-06-02'
+next_review: '2026-08-31'
+prelude: Tp Dmx Adhd Cognitive T4 08 Hyperfocus Latch 001 Implementation Notes (explanation)
+  for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001 Implementation Notes
+
+## Authority and Scope
+
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/adhd-hyperfocus-latch-001`
+- Branch: `codex/adhd-hyperfocus-latch-001`
+- Base: `origin/codex/adhd-boundary-detection-001`
+- Primary checkout dirty state was not modified.
+- Canonical T4 activity writer observed: `ADHDAccommodationEngine.record_activity_update`.
+- Line-numbered defect surface observed: `src/dopemux/adhd/attention_monitor.py` pause/hyperfocus state classification.
+
+## Initial Validation
+
+- `python -m pytest tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py tests/test_attention_monitor.py`
+  - Result: PASS, `95 passed in 1.89s`
+
+## Planned Slice
+
+- Add targeted failing tests for:
+  - engine hyperfocus latching through lone idle evidence;
+  - engine hyperfocus exit only with a work boundary or two corroborating degradation signals;
+  - legacy monitor pause-only classification no longer marking `distracted`;
+  - legacy monitor hyperfocus staying latched through lone pause evidence.
+- Implement only content-free latch/corroboration logic.
+
+## Final Proof
+
+- RED validation:
+  - `python -m pytest tests/unit/test_adhd_hyperfocus_latch.py tests/test_attention_monitor.py`
+  - Result: FAIL as expected, 4 failing assertions covering idle-only hyperfocus latch, single-signal hyperfocus latch, pause-only neutral classification, and pause-only hyperfocus latch.
+- Implementation:
+  - `services/adhd_engine/core/engine.py` keeps previous `HYPERFOCUSED` latched unless a content-free boundary is present or two independent degradation categories corroborate exit.
+  - `services/adhd_engine/core/engine.py` accepts bounded scalar `tool_failures`, `idle_detected`, and `idle_minutes` metrics; content-bearing fields remain excluded.
+  - `src/dopemux/adhd/attention_monitor.py` treats a long pause as distracted only when corroborated by error and context-switch pressure, and latches existing hyperfocus through lone pause evidence.
+- GREEN validation:
+  - `python -m pytest tests/unit/test_adhd_hyperfocus_latch.py tests/test_attention_monitor.py`
+    - Result: PASS, `38 passed in 2.82s`
+  - `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+    - Result: PASS
+  - `python -m py_compile services/adhd_engine/core/engine.py src/dopemux/adhd/attention_monitor.py`
+    - Result: PASS
+  - `python -m pytest tests/unit/test_adhd_hyperfocus_latch.py tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py tests/test_attention_monitor.py`
+    - Result: PASS, `100 passed in 1.87s`
+  - `git diff --check`
+    - Result: PASS
+- PAL codereview:
+  - Tool/model: `mcp__pal.codereview`, `gpt-5-codex`
+  - Result: PASS, no blocking issues.
+  - Residual note: legacy `attention_monitor.py` has no boundary input, so it can only release hyperfocus by corroborating pressure.
+- NOT_RUN:
+  - Live Redis/EventBus/provider/notifier/dashboard/shell-hook validation: not authorized by packet.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001.json
@@ -1,0 +1,147 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001",
+  "project": "dopemux-mvp",
+  "target": "ADHD Engine hyperfocus latch and idle corroboration for attention-state exits",
+  "invariants": [
+    "ADHD Engine remains cognitive-only and must not store prompts, paths, filenames, code content, raw tool arguments, task records, or PM records.",
+    "Hyperfocus exits must require a real content-free boundary or at least two corroborating attention-degradation signals.",
+    "Lone idle or pause evidence must not classify the operator as distracted, scattered, or overwhelmed.",
+    "Boundary signal authority remains content-free categories only: commit, test, build, or file_close.",
+    "No live Redis, EventBus, provider, notifier, dashboard, or shell-hook validation is authorized in this slice.",
+    "Do not widen into dashboard UI, persistent calibration changes, raw-command persistence, or PM/task authority work."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-boundary-detection-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-hyperfocus-latch-001",
+    "base_branch": "codex/adhd-boundary-detection-001",
+    "stacked_because": "Hyperfocus latch consumes the operator identity, privacy-safe activity loop, baseline calibration, and boundary detection slices from the T4 stack."
+  },
+  "commit": {
+    "message": "feat(adhd): latch hyperfocus until corroborated exit",
+    "allowlist": [
+      "services/adhd_engine/core/engine.py",
+      "src/dopemux/adhd/attention_monitor.py",
+      "tests/unit/test_adhd_hyperfocus_latch.py",
+      "tests/test_attention_monitor.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_adhd_hyperfocus_latch.py tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py tests/test_attention_monitor.py",
+      "python -m py_compile services/adhd_engine/core/engine.py src/dopemux/adhd/attention_monitor.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(adhd): latch hyperfocus until corroborated exit",
+    "body": "## Summary\n- keep hyperfocus latched until a content-free work boundary or at least two corroborating degradation signals justify exit\n- ensure lone idle/pause evidence does not mark the operator distracted, scattered, or overwhelmed\n- cover both the active ADHD Engine assessment path and the line-numbered legacy attention monitor path\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_adhd_hyperfocus_latch.py tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py tests/test_attention_monitor.py\n- python -m py_compile services/adhd_engine/core/engine.py src/dopemux/adhd/attention_monitor.py\n- git diff --check",
+    "base": "codex/adhd-boundary-detection-001"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect active ADHD Engine attention assessment and line-numbered attention monitor classification before editing.",
+      "requirements": [
+        "Confirm canonical T4 writer remains ADHDAccommodationEngine.record_activity_update.",
+        "Confirm legacy monitor line-numbered idle/pause behavior is test-covered before changing it.",
+        "Do not persist prompt/path/content data or introduce task/PM authority."
+      ],
+      "commands": [
+        "rg -n \"hyperfocus|idle|distract|scattered|AttentionState|record_activity_update|_assess_attention_state|_classify_attention_state\" src/dopemux/adhd services/adhd_engine tests -g '*.py'",
+        "nl -ba services/adhd_engine/core/engine.py | sed -n '1198,1288p'",
+        "nl -ba src/dopemux/adhd/attention_monitor.py | sed -n '297,350p'"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Active engine-equivalent and legacy line-numbered behavior are identified before tests or production edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-07-BOUNDARY-DETECTION-001.json",
+        "services/adhd_engine/core/engine.py",
+        "src/dopemux/adhd/attention_monitor.py",
+        "tests/unit/test_adhd_boundary_detection.py",
+        "tests/test_attention_monitor.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add failing tests, then implement hyperfocus latch and idle corroboration without retaining content-bearing evidence.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "Hyperfocus must remain latched through a lone idle/pause or a single degradation signal.",
+        "A content-free work boundary may release the latch to normal assessment.",
+        "At least two degradation signals may release the latch to scattered or overwhelmed.",
+        "Lone idle/pause evidence must not classify as distracted, scattered, or overwhelmed."
+      ],
+      "commands": [
+        "apply_patch",
+        "python -m pytest tests/unit/test_adhd_hyperfocus_latch.py tests/test_attention_monitor.py"
+      ],
+      "expected_files": [
+        "services/adhd_engine/core/engine.py",
+        "src/dopemux/adhd/attention_monitor.py",
+        "tests/unit/test_adhd_hyperfocus_latch.py",
+        "tests/test_attention_monitor.py"
+      ],
+      "validation": [
+        "Targeted latch and idle tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, focused tests, syntax, diff scope, PAL codereview, and precommit checks for the hyperfocus latch slice.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim live hook/eventbus validation beyond tested in-process paths."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_adhd_hyperfocus_latch.py tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py tests/test_attention_monitor.py",
+        "python -m py_compile services/adhd_engine/core/engine.py src/dopemux/adhd/attention_monitor.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/test_attention_monitor.py
+++ b/tests/test_attention_monitor.py
@@ -195,15 +195,44 @@ class TestAttentionMonitor:
         assert score == 0.0  # Should be clamped to 0
 
     def test_classify_attention_state_distracted(self, attention_monitor):
-        """Test classifying distracted state."""
+        """Test classifying distracted state with corroborating pressure."""
         state = attention_monitor._classify_attention_state(
             keystroke_rate=0,
-            error_rate=0,
-            context_switches=0,
+            error_rate=3,
+            context_switches=5,
             pause_duration=700,  # > 10 minutes
             focus_score=0.5,
         )
         assert state == AttentionState.DISTRACTED
+
+    def test_classify_attention_state_lone_pause_is_not_distracted(
+        self, attention_monitor
+    ):
+        """Test lone pause evidence does not classify as distracted."""
+        state = attention_monitor._classify_attention_state(
+            keystroke_rate=0,
+            error_rate=0,
+            context_switches=0,
+            pause_duration=700,
+            focus_score=0.0,
+        )
+        assert state == AttentionState.NORMAL
+
+    def test_classify_attention_state_hyperfocus_latches_through_lone_pause(
+        self, attention_monitor
+    ):
+        """Test hyperfocus stays latched until corroborating evidence."""
+        attention_monitor._current_state = AttentionState.HYPERFOCUS
+        attention_monitor._state_duration = 50 * 60
+
+        state = attention_monitor._classify_attention_state(
+            keystroke_rate=0,
+            error_rate=0,
+            context_switches=0,
+            pause_duration=700,
+            focus_score=0.0,
+        )
+        assert state == AttentionState.HYPERFOCUS
 
     def test_classify_attention_state_scattered(self, attention_monitor):
         """Test classifying scattered state."""

--- a/tests/unit/test_adhd_hyperfocus_latch.py
+++ b/tests/unit/test_adhd_hyperfocus_latch.py
@@ -1,0 +1,91 @@
+import pytest
+
+
+USER_ID = "operator-local-001"
+
+
+@pytest.mark.asyncio
+async def test_hyperfocus_latches_through_lone_idle_signal(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+    from services.adhd_engine.core.models import AttentionState
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: USER_ID)
+    engine = engine_module.ADHDAccommodationEngine()
+    engine.current_attention_states[USER_ID] = AttentionState.HYPERFOCUSED
+
+    result = await engine.record_activity_update(
+        USER_ID,
+        {
+            "idle_detected": True,
+            "idle_minutes": 18,
+        },
+    )
+
+    assert result["attention_state"] == AttentionState.HYPERFOCUSED
+    assert engine.current_attention_states[USER_ID] == AttentionState.HYPERFOCUSED
+
+
+@pytest.mark.asyncio
+async def test_hyperfocus_exit_requires_two_degradation_signals(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+    from services.adhd_engine.core.models import AttentionState
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: USER_ID)
+    engine = engine_module.ADHDAccommodationEngine()
+    engine.current_attention_states[USER_ID] = AttentionState.HYPERFOCUSED
+
+    single_signal = await engine.record_activity_update(
+        USER_ID,
+        {
+            "context_switches": 14,
+            "completion_rate": 0.7,
+            "break_compliance": 0.9,
+            "minutes_since_break": 35,
+        },
+    )
+
+    assert single_signal["attention_state"] == AttentionState.HYPERFOCUSED
+
+    corroborated = await engine.record_activity_update(
+        USER_ID,
+        {
+            "context_switches": 14,
+            "tool_failures": 4,
+            "completion_rate": 0.7,
+            "break_compliance": 0.9,
+            "minutes_since_break": 35,
+        },
+    )
+
+    assert corroborated["attention_state"] == AttentionState.OVERWHELMED
+
+
+@pytest.mark.asyncio
+async def test_work_boundary_releases_hyperfocus_latch(monkeypatch):
+    from services.adhd_engine.core import engine as engine_module
+    from services.adhd_engine.core.models import AttentionState
+
+    monkeypatch.setattr(engine_module, "resolve_operator_user_id", lambda: USER_ID)
+    engine = engine_module.ADHDAccommodationEngine()
+    engine.current_attention_states[USER_ID] = AttentionState.HYPERFOCUSED
+
+    await engine.record_activity_update(
+        USER_ID,
+        {
+            "hook_event_name": "PostToolUse",
+            "status": "success",
+            "tool_name": "Bash",
+            "boundary_type": "test",
+        },
+    )
+    result = await engine.record_activity_update(
+        USER_ID,
+        {
+            "context_switches": 14,
+            "completion_rate": 0.7,
+            "break_compliance": 0.9,
+            "minutes_since_break": 35,
+        },
+    )
+
+    assert result["attention_state"] == AttentionState.SCATTERED


### PR DESCRIPTION
## Summary
- keep hyperfocus latched until a content-free work boundary or at least two corroborating degradation categories justify exit
- ensure lone idle/pause evidence does not mark the operator distracted, scattered, or overwhelmed
- cover both the active ADHD Engine assessment path and the line-numbered legacy attention monitor path

## Release notes
- ADHD attention classification now treats idle/pause as neutral evidence unless corroborated by additional bounded signals.
- Hyperfocus state protection now resists single-signal exits and releases on content-free work boundaries or corroborated degradation.

## Documentation and feature list sync
- Added task packet `TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001`.
- Added implementation notes with RED/GREEN proof and explicit NOT_RUN live validation boundaries.

## Validation
- RED: `python -m pytest tests/unit/test_adhd_hyperfocus_latch.py tests/test_attention_monitor.py` failed first with 4 targeted failures
- PASS: `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- PASS: `python -m pytest tests/unit/test_adhd_hyperfocus_latch.py tests/unit/test_adhd_boundary_detection.py tests/unit/test_adhd_baseline_calibration.py tests/unit/test_adhd_privacy_guard.py tests/unit/test_adhd_real_assessment.py tests/unit/test_adhd_activity_loop.py tests/unit/test_adhd_operator_profile_seed.py tests/unit/test_adhd_operator_identity.py tests/unit/test_adhd_engine_settings_contract.py tests/unit/test_adhd_engine_task_orchestrator_url.py services/adhd_engine/tests/test_activity_tracker.py services/adhd_engine/tests/test_api.py tests/test_attention_monitor.py` (`100 passed in 2.34s` fresh post-precommit proof)
- PASS: `python -m py_compile services/adhd_engine/core/engine.py src/dopemux/adhd/attention_monitor.py`
- PASS: `git diff --check`
- PASS: `pre-commit run --files services/adhd_engine/core/engine.py src/dopemux/adhd/attention_monitor.py tests/unit/test_adhd_hyperfocus_latch.py tests/test_attention_monitor.py task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001-implementation-notes.md`
- PASS: PAL codereview with `gpt-5-codex`, no blocking issues

## NOT_RUN
- Live Redis/EventBus/provider/notifier/dashboard/shell-hook validation was not run; packet explicitly does not authorize live validation for this slice.

## Residual risk
- Legacy `src/dopemux/adhd/attention_monitor.py` has no boundary input, so it can release hyperfocus only through corroborating local pressure. The active T4 engine path handles content-free boundary release.

@codex review
@gemini
@copilot
