### PR TITLE
fix(adhd): gate dashboard trend demos

### DIFF
--- a/src/dopemux/ui/dashboard.py
+++ b/src/dopemux/ui/dashboard.py
@@ -372,9 +372,34 @@ class ServicesGrid(Static):
 class TrendsPanel(Static):
     """Sparkline trends (Tier 3)."""
 
-    cognitive_history = reactive(DEMO_COGNITIVE_HISTORY)
-    velocity_history = reactive(DEMO_VELOCITY_HISTORY)
-    switches_history = reactive(DEMO_SWITCHES_HISTORY)
+    cognitive_history = reactive([])
+    velocity_history = reactive([])
+    switches_history = reactive([])
+    source_label = reactive("unavailable")
+    last_sampled_at = reactive(None)
+
+    async def on_mount(self) -> None:
+        self.set_interval(30.0, self.update_trends)
+        await self.update_trends()
+
+    async def update_trends(self) -> None:
+        app: DopemuxDashboard = self.app  # type: ignore[assignment]
+        if app.demo:
+            self.apply_demo_trends()
+            return
+
+        self.cognitive_history = []
+        self.velocity_history = []
+        self.switches_history = []
+        self.source_label = "unavailable"
+        self.last_sampled_at = None
+
+    def apply_demo_trends(self) -> None:
+        self.cognitive_history = list(DEMO_COGNITIVE_HISTORY)
+        self.velocity_history = list(DEMO_VELOCITY_HISTORY)
+        self.switches_history = list(DEMO_SWITCHES_HISTORY)
+        self.source_label = "demo"
+        self.last_sampled_at = datetime.now(timezone.utc)
 
     def render(self) -> object:
         def sparkline(data: list[float | int]) -> str:
@@ -382,18 +407,28 @@ class TrendsPanel(Static):
             mx = max(data) or 1
             return "".join(chars[min(int((v / mx) * 7), 7)] for v in data)
 
+        def trend_value(data: list[float | int], style: str) -> str:
+            if not data:
+                return "[warning]UNAVAILABLE no live trend data[/]"
+            return f"[{style}]{sparkline(data)}[/]"
+
         table = _grid_table()
         table.add_row(
             "[label]Cognitive load[/]",
-            f"[mint.soft]{sparkline(self.cognitive_history)}[/] [text.dim](last 2h)[/]",
+            f"{trend_value(self.cognitive_history, 'mint.soft')} [text.dim](last 2h)[/]",
         )
         table.add_row(
             "[label]Task velocity[/]",
-            f"[info]{sparkline(self.velocity_history)}[/] [text.dim](last 7d)[/]",
+            f"{trend_value(self.velocity_history, 'info')} [text.dim](last 7d)[/]",
         )
         table.add_row(
             "[label]Context switches[/]",
-            f"[warning]{sparkline(self.switches_history)}[/] [text.dim](last 24h)[/]",
+            f"{trend_value(self.switches_history, 'warning')} [text.dim](last 24h)[/]",
+        )
+        table.add_row("[label]Source[/]", f"[text.dim]{self.source_label}[/]")
+        table.add_row(
+            "[label]Updated[/]",
+            f"[text.dim]{refresh_age_label(self.last_sampled_at)}[/]",
         )
 
         return styled_panel(table, title="📈 COGNITIVE TRENDS", border_style="warning")
@@ -502,6 +537,8 @@ class DopemuxDashboard(App):
             panel.call_later(panel.update_metrics)
         for panel in self.query(ServicesGrid):
             panel.call_later(panel.update_services)
