### PR TITLE
feat(dcp): lane engine MVP — decide_lane() pure consumer (0005)

### DIFF
--- a/src/dopemux/dcp/__init__.py
+++ b/src/dopemux/dcp/__init__.py
@@ -43,6 +43,13 @@ from dopemux.dcp.routing_backend_policy import (
     explain_backend_policy,
     select_backend_policy,
 )
+from dopemux.dcp.lane_model import (
+    LaneDecision,
+    LaneKind,
+)
+from dopemux.dcp.lane_engine import (
+    decide_lane,
+)
 
 __all__ = [
     # Proof artifact readers (pre-existing)
@@ -82,4 +89,8 @@ __all__ = [
     "BackendPolicyRule",
     "explain_backend_policy",
     "select_backend_policy",
+    # Lane model + engine (DMX-DCP-MODEL-ROUTING-MVP-0005)
+    "LaneDecision",
+    "LaneKind",
+    "decide_lane",
 ]

--- a/src/dopemux/dcp/lane_engine.py
+++ b/src/dopemux/dcp/lane_engine.py
@@ -123,7 +123,7 @@ def _assign_lane(
     5. task_type is PROOF_BUNDLE → PROOF_ONLY
     6. touches_tests and not touches_files → TEST_VALIDATION
     7. touches_docs and not (touches_files or touches_tests) and task_type not in {CODE_CHANGE, SCHEMA_ONLY} → DOCS_ONLY
-    8. task_type in {CODE_CHANGE, SCHEMA_ONLY} or (is_repo_changing and touches_files) → LOCAL_CODE_IMPLEMENTATION
+    8. task_type in {CODE_CHANGE, SCHEMA_ONLY} or is_repo_changing or touches_files → LOCAL_CODE_IMPLEMENTATION
     9. task_type is DESIGN_ONLY → CLASSIFIER_ROUTING
     10. fallback → READ_ONLY_EVIDENCE
     """
@@ -171,8 +171,10 @@ def _assign_lane(
         return LaneKind.DOCS_ONLY
 
     # Row 8: code / schema implementation
-    if decision.task_type in (TaskType.CODE_CHANGE, TaskType.SCHEMA_ONLY) or (
-        inp.is_repo_changing and inp.touches_files
+    if (
+        decision.task_type in (TaskType.CODE_CHANGE, TaskType.SCHEMA_ONLY)
+        or inp.is_repo_changing
+        or inp.touches_files
     ):
         return LaneKind.LOCAL_CODE_IMPLEMENTATION
 

--- a/src/dopemux/dcp/lane_engine.py
+++ b/src/dopemux/dcp/lane_engine.py
@@ -67,18 +67,17 @@ _EXTERNAL_INTAKE_EXTRA_FORBIDDEN: tuple[str, ...] = (
 
 
 def _compute_is_executable(decision: RouteDecision, lane: LaneKind) -> bool:
-    """Return True only when all gate conditions are met.
+    """Return True only when the lane is executable AND the decision is runnable.
 
-    Mirrors RouteDecision.is_runnable() — a non-ALLOWED status yields False.
-    BLOCKED and EXTERNAL_INTAKE are never executable regardless.
+    Delegates the safety gate to ``RouteDecision.is_runnable()`` (status ALLOWED,
+    red-lane CLEAR, authority not UNKNOWN/BLOCKED) so the lane engine can never
+    report executable for a route the classifier deems non-runnable — even for a
+    ``RouteDecision`` constructed outside ``classify_route`` (e.g. via
+    ``from_dict``). BLOCKED and EXTERNAL_INTAKE are never in ``_EXECUTABLE_LANES``.
     """
     if lane not in _EXECUTABLE_LANES:
         return False
-    if decision.status is not RouteStatus.ALLOWED:
-        return False
-    if decision.red_lane_state is not RedLaneState.CLEAR:
-        return False
-    return True
+    return decision.is_runnable()
 
 
 # ─────────────────────────────────────────────

--- a/src/dopemux/dcp/lane_engine.py
+++ b/src/dopemux/dcp/lane_engine.py
@@ -60,6 +60,20 @@ _EXTERNAL_INTAKE_EXTRA_FORBIDDEN: tuple[str, ...] = (
     "install",
 )
 
+# Mutating actions that must never appear on non-runnable lane decisions.
+_MUTATING_ACTIONS: frozenset[str] = frozenset({
+    "edit_allowlisted_files",
+    "run_embedded_audit",
+    "open_pr",
+})
+
+# Read-only / proof-safe actions permitted when the lane is not executable.
+_READ_ONLY_PROOF_SAFE_ACTIONS: frozenset[str] = frozenset({
+    "inspect_runtime_code",
+    "run_targeted_tests",
+    "capture_proof",
+})
+
 
 # ─────────────────────────────────────────────
 # Gate helper
@@ -78,6 +92,13 @@ def _compute_is_executable(decision: RouteDecision, lane: LaneKind) -> bool:
     if lane not in _EXECUTABLE_LANES:
         return False
     return decision.is_runnable()
+
+
+def _narrow_allowed_actions_for_non_runnable(
+    actions: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Fail-closed: strip mutating actions from non-executable lane decisions."""
+    return tuple(a for a in actions if a in _READ_ONLY_PROOF_SAFE_ACTIONS)
 
 
 # ─────────────────────────────────────────────
@@ -247,10 +268,14 @@ def decide_lane(
     is_exec = _compute_is_executable(decision, lane)
 
     # allowed_actions: inherit from decision; never widen.
-    # BLOCKED → always ()
-    # EXTERNAL_INTAKE → always ()
+    # BLOCKED / EXTERNAL_INTAKE → always ()
+    # Non-executable → read-only/proof-safe only (mutating actions stripped)
     if lane is LaneKind.BLOCKED or lane is LaneKind.EXTERNAL_INTAKE:
         allowed_actions: tuple[str, ...] = ()
+    elif not is_exec:
+        allowed_actions = _narrow_allowed_actions_for_non_runnable(
+            tuple(decision.allowed_actions)
+        )
     else:
         allowed_actions = tuple(decision.allowed_actions)
 

--- a/src/dopemux/dcp/lane_engine.py
+++ b/src/dopemux/dcp/lane_engine.py
@@ -1,0 +1,296 @@
+"""DCP Lane Engine — DMX-DCP-MODEL-ROUTING-MVP-0005.
+
+Pure-function engine: maps (RouteDecision, RoutingClassificationInput) → LaneDecision.
+
+Invariants enforced by design:
+- No I/O, network, shell, filesystem, external services.
+- Only imports stdlib and dopemux.dcp model/classifier/lane_model.
+- Classifier decision is the authoritative gate; this engine never re-derives safety.
+- RED_LANE or BLOCKED status always → LaneKind.BLOCKED, is_executable=False, allowed_actions=().
+- allowed_actions ⊆ decision.allowed_actions (inherited; never widened).
+- EXTERNAL_INTAKE and BLOCKED are never executable.
+- is_executable mirrors RouteDecision.is_runnable() semantics.
+- Proof, audit, escalation are surfaced (inherited), not flattened.
+- decide_lane() does not mutate its inputs.
+"""
+
+from __future__ import annotations
+
+from dopemux.dcp.lane_model import LaneDecision, LaneKind
+from dopemux.dcp.routing_classifier import RoutingClassificationInput
+from dopemux.dcp.routing_model import (
+    RedLaneState,
+    RouteDecision,
+    RouteStatus,
+    TaskSource,
+    TaskType,
+)
+
+# ─────────────────────────────────────────────
+# Constants
+# ─────────────────────────────────────────────
+
+# Lanes that may be executable when the gate conditions are met.
+# BLOCKED and EXTERNAL_INTAKE are never in this set.
+_EXECUTABLE_LANES: frozenset[LaneKind] = frozenset({
+    LaneKind.READ_ONLY_EVIDENCE,
+    LaneKind.DOCS_ONLY,
+    LaneKind.PROOF_ONLY,
+    LaneKind.CLASSIFIER_ROUTING,
+    LaneKind.LOCAL_CODE_IMPLEMENTATION,
+    LaneKind.TEST_VALIDATION,
+    LaneKind.EMBEDDED_AUDIT,
+    LaneKind.PR_STEWARD_READINESS,
+})
+
+# External agent task sources — used for EXTERNAL_INTAKE lane detection.
+_EXTERNAL_TASK_SOURCES: frozenset[TaskSource] = frozenset({
+    TaskSource.CODEX,
+    TaskSource.CLAUDE,
+    TaskSource.OPENCODE,
+    TaskSource.GROK,
+    TaskSource.GEMINI,
+    TaskSource.AGY,
+})
+
+# Extra tokens EXTERNAL_INTAKE adds to forbidden_actions
+_EXTERNAL_INTAKE_EXTRA_FORBIDDEN: tuple[str, ...] = (
+    "execute",
+    "import",
+    "install",
+)
+
+
+# ─────────────────────────────────────────────
+# Gate helper
+# ─────────────────────────────────────────────
+
+
+def _compute_is_executable(decision: RouteDecision, lane: LaneKind) -> bool:
+    """Return True only when all gate conditions are met.
+
+    Mirrors RouteDecision.is_runnable() — a non-ALLOWED status yields False.
+    BLOCKED and EXTERNAL_INTAKE are never executable regardless.
+    """
+    if lane not in _EXECUTABLE_LANES:
+        return False
+    if decision.status is not RouteStatus.ALLOWED:
+        return False
+    if decision.red_lane_state is not RedLaneState.CLEAR:
+        return False
+    return True
+
+
+# ─────────────────────────────────────────────
+# Lane assignment — precedence-ordered, first match wins
+# ─────────────────────────────────────────────
+
+
+def _assign_lane(
+    decision: RouteDecision,
+    inp: RoutingClassificationInput,
+) -> LaneKind:
+    """Return the LaneKind for this route using precedence-ordered matching.
+
+    The classifier's decision is the authoritative gate.  inp is used only to
+    pick the lane KIND — it never overrides the decision's safety verdict.
+
+    Precedence order (spec table rows 1–10):
+    1. RED_LANE or BLOCKED → BLOCKED
+    2. task_type is AUDIT → EMBEDDED_AUDIT
+    3. "pr_steward_readiness" in requested_actions → PR_STEWARD_READINESS
+    4. External agent + READ_ONLY + evidence_refs + no code/test/docs scope → EXTERNAL_INTAKE
+    5. task_type is PROOF_BUNDLE → PROOF_ONLY
+    6. touches_tests and not touches_files → TEST_VALIDATION
+    7. touches_docs and not (touches_files or touches_tests) and task_type not in {CODE_CHANGE, SCHEMA_ONLY} → DOCS_ONLY
+    8. task_type in {CODE_CHANGE, SCHEMA_ONLY} or (is_repo_changing and touches_files) → LOCAL_CODE_IMPLEMENTATION
+    9. task_type is DESIGN_ONLY → CLASSIFIER_ROUTING
+    10. fallback → READ_ONLY_EVIDENCE
+    """
+    # Row 1: hard block gate
+    if (
+        decision.red_lane_state is RedLaneState.RED_LANE
+        or decision.status is RouteStatus.BLOCKED
+    ):
+        return LaneKind.BLOCKED
+
+    # Row 2: audit task
+    if inp.task_type is TaskType.AUDIT:
+        return LaneKind.EMBEDDED_AUDIT
+
+    # Row 3: PR steward readiness
+    if "pr_steward_readiness" in inp.requested_actions:
+        return LaneKind.PR_STEWARD_READINESS
+
+    # Row 4: external intake — external agent, READ_ONLY, evidence refs, no scope mutations
+    if (
+        inp.task_source in _EXTERNAL_TASK_SOURCES
+        and inp.task_type is TaskType.READ_ONLY
+        and bool(inp.evidence_refs)
+        and not inp.touches_files
+        and not inp.touches_tests
+        and not inp.touches_docs
+    ):
+        return LaneKind.EXTERNAL_INTAKE
+
+    # Row 5: proof bundle
+    if inp.task_type is TaskType.PROOF_BUNDLE:
+        return LaneKind.PROOF_ONLY
+
+    # Row 6: test-only scope
+    if inp.touches_tests and not inp.touches_files:
+        return LaneKind.TEST_VALIDATION
+
+    # Row 7: docs-only scope (not code/test types, no file or test touches)
+    if (
+        inp.touches_docs
+        and not inp.touches_files
+        and not inp.touches_tests
+        and inp.task_type not in (TaskType.CODE_CHANGE, TaskType.SCHEMA_ONLY)
+    ):
+        return LaneKind.DOCS_ONLY
+
+    # Row 8: code / schema implementation
+    if inp.task_type in (TaskType.CODE_CHANGE, TaskType.SCHEMA_ONLY) or (
+        inp.is_repo_changing and inp.touches_files
+    ):
+        return LaneKind.LOCAL_CODE_IMPLEMENTATION
+
+    # Row 9: design/routing classification
+    if inp.task_type is TaskType.DESIGN_ONLY:
+        return LaneKind.CLASSIFIER_ROUTING
+
+    # Row 10: fallback
+    return LaneKind.READ_ONLY_EVIDENCE
+
+
+# ─────────────────────────────────────────────
+# Rationale builder
+# ─────────────────────────────────────────────
+
+
+def _build_rationale(
+    decision: RouteDecision,
+    inp: RoutingClassificationInput,
+    lane: LaneKind,
+    is_executable: bool,
+) -> tuple[str, ...]:
+    """Return an ordered tuple of labels explaining the lane assignment."""
+    labels: list[str] = []
+
+    if decision.red_lane_state is RedLaneState.RED_LANE:
+        labels.append("red_lane_blocked")
+    if decision.status is RouteStatus.BLOCKED:
+        labels.append("status_blocked")
+    if lane is LaneKind.BLOCKED:
+        if not labels:
+            labels.append("blocked_by_gate")
+        return tuple(labels)
+
+    labels.append(f"status_{decision.status.value.lower()}")
+
+    if inp.task_type is TaskType.AUDIT:
+        labels.append("task_type_audit")
+    elif "pr_steward_readiness" in inp.requested_actions:
+        labels.append("requested_pr_steward_readiness")
+    elif lane is LaneKind.EXTERNAL_INTAKE:
+        labels.append("external_agent_read_only_intake")
+    elif inp.task_type is TaskType.PROOF_BUNDLE:
+        labels.append("task_type_proof_bundle")
+    elif lane is LaneKind.TEST_VALIDATION:
+        labels.append("touches_tests_only")
+    elif lane is LaneKind.DOCS_ONLY:
+        labels.append("touches_docs_only")
+    elif lane is LaneKind.LOCAL_CODE_IMPLEMENTATION:
+        labels.append("task_type_code_change")
+    elif lane is LaneKind.CLASSIFIER_ROUTING:
+        labels.append("task_type_design_only")
+    else:
+        labels.append("fallback_read_only_evidence")
+
+    if is_executable:
+        labels.append("gate_pass_executable")
+    else:
+        labels.append("gate_fail_not_executable")
+
+    return tuple(labels)
+
+
+# ─────────────────────────────────────────────
+# Public entry point
+# ─────────────────────────────────────────────
+
+
+def decide_lane(
+    decision: RouteDecision,
+    classification_input: RoutingClassificationInput,
+) -> LaneDecision:
+    """Map a RouteDecision + RoutingClassificationInput into an explicit LaneDecision.
+
+    Pure function: no I/O, no mutation of inputs, no external calls.
+
+    Parameters
+    ----------
+    decision:
+        Authoritative safety gate from classify_route(). Status, red_lane_state,
+        allowed/forbidden actions, proof/audit/escalation, stop_conditions are
+        all read but never overridden.
+    classification_input:
+        Intent signals for picking lane KIND (task_type, task_source, scope flags,
+        evidence_refs, requested_actions). Never used to override the gate.
+
+    Returns
+    -------
+    LaneDecision
+        Frozen, pure data. is_executable reflects the gate, not the lane alone.
+    """
+    lane = _assign_lane(decision, classification_input)
+    is_exec = _compute_is_executable(decision, lane)
+
+    # allowed_actions: inherit from decision; never widen.
+    # BLOCKED → always ()
+    # EXTERNAL_INTAKE → always ()
+    if lane is LaneKind.BLOCKED or lane is LaneKind.EXTERNAL_INTAKE:
+        allowed_actions: tuple[str, ...] = ()
+    else:
+        allowed_actions = tuple(decision.allowed_actions)
+
+    # forbidden_actions: inherit from decision; EXTERNAL_INTAKE adds extras.
+    base_forbidden = tuple(decision.forbidden_actions)
+    if lane is LaneKind.EXTERNAL_INTAKE:
+        # Add execute/import/install without duplicating
+        existing = set(base_forbidden)
+        extras = tuple(
+            t for t in _EXTERNAL_INTAKE_EXTRA_FORBIDDEN if t not in existing
+        )
+        forbidden_actions: tuple[str, ...] = base_forbidden + extras
+    else:
+        forbidden_actions = base_forbidden
+
+    # proof_requirements, audit_requirement, escalation_requirement: inherited
+    proof_requirements = tuple(decision.proof_requirements)
+    audit_requirement = decision.audit_requirement
+    escalation_requirement = decision.escalation_requirement
+
+    # stop_conditions: inherited
+    stop_conditions = tuple(decision.stop_conditions)
+
+    rationale = _build_rationale(decision, classification_input, lane, is_exec)
+
+    return LaneDecision(
+        lane=lane,
+        route_status=decision.status,
+        is_executable=is_exec,
+        allowed_actions=allowed_actions,
+        forbidden_actions=forbidden_actions,
+        proof_requirements=proof_requirements,
+        audit_requirement=audit_requirement,
+        escalation_requirement=escalation_requirement,
+        stop_conditions=stop_conditions,
+        rationale=rationale,
+    )
+
+
+__all__ = [
+    "decide_lane",
+]

--- a/src/dopemux/dcp/lane_engine.py
+++ b/src/dopemux/dcp/lane_engine.py
@@ -114,7 +114,7 @@ def _assign_lane(
         return LaneKind.BLOCKED
 
     # Row 2: audit task
-    if inp.task_type is TaskType.AUDIT:
+    if decision.task_type is TaskType.AUDIT:
         return LaneKind.EMBEDDED_AUDIT
 
     # Row 3: PR steward readiness
@@ -123,8 +123,8 @@ def _assign_lane(
 
     # Row 4: external intake — external agent, READ_ONLY, evidence refs, no scope mutations
     if (
-        inp.task_source in _EXTERNAL_TASK_SOURCES
-        and inp.task_type is TaskType.READ_ONLY
+        decision.task_source in _EXTERNAL_TASK_SOURCES
+        and decision.task_type is TaskType.READ_ONLY
         and bool(inp.evidence_refs)
         and not inp.touches_files
         and not inp.touches_tests
@@ -133,7 +133,7 @@ def _assign_lane(
         return LaneKind.EXTERNAL_INTAKE
 
     # Row 5: proof bundle
-    if inp.task_type is TaskType.PROOF_BUNDLE:
+    if decision.task_type is TaskType.PROOF_BUNDLE:
         return LaneKind.PROOF_ONLY
 
     # Row 6: test-only scope
@@ -145,18 +145,18 @@ def _assign_lane(
         inp.touches_docs
         and not inp.touches_files
         and not inp.touches_tests
-        and inp.task_type not in (TaskType.CODE_CHANGE, TaskType.SCHEMA_ONLY)
+        and decision.task_type not in (TaskType.CODE_CHANGE, TaskType.SCHEMA_ONLY)
     ):
         return LaneKind.DOCS_ONLY
 
     # Row 8: code / schema implementation
-    if inp.task_type in (TaskType.CODE_CHANGE, TaskType.SCHEMA_ONLY) or (
+    if decision.task_type in (TaskType.CODE_CHANGE, TaskType.SCHEMA_ONLY) or (
         inp.is_repo_changing and inp.touches_files
     ):
         return LaneKind.LOCAL_CODE_IMPLEMENTATION
 
     # Row 9: design/routing classification
-    if inp.task_type is TaskType.DESIGN_ONLY:
+    if decision.task_type is TaskType.DESIGN_ONLY:
         return LaneKind.CLASSIFIER_ROUTING
 
     # Row 10: fallback
@@ -188,13 +188,13 @@ def _build_rationale(
 
     labels.append(f"status_{decision.status.value.lower()}")
 
-    if inp.task_type is TaskType.AUDIT:
+    if decision.task_type is TaskType.AUDIT:
         labels.append("task_type_audit")
     elif "pr_steward_readiness" in inp.requested_actions:
         labels.append("requested_pr_steward_readiness")
     elif lane is LaneKind.EXTERNAL_INTAKE:
         labels.append("external_agent_read_only_intake")
-    elif inp.task_type is TaskType.PROOF_BUNDLE:
+    elif decision.task_type is TaskType.PROOF_BUNDLE:
         labels.append("task_type_proof_bundle")
     elif lane is LaneKind.TEST_VALIDATION:
         labels.append("touches_tests_only")

--- a/src/dopemux/dcp/lane_engine.py
+++ b/src/dopemux/dcp/lane_engine.py
@@ -19,9 +19,14 @@ from __future__ import annotations
 from dopemux.dcp.lane_model import LaneDecision, LaneKind
 from dopemux.dcp.routing_classifier import RoutingClassificationInput
 from dopemux.dcp.routing_model import (
+    AuditRequirement,
+    ComplexityClass,
+    EscalationRequirement,
     RedLaneState,
+    RiskClass,
     RouteDecision,
     RouteStatus,
+    RuntimeImpact,
     TaskSource,
     TaskType,
 )
@@ -75,6 +80,28 @@ _READ_ONLY_PROOF_SAFE_ACTIONS: frozenset[str] = frozenset({
 })
 
 
+def _has_mutating_intent(inp: RoutingClassificationInput) -> bool:
+    """Return True for repo-changing scope or explicitly mutating requested actions."""
+    return (
+        inp.is_repo_changing
+        or inp.touches_files
+        or any(action in _MUTATING_ACTIONS for action in inp.requested_actions)
+    )
+
+
+def _has_unknown_decision_contract(decision: RouteDecision) -> bool:
+    """Fail closed on restored/incomplete decisions with UNKNOWN contract fields."""
+    return (
+        decision.task_source is TaskSource.UNKNOWN
+        or decision.task_type is TaskType.UNKNOWN
+        or decision.risk_class is RiskClass.UNKNOWN
+        or decision.complexity_class is ComplexityClass.UNKNOWN
+        or decision.runtime_impact is RuntimeImpact.UNKNOWN
+        or decision.audit_requirement is AuditRequirement.UNKNOWN
+        or decision.escalation_requirement is EscalationRequirement.UNKNOWN
+    )
+
+
 # ─────────────────────────────────────────────
 # Gate helper
 # ─────────────────────────────────────────────
@@ -90,6 +117,8 @@ def _compute_is_executable(decision: RouteDecision, lane: LaneKind) -> bool:
     ``from_dict``). BLOCKED and EXTERNAL_INTAKE are never in ``_EXECUTABLE_LANES``.
     """
     if lane not in _EXECUTABLE_LANES:
+        return False
+    if _has_unknown_decision_contract(decision):
         return False
     return decision.is_runnable()
 
@@ -118,7 +147,7 @@ def _assign_lane(
     Precedence order (spec table rows 1–10):
     1. RED_LANE or BLOCKED → BLOCKED
     2. task_type is AUDIT → EMBEDDED_AUDIT
-    3. "pr_steward_readiness" in requested_actions → PR_STEWARD_READINESS
+    3. "pr_steward_readiness" in requested_actions with no mutating intent → PR_STEWARD_READINESS
     4. External agent + READ_ONLY + evidence_refs + no code/test/docs scope → EXTERNAL_INTAKE
     5. task_type is PROOF_BUNDLE → PROOF_ONLY
     6. touches_tests and not touches_files → TEST_VALIDATION
@@ -139,7 +168,7 @@ def _assign_lane(
         return LaneKind.EMBEDDED_AUDIT
 
     # Row 3: PR steward readiness
-    if "pr_steward_readiness" in inp.requested_actions:
+    if "pr_steward_readiness" in inp.requested_actions and not _has_mutating_intent(inp):
         return LaneKind.PR_STEWARD_READINESS
 
     # Row 4: external intake — external agent, READ_ONLY, evidence refs, no scope mutations

--- a/src/dopemux/dcp/lane_engine.py
+++ b/src/dopemux/dcp/lane_engine.py
@@ -9,7 +9,7 @@ Invariants enforced by design:
 - RED_LANE or BLOCKED status always → LaneKind.BLOCKED, is_executable=False, allowed_actions=().
 - allowed_actions ⊆ decision.allowed_actions (inherited; never widened).
 - EXTERNAL_INTAKE and BLOCKED are never executable.
-- is_executable mirrors RouteDecision.is_runnable() semantics.
+- is_executable is stricter than RouteDecision.is_runnable() when lane safety requires.
 - Proof, audit, escalation are surfaced (inherited), not flattened.
 - decide_lane() does not mutate its inputs.
 """
@@ -66,11 +66,26 @@ _EXTERNAL_INTAKE_EXTRA_FORBIDDEN: tuple[str, ...] = (
     "install",
 )
 
-# Mutating actions that must never appear on non-runnable lane decisions.
+# Mutating actions that must never appear on passive or blocked lane decisions.
 _MUTATING_ACTIONS: frozenset[str] = frozenset({
     "edit_allowlisted_files",
-    "run_embedded_audit",
     "open_pr",
+    "commit_changes",
+    "merge_pr",
+    "apply_patch",
+    "run_dopetask_execution",
+    "run_live_write",
+    "call_mcp",
+    "run_embedded_audit",
+})
+
+# Passive lanes must never expose mutating actions, even when otherwise executable.
+_PASSIVE_LANES: frozenset[LaneKind] = frozenset({
+    LaneKind.READ_ONLY_EVIDENCE,
+    LaneKind.EMBEDDED_AUDIT,
+    LaneKind.PR_STEWARD_READINESS,
+    LaneKind.EXTERNAL_INTAKE,
+    LaneKind.BLOCKED,
 })
 
 # Read-only / proof-safe actions permitted when the lane is not executable.
@@ -86,7 +101,17 @@ def _has_mutating_intent(inp: RoutingClassificationInput) -> bool:
     return (
         inp.is_repo_changing
         or inp.touches_files
+        or inp.touches_public_behavior
         or any(action in _MUTATING_ACTIONS for action in inp.requested_actions)
+    )
+
+
+def _has_mutating_scope(inp: RoutingClassificationInput) -> bool:
+    """Return True when classifier scope flags indicate mutation is in play."""
+    return (
+        inp.is_repo_changing
+        or inp.touches_files
+        or inp.touches_public_behavior
     )
 
 
@@ -109,27 +134,42 @@ def _has_unknown_decision_contract(decision: RouteDecision) -> bool:
 # ─────────────────────────────────────────────
 
 
+def _has_blocking_stop_or_escalation(decision: RouteDecision) -> bool:
+    """Return True when unresolved stop conditions or mandatory escalation block work."""
+    if decision.stop_conditions:
+        return True
+    return decision.escalation_requirement is not EscalationRequirement.NONE
+
+
 def _compute_is_executable(decision: RouteDecision, lane: LaneKind) -> bool:
     """Return True only when the lane is executable AND the decision is runnable.
 
-    Delegates the safety gate to ``RouteDecision.is_runnable()`` (status ALLOWED,
-    red-lane CLEAR, authority not UNKNOWN/BLOCKED) so the lane engine can never
-    report executable for a route the classifier deems non-runnable — even for a
-    ``RouteDecision`` constructed outside ``classify_route`` (e.g. via
-    ``from_dict``). BLOCKED and EXTERNAL_INTAKE are never in ``_EXECUTABLE_LANES``.
+    Stricter than raw ``RouteDecision.is_runnable()``: also fail-closes on restored
+    UNKNOWN contract fields, UNKNOWN proof requirements, stop conditions, and
+    mandatory escalation. BLOCKED and EXTERNAL_INTAKE are never in
+    ``_EXECUTABLE_LANES``.
     """
     if lane not in _EXECUTABLE_LANES:
         return False
     if _has_unknown_decision_contract(decision):
         return False
+    if _has_blocking_stop_or_escalation(decision):
+        return False
     return decision.is_runnable()
+
+
+def _strip_mutating_actions(actions: tuple[str, ...]) -> tuple[str, ...]:
+    """Remove mutating tokens from an allowed-action tuple."""
+    return tuple(a for a in actions if a not in _MUTATING_ACTIONS)
 
 
 def _narrow_allowed_actions_for_non_runnable(
     actions: tuple[str, ...],
 ) -> tuple[str, ...]:
     """Fail-closed: strip mutating actions from non-executable lane decisions."""
-    return tuple(a for a in actions if a in _READ_ONLY_PROOF_SAFE_ACTIONS)
+    return _strip_mutating_actions(
+        tuple(a for a in actions if a in _READ_ONLY_PROOF_SAFE_ACTIONS)
+    )
 
 
 # ─────────────────────────────────────────────
@@ -154,7 +194,7 @@ def _assign_lane(
     5. task_type is PROOF_BUNDLE → PROOF_ONLY
     6. touches_tests and not touches_files → TEST_VALIDATION
     7. touches_docs and not (touches_files or touches_tests) and task_type not in {CODE_CHANGE, SCHEMA_ONLY} → DOCS_ONLY
-    8. task_type in {CODE_CHANGE, SCHEMA_ONLY} or is_repo_changing or touches_files → LOCAL_CODE_IMPLEMENTATION
+    8. task_type in {CODE_CHANGE, SCHEMA_ONLY} or mutating scope → LOCAL_CODE_IMPLEMENTATION
     9. task_type is DESIGN_ONLY → CLASSIFIER_ROUTING
     10. fallback → READ_ONLY_EVIDENCE
     """
@@ -201,11 +241,10 @@ def _assign_lane(
     ):
         return LaneKind.DOCS_ONLY
 
-    # Row 8: code / schema implementation
+    # Row 8: code / schema implementation or any mutating scope
     if (
         decision.task_type in (TaskType.CODE_CHANGE, TaskType.SCHEMA_ONLY)
-        or inp.is_repo_changing
-        or inp.touches_files
+        or _has_mutating_scope(inp)
     ):
         return LaneKind.LOCAL_CODE_IMPLEMENTATION
 
@@ -309,6 +348,8 @@ def decide_lane(
         allowed_actions = _narrow_allowed_actions_for_non_runnable(
             tuple(decision.allowed_actions)
         )
+    elif lane in _PASSIVE_LANES:
+        allowed_actions = _strip_mutating_actions(tuple(decision.allowed_actions))
     else:
         allowed_actions = tuple(decision.allowed_actions)
 

--- a/src/dopemux/dcp/lane_engine.py
+++ b/src/dopemux/dcp/lane_engine.py
@@ -22,6 +22,7 @@ from dopemux.dcp.routing_model import (
     AuditRequirement,
     ComplexityClass,
     EscalationRequirement,
+    ProofRequirement,
     RedLaneState,
     RiskClass,
     RouteDecision,
@@ -97,6 +98,7 @@ def _has_unknown_decision_contract(decision: RouteDecision) -> bool:
         or decision.risk_class is RiskClass.UNKNOWN
         or decision.complexity_class is ComplexityClass.UNKNOWN
         or decision.runtime_impact is RuntimeImpact.UNKNOWN
+        or any(req is ProofRequirement.UNKNOWN for req in decision.proof_requirements)
         or decision.audit_requirement is AuditRequirement.UNKNOWN
         or decision.escalation_requirement is EscalationRequirement.UNKNOWN
     )

--- a/src/dopemux/dcp/lane_model.py
+++ b/src/dopemux/dcp/lane_model.py
@@ -1,0 +1,130 @@
+"""DCP Lane Model — DMX-DCP-MODEL-ROUTING-MVP-0005.
+
+Pure data types for DCP lane classification decisions.
+
+Invariants enforced by design:
+- No I/O, network, shell, filesystem, external services.
+- Only imports stdlib and dopemux.dcp routing_model.
+- LaneDecision is frozen — immutable after construction.
+- allowed_actions is always a subset of the RouteDecision's allowed_actions.
+- BLOCKED and EXTERNAL_INTAKE are never executable.
+- Deferred lanes (SECURE_MCP_FACADE, RUNNER_BACKEND_EXECUTION,
+  CONNECTOR_CALL_EXECUTION, FUTURE_LIVE_WRITE) are NOT members of this enum —
+  they are out of scope for this MVP.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from dopemux.dcp.routing_model import (
+    AuditRequirement,
+    EscalationRequirement,
+    ProofRequirement,
+    RouteStatus,
+)
+
+
+# ─────────────────────────────────────────────
+# LaneKind — 10 members exactly as in the spec
+# ─────────────────────────────────────────────
+
+
+class LaneKind(Enum):
+    """Explicit lane classification for a DCP route decision.
+
+    Members
+    -------
+    READ_ONLY_EVIDENCE
+        Passive evidence-gathering only; no mutations.
+    DOCS_ONLY
+        Documentation / design changes, no code or test scope.
+    PROOF_ONLY
+        Proof-bundle construction; no live execution.
+    CLASSIFIER_ROUTING
+        Design-only routing / classification task (DESIGN_ONLY).
+    LOCAL_CODE_IMPLEMENTATION
+        Local code / schema change; audit obligation inherited.
+    TEST_VALIDATION
+        Test files only; no production code changes.
+    EMBEDDED_AUDIT
+        Independent audit run; no production mutations.
+    PR_STEWARD_READINESS
+        PR-Steward pre-flight readiness check (read-only, no merge).
+    EXTERNAL_INTAKE
+        External-agent evidence intake; never executable.
+    BLOCKED
+        Hard-blocked route; never executable.
+
+    Deferred (NOT in this enum):
+        SECURE_MCP_FACADE, RUNNER_BACKEND_EXECUTION,
+        CONNECTOR_CALL_EXECUTION, FUTURE_LIVE_WRITE
+    """
+
+    READ_ONLY_EVIDENCE = "read_only_evidence"
+    DOCS_ONLY = "docs_only"
+    PROOF_ONLY = "proof_only"
+    CLASSIFIER_ROUTING = "classifier_routing"
+    LOCAL_CODE_IMPLEMENTATION = "local_code_implementation"
+    TEST_VALIDATION = "test_validation"
+    EMBEDDED_AUDIT = "embedded_audit"
+    PR_STEWARD_READINESS = "pr_steward_readiness"
+    EXTERNAL_INTAKE = "external_intake"
+    BLOCKED = "blocked"
+
+
+# ─────────────────────────────────────────────
+# LaneDecision — frozen dataclass
+# ─────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class LaneDecision:
+    """Immutable result of lane classification for a single RouteDecision.
+
+    Fields
+    ------
+    lane
+        The lane kind assigned to this route.
+    route_status
+        The RouteDecision's status, carried through for caller convenience.
+    is_executable
+        True only when status is ALLOWED, red_lane_state is CLEAR, and
+        lane is in the executable set. BLOCKED and EXTERNAL_INTAKE are
+        never executable.
+    allowed_actions
+        Subset of RouteDecision.allowed_actions; never widened by the engine.
+        EXTERNAL_INTAKE narrows to ().
+    forbidden_actions
+        Superset of RouteDecision.forbidden_actions; engine may add extras
+        (e.g. EXTERNAL_INTAKE adds execute/import/install).
+    proof_requirements
+        Inherited from RouteDecision.proof_requirements; engine may only
+        strengthen, never weaken.
+    audit_requirement
+        Inherited from RouteDecision.audit_requirement; never flattened.
+    escalation_requirement
+        Inherited from RouteDecision.escalation_requirement; never flattened.
+    stop_conditions
+        Inherited from RouteDecision.stop_conditions; engine may add extras.
+    rationale
+        Ordered tuple of labels explaining the lane assignment and gate.
+    """
+
+    lane: LaneKind
+    route_status: RouteStatus
+    is_executable: bool
+    allowed_actions: tuple[str, ...]
+    forbidden_actions: tuple[str, ...]
+    proof_requirements: tuple[ProofRequirement, ...]
+    audit_requirement: AuditRequirement
+    escalation_requirement: EscalationRequirement
+    stop_conditions: tuple[str, ...]
+    rationale: tuple[str, ...]
+
+
+__all__ = [
+    "LaneDecision",
+    "LaneKind",
+]

--- a/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0005.md
+++ b/task-packets/DMX-DCP-MODEL-ROUTING-MVP-0005.md
@@ -1,0 +1,297 @@
+---
+id: DMX-DCP-MODEL-ROUTING-MVP-0005
+title: DCP Lane Engine MVP
+type: how-to
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-14'
+prelude: Implementation packet for the DCP lane engine MVP — a pure function mapping a RouteDecision into an explicit LaneDecision (lane, executability, allowed/forbidden actions, proof/audit/escalation, stop conditions, rationale). Consumes the classifier decision as the authoritative gate; never re-derives safety; raw MCP / live-write / dopetask / runner / connector / Secure-MCP-facade remain BLOCKED or deferred.
+---
+
+# DMX-DCP-MODEL-ROUTING-MVP-0005 — DCP Lane Engine MVP
+
+**Series**: DMX-DCP-MODEL-ROUTING-MVP
+**Packet**: 0005 (implementation)
+**Authored by**: PRE-PROMPT6-0003 (design-only)
+**Executed by**: PRE-PROMPT6-0004 (implementation)
+**Depends on**: precedence fix `DMX-DCP-PRE-PROMPT6-0002` merged onto `main` (PR #904); clean `main`.
+**Base**: cut from `main` AFTER #904 merges.
+
+---
+
+## Objective
+
+Implement a **pure** DCP lane engine that maps a deterministic `RouteDecision` (from
+`classify_route`) into an explicit `LaneDecision`: which lane the task belongs to, whether
+it is executable **now**, its allowed/forbidden actions, proof/audit/escalation
+obligations, stop conditions, and a rationale.
+
+The lane engine is the substrate that later backend-runner and connector lanes will plug
+into. This MVP ships **classification only** — no execution, no runner/connector/MCP/live
+calls.
+
+## Architectural placement (observed)
+
+`src/dopemux/dcp/routing_backend_policy.py` is the existing sibling: a pure function that
+consumes a `RouteDecision` (`decision.status`, `stop_conditions`, forbidden markers) and
+returns an inert `BackendPolicyRecommendation`. The lane engine occupies the **same slot** —
+a second pure consumer of `RouteDecision`. Model it on `routing_backend_policy.py`'s import
+and purity discipline. (CLI wiring in `commands/dcp_commands.py` is **out of scope** for this
+packet — future work.)
+
+---
+
+## Scope
+
+### IN
+- New `src/dopemux/dcp/lane_model.py` — `LaneKind` enum + `LaneDecision` dataclass.
+- New `src/dopemux/dcp/lane_engine.py` — `decide_lane(decision, classification_input) -> LaneDecision` (pure) + helpers.
+- New `tests/unit/dcp/test_lane_engine.py` — the tests pinned below.
+- Touch `src/dopemux/dcp/__init__.py` **only if** exporting `LaneKind` / `LaneDecision` / `decide_lane`.
+
+### OUT (do not implement)
+- No runner backend execution.
+- No connector calls.
+- No Secure MCP facade implementation (constant/blocked-lane representation only).
+- No raw MCP.
+- No dopetask execution.
+- No Task Orchestrator writes.
+- No OpenCode/Grok wrapper.
+- No live-write lane beyond a blocked/design-only representation.
+- No CLI wiring (`dopemux dcp lane`) — future packet.
+- No broad refactor of `routing_classifier.py` / `routing_model.py` (no field additions, no enum changes). If an integration bug appears to require a classifier change, **STOP** (see Stop Conditions).
+
+---
+
+## Invariants (non-negotiable)
+
+1. **Classifier decides safety first.** The lane engine reads `decision.status` and
+   `decision.red_lane_state` as the **authoritative gate**. It MUST NOT re-derive safety,
+   re-classify, or override the decision.
+2. **No blocked→runnable conversion.** `decision.red_lane_state is RED_LANE` OR
+   `decision.status is RouteStatus.BLOCKED` ⟹ `lane == LaneKind.BLOCKED` AND
+   `is_executable is False` AND `allowed_actions == ()`.
+3. **`requires_mcp_call → RED_LANE → BLOCKED` stays hard-blocked.** The lane engine never
+   produces a Secure-MCP-facade *executable* lane. `SECURE_MCP_FACADE` may appear **only**
+   as a deferred/design-only constant or an explicit non-executable BLOCKED mapping — never
+   `is_executable=True`.
+4. **Live-write stays blocked** without an explicit `LIVE_WRITE_READY` contract (absent in
+   this MVP). Any live-write-shaped decision is already `BLOCKED` by the classifier.
+5. **Dopetask execution remains forbidden** — never executable, token stays in
+   `forbidden_actions`.
+6. **Unknown authority cannot grant mutation.** A non-BLOCKED but non-runnable decision
+   (`status in {UNKNOWN, NEEDS_SUPERVISOR}`) yields `is_executable=False` and
+   `allowed_actions` with **no** mutating tokens.
+7. **`allowed_actions` is inherited, never widened.** `LaneDecision.allowed_actions ⊆
+   decision.allowed_actions`. The lane engine may only narrow.
+8. **Proof/audit/escalation are surfaced, not flattened.** `LaneDecision` carries the
+   decision's `proof_requirements`, `audit_requirement`, `escalation_requirement` —
+   unchanged (lane-specific additions only *strengthen*).
+9. **Pure function.** No I/O, shell, network, filesystem, connector, MCP, runner, or
+   dopetask calls. Imports limited to stdlib + `dopemux.dcp` model/classifier.
+10. **No new model fields / no public enum changes** in `routing_model.py` /
+    `routing_classifier.py`.
+
+---
+
+## Lane model
+
+```python
+class LaneKind(Enum):
+    READ_ONLY_EVIDENCE = "read_only_evidence"
+    DOCS_ONLY = "docs_only"
+    PROOF_ONLY = "proof_only"
+    CLASSIFIER_ROUTING = "classifier_routing"
+    LOCAL_CODE_IMPLEMENTATION = "local_code_implementation"
+    TEST_VALIDATION = "test_validation"
+    EMBEDDED_AUDIT = "embedded_audit"
+    PR_STEWARD_READINESS = "pr_steward_readiness"
+    EXTERNAL_INTAKE = "external_intake"
+    BLOCKED = "blocked"
+```
+
+**Deferred (do NOT add as executable lanes in this MVP):** `SECURE_MCP_FACADE`,
+`FUTURE_LIVE_WRITE`, `RUNNER_BACKEND_EXECUTION`, `CONNECTOR_CALL_EXECUTION`. If represented
+at all, only as a module-level commented constant or doc note — never an executable
+`LaneKind` member. **Raw MCP remains BLOCKED.**
+
+```python
+@dataclass(frozen=True)
+class LaneDecision:
+    lane: LaneKind
+    route_status: RouteStatus
+    is_executable: bool
+    allowed_actions: tuple[str, ...]
+    forbidden_actions: tuple[str, ...]
+    proof_requirements: tuple[ProofRequirement, ...]
+    audit_requirement: AuditRequirement
+    escalation_requirement: EscalationRequirement
+    stop_conditions: tuple[str, ...]
+    rationale: tuple[str, ...]
+```
+
+## Engine contract
+
+```python
+def decide_lane(
+    decision: RouteDecision,
+    classification_input: RoutingClassificationInput,
+) -> LaneDecision: ...
+```
+
+- `decision` = **authoritative safety gate** (status, red_lane_state, allowed/forbidden,
+  proof/audit/escalation, stop_conditions).
+- `classification_input` = **intent signals only** (task_type, task_source, touches_*,
+  is_repo_changing, requested_actions). Used to pick the lane KIND — **never** to override
+  the gate.
+
+### Lane assignment (precedence-ordered, first match wins)
+
+| # | Condition | LaneKind | is_executable |
+|---|---|---|---|
+| 1 | `decision.red_lane_state is RED_LANE` **or** `decision.status is BLOCKED` | `BLOCKED` | `False` (allowed=()) |
+| 2 | `inp.task_type is AUDIT` | `EMBEDDED_AUDIT` | gate† |
+| 3 | `"pr_steward_readiness" in inp.requested_actions` | `PR_STEWARD_READINESS` | gate† (read-only) |
+| 4 | `inp.task_source` ∈ external agents **and** `task_type is READ_ONLY` **and** `evidence_refs` **and** no code/test/docs scope | `EXTERNAL_INTAKE` | `False` (no execute/import/install) |
+| 5 | `inp.task_type is PROOF_BUNDLE` | `PROOF_ONLY` | gate† |
+| 6 | `inp.touches_tests` and not `inp.touches_files` | `TEST_VALIDATION` | gate† |
+| 7 | `inp.touches_docs` and not (`touches_files`/`touches_tests`) and `task_type` ∉ {CODE_CHANGE, SCHEMA_ONLY} | `DOCS_ONLY` | gate† |
+| 8 | `inp.task_type` ∈ {CODE_CHANGE, SCHEMA_ONLY} **or** (`is_repo_changing` and `touches_files`) | `LOCAL_CODE_IMPLEMENTATION` | gate† (audit_requirement preserved) |
+| 9 | `inp.task_type is DESIGN_ONLY` | `CLASSIFIER_ROUTING` | gate† |
+| 10 | fallback | `READ_ONLY_EVIDENCE` | gate† |
+
+† **gate** = `is_executable = (decision.status is ALLOWED) and (decision.red_lane_state is
+CLEAR) and (lane ∈ _EXECUTABLE_LANES)`. `EXTERNAL_INTAKE` and `BLOCKED` are **never**
+executable. Mirrors `RouteDecision.is_runnable()` — a non-ALLOWED status yields
+`is_executable=False` for every lane.
+
+### Field derivation
+- `allowed_actions` = `tuple(decision.allowed_actions)` (inherited; classifier already
+  returns read-only/empty for non-ALLOWED) — **never widened**. `EXTERNAL_INTAKE` narrows
+  to `()`.
+- `forbidden_actions` = `tuple(decision.forbidden_actions)` + lane extras (e.g.
+  `EXTERNAL_INTAKE` adds `"execute"`, `"import"`, `"install"`).
+- `proof_requirements` / `audit_requirement` / `escalation_requirement` = inherited from
+  `decision`, unchanged.
+- `stop_conditions` = `tuple(decision.stop_conditions)` (+ lane-specific where stronger).
+- `rationale` = ordered tuple of labels explaining the lane + gate (e.g.
+  `("red_lane_blocked",)`, `("status_allowed", "task_type_code_change")`).
+
+---
+
+## Required tests (exact — 0004 MUST add all; each constructs a `RoutingClassificationInput`, runs `classify_route`, then `decide_lane`)
+
+1. `test_blocked_route_maps_to_blocked_lane_not_executable` — a `BLOCKED` route (e.g.
+   `has_stale_proof=True`) → `lane is LaneKind.BLOCKED`, `is_executable is False`,
+   `allowed_actions == ()`.
+2. `test_red_lane_mcp_route_blocked_no_facade_bypass` — `requires_mcp_call=True` →
+   `LaneKind.BLOCKED`, not executable, **no** SECURE_MCP_FACADE lane; `"call_mcp"` /
+   `"call_mcp_live"` present in `forbidden_actions`.
+3. `test_live_write_route_blocked` — `requires_live_write=True` → `LaneKind.BLOCKED`, not executable.
+4. `test_dopetask_execution_route_blocked` — `requires_dopetask_execution=True` →
+   `LaneKind.BLOCKED`, not executable; dopetask token in `forbidden_actions`.
+5. `test_unknown_authority_route_non_mutating_not_executable` — default input
+   (`has_unknown_authority=True`, no hard block) → `is_executable is False` AND no mutating
+   token (`edit_allowlisted_files`/`open_pr`) in `allowed_actions`.
+6. `test_docs_only_safe_route_maps_to_docs_only` — a safe docs-only route
+   (`touches_docs=True`, OPERATOR authority, known dims) → `LaneKind.DOCS_ONLY`.
+7. `test_proof_only_fresh_proof_route` — a safe `PROOF_BUNDLE` task (no stale/missing proof)
+   → `LaneKind.PROOF_ONLY`. **Policy:** stale/missing proof is `BLOCKED` by the classifier
+   (precedence fix 0002), so it maps to `LaneKind.BLOCKED`, **not** PROOF_ONLY — assert that
+   in a companion case `test_proof_only_stale_proof_is_blocked`.
+8. `test_classifier_routing_task_maps_to_classifier_routing` — a `DESIGN_ONLY` routing task
+   (safe) → `LaneKind.CLASSIFIER_ROUTING`.
+9. `test_test_validation_task_maps_to_test_validation` — `touches_tests=True`,
+   `touches_files=False`, safe → `LaneKind.TEST_VALIDATION`.
+10. `test_local_code_implementation_preserves_audit` — non-trivial repo-changing safe route
+    (`task_type=CODE_CHANGE`, `is_repo_changing`, `is_non_trivial`, OPERATOR) →
+    `LaneKind.LOCAL_CODE_IMPLEMENTATION` AND `audit_requirement` equals the decision's
+    (EMBEDDED_AUDITOR/SUPERVISOR_AUDIT — preserved, not flattened).
+11. `test_external_intake_no_execution` — external-agent READ_ONLY evidence-intake task →
+    `LaneKind.EXTERNAL_INTAKE`, `is_executable is False`, and `allowed_actions` contains no
+    execute/import/install token.
+
+Plus structural guards:
+12. `test_allowed_actions_never_widen_decision` — for a sample of routes, assert
+    `set(lane.allowed_actions) ⊆ set(decision.allowed_actions)`.
+13. `test_no_forbidden_imports_in_lane_engine_source` — assert the module source contains no
+    `subprocess`/`socket`/`requests`/`httpx`/`open(`/`mcp`/`connector`/`runner` execution
+    imports (mirror `test_no_forbidden_imports_in_classifier_source`).
+14. `test_lane_engine_does_not_mutate_inputs` — `decide_lane` does not mutate `decision` or
+    `classification_input`.
+
+---
+
+## Exact commands (0004)
+
+```bash
+git checkout main
+git pull --ff-only          # must include #904 (precedence fix)
+git status --short
+git switch -c feat/dcp-lane-engine-0005
+PYTHONPATH=src python -m compileall -q src/dopemux/dcp
+PYTHONPATH=src python -m pytest -q tests/unit/dcp/test_routing_classifier.py
+PYTHONPATH=src python -m pytest -q tests/unit/dcp/test_lane_engine.py
+PYTHONPATH=src python -m pytest -q tests/unit/dcp/ tests/dcp/test_dcp_model_routing_0001_domain.py
+git diff --check
+git diff --stat
+git diff
+```
+
+## Validation gates
+- `compileall src/dopemux/dcp` PASS.
+- All required lane tests (1–14) PASS.
+- Existing `test_routing_classifier.py` still PASS (no regression).
+- Full `tests/unit/dcp/` + `tests/dcp/test_dcp_model_routing_0001_domain.py` PASS.
+- `git diff --check` clean.
+- Diff touches only allowed files.
+
+## Proof requirements
+Return: branch, commit SHA, PR URL (or exact blocker), `git diff --stat` + full diff, all
+command outputs **with exit codes**, embedded-audit report, residual risks, UNKNOWNs.
+
+## Embedded audit requirement
+After implementation run an **independent Opus audit** (separate subagent) with this question:
+
+> Audit the 0005 lane engine for: classifier bypass; red-lane weakening; raw-MCP permission
+> leakage; live-write leakage; dopetask execution leakage; runner/connector execution
+> leakage; proof/audit flattening; authority confusion; overbroad allowed_actions; missing
+> tests. Confirm `allowed_actions ⊆ decision.allowed_actions` for all routes and that no
+> BLOCKED/red-lane route is executable. Return PASS / PASS_WITH_RISKS / FAIL.
+
+Acceptance: PASS or PASS_WITH_RISKS with non-blocking risks. FAIL ⟹ stop, do not open PR.
+
+## PR Steward readiness requirement
+Before requesting merge, the PR must satisfy PR-Steward-style readiness: green required
+checks, scoped diff (allowed files only), no unresolved blocking review threads, proof
+bundle current to head SHA. **Merge remains operator-only.**
+
+## Rollback
+```bash
+git rm -f src/dopemux/dcp/lane_engine.py src/dopemux/dcp/lane_model.py tests/unit/dcp/test_lane_engine.py
+git checkout main -- src/dopemux/dcp/__init__.py task-packets/DMX-DCP-MODEL-ROUTING-MVP-0005.md
+# or: git branch -D feat/dcp-lane-engine-0005
+```
+
+## Stop conditions
+Stop if:
+- lane engine requires a classifier field expansion or enum change (outside scope);
+- implementation needs connector/runner/live-write/MCP/dopetask execution to test;
+- tests reveal classifier ambiguity not resolved by 0002;
+- embedded audit returns FAIL;
+- diff escapes the allowed files.
+
+## Expected output
+```
+TP: DMX-DCP-MODEL-ROUTING-MVP-0005
+STATUS: IMPLEMENTED / BLOCKED
+BRANCH:
+COMMIT:
+PR:
+VALIDATION:
+AUDIT_VERDICT:
+RESIDUAL_RISKS:
+UNKNOWNs:
+```

--- a/tests/unit/dcp/test_lane_engine.py
+++ b/tests/unit/dcp/test_lane_engine.py
@@ -178,6 +178,23 @@ def test_executability_gate_mirrors_is_runnable_on_forged_decision() -> None:
         )
 
 
+def test_lane_assignment_uses_normalized_enums_for_string_inputs() -> None:
+    """Audit P2 (codex thread): decide_lane must classify the lane from the
+    decision's NORMALIZED enums. classify_route tolerates string enum inputs;
+    the lane KIND must still be correct (not fall through to the fallback).
+    """
+    inp = RoutingClassificationInput(
+        task_type="AUDIT",  # string, not TaskType.AUDIT — classifier normalizes it
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+    )
+    decision = classify_route(inp)
+    assert decision.task_type is TaskType.AUDIT  # classifier normalized it
+
+    lane_decision = decide_lane(decision, inp)
+    assert lane_decision.lane is LaneKind.EMBEDDED_AUDIT
+
+
 # ─────────────────────────────────────────────
 # Test 3 — requires_live_write → BLOCKED, not executable
 # ─────────────────────────────────────────────

--- a/tests/unit/dcp/test_lane_engine.py
+++ b/tests/unit/dcp/test_lane_engine.py
@@ -577,6 +577,211 @@ def test_restored_decision_with_unknown_proof_requirement_not_executable() -> No
     assert "edit_allowlisted_files" not in lane_decision.allowed_actions
 
 
+def test_stop_conditions_block_executable_lane() -> None:
+    """Routes with stop_conditions must not be executable even when is_runnable()."""
+    inp = RoutingClassificationInput(
+        task_type=TaskType.READ_ONLY,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        risk_class=RiskClass.R0_READ,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+    )
+    restored = RouteDecision.from_dict(
+        {
+            "status": "ALLOWED",
+            "red_lane_state": "CLEAR",
+            "authority_class": "OPERATOR",
+            "task_source": "OPERATOR",
+            "task_type": "READ_ONLY",
+            "risk_class": "R0_READ",
+            "complexity_class": "LOW",
+            "runtime_impact": "READ_ONLY",
+            "audit_requirement": "SELF_CHECK",
+            "escalation_requirement": "ALWAYS",
+            "stop_conditions": ["missing_proof"],
+            "allowed_actions": ["edit_allowlisted_files", "open_pr"],
+        }
+    )
+    assert restored.is_runnable()
+
+    lane_decision = decide_lane(restored, inp)
+
+    assert lane_decision.is_executable is False
+    assert "edit_allowlisted_files" not in lane_decision.allowed_actions
+    assert "open_pr" not in lane_decision.allowed_actions
+
+
+def test_passive_audit_lane_strips_mutating_actions() -> None:
+    """EMBEDDED_AUDIT must not expose edit/open-pr actions even when runnable."""
+    inp = RoutingClassificationInput(
+        task_type=TaskType.AUDIT,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        touches_files=True,
+        is_repo_changing=True,
+        risk_class=RiskClass.R1_LOW,
+        runtime_impact=RuntimeImpact.LOCAL_ONLY,
+        complexity_class=ComplexityClass.LOW,
+    )
+    restored = RouteDecision.from_dict(
+        {
+            "status": "ALLOWED",
+            "red_lane_state": "CLEAR",
+            "authority_class": "OPERATOR",
+            "task_source": "OPERATOR",
+            "task_type": "AUDIT",
+            "risk_class": "R1_LOW",
+            "complexity_class": "LOW",
+            "runtime_impact": "LOCAL_ONLY",
+            "audit_requirement": "EMBEDDED_AUDITOR",
+            "escalation_requirement": "NONE",
+            "allowed_actions": [
+                "edit_allowlisted_files",
+                "open_pr",
+                "run_embedded_audit",
+                "inspect_runtime_code",
+            ],
+        }
+    )
+    assert restored.is_runnable()
+
+    lane_decision = decide_lane(restored, inp)
+
+    assert lane_decision.lane is LaneKind.EMBEDDED_AUDIT
+    assert "edit_allowlisted_files" not in lane_decision.allowed_actions
+    assert "open_pr" not in lane_decision.allowed_actions
+
+
+def test_public_behavior_routes_out_of_evidence_lane() -> None:
+    """Public-behavior scope must route to implementation, not evidence fallback."""
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.OPERATOR,
+        task_type=TaskType.READ_ONLY,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        touches_public_behavior=True,
+        risk_class=RiskClass.R1_LOW,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+    )
+    restored = RouteDecision.from_dict(
+        {
+            "status": "ALLOWED",
+            "red_lane_state": "CLEAR",
+            "authority_class": "OPERATOR",
+            "task_source": "OPERATOR",
+            "task_type": "READ_ONLY",
+            "risk_class": "R1_LOW",
+            "complexity_class": "LOW",
+            "runtime_impact": "READ_ONLY",
+            "audit_requirement": "SELF_CHECK",
+            "escalation_requirement": "NONE",
+            "allowed_actions": ["edit_allowlisted_files", "open_pr", "inspect_runtime_code"],
+        }
+    )
+    assert restored.is_runnable()
+
+    lane_decision = decide_lane(restored, inp)
+
+    assert lane_decision.lane is LaneKind.LOCAL_CODE_IMPLEMENTATION
+    assert lane_decision.lane is not LaneKind.READ_ONLY_EVIDENCE
+    assert "fallback_read_only_evidence" not in lane_decision.rationale
+
+
+def test_public_behavior_does_not_return_executable_evidence_with_mutating() -> None:
+    """READ_ONLY_EVIDENCE must never be executable with mutating actions."""
+    inp = RoutingClassificationInput(
+        task_type=TaskType.READ_ONLY,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        risk_class=RiskClass.R0_READ,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+    )
+    restored = RouteDecision.from_dict(
+        {
+            "status": "ALLOWED",
+            "red_lane_state": "CLEAR",
+            "authority_class": "OPERATOR",
+            "task_source": "OPERATOR",
+            "task_type": "READ_ONLY",
+            "risk_class": "R0_READ",
+            "complexity_class": "LOW",
+            "runtime_impact": "READ_ONLY",
+            "audit_requirement": "SELF_CHECK",
+            "escalation_requirement": "NONE",
+            "allowed_actions": ["edit_allowlisted_files", "open_pr"],
+        }
+    )
+    lane_decision = decide_lane(restored, inp)
+
+    if lane_decision.lane is LaneKind.READ_ONLY_EVIDENCE:
+        assert lane_decision.is_executable is False or not {
+            "edit_allowlisted_files",
+            "open_pr",
+        } & set(lane_decision.allowed_actions)
+
+
+def test_restored_unknown_audit_requirement_not_executable() -> None:
+    """Restored decisions with omitted audit_requirement (UNKNOWN) must fail closed."""
+    inp = _safe_code_change_input()
+    restored = RouteDecision.from_dict(
+        {
+            "status": "ALLOWED",
+            "red_lane_state": "CLEAR",
+            "authority_class": "OPERATOR",
+            "task_source": "OPERATOR",
+            "task_type": "CODE_CHANGE",
+            "risk_class": "R1_LOW",
+            "complexity_class": "LOW",
+            "runtime_impact": "LOCAL_ONLY",
+            "escalation_requirement": "NONE",
+            "allowed_actions": ["edit_allowlisted_files", "open_pr"],
+        }
+    )
+    assert restored.audit_requirement is AuditRequirement.UNKNOWN
+    assert restored.is_runnable()
+
+    lane_decision = decide_lane(restored, inp)
+
+    assert lane_decision.is_executable is False
+    assert "edit_allowlisted_files" not in lane_decision.allowed_actions
+
+
+def test_pr_steward_readiness_strips_mutating_requested_actions() -> None:
+    """PR_STEWARD_READINESS must not expose open_pr even when inherited on decision."""
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.OPERATOR,
+        task_type=TaskType.READ_ONLY,
+        risk_class=RiskClass.R0_READ,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        requested_actions=["pr_steward_readiness"],
+    )
+    restored = RouteDecision.from_dict(
+        {
+            "status": "ALLOWED",
+            "red_lane_state": "CLEAR",
+            "authority_class": "OPERATOR",
+            "task_source": "OPERATOR",
+            "task_type": "READ_ONLY",
+            "risk_class": "R0_READ",
+            "complexity_class": "LOW",
+            "runtime_impact": "READ_ONLY",
+            "audit_requirement": "SELF_CHECK",
+            "escalation_requirement": "NONE",
+            "allowed_actions": ["open_pr", "inspect_runtime_code"],
+        }
+    )
+    lane_decision = decide_lane(restored, inp)
+
+    assert lane_decision.lane is LaneKind.PR_STEWARD_READINESS
+    assert "open_pr" not in lane_decision.allowed_actions
+
+
 # ─────────────────────────────────────────────
 # Test 11 — External intake READ_ONLY evidence → EXTERNAL_INTAKE, not executable
 # ─────────────────────────────────────────────

--- a/tests/unit/dcp/test_lane_engine.py
+++ b/tests/unit/dcp/test_lane_engine.py
@@ -21,13 +21,10 @@ Structural guards:
 
 from __future__ import annotations
 
-import copy
 import inspect
 
-import pytest
-
 from dopemux.dcp.lane_engine import decide_lane
-from dopemux.dcp.lane_model import LaneDecision, LaneKind
+from dopemux.dcp.lane_model import LaneKind
 from dopemux.dcp.routing_classifier import (
     RoutingClassificationInput,
     classify_route,
@@ -520,6 +517,39 @@ def test_file_touching_read_only_maps_to_implementation() -> None:
     assert "fallback_read_only_evidence" not in lane_decision.rationale
 
 
+def test_pr_steward_readiness_does_not_override_mutating_scope() -> None:
+    """PR readiness must not inherit mutating scope or mutating requested actions."""
+    inp = _safe_code_change_input(
+        requested_actions=["pr_steward_readiness", "open_pr"],
+    )
+    decision = classify_route(inp)
+    assert decision.is_runnable()
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.LOCAL_CODE_IMPLEMENTATION
+    assert lane_decision.lane is not LaneKind.PR_STEWARD_READINESS
+
+
+def test_restored_decision_with_unknown_contract_fields_not_executable() -> None:
+    """Restored ALLOWED decisions with UNKNOWN defaults must fail closed."""
+    inp = _safe_code_change_input()
+    restored = RouteDecision.from_dict(
+        {
+            "status": "ALLOWED",
+            "red_lane_state": "CLEAR",
+            "authority_class": "OPERATOR",
+            "allowed_actions": ["edit_allowlisted_files"],
+        }
+    )
+    assert restored.is_runnable()
+
+    lane_decision = decide_lane(restored, inp)
+
+    assert lane_decision.is_executable is False
+    assert "edit_allowlisted_files" not in lane_decision.allowed_actions
+
+
 # ─────────────────────────────────────────────
 # Test 11 — External intake READ_ONLY evidence → EXTERNAL_INTAKE, not executable
 # ─────────────────────────────────────────────
@@ -527,24 +557,6 @@ def test_file_touching_read_only_maps_to_implementation() -> None:
 
 def test_external_intake_no_execution() -> None:
     """External-agent READ_ONLY with evidence_refs → LaneKind.EXTERNAL_INTAKE, not executable."""
-    inp = RoutingClassificationInput(
-        task_source=TaskSource.CODEX,
-        task_type=TaskType.READ_ONLY,
-        risk_class=RiskClass.R0_READ,
-        runtime_impact=RuntimeImpact.READ_ONLY,
-        complexity_class=ComplexityClass.LOW,
-        authority_class=AuthorityClass.OPERATOR,
-        has_unknown_authority=False,
-        has_conflicting_evidence=False,
-        has_stale_proof=False,
-        has_missing_proof=False,
-        evidence_refs=["proof/abc.json"],
-        touches_files=False,
-        touches_tests=False,
-        touches_docs=False,
-        is_repo_changing=False,
-        requested_actions=["pr_steward_readiness"],  # NOT present → skip row 3
-    )
     # Build an input that truly hits EXTERNAL_INTAKE row: external agent, READ_ONLY, evidence, no scope
     inp_external = RoutingClassificationInput(
         task_source=TaskSource.CODEX,

--- a/tests/unit/dcp/test_lane_engine.py
+++ b/tests/unit/dcp/test_lane_engine.py
@@ -178,6 +178,44 @@ def test_executability_gate_mirrors_is_runnable_on_forged_decision() -> None:
         )
 
 
+def test_non_runnable_lane_strips_mutating_allowed_actions_from_forged_decision() -> None:
+    """P2 regression: forged/restored RouteDecision with ALLOWED + CLEAR red-lane
+    but UNKNOWN/BLOCKED authority must not expose mutating allowed_actions even when
+    those actions are present on the source decision.
+    """
+    inp = RoutingClassificationInput(
+        task_type=TaskType.CODE_CHANGE,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+    )
+    mutating_actions = [
+        "edit_allowlisted_files",
+        "open_pr",
+        "run_embedded_audit",
+        "run_targeted_tests",
+        "capture_proof",
+    ]
+    mutating_tokens = {"edit_allowlisted_files", "open_pr", "run_embedded_audit"}
+
+    for bad_authority in (AuthorityClass.BLOCKED, AuthorityClass.UNKNOWN):
+        forged = RouteDecision.from_dict(
+            {
+                "status": "ALLOWED",
+                "red_lane_state": "CLEAR",
+                "authority_class": bad_authority.value,
+                "allowed_actions": mutating_actions,
+            }
+        )
+        lane_decision = decide_lane(forged, inp)
+
+        assert lane_decision.is_executable is False
+        for action in lane_decision.allowed_actions:
+            assert action not in mutating_tokens, (
+                f"non-runnable lane must not expose mutating action '{action}' "
+                f"for authority={bad_authority.value}"
+            )
+
+
 def test_lane_assignment_uses_normalized_enums_for_string_inputs() -> None:
     """Audit P2 (codex thread): decide_lane must classify the lane from the
     decision's NORMALIZED enums. classify_route tolerates string enum inputs;

--- a/tests/unit/dcp/test_lane_engine.py
+++ b/tests/unit/dcp/test_lane_engine.py
@@ -38,6 +38,7 @@ from dopemux.dcp.routing_model import (
     ComplexityClass,
     RedLaneState,
     RiskClass,
+    RouteDecision,
     RouteStatus,
     RuntimeImpact,
     TaskSource,
@@ -143,11 +144,38 @@ def test_red_lane_mcp_route_blocked_no_facade_bypass() -> None:
 
     assert lane_decision.lane is LaneKind.BLOCKED
     assert lane_decision.is_executable is False
-    # Must not be the Secure-MCP-Facade lane — it is never produced
-    assert lane_decision.lane is not LaneKind.BLOCKED or True  # always blocked, never facade
+    # Must not be the Secure-MCP-Facade lane — that lane is never even defined.
+    assert not hasattr(LaneKind, "SECURE_MCP_FACADE")
     # The MCP tokens must appear somewhere in forbidden_actions
     forbidden_str = " ".join(lane_decision.forbidden_actions)
     assert "mcp" in forbidden_str or "call_mcp" in forbidden_str
+
+
+def test_executability_gate_mirrors_is_runnable_on_forged_decision() -> None:
+    """Defense-in-depth (audit RISK-1): a RouteDecision with ALLOWED status +
+    CLEAR red-lane but BLOCKED/UNKNOWN authority — constructible via from_dict,
+    never emitted by classify_route — must NOT be executable. The lane gate
+    delegates to RouteDecision.is_runnable(), which fail-closes on authority.
+    """
+    inp = RoutingClassificationInput(
+        task_type=TaskType.CODE_CHANGE,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+    )
+    for bad_authority in (AuthorityClass.BLOCKED, AuthorityClass.UNKNOWN):
+        forged = RouteDecision.from_dict(
+            {
+                "status": "ALLOWED",
+                "red_lane_state": "CLEAR",
+                "authority_class": bad_authority.value,
+                "allowed_actions": ["edit_allowlisted_files"],
+            }
+        )
+        assert forged.is_runnable() is False  # is_runnable already fail-closes
+        lane_decision = decide_lane(forged, inp)
+        assert lane_decision.is_executable is False, (
+            f"forged ALLOWED + {bad_authority.value} authority must not be executable"
+        )
 
 
 # ─────────────────────────────────────────────

--- a/tests/unit/dcp/test_lane_engine.py
+++ b/tests/unit/dcp/test_lane_engine.py
@@ -478,6 +478,48 @@ def test_local_code_implementation_preserves_audit() -> None:
     )
 
 
+def test_repo_changing_read_only_without_file_touch_maps_to_implementation() -> None:
+    """Repo-changing scope must not fall through to READ_ONLY_EVIDENCE."""
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.OPERATOR,
+        task_type=TaskType.READ_ONLY,
+        risk_class=RiskClass.R1_LOW,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        is_repo_changing=True,
+        touches_files=False,
+    )
+    decision = classify_route(inp)
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.LOCAL_CODE_IMPLEMENTATION
+    assert "fallback_read_only_evidence" not in lane_decision.rationale
+
+
+def test_file_touching_read_only_maps_to_implementation() -> None:
+    """File-touching scope must not be classified as evidence-only work."""
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.OPERATOR,
+        task_type=TaskType.READ_ONLY,
+        risk_class=RiskClass.R1_LOW,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        is_repo_changing=False,
+        touches_files=True,
+    )
+    decision = classify_route(inp)
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.LOCAL_CODE_IMPLEMENTATION
+    assert "fallback_read_only_evidence" not in lane_decision.rationale
+
+
 # ─────────────────────────────────────────────
 # Test 11 — External intake READ_ONLY evidence → EXTERNAL_INTAKE, not executable
 # ─────────────────────────────────────────────

--- a/tests/unit/dcp/test_lane_engine.py
+++ b/tests/unit/dcp/test_lane_engine.py
@@ -1,0 +1,551 @@
+"""Unit tests for DMX-DCP-MODEL-ROUTING-MVP-0005 lane engine.
+
+14 required tests (numbered per spec):
+1.  test_blocked_route_maps_to_blocked_lane_not_executable
+2.  test_red_lane_mcp_route_blocked_no_facade_bypass
+3.  test_live_write_route_blocked
+4.  test_dopetask_execution_route_blocked
+5.  test_unknown_authority_route_non_mutating_not_executable
+6.  test_docs_only_safe_route_maps_to_docs_only
+7.  test_proof_only_fresh_proof_route  + test_proof_only_stale_proof_is_blocked
+8.  test_classifier_routing_task_maps_to_classifier_routing
+9.  test_test_validation_task_maps_to_test_validation
+10. test_local_code_implementation_preserves_audit
+11. test_external_intake_no_execution
+
+Structural guards:
+12. test_allowed_actions_never_widen_decision
+13. test_no_forbidden_imports_in_lane_engine_source
+14. test_lane_engine_does_not_mutate_inputs
+"""
+
+from __future__ import annotations
+
+import copy
+import inspect
+
+import pytest
+
+from dopemux.dcp.lane_engine import decide_lane
+from dopemux.dcp.lane_model import LaneDecision, LaneKind
+from dopemux.dcp.routing_classifier import (
+    RoutingClassificationInput,
+    classify_route,
+)
+from dopemux.dcp.routing_model import (
+    AuditRequirement,
+    AuthorityClass,
+    ComplexityClass,
+    RedLaneState,
+    RiskClass,
+    RouteStatus,
+    RuntimeImpact,
+    TaskSource,
+    TaskType,
+)
+
+# ─────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────
+
+FORBIDDEN_IMPORTS_IN_LANE_ENGINE = {
+    "subprocess",
+    "socket",
+    "requests",
+    "httpx",
+    "urllib.request",
+    "opencode",
+    "grok",
+    "github",
+    "docker",
+    "conport",
+    "dope_memory",
+    "dope_context",
+    "task_orchestrator",
+    "dopetask",
+    "mcp.tool",
+    "GraphQL",
+    "runner",
+    "connector",
+}
+
+# An operator input that is safe, ALLOWED, mutating, non-trivial code change.
+def _safe_code_change_input(
+    *,
+    task_type: TaskType = TaskType.CODE_CHANGE,
+    task_source: TaskSource = TaskSource.OPERATOR,
+    risk_class: RiskClass = RiskClass.R1_LOW,
+    runtime_impact: RuntimeImpact = RuntimeImpact.LOCAL_ONLY,
+    complexity_class: ComplexityClass = ComplexityClass.LOW,
+    authority_class: AuthorityClass = AuthorityClass.OPERATOR,
+    is_non_trivial: bool = True,
+    is_repo_changing: bool = True,
+    touches_files: bool = True,
+    **kwargs: object,
+) -> RoutingClassificationInput:
+    return RoutingClassificationInput(
+        task_source=task_source,
+        task_type=task_type,
+        risk_class=risk_class,
+        runtime_impact=runtime_impact,
+        complexity_class=complexity_class,
+        authority_class=authority_class,
+        is_non_trivial=is_non_trivial,
+        is_repo_changing=is_repo_changing,
+        touches_files=touches_files,
+        has_unknown_authority=False,
+        has_conflicting_evidence=False,
+        has_stale_proof=False,
+        has_missing_proof=False,
+        **kwargs,
+    )
+
+
+# ─────────────────────────────────────────────
+# Test 1 — BLOCKED route → LaneKind.BLOCKED, not executable, allowed_actions=()
+# ─────────────────────────────────────────────
+
+
+def test_blocked_route_maps_to_blocked_lane_not_executable() -> None:
+    """A stale-proof route (BLOCKED by classifier) → LaneKind.BLOCKED, not executable."""
+    inp = RoutingClassificationInput(
+        has_stale_proof=True,
+        task_type=TaskType.CODE_CHANGE,
+        is_repo_changing=True,
+    )
+    decision = classify_route(inp)
+    assert decision.status is RouteStatus.BLOCKED  # pre-condition
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.BLOCKED
+    assert lane_decision.is_executable is False
+    assert lane_decision.allowed_actions == ()
+
+
+# ─────────────────────────────────────────────
+# Test 2 — requires_mcp_call → BLOCKED, no SECURE_MCP_FACADE bypass
+# ─────────────────────────────────────────────
+
+
+def test_red_lane_mcp_route_blocked_no_facade_bypass() -> None:
+    """requires_mcp_call → RED_LANE → LaneKind.BLOCKED; no SECURE_MCP_FACADE produced."""
+    inp = RoutingClassificationInput(
+        requires_mcp_call=True,
+        task_type=TaskType.READ_ONLY,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+    )
+    decision = classify_route(inp)
+    assert decision.red_lane_state is RedLaneState.RED_LANE  # pre-condition
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.BLOCKED
+    assert lane_decision.is_executable is False
+    # Must not be the Secure-MCP-Facade lane — it is never produced
+    assert lane_decision.lane is not LaneKind.BLOCKED or True  # always blocked, never facade
+    # The MCP tokens must appear somewhere in forbidden_actions
+    forbidden_str = " ".join(lane_decision.forbidden_actions)
+    assert "mcp" in forbidden_str or "call_mcp" in forbidden_str
+
+
+# ─────────────────────────────────────────────
+# Test 3 — requires_live_write → BLOCKED, not executable
+# ─────────────────────────────────────────────
+
+
+def test_live_write_route_blocked() -> None:
+    """requires_live_write → RED_LANE → LaneKind.BLOCKED, not executable."""
+    inp = RoutingClassificationInput(
+        requires_live_write=True,
+    )
+    decision = classify_route(inp)
+    assert decision.red_lane_state is RedLaneState.RED_LANE  # pre-condition
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.BLOCKED
+    assert lane_decision.is_executable is False
+
+
+# ─────────────────────────────────────────────
+# Test 4 — requires_dopetask_execution → BLOCKED, dopetask in forbidden_actions
+# ─────────────────────────────────────────────
+
+
+def test_dopetask_execution_route_blocked() -> None:
+    """requires_dopetask_execution → RED_LANE → LaneKind.BLOCKED; dopetask in forbidden."""
+    inp = RoutingClassificationInput(
+        requires_dopetask_execution=True,
+    )
+    decision = classify_route(inp)
+    assert decision.red_lane_state is RedLaneState.RED_LANE  # pre-condition
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.BLOCKED
+    assert lane_decision.is_executable is False
+    assert any("dopetask" in action for action in lane_decision.forbidden_actions)
+
+
+# ─────────────────────────────────────────────
+# Test 5 — Unknown authority → not executable, no mutating tokens in allowed_actions
+# ─────────────────────────────────────────────
+
+
+def test_unknown_authority_route_non_mutating_not_executable() -> None:
+    """Default input (unknown authority) → not executable AND no mutating token in allowed_actions."""
+    inp = RoutingClassificationInput(
+        has_unknown_authority=True,
+        authority_class=AuthorityClass.UNKNOWN,
+    )
+    decision = classify_route(inp)
+    # status should be UNKNOWN (not BLOCKED) given no hard block
+    assert decision.status is RouteStatus.UNKNOWN
+    assert not decision.is_runnable()
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.is_executable is False
+    mutating_tokens = {"edit_allowlisted_files", "open_pr", "run_embedded_audit"}
+    for action in lane_decision.allowed_actions:
+        assert action not in mutating_tokens, (
+            f"Mutation action '{action}' must not be allowed under unknown authority"
+        )
+
+
+# ─────────────────────────────────────────────
+# Test 6 — Safe docs-only route → LaneKind.DOCS_ONLY
+# ─────────────────────────────────────────────
+
+
+def test_docs_only_safe_route_maps_to_docs_only() -> None:
+    """A safe docs-only route (OPERATOR, known dims, touches_docs, not code/test) → DOCS_ONLY."""
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.OPERATOR,
+        task_type=TaskType.DESIGN_ONLY,
+        risk_class=RiskClass.R0_READ,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        has_conflicting_evidence=False,
+        has_stale_proof=False,
+        has_missing_proof=False,
+        touches_docs=True,
+        touches_files=False,
+        touches_tests=False,
+        touches_ci=False,
+        touches_security=False,
+        touches_auth=False,
+        touches_secrets=False,
+        requires_live_write=False,
+        requires_runner_execution=False,
+        requires_connector_call=False,
+        requires_mcp_call=False,
+        requires_dopetask_execution=False,
+        requires_task_orchestrator_write=False,
+    )
+    decision = classify_route(inp)
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.DOCS_ONLY
+
+
+# ─────────────────────────────────────────────
+# Test 7a — Fresh PROOF_BUNDLE → LaneKind.PROOF_ONLY
+# ─────────────────────────────────────────────
+
+
+def test_proof_only_fresh_proof_route() -> None:
+    """A safe PROOF_BUNDLE task (no stale/missing proof, OPERATOR) → LaneKind.PROOF_ONLY."""
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.OPERATOR,
+        task_type=TaskType.PROOF_BUNDLE,
+        risk_class=RiskClass.R1_LOW,
+        runtime_impact=RuntimeImpact.LOCAL_ONLY,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        has_conflicting_evidence=False,
+        has_stale_proof=False,
+        has_missing_proof=False,
+        touches_files=True,
+        is_repo_changing=True,
+    )
+    decision = classify_route(inp)
+    # Must be ALLOWED for the lane to be PROOF_ONLY (not BLOCKED)
+    assert decision.status is RouteStatus.ALLOWED, (
+        f"expected ALLOWED for fresh-proof input, got {decision.status}"
+    )
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.PROOF_ONLY
+
+
+# ─────────────────────────────────────────────
+# Test 7b — Stale proof → LaneKind.BLOCKED (not PROOF_ONLY)
+# ─────────────────────────────────────────────
+
+
+def test_proof_only_stale_proof_is_blocked() -> None:
+    """Stale proof is BLOCKED by classifier; must map to LaneKind.BLOCKED, not PROOF_ONLY."""
+    inp = RoutingClassificationInput(
+        task_type=TaskType.PROOF_BUNDLE,
+        has_stale_proof=True,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+    )
+    decision = classify_route(inp)
+    assert decision.status is RouteStatus.BLOCKED  # pre-condition
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.BLOCKED
+    assert lane_decision.lane is not LaneKind.PROOF_ONLY
+
+
+# ─────────────────────────────────────────────
+# Test 8 — DESIGN_ONLY → LaneKind.CLASSIFIER_ROUTING
+# ─────────────────────────────────────────────
+
+
+def test_classifier_routing_task_maps_to_classifier_routing() -> None:
+    """A safe DESIGN_ONLY routing task → LaneKind.CLASSIFIER_ROUTING."""
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.OPERATOR,
+        task_type=TaskType.DESIGN_ONLY,
+        risk_class=RiskClass.R0_READ,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        has_conflicting_evidence=False,
+        has_stale_proof=False,
+        has_missing_proof=False,
+        # No docs, files, tests: pure design
+        touches_docs=False,
+        touches_files=False,
+        touches_tests=False,
+    )
+    decision = classify_route(inp)
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.CLASSIFIER_ROUTING
+
+
+# ─────────────────────────────────────────────
+# Test 9 — touches_tests + not touches_files → LaneKind.TEST_VALIDATION
+# ─────────────────────────────────────────────
+
+
+def test_test_validation_task_maps_to_test_validation() -> None:
+    """touches_tests=True, touches_files=False → LaneKind.TEST_VALIDATION."""
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.OPERATOR,
+        task_type=TaskType.CODE_CHANGE,
+        risk_class=RiskClass.R1_LOW,
+        runtime_impact=RuntimeImpact.LOCAL_ONLY,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        has_conflicting_evidence=False,
+        has_stale_proof=False,
+        has_missing_proof=False,
+        touches_tests=True,
+        touches_files=False,
+    )
+    decision = classify_route(inp)
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.TEST_VALIDATION
+
+
+# ─────────────────────────────────────────────
+# Test 10 — Non-trivial CODE_CHANGE → LOCAL_CODE_IMPLEMENTATION, audit preserved
+# ─────────────────────────────────────────────
+
+
+def test_local_code_implementation_preserves_audit() -> None:
+    """Non-trivial repo-changing CODE_CHANGE → LOCAL_CODE_IMPLEMENTATION; audit_requirement preserved."""
+    inp = _safe_code_change_input(
+        task_type=TaskType.CODE_CHANGE,
+        is_non_trivial=True,
+        is_repo_changing=True,
+        touches_files=True,
+    )
+    decision = classify_route(inp)
+    assert decision.status is RouteStatus.ALLOWED
+
+    lane_decision = decide_lane(decision, inp)
+
+    assert lane_decision.lane is LaneKind.LOCAL_CODE_IMPLEMENTATION
+    # audit_requirement must be inherited, not flattened
+    assert lane_decision.audit_requirement == decision.audit_requirement
+    assert lane_decision.audit_requirement in (
+        AuditRequirement.EMBEDDED_AUDITOR,
+        AuditRequirement.SUPERVISOR_AUDIT,
+        AuditRequirement.SELF_CHECK,
+        AuditRequirement.DISTINCT_AUDITOR,
+    )
+
+
+# ─────────────────────────────────────────────
+# Test 11 — External intake READ_ONLY evidence → EXTERNAL_INTAKE, not executable
+# ─────────────────────────────────────────────
+
+
+def test_external_intake_no_execution() -> None:
+    """External-agent READ_ONLY with evidence_refs → LaneKind.EXTERNAL_INTAKE, not executable."""
+    inp = RoutingClassificationInput(
+        task_source=TaskSource.CODEX,
+        task_type=TaskType.READ_ONLY,
+        risk_class=RiskClass.R0_READ,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        has_conflicting_evidence=False,
+        has_stale_proof=False,
+        has_missing_proof=False,
+        evidence_refs=["proof/abc.json"],
+        touches_files=False,
+        touches_tests=False,
+        touches_docs=False,
+        is_repo_changing=False,
+        requested_actions=["pr_steward_readiness"],  # NOT present → skip row 3
+    )
+    # Build an input that truly hits EXTERNAL_INTAKE row: external agent, READ_ONLY, evidence, no scope
+    inp_external = RoutingClassificationInput(
+        task_source=TaskSource.CODEX,
+        task_type=TaskType.READ_ONLY,
+        risk_class=RiskClass.R0_READ,
+        runtime_impact=RuntimeImpact.READ_ONLY,
+        complexity_class=ComplexityClass.LOW,
+        authority_class=AuthorityClass.OPERATOR,
+        has_unknown_authority=False,
+        has_conflicting_evidence=False,
+        has_stale_proof=False,
+        has_missing_proof=False,
+        evidence_refs=["proof/abc.json"],
+        touches_files=False,
+        touches_tests=False,
+        touches_docs=False,
+        is_repo_changing=False,
+        # no requested_actions that are pr_steward_readiness
+    )
+    decision = classify_route(inp_external)
+
+    lane_decision = decide_lane(decision, inp_external)
+
+    assert lane_decision.lane is LaneKind.EXTERNAL_INTAKE
+    assert lane_decision.is_executable is False
+    disallowed = {"execute", "import", "install"}
+    for action in lane_decision.allowed_actions:
+        assert action not in disallowed, (
+            f"EXTERNAL_INTAKE must not permit '{action}' in allowed_actions"
+        )
+
+
+# ─────────────────────────────────────────────
+# Test 12 — allowed_actions never widen decision.allowed_actions
+# ─────────────────────────────────────────────
+
+
+def test_allowed_actions_never_widen_decision() -> None:
+    """For a sample of routes: set(lane.allowed_actions) ⊆ set(decision.allowed_actions)."""
+    sample_inputs = [
+        RoutingClassificationInput(),  # all-default
+        RoutingClassificationInput(
+            task_source=TaskSource.OPERATOR,
+            task_type=TaskType.READ_ONLY,
+            risk_class=RiskClass.R0_READ,
+            runtime_impact=RuntimeImpact.READ_ONLY,
+            complexity_class=ComplexityClass.LOW,
+            authority_class=AuthorityClass.OPERATOR,
+            has_unknown_authority=False,
+        ),
+        _safe_code_change_input(),
+        RoutingClassificationInput(
+            task_type=TaskType.PROOF_BUNDLE,
+            task_source=TaskSource.OPERATOR,
+            risk_class=RiskClass.R1_LOW,
+            runtime_impact=RuntimeImpact.LOCAL_ONLY,
+            complexity_class=ComplexityClass.LOW,
+            authority_class=AuthorityClass.OPERATOR,
+            has_unknown_authority=False,
+            touches_files=True,
+        ),
+        RoutingClassificationInput(has_stale_proof=True),
+        RoutingClassificationInput(requires_mcp_call=True),
+    ]
+    for inp in sample_inputs:
+        decision = classify_route(inp)
+        lane_decision = decide_lane(decision, inp)
+        lane_set = set(lane_decision.allowed_actions)
+        decision_set = set(decision.allowed_actions)
+        assert lane_set <= decision_set, (
+            f"allowed_actions widened: lane={lane_set - decision_set} not in decision={decision_set}"
+        )
+
+
+# ─────────────────────────────────────────────
+# Test 13 — No forbidden imports in lane_engine source
+# ─────────────────────────────────────────────
+
+
+def test_no_forbidden_imports_in_lane_engine_source() -> None:
+    """Lane engine source must not import subprocess, socket, requests, httpx, mcp, connector, runner, etc."""
+    import dopemux.dcp.lane_engine as mod
+
+    source = inspect.getsource(mod)
+    import_lines = [
+        line.strip()
+        for line in source.splitlines()
+        if line.strip().startswith(("import ", "from "))
+    ]
+    for forbidden in FORBIDDEN_IMPORTS_IN_LANE_ENGINE:
+        for line in import_lines:
+            # Allow "runner" as a comment or string, only check import lines
+            assert forbidden not in line, (
+                f"Forbidden import '{forbidden}' found in lane_engine: {line}"
+            )
+
+
+# ─────────────────────────────────────────────
+# Test 14 — decide_lane does not mutate inputs
+# ─────────────────────────────────────────────
+
+
+def test_lane_engine_does_not_mutate_inputs() -> None:
+    """decide_lane must not mutate decision or classification_input."""
+    inp = RoutingClassificationInput(
+        is_non_trivial=True,
+        touches_tests=False,
+        evidence_refs=["ref1", "ref2"],
+        touches_files=True,
+        is_repo_changing=True,
+    )
+    decision = classify_route(inp)
+
+    # Deep-copy decision's mutable state to compare after
+    original_allowed = list(decision.allowed_actions)
+    original_forbidden = list(decision.forbidden_actions)
+    original_stop = list(decision.stop_conditions)
+    original_refs = list(inp.evidence_refs)
+    original_non_trivial = inp.is_non_trivial
+
+    decide_lane(decision, inp)
+
+    # decision not mutated
+    assert decision.allowed_actions == original_allowed
+    assert decision.forbidden_actions == original_forbidden
+    assert decision.stop_conditions == original_stop
+    # inp not mutated
+    assert inp.evidence_refs == original_refs
+    assert inp.is_non_trivial == original_non_trivial

