### PR TITLE
fix(docker): copy full src/ and tools/ before installing dopemux wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy dependency manifests first for better caching
-COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/__init__.py
+# Copy dependency manifests and package sources required by setuptools metadata
+# (pyproject [tool.setuptools] packages spans conport/core/dopemux + tools.*)
+COPY pyproject.toml ./
+COPY src/ src/
+COPY tools/ tools/
 
 # Create virtual environment
 RUN python -m venv /opt/venv

--- a/docker/mcp-servers-source/conport/Dockerfile
+++ b/docker/mcp-servers-source/conport/Dockerfile
@@ -4,9 +4,11 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 WORKDIR /app
 
-# Copy dependency manifests first for better caching
-COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/
+# Copy dependency manifests and package sources required by setuptools metadata
+# (pyproject [tool.setuptools] packages spans conport/core/dopemux + tools.*)
+COPY pyproject.toml ./
+COPY src/ src/
+COPY tools/ tools/
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \

--- a/services/adhd_engine/Dockerfile
+++ b/services/adhd_engine/Dockerfile
@@ -11,9 +11,11 @@ WORKDIR /app
 # Keep minimal; remove what you don't need
 RUN apk add --no-cache build-base gcc musl-dev libffi-dev openssl-dev curl
 
-# Copy dependency manifests first for better caching
+# Copy dependency manifests and package sources required by setuptools metadata
+# (pyproject [tool.setuptools] packages spans conport/core/dopemux + tools.*)
 COPY pyproject.toml /app/pyproject.toml
-COPY src/dopemux/__init__.py /app/src/dopemux/__init__.py
+COPY src/ /app/src/
+COPY tools/ /app/tools/
 RUN python -m venv /app/venv && \
     /app/venv/bin/pip install --no-cache-dir /app/.[services]
 
@@ -21,8 +23,6 @@ RUN python -m venv /app/venv && \
 COPY services/adhd_engine /app/services/adhd_engine
 COPY services/adhd_engine/mcp_stdio.py /app/mcp_stdio.py
 COPY services/shared /app/services/shared
-# Note: src/dopemux/__init__.py was already copied above
-COPY src/dopemux /app/src/dopemux
 # Copy repo root shared/ for monitoring module
 COPY shared /app/shared
 

--- a/services/claude_brain/Dockerfile
+++ b/services/claude_brain/Dockerfile
@@ -9,9 +9,11 @@ RUN apt-get update && apt-get install -y \
     gcc \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy dependency manifests first for better caching
-COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/__init__.py
+# Copy dependency manifests and package sources required by setuptools metadata
+# (pyproject [tool.setuptools] packages spans conport/core/dopemux + tools.*)
+COPY pyproject.toml ./
+COPY src/ src/
+COPY tools/ tools/
 
 # Install Python dependencies from centralized manifest
 RUN pip install --no-cache-dir .[services]

--- a/services/dopecon-bridge/Dockerfile
+++ b/services/dopecon-bridge/Dockerfile
@@ -12,10 +12,11 @@ RUN apt-get update && apt-get install -y \
 # Set up working directory
 WORKDIR /app
 
-# Copy dependency manifests first for better caching
-# We need pyproject.toml and the core package structure for pip install .[services]
-COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/__init__.py
+# Copy dependency manifests and package sources required by setuptools metadata
+# (pyproject [tool.setuptools] packages spans conport/core/dopemux + tools.*)
+COPY pyproject.toml ./
+COPY src/ src/
+COPY tools/ tools/
 
 # Install Python dependencies from centralized manifest
 RUN pip install --no-cache-dir .[services]

--- a/services/task-orchestrator/Dockerfile
+++ b/services/task-orchestrator/Dockerfile
@@ -8,9 +8,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   curl \
   && rm -rf /var/lib/apt/lists/*
 
-# Copy dependency manifests first for better caching
-COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/__init__.py
+# Copy dependency manifests and package sources required by setuptools metadata
+# (pyproject [tool.setuptools] packages spans conport/core/dopemux + tools.*)
+COPY pyproject.toml ./
+COPY src/ src/
+COPY tools/ tools/
 
 # Install Python dependencies from centralized manifest
 RUN uv pip install --system --no-cache .[services]

--- a/services/webhook_receiver/Dockerfile
+++ b/services/webhook_receiver/Dockerfile
@@ -2,9 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Copy dependency manifests first for better caching
-COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/
+# Copy dependency manifests and package sources required by setuptools metadata
+# (pyproject [tool.setuptools] packages spans conport/core/dopemux + tools.*)
+COPY pyproject.toml ./
+COPY src/ src/
+COPY tools/ tools/
 
 RUN apt-get update && apt-get install -y sqlite3 && rm -rf /var/lib/apt/lists/*
 # Install Python dependencies from centralized manifest

--- a/services/working-memory-assistant/Dockerfile.dope-memory
+++ b/services/working-memory-assistant/Dockerfile.dope-memory
@@ -28,9 +28,11 @@ RUN apt-get update && apt-get install -y \
 # Create app directory
 WORKDIR /app
 
-# Copy dependency manifests first for better caching
-COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/__init__.py
+# Copy dependency manifests and package sources required by setuptools metadata
+# (pyproject [tool.setuptools] packages spans conport/core/dopemux + tools.*)
+COPY pyproject.toml ./
+COPY src/ src/
+COPY tools/ tools/
 
 # Install Python dependencies from centralized manifest
 RUN pip install --no-cache-dir .[services]


### PR DESCRIPTION
## Summary

The GHCR container-build workflow (`containers.yml`) fails for all 8 matrix services that install the repo package — adhd-engine, claude-brain, conport, dope-memory, dopecon-bridge, dopemux-backend, task-orchestrator, webhook-receiver — with:

```
× Failed to build dopemux @ file:///app
  error: package directory 'src/conport' does not exist
```

Example failing run: https://github.com/DDD-Enterprises/dopemux-mvp/actions/runs/27264302283

**Root cause**: `pyproject.toml` `[tool.setuptools]` declares 67 packages spanning `src/conport`, `src/core`, `src/dopemux.*`, and `tools.*`, but these Dockerfiles copied only `pyproject.toml` + `src/dopemux/__init__.py` before `uv/pip install .[services]`, so setuptools could not find the declared package directories and the wheel build aborted. (litellm is the only matrix entry that doesn't install the package — and the only green job.)

**Fix**: apply the same pattern already used for serena on #852 — `COPY pyproject.toml` + `src/` + `tools/` before the install. Also drops the now-redundant `COPY src/dopemux` in the adhd_engine builder stage.

## Verification

All 8 images built locally with repo-root context:

| Service | Result |
|---|---|
| dopemux-backend | PASS (native) |
| conport | PASS (native) |
| task-orchestrator | PASS (native) |
| claude-brain | PASS (native) |
| adhd-engine | PASS (`--platform linux/amd64`) |
| dopecon-bridge | PASS (native) |
| webhook-receiver | PASS (native) |
| dope-memory | PASS (native) |

Note on adhd-engine: it fails to build natively on arm64 Macs because pymupdf publishes no musllinux aarch64 wheel (alpine base → source build of MuPDF). CI runs linux/amd64, where the `musllinux_1_2_x86_64` wheel exists — verified by building with `--platform linux/amd64`, which passes. Pre-existing condition, unrelated to this fix.

Side check: the wheel build was verified to succeed without `README.md` in the build context (`.dockerignore` excludes `*.md`; setuptools tolerates the missing readme declared in `pyproject.toml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)