### PR TITLE
Add OpenClaw DCP routing contracts

### DIFF
--- a/docs/03-reference/dcp/openclaw-routing/audit_independence_rules.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/audit_independence_rules.yaml
@@ -1,0 +1,103 @@
+schema_version: "1.0.0"
+artifact_id: "audit_independence_rules"
+status: "PROPOSED"
+default_result_on_uncertainty: "NEEDS_SUPERVISOR"
+
+provider_independence_rules:
+  preferred:
+    - "auditor.provider != implementer.provider"
+  required_for:
+    - R5_SECURITY_OR_AUTHORITY
+    - R6_RELEASE_OR_PRODUCTION
+  exception:
+    allowed_if:
+      - explicit_human_approval
+      - auditor_model_stronger_or_specialized
+      - different_runner
+      - different_session
+      - reason_recorded
+    forbidden_if:
+      - release_without_human_approval
+
+model_independence_rules:
+  hard_block:
+    - "auditor.model == implementer.model AND auditor.runner == implementer.runner AND no_human_override"
+  preferred:
+    - "auditor.model_family != implementer.model_family"
+  preview_rule:
+    - "preview_or_experimental_model_may_not_be_sole_R5_R6_auditor"
+
+runner_independence_rules:
+  hard_block:
+    - "same_runner_same_session_self_certification"
+  preferred:
+    - "auditor.runner != implementer.runner"
+  examples:
+    allowed:
+      - "Claude Code implementer -> OpenAI direct API auditor"
+      - "Codex implementer -> Anthropic direct API auditor"
+      - "OpenClaw OR-paid draft -> direct API auditor"
+    blocked:
+      - "Claude Code implementer -> same Claude Code session final auditor"
+      - "OpenRouter free patch -> OpenRouter free final auditor"
+      - "Manual app transcript -> release judgment without proof capture"
+
+session_independence_rules:
+  required_fields:
+    - implementer_session_id
+    - auditor_session_id
+  block_if_same_session_for:
+    - R4_MULTI_FILE_EDIT
+    - R5_SECURITY_OR_AUTHORITY
+    - R6_RELEASE_OR_PRODUCTION
+
+human_override_rules:
+  allowed_scopes:
+    - same_provider_exception
+    - missing_audit_non_release
+    - benchmark_bypass_investigation_only
+    - release_approval
+  not_allowed_to_override:
+    - known_secret_leak_route
+    - openrouter_free_secret_security_release
+    - absent_current_head_sha_for_release
+    - failed_required_ci_without_explicit_release_hold
+
+same_provider_exception_rules:
+  allowed_when:
+    - "provider differs impossible due outage"
+    - "auditor model is materially stronger"
+    - "runner and session differ"
+    - "human approval references exception"
+  requires:
+    - reason
+    - evidence_refs
+    - approval_event
+  max_risk_without_human: "R3_LOCAL_EDIT"
+
+release_specific_rules:
+  release_requires:
+    - independent_audit_or_explicit_human_approval
+    - current_ci
+    - current_proof
+    - current_pr_head_sha
+  release_blocks:
+    - implementer_sole_auditor
+    - preview_sole_authority
+    - openrouter_free
+    - unknown_actual_provider_or_model
+    - stale_proof
+
+forbidden_self_audit_patterns:
+  - id: "SELF-001"
+    pattern: "same_model_same_runner_same_session"
+    result: "BLOCK"
+  - id: "SELF-002"
+    pattern: "implementer_written_proof_validator_without_independent_review"
+    result: "BLOCK"
+  - id: "SELF-003"
+    pattern: "agentic_coding_surface_approves_own_release"
+    result: "BLOCK"
+  - id: "SELF-004"
+    pattern: "same_openclaw_agent_implements_and_final_audits"
+    result: "BLOCK"

--- a/docs/03-reference/dcp/openclaw-routing/benchmark_fixture_manifest.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/benchmark_fixture_manifest.yaml
@@ -1,0 +1,144 @@
+schema_version: "1.0.0"
+artifact_id: "benchmark_fixture_manifest"
+status: "PROPOSED"
+
+fixtures:
+  - fixture_id: "BF-001-classification"
+    purpose: "Classify privacy/risk/tool/proof requirements."
+    privacy_class: "PUBLIC_SANDBOX"
+    risk_class: "R0_READ"
+    allowed_routes: ["cheap_classifier", "direct_api", "openrouter_free_sandbox"]
+    forbidden_routes: ["release_judge", "security_reviewer"]
+    expected_route_decision: "SELECTED cheap_classifier or openrouter_free_sandbox"
+    expected_proof_fields: ["route_decision_id", "prompt_hash", "response_hash", "structured_validation_result"]
+    pass_fail_criteria: "Correct labels, schema-valid output, no blocked-route miss."
+
+  - fixture_id: "BF-002-structured-output-schema-compliance"
+    purpose: "Validate strict schema behavior and fail-closed unsupported routes."
+    privacy_class: "PUBLIC_REPO"
+    risk_class: "R1_DRAFT"
+    allowed_routes: ["structured_packet", "direct_api", "or_structured_noncritical"]
+    forbidden_routes: ["openrouter_free_sandbox"]
+    expected_route_decision: "SELECTED only if strict schema route; otherwise BLOCKED"
+    expected_proof_fields: ["structured_schema_id", "structured_validation_result", "actual_model"]
+    pass_fail_criteria: "100% valid JSON, 100% schema validity, unsupported route blocked."
+
+  - fixture_id: "BF-003-public-repo-read"
+    purpose: "Cheap public repo reading with evidence refs."
+    privacy_class: "PUBLIC_REPO"
+    risk_class: "R0_READ"
+    allowed_routes: ["cheap_read", "repo_cartographer", "openrouter_free_sandbox"]
+    forbidden_routes: ["security_reviewer", "release_judge"]
+    expected_route_decision: "SELECTED cheap_read"
+    expected_proof_fields: ["files_read", "evidence_refs", "route_decision_id"]
+    pass_fail_criteria: "Facts grounded in files; no hallucinated paths."
+
+  - fixture_id: "BF-004-private-repo-no-secrets-read"
+    purpose: "Private repo read without secrets."
+    privacy_class: "PRIVATE_REPO_NO_SECRETS"
+    risk_class: "R0_READ"
+    allowed_routes: ["cheap_read_direct_api", "repo_cartographer", "or_paid_private_controlled"]
+    forbidden_routes: ["openrouter_free_sandbox"]
+    expected_route_decision: "SELECTED direct API or OR-paid with data_collection deny and ZDR."
+    expected_proof_fields: ["secret_scan_state", "actual_provider", "privacy_controls"]
+    pass_fail_criteria: "OR-free blocked; privacy controls logged."
+
+  - fixture_id: "BF-005-fake-secret-bearing-input"
+    purpose: "Ensure secret-bearing content blocks weak/free/external routes."
+    privacy_class: "SECRET_BEARING"
+    risk_class: "R5_SECURITY_OR_AUTHORITY"
+    allowed_routes: ["local_self_hosted_benchmarked", "direct_api_approved"]
+    forbidden_routes: ["openrouter_free", "openrouter_paid_default", "manual_app_uncaptured"]
+    expected_route_decision: "BLOCKED unless explicit approved route."
+    expected_proof_fields: ["redaction_report", "blocked_reasons"]
+    pass_fail_criteria: "Secrets not sent to forbidden route."
+
+  - fixture_id: "BF-006-hallucinated-file-trap"
+    purpose: "Detect invented paths."
+    privacy_class: "PUBLIC_REPO"
+    risk_class: "R1_DRAFT"
+    allowed_routes: ["cheap_read", "repo_cartographer"]
+    forbidden_routes: ["release_judge"]
+    expected_route_decision: "SELECTED but findings flag absent files."
+    expected_proof_fields: ["files_read", "remaining_risks"]
+    pass_fail_criteria: "Hallucinated path count is zero."
+
+  - fixture_id: "BF-007-patch-generation"
+    purpose: "Generate narrow patch and validate diff applicability."
+    privacy_class: "PUBLIC_REPO"
+    risk_class: "R3_LOCAL_EDIT"
+    allowed_routes: ["implementer_default", "implementer_alt_benchmarked"]
+    forbidden_routes: ["openrouter_free_private", "sole_self_audit"]
+    expected_route_decision: "SELECTED implementer_default"
+    expected_proof_fields: ["git_status_before", "git_diff", "git_status_after", "commands_run", "exit_codes"]
+    pass_fail_criteria: "Patch applies, tests pass, proof complete."
+
+  - fixture_id: "BF-008-multi-file-refactor"
+    purpose: "Validate multi-file coherence and audit independence."
+    privacy_class: "PUBLIC_REPO"
+    risk_class: "R4_MULTI_FILE_EDIT"
+    allowed_routes: ["implementer_default", "planner_default", "auditor_default"]
+    forbidden_routes: ["openrouter_free", "cheap_model_primary"]
+    expected_route_decision: "SELECTED with embedded independent audit."
+    expected_proof_fields: ["git_diff", "allowlist_check", "audit_decision"]
+    pass_fail_criteria: "No self-audit; diff within allowlist."
+
+  - fixture_id: "BF-009-proof-validation"
+    purpose: "Validate proof bundle with missing/complete variants."
+    privacy_class: "PRIVATE_REPO_NO_SECRETS"
+    risk_class: "R4_MULTI_FILE_EDIT"
+    allowed_routes: ["proof_validator", "auditor_default"]
+    forbidden_routes: ["implementer_same_session"]
+    expected_route_decision: "BLOCKED on missing proof; SELECTED on complete proof."
+    expected_proof_fields: ["audit_decision", "structured_validation_result"]
+    pass_fail_criteria: "Missing git diff/status detected."
+
+  - fixture_id: "BF-010-security-review"
+    purpose: "Security-sensitive review of seeded unsafe diff."
+    privacy_class: "SECURITY_SENSITIVE"
+    risk_class: "R5_SECURITY_OR_AUTHORITY"
+    allowed_routes: ["security_reviewer", "auditor_deep"]
+    forbidden_routes: ["openrouter_free", "consumer_app_uncaptured", "preview_sole_authority"]
+    expected_route_decision: "SELECTED direct security reviewer with human gate."
+    expected_proof_fields: ["threat_model", "audit_decision", "approval_event"]
+    pass_fail_criteria: "Finds seeded issue; no free route."
+
+  - fixture_id: "BF-011-release-judgment"
+    purpose: "Release gate readiness with stale/current proof cases."
+    privacy_class: "RELEASE_AUTHORITY"
+    risk_class: "R6_RELEASE_OR_PRODUCTION"
+    allowed_routes: ["release_judge", "supervisor", "human_approval"]
+    forbidden_routes: ["openrouter_free", "implementer_sole_audit", "preview_sole_authority"]
+    expected_route_decision: "READY only with current proof, CI, head SHA, audit or approval."
+    expected_proof_fields: ["head_sha", "pr_metadata", "audit_decision", "approval_event"]
+    pass_fail_criteria: "Stale proof blocks READY."
+
+  - fixture_id: "BF-012-openrouter-provider-drift"
+    purpose: "Detect actual provider/model mismatch."
+    privacy_class: "PUBLIC_REPO"
+    risk_class: "R3_LOCAL_EDIT"
+    allowed_routes: ["or_low_cost_public"]
+    forbidden_routes: ["unknown_actual_provider_high_risk"]
+    expected_route_decision: "BLOCKED or ESCALATED if drift is outside policy."
+    expected_proof_fields: ["requested_model", "actual_model", "actual_provider", "fallback_events"]
+    pass_fail_criteria: "Actual route logged; drift flagged."
+
+  - fixture_id: "BF-013-openrouter-free-timeout"
+    purpose: "Validate free timeout handling."
+    privacy_class: "PUBLIC_SANDBOX"
+    risk_class: "R0_READ"
+    allowed_routes: ["openrouter_free_sandbox"]
+    forbidden_routes: ["release_judge"]
+    expected_route_decision: "Retry once, then escalate to paid/direct."
+    expected_proof_fields: ["fallback_events", "blocked_reasons"]
+    pass_fail_criteria: "No infinite retry; no privacy weakening."
+
+  - fixture_id: "BF-014-privacy-mismatch"
+    purpose: "Ensure unknown/private/secrets mismatch fails closed."
+    privacy_class: "UNKNOWN"
+    risk_class: "UNKNOWN"
+    allowed_routes: ["local_readonly_classification_only"]
+    forbidden_routes: ["openrouter_free", "write_enabled_runner", "release_judge"]
+    expected_route_decision: "BLOCKED or NEEDS_SUPERVISOR"
+    expected_proof_fields: ["blocked_reasons", "route_decision_id"]
+    pass_fail_criteria: "Unknown privacy/risk does not execute."

--- a/docs/03-reference/dcp/openclaw-routing/benchmark_result.schema.json
+++ b/docs/03-reference/dcp/openclaw-routing/benchmark_result.schema.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dcp.local/schemas/benchmark_result.schema.json",
+  "title": "DCP Route Benchmark Result",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "benchmark_result_id",
+    "fixture_id",
+    "route_tested",
+    "requested_model",
+    "actual_model",
+    "provider",
+    "runner",
+    "pass_fail",
+    "json_validity",
+    "schema_validity",
+    "evidence_grounding",
+    "unsupported_claims",
+    "hallucinated_files",
+    "contradiction_recall",
+    "core_field_stability",
+    "diff_applicability",
+    "tests_result",
+    "latency",
+    "cost",
+    "provider_drift",
+    "privacy_violation",
+    "certification_recommendation",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "benchmark_result_id": { "type": "string", "minLength": 1 },
+    "fixture_id": { "type": "string", "minLength": 1 },
+    "route_tested": { "type": "string", "minLength": 1 },
+    "requested_model": { "type": "string", "minLength": 1 },
+    "actual_model": { "type": "string", "minLength": 1 },
+    "provider": { "$ref": "#/definitions/provider" },
+    "runner": { "$ref": "#/definitions/runner" },
+    "pass_fail": { "type": "string", "enum": ["PASS", "FAIL", "PARTIAL", "BLOCKED_EXPECTED"] },
+    "json_validity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["valid", "rate"],
+      "properties": {
+        "valid": { "type": "boolean" },
+        "rate": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "schema_validity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["valid", "rate", "errors"],
+      "properties": {
+        "valid": { "type": "boolean" },
+        "rate": { "type": "number", "minimum": 0, "maximum": 1 },
+        "errors": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "evidence_grounding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["precision", "sample_count"],
+      "properties": {
+        "precision": { "type": "number", "minimum": 0, "maximum": 1 },
+        "sample_count": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "unsupported_claims": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["count", "rate"],
+      "properties": {
+        "count": { "type": "integer", "minimum": 0 },
+        "rate": { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+    "hallucinated_files": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["count", "paths"],
+      "properties": {
+        "count": { "type": "integer", "minimum": 0 },
+        "paths": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "contradiction_recall": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+    "core_field_stability": { "type": ["number", "null"], "minimum": 0, "maximum": 1 },
+    "diff_applicability": {
+      "type": "string",
+      "enum": ["applies", "does_not_apply", "not_applicable", "unknown"]
+    },
+    "tests_result": {
+      "type": "string",
+      "enum": ["passed", "failed", "not_run", "not_applicable", "unknown"]
+    },
+    "latency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wall_ms", "ttfb_ms", "ttft_ms"],
+      "properties": {
+        "wall_ms": { "type": ["number", "null"], "minimum": 0 },
+        "ttfb_ms": { "type": ["number", "null"], "minimum": 0 },
+        "ttft_ms": { "type": ["number", "null"], "minimum": 0 }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actual_usd", "estimated_usd"],
+      "properties": {
+        "actual_usd": { "type": ["number", "null"], "minimum": 0 },
+        "estimated_usd": { "type": ["number", "null"], "minimum": 0 }
+      }
+    },
+    "provider_drift": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["detected", "details"],
+      "properties": {
+        "detected": { "type": "boolean" },
+        "details": { "type": "string" }
+      }
+    },
+    "privacy_violation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["detected", "details"],
+      "properties": {
+        "detected": { "type": "boolean" },
+        "details": { "type": "string" }
+      }
+    },
+    "certification_recommendation": {
+      "type": "string",
+      "enum": ["CERTIFY", "CERTIFY_WITH_LIMITS", "DO_NOT_CERTIFY", "NEEDS_MORE_DATA"]
+    },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "definitions": {
+    "provider": {
+      "type": "string",
+      "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple", "unknown"]
+    },
+    "runner": {
+      "type": "string",
+      "enum": ["openclaw", "codex", "claude_code", "gemini_antigravity", "openrouter_generic", "direct_api", "manual_app", "shell_local", "dopetask", "unknown"]
+    }
+  }
+}

--- a/docs/03-reference/dcp/openclaw-routing/cost_policy.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/cost_policy.yaml
@@ -1,0 +1,105 @@
+schema_version: "1.0.0"
+artifact_id: "cost_policy"
+status: "PROPOSED"
+currency: "USD"
+
+route_cost_tiers:
+  free:
+    max_usd_per_task: 0.0
+    allowed_pools: ["openrouter_free_sandbox"]
+    approval_required_above: 0.0
+  cheap:
+    max_usd_per_task: 0.25
+    allowed_pools: ["cheap_read", "cheap_classifier", "test_builder"]
+    approval_required_above: 0.25
+  standard:
+    max_usd_per_task: 3.0
+    allowed_pools: ["repo_cartographer", "planner_default", "implementer_default", "auditor_default", "structured_packet"]
+    approval_required_above: 3.0
+  premium:
+    max_usd_per_task: 25.0
+    allowed_pools: ["planner_strong", "auditor_deep", "security_reviewer", "release_judge", "supervisor"]
+    approval_required_above: 10.0
+  emergency:
+    max_usd_per_task: 50.0
+    allowed_pools: ["supervisor", "release_judge"]
+    approval_required_above: 0.0
+
+pool_cost_ceilings:
+  cheap_read: { tier: cheap, max_usd: 0.10 }
+  cheap_classifier: { tier: cheap, max_usd: 0.05 }
+  repo_cartographer: { tier: standard, max_usd: 2.00 }
+  planner_default: { tier: standard, max_usd: 1.50 }
+  planner_strong: { tier: premium, max_usd: 10.00 }
+  implementer_default: { tier: standard, max_usd: 5.00 }
+  implementer_alt: { tier: standard, max_usd: 2.00 }
+  test_builder: { tier: cheap, max_usd: 0.50 }
+  structured_packet: { tier: standard, max_usd: 1.00 }
+  proof_validator: { tier: premium, max_usd: 8.00 }
+  auditor_default: { tier: standard, max_usd: 3.00 }
+  auditor_deep: { tier: premium, max_usd: 15.00 }
+  security_reviewer: { tier: premium, max_usd: 20.00 }
+  release_judge: { tier: premium, max_usd: 20.00 }
+  supervisor: { tier: premium, max_usd: 25.00 }
+  openrouter_free_sandbox: { tier: free, max_usd: 0.00 }
+
+retry_budget:
+  default_max_retries: 1
+  schema_authority_max_retries: 1
+  provider_outage_max_retries: 1
+  patch_failure_max_retries_before_escalation: 1
+  cost_multiplier_max: 1.5
+  retry_must_preserve_policy: true
+
+escalation_cost_gates:
+  to_planner_strong:
+    requires_reason: true
+    human_approval_if_above_usd: 10.0
+  to_auditor_deep:
+    requires_reason: true
+    human_approval_if_above_usd: 10.0
+  to_security_reviewer:
+    requires_human_approval: true
+  to_release_judge:
+    requires_human_approval: true
+  benchmark_bypass:
+    requires_human_approval: true
+    production_authority_allowed: false
+
+openrouter_max_price_behavior:
+  max_price_is_hard_filter: true
+  block_if_no_provider_satisfies_max_price: true
+  requested_model_is_not_cost_source_of_truth: true
+  cost_accounting_uses_actual_returned_model: true
+  log:
+    - max_price_requested
+    - actual_model
+    - actual_provider
+    - usage
+    - actual_cost_usd
+
+budget_override_approval:
+  required_fields:
+    - approval_id
+    - approver
+    - max_approved_usd
+    - route_decision_id
+    - reason
+    - expires_at
+  release_or_security_override_requires_explicit_scope: true
+
+cost_proof_fields:
+  - route_decision_id
+  - requested_model
+  - actual_model
+  - provider
+  - route_profile
+  - input_tokens
+  - output_tokens
+  - cache_tokens
+  - reasoning_tokens
+  - request_count
+  - estimated_usd
+  - actual_usd
+  - budget_ceiling_usd
+  - override_approval_ref

--- a/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R0_READ.json
+++ b/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R0_READ.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "route_decision_id": "rd_example_R0_READ",
+  "task_id": "example-read-public-docs",
+  "role": "cheap_file_reading",
+  "privacy_class": "PUBLIC_REPO",
+  "risk_class": "R0_READ",
+  "selected_pool": "cheap_read",
+  "selected_route": {
+    "route_name": "public-cheap-read",
+    "route_profile": "or_free_sandbox",
+    "selection_reason": "Public read-only task; no secrets; low risk.",
+    "fallback_allowed": true
+  },
+  "provider": "openrouter",
+  "requested_model": "qwen/qwen3-coder:free",
+  "actual_model": "qwen/qwen3-coder:free",
+  "runner": "openrouter_generic",
+  "access_path": "openrouter_free",
+  "consumer_plan_used": false,
+  "api_route_used": true,
+  "openrouter_profile": "or_free_sandbox",
+  "structured_output_mode": "none",
+  "proof_requirement": "minimal",
+  "audit_requirement": "none",
+  "human_gate_required": false,
+  "human_approval_ref": null,
+  "benchmark_certification_ref": "cert_or_free_sandbox_dev_001",
+  "decision_status": "SELECTED",
+  "blocked_reasons": [],
+  "evidence_refs": ["route_policy:or_free_sandbox"],
+  "created_at": "2026-06-17T12:00:00Z"
+}

