### PR TITLE
feat(conport): expose search content MCP tool

### DIFF
--- a/docker/mcp-servers-source/conport/conport_mcp_stdio.py
+++ b/docker/mcp-servers-source/conport/conport_mcp_stdio.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 from typing import Any, Optional, List
-from urllib.parse import urlencode
+from urllib.parse import quote, quote_plus, urlencode
 
 import aiohttp
 from mcp.server.fastmcp import FastMCP
@@ -205,6 +205,15 @@ async def delete_custom_data(workspace_id: str, category: str, key: str) -> str:
     query = urlencode({"workspace_id": workspace_id, "category": category, "key": key})
     data = await _delete_json(f"{CONPORT_URL}/api/custom_data?{query}")
     return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def search_content(workspace_id: str, query: str) -> str:
+    """Search decisions and progress entries in a workspace."""
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        url = f"{CONPORT_URL}/api/search/{quote(workspace_id, safe='')}?q={quote_plus(query)}"
+        data = await _get_json(session, url)
+        return json.dumps(data, ensure_ascii=False, indent=2)
 
 
 async def main():

--- a/docker/mcp-servers-source/conport/enhanced_server.py
+++ b/docker/mcp-servers-source/conport/enhanced_server.py
@@ -15,7 +15,7 @@ from typing import Dict, Any, Optional, List
 import subprocess
 from pathlib import Path
 from datetime import datetime, timedelta
-from urllib.parse import urlencode, urlparse
+from urllib.parse import quote, quote_plus, urlencode, urlparse
 
 # Setup logging first
 logging.basicConfig(level=logging.INFO)
@@ -1748,6 +1748,7 @@ class EnhancedConPortServer:
             'conport_get_custom_data': self._get_custom_data_tool,
             'conport_save_custom_data': self._save_custom_data_tool,
             'conport_delete_custom_data': self._delete_custom_data_tool,
+            'conport_search_content': self._search_content_tool,
             # Instance management
             'conport_fork_instance': self._fork_instance,
             'conport_promote': self._promote_progress,
@@ -1831,6 +1832,18 @@ class EnhancedConPortServer:
 
     async def _delete_custom_data_tool(self, args):
         return await self._request_custom_data_tool("DELETE", args)
+
+    async def _search_content_tool(self, args):
+        workspace_id = args.get('workspace_id')
+        query = args.get('query')
+        url = f"http://127.0.0.1:{self.port}/api/search/{quote(workspace_id or '', safe='')}?q={quote_plus(query or '')}"
+        timeout = aiohttp.ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(url) as resp:
+                data = await resp.json()
+                if resp.status >= 400:
+                    return {"error": data.get("error", "search_content failed")}
+                return data
 
     def _get_tool_schemas(self) -> List[Dict[str, Any]]:
         """Returns the list of supported tools with their JSON schemas"""
@@ -1999,6 +2012,18 @@ class EnhancedConPortServer:
                         "key": {"type": "string"}
                     },
                     "required": ["workspace_id", "category", "key"]
+                }
+            },
+            {
+                "name": "conport_search_content",
+                "description": "Search decisions and progress entries in a workspace",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {"type": "string"},
+                        "query": {"type": "string"}
+                    },
+                    "required": ["workspace_id", "query"]
                 }
             }
         ]

--- a/docker/mcp-servers-source/conport/server.py
+++ b/docker/mcp-servers-source/conport/server.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import os
 from typing import Any, Optional, List
-from urllib.parse import urlencode
+from urllib.parse import quote, quote_plus, urlencode
 
 import aiohttp
 from mcp.server.fastmcp import FastMCP
