### PR TITLE
fix(dcp): status precedence — hard-BLOCKED reasons outrank UNKNOWN-authority

### DIFF
--- a/src/dopemux/dcp/routing_classifier.py
+++ b/src/dopemux/dcp/routing_classifier.py
@@ -201,12 +201,18 @@ def _derive_route_status(
     inp: RoutingClassificationInput,
     red_lane: RedLaneState,
 ) -> RouteStatus:
-    """Derive conservative route status from attributes and red-lane state."""
+    """Derive conservative route status from attributes and red-lane state.
+
+    Status precedence is most-severe-first: a hard-BLOCKED reason outranks an
+    UNKNOWN one. The hard-BLOCKED checks (red-lane, BLOCKED authority, missing
+    proof on a mutating/non-trivial route, stale proof) are evaluated BEFORE the
+    UNKNOWN-authority guard so that a caller inspecting ``status`` learns *why* a
+    route is blocked even when authority is also unknown. An unknown-authority
+    route is non-runnable regardless, so this ordering strengthens
+    discoverability without weakening any fail-closed guarantee.
+    """
     if red_lane is RedLaneState.RED_LANE:
         return RouteStatus.BLOCKED
-
-    if inp.has_unknown_authority or inp.authority_class is AuthorityClass.UNKNOWN:
-        return RouteStatus.UNKNOWN
 
     if inp.authority_class is AuthorityClass.BLOCKED:
         return RouteStatus.BLOCKED
