### PR TITLE
ci(gemini): restore trusted-workspace for Gemini review

### DIFF
--- a/.github/workflows/gemini-review.yml
+++ b/.github/workflows/gemini-review.yml
@@ -20,6 +20,12 @@ jobs:
   review:
     runs-on: 'ubuntu-latest'
     timeout-minutes: 7
+    # The Gemini CLI hard-fails in headless mode unless the workspace is trusted.
+    # Review is gated by gemini-dispatch.yml to OWNER/MEMBER/COLLABORATOR authors
+    # only, which bounds the trust to repo collaborators' PRs. Re-added after
+    # 4206a2972 removed it (a newer CLI now enforces trusted-folders).
+    env:
+      GEMINI_CLI_TRUST_WORKSPACE: 'true'
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
## Problem
The **Gemini Review** workflow fails on every PR with:
> `Gemini CLI is not running in a trusted directory… set GEMINI_CLI_TRUST_WORKSPACE=true`

A newer Gemini CLI now **enforces** the trusted-folders check in headless mode. The trust env var was removed in `4206a2972 fix(ci): stop trusting PR workspace in gemini review` (May 7) — at the time the CLI tolerated its absence, but it no longer does, so review has been hard-failing (e.g. [run 27034473013](https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/27034473013)).

## Fix
Restore the job-level `GEMINI_CLI_TRUST_WORKSPACE: 'true'` on the `review` job (one env block, with a comment explaining the tradeoff).

## Security note (deliberate, operator-approved)
Re-enabling workspace trust means Gemini trusts PR-author-controlled files (`.gemini/`, `GEMINI.md`) during review — the prompt-injection surface the original removal guarded against. This is **bounded** because `gemini-dispatch.yml` only routes `/review` when the triggering author's association is `OWNER` / `MEMBER` / `COLLABORATOR`, so the trusted workspace is always a repo collaborator's PR, never an arbitrary external contributor. Operator explicitly chose to re-enable.

## Validation
- `python -c "import yaml; yaml.safe_load(...)"` → YAML OK.
- Scope: single job-level env block; no other workflow logic changed.

## Rollback
`git revert` this commit (returns to the secure-but-non-functional state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)