@@ -204,6 +204,15 @@ async def delete_custom_data(workspace_id: str, category: str, key: str) -> str:
     query = urlencode({"workspace_id": workspace_id, "category": category, "key": key})
     data = await _delete_json(f"{CONPORT_URL}/api/custom_data?{query}")
     return json.dumps(data, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+async def search_content(workspace_id: str, query: str) -> str:
+    """Search decisions and progress entries in a workspace."""
+    async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+        url = f"{CONPORT_URL}/api/search/{quote(workspace_id, safe='')}?q={quote_plus(query)}"
+        data = await _get_json(session, url)
+        return json.dumps(data, ensure_ascii=False, indent=2)
 
 
 if __name__ == "__main__":

--- a/docker/mcp-servers-source/conport/tests/test_mcp_search.py
+++ b/docker/mcp-servers-source/conport/tests/test_mcp_search.py
@@ -102,3 +102,68 @@ def test_fastmcp_modules_expose_search_content_tool_function():
     for module in (mcp_server, conport_mcp_stdio):
         tool = getattr(module, "search_content")
         assert inspect.iscoroutinefunction(tool)
+
+
+def test_jsonrpc_search_content_url_encodes_path_workspace_id(monkeypatch):
+    """Regression: a path-shaped workspace_id must be percent-encoded into the
+    /api/search/{workspace_id} path segment. Raw slashes 404 against aiohttp's
+    single-segment route; only %2F-encoded slashes match."""
+    import enhanced_server as es
+
+    captured = {}
+
+    class _FakeResp:
+        status = 200
+
+        async def json(self):
+            return {"results": {"decisions": [], "progress": []}, "total_count": 0}
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakeSession:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def get(self, url):
+            captured["url"] = url
+            return _FakeResp()
+
+    monkeypatch.setattr(es.aiohttp, "ClientSession", _FakeSession)
+
+    app = es.EnhancedConPortServer()
+    asyncio.run(
+        app._search_content_tool(
+            {"workspace_id": "/Users/hue/code/dopemux-mvp", "query": "a b"}
+        )
+    )
+
+    assert "%2FUsers%2Fhue%2Fcode%2Fdopemux-mvp" in captured["url"]
+    assert "/api/search//Users" not in captured["url"]
+    assert "q=a+b" in captured["url"]
+
+
+def test_fastmcp_search_content_url_encodes_path_workspace_id(monkeypatch):
+    """Same regression for the FastMCP stdio/server search_content tools."""
+    ws = "/Users/hue/code/dopemux-mvp"
+    for module in (mcp_server, conport_mcp_stdio):
+        captured = {}
+
+        async def fake_get_json(session, url):
+            captured["url"] = url
+            return {"results": {"decisions": [], "progress": []}, "total_count": 0}
+
+        monkeypatch.setattr(module, "_get_json", fake_get_json)
+        asyncio.run(module.search_content(ws, "a b"))
+
+        assert "%2FUsers%2Fhue%2Fcode%2Fdopemux-mvp" in captured["url"], module.__name__
+        assert "/api/search//Users" not in captured["url"], module.__name__

--- a/docker/mcp-servers-source/conport/tests/test_mcp_search.py
+++ b/docker/mcp-servers-source/conport/tests/test_mcp_search.py
@@ -1,0 +1,104 @@
+import asyncio
+import inspect
+import json
+import sys
+import types
+from pathlib import Path
+
+
+CONPORT_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CONPORT_DIR))
+
+
+class _FastMCPStub:
+    def __init__(self, *args, **kwargs):
+        self.tools = []
+
+    def tool(self):
+        def decorator(func):
+            self.tools.append(func.__name__)
+            return func
+
+        return decorator
+
+
+fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+fastmcp_module.FastMCP = _FastMCPStub
+mcp_module = types.ModuleType("mcp")
+mcp_server_module = types.ModuleType("mcp.server")
+mcp_server_models_module = types.ModuleType("mcp.server.models")
+mcp_server_models_module.InitializationOptions = object
+mcp_server_stdio_module = types.ModuleType("mcp.server.stdio")
+mcp_server_stdio_module.stdio_server = object
+
+sys.modules.setdefault("mcp", mcp_module)
+sys.modules.setdefault("mcp.server", mcp_server_module)
+sys.modules.setdefault("mcp.server.fastmcp", fastmcp_module)
+sys.modules.setdefault("mcp.server.models", mcp_server_models_module)
+sys.modules.setdefault("mcp.server.stdio", mcp_server_stdio_module)
+
+import conport_mcp_stdio
+import server as mcp_server
+from enhanced_server import EnhancedConPortServer
+
+
+def _response_json(response):
+    return json.loads(response.text)
+
+
+def test_jsonrpc_search_content_tool_is_advertised():
+    app = EnhancedConPortServer()
+
+    tools = {tool["name"]: tool for tool in app._get_tool_schemas()}
+
+    assert "conport_search_content" in tools
+    assert tools["conport_search_content"]["inputSchema"]["required"] == [
+        "workspace_id",
+        "query",
+    ]
+
+
+def test_jsonrpc_search_content_dispatch_returns_seeded_result(monkeypatch):
+    app = EnhancedConPortServer()
+    seeded = {
+        "workspace_id": "ws-105",
+        "query": "needle",
+        "results": {
+            "decisions": [
+                {
+                    "id": "decision-1",
+                    "workspace_id": "ws-105",
+                    "summary": "needle decision",
+                    "rationale": "seeded result",
+                    "rank": 0.5,
+                }
+            ],
+            "progress": [],
+        },
+        "total_count": 1,
+    }
+
+    async def fake_search(args):
+        assert args == {"workspace_id": "ws-105", "query": "needle"}
+        return seeded
+
+    monkeypatch.setattr(app, "_search_content_tool", fake_search, raising=False)
+
+    response = _response_json(
+        asyncio.run(
+            app._dispatch_tool(
+                1,
+                "conport_search_content",
+                {"workspace_id": "ws-105", "query": "needle"},
+            )
+        )
+    )
+
+    assert response["result"]["total_count"] == 1
+    assert response["result"]["results"]["decisions"][0]["summary"] == "needle decision"
+
+
+def test_fastmcp_modules_expose_search_content_tool_function():
+    for module in (mcp_server, conport_mcp_stdio):
+        tool = getattr(module, "search_content")
+        assert inspect.iscoroutinefunction(tool)

