### PR TITLE
DCP facade: dopemux init/registry discovery (TP-DCP-MCP-RO-0003)

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/DOPEMUX_INIT_REGISTRY_DISCOVERY.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/DOPEMUX_INIT_REGISTRY_DISCOVERY.md
@@ -80,7 +80,7 @@ Grounded in §1–§4, the facade's project resolution is:
    - the registered `workspace_path` resolves (canonical, symlink-followed) to a path **inside an approved root**;
    - it is a real workspace per `validate_workspace()` / `get_workspace_root()` (git toplevel);
    - it contains a **`.dopemux/`** directory (init marker, §1);
-   - its **`.repo_id`** identity matches the registry entry (project/owner), per the DCP schema convention (§3).
+   - its **`.repo_id`** `project=` matches the registry entry's required `identity.project`, and its `owner=` matches `identity.owner` only when that field is declared (conditional, always satisfiable), per the DCP schema convention (§3).
 3. Any check failing → `BLOCKED`; a partially-bound project → `PARTIAL`; never fabricated data.
 
 This is reflected in [`MULTI_PROJECT_REGISTRY_CONTRACT.md`](MULTI_PROJECT_REGISTRY_CONTRACT.md) §4–§5.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/DOPEMUX_INIT_REGISTRY_DISCOVERY.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/DOPEMUX_INIT_REGISTRY_DISCOVERY.md
