### PR TITLE
feat(opencode): wire PAL MCP into OpenCode with agents, guide, and hygiene updates

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,5 +1,6 @@
 ---
 name: architect
+description: Strategic design specialist for system architecture, architectural decisions, pattern identification, and technical strategy (PM Plane, PLAN-mode optimized).
 ---
 
 # Architect Agent Configuration

--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -1,5 +1,6 @@
 ---
 name: developer
+description: Implementation-focused specialist for code generation, debugging, testing, and artifact creation (Cognitive Plane, ACT-mode optimized).
 ---
 
 # Developer Agent Configuration

--- a/.claude/agents/project-manager.md
+++ b/.claude/agents/project-manager.md
@@ -1,5 +1,6 @@
 ---
 name: project-manager
+description: Cross-plane coordination specialist for sprint management, task orchestration, plane coordination, and progress tracking (Integration Bridge).
 ---
 
 # Project Manager Agent Configuration

--- a/.claude/agents/researcher.md
+++ b/.claude/agents/researcher.md
@@ -1,5 +1,6 @@
 ---
 name: researcher
+description: Information gathering and analysis specialist for documentation research, technology evaluation, information synthesis, and knowledge curation (cross-plane).
 ---
 
 # Researcher Agent Configuration

--- a/.opencode/agents/pal-planner.md
+++ b/.opencode/agents/pal-planner.md
@@ -1,3 +1,8 @@
+---
+description: PAL planning subagent — delegates to the local pal MCP server for multi-model planning and the analyze → planner → codereview → precommit chain. See config/instructions/pal-opencode-guide.md and AGENTS.md.
+mode: subagent
+---
+
 # PAL Planner (OpenCode)
 
 See `config/instructions/pal-opencode-guide.md` and `AGENTS.md` for full PAL usage, tool permissions (pal_* = ask), and chain rules (analyze → planner → codereview → precommit minimum).

--- a/.opencode/agents/pal-planner.md
+++ b/.opencode/agents/pal-planner.md
@@ -1,0 +1,5 @@
+# PAL Planner (OpenCode)
+
+See `config/instructions/pal-opencode-guide.md` and `AGENTS.md` for full PAL usage, tool permissions (pal_* = ask), and chain rules (analyze → planner → codereview → precommit minimum).
+
+This agent delegates to the local `pal` MCP server registered in opencode.jsonc (via start-pal.sh).

--- a/.opencode/agents/pal-reviewer.md
+++ b/.opencode/agents/pal-reviewer.md
@@ -1,3 +1,8 @@
+---
+description: PAL codereview/precommit subagent — uses the pal MCP codereview and precommit tools for multi-model validation before commits. See config/instructions/pal-opencode-guide.md and AGENTS.md §5.
+mode: subagent
+---
+
 # PAL Reviewer / Codereview (OpenCode)
 
 See `config/instructions/pal-opencode-guide.md` and `AGENTS.md` §5 for PAL codereview and precommit expectations.

--- a/.opencode/agents/pal-reviewer.md
+++ b/.opencode/agents/pal-reviewer.md
@@ -1,0 +1,5 @@
+# PAL Reviewer / Codereview (OpenCode)
+
+See `config/instructions/pal-opencode-guide.md` and `AGENTS.md` §5 for PAL codereview and precommit expectations.
+
+Use the `codereview` and `precommit` tools from the pal MCP for multi-model validation before commits.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,6 +129,7 @@ repos:
               if [[ "$normalized" =~ /\.taskx/ ]]; then continue; fi
               if [[ "$normalized" =~ /\.vibe/ ]]; then continue; fi
               if [[ "$normalized" =~ /\.Jules/ ]]; then continue; fi
+              if [[ "$normalized" =~ /\.opencode/ ]]; then continue; fi
               if [[ "$normalized" =~ ^\./(\.conport/|conport_export/) ]]; then continue; fi
               if [[ "$normalized" =~ ^\./(\.github/) ]]; then continue; fi
               if [[ "$normalized" =~ ^\./(examples/) ]]; then continue; fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,3 +158,23 @@ When updating doctrine, keep these three files in sync:
 - `AGENTS.md` (this file) — Codex authority, Task Packet rules, PAL chains, proof bundle requirements
 - `.claude/claude.md` — Claude-Code-facing summary + non-negotiables checklist
 - `.claude/modules/shared/governance-principles.md` — full canonical doctrine, referenced by both
+
+## 11. OpenCode Auto-Load Behavior (2026-06)
+
+OpenCode does **not** behave like Claude Code regarding instruction files.
+
+**What OpenCode automatically reads:**
+- `AGENTS.md` in the project root
+- `~/.config/opencode/AGENTS.md` (global)
+- Files listed in the `"instructions"` array inside `opencode.json` or `opencode.jsonc`
+
+**What OpenCode does NOT automatically read:**
+- `CLAUDE.md` (unless explicitly listed in `"instructions"`)
+- Arbitrary files under `~/.claude/` (e.g. `~/.claude/PAL_OPENCODE_GUIDE.md`)
+- `CLAUDE.local.md` or similar Claude-specific files
+
+**Rule for this repo:**
+- All OpenCode-specific guidance (including PAL tool usage rules) must be placed in one of:
+  - `AGENTS.md`
+  - A file referenced via `"instructions"` in `opencode.jsonc`
+- Never rely on `~/.claude/*.md` files being loaded by OpenCode.

