### PR TITLE
feat(pcp): Packet 3 — de-Dopemux the PCP core boundary

### DIFF
--- a/docs/ops/project-control-plane/dedopemux-boundary.md
+++ b/docs/ops/project-control-plane/dedopemux-boundary.md
@@ -1,0 +1,113 @@
+---
+id: PCP-DEDOPEMUX-BOUNDARY
+title: De-Dopemux Boundary Repair for PCP Core
+type: explanation
+owner: '@hu3mann'
+author: claude
+date: '2026-06-19'
+last_review: '2026-06-19'
+next_review: '2026-09-17'
+prelude: De-Dopemux Boundary Repair for PCP Core (explanation) for dopemux documentation
+  and developer workflows.
+---
+# De-Dopemux Boundary Repair for PCP Core
+
+## Context
+
+PCP Core is the reusable, project-agnostic parent substrate that any Git repository can
+adopt. DCP (Dopemux Control Plane) is PCP Core plus the Dopemux extension. The previous
+iteration of `project_evidence_export.schema.json` contained three boundary violations
+that embedded Dopemux-specific concepts directly into the core schema. This document
+records the four repairs applied to correct that.
+
+## Changes Applied
+
+### 1. `generated_from_fixture` Relaxed
+
+**Before:** `"const": true` — hard-coded the exporter to always claim it ran from a
+fixture. This trapped every export in fixture mode and made the field useless for
+distinguishing real runtime exports from fixture-shaped ones.
+
+**After:** `"type": "boolean", "default": false` — the field is now an honest boolean.
+Fixture runs set it to `true`; real runtime exports leave it `false` (the default). The
+schema no longer mandates a particular value.
+
+### 2. Dopemux Extension Schemas Moved to `schemas/dcp_extension/`
+
+Two schemas that model Dopemux-specific concepts were living inside the PCP Core schema
+directory and therefore implied they were part of PCP Core:
+
+- `schemas/project_control_plane/dopetask_packet_mapping.schema.json`
+- `schemas/project_control_plane/orchestrator_item.schema.json`
+
+Both have been moved to `schemas/dcp_extension/`. Their `$id` URIs reflect the new
+location (`https://dopemux.dev/schemas/dcp_extension/…`). The PCP Core schema directory
+no longer contains Dopemux concepts.
+
+### 3. `forbidden_action_confirmation` Keys Generalized
+
+**Before:**
+
+| Old key | Meaning |
+| --- | --- |
+| `dopetask_executed` | Dopetask (Dopemux task runner) executed |
+| `live_task_orchestrator_written` | Task Orchestrator (Dopemux MCP) written |
+
+These names embedded the Dopemux system labels into the core schema's confirmation
+block, making the block meaningless for any non-Dopemux project.
+
+**After:**
+
+| New key | Meaning |
+| --- | --- |
+| `external_runner_executed` | Any external task runner executed (e.g. Dopetask in the DCP extension) |
+| `external_workflow_written` | Any external workflow system written (e.g. Task Orchestrator in the DCP extension) |
+
+The DCP extension layer maps `external_runner` → Dopetask and `external_workflow` →
+Task Orchestrator. This mapping will be formalized in Packet 5 (extension contract).
+The values remain `const: false` — these are still fail-closed attestations that no
+live writes occurred.
+
+All four instance files (`dnh_crm_fixture`, `dopemux_fixture`, `minimal_fixture`
+`evidence_export.json` and `E2E_DRY_RUN_RESULT.json`) have been updated to use the new
+key names.
+
+### 4. Runtime `head_sha` Gate Added
+
+A new `allOf` conditional enforces that any real (non-fixture) export must capture a
+real commit SHA:
+
+- When `generated_from_fixture` is `false`, `repo_state.head_sha` must be a non-null
+  string with `minLength: 1`.
+- When `generated_from_fixture` is `true` (fixture mode), `head_sha` may be any
+  string or `null` (e.g. the placeholder `"sha256:PLACEHOLDER-illustrative-not-computed"`
+  used in fixture files remains valid).
+
+This gate prevents a real exporter from accidentally emitting `null` for the SHA and
+having the export accepted as trustworthy evidence.
+
+---
+
+## Scope
+
+These are **contracts only** — schema definitions and instance files. No runtime
+exporter has been implemented. A real generic exporter that reads a live repository
+and emits a valid `project_evidence_export.v0` instance is the subject of Packet 4.
+
+Until Packet 4 ships, every real-runtime usage of this schema requires a hand-authored
+or tool-assisted instance. The fixture files in
+`reports/project-control-plane/fixtures/` serve as reference shapes.
+
+## Test Coverage
+
+`tests/project_control_plane/test_core_boundary.py` covers:
+
+- Schema meta-validates (Draft 2020-12).
+- `dopetask_packet_mapping` and `orchestrator_item` schemas exist in `schemas/dcp_extension/`
+  and meta-validate, and are absent from `schemas/project_control_plane/`.
+- A minimal real-runtime instance (generated_from_fixture=False, head_sha non-null)
+  validates with zero errors.
+- The same instance with head_sha=None is rejected by the runtime gate.
+- An instance using the old key names (`dopetask_executed`,
+  `live_task_orchestrator_written`) is rejected by `additionalProperties: false`.
+- Each of the three fixture `evidence_export.json` files validates against the schema.

