### PR TITLE
feat(conport): expose custom-data + search MCP tools (packets 104+105)

### DIFF
--- a/docker/mcp-servers-source/conport/conport_mcp_stdio.py
+++ b/docker/mcp-servers-source/conport/conport_mcp_stdio.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 from typing import Any, Optional, List
-from urllib.parse import urlencode
+from urllib.parse import quote, quote_plus, urlencode
 
 import aiohttp
 from mcp.server.fastmcp import FastMCP
@@ -205,6 +205,15 @@ async def delete_custom_data(workspace_id: str, category: str, key: str) -> str:
     query = urlencode({"workspace_id": workspace_id, "category": category, "key": key})
     data = await _delete_json(f"{CONPORT_URL}/api/custom_data?{query}")
     return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def search_content(workspace_id: str, query: str) -> str:
+    """Search decisions and progress entries in a workspace."""
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        url = f"{CONPORT_URL}/api/search/{quote(workspace_id, safe='')}?q={quote_plus(query)}"
+        data = await _get_json(session, url)
+        return json.dumps(data, ensure_ascii=False, indent=2)
 
 
 async def main():

--- a/docker/mcp-servers-source/conport/conport_mcp_stdio.py
+++ b/docker/mcp-servers-source/conport/conport_mcp_stdio.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import os
-from typing import Optional, List
+from typing import Any, Optional, List
+from urllib.parse import urlencode
 
 import aiohttp
 from mcp.server.fastmcp import FastMCP
@@ -29,6 +30,13 @@ async def _post_json(url: str, payload: dict):
 async def _put_json(url: str, payload: dict):
     async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
         async with session.put(url, json=payload) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+
+async def _delete_json(url: str):
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        async with session.delete(url) as resp:
             resp.raise_for_status()
             return await resp.json()
 
@@ -162,6 +170,40 @@ async def log_progress(workspace_id: str, description: str, status: str = "IN_PR
         
     url = f"{CONPORT_URL}/api/progress"
     data = await _post_json(url, payload)
+    return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def get_custom_data(workspace_id: str, category: Optional[str] = None, key: Optional[str] = None) -> str:
+    """Retrieve custom data for a workspace, optionally filtered by category and key."""
+    query = {"workspace_id": workspace_id}
+    if category is not None:
+        query["category"] = category
+    if key is not None:
+        query["key"] = key
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        data = await _get_json(session, f"{CONPORT_URL}/api/custom_data?{urlencode(query)}")
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def save_custom_data(workspace_id: str, category: str, key: str, value: Any) -> str:
+    """Save or update custom data for a workspace."""
+    payload = {
+        "workspace_id": workspace_id,
+        "category": category,
+        "key": key,
+        "value": value,
+    }
+    data = await _post_json(f"{CONPORT_URL}/api/custom_data", payload)
+    return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def delete_custom_data(workspace_id: str, category: str, key: str) -> str:
+    """Delete custom data for a workspace."""
+    query = urlencode({"workspace_id": workspace_id, "category": category, "key": key})
+    data = await _delete_json(f"{CONPORT_URL}/api/custom_data?{query}")
     return json.dumps(data, ensure_ascii=False, indent=2)
 
 

--- a/docker/mcp-servers-source/conport/enhanced_server.py
+++ b/docker/mcp-servers-source/conport/enhanced_server.py
@@ -15,7 +15,7 @@ from typing import Dict, Any, Optional, List
 import subprocess
 from pathlib import Path
 from datetime import datetime, timedelta
-from urllib.parse import urlparse
+from urllib.parse import urlencode, urlparse
 
 # Setup logging first
 logging.basicConfig(level=logging.INFO)
@@ -1757,6 +1757,9 @@ class EnhancedConPortServer:
             'conport_update_progress': self._update_progress_tool,
             'conport_get_recent_activity': self._get_recent_activity_tool,
             'conport_get_active_work': self._get_active_work_tool,
+            'conport_get_custom_data': self._get_custom_data_tool,
+            'conport_save_custom_data': self._save_custom_data_tool,
+            'conport_delete_custom_data': self._delete_custom_data_tool,
             # Instance management
             'conport_fork_instance': self._fork_instance,
             'conport_promote': self._promote_progress,
@@ -1797,6 +1800,49 @@ class EnhancedConPortServer:
 
     async def _get_active_work_tool(self, args):
         return await self._get_active_work(args.get('workspace_id'))
+
+    async def _request_custom_data_tool(self, method: str, args: Dict[str, Any]) -> Dict[str, Any]:
+        query = {"workspace_id": args.get("workspace_id")}
+        if args.get("category") is not None:
+            query["category"] = args.get("category")
+        if args.get("key") is not None:
+            query["key"] = args.get("key")
+
+        url = f"http://127.0.0.1:{self.port}/api/custom_data"
+        if method in {"GET", "DELETE"}:
+            url = f"{url}?{urlencode(query)}"
+
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            if method == "GET":
+                response_ctx = session.get(url)
+            elif method == "POST":
+                payload = {
+                    "workspace_id": args.get("workspace_id"),
+                    "category": args.get("category"),
+                    "key": args.get("key"),
+                    "value": args.get("value"),
+                }
+                response_ctx = session.post(url, json=payload)
+            elif method == "DELETE":
+                response_ctx = session.delete(url)
+            else:
+                return {"error": f"unsupported custom_data method: {method}"}
+
+            async with response_ctx as resp:
+                data = await resp.json()
+                if resp.status >= 400:
+                    return {"error": data.get("error", f"custom_data {method} failed")}
+                return data
+
+    async def _get_custom_data_tool(self, args):
+        return await self._request_custom_data_tool("GET", args)
+
+    async def _save_custom_data_tool(self, args):
+        return await self._request_custom_data_tool("POST", args)
+
+    async def _delete_custom_data_tool(self, args):
+        return await self._request_custom_data_tool("DELETE", args)
 
     def _get_tool_schemas(self) -> List[Dict[str, Any]]:
         """Returns the list of supported tools with their JSON schemas"""
@@ -1925,6 +1971,46 @@ class EnhancedConPortServer:
                         "workspace_id": {"type": "string"}
                     },
                     "required": ["workspace_id"]
