### PR TITLE
style(start): DMX-START Wave 3 UI theming (3C-4/3C-5) — routing_cli, splash, brand_lint

### DIFF
--- a/claudedocs/DMX-START-WAVE3-HANDOFF.md
+++ b/claudedocs/DMX-START-WAVE3-HANDOFF.md
@@ -1,8 +1,14 @@
 # DMX-START Wave 3 — Session Handoff
 
 **For:** a fresh thread continuing the `dopemux start` audit-and-fix program.
-**Date:** 2026-06-08 · **Branch:** `claude/modest-cartwright-340c04` · **HEAD:** `5cb020a6f`
+**Date:** 2026-06-09 · **Branch:** `claude/modest-cartwright-340c04` · **HEAD:** `7d87dfd93`
 **Worktree:** `/Users/hue/code/dopemux-mvp/.claude/worktrees/modest-cartwright-340c04`
+
+> **Orchestrator tracking:** this program is now also loaded in the task-orchestrator —
+> root `400344c8` ("DMX-START-WAVE3: remaining work") with one child per remaining task.
+> 3C-4 = `3738e834` (terminal/done). Each child's completion gate is a `proof-bundle`
+> review note. Use the `/dx:*` skills (`/dx:tree 400344c8`, `/dx:next`, `/dx:start`,
+> `/dx:complete`) to drive it, or just follow §4 below.
 
 ---
 
@@ -11,7 +17,7 @@ An in-flight **DMX-START** program: audit `dopemux start` (`src/dopemux/cli.py`)
 
 **Approved + PAL-validated plan:** `/Users/hue/.claude/plans/ok-i-need-to-mossy-twilight.md` (read it — it has the full track breakdown + advisor/PAL refinements).
 
-## 2. Work done THIS session (5 local commits, NOT pushed)
+## 2. Work done (commits are LOCAL ONLY, NOT pushed)
 | # | SHA | What | Verify |
 |---|---|---|---|
 | 3A-1 | `3aae09746` | `setup_project_config` accepts `role=`; `--role X` no longer `TypeError`s; doctrine `.claude/CLAUDE.md` preserved (no clobber) | `tests/integration/test_start_wave3.py` |
@@ -19,8 +25,11 @@ An in-flight **DMX-START** program: audit `dopemux start` (`src/dopemux/cli.py`)
 | 3C-1 | `11754e017` | Fix `gremlin.pink` (undefined in default `mint-mojo` → `[error]` in console.py/ui-logging/ui-errors); dangerous-mode `Panel`→`styled_panel` + theme tokens | brand_lint + dangerous-mode tests |
 | 3C-2 | `b29888faa` | `_start_mcp_servers_with_progress`: `style="red"`→`error`, emoji→`Glyphs.SKIPPED/ERROR/SUCCESS` | `test_cli_mcp_startup.py` |
 | 3C-3 | `5cb020a6f` | `worktree_recovery.py` menu + `worktrees_commands.py` switch guidance → themed console (markup=False on user/literal-bracket text; left stderr/data-capture/interactive plain) | `test_startup_integration.py` |
+| 3C-4 | `7d87dfd93` | `routing_cli.py`: ~106 display `click.echo`→`console.print` (markup=False on interpolated f-strings); preserved 3 json.dumps + 21 `err=True` + 2 docker snippet bodies (26 plain echos) | `pytest -k routing` (38 pass) + brand_lint |
 
-Working tree clean except `.claude/claude_config.json` (tool-managed by a hook — NOT ours; never stage it). `cli.py` is **6326 lines** (3C-1 removed a dead `from rich.panel import Panel`).
+(Plus 2 handoff-doc commits `8eb801c08`, `ebfc75800` and proof-seal `f9db43a8f`.)
+
+Working tree clean except `.claude/claude_config.json` (tool-managed by a hook — NOT ours; never stage it). `cli.py` is **6326 lines** (3C-1 removed a dead `from rich.panel import Panel`); routing_cli.py is **587 lines**.
 
 ## 3. CRITICAL gotchas (read before doing anything)
 1. **Subagents read the WRONG checkout.** Subagents resolve *relative* paths against the MAIN repo (`/Users/hue/code/dopemux-mvp`, often a different branch), NOT this worktree. The entire original audit was contaminated this way. **Every subagent prompt MUST**: `cd` to the absolute worktree path first, use absolute paths, and self-check `wc -l src/dopemux/cli.py == 6326` (STOP if it reports ~6414 = wrong checkout). See memory `feedback-subagent-worktree-path-resolution`.
