### PR TITLE
feat(rte): align cost profile controls

### DIFF
--- a/services/repo-truth-extractor/rte_ops_surfaces.py
+++ b/services/repo-truth-extractor/rte_ops_surfaces.py
@@ -837,6 +837,14 @@ def run_provider_preflight(
         "rerun_worthiness": rerun_worthiness,
         "routing_policy": cfg.routing_policy,
         "routing_policy_version": routing_policy_version,
+        "requested_cost_profile": getattr(cfg, "requested_cost_profile", None),
+        "resolved_cost_profile": getattr(cfg, "cost_profile", None),
+        "cost_profile": getattr(cfg, "cost_profile", None),
+        "model_aliases": {
+            str(key): str(value)
+            for key, value in tuple(getattr(cfg, "model_alias_overrides", ()) or ())
+        },
+        "disabled_providers": list(getattr(cfg, "disabled_providers", ()) or ()),
         "batch_capability": batch_capability,
     }
     doctor_dir = current_doctor_root(root)

--- a/services/repo-truth-extractor/run_extraction_v5.py
+++ b/services/repo-truth-extractor/run_extraction_v5.py
@@ -894,6 +894,23 @@ LEGACY_ROUTING_POLICY_TO_COST_PROFILE: Dict[str, str] = {
     "optimal": "quality",
 }
 
