### PR TITLE
[codex] fix(orchestrator): tighten transition proof schema version

### DIFF
--- a/src/dopemux/orchestrator/operator_workflows.py
+++ b/src/dopemux/orchestrator/operator_workflows.py
@@ -551,14 +551,14 @@ def _validate_transition_proof_envelope(
     schema_version = payload.get("schema_version")
     if (
         _non_empty_string(schema_version)
-        and schema_version not in {"1", "1.0"}
+        and schema_version != SUPPORTED_TRANSITION_PROOF_SCHEMA_VERSION
     ):
         errors.append(
             issue(
                 "TRANSITION_PROOF_SCHEMA_VERSION_UNSUPPORTED",
                 (
                     f"Transition proof schema_version must be "
-                    f"one of {{'1', '1.0'}}; "
+                    f"{SUPPORTED_TRANSITION_PROOF_SCHEMA_VERSION!r}; "
                     f"got {schema_version!r}."
                 ),
                 path="/schema_version",

--- a/tests/unit/orchestrator/test_operator_workflows.py
+++ b/tests/unit/orchestrator/test_operator_workflows.py
@@ -483,7 +483,7 @@ def test_transition_proof_envelope_accepts_supported_schema_version(tmp_path):
 
 def test_transition_proof_envelope_rejects_unsupported_schema_version(tmp_path):
     envelope = _envelope_payload()
-    envelope["schema_version"] = "999"
+    envelope["schema_version"] = "1.0"
     envelope_path = tmp_path / "envelope.json"
     envelope_path.write_text(json.dumps(envelope), encoding="utf-8")
 


### PR DESCRIPTION
## Summary
Isolated the orchestrator transition proof schema-version tightening into its own branch/PR so it can be reviewed separately from the cockpit design work.

## What changed
- Tightened transition proof validation to accept only schema version `1`.
- Kept the unsupported-version test aligned to the contract by checking that `1.0` is rejected.

## Why
The transition proof envelope contract pins the schema to `1`, so the consumer should fail closed instead of treating `1.0` as compatible.

## Impact
- Future transition proof envelopes with `schema_version=1.0` are rejected.
- The fix is isolated from the broader design/docs branch.

## Validation
- `git diff --check`
- `/Users/hue/code/dopemux-mvp/.venv/bin/python -m pytest -q tests/unit/orchestrator/test_operator_workflows.py tests/unit/orchestrator/test_transitions.py tests/unit/test_cli_orchestrator_validation_commands.py`
