### PR TITLE
fix(wma): fail closed on work_log_entries constraint violations

### DIFF
--- a/services/working-memory-assistant/README.md
+++ b/services/working-memory-assistant/README.md
@@ -212,6 +212,37 @@ Gentle Re-orientation → Flow State Resumed
 - **Memory Footprint**: <50MB sustained
 - **Cache Hit Rate**: >90% for optimal performance
 
+### Chronicle Store Write Semantics
+
+`insert_work_log_entry` (in `chronicle/store.py`) validates enum fields before the INSERT and raises `ValueError` if any value is outside the allowed set. This mirrors the CHECK constraints in `schema.sql` and prevents the `INSERT OR IGNORE` clause from silently swallowing constraint violations while returning a phantom `entry_id`.
+
+Fields validated at write time:
+
+| Field | Allowed values (mirrors `schema.sql`) |
+|---|---|
+| `category` | `architecture`, `debugging`, `deployment`, `documentation`, `implementation`, `planning`, `research`, `review` |
+| `entry_type` | `blocker`, `decision`, `error`, `manual_note`, `milestone`, `resolution`, `task_event`, `workflow_transition` |
+| `workflow_phase` | `audit`, `deployment`, `implementation`, `maintenance`, `planning`, `review` (or `None`) |
+| `outcome` | `abandoned`, `blocked`, `failed`, `in_progress`, `partial`, `success` |
+| `importance_score` | integer 1–10 |
+
+**Idempotent replay**: if the INSERT is silently ignored (`rowcount == 0`) and the computed `entry_id` already exists in the database, the existing `id` is returned without error. This is the only legitimate case for `OR IGNORE` — a retry of an identical provenance tuple.
+
+**MCP tool effect**: the `memory_store` MCP tool returns `success=false` with the validation error message when any of the above checks fail. Callers should not treat a returned `entry_id` as evidence of a successful write without also checking `success`.
+
+### Promotion-Time Validation for Manual Events
+
+`manual.memory_store` events carry caller-controlled `category`, `entry_type`, `outcome`, and `workflow_phase`. The promotion handler (`promotion/promotion.py:_promote_manual_memory_store`) validates these fields before constructing a `PromotedEntry`:
+
+- **`category`**: must be in `VALID_CATEGORIES` (same set as above).
+- **`entry_type`**: restricted to the manual subset — `manual_note`, `decision`, `blocker`, `resolution`, `milestone`. Machine-generated types (`error`, `workflow_transition`, `task_event`) are not accepted via manual events.
+- **`outcome`**: must be in `VALID_OUTCOMES`. Invalid values cause the handler to return `None`.
+- **`workflow_phase`**: must be in `VALID_WORKFLOW_PHASES` if provided. `None` is accepted.
+
+When the handler returns `None`, the eventbus consumer treats the event as not-promotable and acks it, leaving only a raw event record. This prevents a poison-message loop: if validation were deferred to the store layer, the store's `ValueError` would propagate to the consumer, which never acks on exception, causing indefinite retries.
+
+Regression tests: `tests/test_store_fail_closed.py` (12 tests, including schema-parity assertions that parse `schema.sql` CHECK constraints and compare them to the module-level frozensets) and `tests/test_promotion_allowlist.py::TestManualMemoryStoreFieldValidation` (4 tests).
+
 ## Integration Points
 
 ### ADHD Engine Integration

--- a/services/working-memory-assistant/chronicle/store.py
+++ b/services/working-memory-assistant/chronicle/store.py
@@ -36,6 +36,23 @@ except ImportError:
 
 MAX_CHAIN_DEPTH = 10
 
+# Enum values mirror the CHECK constraints in schema.sql (work_log_entries).
+# Keep in sync — schema.sql is the canonical writer.
+VALID_CATEGORIES = frozenset({
+    'planning', 'implementation', 'review', 'debugging',
+    'research', 'deployment', 'architecture', 'documentation',
+})
+VALID_ENTRY_TYPES = frozenset({
+    'decision', 'blocker', 'resolution', 'milestone', 'error',
+    'workflow_transition', 'manual_note', 'task_event',
+})
+VALID_WORKFLOW_PHASES = frozenset({
+    'planning', 'implementation', 'review', 'audit', 'deployment', 'maintenance',
+})
+VALID_OUTCOMES = frozenset({
+    'success', 'partial', 'blocked', 'abandoned', 'in_progress', 'failed',
+})
+
 LOGGER = logging.getLogger(__name__)
 SCHEMA_PATH = Path(__file__).parent / "schema.sql"
 MIGRATIONS_DIR = Path(__file__).parent / "migrations"