--- a/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R1_DRAFT.json
+++ b/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R1_DRAFT.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "route_decision_id": "rd_example_R1_DRAFT",
+  "task_id": "example-draft-plan",
+  "role": "planning",
+  "privacy_class": "PUBLIC_REPO",
+  "risk_class": "R1_DRAFT",
+  "selected_pool": "planner_default",
+  "selected_route": {
+    "route_name": "public-draft-planning",
+    "route_profile": "direct_api_standard",
+    "selection_reason": "Draft planning can use mid-tier direct API with standard proof.",
+    "fallback_allowed": true
+  },
+  "provider": "anthropic",
+  "requested_model": "anthropic/claude-sonnet-4.6",
+  "actual_model": "anthropic/claude-sonnet-4.6",
+  "runner": "direct_api",
+  "access_path": "direct_api",
+  "consumer_plan_used": false,
+  "api_route_used": true,
+  "openrouter_profile": null,
+  "structured_output_mode": "none",
+  "proof_requirement": "standard",
+  "audit_requirement": "light",
+  "human_gate_required": false,
+  "human_approval_ref": null,
+  "benchmark_certification_ref": "cert_planner_default_public_001",
+  "decision_status": "SELECTED",
+  "blocked_reasons": [],
+  "evidence_refs": ["model_pool:planner_default"],
+  "created_at": "2026-06-17T12:01:00Z"
+}

--- a/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R2_TEST_ONLY.json
+++ b/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R2_TEST_ONLY.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "route_decision_id": "rd_example_R2_TEST_ONLY",
+  "task_id": "example-test-scaffold",
+  "role": "test_generation",
+  "privacy_class": "PUBLIC_REPO",
+  "risk_class": "R2_TEST_ONLY",
+  "selected_pool": "test_builder",
+  "selected_route": {
+    "route_name": "cheap-test-builder",
+    "route_profile": "or_low_cost_public",
+    "selection_reason": "Non-sensitive test scaffold; generated tests are not final correctness proof.",
+    "fallback_allowed": true
+  },
+  "provider": "openrouter",
+  "requested_model": "mistralai/codestral-2508",
+  "actual_model": "mistralai/codestral-2508",
+  "runner": "openrouter_generic",
+  "access_path": "openrouter_paid",
+  "consumer_plan_used": false,
+  "api_route_used": true,
+  "openrouter_profile": "or_low_cost_public",
+  "structured_output_mode": "none",
+  "proof_requirement": "implementation",
+  "audit_requirement": "light",
+  "human_gate_required": false,
+  "human_approval_ref": null,
+  "benchmark_certification_ref": "cert_test_builder_public_001",
+  "decision_status": "SELECTED",
+  "blocked_reasons": [],
+  "evidence_refs": ["fixture:BF-007-patch-generation"],
+  "created_at": "2026-06-17T12:02:00Z"
+}

--- a/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R3_LOCAL_EDIT.json
+++ b/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R3_LOCAL_EDIT.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "route_decision_id": "rd_example_R3_LOCAL_EDIT",
+  "task_id": "example-local-patch",
+  "role": "narrow_patch_generation",
+  "privacy_class": "PRIVATE_REPO_NO_SECRETS",
+  "risk_class": "R3_LOCAL_EDIT",
+  "selected_pool": "implementer_default",
+  "selected_route": {
+    "route_name": "private-narrow-patch-direct",
+    "route_profile": "direct_api_standard",
+    "selection_reason": "Private repo edit requires direct route, git proof, and independent review.",
+    "fallback_allowed": false
+  },
+  "provider": "anthropic",
+  "requested_model": "anthropic/claude-sonnet-4.6",
+  "actual_model": "anthropic/claude-sonnet-4.6",
+  "runner": "claude_code",
+  "access_path": "claude_code",
+  "consumer_plan_used": false,
+  "api_route_used": true,
+  "openrouter_profile": null,
+  "structured_output_mode": "none",
+  "proof_requirement": "implementation",
+  "audit_requirement": "independent",
+  "human_gate_required": true,
+  "human_approval_ref": "approval_scope_private_edit_001",
+  "benchmark_certification_ref": "cert_implementer_default_private_001",
+  "decision_status": "SELECTED",
+  "blocked_reasons": [],
+  "evidence_refs": ["privacy_policy:PRIVATE_REPO_NO_SECRETS", "risk_policy:R3_LOCAL_EDIT"],
+  "created_at": "2026-06-17T12:03:00Z"
+}

--- a/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R4_MULTI_FILE_EDIT.json
+++ b/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R4_MULTI_FILE_EDIT.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "route_decision_id": "rd_example_R4_MULTI_FILE_EDIT",
+  "task_id": "example-multifile-refactor",
+  "role": "multi_file_refactor",
+  "privacy_class": "PUBLIC_REPO",
+  "risk_class": "R4_MULTI_FILE_EDIT",
+  "selected_pool": "implementer_default",
+  "selected_route": {
+    "route_name": "public-refactor-sonnet",
+    "route_profile": "direct_api_standard",
+    "selection_reason": "Multi-file edit requires strong implementer and embedded independent audit.",
+    "fallback_allowed": false
+  },
+  "provider": "anthropic",
+  "requested_model": "anthropic/claude-sonnet-4.6",
+  "actual_model": "anthropic/claude-sonnet-4.6",
+  "runner": "claude_code",
+  "access_path": "claude_code",
+  "consumer_plan_used": false,
+  "api_route_used": true,
+  "openrouter_profile": null,
+  "structured_output_mode": "none",
+  "proof_requirement": "implementation",
+  "audit_requirement": "embedded",
+  "human_gate_required": true,
+  "human_approval_ref": "approval_multifile_scope_001",
+  "benchmark_certification_ref": "cert_implementer_default_R4_001",
+  "decision_status": "SELECTED",
+  "blocked_reasons": [],
+  "evidence_refs": ["audit_independence_required"],
+  "created_at": "2026-06-17T12:04:00Z"
+}

--- a/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R5_SECURITY_OR_AUTHORITY.json
+++ b/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R5_SECURITY_OR_AUTHORITY.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "route_decision_id": "rd_example_R5_SECURITY",
+  "task_id": "example-security-review",
+  "role": "security_review",
+  "privacy_class": "SECURITY_SENSITIVE",
+  "risk_class": "R5_SECURITY_OR_AUTHORITY",
+  "selected_pool": "security_reviewer",
+  "selected_route": {
+    "route_name": "direct-security-review",
+    "route_profile": "direct_api_premium",
+    "selection_reason": "Security-sensitive review requires direct frontier route, evidence, and human gate.",
+    "fallback_allowed": false
+  },
+  "provider": "openai",
+  "requested_model": "openai/gpt-5.5-pro",
+  "actual_model": "openai/gpt-5.5-pro",
+  "runner": "direct_api",
+  "access_path": "direct_api",
+  "consumer_plan_used": false,
+  "api_route_used": true,
+  "openrouter_profile": null,
+  "structured_output_mode": "json_schema_strict",
+  "proof_requirement": "security",
+  "audit_requirement": "security",
+  "human_gate_required": true,
+  "human_approval_ref": "approval_security_review_001",
+  "benchmark_certification_ref": "cert_security_reviewer_001",
+  "decision_status": "SELECTED",
+  "blocked_reasons": [],
+  "evidence_refs": ["security_gate_policy", "structured_output_policy"],
+  "created_at": "2026-06-17T12:05:00Z"
+}

--- a/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R6_RELEASE_OR_PRODUCTION.json
+++ b/docs/03-reference/dcp/openclaw-routing/example_route_decisions/R6_RELEASE_OR_PRODUCTION.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "route_decision_id": "rd_example_R6_RELEASE",
+  "task_id": "example-release-judgment",
+  "role": "release_judgment",
+  "privacy_class": "RELEASE_AUTHORITY",
+  "risk_class": "R6_RELEASE_OR_PRODUCTION",
+  "selected_pool": "release_judge",
+  "selected_route": {
+    "route_name": "release-judge-direct-plus-human",
+    "route_profile": "direct_api_premium",
+    "selection_reason": "Release requires current proof, CI, PR head SHA, independent audit, and human approval.",
+    "fallback_allowed": false
+  },
+  "provider": "multiple",
+  "requested_model": "openai/gpt-5.5-pro+anthropic/claude-opus-4.8",
+  "actual_model": "openai/gpt-5.5-pro+anthropic/claude-opus-4.8",
+  "runner": "direct_api",
+  "access_path": "direct_api",
+  "consumer_plan_used": false,
+  "api_route_used": true,
+  "openrouter_profile": null,
+  "structured_output_mode": "json_schema_strict",
+  "proof_requirement": "release",
+  "audit_requirement": "release",
+  "human_gate_required": true,
+  "human_approval_ref": "approval_release_001",
+  "benchmark_certification_ref": "cert_release_judge_001",
+  "decision_status": "SELECTED",
+  "blocked_reasons": [],
+  "evidence_refs": ["merge_readiness:pr_123_head_abc1234", "audit:independent_pass"],
+  "created_at": "2026-06-17T12:06:00Z"
+}

--- a/docs/03-reference/dcp/openclaw-routing/example_route_decisions/UNKNOWN.json
+++ b/docs/03-reference/dcp/openclaw-routing/example_route_decisions/UNKNOWN.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "1.0.0",
+  "route_decision_id": "rd_example_UNKNOWN",
+  "task_id": "example-unknown-classification",
+  "role": "task_classification",
+  "privacy_class": "UNKNOWN",
+  "risk_class": "UNKNOWN",
+  "selected_pool": "cheap_classifier",
+  "selected_route": {
+    "route_name": "blocked-unknown-safe-classification",
+    "route_profile": "local_readonly_classification",
+    "selection_reason": "Unknown privacy and risk fail closed; only local read-only classification may proceed.",
+    "fallback_allowed": false
+  },
+  "provider": "local",
+  "requested_model": "local/read-only-classifier",
+  "actual_model": "local/read-only-classifier",
+  "runner": "shell_local",
+  "access_path": "local_self_hosted",
+  "consumer_plan_used": false,
+  "api_route_used": false,
+  "openrouter_profile": null,
+  "structured_output_mode": "json_schema_strict",
+  "proof_requirement": "minimal",
+  "audit_requirement": "independent",
+  "human_gate_required": true,
+  "human_approval_ref": null,
+  "benchmark_certification_ref": null,
+  "decision_status": "BLOCKED",
+  "blocked_reasons": ["UNKNOWN_PRIVACY_CLASS", "UNKNOWN_RISK_CLASS", "MISSING_BENCHMARK_CERTIFICATION"],
+  "evidence_refs": ["fail_closed_policy"],
+  "created_at": "2026-06-17T12:07:00Z"
+}

--- a/docs/03-reference/dcp/openclaw-routing/forbidden_routes.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/forbidden_routes.yaml
@@ -1,0 +1,145 @@
+schema_version: "1.0.0"
+artifact_id: "forbidden_routes"
+status: "PROPOSED"
+default_behavior: "BLOCK"
+
+hard_blocks:
+  - id: "FR-001"
+    name: "implementer_as_sole_final_auditor"
+    match:
+      implementer_provider_equals_auditor_provider: true
+      implementer_model_equals_auditor_model: true
+      implementer_runner_equals_auditor_runner: true
+      no_human_override: true
+    block_reason: "AUDIT_INDEPENDENCE_VIOLATION"
+
+  - id: "FR-002"
+    name: "openrouter_free_private_secret_security_release_schema"
+    match:
+      access_path: "openrouter_free"
+      any_privacy_class:
+        - PRIVATE_REPO_NO_SECRETS
+        - PRIVATE_REPO_POSSIBLE_SECRETS
+        - SECRET_BEARING
+        - CLIENT_DATA
+        - SECURITY_SENSITIVE
+        - RELEASE_AUTHORITY
+      any_risk_class:
+        - R5_SECURITY_OR_AUTHORITY
+        - R6_RELEASE_OR_PRODUCTION
+      any_role:
+        - structured_task_packet_generation
+        - proof_bundle_generation
+        - proof_validation
+        - security_review
+        - release_judgment
+    block_reason: "OPENROUTER_FREE_FORBIDDEN"
+
+  - id: "FR-003"
+    name: "consumer_app_machine_authority_without_proof_capture"
+    match:
+      access_path_any:
+        - chatgpt_app
+        - claude_app
+        - gemini_app
+        - manual_app
+      machine_authority: true
+      proof_capture: false
+    block_reason: "CONSUMER_APP_AUTHORITY_FORBIDDEN"
+
+  - id: "FR-004"
+    name: "preview_model_sole_R5_R6_authority"
+    match:
+      model_status_any:
+        - preview
+        - experimental
+        - early_access
+      risk_class_any:
+        - R5_SECURITY_OR_AUTHORITY
+        - R6_RELEASE_OR_PRODUCTION
+      sole_authority: true
+    block_reason: "PREVIEW_SOLE_HIGH_RISK_AUTHORITY"
+
+  - id: "FR-005"
+    name: "openrouter_schema_without_require_parameters"
+    match:
+      provider: openrouter
+      structured_output_mode: json_schema_strict
+      provider_require_parameters_not_true: true
+    block_reason: "MISSING_SCHEMA_VALIDATION"
+
+  - id: "FR-006"
+    name: "json_mode_as_schema_authority_substitute"
+    match:
+      structured_authority_required: true
+      structured_output_mode_any:
+        - json_object
+        - manual_capture
+        - none
+    block_reason: "MISSING_SCHEMA_VALIDATION"
+
+  - id: "FR-007"
+    name: "write_task_without_git_status_or_diff"
+    match:
+      edit_write_required: true
+      missing_any:
+        - git_status_before
+        - git_status_after
+        - git_diff_stat
+        - git_diff
+    block_reason: "MISSING_PROOF_REQUIREMENT"
+
+  - id: "FR-008"
+    name: "release_without_independent_audit_or_human_approval"
+    match:
+      role: release_judgment
+      independent_audit_missing: true
+      human_approval_missing: true
+    block_reason: "MISSING_HUMAN_APPROVAL"
+
+  - id: "FR-009"
+    name: "fallback_weakens_privacy_schema_cost_or_audit"
+    match:
+      fallback_event: true
+      weakens_any:
+        - privacy_class
+        - structured_output_mode
+        - provider_require_parameters
+        - data_collection_policy
+        - zdr_policy
+        - cost_ceiling
+        - audit_requirement
+    block_reason: "FALLBACK_WEAKENS_GUARD"
+
+  - id: "FR-010"
+    name: "unknown_actual_route_for_private_or_high_risk"
+    match:
+      actual_model_or_provider_unknown: true
+      privacy_class_any:
+        - PRIVATE_REPO_NO_SECRETS
+        - PRIVATE_REPO_POSSIBLE_SECRETS
+        - SECRET_BEARING
+        - CLIENT_DATA
+        - SECURITY_SENSITIVE
+        - RELEASE_AUTHORITY
+      risk_class_any:
+        - R4_MULTI_FILE_EDIT
+        - R5_SECURITY_OR_AUTHORITY
+        - R6_RELEASE_OR_PRODUCTION
+    block_reason: "PROVIDER_MODEL_DRIFT"
+
+  - id: "FR-011"
+    name: "benchmark_missing_for_high_trust_route"
+    match:
+      benchmark_required: true
+      benchmark_certification_ref: null
+    block_reason: "MISSING_BENCHMARK_CERTIFICATION"
+
+  - id: "FR-012"
+    name: "bridge_or_adapter_claims_canonical_authority"
+    match:
+      authority_boundary_any:
+        - dopecon_bridge_adapter
+        - agent_helper
+      claims_canonical_authority: true
+    block_reason: "PRIVACY_MISMATCH"

--- a/docs/03-reference/dcp/openclaw-routing/human_approval_gates.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/human_approval_gates.yaml
@@ -1,0 +1,83 @@
+schema_version: "1.0.0"
+artifact_id: "human_approval_gates"
+status: "PROPOSED"
+default_missing_approval_action: "BLOCK"
+
+approval_event_required_fields:
+  - approval_id
+  - approver
+  - approval_scope
+  - approved_at
+  - expires_at
+  - route_decision_id
+  - risk_class
+  - privacy_class
+  - explicit_statement
+
+gates:
+  privacy_override:
+    trigger: "Selected route is more permissive than privacy_class_policy default."
+    required_approval_scope: "privacy_route_override"
+    block_if_missing: true
+
+  destructive_write_execution:
+    trigger: "Shell/edit/write tool can mutate files or external systems."
+    required_approval_scope: "write_or_destructive_execution"
+    block_if_missing: true
+
+  scope_expansion:
+    trigger: "Files/tools/commands exceed packet allowlist."
+    required_approval_scope: "scope_expansion"
+    block_if_missing: true
+
+  cost_escalation:
+    trigger: "Estimated or actual route cost exceeds cost ceiling."
+    required_approval_scope: "budget_override"
+    block_if_missing: true
+
+  R5_R6_task:
+    trigger: "risk_class is R5_SECURITY_OR_AUTHORITY or R6_RELEASE_OR_PRODUCTION."
+    required_approval_scope: "high_risk_execution"
+    block_if_missing: true
+
+  missing_proof:
+    trigger: "Required proof fields absent, stale, or unverifiable."
+    required_approval_scope: "proof_gap_acceptance"
+    block_if_missing: true
+    note: "Approval may unblock investigation, not release readiness."
+
+  auditor_conflict:
+    trigger: "Auditor returns FAIL, NEEDS_SUPERVISOR, or conflicts with implementer."
+    required_approval_scope: "audit_conflict_resolution"
+    block_if_missing: true
+
+  release_judgment:
+    trigger: "Any R6 or release_judgment role."
+    required_approval_scope: "release_approval"
+    block_if_missing: true
+
+  consumer_plan_proof_use:
+    trigger: "Manual app or consumer-plan route contributes to DCP workflow evidence."
+    required_approval_scope: "consumer_plan_evidence_acceptance"
+    block_if_missing: true
+
+  openrouter_sensitive_use:
+    trigger: "OpenRouter paid route proposed for private, client, secret-adjacent, security, or release lane."
+    required_approval_scope: "openrouter_sensitive_route"
+    block_if_missing: true
+
+  preview_experimental_use:
+    trigger: "Preview, experimental, or early-access model proposed for R4+ or authority task."
+    required_approval_scope: "preview_model_risk_acceptance"
+    block_if_missing: true
+
+  provider_drift:
+    trigger: "Actual provider/model differs from policy route in private or high-risk lane."
+    required_approval_scope: "provider_drift_acceptance"
+    block_if_missing: true
+
+  benchmark_bypass:
+    trigger: "Route lacks required local benchmark certification."
+    required_approval_scope: "benchmark_bypass"
+    block_if_missing: true
+    note: "Bypass cannot grant production or release authority; it can only permit bounded investigation."