--- a/proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
+++ b/proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
@@ -17,6 +17,30 @@
 - Added focused MCP search tests in:
   - `docker/mcp-servers-source/conport/tests/test_mcp_search.py`
 
+## Post-Review Restack + Encoding Fix (2026-06-22)
+
+During PR review the branch was rebased onto packet 104
+(`codex/conport-optimal-104-mcp-surface-custom-data`, tip `c6434014e`) so the two
+ConPort-surface PRs stack and merge conflict-free. The conflicts were purely
+additive (shared import line, dispatch dict, tool-method block, schema tail) and
+were resolved as unions of both tool families.
+
+A correctness defect was found and fixed during the restack:
+
+- **Bug**: `search_content` injected `workspace_id` raw into the
+  `/api/search/{workspace_id}` path. aiohttp routes `{workspace_id}` as a single
+  path segment, so a real path-shaped workspace id (e.g.
+  `/Users/hue/code/dopemux-mvp`) produced `/api/search//Users/...` and 404'd. The
+  original proof masked this by seeding under the slash-free slug
+  `packet-105-live`.
+- **Fix**: percent-encode the workspace id with `quote(workspace_id, safe='')` at
+  all three call sites (`enhanced_server._search_content_tool`,
+  `conport_mcp_stdio.search_content`, `server.search_content`).
+- **Regression coverage**: added
+  `test_jsonrpc_search_content_url_encodes_path_workspace_id` and
+  `test_fastmcp_search_content_url_encodes_path_workspace_id`, which assert the
+  built URL contains `%2FUsers%2F...` and never `/api/search//Users`.
+
 ## Analysis Performed
 
 - Read `AGENTS.md`.
@@ -131,14 +155,64 @@ curl -sS -X POST http://localhost:3004/mcp \
 
 Observed: JSON-RPC search result contained the seeded keyword.
 
+### Integrated coexistence + path-workspace e2e (post-restack, 2026-06-22)
+
+Run against the rebased branch (104 + 105 stacked) without disturbing the live
+`mcp-conport` container.
+
+PASS — full conport unit suite on the combined branch:
+
+```text
+python3 -m pytest docker/mcp-servers-source/conport/tests/ -q
+```
+
+Observed: 42 passed (104 `test_mcp_custom_data` + 105 `test_mcp_search` coexisting).
+
+PASS — built the combined image and ran an ephemeral container on alt port
+`3014:3004` against the real DB/network:
+
+```text
+docker build -f docker/mcp-servers/conport/Dockerfile -t dopemux-conport:stack105 .
+docker run -d --name conport-stack105-test --network dopemux-network -p 3014:3004 <db/redis/qdrant env> dopemux-conport:stack105
+```
+
+- `tools/list` advertised all 13 tools including `conport_search_content` and the
+  three `conport_*_custom_data` tools.
+- `conport_search_content` with a **path-shaped** workspace
+  (`/tmp/conport-stack105-e2e`) returned a seeded decision — the exact case that
+  404'd before the encoding fix.
+- `conport_save/get/delete_custom_data` round-trip succeeded under the same path
+  workspace.
+- Negative control: `GET /api/search/<raw-path>` → 404; `GET /api/search/<%2F-encoded>` → 200.
+
+Cleanup: seeded throwaway decision deleted from the DB (`DELETE 1`, verified 0
+remaining), ephemeral container and `dopemux-conport:stack105` image removed, live
+`mcp-conport` confirmed still healthy (`health=200`).
+
 ## Residual Risk
 
