### PR TITLE
feat(dcp): routing/OpenClaw/OpenRouter extension contracts (contracts-only)

### DIFF
--- a/docs/03-reference/dcp/dcp-routing-extension.md
+++ b/docs/03-reference/dcp/dcp-routing-extension.md
@@ -1,0 +1,59 @@
+---
+id: DCP-ROUTING-EXTENSION
+title: DCP Routing Extension Contract
+type: reference
+status: PROPOSED
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-22'
+last_review: '2026-06-22'
+next_review: '2026-09-20'
+prelude: DCP Routing Extension Contract (reference) for dopemux documentation and
+  developer workflows.
+---
+# DCP Routing Extension Contract
+
+This page defines the Packet 6 routing contract surface for DCP. It is a contracts-only artifact set:
+
+- `schemas/dcp_extension/routing/route_decision.schema.json`
+- `schemas/dcp_extension/routing/lane_engine.schema.json`
+- `schemas/dcp_extension/routing/openclaw_route.schema.json`
+- `tests/dcp_extension/routing/test_routing_contracts.py`
+
+These schemas are the canonical Packet 6 contract artifacts. Existing OpenClaw routing files under `docs/03-reference/dcp/openclaw-routing/` remain advisory reference inputs unless a later accepted packet explicitly imports them.
+
+## Non-Authority Boundaries
+
+The routing extension does not implement production routing, call OpenClaw, call OpenRouter, select providers, or certify benchmark readiness. It records the shape of future route decisions and route metadata only.
+
+Provider, model, router, bridge, adapter, and cache outputs are not authority surfaces. Runtime/source truth, current PR state, proof freshness, and accepted PCP/DCP governance remain higher authority.
+
+## Fail-Closed Contract
+
+Consumers of this contract must treat unknown, invalid, or incomplete routing decisions as fail-closed. The schemas encode this by requiring:
+
+- `UNKNOWN` privacy or risk classes to produce a blocked, escalated, or supervisor-needed decision.
+- blocked decisions to carry at least one machine-readable `blocked_reasons` value.
+- live-write runner selection to remain `false`.
+- undeclared runtime fields to be rejected.
+
+Packet 6 does not execute those decisions. Runtime enforcement belongs to later packets.
+
+## Protected Lanes
+
+Protected lanes include security-sensitive, release-authority, secret-bearing, client-data, and unknown classification paths. They must not use OpenRouter-free routes. Security and release paths require independent or stronger audit posture and human-gate visibility.
+
+The contract supports public low-risk OpenRouter-free route metadata, but only outside protected lanes. OpenRouter remains a routing/control layer, not a trust oracle.
+
+## Downstream Consumers
+
+Later PR Steward, Task Orchestrator visibility, live-write-gate, and bridge packets may consume these schemas. They must not infer runtime readiness or benchmark certification from this packet alone.
+
+Breaking changes include removing or renaming enum values, changing required route-decision fields, or weakening fail-closed constraints. Additive fields require schema and consumer review before use.
+
+## Remaining Unknowns
+
+- Actual OpenClaw runtime behavior is not exercised.
+- Actual OpenRouter provider/model behavior is not exercised.
+- Benchmark certification is not run.
+- External acceptance status of older OpenClaw reference documents remains unknown.