--- a/config/instructions/pal-opencode-guide.md
+++ b/config/instructions/pal-opencode-guide.md
@@ -1,0 +1,46 @@
+# PAL for OpenCode
+
+Use PAL tools as workflow gates, not decoration.
+
+## Core Chain (non-trivial repo work)
+
+```
+analyze → thinkdeep → challenge → planner → challenge → codereview → precommit → challenge
+```
+
+## Rules
+
+- **Do not** use `planner` before validated understanding (MEDIUM+ confidence).
+- **Do not** implement before plan challenge.
+- **Do not** use `consensus` unless there are at least two credible approaches.
+- **Do not** use `debug` unless there is a failure, contradiction, or concrete uncertainty.
+- **Do not** call completion without evidence.
+
+## Tool Usage
+
+| Tool            | When to Use                                      | Output Requirements                     |
+|-----------------|--------------------------------------------------|-----------------------------------------|
+| `pal_thinkdeep` | Hidden coupling, second-order effects, architecture risk | Evidence ledger + assumptions           |
+| `pal_planner`   | Only after understanding reaches MEDIUM          | Phased breakdown + validation gates     |
+| `pal_consensus` | Expensive or reversible design forks             | For/against/neutral synthesis           |
+| `pal_debug`     | Concrete failure or contradiction                | Root cause + reproduction steps         |
+| `pal_codereview`| After diff stabilizes                            | Quality, security, performance findings |
+| `pal_precommit` | Before any commit                                | Checklist + residual risk               |
+| `pal_challenge` | Before advancing any major phase                 | Attack assumptions + failure modes      |
+
+## Required Output Shape (every PAL stage)
+
+Every response from a PAL tool must contain:
+
+- **Summary** — one sentence
+- **Evidence Ledger** — what was inspected
+- **Assumptions** — what is being taken as given
+- **Confidence** — exploring / low / medium / high / certain
+- **Next Action** — concrete next step (or stop)
+
+## Lazy-Load Deeper Doctrine
+
+Only when needed:
+
+- `docs/03-reference/execution/pal-execution-rules.md`
+- `docs/03-reference/execution/pal-chaining-doctrine.md`

--- a/config/repo_hygiene/root_hygiene_policy.json
+++ b/config/repo_hygiene/root_hygiene_policy.json
@@ -61,7 +61,8 @@
     "proof_bundle",
     "llm-docs",
     "dopemux",