--- a/reports/project-control-plane/fixtures/dnh_crm_fixture/evidence_export.json
+++ b/reports/project-control-plane/fixtures/dnh_crm_fixture/evidence_export.json
@@ -86,8 +86,8 @@
     "paths": []
   },
   "forbidden_action_confirmation": {
-    "live_task_orchestrator_written": false,
-    "dopetask_executed": false,
+    "external_workflow_written": false,
+    "external_runner_executed": false,
     "github_mutated": false,
     "runtime_written": false
   }

--- a/reports/project-control-plane/fixtures/dopemux_fixture/evidence_export.json
+++ b/reports/project-control-plane/fixtures/dopemux_fixture/evidence_export.json
@@ -81,8 +81,8 @@
     "paths": []
   },
   "forbidden_action_confirmation": {
-    "live_task_orchestrator_written": false,
-    "dopetask_executed": false,
+    "external_workflow_written": false,
+    "external_runner_executed": false,
     "github_mutated": false,
     "runtime_written": false
   }

--- a/reports/project-control-plane/fixtures/minimal_fixture/evidence_export.json
+++ b/reports/project-control-plane/fixtures/minimal_fixture/evidence_export.json
@@ -73,8 +73,8 @@
     "paths": []
   },
   "forbidden_action_confirmation": {
-    "live_task_orchestrator_written": false,
-    "dopetask_executed": false,
+    "external_workflow_written": false,
+    "external_runner_executed": false,
     "github_mutated": false,
     "runtime_written": false
   }

--- a/schemas/dcp_extension/dopetask_packet_mapping.schema.json
+++ b/schemas/dcp_extension/dopetask_packet_mapping.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://dopemux.dev/schemas/project_control_plane/dopetask_packet_mapping.schema.json",
+  "$id": "https://dopemux.dev/schemas/dcp_extension/dopetask_packet_mapping.schema.json",
   "title": "Dopetask Packet Mapping Dry Run",
   "type": "object",
   "additionalProperties": false,

--- a/schemas/dcp_extension/orchestrator_item.schema.json
+++ b/schemas/dcp_extension/orchestrator_item.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://dopemux.dev/schemas/project_control_plane/orchestrator_item.schema.json",
+  "$id": "https://dopemux.dev/schemas/dcp_extension/orchestrator_item.schema.json",
   "title": "Task Orchestrator Item Dry Run",
   "type": "object",
   "additionalProperties": false,

