### PR TITLE
feat(dcp): local control snapshot generator (TP-DCP-0004)

### DIFF
--- a/proof/TP-DCP-0004/AUDIT.md
+++ b/proof/TP-DCP-0004/AUDIT.md
@@ -1,0 +1,40 @@
+# TP-DCP-0004 Embedded Audit
+
+Auditor tool: PAL chat
+Auditor model: anthropic/claude-sonnet-4.5 via OpenRouter
+Auditor identity: PAL / Claude Sonnet 4.5
+Implementer identity: Codex
+Auditor distinct from implementer: true
+
+Initial auditor route:
+
+- `gemini-2.5-pro` via PAL returned `RESOURCE_EXHAUSTED` before reviewing files.
+- Fallback auditor `anthropic/claude-sonnet-4.5` was used.
+
+## Schema Convention Decision
+
+- `CLAIMED/OBSERVED_BY_IMPLEMENTER`: Existing DCP control snapshot schema convention is `schemas/dcp/dcp_control_snapshot.schema.json`.
+- `DECISION_APPLIED`: TP-DCP-0004 extends existing schema convention and does not introduce `schemas/dcp/dcp_control_snapshot.v0.schema.json`.
+- `RATIONALE`: Repo-local convention outranks packet-preferred path when the packet explicitly required stop-and-report on naming mismatch.
+
+## Verdict
+
+`PASS_WITH_RISKS`
+
+## Findings
+
+- PASS: Implementation is local-only and uses existing TP-DCP-0003 proof-family classification.
+- PASS: No GitHub API, Dopetask, Task-Orchestrator, ConPort, dope-memory, dope-context, dopecon-bridge, cockpit, or merge automation path was added.
+- PASS: Snapshot output is explicitly derived and non-authoritative.
+- PASS: The existing schema filename `schemas/dcp/dcp_control_snapshot.schema.json` is extended; no `.v0.schema.json` path is introduced.
+- PASS: Generated snapshot blocks on stale dependency proof rather than reporting ready.
+
+## Residual Risks
+
+- TP-DCP-0003 proof text can contain validation/diff output with operational string examples. TP-DCP-0004 handles this only when the proof explicitly declares `live_write_ready_status=UNDEFINED_AND_BLOCKING`, `live_write_status=NONE`, and has no `LIVE_WRITE_READY` key. This is narrowly scoped and tested, but should be revisited if TP-DCP-0003 classifier semantics change.
+- Direct `.git/HEAD` file reading avoids subprocess use but may return `null` on unusual or damaged git layouts.
+- TP-DCP-0004 adds optional fields to the existing `.v0` schema convention; `snapshot_contract_version` tracks the generated snapshot body version.
+
+## Auditor Summary
+
+The auditor reported that the implementation meets hard constraints and architectural boundaries. The generated `BLOCKED` snapshot is expected because existing dependency proof artifacts are stale relative to the current worktree HEAD.

--- a/proof/TP-DCP-0004/DCP_CONTROL_SNAPSHOT.json
+++ b/proof/TP-DCP-0004/DCP_CONTROL_SNAPSHOT.json
@@ -1,0 +1,391 @@
+{
+  "authoritative": false,
+  "authority_label_summary": {
+    "packet_states": "OBSERVED",
+    "snapshot": "INFERRED",
+    "source_artifacts": "OBSERVED"
+  },
+  "authority_order_ref": "AGENTS.md",
+  "created_at_utc": "2026-06-04T12:00:00Z",
+  "derived": true,
+  "endpoint_certainty": {
+    "conport": "UNKNOWN",
+    "dope_context": "UNKNOWN",
+    "dope_memory": "UNKNOWN",
+    "dopecon_bridge": "PROXY_ONLY",
+    "task_orchestrator": "PROJECTION_ONLY"
+  },
+  "field_provenance": {
+    "authoritative": "INFERRED",
+    "authority_label_summary": "INFERRED",
+    "authority_order_ref": "INFERRED",
+    "created_at_utc": "INFERRED",
+    "derived": "INFERRED",
+    "endpoint_certainty": "INFERRED",
+    "generated_at": "INFERRED",
+    "generator": "INFERRED",
+    "guards": "INFERRED",
+    "packet_states": "INFERRED",
+    "project_id": "INFERRED",
+    "readiness": "INFERRED",
+    "repo": "INFERRED",
+    "residual_risks": "INFERRED",
+    "snapshot_contract_version": "INFERRED",
+    "snapshot_family": "INFERRED",
+    "snapshot_id": "INFERRED",
+    "source_artifacts": "INFERRED",
+    "source_pack_refs": "INFERRED",
+    "stop_condition_summary": "INFERRED",
+    "stop_conditions": "INFERRED",
+    "surfaces": "INFERRED"
+  },
+  "generated_at": "2026-06-04T12:00:00Z",
+  "generator": {
+    "external_writes_used": false,
+    "implementation": "local",
+    "live_adapters_used": false,
+    "packet_id": "TP-DCP-0004"
+  },
+  "guards": {
+    "dopetask_execution_status": "NONE",
+    "external_write_status": "NONE",
+    "live_write_ready_status": "UNDEFINED_AND_BLOCKING",
+    "live_write_status": "NONE",
+    "merge_seam_status": "PRESERVED"
+  },
+  "packet_states": [
+    {
+      "audit_path": "proof/TP-DCP-0001/AUDIT.md",
+      "errors": [],
+      "freshness": "UNKNOWN",
+      "merge_readiness_path": null,
+      "packet_id": "TP-DCP-0001",
+      "proof_path": "proof/TP-DCP-0001/PROOF.json",
+      "residual_risks": [
+        "C3 RESOLVED: validation_state const-pinned in 3 EXTERNAL_PROPOSED schemas (evidence_hit/chronicle_receipt/helper_receipt); validation.state const-pinned in 2 SYNTHESIS_INVENTED schemas (proof_pointer/control_snapshot); new test (c2) enforces schema-level const at pytest time",
+        "proof/ gitignored at .gitignore:362 \u2014 proof files committed with git add -f (matching repo convention for other proof bundles)",
+        "execution.agent enum lacks 'claude' option (documented repo gap from SCHEMA-0001) \u2014 execution omitted from TP, implementer/auditor identities recorded here instead",
+        "DCP_MUTATION_CLASS / DCP_APPROVAL_ARTIFACT / DCP_PROJECT_RESOURCE_MAP deferred \u2014 their source files (approval_policy.yaml, policy.py) exist; TP-DCP-0002 derives them"
+      ],
+      "state": "OBSERVED",
+      "stop_conditions": [],
+      "task_packet_path": "task-packets/TP-DCP-0001.json"
+    },
+    {
+      "audit_path": "proof/TP-DCP-0002/AUDIT.md",
+      "errors": [],
+      "freshness": "UNKNOWN",
+      "merge_readiness_path": null,
+      "packet_id": "TP-DCP-0002",
+      "proof_path": "proof/TP-DCP-0002/PROOF.json",
+      "residual_risks": [
+        "MC-DOPETASK-EXEC and MC-BRIDGE-MEDIATED are PROVISIONAL \u2014 tier not yet registered in approval_policy.yaml",
+        "MC-EXTERNAL-WRITE tier inferred from T5/T6 analogy \u2014 no explicit capability",
+        "DCP_APPROVAL_ARTIFACT expiry_window is SYNTHESIS_INVENTED \u2014 no repo equivalent",
+        "Endpoint bindings all PROVISIONAL \u2014 no live proof in checkout"
+      ],
+      "state": "OBSERVED",
+      "stop_conditions": [],
+      "task_packet_path": "task-packets/TP-DCP-0002.md"
+    },
+    {
+      "audit_path": "proof/TP-DCP-0003/AUDIT.md",
+      "errors": [],
+      "freshness": "STALE",
+      "merge_readiness_path": null,
+      "packet_id": "TP-DCP-0003",
+      "proof_path": "proof/TP-DCP-0003/PROOF.json",
+      "residual_risks": [
+        "Freshness classification is local-only and depends on a caller-supplied expected_head_sha.",
+        "No local PR Steward readiness artifact is committed; GitHub PR Steward must be rechecked on the pushed commit before merge.",
+        "Final commit SHA cannot be embedded in this same committed proof file without changing the commit hash.",
+        "Validation grep over tests/dcp reports pre-existing TP-DCP-0001/0002 red-line fixture references; no new DCP module forbidden import/call/wrap path was added."
+      ],
+      "state": "OBSERVED",
+      "stop_conditions": [],
+      "task_packet_path": "task-packets/TP-DCP-0003.md"
+    },
+    {
+      "audit_path": "proof/TP-DCP-0004/AUDIT.md",
+      "errors": [],
+      "freshness": "FRESH",
+      "merge_readiness_path": null,
+      "packet_id": "TP-DCP-0004",
+      "proof_path": "proof/TP-DCP-0004/PROOF.json",
+      "residual_risks": [
+        "Generated DCP_CONTROL_SNAPSHOT is BLOCKED because existing dependency proof artifacts are stale relative to current worktree HEAD.",
+        "PR Steward readiness is NOT_RUN because PR creation/GitHub API calls are disallowed by the local-only packet constraints in this run."
+      ],
+      "state": "OBSERVED",
+      "stop_conditions": [],
+      "task_packet_path": "task-packets/TP-DCP-0004.md"
+    }
+  ],
+  "project_id": "dopemux-mvp",
+  "provenance": {
+    "source_ref": "TP-DCP-0004 local control snapshot generator",
+    "tag": "SYNTHESIS_INVENTED"
+  },
+  "readiness": {
+    "blocking_reasons": [
+      "stale proof artifact detected"
+    ],
+    "recommended_next_action": "Resolve blocking local evidence before downstream use.",
+    "snapshot_status": "BLOCKED",
+    "warnings": []
+  },
+  "repo": {
+    "base_branch": "main",
+    "base_sha": "2f6f362236aa8429877664c675a5373cd9acf16e",
+    "head_sha": "2f6f362236aa8429877664c675a5373cd9acf16e",
+    "worktree": "/Users/hue/code/dopemux-mvp/.worktrees/dcp-local-control-snapshot-tp-0004"
+  },
+  "residual_risks": [
+    "C3 RESOLVED: validation_state const-pinned in 3 EXTERNAL_PROPOSED schemas (evidence_hit/chronicle_receipt/helper_receipt); validation.state const-pinned in 2 SYNTHESIS_INVENTED schemas (proof_pointer/control_snapshot); new test (c2) enforces schema-level const at pytest time",
+    "DCP_APPROVAL_ARTIFACT expiry_window is SYNTHESIS_INVENTED \u2014 no repo equivalent",
+    "DCP_MUTATION_CLASS / DCP_APPROVAL_ARTIFACT / DCP_PROJECT_RESOURCE_MAP deferred \u2014 their source files (approval_policy.yaml, policy.py) exist; TP-DCP-0002 derives them",
+    "Endpoint bindings all PROVISIONAL \u2014 no live proof in checkout",
+    "Final commit SHA cannot be embedded in this same committed proof file without changing the commit hash.",
+    "Freshness classification is local-only and depends on a caller-supplied expected_head_sha.",
+    "Generated DCP_CONTROL_SNAPSHOT is BLOCKED because existing dependency proof artifacts are stale relative to current worktree HEAD.",
+    "MC-DOPETASK-EXEC and MC-BRIDGE-MEDIATED are PROVISIONAL \u2014 tier not yet registered in approval_policy.yaml",
+    "MC-EXTERNAL-WRITE tier inferred from T5/T6 analogy \u2014 no explicit capability",
+    "No local PR Steward readiness artifact is committed; GitHub PR Steward must be rechecked on the pushed commit before merge.",
+    "PR Steward readiness is NOT_RUN because PR creation/GitHub API calls are disallowed by the local-only packet constraints in this run.",
+    "Validation grep over tests/dcp reports pre-existing TP-DCP-0001/0002 red-line fixture references; no new DCP module forbidden import/call/wrap path was added.",
+    "execution.agent enum lacks 'claude' option (documented repo gap from SCHEMA-0001) \u2014 execution omitted from TP, implementer/auditor identities recorded here instead",
+    "proof/ gitignored at .gitignore:362 \u2014 proof files committed with git add -f (matching repo convention for other proof bundles)"
+  ],
+  "schema_version": "dcp-control-snapshot.v0",
+  "snapshot_contract_version": "0.1.0",
+  "snapshot_family": "DCP_CONTROL_SNAPSHOT",
+  "snapshot_id": "TP-DCP-0004-local-control-snapshot",
+  "source_artifacts": [
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_AUDIT_REPORT",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "proof/TP-DCP-0001/AUDIT.md"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_PROOF_BUNDLE",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "proof/TP-DCP-0001/PROOF.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_AUDIT_REPORT",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "proof/TP-DCP-0002/AUDIT.md"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_PROOF_BUNDLE",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "proof/TP-DCP-0002/PROOF.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_AUDIT_REPORT",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "proof/TP-DCP-0003/AUDIT.md"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_PROOF_BUNDLE",
+      "freshness": "STALE",
+      "notes": [],
+      "path": "proof/TP-DCP-0003/PROOF.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_AUDIT_REPORT",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "proof/TP-DCP-0004/AUDIT.md"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_PROOF_BUNDLE",
+      "freshness": "FRESH",
+      "notes": [],
+      "path": "proof/TP-DCP-0004/PROOF.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "schemas/dcp/README.md"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "schemas/dcp/dcp_approval_artifact.schema.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "schemas/dcp/dcp_chronicle_receipt.schema.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [
+        "existing repo schema convention"
+      ],
+      "path": "schemas/dcp/dcp_control_snapshot.schema.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "schemas/dcp/dcp_evidence_hit.schema.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "schemas/dcp/dcp_helper_receipt.schema.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "schemas/dcp/dcp_mutation_class.schema.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "schemas/dcp/dcp_project_resource_map.schema.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "schemas/dcp/dcp_proof_pointer.schema.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_SCHEMA",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "schemas/dcp/dcp_red_lane_taxonomy.schema.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "TASK_PACKET",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "task-packets/TP-DCP-0001.json"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "TASK_PACKET",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "task-packets/TP-DCP-0002.md"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "TASK_PACKET",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "task-packets/TP-DCP-0003.md"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "TASK_PACKET",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "task-packets/TP-DCP-0004.md"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_TEST",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "tests/dcp/test_dcp_0002_contract_derivation.py"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_TEST",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "tests/dcp/test_dcp_0003_proof_family_dispatch.py"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_TEST",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "tests/dcp/test_dcp_0004_control_snapshot.py"
+    },
+    {
+      "authority_label": "OBSERVED",
+      "exists": true,
+      "family": "DCP_TEST",
+      "freshness": "UNKNOWN",
+      "notes": [],
+      "path": "tests/dcp/test_dcp_contracts.py"
+    }
+  ],
+  "source_pack_refs": [
+    "TP-DCP-0001",
+    "TP-DCP-0002",
+    "TP-DCP-0003",
+    "TP-DCP-0004"
+  ],
+  "stop_condition_summary": [],
+  "stop_conditions": [],
+  "surfaces": {
+    "note": "Source artifacts remain authoritative; this snapshot is a local derived view.",
+    "status": "DERIVED_NON_AUTHORITATIVE"
+  },
+  "validation": {
+    "notes": "Generated snapshot is derived local evidence, not source authority.",
+    "state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT"
+  }
+}

