### PR TITLE
docs(adhd): label planned focus automation honestly

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -25,11 +25,11 @@
 
 ## 🧠 Core ADHD Principles
 
-- **Context Preservation**: Auto-save every 30 seconds, maintain awareness across interruptions
+- **Context Preservation**: Manual `dopemux save` and `/dx:save` support context capture; Stop hooks can perform best-effort saves when the ADHD Engine is running. A background 30-second save loop is planned/configured behavior, not observed Claude runtime support.
 - **Gentle Guidance**: Encouraging, supportive language with clear next steps
 - **Progressive Disclosure**: Essential info first, details on request
 - **Decision Reduction**: Maximum 3 options to reduce cognitive overwhelm
-- **Task Chunking**: Break work into 25-minute segments with visual progress
+- **Task Chunking**: Use operator-managed 25-minute checkpoints with visual progress; automatic timer enforcement is not observed runtime support.
 
 ## ⚡ Simplified Task & Cognitive Architecture
 
@@ -37,7 +37,7 @@
 **Authorities**: Task storage, PRD decomposition, ADHD optimization, progress tracking
 - **ConPort (PostgreSQL AGE)**: Task storage via progress_entry, metadata in custom_data, dependencies via link_conport_items, knowledge graph queries for unblocked tasks, decision logging
 - **SuperClaude**: PRD parsing via `/dx:prd-parse` with PAL planner, 25 standard commands, 15 specialized agents, `/dx:` custom commands for ADHD workflows
-- **Python ADHD Engine**: Energy tracking, cognitive load calculation, break monitoring, attention state analysis, smart task routing, hyperfocus protection
+- **Python ADHD Engine**: Energy tracking, cognitive load calculation, break monitoring, attention state analysis, smart task routing, and hyperfocus-support modules. Claude-facing timer, break, and forced-pause automation remains not proven wired unless an explicit command/service path is verified.
 - **React Ink Dashboard**: Visual task progress, ADHD metrics, attention-aware UI, real-time updates
 
 ### Cognitive Plane
@@ -121,7 +121,11 @@ All Dopemux MCPs documented in `~/.claude/MCP_*.md` (auto-imported):
 
 The project's `.claude/settings.json` registers 10 lifecycle hooks (`SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `PostToolUseFailure`, `PermissionRequest`, `Stop`, `SubagentStop`, `PreCompact`, `SessionEnd`), all dispatched through one entry point: `src/dopemux/claude/native_hooks.py`. Individual hook scripts live under `.claude/hooks/` (e.g., `check_energy.sh`, `log_progress.sh`, `save_context.sh`, `track_file_edit.sh`, `prompt_analyzer.py`, `session_lifecycle.py`).
 
-Hooks run outside the model's turn — they're how the project automates auto-save, energy/break tracking, and ConPort context preservation. If you want to change hook behavior, edit the dispatcher or `.claude/hooks/` scripts; routine settings tweaks should go through the `update-config` skill rather than hand-editing `settings.json`. Hook output reaches the model as `<user-prompt-submit-hook>` blocks — treat as user input.
+**Observed runtime support**: Settings dispatch all lifecycle events through `native_hooks.py`; hook scripts provide best-effort context save on Stop, energy warnings before complex tools, and progress/edit event signals.
+
+**Planned/specification behavior**: focus-session timers, periodic save loops, automatic break prompts, and forced hyperfocus pauses are not proven wired in the observed Claude runtime.
+
+Hooks run outside the model's turn. If you want to change hook behavior, edit the dispatcher or `.claude/hooks/` scripts; routine settings tweaks should go through the `update-config` skill rather than hand-editing `settings.json`. Hook output reaches the model as `<user-prompt-submit-hook>` blocks — treat as user input.
 
 ## 📚 Detailed Information Locations
 
@@ -131,7 +135,7 @@ When you need comprehensive details, refer to:
 **SuperClaude Workflows**: `.claude/modules/shared/superclaude-workflows.md` (integration patterns, command selection, ADHD sessions)
 **Task Management**: `.claude/modules/superclaude-integration.md`, `.claude/modules/custom-commands.md`
 **Cognitive Plane**: `.claude/modules/cognitive-plane/` (serena-lsp.md, conport-memory.md)
-**ADHD Engine**: `.claude/modules/shared/adhd-patterns.md` (sessions, energy tracking, break management)
+**ADHD Engine**: `.claude/modules/shared/adhd-patterns.md` (sessions, energy tracking, break management; separates observed support from planned automation)
 **Shared Systems**: `.claude/modules/shared/` (sprint.md, event-patterns.md, superclaude-workflows.md)
 **Filesystem Organization**: `docs/03-reference/filesystem-guide.md` (directory structure, file placement rules)
 **Harness features** (Plan mode, advisor, /loop, ToolSearch, Skill): `~/.claude/MODES_AND_TOOLS.md`

