### PR TITLE
Secure MCP Tunnel integration docs for readonly facade

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/FAILURE_RUNBOOK.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/FAILURE_RUNBOOK.md
@@ -1,0 +1,135 @@
+---
+id: dcp-mcp-readonly-failure-runbook
+title: DCP Read-Only MCP Facade — Failure-Mode Runbook
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-10'
+last_review: '2026-06-10'
+next_review: '2026-09-08'
+prelude: Failure modes, symptoms, and fail-closed recovery for the Secure MCP Tunnel + read-only MCP evidence facade for dopemux documentation and developer workflows.
+---
+
+# Failure-Mode Runbook
+
+> **Status.** `PROPOSED` operator runbook. Recovery steps preserve the facade's
+> **fail-closed** invariants ([`SECURITY_MODEL.md`](SECURITY_MODEL.md) §8): unknown
+> project, disabled project, denied route, path/symlink escape, or unreachable
+> backend resolve to `PARTIAL`/`BLOCKED` — never fabricated data, never silent
+> success. When a failure is ambiguous, **fail closed**: stop the tunnel rather
+> than expose a degraded surface.
+
+## Severity key
+
+- 🔴 **Security-critical** — stop the tunnel immediately; do not expose.
+- 🟡 **Degraded** — facade still safe; a tool returns `PARTIAL`/`BLOCKED`.
+- 🟢 **Operational** — local setup/connectivity; no exposure risk.
+
+## 1. 🔴 Facade bound to a non-loopback interface
+
+- **Symptom:** bind check ([`TUNNEL_INTEGRATION.md`](TUNNEL_INTEGRATION.md) §2)
+  shows `0.0.0.0:<FACADE_PORT>` or a LAN IP.
+- **Cause:** transport switched to HTTP without pinning host; the scaffold passes
+  no host/port (`server.py:102-104`), so the runtime default applied.
+- **Recovery:** stop the facade and tunnel. Set the loopback host env
+  (`FASTMCP_HOST=127.0.0.1` — verify the name for your runtime), restart, re-run
+  the bind check, and only then start the tunnel. Treat any prior exposure window
+  as an incident.
+
+## 2. 🔴 Tunnel ingress points at a backend service
+
+- **Symptom:** tunnel config `ingress` lists a backend port (`:3004`, `:3020`,
+  `:3010`, `:8000`, `:3016`) instead of the facade endpoint.
+- **Cause:** misconfigured `service:` target.
+- **Recovery:** rewrite ingress so the only `service:` is
+  `http://127.0.0.1:<FACADE_PORT>`, with a catch-all `http_status:404`
+  ([`TUNNEL_INTEGRATION.md`](TUNNEL_INTEGRATION.md) §3). Backends are never tunnel
+  targets — direct backend exposure bypasses the read-only denylist entirely.
+
+## 3. 🔴 A write/mutating tool is reachable from the connector
+
+- **Symptom:** the connector lists or can call a transition / `manage_*` /
+  `memory_correct` / `index_*` / `sync_*` tool, or §5.1 of
+  [`MANUAL_VALIDATION.md`](MANUAL_VALIDATION.md) fails.
+- **Cause:** a backend MCP server was tunneled directly, or the wrong endpoint was
+  connected — **not** the facade.
+- **Recovery:** disconnect the connector immediately. Confirm the connector URL
+  resolves to the facade endpoint only. The facade exposes read tools only and
+  denies mutating/proxy/side-effect routes structurally
+  ([`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) §2); if a write tool is visible, you are
+  not talking to the facade.
+
+## 4. 🟡 `search_progress` returns `BLOCKED`
+
+- **Symptom:** every `search_progress` call is `BLOCKED`.
+- **Cause:** **intended** fail-closed default. ConPort's default enhanced server
+  auto-forks (writes) progress rows when a workspace has none
+  (`DOPEMUX_AUTO_FORK_PROGRESS=1`), so the read can mutate
+  ([`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) §1b note †).
+- **Recovery:** leave blocked unless you have set `DOPEMUX_AUTO_FORK_PROGRESS=0` on
+  that ConPort backend **first**, then set
+  `service_profiles.conport.progress_readonly_safe: true` in the registry. Do not
+  enable the flag without the backend change — that re-introduces write-on-read.
+
+## 5. 🟡 `search_decisions(query=…)` returns `PARTIAL`
+
+- **Symptom:** query mode returns `PARTIAL` with a deferral note; list mode works.
+- **Cause:** **intended.** ConPort `GET /api/search/{ws}` returns HTTP 500 on the
+  default backend (UUID not serialized) ([`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) §1b
+  note ‡). The facade refuses to surface a broken read.
+- **Recovery:** use list mode (`GET /api/decisions`) until the backend serializes
+  ids. No facade change needed.
+
+## 6. 🟡 dope-context tools (`search_code_docs`, `get_index_status`) return `BLOCKED`
+
+- **Symptom:** these always `BLOCKED`.
+- **Cause:** **intended** Phase-1 posture. dope-context exposes MCP JSON-RPC at
+  `/mcp`; the facade's `ReadOnlyHttpClient` speaks REST only — no transport bridge
+  yet ([`ARCHITECTURE.md`](ARCHITECTURE.md) §20, [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) §1c).
+- **Recovery:** none for Phase 1; the fail-closed `BLOCKED` is correct. Transport
+  bridge + formal inventory are Phase-2 work.
+
+## 7. 🟡 Backend unreachable / timeout
+
+- **Symptom:** a service-backed tool returns `PARTIAL`/`BLOCKED` with a backend
+  error reason.
+- **Cause:** backend not running, wrong `base_url`, or non-2xx response (only 2xx
+  bodies are parsed; `SECURITY_MODEL.md` + `FACADE_LOCAL_RUN.md` §5).
+- **Recovery:** confirm the backend is up on its loopback port; the facade fails
+  closed and must **not** be "fixed" by relaxing validation. Loopback-only
+  `base_url` is enforced (SSRF guard) — a non-loopback `base_url` is rejected by
+  design.
+
+## 8. 🔴 Secret scan finds a real credential
+
+- **Symptom:** the scan flags a value that is **not** an env-var name or placeholder.
+
+  ```bash
+  rg -n "CONTROL_PLANE_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|sk-|Bearer |TOKEN=|PASSWORD=|SECRET=|tunnel_[A-Za-z0-9]" \
+    docs/03-reference/dcp/chatgpt-mcp-readonly services/dcp-readonly-facade
+  ```
+
+- **Cause:** a registry, tunnel config, or credentials file was committed, or a
+  real value was pasted into docs.
+- **Recovery:** **stop.** Do not commit. Remove the value, rotate the credential
+  out of band, and keep registry/tunnel/credential files outside the repo
+  ([`FACADE_LOCAL_RUN.md`](FACADE_LOCAL_RUN.md) §1). Hits that are clearly env-var
+  **names** or `<PLACEHOLDER>` tokens are documentation references, not secrets —
+  but verify each before proceeding.
+
+## 9. 🟢 Tunnel client won't connect
+
+- **Symptom:** connector cannot reach the facade; tunnel client errors.
+- **Cause:** facade not started, transport still `stdio` (no network endpoint),
+  wrong port, or tunnel credentials/token missing.
+- **Recovery:** confirm `DCP_FACADE_TRANSPORT` is an HTTP-class transport and the
+  facade is listening on `127.0.0.1:<FACADE_PORT>`; confirm the tunnel token is
+  supplied out of band; re-run [`MANUAL_VALIDATION.md`](MANUAL_VALIDATION.md) §0.
+
+## 10. Escalation
+
+If a failure cannot be made to fail closed — e.g. official tunnel behavior
+contradicts this runbook, the tunnel requires root, or it requires storing
+credentials unencrypted in the repo — **stop and reconcile** (these are STOP-IF
+conditions for TP-DCP-MCP-RO-0007). Do not work around a security invariant to
+restore connectivity.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md
@@ -1,0 +1,114 @@
+---
+id: dcp-mcp-readonly-manual-validation
+title: DCP Read-Only MCP Facade — Manual Validation Checklist
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-10'
+last_review: '2026-06-10'
+next_review: '2026-09-08'
+prelude: Manual validation checklist (MCP inspector + ChatGPT connector) covering exposure, read tools, fail-closed denials, and freshness warnings for the read-only MCP evidence facade for dopemux documentation and developer workflows.
+---
+
+# Manual Validation Checklist
+
+> **Status.** `PROPOSED` operator procedure. Expected behaviors are `OBSERVED` from
+> the facade tools ([`FACADE_LOCAL_RUN.md`](FACADE_LOCAL_RUN.md),
+> [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md)) and the fail-closed model
+> ([`SECURITY_MODEL.md`](SECURITY_MODEL.md)). This checklist is **manual** — no
+> tunnel client and no connector automation runs in CI (packet invariant: *"No
+> running tunnel-client in CI", "No connector creation automation"*). Run it after
+> any tunnel or connector change.
+
+## 0. Preconditions
+
+- Registry configured with at least one `enabled` project
+  ([`FACADE_LOCAL_RUN.md`](FACADE_LOCAL_RUN.md) §1); `DCP_FACADE_REGISTRY` set.
+- Facade bind **verified loopback** ([`TUNNEL_INTEGRATION.md`](TUNNEL_INTEGRATION.md) §2).
+- The automated suite is green first (this is the structural baseline; the manual
+  steps below add live + connector coverage):
+
+  ```bash
+  python -m pytest -q services/dcp-readonly-facade/tests
+  ```
+
+You can drive the tools two ways:
+
+- **MCP inspector** — point an MCP inspector/dev client at the facade endpoint
+  (stdio locally, or the loopback HTTP endpoint when transport is switched). Verify
+  against your inspector's current docs; tool names below are the contract surface.
+- **ChatGPT connector** — once the tunnel + connector are wired
+  ([`TUNNEL_INTEGRATION.md`](TUNNEL_INTEGRATION.md) §4), issue the same calls from
+  ChatGPT.
+
+Each call returns the canonical envelope (`project_id`, `branch`, `head_sha`,
+`dirty`, `source_system`, `authority_label`, `freshness`, `limitations`,
+`warnings`, `redactions`, `blocked_reasons`, `data`) — see
+[`RESPONSE_ENVELOPE_SCHEMA.md`](RESPONSE_ENVELOPE_SCHEMA.md). Confirm the envelope
+shape on every result.
+
+## 1. Exposure — `list_projects`
+
+| # | Action | Expected | Pass |
+| --- | --- | --- | --- |
+| 1.1 | Call `list_projects` (no args) | Returns **only** `enabled: true` registry projects; disabled/unlisted projects absent | ☐ |
+| 1.2 | Disable a project in the registry, restart facade, call again | The project disappears from the list (exposure = registry entry + `enabled`, not eligibility) | ☐ |
+| 1.3 | Inspect a returned entry | No absolute host paths leak; capabilities reflect configured backends | ☐ |
+
+## 2. Repo evidence — `get_repo_state_snapshot`
+
+| # | Action | Expected | Pass |
+| --- | --- | --- | --- |
+| 2.1 | Call `get_repo_state_snapshot` with a valid `project_id` | Envelope carries `branch`, `head_sha`, `dirty` from a read-only git snapshot | ☐ |
+| 2.2 | Make the worktree dirty (touch a file), call again | `dirty: true` and a dirty-state `warning` is present (surfaced, not hidden) | ☐ |
+| 2.3 | Call with an **unknown** `project_id` | `BLOCKED` envelope with explicit `blocked_reasons`; no git data | ☐ |
+
+## 3. Proof bundles — `list_proof_bundles` / `fetch_proof_bundle`
+
+| # | Action | Expected | Pass |
+| --- | --- | --- | --- |
+| 3.1 | `list_proof_bundles(project_id)` | Bundle ids under `<workspace>/proof/`, capped at 20 | ☐ |
+| 3.2 | `list_proof_bundles(project_id, packet_id_filter="TP-DCP-MCP-RO-0007")` | Literal-substring match only (no regex semantics) | ☐ |
+| 3.3 | `fetch_proof_bundle(project_id, bundle_id)` for a real bundle | Returns bundle files; absolute paths redacted | ☐ |
+| 3.4 | `fetch_proof_bundle` with `../`, a symlink, or a cross-project id | `BLOCKED` (containment + symlink-escape prevention) | ☐ |
+
+## 4. Stale-proof + freshness warnings
+
+| # | Action | Expected | Pass |
+| --- | --- | --- | --- |
+| 4.1 | Fetch a proof bundle whose recorded `head_sha` ≠ current `head_sha` | Result includes a **stale-proof `warning`** (head_sha mismatch); data still returned, flagged not hidden | ☐ |
+| 4.2 | Fetch any bundle on a dirty worktree | A dirty-state `warning` accompanies the result | ☐ |
+| 4.3 | Confirm `freshness` is populated on every envelope | Present on success, partial, and blocked results | ☐ |
+
+## 5. Denied / fail-closed routes (the security gate)
+
+These confirm the mandatory denylist — the control that does **not** depend on the
+tunnel ([`SECURITY_MODEL.md`](SECURITY_MODEL.md) §3, [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) §2).
+
+| # | Action | Expected | Pass |
+| --- | --- | --- | --- |
+| 5.1 | Confirm no write/transition tool is offered to the connector | Tool list contains read tools only; no `transition`, `manage_*`, `advance_item`, `claim_item`, `memory_correct`, `index_*`, `sync_*` | ☐ |
+| 5.2 | `search_progress` without `progress_readonly_safe: true` | `BLOCKED` (auto-fork write hazard — fail-closed by default) | ☐ |
+| 5.3 | `search_decisions(project_id, query="…")` (query mode) | `PARTIAL` with deferral note (ConPort `/api/search` 500s); list mode unaffected | ☐ |
+| 5.4 | `search_code_docs` / `get_index_status` (dope-context) | `BLOCKED` — MCP JSON-RPC transport not bridged in Phase 1 (fail-closed, not fabricated) | ☐ |
+| 5.5 | Any attempt to pass a raw path / URL / port / route / SQL / shell | Rejected — no tool accepts such input; only `project_id` + typed params | ☐ |
+| 5.6 | Confirm `search_all` and `dopecon-bridge` are unreachable | Not in the tool surface (side-effect / proxy denials) | ☐ |
+
+## 6. Authority + redaction spot-check
+
+| # | Action | Expected | Pass |
+| --- | --- | --- | --- |
+| 6.1 | Inspect `authority_label` on ConPort / task-orchestrator results | `CANONICAL`; facade never labels itself an authority | ☐ |
+| 6.2 | Inspect any result containing a path or token-like string | Absolute paths and secret patterns redacted before leaving the facade | ☐ |
+| 6.3 | Confirm task-orchestrator results carry the **workflow-view-only** limitation | Present on every task-orchestrator envelope | ☐ |
+
+## 7. Sign-off
+
+- [ ] Sections 1–6 pass.
+- [ ] Bind verified loopback; no backend port reachable through the tunnel.
+- [ ] No secrets in any committed file (run the scan in
+  [`FAILURE_RUNBOOK.md`](FAILURE_RUNBOOK.md) §6).
+- Record date, operator, facade `head_sha`, and any deviations in the run notes.
+
+> Any `FAIL` on §5 is a **blocking** result — do not expose the connector. Route
+> recovery through [`FAILURE_RUNBOOK.md`](FAILURE_RUNBOOK.md).

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/TUNNEL_INTEGRATION.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/TUNNEL_INTEGRATION.md
@@ -1,0 +1,182 @@
+---
+id: dcp-mcp-readonly-tunnel-integration
+title: DCP Read-Only MCP Facade — Secure MCP Tunnel Integration
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-10'
+last_review: '2026-06-10'
+next_review: '2026-09-08'
+prelude: Local Secure MCP Tunnel integration, redacted client config, loopback-only runtime posture, and ChatGPT connector wiring for the read-only MCP evidence facade for dopemux documentation and developer workflows.
+---
+
+# Secure MCP Tunnel Integration
+
+> **Status.** This guide is `PROPOSED` operator procedure. The facade runtime
+> facts it relies on are `OBSERVED` from `services/dcp-readonly-facade/src/mcp/server.py`
+> and [`FACADE_LOCAL_RUN.md`](FACADE_LOCAL_RUN.md); the security constraints are
+> `OBSERVED`/`PROPOSED` from [`SECURITY_MODEL.md`](SECURITY_MODEL.md). Tunnel-client
+> and ChatGPT-connector specifics change with vendor releases — every vendor-specific
+> example below is a **placeholder** and **must be verified against the current
+> official tunnel and ChatGPT connector documentation** before use. If official
+> tunnel behavior contradicts anything here, **stop and reconcile the docs** (this is
+> a STOP-IF condition for TP-DCP-MCP-RO-0007). **No real tunnel IDs, hostnames,
+> tokens, or credentials are committed to this repository.**
+
+## 1. What the tunnel is (and is not)
+
+A *Secure MCP Tunnel* is the transport that lets a remote ChatGPT connector reach
+the facade's **loopback-only** MCP endpoint. It exists only to forward MCP traffic
+to the facade and nothing else.
+
+- The tunnel client connects to the **facade endpoint only** — never to a backend
+  service (ConPort `:3004`, dope-memory `:3020`, dope-context `:3010`,
+  task-orchestrator `:8000`, dopecon-bridge `:3016`).
+- The tunnel does **not** provide the security boundary. ChatGPT developer mode
+  can expose read **and write** MCP tools, and a tunnel forwards whatever the
+  endpoint serves. The mandatory control is the **facade's own read-only surface +
+  route denylist** ([`TOOL_CONTRACT.md`](TOOL_CONTRACT.md),
+  [`SECURITY_MODEL.md`](SECURITY_MODEL.md) §3), not tunnel trust.
+- The facade holds **no write authority**; it is an evidence projection layer
+  ([`ARCHITECTURE.md`](ARCHITECTURE.md) §1).
+
+### Topology
+
+```
+ChatGPT (untrusted client)
+   → Secure MCP Tunnel (public edge → encrypted tunnel)
+      → tunnel-client (on the operator host)
+         → 127.0.0.1:<FACADE_PORT>   ← facade endpoint ONLY
+            → DCP Read-Only Facade (loopback bind, read-only tools)
+               → backend adapters (route/method allowlist)
+
+NEVER:  tunnel-client → 127.0.0.1:3004 / :3020 / :3010 / :8000 / :3016
+        (backend services are not tunnel targets)
+```
+
+## 2. Runtime posture — loopback binding is operator-enforced
+
+`OBSERVED` (`server.py:102-104`): the facade reads `DCP_FACADE_TRANSPORT`
+(default `stdio`) and calls `mcp.run(transport=transport)`. **The scaffold does
+not pin a host or port.** Loopback binding is therefore the **operator's
+responsibility** (`SECURITY_MODEL.md` §1: *"Loopback-only binding is the
+operator's responsibility … this scaffold defaults to stdio transport"*).
+
+A tunnel needs a network endpoint, so the operator switches the facade to an
+HTTP-class transport. Because the scaffold passes no host/port, you **must**
+constrain the bind to loopback explicitly and **verify** it before exposing a
+tunnel:
+
+```bash
+cd services/dcp-readonly-facade
+
+# Switch to an HTTP-class transport for tunneling (verify the exact transport
+# name your installed MCP/FastMCP version accepts — e.g. streamable-http or sse).
+export DCP_FACADE_TRANSPORT="streamable-http"   # PLACEHOLDER — verify against your runtime
+
+# Constrain the listener to loopback. The scaffold does not set these; the
+# operator MUST. (Names are runtime-version dependent — verify.)
+export FASTMCP_HOST="127.0.0.1"                 # PLACEHOLDER — verify env name
+export FASTMCP_PORT="<FACADE_PORT>"             # e.g. a high local port
+
+export DCP_FACADE_REGISTRY=~/.dopemux/dcp-facade-registry.yaml
+python -m src.mcp.server
+```
+
+> **`UNKNOWN`/verify:** the exact transport string and the host/port env-var names
+> depend on the installed `fastmcp` version. Do not assume a default of
+> `127.0.0.1`. If your runtime defaults to `0.0.0.0`, an unconstrained switch
+> publishes the facade on all interfaces — a public-exposure regression. Confirm
+> the bind with the verification step below **before** starting any tunnel.
+
+### Verify the bind is loopback (mandatory gate)
+
+```bash
+# Expect ONLY 127.0.0.1:<FACADE_PORT> (or ::1). Any 0.0.0.0 / LAN IP = STOP.
+lsof -nP -iTCP -sTCP:LISTEN | grep "<FACADE_PORT>"
+# or:
+#   ss -ltnp | grep "<FACADE_PORT>"      (Linux)
+#   netstat -an -p tcp | grep "<FACADE_PORT>"
+```
+
+If the listener is on anything other than loopback, **do not start the tunnel** —
+fix the bind first. (`FORBIDDEN`: no public ingress; STOP-IF on backend/public
+exposure per the packet invariants.)
+
+## 3. Tunnel-client config (redacted examples)
+
+The tunnel client's ingress must route a single hostname to the **facade loopback
+endpoint only**. The repository already uses a cloudflared tunnel for the
+extraction webhook (`ops/cloudflared/config.yml`); use that as the *pattern*, with
+its own credentials, kept **outside** this repo.
+
+### Generic ingress (placeholder)
+
+```yaml
+# Store OUTSIDE the repo (e.g. ~/.dopemux/dcp-tunnel.example.yaml).
+# Every value here is a PLACEHOLDER. NEVER commit a populated tunnel config.
+tunnel: "<TUNNEL_ID>"                        # opaque tunnel id — NOT committed
+credentials-file: "~/.dopemux/<TUNNEL_ID>.json"   # secret material — NOT committed
+
+ingress:
+  # The ONLY backend target is the facade loopback endpoint.
+  - hostname: "<your-facade-host.example.com>"
+    service: "http://127.0.0.1:<FACADE_PORT>"
+  # Catch-all: refuse everything else (no backend services exposed).
+  - service: "http_status:404"
+```
+
+### Auth token (when the tunnel client takes one)
+
+Provide any tunnel auth token **out of band** — environment or secret store, never
+a repo file:
+
+```bash
+# Exported from your secret store at runtime; the value is NEVER written to the repo.
+export TUNNEL_TOKEN   # value injected out-of-band; do not assign it in a committed file
+```
+
+> Do **not** add backend service ports to `ingress`. The catch-all `404` rule is
+> the fail-closed default: a misconfigured hostname returns 404 rather than
+> falling through to a service.
+
+## 4. ChatGPT connector wiring
+
+`PROPOSED` — verify against the current ChatGPT connector / developer-mode docs;
+the UI and capability model change over time.
+
+1. In ChatGPT, add a **remote MCP server / custom connector** pointing at the
+   tunnel's public URL (`https://<your-facade-host.example.com>`), **not** at any
+   backend.
+2. The connector will discover the facade's tools (`list_projects`,
+   `get_repo_state_snapshot`, `list_proof_bundles`, `fetch_proof_bundle`,
+   `search_decisions`, `search_progress`, `search_chronicle`,
+   `replay_chronicle_session`; service-backed dope-context tools are Phase-1
+   **BLOCKED** per [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) §1c).
+3. **Developer-mode warning.** ChatGPT developer mode can call read **and write**
+   MCP tools on a connector. The facade is the boundary: it exposes only read
+   tools and structurally denies every mutating/proxy/side-effect route
+   ([`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) §2, [`SECURITY_MODEL.md`](SECURITY_MODEL.md) §3).
+   Never tunnel a backend MCP server directly to a connector — its write tools
+   would be reachable.
+4. Validate the connector against [`MANUAL_VALIDATION.md`](MANUAL_VALIDATION.md)
+   before treating it as trusted.
+
+## 5. Secrets posture
+
+- The registry (`~/.dopemux/dcp-facade-registry.yaml`), the tunnel config, and the
+  tunnel credentials file all live **outside** the repo. None is ever committed
+  (`FACADE_LOCAL_RUN.md` §1; packet invariant *"No secrets committed"*).
+- Docs use placeholders only (`<TUNNEL_ID>`, `<FACADE_PORT>`,
+  `<your-facade-host.example.com>`).
+- Backend service credentials (e.g. a ConPort/control-plane API key) are never
+  surfaced to the facade caller and never written to docs. Any literal env-var
+  **name** appearing in this guide is a reference, not a value.
+
+## 6. Related
+
+- [`FACADE_LOCAL_RUN.md`](FACADE_LOCAL_RUN.md) — registry config, local run, tests.
+- [`MANUAL_VALIDATION.md`](MANUAL_VALIDATION.md) — connector validation checklist.
+- [`FAILURE_RUNBOOK.md`](FAILURE_RUNBOOK.md) — failure modes and recovery.
+- [`SECURITY_MODEL.md`](SECURITY_MODEL.md), [`ARCHITECTURE.md`](ARCHITECTURE.md),
+  [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) — boundary, topology, tool surface.

--- a/proof/TP-DCP-MCP-RO-0007/AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0007/AUDIT.md
@@ -1,0 +1,72 @@
+# TP-DCP-MCP-RO-0007 — Embedded Audit
+
+**Verdict: PASS_WITH_RISKS** (non-blocking). Docs-only packet; self-audit by the
+implementing agent challenging doc safety and secret leakage per S3.
+
+## 1. Scope conformance
+
+- Deliverables present: `TUNNEL_INTEGRATION.md`, `MANUAL_VALIDATION.md`,
+  `FAILURE_RUNBOOK.md`, proof bundle (`PROOF.json`, `COMMAND_LOG.md`, `AUDIT.md`).
+- Only allowlisted paths changed (`docs/03-reference/dcp/chatgpt-mcp-readonly/**`,
+  `proof/TP-DCP-MCP-RO-0007/**`). No `services/**`, `src/**`, `.env*`,
+  `.dopemux/**`, `compose*.yml`. README under `services/dcp-readonly-facade/` was
+  **not** touched (was permitted only "if strictly needed" — not needed).
+
+## 2. Secret-leakage challenge (the critical risk)
+
+The commit.verify regex matches in the repo. I inspected **every** hit:
+
+| Hit class | Example | Real secret? |
+| --- | --- | --- |
+| Documented scan command | `FAILURE_RUNBOOK.md:108` | No — the pattern is the runbook's own grep command, no value. |
+| `sk-` in "ta**sk-**orchestrator" | `MANUAL_VALIDATION.md`, `TUNNEL_INTEGRATION.md` | No — substring of a service name. |
+| `tunnel_s` in `chatgpt_tunnel_suitability` | `READ_ONLY_SURFACE_INVENTORY.json` (pre-existing) | No — inventory field name. |
+| Redaction regex literals | `redaction.py`, `test_redaction.py` (pre-existing) | No — the redaction code/fixtures. |
+
+**Conclusion:** zero real credentials. All tunnel ids, hostnames, ports, and
+tokens in the new docs are `<PLACEHOLDER>` tokens. No registry, tunnel config, or
+credentials file is committed.
+
+**Residual risk (LOW, accepted):** the runbook intentionally inlines the secret-scan
+pattern so operators can copy it. This will always self-trigger the scan. Chose
+operator usefulness over a clean scan; the `|| true` in commit.verify makes it
+non-blocking and the criterion is "no real secrets", which holds.
+
+## 3. Doc-safety challenge
+
+- **Loopback claim is honest.** Docs state plainly that the scaffold defaults to
+  stdio and does **not** pin host/port (`server.py:102-104`), so loopback is an
+  operator-enforced manual control with a mandatory bind-verification gate. They do
+  **not** claim automatic loopback. This avoids a false-safety assertion.
+- **Tunnel→facade-only invariant** is stated in all three docs, with a backend-port
+  denylist and a catch-all `404` ingress default.
+- **Dev-mode read/write warning** present (TUNNEL_INTEGRATION §4, MANUAL_VALIDATION
+  §5.1, FAILURE_RUNBOOK §3): the facade denylist — not tunnel trust — is the
+  boundary.
+- **Vendor specifics labelled `PROPOSED`/placeholder** with explicit "verify
+  against current official docs" and STOP-IF reconciliation, satisfying the
+  "official tunnel behavior contradicts docs" STOP-IF without asserting unverified
+  vendor behavior as fact.
+- **Provenance discipline:** runtime facts labelled `OBSERVED` with file:line;
+  procedure labelled `PROPOSED`; version-dependent transport/host env names flagged
+  `UNKNOWN`/verify.
+
+## 4. Findings
+
+| ID | Severity | Status | Note |
+| --- | --- | --- | --- |
+| F-0007-LOW-1 | LOW | ACCEPTED_RISK | Runbook self-triggers the secret scan by inlining the grep pattern (§2). Operator-usefulness tradeoff; non-blocking. |
+| F-0007-LOW-2 | LOW | ACCEPTED_RISK | Exact `DCP_FACADE_TRANSPORT` transport string and FastMCP host/port env names are runtime-version dependent; docs flag them `UNKNOWN`/verify rather than assert. Verified at integration time, not in CI. |
+
+No HIGH/CRITICAL findings. No mutating surface introduced (docs only).
+
+## 5. Validation buckets
+
+- **PASS:** facade test suite (108 passed, 1 skipped, exit 0); diff-scope check
+  (allowlist only); secret scan (no real secrets).
+- **NOT_RUN:** live tunnel-client connection, ChatGPT connector creation, MCP
+  inspector session — **out of scope by packet invariant** (no tunnel/connector in
+  CI). These are the manual steps the new `MANUAL_VALIDATION.md` exists to drive;
+  residual risk is that vendor-specific UI/transport names drift before an operator
+  runs them.
+- **FAIL:** none.

--- a/proof/TP-DCP-MCP-RO-0007/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0007/AUDITOR_REPORT.md
@@ -1,0 +1,72 @@
+# TP-DCP-MCP-RO-0007 — Embedded Audit
+
+**Verdict: PASS_WITH_RISKS** (non-blocking). Docs-only packet; self-audit by the
+implementing agent challenging doc safety and secret leakage per S3.
+
+## 1. Scope conformance
+
+- Deliverables present: `TUNNEL_INTEGRATION.md`, `MANUAL_VALIDATION.md`,
+  `FAILURE_RUNBOOK.md`, proof bundle (`PROOF.json`, `COMMAND_LOG.md`, `AUDIT.md`).
+- Only allowlisted paths changed (`docs/03-reference/dcp/chatgpt-mcp-readonly/**`,
+  `proof/TP-DCP-MCP-RO-0007/**`). No `services/**`, `src/**`, `.env*`,
+  `.dopemux/**`, `compose*.yml`. README under `services/dcp-readonly-facade/` was
+  **not** touched (was permitted only "if strictly needed" — not needed).
+
+## 2. Secret-leakage challenge (the critical risk)
+
+The commit.verify regex matches in the repo. I inspected **every** hit:
+
+| Hit class | Example | Real secret? |
+| --- | --- | --- |
+| Documented scan command | `FAILURE_RUNBOOK.md:108` | No — the pattern is the runbook's own grep command, no value. |
+| `sk-` in "ta**sk-**orchestrator" | `MANUAL_VALIDATION.md`, `TUNNEL_INTEGRATION.md` | No — substring of a service name. |
+| `tunnel_s` in `chatgpt_tunnel_suitability` | `READ_ONLY_SURFACE_INVENTORY.json` (pre-existing) | No — inventory field name. |
+| Redaction regex literals | `redaction.py`, `test_redaction.py` (pre-existing) | No — the redaction code/fixtures. |
+
+**Conclusion:** zero real credentials. All tunnel ids, hostnames, ports, and
+tokens in the new docs are `<PLACEHOLDER>` tokens. No registry, tunnel config, or
+credentials file is committed.
+
+**Residual risk (LOW, accepted):** the runbook intentionally inlines the secret-scan
+pattern so operators can copy it. This will always self-trigger the scan. Chose
+operator usefulness over a clean scan; the `|| true` in commit.verify makes it
+non-blocking and the criterion is "no real secrets", which holds.
+
+## 3. Doc-safety challenge
+
+- **Loopback claim is honest.** Docs state plainly that the scaffold defaults to
+  stdio and does **not** pin host/port (`server.py:102-104`), so loopback is an
+  operator-enforced manual control with a mandatory bind-verification gate. They do
+  **not** claim automatic loopback. This avoids a false-safety assertion.
+- **Tunnel→facade-only invariant** is stated in all three docs, with a backend-port
+  denylist and a catch-all `404` ingress default.
+- **Dev-mode read/write warning** present (TUNNEL_INTEGRATION §4, MANUAL_VALIDATION
+  §5.1, FAILURE_RUNBOOK §3): the facade denylist — not tunnel trust — is the
+  boundary.
+- **Vendor specifics labelled `PROPOSED`/placeholder** with explicit "verify
+  against current official docs" and STOP-IF reconciliation, satisfying the
+  "official tunnel behavior contradicts docs" STOP-IF without asserting unverified
+  vendor behavior as fact.
+- **Provenance discipline:** runtime facts labelled `OBSERVED` with file:line;
+  procedure labelled `PROPOSED`; version-dependent transport/host env names flagged
+  `UNKNOWN`/verify.
+
+## 4. Findings
+
+| ID | Severity | Status | Note |
+| --- | --- | --- | --- |
+| F-0007-LOW-1 | LOW | ACCEPTED_RISK | Runbook self-triggers the secret scan by inlining the grep pattern (§2). Operator-usefulness tradeoff; non-blocking. |
+| F-0007-LOW-2 | LOW | ACCEPTED_RISK | Exact `DCP_FACADE_TRANSPORT` transport string and FastMCP host/port env names are runtime-version dependent; docs flag them `UNKNOWN`/verify rather than assert. Verified at integration time, not in CI. |
+
+No HIGH/CRITICAL findings. No mutating surface introduced (docs only).
+
+## 5. Validation buckets
+
+- **PASS:** facade test suite (108 passed, 1 skipped, exit 0); diff-scope check
+  (allowlist only); secret scan (no real secrets).
+- **NOT_RUN:** live tunnel-client connection, ChatGPT connector creation, MCP
+  inspector session — **out of scope by packet invariant** (no tunnel/connector in
+  CI). These are the manual steps the new `MANUAL_VALIDATION.md` exists to drive;
+  residual risk is that vendor-specific UI/transport names drift before an operator
+  runs them.
+- **FAIL:** none.

--- a/proof/TP-DCP-MCP-RO-0007/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0007/COMMAND_LOG.md
@@ -1,0 +1,70 @@
+# TP-DCP-MCP-RO-0007 — Command Log
+
+Docs-only packet (Secure MCP Tunnel integration docs + manual validation). No
+source code changed; no tunnel client or connector run in CI.
+
+## Environment
+
+```
+$ pwd
+/Users/hue/code/dopemux-mvp/.claude/worktrees/musing-visvesvaraya-c837f0
+$ git rev-parse --show-toplevel
+/Users/hue/code/dopemux-mvp/.claude/worktrees/musing-visvesvaraya-c837f0
+$ git branch --show-current
+dcp/chatgpt-mcp-ro-0007-secure-mcp-tunnel-integration-do
+$ git rev-parse HEAD   # base before commit
+06f3344b6de092b03912799ac9bf153763cf8673
+```
+
+## S2 — packet validation
+
+### Tests (structural baseline unchanged by docs)
+
+```
+$ python -m pytest -q services/dcp-readonly-facade/tests
+... 108 passed, 1 skipped ...
+SKIPPED [1] tests/test_live_optional.py:26: set DCP_FACADE_LIVE_TESTS=1 to run live tests
+exit_code = 0
+```
+
+### Secret scan (commit.verify regex)
+
+```
+$ rg -n "CONTROL_PLANE_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|sk-|Bearer |TOKEN=|PASSWORD=|SECRET=|tunnel_[A-Za-z0-9]" \
+    docs/03-reference/dcp/chatgpt-mcp-readonly services/dcp-readonly-facade
+exit_code = 0   (matches present; ALL classified as false positives — see AUDIT.md §2)
+```
+
+Hit classification (no real secrets):
+
+- **New files (this packet):**
+  - `FAILURE_RUNBOOK.md:108` — the literal documented scan command (operators must
+    run it). Contains the pattern by design; no value.
+  - `MANUAL_VALIDATION.md:101,103` and `TUNNEL_INTEGRATION.md:34` — substring `sk-`
+    inside the word "ta**sk-**orchestrator". Not a key.
+- **Pre-existing files (not modified here):** `chatgpt_tunnel_suitability` →
+  `tunnel_s` matches `tunnel_[A-Za-z0-9]`; "task-orchestrator" → `sk-`; redaction
+  code/tests intentionally contain `sk-`/`Bearer ` regex literals.
+
+No `CONTROL_PLANE_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`,
+`GEMINI_API_KEY`, real `sk-…` value, `Bearer <token>`, `TOKEN=`, `PASSWORD=`,
+`SECRET=`, or real `tunnel_<id>` value appears in any new file.
+
+### Diff scope
+
+```
+$ git add -A && git diff --cached --stat
+ docs/03-reference/dcp/chatgpt-mcp-readonly/FAILURE_RUNBOOK.md    | 135 ++++
+ docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md  | 114 ++++
+ docs/03-reference/dcp/chatgpt-mcp-readonly/TUNNEL_INTEGRATION.md | 182 ++++
+ 3 files changed, 431 insertions(+)
+```
+
+All changed paths are within `commit.allowlist`
+(`docs/03-reference/dcp/chatgpt-mcp-readonly/**`, `proof/TP-DCP-MCP-RO-0007/**`).
+No `services/**`, `src/**`, `.env*`, `.dopemux/**`, or `compose*.yml` touched.
+
+```
+$ git status --short --branch
+## dcp/chatgpt-mcp-ro-0007-secure-mcp-tunnel-integration-do
+```

--- a/proof/TP-DCP-MCP-RO-0007/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0007/PROOF.json
@@ -15,7 +15,8 @@
       "docs/03-reference/dcp/chatgpt-mcp-readonly/FAILURE_RUNBOOK.md",
       "proof/TP-DCP-MCP-RO-0007/PROOF.json",
       "proof/TP-DCP-MCP-RO-0007/COMMAND_LOG.md",
-      "proof/TP-DCP-MCP-RO-0007/AUDIT.md"
+      "proof/TP-DCP-MCP-RO-0007/AUDIT.md",
+      "proof/TP-DCP-MCP-RO-0007/AUDITOR_REPORT.md"
     ]
   },
   "test_results": {
@@ -51,10 +52,10 @@
     "required": true,
     "status": "PASS_WITH_RISKS",
     "auditor_tool": "claude-code-cli",
-    "auditor_model": "claude-opus-4-8",
+    "auditor_model": "opus",
     "invocation": "self-audit of TP-DCP-MCP-RO-0007 docs challenging doc safety and secret leakage (S3)",
     "exit_code": 0,
-    "report_path": "proof/TP-DCP-MCP-RO-0007/AUDIT.md",
+    "report_path": "proof/TP-DCP-MCP-RO-0007/AUDITOR_REPORT.md",
     "findings": [
       {
         "id": "F-0007-LOW-1",

--- a/proof/TP-DCP-MCP-RO-0007/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0007/PROOF.json
@@ -1,0 +1,81 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0007",
+  "series": "DCP-MCP-RO",
+  "branch": "dcp/chatgpt-mcp-ro-0007-secure-mcp-tunnel-integration-do",
+  "base": "main",
+  "head_sha": "1971da03211efce1190975042799ed98338aa939",
+  "agent": "claude-opus-4-8",
+  "timestamp": "2026-06-10T01:43:17-07:00",
+  "kind": "docs-only",
+  "files_changed": {
+    "modified": [],
+    "created": [
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/TUNNEL_INTEGRATION.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/FAILURE_RUNBOOK.md",
+      "proof/TP-DCP-MCP-RO-0007/PROOF.json",
+      "proof/TP-DCP-MCP-RO-0007/COMMAND_LOG.md",
+      "proof/TP-DCP-MCP-RO-0007/AUDIT.md"
+    ]
+  },
+  "test_results": {
+    "command": "python -m pytest -q services/dcp-readonly-facade/tests",
+    "exit_code": 0,
+    "summary": "108 passed, 1 skipped (live tests require DCP_FACADE_LIVE_TESTS=1)"
+  },
+  "secret_scan": {
+    "command": "rg -n 'CONTROL_PLANE_API_KEY|OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|sk-|Bearer |TOKEN=|PASSWORD=|SECRET=|tunnel_[A-Za-z0-9]' docs/03-reference/dcp/chatgpt-mcp-readonly services/dcp-readonly-facade",
+    "exit_code": 0,
+    "verdict": "NO_REAL_SECRETS",
+    "note": "All matches are false positives: documented scan command (FAILURE_RUNBOOK.md:108), 'sk-' substring of 'task-orchestrator', 'tunnel_s' substring of 'chatgpt_tunnel_suitability', and redaction.py/test_redaction.py regex literals. New files contain only <PLACEHOLDER> tokens. See COMMAND_LOG.md and AUDIT.md §2."
+  },
+  "diff_scope": {
+    "command": "git diff --cached --stat",
+    "summary": "3 files changed, 431 insertions(+); all within commit.allowlist",
+    "outside_allowlist": false,
+    "forbidden_paths_touched": []
+  },
+  "validations": {
+    "deliverable_tunnel_integration_md": "PASS (docs/03-reference/dcp/chatgpt-mcp-readonly/TUNNEL_INTEGRATION.md)",
+    "deliverable_manual_validation_md": "PASS (docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md)",
+    "deliverable_failure_runbook_md": "PASS (docs/03-reference/dcp/chatgpt-mcp-readonly/FAILURE_RUNBOOK.md)",
+    "tunnel_topology_and_loopback_listener": "PASS (TUNNEL_INTEGRATION §1-2; loopback bind documented as operator-enforced with verification gate)",
+    "no_real_credentials_in_docs": "PASS (placeholders only; secret scan classified)",
+    "tunnel_points_only_at_facade": "PASS (TUNNEL_INTEGRATION §3 ingress facade-only + 404 catch-all; FAILURE_RUNBOOK §2)",
+    "manual_checklist_covers_required_cases": "PASS (list_projects §1, get_repo_state_snapshot §2, denied-route tests §5, stale-proof warning §4)",
+    "dev_mode_read_write_warning": "PASS (TUNNEL_INTEGRATION §4, MANUAL_VALIDATION §5.1, FAILURE_RUNBOOK §3)",
+    "existing_tests_pass": "PASS (exit 0, 108 passed)",
+    "secret_scan_no_real_secrets": "PASS (verdict NO_REAL_SECRETS)"
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "PASS_WITH_RISKS",
+    "auditor_tool": "claude-code-cli",
+    "auditor_model": "claude-opus-4-8",
+    "invocation": "self-audit of TP-DCP-MCP-RO-0007 docs challenging doc safety and secret leakage (S3)",
+    "exit_code": 0,
+    "report_path": "proof/TP-DCP-MCP-RO-0007/AUDIT.md",
+    "findings": [
+      {
+        "id": "F-0007-LOW-1",
+        "severity": "LOW",
+        "title": "Failure runbook self-triggers the secret scan by inlining the grep pattern",
+        "status": "ACCEPTED_RISK",
+        "body": "FAILURE_RUNBOOK.md §6/§8 documents the literal secret-scan command so operators can copy it; this always matches the scan. Operator-usefulness tradeoff; commit.verify uses '|| true' (non-blocking) and the criterion is 'no real secrets', which holds."
+      },
+      {
+        "id": "F-0007-LOW-2",
+        "severity": "LOW",
+        "title": "Transport string and FastMCP host/port env names are runtime-version dependent",
+        "status": "ACCEPTED_RISK",
+        "body": "Exact DCP_FACADE_TRANSPORT value and host/port env-var names depend on the installed fastmcp version. Docs flag these UNKNOWN/verify with a mandatory loopback bind-verification gate rather than asserting an unverified default."
+      }
+    ],
+    "fixes_applied": [],
+    "remaining_risks": [
+      "Live tunnel-client connection, ChatGPT connector creation, and MCP inspector session are NOT_RUN (out of scope by packet invariant: no tunnel/connector in CI). The new MANUAL_VALIDATION.md exists to drive these manually.",
+      "Vendor-specific tunnel/connector UI and transport names may drift before an operator runs the manual checklist."
+    ],
+    "skip_reason": null
+  }
+}


### PR DESCRIPTION
## Objective
Document local **Secure MCP Tunnel** integration for the DCP read-only MCP evidence facade: redacted sample configs, local-only runtime posture, manual validation, and the ChatGPT connector test flow — without committing any secrets. (TP-DCP-MCP-RO-0007, 6th of the 7-packet DCP-MCP-RO series.)

## Scope
Docs-only. Three new guides under `docs/03-reference/dcp/chatgpt-mcp-readonly/`:
- `TUNNEL_INTEGRATION.md` — topology, operator-enforced loopback bind + verification gate, redacted tunnel-client ingress (facade-only + `404` catch-all), ChatGPT connector wiring, dev-mode read/write warning, secrets posture.
- `MANUAL_VALIDATION.md` — MCP-inspector/connector checklist: `list_projects`, `get_repo_state_snapshot`, proof-bundle containment, **stale-proof/freshness warnings**, and the **denied/fail-closed route** gate.
- `FAILURE_RUNBOOK.md` — severity-tagged failure modes (non-loopback bind, ingress→backend, write-tool reachable, fail-closed `BLOCKED`/`PARTIAL` reads, secret-scan hit) with fail-closed recovery.

No source, `services/**`, `src/**`, `.env*`, `.dopemux/**`, or `compose*.yml` touched. Allowlist: `docs/03-reference/dcp/chatgpt-mcp-readonly/**`, `proof/TP-DCP-MCP-RO-0007/**`.

## Evidence
Docs grounded in observed runtime: facade defaults to `stdio` and does **not** pin host/port (`server.py:102-104`) → loopback is an operator-enforced control with a mandatory bind-verification step (matches `SECURITY_MODEL.md` §1). Tunnel→facade-only and read/write-denylist invariants traced from `SECURITY_MODEL.md`, `ARCHITECTURE.md`, `TOOL_CONTRACT.md`. Runtime facts labelled `OBSERVED`; procedure `PROPOSED`; version-dependent transport/host names `UNKNOWN`/verify.

## Validation
- **PASS** — `python -m pytest -q services/dcp-readonly-facade/tests`: 108 passed, 1 skipped (exit 0). Docs change nothing structural; run as baseline.
- **PASS** — secret scan (commit.verify regex): exit 0, verdict **NO_REAL_SECRETS**. All hits classified false-positive (documented scan command; `sk-` inside "ta**sk**-orchestrator"; `tunnel_s` inside `chatgpt_tunnel_suitability`; redaction regex literals). New files carry only `<PLACEHOLDER>` tokens.
- **PASS** — diff scope: 3 files, 431 insertions, all within allowlist; zero forbidden paths.
- **NOT_RUN** — live tunnel-client connection, ChatGPT connector creation, MCP-inspector session: out of scope by packet invariant (no tunnel/connector in CI). These are exactly what `MANUAL_VALIDATION.md` exists to drive by hand.

## Embedded audit
Self-audit (`proof/TP-DCP-MCP-RO-0007/AUDIT.md`), verdict **PASS_WITH_RISKS** (non-blocking). Challenged doc safety + secret leakage; no HIGH/CRITICAL. Two LOW accepted risks (F-0007-LOW-1, F-0007-LOW-2).

## Risks and unknowns
- LOW: runbook inlines the secret-scan pattern → self-triggers the scan (operator-usefulness tradeoff; `|| true` non-blocking).
- LOW: exact `DCP_FACADE_TRANSPORT` value + FastMCP host/port env names are runtime-version dependent → flagged `UNKNOWN`/verify with a hard loopback-bind gate rather than asserting a default.
- Vendor tunnel/connector UI + transport names may drift before an operator runs the manual checklist.

## Rollback
`git revert <merge>` or delete branch `dcp/chatgpt-mcp-ro-0007-secure-mcp-tunnel-integration-do`. Docs-only; no runtime/migration/schema impact.

## Proof bundle links
`proof/TP-DCP-MCP-RO-0007/` — `PROOF.json`, `COMMAND_LOG.md`, `AUDIT.md`.