+                }
+            },
+            {
+                "name": "conport_get_custom_data",
+                "description": "Retrieve custom data for a workspace",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {"type": "string"},
+                        "category": {"type": "string"},
+                        "key": {"type": "string"}
+                    },
+                    "required": ["workspace_id"]
+                }
+            },
+            {
+                "name": "conport_save_custom_data",
+                "description": "Save or update custom data for a workspace",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {"type": "string"},
+                        "category": {"type": "string"},
+                        "key": {"type": "string"},
+                        "value": {}
+                    },
+                    "required": ["workspace_id", "category", "key", "value"]
+                }
+            },
+            {
+                "name": "conport_delete_custom_data",
+                "description": "Delete custom data for a workspace",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {"type": "string"},
+                        "category": {"type": "string"},
+                        "key": {"type": "string"}
+                    },
+                    "required": ["workspace_id", "category", "key"]
                 }
             }
         ]

--- a/docker/mcp-servers-source/conport/enhanced_server.py
+++ b/docker/mcp-servers-source/conport/enhanced_server.py
@@ -15,7 +15,7 @@ from typing import Dict, Any, Optional, List
 import subprocess
 from pathlib import Path
 from datetime import datetime, timedelta
-from urllib.parse import urlencode, urlparse
+from urllib.parse import quote, quote_plus, urlencode, urlparse
 
 # Setup logging first
 logging.basicConfig(level=logging.INFO)
@@ -1760,6 +1760,7 @@ class EnhancedConPortServer:
             'conport_get_custom_data': self._get_custom_data_tool,
             'conport_save_custom_data': self._save_custom_data_tool,
             'conport_delete_custom_data': self._delete_custom_data_tool,
+            'conport_search_content': self._search_content_tool,
             # Instance management
             'conport_fork_instance': self._fork_instance,
             'conport_promote': self._promote_progress,
@@ -1843,6 +1844,18 @@ class EnhancedConPortServer:
 
     async def _delete_custom_data_tool(self, args):
         return await self._request_custom_data_tool("DELETE", args)
+
+    async def _search_content_tool(self, args):
+        workspace_id = args.get('workspace_id')
+        query = args.get('query')
+        url = f"http://127.0.0.1:{self.port}/api/search/{quote(workspace_id or '', safe='')}?q={quote_plus(query or '')}"
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url) as resp:
+                data = await resp.json()
+                if resp.status >= 400:
+                    return {"error": data.get("error", "search_content failed")}
+                return data
 
     def _get_tool_schemas(self) -> List[Dict[str, Any]]:
         """Returns the list of supported tools with their JSON schemas"""
@@ -2011,6 +2024,18 @@ class EnhancedConPortServer:
                         "key": {"type": "string"}
                     },
                     "required": ["workspace_id", "category", "key"]
+                }
+            },
+            {
+                "name": "conport_search_content",
+                "description": "Search decisions and progress entries in a workspace",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {"type": "string"},
+                        "query": {"type": "string"}
+                    },
+                    "required": ["workspace_id", "query"]
                 }
             }
         ]

