### PR TITLE
fix(mcp): repair MCP server configs (conport SSE, pal-stdio, serena image)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "conport": {
       "type": "sse",
-      "url": "http://localhost:${CONPORT_MCP_PORT:-3005}/mcp",
+      "url": "http://localhost:${CONPORT_MCP_PORT:-3005}/sse",
       "env": {
         "DOPEMUX_WORKSPACE_ID": "${DOPEMUX_WORKSPACE_ID:-}",
         "GEMINI_API_KEY": "${GEMINI_API_KEY:-}",
@@ -12,7 +12,7 @@
       "description": "Knowledge graph, decisions, progress (PostgreSQL+AGE; per-worktree state)"
     },
     "dope-memory": {
-      "type": "sse",
+      "type": "http",
       "url": "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp",
       "env": {
         "DOPE_MEMORY_WORKSPACE_ID": "${DOPE_MEMORY_WORKSPACE_ID:-}",

--- a/compose.yml
+++ b/compose.yml
@@ -298,6 +298,8 @@ services:
       dockerfile: docker/mcp-servers/pal-stdio/Dockerfile
     container_name: mcp-pal-stdio
     restart: unless-stopped
+    # stdio server is PID 1; keep stdin open or it reads EOF and restart-loops
+    stdin_open: true
     networks:
       - dopemux-network
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -291,6 +291,21 @@ services:
       retries: 3
       interval: 30s
 
+  # PAL Stdio - Docker MCP Toolkit variant (runs server.py directly on stdio)
+  pal-stdio:
+    build:
+      context: .
+      dockerfile: docker/mcp-servers/pal-stdio/Dockerfile
+    container_name: mcp-pal-stdio
+    restart: unless-stopped
+    networks:
+      - dopemux-network
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+    # No ports exposed - Docker MCP Toolkit execs into container for stdio transport
+
   # LiteLLM - Model Router
   litellm:
     build:

--- a/docker/mcp-servers-source/serena/Dockerfile
+++ b/docker/mcp-servers-source/serena/Dockerfile
@@ -3,9 +3,11 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-# Copy dependency manifests first for better caching
-COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/
+# Copy dependency manifests and package sources required by setuptools metadata
+# (pyproject [tool.setuptools] packages spans conport/core/dopemux + tools.*)
+COPY pyproject.toml ./
+COPY src/ src/
+COPY tools/ tools/
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -17,6 +19,10 @@ RUN apt-get update && apt-get install -y \
 # We also include serena from git as before
 RUN uv pip install --system --no-cache .[services] && \
     uv pip install --system --no-cache "git+https://github.com/oraios/serena.git@f561204840eb4a96c6956d5cd98712f8ed52d0cb"
+
+# mcp-proxy CLI is invoked by wrapper.py to bridge serena stdio -> SSE on :3006;
+# it is not part of the [services] extra, so install it explicitly
+RUN uv pip install --system --no-cache mcp-proxy
 
 # Copy wrapper script and info server (relative to root)
 COPY docker/mcp-servers-source/serena/wrapper.py /app/wrapper.py

--- a/mcp_catalog.yaml
+++ b/mcp_catalog.yaml
@@ -86,6 +86,15 @@ servers:
     requires_env: ["EXA_API_KEY"]
     description: "Neural web search"
 
+  pal-stdio:
+    scope: singleton
+    transport: stdio
+    command: docker
+    args: ["exec", "-i", "mcp-pal-stdio", "/app/.venv/bin/python", "server.py"]
+    docker_compose_service: pal-stdio
+    requires_env: ["OPENAI_API_KEY", "GEMINI_API_KEY"]
+    description: "PAL via Docker MCP (thinkdeep, planner, consensus, debug, codereview, precommit)"
+
   MCP_DOCKER:
     scope: singleton
     transport: stdio

--- a/mcp_catalog.yaml
+++ b/mcp_catalog.yaml
@@ -109,7 +109,7 @@ servers:
     transport: sse
     # Port var names match compose.yml conventions so `init` writes env that
     # `docker compose up` reads directly.
-    url_template: "http://localhost:${CONPORT_MCP_PORT:-3005}/mcp"
+    url_template: "http://localhost:${CONPORT_MCP_PORT:-3005}/sse"
     port_var: CONPORT_MCP_PORT
     default_port_base: 3005
     extra_port_vars:
@@ -126,7 +126,7 @@ servers:
 
   dope-memory:
     scope: per-worktree
-    transport: sse
+    transport: http
     url_template: "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp"
     port_var: DOPE_MEMORY_PORT
     default_port_base: 3020


### PR DESCRIPTION
## Summary

- .mcp.json: point conport at its real /sse endpoint (was /mcp, 404); declare dope-memory as http transport
- mcp_catalog.yaml + compose.yml: add pal-stdio service/catalog entry (docker-exec stdio variant of PAL, avoids the single-session SSE wrapper contention)
- serena Dockerfile: copy full src/+tools/ for setuptools metadata and install mcp-proxy needed by wrapper.py stdio->SSE bridge

## Context

conport serves SSE at /sse so the old /mcp URL could never connect. dope-memory's /mcp endpoint does not exist yet server-side (config documents intent; surface implementation tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)