### PR TITLE
feat(dcp): add backend policy recommendations

### DIFF
--- a/src/dopemux/dcp/__init__.py
+++ b/src/dopemux/dcp/__init__.py
@@ -37,6 +37,12 @@ from dopemux.dcp.routing_classifier import (
     RoutingClassificationInput,
     classify_route,
 )
+from dopemux.dcp.routing_backend_policy import (
+    BackendPolicyRecommendation,
+    BackendPolicyRule,
+    explain_backend_policy,
+    select_backend_policy,
+)
 
 __all__ = [
     # Proof artifact readers (pre-existing)
@@ -71,4 +77,9 @@ __all__ = [
     # Routing classification engine (DMX-DCP-MODEL-ROUTING-MVP-0002)
     "RoutingClassificationInput",
     "classify_route",
+    # Backend policy recommendations (DMX-DCP-MODEL-ROUTING-MVP-0003)
+    "BackendPolicyRecommendation",
+    "BackendPolicyRule",
+    "explain_backend_policy",
+    "select_backend_policy",
 ]

--- a/src/dopemux/dcp/routing_backend_policy.py
+++ b/src/dopemux/dcp/routing_backend_policy.py
@@ -251,10 +251,7 @@ def _block_reasons(decision: RouteDecision) -> list[str]:
         reasons.append("red_lane_active")
     if not decision.is_runnable():
         reasons.append("route_status_not_allowed")
-    if decision.escalation_requirement in (
-        EscalationRequirement.ALWAYS,
-        EscalationRequirement.UNKNOWN,
-    ):
+    if decision.escalation_requirement is not EscalationRequirement.NONE:
         reasons.append("escalation_required")
     if decision.unknowns:
         reasons.append("unknowns_present")
@@ -277,7 +274,7 @@ def _requires_supervisor(decision: RouteDecision) -> bool:
         decision.status is RouteStatus.NEEDS_SUPERVISOR
         or decision.risk_class in _SUPERVISOR_RISKS
         or decision.escalation_requirement
-        in (EscalationRequirement.ALWAYS, EscalationRequirement.ON_RISK)
+        is not EscalationRequirement.NONE
     )
 
 

--- a/src/dopemux/dcp/routing_backend_policy.py
+++ b/src/dopemux/dcp/routing_backend_policy.py
@@ -90,8 +90,16 @@ _SUPERVISOR_AUTHORITY_CLASSES = {
     AuthorityClass.DUAL,
 }
 
+_SUPERVISOR_COMPLEXITY_CLASSES = {
+    ComplexityClass.ARCHITECTURAL,
+}
+
 _SUPERVISOR_AUDIT_REQUIREMENTS = {
     AuditRequirement.SUPERVISOR_AUDIT,
+}
+
+_SUPERVISOR_PROOF_REQUIREMENTS = {
+    ProofRequirement.SUPERVISOR_REVIEW,
 }
 
 _BLOCKING_FORBIDDEN_ACTIONS = frozenset(
@@ -329,7 +337,12 @@ def _requires_supervisor(decision: RouteDecision) -> bool:
         decision.status is RouteStatus.NEEDS_SUPERVISOR
         or decision.risk_class in _SUPERVISOR_RISKS
         or decision.authority_class in _SUPERVISOR_AUTHORITY_CLASSES
+        or decision.complexity_class in _SUPERVISOR_COMPLEXITY_CLASSES
         or decision.audit_requirement in _SUPERVISOR_AUDIT_REQUIREMENTS
+        or any(
+            requirement in _SUPERVISOR_PROOF_REQUIREMENTS
+            for requirement in decision.proof_requirements
+        )
         or decision.escalation_requirement
         is not EscalationRequirement.NONE
     )

