### PR TITLE
fix(rte): contain pre-live validator execution

### DIFF
--- a/proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md
+++ b/proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md
@@ -1,0 +1,61 @@
+---
+id: TP-RTE-GOLIVE-REMEDIATION-002-IMPLEMENTATION-NOTES
+title: RTE Go-Live Remediation Slice 2 Implementation Notes
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-06-04'
+last_review: '2026-06-04'
+next_review: '2026-07-04'
+prelude: Implementation notes for the second RTE go-live remediation slice.
+---
+
+# RTE Go-Live Remediation Slice 2 Implementation Notes
+
+## Scope
+
+- Task Packet: `task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json`
+- Branch: `codex/rte-golive-remediation-002`
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/rte-golive-remediation-002`
+- Base: `origin/main` at `62d16375119c8c7fac2fc3280152c4095c5898ac`
+
+## Changes
+
+- Added focused tests for the live-execution validator subprocess fail-closed behavior when stdout is empty or lacks a parsed verdict.
+- Added focused tests proving the runner passes an explicit validator `--output-dir`.
+- Added focused tests for valid JSON that is not an object, so validator stdout like `[]` blocks through the structured path instead of crashing.
+- Updated the live-execution validator gate to require parsed JSON `verdict=GO` plus exit code 0 before allowing execution.
+- Updated the runner validator command construction to isolate validator output artifacts outside the repo working tree.
+- Updated validator block parsing helpers to ignore non-object JSON payloads and fail closed through the existing missing-verdict path.
+
+## TDD Evidence
+
+- RED: `test_enforce_pre_live_validator_fails_closed_on_empty_stdout` failed because empty stdout with exit 0 did not raise.
+- RED: `test_enforce_pre_live_validator_passes_isolated_output_dir` failed because the validator command lacked `--output-dir`.
+- RED: `test_enforce_pre_live_validator_fails_closed_on_non_object_stdout` failed with a list `.get` crash.
+- RED: `test_emit_validator_first_preset_block_non_object_stdout` failed with the same list `.get` crash.
+
+## Validation
+
+- `python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json >/dev/null` - PASS
+- `python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` - PASS; emitted jsonschema CLI deprecation warning only.
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov` - PASS, 28 passed
+- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py` - PASS
+- `git diff --check` - PASS
+- `pre-commit run --files ...` on the Task Packet allowlist - PASS
+
+## Not Run
+
+- Live extraction.
+- Live provider calls.
+- Network provider preflight.
+- Full RTE suite.
+- Route availability changes.
+- Network/secrets containment.
+- Prescan closeout.
+
+## Residual Risk
+
+- This slice does not resolve the audit's default model routing availability blocker.
+- This slice does not harden compose network binds or weak default secrets.
+- Full-suite regressions remain possible outside the targeted validator path and are left to CI or a separate full-suite packet.

--- a/proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md
+++ b/proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md
@@ -27,6 +27,8 @@ prelude: Implementation notes for the second RTE go-live remediation slice.
 - Updated the live-execution validator gate to require parsed JSON `verdict=GO` plus exit code 0 before allowing execution.
 - Updated the runner validator command construction to isolate validator output artifacts outside the repo working tree.
 - Updated validator block parsing helpers to ignore non-object JSON payloads and fail closed through the existing missing-verdict path.
+- Review follow-up: extended the validator-first preset helper path to pass an isolated `--output-dir` as well.
+- Review follow-up: fail-closed validator blocks now report the known isolated output directory when validator stdout omits `output_dir`.
 
 ## TDD Evidence
 
@@ -34,13 +36,16 @@ prelude: Implementation notes for the second RTE go-live remediation slice.
 - RED: `test_enforce_pre_live_validator_passes_isolated_output_dir` failed because the validator command lacked `--output-dir`.
 - RED: `test_enforce_pre_live_validator_fails_closed_on_non_object_stdout` failed with a list `.get` crash.
 - RED: `test_emit_validator_first_preset_block_non_object_stdout` failed with the same list `.get` crash.
+- RED: review follow-up `test_enforce_pre_live_validator_fails_closed_on_empty_stdout` failed because the block still reported `output_dir: <unknown>`.
+- RED: review follow-up `test_run_pre_live_validator_passes_isolated_output_dir` failed because `run_pre_live_validator` did not accept `output_dir`.
+- RED: review follow-up `test_first_live_preset_validator_uses_isolated_output_dir` failed because the preset validator-first path did not pass `output_dir`.
 
 ## Validation
 
 - `python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json >/dev/null` - PASS
 - `python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` - PASS; emitted jsonschema CLI deprecation warning only.
-- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov` - PASS, 28 passed
-- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py` - PASS
+- `RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov` - PASS
+- `python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/validate_pre_live_gate_v25.py` - PASS
 - `git diff --check` - PASS
 - `pre-commit run --files ...` on the Task Packet allowlist - PASS
 

--- a/services/repo-truth-extractor/rte_ops_surfaces.py
+++ b/services/repo-truth-extractor/rte_ops_surfaces.py
@@ -162,9 +162,12 @@ def run_pre_live_validator(
     subprocess_run: Callable[..., Any],
     now_iso: Callable[[], str],
     write_json: Callable[[Path, Any], None],
+    output_dir: Optional[Path] = None,
 ) -> Tuple[bool, Dict[str, Any]]:
     validator_path = extractor_service_dir / "validate_pre_live_gate_v25.py"
     args = [python_executable, str(validator_path)]
+    if output_dir is not None:
+        args.extend(["--output-dir", str(output_dir)])
     if target_policy:
         args.extend(["--target-policy", str(target_policy)])
     if target_phases:
@@ -189,6 +192,8 @@ def run_pre_live_validator(
         "stdout": result.stdout[-4000:],
         "stderr": result.stderr[-4000:],
     }
+    if output_dir is not None:
+        payload["output_dir"] = str(output_dir)
     if run_root is not None:
         write_json(run_root / "PRELIVE_VALIDATOR_RESULT.json", payload)
     return result.returncode == 0, payload

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -3840,7 +3840,14 @@ def _emit_validator_first_preset_block(
         str(parsed_payload.get("verdict") or "NO_GO").strip().upper() or "NO_GO"
     )
     reason_codes_list = _normalize_reason_codes(parsed_payload.get("reason_codes"))
-    output_dir_value = str(parsed_payload.get("output_dir") or "").strip() or None
+    output_dir_value = (
+        str(
+            parsed_payload.get("output_dir")
+            or validator_payload.get("output_dir")
+            or ""
+        ).strip()
+        or None
+    )
     raw_stderr = str(validator_payload.get("stderr") or "").strip()
     sanitized_stderr = sanitize_text_for_output(raw_stderr) if raw_stderr else ""
     artifact_path = str(run_root / "PRELIVE_VALIDATOR_RESULT.json")
@@ -3905,7 +3912,10 @@ def enforce_pre_live_validator_for_execution(
     verdict = explicit_verdict or "NO_GO"
     if proc.returncode != 0 or verdict != "GO" or parse_error or missing_verdict:
         reason_codes_list = _normalize_reason_codes(payload.get("reason_codes"))
-        output_dir_value = str(payload.get("output_dir") or "").strip() or None
+        output_dir_value = (
+            str(payload.get("output_dir") or "").strip()
+            or str(validator_output_dir)
+        )
         sanitized_stderr = sanitize_text_for_output(stderr) if stderr else ""
         block_verdict = (
             "NO_GO" if parse_error or missing_verdict or proc.returncode != 0 else verdict
@@ -21954,6 +21964,7 @@ def run_pre_live_validator(
     target_policy: Optional[str] = None,
     target_phases: Optional[Sequence[str]] = None,
     allow_online_preflight: bool = False,
+    output_dir: Optional[Path] = None,
 ) -> Tuple[bool, Dict[str, Any]]:
     return _run_pre_live_validator_impl(
         root,
@@ -21963,6 +21974,7 @@ def run_pre_live_validator(
         target_policy=target_policy,
         target_phases=target_phases,
         allow_online_preflight=allow_online_preflight,
+        output_dir=output_dir,
         subprocess_run=subprocess.run,
         now_iso=now_iso,
         write_json=write_json,
@@ -23458,6 +23470,7 @@ def main() -> None:
             target_policy=args.routing_policy,
             target_phases=phase_sequence,
             allow_online_preflight=True,
+            output_dir=create_pre_live_validator_output_dir(root),
         )
         write_confidence_ramp_artifacts(
             dirs["root"],

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -20,6 +20,7 @@ import platform
 import subprocess
 import sys
 import threading
+import tempfile
 import time
 import textwrap
 import importlib.util
@@ -3475,6 +3476,7 @@ def build_pre_live_validator_command(
     allow_online_preflight: bool,
     target_step: Optional[str] = None,
     s_prompts_mode: Optional[str] = None,
+    output_dir: Optional[Path] = None,
 ) -> List[str]:
     cmd = [
         sys.executable,
@@ -3482,6 +3484,8 @@ def build_pre_live_validator_command(
         "--target-policy",
         str(target_policy),
     ]
+    if output_dir is not None:
+        cmd.extend(["--output-dir", str(output_dir)])
     if target_step:
         cmd.extend(["--step", str(target_step)])
     normalized_s_prompts_mode = str(s_prompts_mode or "").strip().lower()
@@ -3495,6 +3499,12 @@ def build_pre_live_validator_command(
     if allow_online_preflight:
         cmd.append("--allow-online-preflight")
     return cmd
+
+
+def create_pre_live_validator_output_dir(_root: Path) -> Path:
+    """Create an isolated validator output directory outside the repo tree."""
+
+    return Path(tempfile.mkdtemp(prefix="rte-prelive-validator-")).resolve()
 
 
 def _validator_phase_targets(
@@ -3727,6 +3737,7 @@ def format_pre_live_validator_block(
     output_dir: Optional[str] = None,
     stderr_text: Optional[str] = None,
     parse_error: bool = False,
+    missing_verdict: bool = False,
     artifact_path: Optional[str] = None,
     next_step_hint: Optional[str] = None,
 ) -> str:
@@ -3744,6 +3755,11 @@ def format_pre_live_validator_block(
     if parse_error:
         lines.append(
             "  parse_status: validator stdout was not parseable as JSON; "
+            "treating as block (fail-closed)."
+        )
+    elif missing_verdict:
+        lines.append(
+            "  parse_status: validator stdout did not contain a parsed verdict; "
             "treating as block (fail-closed)."
         )
     if reason_codes:
@@ -3814,7 +3830,9 @@ def _emit_validator_first_preset_block(
     raw_stdout = str(validator_payload.get("stdout") or "").strip()
     if raw_stdout:
         try:
-            parsed_payload = json.loads(raw_stdout)
+            raw_payload = json.loads(raw_stdout)
+            if isinstance(raw_payload, dict):
+                parsed_payload = raw_payload
         except Exception:
             parsed_payload = {}
             parse_error = True
@@ -3854,12 +3872,14 @@ def enforce_pre_live_validator_for_execution(
             "verdict": "SKIPPED_NO_CONSENT",
             "reason": f"{DPMX_LIVE_OK_ENV}_NOT_SET",
         }
+    validator_output_dir = create_pre_live_validator_output_dir(root)
     cmd = build_pre_live_validator_command(
         target_policy=str(getattr(args, "routing_policy", DEFAULT_ROUTING_POLICY)),
         target_phases=_validator_phase_targets(args, phase_sequence),
         allow_online_preflight=True,
         target_step=getattr(args, "step", None),
         s_prompts_mode=getattr(args, "s_prompts", None),
+        output_dir=validator_output_dir,
     )
     proc = subprocess.run(
         cmd,
@@ -3874,28 +3894,29 @@ def enforce_pre_live_validator_for_execution(
     parse_error = False
     if stdout:
         try:
-            payload = json.loads(stdout)
+            parsed_payload = json.loads(stdout)
+            if isinstance(parsed_payload, dict):
+                payload = parsed_payload
         except Exception:
             payload = {}
             parse_error = True
     explicit_verdict = str(payload.get("verdict") or "").strip().upper()
-    if explicit_verdict:
-        verdict = explicit_verdict
-    elif proc.returncode == 0 and not parse_error:
-        verdict = "GO"
-    else:
-        verdict = "NO_GO"
-    if proc.returncode != 0 or verdict == "NO_GO" or parse_error:
+    missing_verdict = not explicit_verdict and not parse_error
+    verdict = explicit_verdict or "NO_GO"
+    if proc.returncode != 0 or verdict != "GO" or parse_error or missing_verdict:
         reason_codes_list = _normalize_reason_codes(payload.get("reason_codes"))
         output_dir_value = str(payload.get("output_dir") or "").strip() or None
         sanitized_stderr = sanitize_text_for_output(stderr) if stderr else ""
-        block_verdict = verdict if not parse_error else "NO_GO"
+        block_verdict = (
+            "NO_GO" if parse_error or missing_verdict or proc.returncode != 0 else verdict
+        )
         block_text = format_pre_live_validator_block(
             verdict=block_verdict,
             reason_codes=reason_codes_list,
             output_dir=output_dir_value,
             stderr_text=sanitized_stderr,
             parse_error=parse_error,
+            missing_verdict=missing_verdict,
         )
         _emit_pre_live_validator_block(block_text)
         raise RuntimeError(
@@ -3907,6 +3928,7 @@ def enforce_pre_live_validator_for_execution(
         "returncode": int(proc.returncode),
         "verdict": verdict,
         "payload": payload,
+        "validator_output_dir": str(validator_output_dir),
     }
 
 

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
@@ -686,6 +686,90 @@ def test_run_pre_live_validator_records_artifact(monkeypatch, tmp_path: Path) ->
     assert saved["status"] == "pass"
 
 
+def test_run_pre_live_validator_passes_isolated_output_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner = _load_runner_module()
+    called = {}
+    output_dir = tmp_path / "isolated-prelive-output"
+
+    def _fake_run(*args, **kwargs):
+        called["args"] = list(args[0])
+        return subprocess.CompletedProcess(
+            args=["python", "validate_pre_live_gate_v25.py"],
+            returncode=0,
+            stdout='{"verdict":"GO"}\n',
+            stderr="",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", _fake_run)
+
+    ok, payload = runner.run_pre_live_validator(
+        tmp_path,
+        tmp_path,
+        target_policy="cost",
+        target_phases=["A"],
+        allow_online_preflight=True,
+        output_dir=output_dir,
+    )
+
+    assert ok is True
+    assert payload["output_dir"] == str(output_dir)
+    assert "--output-dir" in called["args"]
+    assert called["args"][called["args"].index("--output-dir") + 1] == str(output_dir)
+
+
+def test_first_live_preset_validator_uses_isolated_output_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner = _load_runner_module()
+    expected_output_dir = tmp_path / "preset-prelive-output"
+    captured = {}
+
+    monkeypatch.setenv("DPMX_LIVE_OK", "1")
+    monkeypatch.setattr(
+        runner,
+        "enforce_pre_live_validator_for_execution",
+        lambda **kwargs: {"verdict": "GO"},
+    )
+    monkeypatch.setattr(
+        runner,
+        "create_pre_live_validator_output_dir",
+        lambda root: expected_output_dir,
+    )
+
+    def _fake_run_pre_live_validator(*args, **kwargs):
+        captured["output_dir"] = kwargs.get("output_dir")
+        raise SystemExit(23)
+
+    monkeypatch.setattr(runner, "run_pre_live_validator", _fake_run_pre_live_validator)
+    monkeypatch.setattr(
+        runner,
+        "write_confidence_ramp_artifacts",
+        lambda *args, **kwargs: None,
+    )
+
+    code, _stdout, _stderr, _output_root = _invoke_runner_main(
+        runner,
+        monkeypatch,
+        tmp_path,
+        [
+            "--preset",
+            "first-live",
+            "--execute",
+            "--skip-prescan",
+            "--run-id",
+            "preset_validator_output_dir_test",
+            "--no-write-latest",
+        ],
+    )
+
+    assert code == 23
+    assert captured["output_dir"] == expected_output_dir
+
+
 def test_run_provider_preflight_records_openrouter_specific_remediation(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py
@@ -299,6 +299,68 @@ def test_enforce_pre_live_validator_fails_closed_on_malformed_stdout(
     assert "verdict=NO_GO" in str(excinfo.value)
 
 
+def test_enforce_pre_live_validator_fails_closed_on_empty_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("DPMX_LIVE_OK", "1")
+
+    def _fake_subprocess_run(*args, **kwargs):
+        return _FakeCompletedProcess(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(runner.subprocess, "run", _fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        runner.enforce_pre_live_validator_for_execution(
+            root=Path("."),
+            args=_make_args(execute=True),
+            phase_sequence=["A"],
+        )
+
+    captured = capsys.readouterr()
+    assert "Pre-live validator blocked live execution." in captured.err
+    assert (
+        "  parse_status: validator stdout did not contain a parsed verdict; "
+        "treating as block (fail-closed)."
+    ) in captured.err
+    assert "  verdict: NO_GO" in captured.err
+    assert "verdict=NO_GO" in str(excinfo.value)
+
+
+def test_enforce_pre_live_validator_fails_closed_on_non_object_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("DPMX_LIVE_OK", "1")
+
+    def _fake_subprocess_run(*args, **kwargs):
+        return _FakeCompletedProcess(
+            returncode=0,
+            stdout=json.dumps(["GO"]),
+            stderr="",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", _fake_subprocess_run)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        runner.enforce_pre_live_validator_for_execution(
+            root=Path("."),
+            args=_make_args(execute=True),
+            phase_sequence=["A"],
+        )
+
+    captured = capsys.readouterr()
+    assert "Pre-live validator blocked live execution." in captured.err
+    assert (
+        "  parse_status: validator stdout did not contain a parsed verdict; "
+        "treating as block (fail-closed)."
+    ) in captured.err
+    assert "  verdict: NO_GO" in captured.err
+    assert "verdict=NO_GO" in str(excinfo.value)
+
+
 def test_enforce_pre_live_validator_returns_payload_on_go(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -325,6 +387,45 @@ def test_enforce_pre_live_validator_returns_payload_on_go(
     assert "Pre-live validator blocked" not in captured.err
     assert result["verdict"] == "GO"
     assert result["returncode"] == 0
+
+
+def test_enforce_pre_live_validator_passes_isolated_output_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runner = _load_runner_module()
+    monkeypatch.setenv("DPMX_LIVE_OK", "1")
+    expected_output_dir = tmp_path / "prelive-validator"
+    captured = {}
+
+    monkeypatch.setattr(
+        runner,
+        "create_pre_live_validator_output_dir",
+        lambda root: expected_output_dir,
+        raising=False,
+    )
+
+    def _fake_subprocess_run(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return _FakeCompletedProcess(
+            returncode=0,
+            stdout=json.dumps({"verdict": "GO"}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", _fake_subprocess_run)
+
+    result = runner.enforce_pre_live_validator_for_execution(
+        root=Path("."),
+        args=_make_args(execute=True),
+        phase_sequence=["A"],
+    )
+
+    assert result["verdict"] == "GO"
+    assert "--output-dir" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("--output-dir") + 1] == str(
+        expected_output_dir
+    )
 
 
 def test_enforce_pre_live_validator_forwards_s_prompts_mode(
@@ -430,6 +531,28 @@ def test_emit_validator_first_preset_block_malformed_stdout(
     assert "  output_dir: <unknown>" in out
     assert "    validator crashed mid-run" in out
     assert "  artifact: /tmp/run_tuv/PRELIVE_VALIDATOR_RESULT.json" in out
+
+
+def test_emit_validator_first_preset_block_non_object_stdout(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = _load_runner_module()
+
+    payload = {
+        "exit_code": 0,
+        "status": "fail",
+        "stdout": json.dumps(["GO"]),
+        "stderr": "",
+    }
+
+    runner._emit_validator_first_preset_block(payload, Path("/tmp/run_non_object"))
+    out = capsys.readouterr().err
+
+    assert "Pre-live validator blocked live execution." in out
+    assert "  verdict: NO_GO" in out
+    assert "  reason_codes: none reported" in out
+    assert "  output_dir: <unknown>" in out
+    assert "  artifact: /tmp/run_non_object/PRELIVE_VALIDATOR_RESULT.json" in out
 
 
 def test_emit_validator_first_preset_block_empty_payload(

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py
@@ -267,9 +267,17 @@ def test_enforce_pre_live_validator_emits_block_on_structured_no_go(
 def test_enforce_pre_live_validator_fails_closed_on_malformed_stdout(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
 ) -> None:
     runner = _load_runner_module()
     monkeypatch.setenv("DPMX_LIVE_OK", "1")
+    expected_output_dir = tmp_path / "malformed-prelive-output"
+
+    monkeypatch.setattr(
+        runner,
+        "create_pre_live_validator_output_dir",
+        lambda root: expected_output_dir,
+    )
 
     def _fake_subprocess_run(*args, **kwargs):
         return _FakeCompletedProcess(
@@ -294,7 +302,7 @@ def test_enforce_pre_live_validator_fails_closed_on_malformed_stdout(
         "treating as block (fail-closed)."
     ) in captured.err
     assert "  reason_codes: none reported" in captured.err
-    assert "  output_dir: <unknown>" in captured.err
+    assert f"  output_dir: {expected_output_dir}" in captured.err
     assert "    oops" in captured.err
     assert "verdict=NO_GO" in str(excinfo.value)
 
@@ -302,9 +310,17 @@ def test_enforce_pre_live_validator_fails_closed_on_malformed_stdout(
 def test_enforce_pre_live_validator_fails_closed_on_empty_stdout(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
 ) -> None:
     runner = _load_runner_module()
     monkeypatch.setenv("DPMX_LIVE_OK", "1")
+    expected_output_dir = tmp_path / "prelive-validator-output"
+
+    monkeypatch.setattr(
+        runner,
+        "create_pre_live_validator_output_dir",
+        lambda root: expected_output_dir,
+    )
 
     def _fake_subprocess_run(*args, **kwargs):
         return _FakeCompletedProcess(returncode=0, stdout="", stderr="")
@@ -325,6 +341,7 @@ def test_enforce_pre_live_validator_fails_closed_on_empty_stdout(
         "treating as block (fail-closed)."
     ) in captured.err
     assert "  verdict: NO_GO" in captured.err
+    assert f"  output_dir: {expected_output_dir}" in captured.err
     assert "verdict=NO_GO" in str(excinfo.value)
 
 

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -59,6 +59,7 @@ A packet is superseded by another packet
 | TP-RTE-V3-CONSENT-004 | Repo Truth Extractor | Gate legacy v3 execution and fail closed on unknown pipeline versions | Active | N/A |
 | TP-RTE-WALKER-006 | Repo Truth Extractor | Exclude generated artifacts and secret-bearing files from prescan walker input | Active | N/A |
 | TP-RTE-GOLIVE-REMEDIATION-001 | Repo Truth Extractor | Harden go-live preflight truth-split, SP registry contract, and cost-cap gates | Active | N/A |
+| TP-RTE-GOLIVE-REMEDIATION-002 | Repo Truth Extractor | Contain pre-live validator execution and require parsed GO verdicts | Active | N/A |
 | TP-RTE-BATCH-005 | Repo Truth Extractor | Repair batch result extraction and strict batch request payload handling | Merged (PR #614) | N/A |
 | TP-RTE-BATCH-E2E-006 | Repo Truth Extractor | Wire strict batch response_format through v5 request construction | Merged (PR #615) | N/A |
 | TP-RTE-STRICT-ATTESTATION-007 | Repo Truth Extractor | Ground strict passthrough attestations in runtime evidence | Merged (PR #616) | N/A |

--- a/task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json
+++ b/task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json
@@ -1,0 +1,116 @@
+{
+  "id": "TP-RTE-GOLIVE-REMEDIATION-002",
+  "project": "dopemux-mvp",
+  "target": "Remediate the second Repo Truth Extractor go-live audit safety slice on main: fail closed unless the pre-live validator subprocess emits a parsed GO verdict and force validator report writes into an isolated output directory outside the repo working tree.",
+  "invariants": [
+    "Runtime/source truth governs behavior claims; generated audit packs and plans are advisory only.",
+    "No live extraction, live provider calls, network preflight, or account-specific checks are authorized by this packet.",
+    "Preserve DPMX_LIVE_OK and pre-live validator consent boundaries; do not weaken live execution gates.",
+    "A validator subprocess success exit code is insufficient authority for live execution without parsed stdout containing verdict=GO.",
+    "Pre-live validator report writes from the live-execution gate must not dirty the repo working tree by default.",
+    "Implement only this second remediation slice; route availability, network/secrets containment, and prescan closeout remain follow-up slices."
+  ],
+  "depends_on": [
+    "TP-RTE-GOLIVE-REMEDIATION-001"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "rte-go-live-remediation",
+    "base_branch": "main",
+    "parent_tp_id": "TP-RTE-GOLIVE-REMEDIATION-001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/rte-golive-remediation-002",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(rte): contain pre-live validator execution",
+    "allowlist": [
+      "task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json",
+      "task-packets/INDEX.md",
+      "proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md",
+      "services/repo-truth-extractor/run_extraction_v5.py",
+      "services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov",
+      "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+      "git diff --check",
+      "pre-commit run --files task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json task-packets/INDEX.md proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
+    ]
+  },
+  "pr": {
+    "title": "fix(rte): contain pre-live validator execution",
+    "body": "## Summary\n- Requires the live-execution pre-live validator subprocess to return parsed JSON with `verdict=GO`; empty stdout, malformed stdout, missing verdicts, and non-zero exits all fail closed.\n- Passes an isolated validator `--output-dir` from the runner gate so validator report artifacts do not dirty the repo working tree by default.\n\n## Validation\n- python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json >/dev/null\n- python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov\n- python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py\n- git diff --check\n- pre-commit run --files task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json task-packets/INDEX.md proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py\n\n## NOT_RUN\n- Live extraction.\n- Live provider calls or network preflight.\n- Full RTE suite.\n- Route availability changes.\n- Network/secrets containment.\n- Prescan closeout.\n\n@codex review\n@gemini\n@copilot",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Register this Task Packet and validate it against the canonical dopetask schema before implementation.",
+      "expected_files": [
+        "task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json",
+        "task-packets/INDEX.md"
+      ],
+      "validation": [
+        "python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json >/dev/null",
+        "python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Add focused RED tests proving that empty or missing validator stdout blocks live execution and that the runner passes an isolated validator output directory.",
+      "expected_files": [
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
+      ],
+      "validation": [
+        "Targeted tests fail before implementation for the new fail-closed and output-dir containment assertions."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement the minimal RTE runner changes required by S2 while preserving consent gates, structured operator block output, and existing GO behavior for parsed validator payloads.",
+      "expected_files": [
+        "services/repo-truth-extractor/run_extraction_v5.py"
+      ],
+      "validation": [
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Record implementation notes, run precommit-grade checks, inspect diff scope, and prepare the PR.",
+      "expected_files": [
+        "proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md"
+      ],
+      "validation": [
+        "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py",
+        "git diff --check",
+        "git status --short --branch"
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json
+++ b/task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json
@@ -37,20 +37,22 @@
       "task-packets/INDEX.md",
       "proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md",
       "services/repo-truth-extractor/run_extraction_v5.py",
+      "services/repo-truth-extractor/rte_ops_surfaces.py",
+      "services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py",
       "services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
     ],
     "verify": [
       "python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json >/dev/null",
       "python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
-      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov",
+      "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov",
       "python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py",
       "git diff --check",
-      "pre-commit run --files task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json task-packets/INDEX.md proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
+      "pre-commit run --files task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json task-packets/INDEX.md proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
     ]
   },
   "pr": {
     "title": "fix(rte): contain pre-live validator execution",
-    "body": "## Summary\n- Requires the live-execution pre-live validator subprocess to return parsed JSON with `verdict=GO`; empty stdout, malformed stdout, missing verdicts, and non-zero exits all fail closed.\n- Passes an isolated validator `--output-dir` from the runner gate so validator report artifacts do not dirty the repo working tree by default.\n\n## Validation\n- python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json >/dev/null\n- python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov\n- python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py\n- git diff --check\n- pre-commit run --files task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json task-packets/INDEX.md proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py\n\n## NOT_RUN\n- Live extraction.\n- Live provider calls or network preflight.\n- Full RTE suite.\n- Route availability changes.\n- Network/secrets containment.\n- Prescan closeout.\n\n@codex review\n@gemini\n@copilot",
+    "body": "## Summary\n- Requires the live-execution pre-live validator subprocess to return parsed JSON with `verdict=GO`; empty stdout, malformed stdout, missing verdicts, and non-zero exits all fail closed.\n- Passes an isolated validator `--output-dir` from the runner gate and preset validator-first path so validator report artifacts do not dirty the repo working tree by default.\n- Reports the known isolated validator output directory in fail-closed blocks when validator stdout omits `output_dir`.\n\n## Validation\n- python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json >/dev/null\n- python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov\n- python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/validate_pre_live_gate_v25.py\n- git diff --check\n- pre-commit run --files task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json task-packets/INDEX.md proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py\n\n## NOT_RUN\n- Live extraction.\n- Live provider calls or network preflight.\n- Full RTE suite.\n- Route availability changes.\n- Network/secrets containment.\n- Prescan closeout.\n\n@codex review\n@gemini\n@copilot",
     "base": "main"
   },
   "pal_chain": {
@@ -82,9 +84,10 @@
     },
     {
       "id": "S2",
-      "task": "Add focused RED tests proving that empty or missing validator stdout blocks live execution and that the runner passes an isolated validator output directory.",
+      "task": "Add focused RED tests proving that empty or missing validator stdout blocks live execution, the runner passes an isolated validator output directory, the preset validator-first path passes an isolated output directory, and fail-closed blocks report the known isolated path.",
       "expected_files": [
-        "services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py"
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py",
+        "services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py"
       ],
       "validation": [
         "Targeted tests fail before implementation for the new fail-closed and output-dir containment assertions."
@@ -94,10 +97,11 @@
       "id": "S3",
       "task": "Implement the minimal RTE runner changes required by S2 while preserving consent gates, structured operator block output, and existing GO behavior for parsed validator payloads.",
       "expected_files": [
-        "services/repo-truth-extractor/run_extraction_v5.py"
+        "services/repo-truth-extractor/run_extraction_v5.py",
+        "services/repo-truth-extractor/rte_ops_surfaces.py"
       ],
       "validation": [
-        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov"
+        "RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Requires the live-execution pre-live validator subprocess to return parsed JSON with `verdict=GO`; empty stdout, malformed stdout, missing verdicts, non-object JSON, and non-zero exits all fail closed.
- Passes an isolated validator `--output-dir` from the runner gate and preset validator-first path so validator report artifacts do not dirty the repo working tree by default.
- Reports the known isolated validator output directory in fail-closed blocks when validator stdout omits `output_dir`.
- Adds focused regression coverage for live gate, preset validator, and validator-first block parsing paths.

## Validation
- python -m json.tool task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json >/dev/null
- python -m jsonschema -i task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- RTE_DISABLE_LIVE_LLM_IN_TESTS=1 PYTHONPATH=services/repo-truth-extractor python -m pytest services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_pre_live_gate_v25.py -q --tb=short --disable-warnings --no-cov
- python -m py_compile services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/validate_pre_live_gate_v25.py
- git diff --check
- pre-commit run --files task-packets/generated/TP-RTE-GOLIVE-REMEDIATION-002.json task-packets/INDEX.md proof/rte-golive-remediation/TP-RTE-GOLIVE-REMEDIATION-002/implementation-notes.md services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_run_extraction_v5_validator.py

## NOT_RUN
- Live extraction.
- Live provider calls or network preflight.
- Full RTE suite.
- Route availability changes.
- Network/secrets containment.
- Prescan closeout.

@codex review
@gemini
@copilot