@@ -216,6 +222,9 @@ def _derive_route_status(
 
     if inp.has_stale_proof:
         return RouteStatus.BLOCKED
+
+    if inp.has_unknown_authority or inp.authority_class is AuthorityClass.UNKNOWN:
+        return RouteStatus.UNKNOWN
 
     if inp.task_source is TaskSource.UNKNOWN:
         return RouteStatus.UNKNOWN

--- a/tests/unit/dcp/test_routing_classifier.py
+++ b/tests/unit/dcp/test_routing_classifier.py
@@ -1221,7 +1221,7 @@ def test_live_write_without_contract_blocks() -> None:
 
 
 def test_unresolved_review_threads_block_readiness() -> None:
-    """Lock: has_stale_proof=True blocks the route (status=BLOCKED) when authority is known.
+    """Lock: has_stale_proof=True blocks the route (status=BLOCKED) regardless of authority.
 
     Note: "unresolved review threads" as a PR-Steward concern is a HIGHER-LAYER
     readiness check that lives outside this classifier.  The stale-proof gate
@@ -1229,31 +1229,70 @@ def test_unresolved_review_threads_block_readiness() -> None:
     gate: a route with stale or invalidated evidence is not actionable until proof
     is refreshed.
 
-    IMPORTANT — precedence finding (surfaced during 0002R reconciliation):
-    With all-default inputs (has_unknown_authority=True), the classifier returns
-    RouteStatus.UNKNOWN instead of RouteStatus.BLOCKED for has_stale_proof=True,
-    because _derive_route_status checks has_unknown_authority BEFORE has_stale_proof.
-    The BLOCKED status is only reachable after the unknown-authority guard passes.
-    This test therefore supplies has_unknown_authority=False to reach the
-    stale-proof BLOCKED path, which is the behaviour this invariant is meant to lock.
-
-    This ordering is NOT a security regression (unknown authority is non-runnable
-    regardless) but is a latent discoverability gap: stale_proof is recorded in
-    stop_conditions even when status=UNKNOWN, so the gate signal is present.
-    A future classifier refactor should ensure has_stale_proof → BLOCKED
-    regardless of authority-gate ordering.
+    PRECEDENCE (fixed in 0003 status-precedence work, was a latent gap in 0002R):
+    A hard-BLOCKED reason such as stale proof MUST be reported in ``status`` even
+    when authority is also unknown.  ``_derive_route_status`` now applies the
+    hard-BLOCKED checks (authority BLOCKED, missing proof, stale proof) BEFORE the
+    UNKNOWN-authority guard — a most-severe-first ordering (BLOCKED > UNKNOWN).
+    The default ``has_unknown_authority=True`` therefore no longer masks the
+    stale-proof BLOCKED status.
     """
     inp = RoutingClassificationInput(
         has_stale_proof=True,
-        # Must bypass the unknown-authority guard to reach the stale-proof BLOCKED path.
-        has_unknown_authority=False,
-        authority_class=AuthorityClass.OPERATOR,
+        # Default authority is UNKNOWN: the stale-proof BLOCKED reason must still
+        # surface in ``status`` (this is the precedence fix being locked).
     )
     decision = classify_route(inp)
 
     assert decision.status is RouteStatus.BLOCKED, (
         f"expected BLOCKED for stale proof input, got {decision.status}"
     )
+    assert not decision.is_runnable()
+    # The stale-proof reason is surfaced in both status and stop_conditions.
+    assert "stale_proof" in decision.stop_conditions
+
+
+def test_hard_blocked_reason_wins_over_unknown_authority() -> None:
+    """Lock: status precedence is most-severe-first — BLOCKED beats UNKNOWN.
+
+    Each hard-BLOCKED reason must be reported in ``status`` even when authority is
+    also unknown (the default).  Before the 0003 precedence fix the UNKNOWN-authority
+    guard returned first and masked these reasons as RouteStatus.UNKNOWN.
+    """
+    # Stale proof + default unknown authority → BLOCKED (not UNKNOWN).
+    stale = classify_route(RoutingClassificationInput(has_stale_proof=True))
+    assert stale.status is RouteStatus.BLOCKED
+
+    # Explicitly BLOCKED authority + default unknown-authority flag → BLOCKED.
+    blocked_auth = classify_route(
+        RoutingClassificationInput(authority_class=AuthorityClass.BLOCKED)
+    )
+    assert blocked_auth.status is RouteStatus.BLOCKED
+
+    # Missing proof on a mutating/non-trivial route + unknown authority → BLOCKED.
+    missing = classify_route(
+        RoutingClassificationInput(
+            has_missing_proof=True,
+            is_repo_changing=True,
+            is_non_trivial=True,
+        )
+    )
+    assert missing.status is RouteStatus.BLOCKED
+
+
+def test_unknown_authority_alone_still_reports_unknown() -> None:
+    """Lock: with no hard-BLOCKED reason, unknown authority still yields UNKNOWN.
+
+    The precedence fix must not over-block: a route whose only defect is unknown
+    authority (no stale/missing proof, not red-lane) remains RouteStatus.UNKNOWN.
+    """
+    decision = classify_route(
+        RoutingClassificationInput(
+            has_unknown_authority=True,
+            authority_class=AuthorityClass.UNKNOWN,
+        )
+    )
+    assert decision.status is RouteStatus.UNKNOWN
     assert not decision.is_runnable()
 
 


### PR DESCRIPTION
## What

Reorders `_derive_route_status` in `routing_classifier.py` so the hard-BLOCKED checks (BLOCKED authority → missing-proof-on-mutating/non-trivial → **stale proof**) are evaluated **before** the UNKNOWN-authority guard.

Before this change, a route with `has_stale_proof=True` and the conservative default `has_unknown_authority=True` returned `RouteStatus.UNKNOWN` and never reached the stale-proof `BLOCKED` branch — so `status` hid the real reason.

## Why it matters (and why it is NOT a safety regression)

UNKNOWN authority already makes a route non-runnable for mutation, so the old ordering **never promoted a stale-proof route to `ALLOWED`** — it fails closed either way. This is a **status-precision / discoverability** fix: a caller inspecting `status` now learns the hard reason (stale proof, blocked authority, missing proof) even when authority is also unknown. `stop_conditions` already carried the detail; `status` now agrees.

Verified no over-blocking: an unknown-authority-only route still returns `UNKNOWN`.

## Context — second 0005 gate

#902 (0002R reconciliation) is **already merged** to `main` (squash `a740edc40`). This precedence fix is the **second and final gate** before `DMX-DCP-MODEL-ROUTING-MVP-0005` (lane engine) — see `claudedocs/dcp-routing-0005-lane-engine-design-2026-06-16.md`. With this on `main`, 0005 can build on a clean classifier.

Rebased directly onto `main`: single commit, diff is exactly the 2 files (no 0002R duplication).

## Validation (head `9b83c981c`)

- `pytest tests/unit/dcp/test_routing_classifier.py` → **77 passed**
- precedence-specific: `test_hard_blocked_reason_wins_over_unknown_authority`, `test_unknown_authority_alone_still_reports_unknown` → **2 passed**
- `ruff check` (both files) → **All checks passed**
- diff scope: 2 files — `routing_classifier.py` (+17/−4), `test_routing_classifier.py` (+73/−21)

## Rollback

Revert the single commit, or close this PR. No runtime surface beyond `_derive_route_status` ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