@@ -1,0 +1,92 @@
+---
+id: dcp-mcp-readonly-dopemux-init-registry-discovery
+title: DCP Read-Only MCP Facade — Dopemux Init & Registry Discovery
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-05'
+last_review: '2026-06-05'
+next_review: '2026-09-03'
+prelude: Static inspection of dopemux init and workspace-identity markers grounding the read-only MCP facade registry contract for dopemux documentation and developer workflows.
+---
+
+# Dopemux Init & Registry Discovery
+
+> **Purpose.** TP-DCP-MCP-RO-0002 left the `dopemux init` / workspace-identity marker contract as `UNKNOWN`. This packet (TP-DCP-MCP-RO-0003) resolves it by **read-only static inspection** of the actual runtime code and repo markers, so the facade's [`MULTI_PROJECT_REGISTRY_CONTRACT.md`](MULTI_PROJECT_REGISTRY_CONTRACT.md) rests on evidence, not assumption. No code, init behavior, or `.dopemux` state was modified. Every claim is labelled `OBSERVED` (verified in the working tree at the cited `file:line`), `CONFLICTING`, or `UNKNOWN`.
+
+## 1. `dopemux init` Behavior (`OBSERVED`)
+
+- CLI entrypoint: `src/dopemux/cli.py:725` (`def init(...)`), which imports `init_project` at `cli.py:204` and calls it at `cli.py:780`. It pre-checks for an existing workspace at `cli.py:770` (`"⚠️ Project already initialized (.dopemux/ exists)"`).
+- Implementation: `src/dopemux/project_init.py` — `class ProjectInitializer` (`:33`), `self.dopemux_dir = self.workspace / ".dopemux"` (`:38`), public `init_project()` (`:265`).
+- What init writes (all under the target workspace):
+  - `.dopemux/` directory — `project_init.py:167` (`self.dopemux_dir.mkdir`).
+  - `.dopemux/databases/` — `:168`.
+  - active profile — `:171` (`self.profile_manager.set_active_profile(...)`).
+  - `.dopemux/config.yaml` (optional project overrides) — `:175`.
+  - It also auto-detects project type from markers (`pyproject.toml`, `package.json`, etc.) before scaffolding.
+
+**Conclusion (`OBSERVED`):** the canonical "this workspace has been `dopemux init`-ialized" marker is the presence of the **`.dopemux/` directory**. `cli.py:770` uses exactly this check.
+
+## 2. Workspace Identity & Detection (`OBSERVED`)
+
+`src/dopemux/workspace_detection.py` is the canonical workspace resolver used across dopemux:
+
+| Function | Line | Behavior |
+| --- | --- | --- |
+| `get_workspace_root()` | `:82` | Resolution order: `DOPEMUX_WORKSPACE_ROOT` env (`:115`) → `git rev-parse --show-toplevel` (`:135`, works for worktrees and main repo) → project markers → cwd fallback. |
+| `export_workspace_env()` | `:184` | Emits `DOPEMUX_WORKSPACE_ROOT` + `DOPEMUX_WORKSPACE_ID` for MCP propagation. |
+| `validate_workspace()` | `:222` | Returns `(is_valid, error_message)`; checks directory exists and is a git repo / has project markers. |
+| `get_workspace_info()` | `:272` | Diagnostics: `workspace_root`, `is_git_repo`, `is_worktree`, `git_branch`, `detection_method`. |
+
+**Conclusion (`OBSERVED`):** workspace *path* identity is git-toplevel based via `get_workspace_root()`; there is a ready-made `validate_workspace()` the facade resolver can reuse rather than re-deriving path logic.
+
+## 3. Repo-Root / Identity Markers (`OBSERVED` + `CONFLICTING`)
+
+Markers actually present at the repo root (existence verified; git-tracking via `git ls-files`):
+
+| Marker | Status | Tracked | Role |
+| --- | --- | --- | --- |
+| `.dopemux/` | **EXISTS** (dir) | — | `dopemux init` eligibility marker (§1). |
+| `.repo_id` | **EXISTS** (file) | yes | Repo identity: `project=dopemux-mvp`, `owner=hu3mann`, `intent=Primary dopemux workspace. Task packets must refuse if repo_id mismatches.` |
+| `.dopetaskroot` | **EXISTS** (file) | yes | Repo-root marker used by the orchestrator. |
+| `dopemux.toml` | **EXISTS** (file) | — | Project tmux/config; not an init/identity marker. |
+| `.n` | **ABSENT** | — | Referenced as `repo_marker: ".n"` / `test -f .n` by several task packets (e.g. `task-packets/TP-DMX-RTECANON-001.json`, `TP-DMX-REPOHYG-003.json`) and `runbooks/BOOTSTRAP.md`, but **does not exist** in the repo. |
+
+`CONFLICTING` — repo-marker fragmentation:
+- `src/dopemux/orchestrator/operator_workflows.py:141` declares `"repo_marker": ".dopetaskroot"`.
+- The DCP core schema `schemas/dcp/dcp_project_resource_map.schema.json` (from TP-DCP-0002) already canonicalizes `.repo_id` (`repo_id` field: *"Repository identifier from .repo_id marker"*) and documents `repo_root_marker` as *"Both .repo_id and dopetaskroot markers observed in repo."*
+- A third marker `.n` is referenced by RTE/hygiene task packets but is **absent** — stale/aspirational drift.
+
+**Resolution for the facade:** treat `.repo_id` as the canonical **identity** marker (consistent with the existing DCP schema authority) and `.dopemux/` as the **eligibility** marker. Do **not** silently adopt `.dopetaskroot` or `.n`; the marker fragmentation is an operator-facing `CONFLICTING` item recorded for resolution, not invented away.
+
+**Identity consumption nuance (`OBSERVED`):** no `src/dopemux` runtime code reads `.repo_id`; it is a *declarative* identity file consumed by task-packet / DCP tooling (and asserted by `dcp_project_resource_map.schema.json`). The facade therefore reads it as data for an identity-match check, not via an existing dopemux API.
+
+## 4. Existing Registries (`OBSERVED`)
+
+| Registry | Location | Scope | Verdict for facade |
+| --- | --- | --- | --- |
+| Global workspace registry | `~/.dopemux/config.json` (`src/dopemux/global_config.py:24`; schema `default_workspace`+`workspaces{}` at `:37`; `register_workspace()` at `:93`, assigns `{name}-{hash}` slug) | **Every workspace the user has ever opened** | = **eligibility**, NOT exposure. Must not be used as the facade's exposed-project list. |
+| Service registry | `services/registry.yaml` | Service ports/health (≈28 services) | Not workspaces; irrelevant to project registry. |
+| MCP server registry | `src/dopemux/mcp/registry.yaml` | MCP server transport/naming | Not workspaces. |
+
+**Conclusion (`OBSERVED`):** there is **no** `list_projects` CLI and **no** per-project exposure registry. dopemux's global registry is an "opened-workspaces" cache. This confirms TP-DCP-MCP-RO-0002 Decision **D2** (eligibility ≠ exposure): the facade must keep its **own explicit allowlist**, never auto-expose from `~/.dopemux/config.json`.
+
+## 5. Resolved Registry/Eligibility Contract (recommendation)
+
+Grounded in §1–§4, the facade's project resolution is:
+
+1. **Exposure** — `project_id` must be present and `enabled: true` in the facade's own explicit registry (operator-maintained). Absent/disabled → `BLOCKED`. (Never derived from the global registry.)
+2. **Eligibility validation** (fail-closed, all `OBSERVED`-backed):
+   - the registered `workspace_path` resolves (canonical, symlink-followed) to a path **inside an approved root**;
+   - it is a real workspace per `validate_workspace()` / `get_workspace_root()` (git toplevel);
+   - it contains a **`.dopemux/`** directory (init marker, §1);
+   - its **`.repo_id`** identity matches the registry entry (project/owner), per the DCP schema convention (§3).
+3. Any check failing → `BLOCKED`; a partially-bound project → `PARTIAL`; never fabricated data.
+
+This is reflected in [`MULTI_PROJECT_REGISTRY_CONTRACT.md`](MULTI_PROJECT_REGISTRY_CONTRACT.md) §4–§5.
+
+## 6. Remaining UNKNOWNs / Open Items
+
+- `CONFLICTING` (operator decision): canonical repo-root marker across the repo — `.repo_id` vs `.dopetaskroot` vs the absent `.n`. The facade adopts `.repo_id` for identity per the DCP schema, but repo-wide marker unification is out of scope here.
+- `UNKNOWN`: whether the facade should additionally assert `.repo_id`'s `intent`/`owner` fields (beyond `project`) at resolve time — deferred to the resolver implementation in TP-DCP-MCP-RO-0004.
+- `OBSERVED` drift to flag upstream (not fixed here): task packets referencing `test -f .n` / `repo_marker: ".n"` point at a non-existent marker.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md
@@ -33,6 +33,9 @@ projects:
   - project_id: "dopemux-mvp"          # opaque caller-facing id
     workspace_path: "/abs/path/..."     # resolved + validated at load
     enabled: true                       # exposure switch; default false
+    identity:                           # matched against the workspace's .repo_id (§4.5)
+      project: "dopemux-mvp"            # REQUIRED; must equal .repo_id `project=`
+      owner: "hu3mann"                  # OPTIONAL; if present, must equal .repo_id `owner=`
     service_profiles:                   # per-backend bindings
       conport:
         workspace_id: "<conport-workspace-id>"