-- The live `mcp-conport` container was rebuilt from packet 105's `origin/main`-based worktree. It validates packet 105, but it does not prove coexistence with unmerged packet 104 custom-data MCP additions.
-- The seeded live validation intentionally wrote one decision record to workspace `packet-105-live` to prove live search behavior.
-- Full suite validation was not run; validation stayed packet-scoped per allowlist and blast radius.
+- Coexistence with packet 104 is now proven: the combined image advertises and
+  serves both tool families over JSON-RPC, validated end-to-end under a path-shaped
+  workspace.
+- The original `packet-105-live` seeded decision (slug workspace) from the
+  pre-restack validation remains in the DB; harmless, isolated under a non-path
+  workspace id.
+- The raw-path-segment pattern is shared by pre-existing tools
+  (`get_active_work`/`get_recent_activity`/`get_context`) which avoid the bug only
+  because `enhanced_server` dispatches them in-process. They remain latently
+  affected for any future HTTP self-call refactor — flagged as a separate
+  follow-up, intentionally out of scope here.
+- Full repository suite was not run; validation stayed conport-surface-scoped per
+  blast radius.
 
 ## Commit / PR
 
-- Implementation commit: `33691c7be53903caafd7eb0b3261bfc19d0349e8`
-- PR: `https://github.com/DDD-Enterprises/dopemux-mvp/pull/959`
-- Note: this proof file was updated after PR creation in a proof-only follow-up commit, so the branch tip may be newer than the implementation commit above.
+- Original implementation commit: `33691c7be53903caafd7eb0b3261bfc19d0349e8`
+- Post-restack: rebased onto `codex/conport-optimal-104-mcp-surface-custom-data`
+  (`c6434014e`); implementation commit replayed as `c76dfbf3e` with the
+  workspace_id encoding fix folded into the conflict resolution.
+- PR: `https://github.com/DDD-Enterprises/dopemux-mvp/pull/959` — base retargeted to
+  the packet 104 branch so it stacks and merges conflict-free; auto-retargets to
+  `main` once 104 merges.
+- Note: this proof was updated post-restack; see "Post-Review Restack + Encoding
+  Fix" and "Integrated coexistence + path-workspace e2e".