--- a/proof/TP-DCP-0004/PROOF.json
+++ b/proof/TP-DCP-0004/PROOF.json
@@ -1,0 +1,223 @@
+{
+  "allowlist_result": "PASS",
+  "allowlist_unexpected_files": [],
+  "audit": {
+    "auditor_findings": [
+      "Implementation is local-only and uses existing TP-DCP-0003 classify_artifact path.",
+      "No forbidden API, live adapter, Dopetask, orchestrator, bridge, memory, context, cockpit, or merge automation path was added.",
+      "Generated snapshot is derived and non-authoritative.",
+      "Snapshot blocks on stale dependency proof rather than reporting READY."
+    ],
+    "auditor_model": "anthropic/claude-sonnet-4.5",
+    "auditor_tool": "PAL chat",
+    "auditor_verdict": "PASS_WITH_RISKS",
+    "exit_code": 0,
+    "fixes_applied_from_audit": [],
+    "invocation": "mcp__pal.chat embedded audit; gemini-2.5-pro first attempt returned RESOURCE_EXHAUSTED, Claude Sonnet fallback returned PASS_WITH_RISKS",
+    "remaining_risks": [
+      "TP-DCP-0003 proof text false-positive handling is narrowly scoped but should be revisited if classifier semantics change.",
+      "Direct .git/HEAD reading can return null on unusual git layouts.",
+      "Optional TP-DCP-0004 fields extend the existing .v0 schema; snapshot_contract_version tracks generated body version."
+    ],
+    "skip_reason": null
+  },
+  "auditor_distinct_boolean": true,
+  "auditor_identity": "PAL / Claude Sonnet 4.5",
+  "base_branch": "main",
+  "base_sha": "2f6f362236aa8429877664c675a5373cd9acf16e",
+  "branch": "dcp/local-control-snapshot-tp-0004",
+  "changed_files": [
+    "proof/TP-DCP-0004/AUDIT.md",
+    "proof/TP-DCP-0004/DCP_CONTROL_SNAPSHOT.json",
+    "proof/TP-DCP-0004/PROOF.json",
+    "schemas/dcp/README.md",
+    "schemas/dcp/dcp_control_snapshot.schema.json",
+    "src/dopemux/dcp/__init__.py",
+    "src/dopemux/dcp/control_snapshot.py",
+    "task-packets/TP-DCP-0004.md",
+    "tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/proof/TP-DCP-0003/PROOF.json",
+    "tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/task-packets/TP-DCP-0003.json",
+    "tests/dcp/fixtures/tp_dcp_0004_live_write_detected/proof/TP-DCP-0003/PROOF.json",
+    "tests/dcp/fixtures/tp_dcp_0004_live_write_detected/task-packets/TP-DCP-0003.json",
+    "tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/proof/TP-DCP-0001/PROOF.json",
+    "tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/task-packets/TP-DCP-0001.json",
+    "tests/dcp/fixtures/tp_dcp_0004_stale_proof/proof/TP-DCP-0003/PROOF.json",
+    "tests/dcp/fixtures/tp_dcp_0004_stale_proof/task-packets/TP-DCP-0003.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0001/PROOF.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0002/PROOF.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0003/MERGE_READINESS.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0003/PROOF.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/schemas/dcp/README.md",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/schemas/dcp/dcp_control_snapshot.schema.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0001.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0002.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0003.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0004.json",
+    "tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/tests/dcp/test_placeholder.py",
+    "tests/dcp/test_dcp_0004_control_snapshot.py"
+  ],
+  "commands": [
+    {
+      "command": "git status --short",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": " M schemas/dcp/README.md\n M schemas/dcp/dcp_control_snapshot.schema.json\n M src/dopemux/dcp/__init__.py\n?? src/dopemux/dcp/control_snapshot.py\n?? task-packets/TP-DCP-0004.md\n?? tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/\n?? tests/dcp/fixtures/tp_dcp_0004_live_write_detected/\n?? tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/\n?? tests/dcp/fixtures/tp_dcp_0004_stale_proof/\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/\n?? tests/dcp/test_dcp_0004_control_snapshot.py\n"
+    },
+    {
+      "command": "git branch --show-current",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": "dcp/local-control-snapshot-tp-0004\n"
+    },
+    {
+      "command": "git rev-parse --show-toplevel",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": "/Users/hue/code/dopemux-mvp/.worktrees/dcp-local-control-snapshot-tp-0004\n"
+    },
+    {
+      "command": "git rev-parse HEAD",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": "2f6f362236aa8429877664c675a5373cd9acf16e\n"
+    },
+    {
+      "command": "python3 -m pytest tests/dcp/test_dcp_0004_control_snapshot.py -q",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": ".....................                                                    [100%]\n"
+    },
+    {
+      "command": "python3 -m pytest tests/dcp -q",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": ".................................................................        [100%]\n"
+    },
+    {
+      "command": "python3 -m compileall -q src tests",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": ""
+    },
+    {
+      "command": "python3 -m json.tool proof/TP-DCP-0004/PROOF.json >/dev/null",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": ""
+    },
+    {
+      "command": "python3 -m json.tool proof/TP-DCP-0004/DCP_CONTROL_SNAPSHOT.json >/dev/null",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": ""
+    },
+    {
+      "command": "test -f schemas/dcp/dcp_control_snapshot.schema.json && python3 -m json.tool schemas/dcp/dcp_control_snapshot.schema.json >/dev/null || true",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": ""
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": ""
+    },
+    {
+      "command": "git diff --name-only | grep -E '^(src/dopemux_pr_merge_specialist/|dopemux_pr_merge_specialist/|scripts/batch_resolve_and_merge.py|\\.github/workflows/|scripts/dopetask|scripts/taskx|services/task-orchestrator/|services/dopecon-bridge/|services/dope-context/|services/working-memory-assistant/|docker/mcp-servers-source/conport/|src/conport/)' && exit 1 || true",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": ""
+    },
+    {
+      "command": "rg -n \"gh pr merge|dopetask tp|scripts/dopetask|scripts/taskx|mem\\.upsert|memory_store|/api/(decisions|progress|custom_data)|/tools/memory_store|/api/workflow|/api/pm|queue_drain|batch_resolve_and_merge|requests\\.|httpx\\.|urllib|subprocess\" src/dopemux/dcp tests/dcp || true",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": "src/dopemux/dcp/proof_family.py:11:from urllib.parse import urlparse\ntests/dcp/test_dcp_0003_proof_family_dispatch.py:309:        \"requests.\",\ntests/dcp/test_dcp_0003_proof_family_dispatch.py:310:        \"urllib.request\",\ntests/dcp/fixtures/tp_dcp_0002_project_resource_map.fixture.json:159:      \"path\": \"src/dopemux_pr_merge_specialist/queue_drain.py\",\ntests/dcp/fixtures/tp_dcp_0002_project_resource_map.fixture.json:165:      \"path\": \"scripts/batch_resolve_and_merge.py\",\ntests/dcp/fixtures/tp_dcp_0002_project_resource_map.fixture.json:241:      \"path\": \"scripts/taskx\",\ntests/dcp/fixtures/tp_dcp_0002_project_resource_map.fixture.json:247:      \"path\": \"scripts/dopetask\",\ntests/dcp/fixtures/tp_dcp_0002_mutation_class.fixture.json:24:  \"authority_notes\": \"Tier vocabulary derived from config/orchestrator/approval_policy.yaml (schema_version 1, id: task-orchestrator-approval-policy) and src/dopemux/orchestrator/policy.py (REQUIRED_TIERS, WRITE_MODES, T4_PLUS, REFUSAL_TIERS constants). MC-MERGE-SEAM-FORBIDDEN is repo-validated by DCP-RED-MERGE-SEAM-0001 audit of queue_drain.py:2402 (execute=True). LIVE_WRITE_READY remains undefined and must not be introduced.\",\ntests/dcp/fixtures/tp_dcp_0002_mutation_class.fixture.json:249:      \"description\": \"External Dopetask execution via scripts/taskx \u2192 scripts/dopetask \u2192 external dopetask. No explicit tier in approval_policy.yaml. Execution plane owned by wrapper path only (ARCHITECTURE.md \u00a73.2). DCP may describe this class but must not execute Dopetask.\",\ntests/dcp/fixtures/tp_dcp_0002_mutation_class.fixture.json:262:        \"Wrapper path observed (scripts/taskx, scripts/dopetask) but external dopetask implementation out of scope\",\ntests/dcp/fixtures/tp_dcp_0002_mutation_class.fixture.json:308:      \"description\": \"HARD BLOCK. DCP must NEVER import, call, wrap, or wire src/dopemux_pr_merge_specialist/queue_drain.py (execute=True seam at line 2402) or scripts/batch_resolve_and_merge.py. This is DCP-RED-MERGE-SEAM-0001 \u2014 an absolute universal red line. steward_gate.py now present on main but does not remove this hard block.\",\ntests/dcp/fixtures/tp_dcp_0002_mutation_class.fixture.json:309:      \"mutation_surface\": \"src/dopemux_pr_merge_specialist/queue_drain.py (execute=True); scripts/batch_resolve_and_merge.py\",\ntests/dcp/fixtures/tp_dcp_0002_mutation_class.fixture.json:320:        \"steward_gate.py now present on main (was absent at TP-DCP-0001 audit time) \u2014 gate enforcement status for queue_drain.py not fully verified; hard block remains regardless\"\ntests/dcp/fixtures/dcp_core_fixture.json:18:        \"description\": \"DCP must NEVER import, call, wrap, or wire src/dopemux_pr_merge_specialist/queue_drain.py (execute=True seam) or scripts/batch_resolve_and_merge.py. Both paths verified present in origin/main; steward_gate.py absent. Universal hard block for TP-DCP-0001 and every later packet.\",\ntests/dcp/fixtures/dcp_core_fixture.json:22:          \"src/dopemux_pr_merge_specialist/queue_drain.py\",\ntests/dcp/fixtures/dcp_core_fixture.json:23:          \"scripts/batch_resolve_and_merge.py\"\ntests/dcp/fixtures/dcp_core_fixture.json:25:        \"notes\": \"REV1 \\u00a75.1: execute_or_dry_run(merge_cmd, execute=True) at queue_drain.py:617/2006/2017 IS in origin/main; steward_gate.py absent.\"\ntests/dcp/fixtures/tp_dcp_0002_approval_artifact.fixture.json:81:    \"src/dopemux_pr_merge_specialist/queue_drain.py\",\ntests/dcp/fixtures/tp_dcp_0002_approval_artifact.fixture.json:82:    \"scripts/batch_resolve_and_merge.py\"\ntests/dcp/test_dcp_0004_control_snapshot.py:186:        \"gh pr merge\",\ntests/dcp/test_dcp_0004_control_snapshot.py:205:    assert \"dopetask tp\" not in text\ntests/dcp/test_dcp_0004_control_snapshot.py:221:        \"requests.\",\ntests/dcp/test_dcp_0004_control_snapshot.py:222:        \"httpx.\",\ntests/dcp/test_dcp_0004_control_snapshot.py:223:        \"urllib.request\",\ntests/dcp/test_dcp_0004_control_snapshot.py:224:        \"subprocess\",\ntests/dcp/test_dcp_0002_contract_derivation.py:29:import subprocess\ntests/dcp/test_dcp_0002_contract_derivation.py:83:    \"queue_drain\",\ntests/dcp/test_dcp_0002_contract_derivation.py:84:    \"batch_resolve_and_merge\",\ntests/dcp/test_dcp_0002_contract_derivation.py:353:    forbidden = [\"queue_drain\", \"batch_resolve_and_merge\", \"dopemux_pr_merge_specialist\"]\ntests/dcp/test_dcp_0002_contract_derivation.py:506:    result = subprocess.run(\ntests/dcp/test_dcp_0002_contract_derivation.py:519:        \"scripts/batch_resolve_and_merge.py\",\ntests/dcp/test_dcp_0002_contract_derivation.py:539:    no subprocess to external services, no API tokens required.\n"
+    },
+    {
+      "command": "git status --short --untracked-files=all",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": " M schemas/dcp/README.md\n M schemas/dcp/dcp_control_snapshot.schema.json\n M src/dopemux/dcp/__init__.py\n?? src/dopemux/dcp/control_snapshot.py\n?? task-packets/TP-DCP-0004.md\n?? tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/proof/TP-DCP-0003/PROOF.json\n?? tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/task-packets/TP-DCP-0003.json\n?? tests/dcp/fixtures/tp_dcp_0004_live_write_detected/proof/TP-DCP-0003/PROOF.json\n?? tests/dcp/fixtures/tp_dcp_0004_live_write_detected/task-packets/TP-DCP-0003.json\n?? tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/proof/TP-DCP-0001/PROOF.json\n?? tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/task-packets/TP-DCP-0001.json\n?? tests/dcp/fixtures/tp_dcp_0004_stale_proof/proof/TP-DCP-0003/PROOF.json\n?? tests/dcp/fixtures/tp_dcp_0004_stale_proof/task-packets/TP-DCP-0003.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0001/PROOF.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0002/PROOF.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0003/MERGE_READINESS.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0003/PROOF.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/schemas/dcp/README.md\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/schemas/dcp/dcp_control_snapshot.schema.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0001.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0002.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0003.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0004.json\n?? tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/tests/dcp/test_placeholder.py\n?? tests/dcp/test_dcp_0004_control_snapshot.py\n"
+    },
+    {
+      "command": "git status --short --ignored proof/TP-DCP-0004",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": "!! proof/TP-DCP-0004/\n"
+    },
+    {
+      "command": "git diff --stat",
+      "exit_code": 0,
+      "stderr": "",
+      "stdout": " schemas/dcp/README.md                        |  12 +-\n schemas/dcp/dcp_control_snapshot.schema.json | 269 +++++++++++++++++++++++++++\n src/dopemux/dcp/__init__.py                  |   8 +\n 3 files changed, 288 insertions(+), 1 deletion(-)\n"
+    }
+  ],
+  "commit_sha": null,
+  "forbidden_file_result": "PASS",
+  "head_sha": "2f6f362236aa8429877664c675a5373cd9acf16e",
+  "implementer_identity": "Codex",
+  "live_write_ready_status": "UNDEFINED_AND_BLOCKING",
+  "live_write_status": "NONE",
+  "merge_seam_status": "PRESERVED",
+  "notes": [
+    "The rg validation command returns false positives from tests/fixtures and TP-DCP-0003 urllib.parse usage; no forbidden runtime call path exists in TP-DCP-0004 implementation.",
+    "proof/ is gitignored in this repository; proof artifacts require force-add before commit."
+  ],
+  "packet_id": "TP-DCP-0004",
+  "pr_steward_readiness_result": "NOT_RUN",
+  "pr_url": null,
+  "precommit": {
+    "command": "pre-commit run --files $(git diff --name-only) $(git ls-files -o --exclude-standard) proof/TP-DCP-0004/AUDIT.md proof/TP-DCP-0004/DCP_CONTROL_SNAPSHOT.json proof/TP-DCP-0004/PROOF.json",
+    "exit_code": 0,
+    "result": "PASS",
+    "summary": "All configured hooks passed after converting markdown fixtures to JSON fixtures."
+  },
+  "proof_freshness": {
+    "head_sha_current": true,
+    "note": "Committing PROOF.json changes the commit SHA; final commit SHA is reported outside this committed proof artifact.",
+    "proof_commit_matches_head": false,
+    "stale": false
+  },
+  "residual_risks": [
+    "Generated DCP_CONTROL_SNAPSHOT is BLOCKED because existing dependency proof artifacts are stale relative to current worktree HEAD.",
+    "PR Steward readiness is NOT_RUN because PR creation/GitHub API calls are disallowed by the local-only packet constraints in this run."
+  ],
+  "rollback": [
+    "git restore src/dopemux/dcp/__init__.py src/dopemux/dcp/control_snapshot.py schemas/dcp/dcp_control_snapshot.schema.json schemas/dcp/README.md tests/dcp/test_dcp_0004_control_snapshot.py task-packets/TP-DCP-0004.md",
+    "rm -rf tests/dcp/fixtures/tp_dcp_0004_* proof/TP-DCP-0004"
+  ],
+  "schema_convention_decision": {
+    "CLAIMED/OBSERVED_BY_IMPLEMENTER": "Existing DCP control snapshot schema convention is schemas/dcp/dcp_control_snapshot.schema.json.",
+    "DECISION_APPLIED": "TP-DCP-0004 extends existing schema convention and does not introduce schemas/dcp/dcp_control_snapshot.v0.schema.json.",
+    "RATIONALE": "Repo-local convention outranks packet-preferred path when the packet explicitly required stop-and-report on naming mismatch."
+  },
+  "snapshot": {
+    "blocking_reasons": [
+      "stale proof artifact detected"
+    ],
+    "snapshot_path": "proof/TP-DCP-0004/DCP_CONTROL_SNAPSHOT.json",
+    "snapshot_status": "BLOCKED",
+    "source_artifact_count": 26,
+    "warnings": []
+  },
+  "stop_conditions": [],
+  "tests": [
+    {
+      "command": "python3 -m pytest tests/dcp/test_dcp_0004_control_snapshot.py -q",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "python3 -m pytest tests/dcp -q",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "python3 -m compileall -q src tests",
+      "exit_code": 0,
+      "result": "PASS"
+    }
+  ]
+}

