### PR TITLE
fix(brand): danger reads red in all themes + brand_lint gate

### DIFF
--- a/scripts/brand_lint.py
+++ b/scripts/brand_lint.py
@@ -247,6 +247,84 @@ def _iter_palette_violations(path: Path) -> list[str]:
     ]
 
 
+# Danger must read RED in every theme so "failed/blocked" never downsamples to
+# ANSI magenta/pink (the cutover fix must hold across opt-in aesthetic themes
+# too, not just the default). The theme set is sourced from theme.py.THEME_NAMES
+# so a newly-added theme can't evade this gate.
+DANGER_SLOTS = ("error", "chip.blocker", "severity.critical")
+
+
+def _hue_degrees(hex_color: str) -> float:
+    if not re.fullmatch(r"#?[0-9A-Fa-f]{6}", hex_color):
+        raise ValueError(f"invalid hex color: {hex_color!r}")
+    h = hex_color.lstrip("#")
+    r, g, b = (int(h[i : i + 2], 16) / 255 for i in (0, 2, 4))
+    mx, mn = max(r, g, b), min(r, g, b)
+    delta = mx - mn
+    if delta == 0:
+        return 0.0
+    if mx == r:
+        hue = ((g - b) / delta) % 6
+    elif mx == g:
+        hue = (b - r) / delta + 2
+    else:
+        hue = (r - g) / delta + 4
+    return hue * 60
+
+
+def _is_red_family(hex_color: str) -> bool:
+    # Red-family band around 0°: accept [340°, 360) ∪ [0°, 20°]. This rejects the
+    # magenta/pink region (~300–330°); reds near pure red (e.g. 346/0/354) pass.
+    hue = _hue_degrees(hex_color)
+    return hue >= 340 or hue <= 20
+
+
+def _iter_theme_danger_hue_violations() -> list[str]:
+    """Danger slots must resolve to a red-family hue in EVERY theme.
+
+    Fails closed: a theme/slot that cannot be resolved to a truecolor hex is a
+    violation, not a silent skip.
+    """
+    errors: list[str] = []
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    try:
+        try:
+            from src.dopemux.ui.theme import THEME_NAMES, build_theme
+        except ModuleNotFoundError:
+            src_dir = str(REPO_ROOT / "src")
+            if src_dir not in sys.path:
+                sys.path.insert(0, src_dir)
+            from dopemux.ui.theme import THEME_NAMES, build_theme
+    except Exception as exc:  # fail closed on import failure
+        return [
+            f"theme.py: could not import build_theme for danger-hue check: {exc} "
+            f"(sys.path[:3]={sys.path[:3]})"
+        ]
+    for name in THEME_NAMES:
+        try:
+            theme = build_theme(name)
+        except Exception as exc:  # fail closed on build failure
+            errors.append(f"theme '{name}': could not build for danger-hue check: {exc}")
+            continue
+        for slot in DANGER_SLOTS:
+            style = theme.styles.get(slot)
+            triplet = style.color.triplet if style and style.color else None
+            if triplet is None:
+                errors.append(
+                    f"theme '{name}' slot '{slot}': missing or non-truecolor danger color"
+                )
+                continue
+            hex_color = triplet.hex.upper()
+            if not _is_red_family(hex_color):
+                errors.append(
+                    f"theme '{name}' slot '{slot}'={hex_color} "
+                    f"(hue {_hue_degrees(hex_color):.0f}°) is not red-family — "
+                    f"danger must read red, not magenta/pink"
+                )
+    return errors
+
+
 def main() -> int:
     errors: list[str] = []
 
@@ -281,6 +359,7 @@ def main() -> int:
         errors.extend(_iter_merge_marker_violations(path))
 
     errors.extend(_iter_theme_default_violations())
+    errors.extend(_iter_theme_danger_hue_violations())
 
     for rel_path in OPERATIONAL_UI_FILES:
         path = _existing_path(rel_path, errors)

