### PR TITLE
refactor(brand): kill status-color hex-drift in theme.py + extend validator

### DIFF
--- a/scripts/sync_brand_tokens.py
+++ b/scripts/sync_brand_tokens.py
@@ -19,9 +19,12 @@ ROOT = Path(__file__).resolve().parent.parent
 def extract_python_constants(path: Path) -> dict[str, str]:
     """Extract color hex constants from theme.py."""
     constants = {}
-    source = path.read_text()
+    source = path.read_text(encoding="utf-8")
     tree = ast.parse(source)
-    for node in ast.walk(tree):
+    # Module-level assignments only — never function/class locals. (build_theme()
+    # now defines local hue vars like `teal = "#2FFFF0"`; walking the whole tree
+    # would scoop those into the constants dict.)
+    for node in tree.body:
         if isinstance(node, ast.Assign):
             for target in node.targets:
                 if isinstance(target, ast.Name) and isinstance(node.value, ast.Constant):
@@ -34,7 +37,7 @@ def extract_python_constants(path: Path) -> dict[str, str]:
 def extract_tcss_variables(path: Path) -> dict[str, str]:
     """Extract $variable: #hex from dopemux.tcss."""
     variables = {}
-    for line in path.read_text().splitlines():
+    for line in path.read_text(encoding="utf-8").splitlines():
         m = re.match(r'\s*\$(\w[\w-]*):\s*(#[0-9a-fA-F]{6})', line)
         if m:
             variables[m.group(1)] = m.group(2).upper()
@@ -44,7 +47,7 @@ def extract_tcss_variables(path: Path) -> dict[str, str]:
 def extract_ts_tokens(path: Path) -> dict[str, str]:
     """Extract key: '#hex' from theme.ts brandTokens.colors."""
     tokens = {}
-    for line in path.read_text().splitlines():
+    for line in path.read_text(encoding="utf-8").splitlines():
         m = re.search(r"(\w+):\s*['\"](#[0-9a-fA-F]{6})['\"]", line)
         if m:
             tokens[m.group(1)] = m.group(2).upper()
@@ -76,6 +79,51 @@ PYTHON_TO_TS = {
     "SAINT_GOLD": "saintGold",
 }
 
+# Semantic status slots (resolved from the DEFAULT theme dict) -> downstream
+# names. The PYTHON_TO_* maps above only cover module-level brand constants and
+# miss the status slots inside build_theme() — exactly where the status-palette
+# cutover had to hand-edit theme.py, dopemux.tcss, and theme.ts in parallel
+# (e.g. the danger/red slot). These maps make that class of drift fail closed.
+# NOTE on the TS asymmetry: theme.ts has a dedicated semantic `errorRed` token
+# but no `successGreen`/`warningYellow` — success/warning are represented by the
+# brand tokens `serumMint`/`giltEdge`, so the maps point there by design.
+STATUS_SLOT_TO_TCSS = {"error": "red", "success": "green", "warning": "yellow"}
+STATUS_SLOT_TO_TS = {"error": "errorRed", "success": "serumMint", "warning": "giltEdge"}
+STATUS_SLOT_TO_TS_HEALTH = {"error": "critical", "success": "low", "warning": "high"}
+
+
+def extract_theme_status_slots() -> dict[str, str]:
+    """Resolve the default (mint-mojo) theme and return status slot -> #HEX.
+
+    Fails closed: raises if the theme cannot be imported/built or if any required
+    status slot (error/success/warning) is absent, so a broken theme surfaces as
+    an error instead of silently passing the drift check.
+    """
+    if str(ROOT) not in sys.path:
+        sys.path.insert(0, str(ROOT))
+    try:
+        try:
+            from src.dopemux.ui.theme import build_theme
+        except ModuleNotFoundError:
+            src_dir = str(ROOT / "src")
+            if src_dir not in sys.path:
+                sys.path.insert(0, src_dir)
+            from dopemux.ui.theme import build_theme
+        theme = build_theme("mint-mojo")
+    except Exception as exc:  # fail closed on any import/build failure
+        raise RuntimeError(f"could not resolve mint-mojo theme: {exc}") from exc
+    slots: dict[str, str] = {}
+    for slot in ("error", "success", "warning"):
+        style = theme.styles.get(slot)
+        if style and style.color and style.color.triplet:
+            slots[slot] = style.color.triplet.hex.upper()
+    missing = [s for s in ("error", "success", "warning") if s not in slots]
+    if missing:
+        raise RuntimeError(
+            f"mint-mojo theme missing required status slots: {', '.join(missing)}"
+        )
+    return slots
+
 
 def main() -> int:
     py_path = ROOT / "src/dopemux/ui/theme.py"