@@ -30,10 +39,11 @@ Working tree clean except `.claude/claude_config.json` (tool-managed by a hook �
 5. **brand_lint gate**: run `python scripts/brand_lint.py` after every UI change — enforces the danger-hue invariant (`error`/`chip.blocker`/`severity.critical` must be red-family) + palette purity (no raw `#hex` outside approved files). All 5 commits keep it 0/0.
 6. **Don't clobber doctrine.** `configurator._create_claude_md` overwrites `.claude/claude.md` (== `.claude/CLAUDE.md` on case-insensitive macOS). 3A-1 guards the `--role` path; 3A-2 persona injection must preserve doctrine (separate file + idempotent `@import`, OR launcher injection).
 7. **`click.confirm` vs `dopemux_confirm`**: dangerous-mode tests patch `dopemux.cli.click.confirm`; `dopemux_confirm` uses `rich.prompt.Confirm` (won't be intercepted). Don't switch confirms without updating test patches.
+8. **Implementer subagents jump the orchestrator gate.** On 3C-4 the Sonnet subagent advanced its orchestrator item to `terminal` and wrote a proof-bundle note **before any commit existed**, and recorded the WRONG branch in that note. Opus had to independently re-verify, commit, and rewrite the proof note. **Supervisor keeps the gate:** the subagent implements + verifies + reports a diff ONLY; Opus reviews the diff, commits (staging only the work file), and writes/repairs the proof-bundle note with the real commit SHA. Tell the subagent explicitly: do NOT touch git, do NOT advance orchestrator items.
 
 ## 4. Remaining Wave 3 (priority order; user chose to finish 3C next)
-- **3C-4 — `routing_cli.py`** (~132 `click.echo` → themed console + `styled_table`). Offline-doable. PRESERVE `--json`/data-for-capture/`err=True` lines as plain. **(NEXT — was about to dispatch when this handoff was requested.)**
-- **3C-5 — SEV-3:** 8 unthemed `Console()` (`adhd/attention_monitor.py:19`, `adhd/context_manager.py:21`, `adhd/task_decomposer.py:22`, `update/health.py:37`, `update/rollback.py:36`, `update/manager.py:86`, `claude_tools/session_manager.py:56`, `startup_hints.py:406` test-only) → shared themed console; **`Glyphs._FALLBACK`** runtime application (Nerd-Font detection — currently dead; important because 3C-1/2/3 added `Glyphs.*` that garble on plain terminals); `splash.py` hardcoded hex; extend `brand_lint` to guard start-path files. Offline-doable.
+- **3C-4 — `routing_cli.py`** ✅ **DONE** (`7d87dfd93`, orchestrator `3738e834` terminal). ~106 display echos themed; 26 plain preserved; brand_lint 0/0; 38 routing tests green.
+- **3C-5 — SEV-3:** **(NEXT — offline-doable, unblocked by 3C-4; orchestrator `a7c36ef2`)** 8 unthemed `Console()` (`adhd/attention_monitor.py:19`, `adhd/context_manager.py:21`, `adhd/task_decomposer.py:22`, `update/health.py:37`, `update/rollback.py:36`, `update/manager.py:86`, `claude_tools/session_manager.py:56`, `startup_hints.py:406` test-only) → shared themed console; **`Glyphs._FALLBACK`** runtime application (Nerd-Font detection — currently dead; important because 3C-1/2/3 added `Glyphs.*` that garble on plain terminals); `splash.py` hardcoded hex; extend `brand_lint` to guard start-path files. Offline-doable.
 - **3E — launcher seam + Codex** (offline-doable): extract `AgentRuntimeLauncher` Protocol; **add env-invariant canary tests FIRST** (esp. `ANTHROPIC_API_KEY` *removal* in legacy proxy mode, `launcher.py:~394-402`; and `__init__` signal/`atexit` side-effects → lazy-init) before refactoring `ClaudeLauncher` (keep the 26 shape-coupled `tests/test_claude_launcher.py` green — same `mcpServers` JSON shape + flags); `get_runtime_launcher` factory + `--runtime claude|codex|copilot` (default claude), replace call sites `cli.py:577` + `cli.py:2452`; `CodexLauncher` emits `~/.codex/config.toml` `[mcp_servers]` from runtime-neutral `config.mcp_servers`. Copilot = design doc only (`mcp-proxy-config.copilot.yaml` already matches shape). Quick win: delete unreachable `logger.error` after `raise` in `_create_settings_file`.
 - **3A-2 — persona injection** (BLOCKED OFFLINE): spike first — does Claude Code honor `@import` in `.claude/CLAUDE.md` + pick up pre-launch edits? If not, inject via launcher `--settings` (then 3A-2 depends on 3E). Wire `InstructionManager.assemble_instructions(role, template)` (currently dead). Guard `_create_claude_md` from regenerating doctrine.
 - **3D — MCP robustness + full-stack e2e** (BLOCKED OFFLINE): healthcheck honesty (`pal` `exit 0`, `dope-context` `||exit 0`, `qdrant` none → real probes or rely on `DiscoveryGate`); `.env.example` add `EXA_API_KEY`/`OPENAI_WEBHOOK_SECRET`/`MYSQL_ROOT_PASSWORD`; `tests/e2e/` **tools-first, two-tier** (no-secrets smoke + secrets-required), explicit skip summary, runtime-agnostic probes.
@@ -46,8 +56,10 @@ Working tree clean except `.claude/claude_config.json` (tool-managed by a hook �
 ## 6. Resume verification (run these to confirm green base)
 ```bash
 cd /Users/hue/code/dopemux-mvp/.claude/worktrees/modest-cartwright-340c04
-git log --oneline 6632772aa..HEAD          # expect the 5 commits above
+wc -l src/dopemux/cli.py                    # MUST be 6326 (else wrong checkout — STOP)
+git log --oneline 6632772aa..HEAD          # expect 3C-1..3C-4 + 3A-1/3B-1 + handoff/proof commits; HEAD 7d87dfd93
 python -m pytest tests/integration/test_start_crit_gaps.py tests/integration/test_start_command.py tests/integration/test_start_wave3.py -q
+python -m pytest tests/ --ignore=tests/e2e -k routing -q    # 3C-4: expect 38 passed
 python scripts/brand_lint.py               # expect 0 errors / 0 warnings
 python -c "import sys; sys.path.insert(0,'src'); from dopemux import cli; print('ok')"
 ```

--- a/claudedocs/DMX-START-WAVE3-RESUME-PROMPT.md
+++ b/claudedocs/DMX-START-WAVE3-RESUME-PROMPT.md
@@ -7,13 +7,15 @@ You are continuing the DMX-START Wave 3 program (auditing/fixing/polishing `dope
 
 == ORIENT FIRST (read these, in order) ==
 Worktree (your cwd for everything): /Users/hue/code/dopemux-mvp/.claude/worktrees/modest-cartwright-340c04
-Branch: claude/modest-cartwright-340c04   HEAD should be 8eb801c08 (6 local commits, unpushed)
+Branch: claude/modest-cartwright-340c04   HEAD should be 7d87dfd93 (3C-4 committed; all local, unpushed)
+Orchestrator: root 400344c8; remaining children are queue items. 3C-4 (3738e834) = done/terminal.
 1. claudedocs/DMX-START-WAVE3-HANDOFF.md   <- full state, gotchas, commit log
 2. /Users/hue/.claude/plans/ok-i-need-to-mossy-twilight.md   <- approved + PAL-validated plan (per-track detail)
 3. claudedocs/dopemux-start-audit-2026-06-06.md   <- the PRE-FIX baseline audit (most gaps already fixed; do NOT re-fix)
 
 == HARD RULES ==
 - Model tiering: Opus supervises (decompose/review/gate); Sonnet implements; Haiku mechanical. Delegate bulk work.
+- SUPERVISOR KEEPS THE GIT + ORCHESTRATOR GATE: implementer subagents IMPLEMENT + VERIFY + return a diff ONLY. They must NOT touch git, must NOT commit, and must NOT advance/complete orchestrator items. (On 3C-4 the subagent advanced its item to terminal + wrote a proof note with the WRONG branch before any commit existed — Opus had to re-verify, commit, and repair the note.) Opus reviews the diff, commits (staging ONLY the work file), and writes/repairs the proof-bundle note with the real commit SHA.
 - SUBAGENT PATH DISCIPLINE (non-negotiable): every subagent prompt must `cd` to the absolute worktree path above, use absolute paths, and self-check `wc -l src/dopemux/cli.py` == 6326. If it reports ~6414, it is in the WRONG checkout (the main repo, a different branch) — STOP. The whole original audit was contaminated by this.
 - Failing-test-first for any code change (red -> green; mutation-check by reverting). brand_lint after every UI change: `python scripts/brand_lint.py` must stay 0 errors / 0 warnings (it enforces danger-hue invariant + palette purity).
 - Commit per increment with `(DMX-START Wave 3, <id>)` in the message + the standard Co-Authored-By footer. Stage ONLY your files — NEVER stage `.claude/claude_config.json` (a hook keeps rewriting it).
@@ -22,21 +24,20 @@ Branch: claude/modest-cartwright-340c04   HEAD should be 8eb801c08 (6 local comm
 
 == VERIFY THE BASE (run before starting) ==
 cd /Users/hue/code/dopemux-mvp/.claude/worktrees/modest-cartwright-340c04
-git log --oneline 6632772aa..HEAD   # expect: handoff + 3C-3 3C-2 3C-1 3B-1 3A-1
+wc -l src/dopemux/cli.py            # MUST be 6326 (else wrong checkout — STOP)
+git log --oneline 6632772aa..HEAD   # expect: 3C-4 (7d87dfd93) + handoff + 3C-3 3C-2 3C-1 3B-1 3A-1
 python -m pytest tests/integration/test_start_crit_gaps.py tests/integration/test_start_command.py tests/integration/test_start_wave3.py -q
+python -m pytest tests/ --ignore=tests/e2e -k routing -q   # 3C-4 guard: expect 38 passed
 python scripts/brand_lint.py
 python -c "import sys; sys.path.insert(0,'src'); from dopemux import cli; print('ok')"
 
 == REMAINING WORK (do in this order; one Sonnet increment at a time, commit each) ==
 
-3C-4  routing_cli.py UI theming  [OFFLINE-OK — DO THIS FIRST]
-  Convert ~132 raw `click.echo` in src/dopemux/routing_cli.py to the themed console
-  (`from dopemux.console import console`; `styled_table`/`Glyphs`/theme tokens from dopemux.ui.theme).
-  PRESERVE as plain: `--json` output, data-for-capture lines, `err=True` (stderr) lines. Display-only;
-  behavior/exit codes unchanged. Verify: brand_lint 0/0; `pytest tests/ --ignore=tests/e2e -k routing`;
-  import ok.
+3C-4  routing_cli.py UI theming  [DONE — commit 7d87dfd93, orchestrator 3738e834 terminal]
+  ~106 display `click.echo`→`console.print` (markup=False on interpolated f-strings); preserved 3
+  json.dumps + 21 err=True + 2 docker snippet bodies. brand_lint 0/0; 38 routing tests green. Skip.
 
-3C-5  SEV-3 cleanup  [OFFLINE-OK]
+3C-5  SEV-3 cleanup  [OFFLINE-OK — DO THIS FIRST]
   (a) Route the 8 unthemed `Console()` to the shared themed console: adhd/attention_monitor.py:19,
       adhd/context_manager.py:21, adhd/task_decomposer.py:22, update/health.py:37, update/rollback.py:36,
       update/manager.py:86, claude_tools/session_manager.py:56, startup_hints.py:406 (test-only).

--- a/scripts/brand_lint.py
+++ b/scripts/brand_lint.py
@@ -103,6 +103,18 @@ OPERATIONAL_UI_FILES = [
     "src/dopemux/ux/wizard/prompts.py",
 ]
 
+START_PATH_UI_FILES = [
+    "src/dopemux/adhd/attention_monitor.py",
+    "src/dopemux/adhd/context_manager.py",
+    "src/dopemux/adhd/task_decomposer.py",
+    "src/dopemux/update/health.py",
+    "src/dopemux/update/rollback.py",
+    "src/dopemux/update/manager.py",
+    "src/dopemux/claude_tools/session_manager.py",
+    "src/dopemux/startup_hints.py",
+    "src/dopemux/ui/splash.py",
+]
+
 APPROVED_THEME_FILES = {
     "src/dopemux/ui/theme.py",
     "src/dopemux/ui/dopemux.tcss",
@@ -247,6 +259,23 @@ def _iter_palette_violations(path: Path) -> list[str]:
     ]
 
 
+def _iter_start_path_ui_violations(path: Path) -> list[str]:
+    """Fail closed on raw UI primitives in audited start-path surfaces."""
+    errors = _iter_palette_violations(path)
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func_name = _attr_name(node.func)
+        if func_name == "Console":
+            errors.append(f"{path}:{node.lineno} raw Console() must use dopemux.console.console")
+        elif func_name == "print":
+            errors.append(f"{path}:{node.lineno} raw print() must use dopemux.console.console")
+        elif func_name == "click.echo":
+            errors.append(f"{path}:{node.lineno} raw click.echo() must use dopemux.console.console")
+    return errors
+
+
 # Danger must read RED in every theme so "failed/blocked" never downsamples to
 # ANSI magenta/pink (the cutover fix must hold across opt-in aesthetic themes
 # too, not just the default). The theme set is sourced from theme.py.THEME_NAMES
@@ -376,6 +405,12 @@ def main() -> int:
             continue
         errors.extend(_iter_operational_ui_tone_violations(path))
         errors.extend(_iter_palette_violations(path))
+
+    for rel_path in START_PATH_UI_FILES:
+        path = _existing_path(rel_path, errors)
+        if path is None:
+            continue
+        errors.extend(_iter_start_path_ui_violations(path))
 
     if errors:
         print("Brand lint failed:")

--- a/src/dopemux/adhd/attention_monitor.py
+++ b/src/dopemux/adhd/attention_monitor.py
@@ -14,9 +14,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
-from rich.console import Console
-
-console = Console()
+from dopemux.console import console
 
 
 @dataclass

--- a/src/dopemux/adhd/context_manager.py
+++ b/src/dopemux/adhd/context_manager.py
@@ -16,9 +16,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from rich.console import Console
-
-console = Console()
+from dopemux.console import console
 
 
 class ContextSnapshot:

--- a/src/dopemux/adhd/task_decomposer.py
+++ b/src/dopemux/adhd/task_decomposer.py
@@ -14,12 +14,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional
 
-from rich.console import Console
-
+from dopemux.console import console
 from dopemux.pm.models import PMTaskStatus
 from dopemux.pm.writes import pm_transition_work_item
-
-console = Console()
 
 
 class TaskPriority(str, Enum):

--- a/src/dopemux/claude_tools/session_manager.py
+++ b/src/dopemux/claude_tools/session_manager.py
@@ -19,8 +19,8 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional
 from datetime import datetime, timedelta
 
-from rich.console import Console
 from rich.table import Table
+from dopemux.console import console
 from dopemux.ui.prompts import dopemux_prompt, dopemux_confirm
 from rich import box
 
@@ -53,7 +53,7 @@ class SessionManager:
         """
         self.context_manager = context_manager
         self.workspace_id = workspace_id or os.getcwd()
-        self.console = Console()
+        self.console = console
         self.session_index = {}
         self.conport_available = self._check_conport_availability()
 

--- a/src/dopemux/routing_cli.py
+++ b/src/dopemux/routing_cli.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import yaml
 
+from dopemux.console import console
 from dopemux.launchd_services import LaunchdServiceManager
 from dopemux.routing_config import RoutingConfig, RoutingConfigError
 from dopemux.freeflow import (
@@ -47,17 +48,17 @@ def freeflow_doctor(offline: bool, json_output: bool):
             click.echo(json.dumps(report, indent=2, sort_keys=True))
             return
 
-        click.echo("Freeflow Strict-Free Router Doctor")
-        click.echo("=" * 50)
-        click.echo(f"Enabled: {report['enabled']}")
-        click.echo(f"Mode: {report['mode']}")
-        click.echo(f"Ledger: {report['ledger_path']}")
+        console.print("Freeflow Strict-Free Router Doctor")
+        console.print("=" * 50)
+        console.print(f"Enabled: {report['enabled']}", markup=False)
+        console.print(f"Mode: {report['mode']}", markup=False)
+        console.print(f"Ledger: {report['ledger_path']}", markup=False)
         for key, value in report["summary"].items():
-            click.echo(f"{key}: {value}")
+            console.print(f"{key}: {value}", markup=False)
         if report["issues"]:
-            click.echo("\nIssues:")
+            console.print("\nIssues:")
             for issue in report["issues"]:
-                click.echo(f"  - {issue}")
+                console.print(f"  - {issue}", markup=False)
     except RoutingConfigError as e:
         click.echo(f"Error: {e}", err=True)
         raise SystemExit(2)
@@ -72,10 +73,10 @@ def freeflow_quota(json_output: bool):
     if json_output:
         click.echo(json.dumps(report, indent=2, sort_keys=True))
         return
-    click.echo(f"Ledger: {report['ledger_path']}")
-    click.echo(f"Generated: {report['generated_at']}")
-    click.echo(f"Buckets: {len(report['buckets'])}")
-    click.echo(f"Cooldowns: {len(report['cooldowns'])}")
+    console.print(f"Ledger: {report['ledger_path']}", markup=False)
+    console.print(f"Generated: {report['generated_at']}", markup=False)
+    console.print(f"Buckets: {len(report['buckets'])}")
+    console.print(f"Cooldowns: {len(report['cooldowns'])}")
 
 
 @freeflow.command("routes")
@@ -96,7 +97,7 @@ def freeflow_routes(json_output: bool):
             else:
                 reason = route["blocked_reason"] or route["paid_cap_blocked_reason"]
                 status = f"blocked:{reason}"
-            click.echo(f"{route['name']} -> {route['effective_provider']} ({status})")
+            console.print(f"{route['name']} -> {route['effective_provider']} ({status})", markup=False)
     except RoutingConfigError as e:
         click.echo(f"Error: {e}", err=True)
         raise SystemExit(2)
@@ -114,18 +115,18 @@ def install(force: bool):
             status = manager.get_service_status()
             if (status.get("litellm", {}).get("status") == "running" or 
                 status.get("ccr", {}).get("status") == "running"):
-                click.echo("⚠️  Services appear to be already installed. Use --force to reinstall.")
+                console.print("⚠️  Services appear to be already installed. Use --force to reinstall.")
                 return
 
-        click.echo("🛠️  Installing Dopemux launchd services...")
+        console.print("🛠️  Installing Dopemux launchd services...")
         manager.install_services()
-        click.echo("✅ Services installed successfully!")
+        console.print("✅ Services installed successfully!")
 
         # Show status
         status = manager.get_service_status()
-        click.echo("\n📊 Service Status:")
+        console.print("\n📊 Service Status:")
         for service, info in status.items():
-            click.echo(f"  {service}: {info['status']}")
+            console.print(f"  {service}: {info['status']}", markup=False)
 
     except Exception as e:
         logger.error(f"Failed to install services: {e}")
@@ -138,9 +139,9 @@ def start():
     """Start all launchd services."""
     try:
         manager = LaunchdServiceManager.get_instance()
-        click.echo("🚀 Starting Dopemux launchd services...")
+        console.print("🚀 Starting Dopemux launchd services...")
         manager.start_services()
-        click.echo("✅ Services started!")
+        console.print("✅ Services started!")
     except Exception as e:
         logger.error(f"Failed to start services: {e}")
         click.echo(f"❌ Error: {e}", err=True)
@@ -152,9 +153,9 @@ def stop():
     """Stop all launchd services."""
     try:
         manager = LaunchdServiceManager.get_instance()
-        click.echo("⏹️  Stopping Dopemux launchd services...")
+        console.print("⏹️  Stopping Dopemux launchd services...")
         manager.stop_services()
-        click.echo("✅ Services stopped!")
+        console.print("✅ Services stopped!")
     except Exception as e:
         logger.error(f"Failed to stop services: {e}")
         click.echo(f"❌ Error: {e}", err=True)
@@ -166,9 +167,9 @@ def reload():
     """Reload all launchd services."""
     try:
         manager = LaunchdServiceManager.get_instance()
-        click.echo("🔄 Reloading Dopemux launchd services...")
+        console.print("🔄 Reloading Dopemux launchd services...")
         manager.reload_services()
-        click.echo("✅ Services reloaded!")
+        console.print("✅ Services reloaded!")
     except Exception as e:
         logger.error(f"Failed to reload services: {e}")
         click.echo(f"❌ Error: {e}", err=True)
@@ -184,22 +185,22 @@ def api(restart: bool):
         config = manager.routing_config.load()
 
         if config.get("mode") == "api":
-            click.echo("ℹ️  Already in API mode")
+            console.print("ℹ️  Already in API mode")
             return
 
         _set_routing_mode(manager.routing_config.config_path, "api")
-        click.echo("✅ Switched to API mode (external models via LiteLLM)")
+        console.print("✅ Switched to API mode (external models via LiteLLM)")
 
         _set_claude_base_url("http://127.0.0.1:4010")
-        click.echo("✅ Updated Claude Code baseUrl → http://127.0.0.1:4010")
+        console.print("✅ Updated Claude Code baseUrl → http://127.0.0.1:4010")
 
         if restart:
-            click.echo("🔄 Restarting services...")
+            console.print("🔄 Restarting services...")
             manager.routing_config._loaded = False
             manager.routing_config.load()
             manager._regenerate_configs()
             manager.reload_services()
-            click.echo("✅ Services restarted!")
+            console.print("✅ Services restarted!")
 
     except Exception as e:
         logger.error(f"Failed to switch to API mode: {e}")
@@ -215,14 +216,14 @@ def direct():
         config = manager.routing_config.load()
 
         if config.get("mode") == "subscription":
-            click.echo("ℹ️  Already in subscription (direct) mode")
+            console.print("ℹ️  Already in subscription (direct) mode")
             return
 
         _set_routing_mode(manager.routing_config.config_path, "subscription")
-        click.echo("✅ Switched to subscription mode (direct to Anthropic)")
+        console.print("✅ Switched to subscription mode (direct to Anthropic)")
 
         _set_claude_base_url("https://api.anthropic.com")
-        click.echo("✅ Updated Claude Code baseUrl → https://api.anthropic.com")
+        console.print("✅ Updated Claude Code baseUrl → https://api.anthropic.com")
 
     except Exception as e:
         logger.error(f"Failed to switch to direct mode: {e}")
@@ -235,9 +236,9 @@ def uninstall():
     """Uninstall all launchd services."""
     try:
         manager = LaunchdServiceManager.get_instance()
-        click.echo("🗑️  Uninstalling Dopemux launchd services...")
+        console.print("🗑️  Uninstalling Dopemux launchd services...")
         manager.uninstall_services()
-        click.echo("✅ Services uninstalled!")
+        console.print("✅ Services uninstalled!")
     except Exception as e:
         logger.error(f"Failed to uninstall services: {e}")
         click.echo(f"❌ Error: {e}", err=True)
@@ -251,35 +252,35 @@ def status():
         manager = LaunchdServiceManager.get_instance()
         status = manager.get_service_status()
 
-        click.echo("📊 Dopemux Launchd Service Status:")
-        click.echo("=" * 50)
+        console.print("📊 Dopemux Launchd Service Status:")
+        console.print("=" * 50)
 
         for service_name, service_info in status.items():
-            click.echo(f"\n{service_name.upper()}:")
-            click.echo(f"  Status: {service_info['status']}")
+            console.print(f"\n{service_name.upper()}:", markup=False)
+            console.print(f"  Status: {service_info['status']}", markup=False)
             if service_info.get('details'):
-                click.echo(f"  Details: {service_info['details'][:100]}...")
+                console.print(f"  Details: {service_info['details'][:100]}...", markup=False)
 
         # Check health if services are running
         health = manager.check_health()
 
         # Check for config errors first
         if "config" in health:
-            click.echo("\n🏥 Service Health:")
-            click.echo("-" * 50)
-            click.echo(f"❌ config: {health['config']['status']}")
-            click.echo(f"   Error: {health['config']['error']}")
+            console.print("\n🏥 Service Health:")
+            console.print("-" * 50)
+            console.print(f"❌ config: {health['config']['status']}", markup=False)
+            console.print(f"   Error: {health['config']['error']}", markup=False)
             return
 
-        click.echo("\n🏥 Service Health:")
-        click.echo("-" * 50)
+        console.print("\n🏥 Service Health:")
+        console.print("-" * 50)
 
         for service_name, health_info in health.items():
             status_emoji = "✅" if health_info['status'] == 'healthy' else "❌"
             port_info = f" (127.0.0.1:{health_info.get('port', 'unknown')})" if health_info.get('port') else ""
-            click.echo(f"{status_emoji} {service_name}: {health_info['status']}{port_info}")
+            console.print(f"{status_emoji} {service_name}: {health_info['status']}{port_info}", markup=False)
             if health_info.get('error'):
-                click.echo(f"   Error: {health_info['error']}")
+                console.print(f"   Error: {health_info['error']}", markup=False)
 
     except Exception as e:
         logger.error(f"Failed to get service status: {e}")
@@ -303,7 +304,7 @@ def health():
         try:
             mode = manager.routing_config.config.get('mode', 'subscription')
             if mode == 'subscription':
-                click.echo("ℹ️  Routing mode is 'subscription' - service health checks not applicable")
+                console.print("ℹ️  Routing mode is 'subscription' - service health checks not applicable")
                 raise SystemExit(0)
         except Exception:
             # If we can't determine mode, assume we need to check services
@@ -319,7 +320,7 @@ def health():
         if unhealthy_services:
             raise SystemExit(1)
         else:
-            click.echo("✅ All services healthy")
+            console.print("✅ All services healthy")
             raise SystemExit(0)
 
     except Exception as e:
@@ -335,21 +336,21 @@ def config():
         manager = LaunchdServiceManager.get_instance()
         config = manager.routing_config.load()
 
-        click.echo("📋 Dopemux Routing Configuration:")
-        click.echo("=" * 50)
-        click.echo(f"Mode: {config.get('mode', 'N/A')}")
-        click.echo(f"LiteLLM Port: {config.get('ports', {}).get('litellm', 'N/A')}")
-        click.echo(f"CCR Port: {config.get('ports', {}).get('ccr', 'N/A')}")
+        console.print("📋 Dopemux Routing Configuration:")
+        console.print("=" * 50)
+        console.print(f"Mode: {config.get('mode', 'N/A')}", markup=False)
+        console.print(f"LiteLLM Port: {config.get('ports', {}).get('litellm', 'N/A')}", markup=False)
+        console.print(f"CCR Port: {config.get('ports', {}).get('ccr', 'N/A')}", markup=False)
 
         providers = config.get('providers', [])
-        click.echo(f"\nProviders ({len(providers)}):")
+        console.print(f"\nProviders ({len(providers)}):")
         for provider in providers:
-            click.echo(f"  - {provider['name']} ({provider.get('label', 'N/A')})")
+            console.print(f"  - {provider['name']} ({provider.get('label', 'N/A')})", markup=False)
 
         models = config.get('models', [])
-        click.echo(f"\nModels ({len(models)}):")
+        console.print(f"\nModels ({len(models)}):")
         for model in models:
-            click.echo(f"  - {model['name']} (via {model['provider']})")
+            console.print(f"  - {model['name']} (via {model['provider']})", markup=False)
 
     except Exception as e:
         logger.error(f"Failed to load routing config: {e}")
@@ -364,35 +365,35 @@ def doctor():
         manager = LaunchdServiceManager.get_instance()
         audit = manager.routing_config.audit_alias_contract()
 
-        click.echo("🩺 Routing Alias Contract Doctor")
-        click.echo("=" * 50)
-        click.echo(f"Config:   {audit['config_path']}")
-        click.echo(f"Template: {audit['template_path']}")
+        console.print("🩺 Routing Alias Contract Doctor")
+        console.print("=" * 50)
+        console.print(f"Config:   {audit['config_path']}", markup=False)
+        console.print(f"Template: {audit['template_path']}", markup=False)
 
         if not audit["stale"]:
-            click.echo("\n✅ Alias contract matches the repo-owned template.")
+            console.print("\n✅ Alias contract matches the repo-owned template.")
             return
 
-        click.echo("\n❌ Stale routing alias contract detected.")
+        console.print("\n❌ Stale routing alias contract detected.")
 
         missing = audit["missing_aliases"]
         if missing:
-            click.echo("\nMissing aliases:")
+            console.print("\nMissing aliases:")
             for alias, target in missing.items():
-                click.echo(f"  - {alias}: expected {target}")
+                console.print(f"  - {alias}: expected {target}", markup=False)
 
         mismatched = audit["mismatched_aliases"]
         if mismatched:
-            click.echo("\nMismatched aliases:")
+            console.print("\nMismatched aliases:")
             for alias, values in mismatched.items():
-                click.echo(
-                    f"  - {alias}: expected {values['expected']}, found {values['actual']}"
+                console.print(
+                    f"  - {alias}: expected {values['expected']}, found {values['actual']}", markup=False
                 )
 
-        click.echo("\nNext steps:")
-        click.echo("  • Preview repair: dopemux routing repair-aliases")
-        click.echo("  • Apply repair: dopemux routing repair-aliases --apply")
-        click.echo("  • Inspect config: dopemux routing config")
+        console.print("\nNext steps:")
+        console.print("  • Preview repair: dopemux routing repair-aliases")
+        console.print("  • Apply repair: dopemux routing repair-aliases --apply")
+        console.print("  • Inspect config: dopemux routing config")
         raise SystemExit(1)
     except RoutingConfigError as e:
         click.echo(f"❌ Error: {e}", err=True)
@@ -415,30 +416,30 @@ def repair_aliases(apply: bool):
         manager = LaunchdServiceManager.get_instance()
         audit = manager.routing_config.audit_alias_contract()
 
-        click.echo("🔧 Routing Alias Contract Repair")
-        click.echo("=" * 50)
+        console.print("🔧 Routing Alias Contract Repair")
+        console.print("=" * 50)
 
         if not audit["stale"]:
-            click.echo("✅ No alias repair needed.")
+            console.print("✅ No alias repair needed.")
             return
 
-        click.echo("Planned alias updates:")
+        console.print("Planned alias updates:")
         for alias, target in audit["missing_aliases"].items():
-            click.echo(f"  - add {alias}: {target}")
+            console.print(f"  - add {alias}: {target}", markup=False)
         for alias, values in audit["mismatched_aliases"].items():
-            click.echo(
-                f"  - set {alias}: {values['actual']} -> {values['expected']}"
+            console.print(
+                f"  - set {alias}: {values['actual']} -> {values['expected']}", markup=False
             )
 
         if not apply:
-            click.echo("\nDry run only. No files changed.")
-            click.echo("Run `dopemux routing repair-aliases --apply` to write the repair.")
+            console.print("\nDry run only. No files changed.")
+            console.print("Run `dopemux routing repair-aliases --apply` to write the repair.")
             return
 
         result = manager.routing_config.repair_alias_contract()
-        click.echo("\n✅ Alias contract repaired.")
-        click.echo(f"Backup: {result['backup_path']}")
-        click.echo(f"Updated: {manager.routing_config.config_path}")
+        console.print("\n✅ Alias contract repaired.")
+        console.print(f"Backup: {result['backup_path']}", markup=False)
+        console.print(f"Updated: {manager.routing_config.config_path}", markup=False)
     except RoutingConfigError as e:
         click.echo(f"❌ Error: {e}", err=True)
         raise SystemExit(2)
@@ -455,11 +456,11 @@ def docker():
         manager = LaunchdServiceManager.get_instance()
         snippets = manager.generate_docker_compose_snippets()
 
-        click.echo("🐳 Docker Compose Snippets:")
-        click.echo("=" * 50)
-        click.echo("\nLiteLLM Service:")
+        console.print("🐳 Docker Compose Snippets:")
+        console.print("=" * 50)
+        console.print("\nLiteLLM Service:")
         click.echo(snippets['litellm'])
-        click.echo("\nCCR Service:")
+        console.print("\nCCR Service:")
         click.echo(snippets['ccr'])
 
     except Exception as e:
@@ -473,15 +474,15 @@ def sync_keys():
     """Sync API keys from current environment to routing.env."""
     try:
         manager = LaunchdServiceManager.get_instance()
-        click.echo("🔑 Syncing API keys from environment...")
+        console.print("🔑 Syncing API keys from environment...")
         manager.sync_keys_from_environment()
-        click.echo("✅ API keys synced successfully!")
+        console.print("✅ API keys synced successfully!")
 
         # Show what was synced
         env_path = manager.DOPEMUX_DIR / "routing.env"
         if env_path.exists():
-            click.echo("\n📋 Synced keys in:")
-            click.echo(f"   {env_path}")
+            console.print("\n📋 Synced keys in:")
+            console.print(f"   {env_path}", markup=False)
 
     except Exception as e:
         logger.error(f"Failed to sync keys: {e}")
@@ -496,7 +497,7 @@ def repair(max_passes: int, allow_sync_keys: bool):
     """Attempt to repair routing services."""
     try:
         manager = LaunchdServiceManager.get_instance()
-        click.echo("🔧 Attempting to repair routing services...")
+        console.print("🔧 Attempting to repair routing services...")
 
         # Run repair
         repair_result = manager.repair(
@@ -506,36 +507,36 @@ def repair(max_passes: int, allow_sync_keys: bool):
 
         # Show results
         if repair_result.get("healthy", False):
-            click.echo("✅ Routing services repaired successfully!")
+            console.print("✅ Routing services repaired successfully!")
 
             # Show final health
             health = repair_result["health"]
-            click.echo("\n🏥 Final Health Status:")
+            console.print("\n🏥 Final Health Status:")
             for service, info in health.items():
                 if service == "mode":
                     continue
                 status_emoji = "✅" if info.get("status") == "healthy" else "❌"
-                click.echo(f"  {status_emoji} {service}: {info.get('status')}")
+                console.print(f"  {status_emoji} {service}: {info.get('status')}", markup=False)
         else:
-            click.echo("❌ Failed to repair routing services")
+            console.print("❌ Failed to repair routing services")
 
             # Show repair attempts
-            click.echo("\n📋 Repair Attempts:")
+            console.print("\n📋 Repair Attempts:")
             for attempt in repair_result.get("attempts", []):
                 status = "✅" if attempt.get("result", {}).get("ok") else "❌"
-                click.echo(f"  {status} Pass {attempt['pass']}: {attempt['action']}")
+                console.print(f"  {status} Pass {attempt['pass']}: {attempt['action']}", markup=False)
 
             # Show diagnostics
-            click.echo("\n🔍 Diagnostics:")
+            console.print("\n🔍 Diagnostics:")
             log_paths = manager._get_log_paths()
-            click.echo(f"  LiteLLM launchd log: {log_paths['litellm_launchd']}")
-            click.echo(f"  CCR launchd log: {log_paths['ccr_launchd']}")
-            click.echo(f"  Latest LiteLLM log: {log_paths['litellm_latest']}")
+            console.print(f"  LiteLLM launchd log: {log_paths['litellm_launchd']}", markup=False)
+            console.print(f"  CCR launchd log: {log_paths['ccr_launchd']}", markup=False)
+            console.print(f"  Latest LiteLLM log: {log_paths['litellm_latest']}", markup=False)
 
-            click.echo("\n💡 Next steps:")
-            click.echo("  • Check logs with: tail -f ~/.dopemux/logs/litellm_launchd.log")
-            click.echo("  • Run health check: dopemux routing health")
-            click.echo("  • Check service status: dopemux routing status")
+            console.print("\n💡 Next steps:")
+            console.print("  • Check logs with: tail -f ~/.dopemux/logs/litellm_launchd.log")
+            console.print("  • Run health check: dopemux routing health")
+            console.print("  • Check service status: dopemux routing status")
 
             raise SystemExit(1)
 

--- a/src/dopemux/startup_hints.py
+++ b/src/dopemux/startup_hints.py
@@ -401,9 +401,8 @@ def create_feature_list_banner() -> Panel:
 
 if __name__ == "__main__":
     # Test the banner
-    from rich.console import Console
+    from dopemux.console import console
     
-    console = Console()
     console.print()
     console.print(create_hint_banner())
     console.print()

--- a/src/dopemux/ui/splash.py
+++ b/src/dopemux/ui/splash.py
@@ -31,21 +31,21 @@ DOPEMUX_STARTUP_BANNER = """\
 
 def _banner_markup() -> str:
     """Return Rich markup for the branded startup banner."""
-    frame = "#00ffff"
+    frame = "mint"
     logo = [
-        "#00ffff",
-        "#00f0ff",
-        "#00e1ff",
-        "#00d2ff",
-        "#5aaaff",
-        "#8c82ff",
-        "#b478ff",
+        "mint",
+        "mint.bright",
+        "info",
+        "mint.soft",
+        "violet",
+        "magenta",
+        "violet",
     ]
-    drip_bar = "#78b4ff"
-    drip_tick = "#b478ff"
-    tag_core = "#ff50dc"
-    tag_mesh = "#b478ff"
-    tag_operator = "#00ffff"
+    drip_bar = "info"
+    drip_tick = "violet"
+    tag_core = "magenta"
+    tag_mesh = "violet"
+    tag_operator = "mint"
 
     return "\n".join(
         [

--- a/src/dopemux/ui/theme.py
+++ b/src/dopemux/ui/theme.py
@@ -338,11 +338,11 @@ class Glyphs:
 
     # ── Fallback map (glyph -> ascii) ──
     _FALLBACK = {
-        SUCCESS: "\u2713",  # ✓
-        ERROR: "\u2717",  # ✗
+        SUCCESS: "OK",
+        ERROR: "X",
         WARNING: "!",
         INFO: "i",
-        RUNNING: "\u25b6",  # ▶
+        RUNNING: ">",
         PENDING: "~",
         BLOCKED: "#",
         SKIPPED: "-",
@@ -356,7 +356,38 @@ class Glyphs:
         ARROW_RIGHT: ">",
         ARROW_DOWN: "v",
         PROMPT: ">",
+        DOCKER: "docker",
+        SERVER: "server",
+        DATABASE: "db",
+        BRAND_MARK: "--- O ---",
+        SECTION_RULE: "---",
     }
+
+
+_GLYPH_ATTRS = tuple(
+    name
+    for name, value in vars(Glyphs).items()
+    if name.isupper() and isinstance(value, str)
+)
+_PRIMARY_GLYPHS = {name: getattr(Glyphs, name) for name in _GLYPH_ATTRS}
+
+
+def _glyph_fallback_requested(mode: RenderMode | None = None) -> bool:
+    """Return whether Glyphs should render as ASCII-safe fallback strings."""
+    override = os.environ.get("DOPEMUX_GLYPHS", "").strip().lower()
+    if override in {"ascii", "fallback", "plain"}:
+        return True
+    if override in {"nerd", "rich", "primary"}:
+        return False
+    return (mode or _detect_render_mode()) == RenderMode.PLAIN
+
+
+def _apply_glyph_render_mode(mode: RenderMode | None = None) -> None:
+    """Apply render-mode-aware glyph fallbacks to Glyphs class attributes."""
+    use_fallback = _glyph_fallback_requested(mode)
+    for name, primary in _PRIMARY_GLYPHS.items():
+        value = Glyphs._FALLBACK.get(primary, primary) if use_fallback else primary
+        setattr(Glyphs, name, value)
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -432,6 +463,7 @@ def get_render_mode() -> RenderMode:
     global _cached_render_mode
     if _cached_render_mode is None:
         _cached_render_mode = _detect_render_mode()
+    _apply_glyph_render_mode(_cached_render_mode)
     return _cached_render_mode
 
 
@@ -440,6 +472,7 @@ def set_render_mode(mode: RenderMode) -> None:
     global _cached_render_mode
     _cached_render_mode = mode
     os.environ["DOPEMUX_RENDER_MODE"] = mode.value
+    _apply_glyph_render_mode(mode)
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -458,6 +491,7 @@ def create_console(**kwargs: Any) -> Console:
         A :class:`rich.console.Console` configured with :data:`DOPEMUX_THEME`.
     """
     mode = _detect_render_mode()
+    _apply_glyph_render_mode(mode)
     no_color = mode == RenderMode.PLAIN
     return Console(
         theme=DOPEMUX_THEME,

--- a/src/dopemux/update/health.py
+++ b/src/dopemux/update/health.py
@@ -15,7 +15,8 @@ from urllib.parse import urlparse
 
 import httpx
 import docker
-from rich.console import Console
+
+from dopemux.console import console
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class HealthChecker:
 
     def __init__(self, project_root: Path):
         self.project_root = project_root
-        self.console = Console()
+        self.console = console
         self.docker_client = None
         self.timeout = 30  # seconds
 

--- a/src/dopemux/update/manager.py
+++ b/src/dopemux/update/manager.py
@@ -18,7 +18,7 @@ from enum import Enum
 
 import click
 import yaml
-from rich.console import Console
+from dopemux.console import console
 from dopemux.ui.progress import branded_progress
 from rich.progress import Progress, TaskID
 
@@ -83,7 +83,7 @@ class UpdateManager:
                  project_root: Optional[Path] = None):
         self.config = config or UpdateConfig()
         self.project_root = project_root or Path.cwd()
-        self.console = Console()
+        self.console = console
 
         # Core components
         self.progress = ProgressTracker(self.console)

--- a/src/dopemux/update/rollback.py
+++ b/src/dopemux/update/rollback.py
@@ -13,8 +13,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Union
 
-from rich.console import Console
 from rich.panel import Panel
+from dopemux.console import console
 from dopemux.ui.prompts import dopemux_confirm
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,7 @@ class RollbackManager:
 
     def __init__(self, project_root: Path):
         self.project_root = project_root
-        self.console = Console()
+        self.console = console
 
         # Directory structure
         self.backup_dir = project_root / ".dopemux" / "backups"

--- a/tests/test_ui_splash.py
+++ b/tests/test_ui_splash.py
@@ -1,5 +1,5 @@
 from dopemux.ui.splash import DOPEMUX_STARTUP_BANNER, render_startup_banner
-from dopemux.ui.theme import RenderMode
+from dopemux.ui.theme import Glyphs, RenderMode, set_render_mode
 
 
 def test_render_startup_banner_plain_mode_emits_plain_banner_text() -> None:
@@ -15,3 +15,20 @@ def test_render_startup_banner_rich_mode_preserves_banner_text() -> None:
     assert "[ deterministic core ]" in banner.plain
     assert "[ memory mesh ]" in banner.plain
     assert "[ operator ]" in banner.plain
+
+
+def test_glyphs_use_ascii_fallback_in_plain_mode() -> None:
+    set_render_mode(RenderMode.PLAIN)
+
+    public_glyphs = [
+        value
+        for name, value in vars(Glyphs).items()
+        if name.isupper() and isinstance(value, str)
+    ]
+
+    try:
+        assert Glyphs.SUCCESS != "\uf058"
+        assert Glyphs.SUCCESS == "OK"
+        assert all(value.isascii() for value in public_glyphs)
+    finally:
+        set_render_mode(RenderMode.RICH)

--- a/tests/unit/test_brand_lint.py
+++ b/tests/unit/test_brand_lint.py
@@ -44,3 +44,25 @@ def test_brand_lint_helpers_catch_merge_markers_and_raw_hex(tmp_path: Path) -> N
     assert "merge conflict markers detected" in merge_errors[0]
     assert palette_errors
     assert "#ff00ff" in palette_errors[0]
+
+
+def test_brand_lint_helpers_catch_start_path_raw_ui_surfaces(tmp_path: Path) -> None:
+    module = _load_brand_lint_module()
+
+    py_file = tmp_path / "start_path.py"
+    py_file.write_text(
+        "from rich.console import Console\n"
+        "import click\n"
+        'console = Console()\n'
+        'print("raw")\n'
+        'click.echo("raw")\n'
+        'ACCENT = "#ff00ff"\n',
+        encoding="utf-8",
+    )
+
+    errors = module._iter_start_path_ui_violations(py_file)
+
+    assert any("raw Console()" in error for error in errors)
+    assert any("raw print()" in error for error in errors)
+    assert any("raw click.echo()" in error for error in errors)
+    assert any("#ff00ff" in error for error in errors)


### PR DESCRIPTION
Recovered unmerged work from the `claude/modest-cartwright-340c04` worktree during the 2026-06-16 worktree reconciliation (it had no PR).

## Scope (3 commits, 16 files / ~278 lines)
- `style(routing)`: theme `routing_cli.py` console output (DMX-START Wave 3, 3C-4)
- `docs(handoff)`: update DMX-START Wave 3 handoff for 3C-4
- `style(start)`: finish SEV-3 UI cleanup (DMX-START Wave 3, 3C-5)

Touches `src/dopemux/routing_cli.py`, `ui/splash.py`, `ui/theme.py`, `scripts/brand_lint.py`, adhd/* and update/* surfaces, plus `tests/test_ui_splash.py` and `tests/unit/test_brand_lint.py`.

## Status
- Draft — branch predates current main; **needs rebase onto `origin/main`** before merge.
- CI will validate on push.

🤖 Recovered & opened during worktree reconciliation.