--- a/scripts/brand_lint.py
+++ b/scripts/brand_lint.py
@@ -275,6 +275,15 @@ def _hue_degrees(hex_color: str) -> float:
 def _is_red_family(hex_color: str) -> bool:
     # Red-family band around 0°: accept [340°, 360) ∪ [0°, 20°]. This rejects the
     # magenta/pink region (~300–330°); reds near pure red (e.g. 346/0/354) pass.
+    # Achromatic colors (R==G==B: white/black/gray) have NO hue — _hue_degrees
+    # returns 0.0 for them, which would otherwise slip through the <=20 band — so
+    # reject zero-saturation colors explicitly: a gray "danger" doesn't read red.
+    if not re.fullmatch(r"#?[0-9A-Fa-f]{6}", hex_color):
+        raise ValueError(f"invalid hex color: {hex_color!r}")
+    h = hex_color.lstrip("#")
+    r, g, b = (int(h[i : i + 2], 16) for i in (0, 2, 4))
+    if max(r, g, b) == min(r, g, b):
+        return False
     hue = _hue_degrees(hex_color)
     return hue >= 340 or hue <= 20
 

--- a/src/dopemux/ui/theme.py
+++ b/src/dopemux/ui/theme.py
@@ -28,6 +28,12 @@ from rich.text import Text
 from rich.theme import Theme
 
 
+# Canonical set of themes build_theme() can return — single source of truth. Add
+# new theme names here so get_active_theme_name() accepts them and brand_lint's
+# danger-hue gate validates them.
+THEME_NAMES = ("mint-mojo", "pastel-neon-dreamscape", "pastel-neon-dreams")
+
+
 def get_active_theme_name() -> str:
     """Return the name of the active theme from environment or default.
 
@@ -37,7 +43,11 @@ def get_active_theme_name() -> str:
     """
     env_theme = os.environ.get("DOPEMUX_THEME")
     if env_theme:
-        return env_theme.lower()
+        candidate = env_theme.lower()
+        if candidate in THEME_NAMES:
+            return candidate
+        # Unknown theme name → fall back to the documented default rather than
+        # silently selecting build_theme()'s catch-all branch.
 
     # Fallback default theme when no environment override is set.
     return "mint-mojo"
@@ -186,7 +196,7 @@ def build_theme(name: str) -> Theme:
             "label": "#A9A9A9",
             "success": "#00FF00",
             "success.soft": "#66FF66",
-            "error": "bold #FF00FF",
+            "error": "bold #FF0000",
             "warning": "#FFFF00",
             "gold": "#FFFF00",
             "amber": "#FFCF78",
@@ -197,7 +207,7 @@ def build_theme(name: str) -> Theme:
             "gilt.edge": "#FFFF00",
             "chip.live": "bold #00FFFF",
             "chip.override": "bold #FFFF00",
-            "chip.blocker": "bold #FF00FF",
+            "chip.blocker": "bold #FF0000",
             "chip.logged": "#66FF66",
             "chip.aftercare": "#FF66FF",
             "chip.edge": "bold #66FFFF",
@@ -212,7 +222,7 @@ def build_theme(name: str) -> Theme:
             "spinner": "#00FFFF",
             "severity.healthy": "#00FF00",
             "severity.warning": "#FFFF00",
-            "severity.critical": "bold #FF00FF",
+            "severity.critical": "bold #FF0000",
             "severity.unknown": "#333333",
             "rule.line": "#333333",
             "surface.black": "#000000",
@@ -242,7 +252,7 @@ def build_theme(name: str) -> Theme:
             "subheading": "bold #7FFFD4",
             "label": "#A9A9A9",
             "success": "#7FFFD4",
-            "error": "bold #FF69B4",
+            "error": "bold #FF6B7A",
             "warning": "#FFFFE0",
             "gold": "#FFFFE0",
             "amber": "#FFCF78",