--- a/schemas/dcp_extension/routing/lane_engine.schema.json
+++ b/schemas/dcp_extension/routing/lane_engine.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.dopemux.local/dcp_extension/routing/lane_engine.schema.json",
+  "title": "DCP Routing Extension Lane Engine Contract",
+  "description": "Contracts-only lane definitions for future route decision generation. This schema does not implement a lane engine.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "default_unknown_behavior",
+    "live_write_runner_allowed",
+    "lanes"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "dcp.routing.lane_engine.v0"
+    },
+    "default_unknown_behavior": {
+      "type": "string",
+      "const": "BLOCK_OR_ESCALATE"
+    },
+    "live_write_runner_allowed": {
+      "type": "boolean",
+      "const": false
+    },
+    "lanes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "lane_id",
+          "privacy_classes",
+          "risk_classes",
+          "allowed_access_paths",
+          "forbidden_access_paths",
+          "proof_requirement",
+          "audit_requirement",
+          "requires_human_approval",
+          "fail_closed_on_unknown"
+        ],
+        "properties": {
+          "lane_id": { "$ref": "#/$defs/lane_id" },
+          "privacy_classes": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "$ref": "#/$defs/privacy_class" }
+          },
+          "risk_classes": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "$ref": "#/$defs/risk_class" }
+          },
+          "allowed_access_paths": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": { "$ref": "#/$defs/access_path" }
+          },
+          "forbidden_access_paths": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": { "$ref": "#/$defs/access_path" }
+          },
+          "proof_requirement": { "$ref": "#/$defs/proof_requirement" },
+          "audit_requirement": { "$ref": "#/$defs/audit_requirement" },
+          "requires_human_approval": { "type": "boolean" },
+          "fail_closed_on_unknown": {
+            "type": "boolean",
+            "const": true
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "lane_id": {
+      "type": "string",
+      "enum": [
+        "public_read",
+        "public_draft",
+        "test_only",
+        "local_edit",
+        "multi_file_edit",
+        "protected_authority",
+        "release_supervisor",
+        "unknown_fail_closed"
+      ]
+    },
+    "privacy_class": {
+      "type": "string",
+      "enum": [
+        "PUBLIC_SANDBOX",
+        "PUBLIC_REPO",
+        "PRIVATE_REPO_NO_SECRETS",
+        "PRIVATE_REPO_POSSIBLE_SECRETS",
+        "SECRET_BEARING",
+        "CLIENT_DATA",
+        "SECURITY_SENSITIVE",
+        "RELEASE_AUTHORITY",
+        "UNKNOWN"
+      ]
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": [
+        "R0_READ",
+        "R1_DRAFT",
+        "R2_TEST_ONLY",
+        "R3_LOCAL_EDIT",
+        "R4_MULTI_FILE_EDIT",
+        "R5_SECURITY_OR_AUTHORITY",
+        "R6_RELEASE_OR_PRODUCTION",
+        "UNKNOWN"
+      ]
+    },
+    "access_path": {
+      "type": "string",
+      "enum": [
+        "direct_api",
+        "openrouter_paid",
+        "openrouter_free",
+        "local_self_hosted",
+        "codex",
+        "claude_code",
+        "gemini_cli",
+        "manual_app"
+      ]
+    },
+    "proof_requirement": {
+      "type": "string",
+      "enum": ["minimal", "standard", "implementation", "security", "release", "unknown"]
+    },
+    "audit_requirement": {
+      "type": "string",
+      "enum": ["none", "light", "embedded", "independent", "deep", "security", "release"]
+    }
+  }
+}

