### PR TITLE
chore(dcp): document TP-DCP-0005 post-merge proof reconciliation

### DIFF
--- a/docs/ops/pr-steward-readiness.md
+++ b/docs/ops/pr-steward-readiness.md
@@ -75,7 +75,7 @@ As of TP-DMX-PR-STEWARD-HARDEN-010:
 
 - **`PROOF_STALE`**: Proof exists but `proof_head_sha` does not match the current PR head SHA. The PR was likely updated after the last proof run. Re-run the proof cycle.
 
-  *Self-Reference Exception Rule*: Updating `PROOF.json` inside a branch changes the branch's head SHA, causing a potential infinite loop of stale proof detections. Under `docs/ops/pr-acceptance.md` §1 (Acceptance Gates), proof freshness may be satisfied by an explicit supervisor-accepted self-reference exception when the proof records proof-only changed-file evidence (e.g. only proof or documentation files have changed since the last validated SHA) and the embedded audit is nonblocking. In post-merge scenarios, reconciliation can be recorded in `POST_MERGE_RECONCILIATION.json` to formally close the gap.
+  Note: Post-merge reconciliation artifacts (`POST_MERGE_RECONCILIATION.json`) are governance records only. The scanner still treats a mismatched `proof_head_sha` as `PROOF_STALE`. Scanner-level reconciliation support is deferred to a future packet.
 
 - **`PROOF_MISSING`**: No proof bundle found (`proof_head_sha` absent). No proof has been produced for this PR. Run the full TP cycle and produce a proof bundle.
 

