### PR TITLE
fix(mcp): restore GPT Researcher container entrypoint

### DIFF
--- a/claudedocs/gptr-mcp-container-update-proof-2026-06-04.md
+++ b/claudedocs/gptr-mcp-container-update-proof-2026-06-04.md
@@ -1,0 +1,243 @@
+# GPT Researcher MCP Container Update Proof - 2026-06-04
+
+## Status
+
+VERIFIED_TARGETED for the local Docker container implementation. Commit SHA and PR URL are recorded in the publish response because they are generated after this proof content is finalized.
+
+## Scope
+
+- Task Packet: `TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001`
+- Task Packet path: `task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json`
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/gptr-mcp-container-update-20260604`
+- Branch: `codex/gptr-mcp-container-update-20260604`
+- Base branch: `origin/main`
+- Base commit: `8571c33873d5c78eead660be9caa6178b5d8b1e3`
+
+## Authority Used
+
+- Latest user instruction: fix and update GPT Researcher in the Dopemux MVP Docker container implementation.
+- `AGENTS.md`: worktree, Task Packet, proof, validation, and truthful finality requirements.
+- Runtime/config truth: `compose.yml`, `docker/mcp-servers-source/gptr-mcp/Dockerfile`, running container `dopemux-mcp-gptr-mcp`.
+- Package truth: PyPI reported `gpt-researcher==0.15.1` as the current release at implementation time.
+- GPT Researcher skill guidance: package config and MCP/runtime context only.
+
+## Analysis Performed
+
+Observed before implementation:
+
+- `compose.yml` service `gptr-mcp` builds from `docker/mcp-servers/gptr-mcp/Dockerfile`.
+- `docker/mcp-servers` is a symlink to `docker/mcp-servers-source`; the tracked Dockerfile authority is `docker/mcp-servers-source/gptr-mcp/Dockerfile`.
+- Running container `dopemux-mcp-gptr-mcp` was healthy, but only for its long-running `/app/gptr-mcp/server.py` command path.
+- Running container had `gpt-researcher==0.14.8`.
+- Running container did not have `/app/server.py`, while a stale MCP client command used `docker exec -i dopemux-mcp-gptr-mcp python /app/server.py`.
+
+Challenge result:
+
+- A wrapper that only runs `/app/gptr-mcp/server.py` would preserve the container service but would not satisfy stdio MCP clients using `docker exec -i`.
+- The wrapper therefore defaults to stdio for bare `python /app/server.py` and the long-lived Docker `CMD` explicitly sets `DOPEMUX_GPTR_TRANSPORT=sse`.
+- The first clean-cache Docker build exposed a separate Dockerfile drift: `uv pip install .[services]` now requires all `pyproject.toml` package trees, not just `src/dopemux/__init__.py`.
+
+## Changes
+
+- `docker/mcp-servers-source/gptr-mcp/Dockerfile`
+  - Copies `src/` and `tools/` before installing `.[services]`, matching the current package layout.
+  - Updates `ARG GPT_RESEARCHER_VERSION` from `0.14.8` to `0.15.1`.
+  - Adds `/app/server.py` compatibility wrapper.
+  - Runs the long-lived container service as SSE via `DOPEMUX_GPTR_TRANSPORT=sse exec python /app/server.py`.
+- `tests/docker/test_gptr_mcp_dockerfile.py`
+  - Adds a focused Dockerfile regression test for the package pin, package-tree copy, and legacy entrypoint wrapper.
+- `task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json`
+  - Adds the scoped Task Packet.
+- `task-packets/INDEX.md`
+  - Registers the Task Packet.
+
+## Validation Performed
+
+### PASS
+
+Task Packet JSON syntax:
+
+```text
+python -m json.tool task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json >/dev/null
+exit: 0
+```
+
+Task Packet schema:
+
+```text
+python -m jsonschema -i task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+exit: 0
+note: jsonschema CLI emitted a deprecation warning only.
+```
+
+TDD pre-fix static test failure:
+
+```text
+python -m pytest -q tests/docker/test_gptr_mcp_dockerfile.py
+exit: 1
+result: failed because the Dockerfile still pinned gpt-researcher 0.14.8 and did not provide /app/server.py.
+```
+
+Post-fix static test:
+
+```text
+python -m pytest -q tests/docker/test_gptr_mcp_dockerfile.py
+exit: 0
+output: ... [100%]
+```
+
+Compose syntax:
+
+```text
+docker compose -f compose.yml config --quiet
+exit: 0
+note: compose emitted unset environment variable warnings for ANTHROPIC_API_KEY, LITELLM_MASTER_KEY, LEANTIME_TOKEN, HOST_CODE_PARENT_DIR, and HOST_PROJECT_RELATIVE_PATH.
+```
+
+Clean-cache build failure found during implementation:
+
+```text
+docker compose -f compose.yml build gptr-mcp
+exit: 1
+error: package directory 'src/conport' does not exist
+resolution: copy src/ and tools/ into the build context before uv pip install .[services].
+```
+
+Final Docker build:
+
+```text
+docker compose -f compose.yml build gptr-mcp
+exit: 0
+key output:
+Built dopemux @ file:///app
++ gpt-researcher==0.15.1
+Image dopemux-gptr-mcp Built
+```
+
+Container restart:
+
+```text
+docker compose -f compose.yml up -d gptr-mcp
+exit: 0
+key output:
+Container dopemux-mcp-gptr-mcp Recreated
+Container dopemux-mcp-gptr-mcp Started
+```
+
+Container package and wrapper verification:
+
+```text
+docker exec dopemux-mcp-gptr-mcp test -f /app/server.py && echo SERVER_WRAPPER_PRESENT
+docker exec dopemux-mcp-gptr-mcp python -m py_compile /app/server.py /app/gptr-mcp/server.py && echo SERVER_COMPILES
+docker exec -i dopemux-mcp-gptr-mcp python - <<'PY'
+import importlib.metadata as m
+for name in ("gpt-researcher", "mcp", "fastmcp", "dopemux"):
+    print(f"{name}=={m.version(name)}")
+PY
+exit: 0
+output:
+SERVER_WRAPPER_PRESENT
+SERVER_COMPILES
+gpt-researcher==0.15.1
+mcp==1.27.2
+fastmcp==3.4.0
+dopemux==0.1.0
+```
+
+Container status and health:
+
+```text
+docker inspect --format 'status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} image={{.Config.Image}} cmd={{json .Config.Cmd}}' dopemux-mcp-gptr-mcp
+exit: 0
+output:
+status=running health=healthy image=dopemux-gptr-mcp cmd=["sh","-c","DOPEMUX_GPTR_TRANSPORT=sse exec python /app/server.py"]
+```
+
+HTTP health:
+
+```text
+curl -fsS http://localhost:3009/health
+exit: 0
+output:
+{"status":"healthy","service":"mcp-server"}
+```
+
+Container log trace:
+
+```text
+docker logs --tail 80 dopemux-mcp-gptr-mcp
+exit: 0
+key output:
+Starting GPT Researcher MCP Server with sse transport...
+Starting MCP server 'GPT Researcher' with transport 'sse' on http://0.0.0.0:3009/sse
+```
+
+Legacy stdio MCP path:
+
+```text
+docker exec -i dopemux-mcp-gptr-mcp python /app/server.py
+exit: 0
+input: one JSON-RPC initialize request
+output:
+{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{"experimental":{},"logging":{},"prompts":{"listChanged":false},"resources":{"subscribe":false,"listChanged":false},"tools":{"listChanged":true},"extensions":{"io.modelcontextprotocol/ui":{}}},"serverInfo":{"name":"GPT Researcher","version":"3.4.0"}}}
+```
+
+Image identity and health:
+
+```text
+docker image inspect --format 'id={{.Id}} created={{.Created}}' dopemux-gptr-mcp:latest
+curl -fsS http://localhost:3009/health
+exit: 0
+output:
+id=sha256:1a4899e879d8b8bd03220c859551fbfb2d988e04543f1e1c5a8db9d48c6cac8a created=2026-06-04T19:30:12.47933667Z
+{"status":"healthy","service":"mcp-server"}
+```
+
+### FAIL
+
+- The first Docker rebuild failed because the Dockerfile copied too little of the current repository package layout. This was fixed by copying `src/` and `tools/` before `uv pip install .[services]`.
+
+### NOT_RUN
+
+- End-to-end real research request through the GPT Researcher tool: not run because it would require provider/network execution beyond the container repair proof.
+
+## Security Note
+
+During local process inspection outside this repository, API key material was visible in another process command line. This proof does not repeat those values. Recommended remediation is to rotate exposed keys and move secrets out of command arguments or other process-list-visible surfaces.
+
+## Precommit Status
+
+PASS:
+
+```text
+pre-commit run --files docker/mcp-servers-source/gptr-mcp/Dockerfile tests/docker/test_gptr_mcp_dockerfile.py task-packets/INDEX.md task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json claudedocs/gptr-mcp-container-update-proof-2026-06-04.md
+exit: 0
+result: all configured hooks passed or skipped for no matching files.
+```
+
+## Codereview Status
+
+Self-review completed before this proof file:
+
+- Allowlist scope is limited to the GPT Researcher MCP Dockerfile, packet/index, narrow test, and proof.
+- The upstream `gptr-mcp` repository ref remains pinned.
+- The wrapper does not silently change the container service transport; Docker `CMD` sets SSE explicitly.
+- Bare `/app/server.py` defaults to stdio for MCP client compatibility.
+
+## Remaining Uncertainty / Risk
+
+- Provider-backed research behavior was not exercised.
+- The `gpt-researcher` update from `0.14.8` to `0.15.1` was validated for import/package installation and MCP server startup, not full research workflow semantics.
+- Existing MCP client configs outside this repo may still carry stale assumptions other than `/app/server.py`.
+
+## Rollback Plan
+
+Revert this branch or restore these paths from `origin/main`:
+
+- `docker/mcp-servers-source/gptr-mcp/Dockerfile`
+- `tests/docker/test_gptr_mcp_dockerfile.py`
+- `task-packets/INDEX.md`
+- `task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json`
+- `claudedocs/gptr-mcp-container-update-proof-2026-06-04.md`
+
+Then rebuild and restart `gptr-mcp` from the restored Dockerfile if local container state must be reverted.

--- a/docker/mcp-servers-source/gptr-mcp/Dockerfile
+++ b/docker/mcp-servers-source/gptr-mcp/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /app
 
 # Copy dependency manifests first for better caching
 COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/
+COPY src/ src/
+COPY tools/ tools/
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -34,11 +35,35 @@ RUN uv pip install --system --no-cache -r /app/gptr-mcp/requirements.txt
 # Force-pin gpt-researcher to an explicit version so rebuilds don't drift backward
 # when upstream gptr-mcp's requirements.txt changes. Override at build time with
 # --build-arg GPT_RESEARCHER_VERSION=<version>.
-ARG GPT_RESEARCHER_VERSION=0.14.8
+ARG GPT_RESEARCHER_VERSION=0.15.1
 RUN uv pip install --system --no-cache "gpt-researcher==${GPT_RESEARCHER_VERSION}"
 
 # Create logs and data directories
 RUN mkdir -p /app/logs /app/data
+
+# Preserve the historical /app/server.py MCP entrypoint while the upstream
+# gptr-mcp server remains checked out under /app/gptr-mcp.
+RUN cat > /app/server.py <<'PY'
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+server_dir = Path("/app/gptr-mcp")
+sys.path.insert(0, str(server_dir))
+spec = importlib.util.spec_from_file_location("gptr_mcp_server", server_dir / "server.py")
+module = importlib.util.module_from_spec(spec)
+if spec.loader is None:
+    raise RuntimeError("Unable to load /app/gptr-mcp/server.py")
+spec.loader.exec_module(module)
+
+transport = os.getenv("DOPEMUX_GPTR_TRANSPORT", "stdio").lower()
+if transport == "stdio":
+    module.mcp.run(transport="stdio")
+else:
+    os.environ.setdefault("MCP_TRANSPORT", transport)
+    module.run_server()
+PY
 
 # Copy wrapper and environment files (relative to root)
 COPY docker/mcp-servers-source/gptr-mcp/wrapper.py /app/wrapper.py
@@ -61,5 +86,5 @@ LABEL mcp.priority="high"
 LABEL mcp.transport="mcp"
 LABEL mcp.description="GPT Researcher MCP server with direct MCP protocol"
 
-# Run the MCP server directly (server.py is the actual MCP server using FastMCP)
-CMD ["python", "/app/gptr-mcp/server.py"]
+# Run the long-lived container service as SSE; bare docker exec uses stdio.
+CMD ["sh", "-c", "DOPEMUX_GPTR_TRANSPORT=sse exec python /app/server.py"]

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -81,6 +81,7 @@ A packet is superseded by another packet
 | TP-UI-DASHBOARD-BUILD-001 | UI Dashboard | Restore ui-dashboard npm install and build | Active | N/A |
 | TP-BETA-MCP-02-COMPOSE-HEALTHCHECKS | Infra | Gate core MCP compose dependencies on healthchecked services | Active | N/A |
 | TP-BETA-MCP-03-ADHD-REDIS-ISOLATION | ADHD Engine | Isolate ADHD Engine Redis keys by instance | Active | N/A |
+| TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001 | Infra / MCP | Restore GPT Researcher MCP container entrypoint and update package pin | Active | N/A |
 | TP-SEC-COMPOSE-LITELLM-LOCALHOST-001 | Security | Externalize LiteLLM healthcheck key and localize compose service ports | Active | N/A |
 | TP-SEC-WEAK-DEFAULT-SECRETS-001 | Security | Reject weak default secrets in env template and installer | Active | N/A |
 | TP-DMX-ADHD-SIGNAL-E2E-WIRING-001 | ADHD Engine / Dashboard | Prove synthetic ADHD state updates reach the dashboard UI band | Active | N/A |

--- a/task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json
+++ b/task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json
@@ -1,0 +1,139 @@
+{
+  "id": "TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001",
+  "project": "dopemux-mvp",
+  "target": "Repair the GPT Researcher MCP Docker image so stale MCP client commands using /app/server.py work, and update the pinned gpt-researcher package to the current PyPI release.",
+  "invariants": [
+    "Preserve compose.yml as the canonical runtime file.",
+    "Do not print or persist provider secret values.",
+    "Do not change provider credential names or environment variable semantics.",
+    "Keep the upstream gptr-mcp repository ref pinned for reproducibility unless a separate packet authorizes changing it.",
+    "Keep the Dockerfile mirror under docker/mcp-servers-source/gptr-mcp aligned with the active Dockerfile."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-GPTR-MCP",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/gptr-mcp-container-update-20260604",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(mcp): restore gpt researcher container entrypoint",
+    "allowlist": [
+      "docker/mcp-servers/gptr-mcp/Dockerfile",
+      "docker/mcp-servers-source/gptr-mcp/Dockerfile",
+      "tests/docker/test_gptr_mcp_dockerfile.py",
+      "task-packets/INDEX.md",
+      "task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json",
+      "claudedocs/gptr-mcp-container-update-proof-2026-06-04.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest -q tests/docker/test_gptr_mcp_dockerfile.py",
+      "docker compose -f compose.yml config --quiet",
+      "docker compose -f compose.yml build gptr-mcp",
+      "docker compose -f compose.yml up -d gptr-mcp",
+      "docker exec dopemux-mcp-gptr-mcp python -m py_compile /app/server.py /app/gptr-mcp/server.py",
+      "docker exec -i dopemux-mcp-gptr-mcp python - <<'PY'\nimport importlib.metadata as m\nprint(m.version('gpt-researcher'))\nPY",
+      "docker exec dopemux-mcp-gptr-mcp test -f /app/server.py",
+      "docker inspect --format '{{json .State.Health.Status}}' dopemux-mcp-gptr-mcp",
+      "git diff --check",
+      "git status --short --branch"
+    ]
+  },
+  "pr": {
+    "title": "fix(mcp): restore GPT Researcher container entrypoint",
+    "body": "## Summary\n- Adds a /app/server.py compatibility wrapper inside the GPT Researcher MCP image so stale client commands work.\n- Updates the pinned gpt-researcher package from 0.14.8 to 0.15.1.\n- Adds a narrow Dockerfile regression test and proof note.\n\n## Test Plan\n- python -m json.tool task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json >/dev/null\n- python -m jsonschema -i task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest -q tests/docker/test_gptr_mcp_dockerfile.py\n- docker compose -f compose.yml config --quiet\n- docker compose -f compose.yml build gptr-mcp\n- docker compose -f compose.yml up -d gptr-mcp\n- docker exec dopemux-mcp-gptr-mcp python -m py_compile /app/server.py /app/gptr-mcp/server.py\n- docker inspect --format '{{json .State.Health.Status}}' dopemux-mcp-gptr-mcp\n- git diff --check\n\n## Security Note\n- Do not include provider keys or raw environment values in proof.\n\n@codex review\n@gemini\n@copilot",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight repo identity, worktree isolation, dirty state, package versions, and container failure surface.",
+      "context_files": [
+        "AGENTS.md",
+        "compose.yml",
+        "docker/mcp-servers/gptr-mcp/Dockerfile",
+        "docker/mcp-servers-source/gptr-mcp/Dockerfile",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ],
+      "validation": [
+        "Worktree is isolated from the dirty primary checkout.",
+        "Running container has gpt-researcher 0.14.8 before this packet.",
+        "PyPI reports gpt-researcher 0.15.1 as current at implementation time.",
+        "Running container lacks /app/server.py while MCP client config calls that path."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Add a focused regression test for the GPT Researcher MCP Dockerfiles.",
+      "expected_files": [
+        "tests/docker/test_gptr_mcp_dockerfile.py"
+      ],
+      "validation": [
+        "python -m pytest -q tests/docker/test_gptr_mcp_dockerfile.py fails before the Dockerfile fix because /app/server.py compatibility and version 0.15.1 are absent."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Patch both GPT Researcher MCP Dockerfile copies minimally.",
+      "expected_files": [
+        "docker/mcp-servers/gptr-mcp/Dockerfile",
+        "docker/mcp-servers-source/gptr-mcp/Dockerfile"
+      ],
+      "validation": [
+        "Both Dockerfiles copy src/ and tools/ before uv pip install .[services] so clean-cache builds include all pyproject-declared package directories.",
+        "Both Dockerfiles pin ARG GPT_RESEARCHER_VERSION=0.15.1.",
+        "Both Dockerfiles create /app/server.py as a wrapper that loads /app/gptr-mcp/server.py with /app/gptr-mcp on sys.path.",
+        "The wrapper defaults to stdio for bare docker exec MCP clients.",
+        "Both Dockerfiles run the long-lived container service with DOPEMUX_GPTR_TRANSPORT=sse."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Validate the static contract, compose syntax, rebuilt container, package version, compatibility path, health, and diff scope.",
+      "expected_files": [
+        "claudedocs/gptr-mcp-container-update-proof-2026-06-04.md"
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python -m pytest -q tests/docker/test_gptr_mcp_dockerfile.py",
+        "docker compose -f compose.yml config --quiet",
+        "docker compose -f compose.yml build gptr-mcp",
+        "docker compose -f compose.yml up -d gptr-mcp",
+        "docker exec dopemux-mcp-gptr-mcp python -m py_compile /app/server.py /app/gptr-mcp/server.py",
+        "docker exec -i dopemux-mcp-gptr-mcp python - <<'PY'\nimport importlib.metadata as m\nprint(m.version('gpt-researcher'))\nPY",
+        "docker exec dopemux-mcp-gptr-mcp test -f /app/server.py",
+        "docker inspect --format '{{json .State.Health.Status}}' dopemux-mcp-gptr-mcp",
+        "git diff --check",
+        "git status --short --branch"
+      ]
+    }
+  ]
+}

--- a/tests/docker/test_gptr_mcp_dockerfile.py
+++ b/tests/docker/test_gptr_mcp_dockerfile.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILES = (
+    ROOT / "docker/mcp-servers/gptr-mcp/Dockerfile",
+    ROOT / "docker/mcp-servers-source/gptr-mcp/Dockerfile",
+)
+
+
+def _dockerfile_texts() -> list[tuple[Path, str]]:
+    return [(path, path.read_text(encoding="utf-8")) for path in DOCKERFILES]
+
+
+def test_gptr_mcp_dockerfiles_pin_current_gpt_researcher_version() -> None:
+    for path, text in _dockerfile_texts():
+        assert "ARG GPT_RESEARCHER_VERSION=0.15.1" in text, path
+
+
+def test_gptr_mcp_dockerfiles_copy_declared_package_trees() -> None:
+    for path, text in _dockerfile_texts():
+        assert "COPY src/ src/" in text, path
+        assert "COPY tools/ tools/" in text, path
+        assert "COPY src/dopemux/__init__.py src/dopemux/" not in text, path
+
+
+def test_gptr_mcp_dockerfiles_provide_legacy_server_entrypoint() -> None:
+    for path, text in _dockerfile_texts():
+        assert 'cat > /app/server.py <<\'PY\'' in text, path
+        assert "import importlib.util" in text, path
+        assert 'server_dir = Path("/app/gptr-mcp")' in text, path
+        assert 'spec_from_file_location("gptr_mcp_server", server_dir / "server.py")' in text, path
+        assert 'os.getenv("DOPEMUX_GPTR_TRANSPORT", "stdio").lower()' in text, path
+        assert 'module.mcp.run(transport="stdio")' in text, path
+        assert 'DOPEMUX_GPTR_TRANSPORT=sse exec python /app/server.py' in text, path


### PR DESCRIPTION
## Summary
- Restores the historical `/app/server.py` MCP entrypoint inside the `gptr-mcp` Docker image so stale `docker exec -i dopemux-mcp-gptr-mcp python /app/server.py` clients work again.
- Updates the explicit `gpt-researcher` package pin from `0.14.8` to `0.15.1`.
- Copies the full `src/` and `tools/` package trees before `uv pip install .[services]` so clean-cache Docker builds match the current package layout.
- Adds a focused Dockerfile regression test, Task Packet, index entry, and proof note.

## Root Cause
The running image served SSE from `/app/gptr-mcp/server.py`, but stale MCP client config invoked `/app/server.py`, which did not exist. During rebuild validation, the Dockerfile also failed against the current package layout because it copied only `src/dopemux/__init__.py` before installing `.[services]`.

## Validation
- `python -m json.tool task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json >/dev/null`
- `python -m jsonschema -i task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `python -m pytest -q tests/docker/test_gptr_mcp_dockerfile.py`
- `docker compose -f compose.yml config --quiet`
- `docker compose -f compose.yml build gptr-mcp`
- `docker compose -f compose.yml up -d gptr-mcp`
- `docker exec dopemux-mcp-gptr-mcp python -m py_compile /app/server.py /app/gptr-mcp/server.py`
- `docker exec` package check confirmed `gpt-researcher==0.15.1`, `mcp==1.27.2`, `fastmcp==3.4.0`, `dopemux==0.1.0`
- `docker inspect` confirmed `status=running health=healthy`
- `curl -fsS http://localhost:3009/health`
- stdio MCP initialize probe through `docker exec -i dopemux-mcp-gptr-mcp python /app/server.py`
- `pre-commit run --files docker/mcp-servers-source/gptr-mcp/Dockerfile tests/docker/test_gptr_mcp_dockerfile.py task-packets/INDEX.md task-packets/generated/TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001.json claudedocs/gptr-mcp-container-update-proof-2026-06-04.md`
- `git diff --cached --check`

## Release Notes
- Fixed the GPT Researcher MCP Docker image by restoring the legacy `/app/server.py` stdio entrypoint while preserving SSE for the long-running container service.
- Updated the container package pin to `gpt-researcher==0.15.1`.

## Not Run
- Provider-backed real research request; this PR validates container build/startup, package installation, health, and MCP initialize compatibility only.

## Security Note
- Proof does not include provider keys or raw environment values. During local process inspection, key material was visible in another process command line; rotate exposed keys and avoid process-argument-visible secrets.

@codex review
@gemini
@copilot