### PR TITLE
DMX-COCKPIT-FONTS-102: Editor proportional Nerd glyphs + stable family name

### DIFF
--- a/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/.gitignore
+++ b/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/.gitignore
@@ -4,3 +4,10 @@
 *.otf
 *.woff
 *.woff2
+
+# Local build outputs from build-dopemux-fonts.sh / patch-nerd-font.sh.
+/out/
+/nerd-font/
+/.dopemux-build-stage/
+/.dopemux-nerd-font-patch/
+.dopemux-built-fonts.txt*

--- a/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh
+++ b/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh
@@ -22,17 +22,41 @@ PLAN_SRC="$SCRIPT_DIR/private-build-plans.toml"
 IOSEVKA_TARGET="${IOSEVKA_TARGET:-ttf}"
 BUILD_MANIFEST="$OUT_DIR/.dopemux-built-fonts.txt"
 BUILD_MANIFEST_TMP="$OUT_DIR/.dopemux-built-fonts.txt.tmp"
+BUILD_STAGE="$OUT_DIR/.dopemux-build-stage"
+PLAN_DST="$IOSEVKA_REPO/private-build-plans.toml"
+PLAN_BACKUP=""
+PLAN_HAD_ORIGINAL=0
 
 # Build plans defined in private-build-plans.toml.