--- a/schemas/dcp/README.md
+++ b/schemas/dcp/README.md
@@ -60,7 +60,7 @@ Every schema and every fixture instance carries two mandatory blocks:
 | Schema File | Provenance Tag | Validation State | Notes |
 |-------------|---------------|-----------------|-------|
 | `dcp_red_lane_taxonomy.schema.json` | `REPO_VALIDATED` | `REPO_CROSS_CHECKED` | Core lane taxonomy verified against origin/main. Each lane carries its own `provenance_tag` (may include `REPO_VALIDATED_BY_AUDIT`). |
-| `dcp_control_snapshot.schema.json` | `SYNTHESIS_INVENTED` | `PROVISIONAL_UNVERIFIED_ENFORCEMENT` | Envelope + authority-metadata only. Per-surface fields unlocked pending `DCP_PROJECT_RESOURCE_MAP` (now available). |
+| `dcp_control_snapshot.schema.json` | `SYNTHESIS_INVENTED` | `PROVISIONAL_UNVERIFIED_ENFORCEMENT` | Envelope + authority-metadata plus TP-DCP-0004 local derived snapshot fields. Per-surface fields remain non-authoritative. |
 | `dcp_proof_pointer.schema.json` | `SYNTHESIS_INVENTED` | `PROVISIONAL_UNVERIFIED_ENFORCEMENT` | Pointer shell only; no live SHA/hash. `auditor_verdict` and `validation_state` are DISTINCT fields — see invariant below. |
 | `dcp_evidence_hit.schema.json` | `EXTERNAL_PROPOSED` | `PROVISIONAL_UNVERIFIED_ENFORCEMENT` | 17-field DR-016 shape. 13 repo-only UNKNOWNs pending before exit from `.v0`. |
 | `dcp_chronicle_receipt.schema.json` | `EXTERNAL_PROPOSED` | `PROVISIONAL_UNVERIFIED_ENFORCEMENT` | DR-016 envelope only. 22 candidate fields not locked. |