@@ -392,6 +409,34 @@ class ChronicleStore:
                 f"promotion_rule={promotion_rule}"
             )
         
+        # Enum validation (fail-closed): INSERT OR IGNORE would otherwise
+        # silently swallow CHECK constraint violations while we still return
+        # a deterministic entry_id that was never written.
+        if category not in VALID_CATEGORIES:
+            raise ValueError(
+                f"Invalid category '{category}'. "
+                f"Must be one of: {', '.join(sorted(VALID_CATEGORIES))}"
+            )
+        if entry_type not in VALID_ENTRY_TYPES:
+            raise ValueError(
+                f"Invalid entry_type '{entry_type}'. "
+                f"Must be one of: {', '.join(sorted(VALID_ENTRY_TYPES))}"
+            )
+        if workflow_phase is not None and workflow_phase not in VALID_WORKFLOW_PHASES:
+            raise ValueError(
+                f"Invalid workflow_phase '{workflow_phase}'. "
+                f"Must be one of: {', '.join(sorted(VALID_WORKFLOW_PHASES))} (or None)"
+            )
+        if outcome not in VALID_OUTCOMES:
+            raise ValueError(
+                f"Invalid outcome '{outcome}'. "
+                f"Must be one of: {', '.join(sorted(VALID_OUTCOMES))}"
+            )
+        if not isinstance(importance_score, int) or not (1 <= importance_score <= 10):
+            raise ValueError(
+                f"Invalid importance_score {importance_score!r}. Must be an integer between 1 and 10."
+            )
+
         # Supersession chain validation (Packet F §3.2, §3.4)
         if supersedes_entry_id:
             # Verify target entry exists
@@ -476,23 +521,27 @@ class ChronicleStore:
         )
         conn.commit()
 
-        # Loud fail for supersession conflicts (Packet F §3.2 fork prevention)
-        if cursor.rowcount == 0 and supersedes_entry_id:
-            # Check if it was ignored because entry_id matches (OK) 
-            # or because supersedes_entry_id matches a DIFFERENT entry (FAIL)
+        # Fail closed on silently-ignored INSERTs. rowcount == 0 with an
+        # existing entry_id is the legitimate idempotent-replay case; anything
+        # else means a constraint rejected the row and OR IGNORE swallowed it.
+        if cursor.rowcount == 0:
             existing = self.get_entry_by_id(workspace_id, instance_id, entry_id)
             if not existing:
-                # If entry_id doesn't exist but rowcount was 0, 
-                # then it MUST be the supersedes_entry_id UNIQUE constraint.
-                row = conn.execute(
-                    "SELECT id FROM work_log_entries WHERE supersedes_entry_id = ? AND workspace_id = ? AND instance_id = ?",
-                    (supersedes_entry_id, workspace_id, instance_id),
-                ).fetchone()
-                if row:
-                    raise ValueError(
-                        f"Supersession fork attempt rejected. Entry {supersedes_entry_id} "
-                        f"is already superseded by {row[0]}."
-                    )
+                # Loud fail for supersession conflicts (Packet F §3.2 fork prevention)
+                if supersedes_entry_id:
+                    row = conn.execute(
+                        "SELECT id FROM work_log_entries WHERE supersedes_entry_id = ? AND workspace_id = ? AND instance_id = ?",
+                        (supersedes_entry_id, workspace_id, instance_id),
+                    ).fetchone()
+                    if row:
+                        raise ValueError(
+                            f"Supersession fork attempt rejected. Entry {supersedes_entry_id} "
+                            f"is already superseded by {row[0]}."
+                        )
+                raise ValueError(
+                    f"work_log_entries INSERT for entry {entry_id} was rejected by a "
+                    f"database constraint and silently ignored; entry was NOT written."
+                )
 
         return entry_id
     