@@ -99,6 +147,32 @@ def main() -> int:
         ts_val = ts_tokens.get(ts_name)
         if py_val and ts_val and py_val != ts_val:
             drift.append(f"TS drift: {py_name}={py_val} but {ts_name}={ts_val}")
+
+    # Semantic status-slot drift: resolve the default theme and compare its
+    # error/success/warning slots against the downstream tcss vars and ts tokens.
+    # status_slots is fail-closed (raises if a slot is absent), so slot_val is
+    # always present; a MISSING downstream var/token is itself treated as drift.
+    status_slots = extract_theme_status_slots()
+    for slot, tcss_name in STATUS_SLOT_TO_TCSS.items():
+        slot_val = status_slots[slot]
+        tcss_val = tcss_vars.get(tcss_name)
+        if tcss_val is None:
+            drift.append(f"TCSS status drift: theme '{slot}'={slot_val} but ${tcss_name} is missing")
+        elif slot_val != tcss_val:
+            drift.append(f"TCSS status drift: theme '{slot}'={slot_val} but ${tcss_name}={tcss_val}")
+    for slot, ts_name in STATUS_SLOT_TO_TS.items():
+        slot_val = status_slots[slot]
+        ts_val = ts_tokens.get(ts_name)
+        if ts_val is None:
+            drift.append(f"TS status drift: theme '{slot}'={slot_val} but {ts_name} is missing")
+        elif slot_val != ts_val:
+            drift.append(f"TS status drift: theme '{slot}'={slot_val} but {ts_name}={ts_val}")
+    # Health block is an optional convenience surface — only checked when present.
+    for slot, ts_name in STATUS_SLOT_TO_TS_HEALTH.items():
+        slot_val = status_slots[slot]
+        ts_val = ts_tokens.get(ts_name)
+        if ts_val and slot_val != ts_val:
+            drift.append(f"TS health drift: theme '{slot}'={slot_val} but health.{ts_name}={ts_val}")
 
     if drift:
         print("❌ Brand token drift detected:")

--- a/src/dopemux/ui/theme.py
+++ b/src/dopemux/ui/theme.py
@@ -92,55 +92,78 @@ STRUCTURAL_BORDER = "#4A9E94"
 def build_theme(name: str) -> Theme:
     """Construct a Rich Theme object for the specified palette."""
     if name == "mint-mojo":