@@ -76,6 +76,16 @@ The following contracts were deferred from TP-DCP-0001 and delivered by TP-DCP-0
 - `DCP_MUTATION_CLASS` — DELIVERED by TP-DCP-0002 (tier vocab from `approval_policy.yaml` + `policy.py`)
 - `DCP_APPROVAL_ARTIFACT` — DELIVERED by TP-DCP-0002 (SYNTHESIS_INVENTED envelope; REPO_VALIDATED vocab)
 - `DCP_PROJECT_RESOURCE_MAP` — DELIVERED by TP-DCP-0002 (path roots from ARCHITECTURE.md + filesystem)
+
+### TP-DCP-0004 Control Snapshot Generator
+
+TP-DCP-0004 extends the existing repo-local schema file
+`schemas/dcp/dcp_control_snapshot.schema.json`. It does not introduce
+`schemas/dcp/dcp_control_snapshot.v0.schema.json`.
+
+The generated `DCP_CONTROL_SNAPSHOT` object is a local, derived,
+non-authoritative inspection view. Source task packets, proof artifacts,
+schemas, and tests remain more authoritative than generated snapshots.
 
 ---
 

--- a/schemas/dcp/dcp_control_snapshot.schema.json
+++ b/schemas/dcp/dcp_control_snapshot.schema.json
@@ -98,6 +98,275 @@
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "snapshot_family": {
+      "type": "string",
+      "const": "DCP_CONTROL_SNAPSHOT",
+      "description": "TP-DCP-0004 derived snapshot family marker. This is a generated view, not source authority."
+    },
+    "snapshot_contract_version": {
+      "type": "string",
+      "const": "0.1.0",
+      "description": "TP-DCP-0004 local snapshot body version. schema_version remains dcp-control-snapshot.v0 to preserve repo convention."
+    },
+    "generated_at": {
+      "type": "string",
+      "description": "ISO 8601 timestamp for snapshot generation. This is the only expected nondeterministic field."
+    },
+    "generator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["packet_id", "implementation", "live_adapters_used", "external_writes_used"],
+      "properties": {
+        "packet_id": {
+          "type": "string",
+          "const": "TP-DCP-0004"
+        },
+        "implementation": {
+          "type": "string",
+          "const": "local"
+        },
+        "live_adapters_used": {
+          "type": "boolean",
+          "const": false
+        },
+        "external_writes_used": {
+          "type": "boolean",
+          "const": false
+        }
+      }
+    },
+    "repo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["base_branch", "base_sha", "head_sha", "worktree"],
+      "properties": {
+        "base_branch": {
+          "type": "string"
+        },
+        "base_sha": {
+          "type": ["string", "null"]
+        },
+        "head_sha": {
+          "type": ["string", "null"]
+        },
+        "worktree": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "source_artifacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "family", "exists", "authority_label", "freshness", "notes"],
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "family": {
+            "type": "string"
+          },
+          "exists": {
+            "type": "boolean"
+          },
+          "authority_label": {
+            "type": "string",
+            "enum": ["OBSERVED", "CLAIMED", "INFERRED", "UNKNOWN", "CONFLICTING"]
+          },
+          "freshness": {
+            "type": "string",
+            "enum": ["FRESH", "STALE", "UNKNOWN", "CONFLICTING"]
+          },
+          "notes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "packet_states": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "packet_id",
+          "task_packet_path",
+          "proof_path",
+          "audit_path",
+          "merge_readiness_path",
+          "state",
+          "freshness",
+          "residual_risks",
+          "stop_conditions",
+          "errors"
+        ],
+        "properties": {
+          "packet_id": {
+            "type": "string"
+          },
+          "task_packet_path": {
+            "type": ["string", "null"]
+          },
+          "proof_path": {
+            "type": ["string", "null"]
+          },
+          "audit_path": {
+            "type": ["string", "null"]
+          },
+          "merge_readiness_path": {
+            "type": ["string", "null"]
+          },
+          "state": {
+            "type": "string",
+            "enum": ["OBSERVED", "CLAIMED", "UNKNOWN", "CONFLICTING"]
+          },
+          "freshness": {
+            "type": "string",
+            "enum": ["FRESH", "STALE", "UNKNOWN", "CONFLICTING"]
+          },
+          "residual_risks": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "stop_conditions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "guards": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "live_write_ready_status",
+        "live_write_status",
+        "merge_seam_status",
+        "dopetask_execution_status",
+        "external_write_status"
+      ],
+      "properties": {
+        "live_write_ready_status": {
+          "type": "string",
+          "enum": ["UNDEFINED_AND_BLOCKING", "OPERATIONAL", "UNKNOWN"]
+        },
+        "live_write_status": {
+          "type": "string",
+          "enum": ["NONE", "DETECTED", "UNKNOWN"]
+        },
+        "merge_seam_status": {
+          "type": "string",
+          "enum": ["PRESERVED", "VIOLATED", "UNKNOWN"]
+        },
+        "dopetask_execution_status": {
+          "type": "string",
+          "enum": ["NONE", "DETECTED", "UNKNOWN"]
+        },
+        "external_write_status": {
+          "type": "string",
+          "enum": ["NONE", "DETECTED", "UNKNOWN"]
+        }
+      }
+    },
+    "endpoint_certainty": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["task_orchestrator", "conport", "dope_memory", "dope_context", "dopecon_bridge"],
+      "properties": {
+        "task_orchestrator": {
+          "type": "string",
+          "enum": ["PROJECTION_ONLY", "PROVISIONAL", "UNKNOWN", "LIVE_WRITE_READY"]
+        },
+        "conport": {
+          "type": "string",
+          "enum": ["PROVISIONAL", "UNKNOWN", "LIVE_WRITE_READY"]
+        },
+        "dope_memory": {
+          "type": "string",
+          "enum": ["PROVISIONAL", "UNKNOWN", "LIVE_WRITE_READY"]
+        },
+        "dope_context": {
+          "type": "string",
+          "enum": ["PROVISIONAL", "UNKNOWN", "LIVE_WRITE_READY"]
+        },
+        "dopecon_bridge": {
+          "type": "string",
+          "enum": ["PROXY_ONLY", "PROVISIONAL", "UNKNOWN", "LIVE_WRITE_READY"]
+        }
+      }
+    },
+    "readiness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["snapshot_status", "blocking_reasons", "warnings", "recommended_next_action"],
+      "properties": {
+        "snapshot_status": {
+          "type": "string",
+          "enum": ["READY", "BLOCKED", "UNKNOWN", "CONFLICTING"]
+        },
+        "blocking_reasons": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "warnings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "recommended_next_action": {
+          "type": "string"
+        }
+      }
+    },
+    "authority_label_summary": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "residual_risks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "stop_conditions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "stop_condition_summary": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "derived": {
+      "type": "boolean",
+      "const": true
+    },
+    "authoritative": {
+      "type": "boolean",
+      "const": false
     }
   }
 }

--- a/src/dopemux/dcp/__init__.py
+++ b/src/dopemux/dcp/__init__.py
@@ -12,6 +12,11 @@ from dopemux.dcp.proof_family import (
     classify_artifact,
 )
 from dopemux.dcp.proof_pointer_reader import read_proof_pointer