--- a/.claude/commands/dx/implement.md
+++ b/.claude/commands/dx/implement.md
@@ -17,6 +17,8 @@ Start an ADHD-optimized 25-minute focused implementation session with intelligen
 
 **Purpose**: Provide structured, supportive implementation sessions that respect ADHD needs for focus, breaks, and progress tracking.
 
+**Runtime truth note**: This command is operator-guided. The current command text does not by itself start an automatic timer, run a recurring save loop, or enforce breaks. Those behaviors remain planned/specification behavior unless a separate runtime path is verified.
+
 ---
 
 ## Phase 1: Task Selection & ADHD Assessment
@@ -147,7 +149,7 @@ Show to user:
 
 ADHD Support Active:
 ✅ Progress tracked in ConPort
-✅ Break reminder at 25 minutes
+✅ Operator checkpoint at 25 minutes
 ✅ Energy-optimized task selection
 
 Let's build! 💪
@@ -312,7 +314,7 @@ Use mcp__conport__update_active_context with:
 - ✅ Session started (ConPort updated to IN_PROGRESS)
 - ✅ User completed focused work
 - ✅ Progress tracked in ConPort
-- ✅ Break reminder shown
+- ✅ Break checkpoint shown
 - ✅ Supportive, encouraging tone maintained throughout
 
 ---
@@ -321,5 +323,5 @@ Use mcp__conport__update_active_context with:
 
 **Tone**: Be warm, encouraging, and supportive. Celebrate progress.
 **Visuals**: Use progress bars, boxes, emojis for visual engagement.
-**Flexibility**: If user wants to deviate from 25min, that's fine - adjust.
+**Flexibility**: If user wants to deviate from 25-minute checkpoints, that's fine - adjust.
 **ADHD First**: Always prioritize user wellbeing over rigid process.

--- a/.claude/commands/save.md
+++ b/.claude/commands/save.md
@@ -3,7 +3,7 @@
 > Save your current development context including open files, mental model, cursor positions, and recent decisions for seamless restoration later.
 
 ## Overview
-The `/save` command integrates with Dopemux's ADHD-optimized context manager to preserve your development session state automatically. This saves:
+The `/save` command integrates with Dopemux's ADHD-optimized context manager to preserve your development session state when invoked. Stop hooks can also perform best-effort context saves when the ADHD Engine is running. Continuous background cadence is not proven wired in the observed command path. This saves:
 
 - **Open files** and cursor positions
 - **Mental model** and current goals
@@ -30,8 +30,8 @@ The `/save` command integrates with Dopemux's ADHD-optimized context manager to 
 5. **Provides feedback**: Shows session ID and save note
 
 ## ADHD Optimizations
-- **25-minute focus-block saves**: Automatically preserves context at the end of each Pomodoro-style focus block
-- **30-second auto-save cadence**: Background state capture every 30 seconds during active sessions
+- **Operator checkpoint saves**: Preserve context at natural focus-session boundaries
+- **Best-effort Stop-hook save**: Context can be captured on Stop when the ADHD Engine is available
 - **Zero interruption**: Doesn't break your focus flow
 - **Context continuity**: Seamless restoration after interruptions
 - **Mental model preservation**: Recaptures your thought processes
@@ -59,7 +59,7 @@ This command works with the full Dopemux CLI:
 - **Add meaningful messages**: Helps identify session purpose later
 - **Save before context switches**: Preserves mental model
 - **Use with task chunks**: Save between 25-minute focus periods
-- **Regular manual saves**: Supplement automatic saves
+- **Regular manual saves**: Use explicit checkpoints for replayable state
 
 ---
-*Powered by Dopemux's 30-second auto-save cadence with 25-minute focus-block checkpoints — ADHD accommodations* 🧠
+*Powered by Dopemux context checkpoints and best-effort hook support — ADHD accommodations* 🧠

--- a/.claude/modules/custom-commands.md
+++ b/.claude/modules/custom-commands.md
@@ -8,6 +8,10 @@
 
 **Note**: /sc: standard commands (25 total) are fully operational now. /dx: commands are detailed specifications for future ADHD-specific enhancements. Use /sc: commands for current workflows.
 
+**Observed runtime support**: manual `/dx:save`, `dopemux save`, registered lifecycle hook dispatch, and best-effort Stop/energy/progress hook signals.
+
+**Planned/specification behavior**: `/dx:implement` timer automation, recurring save checkpoints, break prompts, and hyperfocus pause enforcement are not proven wired in observed Claude runtime.
+
 ## Command Overview
 
 | Command | Purpose | ADHD Value | Frequency | Priority |
@@ -232,17 +236,17 @@ workflow:
 
 **Priority**: 🔴 **CRITICAL** (primary development workflow)
 **Frequency**: Daily (multiple sessions)
-**ADHD Value**: 25min sessions, energy matching, break management, hyperfocus protection
+**ADHD Value**: 25-minute sessions, energy matching, break management, hyperfocus protection
 
 ### Purpose