+        # Single-definition base hues: every repeated/status hue is defined once
+        # here so it cannot drift between slots. (A few single-use decorative
+        # tones stay inline — they have no second slot to drift against.)
+        # `red`/`border` reuse the module constants so the theme dict can never
+        # diverge from ERROR_RED / STRUCTURAL_BORDER (the drift that bit the
+        # status-palette cutover — error was repeated across 3 slots + 1 const).
+        # NOTE: literals here are intentionally static, NOT the dynamic
+        # _active_palette constants (RITUAL_CYAN etc.), so build_theme("mint-mojo")
+        # stays deterministic regardless of the active-theme env var.
+        red = ERROR_RED            # #FF2255 — danger: error / blocker / critical
+        border = STRUCTURAL_BORDER  # #4A9E94 — table / panel / rule borders
+        teal = "#2FFFF0"           # brand cyan — headings / bars / accents
+        teal_soft = "#00C9B8"
+        green = "#00FF85"          # success / healthy
+        gold = "#FFE600"           # warning / hazard / override
+        info_cyan = "#00E5FF"      # info / live (distinct from brand teal)
+        muted = "#808DA0"          # text.muted / severity.unknown
+        dim = "#94A3B8"            # text.dim / label
+        violet = "#C07BFF"         # aftercare / debug
+        pink = "#FF00CC"           # gremlin accent — decorative only
+        navy = "#041628"
+        black = "#020617"
+        plum = "#1A0520"
         return Theme({
-            "mint": "bold #2FFFF0",
-            "mint.soft": "#00C9B8",
+            "mint": f"bold {teal}",
+            "mint.soft": teal_soft,
             "mint.bright": "bold #60FFF5",
-            "mint.dim": "#4A9E94",
-            "magenta": "bold #FF00CC",
-            "violet": "#C07BFF",
+            "mint.dim": border,
+            "magenta": f"bold {pink}",
+            "violet": violet,
             "violet.dim": "#6B4FBF",
             "text": "#E2E8F0",
-            "text.dim": "#94A3B8",
-            "text.muted": "#808DA0",
+            "text.dim": dim,
+            "text.muted": muted,
             "text.disabled": "#475569",
-            "text.emphasis": "bold #00FF85",
-            "heading": "bold #2FFFF0",
-            "subheading": "bold #00C9B8",
-            "label": "#94A3B8",
-            "success": "#00FF85",
-            "error": "bold #FF2255",
-            "warning": "#FFE600",
-            "info": "#00E5FF",
-            "debug": "#C07BFF",
-            "hazard": "#FFE600",
-            "gilt.edge": "#FFE600",
-            "chip.live": "bold #00E5FF",
-            "chip.override": "bold #FFE600",
-            "chip.blocker": "bold #FF2255",
-            "chip.logged": "#00FF85",
-            "chip.aftercare": "#C07BFF",
-            "chip.edge": "bold #2FFFF0",
-            "table.header": "bold #2FFFF0",
-            "table.border": "#4A9E94",
-            "table.row.alt": "on #041628",
-            "panel.border": "#4A9E94",
-            "panel.title": "bold #2FFFF0",
-            "bar.complete": "#2FFFF0",
-            "bar.remaining": "#1A0520",
-            "bar.pulse": "#FF00CC",
-            "spinner": "#2FFFF0",
-            "severity.healthy": "#00FF85",
-            "severity.warning": "#FFE600",
-            "severity.critical": "bold #FF2255",
-            "severity.unknown": "#808DA0",
-            "rule.line": "#4A9E94",
-            "surface.black": "#020617",
-            "surface.navy": "#041628",
-            "surface.plum": "#1A0520",
-            "bg.black": "on #020617",
-            "bg.navy": "on #041628",
-            "row.active": "bold #00FF85 on #041628",
+            "text.emphasis": f"bold {green}",
+            "heading": f"bold {teal}",
+            "subheading": f"bold {teal_soft}",
+            "label": dim,
+            "success": green,
+            "error": f"bold {red}",
+            "warning": gold,
+            "info": info_cyan,
+            "debug": violet,
+            "hazard": gold,
+            "gilt.edge": gold,
+            "chip.live": f"bold {info_cyan}",
+            "chip.override": f"bold {gold}",
+            "chip.blocker": f"bold {red}",
+            "chip.logged": green,
+            "chip.aftercare": violet,
+            "chip.edge": f"bold {teal}",
+            "table.header": f"bold {teal}",
+            "table.border": border,
+            "table.row.alt": f"on {navy}",
+            "panel.border": border,
+            "panel.title": f"bold {teal}",
+            "bar.complete": teal,
+            "bar.remaining": plum,
+            "bar.pulse": pink,
+            "spinner": teal,
+            "severity.healthy": green,
+            "severity.warning": gold,
+            "severity.critical": f"bold {red}",
+            "severity.unknown": muted,
+            "rule.line": border,
+            "surface.black": black,
+            "surface.navy": navy,
+            "surface.plum": plum,
+            "bg.black": f"on {black}",
+            "bg.navy": f"on {navy}",
+            "row.active": f"bold {green} on {navy}",
         })
     elif name == "pastel-neon-dreamscape":
         # New Theme: Pastel Neon Dreamscape on Black


