### PR TITLE
TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001: local proof schema validation before push

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -232,6 +232,17 @@ repos:
         language: system
         files: .*
         pass_filenames: true
+
+      # Proof bundle embedded_audit schema validation (TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001)
+      # Validates PROOF.json["embedded_audit"] against schemas/proof/embedded_audit.schema.json.
+      # Catches report_path pattern, auditor_model enum, and findings[].status enum violations
+      # before they reach CI (these three fields caused a push-fix-push cycle on PR #839).
+      - id: proof-embedded-audit-schema
+        name: Validate proof bundle embedded_audit schema
+        entry: python3 scripts/audit/validate_audit_proof.py
+        language: system
+        files: ^proof/[^/]+/PROOF\.json$
+        pass_filenames: true
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.41.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -239,8 +239,9 @@ repos:
       # before they reach CI (these three fields caused a push-fix-push cycle on PR #839).
       - id: proof-embedded-audit-schema
         name: Validate proof bundle embedded_audit schema
-        entry: python3 scripts/audit/validate_audit_proof.py
-        language: system
+        entry: python scripts/audit/validate_audit_proof.py
+        language: python
+        additional_dependencies: ['jsonschema']
         files: ^proof/[^/]+/PROOF\.json$
         pass_filenames: true
   - repo: https://github.com/igorshubovych/markdownlint-cli

--- a/proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/AUDITOR_REPORT.md
+++ b/proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/AUDITOR_REPORT.md
@@ -1,0 +1,75 @@
+---
+id: TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001-AUDITOR-REPORT
+title: Embedded Audit Report — TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001
+type: auditor_report
+owner: '@hu3mann'
+date: '2026-06-07'
+---
+
+# Embedded Audit Report — TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001
+
+**Auditor**: claude-code-cli (implementer_standard self-audit)
+**Model**: claude-sonnet-4.6
+**Stage**: self_audit
+**Invocation**: post-implementation review inside Claude Code
+**Exit code**: 0
+**Verdict**: PASS_WITH_RISKS
+
+---
+
+## Scope Verified
+
+Diff contains only allowlisted files:
+
+- `.pre-commit-config.yaml` — `proof-embedded-audit-schema` hook added to `local` repo block
+- `task-packets/INDEX.md` — `TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001` registered Active
+- `task-packets/TEMPLATE_TASK_PACKET.md` — Local Proof Validation section added
+- `tests/audit/test_audit_proof.py` — `TestPR839Regressions` class added (3 tests)
+- `proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/PROOF.json` — created
+- `proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/AUDITOR_REPORT.md` — created (this file)
+
+No runtime code, schemas (other than pre-commit config), or CI workflows touched.
+
+---
+
+## Key Finding
+
+`scripts/audit/validate_audit_proof.py` already existed as the canonical CI validator with the exact sub-object extraction behavior required. No new script was written. The task reduced to: wire the pre-commit hook, add regression tests for the three PR #839 wounds, and document the local command in TEMPLATE_TASK_PACKET.md.
+
+---
+
+## Validation Results
+
+| Gate | Result |
+| --- | --- |
+| Existing script validates known-good proofs (3/3 PASS) | PASS |
+| `TestPR839Regressions` all three tests pass | PASS |
+| Pre-commit hook fires correctly on `proof/*/PROOF.json` pattern | PASS |
+| Pre-commit hook passes on known-good proofs | PASS |
+| TEMPLATE updated with local validation command | PASS |
+| INDEX registered Active | PASS |
+| diff --stat shows only allowlisted files | PASS |
+| No runtime/schema/CI workflow changes | PASS |
+
+---
+
+## Findings
+
+### F1 — LOW — Intermediate fixture files not committed
+
+**Status**: ACCEPTED_RISK
+
+Three fixture files (`bad_*.PROOF.json`) were generated locally under `tests/fixtures/proof_schema/` to verify validator behavior, but were not committed. The equivalent coverage is provided by `TestPR839Regressions` using `tmp_path` fixtures, which is the correct pytest pattern. No committed fixtures needed.
+
+### F2 — INFO — Hook pattern excludes nested proof paths
+
+**Status**: ACCEPTED_RISK
+
+Pattern `^proof/[^/]+/PROOF\.json$` covers top-level packet directories only. Nested paths like `proof/TP-X/review_bundle/PROOF.json` are not matched. This is consistent with CI Audit Proof Validator scope (governed by `proof/.validator_scope.json` include_patterns). No expansion needed at this time.
+
+---
+
+## Remaining Risks
+
+- **R1**: Local pre-commit hook is advisory; operators who skip `pre-commit install` will not get local validation. CI Audit Proof Validator remains the authoritative gate.
+- **R2**: Nested proof paths excluded from hook scope — consistent with CI, but not documented in the hook comment. Acceptable for now.