-Structured implementation sessions with automatic break reminders, energy-aware task selection, and context preservation.
+Structured implementation sessions with planned break guidance, energy-aware task selection, and context preservation.
 
 ### Implementation
 
 ```yaml
 # ~/.claude/commands/dx/implement.yaml
 name: implement
-description: ADHD-optimized implementation with 25min focus sessions
+description: ADHD-optimized implementation with 25-minute focus sessions
 category: development
 agent: developer
 
@@ -307,14 +311,14 @@ workflow:
 
       **Task**: {selected_task.description}
       **Duration**: 25:00 ⏱️
-      **Auto-save**: Every 5 minutes
-      **Break reminder**: At 25:00
+      **Save checkpoint**: Every 5 minutes through a verified save path
+      **Break checkpoint**: At 25:00
 
       **Focus Mode Active** - Minimize distractions!
 
 adhd_hooks:
-  # Auto-save to ConPort every 5 minutes
-  auto_save:
+  # Planned recurring save to ConPort every 5 minutes
+  save_checkpoint:
     interval: 300  # seconds
     tool: mcp__conport__update_progress
     params:
@@ -322,8 +326,8 @@ adhd_hooks:
       progress_id: "{selected_task.id}"
       status: "IN_PROGRESS"
 
-  # Break reminder at 25 minutes
-  break_reminder:
+  # Planned break checkpoint at 25 minutes
+  break_checkpoint:
     interval: 1500  # 25 minutes
     action: pause_session
     notification: |
@@ -336,26 +340,26 @@ adhd_hooks:
 
       **Choose**:
       1. Take 5min break (recommended)
-      2. Continue for 10 more min (then mandatory break)
+      2. Continue for 10 more min (then pause)
       3. Save and switch tasks
 
-  # Hyperfocus warning at 60 minutes
-  hyperfocus_warn:
+  # Planned hyperfocus warning at 60 minutes
+  hyperfocus_alert:
     interval: 3600  # 60 minutes
     notification: |
       ⚠️ **Hyperfocus Alert**: You've been coding for 60 minutes straight!
 
       Please take a break soon to avoid burnout.
 
-  # Mandatory break at 90 minutes
-  hyperfocus_force:
+  # Planned forced pause at 90 minutes
+  hyperfocus_pause:
     interval: 5400  # 90 minutes
     action: force_pause
     notification: |
-      🛑 **Mandatory Break**: 90 minutes is the limit!
+      🛑 **Forced Pause**: 90 minutes is the planned limit!
 
       For your health and code quality, taking a 10-minute break now.
-      Your work has been auto-saved.
+      Save your work through a verified manual or hook path before pausing.
 ```
 
 ### Usage Examples
@@ -365,9 +369,9 @@ adhd_hooks:
 /dx:implement
 # → Shows recommended tasks based on energy
 # → User selects task 1
-# → 25min timer starts with auto-save
+# → Operator-managed 25-minute checkpoint starts with planned save checkpoints
 
-# After 25min break reminder
+# After 25-minute break checkpoint
 # User chooses "Take 5min break"
 # → Session pauses, progress saved
 
@@ -379,10 +383,10 @@ adhd_hooks:
 ### ADHD Accommodations
 
 - ✅ **Energy matching** - Tasks recommended based on current energy level
-- ✅ **25min sessions** - Prevent burnout, maintain quality attention
-- ✅ **Auto-save every 5min** - Never lose work, safe interruptions
-- ✅ **Gentle break reminders** - Not punitive, explains benefits
-- ✅ **Hyperfocus protection** - Warns at 60min, forces break at 90min
+- ✅ **25-minute sessions** - Prevent burnout, maintain quality attention
+- ✅ **Save checkpoints** - Preserve work through verified manual or hook paths
+- ✅ **Gentle break guidance** - Not punitive, explains benefits
+- ✅ **Hyperfocus protection** - Planned warning at 60 minutes and forced-pause support at 90 minutes
 - ✅ **Max 3 options** - Reduce decision paralysis
 - ✅ **Visual progress** - Timer, status indicators
 - ✅ **Celebration** - "Great work!" positive reinforcement
@@ -551,7 +555,7 @@ workflow:
       **Next Steps**:
       1. Review tasks: Use ConPort or dashboard
       2. Start implementation: `/dx:implement`
