### PR TITLE
feat(pcp): generic PR Steward proof-readiness intake (Packet 8)

### DIFF
--- a/docs/ops/project-control-plane/pr-steward-readiness.md
+++ b/docs/ops/project-control-plane/pr-steward-readiness.md
@@ -1,0 +1,163 @@
+---
+id: PCP-PR-STEWARD-READINESS
+title: PCP Core PR Steward Proof-Readiness Intake
+type: reference
+owner: '@hu3mann'
+author: claude
+date: '2026-06-22'
+last_review: '2026-06-22'
+next_review: '2026-09-20'
+prelude: PCP Core PR Steward Proof-Readiness Intake (explanation) for dopemux documentation
+  and developer workflows.
+---
+# PCP Core PR Steward Proof-Readiness Intake
+
+## Overview
+
+The PCP-Core PR Steward readiness intake is a **generic, project-agnostic** read-only harness that harvests PR state and emits a structured `MERGE_READINESS` signal.
+
+This component is **ADVISORY only**. It never merges, sets a PR ready, or mutates any repository resource. READY is fail-closed: it is withheld on any blocking condition.
+
+> **AIR Red Lines #7 and #8**: Green CI is NOT semantic proof. Automated checks passing does not mean the implementation is correct, the proof bundle is fresh, or the diff is within scope. READY requires explicit semantic proof — a proof artifact whose recorded head SHA matches the PR head SHA.
+
+---
+
+## The MERGE_READINESS Signal
+
+Schema: `schemas/project_control_plane/merge_readiness.schema.json` (JSON Schema Draft 2020-12).
+
+Module: `src/dopemux/pcp/pr_steward.py`
+
+### Signal fields
+
+| Field | Type | Description |
+|---|---|---|
+| `schema_version` | `const "pcp.merge_readiness.v0"` | Sentinel identifying schema version |
+| `pr_ref` | object | PR identity: `repo`, `number`, `head_ref`, `base_ref` |
+| `head_sha` | string (40 or 64 hex) | Head commit SHA at harvest time |
+| `status` | enum | `READY`, `BLOCKED`, or `NEEDS_SUPERVISOR` |
+| `blocked_reasons` | array of enum | Enumerated reasons READY was withheld |
+| `intake` | object | Harvested evidence (see below) |
+| `advisory` | `const true` | Always true — this signal is never a merge authority |
+| `created_at` | date-time | ISO 8601 datetime of signal assembly |
+
+### Intake fields (harvested evidence)
+
+| Field | Type | Description |
+|---|---|---|
+| `changed_files` | array of string | Paths changed in the PR diff |
+| `commits` | array of string | Commit SHAs in the PR |
+| `checks` | array of objects | CI check results with `name`, `conclusion`, `stale_to_head` |
+| `reviews` | array | Raw review objects (opaque to generic core) |
+| `review_threads` | array of objects | Thread `resolved` and `blocking` flags |
+| `reviewer_classifications` | array of objects | Actor `kind` (`HUMAN`, `KNOWN_BOT`, `UNKNOWN`) |
+| `unclassified_review_items` | array of string | Review item IDs that could not be classified |
+| `proof_refs` | array of objects | Proof artifact references with `path` and `head_sha` |
+| `proof_freshness` | enum | `FRESH`, `STALE`, `MISSING`, or `UNKNOWN` |
+| `diff_escapes_allowlist` | boolean | True if any file is outside the declared allowlist |
+| `security_release_required` | boolean | True if security or release gate approval is required |
+| `security_release_approved` | boolean | True if a qualifying human approver granted the gate |
+
+---
+
+## Fail-Closed Blocking Conditions
+
+READY is withheld when **any** of the following conditions holds.
+
+### Blocked reasons
+
+| `blocked_reason` | Trigger condition |
+|---|---|
+| `STALE_PROOF` | `proof_freshness` is `STALE`, `MISSING`, or `UNKNOWN` |
+| `FAILED_CHECK` | Any check has `conclusion == "FAILURE"` |
+| `STALE_CHECK` | Any check has `stale_to_head == true` or `conclusion` in `{STALE, PENDING, UNKNOWN}` |
+| `UNKNOWN_REVIEWER_OR_BOT` | Any `reviewer_classifications` entry has `kind == "UNKNOWN"` |
+| `UNCLASSIFIED_REVIEW_ITEM` | `unclassified_review_items` is non-empty |
+| `UNRESOLVED_BLOCKING_THREAD` | Any review thread has `blocking == true` and `resolved == false` |
+| `DIFF_OUTSIDE_ALLOWLIST` | `diff_escapes_allowlist == true` |
+| `MISSING_SECURITY_RELEASE_APPROVAL` | `security_release_required == true` and `security_release_approved == false` |
+| `MISSING_REQUIRED_INTAKE` | `intake` is `null`, missing, or `head_sha` is falsy |
+| `UNKNOWN` | Reserved for unclassifiable blocking conditions |
+
+### Status derivation
+
+| Condition | Status |
+|---|---|
+| Zero blocked reasons | `READY` |
+| Only `MISSING_SECURITY_RELEASE_APPROVAL` | `NEEDS_SUPERVISOR` |
+| Any other blocked reason | `BLOCKED` |
+
+### Schema-level fail-closed gates (allOf)
+
+The schema enforces these rules structurally via `allOf` if/then constraints:
+
+- **Gate (a)**: `status == READY` requires `blocked_reasons maxItems 0`, `proof_freshness const "FRESH"`, and `diff_escapes_allowlist const false`.
+- **Gate (b)**: `status` in `{BLOCKED, NEEDS_SUPERVISOR}` requires `blocked_reasons minItems 1`.
+- **Gate (c)**: `proof_freshness` in `{STALE, MISSING, UNKNOWN}` forces `status` to `{BLOCKED, NEEDS_SUPERVISOR}`.
+- **Gate (d)**: `diff_escapes_allowlist == true` forces `status` to `{BLOCKED, NEEDS_SUPERVISOR}`.
+- **Gate (e)**: `status == READY` requires `security_release_required == false` OR `security_release_approved == true` (schema-level defense-in-depth for the unapproved security gate).
+
+---
+
+## Public API
+
+### `assess_merge_readiness`
+
+```python
+from dopemux.pcp.pr_steward import assess_merge_readiness
+
+signal = assess_merge_readiness(
+    intake,                        # dict from harvest_pr_intake
+    pr_ref={"repo": "owner/repo", "number": 42,
+            "head_ref": "feature/x", "base_ref": "main"},
+    head_sha="abc123..." * 5,
+    created_at="2026-06-22T00:00:00Z",
+)
+```
+
+Pure, deterministic, fail-closed. Returns a dict matching `merge_readiness.schema.json`. Never calls external processes.
+
+### `harvest_pr_intake`
+
+```python
+from dopemux.pcp.pr_steward import harvest_pr_intake
+
+result = harvest_pr_intake(
+    123,
+    repo="owner/repo",
+    runner=None,   # injectable for testing; None = default subprocess wrapper
+)
+```
+
+Read-only harvester using `gh pr view`. Returns `{pr_ref, head_sha, intake}`. The `runner` parameter accepts a callable for injecting a fake in tests — no real subprocess runs in unit tests.
+
+> **Note**: The raw harvest always returns `proof_freshness="MISSING"` because proof artifact references are not available from `gh pr view`. A harvested-only signal therefore can never be `READY` — callers must supply proof freshness externally (e.g., by reading a proof artifact and comparing its recorded `head_sha` against the PR head SHA before calling `assess_merge_readiness`).
+
+> **Note**: `stale_to_head` is derived from check conclusion only (`STALE`, `PENDING`, or `UNKNOWN` conclusions set it to `true`). The `gh statusCheckRollup` response is semantically head-scoped, so per-check SHA comparison is not attempted — `gh` does not expose an individual check-run SHA.
+
+---
+
+## Relationship to Existing Dopemux Machinery
+
+This generic PCP-Core module **coexists with** and is **not a replacement for** the Dopemux-specific components:
+
+- `tools/pr_steward/` — Dopemux-specific CLI and classifier that specialises this core.
+- `.claude/skills/pr-merge-specialist/` — Dopemux skill integrating steward gate into the merge workflow.
+- `contracts/openclaw-dcp-routing/pr_steward_merge_readiness.schema.json` — OpenClaw DCP routing contract (Draft 7; Dopemux-specific fields including `readiness`, `risk_tier`, `embedded_audit`, `proof.proof_freshness.status`).
+- `schemas/pr_steward/merge_readiness.schema.json` — Dopemux internal schema (v1.1.0, richer `proof_freshness` object, `mutation_performed` guard).
+
+The PCP-Core schema (`schemas/project_control_plane/merge_readiness.schema.json`) is the **project-agnostic foundation** from which Dopemux-specific schemas extend the concept. It shares field names where the semantics align but does not import or depend on any Dopemux-specific type.
+
+---
+
+## Tests
+
+`tests/project_control_plane/test_pr_steward.py`
+
+Covers: clean-intake READY path, one test per blocking condition, advisory/no-merge source assertion, fake-runner harvest pipeline, and schema Draft 2020-12 self-consistency.
+
+Run with:
+
+```bash
+python -m pytest -q tests/project_control_plane/test_pr_steward.py
+```

