### PR TITLE
test(dcp): 0002R reconciliation — lock 5 routing-classifier invariants

### DIFF
--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0002R.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0002R.md
@@ -1,0 +1,186 @@
+---
+id: DMX-DCP-MODEL-ROUTING-MVP-0002R
+title: Routing Classifier Reconciliation
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-14'
+prelude: Reconciliation packet locking five already-implemented DCP routing
+  classifier invariants with new unit tests; six lane-concept cases deferred to
+  the 0003+ lane engine.
+---
+
+# DMX-DCP-MODEL-ROUTING-MVP-0002R — Routing Classifier Reconciliation
+
+**Series**: DMX-DCP-MODEL-ROUTING-MVP
+**Packet**: 0002R (Reconciliation)
+**Type**: Test-authoring + packet documentation
+**Status**: COMPLETE
+**Branch**: `feat/dcp-routing-0002R-reconciliation`
+**Author**: Subagent (worktree agent-ac40085c9f974d0cd)
+**Date**: 2026-06-16
+
+---
+
+## Objective
+
+Lock down the behavioural invariants of the already-implemented routing classifier
+(`src/dopemux/dcp/routing_classifier.py`) by authoring 5 new unit tests that assert
+existing, observed behaviour — no new classifier fields or logic were introduced.
+
+The scope was deliberately narrowed from the original 12-case gate packet to 5 cases,
+per supervisor decision: the 6 lane-concept cases require fields that do not yet exist in
+the pure-flag classifier and are explicitly deferred to a later lane-engine packet.
+
+---
+
+## Files Touched
+
+| File | Operation | Lines changed |
+|------|-----------|---------------|
+| `tests/unit/dcp/test_routing_classifier.py` | Appended 5 new test functions | +117 lines |
+| `task-packets/DMX-DCP-MODEL-ROUTING-MVP-0002R.md` | Created (this file) | new |
+
+Files NOT touched (read-only inspection only):
+
+- `src/dopemux/dcp/routing_classifier.py`
+- `src/dopemux/dcp/routing_model.py`
+
+---
+
+## Tests Added
+
+All 5 tests assert ALREADY-IMPLEMENTED behaviour. Running them without any source
+change must produce 5 new PASSes.
+
+### 1. `test_unknown_authority_blocks_mutation`
+
+**Covered invariant**: When `has_unknown_authority=True` and
+`authority_class=AuthorityClass.UNKNOWN`, the classifier must not be runnable
+AND must not include any mutation-capable action (`edit_allowlisted_files`,
+`open_pr`, `run_embedded_audit`) in `allowed_actions`.
+
+**Source path**: `_derive_route_status` → `RouteStatus.UNKNOWN` for unknown
+authority; `_derive_allowed_actions` → `_READ_ONLY_BASE_ALLOWED` for non-ALLOWED
+status; `is_runnable()` → False (status != ALLOWED).
+
+---
+
+### 2. `test_dopetask_boundary_blocks_dcp_core_execution`
+
+**Covered invariant**: When `requires_dopetask_execution=True` the decision must
+not be runnable AND `forbidden_actions` must contain at least one token with
+"dopetask" (both `"execute_dopetask"` from `_ALWAYS_FORBIDDEN` and
+`"execute_dopetask_live"` from the conditional path).
+
+**DCP-core-execution boundary**: Dopetask execution is never delegatable through
+the pure-flag classifier. This test pins the boundary explicitly so it cannot
+silently regress.
+
+---
+
+### 3. `test_live_write_without_contract_blocks`
+
+**Covered invariant**: `requires_live_write=True` alone must produce
+`status=RouteStatus.BLOCKED` and `is_runnable()=False`. No contract, proof path,
+or authority override in the current pure-flag classifier can open a live-write
+route — the RED_LANE gate is unconditional.
+
+**Source path**: `_derive_red_lane_state` → `RedLaneState.RED_LANE` when
+`requires_live_write` is set; `_derive_route_status` → `RouteStatus.BLOCKED` for
+RED_LANE.
+
+---
+
+### 4. `test_unresolved_review_threads_block_readiness`
+
+**Covered invariant**: `has_stale_proof=True` produces `status=RouteStatus.BLOCKED`
+and `is_runnable()=False`.
+
+**Docstring note** (pinned in the test): "Unresolved review threads" as a PR-Steward
+readiness concern is a HIGHER-LAYER check that lives outside this classifier. The
+`has_stale_proof` gate is the analogous in-classifier gate: a route with stale or
+invalidated evidence is not actionable until proof is refreshed.
+
+**Source path**: `_derive_route_status` line ~217 — `if inp.has_stale_proof: return
+RouteStatus.BLOCKED`.
+
+---
+
+### 5. `test_secret_pattern_routes_to_supervisor`
+
+**Covered invariant**: `touches_secrets=True` must simultaneously satisfy:
+1. `is_red_lane()` returns `True` (RED_LANE state).
+2. `audit_requirement is AuditRequirement.SUPERVISOR_AUDIT`.
+3. `escalation_requirement is EscalationRequirement.ALWAYS`.
+
+Three invariants are locked together because they derive from the same flag and
+must move in lockstep. A regression in any one of the three is a security issue.
+
+**Source path**: `_derive_red_lane_state` (touches_secrets → RED_LANE),
+`_derive_audit_requirement` (touches_secrets → SUPERVISOR_AUDIT),
+`_derive_escalation_requirement` (touches_secrets → ALWAYS).
+
+---
+
+## DEFERRED Cases
+
+The following 6 lane-concept cases from the original gate-packet scope are
+**explicitly deferred** to 0003+ lane-engine work.
+
+**Rationale**: The pure-flag classifier contains no bridge/proxy lane fields,
+no retrieval-derived lane fields, no secure-MCP-readonly lane fields, no
+ECC-intake lane fields, and no opencode/grok wrapper-proof lane fields.
+These concepts are architecturally labelled `ACCEPTED_LATER` in the DCP
+architecture; introducing them here would require adding new classifier fields
+and policy branches — scope that belongs in a dedicated lane-engine packet.
+
+| # | Lane concept | Why deferred |
+|---|-------------|--------------|
+| 2 | Bridge / proxy lane | No bridge/proxy fields in current classifier |
+| 3 | Retrieval-derived lane | No retrieval-source or retrieval-confidence fields |
+| 6 | Secure-MCP-readonly lane | `requires_mcp_call` → RED_LANE by current policy; secure-readonly MCP is a future ACL layer |
+| 7 | ECC-intake lane | No ECC-source or ECC-validation fields |
+| 11 | OpenCode wrapper proof | No opencode-wrapper or proof-envelope fields |
+| 12 | Grok wrapper proof | No grok-wrapper or proof-envelope fields |
+
+These are not regressions. They are ACCEPTED_LATER scope items that belong to the
+0003+ lane engine design work.
+
+---
+
+## Validation Results
+
+```
+PYTHONPATH=src python -m compileall -q src/dopemux/dcp
+# exit 0 — no compile errors
+
+PYTHONPATH=src python -m pytest -v tests/unit/dcp/ tests/dcp/test_dcp_model_routing_0001_domain.py
+# baseline: 186 passed  (before this packet)
+# after:    191 passed  (+5 new tests)
+# exit 0
+```
+
+---
+
+## Scope Confirmation
+
+- Zero new fields added to `RoutingClassificationInput`.
+- Zero new methods added to `RouteDecision`.
+- Zero edits to any `src/dopemux/dcp/*.py` file.
+- Zero edits to `.github/workflows/`, `services/`, or any other file outside the allowlist.
+- Two and only two files modified/created: `tests/unit/dcp/test_routing_classifier.py`
+  and this packet document.
+
+---
+
+## Rollback
+
+```bash
+git revert HEAD   # reverts both changes in one commit
+# or
+git checkout main -- tests/unit/dcp/test_routing_classifier.py
+git rm task-packets/DMX-DCP-MODEL-ROUTING-MVP-0002R.md
+```