+        for panel in self.query(TrendsPanel):
+            panel.call_later(panel.update_trends)
         self.notify("[LIVE] Refreshing cockpit telemetry.", severity="information")
 
 

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001-implementation-notes.md
@@ -1,0 +1,62 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T1 03 Trendspanel Demo Gate 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-02'
+last_review: '2026-06-02'
+next_review: '2026-08-31'
+prelude: Tp Dmx Adhd Cognitive T1 03 Trendspanel Demo Gate 001 Implementation Notes
+  (explanation) for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001 Implementation Notes
+
+## Authority and Scope
+
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/adhd-trendspanel-demo-gate-001`
+- Branch: `codex/adhd-trendspanel-demo-gate-001`
+- Base: `origin/codex/adhd-status-attention-fail-honest-001`
+- Primary checkout dirty state was not modified.
+- Active task-orchestrator item: `113a7e3f-4005-4feb-9c8f-be54b06f86d8`
+- Live dashboard surface observed: `src/dopemux/ui/dashboard.py` `TrendsPanel`.
+- Current live default observed: `TrendsPanel` reactive histories initialize from demo constants without checking `app.demo`.
+
+## Initial Validation
+
+- `python -m pytest tests/unit/test_dashboard_operator_ui.py`
+  - Result: PASS, `4 passed in 0.12s`
+- Plain `TrendsPanel()` inspection:
+  - Result: demo histories are present by default.
+
+## Planned Slice
+
+- Add targeted failing tests for:
+  - default/live TrendsPanel does not expose demo histories;
+  - unavailable live trend rows render fail-honest no-signal text;
+  - explicit demo application still uses demo histories.
+- Implement only TrendsPanel demo gating and render behavior.
+
+## Final Proof
+
+- RED validation:
+  - `python -m pytest tests/unit/test_dashboard_operator_ui.py`
+  - Result: FAIL as expected, `2 failed, 4 passed`; plain `TrendsPanel()` exposed demo histories and `apply_demo_trends()` did not exist.
+- GREEN validation:
+  - `python -m pytest tests/unit/test_dashboard_operator_ui.py`
+  - Result: PASS, `6 passed in 0.17s`
+- Packet schema:
+  - `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+  - Result: PASS; jsonschema CLI deprecation warning only.
+- Syntax:
+  - `python -m py_compile src/dopemux/ui/dashboard.py`
+  - Result: PASS
+- Diff hygiene:
+  - `git diff --check`
+  - Result: PASS
+- PAL codereview:
+  - Result: PASS, no findings.
+  - Residual uncertainty: live historical trend retrieval remains `UNKNOWN` because no runtime endpoint contract was found; live mode fails honest instead of inventing one.
+- Precommit:
+  - Initial run updated this notes file with required frontmatter; all other hooks passed.
+  - Final rerun result: PASS across all configured hooks for touched files.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001.json
@@ -1,0 +1,141 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001",
+  "project": "dopemux-mvp",
+  "target": "TrendsPanel gates demo sparklines behind demo mode and fails honest in live mode",
+  "invariants": [
+    "Live dashboard mode must not initialize or render DEMO_COGNITIVE_HISTORY, DEMO_VELOCITY_HISTORY, or DEMO_SWITCHES_HISTORY as live telemetry.",
+    "Demo histories may only be applied when the dashboard app is explicitly in demo mode.",
+    "Live TrendsPanel refresh may use only real endpoint responses; missing or malformed trend data must render unavailable rather than fabricated sparkline values.",
+    "The change must not add live writes, telemetry persistence, new services, or broad dashboard refactors.",
+    "No provider, Redis, EventBus, shell-hook, or dashboard integration runtime validation is authorized in this slice.",
+    "Do not widen into doctrine doc cleanup or unrelated dashboard panel behavior."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-status-attention-fail-honest-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T1-02-STATUS-ATTENTION-FAIL-HONEST-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-trendspanel-demo-gate-001",
+    "base_branch": "codex/adhd-status-attention-fail-honest-001",
+    "stacked_because": "TrendsPanel honesty work follows the status --attention fail-honest slice in the T1 honesty layer."
+  },
+  "commit": {
+    "message": "fix(adhd): gate dashboard trend demos",
+    "allowlist": [
+      "src/dopemux/ui/dashboard.py",
+      "tests/unit/test_dashboard_operator_ui.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_dashboard_operator_ui.py",
+      "python -m py_compile src/dopemux/ui/dashboard.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(adhd): gate dashboard trend demos",
+    "body": "## Summary\n- stop TrendsPanel from initializing demo histories in live dashboard mode\n- apply demo sparklines only when --demo is active\n- render live trend rows as unavailable when no real trend data is present\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest tests/unit/test_dashboard_operator_ui.py\n- python -m py_compile src/dopemux/ui/dashboard.py\n- git diff --check",
+    "base": "codex/adhd-status-attention-fail-honest-001"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect dashboard TrendsPanel initialization, demo-mode handling, refresh actions, and existing dashboard tests before editing.",
+      "requirements": [
+        "Identify where demo histories are currently applied.",
+        "Confirm live mode has no proven history endpoint contract before adding fetch behavior.",
+        "Do not change unrelated dashboard panels."
+      ],
+      "commands": [
+        "nl -ba src/dopemux/ui/dashboard.py | sed -n '28,64p'",
+        "nl -ba src/dopemux/ui/dashboard.py | sed -n '372,408p'",
+        "nl -ba src/dopemux/ui/dashboard.py | sed -n '430,505p'",
+        "nl -ba tests/unit/test_dashboard_operator_ui.py | sed -n '1,180p'"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Current fabricated live default histories and missing trend refresh path are identified before implementation."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "src/dopemux/ui/dashboard.py",
+        "src/dopemux/ui/service_endpoints.py",
+        "tests/unit/test_dashboard_operator_ui.py"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Add failing tests, then gate demo histories behind demo mode and make live trends fail honest when data is unavailable.",
+      "requirements": [
+        "Write failing tests before production code.",
+        "A plain TrendsPanel instance must not expose demo histories.",
+        "Demo mode must still expose demo sparklines when explicitly applied.",
+        "Live rendering with no trend data must show unavailable/no signal text instead of sparkline values."
+      ],
+      "commands": [
+        "apply_patch",
+        "python -m pytest tests/unit/test_dashboard_operator_ui.py"
+      ],
+      "expected_files": [
+        "src/dopemux/ui/dashboard.py",
+        "tests/unit/test_dashboard_operator_ui.py"
+      ],
+      "validation": [
+        "Targeted dashboard tests fail before implementation and pass after implementation."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, focused dashboard tests, syntax, diff scope, PAL codereview, and precommit hooks.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim live dashboard runtime validation beyond unit-rendered paths."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest tests/unit/test_dashboard_operator_ui.py",
+        "python -m py_compile src/dopemux/ui/dashboard.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}

--- a/tests/unit/test_dashboard_operator_ui.py
+++ b/tests/unit/test_dashboard_operator_ui.py
@@ -5,7 +5,13 @@ from datetime import datetime, timedelta, timezone
 from io import StringIO
 
 from dopemux.ui import service_endpoints
-from dopemux.ui.dashboard import ADHDStatePanel
+from dopemux.ui.dashboard import (
+    ADHDStatePanel,
+    DEMO_COGNITIVE_HISTORY,
+    DEMO_SWITCHES_HISTORY,
+    DEMO_VELOCITY_HISTORY,
+    TrendsPanel,
+)
 from dopemux.ui.theme import create_console
 
 
@@ -60,6 +66,53 @@ def test_dashboard_panel_render_shows_endpoint_next_action_when_offline() -> Non
     assert (
         "Verify the resolved ADHD Engine endpoint or restart the service." in rendered
     )
+
+
+def _render_to_text(renderable: object) -> str:
+    buffer = StringIO()
+    console = create_console(
+        file=buffer, force_terminal=False, color_system=None, width=160
+    )
+    console.print(renderable)
+    return buffer.getvalue()
+
+
+def _sparkline(data: list[float | int]) -> str:
+    chars = "▁▂▃▄▅▆▇█"
+    mx = max(data) or 1
+    return "".join(chars[min(int((v / mx) * 7), 7)] for v in data)
+
+
+def test_trends_panel_live_defaults_do_not_use_demo_histories() -> None:
+    panel = TrendsPanel()
+
+    assert panel.cognitive_history == []
+    assert panel.velocity_history == []
+    assert panel.switches_history == []
+
+    rendered = _render_to_text(panel.render())
+
+    assert "UNAVAILABLE" in rendered
+    assert "no live trend data" in rendered
+    assert _sparkline(DEMO_COGNITIVE_HISTORY) not in rendered
+    assert _sparkline(DEMO_VELOCITY_HISTORY) not in rendered
+    assert _sparkline(DEMO_SWITCHES_HISTORY) not in rendered
+
+
+def test_trends_panel_demo_histories_are_explicit() -> None:
+    panel = TrendsPanel()
+
+    panel.apply_demo_trends()
+
+    assert panel.cognitive_history == DEMO_COGNITIVE_HISTORY
+    assert panel.velocity_history == DEMO_VELOCITY_HISTORY
+    assert panel.switches_history == DEMO_SWITCHES_HISTORY
+
+    rendered = _render_to_text(panel.render())
+
+    assert _sparkline(DEMO_COGNITIVE_HISTORY) in rendered
+    assert _sparkline(DEMO_VELOCITY_HISTORY) in rendered
+    assert _sparkline(DEMO_SWITCHES_HISTORY) in rendered
 
 
 def test_resolve_dashboard_endpoints_ignores_invalid_explicit_url(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- stop TrendsPanel from initializing demo histories in live dashboard mode
- apply demo sparklines only through an explicit demo path
- render live trend rows as UNAVAILABLE when no real trend history exists
- include TrendsPanel in dashboard refresh wiring without inventing a live trend endpoint

## Validation
- PASS: python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: RED run failed as expected: python -m pytest tests/unit/test_dashboard_operator_ui.py
- PASS: python -m pytest tests/unit/test_dashboard_operator_ui.py
- PASS: python -m py_compile src/dopemux/ui/dashboard.py
- PASS: git diff --check
- PASS: pre-commit run --files on touched allowlist files; notes frontmatter hook auto-updated once, final rerun passed
- PASS: PAL codereview, no findings

## Release Notes
- Dashboard cognitive trends no longer display demo sparklines in live mode; unavailable live histories are labeled honestly.

## Residual Risk
- Live historical trend retrieval remains UNKNOWN/deferred because no runtime endpoint contract was found in this slice. This PR fails honest instead of introducing a guessed endpoint.

@codex review
@gemini
@copilot