--- a/schemas/project_control_plane/merge_readiness.schema.json
+++ b/schemas/project_control_plane/merge_readiness.schema.json
@@ -1,0 +1,323 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/merge_readiness.schema.json",
+  "title": "PCP Core PR Steward Merge Readiness Signal",
+  "description": "Generic, project-agnostic MERGE_READINESS signal emitted by the PCP-Core PR Steward readiness intake. This signal is ADVISORY only — it NEVER merges, sets PR ready, or mutates any resource. READY is fail-closed: withheld on ANY blocking condition.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "pr_ref",
+    "head_sha",
+    "status",
+    "blocked_reasons",
+    "intake",
+    "advisory",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.merge_readiness.v0",
+      "description": "Schema version sentinel. Must be exactly 'pcp.merge_readiness.v0'."
+    },
+    "pr_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "number", "head_ref", "base_ref"],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repository in 'owner/repo' or bare 'repo' form."
+        },
+        "number": {
+          "type": "integer",
+          "description": "Pull request number."
+        },
+        "head_ref": {
+          "type": "string",
+          "description": "Head branch reference name."
+        },
+        "base_ref": {
+          "type": "string",
+          "description": "Base branch reference name (merge target)."
+        }
+      }
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$|^[0-9a-f]{64}$",
+      "description": "SHA-1 (40 hex) or SHA-256 (64 hex) of the PR head commit at harvest time."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["READY", "BLOCKED", "NEEDS_SUPERVISOR"],
+      "description": "Merge readiness verdict. READY is withheld on any blocking condition."
+    },
+    "blocked_reasons": {
+      "type": "array",
+      "uniqueItems": true,
+      "description": "Enumerated reasons READY was withheld. Empty iff status is READY.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "STALE_PROOF",
+          "FAILED_CHECK",
+          "STALE_CHECK",
+          "UNKNOWN_REVIEWER_OR_BOT",
+          "UNCLASSIFIED_REVIEW_ITEM",
+          "UNRESOLVED_BLOCKING_THREAD",
+          "DIFF_OUTSIDE_ALLOWLIST",
+          "MISSING_SECURITY_RELEASE_APPROVAL",
+          "MISSING_REQUIRED_INTAKE",
+          "UNKNOWN"
+        ]
+      }
+    },
+    "intake": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Harvested evidence from the PR at read-only intake time.",
+      "required": [
+        "changed_files",
+        "commits",
+        "checks",
+        "reviews",
+        "review_threads",
+        "reviewer_classifications",
+        "unclassified_review_items",
+        "proof_refs",
+        "proof_freshness",
+        "diff_escapes_allowlist",
+        "security_release_required",
+        "security_release_approved"
+      ],
+      "properties": {
+        "changed_files": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Paths of files changed in the PR diff."
+        },
+        "commits": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Commit SHAs included in the PR (head-to-merge-base)."
+        },
+        "checks": {
+          "type": "array",
+          "description": "CI/status check results harvested for the PR head commit.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "conclusion", "stale_to_head"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Check or workflow name."
+              },
+              "conclusion": {
+                "type": "string",
+                "enum": ["SUCCESS", "FAILURE", "NEUTRAL", "STALE", "PENDING", "UNKNOWN"],
+                "description": "Normalised check conclusion. STALE = ran against an older SHA; PENDING = not yet complete; UNKNOWN = could not classify."
+              },
+              "stale_to_head": {
+                "type": "boolean",
+                "description": "True if this check ran against a commit other than head_sha."
+              }
+            }
+          }
+        },
+        "reviews": {
+          "type": "array",
+          "description": "Raw review objects (shape opaque to generic core; validated downstream).",
+          "items": {}
+        },
+        "review_threads": {
+          "type": "array",
+          "description": "PR review threads with resolution and blocking classification.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["resolved", "blocking"],
+            "properties": {
+              "resolved": {
+                "type": "boolean",
+                "description": "True if the thread has been marked resolved."
+              },
+              "blocking": {
+                "type": "boolean",
+                "description": "True if the thread was classified as a hard blocker."
+              }
+            }
+          }
+        },
+        "reviewer_classifications": {
+          "type": "array",
+          "description": "Actor identity classifications for all reviewers/commenters.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["actor", "kind"],
+            "properties": {
+              "actor": {
+                "type": "string",
+                "description": "GitHub login or bot name."
+              },
+              "kind": {
+                "type": "string",
+                "enum": ["HUMAN", "KNOWN_BOT", "UNKNOWN"],
+                "description": "Identity classification. UNKNOWN triggers UNKNOWN_REVIEWER_OR_BOT blocker."
+              }
+            }
+          }
+        },
+        "unclassified_review_items": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Review item IDs or references that could not be classified. Non-empty triggers UNCLASSIFIED_REVIEW_ITEM blocker."
+        },
+        "proof_refs": {
+          "type": "array",
+          "description": "Proof artifact references harvested from the PR.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "head_sha"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path or URL of the proof artifact."
+              },
+              "head_sha": {
+                "type": ["string", "null"],
+                "description": "The head SHA recorded inside the proof artifact, or null if unreadable."
+              }
+            }
+          }
+        },
+        "proof_freshness": {
+          "type": "string",
+          "enum": ["FRESH", "STALE", "MISSING", "UNKNOWN"],
+          "description": "Proof freshness classification. FRESH requires proof_refs[].head_sha == PR head_sha. STALE/MISSING/UNKNOWN withholds READY."
+        },
+        "diff_escapes_allowlist": {
+          "type": "boolean",
+          "description": "True if any changed file falls outside the declared allowlist for this PR. Withholds READY."
+        },
+        "security_release_required": {
+          "type": "boolean",
+          "description": "True if the diff touches security- or release-gated paths requiring explicit human approval."
+        },
+        "security_release_approved": {
+          "type": "boolean",
+          "description": "True if a qualifying human approver granted the security/release gate."
+        }
+      }
+    },
+    "advisory": {
+      "type": "boolean",
+      "const": true,
+      "description": "Always true. This signal is advisory only — it is NEVER a merge authority. Green CI is NOT semantic proof. See AIR Red Lines #7/#8."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime at which this signal was assembled."
+    }
+  },
+  "allOf": [
+    {
+      "description": "Fail-closed gate (a): READY requires zero blocked_reasons, FRESH proof, and diff within allowlist.",
+      "if": {
+        "properties": { "status": { "const": "READY" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "blocked_reasons": { "maxItems": 0 },
+          "intake": {
+            "properties": {
+              "proof_freshness": { "const": "FRESH" },
+              "diff_escapes_allowlist": { "const": false }
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (b): BLOCKED or NEEDS_SUPERVISOR requires at least one blocked_reason.",
+      "if": {
+        "properties": { "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "blocked_reasons": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (c): stale/missing/unknown proof forces status to non-READY.",
+      "if": {
+        "properties": {
+          "intake": {
+            "properties": {
+              "proof_freshness": { "enum": ["STALE", "MISSING", "UNKNOWN"] }
+            },
+            "required": ["proof_freshness"]
+          }
+        },
+        "required": ["intake"]
+      },
+      "then": {
+        "properties": {
+          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (d): diff outside allowlist forces status to non-READY.",
+      "if": {
+        "properties": {
+          "intake": {
+            "properties": {
+              "diff_escapes_allowlist": { "const": true }
+            },
+            "required": ["diff_escapes_allowlist"]
+          }
+        },
+        "required": ["intake"]
+      },
+      "then": {
+        "properties": {
+          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (e): READY with an unapproved security gate is rejected. If status is READY then intake must have security_release_required=false OR security_release_approved=true.",
+      "if": {
+        "properties": { "status": { "const": "READY" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "intake": {
+            "anyOf": [
+              {
+                "properties": { "security_release_required": { "const": false } },
+                "required": ["security_release_required"]
+              },
+              {
+                "properties": { "security_release_approved": { "const": true } },
+                "required": ["security_release_approved"]
+              }
+            ]
+          }
+        },
+        "required": ["intake"]
+      }
+    }
+  ]
+}

--- a/src/dopemux/pcp/pr_steward.py
+++ b/src/dopemux/pcp/pr_steward.py
@@ -1,0 +1,508 @@
+"""
+Generic PCP-Core PR Steward proof-readiness intake.
+
+Harvests PR state (read-only) and emits a MERGE_READINESS signal with explicit
+BLOCKED reasons.  This module is ADVISORY — it NEVER mutates any resource, sets PR state,
+or triggers a merge.  READY is fail-closed: withheld on ANY blocking condition.
+
+Green CI is NOT semantic proof (see AIR Red Lines #7/#8).
+
+This is the generic, project-agnostic PCP Core.  The Dopemux-specific
+pr-merge-specialist skill (tools/pr_steward/, .claude/skills/) and the OpenClaw
+DCP routing contracts (contracts/openclaw-dcp-routing/pr_steward_merge_readiness.
+schema.json) *specialise* this core — they co-exist with it rather than replacing
+it.
+
+Usage::
+
+    from dopemux.pcp.pr_steward import assess_merge_readiness, harvest_pr_intake
+
+    intake_result = harvest_pr_intake(123, repo="owner/repo")
+    signal = assess_merge_readiness(
+        intake_result["intake"],
+        pr_ref=intake_result["pr_ref"],
+        head_sha=intake_result["head_sha"],
+        created_at="2026-06-22T00:00:00Z",
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+from typing import Any, Callable
+
+from jsonschema import Draft202012Validator
+
+# ---------------------------------------------------------------------------
+# Schema loading — resolved relative to the repo root at import time.
+# src/dopemux/pcp/pr_steward.py  →  4 levels up = repo root
+# ---------------------------------------------------------------------------
+_HERE = pathlib.Path(__file__).resolve()
+_REPO_ROOT = _HERE.parent.parent.parent.parent
+_SCHEMA_PATH = (
+    _REPO_ROOT
+    / "schemas"
+    / "project_control_plane"
+    / "merge_readiness.schema.json"
+)
+
+with _SCHEMA_PATH.open() as _fh:
+    _SCHEMA: dict = json.load(_fh)
+
+_VALIDATOR = Draft202012Validator(_SCHEMA)
+
+# ---------------------------------------------------------------------------
+# Write-operation prohibition — this module is READ-ONLY.
+# No merge, push, commit, or PR-state-mutation commands are issued here.
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Internal helper — injectable subprocess runner for gh CLI calls
+# ---------------------------------------------------------------------------
+
+def _default_runner(args: list[str]) -> str:
+    """Invoke ``gh`` read-only and return stripped stdout.
+
+    Hardened against path injection: no shell, explicit executable list.
+    Only ``gh pr view`` calls (read-only) are issued.
+
+    Raises
+    ------
+    ValueError
+        If ``gh`` returns a non-zero exit code or is unavailable.
+    """
+    try:
+        result = subprocess.run(
+            args,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError(
+            f"gh CLI not found; cannot harvest PR intake: {exc}"
+        ) from exc
+
+    if result.returncode != 0:
+        raise ValueError(
+            f"gh command failed (exit {result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# Public API: assess_merge_readiness
+# ---------------------------------------------------------------------------
+
+def assess_merge_readiness(
+    intake: dict | None,
+    *,
+    pr_ref: dict,
+    head_sha: str,
+    created_at: str,
+) -> dict:
+    """Compute the MERGE_READINESS signal from harvested *intake*.
+
+    This is a **pure**, **fail-closed** function.  All inputs are inspected;
+    ``blocked_reasons`` is accumulated; ``status`` is derived from that list.
+    Nothing is written, merged, or mutated.
+
+    Parameters
+    ----------
+    intake:
+        Harvested evidence dict (matches the ``intake`` sub-object of
+        ``merge_readiness.schema.json``).  If ``None`` or missing required
+        fields, ``MISSING_REQUIRED_INTAKE`` is added.
+    pr_ref:
+        PR identity: ``{repo, number, head_ref, base_ref}``.
+    head_sha:
+        The PR head commit SHA (40 or 64 hex chars).
+    created_at:
+        ISO 8601 datetime string for when the signal was assembled.
+
+    Returns
+    -------
+    dict
+        A dict satisfying ``schemas/project_control_plane/merge_readiness.schema.json``.
+
+    Raises
+    ------
+    jsonschema.ValidationError
+        If the assembled signal does not satisfy the schema (defensive; should
+        not occur in normal operation when inputs are well-formed).
+    """
+    blocked: list[str] = []
+
+    # ------------------------------------------------------------------
+    # Guard: missing/invalid intake OR empty head_sha → MISSING_REQUIRED_INTAKE
+    # Appended AT MOST once even when both conditions hold.
+    # ------------------------------------------------------------------
+    _intake_missing = not isinstance(intake, dict) or not intake
+    if _intake_missing or not head_sha:
+        blocked.append("MISSING_REQUIRED_INTAKE")
+    if not isinstance(intake, dict):
+        intake = {}
+
+    # ------------------------------------------------------------------
+    # Rule 1: proof_freshness != FRESH → STALE_PROOF
+    # ------------------------------------------------------------------
+    proof_freshness = intake.get("proof_freshness", "UNKNOWN")
+    if proof_freshness != "FRESH":
+        if "STALE_PROOF" not in blocked:
+            blocked.append("STALE_PROOF")
+
+    # ------------------------------------------------------------------
+    # Rule 2: any check conclusion == FAILURE → FAILED_CHECK
+    # ------------------------------------------------------------------
+    checks: list[dict] = intake.get("checks", [])
+    if any(c.get("conclusion") == "FAILURE" for c in checks):
+        blocked.append("FAILED_CHECK")
+
+    # ------------------------------------------------------------------
+    # Rule 3: any check stale_to_head truthy or conclusion in
+    #         {STALE, PENDING, UNKNOWN} → STALE_CHECK
+    # ------------------------------------------------------------------
+    stale_conclusions = {"STALE", "PENDING", "UNKNOWN"}
+    if any(
+        bool(c.get("stale_to_head")) or c.get("conclusion") in stale_conclusions
+        for c in checks
+    ):
+        blocked.append("STALE_CHECK")
+
+    # ------------------------------------------------------------------
+    # Rule 4: any reviewer_classification kind == UNKNOWN →
+    #         UNKNOWN_REVIEWER_OR_BOT
+    # ------------------------------------------------------------------
+    reviewer_classifications: list[dict] = intake.get("reviewer_classifications", [])
+    if any(rc.get("kind") == "UNKNOWN" for rc in reviewer_classifications):
+        blocked.append("UNKNOWN_REVIEWER_OR_BOT")
+
+    # ------------------------------------------------------------------
+    # Rule 5: non-empty unclassified_review_items →
+    #         UNCLASSIFIED_REVIEW_ITEM
+    # ------------------------------------------------------------------
+    unclassified: list[str] = intake.get("unclassified_review_items", [])
+    if unclassified:
+        blocked.append("UNCLASSIFIED_REVIEW_ITEM")
+
+    # ------------------------------------------------------------------
+    # Rule 6: any review_thread with blocking truthy and resolved falsy →
+    #         UNRESOLVED_BLOCKING_THREAD
+    # ------------------------------------------------------------------
+    review_threads: list[dict] = intake.get("review_threads", [])
+    if any(
+        bool(t.get("blocking")) and not bool(t.get("resolved"))
+        for t in review_threads
+    ):
+        blocked.append("UNRESOLVED_BLOCKING_THREAD")
+
+    # ------------------------------------------------------------------
+    # Rule 7: diff_escapes_allowlist truthy → DIFF_OUTSIDE_ALLOWLIST
+    # ------------------------------------------------------------------
+    if bool(intake.get("diff_escapes_allowlist")):
+        blocked.append("DIFF_OUTSIDE_ALLOWLIST")
+
+    # ------------------------------------------------------------------
+    # Rule 8: security_release_required truthy and
+    #         security_release_approved falsy →
+    #         MISSING_SECURITY_RELEASE_APPROVAL
+    # (bool() coercion prevents is-True identity bypass, e.g. integer 1)
+    # ------------------------------------------------------------------
+    if bool(intake.get("security_release_required")) and not bool(
+        intake.get("security_release_approved")
+    ):
+        blocked.append("MISSING_SECURITY_RELEASE_APPROVAL")
+
+    # ------------------------------------------------------------------
+    # Derive status
+    # ------------------------------------------------------------------
+    if not blocked:
+        status = "READY"
+    elif blocked == ["MISSING_SECURITY_RELEASE_APPROVAL"]:
+        # Ambiguous authority requirement → escalate to supervisor
+        status = "NEEDS_SUPERVISOR"
+    else:
+        status = "BLOCKED"
+
+    # ------------------------------------------------------------------
+    # Ensure intake has all required fields for schema compliance
+    # ------------------------------------------------------------------
+    canonical_intake: dict[str, Any] = {
+        "changed_files": intake.get("changed_files", []),
+        "commits": intake.get("commits", []),
+        "checks": checks,
+        "reviews": intake.get("reviews", []),
+        "review_threads": review_threads,
+        "reviewer_classifications": reviewer_classifications,
+        "unclassified_review_items": unclassified,
+        "proof_refs": intake.get("proof_refs", []),
+        "proof_freshness": proof_freshness,
+        "diff_escapes_allowlist": bool(intake.get("diff_escapes_allowlist", False)),
+        "security_release_required": bool(
+            intake.get("security_release_required", False)
+        ),
+        "security_release_approved": bool(
+            intake.get("security_release_approved", False)
+        ),
+    }
+
+    signal: dict[str, Any] = {
+        "schema_version": "pcp.merge_readiness.v0",
+        "pr_ref": pr_ref,
+        "head_sha": head_sha if head_sha else "0" * 40,
+        "status": status,
+        "blocked_reasons": blocked,
+        "intake": canonical_intake,
+        "advisory": True,
+        "created_at": created_at,
+    }
+
+    # ------------------------------------------------------------------
+    # Defensive schema validation before returning
+    # ------------------------------------------------------------------
+    _VALIDATOR.validate(signal)
+
+    return signal
+
+
+# ---------------------------------------------------------------------------
+# Public API: harvest_pr_intake
+# ---------------------------------------------------------------------------
+
+def harvest_pr_intake(
+    pr_number: int,
+    *,
+    repo: str,
+    runner: Callable[[list[str]], str] | None = None,
+) -> dict:
+    """Harvest PR intake from GitHub (read-only) using the ``gh`` CLI.
+
+    The *runner* parameter is injectable for testing — pass a callable that
+    accepts a ``list[str]`` of args and returns stdout as a string.  In
+    production the default subprocess wrapper is used; no live ``gh`` calls
+    are made in tests when a fake runner is supplied.
+
+    Only read-only ``gh pr view`` commands are issued.  No write commands
+    are ever called — this function is strictly read-only.
+
+    Parameters
+    ----------
+    pr_number:
+        Pull request number to harvest.
+    repo:
+        Repository in ``owner/repo`` form (required by ``gh``).
+    runner:
+        Callable that takes ``list[str]`` (the full command including ``gh``)
+        and returns stdout.  Defaults to a subprocess wrapper.
+
+    Returns
+    -------
+    dict
+        A dict with keys ``pr_ref``, ``head_sha``, and ``intake``.  The
+        assembled dict validates against ``merge_readiness.schema.json`` when
+        passed to :func:`assess_merge_readiness`.
+
+    Raises
+    ------
+    ValueError
+        If *pr_number* is not a positive integer, *repo* is empty, the runner
+        returns malformed JSON, or required fields are absent.
+    """
+    if not isinstance(pr_number, int) or pr_number < 1:
+        raise ValueError(
+            f"pr_number must be a positive integer; got {pr_number!r}"
+        )
+    if not repo or not isinstance(repo, str):
+        raise ValueError(f"repo must be a non-empty string; got {repo!r}")
+
+    _run = runner if runner is not None else _default_runner
+
+    # ------------------------------------------------------------------
+    # Fetch core PR fields in a single gh invocation
+    # ------------------------------------------------------------------
+    raw = _run(
+        [
+            "gh", "pr", "view", str(pr_number),
+            "--repo", repo,
+            "--json",
+            (
+                "number,headRefName,baseRefName,headRefOid,"
+                "files,commits,reviews,statusCheckRollup,reviewThreads"
+            ),
+        ]
+    )
+
+    try:
+        data: dict = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(
+            f"gh pr view returned non-JSON output: {exc}\nOutput: {raw[:200]!r}"
+        ) from exc
+
+    # ------------------------------------------------------------------
+    # Extract and normalise fields
+    # ------------------------------------------------------------------
+    pr_number_out = data.get("number", pr_number)
+    head_ref = data.get("headRefName", "")
+    base_ref = data.get("baseRefName", "")
+    head_sha: str = data.get("headRefOid", "")
+
+    if not head_sha:
+        raise ValueError(
+            f"gh pr view returned no headRefOid for PR #{pr_number} in {repo!r}"
+        )
+
+    # changed_files: gh returns list of {path, additions, deletions, changeType}
+    raw_files = data.get("files", []) or []
+    changed_files = [
+        f.get("path", "") for f in raw_files if isinstance(f, dict)
+    ]
+
+    # commits: gh returns list of {oid, messageHeadline, ...}
+    raw_commits = data.get("commits", []) or []
+    commits = [
+        c.get("oid", "") for c in raw_commits if isinstance(c, dict)
+    ]
+
+    # reviews: keep as-is (opaque to generic core)
+    reviews = data.get("reviews", []) or []
+
+    # statusCheckRollup: list of {name, conclusion, status, ...}
+    raw_checks = data.get("statusCheckRollup", []) or []
+    checks = _normalise_checks(raw_checks)
+
+    # reviewThreads: gh returns list of {isResolved, comments, ...}
+    raw_threads = data.get("reviewThreads", []) or []
+    review_threads = _normalise_threads(raw_threads)
+
+    # Reviewer classifications from reviews
+    reviewer_classifications = _classify_reviewers(reviews)
+
+    # Proof refs: not available from raw gh pr view; default to empty
+    proof_refs: list[dict] = []
+    proof_freshness = "MISSING"
+
+    intake: dict[str, Any] = {
+        "changed_files": changed_files,
+        "commits": commits,
+        "checks": checks,
+        "reviews": reviews,
+        "review_threads": review_threads,
+        "reviewer_classifications": reviewer_classifications,
+        "unclassified_review_items": [],
+        "proof_refs": proof_refs,
+        "proof_freshness": proof_freshness,
+        "diff_escapes_allowlist": False,
+        "security_release_required": False,
+        "security_release_approved": False,
+    }
+
+    pr_ref = {
+        "repo": repo,
+        "number": pr_number_out,
+        "head_ref": head_ref,
+        "base_ref": base_ref,
+    }
+
+    return {
+        "pr_ref": pr_ref,
+        "head_sha": head_sha,
+        "intake": intake,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internal normalisers
+# ---------------------------------------------------------------------------
+
+def _normalise_checks(raw_checks: list[dict]) -> list[dict]:
+    """Normalise ``statusCheckRollup`` entries to the schema check shape.
+
+    stale_to_head is derived from check conclusion only; gh statusCheckRollup is
+    semantically head-scoped, so per-check SHA comparison is not attempted (gh does
+    not expose a check-run SHA).
+    """
+    _conclusion_map = {
+        "SUCCESS": "SUCCESS",
+        "FAILURE": "FAILURE",
+        "NEUTRAL": "NEUTRAL",
+        "CANCELLED": "NEUTRAL",
+        "SKIPPED": "NEUTRAL",
+        "TIMED_OUT": "FAILURE",
+        "ACTION_REQUIRED": "FAILURE",
+        "PENDING": "PENDING",
+        "IN_PROGRESS": "PENDING",
+        "QUEUED": "PENDING",
+        "STALE": "STALE",
+    }
+    normalised = []
+    for raw in raw_checks:
+        if not isinstance(raw, dict):
+            continue
+        name: str = raw.get("name", "") or raw.get("context", "") or ""
+        conclusion_raw: str = (raw.get("conclusion") or raw.get("state") or "").upper()
+        conclusion = _conclusion_map.get(conclusion_raw, "UNKNOWN")
+        stale_to_head = conclusion in {"STALE", "PENDING", "UNKNOWN"}
+        normalised.append(
+            {
+                "name": name,
+                "conclusion": conclusion,
+                "stale_to_head": stale_to_head,
+            }
+        )
+    return normalised
+
+
+def _normalise_threads(raw_threads: list[dict]) -> list[dict]:
+    """Normalise ``reviewThreads`` to the schema thread shape."""
+    normalised = []
+    for raw in raw_threads:
+        if not isinstance(raw, dict):
+            continue
+        resolved: bool = bool(raw.get("isResolved", False))
+        # gh does not emit a 'blocking' field; classify unresolved as blocking
+        blocking: bool = not resolved
+        normalised.append({"resolved": resolved, "blocking": blocking})
+    return normalised
+
+
+def _classify_reviewers(reviews: list[dict]) -> list[dict]:
+    """Classify reviewer actors from raw review objects.
+
+    GitHub bot login patterns are recognised as KNOWN_BOT; everything else is
+    HUMAN unless the actor is absent (UNKNOWN).
+    """
+    _bot_suffixes = ("[bot]", "-bot", "_bot")
+    _known_bots = {
+        "github-actions",
+        "codecov",
+        "dependabot",
+        "renovate",
+        "google-labs-jules[bot]",
+        "copilot-swe-agent[bot]",
+    }
+
+    seen: dict[str, str] = {}
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        author = review.get("author", {}) or {}
+        login: str = (
+            author.get("login", "") if isinstance(author, dict) else str(author)
+        )
+        if not login:
+            continue
+        if login in seen:
+            continue
+        if login in _known_bots or any(login.endswith(s) for s in _bot_suffixes):
+            kind = "KNOWN_BOT"
+        elif login:
+            kind = "HUMAN"
+        else:
+            kind = "UNKNOWN"
+        seen[login] = kind
+
+    return [{"actor": actor, "kind": kind} for actor, kind in seen.items()]

--- a/tests/project_control_plane/test_pr_steward.py
+++ b/tests/project_control_plane/test_pr_steward.py
@@ -1,0 +1,542 @@
+"""
+Tests for the generic PCP-Core PR Steward readiness intake.
+
+Covers:
+- Clean intake (all gates clear) → READY, blocked_reasons == [], schema-valid.
+- One test per blocking condition: READY withheld, correct blocked_reason, status != READY,
+  schema still valid.
+- Advisory / no-merge proof: module source has no write/merge calls; advisory is True.
+- harvest_pr_intake with a fake runner → schema-valid result; no real subprocess ran.
+- Schema self-consistency: merge_readiness.schema.json is a valid Draft 2020-12 schema.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from jsonschema import Draft202012Validator
+
+# ---------------------------------------------------------------------------
+# Schema loading
+# ---------------------------------------------------------------------------
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_SCHEMA_PATH = (
+    _REPO_ROOT
+    / "schemas"
+    / "project_control_plane"
+    / "merge_readiness.schema.json"
+)
+
+with _SCHEMA_PATH.open() as _fh:
+    _SCHEMA: dict = json.load(_fh)
+
+
+def _schema_errors(instance: dict) -> list:
+    return list(Draft202012Validator(_SCHEMA).iter_errors(instance))
+
+
+# ---------------------------------------------------------------------------
+# Module under test
+# ---------------------------------------------------------------------------
+from dopemux.pcp.pr_steward import assess_merge_readiness, harvest_pr_intake  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_NOW = datetime.now(tz=timezone.utc).isoformat()
+
+_CLEAN_PR_REF = {
+    "repo": "owner/repo",
+    "number": 42,
+    "head_ref": "feature/foo",
+    "base_ref": "main",
+}
+_HEAD_SHA = "a" * 40
+
+
+def _clean_intake(**overrides: Any) -> dict:
+    """Return a clean (all-gates-clear) intake dict, with optional field overrides."""
+    base: dict[str, Any] = {
+        "changed_files": ["src/foo.py"],
+        "commits": ["deadbeef" * 5],
+        "checks": [
+            {"name": "ci/test", "conclusion": "SUCCESS", "stale_to_head": False}
+        ],
+        "reviews": [],
+        "review_threads": [],
+        "reviewer_classifications": [{"actor": "alice", "kind": "HUMAN"}],
+        "unclassified_review_items": [],
+        "proof_refs": [{"path": "proof/PROOF.json", "head_sha": _HEAD_SHA}],
+        "proof_freshness": "FRESH",
+        "diff_escapes_allowlist": False,
+        "security_release_required": False,
+        "security_release_approved": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def _assess(intake: dict | None = None, **kwargs: Any) -> dict:
+    """Shorthand: call assess_merge_readiness with defaults for pr_ref/head_sha/created_at."""
+    return assess_merge_readiness(
+        intake if intake is not None else _clean_intake(),
+        pr_ref=kwargs.get("pr_ref", _CLEAN_PR_REF),
+        head_sha=kwargs.get("head_sha", _HEAD_SHA),
+        created_at=kwargs.get("created_at", _NOW),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Clean intake → READY, blocked_reasons == [], schema-valid
+# ---------------------------------------------------------------------------
+
+class TestCleanIntakeReady:
+    def test_status_is_ready(self) -> None:
+        result = _assess()
+        assert result["status"] == "READY"
+
+    def test_blocked_reasons_empty(self) -> None:
+        result = _assess()
+        assert result["blocked_reasons"] == []
+
+    def test_advisory_true(self) -> None:
+        result = _assess()
+        assert result["advisory"] is True
+
+    def test_schema_valid(self) -> None:
+        result = _assess()
+        errors = _schema_errors(result)
+        assert errors == [], f"Schema validation errors: {errors}"
+
+    def test_schema_version_sentinel(self) -> None:
+        result = _assess()
+        assert result["schema_version"] == "pcp.merge_readiness.v0"
+
+
+# ---------------------------------------------------------------------------
+# 2. Blocking condition tests — one per blocked_reason
+# ---------------------------------------------------------------------------
+
+class TestStaleProof:
+    @pytest.mark.parametrize("freshness", ["STALE", "MISSING", "UNKNOWN"])
+    def test_stale_proof_withholds_ready(self, freshness: str) -> None:
+        intake = _clean_intake(proof_freshness=freshness)
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "STALE_PROOF" in result["blocked_reasons"]
+
+    def test_schema_still_valid(self) -> None:
+        intake = _clean_intake(proof_freshness="STALE")
+        result = _assess(intake)
+        assert _schema_errors(result) == []
+
+
+class TestFailedCheck:
+    def test_failed_check_withholds_ready(self) -> None:
+        intake = _clean_intake(
+            proof_freshness="FRESH",
+            checks=[
+                {"name": "ci/test", "conclusion": "FAILURE", "stale_to_head": False}
+            ],
+        )
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "FAILED_CHECK" in result["blocked_reasons"]
+
+    def test_schema_still_valid(self) -> None:
+        intake = _clean_intake(
+            proof_freshness="FRESH",
+            checks=[
+                {"name": "ci/test", "conclusion": "FAILURE", "stale_to_head": False}
+            ],
+        )
+        result = _assess(intake)
+        assert _schema_errors(result) == []
+
+
+class TestStaleCheck:
+    @pytest.mark.parametrize("conclusion", ["STALE", "PENDING", "UNKNOWN"])
+    def test_stale_check_conclusion_withholds_ready(self, conclusion: str) -> None:
+        intake = _clean_intake(
+            proof_freshness="FRESH",
+            checks=[
+                {"name": "ci/test", "conclusion": conclusion, "stale_to_head": False}
+            ],
+        )
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "STALE_CHECK" in result["blocked_reasons"]
+
+    def test_stale_to_head_true_withholds_ready(self) -> None:
+        intake = _clean_intake(
+            proof_freshness="FRESH",
+            checks=[
+                {"name": "ci/test", "conclusion": "SUCCESS", "stale_to_head": True}
+            ],
+        )
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "STALE_CHECK" in result["blocked_reasons"]
+
+    def test_schema_still_valid(self) -> None:
+        intake = _clean_intake(
+            proof_freshness="FRESH",
+            checks=[
+                {"name": "ci/test", "conclusion": "PENDING", "stale_to_head": False}
+            ],
+        )
+        result = _assess(intake)
+        assert _schema_errors(result) == []
+
+
+class TestUnknownReviewerOrBot:
+    def test_unknown_reviewer_withholds_ready(self) -> None:
+        intake = _clean_intake(
+            reviewer_classifications=[{"actor": "mystery-user", "kind": "UNKNOWN"}]
+        )
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "UNKNOWN_REVIEWER_OR_BOT" in result["blocked_reasons"]
+
+    def test_schema_still_valid(self) -> None:
+        intake = _clean_intake(
+            reviewer_classifications=[{"actor": "mystery-user", "kind": "UNKNOWN"}]
+        )
+        result = _assess(intake)
+        assert _schema_errors(result) == []
+
+
+class TestUnclassifiedReviewItem:
+    def test_unclassified_items_withholds_ready(self) -> None:
+        intake = _clean_intake(
+            unclassified_review_items=["item-id-abc123"]
+        )
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "UNCLASSIFIED_REVIEW_ITEM" in result["blocked_reasons"]
+
+    def test_schema_still_valid(self) -> None:
+        intake = _clean_intake(
+            unclassified_review_items=["item-id-abc123"]
+        )
+        result = _assess(intake)
+        assert _schema_errors(result) == []
+
+
+class TestUnresolvedBlockingThread:
+    def test_unresolved_blocking_thread_withholds_ready(self) -> None:
+        intake = _clean_intake(
+            review_threads=[{"resolved": False, "blocking": True}]
+        )
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "UNRESOLVED_BLOCKING_THREAD" in result["blocked_reasons"]
+
+    def test_resolved_blocking_thread_does_not_block(self) -> None:
+        intake = _clean_intake(
+            review_threads=[{"resolved": True, "blocking": True}]
+        )
+        result = _assess(intake)
+        assert "UNRESOLVED_BLOCKING_THREAD" not in result["blocked_reasons"]
+
+    def test_schema_still_valid(self) -> None:
+        intake = _clean_intake(
+            review_threads=[{"resolved": False, "blocking": True}]
+        )
+        result = _assess(intake)
+        assert _schema_errors(result) == []
+
+
+class TestDiffOutsideAllowlist:
+    def test_diff_escape_withholds_ready(self) -> None:
+        intake = _clean_intake(diff_escapes_allowlist=True)
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "DIFF_OUTSIDE_ALLOWLIST" in result["blocked_reasons"]
+
+    def test_schema_still_valid(self) -> None:
+        intake = _clean_intake(diff_escapes_allowlist=True)
+        result = _assess(intake)
+        assert _schema_errors(result) == []
+
+
+class TestMissingSecurityReleaseApproval:
+    def test_missing_security_approval_withholds_ready(self) -> None:
+        intake = _clean_intake(
+            security_release_required=True,
+            security_release_approved=False,
+        )
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "MISSING_SECURITY_RELEASE_APPROVAL" in result["blocked_reasons"]
+
+    def test_approved_security_gate_does_not_block(self) -> None:
+        intake = _clean_intake(
+            security_release_required=True,
+            security_release_approved=True,
+        )
+        result = _assess(intake)
+        assert "MISSING_SECURITY_RELEASE_APPROVAL" not in result["blocked_reasons"]
+
+    def test_schema_still_valid(self) -> None:
+        intake = _clean_intake(
+            security_release_required=True,
+            security_release_approved=False,
+        )
+        result = _assess(intake)
+        assert _schema_errors(result) == []
+
+
+class TestMissingRequiredIntake:
+    def test_none_intake_withholds_ready(self) -> None:
+        result = assess_merge_readiness(
+            None,
+            pr_ref=_CLEAN_PR_REF,
+            head_sha=_HEAD_SHA,
+            created_at=_NOW,
+        )
+        assert result["status"] != "READY"
+        assert "MISSING_REQUIRED_INTAKE" in result["blocked_reasons"]
+
+    def test_empty_head_sha_withholds_ready(self) -> None:
+        result = assess_merge_readiness(
+            _clean_intake(),
+            pr_ref=_CLEAN_PR_REF,
+            head_sha="",
+            created_at=_NOW,
+        )
+        assert result["status"] != "READY"
+        assert "MISSING_REQUIRED_INTAKE" in result["blocked_reasons"]
+
+    def test_schema_still_valid_with_none_intake(self) -> None:
+        result = assess_merge_readiness(
+            None,
+            pr_ref=_CLEAN_PR_REF,
+            head_sha=_HEAD_SHA,
+            created_at=_NOW,
+        )
+        assert _schema_errors(result) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Advisory / no-merge proof
+# ---------------------------------------------------------------------------
+
+class TestAdvisoryAndNoMerge:
+    def test_advisory_field_always_true(self) -> None:
+        result = _assess()
+        assert result["advisory"] is True
+
+    def test_blocked_result_advisory_true(self) -> None:
+        result = _assess(_clean_intake(proof_freshness="STALE"))
+        assert result["advisory"] is True
+
+    def test_module_source_has_no_merge_calls(self) -> None:
+        """Assert the module source contains no write/merge/push commands."""
+        import dopemux.pcp.pr_steward as _mod
+        source = inspect.getsource(_mod)
+        forbidden_patterns = [
+            "gh pr merge",
+            "gh pr ready",
+            "git push",
+            "git commit",
+            "git merge",
+        ]
+        for pattern in forbidden_patterns:
+            assert pattern not in source, (
+                f"Module source contains forbidden pattern: {pattern!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 4. harvest_pr_intake with a fake runner
+# ---------------------------------------------------------------------------
+
+class TestHarvestPrIntakeWithFakeRunner:
+    """harvest_pr_intake must use the injected runner and produce a schema-valid result."""
+
+    _GH_PR_JSON = json.dumps({
+        "number": 99,
+        "headRefName": "feature/bar",
+        "baseRefName": "main",
+        "headRefOid": "b" * 40,
+        "files": [
+            {"path": "src/bar.py", "additions": 10, "deletions": 2, "changeType": "MODIFIED"}
+        ],
+        "commits": [
+            {"oid": "c" * 40, "messageHeadline": "feat: bar"}
+        ],
+        "reviews": [
+            {"author": {"login": "bob"}, "state": "APPROVED", "body": "lgtm"}
+        ],
+        "statusCheckRollup": [
+            {"name": "ci/lint", "conclusion": "SUCCESS", "state": "COMPLETED"}
+        ],
+        "reviewThreads": [
+            {"isResolved": True, "comments": {"nodes": []}}
+        ],
+    })
+
+    def _make_runner(self) -> tuple[list, object]:
+        calls: list[list[str]] = []
+
+        def fake_runner(args: list[str]) -> str:
+            calls.append(list(args))
+            return self._GH_PR_JSON
+
+        return calls, fake_runner
+
+    def test_no_real_subprocess_called(self) -> None:
+        calls, fake_runner = self._make_runner()
+        harvest_pr_intake(99, repo="owner/repo", runner=fake_runner)
+        assert len(calls) >= 1, "fake runner was never called"
+        # All calls must go through the fake, not subprocess
+        for call in calls:
+            assert call[0] == "gh", f"Unexpected command prefix: {call[0]}"
+
+    def test_returns_pr_ref(self) -> None:
+        _, fake_runner = self._make_runner()
+        result = harvest_pr_intake(99, repo="owner/repo", runner=fake_runner)
+        assert result["pr_ref"]["number"] == 99
+        assert result["pr_ref"]["repo"] == "owner/repo"
+        assert result["pr_ref"]["head_ref"] == "feature/bar"
+        assert result["pr_ref"]["base_ref"] == "main"
+
+    def test_returns_head_sha(self) -> None:
+        _, fake_runner = self._make_runner()
+        result = harvest_pr_intake(99, repo="owner/repo", runner=fake_runner)
+        assert result["head_sha"] == "b" * 40
+
+    def test_produce_schema_valid_signal(self) -> None:
+        """Full pipeline: harvest → assess → schema validate."""
+        _, fake_runner = self._make_runner()
+        harvest = harvest_pr_intake(99, repo="owner/repo", runner=fake_runner)
+        signal = assess_merge_readiness(
+            harvest["intake"],
+            pr_ref=harvest["pr_ref"],
+            head_sha=harvest["head_sha"],
+            created_at=_NOW,
+        )
+        errors = _schema_errors(signal)
+        assert errors == [], f"Schema errors: {errors}"
+
+    def test_invalid_pr_number_raises(self) -> None:
+        _, fake_runner = self._make_runner()
+        with pytest.raises(ValueError, match="pr_number"):
+            harvest_pr_intake(0, repo="owner/repo", runner=fake_runner)
+
+    def test_empty_repo_raises(self) -> None:
+        _, fake_runner = self._make_runner()
+        with pytest.raises(ValueError, match="repo"):
+            harvest_pr_intake(1, repo="", runner=fake_runner)
+
+    def test_malformed_json_raises(self) -> None:
+        def bad_runner(args: list[str]) -> str:
+            return "not json {"
+
+        with pytest.raises(ValueError, match="non-JSON"):
+            harvest_pr_intake(1, repo="owner/repo", runner=bad_runner)
+
+
+# ---------------------------------------------------------------------------
+# 6. Security gate — new tests (fail-open fix + schema gate e)
+# ---------------------------------------------------------------------------
+
+class TestSecurityGateYiedsNeedsSupervisor:
+    def test_security_gate_yields_needs_supervisor(self) -> None:
+        """Clean intake with security_release_required=True, approved=False → NEEDS_SUPERVISOR."""
+        intake = _clean_intake(
+            security_release_required=True,
+            security_release_approved=False,
+        )
+        result = _assess(intake)
+        assert result["status"] == "NEEDS_SUPERVISOR"
+        assert "MISSING_SECURITY_RELEASE_APPROVAL" in result["blocked_reasons"]
+        assert _schema_errors(result) == []
+
+
+class TestSecurityRequiredTruthyNonBoolStillBlocks:
+    def test_security_required_truthy_non_bool_still_blocks(self) -> None:
+        """Truthy integer 1 for security_release_required must still trigger the block.
+
+        This locks the fail-open fix: bool() coercion, not `is True` identity,
+        is required so that non-True truthy values (e.g. integer 1) are caught.
+        """
+        intake = _clean_intake(
+            security_release_required=1,   # integer truthy, not the bool True
+            security_release_approved=0,   # integer falsy, not the bool False
+        )
+        result = _assess(intake)
+        assert result["status"] != "READY"
+        assert "MISSING_SECURITY_RELEASE_APPROVAL" in result["blocked_reasons"]
+
+
+class TestSchemaRejectsReadyWithUnapprovedSecurityGate:
+    def test_schema_rejects_ready_with_unapproved_security_gate(self) -> None:
+        """Schema gate (e) must reject a hand-crafted READY signal with unapproved security gate.
+
+        The code path never produces this combination, but the schema must also
+        independently reject it as defense-in-depth.
+        """
+        bad_signal: dict[str, Any] = {
+            "schema_version": "pcp.merge_readiness.v0",
+            "pr_ref": _CLEAN_PR_REF,
+            "head_sha": _HEAD_SHA,
+            "status": "READY",
+            "blocked_reasons": [],
+            "advisory": True,
+            "created_at": _NOW,
+            "intake": {
+                "changed_files": ["src/foo.py"],
+                "commits": ["deadbeef" * 5],
+                "checks": [
+                    {"name": "ci/test", "conclusion": "SUCCESS", "stale_to_head": False}
+                ],
+                "reviews": [],
+                "review_threads": [],
+                "reviewer_classifications": [{"actor": "alice", "kind": "HUMAN"}],
+                "unclassified_review_items": [],
+                "proof_refs": [{"path": "proof/PROOF.json", "head_sha": _HEAD_SHA}],
+                "proof_freshness": "FRESH",
+                "diff_escapes_allowlist": False,
+                # Unapproved security gate — should be rejected by schema gate (e)
+                "security_release_required": True,
+                "security_release_approved": False,
+            },
+        }
+        errors = _schema_errors(bad_signal)
+        assert len(errors) >= 1, (
+            "Schema gate (e) should reject READY with unapproved security gate, "
+            f"but no errors were found. Signal: {bad_signal}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Schema self-consistency
+# ---------------------------------------------------------------------------
+
+class TestSchemaSelfConsistency:
+    def test_schema_is_valid_draft_2020_12(self) -> None:
+        """merge_readiness.schema.json must be a valid Draft 2020-12 schema."""
+        with _SCHEMA_PATH.open() as fh:
+            schema = json.load(fh)
+        # Check schema raises nothing if meta-schema validation passes
+        Draft202012Validator.check_schema(schema)
+
+    def test_schema_has_required_id(self) -> None:
+        with _SCHEMA_PATH.open() as fh:
+            schema = json.load(fh)
+        assert schema.get("$id") == (
+            "https://dopemux.dev/schemas/project_control_plane/merge_readiness.schema.json"
+        )
+
+    def test_schema_version_is_correct(self) -> None:
+        with _SCHEMA_PATH.open() as fh:
+            schema = json.load(fh)
+        assert schema.get("$schema") == "https://json-schema.org/draft/2020-12/schema"


### PR DESCRIPTION
## Packet 8 — generic PR Steward proof-readiness intake

Project-agnostic PCP-Core PR Steward — **advisory, read-only, fail-closed**. Harvests PR state, emits a `MERGE_READINESS` signal with explicit BLOCKED reasons; never merges/sets-ready/mutates. Green CI is **not** semantic proof.

### Deliverables
- `schemas/project_control_plane/merge_readiness.schema.json` — fail-closed allOf gates (a–e).
- `src/dopemux/pcp/pr_steward.py` — `assess_merge_readiness()` pure gate + `harvest_pr_intake()` read-only gh harvester (injectable runner).
- `tests/project_control_plane/test_pr_steward.py` — 47 tests.
- `docs/ops/project-control-plane/pr-steward-readiness.md`.

### Validation
| Check | Result |
|---|---|
| pytest pcp + dcp + dnh | **PASS** — 305 |
| schema valid (Draft 2020-12) | **PASS** |
| pre-commit (SKIP=docs-graph-validator) | **PASS** |
| fail-open exploit closed (verified) | int-coercion security bypass → NEEDS_SUPERVISOR; schema gate-e rejects forged READY |

### Review
PAL MCP unavailable → independent Sonnet adversarial reviewer + Opus. Verdict **NEEDS_CHANGES** → all fixed:
- 🔴 **fail-open**: `is True` identity check let a truthy non-bool (`1`) bypass the security-approval gate → fixed with `bool()` coercion + schema **gate-e** (defense-in-depth). Re-verified closed at both code and schema layers.
- crash on double-append of `MISSING_REQUIRED_INTAKE` → deduped (returns BLOCKED, never raises).
- untested `NEEDS_SUPERVISOR` branch → test added.
- dead SHA-staleness code in the harvester → removed + documented.

### Residual
- harvester `stale_to_head` is conclusion-derived (gh `statusCheckRollup` is head-scoped; per-check SHA not exposed) — documented.
- generic core; the Dopemux pr-merge-specialist skill + `contracts/openclaw-dcp-routing` schema specialize it (coexist, not replaced).

Packet: `TP-DMX-PCP-PR-STEWARD-PROOF-READINESS-0001` · Branch `claude/pcp-p8-pr-steward-proof-readiness`

🤖 Generated with [Claude Code](https://claude.com/claude-code)