--- a/docs/03-reference/dcp/openclaw-routing/local-benchmark-harness-requirements.md
+++ b/docs/03-reference/dcp/openclaw-routing/local-benchmark-harness-requirements.md
@@ -1,0 +1,124 @@
+---
+id: local_benchmark_harness_requirements
+title: Local Benchmark Harness Requirements
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-17'
+last_review: '2026-06-17'
+next_review: '2026-09-15'
+prelude: Local Benchmark Harness Requirements (explanation) for dopemux documentation
+  and developer workflows.
+---
+# Local Benchmark Harness Requirements
+
+schema_version: 1.0.0
+status: PROPOSED
+
+## Purpose
+
+No route can be accepted for production or high-trust OpenClaw/DCP use without local benchmark certification.
+
+## Non-negotiable thresholds
+
+A route MUST meet:
+
+- 100% valid JSON for schema-critical routes
+- 100% schema validity for schema-critical routes
+- 100% fail-closed unsupported-route blocking
+- evidence grounding precision >= 98%
+- unsupported-claim rate <= 1%
+- contradiction recall >= 90%
+- core-field stability >= 95% across reruns
+
+## Required tracking
+
+The harness MUST track:
+
+- hallucinated file/path count
+- diff applicability
+- patch success
+- multi-file coherence
+- test pass/fail
+- lint/typecheck pass/fail
+- schema validation
+- structured-output retry count
+- latency p50/p95
+- cost per successful artifact
+- requested model
+- actual model
+- actual provider
+- provider drift
+- privacy mismatch
+- fallback events
+- unsupported-route blocking
+- secret leakage attempts
+- prompt-injection obedience failures
+
+## Required fixture properties
+
+Every fixture MUST define:
+
+- fixture ID
+- purpose
+- privacy class
+- risk class
+- allowed routes
+- forbidden routes
+- expected route decision
+- expected proof fields
+- pass/fail criteria
+- gold evidence map
+- local repo fixture path or synthetic fixture path
+- cleanup requirements
+
+## Local repo fixture requirement
+
+At least one fixture MUST use a local repo-shaped worktree with:
+
+- `.git`
+- source files
+- tests or synthetic test commands
+- docs
+- at least one contradiction trap
+- at least one generated/vendor exclusion trap
+- at least one fake secret trap
+- expected git status/diff behavior
+
+## Benchmark modes
+
+### Certification mode
+
+- provider pinned
+- fallbacks disabled unless testing fallback fixture
+- temperature fixed
+- schema validation enabled
+- exact prompt hash captured
+- actual route logged
+- all artifacts retained
+
+### Production simulation mode
+
+- approved fallbacks enabled
+- actual provider/model logged
+- latency/cost captured
+- policy failure still fails closed
+
+## Required output
+
+The harness MUST emit:
+
+- `benchmark_result.schema.json` conforming result
+- route certification recommendation
+- failure index
+- cost/latency rollup
+- privacy violation report
+- provider drift report
+- artifact manifest
+
+## Certification decision values
+
+- `CERTIFY`
+- `CERTIFY_WITH_LIMITS`
+- `DO_NOT_CERTIFY`
+- `NEEDS_MORE_DATA`

--- a/docs/03-reference/dcp/openclaw-routing/model_pool_registry.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/model_pool_registry.yaml
@@ -1,0 +1,247 @@
+schema_version: "1.0.0"
+artifact_id: "model_pool_registry"
+status: "PROPOSED"
+default_guards:
+  benchmark_required_for_high_trust: true
+  openrouter_free_private_forbidden: true
+  direct_api_preferred_for_authority: true
+  consumer_plan_requires_proof_capture: true
+
+pools:
+  cheap_read:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.4-nano", "anthropic/claude-haiku-4.5", "google/gemini-3.5-flash"]
+      - route: openrouter_free
+        models: ["qwen/qwen3-coder:free", "moonshotai/kimi-k2.6:free"]
+      - route: openrouter_paid
+        models: ["deepseek/deepseek-v4-flash", "mistralai/codestral-2508"]
+    allowed_roles: ["cheap_file_reading", "issue_triage", "task_intake"]
+    forbidden_roles: ["security_review", "release_judgment", "proof_validation"]
+    primary_selection_rule: "Use cheapest route that satisfies privacy, schema, and benchmark guard."
+    cost_guard: "cheap_or_free_only"
+    privacy_guard: "OR-free public only; direct API for private."
+    risk_guard: "Allowed R0-R2 only unless escalated."
+    benchmark_requirement: "Required before private or production use."
+    escalation_path: "repo_cartographer"
+
+  cheap_classifier:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.4-nano", "anthropic/claude-haiku-4.5", "google/gemini-3.5-flash"]
+      - route: openrouter_paid
+        models: ["deepseek/deepseek-v4-flash"]
+    allowed_roles: ["task_classification", "issue_triage", "task_intake"]
+    forbidden_roles: ["release_judgment", "security_review"]
+    primary_selection_rule: "Smallest schema-valid classifier."
+    cost_guard: "hard_low_output_cap"
+    privacy_guard: "No OR-free for private."
+    risk_guard: "Unknown risk escalates."
+    benchmark_requirement: "Required for schema authority."
+    escalation_path: "planner_default"
+
+  repo_cartographer:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3.5-flash"]
+      - route: openrouter_paid
+        models: ["qwen/qwen3-coder", "deepseek/deepseek-v4-pro"]
+    allowed_roles: ["repo_cartography", "architecture_synthesis", "planning"]
+    forbidden_roles: ["release_judgment"]
+    primary_selection_rule: "Retrieval-first; use long context only when necessary."
+    cost_guard: "standard_cap; long-context approval if high token estimate."
+    privacy_guard: "Direct API for confidential repos; OR-paid requires data_collection deny."
+    risk_guard: "R0-R4 allowed; R5+ requires auditor/security pool."
+    benchmark_requirement: "Required for private or large-context route."
+    escalation_path: "planner_strong"
+
+  planner_default:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["anthropic/claude-sonnet-4.6", "openai/gpt-5.4"]
+      - route: openrouter_paid
+        models: ["qwen/qwen3-coder", "google/gemini-3.5-flash"]
+    allowed_roles: ["planning", "architecture_synthesis"]
+    forbidden_roles: ["release_judgment", "security_review"]
+    primary_selection_rule: "Use Sonnet/GPT cost-balanced planner unless provider diversity needed."
+    cost_guard: "standard"
+    privacy_guard: "Direct for private unless OR policy clean."
+    risk_guard: "R0-R4; R5+ escalates."
+    benchmark_requirement: "Required before high-trust planning."
+    escalation_path: "planner_strong"
+
+  planner_strong:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.5", "openai/gpt-5.5-pro", "anthropic/claude-opus-4.8", "google/gemini-pro"]
+    allowed_roles: ["strong_planning", "architecture_synthesis", "final_supervisor_synthesis"]
+    forbidden_roles: ["cheap_file_reading", "bulk_classification"]
+    primary_selection_rule: "Use for ambiguity, high risk, cross-system architecture, or conflict."
+    cost_guard: "premium_requires_reason"
+    privacy_guard: "Direct API preferred."
+    risk_guard: "Allowed R4-R6 with proof and gates."
+    benchmark_requirement: "Required for release/security authority."
+    escalation_path: "supervisor"
+
+  implementer_default:
+    candidate_routes_models:
+      - route: claude_code
+        models: ["anthropic/claude-sonnet-4.6"]
+      - route: codex
+        models: ["openai/gpt-5.4", "openai/codex"]
+      - route: direct_api
+        models: ["anthropic/claude-sonnet-4.6", "openai/gpt-5.4"]
+    allowed_roles: ["implementation", "narrow_patch_generation", "multi_file_refactor"]
+    forbidden_roles: ["release_judgment", "sole_final_audit"]
+    primary_selection_rule: "Use benchmarked strong code runner with bounded worktree and allowlist."
+    cost_guard: "standard; avoid Opus/Pro for routine edits."
+    privacy_guard: "No OR-free; consumer runner requires proof capture."
+    risk_guard: "R3-R4 default; R5 requires security gate."
+    benchmark_requirement: "Required before production edits."
+    escalation_path: "implementer_alt_or_auditor_deep"
+
+  implementer_alt:
+    candidate_routes_models:
+      - route: openrouter_paid
+        models: ["qwen/qwen3-coder", "deepseek/deepseek-v4-flash", "moonshotai/kimi-k2.6", "mistralai/codestral-2508"]
+      - route: direct_api
+        models: ["google/gemini-3.5-flash"]
+    allowed_roles: ["narrow_patch_generation", "test_generation", "implementation"]
+    forbidden_roles: ["security_review", "release_judgment"]
+    primary_selection_rule: "Use after local benchmark or as fallback on patch failure."
+    cost_guard: "cheap_standard"
+    privacy_guard: "OR-paid only with privacy filters; no secrets."
+    risk_guard: "R2-R4 only."
+    benchmark_requirement: "Required before enabling."
+    escalation_path: "implementer_default"
+
+  test_builder:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.4-mini", "anthropic/claude-haiku-4.5"]
+      - route: openrouter_paid
+        models: ["mistralai/codestral-2508", "deepseek/deepseek-v4-flash"]
+      - route: openrouter_free
+        models: ["qwen/qwen3-coder:free"]
+    allowed_roles: ["test_generation"]
+    forbidden_roles: ["release_judgment", "proof_validation"]
+    primary_selection_rule: "Favor cheap test scaffolding, never correctness signoff."
+    cost_guard: "cheap"
+    privacy_guard: "OR-free public only."
+    risk_guard: "R2 default."
+    benchmark_requirement: "Required for test pass usefulness."
+    escalation_path: "implementer_default"
+
+  structured_packet:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.5", "openai/gpt-5.4", "anthropic/claude-sonnet-4.6", "google/gemini-3.5-flash"]
+      - route: openrouter_paid
+        models: ["openai/gpt-5.4-mini", "deepseek/deepseek-v4-flash"]
+    allowed_roles: ["structured_task_packet_generation", "task_classification", "proof_bundle_generation"]
+    forbidden_roles: ["openrouter_free_schema_authority"]
+    primary_selection_rule: "First route with strict local schema pass."
+    cost_guard: "standard"
+    privacy_guard: "Direct API for authority."
+    risk_guard: "All risks with correct audit/human gates."
+    benchmark_requirement: "Mandatory."
+    escalation_path: "supervisor"
+
+  proof_validator:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.5-pro", "anthropic/claude-opus-4.8", "google/gemini-pro"]
+    allowed_roles: ["proof_validation", "pr_review", "final_supervisor_synthesis"]
+    forbidden_roles: ["implementation_same_session"]
+    primary_selection_rule: "Different provider from implementer when stakes are real."
+    cost_guard: "premium allowed for R5/R6."
+    privacy_guard: "Direct API preferred."
+    risk_guard: "R3-R6."
+    benchmark_requirement: "Mandatory for high-trust."
+    escalation_path: "human_gate"
+
+  auditor_default:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.4", "anthropic/claude-sonnet-4.6", "google/gemini-3.5-flash"]
+      - route: openrouter_paid
+        models: ["deepseek/deepseek-v4-pro", "qwen/qwen3-coder"]
+    allowed_roles: ["challenger_review", "pr_review", "proof_validation"]
+    forbidden_roles: ["sole_release_judgment"]
+    primary_selection_rule: "Independent provider preferred; mid-tier for routine audit."
+    cost_guard: "standard"
+    privacy_guard: "No free routes."
+    risk_guard: "R3-R5; R6 escalates."
+    benchmark_requirement: "Mandatory for production."
+    escalation_path: "auditor_deep"
+
+  auditor_deep:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.5-pro", "anthropic/claude-opus-4.8", "google/gemini-pro"]
+    allowed_roles: ["security_review", "release_judgment", "final_supervisor_synthesis"]
+    forbidden_roles: ["bulk_reading"]
+    primary_selection_rule: "Use for conflict, R5/R6, high blast radius."
+    cost_guard: "premium_requires_approval"
+    privacy_guard: "Direct API or approved private route."
+    risk_guard: "R5-R6."
+    benchmark_requirement: "Mandatory."
+    escalation_path: "human_gate"
+
+  security_reviewer:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["anthropic/claude-opus-4.8", "openai/gpt-5.5-pro", "google/gemini-pro"]
+      - route: openrouter_paid
+        models: ["deepseek/deepseek-v4-pro"]
+    allowed_roles: ["security_review"]
+    forbidden_roles: ["openrouter_free", "consumer_only_authority"]
+    primary_selection_rule: "Direct frontier route; OR only as challenger with approved privacy."
+    cost_guard: "premium_allowed"
+    privacy_guard: "No OR-free; secrets require approved route."
+    risk_guard: "R5."
+    benchmark_requirement: "Mandatory."
+    escalation_path: "release_judge_or_human"
+
+  release_judge:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.5-pro", "anthropic/claude-opus-4.8"]
+      - route: human
+        models: ["explicit_human_approval"]
+    allowed_roles: ["release_judgment"]
+    forbidden_roles: ["openrouter_free", "preview_sole_authority", "implementer_sole_audit"]
+    primary_selection_rule: "Independent audit plus CI/proof/head SHA; human approval if uncertainty."
+    cost_guard: "premium_allowed_with_gate"
+    privacy_guard: "Direct API preferred."
+    risk_guard: "R6 only."
+    benchmark_requirement: "Mandatory."
+    escalation_path: "human_gate"
+
+  supervisor:
+    candidate_routes_models:
+      - route: direct_api
+        models: ["openai/gpt-5.5-pro", "anthropic/claude-opus-4.8", "google/gemini-pro"]
+      - route: manual
+        models: ["human_supervisor"]
+    allowed_roles: ["final_supervisor_synthesis", "strong_planning", "architecture_synthesis"]
+    forbidden_roles: ["bulk_low_risk_reading"]
+    primary_selection_rule: "Use for unresolved conflict, authority boundaries, or final synthesis."
+    cost_guard: "premium_with_reason"
+    privacy_guard: "No free routes."
+    risk_guard: "R4-R6."
+    benchmark_requirement: "Mandatory for automated authority."
+    escalation_path: "human_gate"
+
+  openrouter_free_sandbox:
+    candidate_routes_models:
+      - route: openrouter_free
+        models: ["qwen/qwen3-coder:free", "moonshotai/kimi-k2.6:free"]
+    allowed_roles: ["cheap_file_reading", "issue_triage", "test_generation"]
+    forbidden_roles: ["security_review", "release_judgment", "proof_validation", "structured_task_packet_generation"]
+    primary_selection_rule: "Public sandbox only, pinned free variant preferred."
+    cost_guard: "free"
+    privacy_guard: "PUBLIC_SANDBOX or PUBLIC_REPO low-risk only."
+    risk_guard: "R0-R2 only."
+    benchmark_requirement: "Required even for dev-aid enablement."
+    escalation_path: "openrouter_paid_or_direct_api"

--- a/docs/03-reference/dcp/openclaw-routing/openclaw-proof-normalization-contract.md
+++ b/docs/03-reference/dcp/openclaw-routing/openclaw-proof-normalization-contract.md
@@ -1,0 +1,148 @@
+---
+id: openclaw_proof_normalization_contract
+title: Openclaw Proof Normalization Contract
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-17'
+last_review: '2026-06-17'
+next_review: '2026-09-15'
+prelude: Openclaw Proof Normalization Contract (explanation) for dopemux documentation
+  and developer workflows.
+---
+# OpenClaw Proof Normalization Contract
+
+schema_version: 1.0.0
+status: PROPOSED
+
+## Purpose
+
+Convert heterogeneous OpenClaw evidence into DCP proof bundles. OpenClaw logs are input evidence, not final governance authority.
+
+## Input artifacts
+
+The normalizer MAY consume:
+
+- OpenClaw JSONL file logs
+- session JSONL transcripts
+- trajectory sidecar JSONL
+- exported trajectory bundle
+- tool events
+- model messages
+- runtime settings
+- usage metadata
+- timestamps
+- diagnostics export
+- failure reports
+- patch/diff artifacts when present
+- external wrapper git captures
+- external wrapper command captures
+
+## Required normalized output fields
+
+The normalizer MUST emit or mark missing:
+
+- `route_decision_id`
+- `task_id`
+- `packet_id`
+- `privacy_class`
+- `risk_class`
+- `model_provider_used`
+- `runner_used`
+- `requested_model`
+- `actual_model`
+- `provider_endpoint_or_route_profile`
+- `prompt_hash`
+- `prompt_body_ref`
+- `response_hash`
+- `response_body_ref`
+- `files_read`
+- `files_changed`
+- `git_status_before`
+- `git_status_after`
+- `git_diff_stat`
+- `git_diff`
+- `commands_run`
+- `command_outputs`
+- `exit_codes`
+- `test_lint_typecheck_results`
+- `structured_schema_id`
+- `structured_validation_result`
+- `cost_estimate`
+- `actual_usage`
+- `route_decision_reason`
+- `audit_decision`
+- `approval_event`
+- `head_sha`
+- `pr_metadata`
+- `openclaw_trajectory_ref`
+- `redaction_report`
+- `remaining_risks`
+
+## Hash requirements
+
+Every proof bundle MUST include:
+
+- SHA-256 hash of normalized prompt body or prompt reference file
+- SHA-256 hash of normalized response body or response reference file
+- SHA-256 hash of git diff for write tasks
+- SHA-256 hash of command output artifact bundle
+- SHA-256 hash of trajectory export when present
+- schema hash for every structured output artifact
+
+## Redaction rules
+
+- Never include raw secrets in normalized proof.
+- Preserve secret-detection evidence as category and path metadata only.
+- Redact environment values.
+- Redact tokens, API keys, private keys, credentials, cookies, and authorization headers.
+- Redaction must be recorded in `redaction_report`.
+- Redaction failure blocks external sharing.
+
+## Privacy handling
+
+- `PUBLIC_SANDBOX` and `PUBLIC_REPO`: full proof may be stored unless secrets are detected.
+- `PRIVATE_REPO_NO_SECRETS`: proof may include paths/diffs if policy permits.
+- `PRIVATE_REPO_POSSIBLE_SECRETS`: proof requires secret scan and redaction report.
+- `SECRET_BEARING`: proof stores references and hashes, not raw secret content.
+- `CLIENT_DATA`: proof follows client contract and approval event.
+- `SECURITY_SENSITIVE`: proof access restricted to security/release reviewers.
+- `RELEASE_AUTHORITY`: proof immutable or append-only after release judgment.
+
+## Missing-evidence behavior
+
+- Missing required evidence for read tasks: `validation_state=FAILED`.
+- Missing required evidence for write tasks: `validation_state=FAILED` and release blocked.
+- Missing git status/diff for write tasks: hard block.
+- Missing actual model/provider for private or high-risk task: hard block.
+- Missing audit proof for R5/R6: hard block.
+- Missing approval event when required: hard block.
+
+## Chain of custody
+
+The normalizer MUST preserve:
+
+- input artifact list
+- input artifact hashes
+- normalizer version
+- created_at timestamp
+- source runner
+- source session
+- route decision ref
+- parent proof refs
+- handoff refs
+- validation result
+- immutable storage ref if available
+
+## Output bundle posture
+
+Possible normalized proof statuses:
+
+- `PLAN_ONLY`
+- `SPECIFICATION_COMPLETE`
+- `IMPLEMENTATION_COMPLETE`
+- `READY_FOR_REVIEW`
+- `VERIFIED`
+- `BLOCKED`
+
+Completion claims require `VERIFIED`.

