### PR TITLE
DMX-COCKPIT-FONTS: cockpit font build/patch remediation series (6 TPs + load plan)

### DIFF
--- a/claudedocs/cockpit-fonts-remediation/CODEX_PRIMER.md
+++ b/claudedocs/cockpit-fonts-remediation/CODEX_PRIMER.md
@@ -1,0 +1,105 @@
+# DMX-COCKPIT-FONTS — Codex Execution Primer
+
+> **Read order:** this primer → repo `AGENTS.md` → the specific packet JSON → the actual files on `origin/main`. Runtime code outranks every doc, including this one.
+
+You are executing a **6-packet remediation series** for the Dopemux cockpit font build/patch pipeline (follow-on to **merged PR #879**). It is already loaded in task-orchestrator. Your job: take one unblocked packet at a time, make the **smallest correct change** that satisfies its invariants, **prove it**, and advance. Do not broaden scope across packet boundaries.
+
+---
+
+## 0. Coordinates
+
+| Thing | Value |
+|---|---|
+| Workspace | `/Users/hue/code/dopemux-mvp` |
+| Orchestrator root | `7890cbc1-3c2f-40a4-bacb-61eb705f3a6f` |
+| Base branch | **`origin/main` @ `a2396a922`** (NOT local `main` — it's a squash-merge with a different SHA) |
+| Packets | `task-packets/generated/DMX-COCKPIT-FONTS/<id>.json` |
+| Design authority | `claudedocs/cockpit-fonts-remediation/DESIGN.md` |
+| Load plan | `docs/ops/load-plans/load_plan-DMX-COCKPIT-FONTS.json` |
+| Target tree | `docs/03-reference/Dopemux Cockpit TUI Design System/` (`fonts/*`, `colors_and_type.css`, doc `*.md`) |
+
+**Leaf UUIDs** (for direct orchestrator ops):
+
+| TP | id | uuid |
+|----|----|------|
+| 101 | `…-101-rename-plan-keys-harden-scripts` | `f2c374cd-abd8-4c59-bbd2-e9c5d8e6ce3d` |
+| 102 | `…-102-patch-flags-editor-proportional-family-name` | `cd11b6c7-372b-4f95-84e4-5253ed6bb17a` |
+| 103 | `…-103-css-font-face-matrix-reconcile` | `6a538831-770e-45fe-bc60-bddc12da1a3a` |
+| 104 | `…-104-resolve-case-collisions` | `04f9d15d-a5d3-4e81-b652-133bb3991fed` |
+| 105 | `…-105-purge-legacy-doc-refs` | `9010543e-f0a0-469e-8bb5-9b4698ff59f6` |
+| 106 | `…-106-verify-remediation` | `cf9a4c16-fd0b-4fae-9a72-7f28258d7164` |
+
+---
+
+## 1. Pickup protocol (per packet)
+
+1. **Find work** — `get_next_item` / `query_items overview` on root `7890cbc1`. **First wave = 101 + 104** (both unblocked, parallel-safe — they touch disjoint files).
+2. **Claim** — `claim_item` the leaf UUID.
+3. **Branch** — `codex/cockpit-fonts-<nnn>-<slug>` off `origin/main` (a dedicated worktree is ideal). *(The load plan's `claude/…` default reflects CC-first; since you are Codex, use `codex/…`.)*
+4. **Read before edit** — the packet JSON (`invariants`, `steps`, `commit.allowlist`, `commit.verify`), the matching `DESIGN.md` section, and the real files. **Patch from runtime truth, not the packet prose.**
+5. **Run the PAL chain** — PAL MCP is up (`mcp__pal__*`). RED-LANE packets (**101, 102, 104**) run the risky chain `analyze→thinkdeep→challenge→planner→[challenge]→implement→codereview→precommit→challenge`; the rest run `analyze→planner→codereview→precommit`. The packet's `pal_chain.steps` is authoritative.
+6. **Implement** — honor every invariant; stay strictly inside `commit.allowlist`.
+7. **Validate** — run `commit.verify`. Run the **manual font-toolchain gate** if you have the toolchain; otherwise record **NOT_RUN** with the missing dependency + static substitute evidence. Never fabricate a build result.
+8. **Proof bundle** — every orchestrator item has a **required `proof-bundle` note** (AGENTS.md §9). Fill it: TP id, worktree, branch, files changed, validations with exit codes, codereview status, precommit status, commit SHA, PR URL or exact blocker, residual risks, UNKNOWNs.
+9. **Land** — commit (allowlist only) → PR (`base: main`) → record proof note → `advance_item`.
+
+---
+
+## 2. The DAG — don't reorder
+
+```
+wave 1:  101   104        (parallel, no deps)
+wave 2:  102               (after 101)
+wave 3:  103  105          (103 after 101+102; 105 after 101+102+104)
+wave 4:  106               (after 101,102,103,104,105 — fan-in)
+```
+
+- `101 → {102, 103, 105, 106}`  ·  `102 → {103, 105, 106}`  ·  `104 → {105, 106}`  ·  `103 → 106`  ·  `105 → 106`
+- **101 is the load-bearing foundation** — almost everything depends on it.
+
+---
+
+## 3. Per-packet cheat sheet — with the gotcha that *will* bite you
+
+**101 — rename plan keys + harden scripts (RED-LANE, foundation)**
+Rename `IosevkaDopemux{Term,Editor}` → `Dopemux{Term,Editor}` across **four** sites: TOML `[buildPlans.*]` headers; `build-dopemux-fonts.sh` `PLANS=` + dist path + pre-clean glob; **`patch-nerd-font.sh` pre-clean glob (~:50) AND the `--mono` family guard (~:62)**.
+🔴 **Why it matters:** the guard tests `family == "DopemuxTerm"`, but `family` is derived from the `IosevkaDopemux*` filename — so **Term is patched WITHOUT `--mono` today**. The rename is what makes Term mono actually fire. Prove it (patched Term faces single-width).
+Also: `mkdir -p OUT_DIR` (don't hard-error); back up/restore Iosevka's `private-build-plans.toml` (don't clobber); no stale manifest on mid-build fail; ensure binaries + the manifest dotfile can't be committed. **Do NOT change the `family =` values.**
+
+**102 — Editor proportional + stable family (RED-LANE)**
+Add `--variable-width-glyphs` to the Editor patch branch (Term keeps `--mono`). Set the family via **explicit per-face `--name "<Family> Nerd Font"`**.
+🔴 **`--name full` is forbidden** — Medium faces export as `Dopemux Term Medium`, which `--name full` parses as a *different family per weight*, breaking the `colors_and_type.css` `font-weight: 500 700` single-family range. Test name tables (ID 16 identical across Regular+Medium of a spacing family) + advance widths (Term single, Editor proportional).
+
+**103 — full @font-face matrix + reconcile** (`colors_and_type.css` only)
+Declare the **full 12-face matrix** (Term+Editor × Regular/Medium × Upright/Italic/Oblique). Italic→`font-style:italic`, Oblique→`font-style:oblique`. Align `--font-mono`/`--font-editor` to 102's family names (kill the stale no-space `DopemuxTerm Nerd Font Mono`). Decide plain-vs-patched `src` (Nerd glyphs in-browser need the patched faces) and document it.
+
+**104 — resolve 6 case-collisions (RED-LANE, foundation)**
+🔴 Use **`git rm --cached`** on the redundant casing — **never `git mv`** (`core.ignorecase=true` makes it a silent no-op). The 6 pairs are byte-identical on `origin/main`. Run from a clean `origin/main`; enumerate via `git ls-tree -r origin/main`; expect **exactly 6** (the working-tree `fonts/README.md` is a different-branch artifact — ignore it). Keep the casing inbound links use (default `README.md` UPPER).
+
+**105 — purge legacy doc refs** (post-104 canonical-cased files)
+`review-pack.md` `fonts/BUILD.md`→`build.md`; delete the `IosevkaHueTerm` "canonical brand mono" claims (README, build.md); reconcile doc-embedded `@font-face`/family/filename examples to 101 filenames + 102 families.
+
+**106 — verify + manual gate (final_packet)**
+`verify-remediation.sh`: **toolchain-free** asserts (zero collisions, zero stale refs, complete `@font-face`, all `--font-mono`/`--font-editor` consumers resolve) — fail-closed. `VERIFICATION.md`: document the manual full-toolchain gate. CI cannot build fonts, so this is the CI-runnable slice + a manual checklist.
+
+---
+
+## 4. Environment gotchas
+
+- **codex CLI config:** `~/.codex/config.toml` has `service_tier="default"`, which codex 0.130.0 **rejects at parse** (the API also rejects `"flex"`). Override per-invocation with **`-c service_tier="fast"`**.
+- **Base off `origin/main`**, not local `main` (squash-merge → different SHA). Repo is a **shallow clone** → three-dot diffs show false "no merge base"; use `gh api repos/DDD-Enterprises/dopemux-mvp/compare/main...<branch>` for the real diff.
+- **Font toolchain** (for the manual gates only): local Iosevka checkout + nerd-fonts checkout + FontForge (`brew install fontforge`) + Node. Set `IOSEVKA_REPO` / `NERD_FONTS_REPO` / `OUT_DIR`. font-patcher runs via `fontforge -script font-patcher` — **not** `python3 font-patcher`. No toolchain → **NOT_RUN** + static evidence.
+- **task-orchestrator** is stdio and can drop under SQLite contention from leaked per-client containers; if it drops, `docker kill` the leaked `task-orchestrator-*` containers (single-id; `docker stop/rm` 404 on Docker Desktop) and retry. Your workspace DB is `dopemux-mvp`; ignore `dnh_crm` containers (different workspace).
+
+---
+
+## 5. Governance (non-negotiable)
+
+- **Authority order:** latest user instruction → `AGENTS.md`/packet → runtime code → schema → tests → config → docs → assumptions. **Runtime (`origin/main`) outranks the packet.**
+- **Validation buckets:** **PASS / FAIL / NOT_RUN** — never collapse NOT_RUN into PASS.
+- **Locked decisions (do not re-litigate):** Oblique→`font-style:oblique`; explicit per-face `--name` (not `--name full`); per-TP manual toolchain gates + toolchain-free 106.
+- **Final confidence** for repo-changing work must be `VERIFIED` with the proof bundle attached (AGENTS.md §8).
+
+## 6. Definition of done (series)
+
+All 6 packets terminal, each with a proof bundle. `verify-remediation.sh` green. The manual build+patch gate run (or NOT_RUN documented) shows: clean `DopemuxTerm-*`/`DopemuxEditor-*` filenames, Term single-width + Editor proportional advances, **one typographic family per spacing**, 7/7 documented PUA codepoints, zero case-collisions, zero stale refs.

--- a/claudedocs/cockpit-fonts-remediation/DESIGN.md
+++ b/claudedocs/cockpit-fonts-remediation/DESIGN.md
@@ -1,0 +1,154 @@
+# DMX-COCKPIT-FONTS — Design Spec (cockpit font build/patch remediation)
+
+**Status:** Approved design → authoring Task Packets
+**Date:** 2026-06-15
+**Authoring branch:** `feat/cockpit-fonts-series` (worktree off `origin/main` @ `a2396a922`)
+**Execution base:** `origin/main`
+**Scope decision (operator):** Full audit remediation — every codex+grok REQUEST-CHANGES finding + 3 research refinements.
+**Series id:** `dmx-cockpit-fonts` · **TP ids:** `DMX-COCKPIT-FONTS-101..106`
+
+---
+
+## 1. Context & problem
+
+PR [#879](https://github.com/DDD-Enterprises/dopemux-mvp/pull/879) (**MERGED** 2026-06-14, squash) shipped a reproducible Dopemux cockpit font build+patch pipeline under
+`docs/03-reference/Dopemux Cockpit TUI Design System/fonts/` (`build-dopemux-fonts.sh`, `patch-nerd-font.sh`, `private-build-plans.toml`) plus `@font-face` in `…/colors_and_type.css`. The live patch **was** run (`DopemuxTerm Nerd Font Mono` → 3519 PUA glyphs, all 7 documented codepoints). An external **codex + grok** audit returned **REQUEST-CHANGES**, but the PR merged with the findings unaddressed and a Codex-agent design-system normalization half-applied. This series remediates those findings on merged main — it is a **refinement/remediation** series, not a rescue.
+
+### 1.1 Verified state (`origin/main` a2396a922)
+
+| Finding | Status | Disposition |
+|---|---|---|
+| `patch-nerd-font.sh:62` `--mono` guard `family=="DopemuxTerm"` never fires (`family` derives from filename = plan key `IosevkaDopemuxTerm`) → **Term currently patched WITHOUT `--mono`** | live, **worse than reported** | TP-101 (rename fixes it) |
+| Editor patched with bare default (no `--variable-width-glyphs`) → double-width icon advances | live | TP-102 |
+| Patched family CamelCases to `DopemuxTerm Nerd Font Mono` (no space) ≠ docs `Dopemux Term Nerd Font` | live | TP-102 + TP-103 + TP-105 |
+| TTF filenames `IosevkaDopemux*` (plan-key derived); build pre-clean glob `DopemuxTerm-*.ttf` misses → stale-file accumulation | live (latent bug) | TP-101 |
+| `build-dopemux-fonts.sh`: no `mkdir -p OUT_DIR` (line 30 hard-errors); clobbers Iosevka's `private-build-plans.toml` (line 35, no backup); stale final manifest window on mid-build fail | live | TP-101 |
+| No-binary-commit guarantee unenforced: `fonts/.gitignore` is dir-scoped; `build.md` says build into `$PWD/out` (not ignored); manifest dotfile not ignored anywhere | live | TP-101 |
+| `colors_and_type.css` `@font-face` covers only Term Regular/Medium **upright** (no Italic, no Oblique, no Editor) | live | TP-103 |
+| 6 case-collision pairs (ACCEPTANCE, PREIMPLEMENTATION, README, SKILL, assets/README, ui_kits/cockpit/README) — all 6 repo-wide collisions are in the design-system dir | live (the audit's real merge-blocker) | TP-104 |
+| `README.md:291` still claims `IosevkaHueTerm-Regular.ttf` is "canonical brand mono"; `build.md:123` references legacy `IosevkaHue*` | live | TP-105 |
+| `review-pack.md:54` references `fonts/BUILD.md` (real file: `build.md`) | live | TP-105 |
+
+### 1.2 Stale / dropped (do NOT re-address)
+
+- "Nerd glyphs missing" — **RESOLVED** (3519 PUA glyphs, 7/7 codepoints present after patch).
+- "live patch NOT_RUN" — **RESOLVED** (ran 2026-06-14 on freed disk; 24 faces installed).
+- "2 routing-gate `asyncio_mode` pytest reds" — **RESOLVED** (behind-main artifact; cleared on merge).
+- D1 `cv__/ss__` ambiguity-reduction variant keys — **out of scope** (an *enhancement* needing manual Iosevka Customizer export, not an audit finding; YAGNI).
+
+---
+
+## 2. Adversarial challenge (PAL-substitute)
+
+The PAL MCP was **down** this session; the PAL `challenge`/`codereview` role was performed by a **Plan subagent** doing a file-grounded adversarial review of the first-draft decomposition. Verdict: **RESTRUCTURE**. Findings that reshaped the plan:
+
+- **C1 (critical):** Term mono is broken *today*; the plan-key rename (101) is the load-bearing fix, and the rename's blast radius straddles `patch-nerd-font.sh` (the `--mono` guard `:62` and pre-clean glob `:50`). → **101 owns the full rename end-to-end; 101 → 102**, and 102 becomes additive-only (new flags).
+- **M1 (critical risk):** **drop `--name full`** — Medium faces export as `Dopemux Term Medium`, which `--name full` would parse as a *different family* per weight, fragmenting the family and breaking the `font-weight: 500 700` single-family range trick in `colors_and_type.css`. → use **explicit per-face `--name "<Family> Nerd Font"`** and **test the name tables**.
+- **M5 (restructure):** 106 cannot be a CI-blocking TP — no committed CI builds fonts (binaries aren't committed; the toolchain is Iosevka+nerd-fonts+FontForge+Node). → heavyweight checks become **per-TP manual gate-notes**; 106 shrinks to toolchain-free asserts.
+- **C2/H3/M6 (missing scope, folded in):** `.gitignore`/OUT_DIR don't prevent binary commits (→101); README still calls `IosevkaHueTerm` canonical (→105); the face matrix is **12 faces** (Regular/Medium × Upright/Italic/Oblique × 2 families), not "add Italic" (→103).
+
+**Confirmed non-issues:** there is no 7th `fonts/` collision pair on origin/main (the working-tree `fonts/README.md` is a `feat/conport-optimal-series` artifact); the 6 cased pairs are **byte-identical** on origin/main, so 104 has no content-merge hazard there — only the `core.ignorecase=true` git mechanic matters.
+
+---
+
+## 3. Decomposition — 6 Task Packets
+
+Executor assignment is deferred to the load plan (`executor_defaults`: impl=`claude-code-sonnet`, audit=`claude-code-opus`, per model-routing policy). `execution` is omitted from the packets (its `agent` enum lacks a Claude value). `pal_chain` is authored for **execution time** (PAL may be up then); RED-LANE packets carry the risky chain.
+
+### TP-101 — Rename plan keys + harden build/patch scripts **(foundation, RED-LANE)**
+**Files:** `private-build-plans.toml`, `build-dopemux-fonts.sh`, `patch-nerd-font.sh`, `fonts/.gitignore`, `build.md`, `readme.md`
+**Scope:**
+- Rename `IosevkaDopemux{Term,Editor}` → `Dopemux{Term,Editor}` across **all four call sites**: TOML `[buildPlans.…]` section headers; `build-dopemux-fonts.sh` `PLANS=(…)` (:27), dist path `dist/$plan/TTF` (:50-51), pre-clean glob (:43); `patch-nerd-font.sh` pre-clean glob (:50) **and the `--mono` family guard (:62) so it fires for Term**.
+- Hardening: `mkdir -p "$OUT_DIR"` instead of hard-error (:30); back up + restore Iosevka's `private-build-plans.toml` around the `cp` (:35) instead of clobbering; close the stale-final-manifest window on mid-build failure (delete old TTFs only after a successful build, or `trap` cleanup).
+- No-binary-commit: ignore the manifest dotfile `.dopemux-built-fonts.txt`, the patched output dir, and a canonical `OUT_DIR`; reconcile `build.md`/`readme.md` so the documented `OUT_DIR` sits inside an ignored path.
+
+**Gates:** post-rename Term patched cmap is single-width (manual build+patch); no residual `IosevkaDopemux*` files; `git status` clean after a build (no TTF/manifest appears); `shellcheck` clean; bash-3.2 portable.
+**Deps:** none. **Blocks:** 102, 103, 105, 106. **PAL:** risky chain.
+
+### TP-102 — Patch flags: Editor proportional + stable family name **(RED-LANE)**
+**Files:** `patch-nerd-font.sh`, `fonts/test-name-tables.sh` (or `tests/fonts/…`)
+**Scope:**
+- Editor faces → add `--variable-width-glyphs`; keep Term `--mono`.
+- Family name: **explicit per-face `--name "<Family> Nerd Font"`** (family known from the post-rename filename stem). NOT `--name full`. Output contract pinned: Term family = `Dopemux Term Nerd Font` (single family across weights; weight via OS/2), Editor family = `Dopemux Editor Nerd Font`.
+- Reconcile Editor patched family against the CSS `--font-editor` expectation (avoid a ` Propo` fork).
+
+**Gate (name-table test, partly manual):** extract `name` IDs 1/2/4/6/16/17 for all patched faces; assert ID 16 (typographic family) **identical** across Regular+Medium of the same spacing family; assert Term advances single-width, Editor proportional; assert family strings equal the pinned contract.
+**Deps:** 101. **Blocks:** 103, 105, 106. **PAL:** risky chain.
+
+### TP-103 — `colors_and_type.css`: full `@font-face` matrix + family reconcile
+**Files:** `colors_and_type.css`
+**Scope:**
+- Enumerate the full face matrix — Term + Editor × {Regular, Medium} × {Upright, Italic, Oblique}. **Decide and document** whether Oblique is web-exposed (default: map Italic→`font-style: italic`, Oblique→`oblique`, or explicitly omit Oblique with a one-line rationale).
+- Confirm which faces the CSS serves (plain vs patched NF) and make `src` filenames consistent with TP-101's renamed output.
+- Reconcile `--font-mono` / `--font-editor` tokens to TP-102's pinned family names (replace the stale no-space `DopemuxTerm Nerd Font Mono` at :81).
+
+**Gate:** every `@font-face` `src` references a real built/patched file; every `var(--font-mono)`/`--font-editor` consumer resolves; family names equal the TP-102 contract.
+**Deps:** 101, 102. **Blocks:** 106. **PAL:** `analyze→planner→codereview→precommit`.
+
+### TP-104 — Resolve 6 design-system case-collisions **(foundation, RED-LANE)**
+**Files:** the redundant cased member of each of the 6 pairs (via `git rm --cached`)
+**Scope:**
+- Decision gate per pair: canonical casing = the casing inbound links already use (default `README.md` UPPER per GitHub convention; verify each).
+- Procedure: gate on byte-identity (`git diff <UPPER> <lower>` empty); `git rm --cached "<redundant>"` (NOT `git mv` — `core.ignorecase=true` no-ops); commit. If a future branch diverges, reconcile content into the keeper first.
+- Run from a **clean `origin/main`** branch; verify via `git ls-tree -r origin/main` (not the working tree); expect exactly 6 pairs; ignore the `fonts/README.md` branch artifact.
+- Fix any inbound references pointing at the removed casing.
+
+**Gate:** `git ls-tree -r <branch> | tr A-Z a-z | sort | uniq -d` empty for the design-system dir; a fresh checkout on a case-insensitive FS materializes all expected files.
+**Deps:** none. **Blocks:** 105, 106. **PAL:** risky chain (file removal is contract-sensitive).
+
+### TP-105 — Purge legacy/stale doc refs + reconcile examples
+**Files:** `review-pack.md`, `README.md` (post-104 keeper), `ACCEPTANCE.md` (post-104 keeper), `build.md`, `fonts/readme.md`, `preview/04b-brand-font.html`
+**Scope:**
+- `review-pack.md:54` `fonts/BUILD.md` → `build.md`.
+- Purge `IosevkaHueTerm` "canonical brand mono" claims (README:291; build.md:123) and any `IosevkaHue*` / off-brand-font references.
+- Reconcile doc-embedded `@font-face`/family/filename examples (README:162,262; ACCEPTANCE:74-75; preview/04b-brand-font.html:20; fonts/readme.md) to TP-101 filenames + TP-102 family names.
+
+**Gate:** `rg` sweep finds zero `BUILD.md`, zero `IosevkaHue`, zero no-space `DopemuxTerm Nerd Font`, zero forbidden-font names (per `build.md`'s own forbidden list).
+**Deps:** 101, 102, 104. **Blocks:** 106. **PAL:** minimum chain.
+
+### TP-106 — Lightweight end-to-end verify + manual gate-note **(final packet)**
+**Files:** `fonts/verify-remediation.sh`, `claudedocs/cockpit-fonts-remediation/VERIFICATION.md`, `proof/cockpit-fonts-106/**`
+**Scope:**
+- Toolchain-free, CI-able asserts: zero case-collisions; zero stale refs (the TP-105 sweep); `@font-face` matrix complete; every page loading `colors_and_type.css` resolves `--font-mono`/`--font-editor` to a declared face.
+- Documented **manual** gate: re-run `build-dopemux-fonts.sh` + `patch-nerd-font.sh` with the full toolchain; inspect name tables (TP-102 gate), advance widths (Term single / Editor proportional), glyph coverage (7/7 codepoints), clean filenames (`DopemuxTerm-*.ttf`), `git status` clean.
+
+**Deps:** 101, 102, 103, 104, 105. **PAL:** minimum chain. `final_packet=true`.
+
+---
+
+## 4. Dependency DAG & waves
+
+```
+101 ─┬─▶ 102 ─┬─▶ 103 ─┐
+     ├────────┼─▶ 105 ─┤
+     ├────────┴────────┤
+     └─────────────────┤
+104 ─┬─▶ 105 ──────────┤
+     └─────────────────┴─▶ 106
+103 ─────────────────────▶ 106
+```
+
+- **Edges (8):** 101→102, 101→103, 101→105, 101→106, 102→103, 102→105, 102→106, 103→106, 104→105, 104→106, 105→106. *(11 edges total; the ASCII is illustrative.)*
+- **First wave (unblocked): 101, 104.**
+- **After 101: 102.** **After 101+102: 103.** **After 101+102+104: 105.** **After all: 106.**
+
+---
+
+## 5. Open decisions & recommendations
+
+1. **Editor family suffix** — resolved by the explicit-`--name` approach: set Editor family = `Dopemux Editor Nerd Font` (no auto ` Propo`), proportional advances still come from `--variable-width-glyphs`. TP-102 must verify the flag interaction empirically.
+2. **Oblique web-exposure** (TP-103) — recommend mapping Italic→`italic`, Oblique→`oblique`; if the preview never uses oblique, omit with a documented rationale.
+3. **Canonical casing** (TP-104) — keep the casing inbound links already use; default `README.md` UPPER. Pairs are byte-identical on origin/main so content is not at risk.
+
+## 6. Validation strategy
+
+- **Per-TP gates** carry the heavyweight, toolchain-dependent checks (name tables, advance widths, glyph coverage) as **manual** steps, because CI can't build fonts.
+- **TP-106** carries only the toolchain-free, CI-able invariants.
+- Each packet's `commit.verify` includes JSON validity + `python -m jsonschema` against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` + `git diff --check`.
+
+## 7. Risks
+
+- **Medium-weight name parsing** (TP-102) — the primary technical risk; mitigated by explicit `--name` + name-table assertions, validated live in TP-106.
+- **CSS serves plain vs patched faces** (TP-103) — must be pinned during execution; if the browser preview needs Nerd glyphs, the `@font-face` `src` must point at the patched NF files and the family must match TP-102.
+- **Case-collision resolution on case-insensitive FS** (TP-104) — `git rm --cached` is the only safe mechanic; `git mv` silently no-ops.
+- **PAL down now** — packets are authored for execution-time PAL; if still down at execution, executors fall back to `advisor()` + the per-TP gates.

--- a/docs/ops/load-plans/load_plan-DMX-COCKPIT-FONTS.json
+++ b/docs/ops/load-plans/load_plan-DMX-COCKPIT-FONTS.json
@@ -4,19 +4,19 @@
   "title": "Cockpit font build/patch remediation — audit findings + research refinements on merged PR #879",
   "description": "6-packet remediation series for the Dopemux cockpit font build/patch pipeline (follow-on to merged PR #879). Clears the codex+grok REQUEST-CHANGES audit findings plus 3 research refinements. 101 renames the Iosevka plan keys + hardens the build/patch scripts (foundation; also fixes Term --mono, which is silently off today). 102 patches Editor with --variable-width-glyphs + sets a stable family via explicit per-face --name. 103 completes + reconciles the colors_and_type.css @font-face matrix. 104 resolves the 6 design-system case-collisions. 105 purges legacy IosevkaHue/BUILD.md doc refs + reconciles examples. 106 adds a toolchain-free verify + documents the manual build+patch gate.",
   "authority": "Task packets at task-packets/generated/DMX-COCKPIT-FONTS/ + design spec at claudedocs/cockpit-fonts-remediation/DESIGN.md. Runtime repo truth (origin/main) outranks this document. Verify paths before edit.",
-  "live_task_orchestrator_load": "PENDING",
+  "live_task_orchestrator_load": "LOADED",
   "offline_artifact": "CREATED",
-  "loaded": false,
+  "loaded": true,
   "load_mechanism_classified_as": "OBSERVED_MCP_TASK_ORCHESTRATOR_V3",
   "load_mechanism_evidence": "Per sibling load plans (DMX-CONPORT-OPTIMAL): task-orchestrator MCP v3 uses create_work_tree for the root, manage_items(operation=create) per node, manage_dependencies for the BLOCKS DAG, manage_notes for gate briefs. Per-packet TP JSONs conform to docs/03-reference/spec/dopetask/dopetask-canonical-spec.json (validated PASS, Draft7).",
-  "task_orchestrator_root_id": "PENDING_LOAD",
+  "task_orchestrator_root_id": "7890cbc1-3c2f-40a4-bacb-61eb705f3a6f",
   "task_orchestrator_leaf_ids": {
-    "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts": "PENDING_LOAD",
-    "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name": "PENDING_LOAD",
-    "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile": "PENDING_LOAD",
-    "DMX-COCKPIT-FONTS-104-resolve-case-collisions": "PENDING_LOAD",
-    "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs": "PENDING_LOAD",
-    "DMX-COCKPIT-FONTS-106-verify-remediation": "PENDING_LOAD"
+    "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts": "f2c374cd-abd8-4c59-bbd2-e9c5d8e6ce3d",
+    "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name": "cd11b6c7-372b-4f95-84e4-5253ed6bb17a",
+    "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile": "6a538831-770e-45fe-bc60-bddc12da1a3a",
+    "DMX-COCKPIT-FONTS-104-resolve-case-collisions": "04f9d15d-a5d3-4e81-b652-133bb3991fed",
+    "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs": "9010543e-f0a0-469e-8bb5-9b4698ff59f6",
+    "DMX-COCKPIT-FONTS-106-verify-remediation": "cf9a4c16-fd0b-4fae-9a72-7f28258d7164"
   },
   "workspace_id": "/Users/hue/code/dopemux-mvp",
   "authoring_branch": "feat/cockpit-fonts-series",
@@ -47,17 +47,50 @@
     "description": "11 BLOCKS edges. Predecessor must complete before successor. 101 and 104 are initially unblocked.",
     "edge_count": 11,
     "edges": [
-      { "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "successor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name" },
-      { "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "successor": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile" },
-      { "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "successor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs" },
-      { "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" },
-      { "predecessor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name", "successor": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile" },
-      { "predecessor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name", "successor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs" },
-      { "predecessor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" },
-      { "predecessor": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" },
-      { "predecessor": "DMX-COCKPIT-FONTS-104-resolve-case-collisions", "successor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs" },
-      { "predecessor": "DMX-COCKPIT-FONTS-104-resolve-case-collisions", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" },
-      { "predecessor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" }
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+        "successor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+        "successor": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+        "successor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+        "successor": "DMX-COCKPIT-FONTS-106-verify-remediation"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+        "successor": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+        "successor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+        "successor": "DMX-COCKPIT-FONTS-106-verify-remediation"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile",
+        "successor": "DMX-COCKPIT-FONTS-106-verify-remediation"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-104-resolve-case-collisions",
+        "successor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-104-resolve-case-collisions",
+        "successor": "DMX-COCKPIT-FONTS-106-verify-remediation"
+      },
+      {
+        "predecessor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs",
+        "successor": "DMX-COCKPIT-FONTS-106-verify-remediation"
+      }
     ]
   },
   "nodes": [
@@ -66,7 +99,7 @@
       "role": "queue",
       "status": "READY",
       "redlane": true,
-      "orchestrator_uuid": "PENDING_LOAD",
+      "orchestrator_uuid": "f2c374cd-abd8-4c59-bbd2-e9c5d8e6ce3d",
       "objective": "Rename Iosevka plan keys IosevkaDopemux{Term,Editor}->Dopemux{Term,Editor} across TOML + build + patch scripts (fixes Term --mono, which the guard never fires today) and harden build-dopemux-fonts.sh + the no-binary-commit guarantee.",
       "depends_on": [],
       "blocks": [
@@ -81,9 +114,11 @@
       "role": "queue",
       "status": "READY_AFTER_DEPENDENCY",
       "redlane": true,
-      "orchestrator_uuid": "PENDING_LOAD",
+      "orchestrator_uuid": "cd11b6c7-372b-4f95-84e4-5253ed6bb17a",
       "objective": "Patch Editor faces with --variable-width-glyphs (Term keeps --mono) and set a stable family via explicit per-face --name '<Family> Nerd Font' (not --name full); add a fontTools name-table + advance-width test.",
-      "depends_on": ["DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts"],
+      "depends_on": [
+        "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts"
+      ],
       "blocks": [
         "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile",
         "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs",
@@ -95,20 +130,22 @@
       "role": "queue",
       "status": "READY_AFTER_DEPENDENCY",
       "redlane": false,
-      "orchestrator_uuid": "PENDING_LOAD",
+      "orchestrator_uuid": "6a538831-770e-45fe-bc60-bddc12da1a3a",
       "objective": "Complete colors_and_type.css @font-face to the full 12-face matrix (Term+Editor x Regular/Medium x Upright/Italic/Oblique) and align --font-mono/--font-editor to the packet-102 spaced families.",
       "depends_on": [
         "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
         "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name"
       ],
-      "blocks": ["DMX-COCKPIT-FONTS-106-verify-remediation"]
+      "blocks": [
+        "DMX-COCKPIT-FONTS-106-verify-remediation"
+      ]
     },
     {
       "id": "DMX-COCKPIT-FONTS-104-resolve-case-collisions",
       "role": "queue",
       "status": "READY",
       "redlane": true,
-      "orchestrator_uuid": "PENDING_LOAD",
+      "orchestrator_uuid": "04f9d15d-a5d3-4e81-b652-133bb3991fed",
       "objective": "Resolve the 6 design-system case-collision pairs via git rm --cached the redundant casing (byte-identical on origin/main; git mv no-ops under core.ignorecase=true).",
       "depends_on": [],
       "blocks": [
@@ -121,21 +158,23 @@
       "role": "queue",
       "status": "READY_AFTER_DEPENDENCY",
       "redlane": false,
-      "orchestrator_uuid": "PENDING_LOAD",
+      "orchestrator_uuid": "9010543e-f0a0-469e-8bb5-9b4698ff59f6",
       "objective": "Fix review-pack.md BUILD.md->build.md, purge IosevkaHueTerm canonical claims, and reconcile doc-embedded @font-face/family/filename examples to packet 101/102 outputs (on the post-104 canonical-cased files).",
       "depends_on": [
         "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
         "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
         "DMX-COCKPIT-FONTS-104-resolve-case-collisions"
       ],
-      "blocks": ["DMX-COCKPIT-FONTS-106-verify-remediation"]
+      "blocks": [
+        "DMX-COCKPIT-FONTS-106-verify-remediation"
+      ]
     },
     {
       "id": "DMX-COCKPIT-FONTS-106-verify-remediation",
       "role": "queue",
       "status": "READY_AFTER_DEPENDENCY",
       "redlane": false,
-      "orchestrator_uuid": "PENDING_LOAD",
+      "orchestrator_uuid": "cf9a4c16-fd0b-4fae-9a72-7f28258d7164",
       "objective": "Toolchain-free verify-remediation.sh (zero collisions, zero stale refs, complete @font-face, tokens resolve) + VERIFICATION.md documenting the manual full-toolchain build+patch gate.",
       "depends_on": [
         "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
@@ -148,11 +187,18 @@
     }
   ],
   "verification": {
-    "status": "PENDING",
-    "expected_leaf_count": 6,
-    "expected_edge_count": 11,
-    "expected_unblocked": ["DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "DMX-COCKPIT-FONTS-104-resolve-case-collisions"],
-    "offline_schema_validation": "PASS (Draft7, all 6 packets, 2026-06-15)"
+    "status": "PASS",
+    "verified_at": "2026-06-16T03:43:50Z",
+    "leaf_count": 6,
+    "edge_count": 11,
+    "unblocked_count": 2,
+    "unblocked": [
+      "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+      "DMX-COCKPIT-FONTS-104-resolve-case-collisions"
+    ],
+    "offline_schema_validation": "PASS (Draft7, all 6 packets, 2026-06-15)",
+    "evidence": "create_work_tree atomic one-shot (root + 6 children + 11 BLOCKS deps + execution-context note, 0 failures). query_items overview on root 7890cbc1 -> childCounts.queue=6. query_dependencies: tp101 incoming=0/outgoing=4, tp104 incoming=0/outgoing=2 (both unblocked), tp106 incoming=5 (fan-in from 101,102,103,104,105). Workspace schema auto-attached required proof-bundle note (AGENTS.md §9) to every item."
   },
-  "replay_instructions": "1) Ensure task-orchestrator MCP is connected (prefer one HTTP singleton; if stdio, prune leaked containers first to avoid SQLite contention). 2) create_work_tree title='DMX-COCKPIT-FONTS' with description above. 3) manage_items(operation=create) for each of the 6 nodes, role=queue. 4) manage_dependencies for all 11 BLOCKS edges. 5) manage_notes for the decisions_applied brief on the root. 6) Update task_orchestrator_root_id + task_orchestrator_leaf_ids with real UUIDs. 7) query_items overview on root (expect childCounts.queue=6) + query_dependencies on 101/104 (expect 0 incoming) to confirm 6 leaves / 11 edges / 2 unblocked."
+  "replay_instructions": "1) Ensure task-orchestrator MCP is connected (prefer one HTTP singleton; if stdio, prune leaked containers first to avoid SQLite contention). 2) create_work_tree title='DMX-COCKPIT-FONTS' with description above. 3) manage_items(operation=create) for each of the 6 nodes, role=queue. 4) manage_dependencies for all 11 BLOCKS edges. 5) manage_notes for the decisions_applied brief on the root. 6) Update task_orchestrator_root_id + task_orchestrator_leaf_ids with real UUIDs. 7) query_items overview on root (expect childCounts.queue=6) + query_dependencies on 101/104 (expect 0 incoming) to confirm 6 leaves / 11 edges / 2 unblocked.",
+  "loaded_at": "2026-06-16T03:43:50Z"
 }

--- a/docs/ops/load-plans/load_plan-DMX-COCKPIT-FONTS.json
+++ b/docs/ops/load-plans/load_plan-DMX-COCKPIT-FONTS.json
@@ -1,0 +1,158 @@
+{
+  "schema_version": "1.0.0",
+  "series_id": "DMX-COCKPIT-FONTS",
+  "title": "Cockpit font build/patch remediation — audit findings + research refinements on merged PR #879",
+  "description": "6-packet remediation series for the Dopemux cockpit font build/patch pipeline (follow-on to merged PR #879). Clears the codex+grok REQUEST-CHANGES audit findings plus 3 research refinements. 101 renames the Iosevka plan keys + hardens the build/patch scripts (foundation; also fixes Term --mono, which is silently off today). 102 patches Editor with --variable-width-glyphs + sets a stable family via explicit per-face --name. 103 completes + reconciles the colors_and_type.css @font-face matrix. 104 resolves the 6 design-system case-collisions. 105 purges legacy IosevkaHue/BUILD.md doc refs + reconciles examples. 106 adds a toolchain-free verify + documents the manual build+patch gate.",
+  "authority": "Task packets at task-packets/generated/DMX-COCKPIT-FONTS/ + design spec at claudedocs/cockpit-fonts-remediation/DESIGN.md. Runtime repo truth (origin/main) outranks this document. Verify paths before edit.",
+  "live_task_orchestrator_load": "PENDING",
+  "offline_artifact": "CREATED",
+  "loaded": false,
+  "load_mechanism_classified_as": "OBSERVED_MCP_TASK_ORCHESTRATOR_V3",
+  "load_mechanism_evidence": "Per sibling load plans (DMX-CONPORT-OPTIMAL): task-orchestrator MCP v3 uses create_work_tree for the root, manage_items(operation=create) per node, manage_dependencies for the BLOCKS DAG, manage_notes for gate briefs. Per-packet TP JSONs conform to docs/03-reference/spec/dopetask/dopetask-canonical-spec.json (validated PASS, Draft7).",
+  "task_orchestrator_root_id": "PENDING_LOAD",
+  "task_orchestrator_leaf_ids": {
+    "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts": "PENDING_LOAD",
+    "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name": "PENDING_LOAD",
+    "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile": "PENDING_LOAD",
+    "DMX-COCKPIT-FONTS-104-resolve-case-collisions": "PENDING_LOAD",
+    "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs": "PENDING_LOAD",
+    "DMX-COCKPIT-FONTS-106-verify-remediation": "PENDING_LOAD"
+  },
+  "workspace_id": "/Users/hue/code/dopemux-mvp",
+  "authoring_branch": "feat/cockpit-fonts-series",
+  "authoring_worktree": "/Users/hue/code/cockpit-fonts-series",
+  "base_branch": "origin/main",
+  "base_commit": "a2396a922",
+  "generated_by": "claude-opus-4-8 (1M) on feat/cockpit-fonts-series, 2026-06-15. Orchestrator UUIDs are PENDING_LOAD until replay load.",
+  "executor_defaults": {
+    "primary": "claude-code-sonnet",
+    "auditor": "claude-code-opus",
+    "fallback_auditor": "gemini-cli",
+    "branch_convention": "claude/cockpit-fonts-<nnn>-<slug> off origin/main"
+  },
+  "first_unblocked_wave": [
+    "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+    "DMX-COCKPIT-FONTS-104-resolve-case-collisions"
+  ],
+  "second_wave_after_101": [
+    "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name"
+  ],
+  "decisions_applied": {
+    "oblique_web_exposure": "Italic -> font-style: italic; Oblique -> font-style: oblique (operator-approved 2026-06-15).",
+    "family_naming": "Explicit per-face --name '<Family> Nerd Font'; --name full forbidden (Medium-weight fragmentation). Operator-approved 2026-06-15.",
+    "verification_model": "Per-TP manual full-toolchain gates + toolchain-free TP-106; CI cannot build fonts. Operator-approved 2026-06-15."
+  },
+  "pickup_protocol": "Each leaf is a self-contained TP at task-packets/generated/DMX-COCKPIT-FONTS/<id>.json. Branch off origin/main as claude/cockpit-fonts-<nnn>-<slug>. RED-LANE packets (101,102,104) run the risky PAL chain (analyze->thinkdeep->challenge->planner->[challenge]->implement->codereview->precommit->challenge) + proof bundle per AGENTS.md §8; others run the minimum chain (analyze->planner->codereview->precommit). Heavyweight font-toolchain checks are MANUAL gate-notes inside 101/102/106. First wave = 101 + 104 (parallel).",
+  "blocks_dag": {
+    "description": "11 BLOCKS edges. Predecessor must complete before successor. 101 and 104 are initially unblocked.",
+    "edge_count": 11,
+    "edges": [
+      { "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "successor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name" },
+      { "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "successor": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile" },
+      { "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "successor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs" },
+      { "predecessor": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" },
+      { "predecessor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name", "successor": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile" },
+      { "predecessor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name", "successor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs" },
+      { "predecessor": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" },
+      { "predecessor": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" },
+      { "predecessor": "DMX-COCKPIT-FONTS-104-resolve-case-collisions", "successor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs" },
+      { "predecessor": "DMX-COCKPIT-FONTS-104-resolve-case-collisions", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" },
+      { "predecessor": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs", "successor": "DMX-COCKPIT-FONTS-106-verify-remediation" }
+    ]
+  },
+  "nodes": [
+    {
+      "id": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+      "role": "queue",
+      "status": "READY",
+      "redlane": true,
+      "orchestrator_uuid": "PENDING_LOAD",
+      "objective": "Rename Iosevka plan keys IosevkaDopemux{Term,Editor}->Dopemux{Term,Editor} across TOML + build + patch scripts (fixes Term --mono, which the guard never fires today) and harden build-dopemux-fonts.sh + the no-binary-commit guarantee.",
+      "depends_on": [],
+      "blocks": [
+        "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+        "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile",
+        "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs",
+        "DMX-COCKPIT-FONTS-106-verify-remediation"
+      ]
+    },
+    {
+      "id": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+      "role": "queue",
+      "status": "READY_AFTER_DEPENDENCY",
+      "redlane": true,
+      "orchestrator_uuid": "PENDING_LOAD",
+      "objective": "Patch Editor faces with --variable-width-glyphs (Term keeps --mono) and set a stable family via explicit per-face --name '<Family> Nerd Font' (not --name full); add a fontTools name-table + advance-width test.",
+      "depends_on": ["DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts"],
+      "blocks": [
+        "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile",
+        "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs",
+        "DMX-COCKPIT-FONTS-106-verify-remediation"
+      ]
+    },
+    {
+      "id": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile",
+      "role": "queue",
+      "status": "READY_AFTER_DEPENDENCY",
+      "redlane": false,
+      "orchestrator_uuid": "PENDING_LOAD",
+      "objective": "Complete colors_and_type.css @font-face to the full 12-face matrix (Term+Editor x Regular/Medium x Upright/Italic/Oblique) and align --font-mono/--font-editor to the packet-102 spaced families.",
+      "depends_on": [
+        "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+        "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name"
+      ],
+      "blocks": ["DMX-COCKPIT-FONTS-106-verify-remediation"]
+    },
+    {
+      "id": "DMX-COCKPIT-FONTS-104-resolve-case-collisions",
+      "role": "queue",
+      "status": "READY",
+      "redlane": true,
+      "orchestrator_uuid": "PENDING_LOAD",
+      "objective": "Resolve the 6 design-system case-collision pairs via git rm --cached the redundant casing (byte-identical on origin/main; git mv no-ops under core.ignorecase=true).",
+      "depends_on": [],
+      "blocks": [
+        "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs",
+        "DMX-COCKPIT-FONTS-106-verify-remediation"
+      ]
+    },
+    {
+      "id": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs",
+      "role": "queue",
+      "status": "READY_AFTER_DEPENDENCY",
+      "redlane": false,
+      "orchestrator_uuid": "PENDING_LOAD",
+      "objective": "Fix review-pack.md BUILD.md->build.md, purge IosevkaHueTerm canonical claims, and reconcile doc-embedded @font-face/family/filename examples to packet 101/102 outputs (on the post-104 canonical-cased files).",
+      "depends_on": [
+        "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+        "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+        "DMX-COCKPIT-FONTS-104-resolve-case-collisions"
+      ],
+      "blocks": ["DMX-COCKPIT-FONTS-106-verify-remediation"]
+    },
+    {
+      "id": "DMX-COCKPIT-FONTS-106-verify-remediation",
+      "role": "queue",
+      "status": "READY_AFTER_DEPENDENCY",
+      "redlane": false,
+      "orchestrator_uuid": "PENDING_LOAD",
+      "objective": "Toolchain-free verify-remediation.sh (zero collisions, zero stale refs, complete @font-face, tokens resolve) + VERIFICATION.md documenting the manual full-toolchain build+patch gate.",
+      "depends_on": [
+        "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+        "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+        "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile",
+        "DMX-COCKPIT-FONTS-104-resolve-case-collisions",
+        "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs"
+      ],
+      "blocks": []
+    }
+  ],
+  "verification": {
+    "status": "PENDING",
+    "expected_leaf_count": 6,
+    "expected_edge_count": 11,
+    "expected_unblocked": ["DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts", "DMX-COCKPIT-FONTS-104-resolve-case-collisions"],
+    "offline_schema_validation": "PASS (Draft7, all 6 packets, 2026-06-15)"
+  },
+  "replay_instructions": "1) Ensure task-orchestrator MCP is connected (prefer one HTTP singleton; if stdio, prune leaked containers first to avoid SQLite contention). 2) create_work_tree title='DMX-COCKPIT-FONTS' with description above. 3) manage_items(operation=create) for each of the 6 nodes, role=queue. 4) manage_dependencies for all 11 BLOCKS edges. 5) manage_notes for the decisions_applied brief on the root. 6) Update task_orchestrator_root_id + task_orchestrator_leaf_ids with real UUIDs. 7) query_items overview on root (expect childCounts.queue=6) + query_dependencies on 101/104 (expect 0 incoming) to confirm 6 leaves / 11 edges / 2 unblocked."
+}

--- a/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json
+++ b/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json
@@ -1,0 +1,123 @@
+{
+  "id": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+  "project": "dopemux-mvp",
+  "target": "Rename the Iosevka build-plan keys IosevkaDopemux{Term,Editor} to Dopemux{Term,Editor} across the TOML, build script, AND patch script — the rename is load-bearing because patch-nerd-font.sh gates --mono on family=='DopemuxTerm' but family derives from the IosevkaDopemux* filename, so Term is currently patched WITHOUT --mono. Also harden build-dopemux-fonts.sh (mkdir -p OUT_DIR instead of hard error; back up/restore Iosevka's private-build-plans.toml instead of clobbering; close the stale-manifest window on mid-build failure) and the no-binary-commit guarantee (ignore the build manifest dotfile and the documented OUT_DIR).",
+  "invariants": [
+    "The rename MUST cover all call sites: TOML [buildPlans.*] headers, build-dopemux-fonts.sh PLANS array + dist path + pre-clean glob, and patch-nerd-font.sh pre-clean glob + the --mono family guard.",
+    "After rename, the patch-nerd-font.sh --mono guard MUST fire for Term faces (family == 'DopemuxTerm') so Term is patched single-width; Editor MUST remain non-mono.",
+    "internal family names in private-build-plans.toml (family = 'Dopemux Term' / 'Dopemux Editor') MUST be unchanged by the plan-key rename.",
+    "No font binaries (*.ttf/*.otf/*.woff*) and no build manifest dotfile may become committable from the documented build workflow.",
+    "The build script MUST NOT leave a final manifest pointing at deleted TTFs if a build fails midway.",
+    "Scripts MUST remain bash-3.2 portable and pass shellcheck.",
+    "Changes are confined to the fonts/ tooling + its two readme/build docs; case-collision and CSS work are separate packets.",
+    "Classify a missing build toolchain as NOT_RUN with static substitute evidence; never fabricate a build result."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-cockpit-fonts",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "commit": {
+    "message": "fix(cockpit-fonts): rename plan keys Dopemux{Term,Editor} + harden build/patch scripts (DMX-COCKPIT-FONTS-101)",
+    "allowlist": [
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/private-build-plans.toml",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/.gitignore",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md",
+      "task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json",
+      "proof/cockpit-fonts-101/**"
+    ],
+    "verify": [
+      "python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json' >/dev/null",
+      "python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "! grep -rq 'IosevkaDopemux' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/'",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(cockpit-fonts): rename plan keys + harden build/patch scripts (DMX-COCKPIT-FONTS-101)",
+    "body": "Foundation packet of the DMX-COCKPIT-FONTS remediation series (follow-on to merged PR #879). Renames the Iosevka build-plan keys IosevkaDopemux{Term,Editor} -> Dopemux{Term,Editor} across the TOML, build-dopemux-fonts.sh, and patch-nerd-font.sh. This is load-bearing: the patch script's --mono guard keys on family=='DopemuxTerm' but family derives from the IosevkaDopemux* filename, so Term is currently patched WITHOUT --mono; the rename makes the guard fire. Also hardens the build script (mkdir -p OUT_DIR, backup/restore Iosevka's plan, stale-manifest guard) and the no-binary-commit guarantee. Internal family names ('Dopemux Term'/'Dopemux Editor') are unchanged.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": ["analyze", "thinkdeep", "challenge", "planner", "challenge", "implement", "codereview", "precommit", "challenge"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight from a clean branch off origin/main. Read the three font scripts + the TOML. Confirm patch-nerd-font.sh derives `family` from the IosevkaDopemux* filename stem and that the --mono guard string is literally 'DopemuxTerm' (proving Term is NOT currently --mono'd). Capture the dist filename pattern, the manifest dotfile name, and the documented OUT_DIR in build.md. Record baseline SHA + clean worktree in proof.",
+      "validation": [
+        "Confirmed: family is computed from the filename stem and the --mono guard token is 'DopemuxTerm'.",
+        "Confirmed current build-plan keys are IosevkaDopemuxTerm / IosevkaDopemuxEditor.",
+        "Baseline SHA and clean status recorded in proof/cockpit-fonts-101/."
+      ],
+      "context_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/private-build-plans.toml",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/.gitignore"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Rename build-plan keys IosevkaDopemuxTerm->DopemuxTerm and IosevkaDopemuxEditor->DopemuxEditor in private-build-plans.toml (the [buildPlans.X] headers and all [buildPlans.X.sub] tables). Do NOT change the `family = 'Dopemux Term'` / `family = 'Dopemux Editor'` values.",
+      "validation": [
+        "Zero occurrences of 'IosevkaDopemux' remain in private-build-plans.toml.",
+        "The two `family =` lines are byte-unchanged.",
+        "The TOML still parses (python tomllib or equivalent)."
+      ],
+      "expected_files": ["docs/03-reference/Dopemux Cockpit TUI Design System/fonts/private-build-plans.toml"]
+    },
+    {
+      "id": "S3",
+      "task": "Update build-dopemux-fonts.sh: PLANS=(DopemuxTerm DopemuxEditor); the dist path dist/$plan/TTF now resolves to the renamed key; the existing pre-clean glob DopemuxTerm-*/DopemuxEditor-*.ttf now matches actual Iosevka output. Update patch-nerd-font.sh: rename the pre-clean glob and the --mono family guard token so the guard fires for Term (family=='DopemuxTerm') and Editor stays non-mono. Run shellcheck on both scripts.",
+      "validation": [
+        "Zero 'IosevkaDopemux' occurrences remain in build-dopemux-fonts.sh or patch-nerd-font.sh.",
+        "patch-nerd-font.sh --mono guard now matches the renamed Term family token.",
+        "shellcheck passes on both scripts (or NOT_RUN if shellcheck absent, noted)."
+      ],
+      "expected_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Harden build-dopemux-fonts.sh: replace the hard-error OUT_DIR check with `mkdir -p \"$OUT_DIR\"`; back up an existing $IOSEVKA_REPO/private-build-plans.toml before the cp and restore it via trap on exit; ensure a mid-build failure does not leave a stale final manifest (only remove old TTFs after a successful build, or trap-clean). Update fonts/.gitignore to also ignore the build manifest dotfile (.dopemux-built-fonts.txt*) and the patched output dir; reconcile build.md/readme.md so the documented OUT_DIR sits inside an ignored path.",
+      "validation": [
+        "Running with a non-existent OUT_DIR now creates it instead of erroring.",
+        "An existing Iosevka private-build-plans.toml is restored after the script exits (success OR failure).",
+        "git status is clean after a build run — no TTF or manifest dotfile is committable.",
+        "build.md and readme.md OUT_DIR guidance matches the ignore rules."
+      ],
+      "expected_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/.gitignore",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "MANUAL GATE (full toolchain): with Iosevka + nerd-fonts + FontForge + Node available, run build-dopemux-fonts.sh then patch-nerd-font.sh. Confirm clean output filenames DopemuxTerm-*.ttf / DopemuxEditor-*.ttf, that patched Term faces are single-width (cmap advance) proving --mono now fires, and that git status is clean. If the toolchain is unavailable, record NOT_RUN with the exact missing dependency plus the static substitute evidence (greps + shellcheck). Then validate the TP JSON, commit allowlisted files only, open the PR, and write the proof bundle.",
+      "validation": [
+        "Either real build+patch produced DopemuxTerm-*.ttf with single-width Term faces (PASS), or NOT_RUN recorded with the missing dependency + static substitute evidence.",
+        "python -m jsonschema exits 0 for this TP JSON.",
+        "Only allowlisted files staged; git diff --check clean.",
+        "Proof bundle records TP id, worktree, branch, files changed, command exit codes, codereview status, precommit status, commit SHA, PR URL or exact blocker, residual risks, UNKNOWNs."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json
+++ b/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json
@@ -1,0 +1,95 @@
+{
+  "id": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+  "project": "dopemux-mvp",
+  "target": "Fix patch-nerd-font.sh so Editor faces patch with --variable-width-glyphs (proportional Nerd-glyph advances) while Term keeps --mono, and set a stable family name via explicit per-face --name '<Family> Nerd Font' (NOT --name full, which fragments the family because Medium faces export as 'Dopemux Term Medium'). Add a name-table test asserting all patched faces of a spacing family share one typographic family and have the expected advance-width behavior.",
+  "invariants": [
+    "Editor faces MUST be patched with --variable-width-glyphs; Term faces MUST keep --mono (relies on packet 101's restored guard).",
+    "The patched family name MUST be set via an explicit per-face --name string; --name full is forbidden.",
+    "All patched faces of one spacing family (Term Regular+Medium, Editor Regular+Medium) MUST report an identical typographic family (name ID 16, or ID 1 if 16 absent): 'Dopemux Term Nerd Font' / 'Dopemux Editor Nerd Font'.",
+    "The Editor patched family MUST match what colors_and_type.css --font-editor expects (no ' Propo' fork).",
+    "This packet MUST NOT modify the plan-key rename or the build script (owned by 101); it only changes patch flags + adds a name-table test.",
+    "Classify a missing FontForge/fontTools toolchain as NOT_RUN with static substitute evidence; never fabricate name-table or advance-width results."
+  ],
+  "depends_on": ["DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts"],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-cockpit-fonts",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "commit": {
+    "message": "fix(cockpit-fonts): Editor --variable-width-glyphs + explicit per-face --name (DMX-COCKPIT-FONTS-102)",
+    "allowlist": [
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/test-name-tables.sh",
+      "task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json",
+      "proof/cockpit-fonts-102/**"
+    ],
+    "verify": [
+      "python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json' >/dev/null",
+      "python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "! grep -q 'name full' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh'",
+      "grep -q 'variable-width-glyphs' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh'",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(cockpit-fonts): Editor proportional Nerd glyphs + stable family name (DMX-COCKPIT-FONTS-102)",
+    "body": "Adds --variable-width-glyphs to the Editor patch branch (proportional Nerd-glyph advances) while Term keeps --mono. Sets the patched family via explicit per-face --name '<Family> Nerd Font' instead of --name full, which would fragment the family across weights because Medium faces export as 'Dopemux Term Medium' and break the colors_and_type.css single-family weight-range. Adds test-name-tables.sh asserting one typographic family per spacing and correct advance widths. Depends on DMX-COCKPIT-FONTS-101 (the rename that makes Term's --mono guard fire).",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": ["analyze", "thinkdeep", "challenge", "planner", "challenge", "implement", "codereview", "precommit", "challenge"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: confirm packet 101 landed (keys renamed, Term --mono guard fires). Read the patch_args construction in patch-nerd-font.sh. Empirically determine how font-patcher honors an explicit free-string --name together with --variable-width-glyphs: does a free-string --name suppress the automatic 'Nerd Font'/' Propo'/' Mono' suffixing? Record the finding (cite the font-patcher behavior) in proof.",
+      "validation": [
+        "Packet 101 confirmed merged/landed (rename + guard).",
+        "Documented whether free-string --name suppresses the auto suffix, with evidence.",
+        "Decision recorded: exact --name string per family."
+      ],
+      "context_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/colors_and_type.css"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "In patch-nerd-font.sh: add --variable-width-glyphs to the Editor branch of patch_args (keep --mono for Term). Add an explicit per-face --name derived from the family token, pinned to 'Dopemux Term Nerd Font' for Term faces and 'Dopemux Editor Nerd Font' for Editor faces. Do NOT use --name full.",
+      "validation": [
+        "Editor patch path includes --variable-width-glyphs; Term path includes --mono and not --variable-width-glyphs.",
+        "patch_args includes an explicit --name '<Family> Nerd Font' per face; the string 'name full' does not appear.",
+        "shellcheck passes (or NOT_RUN noted)."
+      ],
+      "expected_files": ["docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh"]
+    },
+    {
+      "id": "S3",
+      "task": "Author test-name-tables.sh using fontTools (ttx/TTFont) to assert, across all patched faces: (a) name ID 16 (typographic family; fall back to ID 1) is identical across Regular+Medium of each spacing family and equals 'Dopemux Term Nerd Font' / 'Dopemux Editor Nerd Font'; (b) Term faces have single-width advances; (c) Editor faces have proportional (variable) advances. The script must skip gracefully (exit documented) when no patched faces or fontTools are present.",
+      "validation": [
+        "test-name-tables.sh exists and asserts identical typographic family per spacing + advance-width expectations.",
+        "Script degrades to a clear NOT_RUN message when fonts/fontTools are absent (no false PASS)."
+      ],
+      "expected_files": ["docs/03-reference/Dopemux Cockpit TUI Design System/fonts/test-name-tables.sh"]
+    },
+    {
+      "id": "S4",
+      "task": "MANUAL GATE: run patch-nerd-font.sh on the built faces, then run test-name-tables.sh. Record PASS (with the actual name-table dump + advance-width sample) or NOT_RUN with the missing dependency and static substitute evidence. Validate the TP JSON, commit allowlisted files only, open PR, write proof bundle including the name-table evidence.",
+      "validation": [
+        "Either name-table + advance-width assertions PASS on real patched faces, or NOT_RUN with missing dependency + static evidence.",
+        "python -m jsonschema exits 0 for this TP JSON.",
+        "Only allowlisted files staged; git diff --check clean.",
+        "Proof bundle records the pinned family strings actually emitted and the advance-width verdict."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile.json
+++ b/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile.json
@@ -1,0 +1,87 @@
+{
+  "id": "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile",
+  "project": "dopemux-mvp",
+  "target": "Complete and reconcile @font-face in colors_and_type.css: declare the full face matrix (Term + Editor x Regular/Medium x Upright/Italic/Oblique; Italic->font-style:italic, Oblique->font-style:oblique), point every src at the renamed/patched filenames from packet 101, and align the --font-mono/--font-editor tokens to packet 102's pinned family names (replacing the stale no-space 'DopemuxTerm Nerd Font Mono').",
+  "invariants": [
+    "@font-face MUST cover the full 12-face matrix (Term+Editor x Regular/Medium x Upright/Italic/Oblique) OR explicitly document any face deliberately not web-exposed.",
+    "font-family tokens (--font-mono, --font-editor) MUST equal packet 102's pinned families: 'Dopemux Term Nerd Font' / 'Dopemux Editor Nerd Font'.",
+    "Every @font-face src MUST reference a filename produced by packet 101's build/patch output.",
+    "Italic maps to font-style: italic and Oblique to font-style: oblique (operator-approved 2026-06-15).",
+    "The Medium weight MUST continue to be expressed within the single family via the existing font-weight range mechanism (no per-weight family fork).",
+    "Changes are confined to colors_and_type.css; doc-embedded @font-face copies are reconciled in packet 105."
+  ],
+  "depends_on": [
+    "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+    "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-cockpit-fonts",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "commit": {
+    "message": "fix(cockpit-fonts): complete @font-face matrix + reconcile family tokens (DMX-COCKPIT-FONTS-103)",
+    "allowlist": [
+      "docs/03-reference/Dopemux Cockpit TUI Design System/colors_and_type.css",
+      "task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile.json",
+      "proof/cockpit-fonts-103/**"
+    ],
+    "verify": [
+      "python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile.json' >/dev/null",
+      "python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "! grep -q 'DopemuxTerm Nerd Font' 'docs/03-reference/Dopemux Cockpit TUI Design System/colors_and_type.css'",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(cockpit-fonts): full @font-face matrix + family-token reconcile (DMX-COCKPIT-FONTS-103)",
+    "body": "Expands colors_and_type.css @font-face from Term Regular/Medium upright (2 faces) to the full matrix (Term + Editor x Regular/Medium x Upright/Italic/Oblique), with Italic->italic and Oblique->oblique. Repoints src filenames to packet 101's renamed output and aligns --font-mono/--font-editor to packet 102's spaced family names 'Dopemux Term Nerd Font' / 'Dopemux Editor Nerd Font', replacing the stale no-space 'DopemuxTerm Nerd Font Mono'. Depends on 101 (filenames) and 102 (pinned family names).",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: read the current @font-face blocks and the --font-mono/--font-editor token definitions in colors_and_type.css. Confirm packet 102's pinned family strings. Decide, and record, whether the CSS serves the plain Iosevka faces or the patched Nerd Font faces (Nerd glyphs in-browser require the patched faces) and therefore which filenames/family the src + font-family must reference.",
+      "validation": [
+        "Current @font-face coverage enumerated (which faces exist today).",
+        "Plain-vs-patched src decision recorded with rationale.",
+        "Packet 102 pinned families confirmed."
+      ],
+      "context_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/colors_and_type.css",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Declare the full face matrix in colors_and_type.css: Term + Editor x {Regular(400), Medium} x {Upright, Italic->font-style:italic, Oblique->font-style:oblique}. Preserve the existing single-family Medium weight-range mechanism. Point every src at the filename form produced by packet 101 (and patched per 102 if NF faces are served). If any face is intentionally not web-exposed, add a one-line CSS comment stating why.",
+      "validation": [
+        "Every Term+Editor x weight x slope face is present OR documented as intentionally omitted.",
+        "font-style values: italic for Italic, oblique for Oblique.",
+        "No per-weight family fork; Medium stays within the family via font-weight range."
+      ],
+      "expected_files": ["docs/03-reference/Dopemux Cockpit TUI Design System/colors_and_type.css"]
+    },
+    {
+      "id": "S3",
+      "task": "Set --font-mono to 'Dopemux Term Nerd Font' and --font-editor to 'Dopemux Editor Nerd Font' (packet 102 contract). Remove the stale no-space 'DopemuxTerm Nerd Font Mono'. Validate the TP JSON, commit allowlisted files only, open PR, write proof bundle.",
+      "validation": [
+        "--font-mono and --font-editor equal the packet-102 spaced families; the no-space 'DopemuxTerm Nerd Font' string is absent.",
+        "Every @font-face src references a filename listed in the documented build/patch output.",
+        "python -m jsonschema exits 0; only allowlisted files staged; git diff --check clean.",
+        "Proof bundle records the final face count and the src/family mapping."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-104-resolve-case-collisions.json
+++ b/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-104-resolve-case-collisions.json
@@ -1,0 +1,89 @@
+{
+  "id": "DMX-COCKPIT-FONTS-104-resolve-case-collisions",
+  "project": "dopemux-mvp",
+  "target": "Resolve the 6 case-collision pairs in the Dopemux Cockpit TUI Design System dir (ACCEPTANCE/acceptance, PREIMPLEMENTATION/preimplementation, README/readme, SKILL/skill, assets/README+readme, ui_kits/cockpit/README+readme) by removing the redundant casing with git rm --cached after gating on byte-identity, keeping the casing inbound links use (default UPPER). git mv is forbidden because core.ignorecase=true makes it a no-op.",
+  "invariants": [
+    "Run from a clean origin/main branch; enumerate pairs via `git ls-tree -r origin/main` (NOT the working tree); expect exactly 6 pairs.",
+    "Ignore the working-tree-only fonts/README.md artifact (it does not exist on origin/main).",
+    "For each pair, confirm byte-identity (`git diff <UPPER> <lower>` empty) BEFORE removal; if divergent, reconcile content into the keeper first.",
+    "Removal MUST use `git rm --cached` on the redundant member; `git mv` is forbidden (no-op under core.ignorecase=true).",
+    "Canonical casing = the casing inbound links already reference; default README.md UPPER per GitHub convention.",
+    "Only the 6 redundant files are removed; inbound reference fixes are deferred to packet 105.",
+    "After completion, a case-insensitive scan of the design-system dir has zero duplicate paths."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-cockpit-fonts",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "commit": {
+    "message": "fix(cockpit-design-system): resolve 6 case-collision pairs via git rm --cached (DMX-COCKPIT-FONTS-104)",
+    "allowlist": [
+      "docs/03-reference/Dopemux Cockpit TUI Design System/acceptance.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/preimplementation.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/readme.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/skill.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/assets/readme.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/ui_kits/cockpit/readme.md",
+      "task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-104-resolve-case-collisions.json",
+      "proof/cockpit-fonts-104/**"
+    ],
+    "verify": [
+      "python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-104-resolve-case-collisions.json' >/dev/null",
+      "python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-104-resolve-case-collisions.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -z \"$(git ls-files 'docs/03-reference/Dopemux Cockpit TUI Design System' | tr 'A-Z' 'a-z' | sort | uniq -d)\"",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(cockpit-design-system): resolve 6 case-collision pairs (DMX-COCKPIT-FONTS-104)",
+    "body": "Resolves the audit's actual merge-blocker: 6 case-collision pairs (ACCEPTANCE/acceptance, PREIMPLEMENTATION/preimplementation, README/readme, SKILL/skill, assets/README, ui_kits/cockpit/README) where both casings are tracked. On a case-insensitive FS only one of each materializes. The pairs are byte-identical on origin/main, so removal is a clean `git rm --cached` of the redundant casing (git mv no-ops under core.ignorecase=true). Inbound reference fixes follow in packet 105.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": ["analyze", "thinkdeep", "challenge", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "From a clean branch off origin/main, enumerate the case-collision pairs via `git ls-tree -r origin/main -- 'docs/03-reference/Dopemux Cockpit TUI Design System'` lowercased + uniq -d; confirm exactly 6. For each pair, run `git diff <UPPER> <lower>` to confirm byte-identity, and survey inbound links to decide the canonical casing (default UPPER). Record the per-pair keep/remove decision + identity verdict in proof.",
+      "validation": [
+        "Exactly 6 collision pairs enumerated from origin/main (not the working tree).",
+        "Each pair confirmed byte-identical (or a content-reconciliation note recorded if not).",
+        "Per-pair canonical-casing decision recorded with the inbound-link evidence."
+      ],
+      "context_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/README.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/ACCEPTANCE.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "For each pair, `git rm --cached` the redundant-casing member (default: the lowercase twin). Do NOT use git mv. Commit. Produce the inbound-reference handoff list (files that point at a removed casing) for packet 105.",
+      "validation": [
+        "Each redundant member removed via git rm --cached; no git mv used.",
+        "The surviving keeper for each pair is present in the index.",
+        "Handoff list of inbound references to the removed casings written to proof."
+      ],
+      "expected_files": []
+    },
+    {
+      "id": "S3",
+      "task": "Validate: a case-insensitive scan (`git ls-files <dir> | tr A-Z a-z | sort | uniq -d`) of the design-system dir is empty; a fresh checkout on a case-insensitive FS materializes all keepers with no warnings. Validate the TP JSON, commit allowlisted files only, open PR, write proof bundle.",
+      "validation": [
+        "Case-insensitive duplicate scan is empty for the design-system dir.",
+        "python -m jsonschema exits 0; only allowlisted files staged; git diff --check clean.",
+        "Proof bundle records the 6 removals, the kept casing per pair, and the 105 handoff list."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs.json
+++ b/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs.json
@@ -1,0 +1,100 @@
+{
+  "id": "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs",
+  "project": "dopemux-mvp",
+  "target": "Purge stale/legacy documentation references and reconcile doc-embedded font examples across the design-system docs: fix review-pack.md 'fonts/BUILD.md' -> 'build.md', remove the IosevkaHueTerm 'canonical brand mono' claims (README, build.md), and align doc-embedded @font-face/family/filename examples to packet 101 filenames + packet 102 family names.",
+  "invariants": [
+    "review-pack.md MUST reference build.md (lowercase), not BUILD.md.",
+    "No 'IosevkaHue*' canonical-font claim may remain in README or build.md.",
+    "Doc-embedded family-name examples MUST use the spaced 'Dopemux Term Nerd Font' form (no no-space 'DopemuxTerm Nerd Font') matching packet 102.",
+    "Doc filename examples MUST use the renamed DopemuxTerm-*/DopemuxEditor-* form from packet 101.",
+    "Edits target the post-104 canonical-cased files only; no removed casing is reintroduced.",
+    "No font scripts, the TOML, or colors_and_type.css are modified here (owned by 101/102/103)."
+  ],
+  "depends_on": [
+    "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+    "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+    "DMX-COCKPIT-FONTS-104-resolve-case-collisions"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-cockpit-fonts",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "commit": {
+    "message": "docs(cockpit-fonts): purge legacy IosevkaHue refs + reconcile font examples (DMX-COCKPIT-FONTS-105)",
+    "allowlist": [
+      "docs/03-reference/Dopemux Cockpit TUI Design System/review-pack.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/README.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/ACCEPTANCE.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/preview/04b-brand-font.html",
+      "task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs.json",
+      "proof/cockpit-fonts-105/**"
+    ],
+    "verify": [
+      "python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs.json' >/dev/null",
+      "python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "! grep -rqI 'IosevkaHue' 'docs/03-reference/Dopemux Cockpit TUI Design System'",
+      "! grep -rqI 'fonts/BUILD.md' 'docs/03-reference/Dopemux Cockpit TUI Design System'",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(cockpit-fonts): purge legacy refs + reconcile font examples (DMX-COCKPIT-FONTS-105)",
+    "body": "Fixes review-pack.md's dangling fonts/BUILD.md reference (real file build.md), removes the README/build.md claims that legacy IosevkaHueTerm is the 'canonical brand mono', and reconciles doc-embedded @font-face/family/filename examples to the renamed filenames (packet 101) and the spaced 'Dopemux Term Nerd Font' family (packet 102). Operates on the post-104 canonical-cased files. Depends on 101, 102, 104.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: rg the design-system docs for 'BUILD.md', 'IosevkaHue', the no-space 'DopemuxTerm Nerd Font', the legacy 'IosevkaDopemux' filenames, and any forbidden font names listed in fonts/build.md. Produce a file:line hit list. Confirm packet 104 landed so edits target the surviving casings.",
+      "validation": [
+        "Hit list of every stale reference (file:line) produced.",
+        "Packet 104 confirmed landed (canonical casings in place).",
+        "Packet 102 pinned family strings confirmed for the reconciliation target."
+      ],
+      "context_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/review-pack.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/README.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Apply fixes: review-pack.md 'fonts/BUILD.md' -> 'build.md'; remove/replace IosevkaHueTerm 'canonical brand mono' claims (README, build.md) with the Dopemux Term canonical naming; update doc-embedded @font-face/family examples to the spaced 'Dopemux Term Nerd Font' / 'Dopemux Editor Nerd Font'; update filename examples to DopemuxTerm-*/DopemuxEditor-*.",
+      "validation": [
+        "review-pack.md references build.md; no fonts/BUILD.md remains.",
+        "No IosevkaHue* canonical claim remains in README or build.md.",
+        "Doc family/filename examples match packet 101/102 outputs."
+      ],
+      "expected_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/review-pack.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/README.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Validate: the rg sweep returns zero 'BUILD.md', zero 'IosevkaHue', zero no-space 'DopemuxTerm Nerd Font', zero forbidden-font hits across the design-system docs. Validate the TP JSON, commit allowlisted files only, open PR, write proof bundle.",
+      "validation": [
+        "rg sweep returns zero stale/legacy hits for all four patterns.",
+        "python -m jsonschema exits 0; only allowlisted files staged; git diff --check clean.",
+        "Proof bundle records before/after hit counts per pattern."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-106-verify-remediation.json
+++ b/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-106-verify-remediation.json
@@ -1,0 +1,85 @@
+{
+  "id": "DMX-COCKPIT-FONTS-106-verify-remediation",
+  "project": "dopemux-mvp",
+  "target": "Lightweight end-to-end verification of the DMX-COCKPIT-FONTS series: author fonts/verify-remediation.sh with toolchain-free, CI-able asserts (zero case-collisions, zero stale refs, complete @font-face matrix, all --font-mono/--font-editor consumers resolve) and a VERIFICATION.md documenting the manual full-toolchain build+patch gate (name tables, advance widths, 7/7 glyph coverage, clean filenames, clean git status).",
+  "invariants": [
+    "verify-remediation.sh MUST NOT require the font toolchain (no Iosevka/FontForge/Node) so it runs in CI.",
+    "verify-remediation.sh MUST assert: zero design-system case-collisions; zero BUILD.md / IosevkaHue / no-space-family / forbidden-font references; @font-face matrix complete; every var(--font-mono)/--font-editor consumer resolves to a declared face.",
+    "The manual full build+patch gate MUST be documented (not executed in CI) with explicit pass criteria.",
+    "This packet MUST run only after packets 101-105 are complete (fan-in).",
+    "verify-remediation.sh MUST exit non-zero on any failed assert (fail-closed)."
+  ],
+  "depends_on": [
+    "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+    "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+    "DMX-COCKPIT-FONTS-103-css-font-face-matrix-reconcile",
+    "DMX-COCKPIT-FONTS-104-resolve-case-collisions",
+    "DMX-COCKPIT-FONTS-105-purge-legacy-doc-refs"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-cockpit-fonts",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": true
+  },
+  "commit": {
+    "message": "test(cockpit-fonts): toolchain-free remediation verify + manual gate doc (DMX-COCKPIT-FONTS-106)",
+    "allowlist": [
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/verify-remediation.sh",
+      "claudedocs/cockpit-fonts-remediation/VERIFICATION.md",
+      "task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-106-verify-remediation.json",
+      "proof/cockpit-fonts-106/**"
+    ],
+    "verify": [
+      "python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-106-verify-remediation.json' >/dev/null",
+      "python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-106-verify-remediation.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "bash 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/verify-remediation.sh'",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "test(cockpit-fonts): series verification + manual gate (DMX-COCKPIT-FONTS-106)",
+    "body": "Final packet of DMX-COCKPIT-FONTS. Adds fonts/verify-remediation.sh — a toolchain-free, CI-runnable checker asserting zero case-collisions, zero stale/legacy refs, a complete @font-face matrix, and that every --font-mono/--font-editor consumer resolves. Adds VERIFICATION.md documenting the manual full-toolchain build+patch gate (name tables, advance widths, 7/7 glyph coverage, clean filenames, clean git status), which CI cannot run because nothing in CI builds fonts. Depends on 101-105 (fan-in).",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Author fonts/verify-remediation.sh (bash-3.2, fail-closed). Asserts: (a) `git ls-files <design-system dir> | tr A-Z a-z | sort | uniq -d` is empty; (b) rg finds zero 'fonts/BUILD.md', 'IosevkaHue', no-space 'DopemuxTerm Nerd Font', and forbidden-font names; (c) colors_and_type.css declares the full face matrix (Term+Editor x Regular/Medium x Upright/Italic/Oblique, or documents omissions); (d) every var(--font-mono)/--font-editor consumer across preview/surfaces/ui_kits resolves to a face declared in colors_and_type.css.",
+      "validation": [
+        "Script exists, is bash-3.2 portable, and exits non-zero on any failed assert.",
+        "All four assert groups are present and require no font toolchain."
+      ],
+      "expected_files": ["docs/03-reference/Dopemux Cockpit TUI Design System/fonts/verify-remediation.sh"]
+    },
+    {
+      "id": "S2",
+      "task": "Author claudedocs/cockpit-fonts-remediation/VERIFICATION.md documenting the manual full-toolchain gate: how to run build-dopemux-fonts.sh + patch-nerd-font.sh, and the pass criteria (clean DopemuxTerm-*/DopemuxEditor-* filenames; Term single-width + Editor proportional advances; name tables share one typographic family per spacing; 7/7 documented PUA codepoints present; git status clean).",
+      "validation": [
+        "VERIFICATION.md lists the manual gate steps and explicit pass criteria.",
+        "It cross-references the per-TP gates in packets 101 and 102."
+      ],
+      "expected_files": ["claudedocs/cockpit-fonts-remediation/VERIFICATION.md"]
+    },
+    {
+      "id": "S3",
+      "task": "Run verify-remediation.sh; confirm every assert passes (the series is complete). Record the manual-gate status (PASS with toolchain evidence, or NOT_RUN with the missing dependency). Validate the TP JSON, commit allowlisted files only, open PR, write the final proof bundle.",
+      "validation": [
+        "verify-remediation.sh exits 0 (all toolchain-free asserts pass).",
+        "Manual-gate status recorded (PASS+evidence or NOT_RUN+dependency).",
+        "python -m jsonschema exits 0; only allowlisted files staged; git diff --check clean.",
+        "Final proof bundle summarizes the whole series outcome."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Authors + loads the **DMX-COCKPIT-FONTS** remediation series — a 6-packet follow-on to merged #879 that clears the codex+grok REQUEST-CHANGES audit findings plus 3 research refinements on the cockpit font build/patch pipeline.

**This PR adds planning artifacts only** (task packets, load plan, design spec, Codex primer) — no runtime font-script/CSS changes. Each packet is executed in its own PR per the DAG.

## The 6 packets
- **101** rename Iosevka plan keys + harden build/patch scripts (RED-LANE, foundation) — also fixes Term `--mono`, which is silently off today (guard keys on `family=='DopemuxTerm'` but family derives from the `IosevkaDopemux*` filename)
- **102** Editor `--variable-width-glyphs` + explicit per-face `--name` (RED-LANE) — NOT `--name full` (fragments the Medium family, breaks the CSS weight-range)
- **103** complete `colors_and_type.css` `@font-face` matrix (12 faces) + reconcile family tokens
- **104** resolve 6 design-system case-collisions via `git rm --cached` (RED-LANE, foundation)
- **105** purge legacy `IosevkaHue`/`BUILD.md` doc refs + reconcile examples
- **106** toolchain-free verify + manual build+patch gate (final packet)

## DAG
First wave (unblocked): **101 + 104**. Then 102 → 103/105 → 106. 11 BLOCKS edges.

## Loaded
task-orchestrator root `7890cbc1-3c2f-40a4-bacb-61eb705f3a6f` (workspace dopemux-mvp), 6 leaves, 11 edges verified; root note points at the executor primer.

## Artifacts
- Packets: `task-packets/generated/DMX-COCKPIT-FONTS/`
- Load plan: `docs/ops/load-plans/load_plan-DMX-COCKPIT-FONTS.json`
- Design spec: `claudedocs/cockpit-fonts-remediation/DESIGN.md`
- Executor primer: `claudedocs/cockpit-fonts-remediation/CODEX_PRIMER.md`

Decomposition validated via a file-grounded adversarial review (verdict RESTRUCTURE → applied). Schema-valid (Draft7, all 6 packets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
