### PR TITLE
fix(conport): fail closed on incompatible migration ledger

### DIFF
--- a/claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md
+++ b/claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md
@@ -84,11 +84,16 @@ IDs and orchestrator UUID mappings are preserved.
 
 ## Live orchestrator caveat
 
-This repo change does not mutate the already-loaded task-orchestrator root
-`44452f53-615d-4519-b21a-4a9cbc8774a4`. Live orchestrator synchronization is a
-separate operational step and is intentionally not performed by this artifact
-update. Until that sync occurs, live queue state may still show packet 101 as the
-first unblocked packet.
+The initial repo change did not mutate the already-loaded task-orchestrator root
+`44452f53-615d-4519-b21a-4a9cbc8774a4`.
+
+After separate user authorization on 2026-06-16, live synchronization created
+packet 100 as `dcf66b56-8fbf-426f-a6d6-826f0caa5822`. At sync time, live packet
+101 was already terminal and packet 102 was already in review, so a literal
+`100 -> 101` edge would not enforce the gate. The live sync therefore created
+packet 100 blockers to packet 101 and the current non-terminal descendants as
+live-state reconciliation. A fresh repo replay remains the cleaner 19-node /
+22-edge graph with packet 100 blocking packet 101.
 
 ## PAL review summary
 

--- a/claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md
+++ b/claudedocs/conport-optimal-coverage-and-hardening-analysis-2026-06-16.md
@@ -1,0 +1,117 @@
+---
+id: conport-optimal-coverage-and-hardening-analysis-2026-06-16
+title: "ConPort optimal coverage and migration foundation analysis"
+type: analysis
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-14'
+prelude: Separates observed ConPort migration/runtime evidence from inherited claims and gates DMX-CONPORT-OPTIMAL downstream packets on an explicit migration foundation packet.
+---
+
+# ConPort optimal coverage and migration foundation analysis
+
+## Status
+
+This analysis supersedes the earlier no-DAG-change amendment plan for
+DMX-CONPORT-OPTIMAL. The prior plan treated the loaded packet graph as safe to
+preserve while amending downstream packet text. Current evidence shows a hidden
+foundation prerequisite: ConPort migration state is not proven by the runtime
+startup path or Docker image contents.
+
+## Authority and evidence
+
+Observed repo authority:
+
+- `docker/mcp-servers-source/conport/enhanced_server.py` calls `_ensure_schema()`
+  during startup.
+- `_ensure_schema()` checks only for `public.workspace_contexts`; if that table
+  exists it returns without applying migration files.
+- When the sentinel table is absent, `_ensure_schema()` applies only
+  `/app/schema.sql`.
+- `docker/mcp-servers-source/conport/Dockerfile` copies `schema.sql` into the
+  image, but does not copy `docker/mcp-servers-source/conport/migrations/`.
+- `schema.sql` creates the baseline ConPort tables, including
+  `workspace_contexts`, `decisions`, `progress_entries`, `session_snapshots`,
+  `custom_data`, `entity_relationships`, and `search_cache`.
+- Enhanced migration objects are in migration files, not the observed startup
+  bootstrap:
+  - `001_enhanced_decision_model.sql` creates `decision_relationships`,
+    `adhd_metrics`, and `review_reminders`.
+  - `003_multi_tenancy_foundation.sql` adds `user_id` columns and creates
+    `users`, `workspaces`, and `user_workspace_access`.
+
+Inherited but corrected claims:
+
+- Code-only inference is insufficient for image/runtime claims. A live image may
+  contain files or schemas not obvious from a source-only read; any such claim
+  must be rechecked against the live container or marked `NOT_RUN`.
+- The presence of migration SQL files in the repo does not prove they are copied
+  into the image or applied to a live database.
+- Downstream packets must not assume enhanced migration objects exist until a
+  dedicated foundation gate proves the object set and drift behavior.
+
+Live read-only database check on 2026-06-16:
+
+- `dopemux-postgres-age` was running and queried with in-container `psql`; no
+  external credential value is recorded here.
+- `ag_catalog` exists with AGE tables `ag_graph` and `ag_label`.
+- Public ConPort baseline tables observed: `workspace_contexts`, `decisions`,
+  `progress_entries`, `session_snapshots`, `custom_data`,
+  `entity_relationships`, and `search_cache`.
+- Public enhanced migration tables were not present in the inspected output:
+  `decision_relationships`, `review_reminders`, `adhd_metrics`,
+  `decision_patterns`, `users`, `workspaces`, and `user_workspace_access`.
+- `decisions.id` is `uuid`.
+- `entity_relationships` has `source_id` and `target_id` UUID columns and only
+  primary-key/not-null/strength constraints in the inspected constraint set.
+
+## Decision
+
+Add `DMX-CONPORT-OPTIMAL-100-migration-foundation-gate` before packet 101.
+Packet 100 is the explicit Tier-0 gate for:
+
+- migration file availability,
+- deterministic apply/verify behavior,
+- ledger/checksum or equivalent drift proof,
+- read-only live DB introspection where available,
+- fail-closed handling for partial apply, missing objects, checksum mismatch,
+  unavailable DB, or unavailable PAL validation.
+
+The repo load plan is updated so packet 100 blocks packet 101. Existing packet
+IDs and orchestrator UUID mappings are preserved.
+
+## Live orchestrator caveat
+
+This repo change does not mutate the already-loaded task-orchestrator root
+`44452f53-615d-4519-b21a-4a9cbc8774a4`. Live orchestrator synchronization is a
+separate operational step and is intentionally not performed by this artifact
+update. Until that sync occurs, live queue state may still show packet 101 as the
+first unblocked packet.
+
+## PAL review summary
+
+Pre-edit PAL tools were run on 2026-06-16:
+
+- `pal.analyze`: identified downstream schema assumptions as a high-severity
+  hidden prerequisite.
+- `pal.thinkdeep`: confirmed the fail-closed migration foundation gate is the
+  safer replayability boundary.
+- `pal.challenge`: forced the live-orchestrator caveat into scope.
+- `pal.planner`: confirmed the artifact mutation sequence.
+- `pal.consensus`: two of three model stances favored packet 100; the opposing
+  stance warned that repo DAG edits do not update live orchestrator state.
+
+## Packet implications
+
+Affected packets must require packet 100 evidence before execution:
+
+- 101: bringup smoke must not be treated as the first foundation gate.
+- 108: integration test setup must use the packet 100 migration ordering and
+  ledger expectations.
+- 201, 202, 301, 302, 303: schema-dependent feature packets must fail closed if
+  packet 100 did not prove the relevant table/column/constraint state.
+
+Hardening-series expansion remains deferred until packet 100 proves migration
+state, rebuild-from-zero behavior, and drift handling.

--- a/claudedocs/conport-optimal-migration-gate-implementation-notes-2026-06-16.md
+++ b/claudedocs/conport-optimal-migration-gate-implementation-notes-2026-06-16.md
@@ -84,14 +84,20 @@ PASS:
 - `python3 -m json.tool docs/ops/load-plans/load_plan-DMX-CONPORT-OPTIMAL.json`.
 - `git diff --check`.
 
+PASS:
+
+- Separate live task-orchestrator sync after user authorization:
+  - created packet 100 as `dcf66b56-8fbf-426f-a6d6-826f0caa5822`,
+  - created 18 live `BLOCKS` dependencies from packet 100 to packet 101 and
+    current non-terminal descendants,
+  - added audit notes to the live root and packet 100.
+
 NOT_RUN:
 
-- Live task-orchestrator graph mutation or synchronization. This repo artifact
-  update does not mutate root `44452f53-615d-4519-b21a-4a9cbc8774a4`.
 - GitHub PR, branch push, or merge.
 
 ## Residual risk
 
-The repo load plan now expresses packet 100 as the intended first gate, but the
-already-loaded live task-orchestrator root may still show packet 101 as
-unblocked until a separate sync operation is authorized and performed.
+The repo load plan expresses packet 100 as the intended first gate. The live
+root required reconciliation because packet 101 was already terminal at sync
+time, so packet 100 was also wired directly to current non-terminal descendants.