--- a/proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/PROOF.json
+++ b/proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/PROOF.json
@@ -1,0 +1,80 @@
+{
+  "packet_id": "TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001",
+  "status": "READY_FOR_REVIEW",
+  "validation_state": "PASSED",
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "branch": "claude/tp-dmx-ai-routing-003-governance-residue",
+  "head_sha_before": "cfc473d35d053a4c0b6ea7cd6b886412bf915766",
+  "head_sha_after": "ca3db024e",
+  "files_modified": [
+    ".pre-commit-config.yaml",
+    "task-packets/INDEX.md",
+    "task-packets/TEMPLATE_TASK_PACKET.md",
+    "tests/audit/test_audit_proof.py"
+  ],
+  "files_created": [
+    "proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/PROOF.json",
+    "proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/AUDITOR_REPORT.md"
+  ],
+  "commands_run": [
+    "python3 scripts/audit/validate_audit_proof.py proof/TP-DMX-AI-ROUTING-001/PROOF.json proof/TP-DMX-AI-ROUTING-002/PROOF.json proof/TP-DMX-AI-ROUTING-003/PROOF.json",
+    "python3 -m pytest tests/audit/test_audit_proof.py::TestPR839Regressions -v",
+    "pre-commit run proof-embedded-audit-schema --files proof/TP-DMX-AI-ROUTING-003/PROOF.json proof/TP-DMX-AI-ROUTING-001/PROOF.json",
+    "git diff --stat"
+  ],
+  "exit_codes": {
+    "validate known-good proofs (3/3)": 0,
+    "pytest TestPR839Regressions (3 passed)": 0,
+    "pre-commit hook on known-good proofs": 0
+  },
+  "validation_gates": {
+    "existing_script_confirmed_as_ci_parity": "PASS",
+    "three_negative_fixtures_all_fail": "PASS",
+    "pre-commit_hook_passes_known_good": "PASS",
+    "template_updated_with_local_command": "PASS",
+    "index_registered_active": "PASS",
+    "diff_allowlist_only": "PASS"
+  },
+  "key_finding": "scripts/audit/validate_audit_proof.py already existed as the canonical CI validator. Task reduced to: wire pre-commit hook, add regression tests, document in TEMPLATE. No new script written.",
+  "runtime_code_touched": false,
+  "schemas_changed": false,
+  "configs_changed": true,
+  "configs_changed_detail": ".pre-commit-config.yaml — added proof-embedded-audit-schema hook to local repo block",
+  "red_lines_preserved": true,
+  "embedded_audit": {
+    "required": true,
+    "status": "PASS_WITH_RISKS",
+    "auditor_tool": "claude-code-cli",
+    "auditor_model": "claude-sonnet-4.6",
+    "invocation": "implementer_standard self-audit inside Claude Code after implementation",
+    "exit_code": 0,
+    "report_path": "proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/AUDITOR_REPORT.md",
+    "findings": [
+      {
+        "id": "F1",
+        "severity": "LOW",
+        "title": "tests/fixtures/proof_schema/ intermediate files not committed",
+        "status": "ACCEPTED_RISK",
+        "body": "Three fixture files (bad_report_path, bad_auditor_model, bad_finding_status) were generated locally to verify the validator behavior but were not committed — the equivalent logic is covered by the TestPR839Regressions pytest class using tmp_path, so committed fixtures are not needed."
+      },
+      {
+        "id": "F2",
+        "severity": "INFO",
+        "title": "hook only fires on proof/*/PROOF.json pattern — nested proofs (proof/sub/TP-X/PROOF.json) are not matched",
+        "status": "ACCEPTED_RISK",
+        "body": "Pattern ^proof/[^/]+/PROOF\\.json$ matches only top-level packet dirs. Nested proof structures (e.g. review_bundle/PROOF.json) are excluded. This matches CI validator scope behavior (which uses include_patterns from .validator_scope.json). No expansion needed now."
+      }
+    ],
+    "fixes_applied": [],
+    "remaining_risks": [
+      "R1: pre-commit hook does not run in CI Quality gate unless pre-commit itself passes — if pre-commit install is skipped locally, the hook is bypassed. The CI Audit Proof Validator remains the authoritative gate.",
+      "R2: Nested proof paths (e.g. review_bundle/PROOF.json) are not covered by the hook pattern. Consistent with CI scope."
+    ],
+    "skip_reason": null
+  },
+  "remaining_risks": [
+    "R1: local hook is advisory; CI remains authoritative gate.",
+    "R2: nested proof paths excluded from hook scope (consistent with CI)."
+  ],
+  "next_recommended_packet": "TP-DMX-AI-ROUTING-004 (schema enum drift in embedded_audit.schema.json)"
+}

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -41,6 +41,7 @@ A packet is superseded by another packet
 | TP-SIA-EXEC-0006 | Workflow Plane | Auditor Runner + Proof Bundle Manifest | Ready | SIA Packet Execution ADR |
 | TP-SIA-EXEC-0007 | Workflow Plane | Manual Handoff + Operator Resume Semantics | Ready | SIA Packet Execution ADR |
 | TP-SIA-EXEC-0008 | Workflow Plane | Replay Repro Suite + Projection Hardening | Ready | SIA Packet Execution ADR |
+| TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001 | Governance / CI | Local Proof Schema Validation Before Push | Active | N/A |
 | TP-DMX-AIG-001 | Adaptive Ingress Plane | Service Census + Ingress Map + First Safe Slice | Ready | ADR — Adopt a Dopemux Adaptive Ingress Plane with Local Runtime Shims |
 | TP-DMX-REPOHYG-001 | Repo Hygiene | Branch and worktree audit with deterministic cleanup plan | Ready | N/A |
 | TP-DMX-REPOHYG-002 | Repo Hygiene | Execute phase2 safe archive cleanup | Ready | N/A |

--- a/task-packets/TEMPLATE_TASK_PACKET.md
+++ b/task-packets/TEMPLATE_TASK_PACKET.md
@@ -85,6 +85,20 @@ Implementer must return:
 
 ────────────────────────────────────────────────────────────
 
+## Local Proof Validation
+
+Before pushing, validate `embedded_audit` schema conformance locally:
+
+```bash
+python3 scripts/audit/validate_audit_proof.py proof/<PACKET_ID>/PROOF.json
+```
+
+This mirrors the CI `🔍 Audit Proof Validator` exactly (same script, same schema). The pre-commit hook `proof-embedded-audit-schema` also runs this automatically on staged `proof/*/PROOF.json` files.
+
+Common violations to check before push: `report_path` must match `^proof/[^/]+/AUDITOR(_REPAIR(_[0-9]+)?)?_REPORT\.md$`; `auditor_model` must be one of `['sonnet', 'claude-sonnet-4.6', 'opus', 'gemini', 'unknown']`; `findings[].status` must be one of `['OPEN', 'RESOLVED', 'ACCEPTED_RISK']`.
+
+────────────────────────────────────────────────────────────
+
 ## Model Routing
 
 Record the model route actually used for this packet. Source of truth: `config/ai/model-routing.policy.yaml` (human guide: `docs/03-reference/governance/model-routing.md`). Cheap read lanes may gather facts but must not decide architecture, authority, security, CI, workflow legality, or merge readiness.

--- a/tests/audit/test_audit_proof.py
+++ b/tests/audit/test_audit_proof.py
@@ -429,3 +429,53 @@ class TestUsage:
     def test_no_args_exits_2(self) -> None:
         result = _run([])
         assert result.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# Regression: exact wounds from PR #839 / PR #840 (TP-DMX-AI-ROUTING-003)
