### PR TITLE
feat(conport): Tier-0 migration foundation + hardening seams + DAG-safe amendments

### DIFF
--- a/claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md
+++ b/claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md
@@ -1,0 +1,191 @@
+# DMX-CONPORT-OPTIMAL — Coverage & Hardening Analysis
+
+**Type:** analysis dossier · **Status:** draft for operator review · **Date:** 2026-06-16
+**Author:** Claude (Opus 4.8) orchestrating a 17-agent adversarial workflow + live-runtime verification + a gpt-5.2 external review
+**Subject:** Expand and optimize the analysis behind the loaded 18-packet `DMX-CONPORT-OPTIMAL` series; classify every gap; identify defects to fix at source; surface what the series was about to build on sand.
+
+---
+
+## 0. Provenance & method (verified vs inferred)
+
+| Dimension | Value |
+|---|---|
+| Repo state analyzed | `main` @ `a740edc40`; ConPort source @ `a3c2e61ac` ("fix(conport): cold-start grant and unified query 500s" #894, 2026-06-16) |
+| Live runtime inspected | container `mcp-conport` (image `dopemux-conport`, ports 3004–3005) + DB `dopemux-postgres-age` (`apache/age:release_PG16_1.6.0`, db `dopemux_knowledge_graph`, user `dopemux_age`) via `docker exec` + `psql` |
+| Loaded series | `DMX-CONPORT-OPTIMAL`, 18 packets (101–109, 201–206, 301–303), orchestrator root `44452f53`, 21 BLOCKS edges, `get_next_item=101` — **NOT perturbed by this analysis** |
+| Adversarial pass | Workflow `wf_5b4a82ff-801`: 6 specialist lenses (35 findings) → 6 cross-refutations → 3 discovery rounds (+22 gaps) → completeness critic. Final synthesize step **failed on a session-usage limit**; register synthesized by the orchestrator from raw materials. |
+| External review | PAL `consensus` tool down (3× `-32000`); substituted single-model PAL `chat` with **gpt-5.2** (OpenAI). grok-4.1 second-vendor pass failed (PAL disconnected). |
+| Files read directly (this session) | `enhanced_server.py` (:196–217, :2000–2044), `schema.sql` (:100–259), `migrations/001_*.sql` (:101–145, :272–335), `migrations/` dir listing, `Dockerfile`, `.mcp.json`, `TP-202` JSON, `_AUTHORING_KIT.md`; live DB schema (`pg_tables`, `information_schema.columns`, `pg_namespace`) |
+
+**Confidence labels** used below: `RUNTIME-VERIFIED` (I queried the live DB/container), `CODE-VERIFIED` (I read the file:line), `WORKFLOW` (agent-reported, not personally re-read), `INFERRED`, `REFUTED`.
+
+**Honest limitations.**
+- Discovery hit the **round cap (3), not dryness** — round 3 still surfaced 5 new gaps; **the gap space is not exhausted**.
+- The synthesize agent died on a usage limit; this register is the orchestrator's synthesis, not the workflow's.
+- PAL multi-model consensus was unavailable; only one external model (gpt-5.2) reviewed the central decision.
+- The **traversal endpoint was not `curl`-tested**; live-image version vs `main` HEAD not reconciled (#894 recently touched this surface). These are residual `UNKNOWN`s.
+
+---
+
+## 0.5 Post-authoring correction — PR #894 reconciliation (git-verified)
+
+After authoring the Tier-0 packets, a direct `git show a3c2e61ac` of PR #894 ("fix(conport): cold-start grant and unified query 500s") showed it **already resolved two traversal sub-findings** that the adversarial workflow had reported from a pre-#894 mental model:
+
+- **CTE column bug RESOLVED** — #894 changed the recursive CTE `r.target_item_id::int`/`source_item_id` → `r.source_id::text`/`target_id::text` (git-diff proven). Current `unified_queries.py` is correct.
+- **`int(decision_id)` cast RESOLVED** — #894 changed `decision_id=int(decision_id)` → `decision_id=decision_id` (git-diff proven, `enhanced_server.py`). #894 also copied `unified_queries.py` into the image (matches §2's live-container finding). Its commit message even cites "DMX-CONPORT-OPTIMAL-101" — #894 was a partial execution of this series.
+
+**What survives unchanged:**
+- **The core finding STANDS** — #894's `--stat` touched only `enhanced_server.py`/`unified_queries.py`/`schema.sql`; it added **no migration-apply path** (grep confirms none in startup). T0-MIGRATE (migrations-never-applied, RUNTIME-VERIFIED via psql) is unaffected.
+- **One surviving traversal bug:** `max_depth` is still unclamped at `enhanced_server.py:2023` (B-MAXDEPTH, latent/low).
+
+**Effect on the register below:** §3.1 **T0-TRAVERSE** collapses to a regression-guard + the `max_depth` clamp (Tier-0 packet 002 was authored VERIFIED-NO-OP-aware; TP-203 corrected to match). §3.2 **B-INT-UUID** → RESOLVED. The earlier-session read that showed the pre-#894 code reflected stale state; the live, git-clean HEAD has the fixes. This correction is the analysis self-correcting against runtime truth.
+
+---
+
+## 1. Headline — the series was about to build on sand
+
+The loaded series is **correctness-focused** (4 named bugs) + knowledge-graph/context modeling (Tier 2) + retrospective (Tier 3). The adversarial pass + runtime verification found a **root cause beneath all of Tier-2/Tier-3 that the plan did not have**:
+
+> **The ConPort server never applies its migrations.** `enhanced_server.py::_ensure_schema` runs only base `schema.sql`; the `migrations/*.sql` files are never executed by the server, and nothing in the postgres infra or compose applies them either. **RUNTIME-VERIFIED:** the live DB contains only `decisions` + `entity_relationships`. `decision_relationships`, `review_reminders`, `adhd_metrics`, `decision_patterns`, the multi-tenancy tables, and migration 001's 14 "enhanced decision" columns **do not exist**.
+
+Consequence: **five queued feature packets target objects that don't exist at runtime.**
+
+| Packet | Targets | Runtime reality |
+|---|---|---|
+| TP-303 | write `decision_relationships` | table absent (migration 001 never applied) — RUNTIME-VERIFIED |
+| TP-302 | write `review_reminders` | table absent — RUNTIME-VERIFIED |
+| TP-301 | set decision outcome/review columns | columns absent (`decisions` has only `id:uuid`, base fields) — RUNTIME-VERIFIED |
+| TP-203 | fix relationship traversal | CTE + `int(decision_id)` bugs **RESOLVED by #894** (see §0.5); surviving = `max_depth` unclamped at `:2023` |
+| TP-202 | write `entity_relationships` | table exists, but has no writers and a broken reader |
+
+**gpt-5.2 review (verbatim gist):** gated + fail-closed migration apply is correct for an audit-grade memory server; silent auto-apply "turns process-start into a state-mutating event" and breaks replayability. **No feature packet — including TP-202 — should run pre-foundation**; writing under wrong-schema assumptions risks "poisoning canonical memory" and masking the foundation problem. Biggest underweighted risk: **irreversible divergence of canonical memory via schema drift + replay incompatibility** once writes land — "worse than downtime."
+
+---
+
+## 2. Two workflow claims REFUTED by runtime (truth over fluency)
+
+The adversarial agents reasoned from the Dockerfile and over-claimed; the live container corrected them. Recorded so no future reviewer re-spends effort:
+
+| Workflow claim | Runtime truth | Verdict |
+|---|---|---|
+| `unified_queries.py` not copied → `unified_query_api = None` → endpoints 500 unconditionally | File **is** present at `/app/unified_queries.py` in the running image | **REFUTED** |
+| `ag_catalog`/AGE schema "never created" | `ag_catalog` schema **exists** (apache/age base image provides it) | **REFUTED** |
+| Multi-tenant `user_id` impersonation / access-table leak (NEW-unauth-user_id, access-table-never-consulted) | multi-tenancy tables (`users`/`workspaces`/`user_workspace_access`) **absent** at runtime | **MOOT** (migration 003 never applied) |
+
+The traversal endpoint therefore fails (if it fails) at **query time** (bad column names + uuid/int cast), not via a `None` guard.
+
+---
+
+## 3. Synthesized risk register (deduped, prioritized)
+
+Disposition key: **T0** = new Tier-0 foundation (blocking) · **AMEND** = edit an existing loaded packet · **HARDEN** = companion default-off seam · **DOC** = document-only verdict · **DROP** = closed/moot. Each row carries the strongest evidence + refutation outcome.
+
+### 3.1 Tier-0 foundation (NEW — blocks Tier-2/Tier-3)
+
+| ID | Finding | Evidence | L/I | Disposition |
+|---|---|---|---|---|
+| T0-MIGRATE | Server never applies migrations; required tables/columns absent at runtime | `_ensure_schema` runs `schema.sql` only (WORKFLOW :408–475); live DB has 2 tables (RUNTIME-VERIFIED) | H/H | **T0** gated idempotent ordered runner + checksummed `schema_version` + fail-closed health gate |
+| T0-TRAVERSE | ~~CTE refs `source_item_id`/`target_item_id`, `::int` on uuid~~ **RESOLVED by #894** (git-diff). Surviving: `max_depth` unclamped at `:2023` | #894 diff (git-VERIFIED); live cols `source_id`/`target_id` uuid (RUNTIME-VERIFIED) | L/L | **T0-002** regression-guard (VERIFIED-NO-OP) + `max_depth` clamp owned by TP-203 |
+| T0-HEALTH | `/health` is blind to AGE/`ag_catalog` + schema_version → health lies while graph broken | `init_connections` does no AGE/graph validation (WORKFLOW); survived refutation ("`/health` blind to ag_catalog" — kept IN_SCOPE) | H/M | **T0** + AMEND TP-101/106 (fail health if expected schema absent) |
+
+### 3.2 Confirmed bugs (AMEND loaded packets — no DAG change)
+
+| ID | Finding | Evidence | L/I | Disposition |
+|---|---|---|---|---|
+| B-INT-UUID | ~~`int(decision_id)` crashes on uuid input~~ **RESOLVED by #894** (`decision_id=int(...)` → `decision_id=...`, git-diff) | git-VERIFIED at HEAD a3c2e61ac | — | RESOLVED — TP-203 records VERIFIED-NO-OP |
+| B-MAXDEPTH | `max_depth = int(...)` unclamped → recursive-CTE DOS | `enhanced_server.py:2019` (CODE-VERIFIED); **LATENT** — masked because endpoint already errors | M/M | **AMEND TP-203** (cheap clamp alongside the fix) |
+| B-RECENT-HOURS | `recent_activity` unbounded `hours` param + string-interpolated SQL | WORKFLOW (round 2); distinct site from B-MAXDEPTH | M/L | **AMEND** the recent-activity packet (verify injection surface) |
+| B-PROMOTE-PCT | `promote_all` emits event with `percentage=0` (drops real value) | WORKFLOW; dark method on 3005 | M/L | **AMEND TP-107** (carry percentage or omit) |
+| B-AUTOFORK | auto-fork refetch path raises AttributeError | WORKFLOW (round 2); adjacent to TP-107 | H/M | **AMEND TP-107** |
+| B-DEADLOG | `conport_client.py` `logger.error` after `return` (dead) | `services/adhd_engine/conport_client.py:~42` (WORKFLOW); trivial real defect, survived refutation | H/L | **HARDEN** (trivial) or fold into client packet |
+
+### 3.3 Operator-decision seams (HARDEN — default-off) — re-based on the :3005 agent surface
+
+> **Surface reframing (RUNTIME-VERIFIED):** agents bind ConPort at `:3005` FastMCP (`server.py`), per `.mcp.json:5` (`localhost:3005/sse`) — **not** the `:3004` HTTP surface the seed security analysis assumed. On 3005 `fork_instance`/`promote`/`promote_all` are **advertised `@mcp.tool()`s, not "dark methods"**, and there is **no search tool** (bearing on TP-205/206). All access-control hardening must target 3005, or both surfaces explicitly.
+
+| ID | Finding | Evidence | L/I | Disposition |
+|---|---|---|---|---|
+| H-AUTH | No auth gate on writes (any caller writes any workspace_id) | security lens; facts hold, verdict OPERATOR_DECISION after refutation | M/H | **HARDEN H-101** auth-token seam (default-off), on :3005 |
+| H-AUDIT | No write audit log | security lens; "negative claim is strongest part" (survived) | M/M | **HARDEN H-102** append-only audit row (always-on-safe) |
+| H-RATELIMIT | No rate limiting | devops lens → **DEFER** (L/L); panel did not sustain urgency | L/L | **HARDEN H-103** seam (default-off) *or* DOC — operator call |
+| H-DARKSCOPE | fork/promote/promote_all callable by any agent | refined: advertised on 3005, not hidden (1b) | M/L | **HARDEN** admin-scope flag (default permissive) |
+
+### 3.4 Reclassified / document-only (DOC)
+
+| ID | Finding | Panel verdict | Disposition |
+|---|---|---|---|
+| 3c | DB-level FK + CHECK on `entity_relationships` (no FK; `relationship_type` bare VARCHAR; `strength` not `metadata`) | **OPERATOR_DECISION** (downgraded from plan's "mandatory headline") — app-layer enum may suffice; only integrity arg is orphan-edge accumulation | **DOC** + optional HARDEN H-201-cond; **correct TP-202 S1** which wrongly asserts a `metadata` column (table has `strength`) |
+| 5a | entity vocab `{builds_upon,validates,extends,implements,depends_on,supersedes}` forks from `decision_relationships` vocab `{builds_upon,supersedes,conflicts_with,validates,implements,questions}` (share 3/6) | **OPERATOR_DECISION / document-only** | **DOC** reconciliation table in TP-109 (do not force-merge) |
+| 5b | entity vs decision relationship table consolidation | **DEFER** (survived) | **DOC** non-goal rationale |
+| 6a | authority/source_surface response labels | single-plane = implicitly canonical | **DOC** non-goal |
+
+### 3.5 Dropped / moot (DROP)
+
+| ID | Why closed |
+|---|---|
+| 4a typed-degradation contract | **DEFER** — devops refutation: over-scoped; keep only the dead-logger fix (B-DEADLOG) |
+| 4b DCP facade degradation | **REFUTED** — "unverified premise is false; it IS handled"; verify, then likely no TP-206 amend |
+| 4d task-orchestrator 127 placeholders | **DEFER** — cannot substantiate under any lens; separate product TP |
+| NEW-search-content-cross-workspace-poison | **REFUTED** — non-issue; recorded to prevent phantom-bug TP effort |
+| multi-tenant user_id leaks | **MOOT** — tables absent at runtime (§2) |
+
+### 3.6 Residual / needs-a-probe (from the completeness critic — NOT yet dispositioned)
+
+- **3005 vs 3004 binding** is the pivot for all of §3.3 — re-confirm which surface the orchestrator/agents actually use in production vs dev. (`.mcp.json` says 3005; verify no override.)
+- **`info_server` SSE port-mismatch discovery bug** (OPERATOR_DECISION) — auto-config/ADR-2 surface, outside series scope.
+- **`recent_activity` view is instance-blind** (worktree multi-instance crosstalk) — consistency gap in the instance model.
+- **Second MCP surface parity** (3005 vs 3004 tool sets) frames several per-surface findings; no loaded packet owns cross-surface parity.
+- Because discovery was **cap-bounded**, treat §3 as a high-coverage floor, not a ceiling.
+
+---
+
+## 4. Tier-0 foundation design (consensus-validated)
+
+Derived from the gpt-5.2 review + governance (deterministic, append-only, replayable, fail-closed):
+
+1. **Gated, not auto.** Migration apply is an **explicit operator-invoked** action (runner / one-shot job), **never** silent on every server start. Rationale: process-start must not be a state-mutating event.
+2. **Idempotent + ordered.** Apply in numeric order; each migration guarded (`IF NOT EXISTS` / advisory-locked) so re-runs are no-ops.
+3. **Recorded + checksummed `schema_version`.** Persist applied version **and a checksum of each migration file** in-DB so `schema_version = N` means *the same N everywhere*, not "whatever N was in this image" (tamper-evident chain).
+4. **Fail-closed health gate.** If expected migrations are absent or partially applied, the server reports **degraded** and **refuses writes** (reads policy = open question below). Partial-apply ⇒ degraded until a known-good version is reached.
+5. **Acceptance test (rebuild-from-zero determinism):** "DB + append-only log of operator actions → rebuild from zero → identical schema + behavior."
+6. **No feature packet runs first** — including TP-202 — until the gate is green. (gpt-5.2 explicitly closed the "TP-202 is safe-first" door.)
+
+**Open design questions to resolve when authoring the Tier-0 packet(s):**
+- (Q1) Migration history **append-only/audited in-DB** (recommended) vs an external operator log?
+- (Q2) When degraded: **read-only** (reads allowed, writes refused) vs **refuse all traffic**?
+
+---
+
+## 5. Coverage matrix (capability × surface × covered-by × verdict)
+
+| Capability | Surface | Covered by | Trinity status | Verdict |
+|---|---|---|---|---|
+| Decisions/progress/context write | 3005 `server.py` / 3004 `enhanced_server.py` | base schema (live) | canonical | OK; needs §3.3 auth seam (operator) |
+| Decision genealogy graph | `decision_relationships` | TP-303 | in-scope | **blocked on T0-MIGRATE** |
+| Entity graph (cross-type) | `entity_relationships` | TP-202/203 | in-scope | **blocked on T0-TRAVERSE + T0-MIGRATE** |
+| Relationship traversal API | `unified_queries.py` + :2009 handler | TP-203 | in-scope | **dead at runtime → T0-TRAVERSE** |
+| Decision retrospective | migration-001 enhanced cols | TP-301 | in-scope | **blocked on T0-MIGRATE** |
+| Review reminders | `review_reminders` | TP-302 | in-scope | **blocked on T0-MIGRATE** |
+| Search / DCP facade | (no search tool on 3005) | TP-205/206 | in-scope | re-scope: 3005 has no search surface |
+| AuthZ / audit / rate-limit | middleware | — | operational (NOT a Trinity non-goal) | **HARDEN** default-off seams |
+| Multi-tenant isolation | migration-003 tables | — | absent at runtime | **MOOT** until 003 applied |
+
+---
+
+## 6. DAG-safety & sequencing
+
+- **Amendments (§3.2, §3.4 corrections)** edit only `invariants`/`steps`/`commit.verify` text in packets that already touch the relevant files → **zero `depends_on` changes**; the loaded orchestrator topology (root `44452f53`, 21 edges, recorded `task_orchestrator_uuid`s) stays byte-identical. Re-run `tp:validate` per amended packet.
+- **Tier-0** loads as a **separate orchestrator root** that logically blocks TP-202/203/301/302/303; stored as its own tree so it never perturbs `44452f53` (consistent with the orchestrator HTTP-singleton/stdio-contention notes).
+- **HARDENING** series (§3.3) sequences strictly after the Stabilize tier (101–109), also a separate root.
+
+---
+
+## 7. Recommended next actions (for operator decision)
+
+1. **Author the Tier-0 foundation packet(s)** per §4 (gated migration runner + checksummed schema_version + fail-closed gate + traversal fix), resolving Q1/Q2. *This is the new critical path.*
+2. **Apply the §3.2/§3.4 in-place amendments** to TP-101/106/107/202/203/109 (DAG-safe).
+3. **Author the companion `DMX-CONPORT-HARDENING`** series for §3.3 seams (default-off), re-based on :3005.
+4. **Reframe TP-301/302/303** notes to depend on Tier-0 (tables/columns come from migrations, which Tier-0 now actually applies).
+5. **Close residual probes** (§3.6) — especially confirming the 3005/3004 production binding and curl-testing the traversal endpoint — before finalizing the security verdicts.
+
+> This dossier is the analysis deliverable. The packet authoring (Tier-0 + amendments + HARDENING) is paused pending operator go-ahead and a fresh session budget (the workflow tripped a usage limit). The companion verdict ADR records the durable scope/boundary decisions.

--- a/docs/90-adr/adr-conport-hardening-scope-and-trinity-boundaries.md
+++ b/docs/90-adr/adr-conport-hardening-scope-and-trinity-boundaries.md
@@ -1,0 +1,81 @@
+---
+id: adr-conport-hardening-scope-and-trinity-boundaries
+title: "ADR: ConPort hardening scope and Trinity boundaries"
+type: adr
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-16'
+prelude: Records which ConPort coverage gaps are in-scope, operator-decisions, or Trinity non-goals, and re-sequences the DMX-CONPORT-OPTIMAL series behind a gated migration-apply foundation.
+status: proposed
+graph_metadata:
+  node_type: ADR
+  impact: high
+  relates_to:
+    - adr-memory-trinity-authority-and-interaction-model
+    - adr-conport-as-decision-progress-and-context-authority
+---
+
+# ADR: ConPort hardening scope and Trinity boundaries
+
+**Status:** Proposed
+**Date:** 2026-06-16
+**Owners:** Dopemux Memory Plane
+**Decision Type:** Scope / Authority Boundary / Series Sequencing
+**Scope:** `DMX-CONPORT-OPTIMAL` series, ConPort server (`docker/mcp-servers-source/conport/`), companion `DMX-CONPORT-HARDENING` series
+**Evidence base:** [conport-optimal-coverage-and-hardening-analysis-2026-06-16.md](../../claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md) (17-agent adversarial workflow + live-runtime verification + gpt-5.2 review)
+
+## Context
+
+The loaded 18-packet `DMX-CONPORT-OPTIMAL` series rebuilds/extends ConPort — the canonical Memory-Trinity authority for decisions/progress/structured-context ([adr-memory-trinity-authority-and-interaction-model](adr-memory-trinity-authority-and-interaction-model.md)). An expansion analysis (see evidence base) surfaced a class of operational, security, concurrency, consumer-resilience, and contract-reconciliation gaps the series did not address, plus a **root cause beneath Tier-2/Tier-3**: the server never applies its migrations, so five feature packets target tables/columns that do not exist at runtime (RUNTIME-VERIFIED against the live `mcp-conport` container and `dopemux_knowledge_graph` DB).
+
+Two questions needed durable answers so contributors stop re-deriving them: **(1)** which gaps does the Memory Trinity boundary actually exclude (vs merely not-yet-built)? **(2)** what is the correct sequencing given the migration root cause?
+
+## Decision
+
+### D1 — A gated migration-apply foundation (Tier-0) precedes all feature packets
+
+The series is re-sequenced. A new **Tier-0 foundation** blocks TP-202/203/301/302/303:
+- A **gated, operator-invoked, idempotent, ordered** migration runner — **never** silent auto-apply on server start. Process-start must not be a state-mutating event (preserves determinism/replayability).
+- A **recorded, checksummed `schema_version`** so a version number means the same migrations everywhere (tamper-evident).
+- A **fail-closed health gate**: when expected migrations are absent or partially applied, the server reports **degraded** and **refuses writes**.
+- A `max_depth` clamp + regression-guard on the traversal handler. **Reconciliation (git-verified):** the CTE column-name and `int(decision_id)` fixes were already landed by PR #894, so the Tier-0 traversal packet (002) is a VERIFIED-NO-OP regression-guard plus the one surviving fix (`max_depth` unclamped at `:2023`), **not** a re-fix.
+- **No feature packet — including TP-202 — runs until the gate is green.** Writing under wrong-schema assumptions risks irreversible divergence of canonical memory (worse than downtime for an audit-grade store).
+
+Two design parameters are deferred to packet authoring: (Q1) migration history append-only in-DB vs external log; (Q2) read-only-when-degraded vs refuse-all.
+
+### D2 — Operational/security hardening is IN-SCOPE; only cross-plane authority expansion is a Trinity non-goal
+
+The Memory Trinity boundary excludes **cross-plane authority escalation**, not operational hardening. Therefore:
+- **IN-SCOPE (fix at source):** the 4 confirmed bugs, the migration/foundation gaps, health-gate honesty, the traversal fix.
+- **OPERATOR-DECISION (commit a default-off seam + document):** write-path auth (H-101), write audit log (H-102), rate limiting (H-103), admin-scoping of `fork`/`promote`/`promote_all`. These ship **default-off** because ConPort's threat model assumes a trusted local/network boundary; turning them on is an operator's deployment choice, not a code default. **All such seams target the `:3005` FastMCP surface** that agents actually bind (`.mcp.json`), not the `:3004` HTTP surface the original framing assumed.
+- **TRINITY NON-GOAL (document, do not build):** authority/source_surface response labels (single-plane = implicitly canonical); entity-vs-decision relationship-table consolidation; the multi-tenant `user_id` surface (its tables are absent at runtime and tenancy is a cross-plane concern).
+
+### D3 — Reclassifications correcting the original plan
+
+- **Entity-relationship DB FK + CHECK constraints** → **OPERATOR_DECISION**, not a mandatory amendment (app-layer enum enforcement exists; only integrity argument is orphan-edge accumulation). The TP-202 packet text asserting a `metadata` column is **corrected** — the live table has `strength`.
+- **Vocabulary divergence** between `entity_relationships` and `decision_relationships` (share 3/6 terms) → **document the intentional split** in TP-109; do **not** force-merge.
+- **Typed degradation contract (4a)** → **DEFER** (over-scoped); keep only the trivial dead-logger fix.
+- **DCP facade degradation (4b)** → **REFUTED** as already-handled; verify, then no amendment.
+
+## Consequences
+
+**Positive:** feature packets stop targeting nonexistent schema; canonical memory is protected from schema-drift poisoning; security posture is explicit and operator-controlled rather than absent-by-accident; the Trinity boundary is documented so future reviewers don't re-litigate it; the loaded orchestrator DAG (`44452f53`) is untouched (amendments are text-only; Tier-0 and HARDENING load as separate roots).
+
+**Negative / costs:** adds a Tier-0 critical path before the visible feature work; introduces an operator migration step (deliberately — the alternative undermines auditability); default-off seams mean security is not on unless deployed-on (documented, not hidden).
+
+**Residual risk / UNKNOWN:** discovery was cap-bounded (not exhausted); the production 3005/3004 binding and the live-image-vs-HEAD version were not fully reconciled; the traversal endpoint was not `curl`-tested. These must be closed before the §3.3 security verdicts are treated as final.
+
+## Alternatives considered
+
+- **Silent auto-apply migrations on startup** — rejected: makes process-start a state-mutating event, breaks replayability, risks partial-apply in an undefined state (gpt-5.2-validated).
+- **Let TP-202 run first** (it writes the one existing table) — rejected: gpt-5.2 closed this door; rows written under pre-foundation assumptions can be invalidated by the traversal/constraint fixes and mask the foundation problem.
+- **Treat auth/audit as IN-SCOPE mandatory** — rejected: ConPort's trusted-boundary threat model makes these operator deployment choices; committing them default-off preserves both options.
+- **Execute the original plan as approved** — rejected: runtime evidence falsified its premises (the "headline" TP-202 FK fix is moot against an unmigrated DB with a dead reader).
+
+## References
+
+- Evidence dossier: [conport-optimal-coverage-and-hardening-analysis-2026-06-16.md](../../claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md)
+- Trinity boundary: [adr-memory-trinity-authority-and-interaction-model](adr-memory-trinity-authority-and-interaction-model.md)
+- Series: `task-packets/generated/DMX-CONPORT-OPTIMAL/` (orchestrator root `44452f53`)

--- a/docs/ops/load-plans/load_plan-DMX-CONPORT-HARDENING.json
+++ b/docs/ops/load-plans/load_plan-DMX-CONPORT-HARDENING.json
@@ -1,0 +1,46 @@
+{
+  "program": "DMX-CONPORT-HARDENING",
+  "date": "2026-06-16",
+  "source_plan": "claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md",
+  "validation": "PAL risky/architecture chain (analyze,thinkdeep,challenge,planner,challenge,implement,codereview,precommit,challenge) per packet; verdicts: H-AUTH=OPERATOR_DECISION, H-AUDIT=always-on-safe, H-RATELIMIT=OPERATOR_DECISION (dossier §3.3)",
+  "tag": "dmx-conport-hardening,series,supervised-only",
+  "root": {
+    "ref": "root",
+    "title": "ConPort Hardening — default-off security seams (H-101/102/103)",
+    "summary": "Three companion default-off seams for the ConPort :3005 FastMCP surface and :3004 enhanced_server.py, sequenced logically after the DMX-CONPORT-OPTIMAL Stabilize tier (TP-109). All seams are no-ops unless an operator explicitly sets the controlling env var. 101 = write-path auth (CONPORT_AUTH_TOKEN); 102 = append-only write audit log (always-on-safe); 103 = per-caller write rate-limit (CONPORT_RATE_LIMIT_WRITES_PER_MINUTE). This series loads as a SEPARATE orchestrator root from DMX-CONPORT-OPTIMAL (root 44452f53) and must not perturb that DAG. Targets the :3005 surface that agents actually bind (per .mcp.json), with :3004 middleware also addressed where relevant."
+  },
+  "epics": [
+    {"ref": "E1", "title": "ConPort write-path security seams", "phase": 1}
+  ],
+  "leaves": [
+    {
+      "ref": "L101",
+      "parent": "E1",
+      "title": "DMX-CONPORT-HARDENING-101 — default-off write-path auth seam (CONPORT_AUTH_TOKEN)",
+      "disp": "HARDEN",
+      "targets": "docker/mcp-servers-source/conport/server.py, docker/mcp-servers-source/conport/enhanced_server.py",
+      "accept": "When CONPORT_AUTH_TOKEN is unset: zero behavior change. When set: write tools return 401/MCP-error on missing or invalid bearer; read tools unaffected. Tests pass."
+    },
+    {
+      "ref": "L102",
+      "parent": "E1",
+      "title": "DMX-CONPORT-HARDENING-102 — append-only write audit log on all write handlers",
+      "disp": "HARDEN",
+      "targets": "docker/mcp-servers-source/conport/server.py, docker/mcp-servers-source/conport/enhanced_server.py",
+      "accept": "Every write handler emits one structured audit row (timestamp, surface, workspace_id, identity, tool_or_method) per call. Audit failure never blocks the primary write. Full payload content is never captured. Tests pass."
+    },
+    {
+      "ref": "L103",
+      "parent": "E1",
+      "title": "DMX-CONPORT-HARDENING-103 — default-off per-caller write rate-limit (CONPORT_RATE_LIMIT_*)",
+      "disp": "HARDEN",
+      "targets": "docker/mcp-servers-source/conport/server.py, docker/mcp-servers-source/conport/enhanced_server.py",
+      "accept": "When CONPORT_RATE_LIMIT_WRITES_PER_MINUTE is unset: zero behavior change. When set: write calls exceeding the limit return 429/MCP-error with Retry-After; reads unaffected. Redis backend optional and degrades gracefully. Tests pass (in-memory path)."
+    }
+  ],
+  "blocks": [
+    ["L101", "L102"],
+    ["L101", "L103"]
+  ],
+  "notes": "SEPARATE orchestrator root — do NOT merge into DMX-CONPORT-OPTIMAL root (44452f53). Load only after DMX-CONPORT-OPTIMAL TP-109 (Stabilize tier complete) per §6 of the dossier. All three seams are default-off; committing them is safe and does not change runtime behavior. L102 (audit log) is always-on-safe (no behavior change beyond logging) but depends on L101 for the identity-extraction helper in auth.py. L103 depends on L101 for the same reason. Execution agent: codex on dedicated worktrees per AGENTS.md; PAL risky/architecture chain per packet. Proof bundle per AGENTS.md §8 required before each PR merge. The :3005 FastMCP SSE surface (server.py) is the primary target; :3004 enhanced_server.py write routes are also addressed. Confirm the 3005/3004 production binding before finalizing security verdicts (residual UNKNOWN per dossier §3.6)."
+}

--- a/docs/ops/load-plans/load_plan-DMX-CONPORT-OPTIMAL-TIER0.json
+++ b/docs/ops/load-plans/load_plan-DMX-CONPORT-OPTIMAL-TIER0.json
@@ -1,0 +1,37 @@
+{
+  "program": "DMX-CONPORT-OPTIMAL-TIER0",
+  "date": "2026-06-16",
+  "source_plan": "claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md",
+  "validation": "17-agent adversarial workflow + gpt-5.2 external review; verdict: Tier-0 foundation is a prerequisite before any feature packet; see dossier §1 §4 and ADR docs/90-adr/adr-conport-hardening-scope-and-trinity-boundaries.md D1",
+  "tag": "dmx-conport-optimal-tier0,series,supervised-only",
+  "root": {
+    "ref": "root",
+    "title": "DMX-CONPORT-OPTIMAL-TIER0: migration-apply foundation + traversal repair (blocks Tier-2/Tier-3)",
+    "summary": "Two-packet foundation that must complete before any DMX-CONPORT-OPTIMAL feature packets (202/203/301/302/303) execute. RUNTIME-VERIFIED finding: the live ConPort DB has only 2 tables (decisions, entity_relationships) because enhanced_server.py::_ensure_schema applies only schema.sql and never invokes the migrations/ directory. Five Tier-2/Tier-3 packets target tables/columns that do not exist at runtime. Packet 001 ships a gated, operator-invoked, idempotent, ordered migration runner (migrate.py) plus a checksummed schema_migrations table and a fail-closed /health gate that refuses writes when migrations are absent or partial. Packet 002 repairs the entity_relationships CTE column names and uuid handling in unified_queries.py so the traversal endpoint executes cleanly against the real schema. This is a SEPARATE orchestrator root — do NOT perturb the existing loaded root 44452f53."
+  },
+  "epics": [
+    {"ref": "E0", "title": "Tier-0: migration and traversal foundation", "phase": 0}
+  ],
+  "leaves": [
+    {
+      "ref": "L001",
+      "parent": "E0",
+      "title": "DMX-CONPORT-OPTIMAL-001: gated migration runner + checksummed schema_migrations + fail-closed health gate",
+      "disp": "HARDEN",
+      "targets": "docker/mcp-servers-source/conport/migrate.py (new); docker/mcp-servers-source/conport/enhanced_server.py (health gate + write-refusal); docker/mcp-servers-source/conport/tests/test_migration_runner.py (new)",
+      "accept": "migrate.py applies migrations idempotently in numeric order; schema_migrations table records version + checksum + applied_at; /health reports degraded when migrations absent or partial; write endpoints return 503 when degraded; reads succeed; rebuild-from-zero test passes"
+    },
+    {
+      "ref": "L002",
+      "parent": "E0",
+      "title": "DMX-CONPORT-OPTIMAL-002: entity_relationships CTE column-name and uuid-handling repair in unified_queries.py",
+      "disp": "REBUILD",
+      "targets": "docker/mcp-servers-source/conport/unified_queries.py; docker/mcp-servers-source/conport/tests/test_entity_traversal.py (new)",
+      "accept": "CTE references source_id/target_id (matching live schema); no ::int cast on uuid columns; get_related_decisions returns correct graph shape; all traversal tests pass; VERIFIED-NO-OP recorded if bug already fixed by prior PR"
+    }
+  ],
+  "blocks": [
+    ["L001", "L002"]
+  ],
+  "notes": "CRITICAL SEQUENCING: This Tier-0 root is a SEPARATE orchestrator tree from the existing loaded DMX-CONPORT-OPTIMAL root (task_orchestrator_root_id 44452f53). Do NOT add Tier-0 leaves to the existing tree and do NOT reorder or remove any edges from the 44452f53 DAG. Load this as a new independent root. The logical blocking relationship is: Tier-0 (L001 then L002) must complete before executing DMX-CONPORT-OPTIMAL-202, 203, 301, 302, 303 from the existing tree. Enforcing this cross-tree constraint is the operator's responsibility (the task-orchestrator does not natively enforce cross-root deps). Recommend operator annotation: after loading this tree, add a gate note to existing DMX-CONPORT-OPTIMAL-202 stating 'blocked until Tier-0 root complete'. OPERATOR-DECISION defaults (baked into L001 invariants): Q1 = migration history append-only in-DB (schema_migrations table); Q2 = degraded mode = read-only (writes refused, reads allowed). To change these defaults, amend the invariants before execution — not at runtime. Packet 002 (L002) depends on 001 (L001) being complete and /health reporting healthy, so the migration-apply path is live before the traversal repair runs. The executing agent for 002 must re-verify column names at HEAD before patching (the dossier finding may have been resolved by PR #894 or subsequent commits); VERIFIED-NO-OP is a valid and acceptable outcome."
+}

--- a/task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-101-auth-write-seam.json
+++ b/task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-101-auth-write-seam.json
@@ -1,0 +1,129 @@
+{
+  "id": "DMX-CONPORT-HARDENING-101-auth-write-seam",
+  "project": "dopemux-mvp",
+  "target": "Insert a write-path auth check (bearer / shared-secret) that is ACTIVE only when env CONPORT_AUTH_TOKEN is set, and is a pure no-op otherwise; gate the FastMCP write tools in server.py and the :3004 monitoring_middleware chain in enhanced_server.py.",
+  "invariants": [
+    "This seam must default to OFF / no-op when CONPORT_AUTH_TOKEN is unset; it must not change runtime behavior unless explicitly enabled by the operator.",
+    "This packet must not add auth to read-only tools (get_progress, get_decisions, get_recent_activity, get_active_work, workspace_summary, get_context).",
+    "When CONPORT_AUTH_TOKEN is set and a write request is missing or has an invalid bearer token the server must return HTTP 401 (or MCP error) and must NOT write to the database.",
+    "The auth check must be fail-closed only when the token IS configured; when unset it is a transparent pass-through.",
+    "This packet must not modify schema.sql or any migration file.",
+    "This packet must not alter the :3005 SSE transport binding or the FastMCP tool signatures visible to agents.",
+    "This packet must not commit secrets or hardcode any token value."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-conport-hardening",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/conport-hardening-101-auth-write-seam",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(conport): add default-off write-path auth seam (CONPORT_AUTH_TOKEN)",
+    "allowlist": [
+      "docker/mcp-servers-source/conport/server.py",
+      "docker/mcp-servers-source/conport/enhanced_server.py",
+      "docker/mcp-servers-source/conport/auth.py",
+      "docker/mcp-servers-source/conport/tests/test_auth_write_seam.py",
+      "task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-101-auth-write-seam.json",
+      "proof/conport-hardening-101/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-101-auth-write-seam.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-101-auth-write-seam.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest docker/mcp-servers-source/conport/tests/test_auth_write_seam.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(conport): default-off write-path auth seam (CONPORT_AUTH_TOKEN)",
+    "body": "Adds a write-path auth check to the ConPort :3005 FastMCP surface (server.py) and the :3004 enhanced_server.py monitoring_middleware chain. When CONPORT_AUTH_TOKEN is unset (default) the check is a transparent no-op and runtime behavior is unchanged. When the token is set, every write tool call must present a matching bearer token or receive a 401 / MCP error — no write reaches the database. Read-only tools are not gated. Auth module lives in a new auth.py to keep both server files minimal.\n\nSurface: :3005 FastMCP (server.py) write tools — log_decision, log_progress, update_progress, update_context, fork_instance, promote, promote_all — plus :3004 enhanced_server.py write routes via middleware.\nBehavior when flag unset: zero change.\nBehavior when flag set: fail-closed on missing/wrong token.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: verify fresh worktree from origin/main, confirm repo marker, origin identity, branch, and clean status. Read docker/mcp-servers-source/conport/server.py and enhanced_server.py in full. Identify every write tool in server.py (@mcp.tool() functions that POST/PUT) and every write route in enhanced_server.py. Record findings in the proof preflight note.",
+      "validation": [
+        "All write tools in server.py are enumerated: log_decision, log_progress, update_progress, update_context, fork_instance, promote, promote_all.",
+        "The :3004 monitoring_middleware insertion point (~line 148-150 in enhanced_server.py) is identified and confirmed.",
+        "No write to primary checkout; worktree is clean and at origin/main HEAD."
+      ],
+      "context_files": [
+        "docker/mcp-servers-source/conport/server.py",
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docs/90-adr/adr-conport-hardening-scope-and-trinity-boundaries.md",
+        "claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Author docker/mcp-servers-source/conport/auth.py implementing: (a) check_auth_token(token_header: str | None) -> bool that reads os.getenv('CONPORT_AUTH_TOKEN'), returns True immediately when env is unset (no-op path), returns True when token matches, returns False when token is set but header is missing or does not match; (b) WRITE_TOOLS = frozenset of the write tool names for use as a guard list. Write failing tests in docker/mcp-servers-source/conport/tests/test_auth_write_seam.py covering: token-unset always passes, token-set correct bearer passes, token-set wrong bearer fails, token-set missing header fails, read-tool bypass (not gated).",
+      "validation": [
+        "auth.py exists and has no hardcoded token values.",
+        "Tests fail (production code not yet wired) covering all four cases plus read-tool bypass.",
+        "CONPORT_AUTH_TOKEN unset path returns True without inspecting the header at all."
+      ],
+      "expected_files": [
+        "docker/mcp-servers-source/conport/auth.py",
+        "docker/mcp-servers-source/conport/tests/test_auth_write_seam.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Wire the auth check into server.py: import check_auth_token from auth; add a _check_write_auth(request_context) helper that is called at the top of each write tool function (log_decision, log_progress, update_progress, update_context, fork_instance, promote, promote_all). When check_auth_token returns False, raise an MCP-compatible error with message 'Unauthorized: CONPORT_AUTH_TOKEN is configured but request is missing or has an invalid token.' Read-only tools (get_progress, get_decisions, get_recent_activity, get_active_work, workspace_summary, get_context) must NOT be touched.",
+      "validation": [
+        "Every @mcp.tool() write function calls _check_write_auth early before any I/O.",
+        "Read-only @mcp.tool() functions are unmodified.",
+        "No token value appears in source; only os.getenv('CONPORT_AUTH_TOKEN') in auth.py.",
+        "Tests for the server.py gate pass (mock CONPORT_AUTH_TOKEN env var)."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Wire the auth check into enhanced_server.py :3004 surface: insert an auth middleware immediately ahead of monitoring_middleware (~line 148-150). The middleware reads the Authorization header, calls check_auth_token, and returns a 401 JSON response for write HTTP methods (POST, PUT, PATCH, DELETE) when auth fails. For GET requests (reads) it is a pass-through regardless of token configuration.",
+      "validation": [
+        "The auth middleware is the FIRST entry in app.middlewares, before monitoring_middleware.",
+        "GET requests pass through without auth check even when CONPORT_AUTH_TOKEN is set.",
+        "POST/PUT/DELETE to any route return 401 JSON when token is set and header is wrong.",
+        "Tests cover the middleware path for both surfaces."
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Run all tests, validate the TP JSON, commit only allowlisted files, push the branch, open a PR against main, and file the proof bundle at proof/conport-hardening-101/ including: TP path+ID, worktree path, branch, repo identity, slices completed, files changed, validations with exit codes, codereview status, precommit status, commit SHA, PR URL, residual risks, UNKNOWNs, and cleanup status.",
+      "validation": [
+        "python -m pytest docker/mcp-servers-source/conport/tests/test_auth_write_seam.py -q exits 0.",
+        "python -m jsonschema -i task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-101-auth-write-seam.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "git diff --check exits 0.",
+        "Only allowlisted files are staged.",
+        "PR is open against main with proof bundle committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-102-write-audit-log.json
+++ b/task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-102-write-audit-log.json
@@ -1,0 +1,130 @@
+{
+  "id": "DMX-CONPORT-HARDENING-102-write-audit-log",
+  "project": "dopemux-mvp",
+  "target": "Append an append-only structured audit row (handler/route, workspace_id, identity-or-anon, timestamp) on every write handler in the ConPort :3005 FastMCP surface (server.py) and :3004 enhanced_server.py write routes; always-on-safe with no behavior change beyond logging.",
+  "invariants": [
+    "This seam must default to OFF / no-op when its env flag is unset; it must not change runtime behavior unless explicitly enabled by the operator.",
+    "The audit log must be append-only; existing rows must never be modified or deleted by this code path.",
+    "An audit log write failure must NOT cause the primary write operation to fail; log errors are swallowed with a logger.error and the original response is returned.",
+    "The audit row must capture at minimum: timestamp (UTC ISO-8601), surface (server.py tool name or enhanced_server.py route), workspace_id (from request payload or path), identity (bearer token subject or literal string 'anon'), and http_method or tool_name.",
+    "The audit log must not capture the full request payload, decision text, rationale, or any user content — only the routing metadata listed above.",
+    "This packet must not modify schema.sql or any migration file.",
+    "This packet must not alter the :3005 SSE transport binding or tool signatures."
+  ],
+  "depends_on": [
+    "DMX-CONPORT-HARDENING-101-auth-write-seam"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-conport-hardening",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-CONPORT-HARDENING-101-auth-write-seam",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/conport-hardening-102-write-audit-log",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(conport): append-only write audit log on all write handlers",
+    "allowlist": [
+      "docker/mcp-servers-source/conport/server.py",
+      "docker/mcp-servers-source/conport/enhanced_server.py",
+      "docker/mcp-servers-source/conport/audit_log.py",
+      "docker/mcp-servers-source/conport/tests/test_write_audit_log.py",
+      "task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-102-write-audit-log.json",
+      "proof/conport-hardening-102/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-102-write-audit-log.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-102-write-audit-log.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest docker/mcp-servers-source/conport/tests/test_write_audit_log.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(conport): append-only write audit log on all ConPort write handlers",
+    "body": "Adds an append-only structured audit record to every write handler in ConPort. The audit module (audit_log.py) writes one JSON-lines row per successful write call to a configurable append-only sink (default: stderr / logger; extensible to a file or DB table via CONPORT_AUDIT_SINK env var). Audit failures are swallowed and never block the primary operation.\n\nAudit row fields: timestamp (UTC ISO-8601), surface (tool name or HTTP route), workspace_id, identity ('anon' or bearer subject), tool_name or http_method. Full request payloads are never captured (privacy).\n\nAlways-on-safe: no behavior change beyond an extra log line per write. Depends on DMX-CONPORT-HARDENING-101 for the auth.py identity extraction helper.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: verify fresh worktree from origin/main (stacked on or rebased to include 101 changes). Confirm auth.py is present (from 101). Read server.py and enhanced_server.py to enumerate all write handlers. Record the identity-extraction pattern from auth.py (check_auth_token) to reuse for audit identity field.",
+      "validation": [
+        "auth.py from TP-101 is present (dependency is satisfied).",
+        "All write tool functions in server.py are re-enumerated and match the 101 enumeration.",
+        "Proof preflight note is filed."
+      ],
+      "context_files": [
+        "docker/mcp-servers-source/conport/server.py",
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docker/mcp-servers-source/conport/auth.py",
+        "task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-101-auth-write-seam.json"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Author docker/mcp-servers-source/conport/audit_log.py implementing: (a) audit_write(surface: str, workspace_id: str, identity: str, tool_or_method: str) -> None that constructs a structured row dict with timestamp/surface/workspace_id/identity/tool_or_method and emits it; (b) a configurable sink: when CONPORT_AUDIT_SINK env is 'logger' (default) or unset, emit via logger.info(json.dumps(row)); when set to a file path, open in append mode and write; (c) all errors in the sink are caught and logged to logger.error without re-raising. Write failing tests in test_write_audit_log.py covering: row structure and required fields, sink=logger path, sink=file path, sink error is swallowed, payload content is never captured.",
+      "validation": [
+        "audit_log.py exists with no hardcoded file paths.",
+        "All required fields (timestamp, surface, workspace_id, identity, tool_or_method) appear in the emitted row.",
+        "Tests fail because the audit calls are not yet wired into server.py / enhanced_server.py."
+      ],
+      "expected_files": [
+        "docker/mcp-servers-source/conport/audit_log.py",
+        "docker/mcp-servers-source/conport/tests/test_write_audit_log.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Wire audit_write into server.py: after the auth check (if any) and after the primary write returns successfully, call audit_write with surface='server.py:<tool_name>', workspace_id extracted from the tool arguments, identity derived from the authorization context (reuse auth.py helper; 'anon' when no token configured), tool_or_method=<tool_name>. The call is wrapped in try/except so any audit failure is silent. Read-only tools are not touched.",
+      "validation": [
+        "Every write @mcp.tool() function in server.py calls audit_write after the primary write, wrapped in try/except.",
+        "Read-only tools are unmodified.",
+        "Tests for server.py audit wiring pass (mock audit_write to capture calls)."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Wire audit_write into enhanced_server.py :3004 surface: add an audit post-processing step in the write middleware or in each write route handler. After a successful write response (status 2xx), call audit_write with surface='enhanced_server.py:<route>', workspace_id extracted from request body or path, identity from Authorization header (or 'anon'), tool_or_method=request.method. Wrap in try/except; errors are silent.",
+      "validation": [
+        "All POST/PUT/DELETE routes in enhanced_server.py emit an audit row on success.",
+        "GET routes do not emit audit rows.",
+        "Audit errors do not change the HTTP response code or body.",
+        "Tests for enhanced_server.py middleware audit pass."
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Run all tests, validate the TP JSON, commit only allowlisted files, push the branch, open a PR against main, and file the proof bundle at proof/conport-hardening-102/ including: TP path+ID, worktree path, branch, repo identity, slices completed, files changed, validations with exit codes, codereview status, precommit status, commit SHA, PR URL, residual risks, UNKNOWNs, and cleanup status.",
+      "validation": [
+        "python -m pytest docker/mcp-servers-source/conport/tests/test_write_audit_log.py -q exits 0.",
+        "python -m jsonschema -i task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-102-write-audit-log.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "git diff --check exits 0.",
+        "Only allowlisted files are staged.",
+        "PR is open against main with proof bundle committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-103-rate-limit-seam.json
+++ b/task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-103-rate-limit-seam.json
@@ -1,0 +1,135 @@
+{
+  "id": "DMX-CONPORT-HARDENING-103-rate-limit-seam",
+  "project": "dopemux-mvp",
+  "target": "Add a per-caller write rate-limit seam to the ConPort :3005 FastMCP surface (server.py) and :3004 enhanced_server.py write routes, env-gated default-off via CONPORT_RATE_LIMIT_WRITES_PER_MINUTE and CONPORT_RATE_LIMIT_BURST; no-op when unset.",
+  "invariants": [
+    "This seam must default to OFF / no-op when CONPORT_RATE_LIMIT_WRITES_PER_MINUTE is unset; it must not change runtime behavior unless explicitly enabled by the operator.",
+    "The rate-limiter must key per-caller identity (bearer token subject if auth is active, or the literal string 'anon' if CONPORT_AUTH_TOKEN is unset), not per workspace_id.",
+    "When the rate limit is exceeded the server must return HTTP 429 (or MCP error) with a Retry-After header or field indicating when the caller may retry.",
+    "The in-process rate-limit state must use a sliding-window or token-bucket algorithm and must be stored in-memory (no external dependency required); Redis integration is optional and only attempted when REDIS_URL is set.",
+    "Rate-limit state must be reset on process restart; persistence across restarts is not required.",
+    "Read-only tools and GET routes must not be rate-limited.",
+    "This packet must not modify schema.sql or any migration file.",
+    "This packet must not alter the :3005 SSE transport binding or FastMCP tool signatures."
+  ],
+  "depends_on": [
+    "DMX-CONPORT-HARDENING-101-auth-write-seam"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-conport-hardening",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-CONPORT-HARDENING-101-auth-write-seam",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/conport-hardening-103-rate-limit-seam",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(conport): default-off per-caller write rate-limit seam (CONPORT_RATE_LIMIT_*)",
+    "allowlist": [
+      "docker/mcp-servers-source/conport/server.py",
+      "docker/mcp-servers-source/conport/enhanced_server.py",
+      "docker/mcp-servers-source/conport/rate_limit.py",
+      "docker/mcp-servers-source/conport/tests/test_rate_limit_seam.py",
+      "task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-103-rate-limit-seam.json",
+      "proof/conport-hardening-103/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-103-rate-limit-seam.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-103-rate-limit-seam.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest docker/mcp-servers-source/conport/tests/test_rate_limit_seam.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(conport): default-off per-caller write rate-limit seam (CONPORT_RATE_LIMIT_*)",
+    "body": "Adds a per-caller write rate-limit seam to ConPort. Controlled by two env vars: CONPORT_RATE_LIMIT_WRITES_PER_MINUTE (sustained rate) and CONPORT_RATE_LIMIT_BURST (burst allowance). When both are unset (default) the limiter is a transparent no-op and runtime behavior is unchanged.\n\nWhen configured: a token-bucket / sliding-window in-memory store (rate_limit.py) keys on caller identity (bearer subject from auth.py or 'anon'). Write calls that exceed the configured rate receive HTTP 429 / MCP error with a Retry-After indicator. GET routes and read-only tools are never rate-limited. Optional Redis backend is activated only when REDIS_URL is also set (degrades gracefully to in-memory if Redis is unreachable).\n\nDepends on DMX-CONPORT-HARDENING-101 for the identity-extraction helper from auth.py.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: verify fresh worktree from origin/main (includes or rebases onto 101 changes). Confirm auth.py is present. Read server.py and enhanced_server.py. Identify the caller-identity pattern from auth.py to derive the rate-limit key. Plan the algorithm choice (token bucket vs sliding window) and document the rationale in the proof note — token bucket is preferred for burst clarity.",
+      "validation": [
+        "auth.py from TP-101 is present.",
+        "Caller-identity derivation (bearer subject or 'anon') is confirmed available from auth.py.",
+        "Algorithm choice is recorded in proof preflight note with rationale.",
+        "Proof preflight note is filed; primary checkout is untouched."
+      ],
+      "context_files": [
+        "docker/mcp-servers-source/conport/server.py",
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docker/mcp-servers-source/conport/auth.py",
+        "task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-101-auth-write-seam.json"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Author docker/mcp-servers-source/conport/rate_limit.py implementing: (a) RateLimiter class with is_allowed(caller_id: str) -> tuple[bool, int] that returns (True, 0) immediately when CONPORT_RATE_LIMIT_WRITES_PER_MINUTE is unset (no-op path); when set, applies token-bucket algorithm using CONPORT_RATE_LIMIT_WRITES_PER_MINUTE (int) and CONPORT_RATE_LIMIT_BURST (int, default = writes_per_minute); returns (False, retry_after_seconds) when limit exceeded; (b) optional Redis backend: if REDIS_URL is set and redis is importable, use Redis for state; otherwise use a thread-safe in-memory dict with a lock; Redis errors degrade to in-memory silently; (c) module-level singleton get_rate_limiter() -> RateLimiter. Write failing tests in test_rate_limit_seam.py covering: flag-unset always returns (True, 0), within-limit call returns True, over-limit call returns (False, >0), burst allows burst count, Redis-unavailable degrades to in-memory.",
+      "validation": [
+        "rate_limit.py exists with no hardcoded rate values.",
+        "Tests fail because rate_limit calls are not yet wired.",
+        "The no-op path (env unset) returns (True, 0) without inspecting the caller_id at all.",
+        "The algorithm is deterministic for a given sequence of calls in tests."
+      ],
+      "expected_files": [
+        "docker/mcp-servers-source/conport/rate_limit.py",
+        "docker/mcp-servers-source/conport/tests/test_rate_limit_seam.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Wire the rate limiter into server.py: import get_rate_limiter; at the top of each write tool function (after the auth check from 101), call get_rate_limiter().is_allowed(identity) where identity comes from auth.py. If (False, retry_after): raise an MCP-compatible error with message 'Rate limit exceeded. Retry after {retry_after}s.' and include retry_after in the error detail. Read-only tools are not touched.",
+      "validation": [
+        "Every write @mcp.tool() function calls the rate limiter after the auth check and before any I/O.",
+        "Read-only tools are unmodified.",
+        "Rate-limit error surfaces a Retry-After value.",
+        "Tests for server.py rate-limit wiring pass (mock get_rate_limiter)."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Wire the rate limiter into enhanced_server.py :3004 surface: in the write middleware (from 101 or a sibling middleware), after the auth check, call get_rate_limiter().is_allowed(identity). On (False, retry_after): return a 429 JSON response with {'error': 'rate_limit_exceeded', 'retry_after': retry_after} and Retry-After header. Pass-through for GET requests without checking the rate limiter.",
+      "validation": [
+        "POST/PUT/DELETE routes return 429 with Retry-After when limit exceeded.",
+        "GET routes are not rate-limited.",
+        "The 429 response body includes retry_after in seconds.",
+        "Tests for enhanced_server.py rate-limit middleware pass."
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Run all tests, validate the TP JSON, commit only allowlisted files, push the branch, open a PR against main, and file the proof bundle at proof/conport-hardening-103/ including: TP path+ID, worktree path, branch, repo identity, slices completed, files changed, validations with exit codes, codereview status, precommit status, commit SHA, PR URL, residual risks, UNKNOWNs, and cleanup status. Note in the proof that the Redis backend path is NOT_RUN in CI (requires a live Redis); mark as residual risk.",
+      "validation": [
+        "python -m pytest docker/mcp-servers-source/conport/tests/test_rate_limit_seam.py -q exits 0 (in-memory path only).",
+        "python -m jsonschema -i task-packets/generated/DMX-CONPORT-HARDENING/DMX-CONPORT-HARDENING-103-rate-limit-seam.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "git diff --check exits 0.",
+        "Only allowlisted files are staged.",
+        "PR is open against main with proof bundle committed.",
+        "Proof bundle records Redis backend as NOT_RUN with residual risk noted."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-001-migration-apply-foundation.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-001-migration-apply-foundation.json
@@ -1,0 +1,141 @@
+{
+  "id": "DMX-CONPORT-OPTIMAL-001-migration-apply-foundation",
+  "project": "dopemux-mvp",
+  "target": "Give ConPort a gated, operator-invoked, idempotent, ordered migration-apply path plus a fail-closed health gate so that the migration files under docker/mcp-servers-source/conport/migrations/ actually reach the live DB — today the server applies only schema.sql and never runs migrations, leaving the live DB with only the base tables and none of the tables/columns targeted by Tier-2 and Tier-3 feature packets.",
+  "invariants": [
+    "Process-start (server startup) MUST NOT auto-apply migrations. Migration apply is an explicit operator-invoked action only.",
+    "Migrations must be applied in strictly ascending numeric order (001, 002, 003, ...). Out-of-order apply is an error.",
+    "Every migration must be idempotent: re-running against an already-migrated DB must be a no-op with zero side effects.",
+    "A schema_migrations table must be created in the DB (append-only): columns version (integer), checksum (text — SHA-256 of migration file contents), applied_at (timestamptz), applied_by (text). Rows are never updated or deleted.",
+    "Checksum integrity: if a previously-applied migration file's content has changed (checksum mismatch), the runner must refuse to proceed and report the discrepancy — never silently re-apply.",
+    "Fail-closed health gate: when the server starts and expected migrations are absent or only partially applied relative to the migration files present in /app/migrations/, the /health endpoint must report status=degraded and the server must refuse all write operations (reads allowed, writes refused). The server must NOT refuse reads in degraded mode (OPERATOR-DECISION Q2 — CONFIRMED by operator 2026-06-16: read-only-when-degraded; refuse-all rejected).",
+    "Migration history is stored in-DB in schema_migrations (OPERATOR-DECISION Q1 — CONFIRMED by operator 2026-06-16: append-only in-DB; external-log-only rejected).",
+    "The runner module (migrate.py) must be importable standalone and invocable as: python migrate.py --database-url <DSN> [--dry-run] [--target-version N].",
+    "dry-run mode must report what would be applied without mutating the DB.",
+    "No feature packet — including DMX-CONPORT-OPTIMAL-202 — may run until this packet is complete and the health gate reports healthy.",
+    "Classify any operator input that is absent, ambiguous, or undecided as UNKNOWN and fail closed.",
+    "The acceptance proof must demonstrate rebuild-from-zero determinism: drop DB, re-apply schema.sql + invoke migrate.py, assert identical schema + schema_migrations rows.",
+    "Do not modify existing migration SQL files. The runner reads them; it does not rewrite them.",
+    "Do not silently swallow migration errors. Any SQL error during migration must abort the run and report the failing migration version and error."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-conport-optimal",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/conport-optimal-001-migration-apply-foundation",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(conport): gated idempotent migration runner + checksummed schema_migrations + fail-closed health gate",
+    "allowlist": [
+      "docker/mcp-servers-source/conport/migrate.py",
+      "docker/mcp-servers-source/conport/enhanced_server.py",
+      "docker/mcp-servers-source/conport/tests/test_migration_runner.py",
+      "task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-001-migration-apply-foundation.json",
+      "proof/conport-optimal-001/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-001-migration-apply-foundation.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-001-migration-apply-foundation.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest docker/mcp-servers-source/conport/tests/test_migration_runner.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(conport): gated migration runner, checksummed schema_migrations, fail-closed /health gate",
+    "body": "Adds an explicit operator-invoked migration runner (docker/mcp-servers-source/conport/migrate.py) so the migration SQL files under migrations/ actually reach the live DB.\n\nToday enhanced_server.py::_ensure_schema applies only schema.sql; the migrations/ directory is never executed. The live DB therefore contains only the base tables (decisions, entity_relationships, etc.) and none of the tables/columns targeted by Tier-2/Tier-3 packets (decision_relationships, review_reminders, adhd_metrics, enhanced decision columns).\n\nThis packet ships:\n- migrate.py: standalone runner; applies migrations in numeric order; idempotent (re-runs are no-ops); records version + SHA-256 checksum + applied_at + applied_by in a schema_migrations table; refuses to continue on checksum mismatch; supports --dry-run and --target-version; never called from server startup.\n- enhanced_server.py: /health gate extended to compare expected migration count against schema_migrations rows; reports status=degraded when migrations are absent or partial; refuses write operations when degraded (reads allowed).\n- tests/test_migration_runner.py: idempotency, ordering, checksum-mismatch refusal, dry-run no-op, rebuild-from-zero determinism, degraded-mode write refusal.\n\nOPERATOR-DECISION defaults encoded as invariants: Q1 = in-DB append-only history; Q2 = read-only-when-degraded (writes refused, reads allowed).",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: verify the worktree is on a fresh branch from origin/main. Confirm repo identity (repo_marker .dopetaskroot, origin DDD-Enterprises/dopemux-mvp). Read AGENTS.md, this TP JSON, the dossier (claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md §1 §4), the ADR (docs/90-adr/adr-conport-hardening-scope-and-trinity-boundaries.md D1 §4), enhanced_server.py::_ensure_schema, migrations/ directory listing, schema.sql, and migrations/001_enhanced_decision_model.sql. Record current state of live DB if accessible (table list). Identify all migration files and their numeric order. Record any UNKNOWN or ambiguity as UNKNOWN in the proof.",
+      "validation": [
+        "Branch is clean and based on origin/main; repo identity verified.",
+        "The full list of migration files (numeric order, filenames) is recorded in proof.",
+        "_ensure_schema behavior confirmed: applies schema.sql only, never migrations.",
+        "UNKNOWN items (e.g. live DB state if inaccessible) are explicitly recorded."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docker/mcp-servers-source/conport/schema.sql",
+        "docker/mcp-servers-source/conport/migrations/001_enhanced_decision_model.sql",
+        "claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md",
+        "docs/90-adr/adr-conport-hardening-scope-and-trinity-boundaries.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write failing tests in docker/mcp-servers-source/conport/tests/test_migration_runner.py BEFORE writing production code (TDD). Test cases required: (a) migrate.py applies migrations in numeric order; (b) re-running migrate.py on an already-migrated DB is a no-op (idempotent); (c) checksum mismatch on a previously-applied migration causes refusal with a non-zero exit code and an error message naming the version; (d) --dry-run reports what would be applied without mutating schema_migrations; (e) after applying all migrations, schema_migrations has one row per migration with correct version + checksum + applied_at; (f) a server with missing migrations reports /health degraded; (g) write operations are refused (return error) when the server is in degraded mode; (h) read operations succeed when the server is in degraded mode; (i) rebuild-from-zero: drop schema_migrations, rerun migrate.py, assert identical row count and checksums.",
+      "validation": [
+        "All 9 test cases are present and fail (no production code exists yet).",
+        "Tests use a real or mocked asyncpg connection; they do not mock away the SQL execution logic.",
+        "No test is skipped or marked xfail without a recorded justification in proof."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement docker/mcp-servers-source/conport/migrate.py. Requirements: (1) Create schema_migrations table if absent (version INTEGER NOT NULL, checksum TEXT NOT NULL, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), applied_by TEXT NOT NULL DEFAULT 'migrate.py', PRIMARY KEY(version)); (2) Scan /app/migrations/*.sql (or a configurable migrations_dir), sort by numeric prefix, skip non-numeric-prefixed files; (3) For each migration: if already in schema_migrations, verify checksum matches — mismatch = abort with error; if not yet applied, execute SQL in a single transaction, then INSERT into schema_migrations; (4) --dry-run flag: report plan without executing; (5) --target-version N: apply up to version N only; (6) --database-url: accept DSN or fall back to DATABASE_URL env var; (7) exit 0 on success, non-zero on any error. The module must be importable as a library (if __name__ == '__main__' guard).",
+      "validation": [
+        "migrate.py is importable without side effects.",
+        "All test cases (a)-(i) from S2 pass.",
+        "No migration SQL file is modified by the runner.",
+        "schema_migrations rows are immutable after insert (no UPDATE/DELETE issued by runner)."
+      ],
+      "expected_files": [
+        "docker/mcp-servers-source/conport/migrate.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Extend enhanced_server.py to add the fail-closed health gate. In the startup path (init_connections or a new _check_migration_status coroutine), connect to DB and compare the count of applied migrations in schema_migrations against the count of numeric migration files in /app/migrations/. If schema_migrations is absent or count(applied) < count(files): set an internal flag self._migration_degraded = True. In the /health handler: if _migration_degraded, return JSON {status: 'degraded', reason: 'migrations_pending', pending_count: N} with HTTP 200 (health checks must not 500). In every write-path handler (log_decision, log_progress, update_active_context, update_product_context, log_system_pattern, log_custom_data, link_conport_items, delete_*, batch_log_items, and any other mutation endpoint): if _migration_degraded, return HTTP 503 with {error: 'service_degraded', reason: 'migrations_pending'}. Read endpoints must continue to serve normally. Do not call migrate.py automatically; the gate is read-only (it checks, never applies).",
+      "validation": [
+        "When schema_migrations is absent, /health returns {status: degraded} (HTTP 200).",
+        "Write endpoints return 503 when _migration_degraded is True.",
+        "Read endpoints return normal responses when _migration_degraded is True.",
+        "When all migrations are applied, /health returns {status: healthy} (or the existing healthy shape).",
+        "The server startup does not invoke migrate.py."
+      ],
+      "context_files": [
+        "docker/mcp-servers-source/conport/enhanced_server.py"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Run the full test suite (test_migration_runner.py + existing conport tests), validate the TP JSON against the canonical schema, commit only allowlisted files, push the branch, open a PR against main, and assemble the proof bundle. Proof bundle must include: TP id, worktree absolute path, branch, repo origin identity, files changed with line counts, test exit codes (pytest -v output), codereview status (PAL codereview invoked), precommit status, commit SHA, PR URL or exact blocker, residual risks including any UNKNOWN items from S1, rebuild-from-zero test result, cleanup status.",
+      "validation": [
+        "pytest docker/mcp-servers-source/conport/tests/test_migration_runner.py exits 0; all 9 cases pass.",
+        "python -m jsonschema exits 0 for this TP JSON.",
+        "Only allowlisted files are staged and committed.",
+        "Proof bundle is written to proof/conport-optimal-001/ and included in the commit.",
+        "Residual risks and any UNKNOWN items are explicitly listed; none are collapsed to PASS."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-002-entity-traversal-repair.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-002-entity-traversal-repair.json
@@ -1,0 +1,120 @@
+{
+  "id": "DMX-CONPORT-OPTIMAL-002-entity-traversal-repair",
+  "project": "dopemux-mvp",
+  "target": "Repair the entity_relationships traversal at the data layer in unified_queries.py: fix any CTE column-name mismatches against the live entity_relationships schema (source_id/target_id, both uuid), remove any ::int casts applied to uuid values, and ensure the recursive CTE executes cleanly against the real table columns as RUNTIME-VERIFIED in the live DB. Handler-layer bugs (unclamped max_depth, int() coercion on handler params) are owned by the amended DMX-CONPORT-OPTIMAL-203 and must NOT be duplicated here.",
+  "invariants": [
+    "This packet owns ONLY unified_queries.py CTE column-name and uuid-handling fixes. Handler-layer fixes (int(max_depth) clamping, decision_id validation) belong to DMX-CONPORT-OPTIMAL-203.",
+    "The executing agent must re-verify the actual column names in entity_relationships against the live DB (or schema.sql) before making any changes — do not patch from the dossier alone. If the column names are already correct at HEAD, record that as VERIFIED and close the step with a no-op; do not create a fabricated fix.",
+    "The CTE must use the actual column names as they exist in the live entity_relationships table. RUNTIME-VERIFIED columns: source_id (uuid), target_id (uuid). Do not introduce source_item_id or target_item_id.",
+    "No ::int cast may be applied to any uuid column (source_id, target_id, decisions.id). Use ::text for string comparison where needed.",
+    "Do not alter the entity_relationships table schema. This packet touches only Python/SQL query code.",
+    "Do not alter enhanced_server.py except for import adjustments if the UnifiedQueryAPI interface signature changes.",
+    "The response shape of get_related_decisions must be preserved: root, nodes (id, workspace_id, summary, depth), total_nodes, max_depth_reached.",
+    "Classify any ambiguity between dossier claims and HEAD code as UNKNOWN; re-verify from source before patching.",
+    "If PAL codereview identifies additional uuid-handling issues in unified_queries.py (outside the CTE fix), record them as findings but do not fix them in this packet — create a follow-on note instead."
+  ],
+  "depends_on": [
+    "DMX-CONPORT-OPTIMAL-001-migration-apply-foundation"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-conport-optimal",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-CONPORT-OPTIMAL-001-migration-apply-foundation",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/conport-optimal-002-entity-traversal-repair",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "fix(conport): repair entity_relationships CTE column names and uuid handling in unified_queries.py",
+    "allowlist": [
+      "docker/mcp-servers-source/conport/unified_queries.py",
+      "docker/mcp-servers-source/conport/tests/test_entity_traversal.py",
+      "task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-002-entity-traversal-repair.json",
+      "proof/conport-optimal-002/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-002-entity-traversal-repair.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-002-entity-traversal-repair.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest docker/mcp-servers-source/conport/tests/test_entity_traversal.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(conport): repair entity_relationships CTE column names and uuid handling (data layer only)",
+    "body": "Repairs the entity_relationships traversal at the data layer in unified_queries.py.\n\nContext: The dossier (conport-optimal-coverage-and-hardening-analysis-2026-06-16.md §3.1 T0-TRAVERSE) RUNTIME-VERIFIED that the live entity_relationships table has columns source_id (uuid) and target_id (uuid) — not source_item_id / target_item_id. Any CTE referencing the wrong column names would produce a PostgreSQL error at query time. Additionally, ::int casts on uuid values are invalid and must be removed.\n\nThis packet's scope is exclusively the data-layer fix in unified_queries.py (get_related_decisions and related CTE helpers). Handler-layer issues (max_depth clamping, int() coercion on query params in enhanced_server.py) are owned by DMX-CONPORT-OPTIMAL-203.\n\nThe executing agent must verify actual column names at HEAD against schema.sql / live DB before patching. If the fix was already applied by a prior PR (e.g. #894), the agent records VERIFIED-NO-OP and closes the step with no change to unified_queries.py. Fabricated fixes are not acceptable.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: verify worktree is on a fresh branch from origin/main, DMX-CONPORT-OPTIMAL-001 is complete (schema_migrations table exists in DB, /health reports healthy). Read schema.sql for entity_relationships column definitions. Read unified_queries.py get_related_decisions in full. Run 'SELECT column_name, data_type FROM information_schema.columns WHERE table_name = entity_relationships' against the live DB if accessible. Record the actual column names (source_id vs source_item_id, etc.) and data types as RUNTIME-VERIFIED or UNKNOWN. Read DMX-CONPORT-OPTIMAL-203 JSON to confirm handler-layer bugs are excluded from this packet's scope.",
+      "validation": [
+        "Actual entity_relationships column names are recorded with evidence source (schema.sql line / live DB query result / UNKNOWN).",
+        "The current unified_queries.py CTE column references are recorded verbatim.",
+        "Any discrepancy between dossier claims and HEAD code is documented as an UNKNOWN or RESOLVED item.",
+        "DMX-CONPORT-OPTIMAL-203 scope is confirmed as distinct from this packet."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docker/mcp-servers-source/conport/unified_queries.py",
+        "docker/mcp-servers-source/conport/schema.sql",
+        "task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-203-fix-workspace-relationships-traversal.json",
+        "claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write failing tests in docker/mcp-servers-source/conport/tests/test_entity_traversal.py BEFORE any production changes. Tests must cover: (a) get_related_decisions with a valid UUID decision_id returns a graph dict with keys root, nodes, total_nodes, max_depth_reached; (b) no ValueError or psycopg/asyncpg ProgrammingError is raised for UUID source_id / target_id values (catches ::int cast bugs); (c) depth-1 traversal returns only direct neighbors; (d) depth-2 traversal returns second-hop nodes; (e) the CTE does not reference source_item_id or target_item_id (static analysis of the generated SQL string or an assertion on column names used). If S1 found the bug is already fixed (VERIFIED-NO-OP), write tests that assert the correct behavior holds — they should pass immediately and serve as regression guards.",
+      "validation": [
+        "All 5 test cases are present.",
+        "Tests that exercise new behavior fail before the fix (if the bug exists at HEAD); tests that assert already-correct behavior pass immediately.",
+        "Tests use UUID strings for all entity IDs, not integers.",
+        "Test file path matches commit allowlist."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Apply the minimal fix to unified_queries.py. If S1 confirmed the column names are already correct (source_id / target_id) and no ::int casts exist on uuid columns: record VERIFIED-NO-OP in proof, do not modify unified_queries.py. If bugs are present: rename any source_item_id to source_id, any target_item_id to target_id; remove any ::int cast applied to source_id, target_id, or decisions.id; use ::text for comparisons where string equality is needed (the existing pattern r.source_id::text = dg.id is the correct idiom). Do not change the response shape, caching logic, or any code outside the CTE and its column references.",
+      "validation": [
+        "All S2 tests pass after the change (or pass unchanged if VERIFIED-NO-OP).",
+        "No ::int cast remains on any uuid column in unified_queries.py.",
+        "The CTE references source_id and target_id (matching entity_relationships schema).",
+        "Response shape is unchanged: root (str), nodes (list of {id, workspace_id, summary, depth}), total_nodes (int), max_depth_reached (int)."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Run the full test suite (test_entity_traversal.py + existing conport tests), validate the TP JSON, commit only allowlisted files, push branch, open PR against main, record proof bundle. Proof bundle must include: TP id, worktree path, branch, repo identity, list of files changed with line counts (or VERIFIED-NO-OP for unified_queries.py if no change made), test exit codes, codereview status (PAL codereview), precommit status, commit SHA, PR URL or exact blocker, residual risks. Explicitly list any out-of-scope findings surfaced by PAL codereview that belong to DMX-CONPORT-OPTIMAL-203 or follow-on packets.",
+      "validation": [
+        "pytest test_entity_traversal.py exits 0; all 5 cases pass.",
+        "python -m jsonschema exits 0 for this TP JSON.",
+        "Only allowlisted files are staged.",
+        "Proof bundle written to proof/conport-optimal-002/ and included in the commit.",
+        "VERIFIED-NO-OP outcome (if applicable) is recorded with evidence, not treated as a skip."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-101-server-bringup-smoke.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-101-server-bringup-smoke.json
@@ -7,7 +7,8 @@
     "This packet must not modify production data or workspace state.",
     "This packet must not alter schema.sql or migration files.",
     "Smoke output must be captured and included in the proof bundle.",
-    "Failure to reach health endpoint is a hard FAIL — do not mark PASS with inference."
+    "Failure to reach health endpoint is a hard FAIL — do not mark PASS with inference.",
+    "The smoke test MUST fail if /health reports healthy while ag_catalog schema is absent from the database OR expected schema_migrations rows are absent — a healthy status over a broken graph or un-migrated DB is a lie and must be surfaced as FAIL, not silently passed."
   ],
   "depends_on": [],
   "repo_binding": {
@@ -99,6 +100,20 @@
     },
     {
       "id": "S4",
+      "task": "Validate graph and migration state: query the live DB (via docker exec psql) to confirm (a) ag_catalog schema is present (SELECT schema_name FROM information_schema.schemata WHERE schema_name='ag_catalog'), and (b) expected schema_migrations rows exist (SELECT COUNT(*) FROM schema_migrations where applied = true, or equivalent). If either check returns absent/zero, the smoke MUST be marked FAIL regardless of /health HTTP 200 — record this as health-lies-over-broken-state. Capture query output in proof bundle.",
+      "commands": [
+        "docker exec dopemux-postgres-age psql -U dopemux_age -d dopemux_knowledge_graph -c \"SELECT schema_name FROM information_schema.schemata WHERE schema_name='ag_catalog';\"",
+        "docker exec dopemux-postgres-age psql -U dopemux_age -d dopemux_knowledge_graph -c \"SELECT COUNT(*) FROM schema_migrations;\" 2>/dev/null || echo 'schema_migrations_absent'"
+      ],
+      "validation": [
+        "ag_catalog schema presence confirmed by direct DB query — if absent, result is FAIL even if /health returned 200.",
+        "schema_migrations table existence and applied-row count confirmed by direct DB query — if absent or zero rows, result is FAIL.",
+        "Both query outputs captured in proof bundle.",
+        "If either check fails, proof bundle records 'health-lies-over-broken-state' and the overall smoke result is FAIL."
+      ]
+    },
+    {
+      "id": "S5",
       "task": "Commit proof bundle, validate packet JSON against canonical spec, and open PR.",
       "validation": [
         "TP JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-106-jsonrpc-parity-transport.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-106-jsonrpc-parity-transport.json
@@ -8,7 +8,8 @@
     "Do not change the REST route shapes or response envelopes.",
     "info_server.py SSE URL fix must change :3004 to :3005 only for the advertised SSE endpoint.",
     "Dockerfile EXPOSE 3005 must be additive — do not remove existing EXPOSE directives.",
-    "tools/list must advertise exactly 13 tools after this packet (verify count)."
+    "tools/list must advertise exactly 13 tools after this packet (verify count).",
+    "The /health sub-check added by this packet must probe ag_catalog schema availability and the applied schema_version from schema_migrations; when either is absent the health response MUST surface 'graph: degraded' — a healthy status over a missing AGE graph or un-migrated DB is classified as a lie and must not pass."
   ],
   "depends_on": [
     "DMX-CONPORT-OPTIMAL-104-mcp-surface-custom-data",
@@ -104,6 +105,17 @@
     },
     {
       "id": "S4",
+      "task": "Extend /health to include a graph sub-check: query the DB for ag_catalog schema presence (SELECT schema_name FROM information_schema.schemata WHERE schema_name='ag_catalog') and the highest applied schema_version from schema_migrations. When ag_catalog is absent OR schema_migrations is absent or empty, the /health JSON response MUST include a 'graph' key set to 'degraded'. When both checks pass, 'graph' should be 'ok'. The HTTP status code may remain 200 but the 'graph' field must distinguish the two states. Add a corresponding test in test_jsonrpc_parity.py that asserts 'graph' key is present in /health response.",
+      "validation": [
+        "GET /health response JSON contains a 'graph' key.",
+        "When ag_catalog schema is absent, 'graph' equals 'degraded'.",
+        "When schema_migrations is absent or has zero applied rows, 'graph' equals 'degraded'.",
+        "When both checks pass, 'graph' equals 'ok'.",
+        "Test for 'graph' key presence added to test_jsonrpc_parity.py."
+      ]
+    },
+    {
+      "id": "S5",
       "task": "Run tests against live container. Verify tools/list count is 13. Run PAL codereview and precommit. Commit, push, open PR, file proof bundle.",
       "commands": [
         "python3 -m pytest docker/mcp-servers-source/conport/tests/test_jsonrpc_parity.py -q"
@@ -111,6 +123,7 @@
       "validation": [
         "All parity tests PASS with exit code 0.",
         "tools/list JSON response captured in proof with tool count verified at 13.",
+        "/health response captured in proof showing 'graph' key present.",
         "Only allowlisted files staged and committed."
       ]
     }

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-107-gate-autofork-on-get.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-107-gate-autofork-on-get.json
@@ -9,7 +9,11 @@
     "The env var DOPEMUX_AUTO_FORK_PROGRESS may set the default to true for backward compatibility in specific deployments — document this in a comment.",
     "The DCP readonly facade (services/dcp-readonly-facade/) must not be given write capability.",
     "Do not alter any other GET route to add write side-effects.",
-    "Classify any ambiguous caller behavior as UNKNOWN — do not assume."
+    "Classify any ambiguous caller behavior as UNKNOWN — do not assume.",
+    "fork_instance, promote, and promote_all MUST be marked admin-scoped behind a default-permissive flag (default: any caller may invoke them; operator may restrict to admin-only by setting the flag). NOTE: agents bind the :3005 FastMCP surface where these are advertised @mcp.tool() tools, not hidden dark methods.",
+    "promote MUST include an idempotency guard: calling promote on an already-promoted item must be a no-op (return success without re-applying), not an error or a double-apply.",
+    "promote_all MUST carry the real percentage value through the event it emits — today it emits percentage=0, losing the actual value. Fix the event payload to include the correct percentage.",
+    "The auto-fork refetch path that currently raises AttributeError MUST be fixed; classify the root cause before patching."
   ],
   "depends_on": [
     "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke"
@@ -100,15 +104,41 @@
     },
     {
       "id": "S4",
-      "task": "Update DCP facade conport.py to ensure its progress call does not include ?auto_fork=true. Run all tests. Run PAL codereview and precommit. Commit, push, open PR, file proof bundle.",
+      "task": "Update DCP facade conport.py to ensure its progress call does not include ?auto_fork=true. Run auto-fork tests.",
+      "commands": [
+        "python3 -m pytest docker/mcp-servers-source/conport/tests/test_gate_autofork.py -q"
+      ],
+      "validation": [
+        "All auto-fork tests PASS with exit code 0.",
+        "Zero-row assertion confirmed via test output captured in proof.",
+        "DCP facade file diff confirms no ?auto_fork=true added."
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Trace and fix the three admin-tool bugs in server.py / enhanced_server.py (whichever file hosts fork_instance, promote, promote_all on the :3005 FastMCP surface): (a) Add a default-permissive admin-scope flag (e.g. DOPEMUX_ADMIN_ONLY_FORK env var, default false) that gates fork_instance/promote/promote_all — document in a comment that agents bind :3005 where these are advertised tools; (b) Add a promote idempotency guard so calling promote on an already-promoted item is a no-op returning success; (c) Fix promote_all to carry the real percentage value through its emitted event (locate the event payload construction and pass the actual percentage argument, not a hardcoded 0); (d) Fix the auto-fork refetch path that raises AttributeError — read the method, identify the missing attribute, and add a None-guard or correct attribute reference.",
+      "context_files": [
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docker/mcp-servers-source/conport/server.py"
+      ],
+      "validation": [
+        "Admin-scope flag present and documented in a comment naming the :3005 FastMCP surface.",
+        "promote idempotency guard present — calling promote twice does not double-apply.",
+        "promote_all event payload carries the real percentage value, not 0.",
+        "AttributeError-raising refetch path is patched with a None-guard or correct attribute reference.",
+        "grep confirms no unconditional AttributeError-raising path remains in the fork refetch logic."
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Run all tests, validate TP JSON, commit allowlisted files, push, open PR, file proof bundle.",
       "commands": [
         "python3 -m pytest docker/mcp-servers-source/conport/tests/test_gate_autofork.py -q"
       ],
       "validation": [
         "All tests PASS with exit code 0.",
-        "Zero-row assertion confirmed via test output captured in proof.",
-        "DCP facade file diff confirms no ?auto_fork=true added.",
-        "Only allowlisted files staged and committed."
+        "Only allowlisted files staged and committed.",
+        "Proof bundle records all four fixes (admin-scope, idempotency, percentage, AttributeError) with evidence."
       ]
     }
   ]

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-109-docs-reconciliation.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-109-docs-reconciliation.json
@@ -38,6 +38,7 @@
     "allowlist": [
       ".claude/modules/cognitive-plane/conport-memory.md",
       "docs/systems/conport/TRINITY_BOUNDS.md",
+      "docs/systems/conport/relationship-vocab-reconciliation.md",
       "docker/mcp-servers-source/conport/SURFACE_INVENTORY.md",
       "docs/systems/conport/surface-equivalence-and-drift.md",
       "docker/mcp-servers-source/conport/schema.sql",
@@ -114,6 +115,17 @@
     },
     {
       "id": "S5",
+      "task": "Add a relationship-vocabulary reconciliation section to TRINITY_BOUNDS.md (or as a standalone doc/systems/conport/relationship-vocab-reconciliation.md if TRINITY_BOUNDS.md is already complete). The section MUST include a table documenting that the two relationship vocabularies are INTENTIONALLY DISTINCT and must NOT be merged: entity_relationships vocab = {builds_upon, validates, extends, implements, depends_on, supersedes} (6 terms, all cross-type entity edges); decision_relationships vocab = {builds_upon, supersedes, conflicts_with, validates, implements, questions} (6 terms, decision-to-decision semantic links). The table must call out the 3 shared terms (builds_upon, validates, implements) and note they carry the same surface meaning but operate on different subject types. The section must explicitly state: 'These vocabularies are intentionally separate by ADR-conport-hardening-scope-and-trinity-boundaries D3. Do not merge them.'",
+      "validation": [
+        "Relationship vocabulary reconciliation table is present in TRINITY_BOUNDS.md or the dedicated vocab doc.",
+        "Table lists all 6 terms of entity_relationships vocab and all 6 terms of decision_relationships vocab.",
+        "3 shared terms (builds_upon, validates, implements) are explicitly called out.",
+        "Text explicitly states the split is intentional per ADR-D3 and must not be merged.",
+        "No merger of the two vocabularies is performed or implied by any other change in this packet."
+      ]
+    },
+    {
+      "id": "S6",
       "task": "Run verify commands. Confirm grep for FROZEN returns exactly 3. Run PAL codereview and precommit. Commit, push, open PR, file proof bundle.",
       "commands": [
         "grep -c 'FROZEN: belongs in dope-memory' docker/mcp-servers-source/conport/schema.sql"
@@ -121,6 +133,7 @@
       "validation": [
         "grep command returns exactly 3.",
         "All docs reference only existing tools — no aspirational tool names remain.",
+        "Relationship vocabulary reconciliation table exists and is accurate.",
         "PR opened with proof bundle capturing pre/post diff of each doc file.",
         "Only allowlisted files staged and committed."
       ]

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-202-entity-relationship-write-api.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-202-entity-relationship-write-api.json
@@ -3,7 +3,8 @@
   "project": "dopemux-mvp",
   "target": "Make the ConPort knowledge graph real by implementing POST/GET/DELETE REST endpoints for entity_relationships, adding link_items and get_linked_items MCP tools in server.py and conport_mcp_stdio.py, and adding Redis cache invalidation for relationship keys — with relationship_type enum defaulting to builds_upon, validates, extends, implements, depends_on, supersedes (Operator Decision Gate 2 default).",
   "invariants": [
-    "This packet must not modify entity_relationships table structure — only add REST and MCP write paths to the existing table.",
+    "This packet must not execute until the Tier-0 migration foundation (DMX-CONPORT-OPTIMAL-001) is applied and the schema_version health gate is green — writing entity_relationships rows before the foundation is applied risks irreversible schema-drift poisoning of canonical memory.",
+    "This packet must not modify entity_relationships table structure — only add REST and MCP write paths to the existing table. Adding DB-level FK and CHECK constraints is an OPERATOR_DECISION explicitly out of this packet's mandatory scope; app-layer enum enforcement is the in-scope default.",
     "relationship_type must be validated against the Decision-2 enum: builds_upon, validates, extends, implements, depends_on, supersedes.",
     "Unknown relationship_type values must be rejected with 422, not silently accepted.",
     "DELETE must be soft-checked: return 404 if the relationship does not exist rather than silently no-op.",
@@ -73,7 +74,7 @@
       "id": "S1",
       "task": "Preflight: read AGENTS.md, enhanced_server.py, server.py, conport_mcp_stdio.py, and schema.sql to map the existing entity_relationships table structure and any existing read-only relationship code. Identify Redis cache key patterns used for relationships. Record baseline SHA and worktree status.",
       "validation": [
-        "entity_relationships table columns (id, workspace_id, source_id, source_type, target_id, target_type, relationship_type, metadata, created_at) are confirmed from schema.sql.",
+        "entity_relationships table columns are confirmed by direct DB inspection: RUNTIME-VERIFIED columns are (id, workspace_id, source_type, source_id, target_type, target_id, relationship_type, strength, created_at) — NOTE: the column is 'strength' NOT 'metadata'; any prior reference to a 'metadata' column was incorrect and must not be used in queries or INSERT statements.",
         "Existing relationship read paths are identified and their signatures captured for non-regression reference.",
         "Redis cache key pattern for relationships is documented in proof."
       ],

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-203-fix-workspace-relationships-traversal.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-203-fix-workspace-relationships-traversal.json
@@ -1,11 +1,13 @@
 {
   "id": "DMX-CONPORT-OPTIMAL-203-fix-workspace-relationships-traversal",
   "project": "dopemux-mvp",
-  "target": "Fix the workspace_relationships graph read traversal in enhanced_server.py so it queries public.entity_relationships via a UUID-safe recursive CTE, removes the int(decision_id) coercion that causes ValueError on UUID IDs, and supports traversal depth 1–3.",
+  "target": "Harden the workspace_relationships graph read traversal in enhanced_server.py: clamp the unclamped max_depth (approximately line 2023) to 1–3 with 422 on out-of-range, and add UUID-safe regression tests. RECONCILIATION (git-verified at HEAD a3c2e61ac): PR #894 already removed the int(decision_id) coercion and made the recursive CTE UUID-safe — verify absent at HEAD and record VERIFIED-NO-OP rather than re-fixing.",
   "invariants": [
+    "This packet must not execute until the Tier-0 migration foundation (DMX-CONPORT-OPTIMAL-001) is applied and the schema_version health gate is green — the traversal fix targets entity_relationships which is foundational to Tier-2 correctness.",
+    "This packet is scoped to HANDLER-LAYER hardening in enhanced_server.py only. RECONCILIATION (git-verified at HEAD a3c2e61ac): PR #894 ALREADY removed the int(decision_id) cast (now decision_id=decision_id) AND repaired the unified_queries.py CTE column names/uuid casts (source_id/target_id::text). The SURVIVING handler bug is the UNCLAMPED max_depth at approximately line 2023 — clamp it to 1–3 with 422 on out-of-range. The executing agent must VERIFY at HEAD: if int(decision_id) is already absent, record VERIFIED-NO-OP and do NOT fabricate a fix; the unified_queries.py CTE repair is owned by DMX-CONPORT-OPTIMAL-002 (also expected VERIFIED-NO-OP post-#894).",
     "This packet must not alter the entity_relationships table schema.",
-    "The recursive CTE must be UUID-safe — no integer coercion on any ID column.",
-    "Depth parameter must be clamped to 1–3; requests outside this range must be rejected, not silently clamped.",
+    "The recursive CTE, if touched, must be UUID-safe — no integer coercion on any ID column.",
+    "Depth parameter must be clamped to 1–3; requests outside this range must be rejected with 422, not silently clamped.",
     "The traversal must traverse public.entity_relationships only — not any legacy relationships table.",
     "Existing callers of workspace_relationships must continue to receive the same response shape.",
     "Do not remove or alias unified_queries.py without updating all callers.",
@@ -49,7 +51,7 @@
   },
   "pr": {
     "title": "fix(conport): UUID-safe recursive CTE traversal for workspace_relationships, depth 1-3",
-    "body": "Rewrites the workspace_relationships handler in enhanced_server.py (~lines 1993-2038) to traverse public.entity_relationships via a recursive CTE without int() coercion on UUID decision IDs. Removes the ValueError-causing int(decision_id) cast at approximately line 2024. Adds depth parameter (1-3) with 422 on out-of-range. Updates unified_queries.py if the CTE logic is factored there. Adds regression tests for depth-1, depth-2, depth-3 traversal and confirms no ValueError or 500 on UUID IDs.",
+    "body": "Hardens the workspace_relationships handler in enhanced_server.py (~lines 1993-2038). RECONCILIATION (git-verified at HEAD a3c2e61ac): PR #894 already removed the int(decision_id) cast and made the unified_queries.py CTE UUID-safe (source_id/target_id::text). The surviving fix here is clamping the unclamped max_depth (approximately line 2023) to 1-3 with 422 on out-of-range; the int-cast removal and CTE repair are recorded as VERIFIED-NO-OP unless still present at HEAD. Adds regression tests for depth-1/2/3 traversal confirming no ValueError or 500 on UUID IDs.",
     "base": "main"
   },
   "pal_chain": {
@@ -69,12 +71,13 @@
   "steps": [
     {
       "id": "S1",
-      "task": "Trace the existing workspace_relationships handler in enhanced_server.py lines ~1993-2038. Locate the int(decision_id) coercion and document the exact line number. Identify which table (public.entity_relationships vs any legacy table) is currently queried. Read unified_queries.py to determine if the query logic is already factored out. Record the current response shape so it can be preserved.",
+      "task": "Trace the existing workspace_relationships handler in enhanced_server.py lines ~1993-2038. VERIFY whether the int(decision_id) coercion is present — PR #894 removed it, so expect ABSENT (decision_id=decision_id); record presence/absence with the exact line. Locate the max_depth parameter (approximately line 2023) and document the exact line — this is the surviving unclamped bug this packet fixes. Identify which table (public.entity_relationships vs any legacy table) is currently queried. Read unified_queries.py to confirm the CTE column-name/uuid repair is already applied (owned by DMX-CONPORT-OPTIMAL-002; expect VERIFIED-NO-OP post-#894) and record OUT_OF_SCOPE here. Record the current response shape so it can be preserved.",
       "validation": [
-        "The exact line of int(decision_id) coercion is identified and recorded in proof.",
+        "The presence or absence of the int(decision_id) coercion is recorded with the exact line (expected ABSENT post-#894 → VERIFIED-NO-OP).",
+        "The exact line of max_depth parsing is identified and recorded in proof.",
         "The current query target table is confirmed (legacy vs entity_relationships).",
         "The response shape (keys, types) for workspace_relationships is captured.",
-        "unified_queries.py relationship query functions are enumerated."
+        "unified_queries.py CTE column-name repairs are noted as OUT_OF_SCOPE — owned by DMX-CONPORT-OPTIMAL-002."
       ],
       "context_files": [
         "AGENTS.md",
@@ -93,7 +96,7 @@
     },
     {
       "id": "S3",
-      "task": "Rewrite the workspace_relationships handler: replace the legacy query with a recursive CTE over public.entity_relationships (WITH RECURSIVE traversal(id, source_id, target_id, relationship_type, depth) AS (base UNION ALL recursive step WHERE depth < ?)); remove int() coercion; validate depth parameter (1-3, return 422 otherwise); return edges in the existing response shape. If the CTE is better placed in unified_queries.py, factor it there and call from enhanced_server.py.",
+      "task": "Apply the surviving handler fix: clamp/validate the max_depth parameter (1-3, return 422 otherwise). If S1 found the int(decision_id) coercion already removed by #894, record VERIFIED-NO-OP and do not re-touch it; only if a coercion is still present should it be removed. Keep the recursive CTE UUID-safe (post-#894 it already references public.entity_relationships with source_id/target_id::text). Return edges in the existing response shape. Do not duplicate the unified_queries.py CTE repair (owned by DMX-CONPORT-OPTIMAL-002).",
       "validation": [
         "No int() or integer coercion on any ID field remains in the handler.",
         "Recursive CTE references public.entity_relationships explicitly.",

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-301-decision-outcome-retrospective.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-301-decision-outcome-retrospective.json
@@ -3,6 +3,7 @@
   "project": "dopemux-mvp",
   "target": "Add PATCH /api/decisions/{decision_id}/outcome REST endpoint and update_decision_outcome MCP tool so agents can record retrospective outcomes on existing decisions without touching the immutable summary/rationale fields.",
   "invariants": [
+    "This packet must not execute until the Tier-0 migration foundation (DMX-CONPORT-OPTIMAL-001) is applied and the schema_version health gate is green — the target outcome columns (outcome_status, outcome_notes, outcome_date, lessons_learned) on the decisions table are created by migration 001, which Tier-0 now applies; this packet MUST NOT attempt to create or use those columns before the foundation is confirmed applied.",
     "This packet must not modify the summary or rationale fields of any existing decision.",
     "This packet must preserve the append-only invariant: only outcome_status, outcome_notes, outcome_date, and lessons_learned may be written by the new endpoint.",
     "This packet must not add a new migration if migration 001 already defines the outcome columns; verify before adding SQL.",
@@ -69,10 +70,11 @@
   "steps": [
     {
       "id": "S1",
-      "task": "Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker (.dopetaskroot), origin identity, branch name, and clean baseline. Read docker/mcp-servers-source/conport/schema.sql and migrations/001*.sql to confirm that outcome_status, outcome_notes, outcome_date, and lessons_learned columns already exist on the decisions table. Record findings in proof.",
+      "task": "NOTE: The outcome columns (outcome_status, outcome_notes, outcome_date, lessons_learned) on the decisions table are created by migration 001, which is applied by the Tier-0 foundation packet (DMX-CONPORT-OPTIMAL-001). This packet MUST NOT proceed unless the Tier-0 health gate is confirmed green (schema_version shows migration 001 applied). Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker (.dopetaskroot), origin identity, branch name, and clean baseline. Confirm Tier-0 gate is green by checking /health 'graph' and 'schema_version' fields. Then read docker/mcp-servers-source/conport/schema.sql and migrations/001*.sql to confirm that outcome columns exist at runtime. Record findings in proof.",
       "validation": [
         "Worktree path, branch, origin, marker verified and recorded in proof.",
-        "Confirmed (or UNKNOWN) whether outcome columns exist in migration 001 — no guessing."
+        "Tier-0 health gate confirmed green (schema_version shows migration 001 applied) before proceeding — if not green, STOP and record BLOCKED.",
+        "Confirmed (or UNKNOWN) whether outcome columns exist in migration 001 at runtime — no guessing."
       ],
       "context_files": [
         "docker/mcp-servers-source/conport/schema.sql",

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-302-review-reminders.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-302-review-reminders.json
@@ -3,6 +3,7 @@
   "project": "dopemux-mvp",
   "target": "Activate the review_reminders table and expose REST + MCP interfaces to create, list, and complete decision-review reminders, giving ADHD practitioners a schedulable nudge loop for revisiting past decisions.",
   "invariants": [
+    "This packet must not execute until the Tier-0 migration foundation (DMX-CONPORT-OPTIMAL-001) is applied and the schema_version health gate is green — the review_reminders table is created by migration 001, which Tier-0 now applies; this packet MUST NOT attempt to use that table before the foundation is confirmed applied.",
     "This packet must verify whether review_reminders exists in migration 001 or schema.sql before adding any migration.",
     "This packet must add migration 009_review_reminders.sql only if the table is confirmed absent; if it is present, the migration step is NOT_RUN.",
     "This packet must not modify existing decisions data or the decisions table schema.",
@@ -69,9 +70,10 @@
   "steps": [
     {
       "id": "S1",
-      "task": "Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker, origin identity, branch, and clean baseline. Inspect docker/mcp-servers-source/conport/schema.sql and all migration files under migrations/ to determine whether a review_reminders table is already defined. Record finding (EXISTS / ABSENT / UNKNOWN) in proof.",
+      "task": "NOTE: The review_reminders table is created by migration 001, which is applied by the Tier-0 foundation packet (DMX-CONPORT-OPTIMAL-001). This packet MUST NOT proceed unless the Tier-0 health gate is confirmed green (schema_version shows migration 001 applied). Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker, origin identity, branch, and clean baseline. Confirm Tier-0 gate is green by checking /health 'graph' and 'schema_version' fields. Then inspect docker/mcp-servers-source/conport/schema.sql and all migration files under migrations/ to determine whether a review_reminders table is already defined at runtime. Record finding (EXISTS / ABSENT / UNKNOWN) in proof.",
       "validation": [
         "Worktree path, branch, origin, marker verified and recorded in proof.",
+        "Tier-0 health gate confirmed green (schema_version shows migration 001 applied) before proceeding — if not green, STOP and record BLOCKED.",
         "Table existence classified as EXISTS, ABSENT, or UNKNOWN — not assumed."
       ],
       "context_files": [

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-303-decision-to-decision-relationships.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-303-decision-to-decision-relationships.json
@@ -3,6 +3,7 @@
   "project": "dopemux-mvp",
   "target": "Activate the decision_relationships table and expose REST + MCP interfaces to create and list typed decision-to-decision links (builds_upon, supersedes, conflicts_with, validates, implements, questions), enabling semantic knowledge-graph traversal across related decisions.",
   "invariants": [
+    "This packet must not execute until the Tier-0 migration foundation (DMX-CONPORT-OPTIMAL-001) is applied and the schema_version health gate is green — the decision_relationships table is created by migration 001, which Tier-0 now applies; this packet MUST NOT attempt to create or use that table before the foundation is confirmed applied.",
     "This packet must not merge decision_relationships into entity_relationships; that consolidation is deferred and must not happen here.",
     "This packet must verify whether decision_relationships exists in schema.sql or any migration before adding new SQL.",
     "This packet must fail-closed on unknown source_decision_id or target_decision_id (404).",
@@ -70,9 +71,10 @@
   "steps": [
     {
       "id": "S1",
-      "task": "Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker, origin identity, branch, and clean baseline. Inspect schema.sql and all migration files to determine whether decision_relationships is already defined. Also confirm that entity_relationships exists (it should, per DMX-CONPORT-OPTIMAL-202 dependency). Record both findings in proof. Note: do NOT attempt to merge or alias these tables — they are intentionally separate.",
+      "task": "NOTE: The decision_relationships table is created by migration 001, which is applied by the Tier-0 foundation packet (DMX-CONPORT-OPTIMAL-001). This packet MUST NOT proceed unless the Tier-0 health gate is confirmed green (schema_version shows migration 001 applied). Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker, origin identity, branch, and clean baseline. Confirm Tier-0 gate is green by checking /health 'graph' and 'schema_version' fields. Then inspect schema.sql and all migration files to determine whether decision_relationships is already defined at runtime. Also confirm that entity_relationships exists (it should, per DMX-CONPORT-OPTIMAL-202 dependency). Record all findings in proof. Note: do NOT attempt to merge or alias these tables — they are intentionally separate per ADR-D3.",
       "validation": [
         "Worktree verified and recorded in proof.",
+        "Tier-0 health gate confirmed green (schema_version shows migration 001 applied) before proceeding — if not green, STOP and record BLOCKED.",
         "decision_relationships table existence classified as EXISTS, ABSENT, or UNKNOWN.",
         "entity_relationships confirmed present (or recorded as UNKNOWN if not found).",
         "No merger of the two tables performed or planned."


### PR DESCRIPTION
## What

Prepends a **Tier-0 migration foundation** to the `DMX-CONPORT-OPTIMAL` series, adds a companion default-off **`DMX-CONPORT-HARDENING`** series, and applies DAG-safe in-place amendments to 9 loaded packets — backed by a runtime-verified analysis dossier and a scope/boundary ADR.

**Docs + task-packets only — no runtime source changes in this PR** (implementation lands when the packets execute).

## Why

Live-DB inspection (`psql` on the running `dopemux-postgres-age`) found the ConPort server **never applies its migrations** — `_ensure_schema` runs only `schema.sql`. The live DB has just `decisions` + `entity_relationships`; the migration tables (`decision_relationships`, `review_reminders`, `adhd_metrics`, the 14 enhanced-decision columns, multi-tenancy) do not exist at runtime. Five feature packets (202/203/301/302/303) therefore targeted nonexistent schema. A gated, fail-closed migration foundation must precede them.

## Contents

**New — Tier-0 (`DMX-CONPORT-OPTIMAL`):**
- `001-migration-apply-foundation` — gated, operator-invoked, idempotent, ordered migration runner; append-only checksummed `schema_migrations`; fail-closed health gate (read-only-when-degraded). NOT silent auto-apply.
- `002-entity-traversal-repair` — VERIFIED-NO-OP-aware (PR #894 already fixed the CTE columns + casts).
- `load_plan-DMX-CONPORT-OPTIMAL-TIER0.json`

**New — `DMX-CONPORT-HARDENING` (default-off seams on the :3005 surface):**
- `101-auth-write-seam`, `102-write-audit-log`, `103-rate-limit-seam` + load plan

**Amended in place (`depends_on` UNCHANGED — loaded DAG `44452f53` byte-identical):**
101, 106, 107, 109, 202, 203, 301, 302, 303

**Analysis:**
- `claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md`
- `docs/90-adr/adr-conport-hardening-scope-and-trinity-boundaries.md`

## Reconciliation with #894

PR #894 already resolved the `entity_relationships` CTE column names and the `int(decision_id)` cast; only the unclamped `max_depth` survives. TP-203, the dossier, and the ADR record this (VERIFIED-NO-OP) rather than re-asserting fixed bugs.

## Validation

- All packets schema-validated against `dopetask-canonical-spec.json`.
- `depends_on` unchanged on all 9 amended packets (loaded orchestrator DAG preserved).
- Operator decisions confirmed: Q1 = append-only in-DB `schema_migrations`; Q2 = read-only-when-degraded.
- Loaded into the task-orchestrator as 2 separate roots (Tier-0 `a3c7a18e`, HARDENING `cf62771e`); existing root `44452f53` untouched.

## Method

17-agent adversarial workflow + live-runtime verification + gpt-5.2 review. The dossier §0 documents provenance and limitations honestly (e.g. discovery was cap-bounded, not exhausted; PAL multi-model consensus was unavailable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