### PR DESCRIPTION
## Summary

Drift-resistance hardening for the CLI/TUI/web theme contract surface, follow-on to the merged palette cutover ([#803](https://github.com/DDD-Enterprises/dopemux-mvp/pull/803)). **No behavior change** — `theme.py` is a verified pure refactor; the validator gains real teeth. This is option **B2** ("derive + extend validator") of the "kill hex-drift" task.

The cutover had to hand-edit the danger color in **4 places** (`ERROR_RED` const + `error`/`chip.blocker`/`severity.critical` dict slots) plus tcss + theme.ts — a drift hazard the existing guard didn't catch.

## Changes

**`src/dopemux/ui/theme.py`** — refactor the default `mint-mojo` branch of `build_theme()` so every repeated/status hue is defined once as a named local. `red = ERROR_RED` and `border = STRUCTURAL_BORDER` tie the dict to the module constants (danger can no longer drift between the 4 places). Locals are **static literals**, *not* the dynamic `_active_palette` constants — so `build_theme("mint-mojo")` stays deterministic regardless of the active-theme env var. The two pastel themes are intentionally untouched (a separate follow-up reworks their danger slots).

**`scripts/sync_brand_tokens.py`** — extend the cross-file drift validator (previously only 9 module brand constants, several of which were silent no-ops because they derive from a `Subscript`) to resolve the default theme and assert `error`/`success`/`warning` match downstream `$red/$green/$yellow`, `errorRed/serumMint/giltEdge`, and the `health` block. **Fails closed**: raises if the theme can't resolve or a required slot is missing, and treats a missing downstream var/token as drift. Constant extraction constrained to module-level (`tree.body`) so the refactor's new locals don't pollute the constants dict.

## Validation (all this session)

- **PASS** — 595-slot resolved-theme **equality proof** before/after across all 3 themes (pure refactor, zero behavior change)
- **PASS** — `sync_brand_tokens.py` positive run; `brand_lint.py` 0/0; theme/brand `pytest` 10 passed; `generate_tokens.py` self-validation
- **PASS** — negative drift tests all fire then revert clean: tcss `$red` value-drift, `$green` value-drift, `$red` **deletion** (missing-downstream), theme.ts `errorRed` value-drift
- **PASS** — `tree.body` excludes the new locals (`teal/green/...`) while keeping `ERROR_RED`
- **NOT_RUN** — `black`/`pyflakes` (not installed in env; both files import + execute cleanly, proving compilation)

## Review chain (PAL, gpt-5.1)
`pal/codereview` → Part 1 confirmed contract-safe; accepted fail-closed extraction + `tree.body` + comment fixes (rejected an AST-rewrite suggestion — importing resolves exactly what runtime does — and a health-block false-skip claim — health values are literal hex, confirmed). `pal/precommit` → accepted fail-open-on-missing tightening (scoped to the new status checks; pre-existing brand-constant loops deliberately left lenient since they'd false-trigger on the legitimately-unextracted `Subscript` constants), TS-asymmetry doc, encoding consistency.

## Residual / out of scope
- Pre-existing brand-constant checks remain lenient on missing keys (tightening them would break the green state — `RITUAL_CYAN` etc. derive from `_active_palette` and aren't literal-extractable).
- The two pastel themes still route danger to magenta/pink — tracked as a separate follow-up.

## Rollback
`git revert <merge>` or reset `feat/theme-drift-guard` to `origin/main`. Pure refactor + a script — no data/runtime migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