--- a/proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
+++ b/proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
@@ -1,0 +1,143 @@
+# DMX-CONPORT-OPTIMAL-105 MCP Surface Search Proof
+
+## Scope
+
+- Packet: `task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-105-mcp-surface-search.json`
+- Worktree: `/Users/hue/.codex/worktrees/conport-optimal-105-mcp-surface-search`
+- Branch: `codex/conport-optimal-105-mcp-surface-search`
+- Base HEAD observed before implementation: `db3eb365ea0116aa36cf80efbf4cbbbd61eb4b57`
+
+## Change Summary
+
+- Added `search_content(workspace_id, query)` FastMCP tools in:
+  - `docker/mcp-servers-source/conport/server.py`
+  - `docker/mcp-servers-source/conport/conport_mcp_stdio.py`
+- Added `conport_search_content` JSON-RPC schema and dispatch in:
+  - `docker/mcp-servers-source/conport/enhanced_server.py`
+- Added focused MCP search tests in:
+  - `docker/mcp-servers-source/conport/tests/test_mcp_search.py`
+
+## Analysis Performed
+
+- Read `AGENTS.md`.
+- Read packet 105 JSON and verified allowlist/validation obligations.
+- Inspected existing ConPort REST search handler and JSON-RPC dispatch pattern.
+- Verified existing search path had no uncommented `ag_catalog` references in the inspected source paths.
+- Confirmed implementation proxies to the existing `GET /api/search/{workspace_id}?q=...` endpoint instead of adding a second search implementation.
+
+## TDD Evidence
+
+RED:
+
+```text
+python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_search.py -q
+```
+
+Result: FAIL, 3 expected failures before implementation for missing `conport_search_content` schema/dispatch and missing FastMCP `search_content` tool.
+
+GREEN:
+
+```text
+python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_search.py -q
+```
+
+Result: PASS.
+
+## Validation
+
+PASS:
+
+```text
+python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_search.py -q
+```
+
+PASS:
+
+```text
+python3 -m py_compile \
+  docker/mcp-servers-source/conport/server.py \
+  docker/mcp-servers-source/conport/conport_mcp_stdio.py \
+  docker/mcp-servers-source/conport/enhanced_server.py
+```
+
+PASS:
+
+```text
+python3 -m json.tool task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-105-mcp-surface-search.json >/dev/null
+python3 -m jsonschema \
+  -i task-packets/generated/DMX-CONPORT-OPTIMAL/DMX-CONPORT-OPTIMAL-105-mcp-surface-search.json \
+  docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+```
+
+PASS:
+
+```text
+git diff --check
+```
+
+PASS:
+
+```text
+pre-commit run --files \
+  docker/mcp-servers-source/conport/server.py \
+  docker/mcp-servers-source/conport/conport_mcp_stdio.py \
+  docker/mcp-servers-source/conport/enhanced_server.py \
+  docker/mcp-servers-source/conport/tests/test_mcp_search.py \
+  proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
+```
+
+PASS with existing allowlisted match only:
+
+```text
+rg -n "(sk-proj-[A-Za-z0-9_-]+|sk-svcacct-[A-Za-z0-9_-]+|ghp_[A-Za-z0-9_]+|postgres(ql)?://[^[:space:]]+:[^[:space:]@]+@)" \
+  docker/mcp-servers-source/conport/server.py \
+  docker/mcp-servers-source/conport/conport_mcp_stdio.py \
+  docker/mcp-servers-source/conport/enhanced_server.py \
+  docker/mcp-servers-source/conport/tests/test_mcp_search.py \
+  proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
+```
+
+Observed only the pre-existing `# pragma: allowlist secret` local development Postgres URL in `enhanced_server.py`.
+
+PASS:
+
+```text
+docker compose --env-file /Users/hue/code/dopemux-mvp/.env -f compose.yml build conport
+docker compose --env-file /Users/hue/code/dopemux-mvp/.env -f compose.yml up -d --no-deps conport
+curl http://localhost:3004/health
+```
+
+Observed: `health_http=200`.
+
+PASS:
+
+```text
+curl -sS -X POST http://localhost:3004/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
+Observed: `conport_search_content` advertised.
+
+PASS:
+
+Seeded live decision in workspace `packet-105-live` with keyword `packet105needle1782158062`, then called:
+
+```text
+curl -sS -X POST http://localhost:3004/mcp \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"conport_search_content","arguments":{"workspace_id":"packet-105-live","query":"packet105needle1782158062"}}}'
+```
+
+Observed: JSON-RPC search result contained the seeded keyword.
+
+## Residual Risk
+
+- The live `mcp-conport` container was rebuilt from packet 105's `origin/main`-based worktree. It validates packet 105, but it does not prove coexistence with unmerged packet 104 custom-data MCP additions.
+- The seeded live validation intentionally wrote one decision record to workspace `packet-105-live` to prove live search behavior.
+- Full suite validation was not run; validation stayed packet-scoped per allowlist and blast radius.
+
+## Commit / PR
+
+- Commit: `PENDING`
+- PR: `PENDING`

--- a/proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
+++ b/proof/conport-optimal-105-mcp-surface-search/DMX-CONPORT-OPTIMAL-105-mcp-surface-search/PROOF.md
@@ -139,5 +139,6 @@ Observed: JSON-RPC search result contained the seeded keyword.
 
 ## Commit / PR
 
-- Commit: `PENDING`
-- PR: `PENDING`
+- Implementation commit: `33691c7be53903caafd7eb0b3261bfc19d0349e8`
+- PR: `https://github.com/DDD-Enterprises/dopemux-mvp/pull/959`
+- Note: this proof file was updated after PR creation in a proof-only follow-up commit, so the branch tip may be newer than the implementation commit above.


### PR DESCRIPTION
## Summary
- expose existing ConPort REST search through FastMCP `search_content` tools
- add JSON-RPC `conport_search_content` schema and dispatch
- add focused packet 105 tests and proof bundle

## Validation
- PASS: `python3 -m pytest docker/mcp-servers-source/conport/tests/test_mcp_search.py -q`
- PASS: `python3 -m py_compile docker/mcp-servers-source/conport/server.py docker/mcp-servers-source/conport/conport_mcp_stdio.py docker/mcp-servers-source/conport/enhanced_server.py`
- PASS: packet JSON parse and `jsonschema` validation
- PASS: `git diff --check`
- PASS: file-scoped `pre-commit run --files ...`
- PASS: rebuilt live `mcp-conport`, `/health` returned 200
- PASS: JSON-RPC `tools/list` advertised `conport_search_content`
- PASS: seeded live decision in `packet-105-live`; JSON-RPC search returned the seeded keyword

## Residual Risk
- Live container validation used this packet 105 branch from `origin/main`; it does not prove coexistence with unmerged packet 104 custom-data MCP additions.
- Full suite was not run; validation stayed packet-scoped.
