### PR TITLE
feat(pcp): Task-Orchestrator projection-only visibility (Packet 9)

### DIFF
--- a/docs/ops/project-control-plane/task-orchestrator-visibility.md
+++ b/docs/ops/project-control-plane/task-orchestrator-visibility.md
@@ -1,0 +1,170 @@
+---
+id: PCP-TO-VISIBILITY
+title: PCP Core Task-Orchestrator Projection-Only Visibility
+type: reference
+owner: '@hu3mann'
+author: claude
+date: '2026-06-22'
+last_review: '2026-06-22'
+next_review: '2026-09-20'
+prelude: PCP Core Task-Orchestrator Projection-Only Visibility (explanation) for dopemux
+  documentation and developer workflows.
+---
+# PCP Core Task-Orchestrator Projection-Only Visibility
+
+## Overview
+
+This document describes the **READ/PROJECTION-ONLY** mapping of Task-Orchestrator state
+(items + dependencies) into PCP evidence.
+
+**Hard constraints — enforced in code:**
+
+- There is NO MCP write path of any kind.
+- The projection is NOT proof, PM-metadata, merge authority, or live-write authority.
+- `is_proof` is always `False`.
+- `authority` is always `"NONE"`.
+- `mcp_write_performed` is always `False`.
+
+Module: `src/dopemux/pcp/task_orchestrator_projection.py`
+
+---
+
+## What the Projection Is
+
+The projection is a **read-only snapshot** of Task-Orchestrator state, shaped for
+consumption by downstream PCP evidence pipelines. It records what was observed at a
+point in time and nothing more.
+
+Downstream packets **may consume** this projection as a read view. They **must never**:
+
+- treat it as proof,
+- treat it as a merge authority,
+- use it to drive PM-metadata writes, or
+- pass it to any write surface.
+
+---
+
+## Projection Fields
+
+| Field | Type | Value |
+|---|---|---|
+| `schema_version` | string | `"pcp.to_projection.v0"` |
+| `surface_class` | string | `"PROJECTION"` — never `"PROOF"` |
+| `is_proof` | bool | Always `False` |
+| `authority` | string | Always `"NONE"` |
+| `mcp_write_performed` | bool | Always `False` (const-style sentinel) |
+| `source_truth_refs` | list of string | The `source_ref` passed at projection time |
+| `generated_at` | ISO 8601 string | Timestamp of projection assembly |
+| `items` | list of objects | Read-only subset: `id`, `title`, `role`, `depth`, `status_label` |
+| `dependencies` | list of objects | Read-only subset: `from_id`, `to_id`, `type` |
+
+---
+
+## The Fail-Closed No-Write Guard
+
+`forbid_mcp_write(tool_name)` enforces read-only access at the tool boundary.
+
+**Rules (evaluated in order):**
+
+1. If `tool_name` is in `_WRITE_TOOLS` → raise `ProjectionWriteForbidden`.
+2. If `tool_name` is NOT in `_READ_TOOLS` → raise `ProjectionWriteForbidden` (unknown = deny).
+3. Return `None` only for explicitly recognised read tools.
+
+The **default for anything unknown is DENY** — unknown tool names are never permitted.
+
+### Write tools (always denied)
+
+| Tool name |
+|---|
+| `manage_items` |
+| `advance_item` |
+| `manage_notes` |
+| `manage_dependencies` |
+| `claim_item` |
+| `complete_tree` |
+| `create_work_tree` |
+
+### Read tools (explicitly permitted)
+
+| Tool name |
+|---|
+| `query_items` |
+| `query_dependencies` |
+| `query_notes` |
+| `get_context` |
+| `get_blocked_items` |
+| `get_next_item` |
+| `get_next_status` |
+
+---
+
+## Injectable Harvest
+
+`harvest_projection(*, source_ref, generated_at, runner)` provides a thin read-only
+harvest wrapper. The `runner` parameter is **required** — no default live MCP call is
+made. If `runner` is `None`, `NotImplementedError` is raised immediately.
+
+Runners must call only read tools. The module cannot enforce this at the runner
+boundary, but `forbid_mcp_write` is available for runners to self-validate.
+
+**Testing pattern:** supply a fake runner that returns canned data. No live MCP
+calls are made in tests.
+
+```python
+def fake_runner(*, source_ref: str) -> dict:
+    return {
+        "items": [{"id": "abc", "title": "T", "role": "leaf",
+                   "depth": 1, "status_label": "queue"}],
+        "dependencies": [],
+    }
+
+result = harvest_projection(
+    source_ref="workspace:/path",
+    generated_at="2026-06-22T00:00:00Z",
+    runner=fake_runner,
+)
+assert result["is_proof"] is False
+assert result["authority"] == "NONE"
+```
+
+---
+
+## Relationship to PCP Evidence
+
+The projection sits at the **read layer** of the PCP evidence pipeline:
+
+```
+Task-Orchestrator (source of truth)
+        |
+        | read-only (query_items, query_dependencies)
+        v
+project_orchestrator_state()  ← pure function, no mutation
+        |
+        | projection dict (is_proof=False, authority=NONE)
+        v
+Downstream PCP evidence consumers
+        |
+        | may READ the projection
+        | must NOT treat it as proof or write authority
+        v
+(proof assembly lives elsewhere — separate module, separate authority)
+```
+
+The projection is a **read view**, not a truth surface. Downstream packets that need
+to assert proof must obtain proof from a dedicated proof-assembly path, not from this
+module.
+
+---
+
+## Validation Invariants
+
+The test suite (`tests/project_control_plane/test_to_projection.py`) asserts:
+
+- `is_proof` is `False` and `authority` is `"NONE"` on every projection.
+- Write tool names appear only in the `_WRITE_TOOLS` frozenset definition, never as
+  function call invocations in the module source.
+- `forbid_mcp_write` raises `ProjectionWriteForbidden` for all 7 write tools.
+- `forbid_mcp_write` raises `ProjectionWriteForbidden` for any unrecognised tool name.
+- `forbid_mcp_write` returns `None` for all explicitly recognised read tools.
+- Input lists are not mutated by `project_orchestrator_state`.
+- `ValueError` is raised on malformed input (non-list, empty `source_ref`, missing `id`).