--- a/tests/unit/dcp/test_lane_engine.py
+++ b/tests/unit/dcp/test_lane_engine.py
@@ -550,6 +550,33 @@ def test_restored_decision_with_unknown_contract_fields_not_executable() -> None
     assert "edit_allowlisted_files" not in lane_decision.allowed_actions
 
 
+def test_restored_decision_with_unknown_proof_requirement_not_executable() -> None:
+    """UNKNOWN proof requirements from restored decisions must fail closed."""
+    inp = _safe_code_change_input()
+    restored = RouteDecision.from_dict(
+        {
+            "status": "ALLOWED",
+            "red_lane_state": "CLEAR",
+            "authority_class": "OPERATOR",
+            "task_source": "OPERATOR",
+            "task_type": "CODE_CHANGE",
+            "risk_class": "R1_LOW",
+            "complexity_class": "LOW",
+            "runtime_impact": "LOCAL_ONLY",
+            "proof_requirements": ["UNKNOWN"],
+            "audit_requirement": "SELF_CHECK",
+            "escalation_requirement": "NONE",
+            "allowed_actions": ["edit_allowlisted_files"],
+        }
+    )
+    assert restored.is_runnable()
+
+    lane_decision = decide_lane(restored, inp)
+
+    assert lane_decision.is_executable is False
+    assert "edit_allowlisted_files" not in lane_decision.allowed_actions
+
+
 # ─────────────────────────────────────────────
 # Test 11 — External intake READ_ONLY evidence → EXTERNAL_INTAKE, not executable
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## What

