### PR TITLE
feat(dcp): DMX-DCP-TOOLING 101+102 foundation bundle

### DIFF
--- a/docs/90-adr/adr-222-deterministic-vs-llm-boundary.md
+++ b/docs/90-adr/adr-222-deterministic-vs-llm-boundary.md
@@ -1,0 +1,114 @@
+---
+id: adr-222
+title: ADR-222 - DCP Deterministic vs LLM Enforcement Boundary and Contract Promotion Ladder
+type: adr
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-13'
+last_review: '2026-06-13'
+next_review: '2026-09-13'
+status: accepted
+prelude: Defines the L0–L3 contract promotion ladder, version-precedence rules, and the surface table governing which DCP enforcement actions are deterministic (hard-block capable) versus llm_advisory (never blocks).
+tags:
+- dcp
+- enforcement
+- deterministic
+- llm-advisory
+- promotion-ladder
+- contract-governance
+graph_metadata:
+  node_type: ADR
+  impact: high
+  relates_to:
+  - adr-002
+  - DMX-DCP-TOOLING-101
+---
+
+# ADR-222: DCP Deterministic vs LLM Enforcement Boundary and Contract Promotion Ladder
+
+**Status**: Accepted
+**Date**: 2026-06-13
+**Owners**: @hu3mann
+**Task Packet**: DMX-DCP-TOOLING-101
+**Blocks**: contract promotion decisions in DMX-DCP-TOOLING series (102–115)
+
+---
+
+## Context
+
+The DCP (Data Control Plane) maintains a set of contract schemas under `schemas/dcp/`. As the DCP matures, contracts progress from sketch-level design objects through full runtime wiring. Without a promotion ladder, the repo has no shared vocabulary for "how authoritative is this contract?" and no rules for when a contract may be enforced by a hard-blocking gate versus when it is advisory only.
+
+Additionally, DCP enforcement is distributed across multiple surfaces — CI gates, pre-commit hooks, CLI tools, `.claude/commands` skills, and agent personas — with radically different blocking semantics. Without an explicit surface table, a probabilistic check (an LLM skill) might be mistaken for a deterministic red-lane block, violating the core DCP principle that no deny may live only in an LLM surface.
+
+This ADR establishes:
+1. The L0–L3 contract promotion ladder and its exit criteria.
+2. The version-precedence rule linking `schema_version` (stability marker) and `contract_version` (semver operational version).
+3. The 7-row deterministic-vs-LLM surface table.
+
+---
+
+## Decision
+
+### 1. L0–L3 Contract Promotion Ladder
+
+Each DCP contract (`schemas/dcp/*.schema.json`) occupies exactly one level at a time. Levels gate what enforcement is permitted and what a contract's `validation_state` may claim.
+
+| Level | Name | Exit Criteria | Permitted Enforcement |
+|-------|------|---------------|-----------------------|
+| **L0** | DRAFT | Schema file exists; structural JSON Schema tests pass; `schema_version` ends `.v0`; `validation_state` = `PROVISIONAL_UNVERIFIED_ENFORCEMENT` or `DESIGN_ONLY` | Structural tests only; no runtime enforcement |
+| **L1** | RECONCILED | L0 PLUS: shape has been verified against a repo artifact on `origin/main`; `validation_state` = `REPO_CROSS_CHECKED`; still at `.v0` | CI gate may run schema-round-trip tests; no runtime block |
+| **L2** | WIRED | L1 PLUS: at least one `runtime_producer` AND one `runtime_consumer` listed in `manifest.json` that actually read/write the schema; CI gate exercises the producer→consumer coupling | CI gate exercises full path; deterministic enforcement permitted in non-merge gates (e.g. pre-commit) |
+| **L3** | LOCKED | L2 PLUS: CI gate enforces on the enforcement-side path; schema file is under change-control lane (PR review required, not self-certifiable); `schema_version` bumped from `.v0` to `.v1`; `contract_version` semver bumped in `manifest.json` | Deterministic hard-block permitted in merge gate; contract version under strict change control |
+
+**Invariants**:
+- No contract may claim `LOCKED` `validation_state` while still at `.v0`.
+- No L0/L1 contract may be used as the basis for a merge-blocking hard gate.
+- Promotion from L2→L3 requires operator sign-off (CODEOWNERS gate, not self-certifiable by the implementing subagent).
+
+### 2. Version-Precedence Rule
+
+Two version fields govern each contract:
+
+| Field | Location | Semantics |
+|-------|----------|-----------|
+| `schema_version` | `const` inside the `.schema.json` file itself | **Stability marker** — `.v0` = unstable/DRAFT; `.v1` = locked/change-controlled. This is the authority marker. A contract cannot exit L2 at `.v0`. |
+| `contract_version` | `manifest.json` entry's `contract_version` | **Operational semver** — tracks the manifest entry's own revision history independently of the schema file. Allows manifest metadata to be updated without touching the schema file. |
+
+**Precedence rule**: `schema_version` is the authority marker. When `schema_version` is `.v0`, the contract is UNSTABLE regardless of what `contract_version` says. Both fields bump together at the L2→L3 promotion: `schema_version` moves from `.v0` to `.v1`, `contract_version` moves from `0.x.y` to `1.0.0`.
+
+### 3. Deterministic vs LLM Surface Table
+
+**Governing axioms**:
+- "A probabilistic guard is a vibe plane, not a red-lane gate."
+- "No deny may exist only in an LLM surface."
+
+Any enforcement that can produce a hard block on a code-change path MUST be implemented on a deterministic surface AND duplicated there if it also exists on an LLM surface.
+
+| Surface | Enforcement Type | Block Capability | Notes |
+|---------|-----------------|------------------|-------|
+| `native_hooks.py` PreToolUse hook | **deterministic** | hard-block capable | Runs before every tool invocation; Python, synchronous, exit-code aware. Suitable for schema-level write guards. |
+| pre-commit hooks | **deterministic** | local-only (CI duplicates) | Runs on developer workstation only; CI must duplicate any critical check. Not sufficient alone for merge-gating. |
+| CI gates (`.github/workflows/`) | **deterministic** | AUTHORITY tier | Merge-blocking when required on protected branches. The only surface that satisfies L3 enforcement requirements without additional operator wiring. |
+| `dopemux dcp` CLI | **deterministic** | non-zero-exit | Synchronous subprocess; exit code propagates to callers. Deterministic when schema validation is called inline. |
+| `.claude/commands` skills | **llm_advisory** | never blocks | Produces natural-language guidance only. An LLM may hallucinate, defer, or misclassify. MUST NOT be the sole enforcement surface for any red-lane rule. |
+| Personas and agents | **llm_advisory** | never blocks | Same as skills — advisory only. May refuse to act but cannot produce a hard system block. |
+| PostToolUse / Stop hooks | **deterministic** | receipts only / no block | Record artifacts after the fact; cannot prevent the tool invocation that already completed. Useful for audit trails, not enforcement. |
+
+---
+
+## Consequences
+
+- `manifest.json` MUST be updated whenever a contract promotion occurs (L0→L1, L1→L2, L2→L3). The manifest is the machine-readable source of truth for current level and validation state.
+- The `test_contracts_consistency.py` test suite (`tests/dcp/`) enforces the manifest's internal consistency on every CI run.
+- Contracts at L0/L1 that currently appear in `ci_gates` (e.g. `🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)`) are exercised by schema-round-trip tests only; this is permitted. The CI gate name appearing in `ci_gates` does NOT imply merge-blocking enforcement — only L3 contracts with `enforcement_side: deterministic` carry that claim.
+- Any future DCP surface that gates merges on a schema check must appear in this ADR's surface table before being wired.
+
+---
+
+## Alternatives Considered
+
+**Single enforcement layer (CI-only)**: Rejected — pre-commit and PreToolUse hooks provide fast-feedback loops that reduce CI load and catch violations at the developer's workstation. The surface table allows all layers to coexist as long as the merge-blocking authority always rests on a deterministic surface.
+
+**LLM-advisory promotion ladder**: Rejected — LLM evaluation of "is this contract REPO_CROSS_CHECKED?" is non-deterministic and ungatable. Promotion criteria must be testable with a `pytest` assertion.
+
+**Merging `schema_version` and `contract_version` into one field**: Rejected — `schema_version` is owned by the schema file author and changes only at stability milestones; `contract_version` is owned by the manifest maintainer and tracks operational metadata. Merging them would couple two independent change frequencies.

