### PR TITLE
feat(pcp): LIVE_WRITE_READY contract — fail-closed live-write gate (Packet 10)

### DIFF
--- a/docs/03-reference/architecture/pcp-live-write-gates.md
+++ b/docs/03-reference/architecture/pcp-live-write-gates.md
@@ -1,0 +1,205 @@
+---
+id: PCP-LIVE-WRITE-GATES
+title: PCP Live-Write Readiness Gate Contract
+type: reference
+owner: '@hu3mann'
+author: claude
+date: '2026-06-22'
+last_review: '2026-06-22'
+next_review: '2026-09-20'
+prelude: PCP Live-Write Readiness Gate Contract (reference) for dopemux documentation
+  and developer workflows.
+---
+# PCP Live-Write Readiness Gate Contract
+
+## 1. Purpose and Scope
+
+This document defines the **LIVE_WRITE_READY** contract — the fail-closed gate that every
+future live write against any surface governed by the Project Control Plane (PCP) must pass
+before execution.
+
+**CONTRACTS-ONLY**: No live write is performed by this document or by Packet 10
+(`TP-DMX-PCP-LIVE-WRITE-GATES-0001`). The gate is a schema-level readiness declaration only.
+
+The gate is enforced at the schema level via
+`schemas/project_control_plane/live_write_ready.schema.json` (JSON Schema Draft 2020-12).
+
+---
+
+## 2. The Fail-Closed Rule
+
+**No live write is permitted anywhere until every precondition exists and passes.**
+
+READY is withheld on ANY missing, null, false, or non-passing precondition. There is no
+partial READY. A READY assertion with one weak precondition is schema-invalid.
+
+The schema's `allOf` gates enforce this at validation time:
+
+- If `status` is `"READY"`, ALL preconditions must be present and passing and
+  `blocked_reasons` must be empty (`maxItems: 0`).
+- If `status` is `"BLOCKED"` or `"NEEDS_SUPERVISOR"`, `blocked_reasons` must contain at
+  least one entry (`minItems: 1`).
+
+---
+
+## 3. Preconditions
+
+Every precondition below must be satisfied before a LIVE_WRITE_READY assertion may carry
+`status: "READY"`.
+
+| Precondition | Schema field | READY requirement | Blocked reason when missing/false |
+|---|---|---|---|
+| Canonical writer | `canonical_writer` | Non-null, non-empty string | `MISSING_CANONICAL_WRITER` |
+| Diff within allowlist | `allowlist.diff_within_allowlist` | `true` | `DIFF_OUTSIDE_ALLOWLIST` |
+| Approval granted | `approval.approved` | `true` | `MISSING_APPROVAL` |
+| Idempotency confirmed | `idempotency.idempotent` | `true` | `NOT_IDEMPOTENT` |
+| Rollback available | `rollback.available` | `true` | `NO_ROLLBACK` |
+| Dry-run performed | `dry_run_proof.performed` | `true` | `MISSING_DRY_RUN_PROOF` |
+| Audit performed | `independent_audit.performed` | `true` | `MISSING_INDEPENDENT_AUDIT` |
+| Audit is independent | `independent_audit.independent` | `true` | `AUDIT_NOT_INDEPENDENT` |
+| Audit passed | `independent_audit.status` | `"PASS"` | `AUDIT_NOT_PASSED` |
+| Post-write verification planned | `post_write_verification.planned` | `true` | `MISSING_POST_WRITE_VERIFICATION` |
+
+### 3.1 Canonical Writer
+
+The canonical writer is the only surface authorized to perform the write. A `null` value
+means the writer is unknown and READY is withheld. The canonical writer is identified via
+the PCP authority map (`schemas/project_control_plane/authority_map.schema.json`).
+
+### 3.2 Allowlist
+
+The allowlist declares the set of paths the write operation is permitted to touch. If any
+file the write will touch falls outside the declared paths, `diff_within_allowlist` is
+`false` and READY is withheld. For a READY assertion, `allowlist.paths` must contain at
+least one entry — an empty paths array makes `diff_within_allowlist: true` vacuously true
+and is schema-invalid under READY status.
+
+### 3.3 Approval
+
+Approval must be granted by a known, authorized human or operator. The `approver` field
+records identity; `approval_ref` records the approval artifact (e.g. PR comment URL,
+ConPort decision ID).
+
+### 3.4 Idempotency
+
+The write operation must be safe to replay without producing additional side effects.
+An idempotency `key` should be recorded so that duplicate executions can be detected
+and suppressed.
+
+### 3.5 Rollback
+
+A concrete rollback path must be identified before the write executes. The `plan` field
+must name specific commands or steps sufficient to undo the write. For a READY assertion,
+`plan` must be a non-empty string — `null` and empty string are both schema-invalid under
+READY status.
+
+### 3.6 Dry-Run Proof
+
+A dry-run of the write must be performed and its output inspected before the live write
+is authorized. The `proof_ref` field records the dry-run output artifact.
+
+### 3.7 Independent Audit (AIR Red Line #9)
+
+The write must be audited by a party independent of the implementer. The implementer is
+never the sole final auditor. The audit must:
+
+- be `performed: true`
+- be `independent: true` (auditor identity differs from implementer)
+- have `status: "PASS"` (FAIL or NOT_RUN both withhold READY)
+
+### 3.8 Post-Write Verification
+
+A post-write verification plan must exist before the write executes (`planned: true`).
+The `performed` field tracks whether verification has run (expected `false` at gate-assertion
+time; updated after the write completes).
+
+---
+
+## 4. Schema Enforcement
+
+The schema enforces the fail-closed contract at the structural level via two `allOf` gates:
+
+**Gate A — READY requires all preconditions:**
+
+```
+if status == "READY" then:
+  canonical_writer: non-null, non-empty string
+  allowlist.diff_within_allowlist: true
+  allowlist.paths: non-empty array (minItems: 1)
+  approval.approved: true
+  idempotency.idempotent: true
+  rollback.available: true
+  rollback.plan: non-empty string (minLength: 1)
+  dry_run_proof.performed: true
+  independent_audit.performed: true
+  independent_audit.independent: true
+  independent_audit.status: "PASS"
+  post_write_verification.planned: true
+  blocked_reasons: [] (maxItems: 0)
+```
+
+**Gate B — BLOCKED/NEEDS_SUPERVISOR requires a reason:**
+
+```
+if status in ["BLOCKED", "NEEDS_SUPERVISOR"] then:
+  blocked_reasons: minItems 1
+```
+
+**Const sentinel:** `live_write_performed` is pinned `const: false` in the schema. A
+`LIVE_WRITE_READY` assertion can never record that a live write was performed — it is a
+readiness declaration only.
+
+---
+
+## 5. Forbidden Wiring (Red Line #15)
+
+The following wiring must never be enabled until a passing `LIVE_WRITE_READY` assertion
+exists and covers the target operation:
+
+- `scripts/batch_resolve_and_merge.py` — batch PR merge automation
+- `src/dopemux_pr_merge_specialist/queue_drain.py` with `execute=True` — queue drain
+  execution path
+
+These paths implement live write logic and are gated behind Red Line #15. No code in this
+packet (schema, tests, or this document) references or imports either path.
+
+---
+
+## 6. Relationship to Packet 11
+
+This packet (`TP-DMX-PCP-LIVE-WRITE-GATES-0001`, Packet 10) is the prerequisite gate for
+Packet 11, which implements the FastAPI bridge live adapter. Packet 11 must not be executed
+until a passing `LIVE_WRITE_READY` assertion — validated against this schema — exists for
+each write operation the adapter will perform.
+
+The sequencing invariant is:
+
+```
+Packet 10 (this packet) → LIVE_WRITE_READY schema + tests + doc (CONTRACTS ONLY)
+Packet 11               → FastAPI bridge live adapter (first live-write executor)
+```
+
+Packet 11 must reference a `LIVE_WRITE_READY` assertion by `assertion_id` in its proof
+bundle and confirm `status: "READY"` before any executor path is enabled.
+
+---
+
+## 7. Validation Commands
+
+Validate the schema itself:
+
+```bash
+python -c "import json,jsonschema; jsonschema.Draft202012Validator.check_schema(json.load(open('schemas/project_control_plane/live_write_ready.schema.json')))"
+```
+
+Run the gate tests:
+
+```bash
+python -m pytest -q tests/project_control_plane/test_live_write_gates.py
+```
+
+Run the full project_control_plane test suite to check for regressions:
+
+```bash
+python -m pytest -q tests/project_control_plane/ tests/dcp_extension/ tests/dnh_extension/
+```