Implements the DCP lane engine MVP (`DMX-DCP-MODEL-ROUTING-MVP-0005`): a **pure** `decide_lane(decision, classification_input) -> LaneDecision` mapping a classifier `RouteDecision` into an explicit execution lane. Architectural **sibling to `routing_backend_policy.py`** — consumes the classifier decision as the authoritative safety gate, never re-derives safety.

## Design
- `src/dopemux/dcp/lane_model.py` — `LaneKind` (10 MVP lanes) + frozen `LaneDecision`.
- `src/dopemux/dcp/lane_engine.py` — precedence-ordered lane assignment; **`is_executable` delegates to `RouteDecision.is_runnable()`** (status ALLOWED ∧ red-lane CLEAR ∧ authority OK ∧ lane executable); `allowed_actions` **inherited from the decision, never widened**; `BLOCKED`/`EXTERNAL_INTAKE` never executable; deferred lanes (`SECURE_MCP_FACADE`/runner/connector/live-write) are **not in the enum**; raw MCP stays `BLOCKED`.
- `__init__.py` — additive exports. **No new model fields; no classifier changes.**

## Tests (16, TDD)
14 required spec tests + a stale-proof companion + a defense-in-depth gate test (`test_executability_gate_mirrors_is_runnable_on_forged_decision`).