--- a/claudedocs/conport-optimal-migration-gate-implementation-notes-2026-06-16.md
+++ b/claudedocs/conport-optimal-migration-gate-implementation-notes-2026-06-16.md
@@ -1,0 +1,97 @@
+---
+id: conport-optimal-migration-gate-implementation-notes-2026-06-16
+title: "ConPort optimal migration gate implementation notes"
+type: proof
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-14'
+prelude: Implementation notes and validation evidence for adding the DMX-CONPORT-OPTIMAL packet 100 migration foundation gate.
+---
+
+# ConPort optimal migration gate implementation notes
+
+## Changes
+
+- Added the ConPort migration foundation dossier.
+- Added ADR `adr-conport-migration-foundation-gate`.
+- Added `DMX-CONPORT-OPTIMAL-100-migration-foundation-gate`.
+- Updated the DMX-CONPORT-OPTIMAL repo load plan from 18 nodes / 21 edges to
+  19 nodes / 22 edges.
+- Updated packet 101 to depend on packet 100.
+- Added migration-foundation evidence requirements to packets 101, 108, 201,
+  202, 301, 302, and 303.
+
+## PAL evidence
+
+Pre-edit PAL tools run:
+
+- `pal.analyze`: PASS, identified downstream schema assumptions as high-risk.
+- `pal.thinkdeep`: PASS, confirmed the fail-closed migration foundation
+  boundary and replayability risk.
+- `pal.challenge`: PASS, forced the live task-orchestrator sync caveat into the
+  implementation.
+- `pal.planner`: PASS, confirmed the artifact mutation sequence.
+- `pal.consensus`: PASS, consulted `gpt-5.2`, `gpt-5.5`, and
+  `gpt-5.2-codex`.
+
+PAL consensus result: proceed with packet 100 because the user selected the
+explicit gate strategy, while documenting that repo load-plan changes do not
+mutate the already-loaded live task-orchestrator root.
+
+## Live DB introspection
+
+Read-only metadata introspection was run against the running Postgres container
+with in-container `psql`.
+
+Observed:
+
+- `ag_catalog` exists.
+- Baseline ConPort public tables exist.
+- Enhanced migration tables were not present in the inspected output:
+  `decision_relationships`, `review_reminders`, `adhd_metrics`,
+  `decision_patterns`, `users`, `workspaces`, and `user_workspace_access`.
+- `decisions.id` is `uuid`.
+- `entity_relationships` has UUID `source_id` and `target_id` columns, with
+  only primary-key/not-null/strength constraints in the inspected constraint
+  set.
+
+No credential values are recorded in this proof note.
+
+## Validation
+
+PASS:
+
+- `python3 -m json.tool` on packet 100 and amended packets 101, 108, 201, 202,
+  301, 302, and 303.
+- `python3 -m jsonschema -i <packet> docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+  on packet 100 and amended packets 101, 108, 201, 202, 301, 302, and 303.
+- Load-plan invariant script:
+  - packet 100 exists,
+  - packet 100 blocks packet 101,
+  - node count is 19,
+  - edge count is 22,
+  - existing orchestrator UUID mappings are unchanged.
+- Source evidence script:
+  - Dockerfile copies `schema.sql`,
+  - Dockerfile does not copy the migrations directory,
+  - `_ensure_schema()` uses `workspace_contexts` as the sentinel,
+  - `_ensure_schema()` applies `/app/schema.sql`,
+  - `schema.sql` lacks `decision_relationships`,
+  - migration 001 contains `decision_relationships` and `review_reminders`,
+  - migration 003 contains `users`.
+- `python3 -m json.tool docs/ops/load-plans/load_plan-DMX-CONPORT-OPTIMAL.json`.
+- `git diff --check`.
+
+NOT_RUN:
+
+- Live task-orchestrator graph mutation or synchronization. This repo artifact
+  update does not mutate root `44452f53-615d-4519-b21a-4a9cbc8774a4`.
+- GitHub PR, branch push, or merge.
+
+## Residual risk
+
+The repo load plan now expresses packet 100 as the intended first gate, but the
+already-loaded live task-orchestrator root may still show packet 101 as
+unblocked until a separate sync operation is authorized and performed.

--- a/docker/mcp-servers-source/conport/Dockerfile
+++ b/docker/mcp-servers-source/conport/Dockerfile
@@ -33,7 +33,9 @@ COPY docker/mcp-servers-source/conport/unified_queries.py .
 COPY docker/mcp-servers-source/conport/instance_detector.py .
 COPY docker/mcp-servers-source/conport/integration_bridge_client.py .
 COPY docker/mcp-servers-source/conport/conport_mcp_stdio.py .
+COPY docker/mcp-servers-source/conport/conport_migration_gate.py .
 COPY docker/mcp-servers-source/conport/schema.sql .
+COPY docker/mcp-servers-source/conport/migrations ./migrations
 COPY docker/mcp-servers-source/conport/info_server.py .
 COPY docker/mcp-servers-source/conport/start_with_info.sh .
 

--- a/docker/mcp-servers-source/conport/conport_migration_gate.py
+++ b/docker/mcp-servers-source/conport/conport_migration_gate.py
@@ -44,6 +44,12 @@ class SchemaChecks:
     views: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class LedgerSnapshot:
+    format: str
+    rows: dict[str, dict]
+
+
 def normalize_database_url(raw_url: str) -> str:
     if raw_url.startswith("postgresql+asyncpg://"):
         return "postgresql://" + raw_url.removeprefix("postgresql+asyncpg://")
@@ -154,15 +160,56 @@ async def ensure_ledger(conn) -> None:
     )
 
 
-async def fetch_ledger(conn) -> dict[str, dict]:
+async def ledger_columns(conn) -> set[str]:
     rows = await conn.fetch(
-        f"""
-        SELECT name, rank, checksum, status, error
-        FROM {LEDGER_TABLE}
-        ORDER BY rank
         """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = $1
+        """,
+        LEDGER_TABLE,
     )
-    return {row["name"]: dict(row) for row in rows}
+    return {row["column_name"] for row in rows}
+
+
+async def fetch_ledger(conn) -> LedgerSnapshot:
+    columns = await ledger_columns(conn)
+    canonical_columns = {"name", "rank", "checksum", "status", "error"}
+    legacy_columns = {"version", "filename", "checksum_sha256", "success"}
+
+    if canonical_columns.issubset(columns):
+        rows = await conn.fetch(
+            f"""
+            SELECT name, rank, checksum, status, error
+            FROM {LEDGER_TABLE}
+            ORDER BY rank
+            """
+        )
+        return LedgerSnapshot("canonical", {row["name"]: dict(row) for row in rows})
+
+    if legacy_columns.issubset(columns):
+        rows = await conn.fetch(
+            f"""
+            SELECT version, filename, checksum_sha256, success
+            FROM {LEDGER_TABLE}
+            ORDER BY version
+            """
+        )
+        return LedgerSnapshot(
+            "legacy",
+            {
+                row["filename"]: {
+                    "name": row["filename"],
+                    "rank": row["version"],
+                    "checksum": row["checksum_sha256"],
+                    "status": "applied" if row["success"] else "failed",
+                    "error": None,
+                }
+                for row in rows
+            },
+        )
+
+    raise MigrationGateError("migration ledger has unsupported schema")
 
 
 async def validate_ledger(conn, migrations: Iterable[MigrationFile]) -> list[str]:
@@ -175,13 +222,13 @@ async def validate_ledger(conn, migrations: Iterable[MigrationFile]) -> list[str
         return [f"migration ledger missing: {LEDGER_TABLE}"]
 
     try:
-        rows = await fetch_ledger(conn)
+        snapshot = await fetch_ledger(conn)
     except Exception as exc:
         raise MigrationGateError("migration ledger validation failed") from exc
 
     errors: list[str] = []
     for migration in migrations:
-        row = rows.get(migration.name)
+        row = snapshot.rows.get(migration.name)
         if not row:
             errors.append(f"missing ledger row: {migration.name}")
             continue
@@ -239,9 +286,9 @@ async def apply_gate(conn, migrations: list[MigrationFile]) -> None:
     await conn.execute("SELECT pg_advisory_lock($1)", LOCK_KEY)
     try:
         await ensure_ledger(conn)
-        rows = await fetch_ledger(conn)
+        snapshot = await fetch_ledger(conn)
         for migration in migrations:
-            row = rows.get(migration.name)
+            row = snapshot.rows.get(migration.name)
             if row:
                 if row["checksum"] != migration.checksum:
                     raise MigrationGateError(f"checksum mismatch: {migration.name}")
@@ -250,6 +297,11 @@ async def apply_gate(conn, migrations: list[MigrationFile]) -> None:
                 if row["status"] != "applied":
                     raise MigrationGateError(f"ledger row is not applied: {migration.name}")
                 continue
+
+            if snapshot.format != "canonical":
+                raise MigrationGateError(
+                    "legacy migration ledger cannot be mutated by this gate"
+                )
 
             try:
                 await conn.execute(migration.sql)
@@ -277,7 +329,7 @@ async def apply_gate(conn, migrations: list[MigrationFile]) -> None:
                 migration.rank,
                 migration.checksum,
             )
-            rows[migration.name] = {
+            snapshot.rows[migration.name] = {
                 "name": migration.name,
                 "rank": migration.rank,
                 "checksum": migration.checksum,

--- a/docker/mcp-servers-source/conport/conport_migration_gate.py
+++ b/docker/mcp-servers-source/conport/conport_migration_gate.py
@@ -166,10 +166,19 @@ async def fetch_ledger(conn) -> dict[str, dict]:
 
 
 async def validate_ledger(conn, migrations: Iterable[MigrationFile]) -> list[str]:
-    if not await ledger_exists(conn):
+    try:
+        exists = await ledger_exists(conn)
+    except Exception as exc:
+        raise MigrationGateError("migration ledger validation failed") from exc
+
+    if not exists:
         return [f"migration ledger missing: {LEDGER_TABLE}"]
 
-    rows = await fetch_ledger(conn)
+    try:
+        rows = await fetch_ledger(conn)
+    except Exception as exc:
+        raise MigrationGateError("migration ledger validation failed") from exc
+
     errors: list[str] = []
     for migration in migrations:
         row = rows.get(migration.name)

--- a/docker/mcp-servers-source/conport/conport_migration_gate.py
+++ b/docker/mcp-servers-source/conport/conport_migration_gate.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Operator-run ConPort migration verifier/apply gate."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+FOUNDATION_MIGRATIONS = (
+    "001_enhanced_decision_model.sql",
+    "002_decision_patterns_table.sql",
+    "003_multi_tenancy_foundation.sql",
+)
+
+LEDGER_TABLE = "conport_schema_migrations"
+LOCK_KEY = 2_001_003
+
+
+class MigrationGateError(RuntimeError):
+    """Raised when the migration gate must fail closed."""
+
+
+@dataclass(frozen=True)
+class MigrationFile:
+    name: str
+    path: Path
+    checksum: str
+    sql: str
+    rank: int
+
+
+@dataclass(frozen=True)
+class SchemaChecks:
+    tables: tuple[str, ...]
+    columns: dict[str, tuple[str, ...]]
+    views: tuple[str, ...]
+
+
+def normalize_database_url(raw_url: str) -> str:
+    if raw_url.startswith("postgresql+asyncpg://"):
+        return "postgresql://" + raw_url.removeprefix("postgresql+asyncpg://")
+    return raw_url
+
+
+def checksum_sql(sql: str) -> str:
+    return hashlib.sha256(sql.encode("utf-8")).hexdigest()
+
+
+def discover_foundation_migrations(migrations_dir: Path) -> list[MigrationFile]:
+    missing = [
+        name for name in FOUNDATION_MIGRATIONS if not (migrations_dir / name).is_file()
+    ]
+    if missing:
+        raise MigrationGateError(
+            "missing required migration files: " + ", ".join(sorted(missing))
+        )
+
+    migrations: list[MigrationFile] = []
+    for rank, name in enumerate(FOUNDATION_MIGRATIONS, start=1):
+        path = migrations_dir / name
+        sql = path.read_text(encoding="utf-8")
+        migrations.append(
+            MigrationFile(
+                name=name,
+                path=path,
+                checksum=checksum_sql(sql),
+                sql=sql,
+                rank=rank,
+            )
+        )
+    return migrations
+
+
+def required_schema_checks() -> SchemaChecks:
+    return SchemaChecks(
+        tables=(
+            "decision_relationships",
+            "adhd_metrics",
+            "review_reminders",
+            "decision_patterns",
+            "users",
+            "workspaces",
+            "user_workspace_access",
+        ),
+        columns={
+            "decisions": (
+                "impact_score",
+                "reversibility",
+                "alternatives_considered",
+                "success_criteria",
+                "review_date",
+                "outcome_status",
+                "outcome_notes",
+                "outcome_date",
+                "lessons_learned",
+                "cognitive_load",
+                "decision_time_minutes",
+                "energy_level",
+                "requires_followup",
+                "user_id",
+            ),
+            "progress_entries": ("user_id",),
+            "workspace_contexts": ("user_id",),
+            "session_snapshots": ("user_id",),
+            "custom_data": ("user_id",),
+        },
+        views=("recent_activity", "decisions_needing_review", "pattern_statistics"),
+    )
+
+
+def database_url_from_env() -> str:
+    raw_url = os.environ.get("POSTGRES_URL") or os.environ.get("DATABASE_URL")
+    if not raw_url:
+        raise MigrationGateError("POSTGRES_URL or DATABASE_URL is required")
+    return normalize_database_url(raw_url)
+
+
+async def connect(database_url: str):
+    try:
+        import asyncpg
+    except ImportError as exc:
+        raise MigrationGateError("asyncpg is required to run the migration gate") from exc
+    try:
+        return await asyncpg.connect(database_url)
+    except Exception as exc:
+        raise MigrationGateError("database connection failed") from exc
+
+
+async def ledger_exists(conn) -> bool:
+    result = await conn.fetchval("SELECT to_regclass($1)", LEDGER_TABLE)
+    return result == LEDGER_TABLE
+
+
+async def ensure_ledger(conn) -> None:
+    await conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {LEDGER_TABLE} (
+            name TEXT PRIMARY KEY,
+            rank INTEGER NOT NULL UNIQUE,
+            checksum TEXT NOT NULL,
+            status TEXT NOT NULL CHECK (status IN ('applied', 'failed')),
+            applied_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+            error TEXT
+        )
+        """
+    )
+
+
+async def fetch_ledger(conn) -> dict[str, dict]:
+    rows = await conn.fetch(
+        f"""
+        SELECT name, rank, checksum, status, error
+        FROM {LEDGER_TABLE}
+        ORDER BY rank
+        """
+    )
+    return {row["name"]: dict(row) for row in rows}
+
+
+async def validate_ledger(conn, migrations: Iterable[MigrationFile]) -> list[str]:
+    if not await ledger_exists(conn):
+        return [f"migration ledger missing: {LEDGER_TABLE}"]
+
+    rows = await fetch_ledger(conn)
+    errors: list[str] = []
+    for migration in migrations:
+        row = rows.get(migration.name)
+        if not row:
+            errors.append(f"missing ledger row: {migration.name}")
+            continue
+        if row["status"] != "applied":
+            errors.append(f"ledger row is not applied: {migration.name}")
+        if row["rank"] != migration.rank:
+            errors.append(f"ledger rank mismatch: {migration.name}")
+        if row["checksum"] != migration.checksum:
+            errors.append(f"checksum mismatch: {migration.name}")
+    return errors
+
+
+async def validate_schema(conn) -> list[str]:
+    checks = required_schema_checks()
+    errors: list[str] = []
+
+    for table in checks.tables:
+        exists = await conn.fetchval("SELECT to_regclass($1)", table)
+        if exists != table:
+            errors.append(f"missing table: {table}")
+
+    for table, columns in checks.columns.items():
+        existing = {
+            row["column_name"]
+            for row in await conn.fetch(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = 'public' AND table_name = $1
+                """,
+                table,
+            )
+        }
+        for column in columns:
+            if column not in existing:
+                errors.append(f"missing column: {table}.{column}")
+
+    for view in checks.views:
+        exists = await conn.fetchval("SELECT to_regclass($1)", view)
+        if exists != view:
+            errors.append(f"missing view: {view}")
+
+    return errors
+
+
+async def verify_gate(conn, migrations: list[MigrationFile]) -> None:
+    errors = []
+    errors.extend(await validate_ledger(conn, migrations))
+    errors.extend(await validate_schema(conn))
+    if errors:
+        raise MigrationGateError("migration verification failed: " + "; ".join(errors))
+
+
+async def apply_gate(conn, migrations: list[MigrationFile]) -> None:
+    await conn.execute("SELECT pg_advisory_lock($1)", LOCK_KEY)
+    try:
+        await ensure_ledger(conn)
+        rows = await fetch_ledger(conn)
+        for migration in migrations:
+            row = rows.get(migration.name)
+            if row:
+                if row["checksum"] != migration.checksum:
+                    raise MigrationGateError(f"checksum mismatch: {migration.name}")
+                if row["rank"] != migration.rank:
+                    raise MigrationGateError(f"ledger rank mismatch: {migration.name}")
+                if row["status"] != "applied":
+                    raise MigrationGateError(f"ledger row is not applied: {migration.name}")
+                continue
+
+            try:
+                await conn.execute(migration.sql)
+            except Exception as exc:  # pragma: no cover - exercised against live DB
+                await conn.execute(
+                    f"""
+                    INSERT INTO {LEDGER_TABLE} (name, rank, checksum, status, error)
+                    VALUES ($1, $2, $3, 'failed', $4)
+                    ON CONFLICT (name) DO UPDATE
+                    SET status = 'failed', error = EXCLUDED.error
+                    """,
+                    migration.name,
+                    migration.rank,
+                    migration.checksum,
+                    str(exc),
+                )
+                raise MigrationGateError(f"migration apply failed: {migration.name}") from exc
+
+            await conn.execute(
+                f"""
+                INSERT INTO {LEDGER_TABLE} (name, rank, checksum, status)
+                VALUES ($1, $2, $3, 'applied')
+                """,
+                migration.name,
+                migration.rank,
+                migration.checksum,
+            )
+            rows[migration.name] = {
+                "name": migration.name,
+                "rank": migration.rank,
+                "checksum": migration.checksum,
+                "status": "applied",
+                "error": None,
+            }
+
+        await verify_gate(conn, migrations)
+    finally:
+        await conn.execute("SELECT pg_advisory_unlock($1)", LOCK_KEY)
+
+
+async def run(args: argparse.Namespace) -> dict:
+    migrations = discover_foundation_migrations(args.migrations_dir)
+    database_url = (
+        normalize_database_url(args.database_url)
+        if args.database_url
+        else database_url_from_env()
+    )
+    conn = await connect(database_url)
+    try:
+        if args.apply:
+            await apply_gate(conn, migrations)
+            return {"status": "applied_verified", "migrations": [m.name for m in migrations]}
+        await verify_gate(conn, migrations)
+        return {"status": "verified", "migrations": [m.name for m in migrations]}
+    finally:
+        await conn.close()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify or explicitly apply the ConPort foundation migration gate."
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Mutate the database by applying foundation migrations and recording ledger rows.",
+    )
+    parser.add_argument(
+        "--database-url",
+        help="PostgreSQL URL. Defaults to POSTGRES_URL or DATABASE_URL.",
+    )
+    parser.add_argument(
+        "--migrations-dir",
+        type=Path,
+        default=Path(__file__).resolve().parent / "migrations",
+        help="Directory containing ConPort migration SQL files.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON status.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = asyncio.run(run(args))
+    except MigrationGateError as exc:
+        if args.json:
+            print(json.dumps({"status": "failed", "error": str(exc)}, sort_keys=True))
+        else:
+            print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(result, sort_keys=True))
+    else:
+        print(result["status"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docker/mcp-servers-source/conport/tests/test_migration_gate.py
+++ b/docker/mcp-servers-source/conport/tests/test_migration_gate.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pytest
+
+from conport_migration_gate import (
+    FOUNDATION_MIGRATIONS,
+    MigrationGateError,
+    checksum_sql,
+    discover_foundation_migrations,
+    normalize_database_url,
+    required_schema_checks,
+)
+
+
+def test_normalize_database_url_accepts_asyncpg_scheme():
+    raw = "postgresql+asyncpg://user:pass@db:5432/conport"
+
+    assert normalize_database_url(raw) == "postgresql://user:pass@db:5432/conport"
+
+
+def test_discover_foundation_migrations_is_ordered_and_scoped(tmp_path):
+    for name in FOUNDATION_MIGRATIONS:
+        (tmp_path / name).write_text(f"-- {name}\n", encoding="utf-8")
+    (tmp_path / "004_unified_query_indexes.sql").write_text("-- excluded\n", encoding="utf-8")
+
+    migrations = discover_foundation_migrations(tmp_path)
+
+    assert [migration.name for migration in migrations] == list(FOUNDATION_MIGRATIONS)
+
+
+def test_discover_foundation_migrations_fails_closed_when_missing(tmp_path):
+    (tmp_path / FOUNDATION_MIGRATIONS[0]).write_text("-- present\n", encoding="utf-8")
+
+    with pytest.raises(MigrationGateError, match="missing required migration files"):
+        discover_foundation_migrations(tmp_path)
+
+
+def test_checksum_sql_changes_when_file_content_changes():
+    assert checksum_sql("SELECT 1;\n") != checksum_sql("SELECT 2;\n")
+
+
+def test_required_schema_checks_include_downstream_foundation_objects():
+    checks = required_schema_checks()
+
+    assert "decision_relationships" in checks.tables
+    assert "review_reminders" in checks.tables
+    assert "adhd_metrics" in checks.tables
+    assert "decision_patterns" in checks.tables
+    assert "users" in checks.tables
+    assert "workspaces" in checks.tables
+    assert "user_workspace_access" in checks.tables
+    assert "outcome_status" in checks.columns["decisions"]
+    assert "user_id" in checks.columns["workspace_contexts"]

--- a/docker/mcp-servers-source/conport/tests/test_migration_gate.py
+++ b/docker/mcp-servers-source/conport/tests/test_migration_gate.py
@@ -1,14 +1,17 @@
+import asyncio
 from pathlib import Path
 
 import pytest
 
 from conport_migration_gate import (
     FOUNDATION_MIGRATIONS,
+    LEDGER_TABLE,
     MigrationGateError,
     checksum_sql,
     discover_foundation_migrations,
     normalize_database_url,
     required_schema_checks,
+    verify_gate,
 )
 
 
@@ -51,3 +54,15 @@ def test_required_schema_checks_include_downstream_foundation_objects():
     assert "user_workspace_access" in checks.tables
     assert "outcome_status" in checks.columns["decisions"]
     assert "user_id" in checks.columns["workspace_contexts"]
+
+
+def test_verify_gate_fails_closed_when_ledger_shape_is_incompatible():
+    class IncompatibleLedgerConnection:
+        async def fetchval(self, *_args):
+            return LEDGER_TABLE
+
+        async def fetch(self, *_args):
+            raise RuntimeError('column "name" does not exist')
+
+    with pytest.raises(MigrationGateError, match="migration ledger validation failed"):
+        asyncio.run(verify_gate(IncompatibleLedgerConnection(), []))

--- a/docker/mcp-servers-source/conport/tests/test_migration_gate.py
+++ b/docker/mcp-servers-source/conport/tests/test_migration_gate.py
@@ -6,11 +6,14 @@ import pytest
 from conport_migration_gate import (
     FOUNDATION_MIGRATIONS,
     LEDGER_TABLE,
+    MigrationFile,
     MigrationGateError,
+    apply_gate,
     checksum_sql,
     discover_foundation_migrations,
     normalize_database_url,
     required_schema_checks,
+    validate_ledger,
     verify_gate,
 )
 
@@ -66,3 +69,104 @@ def test_verify_gate_fails_closed_when_ledger_shape_is_incompatible():
 
     with pytest.raises(MigrationGateError, match="migration ledger validation failed"):
         asyncio.run(verify_gate(IncompatibleLedgerConnection(), []))
+
+
+def test_validate_ledger_accepts_legacy_success_rows_with_matching_checksums():
+    migrations = [
+        MigrationFile(
+            name="001_enhanced_decision_model.sql",
+            path=Path("001_enhanced_decision_model.sql"),
+            checksum="abc123",
+            sql="SELECT 1;",
+            rank=1,
+        )
+    ]
+
+    class LegacyLedgerConnection:
+        async def fetchval(self, *_args):
+            return LEDGER_TABLE
+
+        async def fetch(self, query, *_args):
+            if "information_schema.columns" in query:
+                return [
+                    {"column_name": "version"},
+                    {"column_name": "filename"},
+                    {"column_name": "checksum_sha256"},
+                    {"column_name": "success"},
+                ]
+            return [
+                {
+                    "version": 1,
+                    "filename": "001_enhanced_decision_model.sql",
+                    "checksum_sha256": "abc123",
+                    "success": True,
+                }
+            ]
+
+    assert asyncio.run(validate_ledger(LegacyLedgerConnection(), migrations)) == []
+
+
+def test_validate_ledger_rejects_legacy_failed_rows():
+    migrations = [
+        MigrationFile(
+            name="001_enhanced_decision_model.sql",
+            path=Path("001_enhanced_decision_model.sql"),
+            checksum="abc123",
+            sql="SELECT 1;",
+            rank=1,
+        )
+    ]
+
+    class LegacyLedgerConnection:
+        async def fetchval(self, *_args):
+            return LEDGER_TABLE
+
+        async def fetch(self, query, *_args):
+            if "information_schema.columns" in query:
+                return [
+                    {"column_name": "version"},
+                    {"column_name": "filename"},
+                    {"column_name": "checksum_sha256"},
+                    {"column_name": "success"},
+                ]
+            return [
+                {
+                    "version": 1,
+                    "filename": "001_enhanced_decision_model.sql",
+                    "checksum_sha256": "abc123",
+                    "success": False,
+                }
+            ]
+
+    errors = asyncio.run(validate_ledger(LegacyLedgerConnection(), migrations))
+
+    assert errors == ["ledger row is not applied: 001_enhanced_decision_model.sql"]
+
+
+def test_apply_gate_refuses_to_mutate_missing_rows_in_legacy_ledger():
+    migrations = [
+        MigrationFile(
+            name="001_enhanced_decision_model.sql",
+            path=Path("001_enhanced_decision_model.sql"),
+            checksum="abc123",
+            sql="SELECT 1;",
+            rank=1,
+        )
+    ]
+
+    class LegacyLedgerConnection:
+        async def execute(self, *_args):
+            return None
+
+        async def fetch(self, query, *_args):
+            if "information_schema.columns" in query:
+                return [
+                    {"column_name": "version"},
+                    {"column_name": "filename"},
+                    {"column_name": "checksum_sha256"},
+                    {"column_name": "success"},
+                ]
+            return []
+
+    with pytest.raises(MigrationGateError, match="legacy migration ledger"):
+        asyncio.run(apply_gate(LegacyLedgerConnection(), migrations))

--- a/docs/90-adr/adr-conport-migration-foundation-gate.md
+++ b/docs/90-adr/adr-conport-migration-foundation-gate.md
@@ -1,0 +1,79 @@
+---
+id: adr-conport-migration-foundation-gate
+title: "ADR: ConPort migration foundation gate"
+type: adr
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-14'
+prelude: Records the decision to gate DMX-CONPORT-OPTIMAL on explicit migration-state proof before downstream ConPort feature packets execute.
+status: proposed
+graph_metadata:
+  node_type: ADR
+  impact: high
+  relates_to:
+    - adr-memory-trinity-authority-and-interaction-model
+---
+
+# ADR: ConPort migration foundation gate
+
+**Status:** Proposed
+**Date:** 2026-06-16
+**Decision Type:** Architecture / Migration Safety / Task Packet Sequencing
+**Scope:** ConPort, DMX-CONPORT-OPTIMAL task packets, repo load-plan artifacts
+
+## Context
+
+DMX-CONPORT-OPTIMAL contains downstream packets that depend on enhanced ConPort
+schema objects. Current source evidence does not prove those objects are applied
+by the runtime startup path:
+
+- ConPort startup calls `_ensure_schema()`.
+- `_ensure_schema()` checks only for `public.workspace_contexts` before
+  returning.
+- If the sentinel table is missing, startup applies `/app/schema.sql`.
+- The Dockerfile copies `schema.sql`, but does not copy the migrations
+  directory.
+- Enhanced objects such as `decision_relationships`, `review_reminders`,
+  `adhd_metrics`, and multi-tenancy tables live in migration files outside the
+  observed startup bootstrap.
+
+This creates a hidden prerequisite for downstream packets and weakens
+replayability.
+
+## Decision
+
+Add `DMX-CONPORT-OPTIMAL-100-migration-foundation-gate` before
+`DMX-CONPORT-OPTIMAL-101-server-bringup-smoke`.
+
+Packet 100 must prove or fail closed on:
+
+- migration file availability in the execution context,
+- deterministic migration apply or verify behavior,
+- migration ledger/checksum or equivalent drift detection,
+- rebuild-from-zero behavior,
+- partial migration handling,
+- read-only live database introspection where available,
+- PAL gate availability and review status.
+
+The repo load plan is updated so packet 100 blocks packet 101. Existing packet
+IDs and orchestrator UUID mappings remain unchanged.
+
+## Non-decision
+
+This ADR does not authorize silent migration auto-apply on normal ConPort
+startup. Any runtime migration runner must be explicit, operator-gated,
+auditable, and fail closed on drift.
+
+This ADR also does not mutate live task-orchestrator state. Synchronizing the
+already-loaded root is a separate operator action and must not be claimed from
+repo artifact changes alone.
+
+## Consequences
+
+- Packet 100 becomes the first intended execution gate for the repo load plan.
+- Schema-dependent packets must cite packet 100 proof before execution.
+- Live queue state may remain stale until a separate orchestrator sync occurs.
+- Hardening-series expansion remains deferred until migration foundation proof
+  exists.

--- a/docs/90-adr/adr-conport-migration-foundation-gate.md
+++ b/docs/90-adr/adr-conport-migration-foundation-gate.md
@@ -66,9 +66,10 @@ This ADR does not authorize silent migration auto-apply on normal ConPort
 startup. Any runtime migration runner must be explicit, operator-gated,
 auditable, and fail closed on drift.
 
-This ADR also does not mutate live task-orchestrator state. Synchronizing the
-already-loaded root is a separate operator action and must not be claimed from
-repo artifact changes alone.
+This ADR did not mutate live task-orchestrator state when authored.
+Synchronizing the already-loaded root is a separate operator action and must not
+be claimed from repo artifact changes alone. That separate sync was later
+authorized on 2026-06-16 and recorded in the load-plan artifact.
 
 ## Consequences
 

--- a/docs/ops/load-plans/load_plan-DMX-CONPORT-OPTIMAL.json
+++ b/docs/ops/load-plans/load_plan-DMX-CONPORT-OPTIMAL.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0.0",
   "series_id": "DMX-CONPORT-OPTIMAL",
-  "title": "ConPort optimal-version rebuild \u2014 Tier 1 stabilize/consolidate, Tier 2 knowledge-graph+context, Tier 3 ADHD retrospective",
-  "description": "18-packet series to rebuild ConPort to production quality. Tier 1 (101-109): stabilize server bringup, fix runtime 500s, retire dead codebases, expose missing MCP surfaces (custom_data, search), close JSON-RPC gaps, gate auto-fork side-effect, add integration tests, reconcile docs. Tier 2 (201-206): intentional product-vs-active context model, entity-relationship write API, workspace relationships traversal fix, linked progress on decisions, search delegation docs, DCP facade search re-enable. Tier 3 (301-303): decision outcome retrospective, review reminders, decision-to-decision relationships.",
-  "authority": "Task packets at task-packets/generated/DMX-CONPORT-OPTIMAL/ + plan at ~/.claude/plans/conport-is-now-top-valiant-dewdrop.md. Runtime repo truth outranks this document. Verify paths before edit.",
+  "title": "ConPort optimal-version rebuild - Tier 0 migration foundation, Tier 1 stabilize/consolidate, Tier 2 knowledge-graph+context, Tier 3 ADHD retrospective",
+  "description": "19-packet series to rebuild ConPort to production quality. Tier 0 (100): explicit migration foundation gate proving migration file availability, deterministic apply/verify behavior, drift detection, and fail-closed handling before server bringup. Tier 1 (101-109): stabilize server bringup, fix runtime 500s, retire dead codebases, expose missing MCP surfaces, close JSON-RPC gaps, gate auto-fork side-effect, add integration tests, reconcile docs. Tier 2 (201-206): intentional product-vs-active context model, entity-relationship write API, workspace relationships traversal fix, linked progress on decisions, search delegation docs, DCP facade search re-enable. Tier 3 (301-303): decision outcome retrospective, review reminders, decision-to-decision relationships.",
+  "authority": "Task packets at task-packets/generated/DMX-CONPORT-OPTIMAL/ + plan at ~/.claude/plans/conport-is-now-top-valiant-dewdrop.md. Runtime repo truth outranks this document. Verify paths before edit. Replan 2026-06-16 adds repo artifact packet 100 as a migration foundation gate; this does not mutate the already-loaded live task-orchestrator root.",
   "live_task_orchestrator_load": "LOADED",
-  "live_load_evidence": "Loaded 2026-06-14 via create_work_tree (one-shot: root + 18 children + 21 BLOCKS deps + 3 gate notes). Verified: 18 leaves (childCounts.queue=18), 21 edges confirmed via create_work_tree response, tp101 has 0 incoming deps (sole unblocked entry). All gate notes upserted (upserted=3, failed=0).",
+  "live_load_evidence": "Loaded 2026-06-14 via create_work_tree (one-shot: root + 18 children + 21 BLOCKS deps + 3 gate notes). Verified: 18 leaves (childCounts.queue=18), 21 edges confirmed via create_work_tree response, tp101 has 0 incoming deps (sole unblocked entry). All gate notes upserted (upserted=3, failed=0). NOTE: This live load evidence predates packet 100; live task-orchestrator sync for the new gate is NOT_RUN in this artifact update.",
   "offline_artifact": "CREATED",
   "loaded_at": "2026-06-14T17:17:31Z",
   "loaded": true,
@@ -30,7 +30,8 @@
     "DMX-CONPORT-OPTIMAL-206-dcp-facade-reenable-search": "21fc45ff-9afd-4360-949e-940a1003d250",
     "DMX-CONPORT-OPTIMAL-301-decision-outcome-retrospective": "4405d10f-b59a-4e3d-8baa-cf177b1cf2a8",
     "DMX-CONPORT-OPTIMAL-302-review-reminders": "d1a525c9-4396-4b58-b482-2f00f8707438",
-    "DMX-CONPORT-OPTIMAL-303-decision-to-decision-relationships": "709f17fc-fc88-4be7-b4f7-3d62c14940b2"
+    "DMX-CONPORT-OPTIMAL-303-decision-to-decision-relationships": "709f17fc-fc88-4be7-b4f7-3d62c14940b2",
+    "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate": "PENDING_LIVE_SYNC"
   },
   "workspace_id": "/Users/hue/code/dopemux-mvp",
   "generated_by": "claude-sonnet-4-6 subagent on feat/conport-optimal-series, 2026-06-14. Orchestrator MCP NOT available at generation time \u2014 root and leaf UUIDs are PENDING_LOAD. Update this file with real UUIDs after replay load.",
@@ -40,7 +41,7 @@
     "fallback_auditor": "gemini-cli"
   },
   "first_unblocked_wave": [
-    "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke"
+    "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate"
   ],
   "second_wave_after_101": [
     "DMX-CONPORT-OPTIMAL-102-route-bugfixes-500s",
@@ -53,11 +54,16 @@
   "operator_decision_gates": {
     "gate_1_leaf_201": "GATE Operator Decision 1 \u2014 context model. DEFAULT applied = Option B (add product_context column + routes/tools). Alternative = Option A (convention via custom_data). Confirm before execution.",
     "gate_2_leaf_202": "GATE Operator Decision 2 \u2014 relationship vocabulary. DEFAULT applied = upstream set {builds_upon,validates,extends,implements,depends_on,supersedes}. Alternative = current {implements,blocks,relates_to,caused_by}. Confirm before execution.",
-    "gate_root_pickup_protocol": "Execution-context / pickup protocol: each leaf is a self-contained TP at task-packets/generated/DMX-CONPORT-OPTIMAL/<id>.json. RED-LANE (contract-sensitive) packets = 102,104,105,106,107,201,202,203,301,302,303 \u2192 run risky PAL chain (analyze\u2192thinkdeep\u2192challenge\u2192planner\u2192codereview\u2192precommit) + proof bundle per AGENTS.md \u00a78. Others run minimum chain. First unblocked wave = 101, then 102/103/104/106/107/108. Decisions 3 (auth=compose-only) and 4 (session-metrics tables stay FROZEN per Memory Trinity) are defaulted; revisit before Tier 2."
+    "gate_root_pickup_protocol": "Execution-context / pickup protocol: each leaf is a self-contained TP at task-packets/generated/DMX-CONPORT-OPTIMAL/<id>.json. RED-LANE (contract-sensitive) packets = 100,102,104,105,106,107,201,202,203,301,302,303 -> run risky PAL chain (analyze->thinkdeep->challenge->planner->codereview->precommit) + proof bundle per AGENTS.md section 8. Others run minimum chain. Intended repo first unblocked wave = 100, then 101, then 102/103/104/106/107/108. Live task-orchestrator sync for packet 100 is NOT_RUN by this repo artifact update. Decisions 3 (auth=compose-only) and 4 (session-metrics tables stay FROZEN per Memory Trinity) are defaulted; revisit before Tier 2.",
+    "gate_0_leaf_100": "GATE Migration Foundation - packet 100 must prove migration file availability, deterministic apply/verify behavior, drift detection, and fail-closed handling before packet 101. Repo artifact update only; live orchestrator sync is separate and NOT_RUN."
   },
   "blocks_dag": {
-    "description": "21 BLOCKS edges. Predecessor must complete before successor. Only 101 is initially unblocked.",
+    "description": "22 BLOCKS edges. Predecessor must complete before successor. Packet 100 is the intended repo-load-plan entry gate; live task-orchestrator sync is NOT_RUN by this artifact update.",
     "edges": [
+      {
+        "predecessor": "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate",
+        "successor": "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke"
+      },
       {
         "predecessor": "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke",
         "successor": "DMX-CONPORT-OPTIMAL-102-route-bugfixes-500s"
@@ -143,18 +149,33 @@
         "successor": "DMX-CONPORT-OPTIMAL-206-dcp-facade-reenable-search"
       }
     ],
-    "edge_count": 21
+    "edge_count": 22
   },
   "nodes": [
+    {
+      "id": "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate",
+      "tier": 0,
+      "role": "queue",
+      "status": "READY_REPO_ONLY_NOT_LIVE_LOADED",
+      "redlane": true,
+      "orchestrator_uuid": "PENDING_LIVE_SYNC",
+      "objective": "Establish explicit ConPort migration foundation proof before packet 101 by verifying migration file availability, deterministic apply/verify behavior, drift detection, and fail-closed handling.",
+      "depends_on": [],
+      "blocks": [
+        "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke"
+      ]
+    },
     {
       "id": "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke",
       "tier": 1,
       "role": "queue",
-      "status": "READY",
+      "status": "READY_AFTER_PACKET_100_REPO_ONLY",
       "redlane": false,
       "orchestrator_uuid": "4983abdb-0891-491b-acbb-22500fdb8872",
-      "objective": "Bring the ConPort service up via docker compose and verify REST health endpoint and SSE wrapper reachability.",
-      "depends_on": [],
+      "objective": "Bring the ConPort service up via docker compose and verify REST health endpoint and SSE wrapper reachability. This packet is gated by packet 100 migration foundation proof.",
+      "depends_on": [
+        "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate"
+      ],
       "blocks": [
         "DMX-CONPORT-OPTIMAL-102-route-bugfixes-500s",
         "DMX-CONPORT-OPTIMAL-103-retire-dead-codebases",
@@ -420,13 +441,33 @@
   ],
   "verification": {
     "status": "PASS",
-    "verified_at": "2026-06-14T17:17:31Z",
-    "leaf_count": 18,
-    "edge_count": 21,
-    "unblocked_count": 1,
-    "first_unblocked": "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke",
-    "first_unblocked_uuid": "4983abdb-0891-491b-acbb-22500fdb8872",
-    "evidence": "query_items overview on root 44452f53 returned childCounts.queue=18. create_work_tree response listed all 21 BLOCKS edges. query_dependencies on tp101 confirmed 0 incoming edges (sole unblocked entry). gate notes upserted=3 failed=0."
+    "verified_at": "2026-06-16",
+    "node_count": 19,
+    "edge_count": 22,
+    "first_unblocked_repo_artifact": "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate",
+    "live_task_orchestrator_sync": "NOT_RUN",
+    "checks": [
+      "Packet 100 exists in task-packets/generated/DMX-CONPORT-OPTIMAL/.",
+      "Packet 100 blocks packet 101 in blocks_dag.edges.",
+      "Existing packet IDs remain unchanged.",
+      "Existing orchestrator UUID mappings remain unchanged.",
+      "Packet 100 orchestrator UUID is PENDING_LIVE_SYNC until a separate live sync occurs."
+    ]
   },
-  "replay_instructions": "1) Ensure task-orchestrator MCP is connected (one HTTP singleton, not stdio). 2) create_work_tree with title='DMX-CONPORT-OPTIMAL' and description from nodes. 3) manage_items(operation=create) for each of the 18 nodes with role=queue. 4) manage_dependencies for all 21 edges. 5) manage_notes for gate briefs on 201, 202, and root. 6) Update this file with real orchestrator UUIDs. 7) query_items + query_dependencies to confirm 18 leaves and 21 edges."
+  "replay_instructions": "1) Ensure task-orchestrator MCP is connected (one HTTP singleton, not stdio). 2) For a fresh replay, create_work_tree with title='DMX-CONPORT-OPTIMAL' and description from nodes. 3) manage_items(operation=create) for each of the 19 nodes with role=queue. 4) manage_dependencies for all 22 edges, including packet 100 blocking packet 101. 5) manage_notes for gate briefs on 100, 201, 202, and root. 6) Update this file with real orchestrator UUIDs, replacing PENDING_LIVE_SYNC for packet 100. 7) query_items + query_dependencies to confirm 19 leaves and 22 edges. For the already-loaded root 44452f53, this repo artifact does not perform live graph mutation; sync is a separate operator action.",
+  "repo_replan_status": "REPO_ARTIFACT_REPLANNED_WITH_PACKET_100; LIVE_TASK_ORCHESTRATOR_SYNC_NOT_RUN",
+  "second_wave_after_100": [
+    "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke"
+  ],
+  "node_count": 19,
+  "live_load_verification_before_replan": {
+    "status": "PASS",
+    "first_unblocked_uuid": "4983abdb-0891-491b-acbb-22500fdb8872",
+    "verified_at": "2026-06-14T17:17:31Z",
+    "edge_count": 21,
+    "first_unblocked": "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke",
+    "evidence": "query_items overview on root 44452f53 returned childCounts.queue=18. create_work_tree response listed all 21 BLOCKS edges. query_dependencies on tp101 confirmed 0 incoming edges (sole unblocked entry). gate notes upserted=3 failed=0.",
+    "unblocked_count": 1,
+    "leaf_count": 18
+  }
 }

--- a/docs/ops/load-plans/load_plan-DMX-CONPORT-OPTIMAL.json
+++ b/docs/ops/load-plans/load_plan-DMX-CONPORT-OPTIMAL.json
@@ -3,9 +3,9 @@
   "series_id": "DMX-CONPORT-OPTIMAL",
   "title": "ConPort optimal-version rebuild - Tier 0 migration foundation, Tier 1 stabilize/consolidate, Tier 2 knowledge-graph+context, Tier 3 ADHD retrospective",
   "description": "19-packet series to rebuild ConPort to production quality. Tier 0 (100): explicit migration foundation gate proving migration file availability, deterministic apply/verify behavior, drift detection, and fail-closed handling before server bringup. Tier 1 (101-109): stabilize server bringup, fix runtime 500s, retire dead codebases, expose missing MCP surfaces, close JSON-RPC gaps, gate auto-fork side-effect, add integration tests, reconcile docs. Tier 2 (201-206): intentional product-vs-active context model, entity-relationship write API, workspace relationships traversal fix, linked progress on decisions, search delegation docs, DCP facade search re-enable. Tier 3 (301-303): decision outcome retrospective, review reminders, decision-to-decision relationships.",
-  "authority": "Task packets at task-packets/generated/DMX-CONPORT-OPTIMAL/ + plan at ~/.claude/plans/conport-is-now-top-valiant-dewdrop.md. Runtime repo truth outranks this document. Verify paths before edit. Replan 2026-06-16 adds repo artifact packet 100 as a migration foundation gate; this does not mutate the already-loaded live task-orchestrator root.",
+  "authority": "Task packets at task-packets/generated/DMX-CONPORT-OPTIMAL/ + plan at ~/.claude/plans/conport-is-now-top-valiant-dewdrop.md. Runtime repo truth outranks this document. Verify paths before edit. Replan 2026-06-16 adds repo artifact packet 100 as a migration foundation gate; initial repo commit did not mutate the live root; separate user-authorized sync on 2026-06-16 created packet 100 and live reconciliation dependencies.",
   "live_task_orchestrator_load": "LOADED",
-  "live_load_evidence": "Loaded 2026-06-14 via create_work_tree (one-shot: root + 18 children + 21 BLOCKS deps + 3 gate notes). Verified: 18 leaves (childCounts.queue=18), 21 edges confirmed via create_work_tree response, tp101 has 0 incoming deps (sole unblocked entry). All gate notes upserted (upserted=3, failed=0). NOTE: This live load evidence predates packet 100; live task-orchestrator sync for the new gate is NOT_RUN in this artifact update.",
+  "live_load_evidence": "Loaded 2026-06-14 via create_work_tree (one-shot: root + 18 children + 21 BLOCKS deps + 3 gate notes). Verified: 18 leaves (childCounts.queue=18), 21 edges confirmed via create_work_tree response, tp101 has 0 incoming deps (sole unblocked entry). All gate notes upserted (upserted=3, failed=0). NOTE: This live load evidence predates packet 100; live task-orchestrator sync for the new gate is NOT_RUN in this artifact update. Separate sync 2026-06-16 created packet 100 as dcf66b56-8fbf-426f-a6d6-826f0caa5822 and 18 live BLOCKS dependencies from packet 100 to packet 101 plus current non-terminal descendants.",
   "offline_artifact": "CREATED",
   "loaded_at": "2026-06-14T17:17:31Z",
   "loaded": true,
@@ -31,7 +31,7 @@
     "DMX-CONPORT-OPTIMAL-301-decision-outcome-retrospective": "4405d10f-b59a-4e3d-8baa-cf177b1cf2a8",
     "DMX-CONPORT-OPTIMAL-302-review-reminders": "d1a525c9-4396-4b58-b482-2f00f8707438",
     "DMX-CONPORT-OPTIMAL-303-decision-to-decision-relationships": "709f17fc-fc88-4be7-b4f7-3d62c14940b2",
-    "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate": "PENDING_LIVE_SYNC"
+    "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate": "dcf66b56-8fbf-426f-a6d6-826f0caa5822"
   },
   "workspace_id": "/Users/hue/code/dopemux-mvp",
   "generated_by": "claude-sonnet-4-6 subagent on feat/conport-optimal-series, 2026-06-14. Orchestrator MCP NOT available at generation time \u2014 root and leaf UUIDs are PENDING_LOAD. Update this file with real UUIDs after replay load.",
@@ -156,9 +156,9 @@
       "id": "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate",
       "tier": 0,
       "role": "queue",
-      "status": "READY_REPO_ONLY_NOT_LIVE_LOADED",
+      "status": "LIVE_SYNCED_QUEUE",
       "redlane": true,
-      "orchestrator_uuid": "PENDING_LIVE_SYNC",
+      "orchestrator_uuid": "dcf66b56-8fbf-426f-a6d6-826f0caa5822",
       "objective": "Establish explicit ConPort migration foundation proof before packet 101 by verifying migration file availability, deterministic apply/verify behavior, drift detection, and fail-closed handling.",
       "depends_on": [],
       "blocks": [
@@ -445,17 +445,18 @@
     "node_count": 19,
     "edge_count": 22,
     "first_unblocked_repo_artifact": "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate",
-    "live_task_orchestrator_sync": "NOT_RUN",
+    "live_task_orchestrator_sync": "PASS",
     "checks": [
       "Packet 100 exists in task-packets/generated/DMX-CONPORT-OPTIMAL/.",
       "Packet 100 blocks packet 101 in blocks_dag.edges.",
       "Existing packet IDs remain unchanged.",
       "Existing orchestrator UUID mappings remain unchanged.",
-      "Packet 100 orchestrator UUID is PENDING_LIVE_SYNC until a separate live sync occurs."
-    ]
+      "Packet 100 live orchestrator UUID is dcf66b56-8fbf-426f-a6d6-826f0caa5822 after separate live sync."
+    ],
+    "packet_100_live_uuid": "dcf66b56-8fbf-426f-a6d6-826f0caa5822"
   },
-  "replay_instructions": "1) Ensure task-orchestrator MCP is connected (one HTTP singleton, not stdio). 2) For a fresh replay, create_work_tree with title='DMX-CONPORT-OPTIMAL' and description from nodes. 3) manage_items(operation=create) for each of the 19 nodes with role=queue. 4) manage_dependencies for all 22 edges, including packet 100 blocking packet 101. 5) manage_notes for gate briefs on 100, 201, 202, and root. 6) Update this file with real orchestrator UUIDs, replacing PENDING_LIVE_SYNC for packet 100. 7) query_items + query_dependencies to confirm 19 leaves and 22 edges. For the already-loaded root 44452f53, this repo artifact does not perform live graph mutation; sync is a separate operator action.",
-  "repo_replan_status": "REPO_ARTIFACT_REPLANNED_WITH_PACKET_100; LIVE_TASK_ORCHESTRATOR_SYNC_NOT_RUN",
+  "replay_instructions": "1) Ensure task-orchestrator MCP is connected (one HTTP singleton, not stdio). 2) For a fresh replay, create_work_tree with title='DMX-CONPORT-OPTIMAL' and description from nodes. 3) manage_items(operation=create) for each of the 19 nodes with role=queue. 4) manage_dependencies for all 22 edges, including packet 100 blocking packet 101. 5) manage_notes for gate briefs on 100, 201, 202, and root. 6) Update this file with real orchestrator UUIDs, using the live packet 100 UUID only when documenting the current root, or a fresh UUID for a fresh replay. 7) query_items + query_dependencies to confirm 19 leaves and 22 edges. For the already-loaded root 44452f53, this repo artifact does not perform live graph mutation; sync is a separate operator action.",
+  "repo_replan_status": "REPO_ARTIFACT_REPLANNED_WITH_PACKET_100; LIVE_TASK_ORCHESTRATOR_SYNC_APPLIED_2026-06-16",
   "second_wave_after_100": [
     "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke"
   ],
@@ -469,5 +470,17 @@
     "evidence": "query_items overview on root 44452f53 returned childCounts.queue=18. create_work_tree response listed all 21 BLOCKS edges. query_dependencies on tp101 confirmed 0 incoming edges (sole unblocked entry). gate notes upserted=3 failed=0.",
     "unblocked_count": 1,
     "leaf_count": 18
+  },
+  "live_sync_2026_06_16": {
+    "status": "PASS",
+    "root_id": "44452f53-615d-4519-b21a-4a9cbc8774a4",
+    "packet_100_id": "dcf66b56-8fbf-426f-a6d6-826f0caa5822",
+    "repo_commit_basis": "b345e0ffc5fbb1fbc41f6e905e82e0995d3410c4",
+    "created_items": 1,
+    "created_dependencies": 18,
+    "created_notes": 2,
+    "reason_for_extra_live_edges": "Live packet 101 was already terminal and packet 102 was already review, so a literal 100->101 edge would not enforce the gate. Packet 100 was also wired directly to current non-terminal descendants as live-state reconciliation.",
+    "repo_replay_graph": "Fresh repo replay remains 19 nodes / 22 edges with packet 100 blocking packet 101.",
+    "live_reconciliation_edges": "Packet 100 blocks packet 101 and all current non-terminal DMX-CONPORT-OPTIMAL descendants observed at sync time."
   }
 }

--- a/proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/proof.md
+++ b/proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/proof.md
@@ -1,0 +1,161 @@
+---
+id: proof-dmx-conport-optimal-100-migration-foundation-gate
+title: "DMX-CONPORT-OPTIMAL-100 migration foundation gate proof"
+type: proof
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-06-16'
+last_review: '2026-06-16'
+next_review: '2026-09-14'
+prelude: Proof bundle for live packet 100 execution. The gate fails closed because migration application and enhanced schema state are not proven.
+---
+
+# DMX-CONPORT-OPTIMAL-100 migration foundation gate proof
+
+## Result
+
+**FAIL-CLOSED / BLOCKED.**
+
+Packet 100 must not be completed yet. Current evidence does not prove ConPort
+migration foundation readiness:
+
+- The Dockerfile copies `schema.sql` but does not copy the `migrations/`
+  directory.
+- `_ensure_schema()` checks only for `public.workspace_contexts` and applies
+  only `/app/schema.sql`.
+- `schema.sql` lacks enhanced migration objects such as
+  `decision_relationships`.
+- Migration files define the enhanced objects, but no deterministic live apply
+  path or ledger/checksum verifier is proven.
+- Live DB introspection shows `ag_catalog` and baseline public tables, but the
+  inspected enhanced migration tables are absent.
+
+## Live item
+
+- Root: `44452f53-615d-4519-b21a-4a9cbc8774a4`
+- Packet 100: `dcf66b56-8fbf-426f-a6d6-826f0caa5822`
+- Role before execution: `queue`
+- Role after start: `work`
+- Final action: block/fail-closed, not complete
+
+## Source evidence
+
+Dockerfile copies ConPort runtime files and `schema.sql`:
+
+```text
+29 # Copy the enhanced server with PostgreSQL + Redis persistence (relative to root)
+30 COPY docker/mcp-servers-source/conport/server.py .
+31 COPY docker/mcp-servers-source/conport/enhanced_server.py .
+32 COPY docker/mcp-servers-source/conport/instance_detector.py .
+33 COPY docker/mcp-servers-source/conport/integration_bridge_client.py .
+34 COPY docker/mcp-servers-source/conport/conport_mcp_stdio.py .
+35 COPY docker/mcp-servers-source/conport/schema.sql .
+36 COPY docker/mcp-servers-source/conport/info_server.py .
+37 COPY docker/mcp-servers-source/conport/start_with_info.sh .
+```
+
+No `COPY docker/mcp-servers-source/conport/migrations` line is present.
+
+`_ensure_schema()` uses `workspace_contexts` as the readiness sentinel and
+applies `/app/schema.sql` only:
+
+```text
+408 async def _ensure_schema(self) -> None:
+409     """Ensure required tables exist; apply schema.sql via psql if missing."""
+413     SELECT 1 FROM information_schema.tables
+414     WHERE table_schema = 'public' AND table_name = 'workspace_contexts'
+418 if exists:
+419     logger.info("Database schema present (workspace_contexts found)")
+420     return
+422 logger.info("Database schema missing - applying /app/schema.sql")
+435 # Apply schema using psql with ON_ERROR_STOP
+449 "/app/schema.sql",
+```
+
+Structured source checks:
+
+```text
+Dockerfile copies schema.sql: True
+Dockerfile copies migrations directory: False
+_ensure_schema checks workspace_contexts sentinel: True
+_ensure_schema applies /app/schema.sql: True
+schema.sql has decision_relationships: False
+migration001 has decision_relationships: True
+migration001 has review_reminders: True
+migration003 has user_workspace_access: True
+```
+
+## Live DB evidence
+
+Read-only metadata introspection was run through in-container `psql`.
+
+Observed schemas/tables include:
+
+```text
+ag_catalog.ag_graph
+ag_catalog.ag_label
+public.custom_data
+public.decisions
+public.entity_relationships
+public.progress_entries
+public.search_cache
+public.session_snapshots
+public.workspace_contexts
+```
+
+`ag_catalog` exists.
+
+Observed ConPort baseline columns include `decisions.id` as `uuid` and
+`entity_relationships.source_id` / `target_id` as `uuid`.
+
+The inspected output did not include these enhanced migration tables:
+
+```text
+decision_relationships
+review_reminders
+adhd_metrics
+decision_patterns
+users
+workspaces
+user_workspace_access
+```
+
+`entity_relationships` constraints in the inspected set are primary key,
+not-null checks, and `entity_relationships_strength_check`; no FK or
+relationship-type vocabulary CHECK was observed.
+
+## PAL evidence
+
+PAL analyze:
+
+- Identified missing migration runner/ledger and absent enhanced live schema as
+  a high-severity reason not to complete packet 100.
+
+PAL thinkdeep:
+
+- Confirmed packet 100 should be blocked/fail-closed.
+- Recommended proof include Dockerfile copy evidence, `_ensure_schema()`
+  behavior, schema-vs-migration object split, live DB introspection, and
+  concrete unblock criteria.
+
+## Blocker
+
+Packet 100 cannot be completed until ConPort has a deterministic migration
+foundation:
+
+- migrations are available in the execution/runtime context,
+- migrations are applied or verified in a deterministic order,
+- migration state has ledger/checksum or equivalent drift detection,
+- live DB enhanced objects exist or the verifier fails closed,
+- partial migration and drift behavior are documented and tested.
+
+## Minimal unblock criteria
+
+One of these must be implemented and proven:
+
+- Preferred: copy `migrations/` into the image and add an explicit,
+  operator-gated migration runner/verifier with ledger/checksum drift detection.
+- Alternative: fold required migration SQL into the bootstrap path so
+  `schema.sql` matches the runtime expectations, with explicit drift checks.
+
+Until then, downstream DMX-CONPORT-OPTIMAL work remains blocked by packet 100.

--- a/proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/proof.md
+++ b/proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/proof.md
@@ -14,7 +14,7 @@ prelude: Proof bundle for live packet 100 execution and repo-side migration gate
 
 ## Result
 
-**REPO-SIDE GATE IMPLEMENTED / LIVE APPLY NOT_RUN.**
+**REPO-SIDE GATE IMPLEMENTED / LIVE VERIFY PASS / LIVE APPLY NOT_RUN.**
 
 Packet 100 originally failed closed because evidence did not prove ConPort
 migration foundation readiness:
@@ -209,6 +209,12 @@ run and verified:
 - rerun verify and confirm ledger/checksum/schema state,
 - update live task-orchestrator packet 100 proof and status.
 
+Current 2026-06-17 continuation status: the live database path has now been
+verified in read-only mode through the legacy ledger compatibility path. Live
+`--apply` remains NOT_RUN because the live legacy ledger and foundation schema
+already verify. Remaining packet finality depends on task-orchestrator packet
+progression and PR/merge policy, not on a required live schema mutation.
+
 ## Continuation evidence 2026-06-17
 
 Task-orchestrator remains unavailable from this Codex session:
@@ -261,6 +267,60 @@ Live `--apply` remains NOT_RUN. Because the live ledger exists with an
 incompatible schema, applying is not just an ordinary missing-ledger case and
 requires explicit operator approval plus a ledger compatibility decision.
 
+## Ledger compatibility evidence 2026-06-17
+
+Read-only live introspection showed the existing ledger is a legacy successful
+ledger, not an empty or failed ledger. The live ledger columns are:
+
+```text
+version
+filename
+checksum_sha256
+applied_at
+execution_seconds
+success
+```
+
+Observed successful foundation ledger rows:
+
+```text
+1 001_enhanced_decision_model.sql f90baa9ffa40a1f10394381dfd0332c8d7b9779cfae8b472e5867921adb73666 success=true
+2 002_decision_patterns_table.sql 8c9c9988d2799e279fa19b1263b1d72809eea87ce0321813041ddfecc329ec57 success=true
+3 003_multi_tenancy_foundation.sql a4dbd6a53838fcc8b8cae88304d40a3c0ca21dfe6143b0f661452735e49c16a6 success=true
+```
+
+Those checksums match the committed migration files. Read-only object checks
+also found the required foundation tables and views:
+
+```text
+decision_relationships
+adhd_metrics
+review_reminders
+decision_patterns
+users
+workspaces
+user_workspace_access
+recent_activity
+decisions_needing_review
+pattern_statistics
+```
+
+The gate now supports both:
+
+- canonical gate ledger rows: `name`, `rank`, `checksum`, `status`, `error`
+- legacy live ledger rows: `version`, `filename`, `checksum_sha256`, `success`
+
+Legacy ledger support is read/verify compatible only. If a required migration
+row is missing from a legacy ledger, `--apply` fails closed rather than writing
+canonical rows into a legacy ledger shape.
+
+After this compatibility fix, live verify-only execution against the running
+`mcp-conport` container returned:
+
+```json
+{"migrations": ["001_enhanced_decision_model.sql", "002_decision_patterns_table.sql", "003_multi_tenancy_foundation.sql"], "status": "verified"}
+```
+
 ## Validation
 
 PASS:
@@ -269,11 +329,14 @@ PASS:
 - `python3 -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
 - `PYTHONPATH=docker/mcp-servers-source/conport python3 -m pytest docker/mcp-servers-source/conport/tests/test_migration_gate.py -q`
   - 2026-06-17 continuation: `6 passed`
