### PR TITLE
feat(dnh): dNh CRM extension mapping (artifact-only) (Packet 7)

### DIFF
--- a/docs/03-reference/dnh/dnh-extension-mapping.md
+++ b/docs/03-reference/dnh/dnh-extension-mapping.md
@@ -1,0 +1,176 @@
+---
+id: DNH-EXTENSION-MAPPING
+title: dNh CRM Extension Mapping (Packet 7)
+type: reference
+owner: '@hu3mann'
+author: claude
+date: '2026-06-22'
+last_review: '2026-06-22'
+next_review: '2026-09-20'
+prelude: dNh CRM Extension Mapping (Packet 7) (reference) for dopemux documentation
+  and developer workflows.
+---
+# dNh CRM Extension Mapping
+
+**Status**: PROPOSED — artifact-only, read-only stage (Packet 7).
+
+**Scope**: This document describes how the dNh CRM extension attaches to PCP Core
+as a set of READ and PROJECTION adapters. No CRM write, Telegram send, calendar
+write, identity import, policy write, event-store write, or runtime-DB write is
+authorized. Reconciliation service and Task Orchestrator visibility are later
+packets and are out of scope here.
+
+---
+
+## What dNh CRM Is
+
+dNh CRM is PCP Core plus the dNh extension. PCP Core provides the contract schemas
+(`extension_manifest.schema.json`, `authority_map.schema.json`) that govern how any
+extension may attach. The dNh extension declares itself via two JSON instances that
+validate against those contract schemas:
+
+- `schemas/dnh_extension/extension_manifest.dnh.json` — declares the extension
+  identity, capabilities, owned schemas, and the five hard invariants.
+- `schemas/dnh_extension/authority_map.dnh.json` — maps every dNh domain as a
+  READ/PROJECTION/MIRROR/ADAPTER surface with the canonical upstream owner
+  (`dnh-crm`).
+
+dNh never writes any domain. All ten entries in the authority map are artifact-only
+surfaces with `live_write_allowed: false`, `canonical_writer: null`, and
+`unknown_behavior: BLOCK_OR_ESCALATE`. See **Invariant Enforcement** below for how this
+is guaranteed (the generic schema plus this packet's test gate).
+
+---
+
+## Extension Manifest
+
+The manifest (`extension_manifest.dnh.json`) declares:
+
+| Field | Value |
+|---|---|
+| `extension_id` | `dnh-crm` |
+| `extension_kind` | `DNH_CRM` |
+| `status` | `PROPOSED` |
+| `compatible_pcp_core_versions` | `pcp.authority_map.v0`, `pcp.extension_manifest.v0`, `pcp.project_evidence_export.v0` |
+
+**Extension identity**: matches project IDs `dnh-crm` and `dnh-crm-fixture`;
+discovered via repo marker `.dnhroot`.
+
+**Capabilities** (additive-only):
+
+- `authority_map_contributions`: `schemas/dnh_extension/authority_map.dnh.json`
+- `red_lane_contributions`: `reports/project-control-plane/fixtures/dnh_crm_fixture/red_lanes.json`
+- `evidence_export_sections`: `dnh_profile`, `dnh_authority_docs`, `dnh_proof_roots`
+- `proof_status_mappings`: `[]` (none — artifact-only)
+- `runtime_mappings`: `[]` (none — artifact-only)
+- `adapter_mappings`: 10 adapters (one per domain; see table below)
+
+**Schemas**:
+
+- `owned_schema_ids`: `[]` — dNh owns no new schema files in this packet.
+- `forbidden_core_overrides`: `project_evidence_export.schema.json`,
+  `authority_map.schema.json`, `extension_manifest.schema.json`,
+  `project_red_lanes.schema.json`, `project_profile.schema.json`.
+
+**Five hard invariants** (all pinned `true` by the schema):
+
+| Invariant | Value |
+|---|---|
+| `cannot_override_core_fail_closed` | `true` |
+| `cannot_weaken_proof_gates` | `true` |
+| `cannot_weaken_audit_gates` | `true` |
+| `cannot_promote_adapter_to_authority` | `true` |
+| `cannot_require_extension_for_baseline_core` | `true` |
+
+---
+
+## Authority Map
+
+The authority map (`authority_map.dnh.json`) contains exactly ten entries.
+Every entry is artifact-only: `live_write_allowed: false`, `canonical_writer: null`,
+`surface_class` is `PROJECTION`, `ADAPTER`, or `MIRROR` (never `SOURCE`).
+
+| Domain | Action | Surface class | Reader / projection surface | Upstream owner |
+|---|---|---|---|---|
+| `dnh.project_profile` | `project` | `PROJECTION` | dnh project-profile projection | `dnh-crm` |
+| `dnh.authority_docs` | `read` | `ADAPTER` | dnh authority-docs reader | `dnh-crm` |
+| `dnh.proof_roots` | `read` | `ADAPTER` | dnh proof-roots pointer mapping | `dnh-crm` |
+| `dnh.crm` | `read` | `ADAPTER` | dnh CRM runtime read mapping (artifact-only) | `dnh-crm` |
+| `dnh.telegram` | `read` | `ADAPTER` | dnh Telegram adapter (no-send) | `dnh-crm` |
+| `dnh.calendar` | `read` | `ADAPTER` | dnh Calendar adapter (no-write) | `dnh-crm` |
+| `dnh.identity` | `read` | `ADAPTER` | dnh Identity authority mapping (no-merge) | `dnh-crm` |
+| `dnh.policy` | `read` | `ADAPTER` | dnh Policy mapping (no-write) | `dnh-crm` |
+| `dnh.event_store` | `read` | `MIRROR` | dnh event-store read-only evidence map | `dnh-crm` |
+| `dnh.runtime_db` | `read` | `ADAPTER` | dnh runtime-DB FORBIDDEN/red-lane (read-only) | `dnh-crm` |
+
+All entries require `proof_required: true` and fail-closed on unknown ownership
+(`unknown_behavior: BLOCK_OR_ESCALATE`).
+
+---
+
+## Invariant Enforcement
+
+Enforcement comes from two layers — the PCP Core contract schema, and this packet's test suite.
+
+**What the contract schema enforces (generic PCP Core):**
+
+1. A non-SOURCE (derived) surface must have `canonical_writer: null` and `live_write_allowed: false`.
+2. `live_write_allowed: true` is valid only on a `SOURCE` surface with a non-empty `canonical_writer`.
+3. The five manifest invariants are pinned `const: true`; a manifest setting any to `false` is invalid.
+
+**What the contract schema does *not* enforce:** the generic schema deliberately permits a `SOURCE`
+entry to declare a live write — PCP Core must let a real project's authority map name actual sources.
+So the schema alone does not prove that *dNh specifically* owns or writes nothing.
+
+**What guarantees dNh is artifact-only:** this packet's test suite. The per-entry checks assert no dNh
+entry is `SOURCE` (all are `PROJECTION`/`ADAPTER`/`MIRROR`), and `test_source_write_escalation_caught_by_dnh_guard`
+confirms that flipping any dNh entry to `SOURCE` + `live_write_allowed: true` — an edit the generic schema
+would *accept* — is caught by the dNh boundary guard. dNh therefore cannot silently acquire write authority
+without failing the dNh test gate.
+
+---
+
+## Red-Lane Fixture
+
+`reports/project-control-plane/fixtures/dnh_crm_fixture/red_lanes.json` covers the
+five primary mutation red lanes for the dNh CRM project:
+
+| Lane ID | Result |
+|---|---|
+| `crm-write` | `PASS` (no fixture path triggered) |
+| `telegram-send` | `PASS` (no fixture path triggered) |
+| `calendar-write` | `PASS` (no fixture path triggered) |
+| `runtime-db` | `PASS` (no fixture path triggered) |
+| `identity-merge` | `PASS` (no fixture path triggered) |
+
+`default_on_unknown: BLOCK` — any unclassified action blocks by default.
+
+The fixture validates against `schemas/project_control_plane/project_red_lanes.schema.json`.
+
+AIR §9 lists identity among the red-lane domains and requires an *authority map + secret policy* proof
+for identity. The `identity-merge` red lane plus the read-only `dnh.identity` authority-map entry cover
+the authority-map half and the no-merge stop condition. The **secret-policy** proof is recorded here as a
+**forward requirement**: enforcing dNh identity secret handling belongs to a later runtime/live-write
+packet, not this artifact-only mapping.
+
+---
+
+## dNh Must Never Be Required by PCP Core
+
+The invariant `cannot_require_extension_for_baseline_core: true` is the contractual
+guarantee that dNh CRM is a **project extension**, not a PCP Core template or dependency.
+PCP Core operates fully without any dNh artifacts. The extension attaches additively and
+may be removed without breaking PCP Core behavior.
+
+This invariant is pinned `const: true` in `extension_manifest.schema.json`, so any
+manifest that declares it `false` is **invalid by construction**.
+
+---
+
+## Out of Scope (Later Packets)
+
+- Reconciliation service between dNh CRM and PCP Core task state.
+- Task Orchestrator visibility / queue projection for dNh tasks.
+- Live-write authorization for any dNh domain.
+- Identity secret-policy enforcement (AIR §9 identity proof) — recorded as a forward requirement here; runtime enforcement is a later packet.
+- Runtime execution mapping (`runtime_mappings` remains `[]`).

--- a/reports/project-control-plane/fixtures/dnh_crm_fixture/red_lanes.json
+++ b/reports/project-control-plane/fixtures/dnh_crm_fixture/red_lanes.json
@@ -32,6 +32,13 @@
       "reason": "No fixture path requested this lane"
     },
     {
+      "lane_id": "identity-merge",
+      "scope": "PROJECT",
+      "match": "fixture-no-match",
+      "result": "PASS",
+      "reason": "No fixture path requested this lane"
+    },
+    {
       "lane_id": "forbidden-worktree",
       "scope": "PROJECT",
       "match": "fixture-no-match",

--- a/schemas/dnh_extension/authority_map.dnh.json
+++ b/schemas/dnh_extension/authority_map.dnh.json
@@ -1,0 +1,166 @@
+{
+  "schema_version": "pcp.authority_map.v0",
+  "project_id": "dnh-crm-fixture",
+  "entries": [
+    {
+      "domain": "dnh.project_profile",
+      "action": "project",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "PROJECTION",
+      "reader_or_projection_surface": "dnh project-profile projection",
+      "source_truth_refs": [
+        "reports/project-control-plane/fixtures/dnh_crm_fixture/project_profile.json"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "dnh.authority_docs",
+      "action": "read",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dnh authority-docs reader",
+      "source_truth_refs": [
+        "dNh authority docs inventory"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "dnh.proof_roots",
+      "action": "read",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dnh proof-roots pointer mapping",
+      "source_truth_refs": [
+        "dNh proof/status roots"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "dnh.crm",
+      "action": "read",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dnh CRM runtime read mapping (artifact-only)",
+      "source_truth_refs": [
+        "dNh CRM runtime"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "dnh.telegram",
+      "action": "read",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dnh Telegram adapter (no-send)",
+      "source_truth_refs": [
+        "dNh Telegram messaging"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "dnh.calendar",
+      "action": "read",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dnh Calendar adapter (no-write)",
+      "source_truth_refs": [
+        "dNh Calendar"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "dnh.identity",
+      "action": "read",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dnh Identity authority mapping (no-merge)",
+      "source_truth_refs": [
+        "dNh Identity system"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "dnh.policy",
+      "action": "read",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dnh Policy mapping (no-write)",
+      "source_truth_refs": [
+        "dNh Policy domain"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "dnh.event_store",
+      "action": "read",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "MIRROR",
+      "reader_or_projection_surface": "dnh event-store read-only evidence map",
+      "source_truth_refs": [
+        "dNh event store"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "dnh.runtime_db",
+      "action": "read",
+      "canonical_authority_owner": "dnh-crm",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dnh runtime-DB FORBIDDEN/red-lane (read-only)",
+      "source_truth_refs": [
+        "dNh runtime database"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    }
+  ]
+}

--- a/schemas/dnh_extension/extension_manifest.dnh.json
+++ b/schemas/dnh_extension/extension_manifest.dnh.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "pcp.extension_manifest.v0",
+  "status": "PROPOSED",
+  "extension_id": "dnh-crm",
+  "extension_kind": "DNH_CRM",
+  "compatible_pcp_core_versions": [
+    "pcp.authority_map.v0",
+    "pcp.extension_manifest.v0",
+    "pcp.project_evidence_export.v0"
+  ],
+  "extension_identity": {
+    "project_id_patterns": [
+      "dnh-crm",
+      "dnh-crm-fixture"
+    ],
+    "repo_markers": [
+      ".dnhroot"
+    ],
+    "discovery_hints": [
+      "dNh CRM project profile",
+      "reports/project-control-plane/fixtures/dnh_crm_fixture/"
+    ]
+  },
+  "capabilities": {
+    "authority_map_contributions": [
+      "schemas/dnh_extension/authority_map.dnh.json"
+    ],
+    "red_lane_contributions": [
+      "reports/project-control-plane/fixtures/dnh_crm_fixture/red_lanes.json"
+    ],
+    "evidence_export_sections": [
+      "dnh_profile",
+      "dnh_authority_docs",
+      "dnh_proof_roots"
+    ],
+    "proof_status_mappings": [],
+    "runtime_mappings": [],
+    "adapter_mappings": [
+      "dnh-project-profile",
+      "dnh-authority-docs",
+      "dnh-proof-roots",
+      "dnh-crm",
+      "dnh-telegram",
+      "dnh-calendar",
+      "dnh-identity",
+      "dnh-policy",
+      "dnh-event-store",
+      "dnh-runtime-db"
+    ]
+  },
+  "schemas": {
+    "owned_schema_ids": [],
+    "core_schema_extensions": [],
+    "forbidden_core_overrides": [
+      "project_evidence_export.schema.json",
+      "authority_map.schema.json",
+      "extension_manifest.schema.json",
+      "project_red_lanes.schema.json",
+      "project_profile.schema.json"
+    ]
+  },
+  "invariants": {
+    "cannot_override_core_fail_closed": true,
+    "cannot_weaken_proof_gates": true,
+    "cannot_weaken_audit_gates": true,
+    "cannot_promote_adapter_to_authority": true,
+    "cannot_require_extension_for_baseline_core": true
+  }
+}

--- a/tests/dnh_extension/test_dnh_artifact_only.py
+++ b/tests/dnh_extension/test_dnh_artifact_only.py
@@ -1,0 +1,343 @@
+"""
+Tests for the dNh CRM extension mapping (Packet 7).
+
+Validates that:
+  - schemas/dnh_extension/extension_manifest.dnh.json is a valid instance of
+    schemas/project_control_plane/extension_manifest.schema.json
+  - schemas/dnh_extension/authority_map.dnh.json is a valid instance of
+    schemas/project_control_plane/authority_map.schema.json
+  - All entries are ARTIFACT-ONLY: no live writes, no SOURCE surface, canonical_writer is null,
+    unknown_behavior is BLOCK_OR_ESCALATE
+  - No-send / no-write / no-import for all mutation domains
+  - Red-lane fixture validates against project_red_lanes.schema.json with correct defaults
+  - dNh must never be required by PCP Core (cannot_require_extension_for_baseline_core=True)
+  - Manifest declares no live runtime (runtime_mappings==[], proof_status_mappings==[])
+  - Scope lock: exactly the 10 domains, all owned by dnh-crm
+  - Manifest adapter_mappings (10) correspond to the 10 entry domains
+  - Negative tamper: schema gates hold
+"""
+
+import copy
+import json
+import pathlib
+
+import pytest
+from jsonschema import Draft202012Validator
+
+# ---------------------------------------------------------------------------
+# Paths — repo root is 3 levels up from tests/dnh_extension/test_*.py
+# ---------------------------------------------------------------------------
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_SCHEMAS_PCP = _REPO_ROOT / "schemas" / "project_control_plane"
+_SCHEMAS_DNH = _REPO_ROOT / "schemas" / "dnh_extension"
+_FIXTURES_DNH = _REPO_ROOT / "reports" / "project-control-plane" / "fixtures" / "dnh_crm_fixture"
+
+_MANIFEST_SCHEMA_PATH = _SCHEMAS_PCP / "extension_manifest.schema.json"
+_AUTHORITY_SCHEMA_PATH = _SCHEMAS_PCP / "authority_map.schema.json"
+_RED_LANES_SCHEMA_PATH = _SCHEMAS_PCP / "project_red_lanes.schema.json"
+
+_MANIFEST_INST_PATH = _SCHEMAS_DNH / "extension_manifest.dnh.json"
+_AUTHORITY_INST_PATH = _SCHEMAS_DNH / "authority_map.dnh.json"
+_RED_LANES_PATH = _FIXTURES_DNH / "red_lanes.json"
+
+
+def _load(path: pathlib.Path) -> dict:
+    with path.open() as fh:
+        return json.load(fh)
+
+
+# Load once at module level; missing files produce clear FileNotFoundError (no silent skip).
+MANIFEST_SCHEMA = _load(_MANIFEST_SCHEMA_PATH)
+AUTHORITY_SCHEMA = _load(_AUTHORITY_SCHEMA_PATH)
+RED_LANES_SCHEMA = _load(_RED_LANES_SCHEMA_PATH)
+
+MANIFEST_INST = _load(_MANIFEST_INST_PATH)
+AUTHORITY_INST = _load(_AUTHORITY_INST_PATH)
+RED_LANES_INST = _load(_RED_LANES_PATH)
+
+# Canonical 10 domains for this packet
+EXPECTED_DOMAINS = {
+    "dnh.project_profile",
+    "dnh.authority_docs",
+    "dnh.proof_roots",
+    "dnh.crm",
+    "dnh.telegram",
+    "dnh.calendar",
+    "dnh.identity",
+    "dnh.policy",
+    "dnh.event_store",
+    "dnh.runtime_db",
+}
+
+# Domain->adapter-name mapping for the manifest check
+_DOMAIN_TO_ADAPTER = {
+    "dnh.project_profile": "dnh-project-profile",
+    "dnh.authority_docs": "dnh-authority-docs",
+    "dnh.proof_roots": "dnh-proof-roots",
+    "dnh.crm": "dnh-crm",
+    "dnh.telegram": "dnh-telegram",
+    "dnh.calendar": "dnh-calendar",
+    "dnh.identity": "dnh-identity",
+    "dnh.policy": "dnh-policy",
+    "dnh.event_store": "dnh-event-store",
+    "dnh.runtime_db": "dnh-runtime-db",
+}
+
+# Mutation domains that must have no send/write/import
+_MUTATION_DOMAINS = {
+    "dnh.crm",
+    "dnh.telegram",
+    "dnh.calendar",
+    "dnh.identity",
+    "dnh.policy",
+    "dnh.event_store",
+    "dnh.runtime_db",
+}
+
+# Required red-lane IDs per the fixture specification
+_REQUIRED_RED_LANE_IDS = {"crm-write", "telegram-send", "calendar-write", "runtime-db", "identity-merge"}
+
+
+def _schema_errors(schema: dict, instance: dict) -> list:
+    return list(Draft202012Validator(schema).iter_errors(instance))
+
+
+def _entry_by_domain(domain: str) -> dict:
+    matches = [e for e in AUTHORITY_INST["entries"] if e["domain"] == domain]
+    assert matches, f"No entry found for domain '{domain}'"
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# 1. Extension manifest schema validation
+# ---------------------------------------------------------------------------
+class TestExtensionManifestInstance:
+    def test_validates_against_schema(self):
+        errs = _schema_errors(MANIFEST_SCHEMA, MANIFEST_INST)
+        assert errs == [], f"extension_manifest.dnh.json has schema errors: {errs}"
+
+    def test_extension_kind_is_dnh_crm(self):
+        assert MANIFEST_INST["extension_kind"] == "DNH_CRM"
+
+    def test_invariant_cannot_override_core_fail_closed(self):
+        assert MANIFEST_INST["invariants"]["cannot_override_core_fail_closed"] is True
+
+    def test_invariant_cannot_weaken_proof_gates(self):
+        assert MANIFEST_INST["invariants"]["cannot_weaken_proof_gates"] is True
+
+    def test_invariant_cannot_weaken_audit_gates(self):
+        assert MANIFEST_INST["invariants"]["cannot_weaken_audit_gates"] is True
+
+    def test_invariant_cannot_promote_adapter_to_authority(self):
+        assert MANIFEST_INST["invariants"]["cannot_promote_adapter_to_authority"] is True
+
+    def test_invariant_cannot_require_extension_for_baseline_core(self):
+        assert MANIFEST_INST["invariants"]["cannot_require_extension_for_baseline_core"] is True
+
+
+# ---------------------------------------------------------------------------
+# 2. Authority map schema validation
+# ---------------------------------------------------------------------------
+class TestAuthorityMapInstance:
+    def test_validates_against_schema(self):
+        errs = _schema_errors(AUTHORITY_SCHEMA, AUTHORITY_INST)
+        assert errs == [], f"authority_map.dnh.json has schema errors: {errs}"
+
+    def test_entries_non_empty(self):
+        assert len(AUTHORITY_INST["entries"]) > 0, "entries must be non-empty"
+
+
+# ---------------------------------------------------------------------------
+# 3. ARTIFACT-ONLY guarantee: every entry is read-only, no writer, no SOURCE
+# ---------------------------------------------------------------------------
+class TestArtifactOnly:
+    """Every entry must be artifact-only: no live write, no SOURCE, no canonical writer."""
+
+    @pytest.fixture(params=AUTHORITY_INST["entries"], ids=lambda e: e["domain"])
+    def entry(self, request):
+        return request.param
+
+    def test_live_write_not_allowed(self, entry):
+        assert entry["live_write_allowed"] is False, (
+            f"Entry {entry['domain']}/{entry['action']} has live_write_allowed=True"
+        )
+
+    def test_canonical_writer_is_null(self, entry):
+        assert entry["canonical_writer"] is None, (
+            f"Entry {entry['domain']}/{entry['action']} has non-null canonical_writer"
+        )
+
+    def test_surface_class_is_not_source(self, entry):
+        assert entry["surface_class"] != "SOURCE", (
+            f"Entry {entry['domain']}/{entry['action']} has surface_class=SOURCE "
+            "(would mean dNh owns the domain, which violates artifact-only)"
+        )
+
+    def test_unknown_behavior_is_block_or_escalate(self, entry):
+        assert entry["unknown_behavior"] == "BLOCK_OR_ESCALATE", (
+            f"Entry {entry['domain']}/{entry['action']} unknown_behavior is "
+            f"'{entry['unknown_behavior']}', expected BLOCK_OR_ESCALATE"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. No-send / no-write / no-import for mutation domains
+# ---------------------------------------------------------------------------
+class TestMutationDomainsReadOnly:
+    """Mutation-risk domains (CRM/Telegram/calendar/identity/policy/event-store/runtime-db)
+    must exist in the authority map and be read-only."""
+
+    @pytest.fixture(params=sorted(_MUTATION_DOMAINS))
+    def mutation_domain(self, request):
+        return request.param
+
+    def test_mutation_domain_exists_and_is_readonly(self, mutation_domain):
+        entry = _entry_by_domain(mutation_domain)
+        assert entry["live_write_allowed"] is False, (
+            f"Mutation domain '{mutation_domain}' must not allow live writes"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Red-lane fixture validation
+# ---------------------------------------------------------------------------
+class TestRedLanes:
+    def test_red_lanes_validates_against_schema(self):
+        errs = _schema_errors(RED_LANES_SCHEMA, RED_LANES_INST)
+        assert errs == [], f"red_lanes.json has schema errors: {errs}"
+
+    def test_default_on_unknown_is_block(self):
+        assert RED_LANES_INST["default_on_unknown"] == "BLOCK", (
+            "red_lanes.json default_on_unknown must be 'BLOCK'"
+        )
+
+    def test_required_lane_ids_present(self):
+        lane_ids = {c["lane_id"] for c in RED_LANES_INST["classifications"]}
+        missing = _REQUIRED_RED_LANE_IDS - lane_ids
+        assert not missing, (
+            f"red_lanes.json is missing required lane_ids: {missing}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 6. dNh must never be required by PCP Core
+# ---------------------------------------------------------------------------
+class TestDnhNotRequiredByCore:
+    def test_cannot_require_extension_for_baseline_core_is_true(self):
+        """Invariant cannot_require_extension_for_baseline_core=True is the contractual
+        guarantee that dNh is a project extension, not a PCP Core template dependency."""
+        val = MANIFEST_INST["invariants"]["cannot_require_extension_for_baseline_core"]
+        assert val is True, (
+            f"cannot_require_extension_for_baseline_core must be True, got {val!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Manifest declares no live runtime
+# ---------------------------------------------------------------------------
+class TestNoLiveRuntime:
+    def test_runtime_mappings_is_empty(self):
+        assert MANIFEST_INST["capabilities"]["runtime_mappings"] == [], (
+            "dNh extension must declare no runtime_mappings (artifact-only)"
+        )
+
+    def test_proof_status_mappings_is_empty(self):
+        assert MANIFEST_INST["capabilities"]["proof_status_mappings"] == [], (
+            "dNh extension must declare no proof_status_mappings (artifact-only)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. Scope lock: exactly 10 domains, all owned by dnh-crm
+# ---------------------------------------------------------------------------
+class TestScopeLock:
+    def test_exactly_ten_entries(self):
+        assert len(AUTHORITY_INST["entries"]) == 10, (
+            f"Expected exactly 10 authority entries, got {len(AUTHORITY_INST['entries'])}"
+        )
+
+    def test_canonical_authority_owners_is_dnh_crm(self):
+        owners = {e["canonical_authority_owner"] for e in AUTHORITY_INST["entries"]}
+        assert owners == {"dnh-crm"}, (
+            f"All entries must have canonical_authority_owner='dnh-crm', got {owners}"
+        )
+
+    def test_domains_match_expected_set(self):
+        actual = {e["domain"] for e in AUTHORITY_INST["entries"]}
+        assert actual == EXPECTED_DOMAINS, (
+            f"Domain mismatch. "
+            f"Unexpected: {actual - EXPECTED_DOMAINS}; "
+            f"Missing: {EXPECTED_DOMAINS - actual}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 9. Manifest adapter_mappings correspond to the 10 entry domains
+# ---------------------------------------------------------------------------
+class TestManifestAdapterMappings:
+    def test_adapter_mappings_count_matches_entries(self):
+        adapter_mappings = MANIFEST_INST["capabilities"]["adapter_mappings"]
+        entries = AUTHORITY_INST["entries"]
+        assert len(adapter_mappings) == len(entries) == 10, (
+            f"adapter_mappings length ({len(adapter_mappings)}) != entries length "
+            f"({len(entries)}), both must be 10"
+        )
+
+    def test_adapter_mappings_correspond_to_domains(self):
+        adapter_set = set(MANIFEST_INST["capabilities"]["adapter_mappings"])
+        expected_adapters = set(_DOMAIN_TO_ADAPTER.values())
+        assert adapter_set == expected_adapters, (
+            f"adapter_mappings mismatch. "
+            f"Only in manifest: {adapter_set - expected_adapters}; "
+            f"Only in expected: {expected_adapters - adapter_set}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 10. Negative tamper tests — schema gates must hold
+# ---------------------------------------------------------------------------
+class TestNegativeTamper:
+    def test_manifest_with_cannot_require_extension_false_is_rejected(self):
+        """A manifest with cannot_require_extension_for_baseline_core=false must be invalid."""
+        tampered = copy.deepcopy(MANIFEST_INST)
+        tampered["invariants"]["cannot_require_extension_for_baseline_core"] = False
+        errs = _schema_errors(MANIFEST_SCHEMA, tampered)
+        assert errs, (
+            "Schema must reject cannot_require_extension_for_baseline_core=False"
+        )
+
+    def test_source_write_escalation_caught_by_dnh_guard(self):
+        """The generic PCP Core schema PERMITS a SOURCE entry with a live write — PCP Core must
+        allow a real project's authority map to name actual sources. So dNh's artifact-only
+        guarantee is enforced by the dNh boundary guard (this test), not the PCP schema.
+        The test proves the guard catches any SOURCE/live-write escalation attempt."""
+        tampered = copy.deepcopy(AUTHORITY_INST)
+        escalation = {
+            "domain": "dnh.crm",
+            "action": "write",
+            "canonical_authority_owner": "dnh-crm",
+            "canonical_writer": "dnh-attacker",
+            "surface_class": "SOURCE",
+            "reader_or_projection_surface": "escalated surface",
+            "source_truth_refs": ["escalated ref"],
+            "proof_required": True,
+            "live_write_allowed": True,
+            "approval_required": False,
+            "rollback_required": False,
+            "unknown_behavior": "BLOCK_OR_ESCALATE",
+        }
+        tampered["entries"].append(escalation)
+        # Generic PCP Core schema ACCEPTS this (SOURCE + non-empty writer + live write is valid):
+        assert _schema_errors(AUTHORITY_SCHEMA, tampered) == [], (
+            "Generic schema is expected to ACCEPT a SOURCE+live_write entry; if this starts "
+            "failing the core schema gained a SOURCE restriction and the doc must be updated."
+        )
+        # dNh boundary guard REJECTS it (no dNh entry may be SOURCE, writable, or have a writer):
+        offenders = [
+            e
+            for e in tampered["entries"]
+            if e["surface_class"] == "SOURCE"
+            or e["live_write_allowed"] is not False
+            or e["canonical_writer"] is not None
+        ]
+        assert offenders, "dNh boundary guard must catch a SOURCE/live-write escalation"


### PR DESCRIPTION
## Packet 7 — dNh CRM extension mapping (artifact-only)

dNh = PCP Core + dNh project extension. Maps dNh systems as **artifact-only** read/projection surfaces — NO CRM/Telegram/calendar/identity/policy/event-store/DB write, import, or send.

### Deliverables
- `schemas/dnh_extension/extension_manifest.dnh.json` — `DNH_CRM` manifest; 5 invariants true (incl. `cannot_require_extension_for_baseline_core` = dNh never required by core); `runtime_mappings`/`proof_status_mappings` empty; owns no schemas.
- `schemas/dnh_extension/authority_map.dnh.json` — **10** dNh domains, all read/projection (`live_write_allowed=false`, `canonical_writer=null`, never `SOURCE`).
- `reports/.../dnh_crm_fixture/red_lanes.json` — added `identity-merge` red lane (AIR §9).
- `tests/dnh_extension/test_dnh_artifact_only.py` — 69 tests.
- `docs/03-reference/dnh/dnh-extension-mapping.md`.

### Validation
| Check | Result |
|---|---|
| pytest dnh + dcp + pcp | **PASS** — 258 |
| jsonschema (manifest, authority_map, red_lanes) | **PASS** — valid |
| boundary (10/10 artifact-only, no SOURCE/no live write) | **PASS** |
| pre-commit (SKIP=docs-graph-validator) | **PASS** |

### Review
PAL MCP unavailable this session → independent Sonnet adversarial reviewer + Opus. Verdict **NEEDS_CHANGES** → both substantive findings fixed before commit:
- **S1:** doc implied the *schema* enforces artifact-only (it's the *test guard*, same class as the corrected P5 doc) → added **Invariant Enforcement** section.
- **S2:** AIR §9 names **identity** as a red-lane domain + requires "authority map + secret policy" → added `identity-merge` red lane, required it in tests, documented secret-policy as a forward requirement.

### Residual risk / UNKNOWNs
- dNh identity secret-policy enforcement deferred to a later runtime/live-write packet (documented).
- Artifact-only guarantee enforced by the packet test guard, not the generic schema (by PCP Core design).

Packet: `TP-DNH-PCP-EXTENSION-MAPPING-0001` · Worktree `.claude/worktrees/pcp-p7` · Branch `claude/pcp-p7-dnh-extension-mapping`

🤖 Generated with [Claude Code](https://claude.com/claude-code)