## Validation
- `compileall` PASS · `tests/unit/dcp/` + `0001` domain = **209 passed** · 0 regressions · `git diff --check` clean.

## Embedded audit — PASS_WITH_RISKS (independent Opus, adversarial)
A **5.44M-case sweep** found **zero** violations of every safety invariant: no classifier bypass, `allowed_actions ⊆ decision.allowed_actions` always, no MCP/live-write/dopetask/runner/connector executable, proof/audit/escalation inherited unchanged, inputs not mutated. Two findings — **both fixed in `5788e20fc`**:
- **RISK-1** (latent fail-closed gap): the executability gate omitted the authority check `is_runnable()` enforces; a `from_dict`-built `RouteDecision` (a real path) with `ALLOWED`+`BLOCKED`-authority round-tripped to executable → gate now delegates to `is_runnable()`; forged-decision regression test added.
- **RISK-2** (cosmetic): a tautological assertion in the MCP-facade test → now asserts `SECURE_MCP_FACADE` is never even defined.

## Commits
- `d5878f1a6` — lane engine MVP (Sonnet implementer)
- `5788e20fc` — audit-driven hardening (Opus): RISK-1 gate fix + RISK-2 test fix

## Scope
`lane_model.py`, `lane_engine.py`, `test_lane_engine.py`, `__init__.py` (additive), `task-packets/DMX-DCP-MODEL-ROUTING-MVP-0005.md`. Merge stays operator-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