+  - 2026-06-17 ledger compatibility continuation: `9 passed`
 - `python3 -m py_compile docker/mcp-servers-source/conport/conport_migration_gate.py`
 - `python3 docker/mcp-servers-source/conport/conport_migration_gate.py --help >/dev/null`
 - source evidence check confirmed Dockerfile copies gate and migrations and the
   gate contains ledger and advisory lock code
 - `git diff --check`
+- Live verify-only execution against running `mcp-conport` returned exit code 0
+  with `{"migrations": ["001_enhanced_decision_model.sql", "002_decision_patterns_table.sql", "003_multi_tenancy_foundation.sql"], "status": "verified"}`.
 
 FAIL:
 
@@ -288,6 +351,8 @@ FAIL:
 NOT_RUN:
 
 - Live DB `--apply`: requires explicit operator approval for schema mutation.
+  The 2026-06-17 compatibility continuation did not require mutation because
+  the live legacy ledger and schema verified read-only.
 - Live task-orchestrator packet completion/update: task-orchestrator transport
   was unavailable during this pass.
 - Continuation PAL codereview/precommit: PAL transport was unavailable during

--- a/proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/proof.md
+++ b/proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/proof.md
@@ -209,6 +209,58 @@ run and verified:
 - rerun verify and confirm ledger/checksum/schema state,
 - update live task-orchestrator packet 100 proof and status.
 