-      3. Track progress: Auto-saved to ConPort
+      3. Track progress: Saved to ConPort when the verified save path runs
 
       **Tasks are ready for ADHD-optimized workflow!**
 ```

--- a/.claude/modules/shared/adhd-patterns.md
+++ b/.claude/modules/shared/adhd-patterns.md
@@ -7,6 +7,17 @@
 
 ## Core ADHD Principles
 
+### Runtime Status
+
+**Observed runtime support**:
+- Manual context save through `/dx:save` and `dopemux save`
+- Registered lifecycle hook dispatch through `.claude/settings.json` and `src/dopemux/claude/native_hooks.py`
+- Best-effort hook signals for Stop-time context save, energy warnings before complex tools, and progress/edit tracking
+
+**Planned/specification behavior**:
+- `/dx:implement` focus timers, recurring save checkpoints, automatic break prompts, and forced hyperfocus pauses remain not proven wired in the observed Claude runtime
+- Treat timer and break examples below as operator-guided patterns unless a current runtime path is verified
+
 ### Fundamental Accommodations
 - **Context Preservation**: Always maintain awareness of where the user left off
 - **Gentle Guidance**: Use encouraging, non-judgmental language with clear next steps
@@ -106,7 +117,7 @@ ADAPT_FOR_HYPERFOCUS() {
     echo "🔬 Deep analysis mode active"
     echo "🌊 Flow state supported"
     echo "🎯 Extended session: 1-3 hours"
-    echo "⚠️  Remember breaks: Set timer for 90 minutes"
+    echo "Remember breaks: set an operator-managed timer for 90 minutes"
 }
 ```
 
