### PR TITLE
fix(cli): repair `dopemux doctor` and `dopemux status` runtime crashes

### DIFF
--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -2819,11 +2819,18 @@ def status(ctx, attention: bool, context: bool, tasks: bool, mobile: bool):
             )
 
             for task in progress_info.get("tasks", []):
+                task_status = task.get("status", "")
                 status_emoji = (
-                    "✅" if task["completed"] else "🔄" if task["in_progress"] else "⏳"
+                    "✅"
+                    if task_status == "completed"
+                    else "🔄"
+                    if task_status == "in_progress"
+                    else "⏳"
                 )
                 table.add_row(
-                    task["name"], status_emoji, f"{task.get('progress', 0):.0%}"
+                    task.get("description", task.get("id", "?")),
+                    status_emoji,
+                    f"{task.get('progress', 0):.0%}",
                 )
 
             console.logger.info(table)

--- a/src/dopemux/ui/theme.py
+++ b/src/dopemux/ui/theme.py
@@ -508,7 +508,7 @@ def create_console(**kwargs: Any) -> Console:
 
 def styled_table(
     title: str,
-    *columns: str | tuple[str, dict[str, Any]],
+    *columns: str | tuple[str] | tuple[str, dict[str, Any]],
     compact: bool = False,
     **table_kwargs: Any,
 ) -> Table:
@@ -516,8 +516,8 @@ def styled_table(
 
     Args:
         title: Table title (rendered with ``table.header`` style).
-        *columns: Column names, or ``(name, kwargs)`` tuples for
-            :meth:`Table.add_column`.
+        *columns: Column names, or ``(name,)`` / ``(name, kwargs)`` tuples
+            for :meth:`Table.add_column`.
         compact: If ``True``, use ``SIMPLE`` box and tighter padding.
         **table_kwargs: Forwarded to :class:`rich.table.Table`.
 
@@ -553,7 +553,8 @@ def styled_table(
         table.add_column("Timestamp", style="text.dim", no_wrap=True)
     for col in columns:
         if isinstance(col, tuple):
-            name, col_kwargs = col
+            name = col[0]
+            col_kwargs = col[1] if len(col) > 1 else {}
             table.add_column(name, **col_kwargs)
         else:
             table.add_column(col)

--- a/tests/test_cli_status_doctor_regression.py
+++ b/tests/test_cli_status_doctor_regression.py
@@ -1,0 +1,60 @@
+"""Regression tests for two long-standing CLI runtime crashes.
+
+Both bugs pre-date 2026-04 and made `dopemux doctor` and `dopemux status`
+unusable:
+
+* ``doctor`` -> ``styled_table`` received a single-element column tuple
+  ``("Status",)`` and raised ``ValueError: not enough values to unpack``.
+* ``status`` -> iterated ``get_progress()["tasks"]`` using keys
+  (``completed``/``in_progress``/``name``) that the task dict never contains;
+  the real shape exposes ``status`` (string) and ``description``.
+"""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from dopemux.cli import cli
+from dopemux.ui.theme import styled_table
+
+
+def test_styled_table_accepts_single_element_column_tuple():
+    """A ``(name,)`` column (no kwargs) must not raise — root cause of `doctor`."""
+    table = styled_table(
+        "Diag",
+        ("Check", {"style": "text"}),
+        ("Status",),
+    )
+    headers = [col.header for col in table.columns]
+    assert "Check" in headers
+    assert "Status" in headers
+
+
+def test_status_tasks_renders_real_task_shape():
+    """`status --tasks` must render the actual get_progress() task shape.
+
+    The real per-task dict exposes ``status`` (string) and ``description`` —
+    not ``completed``/``in_progress``/``name``.
+    """
+    payload = {
+        "total_tasks": 2,
+        "completed_tasks": 1,
+        "in_progress_tasks": 1,
+        "overall_progress": 0.5,
+        "current_task": None,
+        "tasks": [
+            {"id": "t1", "description": "Write docs", "status": "completed", "progress": 1.0},
+            {"id": "t2", "description": "Fix the bug", "status": "in_progress", "progress": 0.4},
+        ],
+        "summary": {"total": 2, "completed": 1, "in_progress": 1},
+    }
+    runner = CliRunner()
+    with patch(
+        "dopemux.adhd.task_decomposer.TaskDecomposer.get_progress",
+        return_value=payload,
+    ):
+        result = runner.invoke(cli, ["status", "--tasks"])
+
+    assert result.exit_code == 0, (result.output, result.exception)
+    assert "Write docs" in result.output
+    assert "Fix the bug" in result.output


### PR DESCRIPTION
## Summary

`dopemux doctor` and `dopemux status` have crashed since **2026-04-05** (`f018dd105`). The top-level `main()` handler swallows the exception into ` Error: …` and exits 0, so the failures looked like silent no-ops. Real tracebacks (captured via `standalone_mode=False`):

| Command | Error | Root cause |
|---|---|---|
| `dopemux doctor` | `ValueError: not enough values to unpack (expected 2, got 1)` | `_rich_doctor` (`cli.py`) passed a 1-tuple column `("Status",)`; `styled_table` (`ui/theme.py`) only unpacked 2-tuples |
| `dopemux status` | `KeyError: 'completed'` | status task loop read `task["completed"]`/`["in_progress"]`/`["name"]`, but `TaskDecomposer.get_progress()` tasks expose `status` (string) + `description` |

Both are pre-existing on `main` (confirmed via `git blame`/`git show`), not regressions from any feature branch.

## Changes
- `src/dopemux/ui/theme.py` — `styled_table` now accepts a bare `(name,)` column (defense-in-depth at a 47-caller shared helper; widened type hint + docstring).
- `src/dopemux/cli.py` — `status` task loop uses the real `status`/`description`/`progress` keys with `.get()` fallbacks.
- `tests/test_cli_status_doctor_regression.py` — new; both tests fail on prior code, pass now.

## Validation
- **PASS** — 2 new regression tests; 34 existing+new CLI tests (`test_cli.py`), zero regressions; real `dopemux doctor` and `dopemux status` render cleanly.
- **NOT_RUN** — full repo suite (scoped to CLI/theme for speed; changes are localized).

## Not in this PR (operational / machine-local)
Separately, the global editable install was stale (pointed at a deleted worktree) and the `~/.local/bin/dopemux` wrapper failed outside a checkout. Those were fixed locally (reinstall editable + wrapper fallback to the canonical checkout). A real follow-up is that `dopemux.cli` imports top-level `services.*`, which isn't part of the installed package — so the pip console script isn't standalone outside the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)