--- a/docker/mcp-servers-source/conport/server.py
+++ b/docker/mcp-servers-source/conport/server.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 from typing import Any, Optional, List
-from urllib.parse import urlencode
+from urllib.parse import quote, quote_plus, urlencode
 
 import aiohttp
 from mcp.server.fastmcp import FastMCP
@@ -204,6 +204,15 @@ async def delete_custom_data(workspace_id: str, category: str, key: str) -> str:
     query = urlencode({"workspace_id": workspace_id, "category": category, "key": key})
     data = await _delete_json(f"{CONPORT_URL}/api/custom_data?{query}")
     return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def search_content(workspace_id: str, query: str) -> str:
+    """Search decisions and progress entries in a workspace."""
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        url = f"{CONPORT_URL}/api/search/{quote(workspace_id, safe='')}?q={quote_plus(query)}"
+        data = await _get_json(session, url)
+        return json.dumps(data, ensure_ascii=False, indent=2)
 
 
 if __name__ == "__main__":

--- a/docker/mcp-servers-source/conport/server.py
+++ b/docker/mcp-servers-source/conport/server.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import os
-from typing import Optional, List
+from typing import Any, Optional, List
+from urllib.parse import urlencode
 
 import aiohttp
 from mcp.server.fastmcp import FastMCP
@@ -28,6 +29,13 @@ async def _post_json(url: str, payload: dict):
 async def _put_json(url: str, payload: dict):
     async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
         async with session.put(url, json=payload) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+
+async def _delete_json(url: str):
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        async with session.delete(url) as resp:
             resp.raise_for_status()
             return await resp.json()
 
@@ -161,6 +169,40 @@ async def log_progress(workspace_id: str, description: str, status: str = "IN_PR
         
     url = f"{CONPORT_URL}/api/progress"
     data = await _post_json(url, payload)
+    return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def get_custom_data(workspace_id: str, category: Optional[str] = None, key: Optional[str] = None) -> str:
+    """Retrieve custom data for a workspace, optionally filtered by category and key."""
+    query = {"workspace_id": workspace_id}
+    if category is not None:
+        query["category"] = category
+    if key is not None:
+        query["key"] = key
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        data = await _get_json(session, f"{CONPORT_URL}/api/custom_data?{urlencode(query)}")
+        return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def save_custom_data(workspace_id: str, category: str, key: str, value: Any) -> str:
+    """Save or update custom data for a workspace."""
+    payload = {
+        "workspace_id": workspace_id,
+        "category": category,
+        "key": key,
+        "value": value,
+    }
+    data = await _post_json(f"{CONPORT_URL}/api/custom_data", payload)
+    return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def delete_custom_data(workspace_id: str, category: str, key: str) -> str:
+    """Delete custom data for a workspace."""
+    query = urlencode({"workspace_id": workspace_id, "category": category, "key": key})
+    data = await _delete_json(f"{CONPORT_URL}/api/custom_data?{query}")
     return json.dumps(data, ensure_ascii=False, indent=2)
 
 

--- a/docker/mcp-servers-source/conport/tests/test_mcp_custom_data.py
+++ b/docker/mcp-servers-source/conport/tests/test_mcp_custom_data.py
@@ -1,0 +1,135 @@
+import asyncio
+import inspect
+import json
+import sys
+import types
+from pathlib import Path
+
+
+CONPORT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CONPORT_DIR))
+
+
+class _FastMCPStub:
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+
+    def tool(self):
+        def decorator(func):
+            self.tools.append(func.__name__)
+            return func
+
+        return decorator
+
+
+fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+fastmcp_module.FastMCP = _FastMCPStub
+mcp_module = types.ModuleType("mcp")
+mcp_server_module = types.ModuleType("mcp.server")
+mcp_server_models_module = types.ModuleType("mcp.server.models")
+mcp_server_models_module.InitializationOptions = object
+mcp_server_stdio_module = types.ModuleType("mcp.server.stdio")
+mcp_server_stdio_module.stdio_server = object
+
+sys.modules.setdefault("mcp", mcp_module)
+sys.modules.setdefault("mcp.server", mcp_server_module)
+sys.modules.setdefault("mcp.server.fastmcp", fastmcp_module)
+sys.modules.setdefault("mcp.server.models", mcp_server_models_module)
+sys.modules.setdefault("mcp.server.stdio", mcp_server_stdio_module)
+
+import conport_mcp_stdio
+import server as mcp_server
+from enhanced_server import EnhancedConPortServer
+
+
+def _response_json(response):
+    return json.loads(response.text)
+
+
+def test_jsonrpc_custom_data_tools_are_advertised():
+    app = EnhancedConPortServer()
+
+    tools = {tool["name"]: tool for tool in app._get_tool_schemas()}
+
+    assert set(tools) >= {
+        "conport_get_custom_data",
+        "conport_save_custom_data",
+        "conport_delete_custom_data",
+    }
+    assert tools["conport_get_custom_data"]["inputSchema"]["required"] == ["workspace_id"]
+    assert tools["conport_save_custom_data"]["inputSchema"]["required"] == [
+        "workspace_id",
+        "category",
+        "key",
+        "value",
+    ]
+    assert tools["conport_delete_custom_data"]["inputSchema"]["required"] == [
+        "workspace_id",
+        "category",
+        "key",
+    ]
+
+
+def test_jsonrpc_custom_data_dispatch_round_trip(monkeypatch):
+    app = EnhancedConPortServer()
+    store = {}
+
+    async def fake_save(args):
+        store[(args["workspace_id"], args["category"], args["key"])] = args["value"]
+        return {
+            "status": "saved",
+            "workspace_id": args["workspace_id"],
+            "category": args["category"],
+            "key": args["key"],
+        }
+
+    async def fake_get(args):
+        value = store[(args["workspace_id"], args["category"], args["key"])]
+        return {
+            "workspace_id": args["workspace_id"],
+            "category": args["category"],
+            "key": args["key"],
+            "value": value,
+        }
+
+    async def fake_delete(args):
+        store.pop((args["workspace_id"], args["category"], args["key"]))
+        return {
+            "status": "deleted",
+            "workspace_id": args["workspace_id"],
+            "category": args["category"],
+            "key": args["key"],
+        }
+
+    monkeypatch.setattr(app, "_save_custom_data_tool", fake_save, raising=False)
+    monkeypatch.setattr(app, "_get_custom_data_tool", fake_get, raising=False)
+    monkeypatch.setattr(app, "_delete_custom_data_tool", fake_delete, raising=False)
+
+    save_args = {
+        "workspace_id": "ws-104",
+        "category": "agent",
+        "key": "mode",
+        "value": {"enabled": True},
+    }
+
+    save = _response_json(
+        asyncio.run(app._dispatch_tool(1, "conport_save_custom_data", save_args))
+    )
+    get = _response_json(
+        asyncio.run(app._dispatch_tool(2, "conport_get_custom_data", save_args))
+    )
+    delete = _response_json(
+        asyncio.run(app._dispatch_tool(3, "conport_delete_custom_data", save_args))
+    )
+
+    assert save["result"]["status"] == "saved"
+    assert get["result"]["value"] == {"enabled": True}
+    assert delete["result"]["status"] == "deleted"
+    assert store == {}
+
+
+def test_fastmcp_modules_expose_custom_data_tool_functions():
+    for module in (mcp_server, conport_mcp_stdio):
+        for tool_name in ("get_custom_data", "save_custom_data", "delete_custom_data"):
+            tool = getattr(module, tool_name)
+            assert inspect.iscoroutinefunction(tool)