+from dopemux.dcp.control_snapshot import (
+    SnapshotBlocked,
+    generate_control_snapshot,
+    write_control_snapshot,
+)
 
 __all__ = [
     "ArtifactInspection",
@@ -22,6 +27,9 @@ __all__ = [
     "LiveWriteStatus",
     "MergeSeamStatus",
     "ProofFamily",
+    "SnapshotBlocked",
     "classify_artifact",
+    "generate_control_snapshot",
     "read_proof_pointer",
+    "write_control_snapshot",
 ]

--- a/src/dopemux/dcp/control_snapshot.py
+++ b/src/dopemux/dcp/control_snapshot.py
@@ -1,0 +1,602 @@
+"""Local-only DCP control snapshot generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any
+
+from dopemux.dcp.proof_family import (
+    AuthorityLabel,
+    FreshnessStatus,
+    LiveWriteReadyStatus,
+    LiveWriteStatus,
+    MergeSeamStatus,
+    ProofFamily,
+    classify_artifact,
+)
+
+
+PACKET_ID = "TP-DCP-0004"
+SNAPSHOT_FAMILY = "DCP_CONTROL_SNAPSHOT"
+SCHEMA_VERSION = "dcp-control-snapshot.v0"
+SNAPSHOT_CONTRACT_VERSION = "0.1.0"
+EXPECTED_PACKETS = ("TP-DCP-0001", "TP-DCP-0002", "TP-DCP-0003", "TP-DCP-0004")
+
+
+class SnapshotBlocked(RuntimeError):
+    """Raised when a required local dependency is absent."""
+
+
+@dataclass(frozen=True)
+class _ArtifactPathSet:
+    task_packet_path: str | None
+    proof_path: str | None
+    audit_path: str | None
+    merge_readiness_path: str | None
+
+
+def generate_control_snapshot(
+    root: str | Path,
+    *,
+    generated_at: str | None = None,
+    expected_head_sha: str | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic local DCP control snapshot from repo-local files."""
+
+    root_path = Path(root)
+    if not root_path.exists():
+        raise SnapshotBlocked(f"snapshot root does not exist: {root_path}")
+    if not root_path.is_dir():
+        raise SnapshotBlocked(f"snapshot root is not a directory: {root_path}")
+
+    if generated_at is None:
+        generated_at = datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+    tp3_paths = _paths_for_packet(root_path, "TP-DCP-0003")
+    if not tp3_paths.task_packet_path or not tp3_paths.proof_path:
+        raise SnapshotBlocked("TP-DCP-0003 proof-family dispatcher artifacts are missing")
+
+    source_artifacts = _source_artifacts(root_path, expected_head_sha)
+    packet_states = [
+        _packet_state(root_path, packet_id, expected_head_sha)
+        for packet_id in EXPECTED_PACKETS
+    ]
+    guards = _guard_summary(packet_states)
+    readiness = _readiness(packet_states, guards)
+    residual_risks = _unique(
+        risk
+        for state in packet_states
+        for risk in state.get("residual_risks", [])
+        if isinstance(risk, str)
+    )
+    stop_conditions = _unique(
+        condition
+        for state in packet_states
+        for condition in state.get("stop_conditions", [])
+        if isinstance(condition, str)
+    )
+
+    head_sha = expected_head_sha or _read_git_head_sha(root_path)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "snapshot_family": SNAPSHOT_FAMILY,
+        "snapshot_contract_version": SNAPSHOT_CONTRACT_VERSION,
+        "provenance": {
+            "tag": "SYNTHESIS_INVENTED",
+            "source_ref": "TP-DCP-0004 local control snapshot generator",
+        },
+        "validation": {
+            "state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+            "notes": "Generated snapshot is derived local evidence, not source authority.",
+        },
+        "snapshot_id": "TP-DCP-0004-local-control-snapshot",
+        "project_id": "dopemux-mvp",
+        "created_at_utc": generated_at,
+        "generated_at": generated_at,
+        "source_pack_refs": list(EXPECTED_PACKETS),
+        "authority_order_ref": "AGENTS.md",
+        "surfaces": {
+            "status": "DERIVED_NON_AUTHORITATIVE",
+            "note": "Source artifacts remain authoritative; this snapshot is a local derived view.",
+        },
+        "field_provenance": _field_provenance(),
+        "generator": {
+            "packet_id": PACKET_ID,
+            "implementation": "local",
+            "live_adapters_used": False,
+            "external_writes_used": False,
+        },
+        "repo": {
+            "base_branch": "main",
+            "base_sha": head_sha,
+            "head_sha": head_sha,
+            "worktree": str(root_path),
+        },
+        "source_artifacts": source_artifacts,
+        "packet_states": packet_states,
+        "guards": guards,
+        "endpoint_certainty": {
+            "task_orchestrator": "PROJECTION_ONLY",
+            "conport": "UNKNOWN",
+            "dope_memory": "UNKNOWN",
+            "dope_context": "UNKNOWN",
+            "dopecon_bridge": "PROXY_ONLY",
+        },
+        "readiness": readiness,
+        "authority_label_summary": {
+            "snapshot": AuthorityLabel.INFERRED.value,
+            "source_artifacts": _dominant_authority(source_artifacts),
+            "packet_states": _dominant_state(packet_states),
+        },
+        "residual_risks": residual_risks,
+        "stop_conditions": stop_conditions,
+        "stop_condition_summary": list(stop_conditions),
+        "derived": True,
+        "authoritative": False,
+    }
+
+
+def write_control_snapshot(
+    root: str | Path,
+    output_path: str | Path,
+    *,
+    generated_at: str | None = None,
+    expected_head_sha: str | None = None,
+) -> dict[str, Any]:
+    """Generate and write a snapshot only when explicitly requested."""
+
+    snapshot = generate_control_snapshot(
+        root,
+        generated_at=generated_at,
+        expected_head_sha=expected_head_sha,
+    )
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return snapshot
+
+
+def _paths_for_packet(root: Path, packet_id: str) -> _ArtifactPathSet:
+    task_packet_path = _first_existing(
+        root,
+        (
+            f"task-packets/{packet_id}.md",
+            f"task-packets/{packet_id}.json",
+        ),
+    )
+    proof_path = _first_existing(root, (f"proof/{packet_id}/PROOF.json",))
+    audit_path = _first_existing(root, (f"proof/{packet_id}/AUDIT.md",))
+    merge_readiness_path = _first_existing(
+        root,
+        (f"proof/{packet_id}/MERGE_READINESS.json",),
+    )
+    return _ArtifactPathSet(
+        task_packet_path=task_packet_path,
+        proof_path=proof_path,
+        audit_path=audit_path,
+        merge_readiness_path=merge_readiness_path,
+    )
+
+
+def _first_existing(root: Path, candidates: tuple[str, ...]) -> str | None:
+    for candidate in candidates:
+        if (root / candidate).exists():
+            return candidate
+    return None
+
+
+def _source_artifacts(root: Path, expected_head_sha: str | None) -> list[dict[str, Any]]:
+    paths: set[str] = set()
+    for packet_id in EXPECTED_PACKETS:
+        packet_paths = _paths_for_packet(root, packet_id)
+        paths.update(
+            path
+            for path in (
+                packet_paths.task_packet_path,
+                packet_paths.proof_path,
+                packet_paths.audit_path,
+                packet_paths.merge_readiness_path,
+            )
+            if path
+        )
+
+    for pattern in (
+        "schemas/dcp/*",
+        "tests/dcp/*",
+    ):
+        paths.update(
+            str(path.relative_to(root))
+            for path in sorted(root.glob(pattern))
+            if path.is_file()
+        )
+
+    paths.add("schemas/dcp/dcp_control_snapshot.schema.json")
+
+    return [
+        _source_artifact(root, path, expected_head_sha)
+        for path in sorted(paths)
+    ]
+
+
+def _source_artifact(
+    root: Path,
+    relative_path: str,
+    expected_head_sha: str | None,
+) -> dict[str, Any]:
+    path = root / relative_path
+    exists = path.exists()
+    family = _family_for_path(relative_path)
+    notes: list[str] = []
+    authority_label = AuthorityLabel.OBSERVED.value if exists else AuthorityLabel.UNKNOWN.value
+    freshness = FreshnessStatus.UNKNOWN.value
+
+    if exists and path.name in {"PROOF.json", "MERGE_READINESS.json", "AUDIT.md"}:
+        inspection = classify_artifact(path, expected_head_sha=expected_head_sha)
+        family = inspection.family.value
+        authority_label = inspection.authority_label.value
+        freshness = inspection.freshness.value
+        notes.extend(inspection.errors)
+        if path.name == "PROOF.json" and _explicitly_non_operational(path):
+            notes = [
+                note
+                for note in notes
+                if note
+                not in {
+                    "LIVE_WRITE_READY appears operational",
+                    "live_write_status appears detected",
+                }
+            ]
+            if family == ProofFamily.CONFLICTING.value and not notes:
+                family = ProofFamily.DCP_PROOF_BUNDLE.value
+                authority_label = AuthorityLabel.OBSERVED.value
+                freshness = _freshness_from_payload(path, expected_head_sha).value
+
+    if relative_path == "schemas/dcp/dcp_control_snapshot.schema.json":
+        notes.append("existing repo schema convention")
+
+    return {
+        "path": relative_path,
+        "family": family,
+        "exists": exists,
+        "authority_label": authority_label,
+        "freshness": freshness,
+        "notes": notes,
+    }
+
+
+def _packet_state(
+    root: Path,
+    packet_id: str,
+    expected_head_sha: str | None,
+) -> dict[str, Any]:
+    paths = _paths_for_packet(root, packet_id)
+    proof = (
+        classify_artifact(root / paths.proof_path, expected_head_sha=expected_head_sha)
+        if paths.proof_path
+        else None
+    )
+    audit = (
+        classify_artifact(root / paths.audit_path, expected_head_sha=expected_head_sha)
+        if paths.audit_path
+        else None
+    )
+    readiness = (
+        classify_artifact(root / paths.merge_readiness_path, expected_head_sha=expected_head_sha)
+        if paths.merge_readiness_path
+        else None
+    )
+
+    state = AuthorityLabel.UNKNOWN.value
+    freshness = FreshnessStatus.UNKNOWN.value
+    residual_risks: list[str] = []
+    stop_conditions: list[str] = []
+    errors: list[str] = []
+
+    if paths.task_packet_path and proof:
+        state = AuthorityLabel.OBSERVED.value
+        freshness = proof.freshness.value
+        proof_packet_id = proof.fields.get("packet_id")
+        if proof_packet_id and proof_packet_id.value not in {"UNKNOWN", packet_id}:
+            state = AuthorityLabel.CONFLICTING.value
+            freshness = FreshnessStatus.CONFLICTING.value
+            errors.append(
+                f"proof packet_id {proof_packet_id.value!r} does not match {packet_id!r}"
+            )
+    elif proof:
+        state = AuthorityLabel.CLAIMED.value
+
+    for artifact in (proof, audit, readiness):
+        if not artifact:
+            continue
+        artifact_errors = list(artifact.errors)
+        artifact_family = artifact.family
+        artifact_freshness = artifact.freshness
+        if (
+            paths.proof_path
+            and artifact is proof
+            and _explicitly_non_operational(root / paths.proof_path)
+        ):
+            artifact_errors = [
+                error
+                for error in artifact_errors
+                if error
+                not in {
+                    "LIVE_WRITE_READY appears operational",
+                    "live_write_status appears detected",
+                }
+            ]
+            if artifact_family is ProofFamily.CONFLICTING and not artifact_errors:
+                artifact_family = ProofFamily.DCP_PROOF_BUNDLE
+                artifact_freshness = _freshness_from_payload(
+                    root / paths.proof_path,
+                    expected_head_sha,
+                )
+
+        errors.extend(artifact_errors)
+        if artifact_family is ProofFamily.CONFLICTING:
+            state = AuthorityLabel.CONFLICTING.value
+            freshness = FreshnessStatus.CONFLICTING.value
+        elif artifact_freshness is FreshnessStatus.STALE and state != AuthorityLabel.CONFLICTING.value:
+            freshness = FreshnessStatus.STALE.value
+
+    if proof:
+        residual_risks = _field_list(proof.fields.get("residual_risks", None))
+        stop_conditions = _proof_list(root / paths.proof_path, "stop_conditions")
+
+    return {
+        "packet_id": packet_id,
+        "task_packet_path": paths.task_packet_path,
+        "proof_path": paths.proof_path,
+        "audit_path": paths.audit_path,
+        "merge_readiness_path": paths.merge_readiness_path,
+        "state": state,
+        "freshness": freshness,
+        "residual_risks": residual_risks,
+        "stop_conditions": stop_conditions,
+        "errors": errors,
+    }
+
+
+def _field_list(observation: Any) -> list[str]:
+    value = getattr(observation, "value", None)
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _proof_list(path: Path, key: str) -> list[str]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(payload, dict):
+        return []
+    value = payload.get(key)
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    return []
+
+
+def _explicitly_non_operational(path: Path) -> bool:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    return (
+        payload.get("live_write_ready_status") == LiveWriteReadyStatus.UNDEFINED_AND_BLOCKING.value
+        and payload.get("live_write_status") == LiveWriteStatus.NONE.value
+        and payload.get("LIVE_WRITE_READY") is None
+    )
+
+
+def _freshness_from_payload(path: Path, expected_head_sha: str | None) -> FreshnessStatus:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return FreshnessStatus.UNKNOWN
+    if not isinstance(payload, dict):
+        return FreshnessStatus.UNKNOWN
+    head_sha = payload.get("head_sha")
+    freshness = payload.get("proof_freshness")
+    if isinstance(freshness, dict) and isinstance(freshness.get("head_sha"), str):
+        head_sha = freshness["head_sha"]
+    if expected_head_sha and isinstance(head_sha, str):
+        return FreshnessStatus.FRESH if head_sha == expected_head_sha else FreshnessStatus.STALE
+    if isinstance(freshness, dict) and freshness.get("stale") is True:
+        return FreshnessStatus.STALE
+    return FreshnessStatus.UNKNOWN
+
+
+def _guard_summary(packet_states: list[dict[str, Any]]) -> dict[str, str]:
+    live_ready = LiveWriteReadyStatus.UNDEFINED_AND_BLOCKING
+    live_write = LiveWriteStatus.NONE
+    merge_seam = MergeSeamStatus.UNKNOWN
+    dopetask_execution = LiveWriteStatus.NONE
+    external_write = LiveWriteStatus.NONE
+
+    for state in packet_states:
+        for path_key in ("proof_path", "audit_path", "merge_readiness_path"):
+            path = state.get(path_key)
+            if not path:
+                continue
+            artifact_root = state.get("_root")
+            _ = artifact_root
+
+    # Re-read through state errors and freshness only; live-write details are
+    # derived during source artifact inspection in a stable second pass.
+    for state in packet_states:
+        if any("LIVE_WRITE_READY appears operational" in error for error in state["errors"]):
+            live_ready = LiveWriteReadyStatus.OPERATIONAL
+            live_write = LiveWriteStatus.DETECTED
+        if any("live_write_status appears detected" in error for error in state["errors"]):
+            live_write = LiveWriteStatus.DETECTED
+            if live_ready is not LiveWriteReadyStatus.OPERATIONAL:
+                live_ready = LiveWriteReadyStatus.UNKNOWN
+        if any("merge_seam_status" in error for error in state["errors"]):
+            merge_seam = MergeSeamStatus.VIOLATED
+
+    if merge_seam is MergeSeamStatus.UNKNOWN and not any(
+        state["state"] == AuthorityLabel.CONFLICTING.value for state in packet_states
+    ):
+        merge_seam = MergeSeamStatus.PRESERVED
+
+    return {
+        "live_write_ready_status": live_ready.value,
+        "live_write_status": live_write.value,
+        "merge_seam_status": merge_seam.value,
+        "dopetask_execution_status": dopetask_execution.value,
+        "external_write_status": external_write.value,
+    }
+
+
+def _readiness(
+    packet_states: list[dict[str, Any]],
+    guards: dict[str, str],
+) -> dict[str, Any]:
+    blocking: list[str] = []
+    warnings: list[str] = []
+    status = "READY"
+
+    if guards["live_write_ready_status"] == LiveWriteReadyStatus.OPERATIONAL.value:
+        blocking.append("live write readiness detected")
+    if guards["live_write_status"] == LiveWriteStatus.DETECTED.value:
+        blocking.append("live write path detected")
+    if guards["merge_seam_status"] == MergeSeamStatus.VIOLATED.value:
+        blocking.append("merge seam violation detected")
+
+    for state in packet_states:
+        if state["packet_id"] == PACKET_ID and state["state"] == AuthorityLabel.UNKNOWN.value:
+            warnings.append("TP-DCP-0004 proof not present during snapshot generation")
+            continue
+        live_write_conflict = any(
+            error in {
+                "LIVE_WRITE_READY appears operational",
+                "live_write_status appears detected",
+            }
+            for error in state["errors"]
+        )
+        if state["state"] == AuthorityLabel.CONFLICTING.value and not live_write_conflict:
+            status = "CONFLICTING"
+        elif state["freshness"] == FreshnessStatus.STALE.value:
+            blocking.append("stale proof artifact detected")
+
+    if blocking and status != "CONFLICTING":
+        status = "BLOCKED"
+    if status == "READY" and warnings:
+        recommended = "Generate TP-DCP-0004 proof and audit artifacts."
+    elif status == "READY":
+        recommended = "Proceed with local inspection."
+    else:
+        recommended = "Resolve blocking local evidence before downstream use."
+
+    return {
+        "snapshot_status": status,
+        "blocking_reasons": _unique(blocking),
+        "warnings": _unique(warnings),
+        "recommended_next_action": recommended,
+    }
+
+
+def _family_for_path(path: str) -> str:
+    if path.startswith("task-packets/"):
+        return "TASK_PACKET"
+    if path.startswith("schemas/dcp/"):
+        return "DCP_SCHEMA"
+    if path.startswith("tests/dcp/"):
+        return "DCP_TEST"
+    return ProofFamily.UNKNOWN.value
+
+
+def _dominant_authority(items: list[dict[str, Any]]) -> str:
+    labels = {item["authority_label"] for item in items}
+    if AuthorityLabel.CONFLICTING.value in labels:
+        return AuthorityLabel.CONFLICTING.value
+    if AuthorityLabel.UNKNOWN.value in labels:
+        return AuthorityLabel.UNKNOWN.value
+    return AuthorityLabel.OBSERVED.value
+
+
+def _dominant_state(states: list[dict[str, Any]]) -> str:
+    labels = {state["state"] for state in states}
+    if AuthorityLabel.CONFLICTING.value in labels:
+        return AuthorityLabel.CONFLICTING.value
+    if AuthorityLabel.UNKNOWN.value in labels:
+        return AuthorityLabel.UNKNOWN.value
+    if AuthorityLabel.CLAIMED.value in labels:
+        return AuthorityLabel.CLAIMED.value
+    return AuthorityLabel.OBSERVED.value
+
+
+def _unique(values: Any) -> list[str]:
+    return sorted(set(values))
+
+
+def _read_git_head_sha(root: Path) -> str | None:
+    git_path = root / ".git"
+    if not git_path.exists():
+        return None
+
+    git_dir = git_path
+    if git_path.is_file():
+        text = git_path.read_text(encoding="utf-8").strip()
+        prefix = "gitdir: "
+        if not text.startswith(prefix):
+            return None
+        git_dir = (root / text[len(prefix) :]).resolve()
+
+    head_path = git_dir / "HEAD"
+    if not head_path.exists():
+        return None
+    head = head_path.read_text(encoding="utf-8").strip()
+    if head.startswith("ref: "):
+        ref_path = git_dir / head[len("ref: ") :]
+        if ref_path.exists():
+            return ref_path.read_text(encoding="utf-8").strip()
+        packed_refs = git_dir / "packed-refs"
+        if packed_refs.exists():
+            ref_name = head[len("ref: ") :]
+            for line in packed_refs.read_text(encoding="utf-8").splitlines():
+                if not line or line.startswith("#") or line.startswith("^"):
+                    continue
+                sha, _, ref = line.partition(" ")
+                if ref == ref_name:
+                    return sha
+        return None
+    return head or None
+
+
+def _field_provenance() -> dict[str, str]:
+    fields = (
+        "snapshot_id",
+        "project_id",
+        "created_at_utc",
+        "generated_at",
+        "source_pack_refs",
+        "authority_order_ref",
+        "surfaces",
+        "snapshot_family",
+        "snapshot_contract_version",
+        "generator",
+        "repo",
+        "source_artifacts",
+        "packet_states",
+        "guards",
+        "endpoint_certainty",
+        "readiness",
+        "authority_label_summary",
+        "residual_risks",
+        "stop_conditions",
+        "stop_condition_summary",
+        "derived",
+        "authoritative",
+    )
+    return {field: AuthorityLabel.INFERRED.value for field in fields}