--- a/src/dopemux/dcp/routing_backend_policy.py
+++ b/src/dopemux/dcp/routing_backend_policy.py
@@ -1,0 +1,300 @@
+"""Pure backend policy recommendations for DCP routing decisions.
+
+Backend preferences here are inert data only. They do not authorize execution
+and do not call runners, connectors, tools, services, or external systems.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from dopemux.dcp.routing_model import (
+    AuditRequirement,
+    BackendKind,
+    EscalationRequirement,
+    RedLaneState,
+    RiskClass,
+    RouteDecision,
+    RouteStatus,
+    RuntimeImpact,
+    TaskType,
+)
+
+POLICY_VERSION = "DMX-DCP-MODEL-ROUTING-MVP-0003"
+
+_CODE_TASK_TYPES = {
+    TaskType.CODE_CHANGE,
+    TaskType.SCHEMA_ONLY,
+    TaskType.PROOF_BUNDLE,
+}
+
+_DOC_TASK_TYPES = {
+    TaskType.DESIGN_ONLY,
+}
+
+_AUDIT_TASK_TYPES = {
+    TaskType.AUDIT,
+}
+
+_SUPERVISOR_RISKS = {
+    RiskClass.R3_HIGH,
+    RiskClass.RED_LANE,
+    RiskClass.UNKNOWN,
+}
+
+_FORBIDDEN_ACTION_MARKERS = (
+    "live_write",
+    "connector",
+    "mcp",
+    "dopetask",
+    "runner",
+    "github",
+    "merge",
+    "task_orchestrator",
+    "network",
+    "external_service",
+)
+
+
+@dataclass(frozen=True)
+class BackendPolicyRule:
+    """A pure data rule mapping route shapes to backend preferences."""
+
+    task_types: tuple[TaskType, ...]
+    preferred_backend: BackendKind
+    fallback_backends: tuple[BackendKind, ...] = ()
+    reason_code: str = "no_policy_match"
+
+    def matches(self, decision: RouteDecision) -> bool:
+        """Return True when this inert rule applies to the decision data."""
+        return decision.task_type in self.task_types
+
+
+@dataclass(frozen=True)
+class BackendPolicyRecommendation:
+    """Inert backend preference data for an already-classified route."""
+
+    preferred_backend: BackendKind = BackendKind.NONE
+    fallback_backends: list[BackendKind] = field(default_factory=list)
+    blocked: bool = True
+    requires_supervisor: bool = False
+    reason_codes: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    audit_requirement: AuditRequirement = AuditRequirement.UNKNOWN
+    escalation_requirement: EscalationRequirement = EscalationRequirement.UNKNOWN
+    policy_version: str = POLICY_VERSION
+
+    def is_executable_recommendation(self) -> bool:
+        """Return True only when policy data suggests a backend candidate.
+
+        This is not execution authorization. Callers must still enforce their
+        own approval, proof, and runtime gates before doing any work.
+        """
+        return (
+            not self.blocked
+            and self.preferred_backend
+            not in (BackendKind.NONE, BackendKind.UNKNOWN)
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize recommendation data into stable primitive values."""
+        return {
+            "preferred_backend": self.preferred_backend.value,
+            "fallback_backends": [item.value for item in self.fallback_backends],
+            "blocked": self.blocked,
+            "requires_supervisor": self.requires_supervisor,
+            "reason_codes": list(self.reason_codes),
+            "notes": list(self.notes),
+            "audit_requirement": self.audit_requirement.value,
+            "escalation_requirement": self.escalation_requirement.value,
+            "policy_version": self.policy_version,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "BackendPolicyRecommendation":
+        """Construct recommendation data from primitive values."""
+
+        def _backend(value: object) -> BackendKind:
+            try:
+                return BackendKind(str(value))
+            except ValueError:
+                return BackendKind.NONE
+
+        def _audit(value: object) -> AuditRequirement:
+            try:
+                return AuditRequirement(str(value))
+            except ValueError:
+                return AuditRequirement.UNKNOWN
+
+        def _escalation(value: object) -> EscalationRequirement:
+            try:
+                return EscalationRequirement(str(value))
+            except ValueError:
+                return EscalationRequirement.UNKNOWN
+
+        return cls(
+            preferred_backend=_backend(data.get("preferred_backend", "NONE")),
+            fallback_backends=[
+                _backend(item) for item in data.get("fallback_backends", [])
+            ],
+            blocked=bool(data.get("blocked", True)),
+            requires_supervisor=bool(data.get("requires_supervisor", False)),
+            reason_codes=sorted(set(data.get("reason_codes", []))),
+            notes=list(data.get("notes", [])),
+            audit_requirement=_audit(data.get("audit_requirement", "UNKNOWN")),
+            escalation_requirement=_escalation(
+                data.get("escalation_requirement", "UNKNOWN")
+            ),
+            policy_version=str(data.get("policy_version", POLICY_VERSION)),
+        )
+
+
+_SAFE_RULES: tuple[BackendPolicyRule, ...] = (
+    BackendPolicyRule(
+        task_types=tuple(sorted(_AUDIT_TASK_TYPES, key=lambda item: item.value)),
+        preferred_backend=BackendKind.AGY,
+        fallback_backends=(BackendKind.CLAUDE_CODE, BackendKind.GEMINI_CLI),
+        reason_code="safe_audit_route",
+    ),
+    BackendPolicyRule(
+        task_types=tuple(sorted(_DOC_TASK_TYPES, key=lambda item: item.value)),
+        preferred_backend=BackendKind.CODEX,
+        fallback_backends=(BackendKind.CLAUDE_CODE,),
+        reason_code="safe_docs_route",
+    ),
+    BackendPolicyRule(
+        task_types=tuple(sorted(_CODE_TASK_TYPES, key=lambda item: item.value)),
+        preferred_backend=BackendKind.CODEX,
+        fallback_backends=(BackendKind.CLAUDE_CODE, BackendKind.GEMINI_CLI),
+        reason_code="safe_low_risk_code_route",
+    ),
+)
+
+
+def select_backend_policy(
+    decision: RouteDecision,
+) -> BackendPolicyRecommendation:
+    """Return an inert backend policy recommendation for *decision*."""
+    block_reasons = _block_reasons(decision)
+    requires_supervisor = _requires_supervisor(decision)
+
+    if block_reasons:
+        return _blocked_recommendation(
+            decision,
+            reason_codes=block_reasons,
+            requires_supervisor=requires_supervisor,
+        )
+
+    for rule in _SAFE_RULES:
+        if rule.matches(decision):
+            return BackendPolicyRecommendation(
+                preferred_backend=rule.preferred_backend,
+                fallback_backends=list(rule.fallback_backends),
+                blocked=False,
+                requires_supervisor=False,
+                reason_codes=[rule.reason_code],
+                notes=[
+                    "Backend preference is inert data and does not authorize execution."
+                ],
+                audit_requirement=decision.audit_requirement,
+                escalation_requirement=decision.escalation_requirement,
+            )
+
+    return _blocked_recommendation(
+        decision,
+        reason_codes=["no_policy_match"],
+        requires_supervisor=requires_supervisor,
+    )
+
+
+def explain_backend_policy(decision: RouteDecision) -> list[str]:
+    """Return deterministic explanation strings for the selected policy."""
+    recommendation = select_backend_policy(decision)
+    if recommendation.blocked:
+        return [
+            f"blocked:{code}" for code in recommendation.reason_codes
+        ]
+    return [
+        f"preferred_backend:{recommendation.preferred_backend.value}",
+        *[f"reason:{code}" for code in recommendation.reason_codes],
+    ]
+
+
+def _blocked_recommendation(
+    decision: RouteDecision,
+    *,
+    reason_codes: list[str],
+    requires_supervisor: bool,
+) -> BackendPolicyRecommendation:
+    return BackendPolicyRecommendation(
+        preferred_backend=BackendKind.NONE,
+        fallback_backends=[],
+        blocked=True,
+        requires_supervisor=requires_supervisor,
+        reason_codes=sorted(set(reason_codes)) or ["route_status_not_allowed"],
+        notes=[
+            "No executable backend recommendation is available for this route."
+        ],
+        audit_requirement=decision.audit_requirement,
+        escalation_requirement=decision.escalation_requirement,
+    )
+
+
+def _block_reasons(decision: RouteDecision) -> list[str]:
+    reasons: list[str] = []
+
+    if decision.status is not RouteStatus.ALLOWED:
+        reasons.append("route_status_not_allowed")
+    if decision.red_lane_state is not RedLaneState.CLEAR:
+        reasons.append("red_lane_active")
+    if not decision.is_runnable():
+        reasons.append("route_status_not_allowed")
+    if decision.escalation_requirement in (
+        EscalationRequirement.ALWAYS,
+        EscalationRequirement.UNKNOWN,
+    ):
+        reasons.append("escalation_required")
+    if decision.unknowns:
+        reasons.append("unknowns_present")
+    if decision.stop_conditions:
+        reasons.append("stop_conditions_present")
+    if _has_stop_condition(decision, "missing_proof"):
+        reasons.append("missing_proof")
+    if _has_stop_condition(decision, "stale_proof"):
+        reasons.append("stale_proof")
+    if _has_forbidden_action_marker(decision):
+        reasons.append("forbidden_action_present")
+    if _requires_supervisor(decision):
+        reasons.append("risk_requires_supervisor")
+
+    return sorted(set(reasons))
+
+
+def _requires_supervisor(decision: RouteDecision) -> bool:
+    return (
+        decision.status is RouteStatus.NEEDS_SUPERVISOR
+        or decision.risk_class in _SUPERVISOR_RISKS
+        or decision.escalation_requirement
+        in (EscalationRequirement.ALWAYS, EscalationRequirement.ON_RISK)
+    )
+
+
+def _has_stop_condition(decision: RouteDecision, marker: str) -> bool:
+    return any(marker in condition for condition in decision.stop_conditions)
+
+
+def _has_forbidden_action_marker(decision: RouteDecision) -> bool:
+    return any(
+        marker in action
+        for action in decision.forbidden_actions
+        for marker in _FORBIDDEN_ACTION_MARKERS
+    )
+
+
+__all__ = [
+    "BackendPolicyRecommendation",
+    "BackendPolicyRule",
+    "explain_backend_policy",
+    "select_backend_policy",
+]

--- a/src/dopemux/dcp/routing_backend_policy.py
+++ b/src/dopemux/dcp/routing_backend_policy.py
@@ -12,12 +12,14 @@ from typing import Any
 from dopemux.dcp.routing_model import (
     AuditRequirement,
     BackendKind,
+    ComplexityClass,
     EscalationRequirement,
     RedLaneState,
     RiskClass,
     RouteDecision,
     RouteStatus,
     RuntimeImpact,
+    TaskSource,
     TaskType,
 )
 
@@ -35,6 +37,36 @@ _DOC_TASK_TYPES = {
 
 _AUDIT_TASK_TYPES = {
     TaskType.AUDIT,
+}
+
+_UNKNOWN_TASK_TYPES = {
+    TaskType.UNKNOWN,
+}
+
+_UNKNOWN_TASK_SOURCES = {
+    TaskSource.UNKNOWN,
+}
+
+_UNKNOWN_RISK_CLASSES = {
+    RiskClass.UNKNOWN,
+}
+
+_UNKNOWN_COMPLEXITY_CLASSES = {
+    ComplexityClass.UNKNOWN,
+}
+
+_UNKNOWN_RUNTIME_IMPACTS = {
+    RuntimeImpact.UNKNOWN,
+}
+
+_LIVE_TASK_TYPES = {
+    TaskType.MERGE,
+    TaskType.LIVE_WRITE,
+}
+
+_LIVE_RUNTIME_IMPACTS = {
+    RuntimeImpact.SERVICE_MUTATION,
+    RuntimeImpact.LIVE_WRITE,
 }
 
 _SUPERVISOR_RISKS = {
@@ -255,6 +287,8 @@ def _block_reasons(decision: RouteDecision) -> list[str]:
         reasons.append("escalation_required")
     if decision.unknowns:
         reasons.append("unknowns_present")
+    if _has_unknown_dimension(decision):
+        reasons.append("unknowns_present")
     if decision.stop_conditions:
         reasons.append("stop_conditions_present")
     if _has_stop_condition(decision, "missing_proof"):
@@ -263,6 +297,8 @@ def _block_reasons(decision: RouteDecision) -> list[str]:
         reasons.append("stale_proof")
     if _has_forbidden_action_marker(decision):
         reasons.append("forbidden_action_present")
+    if _has_live_runtime_shape(decision):
+        reasons.append("live_runtime_present")
     if _requires_supervisor(decision):
         reasons.append("risk_requires_supervisor")
 
@@ -280,6 +316,23 @@ def _requires_supervisor(decision: RouteDecision) -> bool:
 
 def _has_stop_condition(decision: RouteDecision, marker: str) -> bool:
     return any(marker in condition for condition in decision.stop_conditions)
+
+
+def _has_unknown_dimension(decision: RouteDecision) -> bool:
+    return (
+        decision.task_source in _UNKNOWN_TASK_SOURCES
+        or decision.task_type in _UNKNOWN_TASK_TYPES
+        or decision.risk_class in _UNKNOWN_RISK_CLASSES
+        or decision.complexity_class in _UNKNOWN_COMPLEXITY_CLASSES
+        or decision.runtime_impact in _UNKNOWN_RUNTIME_IMPACTS
+    )
+
+
+def _has_live_runtime_shape(decision: RouteDecision) -> bool:
+    return (
+        decision.task_type in _LIVE_TASK_TYPES
+        or decision.runtime_impact in _LIVE_RUNTIME_IMPACTS
+    )
 
 
 def _has_forbidden_action_marker(decision: RouteDecision) -> bool:

--- a/src/dopemux/dcp/routing_backend_policy.py
+++ b/src/dopemux/dcp/routing_backend_policy.py
@@ -59,6 +59,10 @@ _UNKNOWN_RUNTIME_IMPACTS = {
     RuntimeImpact.UNKNOWN,
 }
 
+_UNKNOWN_AUDIT_REQUIREMENTS = {
+    AuditRequirement.UNKNOWN,
+}
+
 _LIVE_TASK_TYPES = {
     TaskType.MERGE,
     TaskType.LIVE_WRITE,
@@ -73,6 +77,10 @@ _SUPERVISOR_RISKS = {
     RiskClass.R3_HIGH,
     RiskClass.RED_LANE,
     RiskClass.UNKNOWN,
+}
+
+_SUPERVISOR_AUDIT_REQUIREMENTS = {
+    AuditRequirement.SUPERVISOR_AUDIT,
 }
 
 _BLOCKING_FORBIDDEN_ACTIONS = frozenset(
@@ -309,6 +317,7 @@ def _requires_supervisor(decision: RouteDecision) -> bool:
     return (
         decision.status is RouteStatus.NEEDS_SUPERVISOR
         or decision.risk_class in _SUPERVISOR_RISKS
+        or decision.audit_requirement in _SUPERVISOR_AUDIT_REQUIREMENTS
         or decision.escalation_requirement
         is not EscalationRequirement.NONE
     )
@@ -325,6 +334,7 @@ def _has_unknown_dimension(decision: RouteDecision) -> bool:
         or decision.risk_class in _UNKNOWN_RISK_CLASSES
         or decision.complexity_class in _UNKNOWN_COMPLEXITY_CLASSES
         or decision.runtime_impact in _UNKNOWN_RUNTIME_IMPACTS
+        or decision.audit_requirement in _UNKNOWN_AUDIT_REQUIREMENTS
     )
 
 

--- a/src/dopemux/dcp/routing_backend_policy.py
+++ b/src/dopemux/dcp/routing_backend_policy.py
@@ -11,9 +11,11 @@ from typing import Any
 
 from dopemux.dcp.routing_model import (
     AuditRequirement,
+    AuthorityClass,
     BackendKind,
     ComplexityClass,
     EscalationRequirement,
+    ProofRequirement,
     RedLaneState,
     RiskClass,
     RouteDecision,
@@ -63,6 +65,10 @@ _UNKNOWN_AUDIT_REQUIREMENTS = {
     AuditRequirement.UNKNOWN,
 }
 
+_UNKNOWN_PROOF_REQUIREMENTS = {
+    ProofRequirement.UNKNOWN,
+}
+
 _LIVE_TASK_TYPES = {
     TaskType.MERGE,
     TaskType.LIVE_WRITE,
@@ -77,6 +83,11 @@ _SUPERVISOR_RISKS = {
     RiskClass.R3_HIGH,
     RiskClass.RED_LANE,
     RiskClass.UNKNOWN,
+}
+
+_SUPERVISOR_AUTHORITY_CLASSES = {
+    AuthorityClass.SUPERVISOR,
+    AuthorityClass.DUAL,
 }
 
 _SUPERVISOR_AUDIT_REQUIREMENTS = {
@@ -317,6 +328,7 @@ def _requires_supervisor(decision: RouteDecision) -> bool:
     return (
         decision.status is RouteStatus.NEEDS_SUPERVISOR
         or decision.risk_class in _SUPERVISOR_RISKS
+        or decision.authority_class in _SUPERVISOR_AUTHORITY_CLASSES
         or decision.audit_requirement in _SUPERVISOR_AUDIT_REQUIREMENTS
         or decision.escalation_requirement
         is not EscalationRequirement.NONE
@@ -335,6 +347,10 @@ def _has_unknown_dimension(decision: RouteDecision) -> bool:
         or decision.complexity_class in _UNKNOWN_COMPLEXITY_CLASSES
         or decision.runtime_impact in _UNKNOWN_RUNTIME_IMPACTS
         or decision.audit_requirement in _UNKNOWN_AUDIT_REQUIREMENTS
+        or any(
+            requirement in _UNKNOWN_PROOF_REQUIREMENTS
+            for requirement in decision.proof_requirements
+        )
     )
 
 

--- a/src/dopemux/dcp/routing_backend_policy.py
+++ b/src/dopemux/dcp/routing_backend_policy.py
@@ -43,17 +43,18 @@ _SUPERVISOR_RISKS = {
     RiskClass.UNKNOWN,
 }
 
-_FORBIDDEN_ACTION_MARKERS = (
-    "live_write",
-    "connector",
-    "mcp",
-    "dopetask",
-    "runner",
-    "github",
-    "merge",
-    "task_orchestrator",
-    "network",
-    "external_service",
+_BLOCKING_FORBIDDEN_ACTIONS = frozenset(
+    {
+        "network_access",
+        "external_service_access",
+        "merge_task",
+        "live_write_to_service",
+        "call_connector_live",
+        "call_mcp_live",
+        "execute_dopetask_live",
+        "write_task_orchestrator",
+        "execute_runner_live",
+    }
 )
 
 
@@ -286,9 +287,8 @@ def _has_stop_condition(decision: RouteDecision, marker: str) -> bool:
 
 def _has_forbidden_action_marker(decision: RouteDecision) -> bool:
     return any(
-        marker in action
+        action in _BLOCKING_FORBIDDEN_ACTIONS
         for action in decision.forbidden_actions
-        for marker in _FORBIDDEN_ACTION_MARKERS
     )
 
 

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -24,7 +24,7 @@ against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`.
   "invariants": [
     "The backend policy map returns inert recommendation data only; it must not call, import, shell out to, or wire any backend runner, connector, MCP tool, GitHub API, queue, scheduler, or service integration.",
     "RouteDecision runtime/source truth is authoritative for implemented behavior; task packet prose cannot authorize unsupported runtime behavior.",
-    "Blocked, unknown, unknown-audit, supervisor-audit, red-lane, escalation-required, stale-proof, missing-proof, stop-condition, live-write, service-mutation, merge, and dynamic forbidden-action decisions fail closed to BackendKind.NONE.",
+    "Blocked, unknown, unknown-proof, unknown-audit, supervisor-authority, supervisor-audit, red-lane, escalation-required, stale-proof, missing-proof, stop-condition, live-write, service-mutation, merge, and dynamic forbidden-action decisions fail closed to BackendKind.NONE.",
     "Classifier baseline guardrail prohibitions are not themselves backend blockers for otherwise safe runnable decisions.",
     "Backend preference data is not authorization; any future caller must preserve separate approval, proof, runtime, and operator gates.",
     "Validation must include focused unit coverage, DCP unit coverage, syntax checks, diff hygiene, static no-go scanning, and pre-commit on changed files."

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -1,3 +1,15 @@
+---
+id: DMX-DCP-MODEL-ROUTING-MVP-0003
+title: Dmx Dcp Model Routing Mvp 0003
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-15'
+last_review: '2026-06-15'
+next_review: '2026-09-13'
+prelude: Dmx Dcp Model Routing Mvp 0003 (explanation) for dopemux documentation and
+  developer workflows.
+---
 # Task Packet — DMX-DCP-MODEL-ROUTING-MVP-0003 · DCP · Routing Backend Policy Map
 
 This task packet uses Markdown transport because the artifact path is `.md`.

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -1,76 +1,191 @@
----
-id: DMX-DCP-MODEL-ROUTING-MVP-0003
-title: Add pure backend policy recommendation map
-type: explanation
-owner: '@hu3mann'
-author: Codex
-date: '2026-06-16'
-last_review: '2026-06-16'
-next_review: '2026-09-14'
-prelude: Pure backend policy recommendation map for safe DCP RouteDecision data,
-  preserving fail-closed behavior and adding no backend invocation path.
----
+# Task Packet — DMX-DCP-MODEL-ROUTING-MVP-0003 · DCP · Routing Backend Policy Map
 
-# DMX-DCP-MODEL-ROUTING-MVP-0003 - Routing Backend Policy Map
+This task packet uses Markdown transport because the artifact path is `.md`.
+The fenced JSON payload below is the canonical schema payload for validation
+against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`.
 
-## Objective
-
-Add a pure, deterministic backend policy map that recommends inert backend
-preference data for already-classified `RouteDecision` values.
-
-## Scope
-
-**IN**
-- `src/dopemux/dcp/routing_backend_policy.py` - pure backend policy data module
-- `src/dopemux/dcp/__init__.py` - exports added
-- `tests/unit/dcp/test_routing_backend_policy.py` - focused unit tests
-- `task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md` - this note
-
-**OUT**
-- No backend invocation
-- No runner, connector, tool, GitHub, queue, scheduling, or service integration
-- No model or classifier contract edits
-- No dependency, workflow, or CI edits
-
-## Implementation Notes
-
-- `BackendPolicyRecommendation` is frozen dataclass data.
-- `BackendPolicyRule` is frozen dataclass data.
-- `select_backend_policy()` treats `RouteDecision.is_runnable()` as a hard gate.
-- `BackendKind.NONE` is returned for blocked, unknown, red-lane,
-  escalation-required, proof-stopped, and forbidden-action decisions.
-- Safe code, docs/design, and audit routes receive backend preference data only.
-- High-risk or supervisor routes return no executable backend recommendation.
-
-## Validation Summary
-
-| Gate | Result |
-|------|--------|
-| compileall src/dopemux/dcp | PASS |
-| pytest routing_model + routing_classifier + routing_backend_policy | PASS - 157 tests |
-| pytest tests/unit/dcp | PASS - 157 tests |
-| git diff --check | PASS |
-| static no-go scan | PASS - no matches |
-| diff scope | PASS - packet allowlist only |
-| embedded audit | PASS_WITH_RISKS |
-
-## Remaining Risks
-
-- Backend preference data is not authorization. Any future caller must keep
-  approval, proof, and runtime gates outside this module.
-- There is no supervisor-specific `BackendKind`; supervisor-required decisions
-  intentionally fall back to `BackendKind.NONE`.
-
-## Explicit Non-Claims
-
-The backend policy map recommends inert backend preference data for safe
-`RouteDecision` shapes and fails closed for blocked, unknown, red-lane,
-escalation-required, stale-proof, missing-proof, and stop-condition decisions.
-
-DCP routing plane is not production-ready. Backends are not integrated.
-Connectors are not callable. MCP is not wired. This policy does not authorize
-execution.
-
-## Next Packet
-
-`DMX-DCP-MODEL-ROUTING-MVP-0004` - Routing Policy Fixture Corpus
+```json
+{
+  "id": "DMX-DCP-MODEL-ROUTING-MVP-0003",
+  "project": "dopemux-mvp",
+  "target": "Add a pure, deterministic backend policy recommendation map for already-classified DCP RouteDecision values, with no backend invocation or runtime integration.",
+  "invariants": [
+    "The backend policy map returns inert recommendation data only; it must not call, import, shell out to, or wire any backend runner, connector, MCP tool, GitHub API, queue, scheduler, or service integration.",
+    "RouteDecision runtime/source truth is authoritative for implemented behavior; task packet prose cannot authorize unsupported runtime behavior.",
+    "Blocked, unknown, red-lane, escalation-required, stale-proof, missing-proof, stop-condition, live-write, service-mutation, merge, and dynamic forbidden-action decisions fail closed to BackendKind.NONE.",
+    "Classifier baseline guardrail prohibitions are not themselves backend blockers for otherwise safe runnable decisions.",
+    "Backend preference data is not authorization; any future caller must preserve separate approval, proof, runtime, and operator gates.",
+    "Validation must include focused unit coverage, DCP unit coverage, syntax checks, diff hygiene, static no-go scanning, and pre-commit on changed files."
+  ],
+  "depends_on": [
+    "DMX-DCP-MODEL-ROUTING-MVP-0001",
+    "DMX-DCP-MODEL-ROUTING-MVP-0002"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-DCP-MODEL-ROUTING-MVP",
+    "base_branch": "main",
+    "parent_tp_id": "DMX-DCP-MODEL-ROUTING-MVP-0002",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "dcp/model-routing-0003-backend-policy-map",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(dcp): canonicalize DMX-DCP-MODEL-ROUTING-MVP-0003 task packet",
+    "allowlist": [
+      "src/dopemux/dcp/__init__.py",
+      "src/dopemux/dcp/routing_backend_policy.py",
+      "tests/unit/dcp/test_routing_backend_policy.py",
+      "task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md"
+    ],
+    "verify": [
+      "python - <<'PY'\nimport json, re\nfrom pathlib import Path\nfrom jsonschema import Draft7Validator\npacket = Path('task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md').read_text()\nmatch = re.search(r'```json\\n(.*?)\\n```', packet, re.S)\nassert match, 'missing fenced json payload'\npayload = json.loads(match.group(1))\nschema = json.loads(Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text())\nerrors = sorted(Draft7Validator(schema).iter_errors(payload), key=lambda e: list(e.path))\nif errors:\n    raise SystemExit('\\n'.join('%s: %s' % (('/'.join(map(str, e.path)) or '<root>'), e.message) for e in errors))\nprint('PASS task packet payload schema validation')\nPY",
+      "python -m compileall -q src/dopemux/dcp",
+      "python -m pytest -q tests/unit/dcp/test_routing_model.py tests/unit/dcp/test_routing_classifier.py tests/unit/dcp/test_routing_backend_policy.py",
+      "python -m pytest -q tests/unit/dcp",
+      "git diff --check",
+      "rg -n \"subprocess|requests|httpx|urllib|socket|open\\(|write_text|write_bytes|Path\\(.+write|os\\.system|shell=True|gh pr merge|merge_pull_request|queue_drain|execute=True|scripts/dopetask|scripts/taskx|opencode|grok|ECC|npm|npx|pnpm|bun|docker compose up|mcp\\.tool|GraphQL|REST\" src/dopemux/dcp/routing_backend_policy.py tests/unit/dcp/test_routing_backend_policy.py",
+      "pre-commit run --files src/dopemux/dcp/routing_backend_policy.py tests/unit/dcp/test_routing_backend_policy.py task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): add backend policy recommendations",
+    "body": "## Summary\n- add pure DCP backend policy recommendation data for already-classified RouteDecision values\n- fail closed to BackendKind.NONE for blocked, unknown, red-lane, escalation-required, proof-stopped, and forbidden-action decisions\n- export the policy API and add packet-scoped unit coverage with canonical task packet contract\n\n## Validation\n- PASS: embedded task packet schema validation\n- PASS: python -m compileall -q src/dopemux/dcp\n- PASS: python -m pytest -q tests/unit/dcp/test_routing_model.py tests/unit/dcp/test_routing_classifier.py tests/unit/dcp/test_routing_backend_policy.py\n- PASS: python -m pytest -q tests/unit/dcp\n- PASS: git diff --check\n- PASS: static no-go scan over policy, tests, and packet note\n\n## Explicit Non-Claims\nThis does not integrate callable backends, connectors, MCP wiring, Dopetask execution, Task Orchestrator writes, GitHub writes, or production readiness.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "implement",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Inspect DCP routing model, classifier, exports, tests, active task packet constraints, and repo governance before editing.",
+      "requirements": [
+        "Identify RouteDecision fields and fail-closed invariants that the backend policy must preserve.",
+        "Identify classifier baseline guardrails separately from dynamic or live forbidden actions.",
+        "Confirm the change is limited to pure recommendation data and does not introduce backend invocation."
+      ],
+      "commands": [
+        "git status --short --branch",
+        "sed -n '1,260p' src/dopemux/dcp/routing_model.py",
+        "sed -n '1,260p' src/dopemux/dcp/routing_classifier.py",
+        "sed -n '1,220p' tests/unit/dcp/test_routing_classifier.py"
+      ],
+      "expected_files": [
+        "src/dopemux/dcp/routing_backend_policy.py",
+        "tests/unit/dcp/test_routing_backend_policy.py",
+        "task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md"
+      ],
+      "validation": [
+        "Relevant routing model and classifier fields are inspected before implementation.",
+        "Runtime behavior claims are grounded in source and tests, not packet prose."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "src/dopemux/dcp/routing_model.py",
+        "src/dopemux/dcp/routing_classifier.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Add a pure backend policy data module and export its public recommendation types.",
+      "requirements": [
+        "Use frozen dataclasses and enums for inert backend preference data.",
+        "Return BackendKind.NONE for any non-runnable, blocked, unknown, red-lane, escalation-required, stale-proof, missing-proof, stop-condition, dynamic forbidden-action, live-write, service-mutation, merge, or supervisor-required route shape.",
+        "Recommend safe backend preference data only for safe code, docs/design, and audit route shapes.",
+        "Do not add imports or code paths that can execute backends, mutate services, call tools, or invoke subprocesses."
+      ],
+      "commands": [
+        "python -m compileall -q src/dopemux/dcp"
+      ],
+      "expected_files": [
+        "src/dopemux/dcp/routing_backend_policy.py",
+        "src/dopemux/dcp/__init__.py"
+      ],
+      "validation": [
+        "compileall exits 0 for src/dopemux/dcp.",
+        "Static no-go scan finds no backend invocation, shell, network, queue, MCP, GitHub, or service integration markers in the new module."
+      ],
+      "context_files": [
+        "src/dopemux/dcp/routing_model.py",
+        "src/dopemux/dcp/routing_classifier.py",
+        "src/dopemux/dcp/__init__.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Add focused unit tests that lock safe recommendations and fail-closed behavior.",
+      "requirements": [
+        "Cover safe code, docs/design, and audit recommendations.",
+        "Cover blocked status, red-lane state, non-runnable proof conditions, missing or stale proof, stop conditions, escalation requirements including ON_UNKNOWN, first-class UNKNOWN enum dimensions, live runtime impacts, merge/live task types, supervisor requirements, and dynamic forbidden actions.",
+        "Cover classifier-produced safe code routes so baseline guardrail forbidden actions do not block every real classifier decision.",
+        "Keep tests deterministic and free of external services."
+      ],
+      "commands": [
+        "python -m pytest -q tests/unit/dcp/test_routing_model.py tests/unit/dcp/test_routing_classifier.py tests/unit/dcp/test_routing_backend_policy.py",
+        "python -m pytest -q tests/unit/dcp"
+      ],
+      "expected_files": [
+        "tests/unit/dcp/test_routing_backend_policy.py"
+      ],
+      "validation": [
+        "Focused routing model/classifier/backend policy tests pass.",
+        "Full tests/unit/dcp suite passes."
+      ],
+      "context_files": [
+        "tests/unit/dcp/test_routing_model.py",
+        "tests/unit/dcp/test_routing_classifier.py",
+        "tests/unit/dcp/test_routing_backend_policy.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Replace the explanatory packet note with canonical task packet shape, then validate diff hygiene, pre-commit hooks, and PR review closure.",
+      "requirements": [
+        "Task packet fenced JSON validates against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json.",
+        "Changed files stay within commit.allowlist.",
+        "No accidental generated junk or unrelated edits are present.",
+        "Required GitHub checks are distinguished from non-required failures.",
+        "Unresolved review threads are addressed with evidence-backed fixes or explicit technical response."
+      ],
+      "commands": [
+        "python - <<'PY'\nimport json, re\nfrom pathlib import Path\nfrom jsonschema import Draft7Validator\npacket = Path('task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md').read_text()\nmatch = re.search(r'```json\\n(.*?)\\n```', packet, re.S)\nassert match, 'missing fenced json payload'\npayload = json.loads(match.group(1))\nschema = json.loads(Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text())\nerrors = sorted(Draft7Validator(schema).iter_errors(payload), key=lambda e: list(e.path))\nif errors:\n    raise SystemExit('\\n'.join('%s: %s' % (('/'.join(map(str, e.path)) or '<root>'), e.message) for e in errors))\nprint('PASS task packet payload schema validation')\nPY",
+        "git diff --check",
+        "pre-commit run --files src/dopemux/dcp/routing_backend_policy.py tests/unit/dcp/test_routing_backend_policy.py task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md",
+        "git status --short --branch",
+        "gh pr checks 895 --repo DDD-Enterprises/dopemux-mvp"
+      ],
+      "expected_files": [
+        "task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md"
+      ],
+      "validation": [
+        "Task packet schema validation passes.",
+        "git diff --check exits 0.",
+        "pre-commit exits 0 for changed files.",
+        "Working tree is clean after commit.",
+        "Required PR checks pass or any remaining pending/failing required checks are reported explicitly."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md"
+      ]
+    }
+  ]
+}
+```

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -47,8 +47,8 @@ preference data for already-classified `RouteDecision` values.
 | Gate | Result |
 |------|--------|
 | compileall src/dopemux/dcp | PASS |
-| pytest routing_model + routing_classifier + routing_backend_policy | PASS - 154 tests |
-| pytest tests/unit/dcp | PASS - 154 tests |
+| pytest routing_model + routing_classifier + routing_backend_policy | PASS - 157 tests |
+| pytest tests/unit/dcp | PASS - 157 tests |
 | git diff --check | PASS |
 | static no-go scan | PASS - no matches |
 | diff scope | PASS - packet allowlist only |

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -1,0 +1,76 @@
+---
+id: DMX-DCP-MODEL-ROUTING-MVP-0003
+title: Add pure backend policy recommendation map
+type: explanation
+owner: '@hu3mann'
+author: Codex
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-14'
+prelude: Pure backend policy recommendation map for safe DCP RouteDecision data,
+  preserving fail-closed behavior and adding no backend invocation path.
+---
+
+# DMX-DCP-MODEL-ROUTING-MVP-0003 - Routing Backend Policy Map
+
+## Objective
+
+Add a pure, deterministic backend policy map that recommends inert backend
+preference data for already-classified `RouteDecision` values.
+
+## Scope
+
+**IN**
+- `src/dopemux/dcp/routing_backend_policy.py` - pure backend policy data module
+- `src/dopemux/dcp/__init__.py` - exports added
+- `tests/unit/dcp/test_routing_backend_policy.py` - focused unit tests
+- `task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md` - this note
+
+**OUT**
+- No backend invocation
+- No runner, connector, tool, GitHub, queue, scheduling, or service integration
+- No model or classifier contract edits
+- No dependency, workflow, or CI edits
+
+## Implementation Notes
+
+- `BackendPolicyRecommendation` is frozen dataclass data.
+- `BackendPolicyRule` is frozen dataclass data.
+- `select_backend_policy()` treats `RouteDecision.is_runnable()` as a hard gate.
+- `BackendKind.NONE` is returned for blocked, unknown, red-lane,
+  escalation-required, proof-stopped, and forbidden-action decisions.
+- Safe code, docs/design, and audit routes receive backend preference data only.
+- High-risk or supervisor routes return no executable backend recommendation.
+
+## Validation Summary
+
+| Gate | Result |
+|------|--------|
+| compileall src/dopemux/dcp | PASS |
+| pytest routing_model + routing_classifier + routing_backend_policy | PASS - 152 tests |
+| pytest tests/unit/dcp | PASS - 152 tests |
+| git diff --check | PASS |
+| static no-go scan | PASS - no matches |
+| diff scope | PASS - packet allowlist only |
+| embedded audit | PASS_WITH_RISKS |
+
+## Remaining Risks
+
+- Backend preference data is not authorization. Any future caller must keep
+  approval, proof, and runtime gates outside this module.
+- There is no supervisor-specific `BackendKind`; supervisor-required decisions
+  intentionally fall back to `BackendKind.NONE`.
+
+## Explicit Non-Claims
+
+The backend policy map recommends inert backend preference data for safe
+`RouteDecision` shapes and fails closed for blocked, unknown, red-lane,
+escalation-required, stale-proof, missing-proof, and stop-condition decisions.
+
+DCP routing plane is not production-ready. Backends are not integrated.
+Connectors are not callable. MCP is not wired. This policy does not authorize
+execution.
+
+## Next Packet
+
+`DMX-DCP-MODEL-ROUTING-MVP-0004` - Routing Policy Fixture Corpus

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -24,7 +24,7 @@ against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`.
   "invariants": [
     "The backend policy map returns inert recommendation data only; it must not call, import, shell out to, or wire any backend runner, connector, MCP tool, GitHub API, queue, scheduler, or service integration.",
     "RouteDecision runtime/source truth is authoritative for implemented behavior; task packet prose cannot authorize unsupported runtime behavior.",
-    "Blocked, unknown, unknown-proof, unknown-audit, supervisor-authority, supervisor-audit, red-lane, escalation-required, stale-proof, missing-proof, stop-condition, live-write, service-mutation, merge, and dynamic forbidden-action decisions fail closed to BackendKind.NONE.",
+    "Blocked, unknown, unknown-proof, unknown-audit, supervisor-authority, supervisor-complexity, supervisor-proof, supervisor-audit, red-lane, escalation-required, stale-proof, missing-proof, stop-condition, live-write, service-mutation, merge, and dynamic forbidden-action decisions fail closed to BackendKind.NONE.",
     "Classifier baseline guardrail prohibitions are not themselves backend blockers for otherwise safe runnable decisions.",
     "Backend preference data is not authorization; any future caller must preserve separate approval, proof, runtime, and operator gates.",
     "Validation must include focused unit coverage, DCP unit coverage, syntax checks, diff hygiene, static no-go scanning, and pre-commit on changed files."

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -47,8 +47,8 @@ preference data for already-classified `RouteDecision` values.
 | Gate | Result |
 |------|--------|
 | compileall src/dopemux/dcp | PASS |
-| pytest routing_model + routing_classifier + routing_backend_policy | PASS - 153 tests |
-| pytest tests/unit/dcp | PASS - 153 tests |
+| pytest routing_model + routing_classifier + routing_backend_policy | PASS - 154 tests |
+| pytest tests/unit/dcp | PASS - 154 tests |
 | git diff --check | PASS |
 | static no-go scan | PASS - no matches |
 | diff scope | PASS - packet allowlist only |

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -24,7 +24,7 @@ against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`.
   "invariants": [
     "The backend policy map returns inert recommendation data only; it must not call, import, shell out to, or wire any backend runner, connector, MCP tool, GitHub API, queue, scheduler, or service integration.",
     "RouteDecision runtime/source truth is authoritative for implemented behavior; task packet prose cannot authorize unsupported runtime behavior.",
-    "Blocked, unknown, red-lane, escalation-required, stale-proof, missing-proof, stop-condition, live-write, service-mutation, merge, and dynamic forbidden-action decisions fail closed to BackendKind.NONE.",
+    "Blocked, unknown, unknown-audit, supervisor-audit, red-lane, escalation-required, stale-proof, missing-proof, stop-condition, live-write, service-mutation, merge, and dynamic forbidden-action decisions fail closed to BackendKind.NONE.",
     "Classifier baseline guardrail prohibitions are not themselves backend blockers for otherwise safe runnable decisions.",
     "Backend preference data is not authorization; any future caller must preserve separate approval, proof, runtime, and operator gates.",
     "Validation must include focused unit coverage, DCP unit coverage, syntax checks, diff hygiene, static no-go scanning, and pre-commit on changed files."

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md
@@ -47,8 +47,8 @@ preference data for already-classified `RouteDecision` values.
 | Gate | Result |
 |------|--------|
 | compileall src/dopemux/dcp | PASS |
-| pytest routing_model + routing_classifier + routing_backend_policy | PASS - 152 tests |
-| pytest tests/unit/dcp | PASS - 152 tests |
+| pytest routing_model + routing_classifier + routing_backend_policy | PASS - 153 tests |
+| pytest tests/unit/dcp | PASS - 153 tests |
 | git diff --check | PASS |
 | static no-go scan | PASS - no matches |
 | diff scope | PASS - packet allowlist only |

--- a/tests/unit/dcp/test_routing_backend_policy.py
+++ b/tests/unit/dcp/test_routing_backend_policy.py
@@ -135,6 +135,26 @@ def test_non_empty_unknowns_block_backend() -> None:
     _assert_no_backend(decision, "unknowns_present")
 
 
+def test_reloaded_unknown_runtime_field_blocks_backend_without_unknowns_list() -> None:
+    decision = RouteDecision.from_dict(
+        {
+            "route_id": "partial-safe-looking-route",
+            "task_source": TaskSource.OPERATOR.value,
+            "task_type": TaskType.CODE_CHANGE.value,
+            "risk_class": RiskClass.R1_LOW.value,
+            "complexity_class": ComplexityClass.LOW.value,
+            "authority_class": AuthorityClass.OPERATOR.value,
+            "red_lane_state": RedLaneState.CLEAR.value,
+            "escalation_requirement": EscalationRequirement.NONE.value,
+            "status": RouteStatus.ALLOWED.value,
+        }
+    )
+
+    assert decision.unknowns == []
+    assert decision.runtime_impact is RuntimeImpact.UNKNOWN
+    _assert_no_backend(decision, "unknowns_present")
+
+
 def test_non_empty_stop_conditions_block_backend() -> None:
     decision = _safe_decision(stop_conditions=["operator_stop"])
     _assert_no_backend(decision, "stop_conditions_present")
@@ -157,6 +177,16 @@ def test_stale_proof_stop_condition_blocks_backend() -> None:
 def test_live_write_forbidden_action_blocks_backend() -> None:
     decision = _safe_decision(forbidden_actions=["live_write_to_service"])
     _assert_no_backend(decision, "forbidden_action_present")
+
+
+def test_live_write_runtime_impact_blocks_backend_without_forbidden_action() -> None:
+    decision = _safe_decision(runtime_impact=RuntimeImpact.LIVE_WRITE)
+    _assert_no_backend(decision, "live_runtime_present")
+
+
+def test_merge_task_type_blocks_backend_without_forbidden_action() -> None:
+    decision = _safe_decision(task_type=TaskType.MERGE)
+    _assert_no_backend(decision, "live_runtime_present")
 
 
 def test_connector_forbidden_action_blocks_backend() -> None:

--- a/tests/unit/dcp/test_routing_backend_policy.py
+++ b/tests/unit/dcp/test_routing_backend_policy.py
@@ -125,6 +125,11 @@ def test_unknown_escalation_blocks_backend() -> None:
     _assert_no_backend(decision, "escalation_required")
 
 
+def test_on_unknown_escalation_blocks_backend() -> None:
+    decision = _safe_decision(escalation_requirement=EscalationRequirement.ON_UNKNOWN)
+    _assert_no_backend(decision, "escalation_required")
+
+
 def test_non_empty_unknowns_block_backend() -> None:
     decision = _safe_decision(unknowns=["authority_class_unknown"])
     _assert_no_backend(decision, "unknowns_present")

--- a/tests/unit/dcp/test_routing_backend_policy.py
+++ b/tests/unit/dcp/test_routing_backend_policy.py
@@ -323,9 +323,27 @@ def test_dual_authority_requires_supervisor_and_no_backend() -> None:
     assert "risk_requires_supervisor" in recommendation.reason_codes
 
 
+def test_architectural_complexity_requires_supervisor_and_no_backend() -> None:
+    decision = _safe_decision(complexity_class=ComplexityClass.ARCHITECTURAL)
+    recommendation = _recommend(decision)
+    assert recommendation.requires_supervisor is True
+    assert recommendation.preferred_backend is BackendKind.NONE
+    assert recommendation.is_executable_recommendation() is False
+    assert "risk_requires_supervisor" in recommendation.reason_codes
+
+
 def test_unknown_proof_requirement_blocks_backend() -> None:
     decision = _safe_decision(proof_requirements=[ProofRequirement.UNKNOWN])
     _assert_no_backend(decision, "unknowns_present")
+
+
+def test_supervisor_proof_requirement_requires_supervisor_and_no_backend() -> None:
+    decision = _safe_decision(proof_requirements=[ProofRequirement.SUPERVISOR_REVIEW])
+    recommendation = _recommend(decision)
+    assert recommendation.requires_supervisor is True
+    assert recommendation.preferred_backend is BackendKind.NONE
+    assert recommendation.is_executable_recommendation() is False
+    assert "risk_requires_supervisor" in recommendation.reason_codes
 
 
 def test_unknown_backend_kind_on_safe_route_does_not_crash() -> None:

--- a/tests/unit/dcp/test_routing_backend_policy.py
+++ b/tests/unit/dcp/test_routing_backend_policy.py
@@ -1,0 +1,344 @@
+"""Unit tests for DMX-DCP-MODEL-ROUTING-MVP-0003 backend policy data.
+
+The backend policy layer is pure recommendation data. It must never turn a
+non-runnable RouteDecision into an executable recommendation.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import inspect
+
+from dopemux.dcp.routing_model import (
+    AuditRequirement,
+    AuthorityClass,
+    BackendKind,
+    ComplexityClass,
+    EscalationRequirement,
+    RedLaneState,
+    RiskClass,
+    RouteDecision,
+    RouteStatus,
+    RuntimeImpact,
+    TaskSource,
+    TaskType,
+)
+
+
+def _safe_decision(**overrides: object) -> RouteDecision:
+    values = {
+        "route_id": "safe-route",
+        "task_source": TaskSource.OPERATOR,
+        "task_type": TaskType.CODE_CHANGE,
+        "risk_class": RiskClass.R1_LOW,
+        "complexity_class": ComplexityClass.LOW,
+        "authority_class": AuthorityClass.OPERATOR,
+        "runtime_impact": RuntimeImpact.LOCAL_ONLY,
+        "backend_kind": BackendKind.NONE,
+        "audit_requirement": AuditRequirement.SELF_CHECK,
+        "escalation_requirement": EscalationRequirement.NONE,
+        "red_lane_state": RedLaneState.CLEAR,
+        "allowed_actions": ["edit_allowlisted_files", "run_targeted_tests"],
+        "forbidden_actions": [],
+        "stop_conditions": [],
+        "evidence_refs": ["test-proof"],
+        "unknowns": [],
+        "confidence": "MEDIUM",
+        "status": RouteStatus.ALLOWED,
+    }
+    values.update(overrides)
+    return RouteDecision(**values)
+
+
+def _recommend(decision: RouteDecision):
+    from dopemux.dcp.routing_backend_policy import select_backend_policy
+
+    return select_backend_policy(decision)
+
+
+def _assert_no_backend(decision: RouteDecision, expected_reason: str) -> None:
+    recommendation = _recommend(decision)
+    assert recommendation.blocked is True
+    assert recommendation.preferred_backend is BackendKind.NONE
+    assert recommendation.fallback_backends == []
+    assert recommendation.is_executable_recommendation() is False
+    assert expected_reason in recommendation.reason_codes
+
+
+def test_module_imports() -> None:
+    import dopemux.dcp.routing_backend_policy as mod
+
+    assert callable(mod.select_backend_policy)
+    assert callable(mod.explain_backend_policy)
+
+
+def test_default_route_decision_blocks_backend() -> None:
+    _assert_no_backend(RouteDecision(), "route_status_not_allowed")
+
+
+def test_red_lane_decision_blocks_backend() -> None:
+    decision = _safe_decision(red_lane_state=RedLaneState.RED_LANE)
+    _assert_no_backend(decision, "red_lane_active")
+
+
+def test_unknown_red_lane_decision_blocks_backend() -> None:
+    decision = _safe_decision(red_lane_state=RedLaneState.UNKNOWN)
+    _assert_no_backend(decision, "red_lane_active")
+
+
+def test_blocked_status_blocks_backend() -> None:
+    decision = _safe_decision(status=RouteStatus.BLOCKED)
+    _assert_no_backend(decision, "route_status_not_allowed")
+
+
+def test_unknown_status_blocks_backend() -> None:
+    decision = _safe_decision(status=RouteStatus.UNKNOWN)
+    _assert_no_backend(decision, "route_status_not_allowed")
+
+
+def test_pending_status_blocks_backend() -> None:
+    decision = _safe_decision(status=RouteStatus.PENDING)
+    _assert_no_backend(decision, "route_status_not_allowed")
+
+
+def test_needs_supervisor_status_blocks_backend_and_marks_supervisor() -> None:
+    decision = _safe_decision(status=RouteStatus.NEEDS_SUPERVISOR)
+    recommendation = _recommend(decision)
+    assert recommendation.blocked is True
+    assert recommendation.requires_supervisor is True
+    assert recommendation.preferred_backend is BackendKind.NONE
+    assert "route_status_not_allowed" in recommendation.reason_codes
+
+
+def test_escalation_always_blocks_backend() -> None:
+    decision = _safe_decision(escalation_requirement=EscalationRequirement.ALWAYS)
+    _assert_no_backend(decision, "escalation_required")
+
+
+def test_unknown_escalation_blocks_backend() -> None:
+    decision = _safe_decision(escalation_requirement=EscalationRequirement.UNKNOWN)
+    _assert_no_backend(decision, "escalation_required")
+
+
+def test_non_empty_unknowns_block_backend() -> None:
+    decision = _safe_decision(unknowns=["authority_class_unknown"])
+    _assert_no_backend(decision, "unknowns_present")
+
+
+def test_non_empty_stop_conditions_block_backend() -> None:
+    decision = _safe_decision(stop_conditions=["operator_stop"])
+    _assert_no_backend(decision, "stop_conditions_present")
+
+
+def test_missing_proof_stop_condition_blocks_backend() -> None:
+    decision = _safe_decision(stop_conditions=["missing_proof"])
+    recommendation = _recommend(decision)
+    assert recommendation.is_executable_recommendation() is False
+    assert "missing_proof" in recommendation.reason_codes
+
+
+def test_stale_proof_stop_condition_blocks_backend() -> None:
+    decision = _safe_decision(stop_conditions=["stale_proof"])
+    recommendation = _recommend(decision)
+    assert recommendation.is_executable_recommendation() is False
+    assert "stale_proof" in recommendation.reason_codes
+
+
+def test_live_write_forbidden_action_blocks_backend() -> None:
+    decision = _safe_decision(forbidden_actions=["live_write_to_service"])
+    _assert_no_backend(decision, "forbidden_action_present")
+
+
+def test_connector_forbidden_action_blocks_backend() -> None:
+    decision = _safe_decision(forbidden_actions=["call_connector_live"])
+    _assert_no_backend(decision, "forbidden_action_present")
+
+
+def test_mcp_forbidden_action_blocks_backend() -> None:
+    decision = _safe_decision(forbidden_actions=["call_mcp_live"])
+    _assert_no_backend(decision, "forbidden_action_present")
+
+
+def test_dopetask_forbidden_action_blocks_backend() -> None:
+    decision = _safe_decision(forbidden_actions=["execute_dopetask_live"])
+    _assert_no_backend(decision, "forbidden_action_present")
+
+
+def test_safe_low_risk_code_route_prefers_codex_data() -> None:
+    recommendation = _recommend(_safe_decision(task_type=TaskType.CODE_CHANGE))
+    assert recommendation.blocked is False
+    assert recommendation.preferred_backend is BackendKind.CODEX
+    assert BackendKind.CLAUDE_CODE in recommendation.fallback_backends
+    assert "safe_low_risk_code_route" in recommendation.reason_codes
+
+
+def test_safe_docs_route_prefers_codex_data() -> None:
+    decision = _safe_decision(
+        task_type=TaskType.DESIGN_ONLY,
+        risk_class=RiskClass.R0_READ,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        allowed_actions=["inspect_runtime_code"],
+    )
+    recommendation = _recommend(decision)
+    assert recommendation.preferred_backend is BackendKind.CODEX
+    assert "safe_docs_route" in recommendation.reason_codes
+
+
+def test_safe_audit_route_prefers_audit_capable_backend_data() -> None:
+    decision = _safe_decision(
+        task_type=TaskType.AUDIT,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        allowed_actions=["inspect_runtime_code"],
+    )
+    recommendation = _recommend(decision)
+    assert recommendation.preferred_backend is BackendKind.AGY
+    assert BackendKind.CLAUDE_CODE in recommendation.fallback_backends
+    assert "safe_audit_route" in recommendation.reason_codes
+
+
+def test_high_risk_route_requires_supervisor_and_no_backend() -> None:
+    decision = _safe_decision(
+        risk_class=RiskClass.R3_HIGH,
+        status=RouteStatus.NEEDS_SUPERVISOR,
+        escalation_requirement=EscalationRequirement.ON_RISK,
+    )
+    recommendation = _recommend(decision)
+    assert recommendation.requires_supervisor is True
+    assert recommendation.preferred_backend is BackendKind.NONE
+    assert recommendation.is_executable_recommendation() is False
+    assert "risk_requires_supervisor" in recommendation.reason_codes
+
+
+def test_unknown_backend_kind_on_safe_route_does_not_crash() -> None:
+    decision = _safe_decision(backend_kind=BackendKind.UNKNOWN)
+    recommendation = _recommend(decision)
+    assert recommendation.preferred_backend in BackendKind
+    assert recommendation.preferred_backend is not BackendKind.UNKNOWN
+
+
+def test_policy_is_deterministic_for_identical_input() -> None:
+    decision = _safe_decision()
+    assert _recommend(decision) == _recommend(decision)
+
+
+def test_recommendation_serializes_to_dict() -> None:
+    recommendation = _recommend(_safe_decision())
+    payload = recommendation.to_dict()
+    assert payload["preferred_backend"] == BackendKind.CODEX.value
+    assert payload["fallback_backends"]
+    assert payload["blocked"] is False
+    assert payload["policy_version"]
+
+
+def test_recommendation_from_dict_round_trips() -> None:
+    from dopemux.dcp.routing_backend_policy import BackendPolicyRecommendation
+
+    recommendation = _recommend(_safe_decision())
+    restored = BackendPolicyRecommendation.from_dict(recommendation.to_dict())
+    assert restored == recommendation
+
+
+def test_backend_policy_does_not_mutate_route_decision() -> None:
+    decision = _safe_decision()
+    before = copy.deepcopy(decision)
+    _recommend(decision)
+    assert decision == before
+
+
+def test_policy_module_has_no_forbidden_imports() -> None:
+    import dopemux.dcp.routing_backend_policy as mod
+
+    forbidden = {
+        "sub" + "process",
+        "req" + "uests",
+        "ht" + "tpx",
+        "url" + "lib",
+        "sock" + "et",
+        "github",
+        "docker",
+        "task_" + "orchestrator",
+        "dopetask",
+    }
+    tree = ast.parse(inspect.getsource(mod))
+    imports = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.Import, ast.ImportFrom))
+    ]
+    imported_modules = []
+    for node in imports:
+        if isinstance(node, ast.Import):
+            imported_modules.extend(alias.name for alias in node.names)
+        elif node.module:
+            imported_modules.append(node.module)
+    assert not any(
+        module == name or module.startswith(f"{name}.")
+        for module in imported_modules
+        for name in forbidden
+    )
+
+
+def test_policy_module_exposes_no_execution_methods() -> None:
+    import dopemux.dcp.routing_backend_policy as mod
+
+    forbidden_names = {"run", "execute", "dispatch", "invoke", "call", "merge", "push"}
+    exported_callables = {
+        name for name in mod.__all__ if callable(getattr(mod, name, None))
+    }
+    assert exported_callables.isdisjoint(forbidden_names)
+
+
+def test_preferred_backend_is_plain_enum_data() -> None:
+    recommendation = _recommend(_safe_decision())
+    assert isinstance(recommendation.preferred_backend, BackendKind)
+    assert not callable(recommendation.preferred_backend)
+
+
+def test_fallback_backends_are_plain_enum_data() -> None:
+    recommendation = _recommend(_safe_decision())
+    assert all(isinstance(item, BackendKind) for item in recommendation.fallback_backends)
+    assert not any(callable(item) for item in recommendation.fallback_backends)
+
+
+def test_blocked_decision_has_stable_non_empty_reason_codes() -> None:
+    recommendation = _recommend(RouteDecision())
+    assert recommendation.reason_codes
+    assert recommendation.reason_codes == sorted(set(recommendation.reason_codes))
+
+
+def test_safe_route_reason_code_explains_match() -> None:
+    recommendation = _recommend(_safe_decision(task_type=TaskType.PROOF_BUNDLE))
+    assert recommendation.reason_codes == ["safe_low_risk_code_route"]
+
+
+def test_no_policy_match_returns_blocked_default_recommendation() -> None:
+    decision = _safe_decision(task_type=TaskType.READ_ONLY)
+    recommendation = _recommend(decision)
+    assert recommendation.blocked is True
+    assert recommendation.preferred_backend is BackendKind.NONE
+    assert recommendation.reason_codes == ["no_policy_match"]
+
+
+def test_tests_cover_current_backend_enum_members() -> None:
+    assert {member.value for member in BackendKind} == {
+        "CODEX",
+        "CLAUDE_CODE",
+        "OPENCODE",
+        "GROK",
+        "GEMINI_CLI",
+        "AGY",
+        "LOCAL_SCRIPT",
+        "NONE",
+        "UNKNOWN",
+    }
+
+
+def test_red_lane_route_can_never_be_executable_recommendation() -> None:
+    decision = _safe_decision(
+        status=RouteStatus.ALLOWED,
+        red_lane_state=RedLaneState.RED_LANE,
+        risk_class=RiskClass.RED_LANE,
+    )
+    assert decision.is_runnable() is False
+    assert _recommend(decision).is_executable_recommendation() is False

--- a/tests/unit/dcp/test_routing_backend_policy.py
+++ b/tests/unit/dcp/test_routing_backend_policy.py
@@ -155,6 +155,27 @@ def test_reloaded_unknown_runtime_field_blocks_backend_without_unknowns_list() -
     _assert_no_backend(decision, "unknowns_present")
 
 
+def test_reloaded_unknown_audit_requirement_blocks_backend_without_unknowns_list() -> None:
+    decision = RouteDecision.from_dict(
+        {
+            "route_id": "partial-safe-looking-audit-route",
+            "task_source": TaskSource.OPERATOR.value,
+            "task_type": TaskType.CODE_CHANGE.value,
+            "risk_class": RiskClass.R1_LOW.value,
+            "complexity_class": ComplexityClass.LOW.value,
+            "authority_class": AuthorityClass.OPERATOR.value,
+            "runtime_impact": RuntimeImpact.LOCAL_ONLY.value,
+            "red_lane_state": RedLaneState.CLEAR.value,
+            "escalation_requirement": EscalationRequirement.NONE.value,
+            "status": RouteStatus.ALLOWED.value,
+        }
+    )
+
+    assert decision.unknowns == []
+    assert decision.audit_requirement is AuditRequirement.UNKNOWN
+    _assert_no_backend(decision, "unknowns_present")
+
+
 def test_non_empty_stop_conditions_block_backend() -> None:
     decision = _safe_decision(stop_conditions=["operator_stop"])
     _assert_no_backend(decision, "stop_conditions_present")
@@ -267,6 +288,15 @@ def test_high_risk_route_requires_supervisor_and_no_backend() -> None:
         status=RouteStatus.NEEDS_SUPERVISOR,
         escalation_requirement=EscalationRequirement.ON_RISK,
     )
+    recommendation = _recommend(decision)
+    assert recommendation.requires_supervisor is True
+    assert recommendation.preferred_backend is BackendKind.NONE
+    assert recommendation.is_executable_recommendation() is False
+    assert "risk_requires_supervisor" in recommendation.reason_codes
+
+
+def test_supervisor_audit_requirement_requires_supervisor_and_no_backend() -> None:
+    decision = _safe_decision(audit_requirement=AuditRequirement.SUPERVISOR_AUDIT)
     recommendation = _recommend(decision)
     assert recommendation.requires_supervisor is True
     assert recommendation.preferred_backend is BackendKind.NONE

--- a/tests/unit/dcp/test_routing_backend_policy.py
+++ b/tests/unit/dcp/test_routing_backend_policy.py
@@ -10,6 +10,10 @@ import ast
 import copy
 import inspect
 
+from dopemux.dcp.routing_classifier import (
+    RoutingClassificationInput,
+    classify_route,
+)
 from dopemux.dcp.routing_model import (
     AuditRequirement,
     AuthorityClass,
@@ -170,6 +174,31 @@ def test_safe_low_risk_code_route_prefers_codex_data() -> None:
     assert recommendation.blocked is False
     assert recommendation.preferred_backend is BackendKind.CODEX
     assert BackendKind.CLAUDE_CODE in recommendation.fallback_backends
+    assert "safe_low_risk_code_route" in recommendation.reason_codes
+
+
+def test_safe_classifier_code_route_ignores_baseline_guardrail_forbidden_actions() -> None:
+    decision = classify_route(
+        RoutingClassificationInput(
+            task_source=TaskSource.OPERATOR,
+            task_type=TaskType.CODE_CHANGE,
+            risk_class=RiskClass.R1_LOW,
+            complexity_class=ComplexityClass.LOW,
+            authority_class=AuthorityClass.OPERATOR,
+            runtime_impact=RuntimeImpact.LOCAL_ONLY,
+            touches_files=True,
+            touches_tests=True,
+            has_unknown_authority=False,
+            is_repo_changing=True,
+            is_non_trivial=True,
+        )
+    )
+
+    assert decision.is_runnable() is True
+    assert "call_connector" in decision.forbidden_actions
+    recommendation = _recommend(decision)
+    assert recommendation.blocked is False
+    assert recommendation.preferred_backend is BackendKind.CODEX
     assert "safe_low_risk_code_route" in recommendation.reason_codes
 
 

--- a/tests/unit/dcp/test_routing_backend_policy.py
+++ b/tests/unit/dcp/test_routing_backend_policy.py
@@ -20,6 +20,7 @@ from dopemux.dcp.routing_model import (
     BackendKind,
     ComplexityClass,
     EscalationRequirement,
+    ProofRequirement,
     RedLaneState,
     RiskClass,
     RouteDecision,
@@ -302,6 +303,29 @@ def test_supervisor_audit_requirement_requires_supervisor_and_no_backend() -> No
     assert recommendation.preferred_backend is BackendKind.NONE
     assert recommendation.is_executable_recommendation() is False
     assert "risk_requires_supervisor" in recommendation.reason_codes
+
+
+def test_supervisor_authority_requires_supervisor_and_no_backend() -> None:
+    decision = _safe_decision(authority_class=AuthorityClass.SUPERVISOR)
+    recommendation = _recommend(decision)
+    assert recommendation.requires_supervisor is True
+    assert recommendation.preferred_backend is BackendKind.NONE
+    assert recommendation.is_executable_recommendation() is False
+    assert "risk_requires_supervisor" in recommendation.reason_codes
+
+
+def test_dual_authority_requires_supervisor_and_no_backend() -> None:
+    decision = _safe_decision(authority_class=AuthorityClass.DUAL)
+    recommendation = _recommend(decision)
+    assert recommendation.requires_supervisor is True
+    assert recommendation.preferred_backend is BackendKind.NONE
+    assert recommendation.is_executable_recommendation() is False
+    assert "risk_requires_supervisor" in recommendation.reason_codes
+
+
+def test_unknown_proof_requirement_blocks_backend() -> None:
+    decision = _safe_decision(proof_requirements=[ProofRequirement.UNKNOWN])
+    _assert_no_backend(decision, "unknowns_present")
 
 
 def test_unknown_backend_kind_on_safe_route_does_not_crash() -> None:


### PR DESCRIPTION
## Summary
- add pure DCP backend policy recommendation data for already-classified RouteDecision values
- fail closed to BackendKind.NONE for blocked, unknown, red-lane, escalation-required, proof-stopped, and forbidden-action decisions
- export the policy API and add packet-scoped unit coverage/proof note

## Validation
- PASS: python -m compileall -q src/dopemux/dcp
- PASS: python -m pytest -q tests/unit/dcp/test_routing_model.py tests/unit/dcp/test_routing_classifier.py tests/unit/dcp/test_routing_backend_policy.py
- PASS: python -m pytest -q tests/unit/dcp
- PASS: git diff --cached --check
- PASS: static no-go scan over policy, tests, and packet note
- PASS: pre-commit run --files src/dopemux/dcp/routing_backend_policy.py src/dopemux/dcp/__init__.py tests/unit/dcp/test_routing_backend_policy.py task-packets/DMX-DCP-MODEL-ROUTING-MVP-0003.md

## Embedded Audit
- auditor_tool: codex_embedded_review
- auditor_model: GPT-5
- invocation: manual audit of cached diff, AST imports/calls, validation output, and packet invariants
- verdict: PASS_WITH_RISKS
- findings: policy module imports only stdlib plus dopemux.dcp.routing_model; no runner, connector, service, shell, network, or filesystem write path was added; RouteDecision.is_runnable() remains the hard gate; diff scope is packet allowlist only
- remaining_risks: backend preference data is not authorization; no supervisor-specific BackendKind exists, so supervisor-required decisions intentionally return BackendKind.NONE

## Explicit Non-Claims
This does not integrate callable backends, connectors, MCP wiring, Dopetask execution, Task Orchestrator writes, GitHub writes, or production readiness.