-    "dopemux_pr_merge_specialist"
+    "dopemux_pr_merge_specialist",
+    ".opencode"
   ],
   "allowed_root_files": [
     "SPECIMEN_LEDGER_REGEN_BIG.csv",
@@ -179,7 +180,8 @@
     "CHECKLIST.md",
     ".dockerignore",
     ".python-version",
-    "KNOWN_GAPS.md"
+    "KNOWN_GAPS.md",
+    "opencode.jsonc"
   ],
   "legacy_root_files": [
     "ARCHITECTURE.md",

--- a/docker/mcp-servers-source/pal/pal-mcp-server/start-pal.sh
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/start-pal.sh
@@ -17,9 +17,20 @@ if [[ -f "$REPO_ROOT/.env" ]]; then
   set +a
 fi
 
-# Activate virtual environment
-# shellcheck disable=SC1091
-source "$SCRIPT_DIR/.venv/bin/activate"
+# Activate virtual environment.
+# Setup may create either .venv (modern convention) or .zen_venv (legacy PAL
+# setup / run_integration_tests.sh); prefer .venv, fall back to .zen_venv,
+# matching communication_simulator_test.py. Fail loudly if neither exists.
+if [[ -f "$SCRIPT_DIR/.venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/.venv/bin/activate"
+elif [[ -f "$SCRIPT_DIR/.zen_venv/bin/activate" ]]; then
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/.zen_venv/bin/activate"
+else
+  echo "start-pal.sh: no virtualenv found (.venv or .zen_venv) in $SCRIPT_DIR" >&2
+  exit 1
+fi
 
 # Start the PAL server
 exec python "$SCRIPT_DIR/server.py"

--- a/docker/mcp-servers-source/pal/pal-mcp-server/start-pal.sh
+++ b/docker/mcp-servers-source/pal/pal-mcp-server/start-pal.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# start-pal.sh
+# Robust launcher for PAL MCP server inside OpenCode
+# Handles .env loading + venv activation reliably
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+
+# Load environment variables from repo .env
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/.env"
+  set +a
+fi
+
+# Activate virtual environment
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/.venv/bin/activate"
+
+# Start the PAL server
+exec python "$SCRIPT_DIR/server.py"

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "AGENTS.md",
+    "config/instructions/pal-opencode-guide.md"
+  ],
+  "mcp": {
+    "pal": {
+      "type": "local",
+      "command": [
+        "sh",
+        "-lc",
+        "docker/mcp-servers-source/pal/pal-mcp-server/start-pal.sh"
+      ],
+      "enabled": true,
+      "timeout": 30000,
+      "environment": {
+        "OPENAI_API_KEY": "{env:OPENAI_API_KEY}",
+        "OPENROUTER_API_KEY": "{env:OPENROUTER_API_KEY}",
+        "GEMINI_API_KEY": "{env:GEMINI_API_KEY}",
+        "XAI_API_KEY": "{env:XAI_API_KEY}",
+        "DEFAULT_MODEL": "auto",
+        "LOG_LEVEL": "INFO"
+      }
+    }
+  },
+  "permission": {
+    "pal_*": "ask"
+  }
+}

--- a/opencode.jsonc
+++ b/opencode.jsonc
@@ -10,7 +10,7 @@
       "command": [
         "sh",
         "-lc",
-        "docker/mcp-servers-source/pal/pal-mcp-server/start-pal.sh"
+        "exec bash \"$(git rev-parse --show-toplevel)/docker/mcp-servers-source/pal/pal-mcp-server/start-pal.sh\""
       ],
       "enabled": true,
       "timeout": 30000,

--- a/scripts/opencode/verify-pal.sh
+++ b/scripts/opencode/verify-pal.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Script: verify-pal.sh
+# Purpose: Validate that PAL is correctly wired into OpenCode
+#
+# Usage:
+#   ./scripts/opencode/verify-pal.sh
+#
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "🔍 Verifying PAL wiring for OpenCode..."
+
+# 1. Config file exists
+if [[ ! -f opencode.jsonc ]]; then
+  echo "❌ opencode.jsonc not found"
+  exit 1
+fi
+echo "✅ opencode.jsonc exists"
+
+# 2. PAL guide exists
+if [[ ! -f config/instructions/pal-opencode-guide.md ]]; then
+  echo "❌ pal-opencode-guide.md not found"
+  exit 1
+fi
+echo "✅ PAL behavior guide exists"
+
+# 3. Agents exist
+if [[ ! -f .opencode/agents/pal-planner.md ]]; then
+  echo "❌ pal-planner.md not found"
+  exit 1
+fi
+if [[ ! -f .opencode/agents/pal-reviewer.md ]]; then
+  echo "❌ pal-reviewer.md not found"
+  exit 1
+fi
+echo "✅ PAL agents exist"
+
+# 4. Verify script itself
+if [[ ! -x "$0" ]]; then
+  echo "⚠️  verify-pal.sh is not executable (run: chmod +x $0)"
+fi
+
+# 5. Check OpenCode can see the config (best effort)
+if command -v opencode >/dev/null 2>&1; then
+  echo "🔎 Running opencode debug config..."
+  opencode debug config > /tmp/opencode-config.txt 2>/dev/null || true
+
+  if grep -q '"pal"' /tmp/opencode-config.txt; then
+    echo "✅ PAL server present in resolved OpenCode config"
+  else
+    echo "⚠️  Could not confirm 'pal' in opencode debug config (may still work)"
+  fi
+else
+  echo "⚠️  opencode CLI not found in PATH — skipping runtime config check"
+fi
+
+echo ""
+echo "🎯 Next manual smoke test:"
+echo "   opencode run \"Use pal_listmodels and report available models. Do not edit files.\""
+echo ""
+echo "✅ Basic wiring verification complete."


### PR DESCRIPTION
## Summary

Wires PAL multi-model reasoning into OpenCode, the secondary AI coding assistant used alongside Claude Code.

### Core wiring
- **`opencode.jsonc`**: registers local "pal" MCP server via `start-pal.sh`, env placeholders for keys, permission policy `{"pal_*": "ask"}`
- **`start-pal.sh`**: real launcher — sources `.env`, activates `.venv`, `exec python server.py`
- **`.opencode/agents/pal-planner.md` + `pal-reviewer.md`**: minimal agent stubs delegating to PAL guide + AGENTS.md
- **`config/instructions/pal-opencode-guide.md`**: PAL tool usage guide loaded via `opencode.jsonc` instructions array

### Verification
`scripts/opencode/verify-pal.sh` passes fully:
```
✅ opencode.jsonc exists
✅ PAL behavior guide exists
✅ PAL agents exist
✅ PAL server present in resolved OpenCode config
✅ Basic wiring verification complete.
```

### Hygiene
- `config/repo_hygiene/root_hygiene_policy.json`: allowlist `.opencode/` dir (prevents root-hygiene CI failure)
- `.pre-commit-config.yaml`: add `/.opencode/` to root-hygiene bypass regex
- `AGENTS.md` §11: document OpenCode auto-load behavior (does NOT read CLAUDE.md; must use `instructions` array)
- `.claude/agents/*.md`: add `description:` frontmatter fields to all four agent files

## Part of #854 split
Extracted from PR #854. See that PR for full context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)