--- a/docker/mcp-servers-source/conport/tests/test_mcp_search.py
+++ b/docker/mcp-servers-source/conport/tests/test_mcp_search.py
@@ -1,0 +1,169 @@
+import asyncio
+import inspect
+import json
+import sys
+import types
+from pathlib import Path
+
+
+CONPORT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CONPORT_DIR))
+
+
+class _FastMCPStub:
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+
+    def tool(self):
+        def decorator(func):
+            self.tools.append(func.__name__)
+            return func
+
+        return decorator
+
+
+fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+fastmcp_module.FastMCP = _FastMCPStub
+mcp_module = types.ModuleType("mcp")
+mcp_server_module = types.ModuleType("mcp.server")
+mcp_server_models_module = types.ModuleType("mcp.server.models")
+mcp_server_models_module.InitializationOptions = object
+mcp_server_stdio_module = types.ModuleType("mcp.server.stdio")
+mcp_server_stdio_module.stdio_server = object
+
+sys.modules.setdefault("mcp", mcp_module)
+sys.modules.setdefault("mcp.server", mcp_server_module)
+sys.modules.setdefault("mcp.server.fastmcp", fastmcp_module)
+sys.modules.setdefault("mcp.server.models", mcp_server_models_module)
+sys.modules.setdefault("mcp.server.stdio", mcp_server_stdio_module)
+
+import conport_mcp_stdio
+import server as mcp_server
+from enhanced_server import EnhancedConPortServer
+
+
+def _response_json(response):
+    return json.loads(response.text)
+
+
+def test_jsonrpc_search_content_tool_is_advertised():
+    app = EnhancedConPortServer()
+
+    tools = {tool["name"]: tool for tool in app._get_tool_schemas()}
+
+    assert "conport_search_content" in tools
+    assert tools["conport_search_content"]["inputSchema"]["required"] == [
+        "workspace_id",
+        "query",
+    ]
+
+
+def test_jsonrpc_search_content_dispatch_returns_seeded_result(monkeypatch):
+    app = EnhancedConPortServer()
+    seeded = {
+        "workspace_id": "ws-105",
+        "query": "needle",
+        "results": {
+            "decisions": [
+                {
+                    "id": "decision-1",
+                    "workspace_id": "ws-105",
+                    "summary": "needle decision",
+                    "rationale": "seeded result",
+                    "rank": 0.5,
+                }
+            ],
+            "progress": [],
+        },
+        "total_count": 1,
+    }
+
+    async def fake_search(args):
+        assert args == {"workspace_id": "ws-105", "query": "needle"}
+        return seeded
+
+    monkeypatch.setattr(app, "_search_content_tool", fake_search, raising=False)
+
+    response = _response_json(
+        asyncio.run(
+            app._dispatch_tool(
+                1,
+                "conport_search_content",
+                {"workspace_id": "ws-105", "query": "needle"},
+            )
+        )
+    )
+
+    assert response["result"]["total_count"] == 1
+    assert response["result"]["results"]["decisions"][0]["summary"] == "needle decision"
+
+
+def test_fastmcp_modules_expose_search_content_tool_function():
+    for module in (mcp_server, conport_mcp_stdio):
+        tool = getattr(module, "search_content")
+        assert inspect.iscoroutinefunction(tool)
+
+
+def test_jsonrpc_search_content_url_encodes_path_workspace_id(monkeypatch):
+    """Regression: a path-shaped workspace_id must be percent-encoded into the
+    /api/search/{workspace_id} path segment. Raw slashes 404 against aiohttp's
+    single-segment route; only %2F-encoded slashes match."""
+    import enhanced_server as es
+
+    captured = {}
+
+    class _FakeResp:
+        status = 200
+
+        async def json(self):
+            return {"results": {"decisions": [], "progress": []}, "total_count": 0}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakeSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def get(self, url):
+            captured["url"] = url
+            return _FakeResp()
+
+    monkeypatch.setattr(es.aiohttp, "ClientSession", _FakeSession)
+
+    app = es.EnhancedConPortServer()
+    asyncio.run(
+        app._search_content_tool(
+            {"workspace_id": "/Users/hue/code/dopemux-mvp", "query": "a b"}
+        )
+    )
+
+    assert "%2FUsers%2Fhue%2Fcode%2Fdopemux-mvp" in captured["url"]
+    assert "/api/search//Users" not in captured["url"]
+    assert "q=a+b" in captured["url"]
+
+
+def test_fastmcp_search_content_url_encodes_path_workspace_id(monkeypatch):
+    """Same regression for the FastMCP stdio/server search_content tools."""
+    ws = "/Users/hue/code/dopemux-mvp"
+    for module in (mcp_server, conport_mcp_stdio):
+        captured = {}
+
+        async def fake_get_json(session, url):
+            captured["url"] = url
+            return {"results": {"decisions": [], "progress": []}, "total_count": 0}
+
+        monkeypatch.setattr(module, "_get_json", fake_get_json)
+        asyncio.run(module.search_content(ws, "a b"))
+
+        assert "%2FUsers%2Fhue%2Fcode%2Fdopemux-mvp" in captured["url"], module.__name__
+        assert "/api/search//Users" not in captured["url"], module.__name__