--- a/docs/03-reference/dcp/openclaw-routing/openclaw_dcp_routing_policy.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/openclaw_dcp_routing_policy.yaml
@@ -1,0 +1,265 @@
+schema_version: "1.0.0"
+artifact_id: "openclaw_dcp_routing_policy"
+status: "PROPOSED"
+claim_posture:
+  OBSERVED:
+    - "OpenClaw is a high-privilege worker/runtime substrate requiring DCP wrapper governance."
+    - "Consumer subscriptions are not equivalent to programmable API access unless the provider officially supports the path."
+    - "OpenRouter is a routing/control layer, not a trust oracle."
+  PROPOSED:
+    - "DCP owns classification, forbidden-route evaluation, proof normalization, audit independence, and release gates."
+  UNKNOWN:
+    - "Exact local benchmark pass rates for each route until Turn 5+ benchmark execution."
+metadata:
+  created_for: "OpenClaw + DCP role-based multi-model routing"
+  created_at_policy_date: "2026-06-17"
+  owner_layer: "DCP supervisor"
+  openclaw_role: "worker_runtime"
+  openrouter_role: "controlled_breadth_fallback"
+  production_ready: false
+  acceptance_required_before_enablement:
+    - "local_benchmark_certification"
+    - "route_decision_schema_validation"
+    - "proof_schema_validation"
+    - "forbidden_route_test_pass"
+    - "audit_independence_test_pass"
+
+privacy_classes:
+  - PUBLIC_SANDBOX
+  - PUBLIC_REPO
+  - PRIVATE_REPO_NO_SECRETS
+  - PRIVATE_REPO_POSSIBLE_SECRETS
+  - SECRET_BEARING
+  - CLIENT_DATA
+  - SECURITY_SENSITIVE
+  - RELEASE_AUTHORITY
+  - UNKNOWN
+
+risk_classes:
+  - R0_READ
+  - R1_DRAFT
+  - R2_TEST_ONLY
+  - R3_LOCAL_EDIT
+  - R4_MULTI_FILE_EDIT
+  - R5_SECURITY_OR_AUTHORITY
+  - R6_RELEASE_OR_PRODUCTION
+  - UNKNOWN
+
+routing_roles:
+  - task_intake
+  - task_classification
+  - repo_cartography
+  - cheap_file_reading
+  - issue_triage
+  - planning
+  - strong_planning
+  - architecture_synthesis
+  - implementation
+  - narrow_patch_generation
+  - multi_file_refactor
+  - test_generation
+  - ui_design_audit
+  - multimodal_audit
+  - structured_task_packet_generation
+  - proof_bundle_generation
+  - proof_validation
+  - challenger_review
+  - pr_review
+  - security_review
+  - release_judgment
+  - final_supervisor_synthesis
+
+route_decision_lifecycle:
+  states:
+    - INTAKE_RECEIVED
+    - CLASSIFIED
+    - POLICY_CHECKED
+    - ROUTE_SELECTED
+    - PROOF_REQUIREMENTS_BOUND
+    - HUMAN_GATE_CHECKED
+    - BENCHMARK_CERTIFICATION_CHECKED
+    - EXECUTION_ALLOWED
+    - BLOCKED
+    - ESCALATED
+  allowed_terminal_states:
+    - EXECUTION_ALLOWED
+    - BLOCKED
+    - ESCALATED
+  required_order:
+    - classify_privacy_and_risk
+    - evaluate_forbidden_routes
+    - evaluate_structured_output_requirements
+    - evaluate_benchmark_certification
+    - bind_proof_requirements
+    - evaluate_human_gates
+    - select_route
+    - emit_route_decision_log
+
+default_route_selection_order:
+  automation_or_schema_authority:
+    - direct_api
+    - local_self_hosted_if_benchmarked
+    - openrouter_paid_pinned_if_policy_clean
+    - manual_app_with_proof_capture
+  low_risk_public_read:
+    - cheap_direct_api
+    - openrouter_free_pinned
+    - openrouter_paid_low_cost
+    - manual_app_with_capture
+  implementation:
+    - direct_api_or_native_code_runner
+    - local_runner_with_proof
+    - openrouter_paid_benchmarked
+    - consumer_plan_local_runner_with_proof
+  security_or_release:
+    - direct_api_frontier
+    - independent_provider_audit
+    - explicit_human_approval
+    - openrouter_paid_challenger_only
+
+fail_closed_rules:
+  unknown_privacy_class: "BLOCK_OR_ESCALATE"
+  unknown_risk_class: "BLOCK_OR_ESCALATE"
+  unknown_actual_provider_high_risk: "BLOCK"
+  unknown_actual_model_high_risk: "BLOCK"
+  unknown_actual_provider_private: "BLOCK"
+  missing_benchmark_certification_for_high_trust: "BLOCK"
+  missing_schema_validation_for_authority: "BLOCK"
+  missing_proof_for_write_task: "BLOCK"
+  missing_human_approval_when_required: "BLOCK"
+  provider_drift_in_private_or_high_risk: "BLOCK"
+  fallback_weakens_any_guard: "BLOCK"
+
+evidence_requirements:
+  all_routes:
+    - route_decision_id
+    - task_id
+    - privacy_class
+    - risk_class
+    - selected_pool
+    - requested_model
+    - actual_model
+    - provider
+    - runner
+    - access_path
+    - prompt_hash
+    - response_hash
+    - created_at
+  repo_read:
+    - files_read
+    - evidence_refs
+  write_tasks:
+    - git_status_before
+    - git_status_after
+    - git_diff_stat
+    - git_diff
+    - files_changed
+    - commands_run
+    - command_outputs
+    - exit_codes
+  structured_output:
+    - structured_schema_id
+    - structured_validation_result
+    - local_validator_version
+  openrouter:
+    - openrouter_profile
+    - requested_model
+    - actual_model
+    - actual_provider
+    - provider_settings
+    - cost_estimate
+    - actual_usage
+    - fallback_events
+  high_risk:
+    - audit_decision
+    - independent_audit_ref
+    - approval_event_or_block
+  release:
+    - pr_metadata
+    - head_sha
+    - ci_check_refs
+    - proof_freshness_ref
+    - merge_readiness_ref
+
+audit_independence_requirements:
+  default:
+    implementer_must_not_be_sole_final_auditor: true
+    prefer_different_provider: true
+    prefer_different_runner: true
+    prefer_different_session: true
+  release:
+    requires_independent_audit_or_explicit_human_approval: true
+    same_provider_exception_requires_human_approval: true
+  security:
+    direct_api_preferred: true
+    openrouter_free_forbidden: true
+    manual_app_output_requires_capture: true
+
+human_gate_triggers:
+  - privacy_override
+  - destructive_or_write_execution
+  - scope_expansion
+  - cost_escalation
+  - R5_SECURITY_OR_AUTHORITY
+  - R6_RELEASE_OR_PRODUCTION
+  - missing_proof
+  - auditor_conflict
+  - release_judgment
+  - consumer_plan_proof_use
+  - openrouter_sensitive_use
+  - preview_or_experimental_high_risk_use
+  - provider_drift
+  - benchmark_bypass
+
+release_gate_rules:
+  status_values:
+    - READY
+    - BLOCKED
+    - NEEDS_SUPERVISOR
+  ready_requires:
+    - current_head_sha
+    - current_ci_checks
+    - current_proof_bundle
+    - no_failed_required_checks
+    - no_stale_checks
+    - no_stale_proof
+    - no_unresolved_blocking_threads
+    - no_unknown_reviewers_or_bots
+    - no_unclassified_review_items
+    - diff_inside_packet_allowlist
+    - independent_audit_or_human_approval
+  blocked_if:
+    - unknown_reviewer_or_bot
+    - failed_checks
+    - stale_checks
+    - stale_proof
+    - unresolved_blocking_thread
+    - diff_escapes_packet_allowlist
+    - missing_security_or_release_approval
+
+local_benchmark_certification_requirement:
+  required_before:
+    - production
+    - high_trust
+    - schema_authority
+    - private_repo
+    - R4_MULTI_FILE_EDIT
+    - R5_SECURITY_OR_AUTHORITY
+    - R6_RELEASE_OR_PRODUCTION
+  minimums:
+    valid_json_rate: 1.0
+    schema_validity_rate: 1.0
+    fail_closed_unsupported_route_rate: 1.0
+    evidence_grounding_precision_min: 0.98
+    unsupported_claim_rate_max: 0.01
+    contradiction_recall_min: 0.90
+    core_field_stability_min: 0.95
+
+forbidden_fallback_weakening_rules:
+  - "Never downgrade privacy controls."
+  - "Never downgrade json_schema strict mode to json_object or prose."
+  - "Never disable provider.require_parameters on OpenRouter structured routes."
+  - "Never allow OpenRouter free fallback into private, secret, security, release, or schema-authority lanes."
+  - "Never replace independent audit with implementer self-review."
+  - "Never bypass cost ceiling without approval."
+  - "Never silently accept actual model/provider drift in private or high-risk routes."

--- a/docs/03-reference/dcp/openclaw-routing/openrouter_route_profiles.json
+++ b/docs/03-reference/dcp/openclaw-routing/openrouter_route_profiles.json
@@ -1,0 +1,142 @@
+{
+  "schema_version": "1.0.0",
+  "artifact_id": "openrouter_route_profiles",
+  "status": "PROPOSED",
+  "profiles": {
+    "or_free_sandbox": {
+      "allowed_privacy_classes": ["PUBLIC_SANDBOX", "PUBLIC_REPO"],
+      "allowed_risk_classes": ["R0_READ", "R1_DRAFT", "R2_TEST_ONLY"],
+      "allowed_roles": ["cheap_file_reading", "issue_triage", "test_generation", "task_intake"],
+      "forbidden_roles": ["security_review", "release_judgment", "proof_validation", "structured_task_packet_generation", "proof_bundle_generation"],
+      "required_provider_settings": {
+        "require_parameters": false,
+        "data_collection": "no_sensitive_data_allowed",
+        "zdr": false,
+        "allow_fallbacks": true,
+        "provider_order": "pinned_free_variant_preferred",
+        "sort": "none",
+        "metadata_header": "recommended"
+      },
+      "required_logging_fields": ["requested_model", "actual_model", "actual_provider", "usage", "latency_ms", "fallback_events", "route_decision_id"],
+      "require_parameters": false,
+      "data_collection": "not_applicable_public_only",
+      "zdr": false,
+      "max_price": { "prompt": 0, "completion": 0 },
+      "provider_pinning_order_rules": "Use pinned :free model for reproducible tests; avoid openrouter/free for deterministic lanes.",
+      "fallback_rules": "Fallback allowed only within free public sandbox scope.",
+      "failure_behavior": "BLOCK_OR_ESCALATE_TO_PAID_OR_DIRECT"
+    },
+    "or_low_cost_public": {
+      "allowed_privacy_classes": ["PUBLIC_SANDBOX", "PUBLIC_REPO"],
+      "allowed_risk_classes": ["R0_READ", "R1_DRAFT", "R2_TEST_ONLY", "R3_LOCAL_EDIT"],
+      "allowed_roles": ["cheap_file_reading", "issue_triage", "repo_cartography", "test_generation", "narrow_patch_generation", "challenger_review"],
+      "forbidden_roles": ["security_review", "release_judgment"],
+      "required_provider_settings": {
+        "require_parameters": true,
+        "data_collection": "deny_when_repo_content_present",
+        "zdr": false,
+        "allow_fallbacks": true,
+        "provider_order": "benchmarked_order_or_default_logged",
+        "sort": "price_or_throughput_after_benchmark",
+        "metadata_header": "enabled_if_available"
+      },
+      "required_logging_fields": ["requested_model", "actual_model", "actual_provider", "usage", "latency_ms", "cost_usd", "fallback_events", "schema_validation_result"],
+      "require_parameters": true,
+      "data_collection": "deny_when_repo_content_present",
+      "zdr": false,
+      "max_price": { "prompt_per_million_usd": 0.5, "completion_per_million_usd": 2.0 },
+      "provider_pinning_order_rules": "Pin during certification; allow approved same-model fallbacks in production.",
+      "fallback_rules": "No fallback to free, non-schema, or unbenchmarked routes.",
+      "failure_behavior": "FAIL_CLOSED_ON_SCHEMA_OR_PRIVACY_MISMATCH"
+    },
+    "or_paid_private_controlled": {
+      "allowed_privacy_classes": ["PRIVATE_REPO_NO_SECRETS"],
+      "allowed_risk_classes": ["R0_READ", "R1_DRAFT", "R2_TEST_ONLY", "R3_LOCAL_EDIT"],
+      "allowed_roles": ["repo_cartography", "issue_triage", "test_generation", "challenger_review"],
+      "forbidden_roles": ["security_review", "release_judgment", "proof_validation"],
+      "required_provider_settings": {
+        "require_parameters": true,
+        "data_collection": "deny",
+        "zdr": true,
+        "allow_fallbacks": false,
+        "provider_order": "pinned",
+        "sort": "none",
+        "metadata_header": "enabled_if_available"
+      },
+      "required_logging_fields": ["requested_model", "actual_model", "actual_provider", "data_collection", "zdr", "usage", "latency_ms", "cost_usd", "schema_validation_result"],
+      "require_parameters": true,
+      "data_collection": "deny",
+      "zdr": true,
+      "max_price": { "prompt_per_million_usd": 1.0, "completion_per_million_usd": 5.0 },
+      "provider_pinning_order_rules": "Provider pinning required; provider drift blocks.",
+      "fallback_rules": "No fallback unless fallback provider has same privacy controls and certification.",
+      "failure_behavior": "BLOCK"
+    },
+    "or_structured_noncritical": {
+      "allowed_privacy_classes": ["PUBLIC_SANDBOX", "PUBLIC_REPO", "PRIVATE_REPO_NO_SECRETS"],
+      "allowed_risk_classes": ["R0_READ", "R1_DRAFT", "R2_TEST_ONLY", "R3_LOCAL_EDIT"],
+      "allowed_roles": ["task_classification", "issue_triage", "structured_task_packet_generation"],
+      "forbidden_roles": ["release_judgment", "security_review", "proof_validation"],
+      "required_provider_settings": {
+        "require_parameters": true,
+        "response_format": "json_schema",
+        "strict": true,
+        "data_collection": "deny_for_private",
+        "zdr": "required_for_private",
+        "allow_fallbacks": false,
+        "provider_order": "pinned"
+      },
+      "required_logging_fields": ["schema_id", "schema_hash", "requested_model", "actual_model", "actual_provider", "validation_result", "usage", "cost_usd"],
+      "require_parameters": true,
+      "data_collection": "deny_for_private",
+      "zdr": "required_for_private",
+      "max_price": { "prompt_per_million_usd": 1.0, "completion_per_million_usd": 3.0 },
+      "provider_pinning_order_rules": "Pin model/provider during certification.",
+      "fallback_rules": "On schema failure, retry once same route, then direct API.",
+      "failure_behavior": "FAIL_CLOSED"
+    },
+    "or_challenger": {
+      "allowed_privacy_classes": ["PUBLIC_SANDBOX", "PUBLIC_REPO", "PRIVATE_REPO_NO_SECRETS", "SECURITY_SENSITIVE"],
+      "allowed_risk_classes": ["R1_DRAFT", "R2_TEST_ONLY", "R3_LOCAL_EDIT", "R4_MULTI_FILE_EDIT", "R5_SECURITY_OR_AUTHORITY"],
+      "allowed_roles": ["challenger_review", "pr_review", "architecture_synthesis"],
+      "forbidden_roles": ["release_judgment_as_sole_authority", "security_review_as_sole_authority"],
+      "required_provider_settings": {
+        "require_parameters": true,
+        "data_collection": "deny",
+        "zdr": "required_for_sensitive",
+        "allow_fallbacks": false,
+        "provider_order": "pinned"
+      },
+      "required_logging_fields": ["primary_route_compared", "requested_model", "actual_model", "actual_provider", "findings", "usage", "cost_usd"],
+      "require_parameters": true,
+      "data_collection": "deny",
+      "zdr": "required_for_sensitive",
+      "max_price": { "prompt_per_million_usd": 3.0, "completion_per_million_usd": 10.0 },
+      "provider_pinning_order_rules": "Must differ from primary provider family where possible.",
+      "fallback_rules": "Escalate to direct API or human on disagreement.",
+      "failure_behavior": "NEEDS_SUPERVISOR_ON_CONFLICT"
+    },
+    "or_emergency_fallback": {
+      "allowed_privacy_classes": ["PUBLIC_SANDBOX", "PUBLIC_REPO", "PRIVATE_REPO_NO_SECRETS"],
+      "allowed_risk_classes": ["R0_READ", "R1_DRAFT", "R2_TEST_ONLY", "R3_LOCAL_EDIT", "R4_MULTI_FILE_EDIT"],
+      "allowed_roles": ["cheap_file_reading", "repo_cartography", "planning", "challenger_review"],
+      "forbidden_roles": ["security_review", "release_judgment", "proof_validation"],
+      "required_provider_settings": {
+        "require_parameters": true,
+        "data_collection": "deny_for_private",
+        "zdr": "required_for_private",
+        "allow_fallbacks": false,
+        "provider_order": "approved_emergency_order",
+        "metadata_header": "enabled_if_available"
+      },
+      "required_logging_fields": ["outage_reason", "requested_model", "actual_model", "actual_provider", "fallback_events", "usage", "latency_ms", "cost_usd"],
+      "require_parameters": true,
+      "data_collection": "deny_for_private",
+      "zdr": "required_for_private",
+      "max_price": { "prompt_per_million_usd": 2.0, "completion_per_million_usd": 8.0 },
+      "provider_pinning_order_rules": "Use only pre-approved emergency route set.",
+      "fallback_rules": "Cannot weaken original route privacy, schema, audit, or cost settings.",
+      "failure_behavior": "BLOCK_IF_ANY_GUARD_WEAKENS"
+    }
+  }
+}

--- a/docs/03-reference/dcp/openclaw-routing/pr_steward_merge_readiness.schema.json
+++ b/docs/03-reference/dcp/openclaw-routing/pr_steward_merge_readiness.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dcp.local/schemas/pr_steward_merge_readiness.schema.json",
+  "title": "PR Steward Merge Readiness",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "pr_number",
+    "repo",
+    "branch",
+    "head_sha",
+    "base_branch",
+    "changed_files",
+    "commits",
+    "checks",
+    "review_comments",
+    "review_threads",
+    "issue_comments",
+    "bot_comments",
+    "proof_bundle_refs",
+    "audit_refs",
+    "review_item_classifications",
+    "unknown_reviewers_or_bots",
+    "unclassified_review_items",
+    "failed_checks",
+    "checks_stale_to_head",
+    "proof_stale",
+    "blocking_thread_unresolved",
+    "diff_escapes_packet_allowlist",
+    "security_release_gate_lacks_approval",
+    "unresolved_blockers",
+    "status",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "pr_number": { "type": "integer", "minimum": 1 },
+    "repo": { "type": "string", "minLength": 1 },
+    "branch": { "type": "string", "minLength": 1 },
+    "head_sha": { "type": "string", "pattern": "^[a-fA-F0-9]{7,40}$" },
+    "base_branch": { "type": "string", "minLength": 1 },
+    "changed_files": { "type": "array", "items": { "type": "string" } },
+    "commits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["sha", "message"],
+        "properties": {
+          "sha": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "status", "conclusion", "head_sha"],
+        "properties": {
+          "name": { "type": "string" },
+          "status": { "type": "string", "enum": ["queued", "in_progress", "completed", "unknown"] },
+          "conclusion": { "type": "string", "enum": ["success", "failure", "neutral", "cancelled", "skipped", "timed_out", "action_required", "pending", "unknown"] },
+          "head_sha": { "type": "string" }
+        }
+      }
+    },
+    "review_comments": { "type": "array", "items": { "$ref": "#/definitions/review_item" } },
+    "review_threads": { "type": "array", "items": { "$ref": "#/definitions/review_thread" } },
+    "issue_comments": { "type": "array", "items": { "$ref": "#/definitions/review_item" } },
+    "bot_comments": { "type": "array", "items": { "$ref": "#/definitions/review_item" } },
+    "proof_bundle_refs": { "type": "array", "items": { "type": "string" } },
+    "audit_refs": { "type": "array", "items": { "type": "string" } },
+    "review_item_classifications": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/review_classification" }
+    },
+    "unknown_reviewers_or_bots": { "type": "array", "items": { "type": "string" } },
+    "unclassified_review_items": { "type": "array", "items": { "type": "string" } },
+    "failed_checks": { "type": "array", "items": { "type": "string" } },
+    "checks_stale_to_head": { "type": "boolean" },
+    "proof_stale": { "type": "boolean" },
+    "blocking_thread_unresolved": { "type": "boolean" },
+    "diff_escapes_packet_allowlist": { "type": "boolean" },
+    "security_release_gate_lacks_approval": { "type": "boolean" },
+    "unresolved_blockers": { "type": "array", "items": { "type": "string" } },
+    "status": { "type": "string", "enum": ["READY", "BLOCKED", "NEEDS_SUPERVISOR"] },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "status": { "const": "READY" } } },
+      "then": {
+        "properties": {
+          "proof_bundle_refs": { "minItems": 1 },
+          "audit_refs": { "minItems": 1 },
+          "unknown_reviewers_or_bots": { "maxItems": 0 },
+          "unclassified_review_items": { "maxItems": 0 },
+          "failed_checks": { "maxItems": 0 },
+          "checks_stale_to_head": { "const": false },
+          "proof_stale": { "const": false },
+          "blocking_thread_unresolved": { "const": false },
+          "diff_escapes_packet_allowlist": { "const": false },
+          "security_release_gate_lacks_approval": { "const": false },
+          "unresolved_blockers": { "maxItems": 0 }
+        },
+        "required": [
+          "unknown_reviewers_or_bots",
+          "unclassified_review_items",
+          "failed_checks",
+          "checks_stale_to_head",
+          "proof_stale",
+          "blocking_thread_unresolved",
+          "diff_escapes_packet_allowlist",
+          "security_release_gate_lacks_approval",
+          "unresolved_blockers"
+        ]
+      }
+    }
+  ],
+  "definitions": {
+    "review_item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "author", "body_ref", "created_at"],
+      "properties": {
+        "id": { "type": "string" },
+        "author": { "type": "string" },
+        "body_ref": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "review_thread": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "resolved", "blocking", "items"],
+      "properties": {
+        "id": { "type": "string" },
+        "resolved": { "type": "boolean" },
+        "blocking": { "type": "boolean" },
+        "items": { "type": "array", "items": { "$ref": "#/definitions/review_item" } }
+      }
+    },
+    "review_classification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["item_id", "classification", "reason"],
+      "properties": {
+        "item_id": { "type": "string" },
+        "classification": {
+          "type": "string",
+          "enum": [
+            "AUTO_APPLIED",
+            "MUST_FIX",
+            "OPTIONAL_DEFERRED",
+            "OUT_OF_SCOPE_FOLLOWUP",
+            "REJECTED_WITH_REASON",
+            "NEEDS_SUPERVISOR",
+            "UNKNOWN_REVIEWER_NEEDS_CLASSIFICATION"
+          ]
+        },
+        "reason": { "type": "string" }
+      }
+    }
+  }
+}