--- a/docs/ops/pr-steward-readiness.md
+++ b/docs/ops/pr-steward-readiness.md
@@ -74,6 +74,9 @@ Prior to schema 1.1.0 both stale and missing proof emitted a single `PROOF_STALE
 As of TP-DMX-PR-STEWARD-HARDEN-010:
 
 - **`PROOF_STALE`**: Proof exists but `proof_head_sha` does not match the current PR head SHA. The PR was likely updated after the last proof run. Re-run the proof cycle.
+
+  *Self-Reference Exception Rule*: Updating `PROOF.json` inside a branch changes the branch's head SHA, causing a potential infinite loop of stale proof detections. Under `docs/ops/pr-acceptance.md` §1 (Acceptance Gates), proof freshness may be satisfied by an explicit supervisor-accepted self-reference exception when the proof records proof-only changed-file evidence (e.g. only proof or documentation files have changed since the last validated SHA) and the embedded audit is nonblocking. In post-merge scenarios, reconciliation can be recorded in `POST_MERGE_RECONCILIATION.json` to formally close the gap.
+
 - **`PROOF_MISSING`**: No proof bundle found (`proof_head_sha` absent). No proof has been produced for this PR. Run the full TP cycle and produce a proof bundle.
 
 Both remain `NEEDS_SUPERVISOR` tier and map to the `proof-stale` / `proof-missing` action categories in the Action Bridge.

--- a/proof/TP-DCP-0005/AUDIT.md
+++ b/proof/TP-DCP-0005/AUDIT.md
@@ -49,3 +49,10 @@ The implementation follows the surgical, decoupled requirements of the DCP. The 
 
 ## 6. Verdict
 **PASS**
+
+## 7. Post-Merge Remediation & Reconciliation
+Due to a self-reference exception loop (updating `PROOF.json` inside a branch changes the branch's head SHA), PR #820 was merged with `head_sha` set to `57d4807b645fd456148ed69901e051a16fd83b2c` while the actual PR head commit was `55fc77835fd78ec9b764cb13b36b54753535ca7d`.
+
+This discrepancy has been reconciled via `POST_MERGE_RECONCILIATION.json` under packet ID `TP-DCP-0005-POSTMERGE-REMEDIATION`.
+The final checks on the merge commit `62d16375119c8c7fac2fc3280152c4095c5898ac` passed successfully.
+The unfreeze of the DCP series is approved.

--- a/proof/TP-DCP-0005/AUDIT.md
+++ b/proof/TP-DCP-0005/AUDIT.md
@@ -56,3 +56,13 @@ Due to a self-reference exception loop (updating `PROOF.json` inside a branch ch
 This discrepancy has been reconciled via `POST_MERGE_RECONCILIATION.json` under packet ID `TP-DCP-0005-POSTMERGE-REMEDIATION`.
 The final checks on the merge commit `62d16375119c8c7fac2fc3280152c4095c5898ac` passed successfully.
 The unfreeze of the DCP series is approved.
+
+### PR #821 Remediation Scope Clarification
+PR #821 is not a proof-only change. It includes:
+1. **Governance Documentation**: Updated `docs/ops/pr-steward-readiness.md` to define the self-reference exception rule.
+2. **Code Documentation**: Added a non-functional comment to `src/dopemux/dcp/red_lane_scanner.py` explaining the exception.
+3. **Reconciliation Hardening**: Hardened `POST_MERGE_RECONCILIATION.json` with granular check results and mandatory governance fields.
+No changes to runtime scanner behavior or logic were made.
+
+## 8. Final Verdict (Post-Remediation)
+**PASS**

--- a/proof/TP-DCP-0005/AUDIT.md
+++ b/proof/TP-DCP-0005/AUDIT.md
@@ -50,19 +50,14 @@ The implementation follows the surgical, decoupled requirements of the DCP. The 
 ## 6. Verdict
 **PASS**
 
-## 7. Post-Merge Remediation & Reconciliation
-Due to a self-reference exception loop (updating `PROOF.json` inside a branch changes the branch's head SHA), PR #820 was merged with `head_sha` set to `57d4807b645fd456148ed69901e051a16fd83b2c` while the actual PR head commit was `55fc77835fd78ec9b764cb13b36b54753535ca7d`.
+## 7. Post-Merge Proof Discrepancy (Documented Only)
+Due to a proof self-reference issue (updating `PROOF.json` inside a branch changes the branch's head SHA), PR #820 was merged with `head_sha` set to `57d4807b645fd456148ed69901e051a16fd83b2c` while the actual PR head commit was `55fc77835fd78ec9b764cb13b36b54753535ca7d`.
 
-This discrepancy has been reconciled via `POST_MERGE_RECONCILIATION.json` under packet ID `TP-DCP-0005-POSTMERGE-REMEDIATION`.
-The final checks on the merge commit `62d16375119c8c7fac2fc3280152c4095c5898ac` passed successfully.
-The unfreeze of the DCP series is approved.
+This discrepancy has been documented via `POST_MERGE_RECONCILIATION.json` under packet ID `TP-DCP-0005-POSTMERGE-REMEDIATION`.
+The post-merge proof discrepancy is documented and reconciled at the governance-record level only. The DCP series remains FROZEN until a separate scanner-aware reconciliation packet teaches the red-lane scanner to consume POST_MERGE_RECONCILIATION.json or an equivalent supported proof self-reference mechanism.
 
-### PR #821 Remediation Scope Clarification
-PR #821 is not a proof-only change. It includes:
-1. **Governance Documentation**: Updated `docs/ops/pr-steward-readiness.md` to define the self-reference exception rule.
-2. **Code Documentation**: Added a non-functional comment to `src/dopemux/dcp/red_lane_scanner.py` explaining the exception.
-3. **Reconciliation Hardening**: Hardened `POST_MERGE_RECONCILIATION.json` with granular check results and mandatory governance fields.
-No changes to runtime scanner behavior or logic were made.
+### PR #821 Scope
+PR #821 is a documentation-only change. It documents the post-merge proof freshness discrepancy at the governance-record level. It does not unfreeze the DCP series and does not change scanner behavior. A follow-up packet is required if the scanner should consume POST_MERGE_RECONCILIATION.json.
 
 ## 8. Final Verdict (Post-Remediation)
 **PASS**

--- a/proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json
+++ b/proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json
@@ -1,11 +1,31 @@
 {
   "packet_id": "TP-DCP-0005-POSTMERGE-REMEDIATION",
+  "remediates_packet_id": "TP-DCP-0005",
   "merged_pr": 820,
   "merge_commit_sha": "62d16375119c8c7fac2fc3280152c4095c5898ac",
-  "pr_head_sha": "55fc77835fd78ec9b764cb13b36b54753535ca7d",
+  "actual_pr_head_sha": "55fc77835fd78ec9b764cb13b36b54753535ca7d",
   "previous_proof_sha_claim": "57d4807b645fd456148ed69901e051a16fd83b2c",
   "proof_status": "RECONCILED",
-  "review_threads_resolved": true,
-  "checks_final": "PASS",
-  "dcp_series_unfreeze": true
+  "proof_self_reference_policy": "OBSERVED",
+  "checks_final": {
+    "pr_820_head": "PASS",
+    "pr_820_merge_commit": "NO_RUNS_FOUND",
+    "pr_821_head": "PASS",
+    "evidence": [
+      "PR #820 head (55fc778) workflow runs SUCCESS (CodeQL, PR Steward, Complete CI)",
+      "PR #821 head (e6670db) workflow runs SUCCESS (Complete CI, Security Review, PR Steward)"
+    ]
+  },
+  "review_threads_final": "RESOLVED",
+  "dcp_series_status": "UNFROZEN",
+  "unfreeze_allowed": true,
+  "blocking_reasons": [],
+  "evidence": [
+    "PR #820 merged head: 55fc77835fd78ec9b764cb13b36b54753535ca7d",
+    "PR #820 merge commit: 62d16375119c8c7fac2fc3280152c4095c5898ac",
+    "PR #821 head SHA: e6670db6bb038ccd5175a83e669c2fbd4bec6ea8",
+    "PR #821 workflow success for remediation checks",
+    "self-reference exception documented in src/dopemux/dcp/red_lane_scanner.py and docs/ops/pr-steward-readiness.md"
+  ],
+  "recommended_next_action": "Merge PR #821 if review threads are resolved and no new checks fail."
 }

--- a/proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json
+++ b/proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json
@@ -1,31 +1,6 @@
 {
-  "packet_id": "TP-DCP-0005-POSTMERGE-REMEDIATION",
-  "remediates_packet_id": "TP-DCP-0005",
-  "merged_pr": 820,
-  "merge_commit_sha": "62d16375119c8c7fac2fc3280152c4095c5898ac",
-  "actual_pr_head_sha": "55fc77835fd78ec9b764cb13b36b54753535ca7d",
-  "previous_proof_sha_claim": "57d4807b645fd456148ed69901e051a16fd83b2c",
-  "proof_status": "RECONCILED",
-  "proof_self_reference_policy": "OBSERVED",
-  "checks_final": {
-    "pr_820_head": "PASS",
-    "pr_820_merge_commit": "NO_RUNS_FOUND",
-    "pr_821_head": "PASS",
-    "evidence": [
-      "PR #820 head (55fc778) workflow runs SUCCESS (CodeQL, PR Steward, Complete CI)",
-      "PR #821 head (e6670db) workflow runs SUCCESS (Complete CI, Security Review, PR Steward)"
-    ]
-  },
-  "review_threads_final": "RESOLVED",
-  "dcp_series_status": "UNFROZEN",
-  "unfreeze_allowed": true,
-  "blocking_reasons": [],
-  "evidence": [
-    "PR #820 merged head: 55fc77835fd78ec9b764cb13b36b54753535ca7d",
-    "PR #820 merge commit: 62d16375119c8c7fac2fc3280152c4095c5898ac",
-    "PR #821 head SHA: e6670db6bb038ccd5175a83e669c2fbd4bec6ea8",
-    "PR #821 workflow success for remediation checks",
-    "self-reference exception documented in src/dopemux/dcp/red_lane_scanner.py and docs/ops/pr-steward-readiness.md"
-  ],
-  "recommended_next_action": "Merge PR #821 if review threads are resolved and no new checks fail."
+  "proof_status": "RECONCILED_DOCUMENTED",
+  "dcp_series_status": "FROZEN",
+  "unfreeze_allowed": false,
+  "recommended_next_action": "Create a follow-up packet to teach the red-lane scanner how to consume POST_MERGE_RECONCILIATION.json before stale proof can be cleared automatically."
 }

--- a/proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json
+++ b/proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json
@@ -1,0 +1,11 @@
+{
+  "packet_id": "TP-DCP-0005-POSTMERGE-REMEDIATION",
+  "merged_pr": 820,
+  "merge_commit_sha": "62d16375119c8c7fac2fc3280152c4095c5898ac",
+  "pr_head_sha": "55fc77835fd78ec9b764cb13b36b54753535ca7d",
+  "previous_proof_sha_claim": "57d4807b645fd456148ed69901e051a16fd83b2c",
+  "proof_status": "RECONCILED",
+  "review_threads_resolved": true,
+  "checks_final": "PASS",
+  "dcp_series_unfreeze": true
+}

--- a/src/dopemux/dcp/red_lane_scanner.py
+++ b/src/dopemux/dcp/red_lane_scanner.py
@@ -169,6 +169,12 @@ class RedLaneScanner:
                             continue
                             
                         # Stale proof check
+                        # Note: Self-Reference Exception: Updating PROOF.json in a branch changes
+                        # the branch's head SHA. Under docs/ops/pr-acceptance.md §1 (Acceptance Gates),
+                        # proof freshness may be satisfied by an explicit supervisor-accepted
+                        # self-reference exception when the proof records proof-only changed-file
+                        # evidence and the embedded audit is nonblocking. In post-merge scenarios,
+                        # reconciliation can be recorded in POST_MERGE_RECONCILIATION.json to close the gap.
                         proof_head = data.get("head_sha")
                         if expected_head_sha and proof_head and proof_head != expected_head_sha:
                             findings.append(Finding(

--- a/src/dopemux/dcp/red_lane_scanner.py
+++ b/src/dopemux/dcp/red_lane_scanner.py
@@ -169,12 +169,8 @@ class RedLaneScanner:
                             continue
                             
                         # Stale proof check
-                        # Note: Self-Reference Exception: Updating PROOF.json in a branch changes
-                        # the branch's head SHA. Under docs/ops/pr-acceptance.md §1 (Acceptance Gates),
-                        # proof freshness may be satisfied by an explicit supervisor-accepted
-                        # self-reference exception when the proof records proof-only changed-file
-                        # evidence and the embedded audit is nonblocking. In post-merge scenarios,
-                        # reconciliation can be recorded in POST_MERGE_RECONCILIATION.json to close the gap.
+                        # Post-merge reconciliation artifacts are governance records only unless scanner logic explicitly consumes them.
+                        # This scanner still treats mismatched proof head SHA as stale proof.
                         proof_head = data.get("head_sha")
                         if expected_head_sha and proof_head and proof_head != expected_head_sha:
                             findings.append(Finding(

--- a/task-packets/TP-DCP-0005-POSTMERGE-REMEDIATION.json
+++ b/task-packets/TP-DCP-0005-POSTMERGE-REMEDIATION.json
@@ -1,0 +1,83 @@
+{
+  "id": "TP-DCP-0005-POSTMERGE-REMEDIATION",
+  "project": "dopemux-mvp",
+  "target": "Post-merge remediation for TP-DCP-0005 red-lane scanner to unfreeze DCP series",
+  "invariants": [
+    "DCP series is frozen until this post-merge remediation lands.",
+    "Do not revert the merge of PR #820.",
+    "Reconcile proof freshness discrepancies via POST_MERGE_RECONCILIATION.json.",
+    "No live write operations or network calls are allowed."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".repo_id",
+    "origin_hint": "github.com/DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "SERIES-DCP-RED-LANE-001",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DCP-0005",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "gemini"
+  },
+  "commit": {
+    "message": "chore(dcp): landing TP-DCP-0005 post-merge remediation and unfreezing series",
+    "allowlist": [
+      "task-packets/TP-DCP-0005-POSTMERGE-REMEDIATION.json",
+      "proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json",
+      "proof/TP-DCP-0005/AUDIT.md",
+      "docs/ops/pr-steward-readiness.md",
+      "src/dopemux/dcp/red_lane_scanner.py"
+    ],
+    "verify": [
+      "python3 -m pytest tests/dcp/test_dcp_0005_red_lane_scanner.py -q",
+      "python3 -m pytest tests/dcp -q",
+      "python3 -m compileall -q src tests",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "chore(dcp): landing TP-DCP-0005 post-merge remediation and unfreezing series",
+    "body": "Remediation PR to address the stale proof chain and unfreeze the DCP series post-PR #820 merge. Generates POST_MERGE_RECONCILIATION.json and documents the self-reference exception rule.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "implement",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Generate proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json with the required audit fields and status.",
+      "validation": [
+        "test -f proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json",
+        "python3 -m json.tool proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json >/dev/null"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Update proof/TP-DCP-0005/AUDIT.md to reflect post-merge remediation and verification results.",
+      "validation": [
+        "test -f proof/TP-DCP-0005/AUDIT.md"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Document the proof self-reference rule in docs/ops/pr-steward-readiness.md and red_lane_scanner.py code comments.",
+      "validation": [
+        "grep -q \"Self-Reference Exception\" docs/ops/pr-steward-readiness.md",
+        "grep -q \"Self-Reference Exception\" src/dopemux/dcp/red_lane_scanner.py"
+      ]
+    }
+  ]
+}

--- a/task-packets/TP-DCP-0005-POSTMERGE-REMEDIATION.json
+++ b/task-packets/TP-DCP-0005-POSTMERGE-REMEDIATION.json
@@ -1,7 +1,7 @@
 {
   "id": "TP-DCP-0005-POSTMERGE-REMEDIATION",
   "project": "dopemux-mvp",
-  "target": "Post-merge remediation for TP-DCP-0005 red-lane scanner to unfreeze DCP series",
+  "target": "Post-merge proof discrepancy documentation for TP-DCP-0005 red-lane scanner (governance record only; series remains FROZEN)",
   "invariants": [
     "DCP series is frozen until this post-merge remediation lands.",
     "Do not revert the merge of PR #820.",
@@ -25,7 +25,7 @@
     "agent": "gemini"
   },
   "commit": {
-    "message": "chore(dcp): landing TP-DCP-0005 post-merge remediation and unfreezing series",
+    "message": "chore(dcp): downgrade TP-DCP-0005 remediation to documented reconciliation",
     "allowlist": [
       "task-packets/TP-DCP-0005-POSTMERGE-REMEDIATION.json",
       "proof/TP-DCP-0005/POST_MERGE_RECONCILIATION.json",
@@ -41,8 +41,8 @@
     ]
   },
   "pr": {
-    "title": "chore(dcp): landing TP-DCP-0005 post-merge remediation and unfreezing series",
-    "body": "Remediation PR to address the stale proof chain and unfreeze the DCP series post-PR #820 merge. Generates POST_MERGE_RECONCILIATION.json and documents the self-reference exception rule.",
+    "title": "chore(dcp): document TP-DCP-0005 post-merge proof reconciliation",
+    "body": "This PR documents the TP-DCP-0005 post-merge proof freshness discrepancy after PR #820. It does not unfreeze the DCP series and does not change scanner behavior. A follow-up packet is required if the scanner should consume POST_MERGE_RECONCILIATION.json.",
     "base": "main"
   },
   "pal_chain": {
@@ -73,10 +73,10 @@
     },
     {
       "id": "S3",
-      "task": "Document the proof self-reference rule in docs/ops/pr-steward-readiness.md and red_lane_scanner.py code comments.",
+      "task": "Neutralize scanner comment and governance doc: remove self-reference exception prose; replace with governance-record-only note. DCP series stays FROZEN.",
       "validation": [
-        "grep -q \"Self-Reference Exception\" docs/ops/pr-steward-readiness.md",
-        "grep -q \"Self-Reference Exception\" src/dopemux/dcp/red_lane_scanner.py"
+        "grep -q \"governance records only\" docs/ops/pr-steward-readiness.md",
+        "grep -q \"governance records only\" src/dopemux/dcp/red_lane_scanner.py"
       ]
     }
   ]


### PR DESCRIPTION
This PR documents the TP-DCP-0005 post-merge proof freshness discrepancy after PR #820. It does not unfreeze the DCP series and does not change scanner behavior. A follow-up packet is required if the scanner should consume POST_MERGE_RECONCILIATION.json.