@@ -51,6 +54,7 @@ Field notes:
 - `project_id` is the **only** project handle a caller may supply.
 - `workspace_path`, `workspace_id`, `base_url`, ports, and routes are **registry-owned**; callers cannot set or override them.
 - `enabled` defaults to `false`; omission means not exposed.
+- `identity.project` is **required** (the value compared against the workspace's `.repo_id` `project=`); `identity.owner` is **optional** and only enforced when present. The identity block is the registry-side value the §4.5 identity check matches against.
 - `service_profiles` may be partial — a project missing a profile reports that capability as unavailable (see [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) and `get_project_capabilities`), returning `PARTIAL`/`BLOCKED`, never guessed data.
 
 ## 4. Validation Rules (fail closed)
@@ -59,7 +63,7 @@ Field notes:
 2. A `project_id` not present in the registry → `BLOCKED` (unknown project).
 3. A `project_id` present but `enabled: false` → `BLOCKED` (disabled project).
 4. `workspace_path` must resolve (canonical, symlink-followed) to a path **contained within an approved root**. Escape → `BLOCKED`.
-5. **Eligibility validation (`OBSERVED`-backed):** the resolved workspace must (a) validate as a real workspace via `validate_workspace()` / `get_workspace_root()` (`src/dopemux/workspace_detection.py:222`/`:82`, git-toplevel based); (b) contain a **`.dopemux/`** directory (init marker); (c) carry a **`.repo_id`** identity whose `project`/`owner` match the registry entry (`.repo_id` is the canonical identity marker per `schemas/dcp/dcp_project_resource_map.schema.json`). Any miss → `BLOCKED`.
+5. **Eligibility validation (`OBSERVED`-backed):** the resolved workspace must (a) validate as a real workspace via `validate_workspace()` / `get_workspace_root()` (`src/dopemux/workspace_detection.py:222`/`:82`, git-toplevel based); (b) contain a **`.dopemux/`** directory (init marker); (c) carry a **`.repo_id`** whose `project=` equals the registry entry's **required** `identity.project`, and — **only if** the entry declares `identity.owner` — whose `owner=` equals it. (`.repo_id` is the canonical identity marker per `schemas/dcp/dcp_project_resource_map.schema.json`.) Any miss → `BLOCKED`. The owner check is conditional so it is always satisfiable: an entry without `identity.owner` is matched on `project` alone, never blocked for a field the registry didn't declare.
 6. No caller-supplied path, URL, port, backend route, `workspace_id`, SQL, or shell is ever accepted.
 7. Registry load itself fails closed: a malformed entry disables that project rather than exposing it loosely.
 
@@ -72,7 +76,7 @@ project_id
   → workspace_path → realpath  (resolve symlinks; get_workspace_root semantics)
   → containment check          (escapes approved root → BLOCKED)
   → eligibility check          (.dopemux/ present + validate_workspace() ok → else BLOCKED)
-  → identity check             (.repo_id project/owner matches registry → else BLOCKED)
+  → identity check             (.repo_id project == identity.project; owner == identity.owner if declared → else BLOCKED)
   → bind service_profiles      (missing profile → capability unavailable / PARTIAL)
   → canonical path + bindings  → adapter
 ```

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md
@@ -12,7 +12,7 @@ prelude: Multi-project registry and resolver contract for the read-only MCP evid
 
 # Multi-Project Registry Contract
 
-> **Status.** The registry **schema and validation rules** here are `PROPOSED` design. The exact `dopemux init` marker / workspace-identity contract is `UNKNOWN` at this packet and is resolved by static inspection in TP-DCP-MCP-RO-0003. This document must be updated from that evidence before the resolver is implemented in TP-DCP-MCP-RO-0004.
+> **Status.** Schema/resolver shape remains `PROPOSED` design. The `dopemux init` marker / workspace-identity contract is now **`OBSERVED`** — resolved by the static inspection in TP-DCP-MCP-RO-0003 (see [`DOPEMUX_INIT_REGISTRY_DISCOVERY.md`](DOPEMUX_INIT_REGISTRY_DISCOVERY.md)) and reflected in §2/§4/§5 below. Concrete registry file location and load mechanics are implemented in TP-DCP-MCP-RO-0004.
 
 ## 1. Purpose
 
@@ -20,10 +20,10 @@ The registry is the facade's **trust boundary**. It is the single source of trut
 
 ## 2. Eligibility vs Exposure (core invariant)
 
-- **Eligibility**: a workspace that has been `dopemux init`-ialized is *eligible* to be registered.
-- **Exposure**: a workspace is only *exposed* when an operator adds an explicit, `enabled: true` entry to the registry.
+- **Eligibility**: a workspace that has been `dopemux init`-ialized is *eligible* to be registered. `OBSERVED` (§1 of the discovery doc): the init marker is the **`.dopemux/` directory** (`src/dopemux/project_init.py:167`; checked at `cli.py:770`).
+- **Exposure**: a workspace is only *exposed* when an operator adds an explicit, `enabled: true` entry to the facade's own registry.
 
-`dopemux init` is **eligibility, not consent.** Initializing a workspace must never auto-expose it. This is fail-closed: absent a registry entry, a project does not exist as far as the facade is concerned.
+`dopemux init` is **eligibility, not consent.** Initializing a workspace must never auto-expose it. This is fail-closed: absent a registry entry, a project does not exist as far as the facade is concerned. In particular, the facade **must not** derive exposure from dopemux's global workspace registry (`~/.dopemux/config.json`, `src/dopemux/global_config.py:24`), which records *every workspace the user has ever opened* — that is eligibility, not exposure.
 
 ## 3. Registry Schema (`PROPOSED`)
 
@@ -59,8 +59,9 @@ Field notes:
 2. A `project_id` not present in the registry → `BLOCKED` (unknown project).
 3. A `project_id` present but `enabled: false` → `BLOCKED` (disabled project).
 4. `workspace_path` must resolve (canonical, symlink-followed) to a path **contained within an approved root**. Escape → `BLOCKED`.
-5. No caller-supplied path, URL, port, backend route, `workspace_id`, SQL, or shell is ever accepted.
-6. Registry load itself fails closed: a malformed entry disables that project rather than exposing it loosely.
+5. **Eligibility validation (`OBSERVED`-backed):** the resolved workspace must (a) validate as a real workspace via `validate_workspace()` / `get_workspace_root()` (`src/dopemux/workspace_detection.py:222`/`:82`, git-toplevel based); (b) contain a **`.dopemux/`** directory (init marker); (c) carry a **`.repo_id`** identity whose `project`/`owner` match the registry entry (`.repo_id` is the canonical identity marker per `schemas/dcp/dcp_project_resource_map.schema.json`). Any miss → `BLOCKED`.
+6. No caller-supplied path, URL, port, backend route, `workspace_id`, SQL, or shell is ever accepted.
+7. Registry load itself fails closed: a malformed entry disables that project rather than exposing it loosely.
 
 ## 5. Resolver Flow (`PROPOSED`)
 
@@ -68,9 +69,11 @@ Field notes:
 project_id
   → registry lookup            (unknown → BLOCKED)
   → enabled check              (disabled → BLOCKED)
-  → workspace_path → realpath  (resolve symlinks)
+  → workspace_path → realpath  (resolve symlinks; get_workspace_root semantics)
   → containment check          (escapes approved root → BLOCKED)
-  → bind service_profiles      (missing profile → capability unavailable)
+  → eligibility check          (.dopemux/ present + validate_workspace() ok → else BLOCKED)
+  → identity check             (.repo_id project/owner matches registry → else BLOCKED)
+  → bind service_profiles      (missing profile → capability unavailable / PARTIAL)
   → canonical path + bindings  → adapter
 ```
 
@@ -84,6 +87,7 @@ Each project advertises capabilities derived from its `service_profiles` (which 
 
 ## 8. Open Questions / UNKNOWNs
 
-- `UNKNOWN`: the concrete `dopemux init` marker(s) and workspace-identity fields (TP-DCP-MCP-RO-0003).
-- `UNKNOWN`: whether dopemux already exposes a project list/registry primitive the facade should reuse vs. a standalone `registry.yaml` (TP-DCP-MCP-RO-0003).
-- `PROPOSED`: exact location and load mechanics of the registry file (TP-DCP-MCP-RO-0004).
+- ~~`UNKNOWN`: the concrete `dopemux init` marker(s) and workspace-identity fields~~ → **RESOLVED** in TP-DCP-MCP-RO-0003: init marker = `.dopemux/`; identity = `.repo_id`; detection = `get_workspace_root()`/`validate_workspace()`. See [`DOPEMUX_INIT_REGISTRY_DISCOVERY.md`](DOPEMUX_INIT_REGISTRY_DISCOVERY.md).
+- ~~`UNKNOWN`: whether dopemux already exposes a project list/registry primitive~~ → **RESOLVED**: no `list_projects` CLI; the global `~/.dopemux/config.json` is an opened-workspaces cache (eligibility, not exposure); the facade keeps its own explicit allowlist. (Discovery §4.)
+- `CONFLICTING` (operator decision, repo-wide): repo-root marker fragmentation — `.repo_id` vs `.dopetaskroot` (`operator_workflows.py:141`) vs the **absent** `.n` (referenced by some task packets). The facade adopts `.repo_id` for identity per `dcp_project_resource_map.schema.json`; repo-wide unification is out of facade scope.
+- `PROPOSED`: exact location and load mechanics of the facade registry file (TP-DCP-MCP-RO-0004).

--- a/proof/TP-DCP-MCP-RO-0003/AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0003/AUDIT.md
@@ -1,0 +1,31 @@
+# Audit — TP-DCP-MCP-RO-0003 (Inspect Dopemux Init Registry Contract)
+
+Auditor focus per packet `embedded_audit`. Verdict: **PASS_WITH_RISKS** (non-blocking; tracked CONFLICT + deferrals).
+
+## 1. Were the marker findings actually observed?
+
+Yes — every marker claim is reproduced from the working tree at a cited `file:line` (see `COMMAND_LOG.md`):
+- `.dopemux/` init marker: `src/dopemux/project_init.py:167` (mkdir), checked at `src/dopemux/cli.py:770`.
+- Detection: `workspace_detection.py:get_workspace_root():82`, `validate_workspace():222`, `export_workspace_env():184`.
+- Markers present at root: `.repo_id` (git-tracked), `.dopetaskroot` (git-tracked), `.dopemux/` (dir), `dopemux.toml`. `.n` confirmed **ABSENT** despite task-packet references.
+- `.repo_id` content read directly; `.dopetaskroot` repo_marker at `operator_workflows.py:141`; `.repo_id` canonicalized by `schemas/dcp/dcp_project_resource_map.schema.json`.
+
+No invented markers: claims are OBSERVED, the marker fragmentation is `CONFLICTING`, residual items are `UNKNOWN`.
+
+## 2. Did implementation accidentally begin?
+
+No. Only two docs changed (`DOPEMUX_INIT_REGISTRY_DISCOVERY.md` created, `MULTI_PROJECT_REGISTRY_CONTRACT.md` updated) plus this proof bundle. `git diff --cached --name-only | grep src/|services/|docker/|compose` → empty. No facade code, no `.dopemux` writes, no init-behavior changes, no project auto-registration.
+
+## 3. Does the registry contract fail closed?
+
+Yes. The updated contract (§4/§5) requires, in order: registry presence + `enabled` → containment → `.dopemux/` eligibility + `validate_workspace()` → `.repo_id` identity match → service binding. Any miss → `BLOCKED`; partial binding → `PARTIAL`; never fabricated. Exposure is the facade's own explicit allowlist and is explicitly forbidden from being derived from dopemux's global `~/.dopemux/config.json` (which is an opened-workspaces cache = eligibility, not exposure).
+
+## 4. Are UNKNOWNs preserved?
+
+Yes. Two prior UNKNOWNs are marked RESOLVED with evidence; the repo-marker fragmentation is retained as a `CONFLICTING` operator item (`.repo_id` vs `.dopetaskroot` vs absent `.n`); residual `UNKNOWN`s (whether to assert `.repo_id` intent/owner beyond project at resolve time; registry file location) are routed to TP-DCP-MCP-RO-0004.
+
+## Deviations / Residual risks (non-blocking)
+
+- **Filename casing**: packet `allowed_files` spelled the discovery doc `Dopemux_INIT_REGISTRY_DISCOVERY.md`; used `DOPEMUX_INIT_REGISTRY_DISCOVERY.md` (ALL_CAPS) to match the dir's existing `ARCHITECTURE.md`/`MULTI_PROJECT_REGISTRY_CONTRACT.md` style and pass the repo's docs-filename-hygiene hook (mixed-case would risk rejection). Functionally identical.
+- **Branch reset**: the 0003 branch was reset from the superseded stub commit `78b04fb33` onto merged main `59b309f27` so it builds on the comprehensive 0002 docs (avoids regressing 0002).
+- **Upstream drift flagged (not fixed)**: task packets reference `test -f .n` / `repo_marker: ".n"` against a non-existent marker — out of facade scope, recorded for repo owners.

--- a/proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md
@@ -68,3 +68,20 @@ intent=Primary dopemux workspace. Task packets must refuse if repo_id mismatches
 ## Validation — diff within allowlist
 docs/03-reference/dcp/chatgpt-mcp-readonly/DOPEMUX_INIT_REGISTRY_DISCOVERY.md
 docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md
+
+## Final post-commit snapshot (clean tree)
+
+### $ git rev-parse HEAD
+7715e093c4100be00d1829b4bdf4e88575911342
+
+### $ git status --short --branch
+## dcp/chatgpt-mcp-ro-0003-inspect-dopemux-init-registry-co
+ M proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md
+
+### $ git diff --stat 59b309f27ab745a76dee2dfe7c1e6c0c2e0e36fd..HEAD
+ .../DOPEMUX_INIT_REGISTRY_DISCOVERY.md             | 92 ++++++++++++++++++++++
+ .../MULTI_PROJECT_REGISTRY_CONTRACT.md             | 26 +++---
+ proof/TP-DCP-MCP-RO-0003/AUDIT.md                  | 31 ++++++++
+ proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md            | 70 ++++++++++++++++
+ proof/TP-DCP-MCP-RO-0003/PROOF.json                | 46 +++++++++++
+ 5 files changed, 254 insertions(+), 11 deletions(-)

--- a/proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md
@@ -1,0 +1,70 @@
+# COMMAND_LOG — TP-DCP-MCP-RO-0003 (Inspect Dopemux Init Registry Contract)
+
+Read-only static inspection. Run from worktree .worktrees/chatgpt-mcp-ro-0003 (branch reset onto merged main 59b309f27).
+
+## $ git rev-parse --show-toplevel && git branch --show-current && git rev-parse HEAD
+/Users/hue/code/dopemux-mvp/.worktrees/chatgpt-mcp-ro-0003
+dcp/chatgpt-mcp-ro-0003-inspect-dopemux-init-registry-co
+59b309f27ab745a76dee2dfe7c1e6c0c2e0e36fd
+
+## Evidence — dopemux init (cli.py / project_init.py)
+204:from .project_init import init_project
+725:def init(
+770:            f"[warning]⚠️  Project already initialized (.dopemux/ exists)[/warning]"
+780:    success = init_project(workspace, profile, force)
+38:        self.dopemux_dir = self.workspace / ".dopemux"
+114:                self.dopemux_dir = self.workspace / ".dopemux"
+167:        self.dopemux_dir.mkdir(exist_ok=True)
+168:        (self.dopemux_dir / "databases").mkdir(exist_ok=True)
+174:        # Step 4: Create config.yaml (optional project overrides)
+175:        config_file = self.dopemux_dir / "config.yaml"
+178:            console.logger.info(f"   Created: .dopemux/config.yaml")
+188:        console.logger.info(f"  3. (Optional) Edit: [text.dim].dopemux/config.yaml[/text.dim]")
+265:def init_project(workspace: Path, profile: Optional[str], force: bool) -> bool:
+
+## Evidence — workspace detection
+11:2. git rev-parse --show-toplevel (works for worktrees AND main repo!)
+82:def get_workspace_root(start_path: Optional[Path] = None) -> Path:
+129:    # git rev-parse --show-toplevel returns:
+135:            ["git", "rev-parse", "--show-toplevel"],
+184:def export_workspace_env(workspace_path: Optional[Path] = None) -> dict[str, str]:
+222:def validate_workspace(workspace_path: Path) -> tuple[bool, Optional[str]]:
+272:def get_workspace_info(workspace_path: Optional[Path] = None) -> dict[str, any]:
+
+## Evidence — registries
+24:GLOBAL_CONFIG_PATH = CONFIG_DIR / "config.json"
+37:        "default_workspace": None,
+45:    if not GLOBAL_CONFIG_PATH.exists():
+49:        with GLOBAL_CONFIG_PATH.open("r", encoding="utf-8") as fh:
+55:            data.setdefault("default_workspace", None)
+63:    with GLOBAL_CONFIG_PATH.open("w", encoding="utf-8") as fh:
+93:def register_workspace(workspace_path: Path) -> WorkspaceEntry:
+127:def set_default_workspace(workspace_path: Path) -> None:
+130:    config["default_workspace"] = str(workspace_path)
+135:def get_default_workspace() -> Optional[Path]:
+
+## Evidence — repo-root markers (existence + tracking)
+EXISTS .repo_id
+EXISTS .dopetaskroot
+ABSENT .n
+EXISTS .dopemux
+.dopetaskroot
+.repo_id
+
+## Evidence — .repo_id content
+project=dopemux-mvp
+owner=hu3mann
+intent=Primary dopemux workspace. Task packets must refuse if repo_id mismatches.
+
+## Evidence — repo_marker CONFLICT
+141:            "repo_marker": ".dopetaskroot",
+18:    "repo_root_marker",
+95:      "description": "Repository identifier from .repo_id marker."
+97:    "repo_root_marker": {
+
+## Validation — no runtime/service/config changed (expect empty)
+(none)
+
+## Validation — diff within allowlist
+docs/03-reference/dcp/chatgpt-mcp-readonly/DOPEMUX_INIT_REGISTRY_DISCOVERY.md
+docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md

--- a/proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md
@@ -85,3 +85,19 @@ docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md
  proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md            | 70 ++++++++++++++++
  proof/TP-DCP-MCP-RO-0003/PROOF.json                | 46 +++++++++++
  5 files changed, 254 insertions(+), 11 deletions(-)
+
+## Final post-commit snapshot — review round (clean tree)
+
+### $ git rev-parse HEAD
+ac2b4a99ec57ec87ca12274036c627e9a5a41946
+### $ git status --short --branch
+## dcp/chatgpt-mcp-ro-0003-inspect-dopemux-init-registry-co...origin/dcp/chatgpt-mcp-ro-0003-inspect-dopemux-init-registry-co [ahead 1]
+ M proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md
+ M proof/TP-DCP-MCP-RO-0003/PROOF.json
+### $ git diff --stat 59b309f27ab745a76dee2dfe7c1e6c0c2e0e36fd..HEAD
+ .../DOPEMUX_INIT_REGISTRY_DISCOVERY.md             | 92 ++++++++++++++++++++++
+ .../MULTI_PROJECT_REGISTRY_CONTRACT.md             | 30 ++++---
+ proof/TP-DCP-MCP-RO-0003/AUDIT.md                  | 31 ++++++++
+ proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md            | 87 ++++++++++++++++++++
+ proof/TP-DCP-MCP-RO-0003/PROOF.json                | 53 +++++++++++++
+ 5 files changed, 282 insertions(+), 11 deletions(-)

--- a/proof/TP-DCP-MCP-RO-0003/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0003/PROOF.json
@@ -3,22 +3,29 @@
   "title": "Inspect Dopemux Init Registry Contract",
   "branch": "dcp/chatgpt-mcp-ro-0003-inspect-dopemux-init-registry-co",
   "base_sha": "59b309f27ab745a76dee2dfe7c1e6c0c2e0e36fd",
-  "head_sha": "PENDING_POST_COMMIT_SYNC",
+  "head_sha": "7715e093c4100be00d1829b4bdf4e88575911342",
   "task_class": "unknown subsystem/API-sensitive/documentation-sensitive",
   "risk": "MEDIUM",
   "depends_on": "TP-DCP-MCP-RO-0002 (merged via PR #826; 0003 branch reset onto merged main)",
   "outputs": [
     "docs/03-reference/dcp/chatgpt-mcp-readonly/DOPEMUX_INIT_REGISTRY_DISCOVERY.md (created)",
-    "docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md (updated §2/§4/§5/§8)"
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md (updated \u00a72/\u00a74/\u00a75/\u00a78)"
   ],
   "observed_findings": {
-    "init_marker": ".dopemux/ directory — project_init.py:167, checked cli.py:770",
+    "init_marker": ".dopemux/ directory \u2014 project_init.py:167, checked cli.py:770",
     "init_entry": "cli.py:725 -> cli.py:780 init_project(); impl project_init.py:265",
     "workspace_detection": "workspace_detection.py get_workspace_root():82, validate_workspace():222, export_workspace_env():184",
     "identity_marker": ".repo_id (git-tracked; project/owner/intent); canonical per schemas/dcp/dcp_project_resource_map.schema.json",
     "registries": "global ~/.dopemux/config.json (global_config.py:24/93) = opened-workspaces cache (eligibility); services/registry.yaml = services; NO list_projects CLI",
-    "markers_present": [".repo_id", ".dopetaskroot", ".dopemux/", "dopemux.toml"],
-    "markers_absent": [".n (referenced by some task packets but not present)"]
+    "markers_present": [
+      ".repo_id",
+      ".dopetaskroot",
+      ".dopemux/",
+      "dopemux.toml"
+    ],
+    "markers_absent": [
+      ".n (referenced by some task packets but not present)"
+    ]
   },
   "conflicts": [
     "repo_marker fragmentation: .repo_id (task packets / DCP schema) vs .dopetaskroot (operator_workflows.py:141) vs absent .n (RTE/hygiene packets). Facade adopts .repo_id; repo-wide unification out of scope."
@@ -32,13 +39,13 @@
     "precommit_hooks_pass_local": "PASS (frontmatter, filename hygiene, markdownlint, placement)"
   },
   "deviations": [
-    "Discovery doc named DOPEMUX_INIT_REGISTRY_DISCOVERY.md (ALL_CAPS) vs packet's Dopemux_INIT_… spelling, for filename-hygiene-hook conformance + dir consistency.",
+    "Discovery doc named DOPEMUX_INIT_REGISTRY_DISCOVERY.md (ALL_CAPS) vs packet's Dopemux_INIT_\u2026 spelling, for filename-hygiene-hook conformance + dir consistency.",
     "0003 branch reset from stub commit 78b04fb33 onto merged main 59b309f27."
   ],
   "residual_risks": [
-    "CONFLICTING repo-marker fragmentation (.repo_id/.dopetaskroot/.n) — operator/0004 to resolve canonical marker.",
-    "UNKNOWN: whether facade asserts .repo_id intent/owner beyond project at resolve time — deferred to 0004.",
-    "Upstream drift: task packets reference non-existent .n marker — flagged, not fixed (out of scope)."
+    "CONFLICTING repo-marker fragmentation (.repo_id/.dopetaskroot/.n) \u2014 operator/0004 to resolve canonical marker.",
+    "UNKNOWN: whether facade asserts .repo_id intent/owner beyond project at resolve time \u2014 deferred to 0004.",
+    "Upstream drift: task packets reference non-existent .n marker \u2014 flagged, not fixed (out of scope)."
   ],
   "embedded_audit": "PASS_WITH_RISKS",
   "command_log": "proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md",

--- a/proof/TP-DCP-MCP-RO-0003/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0003/PROOF.json
@@ -3,7 +3,7 @@
   "title": "Inspect Dopemux Init Registry Contract",
   "branch": "dcp/chatgpt-mcp-ro-0003-inspect-dopemux-init-registry-co",
   "base_sha": "59b309f27ab745a76dee2dfe7c1e6c0c2e0e36fd",
-  "head_sha": "7715e093c4100be00d1829b4bdf4e88575911342",
+  "head_sha": "ac2b4a99ec57ec87ca12274036c627e9a5a41946",
   "task_class": "unknown subsystem/API-sensitive/documentation-sensitive",
   "risk": "MEDIUM",
   "depends_on": "TP-DCP-MCP-RO-0002 (merged via PR #826; 0003 branch reset onto merged main)",
@@ -49,5 +49,8 @@
   ],
   "embedded_audit": "PASS_WITH_RISKS",
   "command_log": "proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md",
-  "audit": "proof/TP-DCP-MCP-RO-0003/AUDIT.md"
+  "audit": "proof/TP-DCP-MCP-RO-0003/AUDIT.md",
+  "review_feedback_round": {
+    "P2_registry_owner_field": "FIXED \u2014 added identity{project(required),owner(optional)} to \u00a73 schema; \u00a74.5/\u00a75 owner check made conditional (only enforced when identity.owner declared) so it is always satisfiable."
+  }
 }

--- a/proof/TP-DCP-MCP-RO-0003/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0003/PROOF.json
@@ -1,0 +1,46 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0003",
+  "title": "Inspect Dopemux Init Registry Contract",
+  "branch": "dcp/chatgpt-mcp-ro-0003-inspect-dopemux-init-registry-co",
+  "base_sha": "59b309f27ab745a76dee2dfe7c1e6c0c2e0e36fd",
+  "head_sha": "PENDING_POST_COMMIT_SYNC",
+  "task_class": "unknown subsystem/API-sensitive/documentation-sensitive",
+  "risk": "MEDIUM",
+  "depends_on": "TP-DCP-MCP-RO-0002 (merged via PR #826; 0003 branch reset onto merged main)",
+  "outputs": [
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/DOPEMUX_INIT_REGISTRY_DISCOVERY.md (created)",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md (updated §2/§4/§5/§8)"
+  ],
+  "observed_findings": {
+    "init_marker": ".dopemux/ directory — project_init.py:167, checked cli.py:770",
+    "init_entry": "cli.py:725 -> cli.py:780 init_project(); impl project_init.py:265",
+    "workspace_detection": "workspace_detection.py get_workspace_root():82, validate_workspace():222, export_workspace_env():184",
+    "identity_marker": ".repo_id (git-tracked; project/owner/intent); canonical per schemas/dcp/dcp_project_resource_map.schema.json",
+    "registries": "global ~/.dopemux/config.json (global_config.py:24/93) = opened-workspaces cache (eligibility); services/registry.yaml = services; NO list_projects CLI",
+    "markers_present": [".repo_id", ".dopetaskroot", ".dopemux/", "dopemux.toml"],
+    "markers_absent": [".n (referenced by some task packets but not present)"]
+  },
+  "conflicts": [
+    "repo_marker fragmentation: .repo_id (task packets / DCP schema) vs .dopetaskroot (operator_workflows.py:141) vs absent .n (RTE/hygiene packets). Facade adopts .repo_id; repo-wide unification out of scope."
+  ],
+  "validation": {
+    "marker_findings_observed_with_file_line": "PASS",
+    "no_runtime_service_config_files_changed": "PASS",
+    "registry_contract_fail_closed": "PASS",
+    "unknowns_preserved": "PASS",
+    "diff_within_allowlist": "PASS",
+    "precommit_hooks_pass_local": "PASS (frontmatter, filename hygiene, markdownlint, placement)"
+  },
+  "deviations": [
+    "Discovery doc named DOPEMUX_INIT_REGISTRY_DISCOVERY.md (ALL_CAPS) vs packet's Dopemux_INIT_… spelling, for filename-hygiene-hook conformance + dir consistency.",
+    "0003 branch reset from stub commit 78b04fb33 onto merged main 59b309f27."
+  ],
+  "residual_risks": [
+    "CONFLICTING repo-marker fragmentation (.repo_id/.dopetaskroot/.n) — operator/0004 to resolve canonical marker.",
+    "UNKNOWN: whether facade asserts .repo_id intent/owner beyond project at resolve time — deferred to 0004.",
+    "Upstream drift: task packets reference non-existent .n marker — flagged, not fixed (out of scope)."
+  ],
+  "embedded_audit": "PASS_WITH_RISKS",
+  "command_log": "proof/TP-DCP-MCP-RO-0003/COMMAND_LOG.md",
+  "audit": "proof/TP-DCP-MCP-RO-0003/AUDIT.md"
+}


### PR DESCRIPTION
## Objective
Resolve the `dopemux init` / workspace-identity marker contract that TP-DCP-MCP-RO-0002 left `UNKNOWN`, via **read-only static inspection**, and ground the facade registry contract in evidence. Docs-only; no runtime code.

## Scope
- **Create** `docs/03-reference/dcp/chatgpt-mcp-readonly/DOPEMUX_INIT_REGISTRY_DISCOVERY.md`
- **Update** `docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md` §2/§4/§5/§8
- Proof bundle `proof/TP-DCP-MCP-RO-0003/`
- **No** `src/`, `services/`, `docker/`, `compose*`, or `.dopemux` changes.

## Key findings (all OBSERVED with file:line)
- **Init marker** = `.dopemux/` directory (`project_init.py:167`, checked `cli.py:770`).
- **Detection** = `workspace_detection.py` `get_workspace_root():82` / `validate_workspace():222` (git-toplevel based).
- **Identity** = `.repo_id` (git-tracked: project/owner/intent), canonical per `schemas/dcp/dcp_project_resource_map.schema.json`.
- **No `list_projects` CLI**; `~/.dopemux/config.json` (`global_config.py`) is an *opened-workspaces cache* = eligibility, **not** exposure → facade keeps its own explicit allowlist (confirms 0002 D2).
- **CONFLICTING** repo-marker fragmentation: `.repo_id` vs `.dopetaskroot` (`operator_workflows.py:141`) vs the **absent** `.n` (referenced by some task packets / `BOOTSTRAP.md`). Facade adopts `.repo_id`; repo-wide unification out of scope.

## Contract changes
§2 cites the `.dopemux/` eligibility marker and forbids deriving exposure from the global registry. §4/§5 add the fail-closed eligibility (`.dopemux/` + `validate_workspace()`) and identity (`.repo_id` match) checks. §8 marks the two prior UNKNOWNs RESOLVED and retains the marker `CONFLICT`.

## Validation
- ✅ Marker findings reproduced from the tree (see `COMMAND_LOG.md`).
- ✅ No `src/`/`services/`/`docker/`/`compose` touched; diff within allowlist.
- ✅ pre-commit (frontmatter, filename hygiene, markdownlint, placement) pass locally.

## Embedded audit
PASS_WITH_RISKS — `proof/TP-DCP-MCP-RO-0003/AUDIT.md` (findings observed, no implementation, fail-closed, UNKNOWNs preserved).

## Risks / deviations
- Discovery doc uses ALL_CAPS `DOPEMUX_INIT_REGISTRY_DISCOVERY.md` (vs packet's `Dopemux_INIT_…`) for filename-hygiene conformance.
- 0003 branch reset from stale stub `78b04fb33` onto merged main `59b309f27`.
- Upstream drift flagged (not fixed): task packets reference a non-existent `.n` marker.

## Rollback
`git revert 377386f99 7715e093c` or reset branch to `59b309f27`.

## Proof bundle
`proof/TP-DCP-MCP-RO-0003/{PROOF.json,COMMAND_LOG.md,AUDIT.md}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)