### PR TITLE
ci(routing-consistency): add pytest-asyncio to routing-consistency job install

### DIFF
--- a/.github/workflows/ci-complete.yml
+++ b/.github/workflows/ci-complete.yml
@@ -307,7 +307,7 @@ jobs:
           python-version: "3.11"
 
       - name: 📦 Install dependencies
-        run: python -m pip install --upgrade pip pytest pyyaml
+        run: python -m pip install --upgrade pip pytest pyyaml pytest-asyncio
 
       - name: ▶️ Run routing consistency gate
         run: pytest tests/test_model_routing_consistency.py --noconftest -q --tb=short


### PR DESCRIPTION
## Summary

Fixes: DMX-DCP-CI-ROUTING-CONSISTENCY-0001

### Root Cause (VERIFIED)

`pytest.ini` has `asyncio_mode = auto` under `[pytest]`, and `addopts` includes `--strict-config`. Under strict config, any `pytest-asyncio` config keys require the `pytest-asyncio` plugin to be installed — otherwise pytest exits with error code 4 (UsageError) before test collection begins.

The `routing-consistency` CI job installed only `pytest pyyaml`, missing `pytest-asyncio`.

### Fix

Added `pytest-asyncio` to the single install line in the `routing-consistency` job. No other files changed.

```diff
- python -m pip install --upgrade pip pytest pyyaml
+ python -m pip install --upgrade pip pytest pyyaml pytest-asyncio
```

### Validation Gates

- ✅ workflow_yaml_parse=ok (all .github/workflows/*.yml parse)
- ✅ diff --check: clean (no trailing whitespace)
- ✅ changed files: `.github/workflows/ci-complete.yml` only (1 line)
- ✅ No source/test/routing model files touched

### Invariants Preserved

- No `--strict-config` removed
- No `asyncio_mode = auto` removed
- No `continue-on-error` added
- No job disabled
- No branch protection changes
- No DCP routing model changes

### Scope Boundaries

Per packet DMX-DCP-CI-ROUTING-CONSISTENCY-0001: this does not claim all CI is fixed, PR #880 is merge-ready, or DCP routing behavior is correct. This packet scopes only to the pytest-asyncio dependency mismatch in the routing-consistency job.