### PR TITLE
feat(dcp): add inert backend policy map

### DIFF
--- a/src/dopemux/dcp/__init__.py
+++ b/src/dopemux/dcp/__init__.py
@@ -37,6 +37,11 @@ from dopemux.dcp.routing_classifier import (
     RoutingClassificationInput,
     classify_route,
 )
+from dopemux.dcp.routing_backend_policy import (
+    BackendPolicyDecision,
+    select_backend_policy,
+    select_backend_policy_for_input,
+)
 
 __all__ = [
     # Proof artifact readers (pre-existing)
@@ -71,4 +76,8 @@ __all__ = [
     # Routing classification engine (DMX-DCP-MODEL-ROUTING-MVP-0002)
     "RoutingClassificationInput",
     "classify_route",
+    # Routing backend policy map (DMX-DCP-MODEL-ROUTING-MVP-0003)
+    "BackendPolicyDecision",
+    "select_backend_policy",
+    "select_backend_policy_for_input",
 ]

--- a/src/dopemux/dcp/routing_backend_policy.py
+++ b/src/dopemux/dcp/routing_backend_policy.py
@@ -1,0 +1,244 @@
+"""Pure backend policy map for DCP routing decisions.
+
+DMX-DCP-MODEL-ROUTING-MVP-0003 adds inert backend preference data on top of
+classified :class:`RouteDecision` records. It does not invoke backends,
+connectors, runners, provider APIs, GitHub, MCP, Dopetask, or workflow tools.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dopemux.dcp.routing_classifier import (
+    RoutingClassificationInput,
+    classify_route,
+)
+from dopemux.dcp.routing_model import (
+    AuditRequirement,
+    BackendKind,
+    ComplexityClass,
+    EscalationRequirement,
+    RedLaneState,
+    RiskClass,
+    RouteDecision,
+    RouteStatus,
+    RuntimeImpact,
+    TaskType,
+)
+
+
+ALLOWED_POLICY = "ALLOWED_POLICY"
+BLOCKED_POLICY = "BLOCKED_POLICY"
+SUPERVISOR_POLICY = "SUPERVISOR_POLICY"
+UNKNOWN_POLICY = "UNKNOWN_POLICY"
+ADVISORY_ONLY = "ADVISORY_ONLY"
+
+_EXECUTION_BACKENDS: tuple[BackendKind, ...] = (
+    BackendKind.CODEX,
+    BackendKind.CLAUDE_CODE,
+    BackendKind.OPENCODE,
+    BackendKind.GROK,
+    BackendKind.GEMINI_CLI,
+    BackendKind.AGY,
+    BackendKind.LOCAL_SCRIPT,
+)
+
+_NON_DEFAULT_EXECUTION_BACKENDS: tuple[BackendKind, ...] = (
+    BackendKind.OPENCODE,
+    BackendKind.GROK,
+    BackendKind.LOCAL_SCRIPT,
+)
+
+_BLOCKING_STOP_CONDITIONS: frozenset[str] = frozenset(
+    {
+        "red_lane_active",
+        "conflicting_evidence",
+        "secrets_surface_in_scope",
+        "auth_surface_in_scope",
+        "ci_surface_in_scope",
+        "network_required",
+        "external_service_required",
+        "merge_task_requested",
+        "service_mutation_requested",
+        "live_write_requested",
+        "runner_execution_requested",
+        "forbidden_requested_action",
+    }
+)
+
+
+@dataclass(frozen=True)
+class BackendPolicyDecision:
+    """Inert backend preference metadata for a classified route."""
+
+    route_id: str
+    preferred_backend: BackendKind
+    fallback_backends: tuple[BackendKind, ...] = ()
+    forbidden_backends: tuple[BackendKind, ...] = ()
+    policy_status: str = UNKNOWN_POLICY
+    reason_codes: tuple[str, ...] = ()
+    stop_conditions: tuple[str, ...] = ()
+    escalation_required: bool = False
+    evidence_refs: tuple[str, ...] = ()
+
+
+def select_backend_policy(route: RouteDecision) -> BackendPolicyDecision:
+    """Select inert backend policy metadata for an existing route decision."""
+    stop_conditions = tuple(route.stop_conditions)
+    evidence_refs = tuple(route.evidence_refs)
+
+    if _is_blocked_policy(route):
+        return BackendPolicyDecision(
+            route_id=route.route_id,
+            preferred_backend=BackendKind.NONE,
+            forbidden_backends=_EXECUTION_BACKENDS,
+            policy_status=BLOCKED_POLICY,
+            reason_codes=_reason_codes(route, "blocked_route", "route_not_runnable"),
+            stop_conditions=stop_conditions,
+            escalation_required=True,
+            evidence_refs=evidence_refs,
+        )
+
+    if _is_unknown_policy(route):
+        return BackendPolicyDecision(
+            route_id=route.route_id,
+            preferred_backend=BackendKind.UNKNOWN,
+            forbidden_backends=_EXECUTION_BACKENDS,
+            policy_status=UNKNOWN_POLICY,
+            reason_codes=_reason_codes(route, "unknown_route", "route_not_runnable"),
+            stop_conditions=stop_conditions,
+            escalation_required=_requires_escalation(route),
+            evidence_refs=evidence_refs,
+        )
+
+    if _is_supervisor_policy(route):
+        return BackendPolicyDecision(
+            route_id=route.route_id,
+            preferred_backend=BackendKind.NONE,
+            forbidden_backends=_EXECUTION_BACKENDS,
+            policy_status=SUPERVISOR_POLICY,
+            reason_codes=_reason_codes(
+                route, "supervisor_required", "route_not_runnable"
+            ),
+            stop_conditions=stop_conditions,
+            escalation_required=True,
+            evidence_refs=evidence_refs,
+        )
+
+    if not route.is_runnable():
+        return BackendPolicyDecision(
+            route_id=route.route_id,
+            preferred_backend=BackendKind.NONE,
+            forbidden_backends=_EXECUTION_BACKENDS,
+            policy_status=ADVISORY_ONLY,
+            reason_codes=_reason_codes(route, "route_not_runnable"),
+            stop_conditions=stop_conditions,
+            escalation_required=_requires_escalation(route),
+            evidence_refs=evidence_refs,
+        )
+
+    preferred, fallbacks = _allowed_backend_order(route)
+    return BackendPolicyDecision(
+        route_id=route.route_id,
+        preferred_backend=preferred,
+        fallback_backends=fallbacks,
+        forbidden_backends=_NON_DEFAULT_EXECUTION_BACKENDS,
+        policy_status=ALLOWED_POLICY,
+        reason_codes=_reason_codes(route, "route_runnable", "backend_policy_data_only"),
+        stop_conditions=stop_conditions,
+        escalation_required=False,
+        evidence_refs=evidence_refs,
+    )
+
+
+def select_backend_policy_for_input(
+    inp: RoutingClassificationInput,
+) -> BackendPolicyDecision:
+    """Classify input, then select inert backend policy metadata."""
+    return select_backend_policy(classify_route(inp))
+
+
+def _is_blocked_policy(route: RouteDecision) -> bool:
+    if route.red_lane_state is RedLaneState.RED_LANE:
+        return True
+    if route.status is RouteStatus.BLOCKED:
+        return True
+    if route.risk_class is RiskClass.RED_LANE:
+        return True
+    if route.task_type in (TaskType.MERGE, TaskType.LIVE_WRITE):
+        return True
+    if route.runtime_impact in (
+        RuntimeImpact.SERVICE_MUTATION,
+        RuntimeImpact.LIVE_WRITE,
+    ):
+        return True
+    return any(
+        stop in _BLOCKING_STOP_CONDITIONS
+        or stop.startswith("forbidden_action_requested:")
+        for stop in route.stop_conditions
+    )
+
+
+def _is_unknown_policy(route: RouteDecision) -> bool:
+    return (
+        route.status is RouteStatus.UNKNOWN
+        or route.red_lane_state is RedLaneState.UNKNOWN
+        or bool(route.unknowns)
+    )
+
+
+def _is_supervisor_policy(route: RouteDecision) -> bool:
+    return (
+        route.status is RouteStatus.NEEDS_SUPERVISOR
+        or _requires_escalation(route)
+        or route.audit_requirement is AuditRequirement.SUPERVISOR_AUDIT
+        or route.risk_class is RiskClass.R3_HIGH
+        or route.complexity_class is ComplexityClass.ARCHITECTURAL
+    )
+
+
+def _requires_escalation(route: RouteDecision) -> bool:
+    return route.escalation_requirement is not EscalationRequirement.NONE
+
+
+def _allowed_backend_order(
+    route: RouteDecision,
+) -> tuple[BackendKind, tuple[BackendKind, ...]]:
+    if (
+        route.complexity_class is ComplexityClass.MEDIUM
+        or route.risk_class is RiskClass.R2_MEDIUM
+    ):
+        return BackendKind.CLAUDE_CODE, (
+            BackendKind.CODEX,
+            BackendKind.GEMINI_CLI,
+        )
+    return BackendKind.CODEX, (
+        BackendKind.CLAUDE_CODE,
+        BackendKind.GEMINI_CLI,
+    )
+
+
+def _reason_codes(route: RouteDecision, *extra: str) -> tuple[str, ...]:
+    reasons: list[str] = []
+    for reason in extra:
+        _append_unique(reasons, reason)
+    if route.status is RouteStatus.BLOCKED:
+        _append_unique(reasons, "status_blocked")
+    if route.status is RouteStatus.UNKNOWN:
+        _append_unique(reasons, "status_unknown")
+    if route.status is RouteStatus.NEEDS_SUPERVISOR:
+        _append_unique(reasons, "status_needs_supervisor")
+    if route.red_lane_state is RedLaneState.RED_LANE:
+        _append_unique(reasons, "red_lane")
+    if route.red_lane_state is RedLaneState.UNKNOWN:
+        _append_unique(reasons, "red_lane_unknown")
+    if _requires_escalation(route):
+        _append_unique(reasons, "escalation_required")
+    if route.audit_requirement is AuditRequirement.SUPERVISOR_AUDIT:
+        _append_unique(reasons, "supervisor_audit_required")
+    return tuple(reasons)
+
+
+def _append_unique(items: list[str], item: str) -> None:
+    if item not in items:
+        items.append(item)

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -1,0 +1,65 @@
+---
+id: DMX-DCP-MODEL-ROUTING-MVP-0003
+title: Add routing backend policy map as inert data policy
+type: explanation
+owner: '@hu3mann'
+author: codex
+date: '2026-06-14'
+last_review: '2026-06-14'
+next_review: '2026-09-12'
+prelude: Pure backend preference policy for classified DCP RouteDecision data.
+---
+# DMX-DCP-MODEL-ROUTING-MVP-0003 - Routing Backend Policy Map
+
+## Objective
+
+Add a pure Python backend policy layer that maps an already-classified
+`RouteDecision` to inert backend preference metadata.
+
+This packet adds policy preference, not backend authority. The policy does not
+invoke backends, runners, connectors, MCP, GitHub, provider APIs, Dopetask, or
+Task Orchestrator.
+
+## Authority
+
+- Active packet: DMX-DCP-MODEL-ROUTING-MVP-0003 pasted task packet.
+- Runtime dependencies: `src/dopemux/dcp/routing_model.py` and
+  `src/dopemux/dcp/routing_classifier.py`.
+- Advisory context: `config/ai/model-routing.policy.yaml` is proposed
+  governance only, not runtime routing authority.
+
+## Allowlist
+
+- `src/dopemux/dcp/routing_backend_policy.py`
+- `src/dopemux/dcp/__init__.py`
+- `tests/unit/dcp/test_routing_backend_policy.py`
+- `task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md`
+
+## Required PAL Chain
+
+`analyze -> thinkdeep -> challenge -> planner -> challenge -> implement -> codereview -> precommit -> challenge`
+
+## Validation
+
+- `python -m compileall -q src/dopemux/dcp`
+- `python -m pytest -q tests/unit/dcp/test_routing_model.py tests/unit/dcp/test_routing_classifier.py tests/unit/dcp/test_routing_backend_policy.py`
+- `git diff --check`
+- Static no-go scan for network, shell, filesystem-write, backend-runner, MCP,
+  GitHub, merge, queue-drain, and provider invocation terms.
+- Diff scope review with `git diff --name-only` and `git diff --stat`.
+
+## Stop Conditions
+
+- A required enum member is missing and cannot be mapped to actual runtime enum
+  values.
+- Any change is needed in `routing_model.py` or `routing_classifier.py`.
+- Policy code requires runner, connector, filesystem write, subprocess, network,
+  provider, GitHub, MCP, Dopetask, or Task Orchestrator imports.
+
+## Non-Claims
+
+- Backend availability is not proven.
+- Backend health is not proven.
+- Backend execution is not wired.
+- Supervisor review capacity is not proven.
+- This packet does not make any backend authoritative.

--- a/tests/unit/dcp/test_routing_backend_policy.py
+++ b/tests/unit/dcp/test_routing_backend_policy.py
@@ -1,0 +1,453 @@
+"""Unit tests for DMX-DCP-MODEL-ROUTING-MVP-0003 backend policy.
+
+Coverage targets:
+- Pure import and static no-go checks
+- Hard gates for blocked, unknown, red-lane, supervisor, escalation cases
+- No runnable backend policy for security, live-write, connector, MCP,
+  Dopetask, or Task Orchestrator cases
+- Deterministic preferred, fallback, and forbidden backend metadata
+- Evidence, stop conditions, immutability, serializability, and helper parity
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+import inspect
+
+import pytest
+
+from dopemux.dcp.routing_classifier import RoutingClassificationInput, classify_route
+from dopemux.dcp.routing_model import (
+    AuditRequirement,
+    AuthorityClass,
+    BackendKind,
+    ComplexityClass,
+    EscalationRequirement,
+    RedLaneState,
+    RiskClass,
+    RouteDecision,
+    RouteStatus,
+    RuntimeImpact,
+    TaskSource,
+    TaskType,
+)
+
+
+FORBIDDEN_IMPORTS_IN_POLICY = {
+    "subprocess",
+    "requests",
+    "httpx",
+    "urllib",
+    "socket",
+    "github",
+    "docker",
+    "mcp",
+    "dopetask",
+    "task_orchestrator",
+    "conport",
+    "dope_memory",
+    "dope_context",
+}
+
+FORBIDDEN_METHOD_PREFIXES = (
+    "def run",
+    "def execute",
+    "def dispatch",
+    "def invoke",
+    "def merge",
+)
+
+
+def _safe_read_route() -> RouteDecision:
+    return classify_route(
+        RoutingClassificationInput(
+            task_source=TaskSource.OPERATOR,
+            task_type=TaskType.READ_ONLY,
+            risk_class=RiskClass.R0_READ,
+            complexity_class=ComplexityClass.LOW,
+            authority_class=AuthorityClass.OPERATOR,
+            runtime_impact=RuntimeImpact.READ_ONLY,
+            has_unknown_authority=False,
+        )
+    )
+
+
+def _safe_code_route(
+    *,
+    risk_class: RiskClass = RiskClass.R1_LOW,
+    complexity_class: ComplexityClass = ComplexityClass.LOW,
+) -> RouteDecision:
+    return classify_route(
+        RoutingClassificationInput(
+            task_source=TaskSource.OPERATOR,
+            task_type=TaskType.CODE_CHANGE,
+            risk_class=risk_class,
+            complexity_class=complexity_class,
+            authority_class=AuthorityClass.OPERATOR,
+            runtime_impact=RuntimeImpact.LOCAL_ONLY,
+            has_unknown_authority=False,
+        )
+    )
+
+
+def test_import_backend_policy_module() -> None:
+    import dopemux.dcp.routing_backend_policy as mod
+
+    assert callable(mod.select_backend_policy)
+    assert callable(mod.select_backend_policy_for_input)
+    assert hasattr(mod, "BackendPolicyDecision")
+
+
+def test_default_unknown_route_is_not_allowed_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    policy = select_backend_policy(RouteDecision())
+
+    assert policy.policy_status == "UNKNOWN_POLICY"
+    assert policy.preferred_backend is BackendKind.UNKNOWN
+    assert "route_not_runnable" in policy.reason_codes
+
+
+def test_red_lane_route_produces_blocked_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = RouteDecision(
+        route_id="red",
+        status=RouteStatus.ALLOWED,
+        red_lane_state=RedLaneState.RED_LANE,
+        authority_class=AuthorityClass.OPERATOR,
+    )
+    policy = select_backend_policy(route)
+
+    assert policy.policy_status == "BLOCKED_POLICY"
+    assert policy.preferred_backend is BackendKind.NONE
+    assert BackendKind.CODEX in policy.forbidden_backends
+
+
+def test_blocked_route_produces_blocked_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    policy = select_backend_policy(
+        RouteDecision(
+            route_id="blocked",
+            status=RouteStatus.BLOCKED,
+            red_lane_state=RedLaneState.CLEAR,
+            authority_class=AuthorityClass.OPERATOR,
+        )
+    )
+
+    assert policy.policy_status == "BLOCKED_POLICY"
+    assert policy.preferred_backend is BackendKind.NONE
+
+
+def test_unknown_route_produces_unknown_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    policy = select_backend_policy(
+        RouteDecision(
+            route_id="unknown",
+            status=RouteStatus.UNKNOWN,
+            red_lane_state=RedLaneState.CLEAR,
+            authority_class=AuthorityClass.OPERATOR,
+        )
+    )
+
+    assert policy.policy_status == "UNKNOWN_POLICY"
+    assert policy.preferred_backend is BackendKind.UNKNOWN
+
+
+def test_supervisor_needed_route_produces_supervisor_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    policy = select_backend_policy(
+        RouteDecision(
+            route_id="supervisor",
+            status=RouteStatus.NEEDS_SUPERVISOR,
+            red_lane_state=RedLaneState.CLEAR,
+            authority_class=AuthorityClass.OPERATOR,
+        )
+    )
+
+    assert policy.policy_status == "SUPERVISOR_POLICY"
+    assert policy.preferred_backend is BackendKind.NONE
+    assert "supervisor_required" in policy.reason_codes
+
+
+def test_escalation_required_route_is_not_allowed_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = _safe_code_route()
+    route.escalation_requirement = EscalationRequirement.ON_RISK
+    policy = select_backend_policy(route)
+
+    assert policy.policy_status == "SUPERVISOR_POLICY"
+    assert policy.preferred_backend is BackendKind.NONE
+
+
+def test_security_route_has_no_runnable_backend_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = classify_route(RoutingClassificationInput(touches_security=True))
+    policy = select_backend_policy(route)
+
+    assert policy.policy_status == "BLOCKED_POLICY"
+    assert policy.preferred_backend is BackendKind.NONE
+    assert BackendKind.CODEX in policy.forbidden_backends
+
+
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "touches_auth",
+        "touches_secrets",
+        "touches_destructive_path",
+        "requires_live_write",
+        "requires_connector_call",
+        "requires_mcp_call",
+        "requires_dopetask_execution",
+        "requires_task_orchestrator_write",
+    ],
+)
+def test_red_lane_input_flags_have_no_runnable_backend_policy(flag: str) -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = classify_route(RoutingClassificationInput(**{flag: True}))
+    policy = select_backend_policy(route)
+
+    assert not route.is_runnable()
+    assert policy.policy_status == "BLOCKED_POLICY"
+    assert policy.preferred_backend is BackendKind.NONE
+    assert not policy.fallback_backends
+
+
+def test_read_only_known_route_gets_deterministic_preferred_backend() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    policy = select_backend_policy(_safe_read_route())
+
+    assert policy.policy_status == "ALLOWED_POLICY"
+    assert policy.preferred_backend is BackendKind.CODEX
+    assert policy.fallback_backends == (BackendKind.CLAUDE_CODE, BackendKind.GEMINI_CLI)
+
+
+def test_local_code_change_route_gets_deterministic_preferred_backend() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    policy = select_backend_policy(_safe_code_route())
+
+    assert policy.policy_status == "ALLOWED_POLICY"
+    assert policy.preferred_backend is BackendKind.CODEX
+    assert policy.fallback_backends == (BackendKind.CLAUDE_CODE, BackendKind.GEMINI_CLI)
+
+
+def test_medium_complexity_code_change_prefers_claude_code_data() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    policy = select_backend_policy(
+        _safe_code_route(
+            risk_class=RiskClass.R2_MEDIUM,
+            complexity_class=ComplexityClass.MEDIUM,
+        )
+    )
+
+    assert policy.policy_status == "ALLOWED_POLICY"
+    assert policy.preferred_backend is BackendKind.CLAUDE_CODE
+    assert policy.fallback_backends == (BackendKind.CODEX, BackendKind.GEMINI_CLI)
+
+
+def test_architectural_complexity_route_is_supervisor_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = classify_route(
+        RoutingClassificationInput(
+            task_source=TaskSource.OPERATOR,
+            task_type=TaskType.CODE_CHANGE,
+            risk_class=RiskClass.R1_LOW,
+            complexity_class=ComplexityClass.ARCHITECTURAL,
+            authority_class=AuthorityClass.OPERATOR,
+            runtime_impact=RuntimeImpact.LOCAL_ONLY,
+            has_unknown_authority=False,
+        )
+    )
+    policy = select_backend_policy(route)
+
+    assert route.status is RouteStatus.NEEDS_SUPERVISOR
+    assert policy.policy_status == "SUPERVISOR_POLICY"
+
+
+def test_high_risk_route_is_supervisor_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = _safe_code_route(risk_class=RiskClass.R3_HIGH)
+    policy = select_backend_policy(route)
+
+    assert route.status is RouteStatus.NEEDS_SUPERVISOR
+    assert policy.policy_status == "SUPERVISOR_POLICY"
+
+
+def test_fallback_order_is_deterministic() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = _safe_code_route()
+
+    assert (
+        select_backend_policy(route).fallback_backends
+        == select_backend_policy(route).fallback_backends
+    )
+
+
+def test_forbidden_backends_are_deterministic() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = _safe_code_route()
+
+    assert select_backend_policy(route).forbidden_backends == (
+        BackendKind.OPENCODE,
+        BackendKind.GROK,
+        BackendKind.LOCAL_SCRIPT,
+    )
+
+
+def test_evidence_refs_are_preserved() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = _safe_read_route()
+    route.evidence_refs.append("proof/example.json")
+    policy = select_backend_policy(route)
+
+    assert policy.evidence_refs == ("proof/example.json",)
+
+
+def test_stop_conditions_are_preserved() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = RouteDecision(
+        route_id="stopped",
+        status=RouteStatus.BLOCKED,
+        red_lane_state=RedLaneState.RED_LANE,
+        stop_conditions=["red_lane_active", "network_required"],
+    )
+    policy = select_backend_policy(route)
+
+    assert policy.stop_conditions == ("red_lane_active", "network_required")
+
+
+def test_policy_does_not_mutate_input_route() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = _safe_code_route()
+    before = route.to_dict()
+    select_backend_policy(route)
+
+    assert route.to_dict() == before
+
+
+def test_calling_policy_twice_returns_identical_decision() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = _safe_code_route()
+
+    assert select_backend_policy(route) == select_backend_policy(route)
+
+
+def test_classify_input_helper_matches_classify_then_select() -> None:
+    from dopemux.dcp.routing_backend_policy import (
+        select_backend_policy,
+        select_backend_policy_for_input,
+    )
+
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.OPERATOR,
+        task_type=TaskType.READ_ONLY,
+        risk_class=RiskClass.R0_READ,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        has_unknown_authority=False,
+    )
+
+    assert select_backend_policy_for_input(inp) == select_backend_policy(
+        classify_route(inp)
+    )
+
+
+def test_no_forbidden_imports_in_backend_policy_source() -> None:
+    import dopemux.dcp.routing_backend_policy as mod
+
+    source = inspect.getsource(mod)
+    import_lines = [
+        line.strip()
+        for line in source.splitlines()
+        if line.strip().startswith(("import ", "from "))
+    ]
+    for forbidden in FORBIDDEN_IMPORTS_IN_POLICY:
+        for line in import_lines:
+            assert forbidden not in line, (
+                f"Forbidden import '{forbidden}' found in backend policy: {line}"
+            )
+
+
+def test_no_callable_backend_references_are_stored() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    policy = select_backend_policy(_safe_code_route())
+
+    assert not callable(policy.preferred_backend)
+    assert all(not callable(backend) for backend in policy.fallback_backends)
+    assert all(not callable(backend) for backend in policy.forbidden_backends)
+
+
+def test_policy_does_not_expose_run_execute_dispatch_invoke_methods() -> None:
+    import dopemux.dcp.routing_backend_policy as mod
+
+    source = inspect.getsource(mod)
+    for prefix in FORBIDDEN_METHOD_PREFIXES:
+        assert prefix not in source
+
+
+def test_policy_does_not_expose_merge_capability() -> None:
+    import dopemux.dcp.routing_backend_policy as mod
+
+    source = inspect.getsource(mod)
+    assert "merge_pull_request" not in source
+    assert "gh pr merge" not in source
+
+
+def test_policy_handles_available_generic_backend_enum_members() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    policy = select_backend_policy(_safe_read_route())
+
+    assert isinstance(policy.preferred_backend, BackendKind)
+
+
+def test_policy_decision_is_serializable_with_asdict() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    d = asdict(select_backend_policy(_safe_read_route()))
+
+    assert d["policy_status"] == "ALLOWED_POLICY"
+    assert d["preferred_backend"] is BackendKind.CODEX
+
+
+def test_route_evidence_and_stop_condition_tuples_are_caller_isolated() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = _safe_read_route()
+    policy = select_backend_policy(route)
+    route.evidence_refs.append("later")
+    route.stop_conditions.append("later-stop")
+
+    assert policy.evidence_refs == ()
+    assert policy.stop_conditions == ()
+
+
+def test_supervisor_audit_requirement_is_supervisor_policy() -> None:
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    route = _safe_code_route()
+    route.audit_requirement = AuditRequirement.SUPERVISOR_AUDIT
+    policy = select_backend_policy(route)
+
+    assert policy.policy_status == "SUPERVISOR_POLICY"
+    assert policy.preferred_backend is BackendKind.NONE


