### PR TITLE
fix(rte): harden go-live preflight safety

### DIFF
--- a/proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-001/implementation-notes.md
+++ b/proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-001/implementation-notes.md
@@ -1,0 +1,54 @@
+---
+id: TP-RTE-GOLIVE-REMEDIATION-001-IMPLEMENTATION-NOTES
+title: RTE Go-Live Remediation Slice 1 Implementation Notes
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-06-04'
+last_review: '2026-06-04'
+next_review: '2026-07-04'
+prelude: Implementation notes for the first RTE go-live remediation slice.
+---
+
+# RTE Go-Live Remediation Slice 1 Implementation Notes
+
+## Scope
+
+- Task Packet: `task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json`
+- Branch: `codex/rte-golive-remediation-001`
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/rte-golive-remediation-001`
+- Base: `origin/main` at `2f6f362236aa8429877664c675a5373cd9acf16e`
+
+## Changes
+
+- `value-default` now applies a default `--max-cost-usd` cap of `5.00`.
+- `quality` now applies a default `--max-cost-usd` cap of `25.00`.
+- Live pre-flight validator subprocess calls now forward the active `--s-prompts` mode.
+- The pre-live validator now stores and applies `s_prompts_mode` before deriving route scope or prompt views.
+- `collect_truth_split` now emits target-scoped rows from active runner prompt specs, promptset declarations, model-map declarations, and prompt output/contract metadata.
+- Selected SP registry steps without phase contracts now produce a P0 `SP_CONTRACT_MISSING` blocker.
+
+## Validation
+
+- `python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json >/dev/null` - PASS
+- `python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` - PASS
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_cost_profiles.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py services/repo-truth-extractor/tests/test_run_extraction_v5_cost_cap.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py -q --tb=short --disable-warnings --no-cov` - PASS, 49 passed
+- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py` - PASS
+- `git diff --check` - PASS
+- `pre-commit run --files ...` on the Task Packet allowlist - PASS
+- Offline direct probe for `target_phases=("S",)`, `target_step="SP4"`, `s_prompts_mode="registry"` - PASS; returned `FAIL`, one target row, and P0 `SP_CONTRACT_MISSING`.
+
+## Not Run
+
+- Live extraction.
+- Live provider calls.
+- Network provider preflight.
+- Full RTE suite.
+- Follow-up slices for network/secrets containment, pre-live UX cleanup, and prescan closeout.
+- `ruff check` as a completion gate. A focused run was attempted, but `run_extraction_v5.py` has pre-existing import-order and unused-import findings outside this slice. One new validator unused import surfaced by that run was removed.
+
+## Residual Risk
+
+- This slice blocks missing SP contracts but does not add the missing SP contracts themselves.
+- Route-readiness evidence remains bounded to existing offline tests and local route derivation; provider availability was not exercised.
+- Full-suite regressions remain possible outside the targeted files and are left to CI or a separate full-suite packet.

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -650,7 +650,7 @@ COST_PROFILES: Dict[str, Dict[str, Any]] = {
         "enable_cached_input": True,
         "enable_batch_when_supported": True,
         "escalation_max_hops": 2,
-        "max_cost_usd_default": None,
+        "max_cost_usd_default": 5.00,
         "cost_cap_mode": "preventive",
         "notes": (
             "Best cost/quality ratio. Flex tier on EXTRACT/AGG bulk lanes; "
@@ -671,7 +671,7 @@ COST_PROFILES: Dict[str, Dict[str, Any]] = {
         "enable_cached_input": True,
         "enable_batch_when_supported": False,
         "escalation_max_hops": 3,
-        "max_cost_usd_default": None,
+        "max_cost_usd_default": 25.00,
         "cost_cap_mode": "preventive",
         "notes": (
             "Premium models with priority service tier where available. "
@@ -3089,6 +3089,7 @@ def build_pre_live_validator_command(
     target_phases: Sequence[str],
     allow_online_preflight: bool,
     target_step: Optional[str] = None,
+    s_prompts_mode: Optional[str] = None,
 ) -> List[str]:
     cmd = [
         sys.executable,
@@ -3098,6 +3099,9 @@ def build_pre_live_validator_command(
     ]
     if target_step:
         cmd.extend(["--step", str(target_step)])
+    normalized_s_prompts_mode = str(s_prompts_mode or "").strip().lower()
+    if normalized_s_prompts_mode:
+        cmd.extend(["--s-prompts", normalized_s_prompts_mode])
     normalized_phases = [
         str(phase).strip().upper() for phase in target_phases if str(phase).strip()
     ]
@@ -3470,6 +3474,7 @@ def enforce_pre_live_validator_for_execution(
         target_phases=_validator_phase_targets(args, phase_sequence),
         allow_online_preflight=True,
         target_step=getattr(args, "step", None),
+        s_prompts_mode=getattr(args, "s_prompts", None),
     )
     proc = subprocess.run(
         cmd,

--- a/services/repo-truth-extractor/tests/test_cost_profiles.py
+++ b/services/repo-truth-extractor/tests/test_cost_profiles.py
@@ -291,6 +291,7 @@ def test_economy_profile_uses_flex_tier_by_default() -> None:
 def test_quality_profile_uses_priority_tier() -> None:
     assert runner.COST_PROFILES["quality"]["default_service_tier"] == "priority"
     assert runner.COST_PROFILES["quality"]["escalation_max_hops"] == 3
+    assert runner.COST_PROFILES["quality"]["max_cost_usd_default"] == 25.00
 
 
 def test_value_default_profile_balanced_tradeoffs() -> None:
@@ -298,7 +299,7 @@ def test_value_default_profile_balanced_tradeoffs() -> None:
     assert p["default_service_tier"] == "default"
     assert p["enable_cached_input"] is True
     assert p["enable_batch_when_supported"] is True
-    assert p["max_cost_usd_default"] is None  # operator explicitly sets
+    assert p["max_cost_usd_default"] == 5.00
 
 
 def test_cli_help_lists_new_flags() -> None:

--- a/services/repo-truth-extractor/tests/test_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/tests/test_pre_live_gate_v25.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 from pathlib import Path
 import sys
+from types import SimpleNamespace
 
 
 def _load_gate_module():
@@ -61,16 +62,169 @@ def test_truth_split_prefers_specific_classification() -> None:
     )
 
 
-def test_collect_truth_split_fails_closed_until_implemented() -> None:
-    # S7 (audit): the runner/promptset/model-map drift audit is unimplemented. It must
-    # fail closed with a waivable P1 blocker, never a fake PASS.
+def test_collect_truth_split_reports_target_row_match(tmp_path: Path) -> None:
     gate = _load_gate_module()
-    payload, blockers, findings = gate.collect_truth_split(None, None)
-    assert payload["status"] == "NOT_IMPLEMENTED"
-    assert len(blockers) == 1
-    assert blockers[0].reason_code == gate.TRUTH_SPLIT_NOT_IMPLEMENTED
-    assert blockers[0].severity == "P1"
+
+    class FakeRunner:
+        def get_phase_prompts(self, phase):
+            assert phase == "A"
+            return [
+                SimpleNamespace(
+                    step_id="A0",
+                    output_artifacts=("INSTRUCTION_SURFACES.json",),
+                    source="legacy",
+                    contract={"expected_artifacts": ["INSTRUCTION_SURFACES.json"]},
+                )
+            ]
+
+    config = gate.GateConfig(
+        repo_root=Path("/tmp/repo"),
+        output_dir=tmp_path,
+        run_id="truth_split_match",
+        target_policy="cost",
+        target_mode="direct",
+        target_profile="P00_GENERIC",
+        target_phases=("A",),
+        target_step="A0",
+    )
+    payload, blockers, findings = gate.collect_truth_split(FakeRunner(), config)
+    assert payload["status"] == "PASS"
+    assert blockers == []
     assert findings == []
+    assert payload["target_phase_mismatch_count"] == 0
+    assert payload["rows"] == [
+        {
+            "phase": "A",
+            "target_phase": "A",
+            "step_id": "A0",
+            "runner_active": True,
+            "prompt_resolution_active": True,
+            "promptset_declared": True,
+            "model_map_declared": True,
+            "artifact_declarations_present": True,
+            "contract_present": True,
+            "prompt_source": "legacy",
+            "classification": "MATCH",
+        }
+    ]
+
+
+def test_collect_truth_split_blocks_selected_sp_without_contract(tmp_path: Path) -> None:
+    gate = _load_gate_module()
+
+    class FakeRunner:
+        def get_phase_prompts(self, phase):
+            assert phase == "S"
+            return [
+                SimpleNamespace(
+                    step_id="SP4",
+                    output_artifacts=("SP4_TRUTH_PACK_INDEX.json",),
+                    source="registry",
+                    contract=None,
+                )
+            ]
+
+    config = gate.GateConfig(
+        repo_root=Path("/tmp/repo"),
+        output_dir=tmp_path,
+        run_id="truth_split_sp_missing_contract",
+        target_policy="cost",
+        target_mode="direct",
+        target_profile="P00_GENERIC",
+        target_phases=("S",),
+        target_step="SP4",
+        s_prompts_mode="registry",
+    )
+    payload, blockers, findings = gate.collect_truth_split(FakeRunner(), config)
+    assert payload["status"] == "FAIL"
+    assert payload["target_phase_mismatch_count"] == 1
+    assert payload["repo_wide_mismatch_count"] == 0
+    assert findings == []
+    assert payload["rows"][0]["phase"] == "SP"
+    assert payload["rows"][0]["target_phase"] == "S"
+    assert payload["rows"][0]["step_id"] == "SP4"
+    assert payload["rows"][0]["prompt_source"] == "registry"
+    assert payload["rows"][0]["contract_present"] is False
+    assert payload["rows"][0]["classification"] == "STALE_MODEL_MAP"
+    assert [(blocker.reason_code, blocker.severity) for blocker in blockers] == [
+        (gate.SP_CONTRACT_MISSING, "P0")
+    ]
+
+
+def test_run_gate_applies_s_prompts_mode_before_scope_derivation(
+    monkeypatch, tmp_path: Path
+) -> None:
+    gate = _load_gate_module()
+    observed = {}
+
+    class FakeRunner:
+        def set_active_s_prompts_mode(self, mode):
+            observed["set_mode"] = mode
+
+    class FakeContract:
+        def compile_phase_contract_map(self):
+            return {"steps": {}}
+
+    fake_scope = {
+        "validation_started_at": "2026-03-12T00:00:00+00:00",
+        "git_sha": "abc123",
+        "validator_host": "host",
+        "validator_python": "3.11.0",
+        "target_policy": "cost",
+        "target_mode": "direct",
+        "target_profile": "P00_GENERIC",
+        "target_phases": ["S"],
+        "target_step": "SP4",
+        "target_runner_path": "/tmp/run_extraction_v5.py",
+        "target_runner_sha256": "runner",
+        "promptset_sha256": "promptset",
+        "artifacts_sha256": "artifacts",
+        "model_map_sha256": "modelmap",
+        "required_provider_routes": [],
+        "required_api_key_envs": [],
+        "fallback_api_key_envs": [],
+        "all_route_api_key_envs": [],
+        "routing_fingerprint_hash": "routing",
+        "phase_contract_map_hash": "contract",
+    }
+
+    def fake_derive_scope(runner, contract_module, config):
+        observed["scope_mode"] = observed.get("set_mode")
+        return dict(fake_scope)
+
+    monkeypatch.setattr(
+        gate,
+        "load_module",
+        lambda path, name: FakeRunner()
+        if "run_extraction" in str(path)
+        else FakeContract(),
+    )
+    monkeypatch.setattr(gate, "derive_scope", fake_derive_scope)
+    monkeypatch.setattr(gate, "evaluate_import_cli_smoke", lambda config: ({"status": "PASS"}, []))
+    monkeypatch.setattr(gate, "evaluate_prompt_integrity", lambda runner, config: ({"status": "PASS"}, []))
+    monkeypatch.setattr(gate, "collect_truth_split", lambda runner, config: ({"layer": "truth_split_audit", "status": "PASS", "rows": [], "target_phase_mismatch_count": 0, "repo_wide_mismatch_count": 0}, [], []))
+    monkeypatch.setattr(gate, "evaluate_contract_map", lambda runner, contract_module, config: ({"status": "PASS"}, []))
+    monkeypatch.setattr(gate, "evaluate_route_readiness", lambda runner, config, scope: ({"status": "PASS"}, []))
+    monkeypatch.setattr(gate, "evaluate_pytest_layer", lambda **kwargs: ({"status": "PASS"}, [], []))
+    monkeypatch.setattr(gate, "evaluate_pal_validation", lambda config, scope: ({"layer": "pal_provider_validation", "status": "PASS", "routes": []}, [], []))
+    monkeypatch.setattr(gate, "evaluate_online_preflight", lambda runner, config: ({"layer": "online_provider_preflight", "status": "PASS"}, [], []))
+    monkeypatch.setattr(gate, "evaluate_smoke_tests", lambda config: ({"status": "PASS"}, []))
+
+    config = gate.GateConfig(
+        repo_root=Path("/tmp/repo"),
+        output_dir=tmp_path,
+        run_id="registry_mode_gate",
+        target_policy="cost",
+        target_mode="direct",
+        target_profile="P00_GENERIC",
+        target_phases=("S",),
+        target_step="SP4",
+        s_prompts_mode="registry",
+    )
+    result = gate.run_gate(config)
+
+    assert result["verdict"]["verdict"] == "GO"
+    assert observed == {"set_mode": "registry", "scope_mode": "registry"}
 
 
 def test_pal_validation_is_conditional_when_missing_for_active_route(tmp_path: Path) -> None:

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py
@@ -327,6 +327,36 @@ def test_enforce_pre_live_validator_returns_payload_on_go(
     assert result["returncode"] == 0
 
 
+def test_enforce_pre_live_validator_forwards_s_prompts_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("DPMX_LIVE_OK", "1")
+    captured = {}
+
+    def _fake_subprocess_run(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _FakeCompletedProcess(
+            returncode=0,
+            stdout=json.dumps({"verdict": "GO"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", _fake_subprocess_run)
+
+    result = runner.enforce_pre_live_validator_for_execution(
+        root=Path("."),
+        args=_make_args(execute=True, s_prompts="registry", step="SP4"),
+        phase_sequence=["S"],
+    )
+
+    assert result["verdict"] == "GO"
+    assert "--s-prompts" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("--s-prompts") + 1] == "registry"
+    assert "--step" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("--step") + 1] == "SP4"
+
+
 def test_enforce_pre_live_validator_short_circuits_without_consent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/services/repo-truth-extractor/validate_pre_live_gate_v25.py
+++ b/services/repo-truth-extractor/validate_pre_live_gate_v25.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 import hashlib
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Tuple
 from urllib.parse import urlparse
 
 import yaml
@@ -102,6 +102,7 @@ IMPORT_OR_CLI_FAILURE = "IMPORT_OR_CLI_FAILURE"
 TARGET_PROMPT_INTEGRITY_FAILURE = "TARGET_PROMPT_INTEGRITY_FAILURE"
 TARGET_TRUTH_SPLIT_MISMATCH = "TARGET_TRUTH_SPLIT_MISMATCH"
 TRUTH_SPLIT_NOT_IMPLEMENTED = "TRUTH_SPLIT_NOT_IMPLEMENTED"
+SP_CONTRACT_MISSING = "SP_CONTRACT_MISSING"
 CONTRACT_MAP_NONDETERMINISTIC = "CONTRACT_MAP_NONDETERMINISTIC"
 ROUTE_DERIVATION_FAILURE = "ROUTE_DERIVATION_FAILURE"
 REQUIRED_API_KEY_MISSING = "REQUIRED_API_KEY_MISSING"
@@ -124,6 +125,7 @@ class GateConfig:
     target_profile: str
     target_phases: Tuple[str, ...]
     target_step: Optional[str] = None
+    s_prompts_mode: str = "legacy"
     allow_online_preflight: bool = False
     pal_validation_file: Optional[Path] = None
     waiver_codes: Tuple[str, ...] = ()
@@ -273,6 +275,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Execution step filter.",
     )
     parser.add_argument(
+        "--s-prompts",
+        choices=("auto", "legacy", "registry"),
+        default="legacy",
+        help="Phase S prompt surface to validate for live execution.",
+    )
+    parser.add_argument(
         "--pal-validation-file",
         type=Path,
         default=None,
@@ -325,6 +333,7 @@ def build_config(args: argparse.Namespace) -> GateConfig:
         target_profile=str(args.target_profile).strip(),
         target_phases=tuple(str(phase).strip().upper() for phase in args.target_phases),
         target_step=args.step,
+        s_prompts_mode=str(args.s_prompts).strip().lower(),
         allow_online_preflight=bool(args.allow_online_preflight),
         pal_validation_file=pal_file.resolve() if pal_file else None,
         waiver_codes=tuple(sorted({str(code).strip() for code in args.waiver_code if str(code).strip()})),
@@ -389,6 +398,7 @@ def derive_scope(runner: Any, contract_module: Any, config: GateConfig) -> Dict[
         "target_policy": config.target_policy,
         "target_phases": list(config.target_phases),
         "target_step": config.target_step,
+        "target_s_prompts_mode": config.s_prompts_mode,
         "target_mode": config.target_mode,
         "target_runner_path": str(RUNNER_PATH.resolve()),
         "target_contract_map_path": str(CONTRACT_MAP_PATH.resolve()),
@@ -474,34 +484,155 @@ def evaluate_prompt_integrity(runner: Any, config: GateConfig) -> Tuple[Dict[str
     return results, blockers
 
 
+def promptset_declared_step_keys() -> Set[Tuple[str, str]]:
+    payload = read_yaml(PROMPTSET_PATH)
+    phases = payload.get("phases")
+    if not isinstance(phases, Mapping):
+        return set()
+    keys: Set[Tuple[str, str]] = set()
+    for phase, phase_payload in phases.items():
+        phase_code = str(phase or "").strip().upper()
+        steps = phase_payload.get("steps") if isinstance(phase_payload, Mapping) else None
+        if not isinstance(steps, list):
+            continue
+        for row in steps:
+            if not isinstance(row, Mapping):
+                continue
+            step_id = str(row.get("step_id") or "").strip().upper()
+            if phase_code and step_id:
+                keys.add((phase_code, step_id))
+    return keys
+
+
+def model_map_declared_step_keys() -> Set[Tuple[str, str]]:
+    payload = read_yaml(MODEL_MAP_PATH)
+    steps = payload.get("steps")
+    if not isinstance(steps, list):
+        return set()
+    keys: Set[Tuple[str, str]] = set()
+    for row in steps:
+        if not isinstance(row, Mapping):
+            continue
+        phase = str(row.get("phase") or "").strip().upper()
+        step_id = str(row.get("step_id") or "").strip().upper()
+        if phase and step_id:
+            keys.add((phase, step_id))
+    return keys
+
+
 def collect_truth_split(runner: Any, config: GateConfig) -> Tuple[Dict[str, Any], List[Blocker], List[Dict[str, Any]]]:
-    # FAIL-CLOSED (audit finding S7): the runner/promptset/model-map drift audit is not
-    # implemented. This previously returned a hardcoded PASS, which silently asserted
-    # "no drift" without running any check -- giving false go-live confidence. Until
-    # classify_truth_split_row (above) is wired into a real per-step comparison, we must
-    # not claim PASS. Emit a waivable P1 blocker so the gate fails closed; an operator who
-    # accepts the gap may proceed with `--waiver-code TRUTH_SPLIT_NOT_IMPLEMENTED`.
-    blocker = Blocker(
-        reason_code=TRUTH_SPLIT_NOT_IMPLEMENTED,
-        layer="truth_split_audit",
-        severity="P1",
-        message=(
-            "Truth-split drift audit is not implemented; cannot assert runner/promptset/"
-            "model-map alignment. Failing closed. Waive with "
-            "--waiver-code TRUTH_SPLIT_NOT_IMPLEMENTED to proceed without this check."
-        ),
-        details={"implemented": False},
-    )
+    blockers: List[Blocker] = []
+    findings: List[Dict[str, Any]] = []
+    rows: List[Dict[str, Any]] = []
+    if runner is None or config is None:
+        blockers.append(
+            Blocker(
+                TARGET_TRUTH_SPLIT_MISMATCH,
+                "truth_split_audit",
+                "P0",
+                "Truth-split audit could not run without a runner and gate config.",
+                {"runner_present": runner is not None, "config_present": config is not None},
+            )
+        )
+        return (
+            {
+                "layer": "truth_split_audit",
+                "status": "FAIL",
+                "target_phase_mismatch_count": 1,
+                "repo_wide_mismatch_count": 0,
+                "rows": [],
+            },
+            blockers,
+            findings,
+        )
+
+    promptset_declared_keys = promptset_declared_step_keys()
+    model_map_declared_keys = model_map_declared_step_keys()
+    target_step = str(config.target_step or "").strip().upper()
+
+    for target_phase in config.target_phases:
+        target_phase_code = str(target_phase or "").strip().upper()
+        if not target_phase_code:
+            continue
+        specs = runner.get_phase_prompts(target_phase_code)
+        for spec in specs:
+            step_id = str(getattr(spec, "step_id", "") or "").strip().upper()
+            if not step_id:
+                continue
+            if target_step and step_id != target_step:
+                continue
+            effective_phase = "SP" if step_id.startswith("SP") else target_phase_code
+            prompt_source = str(getattr(spec, "source", "") or "").strip().lower() or "unknown"
+            contract = getattr(spec, "contract", None)
+            contract_present = isinstance(contract, dict) and bool(contract)
+            output_artifacts = tuple(getattr(spec, "output_artifacts", ()) or ())
+            promptset_declared = (
+                (effective_phase, step_id) in promptset_declared_keys
+                or prompt_source == "registry"
+            )
+            model_map_declared = (effective_phase, step_id) in model_map_declared_keys
+            artifact_declarations_present = bool(output_artifacts)
+            classification = classify_truth_split_row(
+                step_id=step_id,
+                runner_active=True,
+                prompt_resolution_active=True,
+                promptset_declared=promptset_declared,
+                model_map_declared=model_map_declared,
+                artifact_declarations_present=artifact_declarations_present,
+            )
+            row = {
+                "phase": effective_phase,
+                "target_phase": target_phase_code,
+                "step_id": step_id,
+                "runner_active": True,
+                "prompt_resolution_active": True,
+                "promptset_declared": promptset_declared,
+                "model_map_declared": model_map_declared,
+                "artifact_declarations_present": artifact_declarations_present,
+                "contract_present": contract_present,
+                "prompt_source": prompt_source,
+                "classification": classification,
+            }
+            rows.append(row)
+            if effective_phase == "SP" and not contract_present:
+                blockers.append(
+                    Blocker(
+                        SP_CONTRACT_MISSING,
+                        "truth_split_audit",
+                        "P0",
+                        "Selected SP registry step is missing a phase contract.",
+                        {
+                            "target_phase": target_phase_code,
+                            "phase": effective_phase,
+                            "step_id": step_id,
+                            "s_prompts_mode": config.s_prompts_mode,
+                        },
+                    )
+                )
+            elif classification != "MATCH":
+                blockers.append(
+                    Blocker(
+                        TARGET_TRUTH_SPLIT_MISMATCH,
+                        "truth_split_audit",
+                        "P0",
+                        "Target runner/promptset/model-map/artifact truth split mismatch.",
+                        row,
+                    )
+                )
+
+    mismatch_count = sum(1 for row in rows if row.get("classification") != "MATCH")
+    if any(blocker.reason_code == SP_CONTRACT_MISSING for blocker in blockers):
+        mismatch_count = max(mismatch_count, len(blockers))
     return (
         {
             "layer": "truth_split_audit",
-            "status": "NOT_IMPLEMENTED",
-            "target_phase_mismatch_count": 0,
+            "status": "FAIL" if blockers else "PASS",
+            "target_phase_mismatch_count": mismatch_count,
             "repo_wide_mismatch_count": 0,
-            "rows": [],
+            "rows": rows,
         },
-        [blocker],
-        [],
+        blockers,
+        findings,
     )
 
 
@@ -1258,6 +1389,8 @@ def run_gate(
     config.output_dir.mkdir(parents=True, exist_ok=True)
     runner = load_module(RUNNER_PATH, "run_extraction_v5_pre_live_gate")
     contract_module = load_module(CONTRACT_MAP_PATH, "phase_contract_map_pre_live_gate")
+    if hasattr(runner, "set_active_s_prompts_mode"):
+        runner.set_active_s_prompts_mode(config.s_prompts_mode)
 
     scope = derive_scope(runner, contract_module, config)
     write_json(config.output_dir / "VALIDATION_SCOPE.json", scope)

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -57,6 +57,7 @@ A packet is superseded by another packet
 | TP-DMX-RTECANON-001 | Repo Truth Extractor | Establish `dopemux rte` as the canonical operator entrypoint | Ready | N/A |
 | TP-RTE-V3-CONSENT-004 | Repo Truth Extractor | Gate legacy v3 execution and fail closed on unknown pipeline versions | Active | N/A |
 | TP-RTE-WALKER-006 | Repo Truth Extractor | Exclude generated artifacts and secret-bearing files from prescan walker input | Active | N/A |
+| TP-RTE-GOLIVE-REMEDIATION-001 | Repo Truth Extractor | Harden go-live preflight truth-split, SP registry contract, and cost-cap gates | Active | N/A |
 | TP-RTE-BATCH-005 | Repo Truth Extractor | Repair batch result extraction and strict batch request payload handling | Merged (PR #614) | N/A |
 | TP-RTE-BATCH-E2E-006 | Repo Truth Extractor | Wire strict batch response_format through v5 request construction | Merged (PR #615) | N/A |
 | TP-RTE-STRICT-ATTESTATION-007 | Repo Truth Extractor | Ground strict passthrough attestations in runtime evidence | Merged (PR #616) | N/A |

--- a/task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json
+++ b/task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json
@@ -1,0 +1,119 @@
+{
+  "id": "TP-RTE-GOLIVE-REMEDIATION-001",
+  "project": "dopemux-mvp",
+  "target": "Remediate the first Repo Truth Extractor go-live audit safety slice on main: require the pre-live validator to evaluate the selected S/SP prompt mode, replace the truth-split placeholder with target-scoped runtime rows, hard-block live SP registry selections with missing step contracts, and add default spend caps to value-default and quality cost profiles.",
+  "invariants": [
+    "Runtime/source truth governs behavior claims; generated audit packs and plans are advisory only.",
+    "No live extraction, live provider calls, network preflight, or account-specific checks are authorized by this packet.",
+    "Preserve DPMX_LIVE_OK and pre-live validator consent boundaries; do not weaken live execution gates.",
+    "Truth-split UNKNOWN or missing SP contract state must fail closed for live SP targets.",
+    "Implement only this first remediation slice; network/secrets containment, pre-live UX cleanup, and prescan closeout remain follow-up slices."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "rte-go-live-remediation",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/rte-golive-remediation-001",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(rte): harden go-live preflight safety",
+    "allowlist": [
+      "task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json",
+      "task-packets/INDEX.md",
+      "proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-001/implementation-notes.md",
+      "services/repo-truth-extractor/run_extraction_v5.py",
+      "services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+      "services/repo-truth-extractor/tests/test_cost_profiles.py",
+      "services/repo-truth-extractor/tests/test_pre_live_gate_v25.py",
+      "services/repo-truth-extractor/tests/test_run_extraction_v5_cost_cap.py",
+      "services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_cost_profiles.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py services/repo-truth-extractor/tests/test_run_extraction_v5_cost_cap.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py -q --tb=short --disable-warnings --no-cov",
+      "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(rte): harden go-live preflight safety",
+    "body": "## Summary\n- Passes the active S/SP prompt mode into the pre-live validator so live registry selections are evaluated by the same target mode that execution will use.\n- Replaces the truth-split placeholder with target-scoped rows derived from runtime prompt resolution, model-map declarations, and artifact contract declarations.\n- Hard-blocks selected SP registry steps when their step contract is missing, and adds default cost caps to value-default and quality profiles.\n\n## Validation\n- python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json >/dev/null\n- python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_cost_profiles.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py services/repo-truth-extractor/tests/test_run_extraction_v5_cost_cap.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py -q --tb=short --disable-warnings --no-cov\n- python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py\n- git diff --check\n\n## NOT_RUN\n- Live extraction.\n- Live provider calls or network preflight.\n- Full RTE suite.\n\n@codex review\n@gemini\n@copilot",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Register this Task Packet and validate it against the canonical dopetask schema before implementation.",
+      "expected_files": [
+        "task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Add focused RED tests for default cost caps, pre-live validator S/SP prompt mode propagation, target-scoped truth-split rows, and missing SP contract hard blocking.",
+      "expected_files": [
+        "services/repo-truth-extractor/tests/test_cost_profiles.py",
+        "services/repo-truth-extractor/tests/test_pre_live_gate_v25.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
+      ],
+      "validation": [
+        "Targeted tests fail before implementation for at least one assertion in the new behavior."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement the minimal RTE runtime changes required by S2 while preserving live consent, deterministic ordering, and fail-closed missing-contract semantics.",
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/validate_pre_live_gate_v25.py"
+      ],
+      "validation": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_cost_profiles.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py services/repo-truth-extractor/tests/test_run_extraction_v5_cost_cap.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py -q --tb=short --disable-warnings --no-cov"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Record implementation notes, run precommit-grade checks, inspect diff scope, and prepare the PR.",
+      "expected_files": [
+        "proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-001/implementation-notes.md"
+      ],
+      "validation": [
+        "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+        "git diff --check",
+        "git status --short --branch"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Passes the active `--s-prompts` mode into the pre-live validator subprocess and applies it before validator scope derivation.
- Replaces the truth-split placeholder with target-scoped rows from active runner prompt specs, promptset declarations, model-map declarations, and prompt output/contract metadata.
- Hard-blocks selected SP registry steps without phase contracts via P0 `SP_CONTRACT_MISSING`.
- Adds default spend caps: `value-default` = 5.00 USD, `quality` = 25.00 USD.

## Task Packet
- `TP-RTE-GOLIVE-REMEDIATION-001`
- `task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json`
- Implementation notes: `proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-001/implementation-notes.md`

## Validation
- `python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json >/dev/null`
- `python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_cost_profiles.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py services/repo-truth-extractor/tests/test_run_extraction_v5_cost_cap.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py -q --tb=short --disable-warnings --no-cov` (49 passed)
- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py`
- `git diff --check`
- `git diff --cached --check`
- `pre-commit run --files ...` on the packet allowlist
- Offline direct probe for `target_phases=("S",)`, `target_step="SP4"`, `s_prompts_mode="registry"` returned `FAIL` with P0 `SP_CONTRACT_MISSING`.

## NOT_RUN
- Live extraction.
- Live provider calls or network preflight.
- Full RTE suite.
- Follow-up remediation slices for network/secrets containment, pre-live UX cleanup, and prescan closeout.
- `ruff check` as a completion gate: attempted, but `run_extraction_v5.py` has pre-existing import-order/unused-import findings outside this slice. One new validator unused import found by that attempt was removed.

## Residual Risks / UNKNOWNs
- This slice blocks missing SP contracts but does not add those contracts.
- Route-readiness evidence remains offline/local; provider availability was not exercised.
- Full-suite regressions outside the targeted files are left to CI or a separate full-suite packet.

@codex review
@gemini
@copilot