--- a/proof/conport-optimal-104-mcp-surface-custom-data/DMX-CONPORT-OPTIMAL-104-mcp-surface-custom-data/PROOF.md
+++ b/proof/conport-optimal-104-mcp-surface-custom-data/DMX-CONPORT-OPTIMAL-104-mcp-surface-custom-data/PROOF.md
@@ -1,0 +1,104 @@
+# DMX-CONPORT-OPTIMAL-104 MCP Custom Data Proof
+
+## Scope
+
+TP: `task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-104-mcp-surface-custom-data.json`
+
+Worktree: `/Users/hue/.codex/worktrees/conport-optimal-104-mcp-surface-custom-data`
+
+Branch: `codex/conport-optimal-104-mcp-surface-custom-data`
+
+## Authority
+
+- `AGENTS.md`
+- Packet 104 task packet
+- Existing REST handlers in `docker/mcp-servers-source/conport/enhanced_server.py`
+
+## Contract Observed
+
+Existing REST routes:
+
+- `POST /api/custom_data`
+  - JSON body: `workspace_id`, `category`, `key`, `value`
+- `GET /api/custom_data`
+  - Query params: `workspace_id` required; `category` and `key` optional
+- `DELETE /api/custom_data`
+  - Query params: `workspace_id`, `category`, `key`
+
+The packet PR text listed `category` as required for get, but the runtime REST
+handler only requires `workspace_id`. The implementation follows runtime truth:
+`category` and `key` are optional filters for `get_custom_data`.
+
+## Changes
+
+- Added FastMCP tools to `docker/mcp-servers-source/conport/server.py`:
+  - `get_custom_data`
+  - `save_custom_data`
+  - `delete_custom_data`
+- Added the same FastMCP tools to
+  `docker/mcp-servers-source/conport/conport_mcp_stdio.py`.
+- Added JSON-RPC dispatch entries and schemas to
+  `docker/mcp-servers-source/conport/enhanced_server.py`:
+  - `conport_get_custom_data`
+  - `conport_save_custom_data`
+  - `conport_delete_custom_data`
+- Added focused TDD regression tests in
+  `docker/mcp-servers-source/conport/tests/test_mcp_custom_data.py`.
+
+## TDD Evidence
+
+RED:
+
+- `python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_custom_data.py -q`
+  - First run failed during collection because host Python lacked `mcp`; test
+    harness was corrected with a FastMCP stub.
+  - Second RED run failed for missing custom_data schemas, dispatch entries,
+    and FastMCP functions.
+
+GREEN:
+
+- `python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_custom_data.py -q`
+  - Result: `3 passed`
+
+## Validation
+
+PASS:
+
+- `python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_custom_data.py -q`
+  - Result: `3 passed`
+- `python3 -m py_compile docker/mcp-servers-source/conport/server.py docker/mcp-servers-source/conport/conport_mcp_stdio.py docker/mcp-servers-source/conport/enhanced_server.py`
+  - Result: exit 0
+- `python3 -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-104-mcp-surface-custom-data.json >/dev/null`
+  - Result: exit 0
+- `python3 -m jsonschema -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-104-mcp-surface-custom-data.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+  - Result: exit 0; `jsonschema` CLI deprecation warning only
+- `rg -n "get_custom_data|save_custom_data|delete_custom_data|conport_get_custom_data|conport_save_custom_data|conport_delete_custom_data" docker/mcp-servers-source/conport/server.py docker/mcp-servers-source/conport/conport_mcp_stdio.py docker/mcp-servers-source/conport/enhanced_server.py`
+  - Result: all expected tool names present
+- `git diff --check`
+  - Result: exit 0
+- `docker compose --env-file /Users/hue/code/dopemux-mvp/.env -f compose.yml build conport`
+  - Result: exit 0; image copied updated `server.py`, `enhanced_server.py`, and
+    `conport_mcp_stdio.py`
+- `docker compose --env-file /Users/hue/code/dopemux-mvp/.env -f compose.yml up -d --no-deps conport`
+  - Result: exit 0; `mcp-conport` recreated
+- `curl http://localhost:3004/health`
+  - Result: HTTP 200 after startup
+- `tools/list` via `POST http://localhost:3004/mcp`
+  - Result: advertised `conport_get_custom_data`,
+    `conport_save_custom_data`, and `conport_delete_custom_data`
+- JSON-RPC custom_data round trip via `POST http://localhost:3004/mcp`
+  - Result: save/get/delete pass for workspace `packet-104-live`, category
+    `codex`, key prefix `roundtrip-`
+
+NOT_RUN:
+
+- GitHub push or PR creation.
+- PAL codereview/precommit; no callable PAL tool was available in this session.
+
+## Residual Risk
+
+- Live validation exercised the local-dev ConPort database and removed the
+  round-trip row through the new delete tool. It did not test every possible
+  `get_custom_data` list/category-only shape against seeded data.
+- The live `mcp-conport` container currently runs the locally built packet 104
+  image from this worktree.