+## Continuation evidence 2026-06-17
+
+Task-orchestrator remains unavailable from this Codex session:
+
+```text
+get_context(dcf66b56-8fbf-426f-a6d6-826f0caa5822) -> Transport closed
+get_next_status(dcf66b56-8fbf-426f-a6d6-826f0caa5822) -> Transport closed
+get_blocked_items(includeDetails=true, includeAncestors=true) -> Transport closed
+```
+
+PAL also remains unavailable from this Codex session:
+
+```text
+pal/listmodels -> Transport closed
+```
+
+Live ConPort verify was attempted in read-only mode only. The host environment
+did not expose `POSTGRES_URL` or `DATABASE_URL`, so the committed gate code was
+streamed into the running `mcp-conport` container and allowed to read the
+container-local database environment without printing credentials:
+
+```text
+docker exec -i -w /app mcp-conport python - --json --migrations-dir /app/migrations < docker/mcp-servers-source/conport/conport_migration_gate.py
+```
+
+Observed container packaging state:
+
+```text
+/app/conport_migration_gate.py: missing
+/app/migrations: present
+POSTGRES_URL: SET
+DATABASE_URL: SET
+```
+
+The first verify attempt reproduced a gate bug: the live database already has
+`public.conport_schema_migrations`, but with columns `version`, `filename`,
+`checksum_sha256`, `applied_at`, `execution_seconds`, and `success`. The gate
+expected `name`, `rank`, `checksum`, `status`, and `error`, so it raised an
+uncaught `UndefinedColumnError` while reading the ledger.
+
+The gate was hardened to treat incompatible ledger shape as fail-closed
+verification failure. After the fix, the same read-only live verify command
+returned:
+
+```json
+{"error": "migration ledger validation failed", "status": "failed"}
+```
+
+Live `--apply` remains NOT_RUN. Because the live ledger exists with an
+incompatible schema, applying is not just an ordinary missing-ledger case and
+requires explicit operator approval plus a ledger compatibility decision.
+
 ## Validation
 
 PASS:
@@ -216,6 +268,7 @@ PASS:
 - `python3 -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json >/dev/null`
 - `python3 -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
 - `PYTHONPATH=docker/mcp-servers-source/conport python3 -m pytest docker/mcp-servers-source/conport/tests/test_migration_gate.py -q`
+  - 2026-06-17 continuation: `6 passed`
 - `python3 -m py_compile docker/mcp-servers-source/conport/conport_migration_gate.py`
 - `python3 docker/mcp-servers-source/conport/conport_migration_gate.py --help >/dev/null`
 - source evidence check confirmed Dockerfile copies gate and migrations and the
@@ -227,9 +280,15 @@ FAIL:
 - `python3 docker/mcp-servers-source/conport/conport_migration_gate.py --json`
   returned exit code 1 with `{"error": "POSTGRES_URL or DATABASE_URL is required", "status": "failed"}`.
   This is expected fail-closed behavior when no DB URL is supplied.
+- Live verify-only execution against running `mcp-conport` returned exit code 1
+  with `{"error": "migration ledger validation failed", "status": "failed"}`.
+  This is expected fail-closed behavior for the observed incompatible live
+  ledger schema.
 
 NOT_RUN:
 
 - Live DB `--apply`: requires explicit operator approval for schema mutation.
 - Live task-orchestrator packet completion/update: task-orchestrator transport
   was unavailable during this pass.
+- Continuation PAL codereview/precommit: PAL transport was unavailable during
+  this pass.

--- a/proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/proof.md
+++ b/proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/proof.md
@@ -5,18 +5,18 @@ type: proof
 owner: '@hu3mann'
 author: '@codex'
 date: '2026-06-16'
-last_review: '2026-06-16'
+last_review: '2026-06-17'
 next_review: '2026-09-14'
-prelude: Proof bundle for live packet 100 execution. The gate fails closed because migration application and enhanced schema state are not proven.
+prelude: Proof bundle for live packet 100 execution and repo-side migration gate implementation. Live apply remains operator-gated and not run.
 ---
 
 # DMX-CONPORT-OPTIMAL-100 migration foundation gate proof
 
 ## Result
 
-**FAIL-CLOSED / BLOCKED.**
+**REPO-SIDE GATE IMPLEMENTED / LIVE APPLY NOT_RUN.**
 
-Packet 100 must not be completed yet. Current evidence does not prove ConPort
+Packet 100 originally failed closed because evidence did not prove ConPort
 migration foundation readiness:
 
 - The Dockerfile copies `schema.sql` but does not copy the `migrations/`
@@ -30,6 +30,19 @@ migration foundation readiness:
 - Live DB introspection shows `ag_catalog` and baseline public tables, but the
   inspected enhanced migration tables are absent.
 
+Follow-up implementation added an explicit operator-run migration gate:
+
+- `docker/mcp-servers-source/conport/conport_migration_gate.py`
+- `docker/mcp-servers-source/conport/tests/test_migration_gate.py`
+- Dockerfile copy lines for `conport_migration_gate.py` and `migrations/`
+- Packet 100 allowlist and verification commands for the new gate and tests
+
+The gate is not wired into normal ConPort startup and does not silently apply
+migrations. Default mode is read-only verification; mutation requires
+`--apply`. Live `--apply` was not run in this pass because live DB mutation
+requires explicit operator approval and task-orchestrator transport was not
+available for final live progression.
+
 ## Live item
 
 - Root: `44452f53-615d-4519-b21a-4a9cbc8774a4`
@@ -38,7 +51,7 @@ migration foundation readiness:
 - Role after start: `work`
 - Final action: block/fail-closed, not complete
 
-## Source evidence
+## Original blocker source evidence
 
 Dockerfile copies ConPort runtime files and `schema.sql`:
 
@@ -84,6 +97,34 @@ migration001 has decision_relationships: True
 migration001 has review_reminders: True
 migration003 has user_workspace_access: True
 ```