--- a/schemas/dcp_extension/routing/openclaw_route.schema.json
+++ b/schemas/dcp_extension/routing/openclaw_route.schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.dopemux.local/dcp_extension/routing/openclaw_route.schema.json",
+  "title": "DCP Routing Extension OpenClaw Route Contract",
+  "description": "Contracts-only route metadata for future OpenClaw routing integration. This schema does not enable OpenClaw runtime execution.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "route_id",
+    "route_kind",
+    "provider",
+    "access_path",
+    "runner",
+    "allowed_for_privacy_classes",
+    "allowed_for_risk_classes",
+    "openrouter_free",
+    "benchmark_required",
+    "structured_output_required",
+    "proof_capture_required",
+    "may_be_sole_authority",
+    "live_write_runner",
+    "status"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "dcp.routing.openclaw_route.v0"
+    },
+    "route_id": {
+      "type": "string",
+      "pattern": "^route_[A-Za-z0-9_.:-]+$"
+    },
+    "route_kind": {
+      "type": "string",
+      "enum": ["direct_api", "openrouter_paid", "openrouter_free", "local_self_hosted", "manual_app"]
+    },
+    "provider": {
+      "type": "string",
+      "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple", "unknown"]
+    },
+    "access_path": {
+      "type": "string",
+      "enum": [
+        "direct_api",
+        "openrouter_paid",
+        "openrouter_free",
+        "local_self_hosted",
+        "codex",
+        "claude_code",
+        "gemini_cli",
+        "manual_app"
+      ]
+    },
+    "runner": {
+      "type": "string",
+      "enum": ["openclaw", "codex", "claude_code", "gemini_cli", "manual_app", "shell_local", "unknown"]
+    },
+    "allowed_for_privacy_classes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/privacy_class" }
+    },
+    "allowed_for_risk_classes": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/risk_class" }
+    },
+    "openrouter_free": {
+      "type": "boolean"
+    },
+    "benchmark_required": {
+      "type": "boolean"
+    },
+    "structured_output_required": {
+      "type": "boolean"
+    },
+    "proof_capture_required": {
+      "type": "boolean"
+    },
+    "may_be_sole_authority": {
+      "type": "boolean",
+      "const": false
+    },
+    "live_write_runner": {
+      "type": "boolean",
+      "const": false
+    },
+    "status": {
+      "type": "string",
+      "enum": ["PROPOSED", "BLOCKED", "DEPRECATED"]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "openrouter_free": { "const": true } },
+        "required": ["openrouter_free"]
+      },
+      "then": {
+        "properties": {
+          "provider": { "const": "openrouter" },
+          "access_path": { "const": "openrouter_free" },
+          "route_kind": { "const": "openrouter_free" }
+        },
+        "not": {
+          "anyOf": [
+            {
+              "properties": {
+                "allowed_for_privacy_classes": {
+                  "contains": {
+                    "enum": [
+                      "PRIVATE_REPO_NO_SECRETS",
+                      "PRIVATE_REPO_POSSIBLE_SECRETS",
+                      "SECRET_BEARING",
+                      "CLIENT_DATA",
+                      "SECURITY_SENSITIVE",
+                      "RELEASE_AUTHORITY",
+                      "UNKNOWN"
+                    ]
+                  }
+                }
+              },
+              "required": ["allowed_for_privacy_classes"]
+            },
+            {
+              "properties": {
+                "allowed_for_risk_classes": {
+                  "contains": {
+                    "enum": ["R5_SECURITY_OR_AUTHORITY", "R6_RELEASE_OR_PRODUCTION", "UNKNOWN"]
+                  }
+                }
+              },
+              "required": ["allowed_for_risk_classes"]
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "privacy_class": {
+      "type": "string",
+      "enum": [
+        "PUBLIC_SANDBOX",
+        "PUBLIC_REPO",
+        "PRIVATE_REPO_NO_SECRETS",
+        "PRIVATE_REPO_POSSIBLE_SECRETS",
+        "SECRET_BEARING",
+        "CLIENT_DATA",
+        "SECURITY_SENSITIVE",
+        "RELEASE_AUTHORITY",
+        "UNKNOWN"
+      ]
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": [
+        "R0_READ",
+        "R1_DRAFT",
+        "R2_TEST_ONLY",
+        "R3_LOCAL_EDIT",
+        "R4_MULTI_FILE_EDIT",
+        "R5_SECURITY_OR_AUTHORITY",
+        "R6_RELEASE_OR_PRODUCTION",
+        "UNKNOWN"
+      ]
+    }
+  }
+}

--- a/schemas/dcp_extension/routing/route_decision.schema.json
+++ b/schemas/dcp_extension/routing/route_decision.schema.json
@@ -1,0 +1,265 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.dopemux.local/dcp_extension/routing/route_decision.schema.json",
+  "title": "DCP Routing Extension Route Decision Contract",
+  "description": "Contracts-only DCP route decision. This schema records selected or blocked routing decisions; it does not authorize runtime routing or provider execution.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "decision_id",
+    "task_ref",
+    "lane_id",
+    "privacy_class",
+    "risk_class",
+    "decision",
+    "selected_route_id",
+    "selected_provider",
+    "selected_model",
+    "access_path",
+    "live_write_runner_selected",
+    "blocked_reasons",
+    "proof_requirement",
+    "audit_requirement",
+    "human_gate_required",
+    "benchmark_certification_ref",
+    "evidence_refs",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "dcp.routing.route_decision.v0"
+    },
+    "decision_id": {
+      "type": "string",
+      "pattern": "^rd_[A-Za-z0-9_.:-]+$"
+    },
+    "task_ref": {
+      "type": "string",
+      "minLength": 1
+    },
+    "lane_id": {
+      "$ref": "#/$defs/lane_id"
+    },
+    "privacy_class": {
+      "$ref": "#/$defs/privacy_class"
+    },
+    "risk_class": {
+      "$ref": "#/$defs/risk_class"
+    },
+    "decision": {
+      "type": "string",
+      "enum": ["SELECTED", "BLOCKED", "ESCALATED", "NEEDS_SUPERVISOR"]
+    },
+    "selected_route_id": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "selected_provider": {
+      "type": ["string", "null"],
+      "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple", "unknown", null]
+    },
+    "selected_model": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "access_path": {
+      "anyOf": [
+        { "$ref": "#/$defs/access_path" },
+        { "type": "null" }
+      ]
+    },
+    "live_write_runner_selected": {
+      "type": "boolean",
+      "const": false
+    },
+    "blocked_reasons": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/blocked_reason"
+      }
+    },
+    "proof_requirement": {
+      "$ref": "#/$defs/proof_requirement"
+    },
+    "audit_requirement": {
+      "$ref": "#/$defs/audit_requirement"
+    },
+    "human_gate_required": {
+      "type": "boolean"
+    },
+    "benchmark_certification_ref": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "evidence_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": { "decision": { "const": "SELECTED" } },
+        "required": ["decision"]
+      },
+      "then": {
+        "properties": {
+          "selected_route_id": { "type": "string", "minLength": 1 },
+          "selected_provider": { "type": "string", "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple", "unknown"] },
+          "selected_model": { "type": "string", "minLength": 1 },
+          "access_path": { "$ref": "#/$defs/access_path" },
+          "blocked_reasons": { "maxItems": 0 }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "decision": { "enum": ["BLOCKED", "ESCALATED", "NEEDS_SUPERVISOR"] } },
+        "required": ["decision"]
+      },
+      "then": {
+        "properties": {
+          "selected_route_id": { "type": "null" },
+          "selected_provider": { "type": "null" },
+          "selected_model": { "type": "null" },
+          "access_path": { "type": "null" },
+          "blocked_reasons": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "privacy_class": { "const": "UNKNOWN" } },
+        "required": ["privacy_class"]
+      },
+      "then": {
+        "properties": {
+          "decision": { "enum": ["BLOCKED", "ESCALATED", "NEEDS_SUPERVISOR"] },
+          "blocked_reasons": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "risk_class": { "const": "UNKNOWN" } },
+        "required": ["risk_class"]
+      },
+      "then": {
+        "properties": {
+          "decision": { "enum": ["BLOCKED", "ESCALATED", "NEEDS_SUPERVISOR"] },
+          "blocked_reasons": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "access_path": { "const": "openrouter_free" } },
+        "required": ["access_path"]
+      },
+      "then": {
+        "not": {
+          "anyOf": [
+            { "properties": { "lane_id": { "enum": ["protected_authority", "release_supervisor", "unknown_fail_closed"] } }, "required": ["lane_id"] },
+            { "properties": { "privacy_class": { "enum": ["PRIVATE_REPO_NO_SECRETS", "PRIVATE_REPO_POSSIBLE_SECRETS", "SECRET_BEARING", "CLIENT_DATA", "SECURITY_SENSITIVE", "RELEASE_AUTHORITY", "UNKNOWN"] } }, "required": ["privacy_class"] },
+            { "properties": { "risk_class": { "enum": ["R5_SECURITY_OR_AUTHORITY", "R6_RELEASE_OR_PRODUCTION", "UNKNOWN"] } }, "required": ["risk_class"] },
+            { "properties": { "proof_requirement": { "enum": ["security", "release"] } }, "required": ["proof_requirement"] },
+            { "properties": { "audit_requirement": { "enum": ["independent", "deep", "security", "release"] } }, "required": ["audit_requirement"] }
+          ]
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "lane_id": {
+      "type": "string",
+      "enum": [
+        "public_read",
+        "public_draft",
+        "test_only",
+        "local_edit",
+        "multi_file_edit",
+        "protected_authority",
+        "release_supervisor",
+        "unknown_fail_closed"
+      ]
+    },
+    "privacy_class": {
+      "type": "string",
+      "enum": [
+        "PUBLIC_SANDBOX",
+        "PUBLIC_REPO",
+        "PRIVATE_REPO_NO_SECRETS",
+        "PRIVATE_REPO_POSSIBLE_SECRETS",
+        "SECRET_BEARING",
+        "CLIENT_DATA",
+        "SECURITY_SENSITIVE",
+        "RELEASE_AUTHORITY",
+        "UNKNOWN"
+      ]
+    },
+    "risk_class": {
+      "type": "string",
+      "enum": [
+        "R0_READ",
+        "R1_DRAFT",
+        "R2_TEST_ONLY",
+        "R3_LOCAL_EDIT",
+        "R4_MULTI_FILE_EDIT",
+        "R5_SECURITY_OR_AUTHORITY",
+        "R6_RELEASE_OR_PRODUCTION",
+        "UNKNOWN"
+      ]
+    },
+    "access_path": {
+      "type": "string",
+      "enum": [
+        "direct_api",
+        "openrouter_paid",
+        "openrouter_free",
+        "local_self_hosted",
+        "codex",
+        "claude_code",
+        "gemini_cli",
+        "manual_app"
+      ]
+    },
+    "proof_requirement": {
+      "type": "string",
+      "enum": ["minimal", "standard", "implementation", "security", "release", "unknown"]
+    },
+    "audit_requirement": {
+      "type": "string",
+      "enum": ["none", "light", "embedded", "independent", "deep", "security", "release"]
+    },
+    "blocked_reason": {
+      "type": "string",
+      "enum": [
+        "UNKNOWN_PRIVACY_CLASS",
+        "UNKNOWN_RISK_CLASS",
+        "OPENROUTER_FREE_FORBIDDEN",
+        "CONSUMER_APP_AUTHORITY_FORBIDDEN",
+        "PREVIEW_SOLE_HIGH_RISK_AUTHORITY",
+        "MISSING_BENCHMARK_CERTIFICATION",
+        "MISSING_SCHEMA_VALIDATION",
+        "MISSING_PROOF_REQUIREMENT",
+        "MISSING_HUMAN_APPROVAL",
+        "AUDIT_INDEPENDENCE_VIOLATION",
+        "PROVIDER_MODEL_DRIFT",
+        "FALLBACK_WEAKENS_GUARD",
+        "PRIVACY_MISMATCH",
+        "LIVE_WRITE_RUNNER_FORBIDDEN"
+      ]
+    }
+  }
+}