### PR DESCRIPTION
@codex review
@gemini
@copilot

## Summary
- add DMX-DCP-MODEL-ROUTING-MVP-0003 inert backend policy module for classified RouteDecision data
- export BackendPolicyDecision and selector helpers through dopemux.dcp
- add focused unit coverage for hard gates, deterministic backend preference/fallback/forbidden metadata, purity checks, immutability, helper parity, and serialization
- add the packet/proof note for 0003

## Scope
- Data policy only: no backend invocation, runner integration, connector calls, MCP, GitHub writes, Dopetask execution, Task Orchestrator writes, CI workflow edits, or external dependencies
- routing_model.py and routing_classifier.py were not changed

## Validation
- PASS: TMPDIR=/Users/hue/.codex/tmp python -m compileall -q src/dopemux/dcp
- PASS: TMPDIR=/Users/hue/.codex/tmp python -m pytest -q tests/unit/dcp/test_routing_model.py tests/unit/dcp/test_routing_classifier.py tests/unit/dcp/test_routing_backend_policy.py
- PASS: TMPDIR=/Users/hue/.codex/tmp python -m pytest -q tests/unit/dcp
- PASS: TMPDIR=/Users/hue/.codex/tmp python -m ruff check src/dopemux/dcp/routing_backend_policy.py src/dopemux/dcp/__init__.py tests/unit/dcp/test_routing_backend_policy.py
- PASS: TMPDIR=/Users/hue/.codex/tmp python -m ruff format --check src/dopemux/dcp/routing_backend_policy.py src/dopemux/dcp/__init__.py tests/unit/dcp/test_routing_backend_policy.py
- PASS: git diff --check
- PASS: policy-module no-go scan returned no matches
- PASS: scoped pre-commit run on changed files

## PAL / Audit Notes
- Attempted PAL listmodels, analyze, challenge, and codereview stages. Each timed out at the 300s tool limit, so no external PAL verdict is claimed.
- Local codereview/precommit gates were completed with the validations above.

## Release Notes
- DCP model-routing MVP now has a pure backend preference policy layer for RouteDecision data.

## Remaining Risk
- BackendKind has generic runner-style enum values only; supervisor-required policies therefore use NONE as preferred backend and encode supervisor need via policy_status/reason_codes rather than selecting a runnable supervisor backend.
- Backend availability, health, and execution remain unimplemented by design.