+
+## Follow-up repo-side implementation evidence
+
+Dockerfile now copies the gate and migrations into the image build context:
+
+```text
+COPY docker/mcp-servers-source/conport/conport_migration_gate.py .
+COPY docker/mcp-servers-source/conport/migrations ./migrations
+```
+
+The migration gate implementation includes:
+
+- foundation migration scope fixed to `001_enhanced_decision_model.sql`,
+  `002_decision_patterns_table.sql`, and
+  `003_multi_tenancy_foundation.sql`,
+- SHA-256 checksum calculation for each migration file,
+- `conport_schema_migrations` ledger rows with rank, checksum, status, and
+  error text,
+- default read-only verify mode that fails if the ledger is missing,
+- explicit `--apply` mode for schema mutation,
+- PostgreSQL advisory lock during apply,
+- schema checks for downstream foundation tables, views, and columns,
+- no hard-coded database URL; `POSTGRES_URL`, `DATABASE_URL`, or
+  `--database-url` is required.
+
+Focused tests validate URL normalization, migration discovery ordering and
+scope, missing-file fail-closed behavior, checksum drift sensitivity, and
+required schema check coverage.
 
 ## Live DB evidence
 
@@ -138,24 +179,57 @@ PAL thinkdeep:
   behavior, schema-vs-migration object split, live DB introspection, and
   concrete unblock criteria.
 
+Follow-up PAL:
+
+- `pal.thinkdeep` confirmed verify mode should be no-write and fail when the
+  ledger is absent, `--apply` may create the ledger and apply known foundation
+  migrations, and startup should remain unchanged.
+- `pal.planner` produced the mutation sequence for tests, runner, Dockerfile,
+  packet metadata, proof, validation, and live apply boundary.
+- `pal.consensus` consulted three stances. Two favored new packet 100; all
+  rejected dossier-only. The dissenting stance warned that future enhanced-table
+  runtime consumers must check durable gate state to avoid enforcement drift.
+- `pal.codereview` and `pal.precommit` were invoked after edits, but the PAL
+  tools requested embedded file contents and did not provide line-specific
+  external findings. Treat those as LIMITED PAL checks, not full external
+  approval.
+- Final `pal.challenge` was invoked to attack overclaiming. The resulting proof
+  keeps live DB apply, live packet completion, and downstream unblocking as
+  NOT_RUN until operator-gated live verification succeeds.
+
 ## Blocker
 
-Packet 100 cannot be completed until ConPort has a deterministic migration
-foundation:
+The original deterministic-runner blocker is addressed in repo code, but packet
+100 still cannot be completed live until the operator-gated database path is
+run and verified:
 
-- migrations are available in the execution/runtime context,
-- migrations are applied or verified in a deterministic order,
-- migration state has ledger/checksum or equivalent drift detection,
-- live DB enhanced objects exist or the verifier fails closed,
-- partial migration and drift behavior are documented and tested.
+- run the gate in verify mode against a live ConPort database,
+- if verify fails due missing ledger/schema and operator approves mutation, run
+  `--apply`,
+- rerun verify and confirm ledger/checksum/schema state,
+- update live task-orchestrator packet 100 proof and status.
 
-## Minimal unblock criteria
+## Validation
 
-One of these must be implemented and proven:
+PASS:
 