--- a/tests/dcp_extension/routing/test_routing_contracts.py
+++ b/tests/dcp_extension/routing/test_routing_contracts.py
@@ -1,0 +1,214 @@
+"""
+Tests for the DCP routing extension contracts (Packet 6).
+
+These tests validate schema shape only. They do not execute routing, call
+providers, or certify OpenClaw/OpenRouter runtime behavior.
+"""
+
+import copy
+import json
+import pathlib
+
+from jsonschema import Draft202012Validator
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+_ROUTING_SCHEMAS = _REPO_ROOT / "schemas" / "dcp_extension" / "routing"
+
+_ROUTE_DECISION_SCHEMA_PATH = _ROUTING_SCHEMAS / "route_decision.schema.json"
+_LANE_ENGINE_SCHEMA_PATH = _ROUTING_SCHEMAS / "lane_engine.schema.json"
+_OPENCLAW_ROUTE_SCHEMA_PATH = _ROUTING_SCHEMAS / "openclaw_route.schema.json"
+
+
+def _load(path: pathlib.Path) -> dict:
+    with path.open() as fh:
+        return json.load(fh)
+
+
+ROUTE_DECISION_SCHEMA = _load(_ROUTE_DECISION_SCHEMA_PATH)
+LANE_ENGINE_SCHEMA = _load(_LANE_ENGINE_SCHEMA_PATH)
+OPENCLAW_ROUTE_SCHEMA = _load(_OPENCLAW_ROUTE_SCHEMA_PATH)
+
+
+def errors(schema: dict, instance: dict) -> list:
+    return list(Draft202012Validator(schema).iter_errors(instance))
+
+
+def valid_selected_route_decision() -> dict:
+    return {
+        "schema_version": "dcp.routing.route_decision.v0",
+        "decision_id": "rd_packet6_selected",
+        "task_ref": "TP-DMX-DCP-ROUTING-EXTENSION-MAPPING-0001",
+        "lane_id": "public_read",
+        "privacy_class": "PUBLIC_REPO",
+        "risk_class": "R0_READ",
+        "decision": "SELECTED",
+        "selected_route_id": "route_public_openrouter_free",
+        "selected_provider": "openrouter",
+        "selected_model": "openrouter/public-low-risk",
+        "access_path": "openrouter_free",
+        "live_write_runner_selected": False,
+        "blocked_reasons": [],
+        "proof_requirement": "minimal",
+        "audit_requirement": "none",
+        "human_gate_required": False,
+        "benchmark_certification_ref": None,
+        "evidence_refs": ["docs/03-reference/dcp/dcp-routing-extension.md"],
+        "created_at": "2026-06-22T00:00:00Z",
+    }
+
+
+def valid_blocked_route_decision() -> dict:
+    return {
+        "schema_version": "dcp.routing.route_decision.v0",
+        "decision_id": "rd_packet6_blocked",
+        "task_ref": "TP-DMX-DCP-ROUTING-EXTENSION-MAPPING-0001",
+        "lane_id": "protected_authority",
+        "privacy_class": "SECURITY_SENSITIVE",
+        "risk_class": "R5_SECURITY_OR_AUTHORITY",
+        "decision": "BLOCKED",
+        "selected_route_id": None,
+        "selected_provider": None,
+        "selected_model": None,
+        "access_path": None,
+        "live_write_runner_selected": False,
+        "blocked_reasons": ["OPENROUTER_FREE_FORBIDDEN"],
+        "proof_requirement": "security",
+        "audit_requirement": "independent",
+        "human_gate_required": True,
+        "benchmark_certification_ref": None,
+        "evidence_refs": ["docs/03-reference/dcp/dcp-routing-extension.md"],
+        "created_at": "2026-06-22T00:00:00Z",
+    }
+
+
+def valid_lane_engine() -> dict:
+    return {
+        "schema_version": "dcp.routing.lane_engine.v0",
+        "default_unknown_behavior": "BLOCK_OR_ESCALATE",
+        "live_write_runner_allowed": False,
+        "lanes": [
+            {
+                "lane_id": "public_read",
+                "privacy_classes": ["PUBLIC_SANDBOX", "PUBLIC_REPO"],
+                "risk_classes": ["R0_READ", "R1_DRAFT"],
+                "allowed_access_paths": ["direct_api", "local_self_hosted", "openrouter_free"],
+                "forbidden_access_paths": [],
+                "proof_requirement": "minimal",
+                "audit_requirement": "none",
+                "requires_human_approval": False,
+                "fail_closed_on_unknown": True,
+            },
+            {
+                "lane_id": "protected_authority",
+                "privacy_classes": [
+                    "PRIVATE_REPO_POSSIBLE_SECRETS",
+                    "SECURITY_SENSITIVE",
+                    "RELEASE_AUTHORITY",
+                    "UNKNOWN",
+                ],
+                "risk_classes": [
+                    "R5_SECURITY_OR_AUTHORITY",
+                    "R6_RELEASE_OR_PRODUCTION",
+                    "UNKNOWN",
+                ],
+                "allowed_access_paths": ["direct_api", "local_self_hosted", "manual_app"],
+                "forbidden_access_paths": ["openrouter_free"],
+                "proof_requirement": "security",
+                "audit_requirement": "independent",
+                "requires_human_approval": True,
+                "fail_closed_on_unknown": True,
+            },
+        ],
+    }
+
+
+def valid_openclaw_route() -> dict:
+    return {
+        "schema_version": "dcp.routing.openclaw_route.v0",
+        "route_id": "route_direct_frontier_authority",
+        "route_kind": "direct_api",
+        "provider": "openai",
+        "access_path": "direct_api",
+        "runner": "codex",
+        "allowed_for_privacy_classes": ["SECURITY_SENSITIVE", "RELEASE_AUTHORITY"],
+        "allowed_for_risk_classes": ["R5_SECURITY_OR_AUTHORITY", "R6_RELEASE_OR_PRODUCTION"],
+        "openrouter_free": False,
+        "benchmark_required": True,
+        "structured_output_required": True,
+        "proof_capture_required": True,
+        "may_be_sole_authority": False,
+        "live_write_runner": False,
+        "status": "PROPOSED",
+    }
+
+
+class TestRouteDecisionContract:
+    def test_selected_route_decision_validates(self):
+        errs = errors(ROUTE_DECISION_SCHEMA, valid_selected_route_decision())
+        assert errs == [], f"selected route decision has schema errors: {errs}"
+
+    def test_blocked_route_decision_validates(self):
+        errs = errors(ROUTE_DECISION_SCHEMA, valid_blocked_route_decision())
+        assert errs == [], f"blocked route decision has schema errors: {errs}"
+
+    def test_openrouter_free_is_rejected_for_protected_lane(self):
+        tampered = valid_selected_route_decision()
+        tampered["lane_id"] = "protected_authority"
+        tampered["privacy_class"] = "SECURITY_SENSITIVE"
+        tampered["risk_class"] = "R5_SECURITY_OR_AUTHORITY"
+        tampered["proof_requirement"] = "security"
+        tampered["audit_requirement"] = "independent"
+        errs = errors(ROUTE_DECISION_SCHEMA, tampered)
+        assert errs, "protected lanes must not select openrouter_free"
+
+    def test_blocked_decision_requires_blocked_reason(self):
+        tampered = valid_blocked_route_decision()
+        tampered["blocked_reasons"] = []
+        errs = errors(ROUTE_DECISION_SCHEMA, tampered)
+        assert errs, "BLOCKED route decisions must carry at least one blocked reason"
+
+    def test_route_decision_rejects_extra_fields(self):
+        tampered = valid_selected_route_decision()
+        tampered["runtime_router_enabled"] = True
+        errs = errors(ROUTE_DECISION_SCHEMA, tampered)
+        assert errs, "route decision contract must reject undeclared runtime fields"
+
+
+class TestLaneEngineContract:
+    def test_lane_engine_validates(self):
+        errs = errors(LANE_ENGINE_SCHEMA, valid_lane_engine())
+        assert errs == [], f"lane engine has schema errors: {errs}"
+
+    def test_lane_engine_forbids_live_write_runner(self):
+        tampered = valid_lane_engine()
+        tampered["live_write_runner_allowed"] = True
+        errs = errors(LANE_ENGINE_SCHEMA, tampered)
+        assert errs, "routing contract must not allow live-write runners"
+
+    def test_unknown_lane_fails_closed(self):
+        tampered = valid_lane_engine()
+        tampered["default_unknown_behavior"] = "ALLOW"
+        errs = errors(LANE_ENGINE_SCHEMA, tampered)
+        assert errs, "unknown routing conditions must fail closed"
+
+
+class TestOpenClawRouteContract:
+    def test_openclaw_route_validates(self):
+        errs = errors(OPENCLAW_ROUTE_SCHEMA, valid_openclaw_route())
+        assert errs == [], f"OpenClaw route has schema errors: {errs}"
+
+    def test_openrouter_free_rejected_for_security_or_release_route(self):
+        tampered = copy.deepcopy(valid_openclaw_route())
+        tampered["route_id"] = "route_bad_openrouter_free_authority"
+        tampered["route_kind"] = "openrouter_free"
+        tampered["provider"] = "openrouter"
+        tampered["access_path"] = "openrouter_free"
+        tampered["openrouter_free"] = True
+        errs = errors(OPENCLAW_ROUTE_SCHEMA, tampered)
+        assert errs, "OpenRouter-free route must not cover security or release classes"
+
+    def test_openclaw_route_forbids_live_write_runner(self):
+        tampered = valid_openclaw_route()
+        tampered["live_write_runner"] = True
+        errs = errors(OPENCLAW_ROUTE_SCHEMA, tampered)
+        assert errs, "OpenClaw route contract must not define live-write runners"