--- a/proof/DMX-DCP-TOOLING-101/APPROVAL.json
+++ b/proof/DMX-DCP-TOOLING-101/APPROVAL.json
@@ -1,0 +1,41 @@
+{
+  "artifact_kind": "dcp_sanctioned_change_approval_v0",
+  "note": "Hand-authored sanctioned-change artifact per design B.6 (the dcp_approval_artifact producer 'dcp accept' ships in TP-110). This touches contract-surface paths under schemas/dcp/ (the PROOF-CONTRACT-SCHEMA-MUTATION hard_block lane), so a sanctioning artifact is required. v1 trust model: identities are ASSERTED, not authenticated; the real approval boundary is operator repo write-access + human PR merge.",
+  "tp_id": "DMX-DCP-TOOLING-101",
+  "decision": "gated",
+  "scope_paths": [
+    "schemas/dcp/manifest.json",
+    "schemas/dcp/dcp_contracts_manifest.schema.json",
+    "schemas/dcp/README.md"
+  ],
+  "head_sha": "0b15d09e9349e9afced63d04856656fd8997f95f",
+  "requester": {
+    "id": "claude-sonnet-implementer",
+    "role": "implementer"
+  },
+  "approver": {
+    "id": "claude-opus-auditor",
+    "role": "auditor",
+    "recommendation": "ALLOW"
+  },
+  "requester_neq_approver": true,
+  "supervisor_signoff": {
+    "required": true,
+    "provided": false,
+    "signoff_identity": null,
+    "notes": "Supervisor (human) sign-off NOT provided. This artifact records the implementer→auditor separation and the auditor's ALLOW recommendation only. Final authority = operator merge of the TP-101 PR. No agent has approved a merge."
+  },
+  "red_lanes_present": [
+    "DCP-RED-PROOF-CONTRACT-SCHEMA-MUTATION (new manifest + README under schemas/dcp/)"
+  ],
+  "forbidden_paths_acknowledged": [
+    "merge seam (untouched)",
+    "CODEOWNERS (untouched — OP-0 is an operator action)",
+    ".github/workflows/** (untouched — existing pytest tests/dcp/ gate runs the new test)"
+  ],
+  "expiry_window": {
+    "bound_to_head_sha": "0b15d09e9349e9afced63d04856656fd8997f95f",
+    "invalidated_if": "the approved diff changes (any new commit altering scope_paths invalidates this approval)"
+  },
+  "rationale": "Additive contract registry (manifest) + ADR + consistency test + additive README. No runtime behavior change, no enforcement weakening. Auditor (opus) independently verified scope, tests, and honesty; distinct from implementer (sonnet). Recommended for operator merge after human review."
+}