--- a/schemas/project_control_plane/live_write_ready.schema.json
+++ b/schemas/project_control_plane/live_write_ready.schema.json
@@ -1,0 +1,307 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/live_write_ready.schema.json",
+  "title": "PCP Live-Write Readiness Gate",
+  "description": "Fail-closed gate contract that every future live write must pass before execution. READY is granted ONLY when ALL preconditions are present and passing. Missing or false ANY precondition forces status to BLOCKED or NEEDS_SUPERVISOR. This contract is a readiness declaration only — it NEVER represents a performed write.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assertion_id",
+    "operation_ref",
+    "target_surface",
+    "canonical_writer",
+    "allowlist",
+    "approval",
+    "idempotency",
+    "rollback",
+    "dry_run_proof",
+    "independent_audit",
+    "post_write_verification",
+    "status",
+    "blocked_reasons",
+    "live_write_performed",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.live_write_ready.v0",
+      "description": "Schema version sentinel. Must be exactly 'pcp.live_write_ready.v0'."
+    },
+    "assertion_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this readiness assertion."
+    },
+    "operation_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Reference to the write operation this gate governs (e.g. task-packet ID, PR ref, or operation slug)."
+    },
+    "target_surface": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The surface or resource that would be written (e.g. 'github.pr.merge', 'conport.progress_entry', 'dnh.artifact')."
+    },
+    "canonical_writer": {
+      "type": ["string", "null"],
+      "description": "The authorized canonical writer for this surface. null when the writer is unknown — which forces BLOCKED."
+    },
+    "allowlist": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["paths", "diff_within_allowlist"],
+      "description": "Allowlist declaration: the paths the write is permitted to touch and whether the diff is contained.",
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Declared allowlist paths the write operation is permitted to touch."
+        },
+        "diff_within_allowlist": {
+          "type": "boolean",
+          "description": "True iff every file the write will touch falls within the declared allowlist paths. False forces BLOCKED."
+        }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approved"],
+      "description": "Human or operator approval for the write operation.",
+      "properties": {
+        "approved": {
+          "type": "boolean",
+          "description": "True iff the write has received required approval. False forces BLOCKED."
+        },
+        "approver": {
+          "type": ["string", "null"],
+          "description": "Identity of the approver (GitHub login, operator ID, etc.)."
+        },
+        "approval_ref": {
+          "type": ["string", "null"],
+          "description": "Reference to the approval artifact (PR comment URL, decision ID, etc.)."
+        }
+      }
+    },
+    "idempotency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["idempotent"],
+      "description": "Idempotency declaration for the write operation.",
+      "properties": {
+        "idempotent": {
+          "type": "boolean",
+          "description": "True iff the write operation is idempotent (safe to replay without side-effects). False forces BLOCKED."
+        },
+        "key": {
+          "type": ["string", "null"],
+          "description": "Idempotency key used to deduplicate replays, or null if not yet established."
+        }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available"],
+      "description": "Rollback capability declaration.",
+      "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "True iff a concrete rollback path exists and has been identified. False forces BLOCKED."
+        },
+        "plan": {
+          "type": ["string", "null"],
+          "description": "Non-empty rollback plan/command. null is only permitted for non-READY status; a READY assertion requires a non-empty plan."
+        }
+      }
+    },
+    "dry_run_proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["performed"],
+      "description": "Evidence that a dry-run of the write was performed before live execution.",
+      "properties": {
+        "performed": {
+          "type": "boolean",
+          "description": "True iff a dry-run has been performed and its output inspected. False forces BLOCKED."
+        },
+        "proof_ref": {
+          "type": ["string", "null"],
+          "description": "Reference to the dry-run output artifact (path, URL, etc.)."
+        }
+      }
+    },
+    "independent_audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["performed", "independent", "status"],
+      "description": "Independent audit of the write operation (AIR Red Line #9: implementer is not the sole final auditor).",
+      "properties": {
+        "performed": {
+          "type": "boolean",
+          "description": "True iff an audit was performed. False forces BLOCKED."
+        },
+        "independent": {
+          "type": "boolean",
+          "description": "True iff the auditor is independent of the implementer. False forces BLOCKED."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["PASS", "FAIL", "NOT_RUN"],
+          "description": "Audit verdict. FAIL or NOT_RUN forces BLOCKED."
+        },
+        "auditor": {
+          "type": ["string", "null"],
+          "description": "Identity of the auditor (model ID, GitHub login, tool name, etc.)."
+        }
+      }
+    },
+    "post_write_verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["planned", "performed"],
+      "description": "Post-write verification plan and execution status.",
+      "properties": {
+        "planned": {
+          "type": "boolean",
+          "description": "True iff a post-write verification plan exists. False forces BLOCKED."
+        },
+        "performed": {
+          "type": "boolean",
+          "description": "True iff post-write verification has been performed (expected false at gate-assertion time)."
+        },
+        "verification_ref": {
+          "type": ["string", "null"],
+          "description": "Reference to the verification plan or result artifact."
+        }
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["READY", "BLOCKED", "NEEDS_SUPERVISOR"],
+      "description": "Readiness verdict. READY is fail-closed: withheld on ANY missing or false precondition."
+    },
+    "blocked_reasons": {
+      "type": "array",
+      "uniqueItems": true,
+      "description": "Enumerated reasons READY was withheld. Must be empty iff status is READY.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "MISSING_CANONICAL_WRITER",
+          "DIFF_OUTSIDE_ALLOWLIST",
+          "MISSING_APPROVAL",
+          "NOT_IDEMPOTENT",
+          "NO_ROLLBACK",
+          "MISSING_DRY_RUN_PROOF",
+          "MISSING_INDEPENDENT_AUDIT",
+          "AUDIT_NOT_INDEPENDENT",
+          "AUDIT_NOT_PASSED",
+          "MISSING_POST_WRITE_VERIFICATION",
+          "UNKNOWN"
+        ]
+      }
+    },
+    "live_write_performed": {
+      "type": "boolean",
+      "const": false,
+      "description": "Always false. This schema is a readiness gate contract only. It NEVER represents a performed write. Const-false is enforced by schema."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime at which this readiness assertion was assembled."
+    }
+  },
+  "allOf": [
+    {
+      "description": "Fail-closed READY gate: READY requires ALL preconditions satisfied and zero blocked_reasons.",
+      "if": {
+        "properties": { "status": { "const": "READY" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": [
+          "canonical_writer",
+          "allowlist",
+          "approval",
+          "idempotency",
+          "rollback",
+          "dry_run_proof",
+          "independent_audit",
+          "post_write_verification",
+          "blocked_reasons"
+        ],
+        "properties": {
+          "canonical_writer": {
+            "type": "string",
+            "minLength": 1
+          },
+          "allowlist": {
+            "properties": {
+              "diff_within_allowlist": { "const": true },
+              "paths": { "type": "array", "minItems": 1 }
+            },
+            "required": ["diff_within_allowlist", "paths"]
+          },
+          "approval": {
+            "properties": {
+              "approved": { "const": true }
+            },
+            "required": ["approved"]
+          },
+          "idempotency": {
+            "properties": {
+              "idempotent": { "const": true }
+            },
+            "required": ["idempotent"]
+          },
+          "rollback": {
+            "properties": {
+              "available": { "const": true },
+              "plan": { "type": "string", "minLength": 1 }
+            },
+            "required": ["available", "plan"]
+          },
+          "dry_run_proof": {
+            "properties": {
+              "performed": { "const": true }
+            },
+            "required": ["performed"]
+          },
+          "independent_audit": {
+            "properties": {
+              "performed": { "const": true },
+              "independent": { "const": true },
+              "status": { "const": "PASS" }
+            },
+            "required": ["performed", "independent", "status"]
+          },
+          "post_write_verification": {
+            "properties": {
+              "planned": { "const": true }
+            },
+            "required": ["planned"]
+          },
+          "blocked_reasons": {
+            "maxItems": 0
+          }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed BLOCKED gate: BLOCKED or NEEDS_SUPERVISOR requires at least one blocked_reason.",
+      "if": {
+        "properties": { "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "blocked_reasons": { "minItems": 1 }
+        }
+      }
+    }
+  ]
+}

--- a/tests/project_control_plane/test_live_write_gates.py
+++ b/tests/project_control_plane/test_live_write_gates.py
@@ -1,0 +1,405 @@
+"""
+Tests for the LIVE_WRITE_READY readiness gate schema.
+
+Covers:
+- Schema self-consistency: live_write_ready.schema.json is a valid Draft 2020-12 schema.
+- Clean READY assertion (all preconditions satisfied) validates with zero errors.
+- ONE test per precondition: READY is rejected when that precondition is missing/false.
+  Preconditions tested: canonical_writer null/empty, allowlist.diff_within_allowlist false,
+  approval.approved false, idempotency.idempotent false, rollback.available false,
+  dry_run_proof.performed false, independent_audit.performed false,
+  independent_audit.independent false, independent_audit.status FAIL,
+  independent_audit.status NOT_RUN, post_write_verification.planned false.
+- BLOCKED with empty blocked_reasons is rejected (minItems 1).
+- live_write_performed=true is rejected (const false).
+- Unknown top-level field is rejected (additionalProperties: false).
+- NO-LIVE-WRITE structural proof:
+  - live_write_performed is pinned const false in the schema.
+  - This packet's own files contain no call to forbidden wiring
+    (scripts/batch_resolve_and_merge.py, queue_drain.py execute=True).
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+from jsonschema import Draft202012Validator
+
+# ---------------------------------------------------------------------------
+# Schema loading
+# ---------------------------------------------------------------------------
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_SCHEMA_PATH = (
+    _REPO_ROOT / "schemas" / "project_control_plane" / "live_write_ready.schema.json"
+)
+
+with _SCHEMA_PATH.open() as _fh:
+    _SCHEMA: dict = json.load(_fh)
+
+
+def _schema_errors(instance: dict) -> list:
+    """Return all Draft 2020-12 validation errors for *instance* against _SCHEMA."""
+    return list(Draft202012Validator(_SCHEMA).iter_errors(instance))
+
+
+# ---------------------------------------------------------------------------
+# Fully-satisfied READY builder
+# ---------------------------------------------------------------------------
+
+def _ready_assertion(**overrides) -> dict:
+    """Return a fully-satisfied READY assertion.
+
+    All preconditions are true, independent_audit is PASS + independent,
+    blocked_reasons is empty.  Callers may override individual keys to
+    introduce a single failing precondition.
+    """
+    base: dict = {
+        "schema_version": "pcp.live_write_ready.v0",
+        "assertion_id": "test-assertion-001",
+        "operation_ref": "TP-DMX-PCP-LIVE-WRITE-GATES-0001",
+        "target_surface": "github.pr.merge",
+        "canonical_writer": "dopemux.pr_steward",
+        "allowlist": {
+            "paths": ["src/dopemux/pcp/pr_steward.py"],
+            "diff_within_allowlist": True,
+        },
+        "approval": {
+            "approved": True,
+            "approver": "hu3mann",
+            "approval_ref": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1#approval",
+        },
+        "idempotency": {
+            "idempotent": True,
+            "key": "pr-merge-42-sha-abc123",
+        },
+        "rollback": {
+            "available": True,
+            "plan": "git revert HEAD && git push origin main",
+        },
+        "dry_run_proof": {
+            "performed": True,
+            "proof_ref": "claudedocs/dry-run-pr-42-2026-06-22.txt",
+        },
+        "independent_audit": {
+            "performed": True,
+            "independent": True,
+            "status": "PASS",
+            "auditor": "claude-sonnet-4-6",
+        },
+        "post_write_verification": {
+            "planned": True,
+            "performed": False,
+            "verification_ref": "tests/integration/test_post_merge_state.py",
+        },
+        "status": "READY",
+        "blocked_reasons": [],
+        "live_write_performed": False,
+        "created_at": "2026-06-22T00:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# 1. Schema self-consistency
+# ---------------------------------------------------------------------------
+
+def test_schema_is_valid_draft202012():
+    """The schema itself must be a valid JSON Schema Draft 2020-12 meta-schema."""
+    Draft202012Validator.check_schema(_SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# 2. Clean READY assertion validates
+# ---------------------------------------------------------------------------
+
+def test_clean_ready_assertion_is_valid():
+    """A fully-satisfied READY assertion produces zero schema errors."""
+    errors = _schema_errors(_ready_assertion())
+    assert errors == [], [str(e) for e in errors]
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-precondition rejection tests
+#    Each sets status="READY" with exactly ONE bad precondition → ≥1 schema error.
+# ---------------------------------------------------------------------------
+
+def test_ready_rejected_when_canonical_writer_is_null():
+    """READY must be rejected when canonical_writer is null."""
+    instance = _ready_assertion(canonical_writer=None)
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_canonical_writer_is_empty_string():
+    """READY must be rejected when canonical_writer is an empty string."""
+    instance = _ready_assertion(canonical_writer="")
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_diff_outside_allowlist():
+    """READY must be rejected when allowlist.diff_within_allowlist is false."""
+    instance = _ready_assertion(
+        allowlist={"paths": ["src/dopemux/pcp/pr_steward.py"], "diff_within_allowlist": False}
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_not_approved():
+    """READY must be rejected when approval.approved is false."""
+    instance = _ready_assertion(
+        approval={"approved": False, "approver": None, "approval_ref": None}
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_not_idempotent():
+    """READY must be rejected when idempotency.idempotent is false."""
+    instance = _ready_assertion(
+        idempotency={"idempotent": False, "key": None}
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_no_rollback():
+    """READY must be rejected when rollback.available is false."""
+    instance = _ready_assertion(
+        rollback={"available": False, "plan": None}
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_dry_run_not_performed():
+    """READY must be rejected when dry_run_proof.performed is false."""
+    instance = _ready_assertion(
+        dry_run_proof={"performed": False, "proof_ref": None}
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_audit_not_performed():
+    """READY must be rejected when independent_audit.performed is false."""
+    instance = _ready_assertion(
+        independent_audit={
+            "performed": False,
+            "independent": True,
+            "status": "PASS",
+            "auditor": "claude-sonnet-4-6",
+        }
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_audit_not_independent():
+    """READY must be rejected when independent_audit.independent is false."""
+    instance = _ready_assertion(
+        independent_audit={
+            "performed": True,
+            "independent": False,
+            "status": "PASS",
+            "auditor": "implementer",
+        }
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_audit_status_is_fail():
+    """READY must be rejected when independent_audit.status is FAIL."""
+    instance = _ready_assertion(
+        independent_audit={
+            "performed": True,
+            "independent": True,
+            "status": "FAIL",
+            "auditor": "claude-sonnet-4-6",
+        }
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_audit_status_is_not_run():
+    """READY must be rejected when independent_audit.status is NOT_RUN."""
+    instance = _ready_assertion(
+        independent_audit={
+            "performed": True,
+            "independent": True,
+            "status": "NOT_RUN",
+            "auditor": None,
+        }
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_post_write_verification_not_planned():
+    """READY must be rejected when post_write_verification.planned is false."""
+    instance = _ready_assertion(
+        post_write_verification={
+            "planned": False,
+            "performed": False,
+            "verification_ref": None,
+        }
+    )
+    assert len(_schema_errors(instance)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# 4. BLOCKED with empty blocked_reasons is rejected
+# ---------------------------------------------------------------------------
+
+def test_blocked_with_empty_blocked_reasons_is_rejected():
+    """BLOCKED status with blocked_reasons=[] must be rejected (minItems 1)."""
+    instance = _ready_assertion(status="BLOCKED", blocked_reasons=[])
+    assert len(_schema_errors(instance)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# 5. live_write_performed=true is rejected
+# ---------------------------------------------------------------------------
+
+def test_live_write_performed_true_is_rejected():
+    """live_write_performed=true must be rejected (const false)."""
+    instance = _ready_assertion(live_write_performed=True)
+    assert len(_schema_errors(instance)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# 6. Unknown top-level field is rejected
+# ---------------------------------------------------------------------------
+
+def test_additional_top_level_property_is_rejected():
+    """An unknown top-level field must be rejected (additionalProperties: false)."""
+    instance = _ready_assertion()
+    instance["unknown_field_xyz"] = "should not be allowed"
+    assert len(_schema_errors(instance)) >= 1
+
+
+# ---------------------------------------------------------------------------
+# 7. NO-LIVE-WRITE structural proof
+# ---------------------------------------------------------------------------
+
+def test_schema_pins_live_write_performed_const_false():
+    """The schema must pin live_write_performed as const false."""
+    props = _SCHEMA.get("properties", {})
+    live_write_prop = props.get("live_write_performed", {})
+    assert live_write_prop.get("const") is False, (
+        "live_write_performed must be pinned const:false in the schema"
+    )
+
+
+def test_packet_files_contain_no_forbidden_wiring():
+    """NO-LIVE-WRITE structural proof for this packet's own files.
+
+    Proves that this packet adds no Python source module under src/ and that
+    the test file's executable code contains no live-write invocation patterns.
+
+    Specifically:
+    1. The packet's only .py file is this test file — no new live_write*.py
+       module exists under src/dopemux/pcp/.
+    2. The executable code section of this test file contains no forbidden
+       live-write invocation patterns (checked below via code_section scan).
+    3. The packet's three files (schema, test, doc) exist at their expected paths.
+    """
+    schema_file = _REPO_ROOT / "schemas" / "project_control_plane" / "live_write_ready.schema.json"
+    test_file = _REPO_ROOT / "tests" / "project_control_plane" / "test_live_write_gates.py"
+    doc_file = _REPO_ROOT / "docs" / "03-reference" / "architecture" / "pcp-live-write-gates.md"
+
+    # 1. Packet files exist at their expected paths.
+    assert schema_file.exists(), f"Schema file missing: {schema_file}"
+    assert test_file.exists(), f"Test file missing: {test_file}"
+    assert doc_file.exists(), f"Doc file missing: {doc_file}"
+
+    # 2. No new src/dopemux/pcp/live_write*.py module was added by this packet.
+    src_pcp_dir = _REPO_ROOT / "src" / "dopemux" / "pcp"
+    live_write_modules = list(src_pcp_dir.glob("live_write*.py")) if src_pcp_dir.exists() else []
+    assert live_write_modules == [], (
+        f"This packet must add no live-write Python module under src/; "
+        f"found: {[str(p) for p in live_write_modules]}"
+    )
+
+    # 3. This test file contains no live-write invocation patterns in executable code.
+    #    Patterns are defined as (prefix, suffix) pairs so that the pattern strings
+    #    themselves do not appear literally in this source file and cannot self-match.
+    import ast as _ast
+    raw_source = test_file.read_text(encoding="utf-8")
+    tree = _ast.parse(raw_source, filename=str(test_file))
+    # Collect all string literal values from the AST (docstrings, f-strings excluded).
+    # Then reconstruct the source with all string constants replaced by placeholders
+    # so we can scan for forbidden call/assignment patterns without self-matching.
+    # Simpler: scan token-by-token using tokenize to strip string tokens.
+    import tokenize as _tokenize
+    import io as _io
+    non_string_tokens = []
+    try:
+        for tok in _tokenize.generate_tokens(_io.StringIO(raw_source).readline):
+            if tok.type not in (_tokenize.STRING, _tokenize.COMMENT):
+                non_string_tokens.append(tok.string)
+    except _tokenize.TokenError:
+        pass
+    code_without_strings = " ".join(non_string_tokens)
+
+    # Patterns joined from fragments so they don't self-match as literals here.
+    _eq = "="
+    forbidden_calls = [
+        "execute" + _eq + "True",      # execute=True keyword arg
+        "subprocess",                   # subprocess module usage
+        "gh" + " pr " + "merge",       # gh pr merge invocation
+        "gh" + " pr " + "ready",       # gh pr ready invocation
+        "git" + " push",               # git push invocation
+    ]
+    for pattern in forbidden_calls:
+        assert pattern not in code_without_strings, (
+            f"Forbidden live-write invocation pattern {pattern!r} found in executable "
+            f"code of {test_file}. This test file must contain no live-write wiring."
+        )
+
+
+# ---------------------------------------------------------------------------
+# 8. Fail-open lock tests (lock the two schema security fixes)
+# ---------------------------------------------------------------------------
+
+def test_ready_rejected_when_allowlist_paths_is_empty():
+    """READY must be rejected when allowlist.paths is an empty list.
+
+    An empty allowlist makes 'diff_within_allowlist: true' vacuously true —
+    it proves nothing. The READY gate must require at least one declared path.
+    """
+    instance = _ready_assertion(
+        allowlist={"paths": [], "diff_within_allowlist": True}
+    )
+    errors = _schema_errors(instance)
+    assert len(errors) >= 1, (
+        "Expected ≥1 schema error for READY with allowlist.paths=[] but got none. "
+        "Empty allowlist is a fail-open — READY gate must enforce minItems: 1 on paths."
+    )
+
+
+def test_ready_rejected_when_rollback_plan_is_null():
+    """READY must be rejected when rollback.plan is null.
+
+    rollback.available=true with plan=null is a vacuous guarantee — there is no
+    concrete rollback path. The READY gate must require a non-empty plan string.
+    """
+    instance = _ready_assertion(
+        rollback={"available": True, "plan": None}
+    )
+    errors = _schema_errors(instance)
+    assert len(errors) >= 1, (
+        "Expected ≥1 schema error for READY with rollback.plan=null but got none. "
+        "Null rollback plan is a fail-open — READY gate must require a non-empty plan."
+    )
+
+
+def test_ready_rejected_when_rollback_plan_is_empty_string():
+    """READY must be rejected when rollback.plan is an empty string.
+
+    An empty string is not a concrete rollback plan and must be treated the same
+    as null by the READY gate (minLength: 1 enforcement).
+    """
+    instance = _ready_assertion(
+        rollback={"available": True, "plan": ""}
+    )
+    errors = _schema_errors(instance)
+    assert len(errors) >= 1, (
+        "Expected ≥1 schema error for READY with rollback.plan='' but got none. "
+        "Empty-string rollback plan is a fail-open — READY gate must enforce minLength: 1."
+    )


### PR DESCRIPTION
## Packet 10 — LIVE_WRITE_READY contract (security keystone, contracts-only)

The fail-closed gate that **every future live write** must pass. Contracts-only — **performs no live write** (`live_write_performed` const false). READY is granted **only** when ALL preconditions hold: canonical writer, **non-empty** allowlist (diff within it), approval, idempotency, rollback **with a non-empty plan**, dry-run proof, independent audit (performed + independent + PASS), planned post-write verification.

### Deliverables
- `schemas/project_control_plane/live_write_ready.schema.json` — fail-closed `allOf` READY gate.
- `tests/project_control_plane/test_live_write_gates.py` — 22 tests.
- `docs/03-reference/architecture/pcp-live-write-gates.md`.

### Validation
| Check | Result |
|---|---|
| pytest pcp + dcp + dnh | **PASS** — 405 |
| schema valid (Draft 2020-12) | **PASS** |
| pre-commit | **PASS** |
| keystone gate (verified) | every precondition missing/false/vacuous + READY → schema-rejected; BLOCKED stays flexible |

### Review
PAL down → independent Sonnet adversarial reviewer + Opus exploit-testing. Verdict **NEEDS_CHANGES** → both fail-opens fixed + verified closed:
- 🔴 **empty-allowlist vacuous bypass**: `paths=[]` + `diff_within_allowlist=true` passed READY → READY gate now requires `allowlist.paths minItems 1`.
- 🔴 **null rollback plan**: `rollback.available=true, plan=null` passed READY → READY gate now requires `rollback.plan` non-empty.
- vacuous no-live-write test (scanned JSON/MD for python imports) → replaced with a meaningful structural proof.
- Confirmed closed: no object-omission bypass, `audit.status=NOT_RUN` rejected, no AIR-mandated precondition missing.

### Notes
- Red Line #15 forbidden wiring (`queue_drain.py execute=True`, `scripts/batch_resolve_and_merge.py`) must stay disabled until a passing LIVE_WRITE_READY assertion exists.
- Prerequisite gate for **Packet 11** (FastAPI bridge live adapter).

Packet: `TP-DMX-PCP-LIVE-WRITE-GATES-0001` · Branch `claude/pcp-p10-live-write-gates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)