### PR TITLE
Scaffold DCP readonly MCP facade with registry and proof tools (TP-DCP-MCP-RO-0004)

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md
@@ -1,0 +1,74 @@
+---
+id: dcp-mcp-readonly-facade-local-run
+title: DCP Read-Only MCP Facade — Local Run & Test
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-05'
+last_review: '2026-06-05'
+next_review: '2026-09-03'
+prelude: Local setup, registry configuration, and tests for the read-only MCP evidence facade scaffold for dopemux documentation and developer workflows.
+---
+
+# Facade Local Run & Test
+
+The TP-DCP-MCP-RO-0004 scaffold lives at `services/dcp-readonly-facade/`. It is a
+loopback-only, read-only MCP server. This guide covers configuring the registry,
+running the server locally, and running the tests. (Tunnel/connector wiring is
+TP-DCP-MCP-RO-0007; backend adapters are 0005/0006.)
+
+## 1. Configure the registry (outside the repo, no secrets)
+
+The registry is the trust boundary. **Do not commit a populated registry.**
+
+```bash
+mkdir -p ~/.dopemux
+cp services/dcp-readonly-facade/registry.example.yaml ~/.dopemux/dcp-facade-registry.yaml
+# edit ~/.dopemux/dcp-facade-registry.yaml: set workspace_path, identity.project, enabled
+export DCP_FACADE_REGISTRY=~/.dopemux/dcp-facade-registry.yaml
+```
+
+Resolution order for the registry path: `$DCP_FACADE_REGISTRY` → default
+`~/.dopemux/dcp-facade-registry.yaml`. A missing file loads an **empty** registry
+(every lookup returns `BLOCKED`) — fail-closed by design.
+
+A project is only exposed when it has an `enabled: true` entry **and** the
+workspace passes resolution: contained in an `approved_root`, has a `.dopemux/`
+directory, validates as a workspace, and its `.repo_id` `project` (and `owner`
+if declared) match the entry's `identity`.
+
+## 2. Run the server (stdio)
+
+```bash
+cd services/dcp-readonly-facade
+python -m src.mcp.server          # DCP_FACADE_TRANSPORT defaults to stdio
+```
+
+`fastmcp` is an optional dependency (root `pyproject.toml` `[services]` extra).
+When it is not installed the server falls back to a no-op stub for import
+safety; install `fastmcp` for a live MCP endpoint.
+
+## 3. Run the tests
+
+```bash
+python -m pytest -q services/dcp-readonly-facade/tests
+```
+
+Tests build real temporary git workspaces (with `.dopemux/`, `.repo_id`, proof
+bundles) and exercise the fail-closed paths: unknown/disabled project → `BLOCKED`;
+symlink/cross-project/`..` proof access → `BLOCKED`; stale-proof and dirty-worktree
+→ `warnings`; absolute paths and secrets → redacted.
+
+## 4. Tools (Phase 1)
+
+| Tool | `project_id` | Returns |
+| --- | --- | --- |
+| `list_projects` | no | enabled projects + configured capabilities |
+| `get_project_capabilities` | yes | which backends are configured |
+| `get_repo_state_snapshot` | yes | branch / head_sha / dirty (read-only git) |
+| `list_proof_bundles` | yes | proof bundle ids under `<workspace>/proof/` (cap 20) |
+| `fetch_proof_bundle` | yes | one bundle's files (containment + symlink safe) |
+
+All return the canonical envelope (see
+[RESPONSE_ENVELOPE_SCHEMA.md](RESPONSE_ENVELOPE_SCHEMA.md)); missing/denied reads
+yield `PARTIAL`/`BLOCKED`, never guessed data.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md
@@ -23,8 +23,10 @@ prelude: Phase-1 tool contract, allowed/denied routes, and authority labels for 
 | `list_projects` | no | registry | facade | Returns approved (`enabled`) projects only. |
 | `get_project_capabilities` | yes | registry + reachability | facade | Reports which backends are bound/available. |
 | `get_repo_state_snapshot` | yes | local git (fixed cmd allowlist) | OBSERVED/git | branch, head_sha, dirty state. No arbitrary git. |
-| `list_proof_bundles` | yes | filesystem (proof roots) | OBSERVED/fs | packet_id regex; bounded to proof roots. |
-| `fetch_proof_bundle` | yes | filesystem (proof roots) | OBSERVED/fs | Cannot cross project root; symlink-escape blocked. |
+| `list_proof_bundles` | yes | filesystem (proof roots) | OBSERVED/fs | optional `packet_id_filter` = **literal substring** (≤128 chars, **not** a regex — avoids ReDoS); bounded to proof roots; cap 20. |
+| `fetch_proof_bundle` | yes | filesystem (proof roots) | OBSERVED/fs | Cannot cross project root; symlink-escape blocked; bounded read (256KB/file). |
+
+> **Note (0004 implementation):** `list_proof_bundles`' filter is a literal substring, not a regex. Accepting an untrusted caller-supplied regex is a ReDoS (catastrophic-backtracking) DoS surface; the scaffold therefore matches a bounded literal substring instead. The 0001 inventory / earlier drafts referred to a "packet_id regex" — superseded here for safety.
 
 ### 1b. ConPort + dope-memory read tools — packet 0005
 