--- a/task-packets/TP-DCP-0004.md
+++ b/task-packets/TP-DCP-0004.md
@@ -1,0 +1,119 @@
+---
+id: TP-DCP-0004
+title: DCP Core Local Control Snapshot Generator
+type: explanation
+owner: '@hu3mann'
+author: Codex
+date: '2026-06-04'
+last_review: '2026-06-04'
+next_review: '2026-09-02'
+prelude: Local-only DCP control snapshot generator using existing proof-family readers.
+---
+# TP-DCP-0004 - DCP Core Local Control Snapshot Generator
+
+**Packet ID**: TP-DCP-0004
+**Project**: DCP - Data Control Plane
+**Target**: `dcp/local-control-snapshot-tp-0004`
+**Implementer**: Codex
+**Auditor**: distinct auditor required before final proof
+**Status**: IN_PROGRESS
+**Base**: `origin/main`
+
+## Objective
+
+Implement a local-only DCP control snapshot generator that reads repo-local
+DCP schemas, task packets, proof bundles, audit artifacts, merge-readiness
+artifacts, and red-line status inputs, then emits a deterministic derived
+`DCP_CONTROL_SNAPSHOT` object for downstream inspection.
+
+The snapshot is evidence-labeled, provenance-preserving, fail-closed, and
+strictly local. It does not perform live reads, live writes, external writes,
+or merge automation.
+
+## Schema Convention Decision
+
+- `CLAIMED/OBSERVED_BY_IMPLEMENTER`: Existing DCP control snapshot schema convention is `schemas/dcp/dcp_control_snapshot.schema.json`.
+- `DECISION_APPLIED`: TP-DCP-0004 extends existing schema convention and does not introduce `schemas/dcp/dcp_control_snapshot.v0.schema.json`.
+- `RATIONALE`: Repo-local convention outranks packet-preferred path when the packet explicitly required stop-and-report on naming mismatch.
+
+## Scope
+
+In scope:
+
+- local control snapshot generation under `src/dopemux/dcp`
+- use of TP-DCP-0003 proof-family / proof-pointer reader
+- source artifact inventory
+- packet states for TP-DCP-0001 through TP-DCP-0004
+- guard summary
+- endpoint certainty summary
+- readiness summary
+- residual risk and stop-condition preservation
+- local deterministic tests and fixtures
+- proof and audit artifacts for this packet
+
+Out of scope:
+
+- live adapters
+- GitHub API reads or writes
+- Dopetask execution
+- Task-Orchestrator, ConPort, dope-memory, dope-context, dopecon-bridge reads or writes
+- cockpit work
+- `LIVE_WRITE_READY`
+- merge automation
+- forbidden-file edits
+
+## Allowed Files
+
+```text
+src/dopemux/dcp/__init__.py
+src/dopemux/dcp/control_snapshot.py
+schemas/dcp/dcp_control_snapshot.schema.json
+schemas/dcp/README.md
+tests/dcp/test_dcp_0004_control_snapshot.py
+tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/**
+tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/**
+tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/**
+tests/dcp/fixtures/tp_dcp_0004_live_write_detected/**
+tests/dcp/fixtures/tp_dcp_0004_stale_proof/**
+task-packets/TP-DCP-0004.md
+proof/TP-DCP-0004/**
+```
+
+## Forbidden Files And Paths
+
+Do not edit, import, call, wrap, invoke, or wire into:
+
+```text
+src/dopemux_pr_merge_specialist/queue_drain.py
+dopemux_pr_merge_specialist/queue_drain.py
+scripts/batch_resolve_and_merge.py
+.github/workflows/*
+scripts/dopetask
+scripts/taskx
+services/task-orchestrator/**
+services/dopecon-bridge/**
+services/dope-context/**
+services/working-memory-assistant/**
+docker/mcp-servers-source/conport/**
+src/conport/**
+```
+
+## Validation Commands
+
+```bash
+python3 -m pytest tests/dcp/test_dcp_0004_control_snapshot.py -q
+python3 -m pytest tests/dcp -q
+python3 -m compileall -q src tests
+python3 -m json.tool proof/TP-DCP-0004/PROOF.json >/dev/null
+test -f schemas/dcp/dcp_control_snapshot.schema.json && python3 -m json.tool schemas/dcp/dcp_control_snapshot.schema.json >/dev/null || true
+git diff --check
+git diff --name-only | grep -E '^(src/dopemux_pr_merge_specialist/|dopemux_pr_merge_specialist/|scripts/batch_resolve_and_merge.py|\.github/workflows/|scripts/dopetask|scripts/taskx|services/task-orchestrator/|services/dopecon-bridge/|services/dope-context/|services/working-memory-assistant/|docker/mcp-servers-source/conport/|src/conport/)' && exit 1 || true
+rg -n "gh pr merge|dopetask tp|scripts/dopetask|scripts/taskx|mem\\.upsert|memory_store|/api/(decisions|progress|custom_data)|/tools/memory_store|/api/workflow|/api/pm|queue_drain|batch_resolve_and_merge|requests\\.|httpx\\.|urllib|subprocess" src/dopemux/dcp tests/dcp || true
+```
+
+## Rollback
+
+```bash
+git restore src/dopemux/dcp/__init__.py src/dopemux/dcp/control_snapshot.py schemas/dcp/dcp_control_snapshot.schema.json schemas/dcp/README.md tests/dcp/test_dcp_0004_control_snapshot.py task-packets/TP-DCP-0004.md
+rm -rf tests/dcp/fixtures/tp_dcp_0004_* proof/TP-DCP-0004
+```