--- a/proof/DMX-DCP-TOOLING-101/AUDITOR_REPORT.md
+++ b/proof/DMX-DCP-TOOLING-101/AUDITOR_REPORT.md
@@ -1,0 +1,49 @@
+# Auditor Report — DMX-DCP-TOOLING-101
+
+| | |
+|---|---|
+| **Packet** | DMX-DCP-TOOLING-101 — Contracts manifest + promotion ladder + det-vs-LLM ADR |
+| **Implementer** | claude-sonnet (subagent) |
+| **Auditor** | claude-opus (distinct actor — auditor ≠ implementer per AGENTS.md / design must-fix #4) |
+| **Branch** | `claude/dmx-dcp-tooling-101` @ `0b15d09e9` (off `main` `cd6243721`) |
+| **Date** | 2026-06-12 |
+| **Verdict** | **PASS_WITH_RISKS** (2 non-blocking notes; no blockers) |
+
+## What was audited
+
+Independent re-verification (not relayed from the implementer):
+
+| Check | Result |
+|---|---|
+| Diff scope ⊆ allowlist (no CODEOWNERS / `.github/` / `src/` edits) | PASS — 5 files, all allowlisted |
+| `pytest tests/dcp/test_contracts_consistency.py` re-run by auditor | PASS — 11/11 |
+| `manifest.json` validates against `dcp_contracts_manifest.schema.json` | PASS |
+| Manifest enumerates exactly the 19 `schemas/dcp/*.schema.json` (no unlisted/extra) | PASS — 19 = 19 |
+| Core-contract levels honest vs evidence | PASS — taxonomy/mutation/resource-map = L1/REPO_CROSS_CHECKED/deterministic; helper-receipt/red-lane-report = L0; no fabricated L3 |
+| `runtime_consumers` empty everywhere | PASS — honest (scanner does not load the schema on `main`; coupling is TP-103) |
+| `ci_gates` names exist in `ci-complete.yml` (test (d)) | PASS — references the real DCP gate step name |
+| Negative-path tests are real | PASS — bogus gate flagged; L2-missing-producers fails; verified by reading assertions |
+| ADR content | PASS — L0–L3 ladder, version-precedence rule, 7-row det-vs-LLM table, verbatim "vibe plane" + "no deny may exist only in an LLM surface" |
+| README append additive | PASS — original first line preserved; section appended |
+| Schema-version honesty | PASS — routing/newer schemas with no `schema_version` const recorded as `"UNKNOWN"`, not fabricated |
+
+## Findings (non-blocking)
+
+1. **[MINOR] Per-contract CI-gate precision.** Every entry lists the single DCP pytest gate (`🔴 Run DCP red-lane gate …`) as its `ci_gates`. That gate runs `pytest tests/dcp/`, which exercises the contract-derivation + routing fixtures but does not have a dedicated assertion per individual schema (e.g. `dcp_stop_condition`). The gate name is real and runs; test (d) only checks name existence, which is correct. Refine to per-contract gate mapping in a later TP once enforcement coupling (TP-103/104) lands. Not blocking.
+2. **[NIT] Unused `contract_id` parameter** in `validate_ci_gates`/`validate_l2_l3_runtime` (documents intent; Pyright flags it). Cosmetic.
+
+## Process note
+
+The implementer committed despite the instruction to leave changes uncommitted for pre-commit review. Reviewable via `0b15d09e9`; no correctness impact. Logged for protocol hygiene.
+
+## Build-time red-line check
+
+- Merge seam: not touched. ✓
+- Live fixture SHAs: none computed. ✓
+- Self-certification: avoided — implementer (sonnet) ≠ auditor (opus); supervisor sign-off NOT provided (see APPROVAL.json), final authority = operator PR merge. ✓
+- Endpoint binding: none. ✓
+- External corroboration as authority: none — provenance recorded honestly. ✓
+
+## Recommendation
+
+**ALLOW** the change to proceed to operator review. No code path is altered; the manifest is an additive registry, the ADR/README are docs. Supervisor (human) sign-off pending at PR merge.

--- a/proof/DMX-DCP-TOOLING-101/PROOF.json
+++ b/proof/DMX-DCP-TOOLING-101/PROOF.json
@@ -1,0 +1,61 @@
+{
+  "tp_id": "DMX-DCP-TOOLING-101",
+  "tp_path": "task-packets/generated/DMX-DCP-TOOLING-101.json",
+  "series_id": "DMX-DCP-TOOLING",
+  "branch": "claude/dmx-dcp-tooling-101",
+  "base_branch": "main",
+  "base_sha": "cd6243721",
+  "head_sha": "0b15d09e9349e9afced63d04856656fd8997f95f",
+  "worktree_path": ".claude/worktrees/dcp-tooling-101",
+  "repo_identity": "DDD-Enterprises/dopemux-mvp",
+  "status": "READY_FOR_REVIEW",
+  "validation_state": "PASSED",
+  "implementer_identity": "claude-sonnet-implementer",
+  "auditor_identity": "claude-opus-auditor",
+  "files_changed": [
+    "schemas/dcp/dcp_contracts_manifest.schema.json",
+    "schemas/dcp/manifest.json",
+    "schemas/dcp/README.md",
+    "docs/90-adr/adr-222-deterministic-vs-llm-boundary.md",
+    "tests/dcp/test_contracts_consistency.py"
+  ],
+  "validations": [
+    {"command": "pytest tests/dcp/test_contracts_consistency.py", "exit_code": 0, "bucket": "PASS", "detail": "11 passed (incl. 4 negative-path unit tests); re-run independently by auditor"},
+    {"command": "jsonschema -i schemas/dcp/manifest.json schemas/dcp/dcp_contracts_manifest.schema.json", "exit_code": 0, "bucket": "PASS"},
+    {"command": "manifest-enumeration: 19 schema files == 19 manifest entries", "exit_code": 0, "bucket": "PASS"},
+    {"command": "git diff scope ⊆ allowlist (no CODEOWNERS/.github/src)", "exit_code": 0, "bucket": "PASS"},
+    {"command": "full tests/dcp/ suite", "exit_code": null, "bucket": "NOT_RUN", "detail": "Only the new consistency test was run in isolation; full suite + CI deferred to PR CI."}
+  ],
+  "embedded_audit": {
+    "required": true,
+    "status": "PASS_WITH_RISKS",
+    "auditor_tool": "claude-code-cli",
+    "auditor_model": "opus",
+    "invocation": "Independent audit: re-ran the consistency test, re-validated the manifest against its schema, verified diff scope ⊆ allowlist, checked core-contract levels/enforcement_side honesty, confirmed ADR required content + verbatim lines, confirmed README append is additive.",
+    "exit_code": 0,
+    "report_path": "proof/DMX-DCP-TOOLING-101/AUDITOR_REPORT.md",
+    "findings": [
+      {"id": "TP101-A1", "severity": "LOW", "title": "Per-contract CI-gate precision", "status": "ACCEPTED_RISK", "body": "Every contract entry lists the single DCP pytest gate as its ci_gate. The gate name is real and runs tests/dcp/, but is not a per-schema assertion. Refine to per-contract gate mapping after enforcement coupling (TP-103/104) lands."},
+      {"id": "TP101-A2", "severity": "INFO", "title": "Unused contract_id parameter in test helpers", "status": "ACCEPTED_RISK", "body": "validate_ci_gates/validate_l2_l3_runtime accept contract_id but do not use it (documents intent; Pyright flags it). Cosmetic."}
+    ],
+    "fixes_applied": [],
+    "remaining_risks": [
+      "Full tests/dcp/ suite and CI not run locally — relies on PR CI (the existing 'pytest tests/dcp/' DCP gate auto-runs the new test).",
+      "Per-contract ci_gate precision deferred."
+    ],
+    "skip_reason": null
+  },
+  "approval_ref": "proof/DMX-DCP-TOOLING-101/APPROVAL.json",
+  "codereview_status": "PASS_WITH_RISKS (auditor=opus, distinct from implementer=sonnet)",
+  "precommit_status": "PENDING_PR_CI",
+  "commit_sha": "0b15d09e9349e9afced63d04856656fd8997f95f",
+  "pr_url_or_blocker": "PENDING — PR opened after proof bundle commit",
+  "residual_risks": [
+    "Supervisor (human) sign-off not provided — final approval = operator merge of the TP-101 PR (v1 trust model, design B.6).",
+    "OP-0 CODEOWNERS for schemas/dcp/ not yet in place; recommended before this contract-surface change merges."
+  ],
+  "unknowns": [
+    "Whether ci_gates per-contract precision is desired now or deferred (auditor deferred it)."
+  ],
+  "cleanup_status": "worktree .claude/worktrees/dcp-tooling-101 retained until PR merges; remove with git worktree remove after merge."
+}

--- a/proof/DMX-DCP-TOOLING-102/APPROVAL.json
+++ b/proof/DMX-DCP-TOOLING-102/APPROVAL.json
@@ -1,0 +1,49 @@
+{
+  "artifact_kind": "dcp_sanctioned_change_approval_v0",
+  "note": "Hand-authored sanctioned-change artifact per design B.6 until TP-110 ships the producer. This packet touches schema contract metadata and proof-contract surfaces.",
+  "tp_id": "DMX-DCP-TOOLING-102",
+  "decision": "gated",
+  "scope_paths": [
+    "schemas/dcp/dcp_red_lane_taxonomy.instance.json",
+    "schemas/dcp/dcp_red_lane_report.schema.json",
+    "schemas/dcp/manifest.json",
+    "schemas/dcp/README.md",
+    "src/dopemux/dcp/red_lane.py",
+    "src/dopemux/dcp/red_lane_scanner.py",
+    "src/dopemux/dcp/red_lane_taxonomy.py",
+    "tests/dcp/test_dcp_0102_red_lane_taxonomy.py",
+    "task-packets/generated/DMX-DCP-TOOLING-102.json"
+  ],
+  "head_sha": "637e145f40cbdf489fda3bf762d2329a9a77bcf0",
+  "requester": {
+    "id": "codex-implementation-agent",
+    "role": "implementer"
+  },
+  "approver": {
+    "id": "INDEPENDENT_AUDITOR_NOT_RUN",
+    "role": "not_available",
+    "recommendation": "LOCAL_SELF_REVIEW_ONLY"
+  },
+  "requester_neq_approver": false,
+  "supervisor_signoff": {
+    "required": true,
+    "provided": false,
+    "signoff_identity": null,
+    "notes": "Supervisor sign-off is not provided. Final approval boundary remains operator merge of PR #885. This artifact records local review evidence only."
+  },
+  "red_lanes_present": [
+    "DCP-RED-PROOF-CONTRACT-SCHEMA-MUTATION",
+    "DCP-RED-MERGE-SEAM-0001"
+  ],
+  "forbidden_paths_acknowledged": [
+    "merge seam untouched",
+    "CODEOWNERS untouched",
+    ".github/workflows untouched",
+    "external write surfaces untouched"
+  ],
+  "expiry_window": {
+    "bound_to_head_sha": "637e145f40cbdf489fda3bf762d2329a9a77bcf0",
+    "invalidated_if": "the implementation diff changes outside the TP-102 allowlist"
+  },
+  "rationale": "The change is deterministic and local: taxonomy metadata is now explicit in scanner reports, while live writes, external APIs, Dopetask execution, and PR mutation remain absent."
+}

--- a/proof/DMX-DCP-TOOLING-102/AUDITOR_REPORT.md
+++ b/proof/DMX-DCP-TOOLING-102/AUDITOR_REPORT.md
@@ -1,0 +1,42 @@
+# Auditor Report - DMX-DCP-TOOLING-102
+
+| | |
+|---|---|
+| Packet | DMX-DCP-TOOLING-102 - Taxonomy instance + detector schema evolution |
+| Implementation commit | `637e145f40cbdf489fda3bf762d2329a9a77bcf0` |
+| Branch | `claude/dmx-dcp-tooling-101` |
+| Date | 2026-06-16 |
+| Verdict | PASS_WITH_RISKS |
+
+## Scope Audited
+
+TP-102 adds a standalone `schemas/dcp/dcp_red_lane_taxonomy.instance.json`, points the manifest at it, and evolves local scanner report metadata to include taxonomy id, path, and lane ids.
+
+## Checks
+
+| Check | Result |
+|---|---|
+| Task packet validates against canonical schema | PASS |
+| Taxonomy instance validates against `dcp_red_lane_taxonomy.schema.json` | PASS |
+| Scanner metadata regression tests | PASS |
+| Existing red-lane scanner tests | PASS |
+| TP-101 manifest consistency tests | PASS |
+| Python compile for touched DCP modules | PASS |
+| `git diff --check` | PASS |
+
+## Findings
+
+1. LOW - Scanner metadata is not yet rule-generated. The scanner now records the taxonomy identity in reports, but the blocking regex rules still live in `red_lane_rules.py`. This is intentional for TP-102; schema-driven loading belongs to TP-103.
+2. INFO - Remote PR checks were not rerun before this proof was authored. They must run after the proof commit is pushed.
+
+## Red-Lane Review
+
+- No live writes added.
+- No external API calls added.
+- No Dopetask execution added.
+- No PR mutation path added.
+- `DCP-RED-MERGE-SEAM-0001` remains present in the taxonomy and scanner tests.
+
+## Recommendation
+
+Allow TP-102 to remain bundled into PR #885 with TP-101. Do not mark the DCP tooling item terminal until PR #885 has a terminal remote gate.

--- a/proof/DMX-DCP-TOOLING-102/PROOF.json
+++ b/proof/DMX-DCP-TOOLING-102/PROOF.json
@@ -1,0 +1,112 @@
+{
+  "tp_id": "DMX-DCP-TOOLING-102",
+  "tp_path": "task-packets/generated/DMX-DCP-TOOLING-102.json",
+  "series_id": "DMX-DCP-TOOLING",
+  "branch": "claude/dmx-dcp-tooling-101",
+  "base_branch": "main",
+  "base_sha": "6f0de876363d5f99c529106fa2517624690978dd",
+  "head_sha": "637e145f40cbdf489fda3bf762d2329a9a77bcf0",
+  "worktree_path": ".claude/worktrees/dcp-tooling-101",
+  "repo_identity": "DDD-Enterprises/dopemux-mvp",
+  "status": "READY_FOR_REVIEW",
+  "validation_state": "PASSED_LOCAL",
+  "implementer_identity": "codex-implementation-agent",
+  "auditor_identity": "INDEPENDENT_AUDITOR_NOT_RUN",
+  "files_changed": [
+    "task-packets/generated/DMX-DCP-TOOLING-102.json",
+    "schemas/dcp/dcp_red_lane_taxonomy.instance.json",
+    "schemas/dcp/README.md",
+    "schemas/dcp/dcp_red_lane_report.schema.json",
+    "schemas/dcp/manifest.json",
+    "src/dopemux/dcp/red_lane.py",
+    "src/dopemux/dcp/red_lane_scanner.py",
+    "src/dopemux/dcp/red_lane_taxonomy.py",
+    "tests/dcp/test_dcp_0102_red_lane_taxonomy.py"
+  ],
+  "validations": [
+    {
+      "command": "python -m pytest -q tests/dcp/test_dcp_0102_red_lane_taxonomy.py",
+      "exit_code": 1,
+      "bucket": "PASS",
+      "detail": "Intentional RED run before implementation: 1 passed, 2 failed with AttributeError: ScannerInfo had no taxonomy_id."
+    },
+    {
+      "command": "python -m pytest -q tests/dcp/test_dcp_0102_red_lane_taxonomy.py tests/dcp/test_dcp_0005_red_lane_scanner.py tests/dcp/test_contracts_consistency.py",
+      "exit_code": 0,
+      "bucket": "PASS",
+      "detail": "32 passed."
+    },
+    {
+      "command": "python -m jsonschema -i task-packets/generated/DMX-DCP-TOOLING-102.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "exit_code": 0,
+      "bucket": "PASS",
+      "detail": "jsonschema CLI emitted only its deprecation warning."
+    },
+    {
+      "command": "python -m jsonschema -i schemas/dcp/dcp_red_lane_taxonomy.instance.json schemas/dcp/dcp_red_lane_taxonomy.schema.json",
+      "exit_code": 0,
+      "bucket": "PASS",
+      "detail": "jsonschema CLI emitted only its deprecation warning."
+    },
+    {
+      "command": "python -m py_compile src/dopemux/dcp/red_lane.py src/dopemux/dcp/red_lane_scanner.py src/dopemux/dcp/red_lane_taxonomy.py",
+      "exit_code": 0,
+      "bucket": "PASS"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "bucket": "PASS"
+    },
+    {
+      "command": "remote PR checks after TP-102 push",
+      "exit_code": null,
+      "bucket": "NOT_RUN",
+      "detail": "Pending until the proof commit is pushed to PR #885."
+    }
+  ],
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/DMX-DCP-TOOLING-102/AUDITOR_REPORT.md",
+    "findings": [
+      {
+        "id": "TP102-A1",
+        "severity": "LOW",
+        "title": "Scanner metadata is not yet rule-generated",
+        "status": "ACCEPTED_RISK",
+        "body": "The scanner now exposes taxonomy_id/path/lane_ids, but blocking regex rules still live in red_lane_rules.py. This is intentional for TP-102 L1+ metadata coupling; schema-driven rule loading remains TP-103."
+      },
+      {
+        "id": "TP102-A2",
+        "severity": "INFO",
+        "title": "Remote checks pending after push",
+        "status": "ACCEPTED_RISK",
+        "body": "Local targeted validation passed. PR #885 remote checks must rerun after the proof commit is pushed."
+      }
+    ],
+    "fixes_applied": [],
+    "remaining_risks": [
+      "TP-103 must still remove hardcoded rule drift by loading scanner rules from the taxonomy/schema contract.",
+      "Gemini review on PR #885 previously failed from API quota, not a code finding; it may remain externally blocked."
+    ],
+    "skip_reason": "No independent auditor tool was available for this TP-102 follow-up in the current session. Codex performed local precommit review, but this is not an auditor != implementer proof."
+  },
+  "approval_ref": "proof/DMX-DCP-TOOLING-102/APPROVAL.json",
+  "codereview_status": "LOCAL_SELF_REVIEW_WITH_RISKS; INDEPENDENT_AUDIT_NOT_RUN",
+  "precommit_status": "PASS",
+  "commit_sha": "637e145f40cbdf489fda3bf762d2329a9a77bcf0",
+  "pr_url_or_blocker": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/885",
+  "residual_risks": [
+    "This packet adds scanner metadata coupling only; rule generation/loading remains deferred to TP-103.",
+    "Remote CI/Gemini status is not terminal until PR #885 reruns after push."
+  ],
+  "unknowns": [
+    "Whether the externally blocked Gemini review quota will be restored before PR merge."
+  ],
+  "cleanup_status": "worktree .claude/worktrees/dcp-tooling-101 retained until PR #885 reaches a terminal review gate."
+}