--- a/tests/unit/dcp/test_routing_classifier.py
+++ b/tests/unit/dcp/test_routing_classifier.py
@@ -1138,3 +1138,145 @@ def test_conflicting_evidence_blocks() -> None:
     inp = RoutingClassificationInput(has_conflicting_evidence=True)
     decision = classify_route(inp)
     assert decision.is_red_lane() or decision.is_blocked()
+
+
+# ─────────────────────────────────────────────
+# 0002R: Reconciliation invariant lock-down tests
+# ─────────────────────────────────────────────
+# These 5 tests assert ALREADY-IMPLEMENTED behaviour only.
+# No new classifier fields or logic were introduced.
+# See task-packets/DMX-DCP-MODEL-ROUTING-MVP-0002R.md for full rationale
+# and the DEFERRED lane-concept cases (0003+ lane-engine work).
+# ─────────────────────────────────────────────
+
+
+def test_unknown_authority_blocks_mutation() -> None:
+    """Lock: unknown authority must not permit any mutation actions.
+
+    When has_unknown_authority=True and authority_class=UNKNOWN the
+    classifier MUST produce a non-runnable decision AND MUST NOT include
+    any mutation-capable action (edit/open_pr/write) in allowed_actions.
+
+    Invariant source: _derive_route_status returns RouteStatus.UNKNOWN for
+    unknown authority; _derive_allowed_actions grants only _READ_ONLY_BASE_ALLOWED
+    when status is not ALLOWED.
+    """
+    inp = RoutingClassificationInput(
+        has_unknown_authority=True,
+        authority_class=AuthorityClass.UNKNOWN,
+    )
+    decision = classify_route(inp)
+
+    # Must not be runnable
+    assert not decision.is_runnable()
+
+    # Must not contain any mutation-capable action
+    mutation_actions = {"edit_allowlisted_files", "open_pr", "run_embedded_audit"}
+    for action in decision.allowed_actions:
+        assert action not in mutation_actions, (
+            f"Mutation action '{action}' must not be allowed under unknown authority"
+        )
+
+
+def test_dopetask_boundary_blocks_dcp_core_execution() -> None:
+    """Lock: dopetask execution boundary must be enforced as an explicit forbidden action.
+
+    When requires_dopetask_execution=True the classifier enters RED_LANE,
+    which blocks execution (status=BLOCKED, not runnable) and records
+    "execute_dopetask" and/or "execute_dopetask_live" in forbidden_actions.
+
+    This explicitly asserts the DCP-core-execution boundary: dopetask execution
+    is never delegatable through the pure-flag classifier.
+    """
+    inp = RoutingClassificationInput(
+        requires_dopetask_execution=True,
+    )
+    decision = classify_route(inp)
+
+    # RED_LANE → not runnable
+    assert not decision.is_runnable()
+
+    # The "dopetask" token must appear in at least one forbidden action
+    assert any("dopetask" in action for action in decision.forbidden_actions), (
+        "expected 'dopetask' in forbidden_actions, got: "
+        + repr(decision.forbidden_actions)
+    )
+
+
+def test_live_write_without_contract_blocks() -> None:
+    """Lock: requires_live_write alone must produce status=BLOCKED and not runnable.
+
+    No contract or proof path in the pure-flag classifier can open a live-write
+    route. The RED_LANE gate is unconditional.
+    """
+    inp = RoutingClassificationInput(
+        requires_live_write=True,
+    )
+    decision = classify_route(inp)
+
+    assert decision.status is RouteStatus.BLOCKED, (
+        f"expected BLOCKED status for live-write input, got {decision.status}"
+    )
+    assert not decision.is_runnable()
+
+
+def test_unresolved_review_threads_block_readiness() -> None:
+    """Lock: has_stale_proof=True blocks the route (status=BLOCKED) when authority is known.
+
+    Note: "unresolved review threads" as a PR-Steward concern is a HIGHER-LAYER
+    readiness check that lives outside this classifier.  The stale-proof gate
+    (has_stale_proof=True → RouteStatus.BLOCKED) is the analogous in-classifier
+    gate: a route with stale or invalidated evidence is not actionable until proof
+    is refreshed.
+
+    IMPORTANT — precedence finding (surfaced during 0002R reconciliation):
+    With all-default inputs (has_unknown_authority=True), the classifier returns
+    RouteStatus.UNKNOWN instead of RouteStatus.BLOCKED for has_stale_proof=True,
+    because _derive_route_status checks has_unknown_authority BEFORE has_stale_proof.
+    The BLOCKED status is only reachable after the unknown-authority guard passes.
+    This test therefore supplies has_unknown_authority=False to reach the
+    stale-proof BLOCKED path, which is the behaviour this invariant is meant to lock.
+
+    This ordering is NOT a security regression (unknown authority is non-runnable
+    regardless) but is a latent discoverability gap: stale_proof is recorded in
+    stop_conditions even when status=UNKNOWN, so the gate signal is present.
+    A future classifier refactor should ensure has_stale_proof → BLOCKED
+    regardless of authority-gate ordering.
+    """
+    inp = RoutingClassificationInput(
+        has_stale_proof=True,
+        # Must bypass the unknown-authority guard to reach the stale-proof BLOCKED path.
+        has_unknown_authority=False,
+        authority_class=AuthorityClass.OPERATOR,
+    )
+    decision = classify_route(inp)
+
+    assert decision.status is RouteStatus.BLOCKED, (
+        f"expected BLOCKED for stale proof input, got {decision.status}"
+    )
+    assert not decision.is_runnable()
+
+
+def test_secret_pattern_routes_to_supervisor() -> None:
+    """Lock: touches_secrets=True must set RED_LANE, SUPERVISOR_AUDIT, and ALWAYS escalation.
+
+    Three invariants locked simultaneously because they are all derived from the
+    same flag in the classifier and must move together:
+    1. is_red_lane() True  — hard block on execution.
+    2. audit_requirement == SUPERVISOR_AUDIT  — strongest audit obligation.
+    3. escalation_requirement == ALWAYS  — unconditional escalation to supervisor.
+    """
+    inp = RoutingClassificationInput(
+        touches_secrets=True,
+    )
+    decision = classify_route(inp)
+
+    assert decision.is_red_lane(), (
+        "touches_secrets must produce RED_LANE state"
+    )
+    assert decision.audit_requirement is AuditRequirement.SUPERVISOR_AUDIT, (
+        f"expected SUPERVISOR_AUDIT, got {decision.audit_requirement}"
+    )
+    assert decision.escalation_requirement is EscalationRequirement.ALWAYS, (
+        f"expected ALWAYS escalation, got {decision.escalation_requirement}"
+    )