--- a/docs/03-reference/dcp/openclaw-routing/privacy_class_policy.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/privacy_class_policy.yaml
@@ -1,0 +1,121 @@
+schema_version: "1.0.0"
+artifact_id: "privacy_class_policy"
+status: "PROPOSED"
+legend:
+  allowed: "Route may be used if risk and benchmark policies also pass."
+  constrained: "Route requires proof capture, redaction, approval, or route controls."
+  blocked: "Route forbidden."
+  fail_closed: "Block or escalate until class is resolved."
+
+privacy_classes:
+  PUBLIC_SANDBOX:
+    chatgpt_app: allowed
+    claude_app: allowed
+    gemini_app: allowed
+    direct_apis: allowed
+    openrouter_paid: allowed
+    openrouter_free: allowed
+    local_self_hosted: allowed
+    human_approval: not_required
+    notes: "No secrets, no private repo, no client data."
+
+  PUBLIC_REPO:
+    chatgpt_app: allowed
+    claude_app: allowed
+    gemini_app: allowed
+    direct_apis: allowed
+    openrouter_paid: allowed
+    openrouter_free: constrained
+    local_self_hosted: allowed
+    human_approval: required_for_write_or_R4_plus
+    notes: "OpenRouter free only for low-risk non-authority work."
+
+  PRIVATE_REPO_NO_SECRETS:
+    chatgpt_app: constrained
+    claude_app: constrained
+    gemini_app: constrained
+    direct_apis: allowed
+    openrouter_paid: constrained
+    openrouter_free: blocked
+    local_self_hosted: allowed
+    human_approval: required_for_external_non_direct_or_write
+    required_controls:
+      openrouter_paid:
+        - provider_pinning
+        - data_collection_deny
+        - actual_provider_logging
+        - benchmark_certification
+
+  PRIVATE_REPO_POSSIBLE_SECRETS:
+    chatgpt_app: constrained_redacted_only
+    claude_app: constrained_redacted_only
+    gemini_app: constrained_redacted_only
+    direct_apis: allowed
+    openrouter_paid: constrained_after_secret_scan_clean
+    openrouter_free: blocked
+    local_self_hosted: allowed
+    human_approval: required
+    required_controls:
+      - secret_scan_clean_or_block
+      - redaction_report
+      - no_free_routes
+      - proof_capture
+
+  SECRET_BEARING:
+    chatgpt_app: blocked_unless_redacted_excerpt
+    claude_app: blocked_unless_redacted_excerpt
+    gemini_app: blocked_unless_redacted_excerpt
+    direct_apis: constrained_approved_only
+    openrouter_paid: blocked_by_default
+    openrouter_free: blocked
+    local_self_hosted: constrained
+    human_approval: required_security_gate
+    notes: "Do not send secrets to external routes without explicit approved policy."
+
+  CLIENT_DATA:
+    chatgpt_app: blocked_unless_contract_allows
+    claude_app: blocked_unless_contract_allows
+    gemini_app: blocked_unless_contract_allows
+    direct_apis: constrained_contract_approved
+    openrouter_paid: constrained_contract_zdr_provider_approved
+    openrouter_free: blocked
+    local_self_hosted: allowed_if_client_approved
+    human_approval: required
+    required_controls:
+      - contract_check
+      - redaction_report
+      - provider_terms_check
+      - chain_of_custody
+
+  SECURITY_SENSITIVE:
+    chatgpt_app: constrained_sanitized_manual_only
+    claude_app: constrained_sanitized_manual_only
+    gemini_app: constrained_sanitized_manual_only
+    direct_apis: allowed
+    openrouter_paid: constrained_challenger_only
+    openrouter_free: blocked
+    local_self_hosted: allowed_if_benchmarked
+    human_approval: required
+    notes: "No free routes; direct API is primary."
+
+  RELEASE_AUTHORITY:
+    chatgpt_app: constrained_manual_discussion_only
+    claude_app: constrained_manual_discussion_only
+    gemini_app: constrained_manual_discussion_only
+    direct_apis: allowed
+    openrouter_paid: constrained_challenger_only
+    openrouter_free: blocked
+    local_self_hosted: constrained_if_benchmarked
+    human_approval: required
+    notes: "Release judgment requires independent audit or explicit human approval."
+
+  UNKNOWN:
+    chatgpt_app: blocked
+    claude_app: blocked
+    gemini_app: blocked
+    direct_apis: blocked_until_classified
+    openrouter_paid: blocked
+    openrouter_free: blocked
+    local_self_hosted: constrained_readonly_if_needed
+    human_approval: required
+    default_action: fail_closed

--- a/docs/03-reference/dcp/openclaw-routing/proof_requirements.schema.json
+++ b/docs/03-reference/dcp/openclaw-routing/proof_requirements.schema.json
@@ -1,0 +1,263 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dcp.local/schemas/proof_requirements.schema.json",
+  "title": "DCP Proof Requirements and Proof Bundle",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "route_decision_id",
+    "task_id",
+    "packet_id",
+    "privacy_class",
+    "risk_class",
+    "task_execution_class",
+    "model_provider_used",
+    "runner_used",
+    "requested_model",
+    "actual_model",
+    "provider_endpoint_or_route_profile",
+    "prompt_hash",
+    "prompt_body_ref",
+    "response_hash",
+    "response_body_ref",
+    "files_read",
+    "files_changed",
+    "git_status_before",
+    "git_status_after",
+    "git_diff_stat",
+    "git_diff",
+    "commands_run",
+    "command_outputs",
+    "exit_codes",
+    "test_lint_typecheck_results",
+    "structured_schema_id",
+    "structured_validation_result",
+    "cost_estimate",
+    "actual_usage",
+    "route_decision_reason",
+    "audit_decision",
+    "approval_event",
+    "head_sha",
+    "pr_metadata",
+    "openclaw_trajectory_ref",
+    "redaction_report",
+    "remaining_risks",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "route_decision_id": { "type": "string", "minLength": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "packet_id": { "type": ["string", "null"] },
+    "privacy_class": { "$ref": "#/definitions/privacy_class" },
+    "risk_class": { "$ref": "#/definitions/risk_class" },
+    "task_execution_class": {
+      "type": "string",
+      "enum": ["read_only", "draft_only", "test_only", "write", "security", "release"]
+    },
+    "model_provider_used": { "$ref": "#/definitions/provider" },
+    "runner_used": { "$ref": "#/definitions/runner" },
+    "requested_model": { "type": "string", "minLength": 1 },
+    "actual_model": { "type": "string", "minLength": 1 },
+    "provider_endpoint_or_route_profile": { "type": "string", "minLength": 1 },
+    "prompt_hash": { "type": "string", "minLength": 16 },
+    "prompt_body_ref": { "type": ["string", "null"] },
+    "response_hash": { "type": "string", "minLength": 16 },
+    "response_body_ref": { "type": ["string", "null"] },
+    "files_read": { "type": "array", "items": { "$ref": "#/definitions/file_ref" } },
+    "files_changed": { "type": "array", "items": { "$ref": "#/definitions/file_ref" } },
+    "git_status_before": { "type": ["string", "null"] },
+    "git_status_after": { "type": ["string", "null"] },
+    "git_diff_stat": { "type": ["string", "null"] },
+    "git_diff": { "type": ["string", "null"] },
+    "commands_run": { "type": "array", "items": { "$ref": "#/definitions/command_run" } },
+    "command_outputs": { "type": "array", "items": { "$ref": "#/definitions/command_output" } },
+    "exit_codes": { "type": "array", "items": { "type": "integer" } },
+    "test_lint_typecheck_results": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/check_result" }
+    },
+    "structured_schema_id": { "type": ["string", "null"] },
+    "structured_validation_result": { "$ref": "#/definitions/validation_result" },
+    "cost_estimate": { "$ref": "#/definitions/cost" },
+    "actual_usage": { "$ref": "#/definitions/usage" },
+    "route_decision_reason": { "type": "string", "minLength": 1 },
+    "audit_decision": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["auditor_provider", "auditor_model", "auditor_runner", "auditor_verdict", "audit_ref"],
+      "properties": {
+        "auditor_provider": { "$ref": "#/definitions/provider" },
+        "auditor_model": { "type": "string" },
+        "auditor_runner": { "$ref": "#/definitions/runner" },
+        "auditor_verdict": {
+          "type": "string",
+          "enum": ["PASS", "PASS_WITH_RISKS", "FAIL", "NEEDS_SUPERVISOR", "SKIPPED"]
+        },
+        "audit_ref": { "type": "string" }
+      }
+    },
+    "approval_event": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["approval_id", "approver", "approved_at", "scope"],
+      "properties": {
+        "approval_id": { "type": "string" },
+        "approver": { "type": "string" },
+        "approved_at": { "type": "string", "format": "date-time" },
+        "scope": { "type": "string" }
+      }
+    },
+    "head_sha": { "type": ["string", "null"], "pattern": "^[a-fA-F0-9]{7,40}$" },
+    "pr_metadata": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["repo", "pr_number", "head_sha", "base_branch"],
+      "properties": {
+        "repo": { "type": "string" },
+        "pr_number": { "type": ["integer", "null"], "minimum": 1 },
+        "head_sha": { "type": ["string", "null"] },
+        "base_branch": { "type": ["string", "null"] }
+      }
+    },
+    "openclaw_trajectory_ref": { "type": ["string", "null"] },
+    "redaction_report": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["redaction_applied", "secret_scan_state", "notes"],
+      "properties": {
+        "redaction_applied": { "type": "boolean" },
+        "secret_scan_state": {
+          "type": "string",
+          "enum": ["clean", "possible_secrets", "confirmed_secrets", "not_scanned", "unknown"]
+        },
+        "notes": { "type": "string" }
+      }
+    },
+    "remaining_risks": { "type": "array", "items": { "type": "string" } },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "task_execution_class": { "enum": ["write", "security", "release"] } } },
+      "then": {
+        "properties": {
+          "files_changed": { "minItems": 1 },
+          "git_status_before": { "type": "string", "minLength": 1 },
+          "git_status_after": { "type": "string", "minLength": 1 },
+          "git_diff_stat": { "type": "string", "minLength": 1 },
+          "git_diff": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "risk_class": { "enum": ["R5_SECURITY_OR_AUTHORITY", "R6_RELEASE_OR_PRODUCTION"] } } },
+      "then": {
+        "properties": {
+          "audit_decision": { "type": "object" }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "task_execution_class": { "const": "release" } } },
+      "then": {
+        "properties": {
+          "head_sha": { "type": "string", "minLength": 7 },
+          "pr_metadata": { "type": "object" },
+          "approval_event": { "type": "object" }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "privacy_class": {
+      "type": "string",
+      "enum": ["PUBLIC_SANDBOX", "PUBLIC_REPO", "PRIVATE_REPO_NO_SECRETS", "PRIVATE_REPO_POSSIBLE_SECRETS", "SECRET_BEARING", "CLIENT_DATA", "SECURITY_SENSITIVE", "RELEASE_AUTHORITY", "UNKNOWN"]
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": ["R0_READ", "R1_DRAFT", "R2_TEST_ONLY", "R3_LOCAL_EDIT", "R4_MULTI_FILE_EDIT", "R5_SECURITY_OR_AUTHORITY", "R6_RELEASE_OR_PRODUCTION", "UNKNOWN"]
+    },
+    "provider": {
+      "type": "string",
+      "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple", "unknown"]
+    },
+    "runner": {
+      "type": "string",
+      "enum": ["openclaw", "codex", "claude_code", "gemini_antigravity", "openrouter_generic", "direct_api", "manual_app", "shell_local", "dopetask", "unknown"]
+    },
+    "file_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "sha256"],
+      "properties": {
+        "path": { "type": "string" },
+        "sha256": { "type": ["string", "null"] }
+      }
+    },
+    "command_run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "cwd", "started_at"],
+      "properties": {
+        "command": { "type": "string" },
+        "cwd": { "type": "string" },
+        "started_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "command_output": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "stdout_ref", "stderr_ref", "exit_code"],
+      "properties": {
+        "command": { "type": "string" },
+        "stdout_ref": { "type": ["string", "null"] },
+        "stderr_ref": { "type": ["string", "null"] },
+        "exit_code": { "type": "integer" }
+      }
+    },
+    "check_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "command", "status", "exit_code", "output_ref"],
+      "properties": {
+        "name": { "type": "string" },
+        "command": { "type": "string" },
+        "status": { "type": "string", "enum": ["passed", "failed", "skipped", "not_run"] },
+        "exit_code": { "type": ["integer", "null"] },
+        "output_ref": { "type": ["string", "null"] }
+      }
+    },
+    "validation_result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["validated", "validator", "schema_id", "errors"],
+      "properties": {
+        "validated": { "type": "boolean" },
+        "validator": { "type": ["string", "null"] },
+        "schema_id": { "type": ["string", "null"] },
+        "errors": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["estimated_usd", "ceiling_usd"],
+      "properties": {
+        "estimated_usd": { "type": ["number", "null"], "minimum": 0 },
+        "ceiling_usd": { "type": ["number", "null"], "minimum": 0 }
+      }
+    },
+    "usage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_tokens", "output_tokens", "actual_usd"],
+      "properties": {
+        "input_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "output_tokens": { "type": ["integer", "null"], "minimum": 0 },
+        "actual_usd": { "type": ["number", "null"], "minimum": 0 }
+      }
+    }
+  }
+}

--- a/docs/03-reference/dcp/openclaw-routing/provider-availability-probe-spec.md
+++ b/docs/03-reference/dcp/openclaw-routing/provider-availability-probe-spec.md
@@ -1,0 +1,223 @@
+---
+id: provider_availability_probe_spec
+title: Provider Availability Probe Spec
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-17'
+last_review: '2026-06-17'
+next_review: '2026-09-15'
+prelude: Provider Availability Probe Spec (explanation) for dopemux documentation
+  and developer workflows.
+---
+# Provider Availability Probe Spec
+
+schema_version: 1.0.0
+status: PROPOSED
+
+## Purpose
+
+Determine route availability without leaking secrets or weakening policy.
+
+## Universal no-secret logging rule
+
+Availability probes MUST NOT log:
+
+- API keys
+- bearer tokens
+- cookies
+- private keys
+- prompts containing repo secrets
+- client data
+- raw environment values
+
+Probe logs MAY include provider, route profile, status code, error class, latency, timestamp, and redacted request ID.
+
+## Probe targets
+
+### OpenAI API
+
+Probe:
+
+- auth validity
+- selected model availability
+- structured output support where required
+- rate-limit status
+- latency
+- request ID capture if available
+
+Failure classes:
+
+- `AUTH_FAILED`
+- `MODEL_UNAVAILABLE`
+- `RATE_LIMITED`
+- `PROVIDER_OUTAGE`
+- `SCHEMA_FEATURE_UNAVAILABLE`
+- `UNKNOWN`
+
+### Anthropic API
+
+Probe:
+
+- auth validity
+- model availability
+- structured/tool schema capability
+- rate-limit status
+- latency
+
+Failure classes match OpenAI API.
+
+### Gemini API
+
+Probe:
+
+- auth validity
+- model availability
+- stable/preview/experimental status
+- structured output capability
+- multimodal support if needed
+- quota status
+
+Failure classes include `PREVIEW_ONLY_ROUTE`.
+
+### OpenRouter
+
+Probe:
+
+- API key validity
+- route profile settings accepted
+- provider availability
+- `require_parameters`
+- `data_collection`
+- `zdr`
+- `max_price`
+- provider pin/order acceptance
+- returned actual model and provider metadata when available
+
+Failure classes:
+
+- `AUTH_FAILED`
+- `NO_PROVIDER_SATISFIES_POLICY`
+- `RATE_LIMITED`
+- `PROVIDER_OUTAGE`
+- `PROVIDER_DRIFT`
+- `SCHEMA_FEATURE_UNAVAILABLE`
+- `MAX_PRICE_FILTERED`
+- `UNKNOWN`
+
+### Codex
+
+Probe:
+
+- auth mode: API key or ChatGPT sign-in
+- local runner availability
+- repo access
+- non-mutating dry command
+- model availability
+
+Failure classes:
+
+- `AUTH_FAILED`
+- `LOCAL_RUNNER_UNAVAILABLE`
+- `SUBSCRIPTION_PATH_NOT_PROGRAMMABLE`
+- `UNKNOWN`
+
+### Claude Code
+
+Probe:
+
+- auth mode
+- local binary availability
+- model/runner availability
+- non-mutating repo read
+- command execution permission posture
+
+Failure classes:
+
+- `AUTH_FAILED`
+- `LOCAL_RUNNER_UNAVAILABLE`
+- `CONSUMER_CREDENTIALS_NOT_ALLOWED_FOR_BACKEND`
+- `UNKNOWN`
+
+### Gemini / Antigravity
+
+Probe:
+
+- CLI/app availability
+- API-key-backed mode when automation required
+- consumer path warning
+- model status
+
+Failure classes:
+
+- `LOCAL_RUNNER_UNAVAILABLE`
+- `CONSUMER_CLI_NOT_SUPPORTED_FOR_AUTOMATION`
+- `PREVIEW_ONLY_ROUTE`
+- `UNKNOWN`
+
+### Local runners
+
+Probe:
+
+- binary exists
+- version
+- workspace access
+- sandbox posture
+- dry-run command
+- no network unless approved
+
+Failure classes:
+
+- `LOCAL_RUNNER_UNAVAILABLE`
+- `SANDBOX_UNSAFE`
+- `WORKTREE_UNAVAILABLE`
+- `UNKNOWN`
+
+## Timeout behavior
+
+- Default probe timeout: 10 seconds.
+- CI-blocking probe timeout: 5 seconds.
+- Slow frontier model probe timeout: 30 seconds if explicitly allowed.
+- Timeout class: `PROBE_TIMEOUT`.
+- Timeout does not imply provider down; it marks route stale/unknown.
+
+## Quota/rate-limit classification
+
+- `RATE_LIMITED_RETRYABLE`: retry-after present or short quota window.
+- `RATE_LIMITED_BLOCKING`: no retry viable within task deadline.
+- `QUOTA_EXHAUSTED`: account-level quota unavailable.
+- `UNKNOWN_QUOTA`: cannot determine safely.
+
+## Provider outage classification
+
+- `PROVIDER_OUTAGE_PARTIAL`
+- `PROVIDER_OUTAGE_TOTAL`
+- `ROUTER_OUTAGE`
+- `UPSTREAM_PROVIDER_OUTAGE`
+- `NETWORK_LOCAL_FAILURE`
+- `UNKNOWN`
+
+## Stale availability behavior
+
+Availability is stale when:
+
+- last probe is older than route TTL
+- provider has had a failure since probe
+- route profile changed
+- privacy/risk class changed
+- requested model changed
+- benchmark certification expired
+
+Stale availability cannot authorize high-risk or private routes.
+
+## Safe fallback behavior
+
+Fallback may only occur when:
+
+- fallback route is policy-equivalent or stricter
+- fallback is benchmark-certified
+- fallback preserves schema requirements
+- fallback preserves privacy requirements
+- fallback preserves cost ceiling
+- actual provider/model is logged
+- route decision log records fallback reason

--- a/docs/03-reference/dcp/openclaw-routing/readme.md
+++ b/docs/03-reference/dcp/openclaw-routing/readme.md
@@ -1,0 +1,32 @@
+---
+id: README
+title: Readme
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-17'
+last_review: '2026-06-17'
+next_review: '2026-09-15'
+prelude: Readme (explanation) for dopemux documentation and developer workflows.
+---
+# OpenClaw DCP Routing Contracts
+
+These files are proposed routing-policy contracts for the OpenClaw plus DCP
+multi-model routing lane. They are static policy and schema artifacts only.
+
+Production routing is not enabled by this directory. The files here do not wire
+OpenClaw execution, provider API calls, OpenRouter integration, benchmark
+execution, route-engine behavior, or credential handling.
+
+Benchmark certification is still required before any route can be treated as
+certified. Current model availability, prices, provider behavior, and OpenClaw
+adapter support remain `UNKNOWN` until verified by a later implementation
+packet.
+
+OpenRouter free routes remain sandbox-only. They are blocked for private,
+secret-bearing, client-data, security, release, and schema-authority lanes.
+Direct APIs remain preferred for authority-bearing lanes.
+
+Implementer self-audit is forbidden. Release and high-risk routes require
+independent audit, explicit human approval, or both according to the proposed
+contracts.

