### PR TITLE
feat(pcp): DCP extension mapping instances (Packet 5)

### DIFF
--- a/docs/03-reference/dcp/dcp-extension-mapping.md
+++ b/docs/03-reference/dcp/dcp-extension-mapping.md
@@ -1,0 +1,160 @@
+---
+id: DCP-EXTENSION-MAPPING
+title: DCP Extension Mapping (Packet 5)
+type: reference
+owner: '@hu3mann'
+author: claude
+date: '2026-06-20'
+last_review: '2026-06-20'
+next_review: '2026-09-18'
+prelude: DCP Extension Mapping (Packet 5) (reference) for dopemux documentation and
+  developer workflows.
+---
+# DCP Extension Mapping
+
+**Status**: PROPOSED — read/projection stage only (Packet 5).
+
+**Scope**: This document describes how the Dopemux DCP extension (DCP = PCP Core + the Dopemux
+extension) attaches to PCP Core as a set of READ and PROJECTION adapters. No system is promoted to
+authority. No live writes are authorized. Routing, OpenClaw, and OpenRouter are out of scope
+for this packet (Packet 6).
+
+---
+
+## What DCP Is
+
+DCP is PCP Core plus the Dopemux extension. PCP Core provides the contract schemas
+(`extension_manifest.schema.json`, `authority_map.schema.json`) that govern how any extension
+may attach. The DCP extension declares itself via two JSON instances that validate against those
+contract schemas:
+
+- `schemas/dcp_extension/extension_manifest.dcp.json` — declares the extension identity,
+  capabilities, owned schemas, and the five hard invariants.
+- `schemas/dcp_extension/authority_map.dcp.json` — maps every Dopemux system as a
+  READ/PROJECTION adapter with an explicit canonical owner (the upstream system, not DCP).
+
+DCP never owns or writes any domain. Every entry in the authority map is an adapter, projection,
+mirror, or index surface. The canonical authority owner in each entry is the upstream system that
+actually holds the data.
+
+---
+
+## Extension Manifest
+
+The manifest (`extension_manifest.dcp.json`) declares:
+
+| Field | Value |
+|---|---|
+| `extension_id` | `dopemux-dcp` |
+| `extension_kind` | `DOPEMUX_DCP` |
+| `status` | `PROPOSED` |
+| `compatible_pcp_core_versions` | `pcp.authority_map.v0`, `pcp.extension_manifest.v0`, `pcp.project_evidence_export.v0` |
+
+The five hard invariants are all pinned `true` by the schema. A manifest that sets any of them
+`false` is invalid by construction.
+
+---
+
+## Authority Map — Mapped Systems
+
+Each entry below represents a Dopemux system exposed as a DCP read/projection adapter. The
+`canonical_authority_owner` is the upstream system — the source of truth. DCP is a bridge or
+proxy, never the authority.
+
+| Domain | Action | Canonical Owner | Surface Class | DCP Surface |
+|---|---|---|---|---|
+| `workflow.tasks` | project | task-orchestrator | PROJECTION | dcp task-orchestrator read projection |
+| `memory.decisions` | read | conport | ADAPTER | dcp conport read adapter |
+| `memory.chronicle` | read | dope-memory | ADAPTER | dcp dope-memory read adapter |
+| `retrieval.code_docs` | query | dope-context | INDEX | dcp dope-context retrieval index |
+| `transport.events` | read | dopecon-bridge | ADAPTER | dcp dopecon-bridge transport adapter |
+| `operator.cognitive_state` | read | adhd-engine | ADAPTER | dcp adhd-engine signal adapter |
+| `repo.truth_extraction` | read | repo-truth-extractor | ADAPTER | dcp repo-truth-extractor artifact reader |
+| `execution.external_runner` | map | dopetask | ADAPTER | dcp dopetask execution-mapping adapter |
+| `operator.control` | project | dopemux-cli | PROJECTION | dcp dopemux operator-control projection |
+| `pr.readiness` | read | pr-steward | ADAPTER | dcp pr-steward readiness intake |
+
+All entries share these fail-closed properties:
+
+- `live_write_allowed: false`
+- `canonical_writer: null`
+- `unknown_behavior: BLOCK_OR_ESCALATE`
+- `proof_required: true`
+- `surface_class` is one of PROJECTION, ADAPTER, or INDEX — never SOURCE
+
+---
+
+## Invariant Enforcement
+
+Enforcement comes from two layers — the PCP Core contract schema, and this packet's test suite.
+
+**What the contract schema enforces (generic PCP Core):**
+
+1. A non-SOURCE (derived) surface must have `canonical_writer: null` and `live_write_allowed: false`.
+2. `live_write_allowed: true` is valid only on a `SOURCE` surface with a non-empty `canonical_writer`.
+3. A manifest with any of the five invariants set to `false` is invalid.
+
+**What the contract schema does *not* enforce:** the generic schema deliberately permits a `SOURCE`
+entry to declare a live write — PCP Core must let a real project's authority map name actual
+sources. So the schema alone does not prove that *DCP specifically* owns or writes nothing.
+
+**What guarantees DCP is read-only:** this packet's test suite. `test_surface_class_is_not_source`
+asserts no DCP entry is `SOURCE`, and `test_source_write_escalation_caught_by_dcp_guard` confirms
+that flipping any DCP entry to `SOURCE` + `live_write_allowed: true` — an edit the generic schema
+would *accept* — is caught by the DCP boundary guard. DCP therefore cannot silently acquire write
+authority without failing the DCP test gate.
+
+---
+
+## Owned Schemas
+
+The extension owns two DCP-specific schemas (it does not override any PCP Core schema):
+
+- `dcp_extension/dopetask_packet_mapping.schema.json`
+- `dcp_extension/orchestrator_item.schema.json`
+
+The following PCP Core schemas are explicitly listed as forbidden overrides:
+
+- `project_evidence_export.schema.json`
+- `authority_map.schema.json`
+- `extension_manifest.schema.json`
+
+---
+
+## Deferred / Not Mapped in Packet 5
+
+The Packet 5 target maps exactly the ten Dopemux systems in the table above. Two systems named
+elsewhere in the architecture are intentionally **not** mapped here:
+
+- **GitHub / CI readiness** — named in AIR §7 but assigned there to the *PR Steward
+  proof-readiness* packet, not this one. It will be added as an additional read/projection
+  (`ci.evidence`) entry by that packet.
+- **Leantime** — named in the AIR system inventory (§4 and §261) but has **no row in the AIR §7
+  component table** and is not in this packet's target. It is therefore not mapped in Packet 5;
+  mapping it requires a §7 extension-role definition first (deferred, tracked as an AIR follow-up).
+
+Adding either later is additive — new authority-map entries, no core schema change.
+
+---
+
+## Out of Scope (Packet 6)
+
+Routing, OpenClaw, and OpenRouter authority-map entries are deferred to Packet 6. They will
+follow the same additive-only pattern — additional entries in the authority map, no core
+schema changes.
+
+---
+
+## Validation
+
+The two JSON instances and their test suite are verified by:
+
+```
+python -m pytest -q tests/dcp_extension/
+python -m jsonschema -i schemas/dcp_extension/extension_manifest.dcp.json \
+    schemas/project_control_plane/extension_manifest.schema.json
+python -m jsonschema -i schemas/dcp_extension/authority_map.dcp.json \
+    schemas/project_control_plane/authority_map.schema.json
+```
+
+All checks must pass before any downstream packet that builds on this mapping.

