### PR TITLE
docs(dcp): extract Prompt 5 runway reconciliation

### DIFF
--- a/docs/03-reference/dcp/DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md
+++ b/docs/03-reference/dcp/DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md
@@ -1,0 +1,118 @@
+---
+id: DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION
+title: Dcp Prompt5 Task Orchestrator Reconciliation
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-14'
+prelude: Live-state reconciliation for Prompt 5 chat-history extraction, DCP
+  model-routing task packets, GitHub PR state, and Task Orchestrator availability.
+---
+
+# DCP Prompt 5 Task Orchestrator Reconciliation
+
+> [!NOTE]
+> **Provenance**: `REPO_RECONCILIATION`
+> **Status**: Advisory ledger / non-runtime
+> **Scope**: Reconcile the pasted Prompt 5 chat history against current repo and
+> GitHub truth. Task Orchestrator live item reconciliation is blocked because
+> the MCP transport closed during `get_context()`.
+
+## Authority Used
+
+| Authority | Status | Used for |
+| --- | --- | --- |
+| `AGENTS.md` | OBSERVED | Truth order, no fake completion, Task Packet rules, Task Orchestrator boundary. |
+| `task-packets/INDEX.md` | OBSERVED | Current indexed DCP packet rows and active packet status. |
+| `docs/03-reference/dcp/README.md` | OBSERVED | Existing DCP artifact shelf and non-runtime preservation rules. |
+| GitHub `gh pr view` / GraphQL | OBSERVED live during extraction | PR status, head SHA, review-thread state. |
+| Task Orchestrator MCP `get_context()` | BLOCKED | Tool returned `Transport closed`; no live TO item state was read or mutated. |
+| Pasted chat transcript | EXTERNAL_CHAT_HISTORY_EXTRACT | Source material only; stale unless confirmed by live checks. |
+
+## Live Task Orchestrator Status
+
+Task Orchestrator live reconciliation was attempted through the available MCP
+tool surface:
+
+```text
+get_context()
+-> tool call error
+-> Transport closed
+```
+
+Result:
+
+- `NOT_RUN`: no Task Orchestrator items were queried.
+- `NOT_RUN`: no Task Orchestrator items were created, updated, advanced, or completed.
+- `UNKNOWN`: whether corresponding DCP task-packet items already exist in Task
+  Orchestrator.
+- `BLOCKED`: live TO reconciliation requires a working MCP transport or an
+  approved alternate read path.
+
+## Current Repo and GitHub Reconciliation
+
+Observed base:
+
+| Field | Value |
+| --- | --- |
+| Worktree | `/Users/hue/.codex/worktrees/0c51/dopemux-mvp` |
+| Branch for this reconciliation | `codex/dcp-prompt5-extract-reconcile` |
+| Initial extraction base HEAD / `origin/main` | `6c7f7e7b444c1f56a88a1231d7846404b1687910` |
+| Post-rebase `origin/main` refresh | `817d9d2275cd83d5fc0385828f64f46db2016523` |
+| Repo marker | `.repo_id` declares `project=dopemux-mvp` |
+
+## DCP Packet / PR Ledger
+
+| Item | Live state observed during extraction | Reconciliation |
+| --- | --- | --- |
+| #902 / `DMX-DCP-MODEL-ROUTING-MVP-0002R` | Merged before current main; commit visible in history as `a740edc40`. | Transcript claim that #902 is complete is consistent with current history. |
+| #904 / `DMX-DCP-PRE-PROMPT6-0002` | Merged before current main; commit visible in history as `ba36b58cb`. | Precedence fix is on current main. |
+| #906 / `DMX-DCP-MODEL-ROUTING-MVP-0005` implementation | Initially observed OPEN at head `c24530b1c36bcfe6a01a716476b7e0ddb35c328a` with two unresolved review threads. Post-rebase refresh shows #906 MERGED at `2026-06-17T01:30:37Z` with merge commit `02fa9b30ac0af2a4f418b7c1aa3f16e5bebe89c8`. | The pasted "merge now" state was stale during initial extraction; the later review blockers have since been resolved and merged. |
+| #907 / 0005 design packet | CLOSED with `mergedAt: null`; head `3b3ef7ca95bf41909c57e5c7ed6250e0747cf03c`. | Closed without merge. Do not treat 0005 packet from #907 as main authority unless another merged path introduces it. |
+| #908 / 0006 classifier provenance-hardening packet | Initially OPEN. Post-rebase refresh shows MERGED at `2026-06-16T23:37:32Z` with merge commit `12b3793fe3944f7677132543d80ee31a4d2637b9`. | Now main authority to the extent its merged docs say so; still subordinate to runtime truth. |
+| #909 / 0007 trusted input-provenance contract | Initially OPEN. Post-rebase refresh shows MERGED at `2026-06-17T00:39:40Z` with merge commit `0c521642c0e5c6d63a7b719249e30f2a61ff9a74`. | Now main authority to the extent its merged docs say so; still subordinate to runtime truth. |
+| #915 / 0006 implementation | Initially OPEN. Post-rebase refresh shows MERGED at `2026-06-17T01:42:05Z` with merge commit `556ffff1b31c3232306289211ee889ac9eb8862f`. | Runtime provenance hardening is now on main; verify current code before making behavior claims. |
+| #923 / #906 review-thread remediation | Post-rebase refresh shows MERGED at `2026-06-17T05:18:47Z` with merge commit `817d9d2275cd83d5fc0385828f64f46db2016523`. | Current `origin/main` includes the #906 thread remediation after this branch rebased. |
+
+## Reconciled Current Gate
+
+The pasted thread's #906 blocker state is now historical. After rebasing this
+branch onto `origin/main` at `817d9d227`, the DCP runway state is:
+
+- #906 merged.
+- #908 merged.
+- #909 merged.
+- #915 merged.
+- #923 merged on top of #906 to resolve review-thread remediation.
+- Task Orchestrator live item state remains `UNKNOWN`.
+
+Current safe next action is Task Orchestrator reconciliation once the MCP
+transport is healthy. Do not infer that this repository branch performed live
+Task Orchestrator item creation or advancement.
+
+## Task Orchestrator Reconciliation To Do
+
+When the MCP transport is healthy, run:
+
+```text
+get_context()
+query_items for DCP / model-routing / Prompt 5 / Prompt 6 / #906
+for each existing item: compare title, role, dependencies, notes, and blocker state
+if no item exists: create a root DCP runway item plus child items for #906, #908/#909/#915, and Prompt 6
+advance only through schema gates, with required notes filled
+```
+
+Required note content should include:
+
+- source transcript path
+- current GitHub PR URLs and head SHAs
+- current merged/review-thread state for #906 and follow-up remediation
+- explicit `UNKNOWN` for any unqueried Task Orchestrator state
+- separation between main authority and PR-bound artifacts
+
+## Non-Claims
+
+This ledger does not claim Task Orchestrator has been reconciled. It records why
+live TO reconciliation was blocked and what must be checked next.

