### PR TITLE
feat(adhd): add confidence band renderer

### DIFF
--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -53,6 +53,7 @@ from .ui.theme import (
 )
 from .ui.prompts import dopemux_prompt, dopemux_confirm
 from .ui.voice import VoiceEngine
+from .ux.confidence_band import ConfidenceBandState, render_confidence_band
 
 # Load environment variables from .env file
 load_dotenv()
@@ -2683,7 +2684,14 @@ def status(ctx, attention: bool, context: bool, tasks: bool, mobile: bool):
         table.add_row(
             "Session Duration", f"{metrics.get('session_duration', 0):.1f} min", "⏱️"
         )
-        table.add_row("Focus Score", f"{metrics.get('focus_score', 0):.1%}", "🎯")
+        table.add_row(
+            "Focus Score",
+            render_confidence_band(
+                value=metrics.get("focus_score"),
+                state=ConfidenceBandState.INFERRED,
+            ),
+            "🎯",
+        )
         table.add_row("Context Switches", str(metrics.get("context_switches", 0)), "🔄")
 
         console.logger.info(table)

--- a/src/dopemux/ux/__init__.py
+++ b/src/dopemux/ux/__init__.py
@@ -1,1 +1,5 @@
 """UX utilities for dopemux CLI — interactive prompts, progress displays, and wizards."""
+
+from .confidence_band import ConfidenceBandState, render_confidence_band
+
+__all__ = ["ConfidenceBandState", "render_confidence_band"]