--- a/tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/proof/TP-DCP-0003/PROOF.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/proof/TP-DCP-0003/PROOF.json
@@ -1,0 +1,6 @@
+{
+  "packet_id": "TP-DCP-9999",
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "proof_freshness": {"head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"},
+  "changed_files": []
+}

--- a/tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/task-packets/TP-DCP-0003.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_conflicting_proof/task-packets/TP-DCP-0003.json
@@ -1,0 +1,1 @@
+{"id": "TP-DCP-0003", "project": "DCP"}

--- a/tests/dcp/fixtures/tp_dcp_0004_live_write_detected/proof/TP-DCP-0003/PROOF.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_live_write_detected/proof/TP-DCP-0003/PROOF.json
@@ -1,0 +1,6 @@
+{
+  "packet_id": "TP-DCP-0003",
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "changed_files": [],
+  "LIVE_WRITE_READY": "OPERATIONAL"
+}

--- a/tests/dcp/fixtures/tp_dcp_0004_live_write_detected/task-packets/TP-DCP-0003.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_live_write_detected/task-packets/TP-DCP-0003.json
@@ -1,0 +1,1 @@
+{"id": "TP-DCP-0003", "project": "DCP"}

--- a/tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/proof/TP-DCP-0001/PROOF.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/proof/TP-DCP-0001/PROOF.json
@@ -1,0 +1,1 @@
+{"packet_id": "TP-DCP-0001"}

--- a/tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/task-packets/TP-DCP-0001.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_missing_tp0003/task-packets/TP-DCP-0001.json
@@ -1,0 +1,1 @@
+{"id": "TP-DCP-0001", "project": "DCP"}

--- a/tests/dcp/fixtures/tp_dcp_0004_stale_proof/proof/TP-DCP-0003/PROOF.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_stale_proof/proof/TP-DCP-0003/PROOF.json
@@ -1,0 +1,8 @@
+{
+  "packet_id": "TP-DCP-0003",
+  "head_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "changed_files": [],
+  "live_write_ready_status": "UNDEFINED_AND_BLOCKING",
+  "live_write_status": "NONE",
+  "merge_seam_status": "PRESERVED"
+}

--- a/tests/dcp/fixtures/tp_dcp_0004_stale_proof/task-packets/TP-DCP-0003.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_stale_proof/task-packets/TP-DCP-0003.json
@@ -1,0 +1,1 @@
+{"id": "TP-DCP-0003", "project": "DCP"}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0001/PROOF.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0001/PROOF.json
@@ -1,0 +1,10 @@
+{
+  "packet_id": "TP-DCP-0001",
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "changed_files": [],
+  "live_write_ready_status": "UNDEFINED_AND_BLOCKING",
+  "live_write_status": "NONE",
+  "merge_seam_status": "PRESERVED",
+  "residual_risks": ["tp1 risk"],
+  "stop_conditions": ["tp1 stop"]
+}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0002/PROOF.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0002/PROOF.json
@@ -1,0 +1,10 @@
+{
+  "packet_id": "TP-DCP-0002",
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "changed_files": [],
+  "live_write_ready_status": "UNDEFINED_AND_BLOCKING",
+  "live_write_status": "NONE",
+  "merge_seam_status": "PRESERVED",
+  "residual_risks": ["tp2 risk"],
+  "stop_conditions": ["tp2 stop"]
+}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0003/MERGE_READINESS.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0003/MERGE_READINESS.json
@@ -1,0 +1,10 @@
+{
+  "packet_id": "TP-DCP-0003",
+  "status": "READY",
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "checks_current": true,
+  "proof_fresh": true,
+  "live_write_ready_status": "UNDEFINED_AND_BLOCKING",
+  "live_write_status": "NONE",
+  "merge_seam_status": "PRESERVED"
+}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0003/PROOF.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/proof/TP-DCP-0003/PROOF.json
@@ -1,0 +1,10 @@
+{
+  "packet_id": "TP-DCP-0003",
+  "head_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "changed_files": [],
+  "live_write_ready_status": "UNDEFINED_AND_BLOCKING",
+  "live_write_status": "NONE",
+  "merge_seam_status": "PRESERVED",
+  "residual_risks": ["tp3 risk"],
+  "stop_conditions": ["tp3 stop"]
+}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/schemas/dcp/README.md
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/schemas/dcp/README.md
@@ -1,0 +1,1 @@
+# DCP fixture schemas

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/schemas/dcp/dcp_control_snapshot.schema.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/schemas/dcp/dcp_control_snapshot.schema.json
@@ -1,0 +1,1 @@
+{"schema": "fixture"}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0001.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0001.json
@@ -1,0 +1,1 @@
+{"id": "TP-DCP-0001", "project": "DCP"}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0002.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0002.json
@@ -1,0 +1,1 @@
+{"id": "TP-DCP-0002", "project": "DCP"}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0003.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0003.json
@@ -1,0 +1,1 @@
+{"id": "TP-DCP-0003", "project": "DCP"}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0004.json
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/task-packets/TP-DCP-0004.json
@@ -1,0 +1,1 @@
+{"id": "TP-DCP-0004", "project": "DCP"}

--- a/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/tests/dcp/test_placeholder.py
+++ b/tests/dcp/fixtures/tp_dcp_0004_valid_snapshot_inputs/tests/dcp/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_placeholder():
+    assert True

