### PR TITLE
chore(dcp): remove unused imports flagged by ruff

### DIFF
--- a/src/dopemux/dcp/red_lane_scanner.py
+++ b/src/dopemux/dcp/red_lane_scanner.py
@@ -1,7 +1,7 @@
 import os
 import json
 from datetime import datetime
-from typing import List, Dict, Any, Optional
+from typing import List, Optional
 
 from dopemux.dcp.red_lane import (
     RedLaneReport, Finding, ScannerInfo, RepoInfo, InputsInfo, GuardsInfo, SummaryInfo,

--- a/tests/unit/dcp/test_routing_model.py
+++ b/tests/unit/dcp/test_routing_model.py
@@ -20,7 +20,6 @@ Coverage targets:
 
 import inspect
 
-import pytest
 
 from dopemux.dcp.routing_model import (
     AuditRequirement,


### PR DESCRIPTION
## What
Removes three pre-existing `ruff` F401 (unused import) nits in the DCP area, surfaced during the PR #923 post-merge audit. These files are **unrelated** to #923 — this is pure lint hygiene, no behavior change.

- `src/dopemux/dcp/red_lane_scanner.py` — drop unused `typing.Dict`, `typing.Any` (keeps `List`, `Optional`, both still used)
- `tests/unit/dcp/test_routing_model.py` — drop unused `pytest` import

## Verification
- `ruff check src/dopemux/dcp tests/unit/dcp` → **All checks passed** (was 3 errors)
- `compileall` exit 0
- `pytest tests/unit/dcp/` → green (incl. `test_routing_model.py` 46 passed)
- `git diff --check` clean

Merge is operator's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)