@@ -252,7 +262,7 @@ def build_theme(name: str) -> Theme:
             "gilt.edge": "#FFFFE0",
             "chip.live": "bold #00FFFF",
             "chip.override": "bold #FFFFE0",
-            "chip.blocker": "bold #FF69B4",
+            "chip.blocker": "bold #FF6B7A",
             "chip.logged": "#7FFFD4",
             "chip.aftercare": "#FFB2FF",
             "chip.edge": "bold #B2FFFF",
@@ -267,7 +277,7 @@ def build_theme(name: str) -> Theme:
             "spinner": "#00FFFF",
             "severity.healthy": "#7FFFD4",
             "severity.warning": "#FFFFE0",
-            "severity.critical": "bold #FF69B4",
+            "severity.critical": "bold #FF6B7A",
             "severity.unknown": "#4D4D4D",
             "rule.line": "#A9A9A9",
             "surface.black": "#000000",


### PR DESCRIPTION
## Summary

Completes the danger-color fidelity work: makes **danger read red in every theme**, not just the default. Follow-up to the merged palette cutover (#803) and drift-guard (#807). Resolves the two gaps flagged during #807.

The two opt-in pastel themes still routed danger (`error`/`chip.blocker`/`severity.critical`) to magenta `#FF00FF` / pink `#FF69B4`, contradicting the general "Red means failed, blocked, or urgent" doctrine and reintroducing the magenta-downsample bug for users who opt into them.

## Changes (2 files)

**`src/dopemux/ui/theme.py`**
- `pastel-neon-dreamscape` danger → `#FF0000` (pure neon red — the pure-channel sibling of its `#00FFFF`/`#FF00FF`/`#FFFF00`/`#00FF00`).
- `pastel-neon-dreams` danger → `#FF6B7A` (soft rose-red, salient against the pastels).
- Non-status accents (`magenta`, `bar.pulse`, `gremlin.pink`) **left magenta** by design; `mint-mojo` unchanged.
- New `THEME_NAMES` constant (single source of truth) + `get_active_theme_name()` now validates `DOPEMUX_THEME` against it: an unknown theme name falls back to the documented `mint-mojo` default instead of silently selecting `build_theme()`'s catch-all branch.

**`scripts/brand_lint.py`** — new `_iter_theme_danger_hue_violations()` gate: danger slots must resolve to a **red-family hue** (band `[340°,360)∪[0°,20°]`, excluding pink ~330 / magenta ~300) in **every** theme in `THEME_NAMES`. Fails closed on import/build/missing-slot/bad-hex. Theme set sourced from `theme.py` so a newly-added theme can't evade the gate. Prevents this regression class permanently.

## Validation (all this session, clean bytecode)

| Check | Result |
|---|---|
| Danger hue, all themes | mint-mojo **346°** · dreamscape **0°** · dreams **354°** — all red-family ✓ |
| AA contrast on black | dreamscape 5.25 · dreams 7.64 ✓ |
| Accents preserved | `magenta`/`bar.pulse` still 300–312° ✓ |
| `brand_lint.py` | 0 errors, 0 warnings ✓ |
| Danger-gate negative test | revert a pastel danger → magenta → **gate fires** ✓ |
| Env validation | `GARBAGE`→`mint-mojo`, valid names pass ✓ |
| `sync_brand_tokens.py` | PASS ✓ |
| `pytest` (brand/health/ui) | 31 passed ✓ |

## Review chain (PAL, gpt-5.1)
`pal/codereview` + `pal/precommit`. Accepted: anchor `THEME_NAMES` to a single source, env-var validation, hex-input validation, sys.path error context, comment tightening. **Rejected with rationale**: making `build_theme()` raise on unknown names (would crash on a typo'd `DOPEMUX_THEME` — a runtime behavior change with real risk; the graceful fallback to `mint-mojo` is the safer fix). Truecolor-only is the documented gate contract (themes use hex exclusively).

## Rollback
Revert the merge, or reset `feat/pastel-danger-red` to `origin/main`. Color-data + a lint gate — no data/runtime migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