--- a/schemas/dcp_extension/authority_map.dcp.json
+++ b/schemas/dcp_extension/authority_map.dcp.json
@@ -1,0 +1,166 @@
+{
+  "schema_version": "pcp.authority_map.v0",
+  "project_id": "DDD-Enterprises/dopemux-mvp",
+  "entries": [
+    {
+      "domain": "workflow.tasks",
+      "action": "project",
+      "canonical_authority_owner": "task-orchestrator",
+      "canonical_writer": null,
+      "surface_class": "PROJECTION",
+      "reader_or_projection_surface": "dcp task-orchestrator read projection",
+      "source_truth_refs": [
+        "task-orchestrator MCP (current-tasks.db)"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "memory.decisions",
+      "action": "read",
+      "canonical_authority_owner": "conport",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dcp conport read adapter",
+      "source_truth_refs": [
+        "conport (PostgreSQL+AGE knowledge graph)"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "memory.chronicle",
+      "action": "read",
+      "canonical_authority_owner": "dope-memory",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dcp dope-memory read adapter",
+      "source_truth_refs": [
+        "dope-memory chronicle store"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "retrieval.code_docs",
+      "action": "query",
+      "canonical_authority_owner": "dope-context",
+      "canonical_writer": null,
+      "surface_class": "INDEX",
+      "reader_or_projection_surface": "dcp dope-context retrieval index",
+      "source_truth_refs": [
+        "dope-context Qdrant index"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "transport.events",
+      "action": "read",
+      "canonical_authority_owner": "dopecon-bridge",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dcp dopecon-bridge transport adapter",
+      "source_truth_refs": [
+        "Redis Streams + EventBus (proxied by dopecon-bridge)"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "operator.cognitive_state",
+      "action": "read",
+      "canonical_authority_owner": "adhd-engine",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dcp adhd-engine signal adapter",
+      "source_truth_refs": [
+        "ADHD Engine operator signals"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "repo.truth_extraction",
+      "action": "read",
+      "canonical_authority_owner": "repo-truth-extractor",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dcp repo-truth-extractor artifact reader",
+      "source_truth_refs": [
+        "Repo-Truth-Extractor artifacts"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "execution.external_runner",
+      "action": "map",
+      "canonical_authority_owner": "dopetask",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dcp dopetask execution-mapping adapter",
+      "source_truth_refs": [
+        "Dopetask external execution runtime"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "operator.control",
+      "action": "project",
+      "canonical_authority_owner": "dopemux-cli",
+      "canonical_writer": null,
+      "surface_class": "PROJECTION",
+      "reader_or_projection_surface": "dcp dopemux operator-control projection",
+      "source_truth_refs": [
+        "dopemux CLI/startup"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "pr.readiness",
+      "action": "read",
+      "canonical_authority_owner": "pr-steward",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dcp pr-steward readiness intake",
+      "source_truth_refs": [
+        "PR Steward review-sensor intake"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    }
+  ]
+}

--- a/schemas/dcp_extension/extension_manifest.dcp.json
+++ b/schemas/dcp_extension/extension_manifest.dcp.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "pcp.extension_manifest.v0",
+  "status": "PROPOSED",
+  "extension_id": "dopemux-dcp",
+  "extension_kind": "DOPEMUX_DCP",
+  "compatible_pcp_core_versions": [
+    "pcp.authority_map.v0",
+    "pcp.extension_manifest.v0",
+    "pcp.project_evidence_export.v0"
+  ],
+  "extension_identity": {
+    "project_id_patterns": [
+      "DDD-Enterprises/dopemux-mvp"
+    ],
+    "repo_markers": [
+      ".dopetaskroot"
+    ],
+    "discovery_hints": [
+      "pyproject.toml [tool.dopemux]",
+      "src/dopemux/"
+    ]
+  },
+  "capabilities": {
+    "authority_map_contributions": [
+      "schemas/dcp_extension/authority_map.dcp.json"
+    ],
+    "red_lane_contributions": [],
+    "evidence_export_sections": [
+      "dcp_workflow",
+      "dcp_memory",
+      "dcp_retrieval"
+    ],
+    "proof_status_mappings": [],
+    "runtime_mappings": [],
+    "adapter_mappings": [
+      "task-orchestrator",
+      "conport",
+      "dope-memory",
+      "dope-context",
+      "dopecon-bridge",
+      "adhd-engine",
+      "repo-truth-extractor",
+      "dopetask",
+      "dopemux-cli",
+      "pr-steward"
+    ]
+  },
+  "schemas": {
+    "owned_schema_ids": [
+      "dcp_extension/dopetask_packet_mapping.schema.json",
+      "dcp_extension/orchestrator_item.schema.json"
+    ],
+    "core_schema_extensions": [],
+    "forbidden_core_overrides": [
+      "project_evidence_export.schema.json",
+      "authority_map.schema.json",
+      "extension_manifest.schema.json"
+    ]
+  },
+  "invariants": {
+    "cannot_override_core_fail_closed": true,
+    "cannot_weaken_proof_gates": true,
+    "cannot_weaken_audit_gates": true,
+    "cannot_promote_adapter_to_authority": true,
+    "cannot_require_extension_for_baseline_core": true
+  }
+}

--- a/tests/dcp_extension/test_dcp_extension_mapping.py
+++ b/tests/dcp_extension/test_dcp_extension_mapping.py
@@ -1,0 +1,244 @@
+"""
+Tests for the DCP extension mapping (Packet 5).
+
+Validates that:
+  - schemas/dcp_extension/extension_manifest.dcp.json is a valid instance of
+    schemas/project_control_plane/extension_manifest.schema.json
+  - schemas/dcp_extension/authority_map.dcp.json is a valid instance of
+    schemas/project_control_plane/authority_map.schema.json
+  - No system is promoted to authority (all entries are read/projection only,
+    no live writes, no SOURCE surface_class, canonical_writer is null)
+  - All owned_schema_ids in the manifest correspond to existing files under
+    schemas/dcp_extension/
+  - Negative/tamper tests confirm the schema gates hold
+"""
+
+import copy
+import json
+import pathlib
+
+import pytest
+from jsonschema import Draft202012Validator
+
+# ---------------------------------------------------------------------------
+# Paths — resolved from repo root (tests/dcp_extension/test_*.py is 3 levels up)
+# ---------------------------------------------------------------------------
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_SCHEMAS_PCP = _REPO_ROOT / "schemas" / "project_control_plane"
+_SCHEMAS_DCP = _REPO_ROOT / "schemas" / "dcp_extension"
+
+_MANIFEST_SCHEMA_PATH = _SCHEMAS_PCP / "extension_manifest.schema.json"
+_AUTHORITY_SCHEMA_PATH = _SCHEMAS_PCP / "authority_map.schema.json"
+_MANIFEST_INST_PATH = _SCHEMAS_DCP / "extension_manifest.dcp.json"
+_AUTHORITY_INST_PATH = _SCHEMAS_DCP / "authority_map.dcp.json"
+
+
+def _load(path: pathlib.Path) -> dict:
+    with path.open() as fh:
+        return json.load(fh)
+
+
+# Load once at module level; if files are missing the import itself will fail
+# with a clear FileNotFoundError (no hidden test skip)
+MANIFEST_SCHEMA = _load(_MANIFEST_SCHEMA_PATH)
+AUTHORITY_SCHEMA = _load(_AUTHORITY_SCHEMA_PATH)
+MANIFEST_INST = _load(_MANIFEST_INST_PATH)
+AUTHORITY_INST = _load(_AUTHORITY_INST_PATH)
+
+
+def errors(schema: dict, instance: dict) -> list:
+    return list(Draft202012Validator(schema).iter_errors(instance))
+
+
+# ---------------------------------------------------------------------------
+# 1. JSON Schema validation — extension_manifest.dcp.json
+# ---------------------------------------------------------------------------
+class TestExtensionManifestInstance:
+    def test_validates_against_schema(self):
+        errs = errors(MANIFEST_SCHEMA, MANIFEST_INST)
+        assert errs == [], f"extension_manifest.dcp.json has schema errors: {errs}"
+
+    def test_extension_kind_is_dopemux_dcp(self):
+        assert MANIFEST_INST["extension_kind"] == "DOPEMUX_DCP"
+
+    def test_invariant_cannot_override_core_fail_closed(self):
+        assert MANIFEST_INST["invariants"]["cannot_override_core_fail_closed"] is True
+
+    def test_invariant_cannot_weaken_proof_gates(self):
+        assert MANIFEST_INST["invariants"]["cannot_weaken_proof_gates"] is True
+
+    def test_invariant_cannot_weaken_audit_gates(self):
+        assert MANIFEST_INST["invariants"]["cannot_weaken_audit_gates"] is True
+
+    def test_invariant_cannot_promote_adapter_to_authority(self):
+        assert MANIFEST_INST["invariants"]["cannot_promote_adapter_to_authority"] is True
+
+    def test_invariant_cannot_require_extension_for_baseline_core(self):
+        assert MANIFEST_INST["invariants"]["cannot_require_extension_for_baseline_core"] is True
+
+
+# ---------------------------------------------------------------------------
+# 2. JSON Schema validation — authority_map.dcp.json
+# ---------------------------------------------------------------------------
+class TestAuthorityMapInstance:
+    def test_validates_against_schema(self):
+        errs = errors(AUTHORITY_SCHEMA, AUTHORITY_INST)
+        assert errs == [], f"authority_map.dcp.json has schema errors: {errs}"
+
+    def test_entries_non_empty(self):
+        assert len(AUTHORITY_INST["entries"]) > 0, "entries must be non-empty"
+
+
+# ---------------------------------------------------------------------------
+# 3. No system promoted to authority — P3 gate
+# ---------------------------------------------------------------------------
+class TestNoAuthorityPromotion:
+    """Every entry must be read-only, adapter/projection, no canonical writer."""
+
+    @pytest.fixture(params=AUTHORITY_INST["entries"])
+    def entry(self, request):
+        return request.param
+
+    def test_live_write_not_allowed(self, entry):
+        assert entry["live_write_allowed"] is False, (
+            f"Entry {entry['domain']}/{entry['action']} has live_write_allowed=True"
+        )
+
+    def test_canonical_writer_is_null(self, entry):
+        assert entry["canonical_writer"] is None, (
+            f"Entry {entry['domain']}/{entry['action']} has non-null canonical_writer"
+        )
+
+    def test_surface_class_is_not_source(self, entry):
+        assert entry["surface_class"] != "SOURCE", (
+            f"Entry {entry['domain']}/{entry['action']} is SOURCE (would mean DCP owns it)"
+        )
+
+    def test_unknown_behavior_is_block_or_escalate(self, entry):
+        assert entry["unknown_behavior"] == "BLOCK_OR_ESCALATE", (
+            f"Entry {entry['domain']}/{entry['action']} unknown_behavior is not BLOCK_OR_ESCALATE"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. owned_schema_ids file existence
+# ---------------------------------------------------------------------------
+class TestOwnedSchemaIds:
+    def test_owned_schema_ids_files_exist(self):
+        owned = MANIFEST_INST["schemas"]["owned_schema_ids"]
+        assert owned, "owned_schema_ids must not be empty"
+        for schema_id in owned:
+            # schema_id is relative to schemas/ directory (dcp_extension/foo.schema.json)
+            candidate = _REPO_ROOT / "schemas" / schema_id
+            assert candidate.exists(), (
+                f"owned_schema_id '{schema_id}' does not correspond to an existing file at {candidate}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. Negative/tamper tests — schema gates must hold
+# ---------------------------------------------------------------------------
+class TestNegativeTamper:
+    def test_tampered_manifest_cannot_promote_adapter_false_is_rejected(self):
+        """A manifest with cannot_promote_adapter_to_authority=false must be invalid."""
+        tampered = copy.deepcopy(MANIFEST_INST)
+        tampered["invariants"]["cannot_promote_adapter_to_authority"] = False
+        errs = errors(MANIFEST_SCHEMA, tampered)
+        assert errs, "Schema should reject cannot_promote_adapter_to_authority=False"
+
+    def test_authority_entry_live_write_true_with_null_writer_is_rejected(self):
+        """An entry with live_write_allowed=true and canonical_writer=null must be rejected (P3 gate)."""
+        tampered = copy.deepcopy(AUTHORITY_INST)
+        # Inject a bad entry: live_write=true but no canonical_writer (null) and surface stays ADAPTER
+        bad_entry = {
+            "domain": "workflow.tasks",
+            "action": "write",
+            "canonical_authority_owner": "task-orchestrator",
+            "canonical_writer": None,
+            "surface_class": "ADAPTER",
+            "reader_or_projection_surface": "some surface",
+            "source_truth_refs": ["some ref"],
+            "proof_required": True,
+            "live_write_allowed": True,
+            "approval_required": False,
+            "rollback_required": False,
+            "unknown_behavior": "BLOCK_OR_ESCALATE",
+        }
+        tampered["entries"].append(bad_entry)
+        errs = errors(AUTHORITY_SCHEMA, tampered)
+        assert errs, (
+            "Schema should reject entry with live_write_allowed=true, canonical_writer=null "
+            "(P3 live-write gate)"
+        )
+
+    def test_source_write_escalation_caught_by_dcp_guard(self):
+        """The generic PCP Core schema PERMITS a SOURCE entry with a live write — PCP Core must
+        let a real project's authority map name actual sources. So DCP's read-only guarantee is
+        enforced by the DCP boundary guard, not the schema. This test documents that gap and
+        proves the guard catches the escalation (keeps dcp-extension-mapping.md honest)."""
+        tampered = copy.deepcopy(AUTHORITY_INST)
+        escalation = {
+            "domain": "workflow.tasks",
+            "action": "write",
+            "canonical_authority_owner": "task-orchestrator",
+            "canonical_writer": "dcp-attacker",
+            "surface_class": "SOURCE",
+            "reader_or_projection_surface": "escalated surface",
+            "source_truth_refs": ["escalated ref"],
+            "proof_required": True,
+            "live_write_allowed": True,
+            "approval_required": False,
+            "rollback_required": False,
+            "unknown_behavior": "BLOCK_OR_ESCALATE",
+        }
+        tampered["entries"].append(escalation)
+        # Generic contract ACCEPTS this (SOURCE + non-empty writer + live write is valid PCP Core):
+        assert errors(AUTHORITY_SCHEMA, tampered) == [], (
+            "Generic schema is expected to ACCEPT a SOURCE+live_write entry; if this starts "
+            "failing, the core schema gained a SOURCE restriction and the doc must be updated."
+        )
+        # DCP boundary guard REJECTS it (no DCP entry may be SOURCE, writable, or have a writer):
+        offenders = [
+            e
+            for e in tampered["entries"]
+            if e["surface_class"] == "SOURCE"
+            or e["live_write_allowed"] is not False
+            or e["canonical_writer"] is not None
+        ]
+        assert offenders, "DCP boundary guard must catch a SOURCE/live-write escalation"
+
+
+# ---------------------------------------------------------------------------
+# 6. Packet-5 scope lock — exactly the ten target systems, manifest in sync
+# ---------------------------------------------------------------------------
+class TestPacketScope:
+    """Packet 5 maps exactly its ten target systems — not github-ci (deferred to the PR Steward
+    proof-readiness packet) and not Leantime (no AIR §7 row). Guards against scope drift."""
+
+    EXPECTED_SYSTEMS = {
+        "task-orchestrator",
+        "conport",
+        "dope-memory",
+        "dope-context",
+        "dopecon-bridge",
+        "adhd-engine",
+        "repo-truth-extractor",
+        "dopetask",
+        "dopemux-cli",
+        "pr-steward",
+    }
+
+    def test_mapped_systems_match_packet_target(self):
+        owners = {e["canonical_authority_owner"] for e in AUTHORITY_INST["entries"]}
+        assert owners == self.EXPECTED_SYSTEMS, (
+            f"DCP authority-map systems drifted from the Packet 5 target. "
+            f"Unexpected: {owners - self.EXPECTED_SYSTEMS}; Missing: {self.EXPECTED_SYSTEMS - owners}"
+        )
+
+    def test_manifest_adapter_mappings_match_authority_owners(self):
+        owners = {e["canonical_authority_owner"] for e in AUTHORITY_INST["entries"]}
+        adapter_mappings = set(MANIFEST_INST["capabilities"]["adapter_mappings"])
+        assert adapter_mappings == owners, (
+            f"manifest adapter_mappings out of sync with authority-map owners. "
+            f"Only in manifest: {adapter_mappings - owners}; only in map: {owners - adapter_mappings}"
+        )


### PR DESCRIPTION
## Packet 5 — DCP / Dopemux extension mapping (read/projection stage)

Authors the DCP extension as **instances** of the PCP Core contracts merged in P2/P3. DCP = PCP Core + the Dopemux extension; this packet maps existing Dopemux systems as **read/projection adapters** — nothing is promoted to authority, no live writes.

### Deliverables
- `schemas/dcp_extension/extension_manifest.dcp.json` — `DOPEMUX_DCP` manifest; 5 invariants pinned `true`; owns only the two DCP schemas; forbids overriding the 3 core schemas.
- `schemas/dcp_extension/authority_map.dcp.json` — **10** systems (task-orchestrator, conport, dope-memory, dope-context, dopecon-bridge, adhd-engine, repo-truth-extractor, dopetask, dopemux-cli, pr-steward) as derived surfaces: `live_write_allowed=false`, `canonical_writer=null`, `surface_class` ∈ {PROJECTION,ADAPTER,INDEX} (never SOURCE), `unknown_behavior=BLOCK_OR_ESCALATE`.
- `tests/dcp_extension/test_dcp_extension_mapping.py` — 55 tests.
- `docs/03-reference/dcp/dcp-extension-mapping.md`.

### Scope decisions (grounded in the packet target + AIR §7)
- **github-ci** — *not* mapped here; AIR §7 assigns GitHub/CI readiness to the **PR Steward proof-readiness** packet. (Removed during review; was over-included in the first draft.)
- **Leantime** — *not* mapped; named in AIR §4/§261 but has **no §7 component row** → mapping it would mean fabricating its contract role. Documented as a deferred AIR follow-up.
- **routing / OpenClaw / OpenRouter** — Packet 6.

### Validation
| Check | Result |
|---|---|
| `pytest tests/dcp_extension/ tests/project_control_plane/` | **PASS** — 178 passed (55 dcp + 123 pcp, no regression) |
| `jsonschema -i extension_manifest.dcp.json …/extension_manifest.schema.json` | **PASS** — valid |
| `jsonschema -i authority_map.dcp.json …/authority_map.schema.json` | **PASS** — valid |
| boundary check (all 10 entries read-only/derived, no SOURCE) | **PASS** — 0 violations |
| `pre-commit run --files <changed>` (SKIP=docs-graph-validator) | **PASS** |

### Review (codereview layer)
- **PAL MCP was unavailable this session** (server not connected) and native `advisor()` is not loaded → codereview was done by (a) my own Opus entry-by-entry semantic review and (b) an **independent Sonnet adversarial reviewer** (isolated context, read the actual files + on-main contracts + AIR §7). Verdict: **APPROVE_WITH_NITS**.
- Reviewer findings actioned: doc overclaim corrected (the generic schema permits `SOURCE`+live-write — DCP's read-only property is enforced by the **DCP test guard**, now proven by `test_source_write_escalation_caught_by_dcp_guard`); `dopecon-bridge` source ref deepened to the upstream event store; `compatible_pcp_core_versions` corrected to the 3 core contract versions; github-ci scope-removed; Leantime documented as deferred.

### Residual risk / UNKNOWNs
- AIR internal inconsistency (Leantime in §4/§261, absent from §7) is **documented, not resolved** — needs an operator/architecture decision on whether Leantime gets a §7 row.
- The all-read-only DCP property is enforced by the packet's test suite, **not** by the generic core schema (by PCP Core design). A future DCP-specific schema could harden this structurally if desired (out of P5 scope).

Packet: `task-packets/generated/TP-DMX-DCP-EXTENSION-MAPPING-0001.json` · Worktree `.claude/worktrees/pcp-p5` · Branch `claude/pcp-p5-dcp-extension-mapping`

🤖 Generated with [Claude Code](https://claude.com/claude-code)