--- a/schemas/project_control_plane/project_evidence_export.schema.json
+++ b/schemas/project_control_plane/project_evidence_export.schema.json
@@ -31,7 +31,7 @@
     },
     "generated_from_fixture": {
       "type": "boolean",
-      "const": true
+      "default": false
     },
     "profile_ref": {
       "type": "string"
@@ -343,16 +343,16 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
-        "live_task_orchestrator_written",
-        "dopetask_executed",
+        "external_workflow_written",
+        "external_runner_executed",
         "github_mutated",
         "runtime_written"
       ],
       "properties": {
-        "live_task_orchestrator_written": {
+        "external_workflow_written": {
           "const": false
         },
-        "dopetask_executed": {
+        "external_runner_executed": {
           "const": false
         },
         "github_mutated": {
@@ -363,5 +363,38 @@
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "$comment": "Runtime head_sha gate: a real (non-fixture) export must capture a real head_sha.",
+      "if": {
+        "properties": {
+          "generated_from_fixture": {
+            "const": false
+          }
+        },
+        "required": [
+          "generated_from_fixture"
+        ]
+      },
+      "then": {
+        "required": [
+          "repo_state"
+        ],
+        "properties": {
+          "repo_state": {
+            "required": [
+              "head_sha"
+            ],
+            "properties": {
+              "head_sha": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
 }

--- a/tests/project_control_plane/test_core_boundary.py
+++ b/tests/project_control_plane/test_core_boundary.py
@@ -1,0 +1,263 @@
+"""
+Tests for the de-Dopemux boundary repair on schemas/project_control_plane/project_evidence_export.schema.json.
+
+Covers:
+- Schema meta-validates (Draft 2020-12).
+- dcp_extension schemas (dopetask_packet_mapping, orchestrator_item) exist + meta-validate AND
+  are absent from schemas/project_control_plane/.
+- A real-runtime minimal export (generated_from_fixture=False, non-null head_sha) validates.
+- The same instance with head_sha=None is REJECTED (runtime head_sha gate).
+- An instance using old key names (dopetask_executed / live_task_orchestrator_written) is REJECTED.
+- Each of the 3 fixture evidence_export.json files validates against the schema.
+"""
+
+import json
+import pathlib
+
+from jsonschema import Draft202012Validator
+
+# ---------------------------------------------------------------------------
+# Path setup — resolved from this file so it works from any CWD.
+# Repository root: tests/project_control_plane/test_*.py → 3 levels up.
+# ---------------------------------------------------------------------------
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_PCP_SCHEMA_DIR = _REPO_ROOT / "schemas" / "project_control_plane"
+_DCP_SCHEMA_DIR = _REPO_ROOT / "schemas" / "dcp_extension"
+_EVIDENCE_SCHEMA_PATH = _PCP_SCHEMA_DIR / "project_evidence_export.schema.json"
+_FIXTURE_DIR = _REPO_ROOT / "reports" / "project-control-plane" / "fixtures"
+
+
+def _load_json(path: pathlib.Path) -> dict:
+    with path.open() as fh:
+        return json.load(fh)
+
+
+EVIDENCE_SCHEMA = _load_json(_EVIDENCE_SCHEMA_PATH)
+
+
+def _errors(schema, instance):
+    """Return all Draft 2020-12 validation errors for *instance* against *schema*."""
+    return list(Draft202012Validator(schema).iter_errors(instance))
+
+
+# ---------------------------------------------------------------------------
+# Module-level helper: minimal valid real-runtime instance.
+# generated_from_fixture=False so the head_sha gate activates.
+# ---------------------------------------------------------------------------
+def _minimal_runtime_instance(head_sha: str | None = "abc123def456") -> dict:
+    """
+    Build a fresh minimal instance that satisfies every required field.
+
+    The schema's `required` list:
+        schema_version, project_id, generated_from_fixture, profile_ref,
+        repo_state, authority_docs, active_packet, status_ledger,
+        proof_manifest, workflow_list, pr_review_state, red_lane_results,
+        unknowns, dirty_state, forbidden_action_confirmation
+    """
+    return {
+        "schema_version": "pcp.project_evidence_export.v0",
+        "project_id": "test-runtime-project",
+        "generated_from_fixture": False,
+        "profile_ref": "reports/test/project_profile.json",
+        "repo_state": {
+            "root_verified": True,
+            "worktree_state": "CLEAN",
+            "head_sha": head_sha,
+            "branch": "main",
+        },
+        "authority_docs": [
+            {"path": "AGENTS.md", "state": "PRESENT"},
+        ],
+        "active_packet": {
+            "state": "PRESENT",
+            "packet_id": "TP-TEST-0001",
+            "path": "task-packets/TP-TEST-0001.json",
+        },
+        "status_ledger": {
+            "state": "PRESENT",
+            "path": "status/ledger.json",
+            "entries": [{"id": "entry-001", "status": "READY_FOR_REVIEW"}],
+        },
+        "proof_manifest": {
+            "state": "PRESENT",
+            "path": "proof/TP-TEST-0001/PROOF.json",
+            "freshness": "CURRENT",
+        },
+        "workflow_list": [
+            {"id": "wf-001", "status": "DRY_RUN_ONLY", "source": "fixture"},
+        ],
+        "pr_review_state": {
+            "state": "PRESENT",
+            "authority_allowed": False,
+            "open_prs": [],
+        },
+        "red_lane_results": [
+            {"lane_id": "test-lane", "result": "PASS", "evidence": "test evidence"},
+        ],
+        "unknowns": [],
+        "dirty_state": {
+            "state": "CLEAN",
+            "paths": [],
+        },
+        "forbidden_action_confirmation": {
+            "external_workflow_written": False,
+            "external_runner_executed": False,
+            "github_mutated": False,
+            "runtime_written": False,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema meta-validates (Draft 2020-12).
+# ---------------------------------------------------------------------------
+class TestSchemaMetaValidation:
+    def test_evidence_export_schema_meta_validates(self):
+        """project_evidence_export.schema.json must be a valid Draft 2020-12 schema."""
+        Draft202012Validator.check_schema(EVIDENCE_SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# 2. DCP extension schemas exist + meta-validate AND are absent from pcp core dir.
+# ---------------------------------------------------------------------------
+class TestDcpExtensionSchemaPlacement:
+    def test_dopetask_packet_mapping_exists_in_dcp_extension(self):
+        path = _DCP_SCHEMA_DIR / "dopetask_packet_mapping.schema.json"
+        assert path.exists(), f"Expected {path} to exist"
+
+    def test_orchestrator_item_exists_in_dcp_extension(self):
+        path = _DCP_SCHEMA_DIR / "orchestrator_item.schema.json"
+        assert path.exists(), f"Expected {path} to exist"
+
+    def test_dopetask_packet_mapping_meta_validates(self):
+        schema = _load_json(_DCP_SCHEMA_DIR / "dopetask_packet_mapping.schema.json")
+        Draft202012Validator.check_schema(schema)
+
+    def test_orchestrator_item_meta_validates(self):
+        schema = _load_json(_DCP_SCHEMA_DIR / "orchestrator_item.schema.json")
+        Draft202012Validator.check_schema(schema)
+
+    def test_dopetask_packet_mapping_absent_from_pcp_core(self):
+        path = _PCP_SCHEMA_DIR / "dopetask_packet_mapping.schema.json"
+        assert not path.exists(), (
+            f"{path} must NOT exist in schemas/project_control_plane/ "
+            "(it belongs in schemas/dcp_extension/)"
+        )
+
+    def test_orchestrator_item_absent_from_pcp_core(self):
+        path = _PCP_SCHEMA_DIR / "orchestrator_item.schema.json"
+        assert not path.exists(), (
+            f"{path} must NOT exist in schemas/project_control_plane/ "
+            "(it belongs in schemas/dcp_extension/)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. A real-runtime minimal export validates.
+# ---------------------------------------------------------------------------
+class TestRuntimeMinimalExport:
+    def test_runtime_instance_with_valid_head_sha_validates(self):
+        """generated_from_fixture=False with a non-empty head_sha must produce zero errors."""
+        inst = _minimal_runtime_instance(head_sha="abc123def456")
+        errs = _errors(EVIDENCE_SCHEMA, inst)
+        assert errs == [], f"Unexpected errors: {errs}"
+
+
+# ---------------------------------------------------------------------------
+# 4. head_sha=None with generated_from_fixture=False is REJECTED.
+# ---------------------------------------------------------------------------
+class TestRuntimeHeadShaGate:
+    def test_runtime_instance_with_null_head_sha_is_rejected(self):
+        """Runtime head_sha gate: generated_from_fixture=False, head_sha=None must be rejected."""
+        inst = _minimal_runtime_instance(head_sha=None)
+        errs = _errors(EVIDENCE_SCHEMA, inst)
+        assert errs, (
+            "Expected at least one validation error when generated_from_fixture=False "
+            "and head_sha=None, but got zero errors"
+        )
+
+    def test_runtime_instance_with_missing_head_sha_key_is_rejected(self):
+        """Hardened gate: a runtime export must include repo_state.head_sha (key present)."""
+        inst = _minimal_runtime_instance()
+        del inst["repo_state"]["head_sha"]
+        assert _errors(EVIDENCE_SCHEMA, inst), (
+            "Expected rejection when generated_from_fixture=False and repo_state.head_sha is absent"
+        )
+
+    def test_runtime_instance_with_missing_repo_state_is_rejected(self):
+        """Hardened gate: a runtime export must include repo_state."""
+        inst = _minimal_runtime_instance()
+        del inst["repo_state"]
+        assert _errors(EVIDENCE_SCHEMA, inst), (
+            "Expected rejection when generated_from_fixture=False and repo_state is absent"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Old key names (dopetask_executed / live_task_orchestrator_written) are REJECTED.
+# ---------------------------------------------------------------------------
+class TestOldKeyNamesRejected:
+    def test_old_dopetask_executed_key_is_rejected(self):
+        """forbidden_action_confirmation.dopetask_executed (old name) must be rejected."""
+        inst = _minimal_runtime_instance()
+        inst["forbidden_action_confirmation"] = {
+            "dopetask_executed": False,
+            "external_workflow_written": False,
+            "github_mutated": False,
+            "runtime_written": False,
+        }
+        errs = _errors(EVIDENCE_SCHEMA, inst)
+        assert errs, (
+            "Expected rejection for old key name 'dopetask_executed' in "
+            "forbidden_action_confirmation"
+        )
+
+    def test_old_live_task_orchestrator_written_key_is_rejected(self):
+        """forbidden_action_confirmation.live_task_orchestrator_written (old name) must be rejected."""
+        inst = _minimal_runtime_instance()
+        inst["forbidden_action_confirmation"] = {
+            "live_task_orchestrator_written": False,
+            "external_runner_executed": False,
+            "github_mutated": False,
+            "runtime_written": False,
+        }
+        errs = _errors(EVIDENCE_SCHEMA, inst)
+        assert errs, (
+            "Expected rejection for old key name 'live_task_orchestrator_written' in "
+            "forbidden_action_confirmation"
+        )
+
+    def test_both_old_key_names_together_are_rejected(self):
+        """Using both old key names must be rejected (additionalProperties + missing required)."""
+        inst = _minimal_runtime_instance()
+        inst["forbidden_action_confirmation"] = {
+            "dopetask_executed": False,
+            "live_task_orchestrator_written": False,
+            "github_mutated": False,
+            "runtime_written": False,
+        }
+        errs = _errors(EVIDENCE_SCHEMA, inst)
+        assert errs, (
+            "Expected rejection when both old key names are present in "
+            "forbidden_action_confirmation"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. Each of the 3 fixture evidence_export.json files validates.
+# ---------------------------------------------------------------------------
+class TestFixtureFilesValidate:
+    def test_dnh_crm_fixture_validates(self):
+        inst = _load_json(_FIXTURE_DIR / "dnh_crm_fixture" / "evidence_export.json")
+        errs = _errors(EVIDENCE_SCHEMA, inst)
+        assert errs == [], f"dnh_crm_fixture/evidence_export.json errors: {errs}"
+
+    def test_dopemux_fixture_validates(self):
+        inst = _load_json(_FIXTURE_DIR / "dopemux_fixture" / "evidence_export.json")
+        errs = _errors(EVIDENCE_SCHEMA, inst)
+        assert errs == [], f"dopemux_fixture/evidence_export.json errors: {errs}"
+
+    def test_minimal_fixture_validates(self):
+        inst = _load_json(_FIXTURE_DIR / "minimal_fixture" / "evidence_export.json")
+        errs = _errors(EVIDENCE_SCHEMA, inst)
+        assert errs == [], f"minimal_fixture/evidence_export.json errors: {errs}"


### PR DESCRIPTION
## Packet 3 — de-Dopemux the PCP core boundary (`TP-DMX-PCP-CORE-DEDOPEMUX-BOUNDARY-0001`)

PCP/DCP/Routing series. Removes Dopemux-specific coupling from the generic core and the fixture-only exporter trap, so a generic runtime exporter (Packet 4) can validate real output. **Contracts only** — no runtime exporter, no live writes. Depends on #925 (P1) + #940 (P2), both merged to main.

### Changes
- **`project_evidence_export.schema.json`**
  - `generated_from_fixture`: `const true` → `boolean` (default `false`) — removes the unsatisfiable trap that blocked real runtime exports.
  - `forbidden_action_confirmation`: generalized `dopetask_executed` → `external_runner_executed`, `live_task_orchestrator_written` → `external_workflow_written` (still `const false`). The DCP extension maps `external_runner`→Dopetask, `external_workflow`→Task-Orchestrator (Packet 5).
  - **Runtime `head_sha` gate**: `generated_from_fixture:false` ⇒ `repo_state.head_sha` must be a non-null non-empty string (self-sufficient `required` + type).
- **Moved** `dopetask_packet_mapping` + `orchestrator_item` schemas → `schemas/dcp_extension/` (`$id` updated).
- Fixtures (`dnh_crm`/`dopemux`/`minimal`) renamed the two guard fields; 17-test `test_core_boundary.py`; ops doc.

### Validation
- draft-2020-12 meta-valid; **101 pytest passed**; fail-closed proofs (runtime export needs real head_sha; old key names rejected; fixtures still valid); pre-commit green.
- External review: PAL `gpt-5.2` codereview → PASS_WITH_RISKS; the head_sha gate was **hardened** (added `required`) per the review so it can't fail-open on future base-schema drift.
- Blast radius: no runtime/validator code consumes these schemas; core schema free of Dopemux-system terms.

Draft / NEEDS_SUPERVISOR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)