--- a/services/working-memory-assistant/promotion/promotion.py
+++ b/services/working-memory-assistant/promotion/promotion.py
@@ -8,6 +8,8 @@ the Phase 1 promotion rules defined in spec 05_promotion_redaction.md.
 from dataclasses import dataclass
 from typing import Any, Optional
 
+from chronicle.store import VALID_CATEGORIES, VALID_OUTCOMES, VALID_WORKFLOW_PHASES
+
 from .redactor import Redactor
 
 # Phase 1 promotable event types (canonical dotted form)
@@ -393,17 +395,10 @@ class PromotionEngine:
         if not category or not entry_type or not summary:
             return None
 
-        # Validate category/entry_type
-        valid_categories = {
-            "planning",
-            "implementation",
-            "review",
-            "debugging",
-            "research",
-            "deployment",
-            "architecture",
-            "documentation",
-        }
+        # Validate category/entry_type.
+        # Manual entries are restricted to an intentional subset of the
+        # schema's entry types — machine-generated types (error,
+        # workflow_transition, task_event) cannot be claimed manually.
         valid_entry_types = {
             "manual_note",
             "decision",
@@ -412,7 +407,19 @@ class PromotionEngine:
             "milestone",
         }
 
-        if category not in valid_categories or entry_type not in valid_entry_types:
+        if category not in VALID_CATEGORIES or entry_type not in valid_entry_types:
+            return None
+
+        # Validate caller-controlled outcome/workflow_phase. The fail-closed
+        # store raises ValueError on invalid enums; if that propagated, the
+        # eventbus consumer would never ack the message and retry the poison
+        # event forever. Reject at promotion time instead (not promotable).
+        outcome = data.get("outcome", "in_progress")
+        if outcome not in VALID_OUTCOMES:
+            return None
+
+        workflow_phase = data.get("workflow_phase")
+        if workflow_phase is not None and workflow_phase not in VALID_WORKFLOW_PHASES:
             return None
 
         # Get importance from payload or default
@@ -430,9 +437,9 @@ class PromotionEngine:
             category=category,
             entry_type=entry_type,
             summary=summary[:500],
-            outcome=data.get("outcome", "in_progress"),
+            outcome=outcome,
             importance_score=importance,
-            workflow_phase=data.get("workflow_phase"),
+            workflow_phase=workflow_phase,
             details=details,
             reasoning=data.get("reasoning"),
             tags=self._extract_tags(data),

--- a/services/working-memory-assistant/tests/test_promotion_allowlist.py
+++ b/services/working-memory-assistant/tests/test_promotion_allowlist.py
@@ -186,3 +186,49 @@ class TestPromotionAllowlist:
             {"decision_id": "dec-1", "title": "Test", "rationale": "Because..."},
         )
         assert entry is not None
+
+
+class TestManualMemoryStoreFieldValidation:
+    """manual.memory_store events carry caller-controlled outcome/workflow_phase.
+
+    Invalid values must be rejected at promotion time (return None) — otherwise
+    the fail-closed store raises ValueError downstream and the eventbus consumer
+    never acks the message, retrying the poison event forever.
+    """
+
+    @pytest.fixture
+    def engine(self):
+        return PromotionEngine()
+
+    def _event(self, **payload_overrides):
+        payload = {
+            "category": "planning",
+            "entry_type": "manual_note",
+            "summary": "User note",
+        }
+        payload.update(payload_overrides)
+        return {
+            "id": "evt-manual-1",
+            "event_type": "manual.memory_store",
+            "source": "mcp-server",
+            "ts_utc": "2026-06-10T00:00:00+00:00",
+            "payload": payload,
+        }
+
+    def test_invalid_outcome_is_not_promoted(self, engine):
+        assert engine.promote(self._event(outcome="finished")) is None
+
+    def test_invalid_workflow_phase_is_not_promoted(self, engine):
+        assert engine.promote(self._event(workflow_phase="testing")) is None
+
+    def test_valid_outcome_and_phase_promote(self, engine):
+        entry = engine.promote(self._event(outcome="success", workflow_phase="review"))
+        assert entry is not None
+        assert entry.outcome == "success"
+        assert entry.workflow_phase == "review"
+
+    def test_omitted_outcome_and_phase_promote_with_defaults(self, engine):
+        entry = engine.promote(self._event())
+        assert entry is not None
+        assert entry.outcome == "in_progress"
+        assert entry.workflow_phase is None