+COST_PROFILE_ALIASES: Dict[str, str] = {
+    f"rte-cost-{name}": name for name in COST_PROFILES
+}
+COST_PROFILE_ALIASES.update(
+    {
+        "rte-cost-default": DEFAULT_COST_PROFILE,
+        "rte-cost-value": DEFAULT_COST_PROFILE,
+    }
+)
+
+BLOCKED_COST_PROFILE_ALIASES: Dict[str, str] = {
+    "rte-cost-sandbox-free": (
+        "BLOCKED/deferred: no observed runtime enforcement for non-sensitive "
+        "fail-closed sandbox-free routing."
+    )
+}
+
 
 def resolve_cost_profile(name: Optional[str]) -> Tuple[str, Dict[str, Any]]:
     """Return (canonical_profile_name, profile_dict).
@@ -905,8 +922,16 @@ def resolve_cost_profile(name: Optional[str]) -> Tuple[str, Dict[str, Any]]:
     if not name:
         return DEFAULT_COST_PROFILE, COST_PROFILES[DEFAULT_COST_PROFILE]
     token = str(name).strip().lower()
+    if token in BLOCKED_COST_PROFILE_ALIASES:
+        raise ValueError(
+            f"Cost profile alias {token!r} is blocked: "
+            f"{BLOCKED_COST_PROFILE_ALIASES[token]}"
+        )
     if token in COST_PROFILES:
         return token, COST_PROFILES[token]
+    if token in COST_PROFILE_ALIASES:
+        mapped = COST_PROFILE_ALIASES[token]
+        return mapped, COST_PROFILES[mapped]
     if token in LEGACY_ROUTING_POLICY_TO_COST_PROFILE:
         mapped = LEGACY_ROUTING_POLICY_TO_COST_PROFILE[token]
         return mapped, COST_PROFILES[mapped]
@@ -959,6 +984,18 @@ def _model_alias_overrides_dict(raw: Any) -> Dict[str, str]:
         if key_text and value_text:
             result[key_text] = value_text
     return result
+
+
+def _cost_profile_control_metadata(cfg: "RunnerConfig") -> Dict[str, Any]:
+    return {
+        "requested_cost_profile": getattr(cfg, "requested_cost_profile", None),
+        "resolved_cost_profile": getattr(cfg, "cost_profile", DEFAULT_COST_PROFILE),
+        "routing_policy": getattr(cfg, "routing_policy", DEFAULT_ROUTING_POLICY),
+        "model_aliases": _model_alias_overrides_dict(
+            getattr(cfg, "model_alias_overrides", ())
+        ),
+        "disabled_providers": list(getattr(cfg, "disabled_providers", ()) or ()),
+    }
 
 
 def _route_model_id_from_alias_value(provider: str, model_id: str) -> str:
@@ -2141,6 +2178,8 @@ class RunnerConfig:
     fl_int_provider_timeout_seconds: int = 180
     fl_int_f0_batch_timeout_seconds: int = 210
     # Cost-profile + optimizer fields (May 2026 Phase E6).
+    requested_cost_profile: Optional[str] = None
+    requested_routing_policy: Optional[str] = None
     cost_profile: str = DEFAULT_COST_PROFILE
     default_service_tier: str = "default"  # default | flex | priority | auto
     enable_cached_input: bool = True
@@ -7608,7 +7647,7 @@ def derive_route_readiness_summary(
             live_ok=False,
         )
 
-    return _derive_route_readiness_summary_impl(
+    summary = _derive_route_readiness_summary_impl(
         phases,
         routing_policy,
         selected_step_ids_by_phase=selected_step_ids_by_phase,
@@ -7624,6 +7663,11 @@ def derive_route_readiness_summary(
         resolve_effective_step_route=resolve_effective_step_route,
         provider_api_key_env=PROVIDER_API_KEY_ENV,
     )
+    summary["cost_profile"] = effective_cost_profile
+    summary["model_alias_overrides"] = _model_alias_overrides_dict(
+        tuple(model_alias_overrides)
+    )
+    return summary
 
 
 def run_provider_doctor_probe(
@@ -7744,6 +7788,7 @@ def run_provider_preflight(
             routing_policy=cfg.routing_policy,
             selected_step_ids_by_phase=selected_step_ids_by_phase or None,
             cost_profile=cfg.cost_profile,
+            model_alias_overrides=tuple(cfg.model_alias_overrides or ()),
         )
         provider_probes = [
             run_provider_doctor_probe(
@@ -7834,6 +7879,7 @@ def run_provider_preflight(
             "rerun_worthiness": "ready_now" if not failures else "not_until_root_caused",
             "routing_policy": cfg.routing_policy,
             "routing_policy_version": ROUTING_POLICY_VERSION,
+            **_cost_profile_control_metadata(cfg),
             "batch_capability": batch_capability,
         }
         return (not failures), payload
@@ -19789,7 +19835,9 @@ def print_config(
         phases,
         cfg.routing_policy,
         cost_profile=cfg.cost_profile,
+        model_alias_overrides=cfg.model_alias_overrides,
     )
+    cost_profile_controls = _cost_profile_control_metadata(cfg)
     config_payload = {
         "run_id": run_id,
         "repo_root": str(root.resolve()),
@@ -19801,6 +19849,13 @@ def print_config(
         "cwd": str(Path.cwd().resolve()),
         "phases": phases,
         "cost_profile": cfg.cost_profile,
+        "requested_cost_profile": cost_profile_controls["requested_cost_profile"],
+        "resolved_cost_profile": cost_profile_controls["resolved_cost_profile"],
+        "routing_policy": cost_profile_controls["routing_policy"],
+        "model_aliases": cost_profile_controls["model_aliases"],
+        "disabled_providers": cost_profile_controls["disabled_providers"],
+        "max_cost_usd": cfg.max_cost_usd,
+        "cost_profile_resolution": cost_profile_controls,
         "cli": {
             "phase_argument": args.phase,
             "preset": getattr(args, "preset", None),
@@ -19856,6 +19911,11 @@ def print_config(
             "phase_auth_fail_threshold": args.phase_auth_fail_threshold,
             "partition_workers": args.partition_workers,
             "routing_policy": args.routing_policy,
+            "requested_cost_profile": cost_profile_controls["requested_cost_profile"],
+            "resolved_cost_profile": cost_profile_controls["resolved_cost_profile"],
+            "model_aliases": cost_profile_controls["model_aliases"],
+            "disabled_providers": cost_profile_controls["disabled_providers"],
+            "max_cost_usd": args.max_cost_usd,
             "dpmx_routing_enable": os.getenv(DPMX_ROUTING_ENABLE_ENV, ""),
             "dpmx_model_inventory": os.getenv(DPMX_MODEL_INVENTORY_ENV, ""),
             "dpmx_model_extract": os.getenv(DPMX_MODEL_EXTRACT_ENV, ""),
@@ -21995,11 +22055,13 @@ def write_confidence_ramp_artifacts(
         list(phase_sequence) if phase_sequence else [],
         cfg.routing_policy,
         cost_profile=cfg.cost_profile,
+        model_alias_overrides=cfg.model_alias_overrides,
     )
     batch_pilot = {
         "generated_at": now_iso(),
         "preset": preset_name or None,
         "routing_policy": cfg.routing_policy,
+        **_cost_profile_control_metadata(cfg),
         "phase_sequence": list(phase_sequence),
         "batch_mode": bool(cfg.batch_mode),
         "batch_provider": cfg.batch_provider,
@@ -22195,11 +22257,13 @@ def main() -> None:
     )
     parser.add_argument(
         "--cost-profile",
-        choices=sorted(COST_PROFILES.keys()),
         default=None,
+        metavar="PROFILE",
         help=(
             f"Cost profile selecting model tier + service_tier + cached-input + "
             f"batch behavior. Default: {DEFAULT_COST_PROFILE}. "
+            f"Known profiles: {', '.join(sorted(COST_PROFILES.keys()))}. "
+            "rte-cost-* aliases are normalized through the cost-profile resolver. "
             f"Replaces --routing-policy. See claudedocs/research/routing-design-2026-05.md."
         ),
     )
@@ -22758,30 +22822,35 @@ def main() -> None:
     # ------------------------------------------------------------------
     requested_cost_profile = getattr(args, "cost_profile", None)
     requested_routing_policy = getattr(args, "routing_policy", None)
-    if requested_cost_profile and requested_routing_policy:
-        logger.warning(
-            "Both --cost-profile=%s and --routing-policy=%s provided; "
-            "preferring --cost-profile and ignoring --routing-policy.",
-            requested_cost_profile,
-            requested_routing_policy,
-        )
-        cost_profile_name, cost_profile_cfg = resolve_cost_profile(requested_cost_profile)
-    elif requested_cost_profile:
-        cost_profile_name, cost_profile_cfg = resolve_cost_profile(requested_cost_profile)
-    elif requested_routing_policy:
-        cost_profile_name, cost_profile_cfg = resolve_cost_profile(requested_routing_policy)
-        logger.warning(
-            "DEPRECATION: --routing-policy=%s is deprecated. Migrate to "
-            "--cost-profile=%s. The legacy flag will be removed in a future release. "
-            "See claudedocs/research/routing-design-2026-05.md.",
-            requested_routing_policy,
-            cost_profile_name,
-        )
-    else:
-        cost_profile_name, cost_profile_cfg = resolve_cost_profile(None)
+    try:
+        if requested_cost_profile and requested_routing_policy:
+            logger.warning(
+                "Both --cost-profile=%s and --routing-policy=%s provided; "
+                "preferring --cost-profile and ignoring --routing-policy.",
+                requested_cost_profile,
+                requested_routing_policy,
+            )
+            cost_profile_name, cost_profile_cfg = resolve_cost_profile(requested_cost_profile)
+        elif requested_cost_profile:
+            cost_profile_name, cost_profile_cfg = resolve_cost_profile(requested_cost_profile)
+        elif requested_routing_policy:
+            cost_profile_name, cost_profile_cfg = resolve_cost_profile(requested_routing_policy)
+            logger.warning(
+                "DEPRECATION: --routing-policy=%s is deprecated. Migrate to "
+                "--cost-profile=%s. The legacy flag will be removed in a future release. "
+                "See claudedocs/research/routing-design-2026-05.md.",
+                requested_routing_policy,
+                cost_profile_name,
+            )
+        else:
+            cost_profile_name, cost_profile_cfg = resolve_cost_profile(None)
+    except ValueError as exc:
+        parser.error(str(exc))
     # Backfill args.routing_policy from the resolved profile so all
     # downstream code (which still reads args.routing_policy) continues to work.
     args.routing_policy = cost_profile_cfg.get("routing_policy", DEFAULT_ROUTING_POLICY)
+    args.requested_cost_profile = requested_cost_profile
+    args.requested_routing_policy = requested_routing_policy
     args.cost_profile = cost_profile_name
     # Parse --model-alias K=V pairs into a tuple of (key, value).
     _model_alias_overrides: List[Tuple[str, str]] = []
@@ -23197,6 +23266,8 @@ def main() -> None:
         allow_online_llm=bool(args.allow_online_llm),
         router=router,
         # Cost-profile + optimizer fields (May 2026 Phase E6).
+        requested_cost_profile=getattr(args, "requested_cost_profile", None),
+        requested_routing_policy=getattr(args, "requested_routing_policy", None),
         cost_profile=getattr(args, "cost_profile", DEFAULT_COST_PROFILE),
         default_service_tier=str(
             (COST_PROFILES.get(getattr(args, "cost_profile", DEFAULT_COST_PROFILE))

--- a/services/repo-truth-extractor/tests/test_cost_profiles.py
+++ b/services/repo-truth-extractor/tests/test_cost_profiles.py
@@ -161,6 +161,20 @@ def test_resolve_cost_profile_handles_all_inputs() -> None:
     assert runner.resolve_cost_profile("Quality")[0] == "quality"
 
 
+def test_resolve_cost_profile_accepts_rte_cost_aliases() -> None:
+    assert runner.resolve_cost_profile("rte-cost-economy")[0] == "economy"
+    assert runner.resolve_cost_profile("rte-cost-value-default")[0] == "value-default"
+    assert runner.resolve_cost_profile("rte-cost-quality-mix")[0] == "quality-mix"
+
+
+def test_sandbox_free_profile_alias_is_blocked_until_enforceable() -> None:
+    import pytest
+
+    assert "rte-cost-sandbox-free" not in runner.COST_PROFILES
+    with pytest.raises(ValueError, match="rte-cost-sandbox-free"):
+        runner.resolve_cost_profile("rte-cost-sandbox-free")
+
+
 def test_resolve_cell_alias_resolves_from_profile_defaults() -> None:
     assert (
         runner.resolve_cell_alias("${SYNTH_MODEL}", "quality") == "openai/gpt-5.5"

--- a/services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
+++ b/services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py
@@ -77,6 +77,8 @@ def _run_print_config(
     resume: bool,
     latest_run_id: str | None = None,
     cost_profile: str | None = None,
+    model_aliases: list[str] | None = None,
+    disabled_providers: list[str] | None = None,
 ):
     output_root = tmp_path / "artifact-root"
     if latest_run_id is not None:
@@ -99,6 +101,10 @@ def _run_print_config(
     ]
     if cost_profile is not None:
         cmd.extend(["--cost-profile", cost_profile])
+    for model_alias in model_aliases or []:
+        cmd.extend(["--model-alias", model_alias])
+    for provider in disabled_providers or []:
+        cmd.extend(["--disable-provider", provider])
     if resume:
         cmd.append("--resume")
 
@@ -290,8 +296,31 @@ def test_print_config_reports_selected_cost_profile(tmp_path: Path) -> None:
     )
 
     assert payload["cost_profile"] == "quality"
+    assert payload["requested_cost_profile"] == "quality"
+    assert payload["resolved_cost_profile"] == "quality"
     assert payload["cli"]["routing_policy"] == "quality"
     assert payload["route_readiness_summary"]["target_policy"] == "quality"
+
+
+def test_print_config_reports_cost_profile_resolution_and_route_controls(tmp_path: Path) -> None:
+    payload, _output_root = _run_print_config(
+        tmp_path,
+        resume=False,
+        cost_profile="rte-cost-grok-fast",
+        model_aliases=["BULK_DOCS_MODEL=xai/grok-4-fast"],
+        disabled_providers=["gemini"],
+    )
+
+    assert payload["requested_cost_profile"] == "rte-cost-grok-fast"
+    assert payload["resolved_cost_profile"] == "grok-fast"
+    assert payload["cost_profile"] == "grok-fast"
+    assert payload["routing_policy"] == "balanced_grok_openrouter"
+    assert payload["model_aliases"] == {"BULK_DOCS_MODEL": "xai/grok-4-fast"}
+    assert payload["disabled_providers"] == ["gemini"]
+    assert payload["route_readiness_summary"]["cost_profile"] == "grok-fast"
+    assert payload["route_readiness_summary"]["model_alias_overrides"] == {
+        "BULK_DOCS_MODEL": "xai/grok-4-fast"
+    }
 
 
 def test_print_config_resume_reads_latest_without_mutating_pointer(tmp_path: Path) -> None:

--- a/services/repo-truth-extractor/tests/test_truth_run_cli.py
+++ b/services/repo-truth-extractor/tests/test_truth_run_cli.py
@@ -135,6 +135,53 @@ class TestTruthRunCommandRegistered(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("disabled by default", result.output)
 
+    def test_rte_run_forwards_cost_profile_controls(self):
+        """dopemux rte run must pass cost-profile controls to canonical v5."""
+        src_path = str(_REPO_ROOT / "src")
+        if src_path not in sys.path:
+            sys.path.insert(0, src_path)
+        try:
+            import dopemux.cli as cli_mod
+        except ImportError:
+            self.skipTest("dopemux.cli not importable in this test context")
+
+        calls = []
+
+        def fake_run_extractor_runner(*, pipeline_version, args):
+            calls.append((pipeline_version, args))
+
+        with patch.object(cli_mod, "_run_extractor_runner", fake_run_extractor_runner):
+            result = CliRunner().invoke(
+                cli_mod.cli,
+                [
+                    "rte",
+                    "run",
+                    "--phase",
+                    "A",
+                    "--dry-run",
+                    "--cost-profile",
+                    "rte-cost-grok-fast",
+                    "--model-alias",
+                    "BULK_DOCS_MODEL=xai/grok-4-fast",
+                    "--disable-provider",
+                    "gemini",
+                    "--max-cost-usd",
+                    "0.50",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(calls[0][0], "v5")
+        forwarded = calls[0][1]
+        self.assertIn("--cost-profile", forwarded)
+        self.assertIn("rte-cost-grok-fast", forwarded)
+        self.assertIn("--model-alias", forwarded)
+        self.assertIn("BULK_DOCS_MODEL=xai/grok-4-fast", forwarded)
+        self.assertIn("--disable-provider", forwarded)
+        self.assertIn("gemini", forwarded)
+        self.assertIn("--max-cost-usd", forwarded)
+        self.assertIn("0.5", forwarded)
+
 
 # ---------------------------------------------------------------------------
 # Test 2: partition_start_event adds to active dict

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -5137,6 +5137,27 @@ def extractor_list(ctx, pipeline_version: str, engine_version_legacy: Optional[s
     show_default=False,
     help="LLM routing policy for extraction. Defaults to the model-map policy.",
 )
+@click.option(
+    "--cost-profile",
+    default=None,
+    help="RTE cost profile or rte-cost-* alias to pass to the v5 runner.",
+)
+@click.option(
+    "--model-alias",
+    multiple=True,
+    help="Override a runner cell alias as ALIAS=provider/model. Repeatable.",
+)
+@click.option(
+    "--disable-provider",
+    multiple=True,
+    help="Disable a provider route in the v5 runner. Repeatable.",
+)
+@click.option(
+    "--max-cost-usd",
+    type=float,
+    default=None,
+    help="Forward a hard spend cap to the v5 runner.",
+)
 @click.option("--disable-escalation", is_flag=True, default=False, show_default=True)
 @click.option("--escalation-max-hops", type=int, default=2, show_default=True)
 @click.option("--batch-mode", is_flag=True, default=False, show_default=True)
@@ -5191,6 +5212,10 @@ def extractor_run(
     partition_workers: int,
     max_partitions_per_step: Optional[int],
     routing_policy: Optional[str],
+    cost_profile: Optional[str],
+    model_alias: tuple[str, ...],
+    disable_provider: tuple[str, ...],
+    max_cost_usd: Optional[float],
     disable_escalation: bool,
     escalation_max_hops: int,
     batch_mode: bool,
@@ -5260,7 +5285,16 @@ def extractor_run(
     args.extend(["--partition-workers", str(partition_workers)])
     if max_partitions_per_step is not None:
         args.extend(["--max-partitions-per-step", str(max(0, int(max_partitions_per_step)))])
-    args.extend(["--routing-policy", effective_routing_policy])
+    if routing_policy or not cost_profile:
+        args.extend(["--routing-policy", effective_routing_policy])
+    if cost_profile:
+        args.extend(["--cost-profile", cost_profile])
+    for alias in model_alias:
+        args.extend(["--model-alias", alias])
+    for provider in disable_provider:
+        args.extend(["--disable-provider", provider])
+    if max_cost_usd is not None:
+        args.extend(["--max-cost-usd", str(float(max_cost_usd))])
     if disable_escalation:
         args.append("--disable-escalation")
     args.extend(["--escalation-max-hops", str(max(0, int(escalation_max_hops)))])


### PR DESCRIPTION
## Summary
- Normalize approved rte-cost-* aliases through existing RTE cost-profile machinery.
- Forward cost-profile controls from dopemux rte run to the canonical v5 runner.
- Surface requested/resolved cost profile, routing policy, model aliases, disabled providers, and max-cost in RTE introspection/readiness output.
- Block rte-cost-sandbox-free as deferred because runtime enforcement for non-sensitive fail-closed sandbox-free routing is not observed.

## Validation
- PASS: python -m pytest services/repo-truth-extractor/tests/test_cost_profiles.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_truth_run_cli.py -q
- PASS: python services/repo-truth-extractor/run_extraction_v5.py --phase A --dry-run --print-config --cost-profile rte-cost-grok-fast --model-alias BULK_DOCS_MODEL=xai/grok-4-fast --disable-provider gemini --max-cost-usd 0.50
- PASS: sandbox-free alias fails closed with explicit blocked/deferred message
- PASS: git diff --check
- PASS: pre-commit run --files services/repo-truth-extractor/rte_ops_surfaces.py services/repo-truth-extractor/run_extraction_v5.py services/repo-truth-extractor/tests/test_cost_profiles.py services/repo-truth-extractor/tests/test_run_extraction_v5_operator_safety.py services/repo-truth-extractor/tests/test_truth_run_cli.py src/dopemux/cli.py

## NOT_RUN / Residual Risk
- Live provider execution not run.
- Full repo test suite not run.
- Embedded audit script ran but status was SKIPPED because EMBEDDED_AUDIT_TOKEN was unavailable/UNKNOWN.

@codex review