-PLANS=(IosevkaDopemuxTerm IosevkaDopemuxEditor)
+PLANS=(DopemuxTerm DopemuxEditor)
+
+cleanup() {
+  status=$?
+  rm -f "$BUILD_MANIFEST_TMP"
+  rm -rf "$BUILD_STAGE"
+  if [[ -n "$PLAN_BACKUP" ]]; then
+    if [[ "$PLAN_HAD_ORIGINAL" -eq 1 ]]; then
+      cp "$PLAN_BACKUP" "$PLAN_DST"
+    else
+      rm -f "$PLAN_DST"
+    fi
+    rm -f "$PLAN_BACKUP"
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
 
 [[ -d "$IOSEVKA_REPO" ]] || { printf 'Missing IOSEVKA_REPO directory: %s\n' "$IOSEVKA_REPO" >&2; exit 1; }
-[[ -d "$OUT_DIR" ]]      || { printf 'Missing OUT_DIR directory: %s\n' "$OUT_DIR" >&2; exit 1; }
 [[ -f "$PLAN_SRC" ]]     || { printf 'Missing build plan: %s\n' "$PLAN_SRC" >&2; exit 1; }
 command -v npm >/dev/null || { printf 'npm not found; install Node.js to build Iosevka.\n' >&2; exit 1; }
+mkdir -p "$OUT_DIR"
 
-# Iosevka reads private-build-plans.toml from its repo root.
-cp "$PLAN_SRC" "$IOSEVKA_REPO/private-build-plans.toml"
+PLAN_BACKUP="$(mktemp "${TMPDIR:-/tmp}/dopemux-iosevka-plan.XXXXXX")"
+if [[ -f "$PLAN_DST" ]]; then
+  cp "$PLAN_DST" "$PLAN_BACKUP"
+  PLAN_HAD_ORIGINAL=1
+fi
+cp "$PLAN_SRC" "$PLAN_DST"
 
 if [[ ! -d "$IOSEVKA_REPO/node_modules" ]]; then
   printf 'Installing Iosevka build dependencies (npm ci)...\n'
@@ -40,7 +64,8 @@ if [[ ! -d "$IOSEVKA_REPO/node_modules" ]]; then
 fi
 
 : > "$BUILD_MANIFEST_TMP"
-rm -f "$OUT_DIR"/DopemuxTerm-*.ttf "$OUT_DIR"/DopemuxEditor-*.ttf
+rm -rf "$BUILD_STAGE"
+mkdir -p "$BUILD_STAGE"
 
 for plan in "${PLANS[@]}"; do
   printf 'Building %s (%s)...\n' "$plan" "$IOSEVKA_TARGET"
@@ -62,13 +87,22 @@ for plan in "${PLANS[@]}"; do
     exit 1
   fi
 
-  cp "${ttf_outputs[@]}" "$OUT_DIR"/
   for f in "${ttf_outputs[@]}"; do
-    basename "$f" >> "$BUILD_MANIFEST_TMP"
+    base="$(basename "$f")"
+    cp "$f" "$BUILD_STAGE/$base"
+    printf '%s\n' "$base" >> "$BUILD_MANIFEST_TMP"
   done
   printf '  copied %s TTF face(s) from %s\n' "$count" "$src"
 done
+
+rm -f "$BUILD_MANIFEST"
+rm -f "$OUT_DIR"/DopemuxTerm-*.ttf "$OUT_DIR"/DopemuxEditor-*.ttf
+while IFS= read -r f; do
+  [[ -n "$f" ]] || continue
+  cp "$BUILD_STAGE/$f" "$OUT_DIR/$f"
+done < "$BUILD_MANIFEST_TMP"
 mv "$BUILD_MANIFEST_TMP" "$BUILD_MANIFEST"
+rm -rf "$BUILD_STAGE"
 
 printf '\nBuilt faces in %s:\n' "$OUT_DIR"
 sed "s#^#$OUT_DIR/#" "$BUILD_MANIFEST"

--- a/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md
+++ b/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md
@@ -48,8 +48,7 @@ git clone https://github.com/ryanoasis/nerd-fonts  # NERD_FONTS_REPO
 
 export IOSEVKA_REPO=/path/to/Iosevka
 export NERD_FONTS_REPO=/path/to/nerd-fonts
-export OUT_DIR="$PWD/out"
-mkdir -p "$OUT_DIR"
+export OUT_DIR="$PWD/out"  # ignored by fonts/.gitignore
 
 # 1. Build the unpatched Dopemux Term + Dopemux Editor faces.
 ./build-dopemux-fonts.sh
@@ -58,9 +57,11 @@ mkdir -p "$OUT_DIR"
 ./patch-nerd-font.sh
 ```
 
-`build-dopemux-fonts.sh` copies `private-build-plans.toml` into the Iosevka
-checkout and runs `npm run build -- ttf::IosevkaDopemuxTerm` and
-`... ttf::IosevkaDopemuxEditor`, then collects the TTFs into `OUT_DIR`. Set
+`build-dopemux-fonts.sh` backs up the Iosevka checkout's existing
+`private-build-plans.toml`, installs the cockpit plan for the duration of the
+run, and restores the original plan on exit. It runs
+`npm run build -- ttf::DopemuxTerm` and `... ttf::DopemuxEditor`, then collects
+the TTFs into `OUT_DIR`. The script creates `OUT_DIR` when needed. Set
 `IOSEVKA_TARGET=ttf-unhinted` to skip the `ttfautohint` dependency.
 
 `patch-nerd-font.sh` runs `fontforge -script font-patcher --complete --careful`
@@ -111,9 +112,10 @@ The forbidden check should return nothing. The verification snippet should print
 
 ## No-binary-commit rule
 
-Generated `.ttf`, `.otf`, `.woff`, and `.woff2` files are not committed by
-default (`.gitignore`). Commit binaries only after explicit approval and review
-of the binary list.
+Generated `.ttf`, `.otf`, `.woff`, `.woff2`, `.dopemux-built-fonts.txt*`, and
+the documented `out/` build directory are not committed by default
+(`.gitignore`). Commit binaries only after explicit approval and review of the
+binary list.
 
 ## Notes
 

--- a/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh
+++ b/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh
@@ -59,22 +59,29 @@ for input in "${INPUTS[@]}"; do
   face="${base#*-}"
 
   patch_args=(--complete --careful)
+  patch_name=""
   case "$family" in
     DopemuxTerm)
+      patch_name="Dopemux Term Nerd Font"
       patch_args+=(--mono)
       ;;
     DopemuxEditor)
+      patch_name="Dopemux Editor Nerd Font"
+      patch_args+=(--variable-width-glyphs)
       ;;
     *)
       printf 'Unexpected built font family stem: %s (from %s)\n' "$family" "$(basename "$input")" >&2
       exit 1
       ;;
   esac
+  patch_args+=(--name "$patch_name")
 
   # --complete: all Nerd Font glyph sets (guarantees the codepoints documented in
   #             src/dopemux/ui/theme.py::Glyphs).
   # --mono:     single-width cells for terminal / TUI rendering. Term only;
-  #             Editor remains quasi-proportional.
+  # --variable-width-glyphs: keeps Editor icon advances proportional.
+  # --name:     explicit family name; avoid deriving from full names, which can
+  #             fragment Medium faces into a separate family.
   # --careful:  never overwrite glyphs already present in the source face.
   # font-patcher requires FontForge's Python: run via `fontforge -script`,
   # NOT `python3 font-patcher`.
@@ -98,5 +105,5 @@ done
 cleanup_patch_tmp
 
 printf '\nPatched %s face(s) into %s\n' "$patched" "$PATCHED_DIR"
-printf 'DopemuxTerm uses --mono; DopemuxEditor keeps source spacing.\n'
+printf 'DopemuxTerm uses --mono; DopemuxEditor uses --variable-width-glyphs.\n'
 printf 'Review generated binaries before committing; binaries are not committed by default (.gitignore).\n'

--- a/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh
+++ b/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh
@@ -59,9 +59,17 @@ for input in "${INPUTS[@]}"; do
   face="${base#*-}"
 
   patch_args=(--complete --careful)
-  if [[ "$family" == "DopemuxTerm" ]]; then
-    patch_args+=(--mono)
-  fi
+  case "$family" in
+    DopemuxTerm)
+      patch_args+=(--mono)
+      ;;
+    DopemuxEditor)
+      ;;
+    *)
+      printf 'Unexpected built font family stem: %s (from %s)\n' "$family" "$(basename "$input")" >&2
+      exit 1
+      ;;
+  esac
 
   # --complete: all Nerd Font glyph sets (guarantees the codepoints documented in
   #             src/dopemux/ui/theme.py::Glyphs).

--- a/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/private-build-plans.toml
+++ b/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/private-build-plans.toml
@@ -13,7 +13,7 @@
 #
 # Build with build-dopemux-fonts.sh, then patch with patch-nerd-font.sh. See build.md.
 
-[buildPlans.IosevkaDopemuxTerm]
+[buildPlans.DopemuxTerm]
 family = "Dopemux Term"
 spacing = "term"
 serifs = "sans"
@@ -21,42 +21,42 @@ noCvSs = false
 exportGlyphNames = true
 
 # Customizer-exported ambiguity-reduction variants belong here.
-[buildPlans.IosevkaDopemuxTerm.variants.design]
+[buildPlans.DopemuxTerm.variants.design]
 
-[buildPlans.IosevkaDopemuxTerm.weights.Regular]
+[buildPlans.DopemuxTerm.weights.Regular]
 shape = 400
 menu = 400
 css = 400
 
-[buildPlans.IosevkaDopemuxTerm.weights.Medium]
+[buildPlans.DopemuxTerm.weights.Medium]
 shape = 500
 menu = 500
 css = 500
 
-[buildPlans.IosevkaDopemuxTerm.slopes.Upright]
+[buildPlans.DopemuxTerm.slopes.Upright]
 angle = 0
 shape = "upright"
 menu = "upright"
 css = "normal"
 
-[buildPlans.IosevkaDopemuxTerm.slopes.Italic]
+[buildPlans.DopemuxTerm.slopes.Italic]
 angle = 9.4
 shape = "italic"
 menu = "italic"
 css = "italic"
 
-[buildPlans.IosevkaDopemuxTerm.slopes.Oblique]
+[buildPlans.DopemuxTerm.slopes.Oblique]
 angle = 9.4
 shape = "oblique"
 menu = "oblique"
 css = "oblique"
 
-[buildPlans.IosevkaDopemuxTerm.widths.Normal]
+[buildPlans.DopemuxTerm.widths.Normal]
 shape = 500
 menu = 5
 css = "normal"
 
-[buildPlans.IosevkaDopemuxEditor]
+[buildPlans.DopemuxEditor]
 family = "Dopemux Editor"
 spacing = "quasi-proportional"
 serifs = "sans"
@@ -64,37 +64,37 @@ noCvSs = false
 exportGlyphNames = true
 
 # Customizer-exported ambiguity-reduction variants belong here.
-[buildPlans.IosevkaDopemuxEditor.variants.design]
+[buildPlans.DopemuxEditor.variants.design]
 
-[buildPlans.IosevkaDopemuxEditor.weights.Regular]
+[buildPlans.DopemuxEditor.weights.Regular]
 shape = 400
 menu = 400
 css = 400
 
-[buildPlans.IosevkaDopemuxEditor.weights.Medium]
+[buildPlans.DopemuxEditor.weights.Medium]
 shape = 500
 menu = 500
 css = 500
 
-[buildPlans.IosevkaDopemuxEditor.slopes.Upright]
+[buildPlans.DopemuxEditor.slopes.Upright]
 angle = 0
 shape = "upright"
 menu = "upright"
 css = "normal"
 
-[buildPlans.IosevkaDopemuxEditor.slopes.Italic]
+[buildPlans.DopemuxEditor.slopes.Italic]
 angle = 9.4
 shape = "italic"
 menu = "italic"
 css = "italic"
 
-[buildPlans.IosevkaDopemuxEditor.slopes.Oblique]
+[buildPlans.DopemuxEditor.slopes.Oblique]
 angle = 9.4
 shape = "oblique"
 menu = "oblique"
 css = "oblique"
 
-[buildPlans.IosevkaDopemuxEditor.widths.Normal]
+[buildPlans.DopemuxEditor.widths.Normal]
 shape = 500
 menu = 5
 css = "normal"

--- a/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md
+++ b/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md
@@ -52,7 +52,7 @@ The fallback chain degrades gracefully: every glyph has an ASCII fallback in
 ```sh
 export IOSEVKA_REPO=/path/to/Iosevka          # git clone be5invis/Iosevka
 export NERD_FONTS_REPO=/path/to/nerd-fonts    # git clone ryanoasis/nerd-fonts
-export OUT_DIR="$PWD/out" && mkdir -p "$OUT_DIR"
+export OUT_DIR="$PWD/out"  # ignored by fonts/.gitignore; build script creates it
 
 ./build-dopemux-fonts.sh    # Iosevka -> Dopemux Term / Dopemux Editor TTFs
 ./patch-nerd-font.sh        # -> $OUT_DIR/nerd-font/Dopemux{Term,Editor}NerdFont-*.ttf

--- a/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/test-name-tables.sh
+++ b/docs/03-reference/Dopemux Cockpit TUI Design System/fonts/test-name-tables.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Validate patched Dopemux Nerd Font names and advance-width behavior.
+# Exit 77 means NOT_RUN: required local patched fonts or fontTools are absent.
+
+if [[ "${1:-}" != "" ]]; then
+  PATCHED_DIR="$1"
+elif [[ "${PATCHED_DIR:-}" != "" ]]; then
+  :
+elif [[ "${OUT_DIR:-}" != "" ]]; then
+  PATCHED_DIR="$OUT_DIR/nerd-font"
+else
+  printf 'NOT_RUN: set PATCHED_DIR or OUT_DIR, or pass the patched font directory.\n' >&2
+  exit 77
+fi
+
+if ! python3 -c 'import fontTools.ttLib' >/dev/null 2>&1; then
+  printf 'NOT_RUN: python fontTools is not installed.\n' >&2
+  exit 77
+fi
+
+if [[ ! -d "$PATCHED_DIR" ]]; then
+  printf 'NOT_RUN: patched font directory not found: %s\n' "$PATCHED_DIR" >&2
+  exit 77
+fi
+
+has_fonts=0
+for f in "$PATCHED_DIR"/DopemuxTermNerdFont-*.ttf "$PATCHED_DIR"/DopemuxEditorNerdFont-*.ttf; do
+  [[ -e "$f" ]] || continue
+  has_fonts=1
+done
+if [[ "$has_fonts" -eq 0 ]]; then
+  printf 'NOT_RUN: no patched Dopemux Nerd Font TTFs found in %s\n' "$PATCHED_DIR" >&2
+  exit 77
+fi
+
+python3 - "$PATCHED_DIR" <<'PY'
+from pathlib import Path
+import sys
+from fontTools.ttLib import TTFont
+
+patched_dir = Path(sys.argv[1])
+families = {
+    "DopemuxTermNerdFont": {
+        "expected_name": "Dopemux Term Nerd Font",
+        "expect_single_width": True,
+    },
+    "DopemuxEditorNerdFont": {
+        "expected_name": "Dopemux Editor Nerd Font",
+        "expect_single_width": False,
+    },
+}
+sample_codepoints = [ord(c) for c in "iWm.M0"]
+
+
+def preferred_family(font):
+    names = font["name"].names
+    for name_id in (16, 1):
+        for record in names:
+            if record.nameID == name_id:
+                value = record.toUnicode().strip()
+                if value:
+                    return value
+    raise AssertionError("missing name ID 16 and ID 1 family")
+
+
+def widths_for(font, cps):
+    cmap = font.getBestCmap() or {}
+    hmtx = font["hmtx"]
+    widths = []
+    for cp in cps:
+        glyph = cmap.get(cp)
+        if glyph is None:
+            continue
+        widths.append(hmtx[glyph][0])
+    if len(widths) < 2:
+        raise AssertionError("too few sample glyph widths available")
+    return widths
+
+
+for prefix, contract in families.items():
+    paths = sorted(patched_dir.glob(f"{prefix}-*.ttf"))
+    if not paths:
+        raise AssertionError(f"missing patched faces for {prefix}")
+
+    styles = {p.stem.removeprefix(prefix + "-") for p in paths}
+    for required in ("Regular", "Medium"):
+        if required not in styles:
+            raise AssertionError(f"{prefix} missing required {required} face")
+
+    seen_names = set()
+    for path in paths:
+        font = TTFont(path)
+        family_name = preferred_family(font)
+        seen_names.add(family_name)
+        widths = widths_for(font, sample_codepoints)
+        unique_widths = sorted(set(widths))
+        if contract["expect_single_width"]:
+            if len(unique_widths) != 1:
+                raise AssertionError(f"{path.name}: expected single-width samples, saw {unique_widths}")
+        else:
+            if len(unique_widths) < 2:
+                raise AssertionError(f"{path.name}: expected proportional samples, saw {unique_widths}")
+
+    if seen_names != {contract["expected_name"]}:
+        raise AssertionError(f"{prefix}: expected {contract['expected_name']!r}, saw {sorted(seen_names)!r}")
+
+    print(f"PASS {prefix}: family={contract['expected_name']} faces={len(paths)}")
+PY

--- a/proof/cockpit-fonts-101/proof-bundle.md
+++ b/proof/cockpit-fonts-101/proof-bundle.md
@@ -1,0 +1,53 @@
+# DMX-COCKPIT-FONTS-101 Proof Bundle
+
+## Scope
+
+- TP: `DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts`
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/cockpit-fonts-101-rename-plan-keys`
+- Branch: `codex/cockpit-fonts-101-rename-plan-keys`
+- Base: `origin/main` at `7732c813a5e893d49646c22e097bddd00604328e`
+- Repo marker: `.dopetaskroot` present
+- Authority conflict: primer said base `a2396a922`, but latest user instruction required current `origin/main`; fetched `origin/main` was used.
+- Claim status: task-orchestrator item was advanced from `queue` to `work`; advertised `claim_item` was not exposed in the loaded tool schema.
+- PAL status: PAL MCP tools returned `Transport closed` for `listmodels`, `analyze`, `thinkdeep`, `challenge`, `planner`, `codereview`, and `precommit`.
+
+## Files Changed
+
+- `docs/03-reference/Dopemux Cockpit TUI Design System/fonts/private-build-plans.toml`
+- `docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh`
+- `docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh`
+- `docs/03-reference/Dopemux Cockpit TUI Design System/fonts/.gitignore`
+- `docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md`
+- `docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md`
+- `task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json`
+- `proof/cockpit-fonts-101/proof-bundle.md`
+
+## Validation
+
+PASS:
+
+- Baseline RED static check: `IosevkaDopemuxTerm-Regular.ttf` derives `family=IosevkaDopemuxTerm`, so the old `family == DopemuxTerm` mono guard did not fire.
+- TOML parse: `python3`/`tomllib` parsed `private-build-plans.toml`; build plan keys are `DopemuxEditor`, `DopemuxTerm`; `family = "Dopemux Term"` and `family = "Dopemux Editor"` remain present.
+- `bash -n '.../build-dopemux-fonts.sh' '.../patch-nerd-font.sh'` exited 0.
+- Static guard substitute: `DopemuxTerm-Regular.ttf` => `mono=yes`; `DopemuxEditor-Regular.ttf` => `mono=no`; stale `IosevkaDopemuxTerm-Regular.ttf` => `fail-closed`.
+- Fake Iosevka success path exited 0: non-existent `OUT_DIR` was created, original `private-build-plans.toml` was restored, manifest contained `DopemuxTerm-Regular.ttf,DopemuxEditor-Regular.ttf`, and outputs used renamed stems.
+- Fake Iosevka mid-build failure path exited 42: original `private-build-plans.toml` was restored, the old TTF remained, old manifest still pointed at the old TTF, and no temp manifest remained.
+- `python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json' >/dev/null` exited 0.
+- `python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` exited 0 with a jsonschema CLI deprecation warning.
+- `! grep -rq 'IosevkaDopemux' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/'` exited 0.
+- `git diff --check` exited 0.
+
+NOT_RUN:
+
+- `shellcheck '.../build-dopemux-fonts.sh' '.../patch-nerd-font.sh'`: `shellcheck` command missing, exit 127.
+- Full manual build+patch gate: `NERD_FONTS_REPO` is unset and no local `nerd-fonts` directory or `font-patcher` file was found under `/Users/hue` search depth. Node, npm, Python, FontForge, and a local Iosevka checkout were present, but the full toolchain was incomplete.
+
+## Residual Risk / UNKNOWN
+
+- Full patched-font advance-width proof is UNKNOWN because Nerd Fonts `font-patcher` was unavailable.
+- Shellcheck diagnostics are UNKNOWN because `shellcheck` is not installed.
+- PAL expert review is UNKNOWN because the PAL MCP transport stayed closed.
+
+## Rollback
+
+- Revert the final commit on this branch, or delete branch `codex/cockpit-fonts-101-rename-plan-keys`; the change is confined to the packet allowlist.

--- a/proof/cockpit-fonts-102/proof-bundle.md
+++ b/proof/cockpit-fonts-102/proof-bundle.md
@@ -1,0 +1,61 @@
+# DMX-COCKPIT-FONTS-102 Proof Bundle
+
+## Scope
+
+- TP: `DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name`
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/cockpit-fonts-102-patch-flags`
+- Branch: `codex/cockpit-fonts-102-patch-flags`
+- Base for worktree: `origin/codex/cockpit-fonts-101-rename-plan-keys` at `9165f591011717b80226f84464c276b643e8eaa7`
+- Dependency: stacked on PR #912 because packet 102 depends on packet 101 and PR #912 is not merged into `origin/main`.
+- Repo marker: `.dopetaskroot` present
+
+## Files Changed
+
+- `docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh`
+- `docs/03-reference/Dopemux Cockpit TUI Design System/fonts/test-name-tables.sh`
+- `task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json`
+- `proof/cockpit-fonts-102/proof-bundle.md`
+
+## Evidence
+
+- RED before implementation:
+  - `grep -q 'variable-width-glyphs' patch-nerd-font.sh` exited 1.
+  - `grep -q -- '--name' patch-nerd-font.sh` exited 1.
+  - `test -f test-name-tables.sh` exited 1.
+- Upstream source checked: `https://raw.githubusercontent.com/ryanoasis/nerd-fonts/master/font-patcher`
+  - `--variable-width-glyphs` maps to `nonmono`.
+  - `--mono` implies single-width glyph behavior.
+  - A concrete `--name` string is accepted as a user-supplied name.
+  - Conflicting variable-width and mono flags disable the variable-width path, so the branches must stay separate.
+- Static post-change assertions:
+  - Term branch includes `--mono` and not `--variable-width-glyphs`.
+  - Editor branch includes `--variable-width-glyphs` and not `--mono`.
+  - Pinned explicit names are `Dopemux Term Nerd Font` and `Dopemux Editor Nerd Font`.
+  - The forbidden literal `name full` is absent from `patch-nerd-font.sh`.
+
+## Validation
+
+PASS:
+
+- `bash -n 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/test-name-tables.sh'` exited 0.
+- `python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json' >/dev/null` exited 0.
+- `python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` exited 0 with a jsonschema CLI deprecation warning.
+- `! grep -q 'name full' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh'` exited 0.
+- `grep -q 'variable-width-glyphs' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh'` exited 0.
+- `git diff --check` exited 0.
+- PAL `analyze`, `thinkdeep`, `planner`, `codereview`, `precommit`, and `challenge` ran; no blocking issues were identified.
+
+NOT_RUN:
+
+- `shellcheck`: command missing locally, exit 127.
+- `test-name-tables.sh` real artifact assertions: `fontTools` is not installed, so the script exits 77.
+- Full manual patch/name-table/advance-width gate: `NERD_FONTS_REPO` is unset and no local `nerd-fonts` directory or `font-patcher` file was found under `/Users/hue`; FontForge is present.
+
+## Residual Risk / UNKNOWN
+
+- Actual patched TTF name tables and advance widths are UNKNOWN until Nerd Fonts/font-patcher and fontTools are available.
+- PR #912 must land before packet 102 can be reviewed as an isolated delta against `main`.
+
+## Rollback
+
+- Revert the final packet 102 commit, or delete branch `codex/cockpit-fonts-102-patch-flags`. The change is confined to the packet allowlist.

--- a/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json
+++ b/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json
@@ -1,0 +1,123 @@
+{
+  "id": "DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts",
+  "project": "dopemux-mvp",
+  "target": "Rename the Iosevka build-plan keys IosevkaDopemux{Term,Editor} to Dopemux{Term,Editor} across the TOML, build script, AND patch script — the rename is load-bearing because patch-nerd-font.sh gates --mono on family=='DopemuxTerm' but family derives from the IosevkaDopemux* filename, so Term is currently patched WITHOUT --mono. Also harden build-dopemux-fonts.sh (mkdir -p OUT_DIR instead of hard error; back up/restore Iosevka's private-build-plans.toml instead of clobbering; close the stale-manifest window on mid-build failure) and the no-binary-commit guarantee (ignore the build manifest dotfile and the documented OUT_DIR).",
+  "invariants": [
+    "The rename MUST cover all call sites: TOML [buildPlans.*] headers, build-dopemux-fonts.sh PLANS array + dist path + pre-clean glob, and patch-nerd-font.sh pre-clean glob + the --mono family guard.",
+    "After rename, the patch-nerd-font.sh --mono guard MUST fire for Term faces (family == 'DopemuxTerm') so Term is patched single-width; Editor MUST remain non-mono.",
+    "internal family names in private-build-plans.toml (family = 'Dopemux Term' / 'Dopemux Editor') MUST be unchanged by the plan-key rename.",
+    "No font binaries (*.ttf/*.otf/*.woff*) and no build manifest dotfile may become committable from the documented build workflow.",
+    "The build script MUST NOT leave a final manifest pointing at deleted TTFs if a build fails midway.",
+    "Scripts MUST remain bash-3.2 portable and pass shellcheck.",
+    "Changes are confined to the fonts/ tooling + its two readme/build docs; case-collision and CSS work are separate packets.",
+    "Classify a missing build toolchain as NOT_RUN with static substitute evidence; never fabricate a build result."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-cockpit-fonts",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "commit": {
+    "message": "fix(cockpit-fonts): rename plan keys Dopemux{Term,Editor} + harden build/patch scripts (DMX-COCKPIT-FONTS-101)",
+    "allowlist": [
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/private-build-plans.toml",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/.gitignore",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md",
+      "task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json",
+      "proof/cockpit-fonts-101/**"
+    ],
+    "verify": [
+      "python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json' >/dev/null",
+      "python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "! grep -rq 'IosevkaDopemux' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/'",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(cockpit-fonts): rename plan keys + harden build/patch scripts (DMX-COCKPIT-FONTS-101)",
+    "body": "Foundation packet of the DMX-COCKPIT-FONTS remediation series (follow-on to merged PR #879). Renames the Iosevka build-plan keys IosevkaDopemux{Term,Editor} -> Dopemux{Term,Editor} across the TOML, build-dopemux-fonts.sh, and patch-nerd-font.sh. This is load-bearing: the patch script's --mono guard keys on family=='DopemuxTerm' but family derives from the IosevkaDopemux* filename, so Term is currently patched WITHOUT --mono; the rename makes the guard fire. Also hardens the build script (mkdir -p OUT_DIR, backup/restore Iosevka's plan, stale-manifest guard) and the no-binary-commit guarantee. Internal family names ('Dopemux Term'/'Dopemux Editor') are unchanged.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": ["analyze", "thinkdeep", "challenge", "planner", "challenge", "implement", "codereview", "precommit", "challenge"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight from a clean branch off origin/main. Read the three font scripts + the TOML. Confirm patch-nerd-font.sh derives `family` from the IosevkaDopemux* filename stem and that the --mono guard string is literally 'DopemuxTerm' (proving Term is NOT currently --mono'd). Capture the dist filename pattern, the manifest dotfile name, and the documented OUT_DIR in build.md. Record baseline SHA + clean worktree in proof.",
+      "validation": [
+        "Confirmed: family is computed from the filename stem and the --mono guard token is 'DopemuxTerm'.",
+        "Confirmed current build-plan keys are IosevkaDopemuxTerm / IosevkaDopemuxEditor.",
+        "Baseline SHA and clean status recorded in proof/cockpit-fonts-101/."
+      ],
+      "context_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/private-build-plans.toml",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/.gitignore"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Rename build-plan keys IosevkaDopemuxTerm->DopemuxTerm and IosevkaDopemuxEditor->DopemuxEditor in private-build-plans.toml (the [buildPlans.X] headers and all [buildPlans.X.sub] tables). Do NOT change the `family = 'Dopemux Term'` / `family = 'Dopemux Editor'` values.",
+      "validation": [
+        "Zero occurrences of 'IosevkaDopemux' remain in private-build-plans.toml.",
+        "The two `family =` lines are byte-unchanged.",
+        "The TOML still parses (python tomllib or equivalent)."
+      ],
+      "expected_files": ["docs/03-reference/Dopemux Cockpit TUI Design System/fonts/private-build-plans.toml"]
+    },
+    {
+      "id": "S3",
+      "task": "Update build-dopemux-fonts.sh: PLANS=(DopemuxTerm DopemuxEditor); the dist path dist/$plan/TTF now resolves to the renamed key; the existing pre-clean glob DopemuxTerm-*/DopemuxEditor-*.ttf now matches actual Iosevka output. Update patch-nerd-font.sh: rename the pre-clean glob and the --mono family guard token so the guard fires for Term (family=='DopemuxTerm') and Editor stays non-mono. Run shellcheck on both scripts.",
+      "validation": [
+        "Zero 'IosevkaDopemux' occurrences remain in build-dopemux-fonts.sh or patch-nerd-font.sh.",
+        "patch-nerd-font.sh --mono guard now matches the renamed Term family token.",
+        "shellcheck passes on both scripts (or NOT_RUN if shellcheck absent, noted)."
+      ],
+      "expected_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Harden build-dopemux-fonts.sh: replace the hard-error OUT_DIR check with `mkdir -p \"$OUT_DIR\"`; back up an existing $IOSEVKA_REPO/private-build-plans.toml before the cp and restore it via trap on exit; ensure a mid-build failure does not leave a stale final manifest (only remove old TTFs after a successful build, or trap-clean). Update fonts/.gitignore to also ignore the build manifest dotfile (.dopemux-built-fonts.txt*) and the patched output dir; reconcile build.md/readme.md so the documented OUT_DIR sits inside an ignored path.",
+      "validation": [
+        "Running with a non-existent OUT_DIR now creates it instead of erroring.",
+        "An existing Iosevka private-build-plans.toml is restored after the script exits (success OR failure).",
+        "git status is clean after a build run — no TTF or manifest dotfile is committable.",
+        "build.md and readme.md OUT_DIR guidance matches the ignore rules."
+      ],
+      "expected_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build-dopemux-fonts.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/.gitignore",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/build.md",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/readme.md"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "MANUAL GATE (full toolchain): with Iosevka + nerd-fonts + FontForge + Node available, run build-dopemux-fonts.sh then patch-nerd-font.sh. Confirm clean output filenames DopemuxTerm-*.ttf / DopemuxEditor-*.ttf, that patched Term faces are single-width (cmap advance) proving --mono now fires, and that git status is clean. If the toolchain is unavailable, record NOT_RUN with the exact missing dependency plus the static substitute evidence (greps + shellcheck). Then validate the TP JSON, commit allowlisted files only, open the PR, and write the proof bundle.",
+      "validation": [
+        "Either real build+patch produced DopemuxTerm-*.ttf with single-width Term faces (PASS), or NOT_RUN recorded with the missing dependency + static substitute evidence.",
+        "python -m jsonschema exits 0 for this TP JSON.",
+        "Only allowlisted files staged; git diff --check clean.",
+        "Proof bundle records TP id, worktree, branch, files changed, command exit codes, codereview status, precommit status, commit SHA, PR URL or exact blocker, residual risks, UNKNOWNs."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json
+++ b/task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json
@@ -1,0 +1,95 @@
+{
+  "id": "DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name",
+  "project": "dopemux-mvp",
+  "target": "Fix patch-nerd-font.sh so Editor faces patch with --variable-width-glyphs (proportional Nerd-glyph advances) while Term keeps --mono, and set a stable family name via explicit per-face --name '<Family> Nerd Font' (NOT --name full, which fragments the family because Medium faces export as 'Dopemux Term Medium'). Add a name-table test asserting all patched faces of a spacing family share one typographic family and have the expected advance-width behavior.",
+  "invariants": [
+    "Editor faces MUST be patched with --variable-width-glyphs; Term faces MUST keep --mono (relies on packet 101's restored guard).",
+    "The patched family name MUST be set via an explicit per-face --name string; --name full is forbidden.",
+    "All patched faces of one spacing family (Term Regular+Medium, Editor Regular+Medium) MUST report an identical typographic family (name ID 16, or ID 1 if 16 absent): 'Dopemux Term Nerd Font' / 'Dopemux Editor Nerd Font'.",
+    "The Editor patched family MUST match what colors_and_type.css --font-editor expects (no ' Propo' fork).",
+    "This packet MUST NOT modify the plan-key rename or the build script (owned by 101); it only changes patch flags + adds a name-table test.",
+    "Classify a missing FontForge/fontTools toolchain as NOT_RUN with static substitute evidence; never fabricate name-table or advance-width results."
+  ],
+  "depends_on": ["DMX-COCKPIT-FONTS-101-rename-plan-keys-harden-scripts"],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-cockpit-fonts",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "commit": {
+    "message": "fix(cockpit-fonts): Editor --variable-width-glyphs + explicit per-face --name (DMX-COCKPIT-FONTS-102)",
+    "allowlist": [
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh",
+      "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/test-name-tables.sh",
+      "task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json",
+      "proof/cockpit-fonts-102/**"
+    ],
+    "verify": [
+      "python -m json.tool 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json' >/dev/null",
+      "python -m jsonschema -i 'task-packets/generated/DMX-COCKPIT-FONTS/DMX-COCKPIT-FONTS-102-patch-flags-editor-proportional-family-name.json' docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "! grep -q 'name full' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh'",
+      "grep -q 'variable-width-glyphs' 'docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh'",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(cockpit-fonts): Editor proportional Nerd glyphs + stable family name (DMX-COCKPIT-FONTS-102)",
+    "body": "Adds --variable-width-glyphs to the Editor patch branch (proportional Nerd-glyph advances) while Term keeps --mono. Sets the patched family via explicit per-face --name '<Family> Nerd Font' instead of --name full, which would fragment the family across weights because Medium faces export as 'Dopemux Term Medium' and break the colors_and_type.css single-family weight-range. Adds test-name-tables.sh asserting one typographic family per spacing and correct advance widths. Depends on DMX-COCKPIT-FONTS-101 (the rename that makes Term's --mono guard fire).",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": ["analyze", "thinkdeep", "challenge", "planner", "challenge", "implement", "codereview", "precommit", "challenge"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: confirm packet 101 landed (keys renamed, Term --mono guard fires). Read the patch_args construction in patch-nerd-font.sh. Empirically determine how font-patcher honors an explicit free-string --name together with --variable-width-glyphs: does a free-string --name suppress the automatic 'Nerd Font'/' Propo'/' Mono' suffixing? Record the finding (cite the font-patcher behavior) in proof.",
+      "validation": [
+        "Packet 101 confirmed merged/landed (rename + guard).",
+        "Documented whether free-string --name suppresses the auto suffix, with evidence.",
+        "Decision recorded: exact --name string per family."
+      ],
+      "context_files": [
+        "docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh",
+        "docs/03-reference/Dopemux Cockpit TUI Design System/colors_and_type.css"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "In patch-nerd-font.sh: add --variable-width-glyphs to the Editor branch of patch_args (keep --mono for Term). Add an explicit per-face --name derived from the family token, pinned to 'Dopemux Term Nerd Font' for Term faces and 'Dopemux Editor Nerd Font' for Editor faces. Do NOT use --name full.",
+      "validation": [
+        "Editor patch path includes --variable-width-glyphs; Term path includes --mono and not --variable-width-glyphs.",
+        "patch_args includes an explicit --name '<Family> Nerd Font' per face; the string 'name full' does not appear.",
+        "shellcheck passes (or NOT_RUN noted)."
+      ],
+      "expected_files": ["docs/03-reference/Dopemux Cockpit TUI Design System/fonts/patch-nerd-font.sh"]
+    },
+    {
+      "id": "S3",
+      "task": "Author test-name-tables.sh using fontTools (ttx/TTFont) to assert, across all patched faces: (a) name ID 16 (typographic family; fall back to ID 1) is identical across Regular+Medium of each spacing family and equals 'Dopemux Term Nerd Font' / 'Dopemux Editor Nerd Font'; (b) Term faces have single-width advances; (c) Editor faces have proportional (variable) advances. The script must skip gracefully (exit documented) when no patched faces or fontTools are present.",
+      "validation": [
+        "test-name-tables.sh exists and asserts identical typographic family per spacing + advance-width expectations.",
+        "Script degrades to a clear NOT_RUN message when fonts/fontTools are absent (no false PASS)."
+      ],
+      "expected_files": ["docs/03-reference/Dopemux Cockpit TUI Design System/fonts/test-name-tables.sh"]
+    },
+    {
+      "id": "S4",
+      "task": "MANUAL GATE: run patch-nerd-font.sh on the built faces, then run test-name-tables.sh. Record PASS (with the actual name-table dump + advance-width sample) or NOT_RUN with the missing dependency and static substitute evidence. Validate the TP JSON, commit allowlisted files only, open PR, write proof bundle including the name-table evidence.",
+      "validation": [
+        "Either name-table + advance-width assertions PASS on real patched faces, or NOT_RUN with missing dependency + static evidence.",
+        "python -m jsonschema exits 0 for this TP JSON.",
+        "Only allowlisted files staged; git diff --check clean.",
+        "Proof bundle records the pinned family strings actually emitted and the advance-width verdict."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Change Summary

Packet `DMX-COCKPIT-FONTS-102`.

Depends on #912 (`DMX-COCKPIT-FONTS-101`). This branch is stacked on the 101 branch because 102 requires the renamed `Dopemux{Term,Editor}` stems and PR #912 is not merged yet.

- Keeps Term patching on `--mono` only.
- Adds `--variable-width-glyphs` to the Editor patch branch only.
- Adds explicit per-face `--name` strings:
  - `Dopemux Term Nerd Font`
  - `Dopemux Editor Nerd Font`
- Adds `test-name-tables.sh` to assert pinned typographic family names and sample advance-width behavior when patched TTFs and fontTools are available.

## Validation

PASS:

- RED before implementation:
  - `grep -q 'variable-width-glyphs' patch-nerd-font.sh` exited 1.
  - `grep -q -- '--name' patch-nerd-font.sh` exited 1.
  - `test -f test-name-tables.sh` exited 1.
- Static branch assertions:
  - Term branch includes `--mono` and not `--variable-width-glyphs`.
  - Editor branch includes `--variable-width-glyphs` and not `--mono`.
  - Pinned names are present.
- Upstream Nerd Fonts `font-patcher` source checked: concrete `--name` strings are accepted; `--variable-width-glyphs` maps to non-mono behavior; conflicting mono+variable flags disable variable-width behavior, so branch separation matters.
- `bash -n` on `patch-nerd-font.sh` and `test-name-tables.sh`.
- Packet `commit.verify`:
  - `python -m json.tool ...` exited 0.
  - `python -m jsonschema ...` exited 0 with jsonschema CLI deprecation warning.
  - forbidden `name full` literal absent from `patch-nerd-font.sh`.
  - `variable-width-glyphs` present in `patch-nerd-font.sh`.
  - `git diff --check` exited 0.
- `pre-commit run --files ...` exited 0.
- PAL `analyze`, `thinkdeep`, `planner`, `codereview`, `precommit`, and `challenge` ran; no blocking issues were identified.

NOT_RUN:

- `shellcheck`: command missing locally, exit 127.
- Real `test-name-tables.sh` artifact assertions: local Python lacks `fontTools`, so the script exits 77.
- Full manual patch/name-table/advance-width gate: `NERD_FONTS_REPO` is unset and no local `nerd-fonts` directory or `font-patcher` file was found under `/Users/hue`; FontForge is present.

## Proof

See `proof/cockpit-fonts-102/proof-bundle.md`.
