### PR TITLE
fix(mcp): repair dope-context and desktop-commander Docker builds (clean scope)

### DIFF
--- a/docker/mcp-servers-source/desktop-commander/requirements.txt
+++ b/docker/mcp-servers-source/desktop-commander/requirements.txt
@@ -1,4 +1,3 @@
-fastapi==0.115.2
 uvicorn[standard]==0.35.0
 pydantic==2.11.7
 fastmcp==3.4.2

--- a/services/dope-context/Dockerfile
+++ b/services/dope-context/Dockerfile
@@ -6,7 +6,8 @@ WORKDIR /app
 
 # Copy dependency manifests first for better caching
 COPY pyproject.toml .
-COPY src/dopemux/__init__.py src/dopemux/
+COPY src/ src/
+COPY tools/ tools/
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Replacement for bloated #939. Scope: 2 files only.

- services/dope-context/Dockerfile
- docker/mcp-servers-source/desktop-commander/requirements.txt

Closes scope escape in #939. Do not merge #939.