### PR DESCRIPTION
## Summary
- Adds Packet 6 DCP routing extension contract schemas for route decisions, lane definitions, and OpenClaw route metadata.
- Adds schema-level tests for selected/blocked decisions, OpenRouter-free protected-lane rejection, live-write runner prohibition, fail-closed unknown behavior, and undeclared runtime field rejection.
- Documents canonical Packet 6 contract authority and keeps older OpenClaw routing docs advisory/reference-only.

## Scope Boundaries
- Draft / NEEDS_SUPERVISOR.
- Contracts-only. No production routing, OpenClaw runtime, OpenRouter/provider calls, benchmark certification, live writes, MCP writes, PR-ready, or merge-ready claims.

## Validation
PASS:
- RED: `pytest -q tests/dcp_extension/routing/test_routing_contracts.py` initially failed with missing `schemas/dcp_extension/routing/route_decision.schema.json`.
- GREEN: `pytest -q tests/dcp_extension/routing/test_routing_contracts.py` -> 11 passed.
- `python -m json.tool task-packets/generated/TP-DMX-DCP-ROUTING-EXTENSION-MAPPING-0001.json >/dev/null`
- `python -m jsonschema -i task-packets/generated/TP-DMX-DCP-ROUTING-EXTENSION-MAPPING-0001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` (deprecation warning only)
- `python -m json.tool schemas/dcp_extension/routing/route_decision.schema.json >/dev/null`
- `python -m json.tool schemas/dcp_extension/routing/lane_engine.schema.json >/dev/null`
- `python -m json.tool schemas/dcp_extension/routing/openclaw_route.schema.json >/dev/null`
- `git diff --check origin/main..HEAD`
- `pre-commit run --files docs/03-reference/dcp/dcp-routing-extension.md schemas/dcp_extension/routing/route_decision.schema.json schemas/dcp_extension/routing/lane_engine.schema.json schemas/dcp_extension/routing/openclaw_route.schema.json tests/dcp_extension/routing/test_routing_contracts.py`
- `pre-commit run --from-ref origin/main --to-ref HEAD`

NOT_RUN:
- Runtime routing / OpenClaw execution.
- OpenRouter/provider calls.
- Benchmark certification.
- Live writes.
- External PAL line-level codereview verdict: PAL codereview/precommit workflows ran but repeatedly returned `files_required_to_continue` because file contents were not embedded, so no external line-level PASS is claimed.