--- a/proof/TP-DCP-MCP-RO-0004/AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0004/AUDIT.md
@@ -1,0 +1,39 @@
+# Audit — TP-DCP-MCP-RO-0004 (Facade Scaffold)
+
+Auditor focus per packet `embedded_audit`. Verdict: **PASS_WITH_RISKS** (non-blocking residual risks tracked; HIGH-risk security review completed).
+
+## 1. Can any tool read outside a registered root?
+
+No (within the threat model). Every project-scoped tool resolves through `resolver.resolve()` first (fail-closed): unknown/disabled → `BLOCKED`; `workspace_path` is `realpath`-canonicalized and must be contained in a registry `approved_root`; must contain `.dopemux/` and pass `validate_workspace()`; `.repo_id` `project` (and `owner` iff declared) must match the registry `identity`. Proof reads (`proofs.fetch_bundle`) are confined to `<workspace>/proof/`: the `bundle_id` is a single validated segment, the target is `resolve()`d and re-checked with `relative_to(proof_root)`, and **each file is opened by its resolved path** after a second containment check (closes a check/use TOCTOU window flagged by PAL codereview). Tests cover unknown/disabled, approved-root escape, symlink-workspace escape, symlink-proof escape, cross-project, and `..`/separator bundle ids.
+
+## 2. Can a caller supply a raw path or shell?
+
+No. No tool accepts a filesystem path, URL, port, route, or shell. Callers supply only `project_id`, an optional `packet_id_filter` (a **literal substring**, ≤128 chars — **not** a regex, eliminating the ReDoS surface PAL flagged), and a `bundle_id` (single-segment). `gitstate` runs ONLY a hardcoded argv allowlist (`rev-parse HEAD`, `rev-parse --abbrev-ref HEAD`, `status --porcelain`), `shell=False`, `cwd` = the resolver-chosen workspace, with no caller interpolation. `rg` confirms `src/` has no `write_*`/`open('w')`/`mkdir`/`rmtree`/`shell=True`/`os.system`; the only `subprocess` use is the fixed git allowlist.
+
+## 3. Are outputs redacted and enveloped?
+
+Yes. Every tool returns the canonical envelope (full key set, `OK|PARTIAL|BLOCKED`, never guessed data). All `data` passes `redaction.redact_value`, which recursively masks (a) registry/workspace roots, (b) a broadened set of generic absolute roots (`/Users//home//root//private//mnt//var//opt//srv//usr//etc//tmp/...`) plus any deep (≥3-segment) absolute path, and (c) secret patterns (`sk-`, `gh*_`, `AKIA`, `Bearer`, `API_KEY|TOKEN|PASSWORD|SECRET`=VALUE). Per PAL codereview, **dict keys are also redacted** (proof JSON could carry secrets/paths in keys). Tests assert paths + secrets (including in keys) are stripped and the `redactions` categories are reported.
+
+## 4. Is proof staleness detected?
+
+Yes. `fetch_proof_bundle` reads the current repo head via `gitstate` and compares it to the bundle's `PROOF.json` `head_sha`/`commit_sha`; a mismatch emits a `stale proof bundle` warning and sets `data.stale=true`. Dirty-worktree warnings are emitted by `get_repo_state_snapshot`. Both are tested.
+
+## PAL codereview (gpt-5.2, HIGH-risk gate)
+
+Ran `pal/codereview` (security, external) on resolver/proofs/redaction/gitstate/tools. Findings and dispositions:
+
+- 🔴 **Unbounded file read before cap** → FIXED: bounded `open('rb').read(cap+1)` of the resolved path.
+- 🔴 **ReDoS via caller `packet_id_regex`** → FIXED: replaced with a length-capped literal substring `packet_id_filter`; TOOL_CONTRACT §1a updated; no caller regex remains.
+- 🟠 **TOCTOU (validate `f.resolve()` but read `f`)** → FIXED: read the resolved path.
+- 🟠 **Redaction misses non-home absolute roots + dict keys** → FIXED: broadened roots + deep-path token; dict keys redacted.
+- 🟡 **iterdir DoS on huge proof/** → FIXED: scan bounded to `MAX_BUNDLES*5` before sort.
+- 🟡 **broad `except Exception`** → FIXED: narrowed to `OSError`/`RuntimeError`/`ValueError`.
+- 🟡 **`.repo_id` case-sensitivity** / 🟢 **gitstate error-swallow** → left as-is: exact match is the safer (fail-closed) behavior; swallowing git errors yields `None`/`PARTIAL`, never fabricated data. Noted as accepted.
+
+## Deviations / residual risks (non-blocking)
+
+- **`services/registry.yaml` NOT updated**: the services CLAUDE.md asks new services to register there, but the packet's `forbidden_files` lists `services/registry.yaml`, and this is a stdio MCP server (no HTTP `/health` port). Packet authority wins; not registered. Flagged for operator.
+- **`packet_id_filter` supersedes the inventory's "packet_id regex"**: a deliberate security-driven contract change (documented in TOOL_CONTRACT §1a).
+- **fastmcp optional**: not installed in this env; `src/mcp/server.py` falls back to a no-op stub for import/compile safety. Tests target the pure `dcp_facade` package (no MCP dep). Live MCP endpoint requires `fastmcp` (root `[services]` extra).
+- **Redaction is heuristic** (defence-in-depth), not a proof of zero-leak; deep-path scrub may over-redact (acceptable: "when unsure, redact"). Hardening/adversarial coverage continues in TP-DCP-MCP-RO-0008.
+- Reachability of `service_profiles` is not probed here (configured-only); live binding is 0005/0006.

--- a/proof/TP-DCP-MCP-RO-0004/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0004/COMMAND_LOG.md
@@ -1,0 +1,54 @@
+# COMMAND_LOG — TP-DCP-MCP-RO-0004 (Facade Scaffold)
+
+Worktree .worktrees/chatgpt-mcp-ro-0004; branch reset onto latest origin/main.
+
+## $ git rev-parse --show-toplevel && git branch --show-current && git rev-parse HEAD
+/Users/hue/code/dopemux-mvp/.worktrees/chatgpt-mcp-ro-0004
+dcp/chatgpt-mcp-ro-0004-facade-scaffold-registry-resolve
+9334c2005f16706a96e6433b9c4e6522a9ee5b45
+
+## $ python -m pytest -q services/dcp-readonly-facade/tests
+...................................................                      [100%]
+exit=0
+
+## $ python -m compileall -q services/dcp-readonly-facade
+exit=0
+
+## hazard grep over IMPLEMENTATION (src) — write/shell (expect none)
+(none — no writes/shell in implementation)
+
+## subprocess in src (expected: gitstate fixed read-only argv allowlist only)
+services/dcp-readonly-facade/src/dcp_facade/gitstate.py:12:import subprocess
+services/dcp-readonly-facade/src/dcp_facade/gitstate.py:29:        result = subprocess.run(  # noqa: S603 - fixed argv, shell=False, no caller input
+services/dcp-readonly-facade/src/dcp_facade/gitstate.py:37:    except (OSError, subprocess.SubprocessError):
+
+## caller-supplied regex? (expect none — packet_id_filter is a literal substring)
+(none)
+
+## diff name-only vs origin/main (allowlist check)
+docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md
+docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md
+services/dcp-readonly-facade/README.md
+services/dcp-readonly-facade/conftest.py
+services/dcp-readonly-facade/registry.example.yaml
+services/dcp-readonly-facade/src/dcp_facade/__init__.py
+services/dcp-readonly-facade/src/dcp_facade/envelope.py
+services/dcp-readonly-facade/src/dcp_facade/gitstate.py
+services/dcp-readonly-facade/src/dcp_facade/proofs.py
+services/dcp-readonly-facade/src/dcp_facade/redaction.py
+services/dcp-readonly-facade/src/dcp_facade/registry.py
+services/dcp-readonly-facade/src/dcp_facade/resolver.py
+services/dcp-readonly-facade/src/dcp_facade/tools.py
+services/dcp-readonly-facade/src/mcp/__init__.py
+services/dcp-readonly-facade/src/mcp/fastmcp_stub.py
+services/dcp-readonly-facade/src/mcp/server.py
+services/dcp-readonly-facade/tests/test_envelope.py
+services/dcp-readonly-facade/tests/test_gitstate.py
+services/dcp-readonly-facade/tests/test_proofs.py
+services/dcp-readonly-facade/tests/test_redaction.py
+services/dcp-readonly-facade/tests/test_registry.py
+services/dcp-readonly-facade/tests/test_resolver.py
+services/dcp-readonly-facade/tests/test_tools.py
+
+## outside-allowlist files (expect none)
+(none — diff within allowlist)

--- a/proof/TP-DCP-MCP-RO-0004/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0004/COMMAND_LOG.md
@@ -52,3 +52,22 @@ services/dcp-readonly-facade/tests/test_tools.py
 
 ## outside-allowlist files (expect none)
 (none — diff within allowlist)
+
+## Final post-commit snapshot (clean tree)
+
+### $ git rev-parse HEAD
+0a25035a7ec8e7ec877bc78b412c7e206170ffb6
+### $ git status --short --branch
+## dcp/chatgpt-mcp-ro-0004-facade-scaffold-registry-resolve...origin/main [ahead 1]
+ M proof/TP-DCP-MCP-RO-0004/COMMAND_LOG.md
+### $ git diff --stat 9334c2005f16706a96e6433b9c4e6522a9ee5b45..HEAD
+ .../dcp-readonly-facade/src/mcp/fastmcp_stub.py    |  31 ++++
+ services/dcp-readonly-facade/src/mcp/server.py     |  82 ++++++++++
+ .../dcp-readonly-facade/tests/test_envelope.py     |  39 +++++
+ .../dcp-readonly-facade/tests/test_gitstate.py     |  34 +++++
+ services/dcp-readonly-facade/tests/test_proofs.py  | 102 +++++++++++++
+ .../dcp-readonly-facade/tests/test_redaction.py    |  71 +++++++++
+ .../dcp-readonly-facade/tests/test_registry.py     |  90 +++++++++++
+ .../dcp-readonly-facade/tests/test_resolver.py     | 113 ++++++++++++++
+ services/dcp-readonly-facade/tests/test_tools.py   | 107 +++++++++++++
+ 26 files changed, 1954 insertions(+), 2 deletions(-)

--- a/proof/TP-DCP-MCP-RO-0004/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0004/PROOF.json
@@ -1,0 +1,62 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0004",
+  "title": "Facade Scaffold Registry Resolver Repo Proof Tools",
+  "branch": "dcp/chatgpt-mcp-ro-0004-facade-scaffold-registry-resolve",
+  "base_branch": "main",
+  "head_sha": "PENDING_POST_COMMIT_SYNC",
+  "task_class": "implementation/security-sensitive",
+  "risk": "HIGH",
+  "depends_on": "TP-DCP-MCP-RO-0003 (merged via PR #828)",
+  "scaffold": "services/dcp-readonly-facade/ (net-new): src/dcp_facade/{envelope,redaction,registry,resolver,gitstate,proofs,tools}.py + src/mcp/{server,fastmcp_stub}.py + tests/ + registry.example.yaml + README.md",
+  "tools_implemented": [
+    "list_projects (no project_id; enabled-only)",
+    "get_project_capabilities (project_id)",
+    "get_repo_state_snapshot (project_id; fixed git allowlist)",
+    "list_proof_bundles (project_id; literal packet_id_filter; cap 20)",
+    "fetch_proof_bundle (project_id; containment + symlink safe; 256KB/file)"
+  ],
+  "validation": {
+    "pytest": "PASS (51 passed)",
+    "compileall": "PASS",
+    "no_writes_or_shell_in_implementation": "PASS (rg: src/ has no write_text/open(w)/mkdir/rmtree/shell=True/os.system)",
+    "subprocess_is_fixed_git_allowlist_only": "PASS (gitstate.py only; shell=False; fixed argv)",
+    "no_caller_supplied_regex": "PASS (packet_id_filter is a literal substring)",
+    "diff_within_allowlist": "PASS (services/dcp-readonly-facade, docs/03-reference/dcp/chatgpt-mcp-readonly, proof/TP-DCP-MCP-RO-0004)",
+    "no_forbidden_files_touched": "PASS (no src/, other services, docker, compose, .dopemux, .env, services/registry.yaml)",
+    "precommit_docs": "PASS (markdownlint, docs-frontmatter-guard on FACADE_LOCAL_RUN.md + TOOL_CONTRACT.md)"
+  },
+  "fail_closed_tests": [
+    "unknown project -> BLOCKED",
+    "disabled project -> BLOCKED",
+    "missing .dopemux -> BLOCKED",
+    "identity project/owner mismatch -> BLOCKED (owner conditional)",
+    "workspace escapes approved roots / symlink workspace escape -> BLOCKED",
+    "proof bundle .. / separators / leading-dot -> BLOCKED",
+    "symlink proof escape -> BLOCKED",
+    "cross-project bundle -> not found",
+    "stale proof head_sha mismatch -> warning; dirty worktree -> warning",
+    "overlong packet_id_filter -> BLOCKED",
+    "redaction strips abs paths (incl deep + dict keys) + secrets"
+  ],
+  "pal_codereview": {
+    "tool": "pal/codereview (security, external)",
+    "model": "gpt-5.2",
+    "critical_fixed": ["unbounded-read-before-cap", "ReDoS via packet_id_regex"],
+    "high_fixed": ["TOCTOU read-via-unresolved-path", "redaction misses non-home roots + dict keys"],
+    "medium_fixed": ["iterdir DoS scan-bound", "broad except narrowed"],
+    "accepted_as_is": ["repo_id case-sensitive (fail-closed)", "gitstate swallows errors -> None/PARTIAL"]
+  },
+  "deviations": [
+    "services/registry.yaml NOT updated (packet forbidden_files; stdio MCP server, not HTTP service) — flagged for operator.",
+    "packet_id_filter (literal substring) supersedes the inventory's 'packet_id regex' for ReDoS safety; TOOL_CONTRACT updated.",
+    "branch reset onto latest origin/main before commit (net-new facade; untracked files preserved)."
+  ],
+  "residual_risks": [
+    "Redaction is heuristic defence-in-depth, not a zero-leak proof; deep-path scrub may over-redact (acceptable).",
+    "fastmcp optional/not-installed -> server falls back to no-op stub; live endpoint needs fastmcp.",
+    "service_profiles reachability not probed (configured-only); live binding in 0005/0006."
+  ],
+  "embedded_audit": "PASS_WITH_RISKS",
+  "command_log": "proof/TP-DCP-MCP-RO-0004/COMMAND_LOG.md",
+  "audit": "proof/TP-DCP-MCP-RO-0004/AUDIT.md"
+}

--- a/proof/TP-DCP-MCP-RO-0004/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0004/PROOF.json
@@ -3,7 +3,7 @@
   "title": "Facade Scaffold Registry Resolver Repo Proof Tools",
   "branch": "dcp/chatgpt-mcp-ro-0004-facade-scaffold-registry-resolve",
   "base_branch": "main",
-  "head_sha": "PENDING_POST_COMMIT_SYNC",
+  "head_sha": "0a25035a7ec8e7ec877bc78b412c7e206170ffb6",
   "task_class": "implementation/security-sensitive",
   "risk": "HIGH",
   "depends_on": "TP-DCP-MCP-RO-0003 (merged via PR #828)",
@@ -41,13 +41,25 @@
   "pal_codereview": {
     "tool": "pal/codereview (security, external)",
     "model": "gpt-5.2",
-    "critical_fixed": ["unbounded-read-before-cap", "ReDoS via packet_id_regex"],
-    "high_fixed": ["TOCTOU read-via-unresolved-path", "redaction misses non-home roots + dict keys"],
-    "medium_fixed": ["iterdir DoS scan-bound", "broad except narrowed"],
-    "accepted_as_is": ["repo_id case-sensitive (fail-closed)", "gitstate swallows errors -> None/PARTIAL"]
+    "critical_fixed": [
+      "unbounded-read-before-cap",
+      "ReDoS via packet_id_regex"
+    ],
+    "high_fixed": [
+      "TOCTOU read-via-unresolved-path",
+      "redaction misses non-home roots + dict keys"
+    ],
+    "medium_fixed": [
+      "iterdir DoS scan-bound",
+      "broad except narrowed"
+    ],
+    "accepted_as_is": [
+      "repo_id case-sensitive (fail-closed)",
+      "gitstate swallows errors -> None/PARTIAL"
+    ]
   },
   "deviations": [
-    "services/registry.yaml NOT updated (packet forbidden_files; stdio MCP server, not HTTP service) — flagged for operator.",
+    "services/registry.yaml NOT updated (packet forbidden_files; stdio MCP server, not HTTP service) \u2014 flagged for operator.",
     "packet_id_filter (literal substring) supersedes the inventory's 'packet_id regex' for ReDoS safety; TOOL_CONTRACT updated.",
     "branch reset onto latest origin/main before commit (net-new facade; untracked files preserved)."
   ],

--- a/services/dcp-readonly-facade/README.md
+++ b/services/dcp-readonly-facade/README.md
@@ -1,0 +1,37 @@
+# DCP read-only MCP evidence facade (Phase 1 scaffold)
+
+Loopback-only, **read-only** MCP server that projects repository evidence from a
+registered dopemux workspace to ChatGPT. It holds no write authority and is an
+evidence projection layer, not a canonical source.
+
+This is the **TP-DCP-MCP-RO-0004 scaffold**: registry + resolver + envelope +
+redaction + five local/git/proof tools. Backend adapters (ConPort, dope-memory,
+dope-context, task-orchestrator) are added in 0005/0006.
+
+## Layout
+
+- `src/dcp_facade/` — pure logic (no MCP dependency): `envelope`, `redaction`,
+  `registry`, `resolver`, `gitstate`, `proofs`, `tools`.
+- `src/mcp/server.py` — thin FastMCP wiring (delegates to `dcp_facade.tools`).
+- `tests/` — pytest suite (registry/resolver/proofs/gitstate/envelope/redaction/tools).
+- `registry.example.yaml` — example registry (no secrets).
+
+## Phase-1 tools
+
+`list_projects`, `get_project_capabilities`, `get_repo_state_snapshot`,
+`list_proof_bundles`, `fetch_proof_bundle`. Every project-scoped tool requires
+`project_id`; results are wrapped in the canonical envelope and redacted.
+
+## Run / test
+
+See [FACADE_LOCAL_RUN.md](../../docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md)
+for setup. Quick start:
+
+```bash
+export DCP_FACADE_REGISTRY=~/.dopemux/dcp-facade-registry.yaml   # outside the repo
+python -m pytest -q services/dcp-readonly-facade/tests
+python -m src.mcp.server          # from services/dcp-readonly-facade/ (stdio transport)
+```
+
+Contracts: `docs/03-reference/dcp/chatgpt-mcp-readonly/` (ARCHITECTURE,
+TOOL_CONTRACT, RESPONSE_ENVELOPE_SCHEMA, SECURITY_MODEL, MULTI_PROJECT_REGISTRY_CONTRACT).

--- a/services/dcp-readonly-facade/conftest.py
+++ b/services/dcp-readonly-facade/conftest.py
@@ -1,0 +1,125 @@
+"""Pytest bootstrap + fixtures for the DCP read-only facade.
+
+Adds the facade ``src`` to ``sys.path`` (repo ``src`` is already on
+pytest ``pythonpath`` for the dopemux import). Fixtures build real temporary
+git workspaces with ``.dopemux/``, ``.repo_id``, and proof bundles so the
+resolver/gitstate/proofs logic is exercised against genuine on-disk state.
+
+All filesystem writes here are TEST-FIXTURE setup only; the facade
+implementation modules perform no writes.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+_FACADE_SRC = Path(__file__).resolve().parent / "src"
+if str(_FACADE_SRC) not in sys.path:
+    sys.path.insert(0, str(_FACADE_SRC))
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def make_workspace(tmp_path_factory):
+    """Factory building a real git workspace.
+
+    Returns a dict: {path, head_sha}. Options control eligibility/identity
+    fixtures (missing .dopemux, missing/mismatched .repo_id), dirty state, and
+    proof bundles. ``bundles`` maps bundle_id -> PROOF.json dict.
+    """
+
+    def _make(
+        name: str = "ws",
+        *,
+        project: str = "testproj",
+        owner: Optional[str] = "tester",
+        with_dopemux: bool = True,
+        with_repo_id: bool = True,
+        dirty: bool = False,
+        bundles: Optional[dict] = None,
+        extra_proof_files: Optional[dict] = None,
+    ) -> dict:
+        ws = tmp_path_factory.mktemp(name)
+        _git(ws, "init", "-q")
+        _git(ws, "config", "user.email", "t@example.test")
+        _git(ws, "config", "user.name", "tester")
+        if with_dopemux:
+            (ws / ".dopemux").mkdir()
+        (ws / "README.md").write_text("hello\n", encoding="utf-8")
+        if with_repo_id:
+            lines = [f"project={project}"]
+            if owner is not None:
+                lines.append(f"owner={owner}")
+            (ws / ".repo_id").write_text("\n".join(lines) + "\n", encoding="utf-8")
+        if bundles:
+            for bname, proof_meta in bundles.items():
+                bdir = ws / "proof" / bname
+                bdir.mkdir(parents=True)
+                (bdir / "PROOF.json").write_text(json.dumps(proof_meta), encoding="utf-8")
+                (bdir / "AUDIT.md").write_text(f"# audit {bname}\n", encoding="utf-8")
+        if extra_proof_files:
+            for relpath, content in extra_proof_files.items():
+                fp = ws / "proof" / relpath
+                fp.parent.mkdir(parents=True, exist_ok=True)
+                fp.write_text(content, encoding="utf-8")
+        _git(ws, "add", "-A")
+        _git(ws, "commit", "-q", "-m", "init")
+        head = _git(ws, "rev-parse", "HEAD")
+        if dirty:
+            (ws / "uncommitted.txt").write_text("dirty\n", encoding="utf-8")
+        return {"path": ws, "head_sha": head}
+
+    return _make
+
+
+@pytest.fixture
+def build_registry():
+    """Build an in-memory Registry from project dicts (no file IO)."""
+    from dcp_facade.registry import parse_registry
+
+    def _build(projects: list[dict], approved_roots: Optional[list[str]] = None):
+        doc: dict = {"projects": projects}
+        if approved_roots is not None:
+            doc["approved_roots"] = approved_roots
+        return parse_registry(doc)
+
+    return _build
+
+
+@pytest.fixture
+def project_entry():
+    """Helper to construct a registry project dict pointing at a workspace."""
+
+    def _entry(
+        ws_path: Path,
+        *,
+        project_id: str = "proj",
+        identity_project: str = "testproj",
+        identity_owner: Optional[str] = "tester",
+        enabled: bool = True,
+        service_profiles: Optional[dict] = None,
+    ) -> dict:
+        identity: dict = {"project": identity_project}
+        if identity_owner is not None:
+            identity["owner"] = identity_owner
+        return {
+            "project_id": project_id,
+            "workspace_path": str(ws_path),
+            "enabled": enabled,
+            "identity": identity,
+            "service_profiles": service_profiles or {},
+        }
+
+    return _entry

--- a/services/dcp-readonly-facade/registry.example.yaml
+++ b/services/dcp-readonly-facade/registry.example.yaml
@@ -1,0 +1,31 @@
+# DCP read-only MCP facade — EXAMPLE registry (no secrets).
+#
+# Copy this to a path OUTSIDE the repo and point $DCP_FACADE_REGISTRY at it
+# (default: ~/.dopemux/dcp-facade-registry.yaml). NEVER commit a populated
+# registry with real workspace paths or service credentials.
+#
+# Contract: docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md
+
+# Optional: workspaces must resolve (symlink-followed) inside one of these.
+approved_roots:
+  - /abs/approved/root
+
+projects:
+  - project_id: "dopemux-mvp"          # opaque caller-facing id (the only handle a caller may supply)
+    workspace_path: "/abs/approved/root/dopemux-mvp"
+    enabled: true                       # exposure switch; omit/false = NOT exposed
+    identity:                           # matched against the workspace's .repo_id
+      project: "dopemux-mvp"            # REQUIRED; must equal .repo_id `project=`
+      owner: "hu3mann"                  # OPTIONAL; enforced only when present
+    service_profiles:                   # per-backend bindings (registry-owned; not exposed in Phase 1 tools)
+      conport:
+        workspace_id: "<conport-workspace-id>"
+        base_url: "http://127.0.0.1:3004"
+      dope_memory:
+        profile: "<memory-profile>"
+        base_url: "http://127.0.0.1:3020"
+      dope_context:
+        base_url: "http://127.0.0.1:3010"
+      task_orchestrator:
+        project_id: "<to-project-id>"
+        base_url: "http://127.0.0.1:8000"

--- a/services/dcp-readonly-facade/src/dcp_facade/__init__.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/__init__.py
@@ -1,0 +1,22 @@
+"""DCP read-only MCP evidence facade — Phase 1 scaffold.
+
+A loopback-only, read-only projection layer. This package holds the pure
+(MCP-independent) logic: response envelope, redaction, project registry,
+workspace resolver, fixed read-only git state, and proof-bundle reads.
+
+No module in this package performs filesystem writes, backend HTTP calls,
+arbitrary shell, or accepts a caller-supplied path/URL/port/route. See
+docs/03-reference/dcp/chatgpt-mcp-readonly/ for the contracts implemented here.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "envelope",
+    "redaction",
+    "registry",
+    "resolver",
+    "gitstate",
+    "proofs",
+    "tools",
+]

--- a/services/dcp-readonly-facade/src/dcp_facade/envelope.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/envelope.py
@@ -1,0 +1,96 @@
+"""Canonical response envelope.
+
+Every facade tool result — successful, partial, or blocked — is wrapped in the
+structure defined by
+docs/03-reference/dcp/chatgpt-mcp-readonly/RESPONSE_ENVELOPE_SCHEMA.md.
+
+A missing capability or denied read yields PARTIAL/BLOCKED, never guessed data.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+# --- status tokens ---------------------------------------------------------
+OK = "OK"
+PARTIAL = "PARTIAL"
+BLOCKED = "BLOCKED"
+
+# --- source systems / authority labels ------------------------------------
+SOURCE_FACADE = "facade"
+SOURCE_GIT = "git"
+
+AUTHORITY_FACADE = "facade"
+AUTHORITY_GIT = "OBSERVED/git"
+AUTHORITY_FS = "OBSERVED/fs"
+
+# Canonical field order (also the full key set the envelope always carries).
+ENVELOPE_FIELDS = (
+    "project_id",
+    "branch",
+    "head_sha",
+    "dirty",
+    "source_system",
+    "authority_label",
+    "status",
+    "freshness",
+    "limitations",
+    "warnings",
+    "redactions",
+    "blocked_reasons",
+    "data",
+)
+
+
+def build_envelope(
+    *,
+    project_id: Optional[str],
+    status: str,
+    source_system: str,
+    authority_label: str,
+    data: Any = None,
+    branch: Optional[str] = None,
+    head_sha: Optional[str] = None,
+    dirty: Optional[bool] = None,
+    freshness: Optional[str] = None,
+    limitations: Optional[Iterable[str]] = None,
+    warnings: Optional[Iterable[str]] = None,
+    redactions: Optional[Iterable[str]] = None,
+    blocked_reasons: Optional[Iterable[str]] = None,
+) -> dict:
+    """Return a canonical envelope dict with every field always present."""
+    if status not in (OK, PARTIAL, BLOCKED):
+        raise ValueError(f"invalid status: {status!r}")
+    return {
+        "project_id": project_id,
+        "branch": branch,
+        "head_sha": head_sha,
+        "dirty": dirty,
+        "source_system": source_system,
+        "authority_label": authority_label,
+        "status": status,
+        "freshness": freshness,
+        "limitations": list(limitations or []),
+        "warnings": list(warnings or []),
+        "redactions": list(redactions or []),
+        "blocked_reasons": list(blocked_reasons or []),
+        "data": data,
+    }
+
+
+def blocked(
+    project_id: Optional[str],
+    reason: str,
+    *,
+    source_system: str = SOURCE_FACADE,
+    authority_label: str = AUTHORITY_FACADE,
+) -> dict:
+    """Convenience: a BLOCKED envelope with a single reason and no data."""
+    return build_envelope(
+        project_id=project_id,
+        status=BLOCKED,
+        source_system=source_system,
+        authority_label=authority_label,
+        data=None,
+        blocked_reasons=[reason],
+    )

--- a/services/dcp-readonly-facade/src/dcp_facade/gitstate.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/gitstate.py
@@ -1,0 +1,50 @@
+"""Fixed read-only git state.
+
+Runs ONLY a hardcoded allowlist of read-only git commands with a fixed argv
+list (``shell=False``), ``cwd`` set to an already-resolved workspace, and no
+interpolation of caller-supplied input. There is no code path that accepts a
+git subcommand, flag, or path from a caller — the only variable is the resolved
+workspace directory chosen by the resolver.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+# Internal keys → fixed argv. Keys are never caller-supplied.
+_ALLOWED: dict[str, list[str]] = {
+    "head": ["git", "rev-parse", "HEAD"],
+    "branch": ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+    "status": ["git", "status", "--porcelain"],
+}
+
+_TIMEOUT_SECONDS = 10
+
+
+def _run(key: str, cwd: Path) -> Optional[str]:
+    argv = _ALLOWED[key]  # KeyError is a programming error, not caller input
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed argv, shell=False, no caller input
+            argv,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def repo_state(workspace: Path) -> dict:
+    """Return ``{branch, head_sha, dirty}``; any field is ``None`` if unavailable."""
+    head = _run("head", workspace)
+    branch = _run("branch", workspace)
+    status = _run("status", workspace)
+    dirty: Optional[bool] = None if status is None else bool(status.strip())
+    return {"branch": branch, "head_sha": head, "dirty": dirty}

--- a/services/dcp-readonly-facade/src/dcp_facade/proofs.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/proofs.py
@@ -1,0 +1,170 @@
+"""Proof-bundle reads (containment + symlink safe, bounded).
+
+Proof bundles live at ``<workspace>/proof/<BUNDLE_ID>/``. All reads are
+confined to the resolved workspace's ``proof/`` directory: the ``bundle_id`` is
+validated as a single path segment, the target is canonicalized (``resolve()``)
+and re-checked with ``relative_to`` against the canonical proof root, and each
+file is canonicalized and re-checked before being **opened by its resolved
+path** (so a check/use TOCTOU swap cannot redirect the read). Reads are bounded
+to ``_MAX_FILE_BYTES`` at I/O time, and directory scans are bounded before
+sorting. This module performs no writes.
+
+Filtering uses a **literal substring** (``packet_filter``), not a regex — an
+untrusted caller must never be able to supply a pattern that triggers
+catastrophic backtracking (ReDoS).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+PROOF_DIRNAME = "proof"
+MAX_BUNDLES = 20
+_SCAN_LIMIT = MAX_BUNDLES * 5  # cap directory entries scanned before sort (DoS guard)
+_MAX_FILE_BYTES = 256 * 1024
+_BUNDLE_FILES = ("PROOF.json", "COMMAND_LOG.md", "AUDIT.md")
+
+
+def _proof_root(workspace: Path) -> Path:
+    return workspace / PROOF_DIRNAME
+
+
+def _safe_bundle_id(bundle_id: object) -> bool:
+    """A bundle id must be a single path segment, no separators/traversal."""
+    if not isinstance(bundle_id, str) or not bundle_id:
+        return False
+    if "/" in bundle_id or "\\" in bundle_id:
+        return False
+    if bundle_id.startswith(".") or ".." in bundle_id:
+        return False
+    return True
+
+
+def list_bundles(
+    workspace: Path,
+    packet_filter: Optional[str] = None,
+    cap: int = MAX_BUNDLES,
+    scan_limit: int = _SCAN_LIMIT,
+) -> tuple[list[dict], bool]:
+    """List proof bundles, filtered by a literal substring of the bundle id.
+
+    Returns ``(bundles, truncated)``. The directory scan is bounded to
+    ``scan_limit`` entries before sorting (guards against a workspace with an
+    enormous ``proof/`` directory).
+    """
+    root = _proof_root(workspace)
+    if not root.is_dir():
+        return [], False
+
+    names: list[str] = []
+    truncated = False
+    try:
+        for entry in root.iterdir():
+            try:
+                if not entry.is_dir():
+                    continue
+            except OSError:
+                continue
+            names.append(entry.name)
+            if len(names) >= scan_limit:
+                truncated = True
+                break
+    except OSError:
+        return [], False
+
+    names.sort()
+    if packet_filter:
+        flt = str(packet_filter)
+        names = [n for n in names if flt in n]
+    if len(names) > cap:
+        truncated = True
+        names = names[:cap]
+
+    out: list[dict] = []
+    for name in names:
+        bdir = root / name
+        try:
+            files = sorted(f.name for f in bdir.iterdir() if f.is_file())
+        except OSError:
+            files = []
+        out.append({"bundle_id": name, "files": files})
+    return out, truncated
+
+
+def fetch_bundle(
+    workspace: Path,
+    bundle_id: object,
+    current_head: Optional[str] = None,
+) -> tuple[Optional[dict], Optional[str], list[str]]:
+    """Fetch one bundle's known files. Returns (data, block_reason, warnings).
+
+    Containment is enforced on the resolved bundle dir and on each resolved
+    file; files are opened by their resolved path with a bounded read.
+    """
+    if not _safe_bundle_id(bundle_id):
+        return None, "invalid bundle_id", []
+
+    try:
+        root = _proof_root(workspace).resolve()
+    except (OSError, RuntimeError):
+        return None, "proof root could not be resolved", []
+    try:
+        target = (root / str(bundle_id)).resolve()
+    except (OSError, RuntimeError):
+        return None, "bundle path could not be resolved", []
+    try:
+        target.relative_to(root)
+    except ValueError:
+        return None, "bundle path escapes proof root", []
+    if not target.is_dir():
+        return None, "bundle not found", []
+
+    warnings: list[str] = []
+    contents: dict[str, str] = {}
+    for fname in _BUNDLE_FILES:
+        f = target / fname
+        if not f.is_file():
+            continue
+        try:
+            resolved_f = f.resolve()
+            resolved_f.relative_to(root)  # reject symlinked files pointing outside
+        except (ValueError, OSError, RuntimeError):
+            warnings.append(f"{fname} skipped (escapes proof root)")
+            continue
+        # Bounded read of the RESOLVED path (avoids unbounded read + TOCTOU swap).
+        try:
+            with resolved_f.open("rb") as fh:
+                raw = fh.read(_MAX_FILE_BYTES + 1)
+        except OSError:
+            warnings.append(f"{fname} unreadable")
+            continue
+        if len(raw) > _MAX_FILE_BYTES:
+            raw = raw[:_MAX_FILE_BYTES]
+            warnings.append(f"{fname} truncated")
+        contents[fname] = raw.decode("utf-8", errors="replace")
+
+    bundle_head: Optional[str] = None
+    pj = contents.get("PROOF.json")
+    if pj:
+        try:
+            meta = json.loads(pj)
+            bundle_head = meta.get("head_sha") or meta.get("commit_sha")
+        except (ValueError, AttributeError):
+            bundle_head = None
+
+    stale: Optional[bool] = None
+    if current_head and bundle_head:
+        stale = bundle_head != current_head
+        if stale:
+            warnings.append("stale proof bundle (head_sha mismatch)")
+
+    data = {
+        "bundle_id": str(bundle_id),
+        "files": sorted(contents.keys()),
+        "contents": contents,
+        "bundle_head_sha": bundle_head,
+        "stale": stale,
+    }
+    return data, None, warnings

--- a/services/dcp-readonly-facade/src/dcp_facade/redaction.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/redaction.py
@@ -1,0 +1,139 @@
+"""Redaction baseline.
+
+Strips absolute filesystem paths and secret/token patterns from any payload
+before it leaves the facade. No equivalent utility exists in dopemux core
+(verified during TP-DCP-MCP-RO-0004 discovery), so this is purpose-built and
+intentionally conservative: when unsure, redact.
+
+`redact_value` walks arbitrary JSON-like data (str/dict/list/scalars) and
+returns `(clean_value, redactions)` where `redactions` is a sorted list of the
+categories applied, e.g. ["absolute_paths", "secrets"].
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+ABS_PATHS = "absolute_paths"
+SECRETS = "secrets"
+
+_PATH_PLACEHOLDER = "<redacted-path>"
+
+# Secret patterns. Order matters (most specific first). Each maps a compiled
+# pattern to its replacement.
+_SECRET_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"sk-[A-Za-z0-9_\-]{8,}"), "sk-<redacted>"),
+    (re.compile(r"gh[pousr]_[A-Za-z0-9]{16,}"), "gh<redacted>"),
+    (re.compile(r"AKIA[0-9A-Z]{16}"), "AKIA<redacted>"),
+    (re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._\-]+"), "Bearer <redacted>"),
+    (
+        # KEY=VALUE / KEY: VALUE style for sensitive keys
+        re.compile(
+            r"(?i)\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|PASSWORD|SECRET|PASSWD))\b(\s*[=:]\s*)(\S+)"
+        ),
+        r"\1\2<redacted>",
+    ),
+]
+
+# Generic absolute-path roots that should never leak even if not a registered
+# workspace (home dirs, common unix roots).
+_GENERIC_ABS_ROOTS = (
+    "/Users/",
+    "/home/",
+    "/root/",
+    "/private/",
+    "/mnt/",
+    "/media/",
+    "/var/",
+    "/opt/",
+    "/srv/",
+    "/usr/",
+    "/etc/",
+    "/data/",
+    "/tmp/",
+)
+
+# Defence-in-depth: any absolute unix path with >= 3 segments (e.g.
+# ``/some/deep/internal/path``) — conservative so short route-like strings such
+# as ``/api/decisions`` (2 segments) are preserved. "When unsure, redact."
+_DEEP_PATH = re.compile(r"(?<![\w.])/(?:[^\s\"'/]+/){2,}[^\s\"'/]*")
+
+
+def redact_secrets(text: str) -> tuple[str, bool]:
+    """Return (clean, changed) after masking known secret patterns."""
+    changed = False
+    out = text
+    for pattern, repl in _SECRET_PATTERNS:
+        new = pattern.sub(repl, out)
+        if new != out:
+            changed = True
+            out = new
+    return out, changed
+
+
+def redact_abs_paths(text: str, abs_roots: Iterable[str]) -> tuple[str, bool]:
+    """Mask absolute paths.
+
+    Registered `abs_roots` are replaced with the placeholder first (longest
+    first so nested roots collapse correctly); then any residual generic
+    absolute path token (``/Users/...`` etc.) is masked.
+    """
+    changed = False
+    out = text
+    for root in sorted((r for r in abs_roots if r), key=len, reverse=True):
+        if root in out:
+            out = out.replace(root, _PATH_PLACEHOLDER)
+            changed = True
+    # Residual generic absolute paths (defence in depth).
+    for prefix in _GENERIC_ABS_ROOTS:
+        # Match prefix + path chars (no whitespace).
+        pat = re.compile(re.escape(prefix) + r"[^\s\"']*")
+        new = pat.sub(_PATH_PLACEHOLDER, out)
+        if new != out:
+            out = new
+            changed = True
+    # Any remaining deep absolute path (>= 3 segments).
+    new = _DEEP_PATH.sub(_PATH_PLACEHOLDER, out)
+    if new != out:
+        out = new
+        changed = True
+    return out, changed
+
+
+def _redact_str(text: str, abs_roots: Iterable[str], cats: set[str]) -> str:
+    out, changed = redact_abs_paths(text, abs_roots)
+    if changed:
+        cats.add(ABS_PATHS)
+    out, changed = redact_secrets(out)
+    if changed:
+        cats.add(SECRETS)
+    return out
+
+
+def redact_value(value: Any, abs_roots: Iterable[str]) -> tuple[Any, list[str]]:
+    """Recursively redact a JSON-like value.
+
+    Returns (clean_value, sorted_categories). Dict keys are left intact
+    (only values are redacted) but string keys are not expected to carry
+    secrets; values and nested structures are scrubbed.
+    """
+    cats: set[str] = set()
+    roots = list(abs_roots)
+
+    def _walk(v: Any) -> Any:
+        if isinstance(v, str):
+            return _redact_str(v, roots, cats)
+        if isinstance(v, dict):
+            # Redact string keys too — proof content (e.g. JSON) is untrusted and
+            # could carry secrets/paths in keys.
+            return {
+                (_redact_str(k, roots, cats) if isinstance(k, str) else k): _walk(sub)
+                for k, sub in v.items()
+            }
+        if isinstance(v, (list, tuple)):
+            return [_walk(sub) for sub in v]
+        return v
+
+    clean = _walk(value)
+    return clean, sorted(cats)

--- a/services/dcp-readonly-facade/src/dcp_facade/registry.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/registry.py
@@ -1,0 +1,136 @@
+"""Project registry loader + validator.
+
+The registry is the facade's trust boundary (see
+docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md).
+It maps a caller-facing ``project_id`` to a workspace path, an exposure switch,
+an identity block (matched against the workspace ``.repo_id``), and per-backend
+service profiles.
+
+Loading is **fail-closed**: a malformed project entry is dropped (recorded in
+``warnings``) rather than exposed loosely; ``enabled`` defaults to ``False``.
+No secrets are read from or written to the repo by this module.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+KNOWN_PROFILES = ("conport", "dope_memory", "dope_context", "task_orchestrator")
+
+ENV_REGISTRY_PATH = "DCP_FACADE_REGISTRY"
+DEFAULT_REGISTRY_PATH = "~/.dopemux/dcp-facade-registry.yaml"
+
+
+@dataclass(frozen=True)
+class Project:
+    project_id: str
+    workspace_path: str
+    enabled: bool
+    identity_project: str
+    identity_owner: Optional[str]
+    service_profiles: dict[str, Any] = field(default_factory=dict)
+
+    def configured_capabilities(self) -> dict[str, bool]:
+        """Which known backends have a profile configured (not reachability)."""
+        return {name: name in self.service_profiles for name in KNOWN_PROFILES}
+
+
+@dataclass
+class Registry:
+    projects: dict[str, Project] = field(default_factory=dict)
+    approved_roots: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    def get(self, project_id: str) -> Optional[Project]:
+        return self.projects.get(project_id)
+
+    def enabled_projects(self) -> list[Project]:
+        return [p for p in self.projects.values() if p.enabled]
+
+
+def resolve_registry_path(explicit: Optional[str] = None) -> Path:
+    """Resolve the registry file path: explicit arg > env > default (~)."""
+    raw = explicit or os.getenv(ENV_REGISTRY_PATH) or DEFAULT_REGISTRY_PATH
+    return Path(raw).expanduser()
+
+
+def _coerce_project(raw: Any) -> tuple[Optional[Project], Optional[str]]:
+    """Validate one raw entry. Returns (project, None) or (None, reason)."""
+    if not isinstance(raw, dict):
+        return None, f"entry is not a mapping: {raw!r}"
+    pid = raw.get("project_id")
+    if not isinstance(pid, str) or not pid:
+        return None, f"missing/invalid project_id: {raw!r}"
+    workspace_path = raw.get("workspace_path")
+    if not isinstance(workspace_path, str) or not workspace_path:
+        return None, f"[{pid}] missing/invalid workspace_path"
+    identity = raw.get("identity")
+    if not isinstance(identity, dict):
+        return None, f"[{pid}] missing identity block"
+    identity_project = identity.get("project")
+    if not isinstance(identity_project, str) or not identity_project:
+        return None, f"[{pid}] identity.project is required"
+    identity_owner = identity.get("owner")
+    if identity_owner is not None and not isinstance(identity_owner, str):
+        return None, f"[{pid}] identity.owner must be a string when present"
+    enabled = raw.get("enabled", False)
+    if not isinstance(enabled, bool):
+        return None, f"[{pid}] enabled must be a boolean"
+    profiles = raw.get("service_profiles", {}) or {}
+    if not isinstance(profiles, dict):
+        return None, f"[{pid}] service_profiles must be a mapping"
+    return (
+        Project(
+            project_id=pid,
+            workspace_path=workspace_path,
+            enabled=enabled,
+            identity_project=identity_project,
+            identity_owner=identity_owner,
+            service_profiles=profiles,
+        ),
+        None,
+    )
+
+
+def parse_registry(doc: Any) -> Registry:
+    """Build a Registry from an already-parsed YAML document (fail-closed)."""
+    reg = Registry()
+    if not isinstance(doc, dict):
+        reg.warnings.append("registry root is not a mapping; treating as empty")
+        return reg
+    roots = doc.get("approved_roots", []) or []
+    if isinstance(roots, list):
+        reg.approved_roots = [str(r) for r in roots if isinstance(r, str)]
+    else:
+        reg.warnings.append("approved_roots is not a list; ignored")
+    projects = doc.get("projects", []) or []
+    if not isinstance(projects, list):
+        reg.warnings.append("projects is not a list; treating as empty")
+        projects = []
+    for raw in projects:
+        project, reason = _coerce_project(raw)
+        if project is None:
+            reg.warnings.append(f"dropped project entry ({reason})")
+            continue
+        if project.project_id in reg.projects:
+            reg.warnings.append(f"duplicate project_id {project.project_id}; later entry dropped")
+            continue
+        reg.projects[project.project_id] = project
+    return reg
+
+
+def load_registry(path: Optional[str] = None) -> Registry:
+    """Load + validate the registry from disk (read-only). Missing file → empty."""
+    p = resolve_registry_path(path)
+    if not p.is_file():
+        reg = Registry()
+        reg.warnings.append(f"registry file not found: {p}")
+        return reg
+    with p.open("r", encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    return parse_registry(doc)

--- a/services/dcp-readonly-facade/src/dcp_facade/resolver.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/resolver.py
@@ -1,0 +1,102 @@
+"""Workspace resolver — the fail-closed §5 flow.
+
+Maps a caller-supplied ``project_id`` to a canonical, validated workspace path.
+Every failure mode returns a block reason (never a path or partial result).
+
+Resolution order (MULTI_PROJECT_REGISTRY_CONTRACT.md §5):
+  lookup → enabled → realpath → containment in approved roots
+  → eligibility (.dopemux/ present + validate_workspace)
+  → identity (.repo_id project, and owner iff registry declares it)
+  → bind.
+
+Reuses ``dopemux.workspace_detection.validate_workspace`` when importable
+(repo ``src`` is on pytest ``pythonpath``); a conservative fallback is used
+only when dopemux is unavailable (e.g. a stripped container).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .registry import Project, Registry
+
+try:  # prefer the canonical dopemux validator
+    from dopemux.workspace_detection import validate_workspace as _validate_workspace
+except Exception:  # pragma: no cover - exercised only without dopemux on path
+    def _validate_workspace(workspace_path: Path) -> tuple[bool, Optional[str]]:
+        p = Path(workspace_path)
+        if not p.is_dir():
+            return False, "not a directory"
+        if (p / ".git").exists() or (p / "pyproject.toml").exists() or (p / ".repo_id").exists():
+            return True, None
+        return False, "no workspace markers"
+
+
+@dataclass(frozen=True)
+class Resolved:
+    project: Project
+    workspace: Path  # canonical (realpath) directory
+
+
+def _read_repo_id(workspace: Path) -> dict[str, str]:
+    """Parse the git-tracked ``.repo_id`` identity file (``key=value`` lines)."""
+    f = workspace / ".repo_id"
+    out: dict[str, str] = {}
+    if not f.is_file():
+        return out
+    for line in f.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        out[key.strip()] = val.strip()
+    return out
+
+
+def _within(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except Exception:
+        return False
+
+
+def resolve(registry: Registry, project_id: object) -> tuple[Optional[Resolved], Optional[str]]:
+    """Return (Resolved, None) on success or (None, reason) when blocked."""
+    if not isinstance(project_id, str) or not project_id:
+        return None, "project_id is required"
+
+    project = registry.get(project_id)
+    if project is None:
+        return None, f"unknown project: {project_id}"
+    if not project.enabled:
+        return None, f"project disabled: {project_id}"
+
+    try:
+        real = Path(project.workspace_path).resolve()
+    except Exception:
+        return None, "workspace_path could not be resolved"
+    if not real.is_dir():
+        return None, "workspace path is not a directory"
+
+    if registry.approved_roots:
+        if not any(_within(real, Path(r)) for r in registry.approved_roots):
+            return None, "workspace escapes approved roots"
+
+    # Eligibility: the dopemux init marker + canonical workspace validation.
+    if not (real / ".dopemux").is_dir():
+        return None, "workspace missing .dopemux (not initialized)"
+    ok, err = _validate_workspace(real)
+    if not ok:
+        return None, f"workspace validation failed: {err}"
+
+    # Identity: .repo_id project (always) + owner (only when registry declares it).
+    repo_id = _read_repo_id(real)
+    if repo_id.get("project") != project.identity_project:
+        return None, "repo_id project does not match registry identity"
+    if project.identity_owner is not None and repo_id.get("owner") != project.identity_owner:
+        return None, "repo_id owner does not match registry identity"
+
+    return Resolved(project=project, workspace=real), None

--- a/services/dcp-readonly-facade/src/dcp_facade/tools.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/tools.py
@@ -1,0 +1,143 @@
+"""Phase-1 tool implementations (pure; no MCP dependency).
+
+Each function takes a loaded ``Registry`` and returns a canonical envelope.
+Project-scoped tools resolve the project first (fail-closed) and confine all
+reads to the resolved workspace. All ``data`` is redacted before return.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+_MAX_FILTER_LEN = 128
+
+from . import envelope as E
+from . import gitstate, proofs
+from .redaction import redact_value
+from .registry import Registry
+from .resolver import resolve
+
+
+def _abs_roots(workspace: Optional[Path]) -> list[str]:
+    roots: list[str] = []
+    if workspace is not None:
+        roots.append(str(workspace))
+    home = os.path.expanduser("~")
+    if home and home != "~":
+        roots.append(home)
+    return roots
+
+
+def list_projects(registry: Registry) -> dict:
+    """Approved (enabled) projects only. No project_id; never exposes paths."""
+    data = [
+        {"project_id": p.project_id, "capabilities": p.configured_capabilities()}
+        for p in registry.enabled_projects()
+    ]
+    clean, red = redact_value(data, _abs_roots(None))
+    return E.build_envelope(
+        project_id=None,
+        status=E.OK,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FACADE,
+        data=clean,
+        redactions=red,
+    )
+
+
+def get_project_capabilities(registry: Registry, project_id: object) -> dict:
+    res, reason = resolve(registry, project_id)
+    if res is None:
+        return E.blocked(project_id if isinstance(project_id, str) else None, reason or "blocked")
+    data = {"project_id": res.project.project_id, "capabilities": res.project.configured_capabilities()}
+    clean, red = redact_value(data, _abs_roots(res.workspace))
+    return E.build_envelope(
+        project_id=res.project.project_id,
+        status=E.OK,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FACADE,
+        data=clean,
+        redactions=red,
+    )
+
+
+def get_repo_state_snapshot(registry: Registry, project_id: object) -> dict:
+    res, reason = resolve(registry, project_id)
+    if res is None:
+        return E.blocked(project_id if isinstance(project_id, str) else None, reason or "blocked")
+    st = gitstate.repo_state(res.workspace)
+    warnings: list[str] = []
+    limitations: list[str] = []
+    status = E.OK
+    if st["head_sha"] is None:
+        status = E.PARTIAL
+        limitations.append("git state unavailable")
+    if st["dirty"]:
+        warnings.append("dirty worktree")
+    data = {"branch": st["branch"], "head_sha": st["head_sha"], "dirty": st["dirty"]}
+    clean, red = redact_value(data, _abs_roots(res.workspace))
+    return E.build_envelope(
+        project_id=res.project.project_id,
+        status=status,
+        source_system=E.SOURCE_GIT,
+        authority_label=E.AUTHORITY_GIT,
+        data=clean,
+        branch=st["branch"],
+        head_sha=st["head_sha"],
+        dirty=st["dirty"],
+        warnings=warnings,
+        limitations=limitations,
+        redactions=red,
+    )
+
+
+def list_proof_bundles(
+    registry: Registry,
+    project_id: object,
+    packet_id_filter: Optional[str] = None,
+) -> dict:
+    res, reason = resolve(registry, project_id)
+    if res is None:
+        return E.blocked(project_id if isinstance(project_id, str) else None, reason or "blocked")
+    if packet_id_filter is not None and (
+        not isinstance(packet_id_filter, str) or len(packet_id_filter) > _MAX_FILTER_LEN
+    ):
+        # Literal substring filter only (no regex) — bounded length, no ReDoS surface.
+        return E.blocked(res.project.project_id, "invalid packet_id_filter")
+    bundles, truncated = proofs.list_bundles(res.workspace, packet_id_filter, cap=proofs.MAX_BUNDLES)
+    limitations: list[str] = []
+    if truncated:
+        limitations.append(f"results capped at {proofs.MAX_BUNDLES}")
+    clean, red = redact_value({"bundles": bundles}, _abs_roots(res.workspace))
+    return E.build_envelope(
+        project_id=res.project.project_id,
+        status=E.OK,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FS,
+        data=clean,
+        limitations=limitations,
+        redactions=red,
+    )
+
+
+def fetch_proof_bundle(registry: Registry, project_id: object, bundle_id: object) -> dict:
+    res, reason = resolve(registry, project_id)
+    if res is None:
+        return E.blocked(project_id if isinstance(project_id, str) else None, reason or "blocked")
+    head = gitstate.repo_state(res.workspace)["head_sha"]
+    data, block_reason, warnings = proofs.fetch_bundle(res.workspace, bundle_id, current_head=head)
+    if block_reason is not None:
+        return E.blocked(res.project.project_id, block_reason)
+    clean, red = redact_value(data, _abs_roots(res.workspace))
+    return E.build_envelope(
+        project_id=res.project.project_id,
+        status=E.OK,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FS,
+        data=clean,
+        head_sha=head,
+        warnings=warnings,
+        redactions=red,
+    )

--- a/services/dcp-readonly-facade/src/mcp/__init__.py
+++ b/services/dcp-readonly-facade/src/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""MCP wiring for the DCP read-only facade (thin FastMCP layer)."""

--- a/services/dcp-readonly-facade/src/mcp/fastmcp_stub.py
+++ b/services/dcp-readonly-facade/src/mcp/fastmcp_stub.py
@@ -1,0 +1,31 @@
+"""Lightweight FastMCP stub for environments without fastmcp installed.
+
+Provides minimal decorators so module import succeeds during unit tests and
+byte-compilation. Mirrors the stub used by services/dope-context.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+class FastMCP:
+    """Fallback implementation that no-ops tool registration."""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def tool(self, *dargs: Any, **dkwargs: Any) -> Callable:
+        def decorator(func: Callable) -> Callable:
+            return func
+
+        return decorator
+
+    def run(self, *args: Any, **kwargs: Any) -> None:
+        logger.warning(
+            "fastmcp not installed; FastMCP.run() stub invoked. "
+            "Install fastmcp for full MCP functionality."
+        )

--- a/services/dcp-readonly-facade/src/mcp/server.py
+++ b/services/dcp-readonly-facade/src/mcp/server.py
@@ -1,0 +1,82 @@
+"""DCP read-only MCP evidence facade — FastMCP server (Phase 1 scaffold).
+
+Thin wiring layer: each MCP tool delegates to the pure ``dcp_facade.tools``
+functions, which return canonical envelopes. The registry is loaded once from
+``$DCP_FACADE_REGISTRY`` (or the default path). Loopback-only binding is the
+operator's responsibility per SECURITY_MODEL.md; this scaffold defaults to
+stdio transport.
+
+Run locally:  python -m src.mcp.server   (from services/dcp-readonly-facade)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Make the facade package and repo `src` (for dopemux) importable when run
+# directly (mirrors the services/dope-context bootstrap pattern).
+_HERE = Path(__file__).resolve()
+_FACADE_SRC = _HERE.parents[1]            # services/dcp-readonly-facade/src
+_REPO_ROOT = _HERE.parents[4]             # repo root
+for _p in (str(_FACADE_SRC), str(_REPO_ROOT / "src")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+try:
+    from fastmcp import FastMCP
+except ImportError:  # pragma: no cover - constrained envs
+    from mcp.fastmcp_stub import FastMCP  # type: ignore
+
+from dcp_facade import tools
+from dcp_facade.registry import Registry, load_registry
+
+mcp = FastMCP("dcp-readonly-facade")
+
+# Registry is loaded once at import; reloaded only on process restart.
+_REGISTRY: Registry = load_registry(os.getenv("DCP_FACADE_REGISTRY"))
+
+
+@mcp.tool()
+async def list_projects() -> dict:
+    """List the projects the facade exposes (enabled registry entries only)."""
+    return tools.list_projects(_REGISTRY)
+
+
+@mcp.tool()
+async def get_project_capabilities(project_id: str) -> dict:
+    """Report which backends are configured for a project."""
+    return tools.get_project_capabilities(_REGISTRY, project_id)
+
+
+@mcp.tool()
+async def get_repo_state_snapshot(project_id: str) -> dict:
+    """Return the project's git branch/head/dirty snapshot (read-only)."""
+    return tools.get_repo_state_snapshot(_REGISTRY, project_id)
+
+
+@mcp.tool()
+async def list_proof_bundles(project_id: str, packet_id_filter: Optional[str] = None) -> dict:
+    """List proof bundles under the project's proof/ directory.
+
+    ``packet_id_filter`` is an optional literal substring of the bundle id
+    (not a regex). Results are capped at 20.
+    """
+    return tools.list_proof_bundles(_REGISTRY, project_id, packet_id_filter)
+
+
+@mcp.tool()
+async def fetch_proof_bundle(project_id: str, bundle_id: str) -> dict:
+    """Fetch a single proof bundle's files (containment + symlink safe)."""
+    return tools.fetch_proof_bundle(_REGISTRY, project_id, bundle_id)
+
+
+def main() -> None:
+    transport = os.getenv("DCP_FACADE_TRANSPORT", "stdio")
+    mcp.run(transport=transport)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/dcp-readonly-facade/tests/test_envelope.py
+++ b/services/dcp-readonly-facade/tests/test_envelope.py
@@ -1,0 +1,39 @@
+"""Envelope: field completeness + status semantics."""
+
+from __future__ import annotations
+
+import pytest
+
+from dcp_facade import envelope as E
+
+
+def test_envelope_has_all_canonical_fields():
+    env = E.build_envelope(
+        project_id="p",
+        status=E.OK,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FACADE,
+        data={"x": 1},
+    )
+    assert set(env.keys()) == set(E.ENVELOPE_FIELDS)
+    # list fields are always present as lists
+    for key in ("limitations", "warnings", "redactions", "blocked_reasons"):
+        assert isinstance(env[key], list)
+
+
+def test_invalid_status_rejected():
+    with pytest.raises(ValueError):
+        E.build_envelope(
+            project_id="p",
+            status="SUCCESS",  # not a valid token
+            source_system=E.SOURCE_FACADE,
+            authority_label=E.AUTHORITY_FACADE,
+        )
+
+
+def test_blocked_helper_shape():
+    env = E.blocked("p", "unknown project")
+    assert env["status"] == E.BLOCKED
+    assert env["data"] is None
+    assert env["blocked_reasons"] == ["unknown project"]
+    assert env["project_id"] == "p"

--- a/services/dcp-readonly-facade/tests/test_gitstate.py
+++ b/services/dcp-readonly-facade/tests/test_gitstate.py
@@ -1,0 +1,34 @@
+"""Gitstate: read-only branch/head/dirty over a real repo + fixed allowlist."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dcp_facade import gitstate
+
+
+def test_clean_repo_state(make_workspace):
+    info = make_workspace()
+    st = gitstate.repo_state(info["path"])
+    assert st["head_sha"] == info["head_sha"]
+    assert st["branch"] is not None
+    assert st["dirty"] is False
+
+
+def test_dirty_repo_state(make_workspace):
+    info = make_workspace(dirty=True)
+    st = gitstate.repo_state(info["path"])
+    assert st["dirty"] is True
+
+
+def test_non_git_dir_returns_none_fields(tmp_path: Path):
+    st = gitstate.repo_state(tmp_path)
+    assert st["head_sha"] is None
+    assert st["dirty"] is None
+
+
+def test_allowlist_is_fixed_and_readonly():
+    # Only read-only verbs; no mutating git subcommands present.
+    for argv in gitstate._ALLOWED.values():
+        assert argv[0] == "git"
+        assert argv[1] in {"rev-parse", "status"}

--- a/services/dcp-readonly-facade/tests/test_proofs.py
+++ b/services/dcp-readonly-facade/tests/test_proofs.py
@@ -1,0 +1,102 @@
+"""Proofs: listing, containment, symlink/cross-project rejection, staleness."""
+
+from __future__ import annotations
+
+import os
+
+from dcp_facade import proofs
+
+
+def test_list_bundles_and_substring_filter(make_workspace):
+    info = make_workspace(
+        bundles={"TP-A-0001": {"head_sha": "x"}, "TP-B-0002": {"head_sha": "y"}}
+    )
+    ws = info["path"]
+    bundles, truncated = proofs.list_bundles(ws)
+    names = {b["bundle_id"] for b in bundles}
+    assert names == {"TP-A-0001", "TP-B-0002"}
+    assert truncated is False
+    only_a, _ = proofs.list_bundles(ws, packet_filter="TP-A")
+    assert {b["bundle_id"] for b in only_a} == {"TP-A-0001"}
+
+
+def test_list_bundles_filter_is_literal_not_regex(make_workspace):
+    # a regex metachar is treated as a literal substring (no match, no error)
+    ws = make_workspace(bundles={"TP-A-0001": {"head_sha": "x"}})["path"]
+    out, _ = proofs.list_bundles(ws, packet_filter="TP-A.*")
+    assert out == []
+
+
+def test_list_bundles_cap_truncation(make_workspace):
+    many = {f"TP-{i:04d}": {"head_sha": "h"} for i in range(25)}
+    ws = make_workspace(bundles=many)["path"]
+    bundles, truncated = proofs.list_bundles(ws, cap=20)
+    assert len(bundles) == 20
+    assert truncated is True
+
+
+def test_fetch_valid_bundle(make_workspace):
+    ws = make_workspace(bundles={"TP-A-0001": {"head_sha": "abc"}})["path"]
+    data, block, warnings = proofs.fetch_bundle(ws, "TP-A-0001", current_head=None)
+    assert block is None
+    assert data["bundle_id"] == "TP-A-0001"
+    assert "PROOF.json" in data["contents"]
+    assert "AUDIT.md" in data["contents"]
+
+
+def test_invalid_bundle_id_rejected(make_workspace):
+    ws = make_workspace()["path"]
+    for bad in ("../etc", "a/b", "..", ".hidden", "", None):
+        data, block, _ = proofs.fetch_bundle(ws, bad)
+        assert data is None
+        assert block is not None
+
+
+def test_symlink_escape_rejected(make_workspace, tmp_path):
+    info = make_workspace()
+    ws = info["path"]
+    proof_root = ws / "proof"
+    proof_root.mkdir(exist_ok=True)
+    outside = tmp_path / "outside_secret"
+    outside.mkdir()
+    (outside / "PROOF.json").write_text("{}", encoding="utf-8")
+    os.symlink(outside, proof_root / "evil")
+    data, block, _ = proofs.fetch_bundle(ws, "evil")
+    assert data is None
+    assert "escapes proof root" in block
+
+
+def test_cross_project_bundle_not_found(make_workspace):
+    # bundle exists only in project B; fetching it via A's workspace must not find it
+    make_workspace(name="a", bundles={"TP-ONLY-IN-A": {"head_sha": "1"}})
+    ws_b = make_workspace(name="b")["path"]
+    data, block, _ = proofs.fetch_bundle(ws_b, "TP-ONLY-IN-A")
+    assert data is None
+    assert block == "bundle not found"
+
+
+def test_stale_proof_warning(make_workspace):
+    ws = make_workspace(bundles={"TP-A-0001": {"head_sha": "deadbeefdeadbeef"}})["path"]
+    data, block, warnings = proofs.fetch_bundle(ws, "TP-A-0001", current_head="cafebabecafebabe")
+    assert block is None
+    assert data["stale"] is True
+    assert any("stale proof bundle" in w for w in warnings)
+
+
+def test_fresh_proof_no_stale_warning(make_workspace):
+    ws = make_workspace(bundles={"TP-A-0001": {"head_sha": "matching"}})["path"]
+    data, block, warnings = proofs.fetch_bundle(ws, "TP-A-0001", current_head="matching")
+    assert data["stale"] is False
+    assert not any("stale" in w for w in warnings)
+
+
+def test_large_file_bounded_and_truncated(make_workspace):
+    big = "A" * (proofs._MAX_FILE_BYTES + 5000)
+    ws = make_workspace(
+        bundles={"TP-A-0001": {"head_sha": "h"}},
+        extra_proof_files={"TP-A-0001/COMMAND_LOG.md": big},
+    )["path"]
+    data, block, warnings = proofs.fetch_bundle(ws, "TP-A-0001")
+    assert block is None
+    assert len(data["contents"]["COMMAND_LOG.md"]) <= proofs._MAX_FILE_BYTES
+    assert any("truncated" in w for w in warnings)

--- a/services/dcp-readonly-facade/tests/test_redaction.py
+++ b/services/dcp-readonly-facade/tests/test_redaction.py
@@ -1,0 +1,71 @@
+"""Redaction: absolute paths + secret patterns, including nested structures."""
+
+from __future__ import annotations
+
+from dcp_facade import redaction as R
+
+
+def test_redact_registered_abs_root():
+    clean, changed = R.redact_abs_paths("see /work/proj/file.txt here", ["/work/proj"])
+    assert "/work/proj" not in clean
+    assert "<redacted-path>" in clean
+    assert changed is True
+
+
+def test_redact_generic_home_path():
+    clean, changed = R.redact_abs_paths("at /Users/alice/secret/x", [])
+    assert "/Users/alice" not in clean
+    assert changed is True
+
+
+def test_redact_secret_patterns():
+    for raw in (
+        "key sk-ABCDEFGH12345678",
+        "Authorization: Bearer abc.def-123",
+        "API_KEY=supersecretvalue",
+        "PASSWORD = hunter2hunter2",
+        "ghp_0123456789ABCDEFabcdef",
+    ):
+        clean, changed = R.redact_secrets(raw)
+        assert changed is True
+        assert "<redacted>" in clean
+
+
+def test_no_false_change_on_clean_text():
+    clean, changed = R.redact_secrets("just some ordinary prose")
+    assert changed is False
+    assert clean == "just some ordinary prose"
+
+
+def test_redact_deep_absolute_path_not_in_known_roots():
+    clean, changed = R.redact_abs_paths("config at /var/lib/dopemux/secrets/x.yaml", [])
+    assert "/var/lib/dopemux" not in clean
+    assert changed is True
+
+
+def test_short_route_like_path_preserved():
+    # 2-segment route strings are NOT redacted (avoid over-redacting doc content)
+    clean, changed = R.redact_abs_paths("GET /api/decisions returns json", [])
+    assert "/api/decisions" in clean
+    assert changed is False
+
+
+def test_redact_secret_in_dict_key():
+    clean, cats = R.redact_value({"API_KEY=topsecret123456": "v"}, [])
+    assert R.SECRETS in cats
+    assert "topsecret123456" not in str(clean)
+
+
+def test_redact_value_walks_nested_and_reports_categories():
+    payload = {
+        "path": "/Users/bob/ws/code.py",
+        "items": ["normal", "token=abcdef12345"],
+        "nested": {"k": "Bearer zzz.yyy"},
+        "count": 7,
+    }
+    clean, cats = R.redact_value(payload, ["/Users/bob/ws"])
+    assert R.ABS_PATHS in cats
+    assert R.SECRETS in cats
+    assert "/Users/bob" not in str(clean)
+    assert "abcdef12345" not in str(clean)
+    assert clean["count"] == 7  # non-strings untouched

--- a/services/dcp-readonly-facade/tests/test_registry.py
+++ b/services/dcp-readonly-facade/tests/test_registry.py
@@ -1,0 +1,90 @@
+"""Registry: validation, fail-closed defaults, file loading."""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+from dcp_facade import registry as REG
+
+
+def _valid(project_id="p", enabled=True):
+    return {
+        "project_id": project_id,
+        "workspace_path": "/abs/ws",
+        "enabled": enabled,
+        "identity": {"project": "proj", "owner": "owner"},
+        "service_profiles": {"conport": {"workspace_id": "w"}},
+    }
+
+
+def test_parse_valid_project():
+    reg = REG.parse_registry({"projects": [_valid()], "approved_roots": ["/abs"]})
+    assert "p" in reg.projects
+    p = reg.projects["p"]
+    assert p.enabled is True
+    assert p.identity_project == "proj"
+    assert p.identity_owner == "owner"
+    assert reg.approved_roots == ["/abs"]
+    assert p.configured_capabilities()["conport"] is True
+    assert p.configured_capabilities()["dope_memory"] is False
+
+
+def test_enabled_defaults_false():
+    raw = _valid()
+    del raw["enabled"]
+    reg = REG.parse_registry({"projects": [raw]})
+    assert reg.projects["p"].enabled is False
+
+
+def test_malformed_entries_dropped_failclosed():
+    bad = [
+        {"workspace_path": "/x", "identity": {"project": "a"}},          # no project_id
+        {"project_id": "b", "identity": {"project": "a"}},                # no workspace_path
+        {"project_id": "c", "workspace_path": "/x"},                      # no identity
+        {"project_id": "d", "workspace_path": "/x", "identity": {}},      # no identity.project
+        "not-a-mapping",
+    ]
+    reg = REG.parse_registry({"projects": bad})
+    assert reg.projects == {}
+    assert len(reg.warnings) >= len(bad)
+
+
+def test_duplicate_project_id_dropped():
+    reg = REG.parse_registry({"projects": [_valid("dup"), _valid("dup")]})
+    assert list(reg.projects) == ["dup"]
+    assert any("duplicate" in w for w in reg.warnings)
+
+
+def test_enabled_projects_filter():
+    reg = REG.parse_registry({"projects": [_valid("on", True), _valid("off", False)]})
+    ids = {p.project_id for p in reg.enabled_projects()}
+    assert ids == {"on"}
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path):
+    reg = REG.load_registry(str(tmp_path / "nope.yaml"))
+    assert reg.projects == {}
+    assert any("not found" in w for w in reg.warnings)
+
+
+def test_load_from_yaml_file(tmp_path: Path):
+    f = tmp_path / "reg.yaml"
+    f.write_text(
+        textwrap.dedent(
+            """
+            approved_roots:
+              - /abs
+            projects:
+              - project_id: p
+                workspace_path: /abs/ws
+                enabled: true
+                identity:
+                  project: proj
+            """
+        ),
+        encoding="utf-8",
+    )
+    reg = REG.load_registry(str(f))
+    assert "p" in reg.projects
+    assert reg.projects["p"].identity_owner is None

--- a/services/dcp-readonly-facade/tests/test_resolver.py
+++ b/services/dcp-readonly-facade/tests/test_resolver.py
@@ -1,0 +1,113 @@
+"""Resolver: fail-closed eligibility + identity (the §5 flow)."""
+
+from __future__ import annotations
+
+import os
+
+from dcp_facade.resolver import resolve
+
+
+def test_unknown_project_blocked(build_registry):
+    reg = build_registry([])
+    res, reason = resolve(reg, "ghost")
+    assert res is None
+    assert "unknown project" in reason
+
+
+def test_non_string_project_id_blocked(build_registry):
+    reg = build_registry([])
+    res, reason = resolve(reg, None)
+    assert res is None
+    assert "required" in reason
+
+
+def test_disabled_project_blocked(make_workspace, build_registry, project_entry):
+    ws = make_workspace()["path"]
+    reg = build_registry([project_entry(ws, project_id="p", enabled=False)])
+    res, reason = resolve(reg, "p")
+    assert res is None
+    assert "disabled" in reason
+
+
+def test_missing_dopemux_blocked(make_workspace, build_registry, project_entry):
+    ws = make_workspace(with_dopemux=False)["path"]
+    reg = build_registry([project_entry(ws, project_id="p")], approved_roots=[str(ws.parent)])
+    res, reason = resolve(reg, "p")
+    assert res is None
+    assert ".dopemux" in reason
+
+
+def test_identity_project_mismatch_blocked(make_workspace, build_registry, project_entry):
+    ws = make_workspace(project="actual")["path"]
+    reg = build_registry(
+        [project_entry(ws, project_id="p", identity_project="expected")],
+        approved_roots=[str(ws.parent)],
+    )
+    res, reason = resolve(reg, "p")
+    assert res is None
+    assert "project does not match" in reason
+
+
+def test_identity_owner_mismatch_blocked_when_declared(make_workspace, build_registry, project_entry):
+    ws = make_workspace(project="proj", owner="real")["path"]
+    reg = build_registry(
+        [project_entry(ws, project_id="p", identity_project="proj", identity_owner="wrong")],
+        approved_roots=[str(ws.parent)],
+    )
+    res, reason = resolve(reg, "p")
+    assert res is None
+    assert "owner does not match" in reason
+
+
+def test_owner_check_skipped_when_not_declared(make_workspace, build_registry, project_entry):
+    # workspace has owner=someone, but registry declares no identity.owner → matched on project alone
+    ws = make_workspace(project="proj", owner="someone")["path"]
+    reg = build_registry(
+        [project_entry(ws, project_id="p", identity_project="proj", identity_owner=None)],
+        approved_roots=[str(ws.parent)],
+    )
+    res, reason = resolve(reg, "p")
+    assert reason is None
+    assert res is not None
+
+
+def test_escapes_approved_roots_blocked(make_workspace, build_registry, project_entry):
+    ws = make_workspace()["path"]
+    reg = build_registry(
+        [project_entry(ws, project_id="p")],
+        approved_roots=["/some/unrelated/root"],
+    )
+    res, reason = resolve(reg, "p")
+    assert res is None
+    assert "approved roots" in reason
+
+
+def test_symlink_workspace_escape_blocked(make_workspace, build_registry, project_entry, tmp_path):
+    ws = make_workspace()["path"]
+    # a symlink that lives under an approved root but points at ws outside it
+    approved = tmp_path / "approved"
+    approved.mkdir()
+    link = approved / "linked_ws"
+    os.symlink(ws, link)
+    reg = build_registry(
+        [project_entry(link, project_id="p")],
+        approved_roots=[str(approved)],
+    )
+    res, reason = resolve(reg, "p")
+    # realpath of the symlink resolves to ws which is outside `approved` → blocked
+    assert res is None
+    assert "approved roots" in reason
+
+
+def test_happy_path_resolves(make_workspace, build_registry, project_entry):
+    info = make_workspace(project="proj", owner="tester")
+    ws = info["path"]
+    reg = build_registry(
+        [project_entry(ws, project_id="p", identity_project="proj", identity_owner="tester")],
+        approved_roots=[str(ws.parent)],
+    )
+    res, reason = resolve(reg, "p")
+    assert reason is None
+    assert res is not None
+    assert res.project.project_id == "p"
+    assert res.workspace == ws.resolve()

--- a/services/dcp-readonly-facade/tests/test_tools.py
+++ b/services/dcp-readonly-facade/tests/test_tools.py
@@ -1,0 +1,107 @@
+"""Tools: enveloped, fail-closed, redacted end-to-end behavior."""
+
+from __future__ import annotations
+
+from dcp_facade import envelope as E
+from dcp_facade import tools
+
+
+def test_list_projects_enabled_only_no_path_leak(make_workspace, build_registry, project_entry):
+    on = make_workspace(name="on")["path"]
+    off = make_workspace(name="off")["path"]
+    reg = build_registry(
+        [
+            project_entry(on, project_id="on", enabled=True),
+            project_entry(off, project_id="off", enabled=False),
+        ],
+        approved_roots=[str(on.parent), str(off.parent)],
+    )
+    env = tools.list_projects(reg)
+    assert env["status"] == E.OK
+    ids = {row["project_id"] for row in env["data"]}
+    assert ids == {"on"}
+    # no absolute workspace path leaks into the payload
+    assert str(on) not in str(env["data"])
+
+
+def test_unknown_project_blocked_envelope(build_registry):
+    reg = build_registry([])
+    env = tools.get_repo_state_snapshot(reg, "ghost")
+    assert env["status"] == E.BLOCKED
+    assert env["data"] is None
+    assert any("unknown project" in r for r in env["blocked_reasons"])
+
+
+def test_path_like_project_id_blocked(build_registry):
+    reg = build_registry([])
+    env = tools.get_project_capabilities(reg, "../../etc/passwd")
+    assert env["status"] == E.BLOCKED
+
+
+def test_repo_state_snapshot_dirty_warning(make_workspace, build_registry, project_entry):
+    info = make_workspace(dirty=True)
+    ws = info["path"]
+    reg = build_registry([project_entry(ws, project_id="p")], approved_roots=[str(ws.parent)])
+    env = tools.get_repo_state_snapshot(reg, "p")
+    assert env["status"] == E.OK
+    assert env["head_sha"] == info["head_sha"]
+    assert env["dirty"] is True
+    assert "dirty worktree" in env["warnings"]
+    assert env["authority_label"] == E.AUTHORITY_GIT
+
+
+def test_capabilities_reports_configured_profiles(make_workspace, build_registry, project_entry):
+    ws = make_workspace()["path"]
+    reg = build_registry(
+        [project_entry(ws, project_id="p", service_profiles={"conport": {"workspace_id": "w"}})],
+        approved_roots=[str(ws.parent)],
+    )
+    env = tools.get_project_capabilities(reg, "p")
+    assert env["status"] == E.OK
+    caps = env["data"]["capabilities"]
+    assert caps["conport"] is True
+    assert caps["task_orchestrator"] is False
+
+
+def test_list_proof_bundles_substring_filter(make_workspace, build_registry, project_entry):
+    ws = make_workspace(bundles={"TP-A-0001": {"head_sha": "h"}, "TP-B-0002": {"head_sha": "h"}})["path"]
+    reg = build_registry([project_entry(ws, project_id="p")], approved_roots=[str(ws.parent)])
+    env = tools.list_proof_bundles(reg, "p", packet_id_filter="TP-A")
+    assert env["status"] == E.OK
+    ids = {b["bundle_id"] for b in env["data"]["bundles"]}
+    assert ids == {"TP-A-0001"}
+
+
+def test_list_proof_bundles_overlong_filter_blocked(make_workspace, build_registry, project_entry):
+    ws = make_workspace(bundles={"TP-A-0001": {"head_sha": "h"}})["path"]
+    reg = build_registry([project_entry(ws, project_id="p")], approved_roots=[str(ws.parent)])
+    env = tools.list_proof_bundles(reg, "p", packet_id_filter="x" * 200)
+    assert env["status"] == E.BLOCKED
+    assert any("invalid packet_id_filter" in r for r in env["blocked_reasons"])
+
+
+def test_fetch_proof_bundle_bad_id_blocked(make_workspace, build_registry, project_entry):
+    ws = make_workspace(bundles={"TP-A-0001": {"head_sha": "h"}})["path"]
+    reg = build_registry([project_entry(ws, project_id="p")], approved_roots=[str(ws.parent)])
+    env = tools.fetch_proof_bundle(reg, "p", "../../etc")
+    assert env["status"] == E.BLOCKED
+
+
+def test_fetch_proof_bundle_redacts_secret_in_contents(make_workspace, build_registry, project_entry):
+    # a proof file containing a secret must come back redacted
+    ws = make_workspace(
+        bundles={"TP-A-0001": {"head_sha": "h"}},
+        extra_proof_files={"TP-A-0001/COMMAND_LOG.md": "leak API_KEY=supersecret12345 here\n"},
+    )["path"]
+    reg = build_registry([project_entry(ws, project_id="p")], approved_roots=[str(ws.parent)])
+    env = tools.fetch_proof_bundle(reg, "p", "TP-A-0001")
+    assert env["status"] == E.OK
+    blob = str(env["data"]["contents"])
+    assert "supersecret12345" not in blob
+    assert E_secrets_flag(env)
+
+
+def E_secrets_flag(env) -> bool:
+    from dcp_facade.redaction import SECRETS
+
+    return SECRETS in env["redactions"]


### PR DESCRIPTION
## Objective
Implement the minimal **read-only** MCP facade scaffold (`services/dcp-readonly-facade/`, net-new) the 0002/0003 docs define: project registry, workspace resolver, canonical response envelope, redaction baseline, and five local/git/proof tools — with tests and local-run docs. No backend HTTP, no writes, no adapters (those are 0005/0006).

## Scope
- **Create** `services/dcp-readonly-facade/**` (pure `dcp_facade` package + thin FastMCP server + 51 tests + `registry.example.yaml` + README).
- **Update** `docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md` (§1a `packet_id_filter`); **add** `FACADE_LOCAL_RUN.md`.
- Proof bundle `proof/TP-DCP-MCP-RO-0004/`.
- **No** `src/`, other `services/*`, `docker/`, `compose*`, `.dopemux`, `.env`, or `services/registry.yaml`.

## Evidence
- **resolver** — fail-closed §5: unknown/disabled→BLOCKED; realpath + approved-root containment; `.dopemux/` eligibility + `validate_workspace()`; `.repo_id` identity match (owner conditional); reuses `dopemux.workspace_detection`.
- **proofs** — reads confined to `<workspace>/proof/`; single-segment `bundle_id`; resolved-path containment (×2); **bounded resolved-path reads** (256KB); scan cap.
- **gitstate** — fixed read-only git argv allowlist, `shell=False`, no caller input.
- **redaction** — abs paths (incl. deep + dict keys) + secret patterns.
- **envelope** — canonical fields, `OK|PARTIAL|BLOCKED`, never guessed.

## Validation
- ✅ `pytest` 51 passed; `compileall` OK.
- ✅ No writes/shell in `src/` (only the fixed git `subprocess`); no caller-supplied regex.
- ✅ Diff within allowlist; no forbidden files; docs pre-commit pass.

## Embedded audit
PASS_WITH_RISKS — `proof/TP-DCP-MCP-RO-0004/AUDIT.md`. Includes a **`pal/codereview` (gpt-5.2, security)** pass: fixed 🔴 unbounded read + 🔴 ReDoS (regex→literal `packet_id_filter`), 🟠 TOCTOU, 🟠 redaction gaps, 🟡 iterdir DoS + broad excepts.

## Risks and unknowns
- `packet_id_filter` is a **literal substring** (≤128 chars), not a regex — a deliberate ReDoS-avoidance change to the inventory's "packet_id regex" wording (documented in TOOL_CONTRACT §1a).
- `services/registry.yaml` intentionally **not** updated (packet forbids it; this is a stdio MCP server, not an HTTP service).
- `fastmcp` optional/not-installed → server falls back to a no-op stub; tests target the pure package.
- Redaction is heuristic defence-in-depth (may over-redact); reachability probing + adversarial hardening are 0005/0006/0008.

## Rollback
`git revert 6bfdc14fb 0a25035a7` (or delete the branch; the facade is net-new).

## Proof bundle
`proof/TP-DCP-MCP-RO-0004/{PROOF.json,COMMAND_LOG.md,AUDIT.md}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)