--- a/proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
+++ b/proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
@@ -1,0 +1,218 @@
+# DMX-CONPORT-OPTIMAL-105 MCP Surface Search Proof
+
+## Scope
+
+- Packet: `task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-105-mcp-surface-search.json`
+- Worktree: `/Users/hue/.codex/worktrees/conport-optimal-105-mcp-surface-search`
+- Branch: `codex/conport-optimal-105-mcp-surface-search`
+- Base HEAD observed before implementation: `db3eb365ea0116aa36cf80efbf4cbbbd61eb4b57`
+
+## Change Summary
+
+- Added `search_content(workspace_id, query)` FastMCP tools in:
+  - `docker/mcp-servers-source/conport/server.py`
+  - `docker/mcp-servers-source/conport/conport_mcp_stdio.py`
+- Added `conport_search_content` JSON-RPC schema and dispatch in:
+  - `docker/mcp-servers-source/conport/enhanced_server.py`
+- Added focused MCP search tests in:
+  - `docker/mcp-servers-source/conport/tests/test_mcp_search.py`
+
+## Post-Review Restack + Encoding Fix (2026-06-22)
+
+During PR review the branch was rebased onto packet 104
+(`codex/conport-optimal-104-mcp-surface-custom-data`, tip `c6434014e`) so the two
+ConPort-surface PRs stack and merge conflict-free. The conflicts were purely
+additive (shared import line, dispatch dict, tool-method block, schema tail) and
+were resolved as unions of both tool families.
+
+A correctness defect was found and fixed during the restack:
+
+- **Bug**: `search_content` injected `workspace_id` raw into the
+  `/api/search/{workspace_id}` path. aiohttp routes `{workspace_id}` as a single
+  path segment, so a real path-shaped workspace id (e.g.
+  `/Users/hue/code/dopemux-mvp`) produced `/api/search//Users/...` and 404'd. The
+  original proof masked this by seeding under the slash-free slug
+  `packet-105-live`.
+- **Fix**: percent-encode the workspace id with `quote(workspace_id, safe='')` at
+  all three call sites (`enhanced_server._search_content_tool`,
+  `conport_mcp_stdio.search_content`, `server.search_content`).
+- **Regression coverage**: added
+  `test_jsonrpc_search_content_url_encodes_path_workspace_id` and
+  `test_fastmcp_search_content_url_encodes_path_workspace_id`, which assert the
+  built URL contains `%2FUsers%2F...` and never `/api/search//Users`.
+
+## Analysis Performed
+
+- Read `AGENTS.md`.
+- Read packet 105 JSON and verified allowlist/validation obligations.
+- Inspected existing ConPort REST search handler and JSON-RPC dispatch pattern.
+- Verified existing search path had no uncommented `ag_catalog` references in the inspected source paths.
+- Confirmed implementation proxies to the existing `GET /api/search/{workspace_id}?q=...` endpoint instead of adding a second search implementation.
+
+## TDD Evidence
+
+RED:
+
+```text
+python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_search.py -q
+```
+
+Result: FAIL, 3 expected failures before implementation for missing `conport_search_content` schema/dispatch and missing FastMCP `search_content` tool.
+
+GREEN:
+
+```text
+python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_search.py -q
+```
+
+Result: PASS.
+
+## Validation
+
+PASS:
+
+```text
+python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_search.py -q
+```
+
+PASS:
+
+```text
+python3 -m py_compile \
+  docker/mcp-servers-source/conport/server.py \
+  docker/mcp-servers-source/conport/conport_mcp_stdio.py \
+  docker/mcp-servers-source/conport/enhanced_server.py
+```
+
+PASS:
+
+```text
+python3 -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-105-mcp-surface-search.json >/dev/null
+python3 -m jsonschema \
+  -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-105-mcp-surface-search.json \
+  docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+```
+
+PASS:
+
+```text
+git diff --check
+```
+
+PASS:
+
+```text
+pre-commit run --files \
+  docker/mcp-servers-source/conport/server.py \
+  docker/mcp-servers-source/conport/conport_mcp_stdio.py \
+  docker/mcp-servers-source/conport/enhanced_server.py \
+  docker/mcp-servers-source/conport/tests/test_mcp_search.py \
+  proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
+```
+
+PASS with existing allowlisted match only:
+
+```text
+rg -n "(sk-proj-[A-Za-z0-9_-]+|sk-svcacct-[A-Za-z0-9_-]+|ghp_[A-Za-z0-9_]+|postgres(ql)?://[^[:space:]]+:[^[:space:]@]+@)" \
+  docker/mcp-servers-source/conport/server.py \
+  docker/mcp-servers-source/conport/conport_mcp_stdio.py \
+  docker/mcp-servers-source/conport/enhanced_server.py \
+  docker/mcp-servers-source/conport/tests/test_mcp_search.py \
+  proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
+```
+
+Observed only the pre-existing `# pragma: allowlist secret` local development Postgres URL in `enhanced_server.py`.
+
+PASS:
+
+```text
+docker compose --env-file /Users/hue/code/dopemux-mvp/.env -f compose.yml build conport
+docker compose --env-file /Users/hue/code/dopemux-mvp/.env -f compose.yml up -d --no-deps conport
+curl http://localhost:3004/health
+```
+
+Observed: `health_http=200`.
+
+PASS:
+
+```text
+curl -sS -X POST http://localhost:3004/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Observed: `conport_search_content` advertised.
+
+PASS:
+
+Seeded live decision in workspace `packet-105-live` with keyword `packet105needle1782158062`, then called:
+
+```text
+curl -sS -X POST http://localhost:3004/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"conport_search_content","arguments":{"workspace_id":"packet-105-live","query":"packet105needle1782158062"}}}'
+```
+
+Observed: JSON-RPC search result contained the seeded keyword.
+
+### Integrated coexistence + path-workspace e2e (post-restack, 2026-06-22)
+
+Run against the rebased branch (104 + 105 stacked) without disturbing the live
+`mcp-conport` container.
+
+PASS — full conport unit suite on the combined branch:
+
+```text
+python3 -m pytest docker/mcp-servers-source/conport/tests/ -q
+```
+
+Observed: 42 passed (104 `test_mcp_custom_data` + 105 `test_mcp_search` coexisting).
+
+PASS — built the combined image and ran an ephemeral container on alt port
+`3014:3004` against the real DB/network:
+
+```text
+docker build -f docker/mcp-servers/conport/Dockerfile -t dopemux-conport:stack105 .
+docker run -d --name conport-stack105-test --network dopemux-network -p 3014:3004 <db/redis/qdrant env> dopemux-conport:stack105
+```
+
+- `tools/list` advertised all 13 tools including `conport_search_content` and the
+  three `conport_*_custom_data` tools.
+- `conport_search_content` with a **path-shaped** workspace
+  (`/tmp/conport-stack105-e2e`) returned a seeded decision — the exact case that
+  404'd before the encoding fix.
+- `conport_save/get/delete_custom_data` round-trip succeeded under the same path
+  workspace.
+- Negative control: `GET /api/search/<raw-path>` → 404; `GET /api/search/<%2F-encoded>` → 200.
+
+Cleanup: seeded throwaway decision deleted from the DB (`DELETE 1`, verified 0
+remaining), ephemeral container and `dopemux-conport:stack105` image removed, live
+`mcp-conport` confirmed still healthy (`health=200`).
+
+## Residual Risk
+
+- Coexistence with packet 104 is now proven: the combined image advertises and
+  serves both tool families over JSON-RPC, validated end-to-end under a path-shaped
+  workspace.
+- The original `packet-105-live` seeded decision (slug workspace) from the
+  pre-restack validation remains in the DB; harmless, isolated under a non-path
+  workspace id.
+- The raw-path-segment pattern is shared by pre-existing tools
+  (`get_active_work`/`get_recent_activity`/`get_context`) which avoid the bug only
+  because `enhanced_server` dispatches them in-process. They remain latently
+  affected for any future HTTP self-call refactor — flagged as a separate
+  follow-up, intentionally out of scope here.
+- Full repository suite was not run; validation stayed conport-surface-scoped per
+  blast radius.
+
+## Commit / PR
+
+- Original implementation commit: `33691c7be53903caafd7eb0b3261bfc19d0349e8`
+- Post-restack: rebased onto `codex/conport-optimal-104-mcp-surface-custom-data`
+  (`c6434014e`); implementation commit replayed as `c76dfbf3e` with the
+  workspace_id encoding fix folded into the conflict resolution.
+- PR: `https://github.com/DDD-Enterprises/dopemux-mvp/pull/959` — base retargeted to
+  the packet 104 branch so it stacks and merges conflict-free; auto-retargets to
+  `main` once 104 merges.
+- Note: this proof was updated post-restack; see "Post-Review Restack + Encoding
+  Fix" and "Integrated coexistence + path-workspace e2e".