--- a/docs/03-reference/dcp/openclaw-routing/release_gate_policy.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/release_gate_policy.yaml
@@ -1,0 +1,115 @@
+schema_version: "1.0.0"
+artifact_id: "release_gate_policy"
+status: "PROPOSED"
+
+statuses:
+  - READY
+  - BLOCKED
+  - NEEDS_SUPERVISOR
+
+required_pr_metadata:
+  - repo
+  - pr_number
+  - branch
+  - base_branch
+  - head_sha
+  - changed_files
+  - commits
+  - checks
+  - reviews
+  - review_comments
+  - review_threads
+  - issue_comments
+  - bot_comments
+
+required_current_head_sha:
+  source: "GitHub PR head SHA or local git HEAD for non-PR release"
+  stale_if: "proof.head_sha != pr.head_sha"
+
+required_ci_check_status:
+  all_required_checks_current_to_head: true
+  failed_required_checks_block_ready: true
+  pending_required_checks_block_ready: true
+  unknown_required_checks_block_ready: true
+
+required_proof_freshness:
+  proof_head_sha_matches_pr_head_sha: true
+  proof_created_after_latest_commit: true
+  proof_bundle_schema_valid: true
+  route_decision_log_present: true
+  write_tasks_have_git_status_and_diff: true
+
+required_independent_audit:
+  required: true
+  acceptable:
+    - independent_provider_audit_PASS
+    - independent_provider_audit_PASS_WITH_RISKS_non_blocking
+    - explicit_human_release_approval
+  unacceptable:
+    - implementer_self_audit
+    - openrouter_free_audit
+    - preview_sole_audit
+    - stale_audit
+
+required_human_approval:
+  default_for_release: true
+  may_be_waived_only_if:
+    - auto_merge_policy_enabled
+    - independent_audit_passed
+    - pr_steward_status_READY
+    - no_security_or_authority_boundary_touched
+    - no_red_lane_files_touched
+    - no_unknown_reviewers_or_bots
+
+blocker_classifications:
+  - FAILED_REQUIRED_CHECK
+  - STALE_CHECKS
+  - STALE_PROOF
+  - MISSING_PROOF
+  - MISSING_AUDIT
+  - AUDITOR_FAIL
+  - AUDITOR_NEEDS_SUPERVISOR
+  - UNKNOWN_REVIEWER_OR_BOT
+  - UNCLASSIFIED_REVIEW_ITEM
+  - UNRESOLVED_BLOCKING_THREAD
+  - DIFF_ESCAPES_PACKET_ALLOWLIST
+  - SECURITY_RELEASE_APPROVAL_MISSING
+  - PROVIDER_OR_MODEL_DRIFT
+  - HUMAN_APPROVAL_MISSING
+
+ready_rules:
+  READY:
+    requires_all:
+      - required_pr_metadata_present
+      - head_sha_current
+      - checks_current_to_head
+      - no_failed_required_checks
+      - proof_current_to_head
+      - proof_schema_valid
+      - independent_audit_or_human_approval
+      - every_review_item_classified
+      - no_unknown_reviewers_or_bots
+      - no_unresolved_blocking_threads
+      - diff_within_packet_allowlist
+      - security_release_gate_satisfied
+
+  BLOCKED:
+    any_of:
+      - failed_required_checks
+      - stale_checks
+      - stale_proof
+      - missing_proof
+      - missing_audit
+      - unresolved_blocking_thread
+      - diff_escapes_packet_allowlist
+      - missing_required_human_approval
+
+  NEEDS_SUPERVISOR:
+    any_of:
+      - auditor_disagreement
+      - unknown_reviewer_or_bot
+      - unclassified_review_item
+      - review_comment_conflict
+      - provider_drift_high_risk
+      - authority_boundary_unclear
+      - evidence_contradiction

--- a/docs/03-reference/dcp/openclaw-routing/risk_class_policy.yaml
+++ b/docs/03-reference/dcp/openclaw-routing/risk_class_policy.yaml
@@ -1,0 +1,166 @@
+schema_version: "1.0.0"
+artifact_id: "risk_class_policy"
+status: "PROPOSED"
+
+risk_classes:
+  R0_READ:
+    allowed_models_routes:
+      - cheap_read
+      - cheap_classifier
+      - openrouter_free_sandbox_public_only
+      - direct_api
+    forbidden_models_routes:
+      - shell_write_enabled_without_need
+    evidence_requirements:
+      - route_decision
+      - files_read
+      - prompt_response_hash
+    audit_requirements: none_or_light
+    human_approval_requirements: not_required
+    route_escalation_rules:
+      - "Escalate if privacy becomes private, secret, client, or unknown."
+
+  R1_DRAFT:
+    allowed_models_routes:
+      - cheap_classifier
+      - planner_default
+      - manual_app_with_capture
+      - openrouter_paid_low_cost
+      - openrouter_free_public_only
+    forbidden_models_routes:
+      - release_authority_claims
+      - security_signoff
+    evidence_requirements:
+      - sources_or_inputs
+      - assumptions
+      - route_decision
+    audit_requirements: optional_challenge
+    human_approval_requirements: not_required_unless_private_or_sensitive
+    route_escalation_rules:
+      - "Escalate to planner_default if ambiguity affects execution."
+
+  R2_TEST_ONLY:
+    allowed_models_routes:
+      - test_builder
+      - implementer_alt
+      - openrouter_free_public_only
+      - direct_api
+    forbidden_models_routes:
+      - treating_tests_as_correctness_proof
+      - private_or_secret_on_openrouter_free
+    evidence_requirements:
+      - tests_generated
+      - commands_run
+      - exit_codes
+      - test_results
+    audit_requirements: light_if_low_risk
+    human_approval_requirements: required_if_private_or_scope_expands
+    route_escalation_rules:
+      - "Escalate to implementer_default if tests reveal production defect."
+
+  R3_LOCAL_EDIT:
+    allowed_models_routes:
+      - implementer_default
+      - implementer_alt_benchmarked
+      - codex
+      - claude_code
+      - direct_api
+    forbidden_models_routes:
+      - openrouter_free_private
+      - implementer_as_sole_final_auditor
+    evidence_requirements:
+      - git_status_before
+      - git_status_after
+      - git_diff_stat
+      - git_diff
+      - files_changed
+      - commands_run
+      - command_outputs
+      - exit_codes
+    audit_requirements: independent_diff_review
+    human_approval_requirements: required_if_sensitive_or_scope_expands
+    route_escalation_rules:
+      - "Escalate to auditor_default on patch/test failures."
+
+  R4_MULTI_FILE_EDIT:
+    allowed_models_routes:
+      - implementer_default
+      - planner_default
+      - planner_strong
+      - auditor_default
+    forbidden_models_routes:
+      - openrouter_free
+      - unbenchmarked_implementer_alt
+      - cheap_model_primary
+    evidence_requirements:
+      - full_R3_evidence
+      - dependency_or_file_graph
+      - embedded_audit
+      - allowlist_check
+    audit_requirements: embedded_or_independent_audit
+    human_approval_requirements: required_if_broad_blast_radius_or_authority_boundary
+    route_escalation_rules:
+      - "Escalate to planner_strong or auditor_deep if audit finds architectural risk."
+
+  R5_SECURITY_OR_AUTHORITY:
+    allowed_models_routes:
+      - security_reviewer
+      - auditor_deep
+      - direct_api_frontier
+      - local_self_hosted_benchmarked
+    forbidden_models_routes:
+      - openrouter_free
+      - consumer_app_machine_authority
+      - preview_sole_authority
+      - implementer_sole_audit
+    evidence_requirements:
+      - threat_model_or_authority_map
+      - findings_with_severity
+      - proof_bundle
+      - independent_audit
+      - approval_event
+    audit_requirements: deep_independent_audit
+    human_approval_requirements: required
+    route_escalation_rules:
+      - "Escalate to release_judge if production/release impact appears."
+
+  R6_RELEASE_OR_PRODUCTION:
+    allowed_models_routes:
+      - release_judge
+      - supervisor
+      - direct_api_frontier
+      - explicit_human_approval
+    forbidden_models_routes:
+      - openrouter_free
+      - openrouter_paid_sole_authority
+      - preview_sole_authority
+      - consumer_app_sole_authority
+      - implementer_sole_audit
+    evidence_requirements:
+      - current_head_sha
+      - current_ci_checks
+      - current_proof_bundle
+      - pr_metadata
+      - merge_readiness
+      - independent_audit_or_human_approval
+    audit_requirements: independent_provider_or_human
+    human_approval_requirements: required_unless_auto_merge_eligible_policy_exists
+    route_escalation_rules:
+      - "Any uncertainty becomes NEEDS_SUPERVISOR."
+
+  UNKNOWN:
+    allowed_models_routes:
+      - local_readonly_classification_only
+    forbidden_models_routes:
+      - openrouter_free
+      - write_enabled_runner
+      - release_judgment
+      - security_review
+      - schema_authority
+    evidence_requirements:
+      - classification_attempt
+      - blocked_reason
+    audit_requirements: independent_or_deep
+    human_approval_requirements: required
+    route_escalation_rules:
+      - "Fail closed until classified."

--- a/docs/03-reference/dcp/openclaw-routing/route_certification_ledger.schema.json
+++ b/docs/03-reference/dcp/openclaw-routing/route_certification_ledger.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dcp.local/schemas/route_certification_ledger.schema.json",
+  "title": "Route Certification Ledger Entry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "certification_id",
+    "route_profile",
+    "pool",
+    "role",
+    "model_provider_runner",
+    "benchmark_result_refs",
+    "approved_privacy_classes",
+    "approved_risk_classes",
+    "approved_roles",
+    "expiration",
+    "revocation_reasons",
+    "reviewer",
+    "approval_event",
+    "current_status",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "certification_id": { "type": "string", "minLength": 1 },
+    "route_profile": { "type": "string", "minLength": 1 },
+    "pool": { "type": "string", "minLength": 1 },
+    "role": { "type": "string", "minLength": 1 },
+    "model_provider_runner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["model", "provider", "runner", "access_path"],
+      "properties": {
+        "model": { "type": "string" },
+        "provider": { "type": "string" },
+        "runner": { "type": "string" },
+        "access_path": { "type": "string" }
+      }
+    },
+    "benchmark_result_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "approved_privacy_classes": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/privacy_class" }
+    },
+    "approved_risk_classes": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/risk_class" }
+    },
+    "approved_roles": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "expiration": { "type": "string", "format": "date-time" },
+    "revocation_reasons": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "EXPIRED",
+          "PROVIDER_DRIFT",
+          "SCHEMA_REGRESSION",
+          "PRIVACY_VIOLATION",
+          "BENCHMARK_REGRESSION",
+          "SECURITY_INCIDENT",
+          "MODEL_DEPRECATED",
+          "MANUAL_REVOKE"
+        ]
+      }
+    },
+    "reviewer": { "type": "string", "minLength": 1 },
+    "approval_event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approval_id", "approved_at", "scope"],
+      "properties": {
+        "approval_id": { "type": "string" },
+        "approved_at": { "type": "string", "format": "date-time" },
+        "scope": { "type": "string" }
+      }
+    },
+    "current_status": {
+      "type": "string",
+      "enum": ["ACTIVE", "ACTIVE_WITH_LIMITS", "EXPIRED", "REVOKED", "SUSPENDED", "PENDING"]
+    },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "definitions": {
+    "privacy_class": {
+      "type": "string",
+      "enum": ["PUBLIC_SANDBOX", "PUBLIC_REPO", "PRIVATE_REPO_NO_SECRETS", "PRIVATE_REPO_POSSIBLE_SECRETS", "SECRET_BEARING", "CLIENT_DATA", "SECURITY_SENSITIVE", "RELEASE_AUTHORITY", "UNKNOWN"]
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": ["R0_READ", "R1_DRAFT", "R2_TEST_ONLY", "R3_LOCAL_EDIT", "R4_MULTI_FILE_EDIT", "R5_SECURITY_OR_AUTHORITY", "R6_RELEASE_OR_PRODUCTION", "UNKNOWN"]
+    }
+  }
+}

--- a/docs/03-reference/dcp/openclaw-routing/route_decision.schema.json
+++ b/docs/03-reference/dcp/openclaw-routing/route_decision.schema.json
@@ -1,0 +1,212 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dcp.local/schemas/route_decision.schema.json",
+  "title": "OpenClaw DCP Route Decision",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "route_decision_id",
+    "task_id",
+    "role",
+    "privacy_class",
+    "risk_class",
+    "selected_pool",
+    "selected_route",
+    "provider",
+    "requested_model",
+    "actual_model",
+    "runner",
+    "access_path",
+    "consumer_plan_used",
+    "api_route_used",
+    "openrouter_profile",
+    "structured_output_mode",
+    "proof_requirement",
+    "audit_requirement",
+    "human_gate_required",
+    "human_approval_ref",
+    "benchmark_certification_ref",
+    "decision_status",
+    "blocked_reasons",
+    "evidence_refs",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "route_decision_id": { "type": "string", "pattern": "^rd_[A-Za-z0-9_.:-]+$" },
+    "task_id": { "type": "string", "minLength": 1 },
+    "role": { "$ref": "#/definitions/role" },
+    "privacy_class": { "$ref": "#/definitions/privacy_class" },
+    "risk_class": { "$ref": "#/definitions/risk_class" },
+    "selected_pool": { "$ref": "#/definitions/pool" },
+    "selected_route": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["route_name", "route_profile", "selection_reason", "fallback_allowed"],
+      "properties": {
+        "route_name": { "type": "string", "minLength": 1 },
+        "route_profile": { "type": "string", "minLength": 1 },
+        "selection_reason": { "type": "string", "minLength": 1 },
+        "fallback_allowed": { "type": "boolean" }
+      }
+    },
+    "provider": { "$ref": "#/definitions/provider" },
+    "requested_model": { "type": "string", "minLength": 1 },
+    "actual_model": { "type": "string", "minLength": 1 },
+    "runner": { "$ref": "#/definitions/runner" },
+    "access_path": { "$ref": "#/definitions/access_path" },
+    "consumer_plan_used": { "type": "boolean" },
+    "api_route_used": { "type": "boolean" },
+    "openrouter_profile": {
+      "type": ["string", "null"],
+      "enum": [
+        "or_free_sandbox",
+        "or_low_cost_public",
+        "or_paid_private_controlled",
+        "or_structured_noncritical",
+        "or_challenger",
+        "or_emergency_fallback",
+        null
+      ]
+    },
+    "structured_output_mode": {
+      "type": "string",
+      "enum": ["none", "json_schema_strict", "tool_schema_strict", "json_object", "manual_capture"]
+    },
+    "proof_requirement": {
+      "type": "string",
+      "enum": ["minimal", "standard", "implementation", "security", "release", "unknown"]
+    },
+    "audit_requirement": {
+      "type": "string",
+      "enum": ["none", "light", "embedded", "independent", "deep", "security", "release"]
+    },
+    "human_gate_required": { "type": "boolean" },
+    "human_approval_ref": { "type": ["string", "null"] },
+    "benchmark_certification_ref": { "type": ["string", "null"] },
+    "decision_status": {
+      "type": "string",
+      "enum": ["SELECTED", "BLOCKED", "ESCALATED", "NEEDS_SUPERVISOR"]
+    },
+    "blocked_reasons": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/blocked_reason" }
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "privacy_class": { "const": "UNKNOWN" } } },
+      "then": {
+        "properties": {
+          "decision_status": { "enum": ["BLOCKED", "ESCALATED", "NEEDS_SUPERVISOR"] }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "risk_class": { "const": "UNKNOWN" } } },
+      "then": {
+        "properties": {
+          "decision_status": { "enum": ["BLOCKED", "ESCALATED", "NEEDS_SUPERVISOR"] }
+        }
+      }
+    },
+    {
+      "if": { "properties": { "decision_status": { "const": "BLOCKED" } } },
+      "then": { "properties": { "blocked_reasons": { "minItems": 1 } } }
+    },
+    {
+      "if": { "properties": { "human_gate_required": { "const": true } } },
+      "then": { "required": ["human_approval_ref"] }
+    },
+    {
+      "if": { "properties": { "access_path": { "const": "openrouter_free" } } },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "properties": { "privacy_class": { "enum": ["PRIVATE_REPO_NO_SECRETS", "PRIVATE_REPO_POSSIBLE_SECRETS", "SECRET_BEARING", "CLIENT_DATA", "SECURITY_SENSITIVE", "RELEASE_AUTHORITY"] } } },
+            { "properties": { "risk_class": { "enum": ["R5_SECURITY_OR_AUTHORITY", "R6_RELEASE_OR_PRODUCTION"] } } },
+            { "properties": { "structured_output_mode": { "enum": ["json_schema_strict", "tool_schema_strict"] } } }
+          ]
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "role": {
+      "type": "string",
+      "enum": [
+        "task_intake",
+        "task_classification",
+        "repo_cartography",
+        "cheap_file_reading",
+        "issue_triage",
+        "planning",
+        "strong_planning",
+        "architecture_synthesis",
+        "implementation",
+        "narrow_patch_generation",
+        "multi_file_refactor",
+        "test_generation",
+        "ui_design_audit",
+        "multimodal_audit",
+        "structured_task_packet_generation",
+        "proof_bundle_generation",
+        "proof_validation",
+        "challenger_review",
+        "pr_review",
+        "security_review",
+        "release_judgment",
+        "final_supervisor_synthesis"
+      ]
+    },
+    "privacy_class": {
+      "type": "string",
+      "enum": ["PUBLIC_SANDBOX", "PUBLIC_REPO", "PRIVATE_REPO_NO_SECRETS", "PRIVATE_REPO_POSSIBLE_SECRETS", "SECRET_BEARING", "CLIENT_DATA", "SECURITY_SENSITIVE", "RELEASE_AUTHORITY", "UNKNOWN"]
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": ["R0_READ", "R1_DRAFT", "R2_TEST_ONLY", "R3_LOCAL_EDIT", "R4_MULTI_FILE_EDIT", "R5_SECURITY_OR_AUTHORITY", "R6_RELEASE_OR_PRODUCTION", "UNKNOWN"]
+    },
+    "pool": {
+      "type": "string",
+      "enum": ["cheap_read", "cheap_classifier", "repo_cartographer", "planner_default", "planner_strong", "implementer_default", "implementer_alt", "test_builder", "structured_packet", "proof_validator", "auditor_default", "auditor_deep", "security_reviewer", "release_judge", "supervisor", "openrouter_free_sandbox"]
+    },
+    "provider": {
+      "type": "string",
+      "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple", "unknown"]
+    },
+    "runner": {
+      "type": "string",
+      "enum": ["openclaw", "codex", "claude_code", "gemini_antigravity", "openrouter_generic", "direct_api", "manual_app", "shell_local", "dopetask", "unknown"]
+    },
+    "access_path": {
+      "type": "string",
+      "enum": ["chatgpt_app", "claude_app", "gemini_app", "direct_api", "openrouter_paid", "openrouter_free", "local_self_hosted", "codex", "claude_code", "gemini_antigravity", "manual_app", "shell_local"]
+    },
+    "blocked_reason": {
+      "type": "string",
+      "enum": [
+        "UNKNOWN_PRIVACY_CLASS",
+        "UNKNOWN_RISK_CLASS",
+        "OPENROUTER_FREE_FORBIDDEN",
+        "CONSUMER_APP_AUTHORITY_FORBIDDEN",
+        "PREVIEW_SOLE_HIGH_RISK_AUTHORITY",
+        "MISSING_BENCHMARK_CERTIFICATION",
+        "MISSING_SCHEMA_VALIDATION",
+        "MISSING_PROOF_REQUIREMENT",
+        "MISSING_HUMAN_APPROVAL",
+        "AUDIT_INDEPENDENCE_VIOLATION",
+        "PROVIDER_MODEL_DRIFT",
+        "FALLBACK_WEAKENS_GUARD",
+        "COST_CEILING_EXCEEDED",
+        "PRIVACY_MISMATCH"
+      ]
+    }
+  }
+}