--- a/schemas/dcp/README.md
+++ b/schemas/dcp/README.md
@@ -152,6 +152,8 @@ Both fields bump together at L2→L3: `schema_version` moves from `.v0` to `.v1`
 
 **Do not edit `manifest.json` without updating the corresponding promotion-ladder entry.** Promote a contract's `level` only when all exit criteria for the target level are met (see table above).
 
+DMX-DCP-TOOLING-102 promotes the red-lane taxonomy seed from the aggregate test fixture into the standalone instance file `schemas/dcp/dcp_red_lane_taxonomy.instance.json`. The local scanner reads that instance for report metadata only; it does not gain live-write, external API, or PR mutation authority.
+
 ### Deterministic vs LLM Enforcement Boundary
 
 Enforcement surfaces are classified in [ADR-222](../../docs/90-adr/adr-222-deterministic-vs-llm-boundary.md). The short rule:

--- a/schemas/dcp/README.md
+++ b/schemas/dcp/README.md
@@ -116,3 +116,51 @@ Both paths are present in `origin/main`. Note: `steward_gate.py` was absent at T
 
 - **This packet (TP-DCP-0001):** REV1 §4 (contract registry), §5 (red-lane taxonomy), §6 (envelope field-lists + §6.0 meta-contract).
 - **Fixture data:** Populated ONLY from pasted evidence text. No filesystem traversal of the target repo. All SHA/hash/digest values are illustrative placeholders (`sha256:PLACEHOLDER-illustrative-not-computed`).
+
+---
+
+## Contract Promotion Ladder (L0–L3) — added by DMX-DCP-TOOLING-101
+
+Each schema in this directory has a **level** that tracks its promotion from draft to locked contract. Levels are recorded in `manifest.json` (see below).
+
+| Level | Name | Key Exit Criteria |
+|-------|------|-------------------|
+| **L0** | DRAFT | Schema file present; structural tests pass; `schema_version` ends `.v0`; `validation_state` = `PROVISIONAL_UNVERIFIED_ENFORCEMENT` or `DESIGN_ONLY` |
+| **L1** | RECONCILED | L0 PLUS shape verified against a repo artifact on `origin/main`; `validation_state` = `REPO_CROSS_CHECKED` |
+| **L2** | WIRED | L1 PLUS at least one `runtime_producer` AND one `runtime_consumer` in `manifest.json`; CI gate exercises the coupling |
+| **L3** | LOCKED | L2 PLUS CI gate enforces on merge path; `schema_version` bumped `.v0`→`.v1`; change-control lane active |
+
+### Version-Precedence Rule
+
+Two version fields govern each contract:
+
+- **`schema_version`** (inside the `.schema.json` file, as a `const`) is the **stability marker**. `.v0` = unstable/DRAFT; `.v1` = locked. This field is the authority: a contract at `.v0` is UNSTABLE regardless of `contract_version`.
+- **`contract_version`** (in `manifest.json`, semver string) is the **operational version** of the manifest entry. It tracks metadata changes independently of the schema file.
+
+Both fields bump together at L2→L3: `schema_version` moves from `.v0` to `.v1`, `contract_version` moves from `0.x.y` to `1.0.0`.
+
+---
+
+## Contracts Manifest — `manifest.json`
+
+`schemas/dcp/manifest.json` is the machine-readable registry of all 19 contracts in this directory. It:
+
+- Lists one entry per `.schema.json` file (excluding `dcp_contracts_manifest.schema.json` itself).
+- Records `level`, `validation_state`, `enforcement_side`, `ci_gates`, `instance_files`, `runtime_producers`, and `runtime_consumers` for each contract.
+- Validates against `schemas/dcp/dcp_contracts_manifest.schema.json` (JSON Schema draft-07).
+- Is enforced by `tests/dcp/test_contracts_consistency.py` on every CI run.
+
+**Do not edit `manifest.json` without updating the corresponding promotion-ladder entry.** Promote a contract's `level` only when all exit criteria for the target level are met (see table above).
+
+### Deterministic vs LLM Enforcement Boundary
+
+Enforcement surfaces are classified in [ADR-222](../../docs/90-adr/adr-222-deterministic-vs-llm-boundary.md). The short rule:
+
+> "A probabilistic guard is a vibe plane, not a red-lane gate."
+> "No deny may exist only in an LLM surface."
+
+- `enforcement_side: deterministic` — the contract is or will be enforced by a hard-blocking deterministic surface (CI gate, CLI non-zero exit, PreToolUse hook).
+- `enforcement_side: llm_advisory` — the contract is only checked by LLM reasoning surfaces (skills, personas); advisory output only, never a hard block.
+- `enforcement_side: human` — enforcement requires human approval (e.g. CODEOWNERS, approval artifact).
+
+See [ADR-222](../../docs/90-adr/adr-222-deterministic-vs-llm-boundary.md) for the full 7-row surface table and L0–L3 promotion criteria.

