### PR TITLE
fix(contracts): enforce named openrouter_profile on openrouter_paid routes (PR Steward Item 1)

### DIFF
--- a/contracts/openclaw-dcp-routing/route_decision.schema.json
+++ b/contracts/openclaw-dcp-routing/route_decision.schema.json
@@ -356,6 +356,29 @@
       "if": {
         "properties": {
           "decision_status": { "const": "SELECTED" },
+          "access_path": { "const": "openrouter_paid" }
+        }
+      },
+      "then": {
+        "properties": {
+          "openrouter_profile": {
+            "type": "string",
+            "enum": [
+              "or_free_sandbox",
+              "or_low_cost_public",
+              "or_paid_private_controlled",
+              "or_structured_noncritical",
+              "or_challenger",
+              "or_emergency_fallback"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "decision_status": { "const": "SELECTED" },
           "provider": { "const": "openrouter" },
           "privacy_class": {
             "enum": [

--- a/tests/contracts/test_openclaw_dcp_routing_contracts.py
+++ b/tests/contracts/test_openclaw_dcp_routing_contracts.py
@@ -275,6 +275,37 @@ def test_selected_openrouter_routes_require_named_matching_profile():
         validate(instance=mismatched_profile, schema=schema)
 
 
+def test_selected_openrouter_paid_access_path_requires_named_profile():
+    """Regression for PR Steward Item 1.
+
+    A ``SELECTED`` decision whose ``access_path`` is ``openrouter_paid`` must carry a
+    named (non-null) ``openrouter_profile``. The access_path determines the routing
+    plane, so this holds regardless of the ``provider`` field — otherwise a decision
+    can launder past every per-profile allowlist with ``openrouter_profile: null``.
+    """
+    schema = _json(CONTRACT_ROOT / "route_decision.schema.json")
+    example = _json(EXAMPLE_ROOT / "R2_TEST_ONLY.json")
+
+    # Baseline: an openrouter_paid route with a named profile validates.
+    assert example["access_path"] == "openrouter_paid"
+    assert example["openrouter_profile"] == "or_low_cost_public"
+    validate(instance=example, schema=schema)
+
+    # Null profile on an openrouter_paid route must FAIL — including when the
+    # provider field is set to a non-openrouter value, which is exactly the
+    # laundering hole the provider-keyed guard did not close.
+    for provider in ["openrouter", "openai", "unknown"]:
+        candidate = copy.deepcopy(example)
+        candidate["provider"] = provider
+        candidate["openrouter_profile"] = None
+        with pytest.raises(ValidationError):
+            validate(instance=candidate, schema=schema)
+
+    # Every shipped example decision (R0-R6 + UNKNOWN) still validates.
+    for example_name in EXAMPLE_FILES:
+        validate(instance=_json(EXAMPLE_ROOT / example_name), schema=schema)
+
+
 def test_selected_sensitive_openrouter_routes_require_human_approval():
     schema = _json(CONTRACT_ROOT / "route_decision.schema.json")
     example = _json(EXAMPLE_ROOT / "R2_TEST_ONLY.json")


### PR DESCRIPTION
## Summary

Re-applies **PR Steward MUST_FIX Item 1** from #931 — the one of seven items not carried into the canonical #953/#954 OpenClaw DCP routing contracts on `main`.

### The gap (live on `main`)
In `contracts/openclaw-dcp-routing/route_decision.schema.json`, top-level `openrouter_profile` is `{"type": ["string","null"], "enum": [...]}` (allows `null`), and the only enforcement of a *named* profile is keyed on `provider == "openrouter"`. A `SELECTED` decision with `access_path: "openrouter_paid"` but `provider` set to any other value (`"openai"`, `"unknown"`, …) could therefore carry `openrouter_profile: null` and **bypass every per-profile allowlist** — even though `openclaw_dcp_routing_policy.yaml` (`required_evidence.openrouter`) requires `openrouter_profile` evidence for OpenRouter routes.

### The fix (contracts-only, +54 / -0)
Add one `allOf` conditional requiring a **named (non-null)** `openrouter_profile` whenever `decision_status == "SELECTED"` **AND** `access_path == "openrouter_paid"`, bound to the same six named profiles as the existing provider-keyed guard. The guard keys on `access_path` (the routing plane), so it holds **regardless of `provider`**. Combined with the existing inverse guard (named profile ⟹ `provider == "openrouter"`), this restores the intended invariant: an openrouter_paid route is an OpenRouter route with a named profile.

A negative regression test asserts: `SELECTED` + `openrouter_paid` + null profile **fails** for `provider ∈ {openrouter, openai, unknown}`; the named-profile baseline passes; all `example_route_decisions/*.json` (R0–R6 + UNKNOWN) still validate.

## Validation
- **PASS** — `pytest tests/contracts/test_openclaw_dcp_routing_contracts.py` (64 passed) and full `tests/contracts/` (64 passed), against `origin/main`'s schema after rebase.
- **PASS** — `Draft7Validator.check_schema(route_decision.schema.json)`; guard present, requires named profile.
- **PASS** — `ruff check tests/contracts/test_openclaw_dcp_routing_contracts.py`.
- **PASS (independent review)** — stronger-model advisor review: fix spec-compliant, enum matches `main`, test proves the real hole.
- **NOT_RUN** — full repo test suite (unchanged surfaces; contract-isolated change). Residual risk: none expected — no runtime/code paths touched, schema-only addition that strictly tightens.

## Authority
`openclaw_dcp_routing_policy.yaml` (`required_evidence.openrouter` → `openrouter_profile`); existing schema guards (provider-keyed allowlist + inverse provider guard); PR Steward #931 Item 1.

## Scope note — symmetric hole flagged, **not** fixed here
The same null-profile gap exists symmetrically for `access_path: "openrouter_free"` (its guard constrains privacy/risk/role but never requires a named profile, so `provider ≠ openrouter` + null escapes). That is outside Item 1 — left for a follow-up to keep this PR minimal.

## Rollback
`git revert 639fbc6e9` (single commit) — or drop the one `allOf` entry and the one test.

## Files
- `contracts/openclaw-dcp-routing/route_decision.schema.json` (+23)
- `tests/contracts/test_openclaw_dcp_routing_contracts.py` (+31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