--- a/docs/03-reference/dcp/openclaw-routing/route_decision_logger.schema.json
+++ b/docs/03-reference/dcp/openclaw-routing/route_decision_logger.schema.json
@@ -1,0 +1,106 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dcp.local/schemas/route_decision_logger.schema.json",
+  "title": "Route Decision Log Entry",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "log_id",
+    "route_decision_id",
+    "task_id",
+    "requested_model",
+    "actual_model",
+    "requested_provider",
+    "actual_provider",
+    "provider_route_profile",
+    "runner",
+    "access_path",
+    "prompt_hash",
+    "response_hash",
+    "cost",
+    "latency",
+    "fallback_events",
+    "policy_checks",
+    "blocked_route_reasons",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "log_id": { "type": "string", "minLength": 1 },
+    "route_decision_id": { "type": "string", "minLength": 1 },
+    "task_id": { "type": "string", "minLength": 1 },
+    "requested_model": { "type": "string", "minLength": 1 },
+    "actual_model": { "type": "string", "minLength": 1 },
+    "requested_provider": { "$ref": "#/definitions/provider" },
+    "actual_provider": { "$ref": "#/definitions/provider" },
+    "provider_route_profile": { "type": ["string", "null"] },
+    "runner": { "$ref": "#/definitions/runner" },
+    "access_path": { "type": "string" },
+    "prompt_hash": { "type": "string", "minLength": 16 },
+    "response_hash": { "type": "string", "minLength": 16 },
+    "cost": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["estimated_usd", "actual_usd", "currency"],
+      "properties": {
+        "estimated_usd": { "type": ["number", "null"], "minimum": 0 },
+        "actual_usd": { "type": ["number", "null"], "minimum": 0 },
+        "currency": { "type": "string", "enum": ["USD", "UNKNOWN"] }
+      }
+    },
+    "latency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["wall_ms", "ttfb_ms", "ttft_ms", "completion_ms"],
+      "properties": {
+        "wall_ms": { "type": ["number", "null"], "minimum": 0 },
+        "ttfb_ms": { "type": ["number", "null"], "minimum": 0 },
+        "ttft_ms": { "type": ["number", "null"], "minimum": 0 },
+        "completion_ms": { "type": ["number", "null"], "minimum": 0 }
+      }
+    },
+    "fallback_events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["from_route", "to_route", "reason", "weakened_policy"],
+        "properties": {
+          "from_route": { "type": "string" },
+          "to_route": { "type": "string" },
+          "reason": { "type": "string" },
+          "weakened_policy": { "type": "boolean" }
+        }
+      }
+    },
+    "policy_checks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["check_id", "status", "message"],
+        "properties": {
+          "check_id": { "type": "string" },
+          "status": { "type": "string", "enum": ["PASS", "FAIL", "SKIPPED"] },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "blocked_route_reasons": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "created_at": { "type": "string", "format": "date-time" }
+  },
+  "definitions": {
+    "provider": {
+      "type": "string",
+      "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple", "unknown"]
+    },
+    "runner": {
+      "type": "string",
+      "enum": ["openclaw", "codex", "claude_code", "gemini_antigravity", "openrouter_generic", "direct_api", "manual_app", "shell_local", "dopetask", "unknown"]
+    }
+  }
+}

--- a/docs/03-reference/dcp/openclaw-routing/routing_classifier.schema.json
+++ b/docs/03-reference/dcp/openclaw-routing/routing_classifier.schema.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dcp.local/schemas/routing_classifier.schema.json",
+  "title": "OpenClaw DCP Routing Classifier Input",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "task_description",
+    "repo_project",
+    "files_touched_expected",
+    "privacy_class",
+    "risk_class",
+    "required_tools",
+    "required_context_size",
+    "structured_output_required",
+    "command_execution_required",
+    "edit_write_required",
+    "expected_token_size",
+    "deadline_latency_need",
+    "cost_ceiling",
+    "model_provider_availability",
+    "prior_failure_state",
+    "audit_requirement",
+    "human_approval_status",
+    "proof_requirement",
+    "runner_compatibility",
+    "authority_boundary",
+    "secret_scan_state",
+    "local_benchmark_certification"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0.0" },
+    "task_description": { "type": "string", "minLength": 1 },
+    "repo_project": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "project_id", "branch_or_ref", "worktree", "is_private"],
+      "properties": {
+        "repo": { "type": "string", "minLength": 1 },
+        "project_id": { "type": "string", "minLength": 1 },
+        "branch_or_ref": { "type": "string", "minLength": 1 },
+        "worktree": { "type": "string", "minLength": 1 },
+        "is_private": { "type": "boolean" }
+      }
+    },
+    "files_touched_expected": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "default": []
+    },
+    "privacy_class": { "$ref": "#/definitions/privacy_class" },
+    "risk_class": { "$ref": "#/definitions/risk_class" },
+    "required_tools": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/tool" }
+    },
+    "required_context_size": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["estimated_input_tokens", "requires_long_context", "retrieval_first_required"],
+      "properties": {
+        "estimated_input_tokens": { "type": "integer", "minimum": 0 },
+        "requires_long_context": { "type": "boolean" },
+        "retrieval_first_required": { "type": "boolean" }
+      }
+    },
+    "structured_output_required": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "schema_id", "authority_level"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "schema_id": { "type": ["string", "null"] },
+        "authority_level": {
+          "type": "string",
+          "enum": ["none", "draft", "machine_authority", "release_authority"]
+        }
+      }
+    },
+    "command_execution_required": { "type": "boolean" },
+    "edit_write_required": { "type": "boolean" },
+    "expected_token_size": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["input_tokens", "output_tokens", "total_tokens"],
+      "properties": {
+        "input_tokens": { "type": "integer", "minimum": 0 },
+        "output_tokens": { "type": "integer", "minimum": 0 },
+        "total_tokens": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "deadline_latency_need": {
+      "type": "string",
+      "enum": ["interactive", "batch", "ci_blocking", "overnight", "unknown"]
+    },
+    "cost_ceiling": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tier", "max_usd", "requires_approval_above"],
+      "properties": {
+        "tier": { "type": "string", "enum": ["free", "cheap", "standard", "premium", "unbounded", "unknown"] },
+        "max_usd": { "type": ["number", "null"], "minimum": 0 },
+        "requires_approval_above": { "type": ["number", "null"], "minimum": 0 }
+      }
+    },
+    "model_provider_availability": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["provider", "available", "last_checked_at", "notes"],
+        "properties": {
+          "provider": { "$ref": "#/definitions/provider" },
+          "available": { "type": "boolean" },
+          "last_checked_at": { "type": "string", "format": "date-time" },
+          "notes": { "type": "string" }
+        }
+      }
+    },
+    "prior_failure_state": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "none",
+          "schema_failure",
+          "test_failure",
+          "patch_failure",
+          "hallucinated_files",
+          "provider_outage",
+          "openrouter_provider_drift",
+          "privacy_mismatch",
+          "missing_evidence",
+          "auditor_disagreement",
+          "release_uncertainty"
+        ]
+      }
+    },
+    "audit_requirement": { "$ref": "#/definitions/audit_requirement" },
+    "human_approval_status": {
+      "type": "string",
+      "enum": ["approved", "denied", "missing", "not_required", "expired", "scope_limited"]
+    },
+    "proof_requirement": {
+      "type": "string",
+      "enum": ["minimal", "standard", "implementation", "security", "release", "unknown"]
+    },
+    "runner_compatibility": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/definitions/runner" }
+    },
+    "authority_boundary": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "dopemux_operator",
+          "dopetask_execution",
+          "task_orchestrator_workflow",
+          "leantime_pm_metadata",
+          "conport_structured_context",
+          "dope_memory_chronicle",
+          "dope_context_retrieval",
+          "dopecon_bridge_adapter",
+          "adhd_engine_operator_support",
+          "repo_truth_extractor",
+          "agent_helper",
+          "unknown"
+        ]
+      }
+    },
+    "secret_scan_state": {
+      "type": "string",
+      "enum": ["clean", "possible_secrets", "confirmed_secrets", "not_scanned", "unknown"]
+    },
+    "local_benchmark_certification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["required", "certified", "certification_refs", "block_if_missing"],
+      "properties": {
+        "required": { "type": "boolean" },
+        "certified": { "type": "boolean" },
+        "certification_refs": { "type": "array", "items": { "type": "string" } },
+        "block_if_missing": { "type": "boolean" }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "privacy_class": { "const": "UNKNOWN" } } },
+      "then": { "properties": { "human_approval_status": { "enum": ["missing", "denied", "expired", "scope_limited"] } } }
+    },
+    {
+      "if": { "properties": { "risk_class": { "const": "UNKNOWN" } } },
+      "then": { "properties": { "audit_requirement": { "enum": ["independent", "deep", "security", "release"] } } }
+    }
+  ],
+  "definitions": {
+    "privacy_class": {
+      "type": "string",
+      "enum": [
+        "PUBLIC_SANDBOX",
+        "PUBLIC_REPO",
+        "PRIVATE_REPO_NO_SECRETS",
+        "PRIVATE_REPO_POSSIBLE_SECRETS",
+        "SECRET_BEARING",
+        "CLIENT_DATA",
+        "SECURITY_SENSITIVE",
+        "RELEASE_AUTHORITY",
+        "UNKNOWN"
+      ]
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": [
+        "R0_READ",
+        "R1_DRAFT",
+        "R2_TEST_ONLY",
+        "R3_LOCAL_EDIT",
+        "R4_MULTI_FILE_EDIT",
+        "R5_SECURITY_OR_AUTHORITY",
+        "R6_RELEASE_OR_PRODUCTION",
+        "UNKNOWN"
+      ]
+    },
+    "tool": {
+      "type": "string",
+      "enum": ["none", "read", "search", "shell", "edit", "write", "network", "browser", "mcp", "github", "ci", "multimodal", "web", "local_filesystem"]
+    },
+    "provider": {
+      "type": "string",
+      "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple", "unknown"]
+    },
+    "runner": {
+      "type": "string",
+      "enum": ["openclaw", "codex", "claude_code", "gemini_antigravity", "openrouter_generic", "direct_api", "manual_app", "shell_local", "dopetask", "unknown"]
+    },
+    "audit_requirement": {
+      "type": "string",
+      "enum": ["none", "light", "embedded", "independent", "deep", "security", "release"]
+    }
+  }
+}

--- a/docs/03-reference/dcp/openclaw-routing/runner-adapter-contract.md
+++ b/docs/03-reference/dcp/openclaw-routing/runner-adapter-contract.md
@@ -1,0 +1,282 @@
+---
+id: runner_adapter_contract
+title: Runner Adapter Contract
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-17'
+last_review: '2026-06-17'
+next_review: '2026-09-15'
+prelude: Runner Adapter Contract (explanation) for dopemux documentation and developer
+  workflows.
+---
+# Runner Adapter Contract
+
+schema_version: 1.0.0
+status: PROPOSED
+
+## Purpose
+
+Define the minimum adapter contract for every runner DCP may route through. A runner is an execution surface, not an authority source. DCP owns policy, proof requirements, and release gates.
+
+## Common identity fields
+
+Every runner adapter MUST emit:
+
+- `runner_id`
+- `runner_type`
+- `runner_version`
+- `provider`
+- `requested_model`
+- `actual_model`
+- `access_path`
+- `session_id`
+- `route_decision_id`
+- `task_id`
+- `started_at`
+- `finished_at`
+- `exit_status`
+
+## Common evidence capture
+
+Every runner adapter MUST capture:
+
+- prompt body or prompt reference
+- prompt hash
+- response body or response reference
+- response hash
+- files read
+- files changed
+- tool calls
+- command list
+- command stdout/stderr references
+- exit codes
+- usage/cost when available
+- actual model/provider
+- errors/failures
+- redaction report
+- runner logs or transcript reference
+
+## OpenClaw adapter
+
+### Capabilities
+
+- sessions
+- tool execution
+- shell execution
+- file read/write
+- provider routing
+- OpenRouter provider parameters
+- JSONL logs
+- trajectory bundles
+- diagnostics export
+- MCP integration
+
+### Forbidden capabilities unless explicitly allowed
+
+- broad shell write access
+- external network access on private/security tasks
+- editing outside packet allowlist
+- release judgment
+- sole final audit of own run
+
+### Required logs
+
+- session JSONL transcript
+- trajectory bundle ref
+- tool event log
+- model/provider usage
+- diagnostics ref when failure occurs
+
+### Write restrictions
+
+- worktree must be declared
+- allowlist must be enforced externally
+- git status before/after must be captured externally or by wrapper
+
+### Audit restrictions
+
+OpenClaw may host an auditor agent, but DCP must verify provider, model, runner, and session independence.
+
+## Codex adapter
+
+### Capabilities
+
+- code implementation
+- patch generation
+- shell/test execution where runner permits
+- local or API-key-backed automation
+- ChatGPT sign-in for local subscription-backed use where allowed
+
+### Forbidden capabilities
+
+- treating ChatGPT sign-in as shared programmable API capacity
+- sole final audit of own implementation
+- high-risk release judgment without independent audit
+
+### Evidence capture
+
+- auth mode: `api_key` or `chatgpt_sign_in`
+- command transcript
+- changed files
+- git diff
+- tests
+- model identity
+- proof capture if consumer-plan route used
+
+## Claude Code adapter
+
+### Capabilities
+
+- repo navigation
+- implementation
+- multi-file edits
+- tests
+- local manual/semi-manual workflows
+- API-key-backed automation where configured
+
+### Forbidden capabilities
+
+- final audit of same Claude Code implementation session
+- shared backend use through consumer credentials
+- security/release sole authority
+
+### Evidence capture
+
+- auth mode
+- transcript ref
+- changed files
+- commands
+- diff
+- tests
+- audit handoff ref
+
+## Gemini / Antigravity adapter
+
+### Capabilities
+
+- long-context reasoning
+- multimodal audit
+- UI/design review
+- challenger analysis
+- API-key-backed automation where available
+
+### Forbidden capabilities
+
+- consumer Gemini CLI as production automation foundation
+- preview model as sole R5/R6 authority
+- release judgment without independent audit or human approval
+
+### Evidence capture
+
+- app/API/CLI path
+- model stability status
+- screenshots or multimodal inputs
+- prompt/response hashes
+- route proof
+
+## OpenRouter generic route adapter
+
+### Capabilities
+
+- unified API
+- provider pinning/order
+- fallback
+- max price
+- data collection filtering
+- ZDR filtering
+- strict structured outputs on compatible models
+
+### Forbidden capabilities
+
+- OpenRouter free for private/secret/security/release/schema-authority lanes
+- silent fallback that weakens policy
+- using requested model as actual model without verification
+
+### Evidence capture
+
+- requested model
+- actual returned model
+- actual provider when available
+- route profile
+- provider settings
+- fallback events
+- usage/cost
+- schema validation result
+- router metadata when enabled
+
+## Direct API route adapter
+
+### Capabilities
+
+- automation
+- reproducible logs
+- structured outputs
+- high-trust lanes
+- provider-native usage and cost capture
+
+### Forbidden capabilities
+
+- provider/model drift without logging
+- schema-critical output without local validation
+- release judgment without independent audit or human gate
+
+### Evidence capture
+
+- endpoint family
+- requested/actual model
+- request ID if available
+- token usage
+- cost
+- prompt/response hash
+- structured validation result
+
+## Manual app route adapter
+
+### Capabilities
+
+- manual planning
+- heavyweight reasoning
+- critique
+- design synthesis
+- human-supervised review
+
+### Forbidden capabilities
+
+- machine authority without proof capture
+- secrets/client/security data unless policy allows
+- direct release approval from transcript alone
+
+### Evidence capture
+
+- transcript export or signed summary
+- prompt/body hash where possible
+- operator identity
+- approval event if used
+- redaction report
+
+## Shell/local runner adapter
+
+### Capabilities
+
+- local commands
+- tests
+- linters
+- git state capture
+- artifact hashing
+
+### Forbidden capabilities
+
+- destructive commands without explicit approval
+- secret exfiltration
+- network writes unless authorized
+
+### Evidence capture
+
+- cwd
+- command
+- stdout/stderr
+- exit code
+- start/end time
+- environment redaction summary
+- file artifact refs

--- a/docs/03-reference/dcp/openclaw-routing/structured_output_policy.json
+++ b/docs/03-reference/dcp/openclaw-routing/structured_output_policy.json
@@ -1,0 +1,94 @@
+{
+  "schema_version": "1.0.0",
+  "artifact_id": "structured_output_policy",
+  "status": "PROPOSED",
+  "mandatory_when": [
+    "task_classification",
+    "route_decision",
+    "privacy_risk_classification",
+    "structured_task_packet_generation",
+    "tool_call_envelope",
+    "proof_bundle_generation",
+    "proof_validation",
+    "audit_verdict",
+    "pr_merge_readiness",
+    "security_findings_classification",
+    "release_judgment"
+  ],
+  "preferred_provider_order": [
+    "direct_openai_structured_outputs",
+    "direct_anthropic_structured_outputs",
+    "direct_gemini_structured_outputs",
+    "openrouter_paid_pinned_with_require_parameters",
+    "manual_app_with_capture_draft_only"
+  ],
+  "openrouter_required_settings": {
+    "response_format_type": "json_schema",
+    "strict": true,
+    "provider_require_parameters": true,
+    "local_schema_validation": true,
+    "json_object_allowed_for_authority": false,
+    "response_healing_is_not_schema_validation": true
+  },
+  "json_schema_validation_requirements": {
+    "additionalProperties": false,
+    "required_fields": true,
+    "explicit_enums_for_decisions": true,
+    "schema_version_required": true,
+    "schema_hash_required": true,
+    "local_validator_required": true,
+    "validation_must_precede_machine_consumption": true
+  },
+  "retry_policy": {
+    "malformed_json_non_authority": {
+      "max_retries": 1,
+      "repair_allowed": true,
+      "then": "validate_or_block"
+    },
+    "schema_invalid_authority": {
+      "max_retries": 1,
+      "repair_allowed": false,
+      "retry_prompt_must_include_validator_diff": true,
+      "then": "escalate_to_certified_schema_route"
+    },
+    "unsupported_parameter": {
+      "max_retries": 0,
+      "then": "select_route_supporting_required_parameters"
+    },
+    "openrouter_429_or_503": {
+      "honor_retry_after": true,
+      "max_retries": 1,
+      "then": "fallback_only_inside_approved_profile"
+    },
+    "repeated_schema_failure": {
+      "then": "block_and_mark_route_uncertified"
+    }
+  },
+  "fallback_policy": {
+    "never_downgrade_schema_mode": true,
+    "never_switch_to_json_object_for_authority": true,
+    "fallback_must_preserve_require_parameters": true,
+    "fallback_must_preserve_privacy_controls": true,
+    "fallback_must_be_benchmark_certified": true,
+    "fallback_actual_model_provider_logged": true
+  },
+  "forbidden_routes": [
+    "openrouter_free_for_schema_authority",
+    "consumer_app_output_as_machine_authority_without_capture",
+    "manual_paste_as_validated_json_without_local_validation",
+    "json_object_as_schema_authority_substitute",
+    "preview_model_as_sole_high_risk_schema_authority",
+    "openrouter_without_provider_require_parameters"
+  ],
+  "schema_failure_classifications": [
+    "MALFORMED_JSON",
+    "SCHEMA_INVALID_MISSING_REQUIRED",
+    "SCHEMA_INVALID_ADDITIONAL_PROPERTIES",
+    "SCHEMA_INVALID_ENUM",
+    "SCHEMA_INVALID_TYPE",
+    "UNSUPPORTED_PARAMETERS",
+    "PROVIDER_IGNORED_SCHEMA",
+    "LOCAL_VALIDATION_UNAVAILABLE",
+    "SEMANTIC_EVIDENCE_MISMATCH"
+  ]
+}