--- a/schemas/dcp/dcp_contracts_manifest.schema.json
+++ b/schemas/dcp/dcp_contracts_manifest.schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/DDD-Enterprises/dopemux-mvp/schemas/dcp/dcp_contracts_manifest.schema.json",
+  "title": "DcpContractsManifest",
+  "description": "Registry manifest for all DCP contract schemas — tracks promotion level, validation state, CI gates, and enforcement side for each contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["manifest_version", "contracts"],
+  "properties": {
+    "manifest_version": {
+      "type": "string",
+      "description": "Semver version of this manifest file format."
+    },
+    "contracts": {
+      "type": "array",
+      "description": "One entry per .schema.json file in schemas/dcp/ (excluding this manifest schema itself).",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "contract_id",
+          "schema_file",
+          "schema_version",
+          "contract_version",
+          "validation_state",
+          "level",
+          "instance_files",
+          "runtime_producers",
+          "runtime_consumers",
+          "ci_gates",
+          "enforcement_side"
+        ],
+        "properties": {
+          "contract_id": {
+            "type": "string",
+            "description": "Canonical contract identifier, e.g. DCP_RED_LANE_TAXONOMY."
+          },
+          "schema_file": {
+            "type": "string",
+            "description": "Path relative to repo root of the .schema.json file."
+          },
+          "schema_version": {
+            "type": "string",
+            "description": "Value of the schema's own schema_version const (e.g. dcp-red-lane-taxonomy.v0). Use UNKNOWN if the schema has no const."
+          },
+          "contract_version": {
+            "type": "string",
+            "description": "Operational semver version of this contract entry.",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+          },
+          "validation_state": {
+            "type": "string",
+            "description": "Current promotion/validation state of this contract.",
+            "enum": [
+              "DESIGN_ONLY",
+              "REPO_CROSS_CHECKED",
+              "REPO_VALIDATED",
+              "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+              "LOCKED"
+            ]
+          },
+          "level": {
+            "type": "string",
+            "description": "L0–L3 promotion ladder level. L0=DRAFT, L1=RECONCILED, L2=WIRED, L3=LOCKED.",
+            "enum": ["L0", "L1", "L2", "L3"]
+          },
+          "instance_files": {
+            "type": "array",
+            "description": "Fixture/instance files in the repo that instantiate this schema.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "runtime_producers": {
+            "type": "array",
+            "description": "Source files that produce instances of this contract at runtime. Empty array when none known on this branch.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "runtime_consumers": {
+            "type": "array",
+            "description": "Source files that consume/validate instances of this contract at runtime. Empty array when none known on this branch.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ci_gates": {
+            "type": "array",
+            "description": "CI job or step names (from .github/workflows/) that exercise this contract. Only names that actually exist in CI. Empty if no real gate exists.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "enforcement_side": {
+            "type": "string",
+            "description": "Which enforcement surface owns this contract: deterministic (hard-block capable), llm_advisory (never blocks), or human (approval gate).",
+            "enum": ["deterministic", "llm_advisory", "human"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/dcp/dcp_red_lane_report.schema.json
+++ b/schemas/dcp/dcp_red_lane_report.schema.json
@@ -23,13 +23,16 @@
     "packet_id": { "type": "string" },
     "scanner": {
       "type": "object",
-      "required": ["implementation", "live_adapters_used", "external_writes_used", "dopetask_execution_used", "github_api_used"],
+      "required": ["implementation", "live_adapters_used", "external_writes_used", "dopetask_execution_used", "github_api_used", "taxonomy_id", "taxonomy_path", "taxonomy_lane_ids"],
       "properties": {
         "implementation": { "const": "local" },
         "live_adapters_used": { "const": false },
         "external_writes_used": { "const": false },
         "dopetask_execution_used": { "const": false },
-        "github_api_used": { "const": false }
+        "github_api_used": { "const": false },
+        "taxonomy_id": { "type": "string" },
+        "taxonomy_path": { "type": "string" },
+        "taxonomy_lane_ids": { "type": "array", "items": { "type": "string" } }
       }
     },
     "repo": {

--- a/schemas/dcp/dcp_red_lane_taxonomy.instance.json
+++ b/schemas/dcp/dcp_red_lane_taxonomy.instance.json
@@ -1,0 +1,86 @@
+{
+  "schema_version": "dcp-red-lane-taxonomy.v0",
+  "provenance": {
+    "tag": "REPO_VALIDATED",
+    "source_ref": "TP-DCP-0001 fixture plus PR #885 TP-101 manifest reconciliation"
+  },
+  "validation": {
+    "state": "REPO_CROSS_CHECKED",
+    "notes": "Repo-local seed instance for deterministic scanner metadata. It does not grant write authority."
+  },
+  "taxonomy_id": "dcp-red-lane-taxonomy-v0-seed",
+  "lanes": [
+    {
+      "id": "DCP-RED-MERGE-SEAM-0001",
+      "description": "DCP must never import, call, wrap, or wire the PR merge specialist queue drain execute seam or batch merge script.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED_BY_AUDIT",
+      "paths_forbidden": [
+        "src/dopemux_pr_merge_specialist/queue_drain.py",
+        "dopemux_pr_merge_specialist/queue_drain.py",
+        "scripts/batch_resolve_and_merge.py"
+      ],
+      "notes": "Universal hard block preserved from the TP-DCP-0001 taxonomy."
+    },
+    {
+      "id": "DCP-RED-BRANCH-PROTECTION-MUTATION",
+      "description": "Branch-protection mutation is forbidden.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED"
+    },
+    {
+      "id": "DCP-RED-CODEOWNERS-MUTATION",
+      "description": "CODEOWNERS mutation is forbidden.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED"
+    },
+    {
+      "id": "DCP-RED-WORKFLOW-PERMISSION-ESCALATION",
+      "description": "Workflow permission escalation is forbidden.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED"
+    },
+    {
+      "id": "DCP-RED-SECRETS-IN-ARGV-CACHE-LOGS",
+      "description": "Secrets in argv, cache, or logs are forbidden.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED"
+    },
+    {
+      "id": "DCP-RED-SELF-CERTIFYING-LOOP",
+      "description": "Self-certifying loops are forbidden; auditor and implementer must be distinct.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED"
+    },
+    {
+      "id": "DCP-RED-PULL-REQUEST-TARGET-UNTRUSTED-CHECKOUT",
+      "description": "pull_request_target combined with untrusted checkout is forbidden.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED"
+    },
+    {
+      "id": "DCP-RED-PROOF-CONTRACT-SCHEMA-MUTATION",
+      "description": "Proof contract/schema mutation is forbidden outside a sanctioned task packet with auditor approval.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED"
+    },
+    {
+      "id": "DCP-RED-AGENT-APPROVED-MERGE-WITHOUT-SUPERVISOR",
+      "description": "Agent-approved merge without supervisor sign-off is forbidden.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED"
+    },
+    {
+      "id": "DCP-RED-IDENTITY-CONTACT-MERGE-DESTRUCTIVE-EXTERNAL-WRITE",
+      "description": "Identity/contact merge or destructive external write requires explicit project gate approval.",
+      "gate": "project_gate",
+      "provenance_tag": "REPO_VALIDATED"
+    },
+    {
+      "id": "DCP-RED-AI-AGENT-AUTHORITY-COLLAPSE",
+      "description": "AI agent authority collapse is a hard block unless role separation is proven.",
+      "gate": "hard_block",
+      "provenance_tag": "REPO_VALIDATED"
+    }
+  ]
+}

--- a/schemas/dcp/manifest.json
+++ b/schemas/dcp/manifest.json
@@ -1,0 +1,329 @@
+{
+  "manifest_version": "0.1.0",
+  "contracts": [
+    {
+      "contract_id": "DCP_APPROVAL_ARTIFACT",
+      "schema_file": "schemas/dcp/dcp_approval_artifact.schema.json",
+      "schema_version": "dcp-approval-artifact.v0",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/dcp/fixtures/tp_dcp_0002_approval_artifact.fixture.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "human"
+    },
+    {
+      "contract_id": "DCP_AUDIT_ROUTE",
+      "schema_file": "schemas/dcp/dcp_audit_route.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/fixtures/dcp/model_routing_0001/auditor_verdict_distinct.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_AUTHORITY_SURFACE",
+      "schema_file": "schemas/dcp/dcp_authority_surface.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/fixtures/dcp/model_routing_0001/agent_authority_unknown.json",
+        "tests/fixtures/dcp/model_routing_0001/dopecode_legacy_serena_alias.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_BACKEND_RUNNER",
+      "schema_file": "schemas/dcp/dcp_backend_runner.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/fixtures/dcp/model_routing_0001/opencode_backend_only.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_CHRONICLE_RECEIPT",
+      "schema_file": "schemas/dcp/dcp_chronicle_receipt.schema.json",
+      "schema_version": "dcp-chronicle-receipt.v0",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/dcp/fixtures/dcp_core_fixture.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_CONTROL_SNAPSHOT",
+      "schema_file": "schemas/dcp/dcp_control_snapshot.schema.json",
+      "schema_version": "dcp-control-snapshot.v0",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/dcp/fixtures/dcp_core_fixture.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "deterministic"
+    },
+    {
+      "contract_id": "DCP_EVIDENCE_HIT",
+      "schema_file": "schemas/dcp/dcp_evidence_hit.schema.json",
+      "schema_version": "dcp-evidence-hit.v0",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/dcp/fixtures/dcp_core_fixture.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_EXECUTION_LANE",
+      "schema_file": "schemas/dcp/dcp_execution_lane.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_HELPER_RECEIPT",
+      "schema_file": "schemas/dcp/dcp_helper_receipt.schema.json",
+      "schema_version": "dcp-helper-receipt.v0",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/dcp/fixtures/dcp_core_fixture.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_MODEL_SLOT",
+      "schema_file": "schemas/dcp/dcp_model_slot.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_MUTATION_CLASS",
+      "schema_file": "schemas/dcp/dcp_mutation_class.schema.json",
+      "schema_version": "dcp-mutation-class.v0",
+      "contract_version": "0.1.0",
+      "validation_state": "REPO_CROSS_CHECKED",
+      "level": "L1",
+      "instance_files": [
+        "tests/dcp/fixtures/tp_dcp_0002_mutation_class.fixture.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "deterministic"
+    },
+    {
+      "contract_id": "DCP_PROJECT_RESOURCE_MAP",
+      "schema_file": "schemas/dcp/dcp_project_resource_map.schema.json",
+      "schema_version": "dcp-project-resource-map.v0",
+      "contract_version": "0.1.0",
+      "validation_state": "REPO_CROSS_CHECKED",
+      "level": "L1",
+      "instance_files": [
+        "tests/dcp/fixtures/tp_dcp_0002_project_resource_map.fixture.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "deterministic"
+    },
+    {
+      "contract_id": "DCP_PROOF_POINTER",
+      "schema_file": "schemas/dcp/dcp_proof_pointer.schema.json",
+      "schema_version": "dcp-proof-pointer.v0",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/dcp/fixtures/tp_dcp_0003_valid_proof_pointer.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "deterministic"
+    },
+    {
+      "contract_id": "DCP_RED_LANE_REPORT",
+      "schema_file": "schemas/dcp/dcp_red_lane_report.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "deterministic"
+    },
+    {
+      "contract_id": "DCP_RED_LANE_TAXONOMY",
+      "schema_file": "schemas/dcp/dcp_red_lane_taxonomy.schema.json",
+      "schema_version": "dcp-red-lane-taxonomy.v0",
+      "contract_version": "0.1.0",
+      "validation_state": "REPO_CROSS_CHECKED",
+      "level": "L1",
+      "instance_files": [
+        "tests/dcp/fixtures/dcp_core_fixture.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "deterministic"
+    },
+    {
+      "contract_id": "DCP_ROUTING_CLASSIFICATION",
+      "schema_file": "schemas/dcp/dcp_routing_classification.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/fixtures/dcp/model_routing_0001/design_only_task.json",
+        "tests/fixtures/dcp/model_routing_0001/policy_advisory_not_runtime.json",
+        "tests/fixtures/dcp/model_routing_0001/safe_read_task.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_ROUTING_DECISION",
+      "schema_file": "schemas/dcp/dcp_routing_decision.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_ROUTING_PROOF_EXTENSION",
+      "schema_file": "schemas/dcp/dcp_routing_proof_extension.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/fixtures/dcp/model_routing_0001/proof_extension_additive.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    },
+    {
+      "contract_id": "DCP_STOP_CONDITION",
+      "schema_file": "schemas/dcp/dcp_stop_condition.schema.json",
+      "schema_version": "UNKNOWN",
+      "contract_version": "0.1.0",
+      "validation_state": "PROVISIONAL_UNVERIFIED_ENFORCEMENT",
+      "level": "L0",
+      "instance_files": [
+        "tests/fixtures/dcp/model_routing_0001/arbitrary_selector_rejected.json",
+        "tests/fixtures/dcp/model_routing_0001/dopetask_execution_forbidden.json",
+        "tests/fixtures/dcp/model_routing_0001/litellm_unhealthy_stop.json",
+        "tests/fixtures/dcp/model_routing_0001/mcp_unknown_surface.json",
+        "tests/fixtures/dcp/model_routing_0001/stale_alias_stop.json",
+        "tests/fixtures/dcp/model_routing_0001/task_orchestrator_write_forbidden.json",
+        "tests/fixtures/dcp/model_routing_0001/workflow_red_lane_forbidden.json"
+      ],
+      "runtime_producers": [],
+      "runtime_consumers": [],
+      "ci_gates": [
+        "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
+      ],
+      "enforcement_side": "llm_advisory"
+    }
+  ]
+}

--- a/schemas/dcp/manifest.json
+++ b/schemas/dcp/manifest.json
@@ -242,10 +242,13 @@
       "validation_state": "REPO_CROSS_CHECKED",
       "level": "L1",
       "instance_files": [
-        "tests/dcp/fixtures/dcp_core_fixture.json"
+        "schemas/dcp/dcp_red_lane_taxonomy.instance.json"
       ],
       "runtime_producers": [],
-      "runtime_consumers": [],
+      "runtime_consumers": [
+        "src/dopemux/dcp/red_lane_scanner.py",
+        "src/dopemux/dcp/red_lane_taxonomy.py"
+      ],
       "ci_gates": [
         "🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"
       ],

--- a/src/dopemux/dcp/red_lane.py
+++ b/src/dopemux/dcp/red_lane.py
@@ -53,6 +53,9 @@ class ScannerInfo:
     external_writes_used: bool = False
     dopetask_execution_used: bool = False
     github_api_used: bool = False
+    taxonomy_id: str = "UNKNOWN"
+    taxonomy_path: str = "schemas/dcp/dcp_red_lane_taxonomy.instance.json"
+    taxonomy_lane_ids: List[str] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -60,7 +63,10 @@ class ScannerInfo:
             "live_adapters_used": self.live_adapters_used,
             "external_writes_used": self.external_writes_used,
             "dopetask_execution_used": self.dopetask_execution_used,
-            "github_api_used": self.github_api_used
+            "github_api_used": self.github_api_used,
+            "taxonomy_id": self.taxonomy_id,
+            "taxonomy_path": self.taxonomy_path,
+            "taxonomy_lane_ids": self.taxonomy_lane_ids
         }
 
 @dataclass

--- a/src/dopemux/dcp/red_lane_scanner.py
+++ b/src/dopemux/dcp/red_lane_scanner.py
@@ -7,6 +7,7 @@ from dopemux.dcp.red_lane import (
     RedLaneReport, Finding, ScannerInfo, RepoInfo, InputsInfo, GuardsInfo, SummaryInfo,
     Severity, Status, AuthorityLabel
 )
+from dopemux.dcp.red_lane_taxonomy import load_red_lane_taxonomy_info
 from dopemux.dcp.red_lane_rules import FORBIDDEN_PATHS, TEXT_RULES, is_safe_false_positive, redact_secret_like
 
 class RedLaneScanner:
@@ -28,6 +29,7 @@ class RedLaneScanner:
         proof_paths = proof_paths or []
         audit_paths = audit_paths or []
         merge_readiness_paths = merge_readiness_paths or []
+        taxonomy_info = load_red_lane_taxonomy_info(self.repo_root)
         
         findings = []
         
@@ -120,7 +122,11 @@ class RedLaneScanner:
         return RedLaneReport(
             generated_at=datetime.utcnow().isoformat() + "Z",
             packet_id="TP-DCP-0005",
-            scanner=ScannerInfo(),
+            scanner=ScannerInfo(
+                taxonomy_id=taxonomy_info.taxonomy_id,
+                taxonomy_path=taxonomy_info.taxonomy_path,
+                taxonomy_lane_ids=taxonomy_info.taxonomy_lane_ids,
+            ),
             repo=RepoInfo(head_sha=expected_head_sha),
             inputs=InputsInfo(
                 changed_files=changed_files,

--- a/src/dopemux/dcp/red_lane_taxonomy.py
+++ b/src/dopemux/dcp/red_lane_taxonomy.py
@@ -1,0 +1,35 @@
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List
+
+
+DEFAULT_TAXONOMY_REL_PATH = "schemas/dcp/dcp_red_lane_taxonomy.instance.json"
+
+
+@dataclass
+class RedLaneTaxonomyInfo:
+    taxonomy_id: str = "UNKNOWN"
+    taxonomy_path: str = DEFAULT_TAXONOMY_REL_PATH
+    taxonomy_lane_ids: List[str] = field(default_factory=list)
+
+
+def load_red_lane_taxonomy_info(
+    repo_root: str,
+    taxonomy_rel_path: str = DEFAULT_TAXONOMY_REL_PATH,
+) -> RedLaneTaxonomyInfo:
+    taxonomy_path = Path(repo_root) / taxonomy_rel_path
+    if not taxonomy_path.exists():
+        return RedLaneTaxonomyInfo(taxonomy_path=taxonomy_rel_path)
+
+    data = json.loads(taxonomy_path.read_text(encoding="utf-8"))
+    lane_ids = [
+        lane["id"]
+        for lane in data.get("lanes", [])
+        if isinstance(lane, dict) and isinstance(lane.get("id"), str)
+    ]
+    return RedLaneTaxonomyInfo(
+        taxonomy_id=data.get("taxonomy_id", "UNKNOWN"),
+        taxonomy_path=taxonomy_rel_path,
+        taxonomy_lane_ids=lane_ids,
+    )

--- a/task-packets/generated/DMX-DCP-TOOLING-102.json
+++ b/task-packets/generated/DMX-DCP-TOOLING-102.json
@@ -1,0 +1,121 @@
+{
+  "id": "DMX-DCP-TOOLING-102",
+  "project": "dopemux-mvp",
+  "target": "DCP red-lane taxonomy instance and scanner metadata evolution",
+  "invariants": [
+    "No live writes, external API calls, Dopetask execution, or PR mutation are introduced.",
+    "DCP-RED-MERGE-SEAM-0001 remains a hard block.",
+    "The scanner remains local and deterministic.",
+    "Taxonomy absence must be explicit in report metadata, not a hidden success claim.",
+    "TP-101 manifest and ADR scope remain intact."
+  ],
+  "depends_on": [
+    "DMX-DCP-TOOLING-101"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-DCP-TOOLING",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "claude/dmx-dcp-tooling-101",
+    "base_branch": "main",
+    "stacked_because": "Bundle TP-101 and TP-102 foundation review work in PR #885 to reduce review overhead."
+  },
+  "commit": {
+    "message": "feat(dcp): DMX-DCP-TOOLING-102 taxonomy instance and scanner metadata",
+    "allowlist": [
+      "task-packets/generated/DMX-DCP-TOOLING-102.json",
+      "schemas/dcp/dcp_red_lane_taxonomy.instance.json",
+      "schemas/dcp/README.md",
+      "schemas/dcp/manifest.json",
+      "schemas/dcp/dcp_red_lane_report.schema.json",
+      "src/dopemux/dcp/red_lane.py",
+      "src/dopemux/dcp/red_lane_scanner.py",
+      "src/dopemux/dcp/red_lane_taxonomy.py",
+      "tests/dcp/test_dcp_0102_red_lane_taxonomy.py",
+      "proof/DMX-DCP-TOOLING-102/PROOF.json",
+      "proof/DMX-DCP-TOOLING-102/AUDITOR_REPORT.md",
+      "proof/DMX-DCP-TOOLING-102/APPROVAL.json"
+    ],
+    "verify": [
+      "python -m pytest -q tests/dcp/test_dcp_0102_red_lane_taxonomy.py tests/dcp/test_dcp_0005_red_lane_scanner.py tests/dcp/test_contracts_consistency.py",
+      "python -m jsonschema -i task-packets/generated/DMX-DCP-TOOLING-102.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m jsonschema -i schemas/dcp/dcp_red_lane_taxonomy.instance.json schemas/dcp/dcp_red_lane_taxonomy.schema.json",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): DMX-DCP-TOOLING 101+102 foundation bundle",
+    "body": "Bundles TP-101 contracts manifest/promotion ladder with TP-102 red-lane taxonomy instance and scanner metadata evolution.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "102-red-test",
+      "task": "Add regression tests proving the scanner exposes taxonomy metadata and that the repo taxonomy instance validates against its schema.",
+      "validation": [
+        "python -m pytest -q tests/dcp/test_dcp_0102_red_lane_taxonomy.py"
+      ],
+      "expected_files": [
+        "tests/dcp/test_dcp_0102_red_lane_taxonomy.py"
+      ]
+    },
+    {
+      "id": "102-instance",
+      "task": "Promote the red-lane taxonomy out of the aggregate fixture into a repo-local instance file and point the manifest at it.",
+      "validation": [
+        "python -m jsonschema -i schemas/dcp/dcp_red_lane_taxonomy.instance.json schemas/dcp/dcp_red_lane_taxonomy.schema.json"
+      ],
+      "expected_files": [
+        "schemas/dcp/dcp_red_lane_taxonomy.instance.json",
+        "schemas/dcp/manifest.json"
+      ]
+    },
+    {
+      "id": "102-scanner-metadata",
+      "task": "Update local scanner report metadata to include taxonomy_id, taxonomy_path, and taxonomy_lane_ids without adding external writes.",
+      "validation": [
+        "python -m pytest -q tests/dcp/test_dcp_0102_red_lane_taxonomy.py tests/dcp/test_dcp_0005_red_lane_scanner.py"
+      ],
+      "expected_files": [
+        "src/dopemux/dcp/red_lane.py",
+        "src/dopemux/dcp/red_lane_scanner.py",
+        "src/dopemux/dcp/red_lane_taxonomy.py",
+        "schemas/dcp/dcp_red_lane_report.schema.json"
+      ]
+    },
+    {
+      "id": "102-proof",
+      "task": "Record proof, auditor report, and sanctioned-change approval artifact for the red-lane foundation packet.",
+      "validation": [
+        "python -m json.tool proof/DMX-DCP-TOOLING-102/PROOF.json >/dev/null",
+        "python -m json.tool proof/DMX-DCP-TOOLING-102/APPROVAL.json >/dev/null"
+      ],
+      "expected_files": [
+        "proof/DMX-DCP-TOOLING-102/PROOF.json",
+        "proof/DMX-DCP-TOOLING-102/AUDITOR_REPORT.md",
+        "proof/DMX-DCP-TOOLING-102/APPROVAL.json"
+      ]
+    }
+  ]
+}

--- a/tests/dcp/test_contracts_consistency.py
+++ b/tests/dcp/test_contracts_consistency.py
@@ -1,0 +1,312 @@
+"""
+DCP Contracts Consistency Tests — DMX-DCP-TOOLING-101
+
+Verifies that schemas/dcp/manifest.json is internally consistent and truthful:
+
+  (a) manifest validates against dcp_contracts_manifest.schema.json
+  (b) every schema_file entry exists on disk
+  (c) every .schema.json in schemas/dcp/ (except the manifest schema itself) has
+      EXACTLY ONE entry in the manifest — no unlisted schemas, no duplicates
+  (d) every ci_gates name exists as a job name or step name in
+      .github/workflows/ci-complete.yml
+  (e) every L2/L3 entry has non-empty runtime_producers AND runtime_consumers
+
+Negative-path unit tests (using synthetic dicts):
+  - a bogus ci_gate name must fail the gate-existence check
+  - an L2 entry missing runtime_producers must fail the producers/consumers check
+
+Run:
+  cd <repo-root>
+  PYTHONPATH=src python3 -m pytest tests/dcp/test_contracts_consistency.py -v
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path constants — resolved relative to this file so both invocation modes work
+# ---------------------------------------------------------------------------
+
+_THIS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _THIS_DIR.parent.parent
+_SCHEMAS_DIR = _REPO_ROOT / "schemas" / "dcp"
+_MANIFEST_PATH = _SCHEMAS_DIR / "manifest.json"
+_MANIFEST_SCHEMA_PATH = _SCHEMAS_DIR / "dcp_contracts_manifest.schema.json"
+_CI_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "ci-complete.yml"
+
+# The manifest schema file is excluded from the "every schema must have an entry" check
+_MANIFEST_SCHEMA_FILENAME = "dcp_contracts_manifest.schema.json"
+
+
+# ---------------------------------------------------------------------------
+# Helpers (also called directly by negative-path unit tests)
+# ---------------------------------------------------------------------------
+
+def load_manifest() -> dict:
+    with open(_MANIFEST_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def load_manifest_schema() -> dict:
+    with open(_MANIFEST_SCHEMA_PATH, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def collect_ci_names() -> set:
+    """Return all job names and step names found in ci-complete.yml.
+
+    Parses ``name:`` lines rather than importing a YAML library, so this
+    works even when pyyaml is not installed in the test environment.
+
+    GitHub Actions workflow files use two forms:
+      - Job names:  ``  job-key:\n    name: "Job Name"`` (key ``name:`` at
+        arbitrary indentation, no preceding ``-``)
+      - Step names: ``      - name: Step Name`` (preceded by ``- `` list marker)
+
+    We match both with a single regex:
+      ``\\s*(?:-\\s+)?name:\\s+(.+)``
+    """
+    import re
+    _name_re = re.compile(r"\s*(?:-\s+)?name:\s+(.+)")
+    names: set = set()
+    with open(_CI_WORKFLOW_PATH, encoding="utf-8") as f:
+        for line in f:
+            m = _name_re.match(line)
+            if m:
+                value = m.group(1).strip().strip('"').strip("'")
+                if value:
+                    names.add(value)
+    return names
+
+
+def validate_ci_gates(contract_id: str, ci_gates: list, known_ci_names: set) -> list:
+    """Return a list of gate names that do NOT appear in known_ci_names.
+
+    Returns an empty list when all gates are valid (or when ci_gates is empty).
+    """
+    bad = [g for g in ci_gates if g not in known_ci_names]
+    return bad
+
+
+def validate_l2_l3_runtime(contract_id: str, level: str, producers: list, consumers: list) -> bool:
+    """Return True when the entry satisfies the L2/L3 runtime requirement.
+
+    L2 and L3 contracts MUST have non-empty runtime_producers AND
+    runtime_consumers.  L0/L1 contracts always pass this check.
+    """
+    if level not in ("L2", "L3"):
+        return True
+    return bool(producers) and bool(consumers)
+
+
+# ---------------------------------------------------------------------------
+# (a) manifest validates against dcp_contracts_manifest.schema.json
+# ---------------------------------------------------------------------------
+
+def test_manifest_validates_against_schema():
+    """Skip gracefully when jsonschema is not importable."""
+    jsonschema = pytest.importorskip("jsonschema", reason="jsonschema not installed")
+
+    manifest = load_manifest()
+    manifest_schema = load_manifest_schema()
+
+    try:
+        validator_cls = jsonschema.Draft7Validator
+    except AttributeError:
+        validator_cls = jsonschema.Draft4Validator  # fallback
+
+    validator = validator_cls(manifest_schema)
+    errors = list(validator.iter_errors(manifest))
+    assert errors == [], (
+        f"manifest.json failed schema validation with {len(errors)} error(s):\n"
+        + "\n".join(f"  [{i+1}] {e.message} (path: {list(e.path)})" for i, e in enumerate(errors[:5]))
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) every schema_file in the manifest exists on disk
+# ---------------------------------------------------------------------------
+
+def test_all_schema_files_exist():
+    manifest = load_manifest()
+    missing = []
+    for entry in manifest["contracts"]:
+        path = _REPO_ROOT / entry["schema_file"]
+        if not path.exists():
+            missing.append(entry["schema_file"])
+    assert missing == [], (
+        f"{len(missing)} schema_file(s) listed in manifest do not exist on disk:\n"
+        + "\n".join(f"  {p}" for p in missing)
+    )
+
+
+# ---------------------------------------------------------------------------
+# (c) every .schema.json (except the manifest schema) has exactly one manifest entry
+# ---------------------------------------------------------------------------
+
+def test_no_unlisted_schemas_and_no_duplicates():
+    manifest = load_manifest()
+
+    # Build sets
+    listed_files = [entry["schema_file"] for entry in manifest["contracts"]]
+    listed_basenames = [Path(f).name for f in listed_files]
+
+    # Check for duplicate entries in the manifest
+    seen: dict = {}
+    duplicates = []
+    for basename in listed_basenames:
+        if basename in seen:
+            duplicates.append(basename)
+        seen[basename] = True
+    assert duplicates == [], (
+        f"Duplicate schema entries in manifest: {duplicates}"
+    )
+
+    # Collect actual .schema.json files (excluding the manifest schema itself)
+    actual_schema_files = {
+        f.name
+        for f in _SCHEMAS_DIR.glob("*.schema.json")
+        if f.name != _MANIFEST_SCHEMA_FILENAME
+    }
+
+    # Check for unlisted schemas
+    unlisted = actual_schema_files - set(listed_basenames)
+    assert unlisted == set(), (
+        f"Schemas in schemas/dcp/ that are NOT listed in manifest: {sorted(unlisted)}"
+    )
+
+    # Check for listed schemas that don't exist on disk
+    extra = set(listed_basenames) - actual_schema_files
+    assert extra == set(), (
+        f"Manifest entries that have no corresponding .schema.json file: {sorted(extra)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (d) every ci_gates name must appear in ci-complete.yml
+# ---------------------------------------------------------------------------
+
+def test_ci_gate_names_exist_in_workflow():
+    manifest = load_manifest()
+    known_ci_names = collect_ci_names()
+
+    failures = []
+    for entry in manifest["contracts"]:
+        bad_gates = validate_ci_gates(
+            entry["contract_id"], entry["ci_gates"], known_ci_names
+        )
+        if bad_gates:
+            failures.append(
+                f"  {entry['contract_id']}: unknown ci_gates {bad_gates}"
+            )
+
+    assert failures == [], (
+        f"{len(failures)} contract(s) reference non-existent CI gate names:\n"
+        + "\n".join(failures)
+    )
+
+
+# ---------------------------------------------------------------------------
+# (e) L2/L3 entries must have non-empty runtime_producers AND runtime_consumers
+# ---------------------------------------------------------------------------
+
+def test_l2_l3_entries_have_runtime_coupling():
+    manifest = load_manifest()
+    failures = []
+    for entry in manifest["contracts"]:
+        ok = validate_l2_l3_runtime(
+            entry["contract_id"],
+            entry["level"],
+            entry["runtime_producers"],
+            entry["runtime_consumers"],
+        )
+        if not ok:
+            failures.append(
+                f"  {entry['contract_id']} (level={entry['level']}): "
+                f"runtime_producers={entry['runtime_producers']!r}, "
+                f"runtime_consumers={entry['runtime_consumers']!r}"
+            )
+    assert failures == [], (
+        f"{len(failures)} L2/L3 contract(s) missing runtime coupling:\n"
+        + "\n".join(failures)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative-path unit tests — synthetic dicts (do NOT touch real manifest)
+# ---------------------------------------------------------------------------
+
+class TestNegativePathCiGate:
+    """A bogus ci_gate name MUST be detected as invalid."""
+
+    def test_bogus_ci_gate_fails(self):
+        known = collect_ci_names()
+        bad_gates = validate_ci_gates(
+            "DCP_FAKE_CONTRACT",
+            ["🚀 This Gate Does Not Exist In The Workflow"],
+            known,
+        )
+        assert bad_gates == ["🚀 This Gate Does Not Exist In The Workflow"], (
+            "Expected bogus gate name to be flagged; helper returned empty list"
+        )
+
+    def test_real_ci_gate_passes(self):
+        known = collect_ci_names()
+        bad_gates = validate_ci_gates(
+            "DCP_RED_LANE_TAXONOMY",
+            ["🔴 Run DCP red-lane gate (TP-DMX-DCP-CI-GATE-001)"],
+            known,
+        )
+        assert bad_gates == [], (
+            f"Real gate name was wrongly flagged as missing: {bad_gates}"
+        )
+
+
+class TestNegativePathL2RuntimeCoupling:
+    """An L2 entry missing runtime_producers MUST fail the coupling check."""
+
+    def test_l2_missing_producers_fails(self):
+        ok = validate_l2_l3_runtime(
+            "DCP_FAKE_L2",
+            level="L2",
+            producers=[],          # missing!
+            consumers=["src/dopemux/dcp/consumer.py"],
+        )
+        assert ok is False, (
+            "Expected L2 entry with empty producers to fail; helper returned True"
+        )
+
+    def test_l2_missing_consumers_fails(self):
+        ok = validate_l2_l3_runtime(
+            "DCP_FAKE_L2",
+            level="L2",
+            producers=["src/dopemux/dcp/producer.py"],
+            consumers=[],          # missing!
+        )
+        assert ok is False, (
+            "Expected L2 entry with empty consumers to fail; helper returned True"
+        )
+
+    def test_l2_both_present_passes(self):
+        ok = validate_l2_l3_runtime(
+            "DCP_FAKE_L2",
+            level="L2",
+            producers=["src/dopemux/dcp/producer.py"],
+            consumers=["src/dopemux/dcp/consumer.py"],
+        )
+        assert ok is True, (
+            "Expected L2 entry with both producers and consumers to pass"
+        )
+
+    def test_l0_empty_runtime_passes(self):
+        ok = validate_l2_l3_runtime(
+            "DCP_FAKE_L0",
+            level="L0",
+            producers=[],
+            consumers=[],
+        )
+        assert ok is True, (
+            "Expected L0 entry with empty runtime arrays to pass (L0 has no coupling requirement)"
+        )

--- a/tests/dcp/test_dcp_0102_red_lane_taxonomy.py
+++ b/tests/dcp/test_dcp_0102_red_lane_taxonomy.py
@@ -1,0 +1,62 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from dopemux.dcp.red_lane import Status
+from dopemux.dcp.red_lane_scanner import RedLaneScanner
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TAXONOMY_PATH = REPO_ROOT / "schemas" / "dcp" / "dcp_red_lane_taxonomy.instance.json"
+TAXONOMY_SCHEMA_PATH = REPO_ROOT / "schemas" / "dcp" / "dcp_red_lane_taxonomy.schema.json"
+
+
+def test_repo_taxonomy_instance_validates_against_schema():
+    jsonschema = pytest.importorskip("jsonschema", reason="jsonschema not installed")
+
+    taxonomy = json.loads(TAXONOMY_PATH.read_text(encoding="utf-8"))
+    schema = json.loads(TAXONOMY_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    jsonschema.Draft7Validator(schema).validate(taxonomy)
+    lane_ids = {lane["id"] for lane in taxonomy["lanes"]}
+    assert "DCP-RED-MERGE-SEAM-0001" in lane_ids
+    assert taxonomy["validation"]["state"] == "REPO_CROSS_CHECKED"
+
+
+def test_scanner_report_exposes_repo_taxonomy_metadata():
+    scanner = RedLaneScanner(repo_root=str(REPO_ROOT))
+    report = scanner.scan(
+        changed_files=["src/dopemux/dcp/red_lane.py"],
+        proof_paths=["proof/DMX-DCP-TOOLING-101/PROOF.json"],
+    )
+
+    assert report.status == Status.PASS
+    assert report.scanner.taxonomy_id == "dcp-red-lane-taxonomy-v0-seed"
+    assert report.scanner.taxonomy_path == "schemas/dcp/dcp_red_lane_taxonomy.instance.json"
+    assert "DCP-RED-MERGE-SEAM-0001" in report.scanner.taxonomy_lane_ids
+
+    payload = report.to_dict()
+    assert payload["scanner"]["taxonomy_id"] == report.scanner.taxonomy_id
+    assert payload["scanner"]["taxonomy_path"] == report.scanner.taxonomy_path
+    assert payload["scanner"]["taxonomy_lane_ids"] == report.scanner.taxonomy_lane_ids
+
+
+def test_scanner_missing_taxonomy_is_explicit_not_silent(tmp_path):
+    proof = tmp_path / "PROOF.json"
+    proof.write_text(
+        json.dumps({
+            "implementer_identity": "Agent",
+            "audit": {"auditor_identity": "Human"},
+            "head_sha": "expected123"
+        }),
+        encoding="utf-8",
+    )
+
+    scanner = RedLaneScanner(repo_root=str(tmp_path))
+    report = scanner.scan(proof_paths=["PROOF.json"], expected_head_sha="expected123")
+
+    assert report.status == Status.PASS
+    assert report.scanner.taxonomy_id == "UNKNOWN"
+    assert report.scanner.taxonomy_path == "schemas/dcp/dcp_red_lane_taxonomy.instance.json"
+    assert report.scanner.taxonomy_lane_ids == []


### PR DESCRIPTION
## Summary

Bundles the first DCP tooling foundation packets in one review surface:

- TP-101: contracts manifest, promotion ladder, deterministic-vs-LLM ADR, and proof bundle.
- TP-102: standalone red-lane taxonomy instance plus local scanner report metadata (`taxonomy_id`, `taxonomy_path`, `taxonomy_lane_ids`).

## TP-102 Scope

- Adds `task-packets/generated/DMX-DCP-TOOLING-102.json`.
- Adds `schemas/dcp/dcp_red_lane_taxonomy.instance.json`.
- Updates `schemas/dcp/manifest.json` and `schemas/dcp/dcp_red_lane_report.schema.json` for taxonomy metadata.
- Adds `src/dopemux/dcp/red_lane_taxonomy.py` and scanner integration.
- Adds `tests/dcp/test_dcp_0102_red_lane_taxonomy.py`.
- Adds proof bundle under `proof/DMX-DCP-TOOLING-102/`.

## Validation

PASS:

- `python -m pytest -q tests/dcp/test_dcp_0102_red_lane_taxonomy.py tests/dcp/test_dcp_0005_red_lane_scanner.py tests/dcp/test_contracts_consistency.py` -> 32 passed
- `python -m jsonschema -i task-packets/generated/DMX-DCP-TOOLING-102.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` -> pass, CLI deprecation warning only
- `python -m jsonschema -i schemas/dcp/dcp_red_lane_taxonomy.instance.json schemas/dcp/dcp_red_lane_taxonomy.schema.json` -> pass, CLI deprecation warning only
- `python -m py_compile src/dopemux/dcp/red_lane.py src/dopemux/dcp/red_lane_scanner.py src/dopemux/dcp/red_lane_taxonomy.py` -> pass
- `python scripts/audit/validate_audit_proof.py proof/DMX-DCP-TOOLING-102/PROOF.json` -> 1/1 pass
- `pre-commit run --files ...TP-102 touched files...` -> pass
- `git diff --check` -> pass

NOT_RUN / risk:

- Independent auditor for TP-102 did not run in this session; the proof records this explicitly as `embedded_audit.status=SKIPPED` rather than inventing an auditor.
- Schema-driven rule loading is still TP-103; TP-102 only exposes taxonomy metadata in reports.
- Prior Gemini review failure was an external 429 monthly spending cap, not a code finding. It may recur.

@codex review
@gemini
@copilot