### PR DESCRIPTION
## DMX-DCP-MODEL-ROUTING-MVP-0002R — Classifier Rules + Fixtures Reconciliation (scoped)

Reconciliation-only hardening of the existing DCP routing classifier. **No source changes** — 5 new unit tests that lock already-implemented invariants, plus the packet doc.

### Scope decision (supervisor)
The originating gate packet listed 12 required test cases. Code inspection found **6 of them reference classifier fields that do not exist** (bridge/proxy, retrieval-derived, secure-MCP-readonly, ECC-intake, opencode/grok-wrapper-proof) and map to lanes the architecture explicitly marked `ACCEPTED_LATER` / `DESIGN_ONLY`. Forcing them here would mean building deferred-lane fields under a "reconciliation" packet. So scope was narrowed to **5 reconciliation tests**; the 6 lane-concept cases are **deferred to 0003+ lane engine** (documented in the packet).

### Tests added (assert existing behavior, zero new fields)
1. `test_unknown_authority_blocks_mutation` — unknown authority → no mutation actions in `allowed_actions`
2. `test_dopetask_boundary_blocks_dcp_core_execution` — dopetask exec → explicit forbidden-action token, not runnable
3. `test_live_write_without_contract_blocks` — live-write → `status=BLOCKED` unconditionally
4. `test_unresolved_review_threads_block_readiness` — stale-proof readiness gate → `BLOCKED`
5. `test_secret_pattern_routes_to_supervisor` — secrets → `RED_LANE` + `SUPERVISOR_AUDIT` + `ALWAYS` escalation (3-way lock)

### Finding surfaced (not patched — out of reconciliation scope)
`_derive_route_status` checks `has_unknown_authority` **before** `has_stale_proof`, so a bare `has_stale_proof=True` reports `UNKNOWN` instead of `BLOCKED`. **Not a security regression** (unknown authority is non-runnable regardless), but a latent status-reporting gap. Test 4 documents it and supplies an authority bypass to reach the real gate. Flagged for the 0003+ lane-engine fix.

### Validation
- ✅ 191 pytest pass (`tests/unit/dcp/` + `test_dcp_model_routing_0001_domain.py`) — 186 baseline + 5
- ✅ `compileall src/dopemux/dcp` clean
- ✅ `git diff --check` clean; diff scope = exactly 2 allowlisted files (+314 lines)
- ✅ deterministic-first confirmed (no model-assisted path)

### Files
- `tests/unit/dcp/test_routing_classifier.py` (+142)
- `task-packets/DMX-DCP-MODEL-ROUTING-MVP-0002R.md` (new, +172)

Opus-audited (auditor-separated from Sonnet implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)