### PR TITLE
fix(adhd): make attention status fail honest

### DIFF
--- a/src/dopemux/adhd/attention_monitor.py
+++ b/src/dopemux/adhd/attention_monitor.py
@@ -127,6 +127,9 @@ class AttentionMonitor:
             ),  # Last minute
             "state_duration": self._state_duration,
             "monitoring_active": self._monitoring,
+            "data_status": "available",
+            "status_message": "active monitoring data",
+            "sample_count": len(self._metrics_history),
         }
 
     def get_session_summary(self) -> Dict[str, Any]:
@@ -430,7 +433,10 @@ class AttentionMonitor:
                 ]
             )
 
-        elif current_metrics["focus_score"] < 0.5:
+        elif (
+            current_metrics.get("focus_score") is not None
+            and current_metrics["focus_score"] < 0.5
+        ):
             recommendations.extend(
                 [
                     "Low focus detected - try the Pomodoro technique",
@@ -439,7 +445,10 @@ class AttentionMonitor:
                 ]
             )
 
-        elif current_metrics["session_duration"] > 90:
+        elif (
+            current_metrics.get("session_duration") is not None
+            and current_metrics["session_duration"] > 90
+        ):
             recommendations.append(
                 "Long session detected - consider taking a longer break"
             )
@@ -462,14 +471,17 @@ class AttentionMonitor:
             json.dump(session_data, f, indent=2)
 
     def _get_default_metrics(self) -> Dict[str, Any]:
-        """Get default metrics when no data available."""
+        """Get fail-honest metrics when no attention samples are available."""
         return {
-            "attention_state": AttentionState.NORMAL,
-            "focus_score": 0.5,
-            "session_duration": 0,
-            "keystroke_rate": 0,
-            "error_rate": 0,
-            "context_switches": 0,
-            "state_duration": 0,
+            "attention_state": "unavailable",
+            "focus_score": None,
+            "session_duration": None,
+            "keystroke_rate": None,
+            "error_rate": None,
+            "context_switches": None,
+            "state_duration": None,
             "monitoring_active": self._monitoring,
+            "data_status": "unavailable",
+            "status_message": "no active monitoring data",
+            "sample_count": 0,
         }

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -2668,6 +2668,20 @@ def status(ctx, attention: bool, context: bool, tasks: bool, mobile: bool):
     if attention:
         monitor = AttentionMonitor(project_path)
         metrics = monitor.get_current_metrics()