--- a/src/dopemux/pcp/task_orchestrator_projection.py
+++ b/src/dopemux/pcp/task_orchestrator_projection.py
@@ -1,0 +1,289 @@
+"""
+Generic PCP-Core Task-Orchestrator read/projection-only visibility.
+
+This module provides a READ/PROJECTION-ONLY mapping of Task-Orchestrator state
+(items + dependencies) into PCP evidence.  There is NO MCP write path of any
+kind.  The projection is explicitly NOT proof, PM-metadata, merge, or
+live-write authority.  Any write attempt FAILS CLOSED.
+
+The fail-closed guard (``forbid_mcp_write``) denies all write tools AND any
+unrecognised tool by default — unknown tool names are denied, not permitted.
+
+Design invariants
+-----------------
+* ``is_proof`` is always ``False`` — a projection is never proof.
+* ``authority`` is always ``"NONE"`` — this module holds no authority.
+* ``mcp_write_performed`` is always ``False`` — const-style sentinel.
+* Input lists are copied, never mutated.
+* No Task-Orchestrator write tool is called anywhere in this module.
+
+Usage::
+
+    from dopemux.pcp.task_orchestrator_projection import (
+        project_orchestrator_state,
+        forbid_mcp_write,
+        harvest_projection,
+    )
+
+    projection = project_orchestrator_state(
+        items=[{"id": "abc", "title": "Do work", "role": "leaf",
+                "depth": 1, "status_label": "queue"}],
+        dependencies=[{"from_id": "abc", "to_id": "xyz", "type": "BLOCKS"}],
+        source_ref="workspace:/path/to/project",
+        generated_at="2026-06-22T00:00:00Z",
+    )
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+# ---------------------------------------------------------------------------
+# Exception: write operations are forbidden
+# ---------------------------------------------------------------------------
+
+class ProjectionWriteForbidden(Exception):
+    """Raised when any write tool or unrecognised tool is invoked against the
+    Task-Orchestrator projection surface.
+
+    The fail-closed default means that unknown tool names are denied rather
+    than allowed — only explicitly recognised read tools pass through.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Tool classification — immutable frozensets
+# ---------------------------------------------------------------------------
+
+_WRITE_TOOLS: frozenset[str] = frozenset({
+    "manage_items",
+    "advance_item",
+    "manage_notes",
+    "manage_dependencies",
+    "claim_item",
+    "complete_tree",
+    "create_work_tree",
+})
+
+_READ_TOOLS: frozenset[str] = frozenset({
+    "query_items",
+    "query_dependencies",
+    "query_notes",
+    "get_context",
+    "get_blocked_items",
+    "get_next_item",
+    "get_next_status",
+})
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed write guard
+# ---------------------------------------------------------------------------
+
+def forbid_mcp_write(tool_name: str) -> None:
+    """Fail-closed guard: raise ``ProjectionWriteForbidden`` for any non-read tool.
+
+    Rules (evaluated in order):
+    1. If *tool_name* is in ``_WRITE_TOOLS`` → raise.
+    2. If *tool_name* is NOT in ``_READ_TOOLS`` → raise (unknown = deny).
+    3. Return ``None`` only for explicitly recognised read tools.
+
+    Parameters
+    ----------
+    tool_name:
+        The Task-Orchestrator MCP tool name to validate.
+
+    Returns
+    -------
+    None
+        Only when *tool_name* is an explicit member of ``_READ_TOOLS``.
+
+    Raises
+    ------
+    ProjectionWriteForbidden
+        For write tools, for unrecognised tool names, or for any other
+        non-read tool.
+    """
+    if tool_name in _WRITE_TOOLS:
+        raise ProjectionWriteForbidden(
+            f"Write tool {tool_name!r} is forbidden in the TO projection surface. "
+            "This module is READ/PROJECTION-ONLY — no MCP write path exists."
+        )
+    if tool_name not in _READ_TOOLS:
+        raise ProjectionWriteForbidden(
+            f"Unrecognised tool {tool_name!r} is denied by default (fail-closed). "
+            "Only explicitly recognised read tools are permitted: "
+            f"{sorted(_READ_TOOLS)!r}"
+        )
+    # tool_name is in _READ_TOOLS — permit
+
+
+# ---------------------------------------------------------------------------
+# Pure projection function
+# ---------------------------------------------------------------------------
+
+def project_orchestrator_state(
+    items: list[dict],
+    dependencies: list[dict],
+    *,
+    source_ref: str,
+    generated_at: str,
+) -> dict:
+    """Project Task-Orchestrator state into a read-only PCP evidence dict.
+
+    This is a **pure**, **read-only** function.  Input lists are copied and
+    never mutated.  The returned dict:
+
+    * always has ``is_proof: False`` — a projection is NEVER proof.
+    * always has ``authority: "NONE"`` — holds no authority.
+    * always has ``mcp_write_performed: False`` — const-style sentinel.
+    * always has ``surface_class: "PROJECTION"``.
+
+    Parameters
+    ----------
+    items:
+        List of item dicts from Task-Orchestrator (e.g. from ``query_items``).
+        Each must contain at least an ``"id"`` key.  Malformed items (missing
+        ``"id"``) raise ``ValueError``.
+    dependencies:
+        List of dependency dicts (e.g. from ``query_dependencies``).  Each
+        should contain ``from_id``, ``to_id``, and ``type``.
+    source_ref:
+        Non-empty string identifying the Task-Orchestrator data source
+        (e.g. ``"workspace:/path"`` or a root item UUID).
+    generated_at:
+        ISO 8601 datetime string for when the projection was assembled.
+
+    Returns
+    -------
+    dict
+        A projection dict with schema_version, surface_class, is_proof,
+        authority, mcp_write_performed, source_truth_refs, generated_at,
+        items (read-only subset), and dependencies.
+
+    Raises
+    ------
+    ValueError
+        If ``items`` or ``dependencies`` are not lists, if ``source_ref`` is
+        empty, or if any item is missing the required ``"id"`` key.
+    """
+    if not isinstance(items, list):
+        raise ValueError(
+            f"items must be a list; got {type(items).__name__!r}"
+        )
+    if not isinstance(dependencies, list):
+        raise ValueError(
+            f"dependencies must be a list; got {type(dependencies).__name__!r}"
+        )
+    if not source_ref or not isinstance(source_ref, str):
+        raise ValueError(
+            f"source_ref must be a non-empty string; got {source_ref!r}"
+        )
+
+    # Project items — read-only subset, copy (no mutation of inputs)
+    projected_items: list[dict[str, Any]] = []
+    for raw_item in items:
+        if not isinstance(raw_item, dict):
+            raise ValueError(
+                f"Each item must be a dict; got {type(raw_item).__name__!r}: {raw_item!r}"
+            )
+        if "id" not in raw_item:
+            raise ValueError(
+                f"Item is missing required 'id' key: {raw_item!r}"
+            )
+        projected_items.append({
+            "id": raw_item["id"],
+            "title": raw_item.get("title", ""),
+            "role": raw_item.get("role", ""),
+            "depth": raw_item.get("depth", 0),
+            "status_label": raw_item.get("status_label", ""),
+        })
+
+    # Project dependencies — copy (no mutation of inputs)
+    projected_deps: list[dict[str, Any]] = []
+    for raw_dep in dependencies:
+        if not isinstance(raw_dep, dict):
+            raise ValueError(
+                f"Each dependency must be a dict; got {type(raw_dep).__name__!r}: {raw_dep!r}"
+            )
+        projected_deps.append({
+            "from_id": raw_dep.get("from_id", ""),
+            "to_id": raw_dep.get("to_id", ""),
+            "type": raw_dep.get("type", ""),
+        })
+
+    return {
+        "schema_version": "pcp.to_projection.v0",
+        "surface_class": "PROJECTION",
+        "is_proof": False,             # projection is NEVER proof
+        "authority": "NONE",           # holds no authority
+        "mcp_write_performed": False,  # const-style: always False
+        "source_truth_refs": [source_ref],
+        "generated_at": generated_at,
+        "items": projected_items,
+        "dependencies": projected_deps,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Injectable harvest (thin wrapper — no live MCP calls by default)
+# ---------------------------------------------------------------------------
+
+def harvest_projection(
+    *,
+    source_ref: str,
+    generated_at: str,
+    runner: Callable[..., dict] | None = None,
+) -> dict:
+    """Read-only harvest using an injectable runner, then project the result.
+
+    The *runner* is called to obtain raw ``{"items": [...], "dependencies": [...]}``
+    data from read-only Task-Orchestrator tools (``query_items`` overview +
+    ``query_dependencies``).  If *runner* is ``None``, ``NotImplementedError``
+    is raised — no live MCP call is made by default.
+
+    Only read tools are permitted inside *runner*.  Callers must ensure their
+    runner uses ``query_items`` / ``query_dependencies`` exclusively; the
+    module itself cannot enforce this at the runner boundary, but
+    ``forbid_mcp_write`` is available for runners to self-validate.
+
+    Parameters
+    ----------
+    source_ref:
+        Non-empty string identifying the data source (passed through to
+        ``project_orchestrator_state``).
+    generated_at:
+        ISO 8601 datetime string (passed through).
+    runner:
+        Optional callable that returns ``{"items": list, "dependencies": list}``
+        from Task-Orchestrator read tools.  Defaults to ``None`` (raises
+        ``NotImplementedError``).  Tests supply a fake runner with canned data.
+
+    Returns
+    -------
+    dict
+        Projection dict produced by ``project_orchestrator_state``.
+
+    Raises
+    ------
+    NotImplementedError
+        If *runner* is ``None`` (no live MCP call is made by default).
+    ValueError
+        Propagated from ``project_orchestrator_state`` on malformed data.
+    """
+    if runner is None:
+        raise NotImplementedError(
+            "harvest_projection requires an injectable runner. "
+            "No live MCP call is made by default. "
+            "Supply a runner that calls only read tools "
+            f"(one of: {sorted(_READ_TOOLS)!r})."
+        )
+
+    raw = runner(source_ref=source_ref)
+    return project_orchestrator_state(
+        raw.get("items", []),
+        raw.get("dependencies", []),
+        source_ref=source_ref,
+        generated_at=generated_at,
+    )

--- a/tests/project_control_plane/test_to_projection.py
+++ b/tests/project_control_plane/test_to_projection.py
@@ -1,0 +1,543 @@
+"""
+Tests for the generic PCP-Core Task-Orchestrator projection-only visibility module.
+
+Covers:
+- project_orchestrator_state on sample items+deps → correct structure.
+- Projection is NEVER proof: is_proof False, authority "NONE", surface_class "PROJECTION".
+- mcp_write_performed is always False.
+- Input lists are NOT mutated.
+- forbid_mcp_write raises ProjectionWriteForbidden for EACH write tool.
+- forbid_mcp_write raises ProjectionWriteForbidden for unknown tools (fail-closed).
+- forbid_mcp_write returns None for each recognised read tool.
+- No-write source scan: module source contains write-tool names only in _WRITE_TOOLS,
+  not as invocations.
+- ValueError on malformed input (non-list items, empty source_ref, missing id).
+- harvest_projection with a FAKE runner → valid projection; no live MCP.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+import pytest
+
+from dopemux.pcp.task_orchestrator_projection import (
+    ProjectionWriteForbidden,
+    _READ_TOOLS,
+    _WRITE_TOOLS,
+    forbid_mcp_write,
+    harvest_projection,
+    project_orchestrator_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_SOURCE_REF = "workspace:/test/project"
+_GENERATED_AT = "2026-06-22T00:00:00Z"
+
+_SAMPLE_ITEMS: list[dict] = [
+    {
+        "id": "item-001",
+        "title": "Root task",
+        "role": "root",
+        "depth": 0,
+        "status_label": "queue",
+    },
+    {
+        "id": "item-002",
+        "title": "Child task",
+        "role": "leaf",
+        "depth": 1,
+        "status_label": "work",
+    },
+]
+
+_SAMPLE_DEPS: list[dict] = [
+    {"from_id": "item-001", "to_id": "item-002", "type": "BLOCKS"},
+]
+
+
+def _project(**kwargs: Any) -> dict:
+    """Shorthand: call project_orchestrator_state with defaults."""
+    return project_orchestrator_state(
+        kwargs.get("items", list(_SAMPLE_ITEMS)),
+        kwargs.get("dependencies", list(_SAMPLE_DEPS)),
+        source_ref=kwargs.get("source_ref", _SOURCE_REF),
+        generated_at=kwargs.get("generated_at", _GENERATED_AT),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic structure and field values
+# ---------------------------------------------------------------------------
+
+class TestProjectOrchestratorStateStructure:
+    def test_schema_version(self) -> None:
+        result = _project()
+        assert result["schema_version"] == "pcp.to_projection.v0"
+
+    def test_surface_class(self) -> None:
+        result = _project()
+        assert result["surface_class"] == "PROJECTION"
+
+    def test_is_proof_false(self) -> None:
+        result = _project()
+        assert result["is_proof"] is False
+
+    def test_authority_none(self) -> None:
+        result = _project()
+        assert result["authority"] == "NONE"
+
+    def test_mcp_write_performed_false(self) -> None:
+        result = _project()
+        assert result["mcp_write_performed"] is False
+
+    def test_source_truth_refs_contains_source_ref(self) -> None:
+        result = _project()
+        assert _SOURCE_REF in result["source_truth_refs"]
+
+    def test_generated_at_preserved(self) -> None:
+        result = _project()
+        assert result["generated_at"] == _GENERATED_AT
+
+    def test_items_projected_with_read_only_fields(self) -> None:
+        result = _project()
+        assert len(result["items"]) == 2
+        item_ids = {it["id"] for it in result["items"]}
+        assert item_ids == {"item-001", "item-002"}
+
+    def test_item_fields_are_read_only_subset(self) -> None:
+        result = _project()
+        for item in result["items"]:
+            assert set(item.keys()) == {"id", "title", "role", "depth", "status_label"}
+
+    def test_items_values_correct(self) -> None:
+        result = _project()
+        by_id = {it["id"]: it for it in result["items"]}
+        assert by_id["item-001"]["title"] == "Root task"
+        assert by_id["item-001"]["role"] == "root"
+        assert by_id["item-001"]["depth"] == 0
+        assert by_id["item-001"]["status_label"] == "queue"
+        assert by_id["item-002"]["title"] == "Child task"
+        assert by_id["item-002"]["status_label"] == "work"
+
+    def test_dependencies_projected(self) -> None:
+        result = _project()
+        assert len(result["dependencies"]) == 1
+        dep = result["dependencies"][0]
+        assert dep["from_id"] == "item-001"
+        assert dep["to_id"] == "item-002"
+        assert dep["type"] == "BLOCKS"
+
+    def test_dependency_fields_are_subset(self) -> None:
+        result = _project()
+        for dep in result["dependencies"]:
+            assert set(dep.keys()) == {"from_id", "to_id", "type"}
+
+    def test_empty_items_and_deps(self) -> None:
+        result = project_orchestrator_state(
+            [], [], source_ref=_SOURCE_REF, generated_at=_GENERATED_AT
+        )
+        assert result["items"] == []
+        assert result["dependencies"] == []
+        assert result["is_proof"] is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Projection is NEVER labelled proof
+# ---------------------------------------------------------------------------
+
+class TestProjectionIsNeverProof:
+    def test_is_proof_is_false(self) -> None:
+        result = _project()
+        assert result["is_proof"] is False
+
+    def test_authority_is_none_string(self) -> None:
+        result = _project()
+        assert result["authority"] == "NONE"
+
+    def test_no_key_claims_proof(self) -> None:
+        result = _project()
+        # No key anywhere in the result should have a value that claims proof
+        assert result.get("is_proof") is not True
+        assert result.get("authority") != "FULL"
+        assert result.get("authority") != "MERGE"
+        assert result.get("authority") != "PM"
+
+    def test_surface_class_is_projection_not_proof(self) -> None:
+        result = _project()
+        assert result["surface_class"] == "PROJECTION"
+        assert result["surface_class"] != "PROOF"
+
+    def test_is_proof_and_authority_together(self) -> None:
+        result = _project()
+        assert result["is_proof"] is False
+        assert result["authority"] == "NONE"
+
+
+# ---------------------------------------------------------------------------
+# 3. Input lists are NOT mutated
+# ---------------------------------------------------------------------------
+
+class TestInputListsNotMutated:
+    def test_items_list_not_mutated(self) -> None:
+        items = [{"id": "x", "title": "X", "role": "leaf", "depth": 0, "status_label": "queue"}]
+        items_original_len = len(items)
+        items_original_first = dict(items[0])
+        _project(items=items, dependencies=[])
+        assert len(items) == items_original_len
+        assert items[0] == items_original_first
+
+    def test_deps_list_not_mutated(self) -> None:
+        deps = [{"from_id": "a", "to_id": "b", "type": "BLOCKS"}]
+        deps_original = [dict(d) for d in deps]
+        _project(items=[{"id": "a"}], dependencies=deps)
+        assert deps == deps_original
+
+    def test_projection_items_are_new_dicts(self) -> None:
+        items = [{"id": "item-001", "title": "T", "role": "root", "depth": 0, "status_label": "q"}]
+        result = _project(items=items, dependencies=[])
+        # Mutating the projected item should not affect the original
+        result["items"][0]["title"] = "MUTATED"
+        assert items[0]["title"] == "T"
+
+
+# ---------------------------------------------------------------------------
+# 4. forbid_mcp_write: write tools raise ProjectionWriteForbidden
+# ---------------------------------------------------------------------------
+
+class TestForbidMcpWriteRaisesForWriteTools:
+    @pytest.mark.parametrize("tool_name", sorted(_WRITE_TOOLS))
+    def test_write_tool_raises(self, tool_name: str) -> None:
+        with pytest.raises(ProjectionWriteForbidden):
+            forbid_mcp_write(tool_name)
+
+    def test_manage_items_specifically(self) -> None:
+        with pytest.raises(ProjectionWriteForbidden, match="manage_items"):
+            forbid_mcp_write("manage_items")
+
+    def test_advance_item_specifically(self) -> None:
+        with pytest.raises(ProjectionWriteForbidden, match="advance_item"):
+            forbid_mcp_write("advance_item")
+
+    def test_manage_notes_specifically(self) -> None:
+        with pytest.raises(ProjectionWriteForbidden):
+            forbid_mcp_write("manage_notes")
+
+    def test_manage_dependencies_specifically(self) -> None:
+        with pytest.raises(ProjectionWriteForbidden):
+            forbid_mcp_write("manage_dependencies")
+
+    def test_claim_item_specifically(self) -> None:
+        with pytest.raises(ProjectionWriteForbidden):
+            forbid_mcp_write("claim_item")
+
+    def test_complete_tree_specifically(self) -> None:
+        with pytest.raises(ProjectionWriteForbidden):
+            forbid_mcp_write("complete_tree")
+
+    def test_create_work_tree_specifically(self) -> None:
+        with pytest.raises(ProjectionWriteForbidden):
+            forbid_mcp_write("create_work_tree")
+
+
+# ---------------------------------------------------------------------------
+# 5. forbid_mcp_write: unknown tools raise ProjectionWriteForbidden (fail-closed)
+# ---------------------------------------------------------------------------
+
+class TestForbidMcpWriteFailClosedForUnknownTools:
+    @pytest.mark.parametrize("unknown", [
+        "delete_everything",
+        "drop_table",
+        "exec_sql",
+        "unknown_tool",
+        "",
+        "QUERY_ITEMS",  # case-sensitive: uppercase not recognised
+        "Query_Items",
+        "bogus",
+        "rm_rf",
+    ])
+    def test_unknown_tool_raises(self, unknown: str) -> None:
+        with pytest.raises(ProjectionWriteForbidden):
+            forbid_mcp_write(unknown)
+
+    def test_error_message_mentions_deny_default(self) -> None:
+        with pytest.raises(ProjectionWriteForbidden, match="fail-closed"):
+            forbid_mcp_write("delete_everything")
+
+
+# ---------------------------------------------------------------------------
+# 6. forbid_mcp_write: read tools return None (no raise)
+# ---------------------------------------------------------------------------
+
+class TestForbidMcpWritePermitsReadTools:
+    @pytest.mark.parametrize("tool_name", sorted(_READ_TOOLS))
+    def test_read_tool_returns_none(self, tool_name: str) -> None:
+        result = forbid_mcp_write(tool_name)
+        assert result is None
+
+    def test_query_items_returns_none(self) -> None:
+        assert forbid_mcp_write("query_items") is None
+
+    def test_query_dependencies_returns_none(self) -> None:
+        assert forbid_mcp_write("query_dependencies") is None
+
+    def test_get_context_returns_none(self) -> None:
+        assert forbid_mcp_write("get_context") is None
+
+
+# ---------------------------------------------------------------------------
+# 7. No-write source scan: write-tool names appear only in _WRITE_TOOLS
+# ---------------------------------------------------------------------------
+
+class TestNoWriteSourceScan:
+    """Assert the module source never calls a write tool."""
+
+    def _get_source(self) -> str:
+        import dopemux.pcp.task_orchestrator_projection as _mod
+        return inspect.getsource(_mod)
+
+    def test_advance_item_not_called(self) -> None:
+        src = self._get_source()
+        assert "advance_item(" not in src, (
+            "advance_item( appears in module source as a call — forbidden"
+        )
+
+    def test_manage_items_not_called(self) -> None:
+        src = self._get_source()
+        assert "manage_items(" not in src, (
+            "manage_items( appears in module source as a call — forbidden"
+        )
+
+    def test_manage_notes_not_called(self) -> None:
+        src = self._get_source()
+        assert "manage_notes(" not in src
+
+    def test_manage_dependencies_not_called(self) -> None:
+        src = self._get_source()
+        assert "manage_dependencies(" not in src
+
+    def test_claim_item_not_called(self) -> None:
+        src = self._get_source()
+        assert "claim_item(" not in src
+
+    def test_complete_tree_not_called(self) -> None:
+        src = self._get_source()
+        assert "complete_tree(" not in src
+
+    def test_create_work_tree_not_called(self) -> None:
+        src = self._get_source()
+        assert "create_work_tree(" not in src
+
+    def test_write_tool_names_only_in_frozenset_definition(self) -> None:
+        """Write-tool strings appear ONLY in _WRITE_TOOLS literal, not as invocations."""
+        src = self._get_source()
+        # Each write tool name must appear at least once (in the frozenset definition)
+        # but must NOT appear with a trailing '(' (invocation pattern)
+        for tool in _WRITE_TOOLS:
+            assert tool in src, f"{tool!r} not found in module source at all"
+            assert f"{tool}(" not in src, (
+                f"{tool}( found in module source — write tool invocation is forbidden"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 8. ValueError on malformed input
+# ---------------------------------------------------------------------------
+
+class TestValueErrorOnMalformedInput:
+    def test_non_list_items_raises(self) -> None:
+        with pytest.raises(ValueError, match="items"):
+            project_orchestrator_state(
+                "not a list",  # type: ignore[arg-type]
+                [],
+                source_ref=_SOURCE_REF,
+                generated_at=_GENERATED_AT,
+            )
+
+    def test_none_items_raises(self) -> None:
+        with pytest.raises(ValueError, match="items"):
+            project_orchestrator_state(
+                None,  # type: ignore[arg-type]
+                [],
+                source_ref=_SOURCE_REF,
+                generated_at=_GENERATED_AT,
+            )
+
+    def test_dict_items_raises(self) -> None:
+        with pytest.raises(ValueError, match="items"):
+            project_orchestrator_state(
+                {},  # type: ignore[arg-type]
+                [],
+                source_ref=_SOURCE_REF,
+                generated_at=_GENERATED_AT,
+            )
+
+    def test_non_list_dependencies_raises(self) -> None:
+        with pytest.raises(ValueError, match="dependencies"):
+            project_orchestrator_state(
+                [],
+                "not a list",  # type: ignore[arg-type]
+                source_ref=_SOURCE_REF,
+                generated_at=_GENERATED_AT,
+            )
+
+    def test_empty_source_ref_raises(self) -> None:
+        with pytest.raises(ValueError, match="source_ref"):
+            project_orchestrator_state(
+                [], [], source_ref="", generated_at=_GENERATED_AT
+            )
+
+    def test_none_source_ref_raises(self) -> None:
+        with pytest.raises(ValueError, match="source_ref"):
+            project_orchestrator_state(
+                [], [], source_ref=None, generated_at=_GENERATED_AT  # type: ignore[arg-type]
+            )
+
+    def test_item_missing_id_raises(self) -> None:
+        with pytest.raises(ValueError, match="'id'"):
+            project_orchestrator_state(
+                [{"title": "no id here"}],
+                [],
+                source_ref=_SOURCE_REF,
+                generated_at=_GENERATED_AT,
+            )
+
+    def test_non_dict_item_raises(self) -> None:
+        with pytest.raises(ValueError):
+            project_orchestrator_state(
+                ["not a dict"],  # type: ignore[list-item]
+                [],
+                source_ref=_SOURCE_REF,
+                generated_at=_GENERATED_AT,
+            )
+
+
+# ---------------------------------------------------------------------------
+# 9. harvest_projection with a FAKE runner
+# ---------------------------------------------------------------------------
+
+class TestHarvestProjectionWithFakeRunner:
+    """harvest_projection must use the injected runner and produce a valid projection."""
+
+    _CANNED_DATA = {
+        "items": [
+            {
+                "id": "root-001",
+                "title": "Root",
+                "role": "root",
+                "depth": 0,
+                "status_label": "work",
+            },
+            {
+                "id": "leaf-002",
+                "title": "Leaf",
+                "role": "leaf",
+                "depth": 1,
+                "status_label": "queue",
+            },
+        ],
+        "dependencies": [
+            {"from_id": "root-001", "to_id": "leaf-002", "type": "BLOCKS"},
+        ],
+    }
+
+    def _make_fake_runner(self) -> tuple[list, Any]:
+        calls: list[dict] = []
+
+        def fake_runner(*, source_ref: str) -> dict:
+            calls.append({"source_ref": source_ref})
+            return self._CANNED_DATA
+
+        return calls, fake_runner
+
+    def test_fake_runner_is_used(self) -> None:
+        calls, fake_runner = self._make_fake_runner()
+        harvest_projection(
+            source_ref=_SOURCE_REF,
+            generated_at=_GENERATED_AT,
+            runner=fake_runner,
+        )
+        assert len(calls) == 1, "Fake runner was never called"
+
+    def test_source_ref_passed_to_runner(self) -> None:
+        calls, fake_runner = self._make_fake_runner()
+        harvest_projection(
+            source_ref=_SOURCE_REF,
+            generated_at=_GENERATED_AT,
+            runner=fake_runner,
+        )
+        assert calls[0]["source_ref"] == _SOURCE_REF
+
+    def test_returns_valid_projection(self) -> None:
+        _, fake_runner = self._make_fake_runner()
+        result = harvest_projection(
+            source_ref=_SOURCE_REF,
+            generated_at=_GENERATED_AT,
+            runner=fake_runner,
+        )
+        assert result["schema_version"] == "pcp.to_projection.v0"
+        assert result["is_proof"] is False
+        assert result["authority"] == "NONE"
+        assert result["surface_class"] == "PROJECTION"
+        assert result["mcp_write_performed"] is False
+
+    def test_items_from_canned_data(self) -> None:
+        _, fake_runner = self._make_fake_runner()
+        result = harvest_projection(
+            source_ref=_SOURCE_REF,
+            generated_at=_GENERATED_AT,
+            runner=fake_runner,
+        )
+        assert len(result["items"]) == 2
+        ids = {it["id"] for it in result["items"]}
+        assert ids == {"root-001", "leaf-002"}
+
+    def test_dependencies_from_canned_data(self) -> None:
+        _, fake_runner = self._make_fake_runner()
+        result = harvest_projection(
+            source_ref=_SOURCE_REF,
+            generated_at=_GENERATED_AT,
+            runner=fake_runner,
+        )
+        assert len(result["dependencies"]) == 1
+        assert result["dependencies"][0]["type"] == "BLOCKS"
+
+    def test_no_runner_raises_not_implemented_error(self) -> None:
+        with pytest.raises(NotImplementedError, match="runner"):
+            harvest_projection(
+                source_ref=_SOURCE_REF,
+                generated_at=_GENERATED_AT,
+                runner=None,
+            )
+
+    def test_no_live_mcp_when_runner_provided(self) -> None:
+        """Verify no subprocess or live MCP call happens when a fake runner is supplied."""
+        import subprocess as _subprocess
+        original_run = _subprocess.run
+        calls_to_real_subprocess: list = []
+
+        def _spy_run(*args: Any, **kwargs: Any) -> Any:
+            calls_to_real_subprocess.append(args)
+            return original_run(*args, **kwargs)
+
+        calls, fake_runner = self._make_fake_runner()
+        # monkeypatch subprocess.run temporarily
+        _subprocess.run = _spy_run  # type: ignore[assignment]
+        try:
+            harvest_projection(
+                source_ref=_SOURCE_REF,
+                generated_at=_GENERATED_AT,
+                runner=fake_runner,
+            )
+        finally:
+            _subprocess.run = original_run  # type: ignore[assignment]
+
+        assert calls_to_real_subprocess == [], (
+            "subprocess.run was called unexpectedly — harvest_projection "
+            "with a fake runner must not make live subprocess/MCP calls"
+        )


### PR DESCRIPTION
## Packet 9 — Task-Orchestrator projection-only visibility

Generic **read-only** projection of Task-Orchestrator state (items + dependencies) into PCP evidence. **No MCP write path**; the projection is never proof / PM-metadata / merge / live-write authority; any write attempt **fails closed**.

### Deliverables
- `src/dopemux/pcp/task_orchestrator_projection.py` — `project_orchestrator_state()` (is_proof False, authority NONE, input not mutated) + `forbid_mcp_write()` fail-closed guard (denies all write tools AND any unrecognised tool by default) + `harvest_projection()` (injectable read-only runner, no live MCP) + `ProjectionWriteForbidden`.
- `tests/project_control_plane/test_to_projection.py` — 78 tests.
- `docs/ops/project-control-plane/task-orchestrator-visibility.md`.

### Validation
| Check | Result |
|---|---|
| pytest pcp + dcp + dnh | **PASS** — 383 |
| pre-commit (SKIP=docs-graph-validator) | **PASS** |
| guard fail-closed (verified) | write tools → DENY, unknown tool → DENY, query tools → ALLOW |
| projection never proof (verified) | is_proof False, authority NONE, input not mutated |

### Review
PAL MCP unavailable → Opus direct verification + doc self-review. Low-risk read-only packet (no security gates, no live writes, no schema); 78 comprehensive tests incl. parametrized fail-closed guard, no-write source scan, projection-never-proof, input-immutability. Doc is honest (attributes guarantees to code, not a schema; explicitly notes an injected runner's read-only behavior can't be module-enforced).

Packet: `TP-DMX-PCP-TASK-ORCHESTRATOR-VISIBILITY-0001` · Branch `claude/pcp-p9-to-visibility`

🤖 Generated with [Claude Code](https://claude.com/claude-code)