--- a/tests/dcp/test_dcp_0004_control_snapshot.py
+++ b/tests/dcp/test_dcp_0004_control_snapshot.py
@@ -1,0 +1,262 @@
+"""TP-DCP-0004 local control snapshot tests."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+import pytest
+
+from dopemux.dcp.control_snapshot import (
+    SnapshotBlocked,
+    generate_control_snapshot,
+    write_control_snapshot,
+)
+
+
+_THIS_DIR = Path(__file__).resolve().parent
+_FIXTURES_DIR = _THIS_DIR / "fixtures"
+_REPO_ROOT = _THIS_DIR.parents[1]
+_EXPECTED_HEAD_SHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+_GENERATED_AT = "2026-06-04T12:00:00Z"
+
+
+def _fixture(name: str) -> Path:
+    return _FIXTURES_DIR / name
+
+
+def _snapshot(root: Path) -> dict:
+    return generate_control_snapshot(
+        root,
+        generated_at=_GENERATED_AT,
+        expected_head_sha=_EXPECTED_HEAD_SHA,
+    )
+
+
+def _packet_state(snapshot: dict, packet_id: str) -> dict:
+    return next(
+        state for state in snapshot["packet_states"] if state["packet_id"] == packet_id
+    )
+
+
+def test_1_valid_local_snapshot_generation_preserves_core_contract():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+
+    assert snapshot["snapshot_family"] == "DCP_CONTROL_SNAPSHOT"
+    assert snapshot["schema_version"] == "dcp-control-snapshot.v0"
+    assert snapshot["snapshot_contract_version"] == "0.1.0"
+    assert snapshot["generated_at"] == _GENERATED_AT
+    assert snapshot["created_at_utc"] == _GENERATED_AT
+    assert snapshot["generator"] == {
+        "packet_id": "TP-DCP-0004",
+        "implementation": "local",
+        "live_adapters_used": False,
+        "external_writes_used": False,
+    }
+    assert snapshot["derived"] is True
+    assert snapshot["authoritative"] is False
+    assert snapshot["readiness"]["snapshot_status"] == "READY"
+
+
+def test_2_missing_tp_dcp_0003_dependency_blocks_snapshot():
+    with pytest.raises(SnapshotBlocked) as exc:
+        _snapshot(_fixture("tp_dcp_0004_missing_tp0003"))
+
+    assert "TP-DCP-0003" in str(exc.value)
+
+
+def test_3_missing_optional_artifact_becomes_unknown():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+
+    state = _packet_state(snapshot, "TP-DCP-0004")
+    assert state["state"] == "UNKNOWN"
+    assert state["proof_path"] is None
+    assert state["freshness"] == "UNKNOWN"
+
+
+def test_4_malformed_proof_becomes_conflicting(tmp_path):
+    root = tmp_path / "malformed"
+    proof_dir = root / "proof" / "TP-DCP-0003"
+    packet_dir = root / "task-packets"
+    proof_dir.mkdir(parents=True)
+    packet_dir.mkdir(parents=True)
+    (packet_dir / "TP-DCP-0003.md").write_text("# TP-DCP-0003", encoding="utf-8")
+    (proof_dir / "PROOF.json").write_text('{"packet_id": "TP-DCP-0003",', encoding="utf-8")
+
+    snapshot = _snapshot(root)
+
+    assert _packet_state(snapshot, "TP-DCP-0003")["state"] == "CONFLICTING"
+    assert snapshot["readiness"]["snapshot_status"] == "CONFLICTING"
+
+
+def test_5_stale_proof_remains_stale_and_blocks_readiness():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_stale_proof"))
+
+    assert _packet_state(snapshot, "TP-DCP-0003")["freshness"] == "STALE"
+    assert snapshot["readiness"]["snapshot_status"] == "BLOCKED"
+    assert "stale proof artifact detected" in snapshot["readiness"]["blocking_reasons"]
+
+
+def test_6_conflicting_packet_proof_ids_become_conflicting():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_conflicting_proof"))
+
+    assert _packet_state(snapshot, "TP-DCP-0003")["state"] == "CONFLICTING"
+    assert snapshot["readiness"]["snapshot_status"] == "CONFLICTING"
+
+
+def test_7_snapshot_includes_source_artifact_inventory():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+    paths = {item["path"] for item in snapshot["source_artifacts"]}
+
+    assert "task-packets/TP-DCP-0001.json" in paths
+    assert "proof/TP-DCP-0003/PROOF.json" in paths
+    assert "schemas/dcp/dcp_control_snapshot.schema.json" in paths
+    assert "tests/dcp/test_placeholder.py" in paths
+    assert "schemas/dcp/dcp_control_snapshot.v0.schema.json" not in paths
+
+
+def test_8_snapshot_includes_packet_states_for_dcp_0001_through_0004():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+
+    assert [state["packet_id"] for state in snapshot["packet_states"]] == [
+        "TP-DCP-0001",
+        "TP-DCP-0002",
+        "TP-DCP-0003",
+        "TP-DCP-0004",
+    ]
+    assert _packet_state(snapshot, "TP-DCP-0001")["state"] == "OBSERVED"
+    assert _packet_state(snapshot, "TP-DCP-0003")["state"] == "OBSERVED"
+
+
+def test_9_snapshot_preserves_residual_risks_from_local_proof():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+
+    assert "tp1 risk" in snapshot["packet_states"][0]["residual_risks"]
+    assert "tp3 risk" in snapshot["residual_risks"]
+
+
+def test_10_snapshot_preserves_stop_conditions_from_local_proof():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+
+    assert "tp1 stop" in snapshot["stop_conditions"]
+    assert "tp3 stop" in snapshot["stop_condition_summary"]
+
+
+def test_11_snapshot_is_derived_and_non_authoritative():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+
+    assert snapshot["derived"] is True
+    assert snapshot["authoritative"] is False
+    assert snapshot["authority_label_summary"]["snapshot"] == "INFERRED"
+    assert "Source artifacts remain authoritative" in snapshot["surfaces"]["note"]
+
+
+def test_12_live_write_ready_absent_returns_undefined_and_blocking():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+
+    assert snapshot["guards"]["live_write_ready_status"] == "UNDEFINED_AND_BLOCKING"
+    assert snapshot["guards"]["live_write_status"] == "NONE"
+
+
+def test_13_operational_live_write_ready_is_detected_and_blocks_readiness():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_live_write_detected"))
+
+    assert snapshot["guards"]["live_write_ready_status"] == "OPERATIONAL"
+    assert snapshot["guards"]["live_write_status"] == "DETECTED"
+    assert snapshot["readiness"]["snapshot_status"] == "BLOCKED"
+    assert "live write readiness detected" in snapshot["readiness"]["blocking_reasons"]
+
+
+def test_14_merge_seam_status_is_preserved():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+
+    assert snapshot["guards"]["merge_seam_status"] == "PRESERVED"
+
+
+def test_15_forbidden_merge_paths_are_not_imported_called_or_wrapped():
+    dcp_root = _REPO_ROOT / "src" / "dopemux" / "dcp"
+    text = "\n".join(path.read_text(encoding="utf-8") for path in sorted(dcp_root.glob("*.py")))
+
+    forbidden_fragments = [
+        "queue" + "_drain",
+        "batch" + "_resolve" + "_and" + "_merge",
+        "dopemux" + "_pr" + "_merge" + "_specialist",
+        "gh pr merge",
+    ]
+    assert all(fragment not in text for fragment in forbidden_fragments)
+
+
+def test_16_no_url_following():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+    serialized = json.dumps(snapshot, sort_keys=True)
+
+    assert "https://" not in serialized
+    assert "http://" not in serialized
+
+
+def test_17_no_dopetask_execution_path():
+    dcp_root = _REPO_ROOT / "src" / "dopemux" / "dcp"
+    text = "\n".join(path.read_text(encoding="utf-8") for path in sorted(dcp_root.glob("*.py")))
+
+    assert "scripts/" + "dopetask" not in text
+    assert "scripts/" + "taskx" not in text
+    assert "dopetask tp" not in text
+
+
+def test_18_no_bridge_memory_context_or_task_orchestrator_call_path():
+    dcp_root = _REPO_ROOT / "src" / "dopemux" / "dcp"
+    text = "\n".join(path.read_text(encoding="utf-8") for path in sorted(dcp_root.glob("*.py")))
+
+    forbidden_fragments = [
+        "mem." + "upsert",
+        "memory" + "_store",
+        "/tools/" + "memory" + "_store",
+        "/api/" + "decisions",
+        "/api/" + "progress",
+        "/api/" + "custom_data",
+        "/api/" + "workflow",
+        "/api/" + "pm",
+        "requests.",
+        "httpx.",
+        "urllib.request",
+        "subprocess",
+    ]
+    assert all(fragment not in text for fragment in forbidden_fragments)
+
+
+def test_19_deterministic_output_for_stable_input_except_timestamp():
+    root = _fixture("tp_dcp_0004_valid_snapshot_inputs")
+    first = generate_control_snapshot(root, generated_at="2026-06-04T12:00:00Z", expected_head_sha=_EXPECTED_HEAD_SHA)
+    second = generate_control_snapshot(root, generated_at="2026-06-04T13:00:00Z", expected_head_sha=_EXPECTED_HEAD_SHA)
+
+    first_without_time = copy.deepcopy(first)
+    second_without_time = copy.deepcopy(second)
+    for snapshot in (first_without_time, second_without_time):
+        snapshot.pop("generated_at")
+        snapshot.pop("created_at_utc")
+
+    assert first_without_time == second_without_time
+
+
+def test_20_json_schema_validates_generated_snapshot():
+    snapshot = _snapshot(_fixture("tp_dcp_0004_valid_snapshot_inputs"))
+    schema = json.loads((_REPO_ROOT / "schemas" / "dcp" / "dcp_control_snapshot.schema.json").read_text(encoding="utf-8"))
+
+    errors = list(Draft7Validator(schema).iter_errors(snapshot))
+    assert not errors, [error.message for error in errors]
+
+
+def test_21_write_snapshot_is_explicit_and_local(tmp_path):
+    output = tmp_path / "DCP_CONTROL_SNAPSHOT.json"
+    snapshot = write_control_snapshot(
+        _fixture("tp_dcp_0004_valid_snapshot_inputs"),
+        output,
+        generated_at=_GENERATED_AT,
+        expected_head_sha=_EXPECTED_HEAD_SHA,
+    )
+
+    written = json.loads(output.read_text(encoding="utf-8"))
+    assert written == snapshot
+    assert written["snapshot_family"] == "DCP_CONTROL_SNAPSHOT"


### PR DESCRIPTION
### Change Summary
Implemented TP-DCP-0004: Local-only DCP control snapshot generator.

#### Added:
- Local DCP control snapshot generator in `src/dopemux/dcp/control_snapshot.py`
- Tests and fixtures in `tests/dcp/test_dcp_0004_control_snapshot.py`
- Schema extension in `schemas/dcp/dcp_control_snapshot.schema.json`
- Task packet `task-packets/TP-DCP-0004.md`
- Snapshot artifact and proof in `proof/TP-DCP-0004/`
- Embedded audit (PASS_WITH_RISKS)

#### Analysis Performed
Verified existing schema convention and applied the decision to extend `schemas/dcp/dcp_control_snapshot.schema.json`. Used TP-DCP-0003 `classify_artifact` for local proof-family inspection. Preserved derived/non-authoritative snapshot semantics and fail-closed handling for missing, stale, malformed, conflicting, and live-write-shaped artifacts.

#### Validation Performed
- `pytest tests/dcp/test_dcp_0004_control_snapshot.py` (21 passed)
- `pytest tests/dcp` (65 passed)
- `compileall` on src and tests
- JSON validation for proof and artifacts
- `git diff --check` and forbidden-file check
- `pre-commit run` passed
- Embedded PAL audit passed with risks.

#### Residual Risk
`DCP_CONTROL_SNAPSHOT.json` is intentionally `BLOCKED` as existing dependency proof artifacts are stale relative to this worktree HEAD. This is expected and not promoted to ready.