+# These three violations each caused a CI push-fix-push cycle.
+# ---------------------------------------------------------------------------
+
+
+class TestPR839Regressions:
+    """Regression suite for the three schema violations caught by CI on PR #839.
+
+    Each test uses the exact bad value that was submitted and rejected, ensuring
+    the local validator catches these before a push reaches CI.
+    """
+
+    def test_summary_md_report_path_rejected(self, tmp_path: Path) -> None:
+        """SUMMARY.md does not match the AUDITOR_REPORT naming pattern."""
+        ea = {**_VALID_PASS, "report_path": "proof/TP-DMX-AI-ROUTING-003/SUMMARY.md"}
+        p = _write_proof(tmp_path, ea)
+        result = _run([str(p)])
+        assert result.returncode == 1
+        assert "report_path" in result.stdout
+
+    def test_hyphenated_model_id_rejected(self, tmp_path: Path) -> None:
+        """'claude-sonnet-4-6' (hyphen) is not in the auditor_model enum; correct value uses a dot."""
+        ea = {**_VALID_PASS, "auditor_model": "claude-sonnet-4-6"}
+        p = _write_proof(tmp_path, ea)
+        result = _run([str(p)])
+        assert result.returncode == 1
+        assert "auditor_model" in result.stdout
+
+    def test_deferred_finding_status_rejected(self, tmp_path: Path) -> None:
+        """'DEFERRED' is not a valid finding status; use 'ACCEPTED_RISK' for accepted deferrals."""
+        ea = {
+            **_VALID_PASS,
+            "status": "PASS_WITH_RISKS",
+            "findings": [
+                {
+                    "id": "F-001",
+                    "severity": "INFO",
+                    "title": "Self-closure row deferred",
+                    "status": "DEFERRED",
+                    "body": "Will be added post-merge.",
+                }
+            ],
+        }
+        p = _write_proof(tmp_path, ea)
+        result = _run([str(p)])
+        assert result.returncode == 1
+        assert "findings" in result.stdout


### PR DESCRIPTION
## Summary

Wires local proof bundle schema validation to prevent the push-fix-push cycle that blocked PR #839 three times.

- **Pre-commit hook** (`proof-embedded-audit-schema`): fires on `proof/*/PROOF.json` staged files, runs `scripts/audit/validate_audit_proof.py` — the existing CI-parity validator that extracts `embedded_audit` and validates it against `schemas/proof/embedded_audit.schema.json`.
- **Regression tests** (`TestPR839Regressions`): 3 tests covering the exact three wounds from PR #839 — bad `report_path` (SUMMARY.md), bad `auditor_model` (hyphen variant), bad `findings[].status` (DEFERRED).
- **TEMPLATE_TASK_PACKET.md**: Local Proof Validation section added with canonical command and the three most common enum violations.
- **INDEX.md**: packet registered Active.

**No new script written.** `scripts/audit/validate_audit_proof.py` already existed as the exact CI validator. Task reduced to wiring + tests + docs.

## Files Changed

| File | Change |
| --- | --- |
| `.pre-commit-config.yaml` | `proof-embedded-audit-schema` hook added to local repo block |
| `tests/audit/test_audit_proof.py` | `TestPR839Regressions` class (+3 tests) |
| `task-packets/TEMPLATE_TASK_PACKET.md` | Local Proof Validation section |
| `task-packets/INDEX.md` | packet registered Active |
| `proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/` | proof bundle |

## Test Plan

- [ ] `python3 -m pytest tests/audit/test_audit_proof.py::TestPR839Regressions -v` → 3 passed
- [ ] `pre-commit run proof-embedded-audit-schema --files proof/TP-DMX-AI-ROUTING-003/PROOF.json` → Passed
- [ ] `python3 scripts/audit/validate_audit_proof.py proof/TP-DMX-PROOF-SCHEMA-LOCAL-VALIDATION-001/PROOF.json` → 1/1 PASS
- [ ] `git diff --stat` → only allowlisted files

🤖 Generated with [Claude Code](https://claude.com/claude-code)