-- Preferred: copy `migrations/` into the image and add an explicit,
-  operator-gated migration runner/verifier with ledger/checksum drift detection.
-- Alternative: fold required migration SQL into the bootstrap path so
-  `schema.sql` matches the runtime expectations, with explicit drift checks.
+- `python3 -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json >/dev/null`
+- `python3 -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `PYTHONPATH=docker/mcp-servers-source/conport python3 -m pytest docker/mcp-servers-source/conport/tests/test_migration_gate.py -q`
+- `python3 -m py_compile docker/mcp-servers-source/conport/conport_migration_gate.py`
+- `python3 docker/mcp-servers-source/conport/conport_migration_gate.py --help >/dev/null`
+- source evidence check confirmed Dockerfile copies gate and migrations and the
+  gate contains ledger and advisory lock code
+- `git diff --check`
 
-Until then, downstream DMX-CONPORT-OPTIMAL work remains blocked by packet 100.
+FAIL:
+
+- `python3 docker/mcp-servers-source/conport/conport_migration_gate.py --json`
+  returned exit code 1 with `{"error": "POSTGRES_URL or DATABASE_URL is required", "status": "failed"}`.
+  This is expected fail-closed behavior when no DB URL is supplied.
+
+NOT_RUN:
+
+- Live DB `--apply`: requires explicit operator approval for schema mutation.
+- Live task-orchestrator packet completion/update: task-orchestrator transport
+  was unavailable during this pass.

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json
@@ -1,0 +1,130 @@
+{
+  "id": "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate",
+  "project": "dopemux-mvp",
+  "target": "Establish an explicit ConPort migration foundation gate before server bringup by proving migration file availability, deterministic apply or verify behavior, drift detection, and fail-closed handling before downstream DMX-CONPORT-OPTIMAL packets execute.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must not silently auto-apply migrations during normal ConPort startup.",
+    "This packet must not mutate production data without explicit operator approval.",
+    "This packet must fail closed if migration files are unavailable in the execution context.",
+    "This packet must fail closed on missing migration ledger, checksum mismatch, partial migration, or drifted database state.",
+    "This packet must mark live database introspection as NOT_RUN if no live ConPort database is available.",
+    "This packet must run real PAL gates; if PAL is unavailable, report NOT_RUN with the exact tool error.",
+    "This packet updates repo artifacts only; it does not mutate the already-loaded task-orchestrator root."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-conport-optimal",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/conport-optimal-100-migration-foundation-gate",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(conport): add migration foundation gate",
+    "allowlist": [
+      "docker/mcp-servers-source/conport/Dockerfile",
+      "docker/mcp-servers-source/conport/enhanced_server.py",
+      "docker/mcp-servers-source/conport/schema.sql",
+      "docker/mcp-servers-source/conport/migrations/**",
+      "task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json",
+      "proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python3 - <<'PY'\nfrom pathlib import Path\nrequired = [Path('docker/mcp-servers-source/conport/Dockerfile'), Path('docker/mcp-servers-source/conport/schema.sql'), Path('docker/mcp-servers-source/conport/migrations/001_enhanced_decision_model.sql'), Path('docker/mcp-servers-source/conport/migrations/003_multi_tenancy_foundation.sql')]\nmissing = [str(p) for p in required if not p.exists()]\nprint({'missing': missing})\nraise SystemExit(1 if missing else 0)\nPY",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(conport): add migration foundation gate",
+    "body": "Adds the Tier-0 ConPort migration foundation gate for DMX-CONPORT-OPTIMAL. The packet proves migration file availability, deterministic migration apply or verification behavior, drift detection, live DB introspection where available, and fail-closed handling before packet 101 or downstream schema-dependent feature packets execute. This packet does not mutate live task-orchestrator state.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "consensus",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, clean status, and that this packet is the first intended repo-load-plan gate before packet 101.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Repo load-plan evidence is captured without claiming live task-orchestrator mutation."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docs/ops/load-plans/load_plan-DMX-CONPORT-OPTIMAL.json",
+        "task-packets/generated/DMX-CONPORT-OPTIMAL/_AUTHORING_KIT.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Run PAL analyze, thinkdeep, challenge, planner, and consensus before any runtime or schema implementation. Stop if PAL is unavailable.",
+      "validation": [
+        "PAL outputs are saved to proof.",
+        "If any PAL tool is unavailable, proof records NOT_RUN with the exact error and execution stops."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Verify ConPort Docker/image migration behavior from source. Confirm whether the Dockerfile copies schema.sql and whether it copies migrations into /app.",
+      "commands": [
+        "sed -n '1,120p' docker/mcp-servers-source/conport/Dockerfile",
+        "sed -n '408,485p' docker/mcp-servers-source/conport/enhanced_server.py"
+      ],
+      "validation": [
+        "Proof states whether migrations are present in the image build context.",
+        "Proof states that current _ensure_schema applies schema.sql only when workspace_contexts is absent, unless implementation changes this behavior."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Design or implement the deterministic migration runner/verifier. It must include ledger/checksum or equivalent drift detection, explicit operator gating, and fail-closed behavior for missing files, partial apply, checksum mismatch, and drift.",
+      "validation": [
+        "Migration runner/verifier behavior is documented with exact commands.",
+        "Silent normal-startup auto-apply is not introduced.",
+        "Rollback or recovery behavior is documented for partial migration and drift."
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Run read-only live database introspection if a live ConPort database is available. Check baseline tables, enhanced migration tables, constraints, ag_catalog availability, and migration ledger state.",
+      "validation": [
+        "Live DB introspection results are saved to proof when available.",
+        "If no live DB is available, proof records NOT_RUN and downstream schema-dependent work remains blocked."
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Run packet validation, source evidence checks, PAL codereview, PAL precommit, final PAL challenge, and precommit diff review.",
+      "validation": [
+        "TP JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Source evidence checks pass or are explicitly marked FAIL/NOT_RUN.",
+        "PAL codereview, precommit, and final challenge outputs are saved to proof.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json
@@ -34,15 +34,19 @@
     "message": "feat(conport): add migration foundation gate",
     "allowlist": [
       "docker/mcp-servers-source/conport/Dockerfile",
+      "docker/mcp-servers-source/conport/conport_migration_gate.py",
       "docker/mcp-servers-source/conport/enhanced_server.py",
       "docker/mcp-servers-source/conport/schema.sql",
       "docker/mcp-servers-source/conport/migrations/**",
+      "docker/mcp-servers-source/conport/tests/test_migration_gate.py",
       "task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json",
       "proof/conport-optimal-100-migration-foundation-gate/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate/**"
     ],
     "verify": [
       "python3 -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json >/dev/null",
       "python3 -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "PYTHONPATH=docker/mcp-servers-source/conport python3 -m pytest docker/mcp-servers-source/conport/tests/test_migration_gate.py -q",
+      "python3 docker/mcp-servers-source/conport/conport_migration_gate.py --help >/dev/null",
       "python3 - <<'PY'\nfrom pathlib import Path\nrequired = [Path('docker/mcp-servers-source/conport/Dockerfile'), Path('docker/mcp-servers-source/conport/schema.sql'), Path('docker/mcp-servers-source/conport/migrations/001_enhanced_decision_model.sql'), Path('docker/mcp-servers-source/conport/migrations/003_multi_tenancy_foundation.sql')]\nmissing = [str(p) for p in required if not p.exists()]\nprint({'missing': missing})\nraise SystemExit(1 if missing else 0)\nPY",
       "git diff --check"
     ]

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-101-server-bringup-smoke.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-101-server-bringup-smoke.json
@@ -1,15 +1,18 @@
 {
   "id": "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke",
   "project": "dopemux-mvp",
-  "target": "Bring the ConPort service up via docker compose and verify REST health endpoint and SSE wrapper reachability.",
+  "target": "Bring the ConPort service up via docker compose and verify REST health endpoint and SSE wrapper reachability. This packet is now gated by the Tier-0 ConPort migration foundation packet.",
   "invariants": [
     "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must not execute until DMX-CONPORT-OPTIMAL-100-migration-foundation-gate has recorded migration foundation proof or an explicit NOT_RUN blocker for unavailable live DB introspection.",
     "This packet must not modify production data or workspace state.",
     "This packet must not alter schema.sql or migration files.",
     "Smoke output must be captured and included in the proof bundle.",
-    "Failure to reach health endpoint is a hard FAIL — do not mark PASS with inference."
+    "Failure to reach health endpoint is a hard FAIL \u2014 do not mark PASS with inference."
   ],
-  "depends_on": [],
+  "depends_on": [
+    "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate"
+  ],
   "repo_binding": {
     "project_id": "dopemux-mvp",
     "repo_marker": ".dopetaskroot",
@@ -19,7 +22,7 @@
   "series": {
     "id": "dmx-conport-optimal",
     "base_branch": "origin/main",
-    "parent_tp_id": null,
+    "parent_tp_id": "DMX-CONPORT-OPTIMAL-100-migration-foundation-gate",
     "final_packet": false
   },
   "execution": {
@@ -62,7 +65,8 @@
       "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean status.",
       "validation": [
         "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
-        "Primary checkout remains untouched."
+        "Primary checkout remains untouched.",
+        "Proof references DMX-CONPORT-OPTIMAL-100-migration-foundation-gate outcome before this packet proceeds."
       ],
       "context_files": [
         "AGENTS.md",

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-108-integration-test-scaffolding.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-108-integration-test-scaffolding.json
@@ -4,12 +4,13 @@
   "target": "Create a real integration test suite for ConPort using pytest and testcontainers, covering context CRUD, decision log/get, progress lifecycle, search, and migration correctness.",
   "invariants": [
     "This packet must run from a fresh dedicated worktree based on origin/main.",
-    "Tests must use testcontainers (PostgreSQL + Redis) — no mocking of database or cache layers.",
+    "Tests must use testcontainers (PostgreSQL + Redis) \u2014 no mocking of database or cache layers.",
     "schema.sql and migrations 001-004 and 007 must be applied in test setup in order.",
-    "Tests must not depend on a running docker compose stack — testcontainers spin up isolated instances.",
-    "Target handler coverage is >60% — measure with pytest-cov and record in proof.",
-    "Do not alter production source files — this packet touches only the tests directory.",
-    "All tests must be isolated — no shared state between test functions."
+    "Tests must not depend on a running docker compose stack \u2014 testcontainers spin up isolated instances.",
+    "Target handler coverage is >60% \u2014 measure with pytest-cov and record in proof.",
+    "Do not alter production source files \u2014 this packet touches only the tests directory.",
+    "All tests must be isolated \u2014 no shared state between test functions.",
+    "Integration tests must use the migration ordering and drift expectations proven or specified by DMX-CONPORT-OPTIMAL-100-migration-foundation-gate."
   ],
   "depends_on": [
     "DMX-CONPORT-OPTIMAL-101-server-bringup-smoke"
@@ -78,7 +79,8 @@
       "validation": [
         "Migration file order confirmed: 001-004 and 007 identified by direct read.",
         "Existing test import patterns documented for consistency.",
-        "testcontainers availability confirmed (pip show testcontainers) or noted as needing install."
+        "testcontainers availability confirmed (pip show testcontainers) or noted as needing install.",
+        "Proof references DMX-CONPORT-OPTIMAL-100-migration-foundation-gate outcome before this packet proceeds."
       ]
     },
     {
@@ -107,7 +109,7 @@
       "validation": [
         "Each test file has at least 2 test functions.",
         "No test function shares state with another (no module-level mutable globals).",
-        "All assertions are concrete — no assert True without checking real values."
+        "All assertions are concrete \u2014 no assert True without checking real values."
       ]
     },
     {
@@ -117,8 +119,8 @@
         "python3 -m pytest docker/mcp-servers-source/conport/tests/integration/ -q --tb=short --cov=docker/mcp-servers-source/conport --cov-report=term-missing"
       ],
       "validation": [
-        "pytest exits 0 — all integration tests PASS.",
-        "Coverage report shows >60% handler coverage — exact percentage recorded in proof.",
+        "pytest exits 0 \u2014 all integration tests PASS.",
+        "Coverage report shows >60% handler coverage \u2014 exact percentage recorded in proof.",
         "Coverage report captured in proof bundle.",
         "Only allowlisted files staged and committed."
       ]

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-201-context-model-product-context.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-201-context-model-product-context.json
@@ -1,17 +1,18 @@
 {
   "id": "DMX-CONPORT-OPTIMAL-201-context-model-product-context",
   "project": "dopemux-mvp",
-  "target": "Give ConPort an intentional product-vs-active context model by adding a product_context column to workspace_contexts via migration 008, exposing GET/POST REST endpoints, and adding get_product_context/update_product_context MCP tools — gated on Operator Decision 1 (Option B default; Option A = convention-via-custom_data fallback with no code change).",
+  "target": "Give ConPort an intentional product-vs-active context model by adding a product_context column to workspace_contexts via migration 008, exposing GET/POST REST endpoints, and adding get_product_context/update_product_context MCP tools \u2014 gated on Operator Decision 1 (Option B default; Option A = convention-via-custom_data fallback with no code change).",
   "invariants": [
     "This packet MUST NOT execute unless Operator Decision Gate 1 is explicitly set to Option B.",
     "Option A (no-code fallback via custom_data convention) is the safe default if the operator has not confirmed Option B.",
     "This packet must not modify any table other than workspace_contexts.",
-    "Migration 008 must be additive only — no column drops, no renames, no data loss.",
+    "Migration 008 must be additive only \u2014 no column drops, no renames, no data loss.",
     "The new product_context column must be TEXT NULLABLE so existing rows are unaffected.",
     "product_context and active_context must remain independently readable and writable.",
     "All new MCP tools must be registered in both server.py and conport_mcp_stdio.py.",
     "This packet must not alter existing get_active_context or update_active_context behavior.",
-    "Classify missing operator decision as UNKNOWN; fail closed."
+    "Classify missing operator decision as UNKNOWN; fail closed.",
+    "This packet must cite DMX-CONPORT-OPTIMAL-100-migration-foundation-gate proof before relying on migration 008 or workspace_contexts schema evolution."
   ],
   "depends_on": [
     "DMX-CONPORT-OPTIMAL-109-docs-reconciliation"
@@ -53,7 +54,7 @@
     ]
   },
   "pr": {
-    "title": "feat(conport): product context model — migration 008 + REST + MCP tools",
+    "title": "feat(conport): product context model \u2014 migration 008 + REST + MCP tools",
     "body": "Implements Operator Decision Gate 1, Option B: adds product_context TEXT column to workspace_contexts via migration 008_product_context.sql, exposes GET/POST /api/context/{workspace_id}/product REST endpoints, registers get_product_context and update_product_context MCP tools in server.py and conport_mcp_stdio.py, and updates _ensure_schema for live systems. Product context round-trips independently of active context.",
     "base": "main"
   },
@@ -74,11 +75,12 @@
   "steps": [
     {
       "id": "S1",
-      "task": "Preflight: confirm Operator Decision Gate 1 is set to Option B. Read AGENTS.md, schema.sql, enhanced_server.py, server.py, conport_mcp_stdio.py, and the existing migrations 001–007 to understand current schema and MCP tool registration patterns. Record baseline commit SHA and clean worktree status in proof.",
+      "task": "Preflight: confirm Operator Decision Gate 1 is set to Option B. Read AGENTS.md, schema.sql, enhanced_server.py, server.py, conport_mcp_stdio.py, and the existing migrations 001\u2013007 to understand current schema and MCP tool registration patterns. Record baseline commit SHA and clean worktree status in proof.",
       "validation": [
         "Operator Decision 1 Option B is explicitly confirmed; if absent, abort and record UNKNOWN.",
-        "Migration numbering 001–007 is confirmed; 008 does not yet exist.",
-        "Existing get_active_context / update_active_context tool signatures are captured for non-regression reference."
+        "Migration numbering 001\u2013007 is confirmed; 008 does not yet exist.",
+        "Existing get_active_context / update_active_context tool signatures are captured for non-regression reference.",
+        "Proof references DMX-CONPORT-OPTIMAL-100-migration-foundation-gate outcome before this packet proceeds."
       ],
       "context_files": [
         "AGENTS.md",

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-202-entity-relationship-write-api.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-202-entity-relationship-write-api.json
@@ -1,16 +1,17 @@
 {
   "id": "DMX-CONPORT-OPTIMAL-202-entity-relationship-write-api",
   "project": "dopemux-mvp",
-  "target": "Make the ConPort knowledge graph real by implementing POST/GET/DELETE REST endpoints for entity_relationships, adding link_items and get_linked_items MCP tools in server.py and conport_mcp_stdio.py, and adding Redis cache invalidation for relationship keys — with relationship_type enum defaulting to builds_upon, validates, extends, implements, depends_on, supersedes (Operator Decision Gate 2 default).",
+  "target": "Make the ConPort knowledge graph real by implementing POST/GET/DELETE REST endpoints for entity_relationships, adding link_items and get_linked_items MCP tools in server.py and conport_mcp_stdio.py, and adding Redis cache invalidation for relationship keys \u2014 with relationship_type enum defaulting to builds_upon, validates, extends, implements, depends_on, supersedes (Operator Decision Gate 2 default).",
   "invariants": [
-    "This packet must not modify entity_relationships table structure — only add REST and MCP write paths to the existing table.",
+    "This packet must not modify entity_relationships table structure \u2014 only add REST and MCP write paths to the existing table.",
     "relationship_type must be validated against the Decision-2 enum: builds_upon, validates, extends, implements, depends_on, supersedes.",
     "Unknown relationship_type values must be rejected with 422, not silently accepted.",
     "DELETE must be soft-checked: return 404 if the relationship does not exist rather than silently no-op.",
     "Redis cache invalidation must target only relationship-keyed entries; it must not flush unrelated workspace keys.",
     "All new MCP tools must be registered in both server.py and conport_mcp_stdio.py.",
     "Operator Decision Gate 2 default enum is locked; do not expand or contract it without a new TP.",
-    "Classify missing or undecided operator input as UNKNOWN; fail closed."
+    "Classify missing or undecided operator input as UNKNOWN; fail closed.",
+    "This packet must cite DMX-CONPORT-OPTIMAL-100-migration-foundation-gate proof before relying on entity_relationships schema constraints or migration state."
   ],
   "depends_on": [
     "DMX-CONPORT-OPTIMAL-109-docs-reconciliation"
@@ -33,7 +34,7 @@
     "base_branch": "origin/main"
   },
   "commit": {
-    "message": "feat(conport): entity-relationship write API — POST/GET/DELETE REST + link_items/get_linked_items MCP tools",
+    "message": "feat(conport): entity-relationship write API \u2014 POST/GET/DELETE REST + link_items/get_linked_items MCP tools",
     "allowlist": [
       "docker/mcp-servers-source/conport/enhanced_server.py",
       "docker/mcp-servers-source/conport/server.py",
@@ -75,7 +76,8 @@
       "validation": [
         "entity_relationships table columns (id, workspace_id, source_id, source_type, target_id, target_type, relationship_type, metadata, created_at) are confirmed from schema.sql.",
         "Existing relationship read paths are identified and their signatures captured for non-regression reference.",
-        "Redis cache key pattern for relationships is documented in proof."
+        "Redis cache key pattern for relationships is documented in proof.",
+        "Proof references DMX-CONPORT-OPTIMAL-100-migration-foundation-gate outcome before this packet proceeds."
       ],
       "context_files": [
         "AGENTS.md",

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-301-decision-outcome-retrospective.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-301-decision-outcome-retrospective.json
@@ -8,7 +8,8 @@
     "This packet must not add a new migration if migration 001 already defines the outcome columns; verify before adding SQL.",
     "This packet must fail-closed on unknown decision_id (404) and on attempts to write immutable fields (400).",
     "This packet must classify any unresolved schema ambiguity as UNKNOWN and stop rather than guess.",
-    "This packet must not touch files outside the allowlist."
+    "This packet must not touch files outside the allowlist.",
+    "This packet must cite DMX-CONPORT-OPTIMAL-100-migration-foundation-gate proof before relying on migration 001 decision outcome columns."
   ],
   "depends_on": [
     "DMX-CONPORT-OPTIMAL-109-docs-reconciliation"
@@ -72,7 +73,8 @@
       "task": "Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker (.dopetaskroot), origin identity, branch name, and clean baseline. Read docker/mcp-servers-source/conport/schema.sql and migrations/001*.sql to confirm that outcome_status, outcome_notes, outcome_date, and lessons_learned columns already exist on the decisions table. Record findings in proof.",
       "validation": [
         "Worktree path, branch, origin, marker verified and recorded in proof.",
-        "Confirmed (or UNKNOWN) whether outcome columns exist in migration 001 — no guessing."
+        "Confirmed (or UNKNOWN) whether outcome columns exist in migration 001 \u2014 no guessing.",
+        "Proof references DMX-CONPORT-OPTIMAL-100-migration-foundation-gate outcome before this packet proceeds."
       ],
       "context_files": [
         "docker/mcp-servers-source/conport/schema.sql",
@@ -99,10 +101,10 @@
     },
     {
       "id": "S4",
-      "task": "Implement PATCH /api/decisions/{decision_id}/outcome in enhanced_server.py. Accept a JSON body with only outcome_status, outcome_notes, outcome_date, lessons_learned. Reject (400) any body that includes summary or rationale. Return 404 for unknown decision_id. Use a targeted UPDATE that names each outcome column explicitly — never a wildcard UPDATE.",
+      "task": "Implement PATCH /api/decisions/{decision_id}/outcome in enhanced_server.py. Accept a JSON body with only outcome_status, outcome_notes, outcome_date, lessons_learned. Reject (400) any body that includes summary or rationale. Return 404 for unknown decision_id. Use a targeted UPDATE that names each outcome column explicitly \u2014 never a wildcard UPDATE.",
       "validation": [
         "All four tests from S3 pass (green).",
-        "The UPDATE statement names only outcome columns — summary and rationale are not in the SET clause.",
+        "The UPDATE statement names only outcome columns \u2014 summary and rationale are not in the SET clause.",
         "No regression in existing enhanced_server.py routes (run full test suite if available)."
       ],
       "expected_files": [
@@ -128,7 +130,7 @@
       "validation": [
         "TP JSON validates with exit 0 against dopetask-canonical-spec.json.",
         "All targeted tests pass; any NOT_RUN items are recorded with reason.",
-        "Only allowlisted files are staged — git diff --staged lists no extras.",
+        "Only allowlisted files are staged \u2014 git diff --staged lists no extras.",
         "PR URL recorded in proof bundle."
       ]
     }

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-302-review-reminders.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-302-review-reminders.json
@@ -8,7 +8,8 @@
     "This packet must not modify existing decisions data or the decisions table schema.",
     "This packet must fail-closed on unknown reminder_id (404) and unknown decision_id (400/404).",
     "This packet must not touch files outside the allowlist.",
-    "This packet must classify unresolved ambiguity about table existence as UNKNOWN and stop."
+    "This packet must classify unresolved ambiguity about table existence as UNKNOWN and stop.",
+    "This packet must cite DMX-CONPORT-OPTIMAL-100-migration-foundation-gate proof before relying on review_reminders from migration 001 or adding fallback SQL."
   ],
   "depends_on": [
     "DMX-CONPORT-OPTIMAL-109-docs-reconciliation"
@@ -72,7 +73,8 @@
       "task": "Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker, origin identity, branch, and clean baseline. Inspect docker/mcp-servers-source/conport/schema.sql and all migration files under migrations/ to determine whether a review_reminders table is already defined. Record finding (EXISTS / ABSENT / UNKNOWN) in proof.",
       "validation": [
         "Worktree path, branch, origin, marker verified and recorded in proof.",
-        "Table existence classified as EXISTS, ABSENT, or UNKNOWN — not assumed."
+        "Table existence classified as EXISTS, ABSENT, or UNKNOWN \u2014 not assumed.",
+        "Proof references DMX-CONPORT-OPTIMAL-100-migration-foundation-gate outcome before this packet proceeds."
       ],
       "context_files": [
         "docker/mcp-servers-source/conport/schema.sql",

--- a/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-303-decision-to-decision-relationships.json
+++ b/task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-303-decision-to-decision-relationships.json
@@ -9,7 +9,8 @@
     "This packet must reject relationship_type values not in the allowed enum (builds_upon, supersedes, conflicts_with, validates, implements, questions) with 400.",
     "This packet must not modify existing decisions data or the entity_relationships table.",
     "This packet must not touch files outside the allowlist.",
-    "This packet must classify unresolved schema ambiguity as UNKNOWN and stop."
+    "This packet must classify unresolved schema ambiguity as UNKNOWN and stop.",
+    "This packet must cite DMX-CONPORT-OPTIMAL-100-migration-foundation-gate proof before relying on decision_relationships from migration 001 or adding fallback SQL."
   ],
   "depends_on": [
     "DMX-CONPORT-OPTIMAL-202-entity-relationship-write-api"
@@ -70,12 +71,13 @@
   "steps": [
     {
       "id": "S1",
-      "task": "Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker, origin identity, branch, and clean baseline. Inspect schema.sql and all migration files to determine whether decision_relationships is already defined. Also confirm that entity_relationships exists (it should, per DMX-CONPORT-OPTIMAL-202 dependency). Record both findings in proof. Note: do NOT attempt to merge or alias these tables — they are intentionally separate.",
+      "task": "Preflight: create a fresh dedicated worktree from origin/main. Verify repo marker, origin identity, branch, and clean baseline. Inspect schema.sql and all migration files to determine whether decision_relationships is already defined. Also confirm that entity_relationships exists (it should, per DMX-CONPORT-OPTIMAL-202 dependency). Record both findings in proof. Note: do NOT attempt to merge or alias these tables \u2014 they are intentionally separate.",
       "validation": [
         "Worktree verified and recorded in proof.",
         "decision_relationships table existence classified as EXISTS, ABSENT, or UNKNOWN.",
         "entity_relationships confirmed present (or recorded as UNKNOWN if not found).",
-        "No merger of the two tables performed or planned."
+        "No merger of the two tables performed or planned.",
+        "Proof references DMX-CONPORT-OPTIMAL-100-migration-foundation-gate outcome before this packet proceeds."
       ],
       "context_files": [
         "docker/mcp-servers-source/conport/schema.sql",
@@ -107,7 +109,7 @@
       "task": "Implement two REST routes in enhanced_server.py: POST /api/decisions/{decision_id}/relationships (body: target_decision_id required, relationship_type required from enum, notes optional) and GET /api/decisions/{decision_id}/relationships (returns all edges where decision_id is source or target, each edge includes both decision ids, type, notes, created_at). Validate relationship_type against the enum; fail-closed on invalid type, unknown ids, and duplicate edges.",
       "validation": [
         "All six tests from S3 pass (green).",
-        "relationship_type enum validation is exhaustive — unknown types return 400, not 500.",
+        "relationship_type enum validation is exhaustive \u2014 unknown types return 400, not 500.",
         "Duplicate edge returns 409 (not a silent no-op).",
         "No regression in other enhanced_server.py routes."
       ],


### PR DESCRIPTION
## Summary
- adds the ConPort packet 100 migration gate branch changes
- hardens the gate so an incompatible existing migration ledger fails closed as structured JSON instead of raising an uncaught traceback
- records live verify evidence and remaining packet blockers in the packet proof bundle

## Validation
- `python3 -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json >/dev/null`
- `python3 -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-100-migration-foundation-gate.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `PYTHONPATH=docker/mcp-servers-source/conport python3 -m pytest docker/mcp-servers-source/conport/tests/test_migration_gate.py -q` -> 6 passed
- `python3 -m py_compile docker/mcp-servers-source/conport/conport_migration_gate.py`
- `git diff --check`

## Live gate result
- verify-only execution against running `mcp-conport` fails closed with `{"error": "migration ledger validation failed", "status": "failed"}`
- live `--apply` was NOT_RUN; it requires explicit operator approval and a ledger compatibility decision

## NOT_RUN / blockers
- Task Orchestrator progression: `Transport closed`
- PAL codereview/precommit: `Transport closed`
- downstream ConPort packets remain blocked until packet 100 is live-verified and completed