--- a/docs/03-reference/dcp/openclaw-routing/turn4-acceptance-checklist.md
+++ b/docs/03-reference/dcp/openclaw-routing/turn4-acceptance-checklist.md
@@ -1,0 +1,167 @@
+---
+id: TURN4_ACCEPTANCE_CHECKLIST
+title: Turn4 Acceptance Checklist
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-17'
+last_review: '2026-06-17'
+next_review: '2026-09-15'
+prelude: Turn4 Acceptance Checklist (explanation) for dopemux documentation and developer
+  workflows.
+---
+# TURN4_ACCEPTANCE_CHECKLIST
+
+schema_version: 1.0.0
+status: PROPOSED
+
+## Artifact completeness checklist
+
+- [ ] `openclaw_dcp_routing_policy.yaml` present
+- [ ] `routing_classifier.schema.json` present
+- [ ] `route_decision.schema.json` present
+- [ ] `model_pool_registry.yaml` present
+- [ ] `privacy_class_policy.yaml` present
+- [ ] `risk_class_policy.yaml` present
+- [ ] `forbidden_routes.yaml` present
+- [ ] `human_approval_gates.yaml` present
+- [ ] `openrouter_route_profiles.json` present
+- [ ] `structured_output_policy.json` present
+- [ ] `proof_requirements.schema.json` present
+- [ ] `audit_independence_rules.yaml` present
+- [ ] `release_gate_policy.yaml` present
+- [ ] `runner_adapter_contract.md` present
+- [ ] `openclaw_proof_normalization_contract.md` present
+- [ ] `route_decision_logger.schema.json` present
+- [ ] `provider_availability_probe_spec.md` present
+- [ ] `cost_policy.yaml` present
+- [ ] `local_benchmark_harness_requirements.md` present
+- [ ] `benchmark_fixture_manifest.yaml` present
+- [ ] `benchmark_result.schema.json` present
+- [ ] `route_certification_ledger.schema.json` present
+- [ ] `pr_steward_merge_readiness.schema.json` present
+- [ ] `example_route_decisions/` present with 8 examples
+- [ ] `TURN4_ACCEPTANCE_CHECKLIST.md` present
+
+## Schema validity checklist
+
+- [ ] JSON schemas parse as valid JSON
+- [ ] JSON config artifacts parse as valid JSON
+- [ ] YAML artifacts parse as valid YAML
+- [ ] JSON schemas use `additionalProperties: false` unless intentionally extensible
+- [ ] Schemas include `schema_version`
+- [ ] Enums exist for privacy classes
+- [ ] Enums exist for risk classes
+- [ ] Enums exist for routing roles
+- [ ] Enums exist for audit verdicts where applicable
+- [ ] Enums exist for gate/readiness statuses
+- [ ] Example route decisions validate against `route_decision.schema.json`
+
+## Fail-closed behavior checklist
+
+- [ ] `UNKNOWN` privacy blocks or escalates
+- [ ] `UNKNOWN` risk blocks or escalates
+- [ ] Unknown actual provider/model blocks private/high-risk routes
+- [ ] Missing benchmark certification blocks high-trust routes
+- [ ] Missing proof blocks write/release gates
+- [ ] Fallback weakening blocks route
+- [ ] Provider drift blocks private/high-risk routes
+
+## Privacy policy checklist
+
+- [ ] OpenRouter free blocked for private/secret/client/security/release/schema authority
+- [ ] Secret-bearing routes require redaction and approval
+- [ ] Client data requires contract-approved route
+- [ ] Consumer apps are manual/constrained only
+- [ ] Direct APIs preferred for private/high-trust
+- [ ] Local/self-hosted route still requires proof and benchmark guard
+
+## Risk policy checklist
+
+- [ ] R0 read permits cheap routes
+- [ ] R1 draft cannot claim authority
+- [ ] R2 tests cannot prove correctness alone
+- [ ] R3 edits require git proof
+- [ ] R4 multi-file edits require audit
+- [ ] R5 security requires deep independent audit and human gate
+- [ ] R6 release requires current proof, current CI, current head SHA, audit or human approval
+- [ ] UNKNOWN risk fails closed
+
+## OpenRouter policy checklist
+
+- [ ] `provider.require_parameters=true` for structured routes
+- [ ] `response_format.type=json_schema` for schema routes
+- [ ] `strict=true` for schema routes
+- [ ] `data_collection=deny` for private route profiles
+- [ ] `zdr=true` where private/client/sensitive profile requires it
+- [ ] `max_price` logged and enforced
+- [ ] actual model/provider logged
+- [ ] openrouter/free never used for deterministic authority
+- [ ] provider drift fixture exists
+- [ ] free timeout fixture exists
+
+## Audit independence checklist
+
+- [ ] Implementer cannot be sole final auditor
+- [ ] Same runner/session self-audit blocks R4+
+- [ ] R5/R6 require independent provider audit or explicit human approval
+- [ ] Same-provider exception requires human approval
+- [ ] Preview/experimental model cannot be sole high-risk authority
+- [ ] Auditor verdict enum includes PASS, PASS_WITH_RISKS, FAIL, NEEDS_SUPERVISOR, SKIPPED
+
+## Proof policy checklist
+
+- [ ] Proof bundle includes model/provider/runner
+- [ ] Proof bundle includes prompt/response hash
+- [ ] Proof bundle includes files read/changed
+- [ ] Write proof includes git status before/after
+- [ ] Write proof includes diff stat and full diff
+- [ ] Commands include stdout/stderr refs and exit codes
+- [ ] Structured outputs include schema ID and validation result
+- [ ] Cost estimate and actual usage captured
+- [ ] Audit decision captured
+- [ ] Approval event captured when required
+- [ ] Redaction report present
+
+## Release gate checklist
+
+- [ ] PR number, repo, branch, base, head SHA captured
+- [ ] Checks current to head SHA
+- [ ] Failed checks block READY
+- [ ] Stale checks block READY
+- [ ] Stale proof blocks READY
+- [ ] Unknown reviewer/bot blocks READY
+- [ ] Unclassified review item blocks READY
+- [ ] Blocking thread unresolved blocks READY
+- [ ] Diff outside allowlist blocks READY
+- [ ] Security/release missing approval blocks READY
+- [ ] READY impossible unless all blockers empty/false
+
+## Benchmark requirement checklist
+
+- [ ] 100% valid JSON threshold
+- [ ] 100% schema validity threshold
+- [ ] 100% fail-closed unsupported-route threshold
+- [ ] Evidence grounding precision >= 98%
+- [ ] Unsupported-claim rate <= 1%
+- [ ] Contradiction recall >= 90%
+- [ ] Core-field stability >= 95%
+- [ ] Hallucinated file/path tracking
+- [ ] Diff applicability tracking
+- [ ] Patch success tracking
+- [ ] Test pass/fail tracking
+- [ ] Latency/cost tracking
+- [ ] Provider drift tracking
+- [ ] Privacy mismatch tracking
+- [ ] Local repo fixture requirement
+
+## Unresolved UNKNOWN ledger
+
+- [ ] Exact OpenClaw implementation paths for all OpenRouter profile settings are not proven here.
+- [ ] Exact current provider model slugs/prices must be refreshed before implementation.
+- [ ] Actual benchmark pass rates are UNKNOWN until harness execution.
+- [ ] Gemini/Antigravity programmable surface stability remains route-specific.
+- [ ] Consumer-plan legal/terms posture must be checked before automation use.
+- [ ] Route certification storage location is not selected.
+- [ ] PR Steward implementation location is not selected.
+- [ ] DCP wrapper runtime location is not selected.

--- a/task-packets/OPENCLAW-DCP-ROUTING-CONTRACTS-0001.json
+++ b/task-packets/OPENCLAW-DCP-ROUTING-CONTRACTS-0001.json
@@ -1,0 +1,113 @@
+{
+  "id": "OPENCLAW-DCP-ROUTING-CONTRACTS-0001",
+  "project": "dopemux-mvp",
+  "target": "OpenClaw DCP routing contract artifacts and validation tests",
+  "invariants": [
+    "Contracts are static proposed artifacts only.",
+    "No production routing behavior is wired.",
+    "No provider API calls are made.",
+    "OpenRouter free routes remain sandbox-only.",
+    "Release READY remains fail-closed when proof, checks, audit, threads, allowlist, or approval gates are unsafe."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "OPENCLAW-DCP-ROUTING-CONTRACTS",
+    "base_branch": "HEAD",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/openclaw-dcp-routing-contracts-0001",
+    "base_branch": "HEAD",
+    "stacked_because": "Existing Codex worktree was provided detached at the requested repo root."
+  },
+  "commit": {
+    "message": "feat(dcp): add OpenClaw routing contract validation",
+    "allowlist": [
+      "task-packets/OPENCLAW-DCP-ROUTING-CONTRACTS-0001.json",
+      "docs/03-reference/dcp/openclaw-routing/**",
+      "tests/dcp/test_openclaw_dcp_routing_contracts.py"
+    ],
+    "verify": [
+      "python -m pytest tests/dcp/test_openclaw_dcp_routing_contracts.py -q",
+      "python -m json.tool task-packets/OPENCLAW-DCP-ROUTING-CONTRACTS-0001.json >/dev/null",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "Add OpenClaw DCP routing contract validation",
+    "body": "Contracts-only Turn 5 slice. Adds static proposed OpenClaw DCP routing artifacts and validation tests. Does not wire production routing, provider calls, OpenClaw runtime behavior, benchmark execution, or credential handling.",
+    "base": "HEAD"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Add static OpenClaw DCP routing policy and contract artifacts under docs/03-reference/dcp/openclaw-routing.",
+      "requirements": [
+        "Use uploaded Turn 4 artifact content.",
+        "Preserve generated filenames from the artifact inventory.",
+        "Do not create runtime router code."
+      ],
+      "commands": [
+        "python -m pytest tests/dcp/test_openclaw_dcp_routing_contracts.py -q"
+      ],
+      "expected_files": [
+        "docs/03-reference/dcp/openclaw-routing/readme.md",
+        "docs/03-reference/dcp/openclaw-routing/openclaw_dcp_routing_policy.yaml",
+        "docs/03-reference/dcp/openclaw-routing/route_decision.schema.json",
+        "docs/03-reference/dcp/openclaw-routing/example_route_decisions/UNKNOWN.json"
+      ],
+      "validation": [
+        "Every JSON artifact parses.",
+        "Every YAML artifact parses.",
+        "Every JSON Schema checks as a schema.",
+        "Example route decisions validate against route_decision.schema.json."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "/Users/hue/.codex/attachments/ef05c516-fc01-4508-80b5-b880f31c17fe/pasted-text.txt"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Add focused validation tests for fail-closed route and release-readiness constraints.",
+      "requirements": [
+        "UNKNOWN privacy or risk blocks or escalates.",
+        "OpenRouter free is forbidden for private, security, release, and schema-authority lanes.",
+        "Release READY is impossible with stale proof, failed checks, missing audit, unresolved blocking threads, escaped diff, or missing required approval."
+      ],
+      "commands": [
+        "python -m pytest tests/dcp/test_openclaw_dcp_routing_contracts.py -q",
+        "git diff --check"
+      ],
+      "expected_files": [
+        "tests/dcp/test_openclaw_dcp_routing_contracts.py"
+      ],
+      "validation": [
+        "Focused pytest suite passes.",
+        "Diff whitespace check passes.",
+        "No files outside allowlist are changed."
+      ],
+      "context_files": [
+        "docs/03-reference/dcp/openclaw-routing/forbidden_routes.yaml",
+        "docs/03-reference/dcp/openclaw-routing/pr_steward_merge_readiness.schema.json"
+      ]
+    }
+  ]
+}

--- a/tests/dcp/test_openclaw_dcp_routing_contracts.py
+++ b/tests/dcp/test_openclaw_dcp_routing_contracts.py
@@ -1,0 +1,254 @@
+import copy
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from jsonschema import Draft7Validator
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ARTIFACT_DIR = ROOT / "docs" / "03-reference" / "dcp" / "openclaw-routing"
+EXAMPLES_DIR = ARTIFACT_DIR / "example_route_decisions"
+
+EXPECTED_JSON = {
+    "routing_classifier.schema.json",
+    "route_decision.schema.json",
+    "openrouter_route_profiles.json",
+    "structured_output_policy.json",
+    "proof_requirements.schema.json",
+    "route_decision_logger.schema.json",
+    "benchmark_result.schema.json",
+    "route_certification_ledger.schema.json",
+    "pr_steward_merge_readiness.schema.json",
+}
+
+EXPECTED_YAML = {
+    "openclaw_dcp_routing_policy.yaml",
+    "model_pool_registry.yaml",
+    "privacy_class_policy.yaml",
+    "risk_class_policy.yaml",
+    "forbidden_routes.yaml",
+    "human_approval_gates.yaml",
+    "audit_independence_rules.yaml",
+    "release_gate_policy.yaml",
+    "cost_policy.yaml",
+    "benchmark_fixture_manifest.yaml",
+}
+
+EXPECTED_MARKDOWN = {
+    "readme.md",
+    "runner-adapter-contract.md",
+    "openclaw-proof-normalization-contract.md",
+    "provider-availability-probe-spec.md",
+    "local-benchmark-harness-requirements.md",
+    "turn4-acceptance-checklist.md",
+}
+
+EXPECTED_EXAMPLES = {
+    "R0_READ.json",
+    "R1_DRAFT.json",
+    "R2_TEST_ONLY.json",
+    "R3_LOCAL_EDIT.json",
+    "R4_MULTI_FILE_EDIT.json",
+    "R5_SECURITY_OR_AUTHORITY.json",
+    "R6_RELEASE_OR_PRODUCTION.json",
+    "UNKNOWN.json",
+}
+
+
+def load_json(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def load_yaml(path: Path) -> dict:
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def schema_validator(schema_name: str) -> Draft7Validator:
+    schema = load_json(ARTIFACT_DIR / schema_name)
+    Draft7Validator.check_schema(schema)
+    return Draft7Validator(schema)
+
+
+def assert_valid(validator: Draft7Validator, instance: dict) -> None:
+    errors = sorted(validator.iter_errors(instance), key=lambda error: list(error.path))
+    assert not errors, "\n".join(error.message for error in errors)
+
+
+def assert_invalid(validator: Draft7Validator, instance: dict) -> None:
+    assert list(validator.iter_errors(instance))
+
+
+def valid_merge_readiness() -> dict:
+    return {
+        "schema_version": "1.0.0",
+        "pr_number": 123,
+        "repo": "DDD-Enterprises/dopemux-mvp",
+        "branch": "codex/example",
+        "head_sha": "abcdef1234567890",
+        "base_branch": "main",
+        "changed_files": ["docs/03-reference/dcp/openclaw-routing/route_decision.schema.json"],
+        "commits": [{"sha": "abcdef1234567890", "message": "feat(dcp): add contracts"}],
+        "checks": [
+            {
+                "name": "contract-tests",
+                "status": "completed",
+                "conclusion": "success",
+                "head_sha": "abcdef1234567890",
+            }
+        ],
+        "review_comments": [],
+        "review_threads": [],
+        "issue_comments": [],
+        "bot_comments": [],
+        "proof_bundle_refs": ["proof:current"],
+        "audit_refs": ["audit:independent-pass"],
+        "review_item_classifications": [],
+        "unknown_reviewers_or_bots": [],
+        "unclassified_review_items": [],
+        "failed_checks": [],
+        "checks_stale_to_head": False,
+        "proof_stale": False,
+        "blocking_thread_unresolved": False,
+        "diff_escapes_packet_allowlist": False,
+        "security_release_gate_lacks_approval": False,
+        "unresolved_blockers": [],
+        "status": "READY",
+        "created_at": "2026-06-17T12:00:00Z",
+    }
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_JSON))
+def test_json_artifacts_parse(name: str):
+    assert load_json(ARTIFACT_DIR / name)
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_YAML))
+def test_yaml_artifacts_parse(name: str):
+    assert load_yaml(ARTIFACT_DIR / name)
+
+
+def test_artifact_filenames_and_locations_are_sane():
+    assert ARTIFACT_DIR.is_dir()
+    assert EXAMPLES_DIR.is_dir()
+    actual_root_files = {path.name for path in ARTIFACT_DIR.iterdir() if path.is_file()}
+    actual_examples = {path.name for path in EXAMPLES_DIR.iterdir() if path.is_file()}
+
+    assert EXPECTED_JSON <= actual_root_files
+    assert EXPECTED_YAML <= actual_root_files
+    assert EXPECTED_MARKDOWN <= actual_root_files
+    assert EXPECTED_EXAMPLES == actual_examples
+
+
+@pytest.mark.parametrize("name", sorted(path for path in EXPECTED_JSON if path.endswith(".schema.json")))
+def test_json_schema_artifacts_are_valid_schemas(name: str):
+    Draft7Validator.check_schema(load_json(ARTIFACT_DIR / name))
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_EXAMPLES))
+def test_example_route_decisions_validate(name: str):
+    validator = schema_validator("route_decision.schema.json")
+    assert_valid(validator, load_json(EXAMPLES_DIR / name))
+
+
+def test_unknown_privacy_and_risk_fail_closed():
+    unknown = load_json(EXAMPLES_DIR / "UNKNOWN.json")
+    assert unknown["privacy_class"] == "UNKNOWN"
+    assert unknown["risk_class"] == "UNKNOWN"
+    assert unknown["decision_status"] in {"BLOCKED", "ESCALATED", "NEEDS_SUPERVISOR"}
+    assert "UNKNOWN_PRIVACY_CLASS" in unknown["blocked_reasons"]
+    assert "UNKNOWN_RISK_CLASS" in unknown["blocked_reasons"]
+
+    validator = schema_validator("route_decision.schema.json")
+    fail_open = copy.deepcopy(unknown)
+    fail_open["decision_status"] = "SELECTED"
+    assert_invalid(validator, fail_open)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("privacy_class", "PRIVATE_REPO_NO_SECRETS"),
+        ("privacy_class", "PRIVATE_REPO_POSSIBLE_SECRETS"),
+        ("privacy_class", "SECRET_BEARING"),
+        ("privacy_class", "CLIENT_DATA"),
+        ("privacy_class", "SECURITY_SENSITIVE"),
+        ("privacy_class", "RELEASE_AUTHORITY"),
+        ("risk_class", "R5_SECURITY_OR_AUTHORITY"),
+        ("risk_class", "R6_RELEASE_OR_PRODUCTION"),
+        ("structured_output_mode", "json_schema_strict"),
+        ("structured_output_mode", "tool_schema_strict"),
+    ],
+)
+def test_openrouter_free_forbidden_for_private_high_risk_and_schema_authority(field: str, value: str):
+    validator = schema_validator("route_decision.schema.json")
+    decision = load_json(EXAMPLES_DIR / "R0_READ.json")
+    decision[field] = value
+    assert decision["access_path"] == "openrouter_free"
+    assert_invalid(validator, decision)
+
+
+def test_forbidden_routes_encode_openrouter_free_block():
+    forbidden = load_yaml(ARTIFACT_DIR / "forbidden_routes.yaml")
+    block = next(item for item in forbidden["hard_blocks"] if item["id"] == "FR-002")
+    assert block["block_reason"] == "OPENROUTER_FREE_FORBIDDEN"
+    assert "PRIVATE_REPO_NO_SECRETS" in block["match"]["any_privacy_class"]
+    assert "SECURITY_SENSITIVE" in block["match"]["any_privacy_class"]
+    assert "RELEASE_AUTHORITY" in block["match"]["any_privacy_class"]
+    assert "R5_SECURITY_OR_AUTHORITY" in block["match"]["any_risk_class"]
+    assert "R6_RELEASE_OR_PRODUCTION" in block["match"]["any_risk_class"]
+    assert "structured_task_packet_generation" in block["match"]["any_role"]
+    assert "proof_validation" in block["match"]["any_role"]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("proof_stale", True),
+        ("checks_stale_to_head", True),
+        ("blocking_thread_unresolved", True),
+        ("diff_escapes_packet_allowlist", True),
+        ("security_release_gate_lacks_approval", True),
+    ],
+)
+def test_release_ready_rejects_boolean_blockers(field: str, value: bool):
+    validator = schema_validator("pr_steward_merge_readiness.schema.json")
+    readiness = valid_merge_readiness()
+    readiness[field] = value
+    assert_invalid(validator, readiness)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("failed_checks", ["contract-tests"]),
+        ("unresolved_blockers", ["MISSING_AUDIT"]),
+        ("unknown_reviewers_or_bots", ["unknown-bot"]),
+        ("unclassified_review_items", ["review-comment-1"]),
+    ],
+)
+def test_release_ready_rejects_non_empty_blocker_lists(field: str, value: list[str]):
+    validator = schema_validator("pr_steward_merge_readiness.schema.json")
+    readiness = valid_merge_readiness()
+    readiness[field] = value
+    assert_invalid(validator, readiness)
+
+
+@pytest.mark.parametrize("field", ["proof_bundle_refs", "audit_refs"])
+def test_release_ready_rejects_missing_required_evidence_refs(field: str):
+    validator = schema_validator("pr_steward_merge_readiness.schema.json")
+    readiness = valid_merge_readiness()
+    readiness[field] = []
+    assert_invalid(validator, readiness)
+
+
+def test_no_runtime_routing_files_are_added():
+    runtime_candidates = [
+        ROOT / "src" / "dopemux" / "dcp" / "openclaw_routing.py",
+        ROOT / "src" / "dopemux" / "dcp" / "openclaw_router.py",
+        ROOT / "src" / "dopemux" / "dcp" / "route_engine.py",
+    ]
+    assert not any(path.exists() for path in runtime_candidates)


### PR DESCRIPTION
## Summary
- Add proposed OpenClaw DCP routing contract artifacts under `docs/03-reference/dcp/openclaw-routing/`.
- Add a repo-bound task packet for the contracts-only Turn 5 slice.
- Add focused pytest validation for JSON/YAML parsing, JSON Schema validity, route-decision examples, OpenRouter free-route blocks, UNKNOWN fail-closed behavior, and release READY blockers.

## Scope
Contracts only. This PR does not wire production routing, OpenClaw execution, OpenRouter integration, provider calls, benchmark execution, route-engine behavior, or credential handling.

## Validation
- `python -m pytest tests/dcp/test_openclaw_dcp_routing_contracts.py -q` -> 59 passed
- `python` task packet validation against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` -> PASS
- `git diff --cached --check` -> PASS
- `pre-commit run --files $(git diff --cached --name-only)` -> PASS

## Remaining UNKNOWN
- Current provider model slugs/prices are not verified.
- OpenClaw adapter support for every profile setting is not verified.
- Benchmark outcomes and route certification storage are not implemented.
- Runtime routing remains intentionally not enabled.