--- a/src/dopemux/ux/confidence_band.py
+++ b/src/dopemux/ux/confidence_band.py
@@ -1,0 +1,73 @@
+"""Deterministic confidence-band rendering for honest ADHD UX surfaces."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional, Union
+
+
+class ConfidenceBandState(str, Enum):
+    """Evidence state for a displayed confidence-like value."""
+
+    MEASURED = "measured"
+    INFERRED = "inferred"
+    LOW_CONFIDENCE = "low-conf"
+    CALIBRATING = "calibrating"
+    UNAVAILABLE = "unavailable"
+
+
+_STATE_LABELS = {
+    ConfidenceBandState.MEASURED: "MEASURED",
+    ConfidenceBandState.INFERRED: "INFERRED",
+    ConfidenceBandState.LOW_CONFIDENCE: "LOW-CONF",
+    ConfidenceBandState.CALIBRATING: "CALIBRATING",
+    ConfidenceBandState.UNAVAILABLE: "UNAVAILABLE",
+}
+
+
+def _normalize_state(
+    state: Union[ConfidenceBandState, str],
+) -> ConfidenceBandState:
+    if isinstance(state, ConfidenceBandState):
+        return state
+    normalized = str(state).strip().lower().replace("_", "-")
+    if normalized == "low-confidence":
+        normalized = ConfidenceBandState.LOW_CONFIDENCE.value
+    try:
+        return ConfidenceBandState(normalized)
+    except ValueError:
+        return ConfidenceBandState.UNAVAILABLE
+
+
+def _format_percent(value: float) -> str:
+    bounded = max(0.0, min(1.0, float(value)))
+    return f"{bounded:.0%}"
+
+
+def render_confidence_band(
+    *,
+    value: Optional[float],
+    state: Union[ConfidenceBandState, str],
+    confidence: Optional[float] = None,
+    label: Optional[str] = None,
+) -> str:
+    """Render a value with an explicit evidence band.
+
+    The rendered string is intentionally never just a number or percent. Unknown
+    states fail closed to UNAVAILABLE instead of implying measurement.
+    """
+    normalized_state = _normalize_state(state)
+    if confidence is not None and confidence < 0.5:
+        normalized_state = ConfidenceBandState.LOW_CONFIDENCE
+
+    state_label = _STATE_LABELS[normalized_state]
+    prefix = f"{label}: " if label else ""
+
+    if normalized_state == ConfidenceBandState.UNAVAILABLE or value is None:
+        return f"{prefix}{state_label} no signal"
+    if normalized_state == ConfidenceBandState.CALIBRATING:
+        return f"{prefix}{state_label} {_format_percent(value)}"
+    if normalized_state == ConfidenceBandState.LOW_CONFIDENCE:
+        return f"{prefix}{state_label} {_format_percent(value)} verify"
+
+    return f"{prefix}{state_label} {_format_percent(value)}"

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001-implementation-notes.md
@@ -1,0 +1,67 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T1 01 Confidence Band Ux 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-02'
+last_review: '2026-06-02'
+next_review: '2026-08-31'
+prelude: Tp Dmx Adhd Cognitive T1 01 Confidence Band Ux 001 Implementation Notes (explanation)
+  for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001 Implementation Notes
+
+## Authority and Scope
+
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/adhd-confidence-band-ux-001`
+- Branch: `codex/adhd-confidence-band-ux-001`
+- Base: `origin/codex/adhd-hyperfocus-latch-001`
+- Primary checkout dirty state was not modified.
+- Active task-orchestrator item: `4f839f2a-8369-4c84-9724-f5cbfd594e5c`
+- Live status surface observed: `src/dopemux/cli.py` `status --attention`.
+
+## Initial Validation
+
+- `python -m pytest tests/test_cli.py tests/test_attention_monitor.py`
+  - Result: NOT_RUN/HUNG. The command emitted partial progress only and was terminated after exceeding the useful narrow baseline window.
+- `python -m pytest tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_attention_emoji_mapping`
+  - Result: PASS, `2 passed in 0.49s`
+- `python -m pytest tests/test_attention_monitor.py`
+  - Result: PASS, `35 passed in 1.36s`
+
+## Planned Slice
+
+- Add targeted failing tests for:
+  - confidence-band renderer states: measured, inferred, low-confidence, calibrating, unavailable;
+  - no renderer output equals a bare numeric or percent string;
+  - `status --attention` focus score value includes confidence-band evidence label.
+- Implement only the primitive and focused CLI wiring.
+
+## Final Proof
+
+- RED validation:
+  - `python -m pytest tests/unit/test_confidence_band_ux.py tests/test_cli.py::TestCLI::test_status_command_all_metrics`
+  - Result: FAIL as expected, 8 failures covering missing primitive module and missing `INFERRED` status output label.
+- Implementation:
+  - `src/dopemux/ux/confidence_band.py` adds a deterministic confidence-band renderer for measured, inferred, low-confidence, calibrating, and unavailable states.
+  - `src/dopemux/ux/__init__.py` exports the primitive.
+  - `src/dopemux/cli.py` routes `status --attention` focus score through the primitive as `INFERRED`.
+- GREEN validation:
+  - `python -m pytest tests/unit/test_confidence_band_ux.py tests/test_cli.py::TestCLI::test_status_command_all_metrics`
+    - Result: PASS, `8 passed in 0.51s`
+  - `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+    - Result: PASS
+  - `python -m py_compile src/dopemux/ux/confidence_band.py src/dopemux/cli.py`
+    - Result: PASS
+  - `git diff --check`
+    - Result: PASS
+  - `python -m pytest tests/unit/test_confidence_band_ux.py tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_attention_emoji_mapping tests/test_attention_monitor.py`
+    - Result: PASS, `44 passed in 1.88s`
+- PAL codereview:
+  - Tool/model: `mcp__pal.codereview`, `gpt-5-codex`
+  - Result: PASS, no blocking issues.
+  - Residual note: full `status --attention` fail-honest rewiring remains downstream; this slice targets the confidence-band primitive and focus-score wiring only.
+- NOT_RUN:
+  - Full `python -m pytest tests/test_cli.py tests/test_attention_monitor.py`: terminated after partial progress because it exceeded the useful narrow baseline window.
+  - Live Redis/EventBus/provider/notifier/dashboard/shell-hook validation: not authorized by packet.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json
@@ -1,0 +1,148 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001",
+  "project": "dopemux-mvp",
+  "target": "ADHD confidence-band UX primitive for measured, inferred, low-confidence, calibrating, and unavailable states",
+  "invariants": [
+    "Never present defaults, heuristics, estimates, calibration state, or missing evidence as measurement.",
+    "Confidence-band rendering must always include an explicit evidence label; never render a bare number as the full value.",
+    "The primitive must be deterministic, side-effect-free, and unit-tested for every state.",
+    "Live status --attention wiring may use the primitive but must not add live service calls or data collection.",
+    "No live Redis, EventBus, provider, notifier, dashboard, or shell-hook validation is authorized in this slice.",
+    "Do not widen into full status --attention fail-honest rewiring, TrendsPanel demo gating, dashboard live refresh, or documentation doctrine cleanup."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-hyperfocus-latch-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T4-08-HYPERFOCUS-LATCH-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-confidence-band-ux-001",
+    "base_branch": "codex/adhd-hyperfocus-latch-001",
+    "stacked_because": "Confidence-band UX is the next concrete ADHD remediation task and is stacked on the current ADHD remediation PR tip to preserve series continuity."
+  },
+  "commit": {
+    "message": "feat(adhd): add confidence band renderer",
+    "allowlist": [
+      "src/dopemux/ux/confidence_band.py",
+      "src/dopemux/ux/__init__.py",
+      "src/dopemux/cli.py",
+      "tests/unit/test_confidence_band_ux.py",
+      "tests/test_cli.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_confidence_band_ux.py tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_attention_emoji_mapping tests/test_attention_monitor.py",
+      "python -m py_compile src/dopemux/ux/confidence_band.py src/dopemux/cli.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(adhd): add confidence band renderer",
+    "body": "## Summary\n- add a deterministic confidence-band UX primitive for measured, inferred, low-confidence, calibrating, and unavailable states\n- ensure each rendered value includes explicit evidence status instead of a bare number\n- wire status --attention focus score through the primitive without adding live service calls\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_confidence_band_ux.py tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_attention_emoji_mapping tests/test_attention_monitor.py\n- python -m py_compile src/dopemux/ux/confidence_band.py src/dopemux/cli.py\n- git diff --check",
+    "base": "codex/adhd-hyperfocus-latch-001"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect live status --attention rendering, existing UX/theme helpers, and tests before editing.",
+      "requirements": [
+        "Identify current bare numeric confidence-like outputs.",
+        "Confirm this packet is a primitive/wiring slice only.",
+        "Do not add live telemetry or service calls."
+      ],
+      "commands": [
+        "nl -ba src/dopemux/cli.py | sed -n '2640,2690p'",
+        "find src/dopemux/ux src/dopemux/ui -maxdepth 3 -type f -name '*.py' -print | sort | xargs rg -n \"confidence|band|chip|status|render|label\"",
+        "nl -ba tests/test_cli.py | sed -n '466,610p'"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Live status attention output and local UI helper conventions are identified before tests or production edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "src/dopemux/cli.py",
+        "src/dopemux/ux/interactive_prompts.py",
+        "src/dopemux/ui/theme.py",
+        "tests/test_cli.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add failing tests, then add the confidence-band primitive and wire status --attention focus score through it.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "Test measured, inferred, low-confidence, calibrating, and unavailable states.",
+        "Rendered primitive output must include an explicit state label.",
+        "Rendered primitive output must not equal a bare numeric or percent string.",
+        "status --attention must not show the focus score as only a bare percent."
+      ],
+      "commands": [
+        "apply_patch",
+        "python -m pytest tests/unit/test_confidence_band_ux.py tests/test_cli.py::TestCLI::test_status_command_all_metrics"
+      ],
+      "expected_files": [
+        "src/dopemux/ux/confidence_band.py",
+        "src/dopemux/ux/__init__.py",
+        "src/dopemux/cli.py",
+        "tests/unit/test_confidence_band_ux.py",
+        "tests/test_cli.py"
+      ],
+      "validation": [
+        "Targeted primitive/status tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, focused tests, syntax, diff scope, PAL codereview, and precommit checks.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim live status telemetry validation beyond mocked CLI paths."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_confidence_band_ux.py tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_attention_emoji_mapping tests/test_attention_monitor.py",
+        "python -m py_compile src/dopemux/ux/confidence_band.py src/dopemux/cli.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -518,6 +518,7 @@ class TestCLI:
 
         assert result.exit_code == 0
         assert "Attention Metrics" in result.output
+        assert "INFERRED" in result.output
         assert "Context Information" in result.output
         assert "Task Progress" in result.output
 

--- a/tests/unit/test_confidence_band_ux.py
+++ b/tests/unit/test_confidence_band_ux.py
@@ -1,0 +1,38 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_label"),
+    [
+        ("measured", "MEASURED"),
+        ("inferred", "INFERRED"),
+        ("low-conf", "LOW-CONF"),
+        ("calibrating", "CALIBRATING"),
+        ("unavailable", "UNAVAILABLE"),
+    ],
+)
+def test_confidence_band_renders_explicit_state_label(state, expected_label):
+    from dopemux.ux.confidence_band import render_confidence_band
+
+    rendered = render_confidence_band(value=0.82, state=state)
+
+    assert expected_label in rendered
+    assert rendered not in {"82%", "82.0%", "0.82"}
+
+
+def test_confidence_band_low_confidence_overrides_inferred_state():
+    from dopemux.ux.confidence_band import render_confidence_band
+
+    rendered = render_confidence_band(value=0.82, state="inferred", confidence=0.42)
+
+    assert "LOW-CONF" in rendered
+    assert "INFERRED" not in rendered
+
+
+def test_confidence_band_unavailable_omits_fabricated_number():
+    from dopemux.ux.confidence_band import render_confidence_band
+
+    rendered = render_confidence_band(value=None, state="unavailable")
+
+    assert "UNAVAILABLE" in rendered
+    assert "%" not in rendered


### PR DESCRIPTION
## Summary
- add a deterministic confidence-band UX primitive for measured, inferred, low-confidence, calibrating, and unavailable states
- ensure confidence-like output includes explicit evidence status instead of rendering as only a bare number
- wire `dopemux status --attention` focus score through the primitive as `INFERRED` without adding live service calls

## Release notes
- ADHD UX can now render confidence/state evidence bands consistently across CLI surfaces.
- `status --attention` focus score now communicates that the value is inferred instead of silently presenting it as measurement.

## Documentation and feature list sync
- Added task packet `TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001`.
- Added implementation notes with RED/GREEN proof and explicit NOT_RUN live validation boundaries.

## Validation
- RED: `python -m pytest tests/unit/test_confidence_band_ux.py tests/test_cli.py::TestCLI::test_status_command_all_metrics` failed first with 8 targeted failures
- PASS: `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- PASS: `python -m pytest tests/unit/test_confidence_band_ux.py tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_attention_emoji_mapping tests/test_attention_monitor.py` (`44 passed in 1.86s` fresh post-precommit proof)
- PASS: `python -m py_compile src/dopemux/ux/confidence_band.py src/dopemux/cli.py`
- PASS: `git diff --check`
- PASS: `pre-commit run --files src/dopemux/ux/confidence_band.py src/dopemux/ux/__init__.py src/dopemux/cli.py tests/unit/test_confidence_band_ux.py tests/test_cli.py task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001-implementation-notes.md`
- PASS: PAL codereview with `gpt-5-codex`, no blocking issues

## NOT_RUN
- Full `python -m pytest tests/test_cli.py tests/test_attention_monitor.py` was interrupted after partial progress because it exceeded the useful narrow baseline window.
- Live Redis/EventBus/provider/notifier/dashboard/shell-hook validation was not run; packet explicitly does not authorize live validation for this slice.

## Residual risk
- Full `status --attention` fail-honest rewiring remains downstream. This PR only adds the shared primitive and focus-score wiring.

@codex review
@gemini
@copilot