+        no_attention_data = metrics.get("data_status") == "unavailable"
+        attention_state = metrics.get("attention_state", "unknown")
+        attention_state_value = str(attention_state)
+        session_duration = metrics.get("session_duration")
+        context_switches = metrics.get("context_switches")
+        focus_band_state = (
+            ConfidenceBandState.UNAVAILABLE
+            if no_attention_data
+            else ConfidenceBandState.INFERRED
+        )
+
+        if no_attention_data:
+            message = metrics.get("status_message", "no active monitoring data")
+            attention_state_value = f"UNAVAILABLE {message}"
 
         table = styled_table(
             "🧠 Attention Metrics",
@@ -2678,21 +2692,41 @@ def status(ctx, attention: bool, context: bool, tasks: bool, mobile: bool):
 
         table.add_row(
             "Current State",
-            metrics.get("attention_state", "unknown"),
-            _get_attention_emoji(metrics.get("attention_state")),
+            attention_state_value,
+            _get_attention_emoji(attention_state),
         )
         table.add_row(
-            "Session Duration", f"{metrics.get('session_duration', 0):.1f} min", "⏱️"
+            "Session Duration",
+            (
+                f"{session_duration:.1f} min"
+                if session_duration is not None
+                else render_confidence_band(
+                    value=None,
+                    state=ConfidenceBandState.UNAVAILABLE,
+                )
+            ),
+            "⏱️",
         )
         table.add_row(
             "Focus Score",
             render_confidence_band(
                 value=metrics.get("focus_score"),
-                state=ConfidenceBandState.INFERRED,
+                state=focus_band_state,
             ),
             "🎯",
         )
-        table.add_row("Context Switches", str(metrics.get("context_switches", 0)), "🔄")
+        table.add_row(
+            "Context Switches",
+            (
+                str(context_switches)
+                if context_switches is not None
+                else render_confidence_band(
+                    value=None,
+                    state=ConfidenceBandState.UNAVAILABLE,
+                )
+            ),
+            "🔄",
+        )
 
         console.logger.info(table)
 

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001-implementation-notes.md
@@ -1,0 +1,65 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T1 02 Status Attention Fail Honest 001 Implementation
+  Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-02'
+last_review: '2026-06-02'
+next_review: '2026-08-31'
+prelude: Tp Dmx Adhd Cognitive T1 02 Status Attention Fail Honest 001 Implementation
+  Notes (explanation) for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001 Implementation Notes
+
+## Authority and Scope
+
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/adhd-status-attention-fail-honest-001`
+- Branch: `codex/adhd-status-attention-fail-honest-001`
+- Base: `origin/codex/adhd-confidence-band-ux-001`
+- Primary checkout dirty state was not modified.
+- Active task-orchestrator item: `e5415b02-bc06-4db6-8a66-9d50d16c72aa`
+- Live status surface observed: `src/dopemux/cli.py` `status --attention`.
+- Current no-data fallback observed: `AttentionMonitor._get_default_metrics()` returns `normal` and `0.5` focus score despite no samples.
+
+## Initial Validation
+
+- `python -m pytest tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_attention_monitor.py::TestAttentionMonitor::test_get_current_metrics_no_data tests/unit/test_confidence_band_ux.py`
+  - Result: PASS, `9 passed in 1.27s`
+
+## Planned Slice
+
+- Add targeted failing tests for:
+  - attention monitor no-data metrics do not fabricate `normal` or `0.5`;
+  - `status --attention` no-data path renders unavailable/calibrating evidence via confidence-band.
+- Implement only no-data status shape and CLI rendering.
+
+## Final Proof
+
+- RED validation:
+  - `python -m pytest tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/test_attention_monitor.py::TestAttentionMonitor::test_get_current_metrics_no_data`
+  - Result: FAIL as expected, `2 failed`; monitor still returned `normal` and CLI raised `TypeError` formatting `None`.
+- GREEN validation:
+  - `python -m pytest tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/test_attention_monitor.py::TestAttentionMonitor::test_get_current_metrics_no_data`
+  - Result: PASS, `2 passed in 0.28s`
+- Packet schema:
+  - `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+  - Result: PASS; jsonschema CLI deprecation warning only.
+- Packet pytest:
+  - `python -m pytest tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/test_attention_monitor.py::TestAttentionMonitor::test_get_current_metrics_no_data tests/unit/test_confidence_band_ux.py`
+  - Result: PASS, `10 passed in 0.55s`
+- Expanded focused pytest:
+  - `python -m pytest tests/test_attention_monitor.py tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/unit/test_confidence_band_ux.py`
+  - Result: PASS, `44 passed in 2.22s`
+- Syntax:
+  - `python -m py_compile src/dopemux/adhd/attention_monitor.py src/dopemux/cli.py`
+  - Result: PASS
+- Diff hygiene:
+  - `git diff --check`
+  - Result: PASS
+- PAL codereview:
+  - Result: PASS, no findings; intentional no-data contract change noted as aligned with packet.
+- Precommit:
+  - Initial run updated this notes file with required frontmatter; all other hooks passed.
+  - Final rerun result: PASS across all configured hooks for touched files.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001.json
@@ -1,0 +1,147 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001",
+  "project": "dopemux-mvp",
+  "target": "status --attention fails honest when no active monitoring data exists",
+  "invariants": [
+    "Never present default attention state, focus score, session duration, or context-switch count as observed data.",
+    "No active monitoring data must render as unavailable or calibrating, not normal/focused defaults.",
+    "status --attention must use the confidence-band primitive from T1-01 for missing or inferred focus-score evidence.",
+    "The change must not add live service calls, telemetry collection, persistence, or dashboard behavior.",
+    "No live Redis, EventBus, provider, notifier, dashboard, or shell-hook validation is authorized in this slice.",
+    "Do not widen into TrendsPanel demo gating, dashboard live refresh, interactive prompt wiring, or documentation doctrine cleanup."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-confidence-band-ux-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-status-attention-fail-honest-001",
+    "base_branch": "codex/adhd-confidence-band-ux-001",
+    "stacked_because": "status --attention fail-honest rendering depends on the confidence-band primitive introduced by the preceding T1 slice."
+  },
+  "commit": {
+    "message": "fix(adhd): make attention status fail honest",
+    "allowlist": [
+      "src/dopemux/adhd/attention_monitor.py",
+      "src/dopemux/cli.py",
+      "tests/test_attention_monitor.py",
+      "tests/test_cli.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/test_attention_monitor.py::TestAttentionMonitor::test_get_current_metrics_no_data tests/unit/test_confidence_band_ux.py",
+      "python -m py_compile src/dopemux/adhd/attention_monitor.py src/dopemux/cli.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(adhd): make attention status fail honest",
+    "body": "## Summary\n- stop treating missing attention samples as normal state with a 50% focus score\n- render status --attention no-data state as unavailable/calibrating using the confidence-band primitive\n- preserve existing inferred rendering when real in-process metrics exist\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/test_attention_monitor.py::TestAttentionMonitor::test_get_current_metrics_no_data tests/unit/test_confidence_band_ux.py\n- python -m py_compile src/dopemux/adhd/attention_monitor.py src/dopemux/cli.py\n- git diff --check",
+    "base": "codex/adhd-confidence-band-ux-001"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect attention monitor no-data defaults, status --attention rendering, and current CLI tests before editing.",
+      "requirements": [
+        "Identify fabricated no-data fields before implementation.",
+        "Confirm confidence-band primitive exists in the stack.",
+        "Do not add live telemetry or service calls."
+      ],
+      "commands": [
+        "nl -ba src/dopemux/cli.py | sed -n '2660,2695p'",
+        "nl -ba src/dopemux/adhd/attention_monitor.py | sed -n '440,475p'",
+        "nl -ba tests/test_cli.py | sed -n '466,530p'"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Current fabricated fallback fields and CLI rendering path are identified before tests or production edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T1-01-CONFIDENCE-BAND-UX-001.json",
+        "src/dopemux/cli.py",
+        "src/dopemux/adhd/attention_monitor.py",
+        "src/dopemux/ux/confidence_band.py",
+        "tests/test_cli.py",
+        "tests/test_attention_monitor.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add failing tests, then make attention no-data and status rendering fail honest.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "No metrics history must not return normal attention state or 0.5 focus score as evidence.",
+        "status --attention no-data output must include an unavailable/calibrating evidence label.",
+        "Existing metric samples must still render through the inferred confidence-band path."
+      ],
+      "commands": [
+        "apply_patch",
+        "python -m pytest tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/test_attention_monitor.py::TestAttentionMonitor::test_get_current_metrics_no_data"
+      ],
+      "expected_files": [
+        "src/dopemux/adhd/attention_monitor.py",
+        "src/dopemux/cli.py",
+        "tests/test_attention_monitor.py",
+        "tests/test_cli.py"
+      ],
+      "validation": [
+        "Targeted fail-honest tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, focused tests, syntax, diff scope, PAL codereview, and precommit checks.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim live status telemetry validation beyond mocked CLI paths."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/test_attention_monitor.py::TestAttentionMonitor::test_get_current_metrics_no_data tests/unit/test_confidence_band_ux.py",
+        "python -m py_compile src/dopemux/adhd/attention_monitor.py src/dopemux/cli.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/test_attention_monitor.py
+++ b/tests/test_attention_monitor.py
@@ -85,12 +85,15 @@ class TestAttentionMonitor:
         assert attention_monitor._monitoring is False
 
     def test_get_current_metrics_no_data(self, attention_monitor):
-        """Test getting current metrics when no data available."""
+        """Test current metrics fail honest when no data is available."""
         metrics = attention_monitor.get_current_metrics()
 
-        assert metrics["attention_state"] == AttentionState.NORMAL
-        assert metrics["focus_score"] == 0.5
-        assert metrics["session_duration"] == 0
+        assert metrics["attention_state"] == "unavailable"
+        assert metrics["focus_score"] is None
+        assert metrics["session_duration"] is None
+        assert metrics["context_switches"] is None
+        assert metrics["data_status"] == "unavailable"
+        assert metrics["status_message"] == "no active monitoring data"
         assert metrics["monitoring_active"] is False
 
     def test_get_current_metrics_with_data(self, attention_monitor):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -522,6 +522,33 @@ class TestCLI:
         assert "Context Information" in result.output
         assert "Task Progress" in result.output
 
+    @patch("dopemux.cli.AttentionMonitor")
+    def test_status_attention_no_data_fails_honest(self, mock_attention):
+        """Test status --attention does not render fabricated defaults."""
+        mock_attention_monitor = Mock()
+        mock_attention_monitor.get_current_metrics.return_value = {
+            "attention_state": "unavailable",
+            "session_duration": None,
+            "focus_score": None,
+            "context_switches": None,
+            "data_status": "unavailable",
+            "status_message": "no active monitoring data",
+            "monitoring_active": False,
+        }
+        mock_attention.return_value = mock_attention_monitor
+
+        runner = CliRunner()
+        with patch("dopemux.cli.Path.cwd", return_value=Path("/test")):
+            with patch("dopemux.cli.Path.exists", return_value=True):
+                result = runner.invoke(cli, ["status", "--attention"])
+
+        assert result.exit_code == 0
+        assert "UNAVAILABLE" in result.output
+        assert "no active monitoring data" in result.output
+        assert "INFERRED" not in result.output
+        assert "50%" not in result.output
+        assert "normal" not in result.output
+
     @patch("dopemux.cli.ConfigManager")
     @patch("dopemux.cli.TaskDecomposer")
     def test_task_command_add_task(self, mock_decomposer, mock_config):


### PR DESCRIPTION
## Summary
- stop treating missing attention samples as normal state with a 50% focus score
- render status --attention no-data state as UNAVAILABLE through the confidence-band primitive
- preserve existing INFERRED rendering when real in-process metrics exist

## Validation
- PASS: python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: RED run failed as expected for no-data monitor and CLI formatting paths
- PASS: python -m pytest tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/test_attention_monitor.py::TestAttentionMonitor::test_get_current_metrics_no_data tests/unit/test_confidence_band_ux.py
- PASS: python -m pytest tests/test_attention_monitor.py tests/test_cli.py::TestCLI::test_status_command_all_metrics tests/test_cli.py::TestCLI::test_status_attention_no_data_fails_honest tests/unit/test_confidence_band_ux.py
- PASS: python -m py_compile src/dopemux/adhd/attention_monitor.py src/dopemux/cli.py
- PASS: git diff --check
- PASS: pre-commit run --files on touched allowlist files; notes frontmatter hook auto-updated once, final rerun passed
- PASS: PAL codereview, no findings

## Release Notes
- status --attention now fails honest when attention monitoring has no samples instead of showing fabricated normal/50% defaults.

## Residual Risk
- This slice validates mocked CLI and monitor unit paths only; no live attention daemon, dashboard, or shell-hook runtime was exercised by design.

@codex review
@gemini
@copilot