### PR TITLE
chore(conport): quarantine dead codebases

### DIFF
--- a/docker/mcp-servers-source/conport/SURFACE_INVENTORY.md
+++ b/docker/mcp-servers-source/conport/SURFACE_INVENTORY.md
@@ -7,6 +7,15 @@
 ## Overview
 This document specifies the MCP tool surface exposed by the ConPort MCP server (`server.py` and `conport_mcp_stdio.py`). All tools here act as thin, un-opinionated proxies to the underlying ConPort PM-plane REST API running on port 3004.
 
+## Canonical Codebase
+`docker/mcp-servers-source/conport/` is the single runtime-integrated ConPort
+MCP server codebase for this repository.
+
+The older `src/conport/` and `services/conport_kg/` trees are quarantined
+dead-code surfaces. They must not be imported, deployed, or treated as
+canonical ConPort runtime authority without explicit operator approval and a
+new task packet.
+
 ## Callable-Surface Inventory
 The following 13 tools are currently exposed:
 

--- a/proof/conport-optimal-103/PROOF.md
+++ b/proof/conport-optimal-103/PROOF.md
@@ -1,0 +1,69 @@
+# DMX-CONPORT-OPTIMAL-103 Proof
+
+## Scope
+
+TP: `task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-103-retire-dead-codebases.json`
+
+Worktree: `/Users/hue/.codex/worktrees/conport-optimal-103-retire-dead-codebases`
+
+Branch: `codex/conport-optimal-103-retire-dead-codebases`
+
+## Authority
+
+- `AGENTS.md`
+- Packet 103 task packet
+- Runtime import grep over `src/`, `services/`, and `docker/`
+
+## Changes
+
+- Added a deprecation notice to `src/conport/memory_server.py` while preserving
+  the existing code below it.
+- Added `services/conport_kg/QUARANTINE.md`.
+- Added a `Canonical Codebase` section to
+  `docker/mcp-servers-source/conport/SURFACE_INVENTORY.md`.
+
+## Import Checks
+
+`src/conport/memory_server.py` runtime import grep:
+
+```text
+NONE
+```
+
+`services/conport_kg` runtime import grep:
+
+```text
+services/dope-query/tests/test_password_utils.py:6:    from conport_kg.auth.password_utils import PasswordResetConfirm, PasswordValidationError
+```
+
+Assessment: the `conport_kg` hit is a test-only import under
+`services/dope-query/tests`, not a runtime import path. The referenced
+`conport_kg.auth.password_utils` module is not present under
+`services/conport_kg/` in this checkout.
+
+## Validation
+
+PASS:
+
+- `python3 -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-103-retire-dead-codebases.json >/dev/null`
+  - Result: exit 0
+- `python3 -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-103-retire-dead-codebases.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+  - Result: exit 0; `jsonschema` CLI deprecation warning only
+- `python3 -m py_compile src/conport/memory_server.py`
+  - Result: exit 0
+- `grep -rn 'from src.conport.memory_server\|import src.conport.memory_server\|from conport.memory_server\|import conport.memory_server' src/ services/ docker/ --include='*.py' || echo 'NO RUNTIME IMPORTS FOUND'`
+  - Result: `NO RUNTIME IMPORTS FOUND`
+- `grep -rn 'from services.conport_kg\|import services.conport_kg\|from conport_kg\|import conport_kg' src/ services/ docker/ --include='*.py' | grep -v 'services/conport_kg/' || echo 'NO RUNTIME IMPORTS FOUND'`
+  - Result: one test-only import in `services/dope-query/tests/test_password_utils.py`
+- `git diff --check`
+  - Result: exit 0
+- `pre-commit run --files src/conport/memory_server.py services/conport_kg/QUARANTINE.md docker/mcp-servers-source/conport/SURFACE_INVENTORY.md proof/conport-optimal-103/PROOF.md`
+  - Result: exit 0; applicable hooks passed and unrelated hooks skipped
+
+## Residual Risk
+
+- The packet allowlist and step S5 require a documentation update under the
+  canonical ConPort directory, while one invariant says not to alter the
+  canonical codebase. This proof treats that as a docs-only exception because
+  S5 specifically names `SURFACE_INVENTORY.md` and no runtime code under the
+  canonical directory was changed.

--- a/services/conport_kg/QUARANTINE.md
+++ b/services/conport_kg/QUARANTINE.md
@@ -1,0 +1,12 @@
+# Quarantine Notice
+
+`services/conport_kg/` is a non-canonical Apache AGE graph projection.
+
+Per the Memory Trinity ADR, this directory is not the runtime-integrated
+ConPort MCP server. The canonical ConPort MCP server lives at:
+
+`docker/mcp-servers-source/conport/`
+
+Do not import, deploy, or route runtime traffic to this code without explicit
+operator approval and a new task packet that re-establishes authority,
+integration scope, and validation evidence.

--- a/src/conport/memory_server.py
+++ b/src/conport/memory_server.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 """
+DEAD CODE — superseded by docker/mcp-servers-source/conport/
+
+Canonical runtime path: docker/mcp-servers-source/conport/.
+
 ConPort Memory MCP Server
 
 Implements the unified memory graph for Dopemux with:


### PR DESCRIPTION
## Summary

Completes DMX-CONPORT-OPTIMAL packet 103 by marking non-canonical ConPort code surfaces as quarantined without deleting code.

## Changes

- Adds a deprecation notice to `src/conport/memory_server.py`
- Adds `services/conport_kg/QUARANTINE.md`
- Adds a canonical-codebase note to `docker/mcp-servers-source/conport/SURFACE_INVENTORY.md`
- Adds packet proof at `proof/conport-optimal-103/PROOF.md`

## Validation

- Packet JSON parse/schema validation passed
- `python3 -m py_compile src/conport/memory_server.py` passed
- Runtime import grep for `src.conport.memory_server` found no runtime imports
- Runtime import grep for `services.conport_kg` found one test-only import, recorded in proof
- `git diff --check` passed
- file-scoped pre-commit passed
- Task Orchestrator packet 103 moved to terminal

## Notes

No files were deleted. No runtime code in the canonical ConPort server was changed.