### PR DESCRIPTION
## Summary

Completes DMX-CONPORT-OPTIMAL packet 104 by exposing existing `custom_data` REST handlers through the ConPort MCP surfaces.

## Changes

- Adds FastMCP `get_custom_data`, `save_custom_data`, and `delete_custom_data` tools to `server.py`
- Adds matching FastMCP tools to `conport_mcp_stdio.py`
- Adds JSON-RPC dispatch and `tools/list` schemas for `conport_get_custom_data`, `conport_save_custom_data`, and `conport_delete_custom_data`
- Adds focused TDD regression tests in `docker/mcp-servers-source/conport/tests/test_mcp_custom_data.py`
- Adds packet proof bundle

## Validation

- RED/GREEN pytest for `test_mcp_custom_data.py`; final result `3 passed`
- `py_compile` for touched ConPort modules passed
- Packet JSON parse/schema validation passed
- Tool registration grep passed
- `git diff --check` passed
- file-scoped pre-commit passed
- `docker compose ... build conport` passed
- `docker compose ... up -d --no-deps conport` passed
- `/health` returned HTTP 200
- `tools/list` advertised all three new JSON-RPC tools
- live JSON-RPC save/get/delete custom_data round trip passed
- Task Orchestrator packet 104 moved to terminal

## Notes

The implementation follows runtime REST truth: `GET /api/custom_data` requires `workspace_id`; `category` and `key` are optional filters.