--- a/services/working-memory-assistant/tests/test_store_fail_closed.py
+++ b/services/working-memory-assistant/tests/test_store_fail_closed.py
@@ -1,0 +1,88 @@
+"""
+Regression tests: insert_work_log_entry must fail closed on constraint violations.
+
+Previously, INSERT OR IGNORE silently swallowed CHECK constraint failures
+(e.g. category="testing") while the function still returned the deterministic
+entry_id — callers reported created=True for entries that were never written.
+"""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from chronicle.store import ChronicleStore
+
+
+WORKSPACE_ID = "test_ws"
+INSTANCE_ID = "test_inst"
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> Iterator[ChronicleStore]:
+    s = ChronicleStore(db_path=tmp_path / "chronicle.db")
+    s.initialize_schema()
+    yield s
+    s.close()
+
+
+def _entry_kwargs(**overrides):
+    kwargs = dict(
+        workspace_id=WORKSPACE_ID,
+        instance_id=INSTANCE_ID,
+        category="implementation",
+        entry_type="manual_note",
+        summary="A valid entry",
+        source_event_id="manual-test-0001",
+        source_event_type="manual.memory_store",
+        source_adapter="mcp-server",
+        source_event_ts_utc="2026-06-10T00:00:00+00:00",
+        promotion_rule="manual",
+    )
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _count_entries(store: ChronicleStore) -> int:
+    return store.connect().execute(
+        "SELECT COUNT(*) FROM work_log_entries"
+    ).fetchone()[0]
+
+
+class TestInsertWorkLogEntryFailClosed:
+    def test_invalid_category_raises_and_writes_nothing(self, store):
+        with pytest.raises(ValueError, match="category"):
+            store.insert_work_log_entry(**_entry_kwargs(category="testing"))
+        assert _count_entries(store) == 0
+
+    def test_invalid_entry_type_raises_and_writes_nothing(self, store):
+        with pytest.raises(ValueError, match="entry_type"):
+            store.insert_work_log_entry(**_entry_kwargs(entry_type="bogus"))
+        assert _count_entries(store) == 0
+
+    def test_invalid_outcome_raises_and_writes_nothing(self, store):
+        with pytest.raises(ValueError, match="outcome"):
+            store.insert_work_log_entry(**_entry_kwargs(outcome="finished"))
+        assert _count_entries(store) == 0
+
+    def test_invalid_workflow_phase_raises_and_writes_nothing(self, store):
+        with pytest.raises(ValueError, match="workflow_phase"):
+            store.insert_work_log_entry(**_entry_kwargs(workflow_phase="testing"))
+        assert _count_entries(store) == 0
+
+    def test_out_of_range_importance_score_raises_and_writes_nothing(self, store):
+        with pytest.raises(ValueError, match="importance_score"):
+            store.insert_work_log_entry(**_entry_kwargs(importance_score=11))
+        assert _count_entries(store) == 0
+
+    def test_valid_insert_is_actually_written(self, store):
+        entry_id = store.insert_work_log_entry(**_entry_kwargs())
+        assert _count_entries(store) == 1
+        assert store.get_entry_by_id(WORKSPACE_ID, INSTANCE_ID, entry_id) is not None
+
+    def test_idempotent_replay_still_succeeds(self, store):
+        """Same provenance twice = legitimate IGNORE case, must not raise."""
+        first = store.insert_work_log_entry(**_entry_kwargs())
+        second = store.insert_work_log_entry(**_entry_kwargs())
+        assert first == second
+        assert _count_entries(store) == 1

--- a/services/working-memory-assistant/tests/test_store_fail_closed.py
+++ b/services/working-memory-assistant/tests/test_store_fail_closed.py
@@ -86,3 +86,64 @@ class TestInsertWorkLogEntryFailClosed:
         second = store.insert_work_log_entry(**_entry_kwargs())
         assert first == second
         assert _count_entries(store) == 1