--- a/docs/03-reference/dcp/README.md
+++ b/docs/03-reference/dcp/README.md
@@ -59,3 +59,8 @@ The following artifacts are stored under [artifacts/](file:///Users/hue/code/dop
 | [DCP_ADVERSARIAL_ARCHITECTURE_AUDIT.md](file:///Users/hue/code/dopemux-mvp-wt-dcp-docs-001/docs/03-reference/dcp/artifacts/DCP_ADVERSARIAL_ARCHITECTURE_AUDIT.md) | Adversarial Architecture Audit (Opus) | `EXTERNAL_PROPOSED` |
 | [DCP_ARCHITECTURE_SYNTHESIS_REVISED_DELTA.md](file:///Users/hue/code/dopemux-mvp-wt-dcp-docs-001/docs/03-reference/dcp/artifacts/DCP_ARCHITECTURE_SYNTHESIS_REVISED_DELTA.md) | Architecture Synthesis - Revised Delta (REV1) | `SYNTHESIS_INVENTED` |
 | [DCP_DR_EXTERNAL_CONSTRAINTS_LEDGER.md](file:///Users/hue/code/dopemux-mvp-wt-dcp-docs-001/docs/03-reference/dcp/artifacts/DCP_DR_EXTERNAL_CONSTRAINTS_LEDGER.md) | External Constraints Ledger | `EXTERNAL_PROPOSED` |
+| [DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md](artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md) | Prompt 5 / pre-Prompt 6 chat-history extraction | `EXTERNAL_CHAT_HISTORY_EXTRACT` |
+
+## Current Runway Reconciliation
+
+[DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md](DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md) records the live-state reconciliation for the Prompt 5 chat-history extract, including stale PR claims, #906 review blockers, and the Task Orchestrator MCP transport blocker observed during extraction.

--- a/docs/03-reference/dcp/artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md
+++ b/docs/03-reference/dcp/artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md
@@ -1,0 +1,185 @@
+---
+id: DCP_PROMPT5_CHAT_HISTORY_EXTRACT
+title: Dcp Prompt5 Chat History Extract
+type: reference
+owner: '@hu3mann'
+author: codex
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-14'
+prelude: Advisory extraction from a pasted ChatGPT Prompt 5 / pre-Prompt 6 DCP
+  architecture thread. This artifact preserves the recoverable documents without
+  promoting chat transcript claims to runtime truth.
+---
+
+# DCP Prompt 5 Chat History Extract
+
+> [!NOTE]
+> **Provenance**: `EXTERNAL_CHAT_HISTORY_EXTRACT`
+> **Status**: Preservation only / advisory / non-runtime
+> **Source**: `/Users/hue/.codex/attachments/f92d3469-7740-4a6a-83b4-0c8e3c64d649/pasted-text.txt`
+> **Authority rule**: This extract never outranks active task packets, runtime
+> code, tests, config, GitHub state, or Task Orchestrator state. Treat all PR
+> and branch claims here as stale unless re-verified live.
+
+## Extraction Summary
+
+The pasted chat history contains four recoverable document blocks:
+
+1. Prompt 5: a GPT-5.5 Pro architecture synthesis prompt for Dopemux / DCP.
+2. A "Doctor Report" that resets the pre-Prompt 6 runway around #902,
+   precedence repair, and 0005.
+3. A lane-engine safety-story block that frames 0005, 0006, and 0007 as a
+   design-gate sequence.
+4. Several #906 convergence/status instructions that collapse parallel DCP work
+   onto live PR review blockers.
+
+The transcript is not internally current. Later live checks performed during
+this extraction found conflicts with the pasted state; see
+`../DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md`.
+
+## Document A: Prompt 5 Architecture Synthesis Request
+
+**Observed in transcript**: Lines 28-579 contain a prompt titled
+"GPT-5.5 Pro Prompt 5 - Dopemux / DCP End-to-End Architecture Synthesis".
+
+**Purpose**: Ask GPT-5.5 Pro to synthesize the end-to-end Dopemux / DCP
+architecture and staged build program from evidence across prior prompt work,
+PRs, repo truth docs, system docs, proof contracts, and vendor constraints.
+
+**Non-authority guardrail preserved from the prompt**:
+
+- Runtime code, config, compose wiring, tests, active entrypoints, and live
+  GitHub state outrank prompt synthesis.
+- Candidate syntheses are proposals, not authority.
+- Bridge, proxy, adapter, shim, mirror, retrieval output, model output, PR body,
+  or generated synthesis must not be promoted into authority.
+
+**Required output shape in the prompt**:
+
+1. Executive architecture verdict.
+2. Evidence baseline.
+3. Architecture principles.
+4. System context map.
+5. Authority boundary ledger.
+6. DCP Core internal architecture.
+7. Classification architecture.
+8. Lane engine architecture.
+9. Runner backend architecture.
+10. Connector and evidence facade architecture.
+11. Proof and audit architecture.
+12. PR Steward and GitHub/CI architecture.
+13. External intake / ECC architecture.
+14. Cockpit / operator view.
+15. Build program roadmap.
+16. Dependency graph.
+17. Big risks and unknowns.
+18. Architecture diagrams.
+19. Decision ledger.
+20. Next 10 concrete actions.
+21. Prompt 6 / next Pro turn.
+22. Final recommendation.
+
+**Preserved architecture guardrails**:
+
+- DCP Core is evidence/readiness/proof/action-planning authority only until a
+  live-write contract exists.
+- No live writes until `LIVE_WRITE_READY` exists and passes gates.
+- Task Orchestrator is projection/workflow coordination in early phases, not
+  DCP authority and not universal PM authority.
+- Dopetask proof may be consumed; Dopetask execution must not be triggered by
+  DCP Core until a supervised execution contract exists.
+- PR Steward / Review Sensor is advisory readiness only, not merge authority.
+- GitHub branch protection and the human operator remain merge authority.
+- Secure read-only MCP is a facade / ACL-layer concern, not classifier
+  permission.
+- Raw MCP remains hard-blocked at classifier level.
+- OpenCode and Grok are backend runners only, not authorities.
+- ECC is untrusted external intake only.
+
+## Document B: Pre-Prompt 6 Doctor Report
+
+**Observed in transcript**: Lines 620-930 contain a "Doctor Report" that resets
+the control lane from broad architecture synthesis to pre-Prompt 6 runway
+management.
+
+**Core runway asserted by the transcript**:
+
+```text
+#902 merged
+-> precedence fix verified/PR'd/merged
+-> clean main
+-> 0005 lane engine implemented
+-> embedded audit + PR Steward
+-> Prompt 6 review
+```
+
+**Important correction preserved**:
+
+- Opus/local claims about a precedence commit or 0005 spec are `CLAIMED_ONLY`
+  until verified from local Git/GitHub state.
+- #873 is evidence/documentation lane only and should not block the DCP
+  implementation runway unless a specific artifact is needed.
+- Prompt 6 should review 0005 implementation correctness, not re-run the whole
+  architecture synthesis.
+
+**Doctor-report next action requested in the transcript**: A read-only local
+state doctor that checks repo root, remotes, current branch, `origin/main`,
+whether precedence commit `6c8fb55d5` exists, whether a 0005 spec exists, and
+which task-packet files are present.
+
+## Document C: Lane-Engine Safety Story / 0005-0007 Gate Trail
+
+**Observed in transcript**: Lines 975-1017 contain a "DCP lane-engine safety
+story" framing 0005, 0006, and 0007 as a coherent design sequence.
+
+**Extracted design story**:
+
+| Packet | Claimed role in transcript | Authority status in this extract |
+| --- | --- | --- |
+| `DMX-DCP-MODEL-ROUTING-MVP-0005` | Lane engine pure consumer: `decide_lane()` maps route decisions to lane decisions and never widens safety. | Advisory unless present on merged main or active PR branch. |
+| `DMX-DCP-MODEL-ROUTING-MVP-0006` | Classifier provenance hardening: provenance may only lower trust. | Advisory / PR-bound until live merge verified. |
+| `DMX-DCP-MODEL-ROUTING-MVP-0007` | Trusted input-provenance contract: execution eligibility should require an unforgeable capability, not serializable caller fields. | Advisory / PR-bound until live merge verified. |
+
+**Load-bearing design distinction**:
+
+> A proof flag is not a runner interface.
+
+The transcript treats 0006/0007 as preconditions before any executor can honor
+`is_executable`. This extract preserves that as design guidance only.
+
+## Document D: #906 Convergence Instructions
+
+**Observed in transcript**: Lines 1030-1230 contain multiple status and writing
+blocks that collapse parallel DCP threads onto #906 review blockers.
+
+**Stable content after live re-check**:
+
+- #906 is the lane-engine MVP PR.
+- The pasted "merge now" and "all checks pass" states are not safe to reuse
+  without live GitHub verification.
+- The transcript repeatedly converges to one next action: fix unresolved #906
+  review threads around `src/dopemux/dcp/lane_engine.py` before merge.
+- Post-rebase reconciliation later observed #906 and the related follow-up
+  remediation merged; see `../DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md`
+  for the current ledger.
+
+**Review-thread themes preserved**:
+
+- `READ_ONLY_EVIDENCE` must not expose mutating actions.
+- Repo-changing inputs must route before read-only fallback.
+- File-touching inputs must not land in passive evidence lanes with mutating
+  actions.
+- Non-runnable lanes must expose no mutating actions.
+
+## Non-Claims
+
+This artifact does not claim:
+
+- #906 is merge-ready.
+- #907, #908, #909, or #915 are merged.
+- Task Orchestrator has been updated or reconciled.
+- Prompt 6 is ready.
+- DCP is production-ready.
+- Secure MCP, runner wrappers, live writes, Dopetask execution, or Task
+  Orchestrator writes are authorized.

--- a/proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/AUDITOR_REPORT.md
+++ b/proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/AUDITOR_REPORT.md
@@ -1,0 +1,19 @@
+# Auditor Report
+
+Packet: `DMX-DCP-PROMPT5-EXTRACT-RECON-001`
+
+Embedded audit status: `SKIPPED`
+
+Reason: this packet is a docs-only extraction and reconciliation slice. It adds
+advisory DCP chat-history artifacts, records live GitHub reconciliation, and
+marks Task Orchestrator live reconciliation as blocked because the MCP
+`get_context()` call returned `Transport closed`.
+
+No runtime code, schemas, migrations, service config, or Task Orchestrator state
+was changed.
+
+Residual risks:
+
+- Task Orchestrator item state remains `UNKNOWN`.
+- Open PR status is time-sensitive and must be refreshed before acting.
+- No independent model audit was run for this docs-only slice.

--- a/proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/PROOF.json
+++ b/proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/PROOF.json
@@ -1,0 +1,135 @@
+{
+  "packet_id": "DMX-DCP-PROMPT5-EXTRACT-RECON-001",
+  "status": "PASS_WITH_BLOCKED_TASK_ORCHESTRATOR_RECONCILIATION",
+  "repo": {
+    "worktree": "/Users/hue/.codex/worktrees/0c51/dopemux-mvp",
+    "branch": "codex/dcp-prompt5-extract-reconcile",
+    "initial_base_head": "6c7f7e7b444c1f56a88a1231d7846404b1687910",
+    "post_rebase_origin_main": "817d9d2275cd83d5fc0385828f64f46db2016523",
+    "repo_marker": ".repo_id"
+  },
+  "source_artifact": "/Users/hue/.codex/attachments/f92d3469-7740-4a6a-83b4-0c8e3c64d649/pasted-text.txt",
+  "files_created": [
+    "docs/03-reference/dcp/artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md",
+    "docs/03-reference/dcp/DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md",
+    "task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json",
+    "proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/PROOF.json"
+  ],
+  "files_modified": [
+    "docs/03-reference/dcp/README.md",
+    "task-packets/INDEX.md"
+  ],
+  "live_reconciliation": {
+    "task_orchestrator": {
+      "status": "BLOCKED",
+      "attempted_tool": "get_context()",
+      "result": "Transport closed",
+      "items_queried": false,
+      "items_mutated": false
+    },
+    "github": {
+      "pr_906": {
+        "initial_state": "OPEN",
+        "initial_head": "c24530b1c36bcfe6a01a716476b7e0ddb35c328a",
+        "initial_unresolved_review_threads_observed": 2,
+        "post_rebase_state": "MERGED",
+        "merged_at": "2026-06-17T01:30:37Z",
+        "merge_commit": "02fa9b30ac0af2a4f418b7c1aa3f16e5bebe89c8",
+        "verdict": "MERGED_AFTER_REVIEW_THREAD_REMEDIATION"
+      },
+      "pr_907": {
+        "state": "CLOSED",
+        "merged_at": null,
+        "verdict": "CLOSED_WITHOUT_MERGE"
+      },
+      "pr_908": {
+        "state": "MERGED",
+        "merged_at": "2026-06-16T23:37:32Z",
+        "merge_commit": "12b3793fe3944f7677132543d80ee31a4d2637b9"
+      },
+      "pr_909": {
+        "state": "MERGED",
+        "merged_at": "2026-06-17T00:39:40Z",
+        "merge_commit": "0c521642c0e5c6d63a7b719249e30f2a61ff9a74"
+      },
+      "pr_915": {
+        "state": "MERGED",
+        "merged_at": "2026-06-17T01:42:05Z",
+        "merge_commit": "556ffff1b31c3232306289211ee889ac9eb8862f"
+      },
+      "pr_923": {
+        "state": "MERGED",
+        "merged_at": "2026-06-17T05:18:47Z",
+        "merge_commit": "817d9d2275cd83d5fc0385828f64f46db2016523",
+        "verdict": "CURRENT_ORIGIN_MAIN"
+      }
+    }
+  },
+  "validation": [
+    {
+      "command": "python -m json.tool task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json >/dev/null",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "python - <<'PY' ... Draft7Validator(dopetask-canonical-spec.json) ... PY",
+      "exit_code": 0,
+      "result": "PASS task packet schema validation"
+    },
+    {
+      "command": "rg -n \"EXTERNAL_CHAT_HISTORY_EXTRACT|Transport closed|#906|NOT_RUN|BLOCKED|UNKNOWN\" docs/03-reference/dcp/artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md docs/03-reference/dcp/DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "git diff --check",
+      "exit_code": 0,
+      "result": "PASS"
+    },
+    {
+      "command": "pre-commit run --files docs/03-reference/dcp/README.md docs/03-reference/dcp/artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md docs/03-reference/dcp/DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md task-packets/INDEX.md task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/PROOF.json proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/AUDITOR_REPORT.md",
+      "exit_code": 0,
+      "result": "PASS"
+    }
+  ],
+  "not_run": [
+    {
+      "item": "Task Orchestrator live item reconciliation",
+      "reason": "MCP get_context() failed with Transport closed."
+    },
+    {
+      "item": "Runtime tests",
+      "reason": "Docs-only extraction and reconciliation; no runtime source changed."
+    }
+  ],
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/AUDITOR_REPORT.md",
+    "findings": [],
+    "fixes_applied": [
+      "Added explicit advisory provenance labels to extracted docs.",
+      "Recorded Task Orchestrator MCP transport closure as BLOCKED/NOT_RUN instead of inventing item state.",
+      "Reconciled pasted #906 readiness claims against live GitHub review-thread state and post-rebase merge state."
+    ],
+    "remaining_risks": [
+      "No independent model audit was run for this docs-only extraction.",
+      "Task Orchestrator item state remains UNKNOWN because get_context() failed with Transport closed.",
+      "Open GitHub PR status is time-sensitive and must be refreshed before action."
+    ],
+    "skip_reason": "Docs-only extraction and reconciliation packet. No runtime code, schemas, migrations, service config, or executable workflow state changed; embedded audit was not invoked."
+  },
+  "remaining_uncertainty": [
+    "Live Task Orchestrator item state is UNKNOWN until MCP transport recovers or another approved read path is used.",
+    "Open PR check status is time-sensitive and must be refreshed before acting on remaining open DCP follow-up PRs.",
+    "The pasted transcript remains an advisory artifact, not runtime authority."
+  ],
+  "rollback": [
+    "git restore docs/03-reference/dcp/README.md task-packets/INDEX.md",
+    "git rm docs/03-reference/dcp/artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md docs/03-reference/dcp/DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/PROOF.json"
+  ]
+}

--- a/task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json
+++ b/task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json
@@ -1,0 +1,116 @@
+{
+  "id": "DMX-DCP-PROMPT5-EXTRACT-RECON-001",
+  "project": "dopemux-mvp",
+  "target": "Extract Prompt 5 / pre-Prompt 6 DCP chat-history documents into repo-tracked advisory docs and reconcile task-packet claims against live GitHub and Task Orchestrator availability.",
+  "invariants": [
+    "Extracted chat-history documents remain advisory and must not outrank runtime code, active task packets, tests, config, GitHub state, or Task Orchestrator state.",
+    "No runtime source, service, compose, MCP, or workflow-execution files may be edited.",
+    "No Task Orchestrator write is authorized by this packet.",
+    "Task Orchestrator live reconciliation must be marked NOT_RUN or BLOCKED if the MCP transport is unavailable.",
+    "Stale PR claims from the transcript must be reconciled against live GitHub before being recorded.",
+    "DCP live-write, raw MCP, Dopetask execution, runner execution, and Task Orchestrator writes remain unauthorized."
+  ],
+  "depends_on": [
+    "DMX-DCP-MODEL-ROUTING-MVP-0002R",
+    "DMX-DCP-PRE-PROMPT6-0002"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".repo_id",
+    "origin_hint": "github.com/DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-DCP-PROMPT5-EXTRACT",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dcp-prompt5-extract-reconcile",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "docs(dcp): extract prompt5 runway history and reconciliation",
+    "allowlist": [
+      "docs/03-reference/dcp/README.md",
+      "docs/03-reference/dcp/artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md",
+      "docs/03-reference/dcp/DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md",
+      "task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json >/dev/null",
+      "python - <<'PY'\nimport json\nfrom pathlib import Path\nfrom jsonschema import Draft7Validator\nschema = json.loads(Path('docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text())\npayload = json.loads(Path('task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json').read_text())\nerrors = sorted(Draft7Validator(schema).iter_errors(payload), key=lambda e: list(e.path))\nif errors:\n    raise SystemExit('\\n'.join(f\"{'.'.join(map(str, e.path)) or '<root>'}: {e.message}\" for e in errors))\nprint('PASS task packet schema validation')\nPY",
+      "rg -n \"EXTERNAL_CHAT_HISTORY_EXTRACT|Transport closed|#906|NOT_RUN|BLOCKED|UNKNOWN\" docs/03-reference/dcp/artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md docs/03-reference/dcp/DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(dcp): extract Prompt 5 chat-history runway reconciliation",
+    "body": "Extract advisory Prompt 5 / pre-Prompt 6 DCP chat-history documents, reconcile stale task-packet and PR claims against live GitHub, and record Task Orchestrator MCP reconciliation as blocked by transport closure. No runtime code or Task Orchestrator writes.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "tracer",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Inspect repo authority, task-packet index, existing DCP artifact shelf, pasted chat history, live GitHub PR state, and Task Orchestrator availability before editing.",
+      "requirements": [
+        "Preserve pasted chat-history provenance as advisory only.",
+        "Verify stale PR claims against live GitHub before recording them.",
+        "Attempt Task Orchestrator read context; if unavailable, record BLOCKED/NOT_RUN."
+      ],
+      "commands": [
+        "git status --short --branch",
+        "sed -n '1,260p' AGENTS.md",
+        "sed -n '1,220p' task-packets/INDEX.md",
+        "sed -n '1,220p' docs/03-reference/dcp/README.md",
+        "gh pr view 906 --json number,state,isDraft,mergeable,headRefName,headRefOid,baseRefName,statusCheckRollup,reviewDecision,changedFiles,additions,deletions,url,title",
+        "gh api graphql ... reviewThreads for #906"
+      ],
+      "validation": [
+        "Observed evidence distinguishes repo/GitHub truth from stale transcript claims."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Author extracted advisory artifact and reconciliation ledger within the DCP docs shelf.",
+      "expected_files": [
+        "docs/03-reference/dcp/artifacts/DCP_PROMPT5_CHAT_HISTORY_EXTRACT.md",
+        "docs/03-reference/dcp/DCP_PROMPT5_TASK_ORCHESTRATOR_RECONCILIATION.md"
+      ],
+      "validation": [
+        "Docs label transcript provenance and live Task Orchestrator unknowns explicitly.",
+        "Docs do not claim Prompt 6 readiness or #906 merge readiness."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Update DCP README and task-packet index, then create proof bundle and run validation.",
+      "expected_files": [
+        "docs/03-reference/dcp/README.md",
+        "task-packets/INDEX.md",
+        "proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/PROOF.json"
+      ],
+      "validation": [
+        "Task packet JSON validates against dopetask canonical schema.",
+        "git diff --check passes.",
+        "Diff stays inside commit allowlist."
+      ]
+    }
+  ]
+}

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -121,6 +121,7 @@ A packet is superseded by another packet
 | TP-DCP-MCP-RO-0006 | DCP / MCP | Dope Context And Task Orchestrator Read Adapters | Active | N/A |
 | TP-DCP-MCP-RO-0007 | DCP / MCP | Secure MCP Tunnel Integration Docs And Manual Validation | Active | N/A |
 | TP-DCP-MCP-RO-0008 | DCP / MCP | Hardening Cross Project Isolation And PR Readiness | Active | N/A |
+| DMX-DCP-PROMPT5-EXTRACT-RECON-001 | DCP / Prompt 5 | Extract Prompt 5 chat-history docs and reconcile PR/Task Orchestrator runway state | Active | N/A |
 
 ────────────────────────────────────────────────────────────
 🟢 Completed Task Packets


### PR DESCRIPTION
## Summary
- extract the pasted Prompt 5 / pre-Prompt 6 DCP chat-history documents into a repo-tracked advisory artifact
- add a live reconciliation ledger for DCP task-packet / PR runway state, including stale #906 claims and current review-thread blocker truth
- add packet/proof artifacts for `DMX-DCP-PROMPT5-EXTRACT-RECON-001` and registry pointers in the DCP README and task-packet index

## Authority / Scope
- Source transcript is preserved as `EXTERNAL_CHAT_HISTORY_EXTRACT`, not runtime truth.
- Live GitHub state was checked for #906/#907/#908/#909/#915 before recording PR claims.
- Task Orchestrator live reconciliation was attempted but blocked: `get_context()` returned `Transport closed`.
- No runtime source, service, compose, MCP, or workflow-execution files changed.
- No Task Orchestrator writes were performed.

## Validation
- PASS: `python -m json.tool task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json >/dev/null`
- PASS: canonical dopetask schema validation for `task-packets/DMX-DCP-PROMPT5-EXTRACT-RECON-001.json`
- PASS: `python scripts/audit/validate_audit_proof.py proof/DMX-DCP-PROMPT5-EXTRACT-RECON-001/PROOF.json`
- PASS: targeted `rg` check for provenance/blocker labels
- PASS: `git diff --check`
- PASS: `pre-commit run --files ...` on all touched files

## NOT_RUN / Blocked
- NOT_RUN: runtime tests, because this is docs/proof/packet-only.
- BLOCKED: live Task Orchestrator item reconciliation, because the MCP transport closed on `get_context()` and again on retry.

## Residual Risk
- Open PR state is time-sensitive and must be refreshed before acting on #906, #908, #909, or #915.
- Task Orchestrator item state remains UNKNOWN until MCP transport is healthy or another approved read path is used.