@@ -549,18 +560,18 @@ COORDINATE_EXTERNAL_MEMORY() {
 # Workflow:
 # 1. Check current energy/attention/cognitive load
 # 2. Smart task selection (match energy to task complexity)
-# 3. Start 25min timer with auto-save every 5min
-# 4. Gentle break reminder at 25min
-# 5. Hyperfocus warning at 60min
-# 6. Mandatory break at 90min
+# 3. Start an operator-managed 25-minute checkpoint with planned save checkpoints
+# 4. Gentle break checkpoint at 25 minutes
+# 5. Planned hyperfocus alert at 60 minutes
+# 6. Planned forced pause at 90 minutes
 ```
 
 **ADHD Accommodations**:
 - ✅ **Energy matching**: Tasks recommended by current energy level
-- ✅ **25min sessions**: Prevent burnout, maintain attention quality
-- ✅ **Auto-save every 5min**: Never lose work, safe interruptions
-- ✅ **Gentle break reminders**: "Great work! Time for break" (not punitive)
-- ✅ **Hyperfocus protection**: Warns at 60min, forces at 90min (health)
+- ✅ **25-minute sessions**: Prevent burnout, maintain attention quality
+- ✅ **Save checkpoints**: Preserve work through verified manual or hook paths
+- ✅ **Gentle break guidance**: "Great work! Time for break" (not punitive)
+- ✅ **Hyperfocus protection**: Planned alert at 60 minutes and forced pause at 90 minutes
 - ✅ **Max 3 task options**: Reduce decision paralysis
 - ✅ **Visual timer**: Progress indicators, status updates
 - ✅ **Celebration**: "Great work!" positive reinforcement
@@ -576,7 +587,7 @@ You've been focused for 25 minutes. Taking a break helps:
 
 Choose:
 1. Take 5min break (recommended)
-2. Continue for 10 more min (then mandatory break)
+2. Continue for 10 more minutes, then pause
 3. Save and switch tasks
 ```
 
@@ -585,9 +596,9 @@ Choose:
 ⚠️ Hyperfocus Alert: 60 minutes straight!
 Please take a break soon to avoid burnout.
 
-🛑 Mandatory Break: 90 minutes is the limit!
+🛑 Forced Pause: 90 minutes is the planned limit!
 For your health and code quality, taking 10-min break now.
-Your work has been auto-saved.
+Save your work through a verified manual or hook path before pausing.
 ```
 
 ### Planning Command
@@ -644,9 +655,9 @@ Your work has been auto-saved.
 # Start implementation
 /dx:implement
 # → Energy-aware task selection
-# → 25min timer + auto-save
+# → Operator-managed 25-minute checkpoint plus planned save checkpoints
 
-# (25min later: automatic break reminder)
+# (25 minutes later: planned break checkpoint)
 # "Great work! Time for 5min break ☕"
 
 # Continue or switch
@@ -674,7 +685,7 @@ Your work has been auto-saved.
 # Step 3: Implementation
 /dx:implement
 # → ADHD engine selects optimal task
-# → 25min session with breaks
+# → 25-minute session with breaks
 
 # Step 4: Code review
 /dx:review "src/auth/*.py"

--- a/.claude/modules/shared/superclaude-workflows.md
+++ b/.claude/modules/shared/superclaude-workflows.md
@@ -147,7 +147,7 @@ User Request
 **Planned Commands**:
 
 - `/dx:prd-parse` - PRD decomposition with Zen planner + ConPort import
-- `/dx:implement` - ADHD-optimized 25min sessions with auto-save
+- `/dx:implement` - ADHD-optimized 25-minute sessions with planned save checkpoints
 - `/dx:analyze` - Direct Zen thinkdeep integration
 - `/dx:review` - Direct Zen codereview with multi-model validation
 - `/dx:session` - Focus session management with timers
@@ -242,6 +242,10 @@ Example: "/sc:troubleshoot authentication failing intermittently"
 
 ## ADHD Session Workflow
 
+**Observed runtime support**: manual `/dx:save`, `dopemux save`, registered lifecycle hook dispatch, and best-effort Stop/energy/progress hook signals.
+
+**Planned/specification behavior**: `/dx:implement` timers, recurring save checkpoints, break prompts, and hyperfocus pause enforcement are not proven wired in observed Claude runtime.
+
 ### 25-Minute Focus Session
 
 ```
@@ -253,7 +257,7 @@ Session Start (2 min)
 
 Implementation (20 min)
 ├─ /sc:implement or /sc:fix   # Primary work
-├─ Auto-save every 5 min      # Context preservation
+├─ Save checkpoint every 5 min # Context preservation through verified paths
 ├─ Progress tracking          # Update ConPort progress_entry
 └─ Focus maintenance          # Minimize context switches
 
@@ -264,18 +268,18 @@ Session End (3 min)
 └─ Plan next session          # Set next_steps in active_context
 
 Break (5 min)
-└─ Mandatory after 25 min     # ADHD accommodation
+└─ Recommended after 25 min   # ADHD accommodation
 ```
 
-### Hyperfocus Protection
+### Planned Hyperfocus Protection
 
 ```
 Warning at 60 min
 └─> "You've been coding for 60 minutes. Consider a break soon."
 
-Mandatory at 90 min
+Forced pause at 90 min
 └─> "90 minutes elapsed. Taking a break now to prevent burnout."
-    ├─ /sc:save (forced)
+    ├─ /sc:save or `/dx:save`
     ├─ Session pause
     └─ 15-minute minimum break
 ```
@@ -284,8 +288,8 @@ Mandatory at 90 min
 
 ```
 Interrupted During Work
-├─ Auto-save triggered        # .dopemux/context.db updated
-├─ Session snapshot created   # .dopemux/sessions/session-<id>.json
+├─ Save checkpoint requested  # .dopemux/context.db updated when save path runs
+├─ Session snapshot created   # .dopemux/sessions/session-<id>.json when save path runs
 └─ ConPort context preserved  # active_context unchanged
 
 Resume After Interruption
@@ -915,10 +919,10 @@ sqlite3 .dopemux/context.db "SELECT * FROM session_metadata ORDER BY last_active
 │ Navigate Code:      serena/find_symbol                  │
 │ Multi-Model:        zen/consensus or zen/thinkdeep      │
 │                                                          │
-│ Break Reminder:     Every 25 minutes                    │
-│ Auto-Save:          Every 5 minutes during work         │
-│ Hyperfocus Warn:    At 60 minutes                       │
-│ Mandatory Break:    At 90 minutes                       │
+│ Break Checkpoint:   At 25 minutes, planned              │
+│ Save Checkpoint:    Every 5 minutes, planned            │
+│ Hyperfocus Alert:   At 60 minutes, planned              │
+│ Forced Pause:       At 90 minutes, planned              │
 └─────────────────────────────────────────────────────────┘
 ```
 

--- a/.claude/modules/superclaude-integration.md
+++ b/.claude/modules/superclaude-integration.md
@@ -6,6 +6,10 @@
 **Status**: ✅ Fully Integrated (2025-10-03)
 **SuperClaude Version**: 4.1.5
 
+**Observed runtime support**: `/sc:` command integration, manual `/dx:save`, `dopemux save`, registered lifecycle hook dispatch, and best-effort Stop/energy/progress hook signals.
+
+**Planned/specification behavior**: `/dx:implement` timers, recurring save checkpoints, break prompts, and hyperfocus pause enforcement are not proven wired in observed Claude runtime.
+
 ## Why SuperClaude?
 
 SuperClaude provides an **excellent command framework** with 25 commands and 15 specialized agents. However, Dopemux's MCP stack is **superior**:
@@ -79,7 +83,7 @@ SuperClaude provides an **excellent command framework** with 25 commands and 15 
                              v
 ┌───────────────────────────────────────────────────────────┐
 │              Python ADHD Engine + Dashboard                │
-│  Energy tracking │ 25min sessions │ Break monitoring      │
+│  Energy tracking │ 25-minute specs │ Break monitoring      │
 └───────────────────────────────────────────────────────────┘
 ```
 
@@ -232,13 +236,13 @@ workflow:
 ```
 
 ### 3. `/dx:implement` - ADHD-Optimized Implementation (PRIMARY DEVELOPMENT)
-**Purpose**: 25min focus sessions with energy matching
-**ADHD Value**: Break management, auto-save, hyperfocus protection
+**Purpose**: 25-minute focus sessions with energy matching
+**ADHD Value**: Break management, save checkpoints, hyperfocus protection
 
 ```yaml
 # ~/.claude/commands/dx/implement.yaml
 name: implement
-description: ADHD-optimized implementation with 25min sessions
+description: ADHD-optimized implementation with 25-minute sessions
 agent: developer
 workflow:
   - step: check_energy
@@ -256,7 +260,7 @@ workflow:
       status_filter: "TODO"
 
   - step: start_session
-    description: "Start 25min timer with auto-save every 5min"
+    description: "Start an operator-managed 25-minute checkpoint with planned save checkpoints"
     output: |
       🎯 **Starting 25-minute focus session**
 
@@ -266,17 +270,17 @@ workflow:
       ✅ **Match**: Good fit!
 
       **Timer**: 25:00 ⏱️
-      **Auto-save**: Every 5 minutes
-      **Break**: Reminder at 25min
+      **Save checkpoint**: Every 5 minutes through a verified save path
+      **Break**: Checkpoint at 25 minutes
 
   - step: implementation
     agent: developer
     mode: focused_implementation
     adhd_hooks:
-      - auto_save_interval: 300  # 5 minutes
-      - break_reminder: 1500     # 25 minutes
-      - hyperfocus_warn: 3600    # 60 minutes
-      - hyperfocus_force: 5400   # 90 minutes
+      - save_checkpoint: 300     # 5 minutes, planned
+      - break_checkpoint: 1500   # 25 minutes, planned
+      - hyperfocus_alert: 3600   # 60 minutes, planned
+      - hyperfocus_pause: 5400   # 90 minutes, planned
 ```
 
 ### 4. `/dx:prd-parse` - PRD Decomposition with Human Review
@@ -492,10 +496,10 @@ mcp_servers:
 # ADHD optimizations
 adhd:
   session_duration: 25  # minutes
-  auto_save_interval: 5  # minutes
-  break_reminders: true
-  hyperfocus_warn: 60   # minutes
-  hyperfocus_force: 90  # minutes
+  save_checkpoint_interval: 5  # minutes, planned unless runtime wiring is verified
+  break_checkpoints: true
+  hyperfocus_alert: 60     # minutes, planned unless runtime wiring is verified
+  hyperfocus_pause: 90    # minutes, planned unless runtime wiring is verified
 
   # Progressive disclosure
   max_detail_levels: 3
@@ -538,7 +542,7 @@ Configure MCP routing for:
 
 ### Day 6: Testing & Documentation (6-8 hours)
 - [ ] Test complete workflows (PRD → Implementation → Review)
-- [ ] Verify ADHD accommodations (25min sessions, breaks)
+- [ ] Verify ADHD accommodations (25-minute sessions, breaks)
 - [ ] Document command usage patterns
 - [ ] Create troubleshooting guide
 
@@ -552,7 +556,7 @@ Configure MCP routing for:
 # Start implementation
 /dx:implement
 
-# (25 minutes later: automatic break reminder)
+# (25 minutes later: planned break checkpoint)
 # "Great work! Time for 5min break ☕"
 
 # Continue or switch tasks
@@ -578,7 +582,7 @@ Configure MCP routing for:
 # Step 3: Implementation
 /dx:implement
 # → ADHD engine selects optimal task based on energy
-# → 25min session with auto-save
+# → Operator-managed 25-minute session with planned save checkpoints
 
 # Step 4: Code review
 /dx:review "src/auth/*.py"

--- a/scripts/validate_adhd_doctrine_docs.py
+++ b/scripts/validate_adhd_doctrine_docs.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Validate active ADHD doctrine docs do not overclaim planned automation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+ACTIVE_DOCS = [
+    ".claude/claude.md",
+    ".claude/modules/shared/adhd-patterns.md",
+    ".claude/modules/shared/superclaude-workflows.md",
+    ".claude/modules/custom-commands.md",
+    ".claude/modules/superclaude-integration.md",
+    ".claude/commands/save.md",
+    ".claude/commands/dx/implement.md",
+]
+
+FORBIDDEN_PHRASES = [
+    "auto-save every 5min",
+    "Auto-save every 5 minutes",
+    "automatic break reminder",
+    "automatic break reminders",
+    "break reminder at 25",
+    "Break reminder at 25",
+    "forced break",
+    "forces break at 90",
+    "Mandatory Break",
+    "mandatory break",
+    "25min timer",
+    "25-minute focus-block saves",
+    "30-second auto-save cadence",
+    "automates auto-save",
+    "auto-saved.",
+    "hyperfocus_force",
+    "hyperfocus_warn",
+]
+
+REQUIRED_PHRASES = [
+    "Observed runtime support",
+    "Planned/specification behavior",
+    "not proven wired",
+]
+
+
+def main() -> int:
+    failures: list[str] = []
+    combined = ""
+
+    for rel_path in ACTIVE_DOCS:
+        path = ROOT / rel_path
+        text = path.read_text(encoding="utf-8")
+        combined += text + "\n"
+        for phrase in FORBIDDEN_PHRASES:
+            if phrase in text:
+                failures.append(f"{rel_path}: forbidden phrase {phrase!r}")
+
+    for phrase in REQUIRED_PHRASES:
+        if phrase not in combined:
+            failures.append(f"missing required phrase {phrase!r}")
+
+    if failures:
+        print("ADHD doctrine validation failed:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("ADHD doctrine validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001-implementation-notes.md
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001-implementation-notes.md
@@ -1,0 +1,46 @@
+---
+id: TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001-implementation-notes
+title: Tp Dmx Adhd Cognitive T1 04 Doctrine Doc Corrections 001 Implementation Notes
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-02'
+last_review: '2026-06-02'
+next_review: '2026-08-31'
+prelude: Tp Dmx Adhd Cognitive T1 04 Doctrine Doc Corrections 001 Implementation Notes
+  (explanation) for dopemux documentation and developer workflows.
+---
+# TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001 Implementation Notes
+
+## Authority and Scope
+
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/adhd-doctrine-doc-corrections-001`
+- Branch: `codex/adhd-doctrine-doc-corrections-001`
+- Base: `origin/codex/adhd-trendspanel-demo-gate-001`
+- Primary checkout dirty state was not modified.
+- Active task-orchestrator item: `16737f5d-102f-4b5d-8105-8bab50c7c891`
+- Observed hook registration: `.claude/settings.json` dispatches lifecycle events through `src/dopemux/claude/native_hooks.py`.
+- Observed hook scripts: `.claude/hooks/save_context.sh`, `check_energy.sh`, `log_progress.sh`, and `track_file_edit.sh` provide graceful best-effort context/energy/progress/edit signals.
+- Unsupported active-doc claims observed: automatic 25-minute focus timers, 5-minute auto-save loops, 25-minute break reminders, and forced 90-minute hyperfocus breaks described as current runtime behavior.
+
+## Initial Validation
+
+- `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` passed after packet creation.
+- `python scripts/validate_adhd_doctrine_docs.py` failed before documentation edits, as expected, on unsupported active-doc automation claims and missing runtime/planned labels.
+
+## Planned Slice
+
+- Add deterministic active-doc stale-claim validator.
+- Update active Claude doctrine surfaces so observed runtime support and planned/specification behavior are separated.
+- Do not change runtime code or hook configuration.
+
+## Final Proof
+
+- Runtime code changed: NO.
+- Hook registration changed: NO.
+- Active doctrine docs now include explicit `Observed runtime support`, `Planned/specification behavior`, and `not proven wired` labels.
+- Stale active-doc claim scan: `python scripts/validate_adhd_doctrine_docs.py` PASS.
+- Task Packet schema: `python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` PASS.
+- Whitespace diff: `git diff --check` PASS.
+- Targeted pre-commit hooks over changed files: PASS after frontmatter normalization.
+- Residual UNKNOWN: whether future or external Claude runtimes wire timers/save loops/break enforcement outside the inspected repo surfaces.

--- a/task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json
+++ b/task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json
@@ -1,0 +1,161 @@
+{
+  "id": "TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001",
+  "project": "dopemux-mvp",
+  "target": "Doctrine docs distinguish implemented ADHD runtime support from planned focus-session automation",
+  "invariants": [
+    "Do not present planned or specified ADHD behaviors as implemented runtime truth.",
+    "Runtime-supported hook claims must be limited to behavior observed in .claude/settings.json, src/dopemux/claude/native_hooks.py, and active hook scripts.",
+    "25-minute timers, automatic 5-minute auto-save loops, forced 90-minute breaks, and automatic break reminders must be labeled planned/specification unless runtime evidence is cited.",
+    "Do not change runtime code, hook registration, service behavior, or command behavior in this documentation slice.",
+    "Do not edit archived, deprecated, persona, or generated history copies in this slice.",
+    "Preserve AGENTS.md and governance authority order."
+  ],
+  "depends_on": [
+    "TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-ADHD-COGNITIVE-REMEDIATION",
+    "base_branch": "codex/adhd-trendspanel-demo-gate-001",
+    "parent_tp_id": "TP-DMX-ADHD-COGNITIVE-T1-03-TRENDSPANEL-DEMO-GATE-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/adhd-doctrine-doc-corrections-001",
+    "base_branch": "codex/adhd-trendspanel-demo-gate-001",
+    "stacked_because": "Doctrine correction follows the T1 honesty-layer dashboard and status fail-honest slices."
+  },
+  "commit": {
+    "message": "docs(adhd): label planned focus automation honestly",
+    "allowlist": [
+      ".claude/claude.md",
+      ".claude/modules/shared/adhd-patterns.md",
+      ".claude/modules/shared/superclaude-workflows.md",
+      ".claude/modules/custom-commands.md",
+      ".claude/modules/superclaude-integration.md",
+      ".claude/commands/save.md",
+      ".claude/commands/dx/implement.md",
+      "scripts/validate_adhd_doctrine_docs.py",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json",
+      "task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001-implementation-notes.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python scripts/validate_adhd_doctrine_docs.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(adhd): label planned focus automation honestly",
+    "body": "## Summary\n- correct active Claude doctrine surfaces so planned focus-session automation is not described as live runtime behavior\n- limit hook claims to observed native-hook registration and hook-script behavior\n- keep 25-minute timers, auto-save loops, break reminders, and forced hyperfocus breaks as planned/spec guidance unless runtime-backed\n\n## Validation\n- python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python scripts/validate_adhd_doctrine_docs.py\n- git diff --check",
+    "base": "codex/adhd-trendspanel-demo-gate-001"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect",
+      "task": "Inspect active Claude doctrine and hook/runtime evidence before editing documentation claims.",
+      "requirements": [
+        "Identify observed hook registration and active hook script behavior.",
+        "Identify stale planned-as-runtime ADHD claims in active instruction docs.",
+        "Exclude archived, deprecated, persona, and generated history copies from this slice."
+      ],
+      "commands": [
+        "sed -n '1,150p' .claude/claude.md",
+        "sed -n '500,690p' .claude/modules/shared/adhd-patterns.md",
+        "sed -n '1,140p' .claude/settings.json",
+        "sed -n '1,220p' src/dopemux/claude/native_hooks.py"
+      ],
+      "expected_files": [],
+      "validation": [
+        "Observed runtime support and planned/specification claims are separated before documentation edits."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        ".claude/claude.md",
+        ".claude/settings.json",
+        "src/dopemux/claude/native_hooks.py",
+        ".claude/hooks/save_context.sh",
+        ".claude/hooks/check_energy.sh",
+        ".claude/hooks/log_progress.sh",
+        ".claude/hooks/track_file_edit.sh",
+        ".claude/modules/shared/adhd-patterns.md",
+        ".claude/modules/shared/superclaude-workflows.md",
+        ".claude/modules/custom-commands.md",
+        ".claude/modules/superclaude-integration.md",
+        ".claude/commands/save.md",
+        ".claude/commands/dx/implement.md"
+      ]
+    },
+    {
+      "id": "implement",
+      "task": "Update active doctrine docs so planned ADHD focus-session automation is labeled planned/specification and observed hooks are described narrowly.",
+      "requirements": [
+        "Do not edit runtime code.",
+        "Do not claim 25-minute timers, 5-minute auto-save loops, forced 90-minute breaks, or automatic break reminders are currently wired unless runtime evidence supports it.",
+        "Preserve command guidance as a manual/operator workflow where appropriate.",
+        "Document residual UNKNOWNs explicitly."
+      ],
+      "commands": [
+        "apply_patch",
+        "python scripts/validate_adhd_doctrine_docs.py"
+      ],
+      "expected_files": [
+        ".claude/claude.md",
+        ".claude/modules/shared/adhd-patterns.md",
+        ".claude/modules/shared/superclaude-workflows.md",
+        ".claude/modules/custom-commands.md",
+        ".claude/modules/superclaude-integration.md",
+        ".claude/commands/save.md",
+        ".claude/commands/dx/implement.md",
+        "scripts/validate_adhd_doctrine_docs.py"
+      ],
+      "validation": [
+        "Stale active-doctrine claim scan fails before edits and passes after edits."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate packet schema, stale-claim scan, diff scope, PAL codereview, and precommit hooks.",
+      "requirements": [
+        "Report every NOT_RUN command with reason.",
+        "Inspect git status and diff scope before final summary.",
+        "Do not claim runtime automation behavior changed."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python scripts/validate_adhd_doctrine_docs.py",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001-implementation-notes.md"
+      ],
+      "validation": [
+        "Proof notes and final response distinguish PASS, FAIL, NOT_RUN, and remaining UNKNOWNs."
+      ],
+      "context_files": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- correct active Claude doctrine surfaces so planned focus-session automation is not described as live runtime behavior
- limit hook claims to observed native-hook registration and hook-script behavior
- add deterministic validation for active ADHD doctrine stale-claim phrases

## Validation
- PASS: python -m jsonschema -i task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: python scripts/validate_adhd_doctrine_docs.py
- PASS: git diff --check
- PASS: PAL codereview, no issues found
- PASS: PAL precommit, no issues found
- PASS: pre-commit run --files .claude/claude.md .claude/commands/dx/implement.md .claude/commands/save.md .claude/modules/custom-commands.md .claude/modules/shared/adhd-patterns.md .claude/modules/shared/superclaude-workflows.md .claude/modules/superclaude-integration.md scripts/validate_adhd_doctrine_docs.py task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001.json task-packets/TP-DMX-ADHD-COGNITIVE-T1-04-DOCTRINE-DOC-CORRECTIONS-001-implementation-notes.md

## Release Notes
- Documentation-only: active ADHD doctrine now separates observed runtime support from planned/specification automation.
- No runtime behavior, hook registration, or service behavior changed.

## Review
@codex review
@gemini
@copilot

## Residual Risk
- UNKNOWN: external or future Claude runtime wiring outside the inspected repo surfaces may differ; this PR only corrects active repo docs and adds a deterministic stale-claim validator.