+
+
+class TestCorrectEntryFailClosed:
+    def test_correction_with_invalid_category_raises(self, store):
+        """correct_entry must not return an id for a correction never persisted."""
+        original_id = store.insert_work_log_entry(**_entry_kwargs())
+        with pytest.raises(ValueError, match="category"):
+            store.correct_entry(
+                workspace_id=WORKSPACE_ID,
+                instance_id=INSTANCE_ID,
+                entry_id=original_id,
+                correction_type="category",
+                corrected_category="bogus",
+            )
+        assert _count_entries(store) == 1  # only the original
+
+
+class TestEnumConstantsMatchSchema:
+    """Parse the CHECK constraints out of schema.sql and assert the mirrored
+    frozensets in store.py match exactly, so schema edits fail loudly."""
+
+    def _parse_check_values(self, sql: str, column: str) -> set:
+        import re
+
+        match = re.search(
+            column + r"\s+TEXT[^,]*?CHECK\s*\(\s*" + column + r"\s+IN\s*\(([^)]*)\)",
+            sql,
+            re.DOTALL,
+        )
+        assert match, f"No CHECK constraint found for {column} in schema.sql"
+        return set(re.findall(r"'([^']+)'", match.group(1)))
+
+    @pytest.fixture
+    def schema_sql(self):
+        from chronicle.store import SCHEMA_PATH
+
+        return SCHEMA_PATH.read_text()
+
+    def test_categories_match(self, schema_sql):
+        from chronicle.store import VALID_CATEGORIES
+
+        assert set(VALID_CATEGORIES) == self._parse_check_values(schema_sql, "category")
+
+    def test_entry_types_match(self, schema_sql):
+        from chronicle.store import VALID_ENTRY_TYPES
+
+        assert set(VALID_ENTRY_TYPES) == self._parse_check_values(
+            schema_sql, "entry_type"
+        )
+
+    def test_workflow_phases_match(self, schema_sql):
+        from chronicle.store import VALID_WORKFLOW_PHASES
+
+        assert set(VALID_WORKFLOW_PHASES) == self._parse_check_values(
+            schema_sql, "workflow_phase"
+        )
+
+    def test_outcomes_match(self, schema_sql):
+        from chronicle.store import VALID_OUTCOMES
+
+        assert set(VALID_OUTCOMES) == self._parse_check_values(schema_sql, "outcome")


### PR DESCRIPTION
## Summary
- `insert_work_log_entry` used `INSERT OR IGNORE`, which silently swallowed CHECK constraint violations (e.g. `category="testing"`) while still returning the deterministic entry_id — the `memory_store` MCP tool reported `{"created": true}` for entries that were never written, and later searches returned nothing.
- Fix (fail-closed, two layers): explicit enum validation before insert (`category`/`entry_type`/`workflow_phase`/`outcome`/`importance_score`, raising `ValueError` naming the field and allowed values) plus a rowcount backstop that raises when an INSERT is silently ignored and the entry_id does not already exist. Idempotent replay of identical provenance remains the one legitimate IGNORE case. Supersession-fork detection preserved.
- Review follow-up: `manual.memory_store` events carry caller-controlled `outcome`/`workflow_phase`; these are now rejected at promotion time (handler returns None, consumer acks) so a malformed event cannot become a poison message that the eventbus consumer retries forever (it never acks on exception).
- Docs: service README documents the fail-closed write semantics and promotion-time validation.

## Test plan
- [x] 12 regression tests in `tests/test_store_fail_closed.py` (TDD red-green): each invalid enum raises and writes 0 rows; valid insert persists; idempotent replay returns the same id; `correct_entry` with invalid category raises; schema-parity tests parse `schema.sql` CHECK lists and assert the mirrored frozensets match exactly.
- [x] 4 tests in `tests/test_promotion_allowlist.py::TestManualMemoryStoreFieldValidation`: invalid outcome/workflow_phase not promoted; valid values and defaults still promote.
- [x] End-to-end reproduction: `memory_store(category="testing")` now returns `success=false` with a named error and 0 rows written (was `created: true`, 0 rows).
- [x] Suite baseline comparison: 31 pre-existing failures (old `insert_work_log_entry` signatures) unchanged before/after; no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)