### PR TITLE
feat(pcp): FastAPI live-write bridge — fail-closed gated adapter (Packet 11)

### DIFF
--- a/docs/ops/project-control-plane/fastapi-bridge.md
+++ b/docs/ops/project-control-plane/fastapi-bridge.md
@@ -1,0 +1,77 @@
+---
+id: PCP-FASTAPI-BRIDGE
+title: PCP FastAPI Bridge / Live-Write Adapter
+type: reference
+owner: '@hu3mann'
+author: claude
+date: '2026-06-22'
+last_review: '2026-06-22'
+next_review: '2026-09-20'
+prelude: PCP FastAPI Bridge / Live-Write Adapter (explanation) for dopemux documentation
+  and developer workflows.
+---
+# PCP FastAPI Bridge / Live-Write Adapter
+
+The PCP live-write bridge (`src/dopemux/pcp/bridge/fastapi_bridge.py`) is the only
+component permitted to route a mutation to a canonical writer — and it does so
+**only behind a satisfied `LIVE_WRITE_READY` gate**, dry-run first, fail-closed.
+
+It is an **adapter, never a canonical authority**: every result carries
+`is_authority: false`, and `executed` is true only when a live write actually
+ran. The bridge performs no I/O of its own and wires none of the forbidden
+live-write runtimes (AIR Red Line #15).
+
+## Fail-closed decision
+
+`route_mutation(operation, *, live_write_ready, execute, writer_registry, executed_keys, now)`
+evaluates, in order. A writer is reached only at the final step; every other
+branch returns without invoking any writer.
+
+| Step | Condition | Result if it fails |
+|---|---|---|
+| 1 | `operation` is a dict with non-empty `operation_ref` + `target_surface` | `REJECTED` (`MALFORMED_OPERATION`) |
+| 2 | gate validates against the schema, is `READY`, consistent, and unexpired | `REJECTED` (`GATE_ABSENT` / `GATE_SCHEMA_INVALID` / `GATE_NOT_READY` / `GATE_INCONSISTENT` / `GATE_EXPIRED`) |
+| 3 | gate `operation_ref` + `target_surface` equal the operation's | `REJECTED` (`GATE_OPERATION_MISMATCH`) |
+| 4 | `sha256(canonical(operation))` equals gate `payload_digest` | `REJECTED` (`PAYLOAD_DIGEST_MISMATCH`) |
+| 5 | `execute is True` (identity, not truthiness) | `DRY_RUN` (no write) |
+| 6 | gate's `canonical_writer` name resolves in `writer_registry` | `REJECTED` (`CANONICAL_WRITER_NOT_REGISTERED`) |
+| 7 | `assertion_id` is first-seen in `executed_keys` | `REJECTED` (`DUPLICATE_SUPPRESSED`) |
+| 8 | writer returns normally | `LIVE` on success; `REJECTED` (`WRITER_RAISED:<type>`) on exception |
+
+Modes map to HTTP status on `POST /bridge/mutate`: `REJECTED` → 403, `DRY_RUN` /
+`LIVE` → 200. The endpoint is thin — all logic lives in `route_mutation`.
+
+## No default writer
+
+`create_bridge_router(*, writer_registry=None)` defaults to **no registry**, so a
+deployed app can never perform a live write — every `execute` attempt resolves no
+writer and is rejected. The writer is resolved **by the gate's `canonical_writer`
+name**, not by an arbitrary injected callable; registering a real writer is an
+explicit, deliberate operator action. This is what technically enforces AIR Red
+Line #15 (the forbidden `queue_drain execute=True` / `batch_resolve_and_merge`
+runtimes can never become the bridge's writer unless deliberately registered
+under the gate's approved name) and closes canonical-writer substitution.
+
+## Hardenings beyond the bare gate
+
+These close the gaps an adversarial review identified for a live-write surface:
+
+- **TTL** — the gate's `valid_until` is enforced (`now > valid_until` → `GATE_EXPIRED`); a stale assertion cannot authorize a write.
+- **Payload binding** — `payload_digest` binds the assertion to the exact operation payload, not just its `operation_ref` / `target_surface` (closes confused-deputy / replay against a different resource). Gate authors must compute it as `sha256(json.dumps(operation, sort_keys=True, separators=(",", ":")))` with default `ensure_ascii=True`; a different encoding produces a (fail-closed) `PAYLOAD_DIGEST_MISMATCH`.
+- **Idempotency dedup** — the bridge records each `assertion_id` before the write; a replayed assertion is `DUPLICATE_SUPPRESSED` (in-process, per-router). If the writer raises after the key is recorded, the assertion stays suppressed — a retry requires a fresh `assertion_id` (a failed write is never auto-retried).
+- **Canonical-writer registry** — the gate's named writer must map to a registered callable.
+
+The `valid_until` + `payload_digest` fields were added to
+`schemas/project_control_plane/live_write_ready.schema.json` (required + format-checked
+under the READY gate; optional for non-READY assertions). The schema version
+stays `pcp.live_write_ready.v0` — the contract has no production consumers yet, so
+the additive hardening is pre-use rather than a breaking version change.
+
+## Deferred (out of scope here)
+
+These remain the responsibility of the assertion's production path and the
+operator runbook, not this bridge:
+
+- **Cryptographic signing** of assertions (needs a trusted issuer) — until then, assertion provenance must be guaranteed by the gated, audited process that produces READY assertions.
+- **Distributed / cross-process dedup** — the bridge dedups in-process per router; the registered writer must itself honour the gate's `idempotency.key` for multi-replica safety (the schema declares `idempotency.idempotent`).
+- **Allowlist + auditor-independence** are self-reported in the assertion and verified out of band (AIR Red Line #9); the bridge enforces their presence via the gate, not their truthfulness.

--- a/schemas/project_control_plane/live_write_ready.schema.json
+++ b/schemas/project_control_plane/live_write_ready.schema.json
@@ -213,6 +213,16 @@
       "type": "string",
       "format": "date-time",
       "description": "ISO 8601 datetime at which this readiness assertion was assembled."
+    },
+    "valid_until": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 expiry of this readiness assertion. null is permitted only for non-READY status; a READY assertion requires a non-null timestamp. The consuming bridge rejects with GATE_EXPIRED when now > valid_until — the schema enforces presence and format only, not the time comparison."
+    },
+    "payload_digest": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Lowercase SHA-256 hex of the canonical JSON of the exact operation this assertion authorizes. null is permitted only for non-READY status; a READY assertion requires a non-null digest. The consuming bridge rejects with PAYLOAD_DIGEST_MISMATCH when sha256(canonical(operation)) != payload_digest — the schema enforces presence and format only, not the hash comparison."
     }
   },
   "allOf": [
@@ -232,7 +242,9 @@
           "dry_run_proof",
           "independent_audit",
           "post_write_verification",
-          "blocked_reasons"
+          "blocked_reasons",
+          "valid_until",
+          "payload_digest"
         ],
         "properties": {
           "canonical_writer": {
@@ -287,6 +299,14 @@
           },
           "blocked_reasons": {
             "maxItems": 0
+          },
+          "valid_until": {
+            "type": "string",
+            "minLength": 1
+          },
+          "payload_digest": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
           }
         }
       }

--- a/src/dopemux/pcp/bridge/__init__.py
+++ b/src/dopemux/pcp/bridge/__init__.py
@@ -1,0 +1,23 @@
+"""dopemux.pcp.bridge — fail-closed live-write adapter.
+
+Routes mutations through a registered canonical writer ONLY behind a satisfied,
+unexpired, payload-bound LIVE_WRITE_READY gate. It is an ADAPTER, never a
+canonical authority. No default production writer exists: a live write requires
+an explicitly registered canonical_writer (resolved by the gate's
+``canonical_writer`` name) AND a READY gate bound to the exact operation AND
+``execute is True`` AND a first-time idempotency key.
+"""
+
+from dopemux.pcp.bridge.fastapi_bridge import (
+    check_live_write_gate,
+    create_bridge_app,
+    create_bridge_router,
+    route_mutation,
+)
+
+__all__ = [
+    "check_live_write_gate",
+    "route_mutation",
+    "create_bridge_router",
+    "create_bridge_app",
+]

--- a/src/dopemux/pcp/bridge/fastapi_bridge.py
+++ b/src/dopemux/pcp/bridge/fastapi_bridge.py
@@ -1,0 +1,332 @@
+"""dopemux.pcp.bridge.fastapi_bridge — fail-closed live-write adapter.
+
+This module is the Packet 11 live-write bridge. It routes a mutation to a
+canonical writer ONLY when every fail-closed precondition holds:
+
+  1. the operation is a well-formed dict carrying operation_ref + target_surface;
+  2. a LIVE_WRITE_READY assertion validates against
+     schemas/project_control_plane/live_write_ready.schema.json, has status
+     "READY", is internally consistent, and is NOT expired (valid_until);
+  3. the gate is bound to THIS operation (operation_ref + target_surface equal,
+     and payload_digest == sha256(canonical(operation)));
+  4. ``execute is True`` (identity, not truthiness — the strict direction);
+  5. the gate's named canonical_writer resolves to a registered writer callable
+     (there is NO default writer — a deployed app cannot live-write); and
+  6. the assertion_id has not already been executed (idempotency dedup).
+
+The bridge is an ADAPTER, never a canonical authority: every result carries
+``is_authority: False`` and ``executed`` is True iff a live write actually ran.
+The module performs no I/O of its own and contains no forbidden live-write
+wiring (AIR Red Line #15).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+from fastapi import APIRouter, FastAPI
+from fastapi import status as http_status
+from fastapi.responses import JSONResponse
+from jsonschema import Draft202012Validator
+from pydantic import BaseModel, StrictBool
+
+# ---------------------------------------------------------------------------
+# Schema loading — repo-root relative.
+# src/dopemux/pcp/bridge/fastapi_bridge.py -> parents[4] == repo root
+# (file -> bridge -> pcp -> dopemux -> src -> ROOT). One level deeper than the
+# sibling pcp modules (exporter/pr_steward use parents[3]).
+# ---------------------------------------------------------------------------
+_HERE = pathlib.Path(__file__).resolve()
+_REPO_ROOT = _HERE.parents[4]
+_SCHEMA_PATH = (
+    _REPO_ROOT / "schemas" / "project_control_plane" / "live_write_ready.schema.json"
+)
+
+with _SCHEMA_PATH.open() as _fh:
+    _SCHEMA: dict = json.load(_fh)
+
+_VALIDATOR = Draft202012Validator(_SCHEMA)
+
+_MODE_REJECTED = "REJECTED"
+_MODE_DRY_RUN = "DRY_RUN"
+_MODE_LIVE = "LIVE"
+_RESULT_SCHEMA_VERSION = "pcp.bridge_result.v0"
+
+Writer = Callable[[dict], Any]
+
+
+# ---------------------------------------------------------------------------
+# Time helpers (now is injectable for deterministic tests).
+# ---------------------------------------------------------------------------
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso8601(value: Any) -> datetime | None:
+    """Parse an ISO 8601 timestamp (accepting a trailing 'Z'); None on failure."""
+    if not isinstance(value, str) or not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+# ---------------------------------------------------------------------------
+# Gate evaluation (pure, fail-closed).
+# ---------------------------------------------------------------------------
+
+def check_live_write_gate(
+    assertion: dict | None, *, now: datetime | None = None
+) -> tuple[bool, list[str]]:
+    """Fail-closed evaluation of a LIVE_WRITE_READY assertion.
+
+    Returns ``(permitted, reasons)``. ``permitted`` is True ONLY when the
+    assertion is a dict, validates against the LIVE_WRITE_READY schema with zero
+    errors, has ``status == "READY"``, is internally consistent
+    (``live_write_performed is False`` and ``blocked_reasons == []``), and is not
+    expired (``now <= valid_until``). Every other condition denies.
+    """
+    if not isinstance(assertion, dict):
+        return (False, ["GATE_ABSENT"])
+    if list(_VALIDATOR.iter_errors(assertion)):
+        return (False, ["GATE_SCHEMA_INVALID"])
+    if assertion.get("status") != "READY":
+        reasons = list(assertion.get("blocked_reasons") or [])
+        return (False, reasons or ["GATE_NOT_READY"])
+    # Defense-in-depth: the schema already guarantees these under READY, but an
+    # authorization gate must not single-source-of-truth on a sibling contract.
+    if assertion.get("live_write_performed") is not False:
+        return (False, ["GATE_INCONSISTENT"])
+    if assertion.get("blocked_reasons") != []:
+        return (False, ["GATE_INCONSISTENT"])
+    # TTL: an expired (or unparseable/absent valid_until) assertion is denied.
+    valid_until = _parse_iso8601(assertion.get("valid_until"))
+    if valid_until is None:
+        return (False, ["GATE_EXPIRED"])
+    current = now or _utcnow()
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    if current > valid_until:
+        return (False, ["GATE_EXPIRED"])
+    return (True, [])
+
+
+# ---------------------------------------------------------------------------
+# Payload digest + result construction.
+# ---------------------------------------------------------------------------
+
+def _canonical_digest(operation: dict) -> str:
+    """Lowercase SHA-256 hex of the canonical JSON encoding of *operation*."""
+    canonical = json.dumps(operation, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _result(
+    *,
+    mode: str,
+    permitted: bool,
+    executed: bool,
+    reasons: list[str],
+    operation_ref: str | None,
+    target_surface: str | None,
+    writer_result: dict | None = None,
+) -> dict:
+    return {
+        "schema_version": _RESULT_SCHEMA_VERSION,
+        "mode": mode,
+        "permitted": permitted,
+        "executed": executed,
+        "reasons": reasons,
+        "operation_ref": operation_ref,
+        "target_surface": target_surface,
+        "is_authority": False,
+        "writer_result": writer_result,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Mutation routing (the only write path).
+# ---------------------------------------------------------------------------
+
+def route_mutation(
+    operation: dict,
+    *,
+    live_write_ready: dict | None = None,
+    execute: bool = False,
+    writer_registry: dict[str, Writer] | None = None,
+    executed_keys: set | None = None,
+    now: datetime | None = None,
+) -> dict:
+    """Route a single mutation through the fail-closed live-write gate.
+
+    A writer is invoked ONLY at the final branch, reachable only when ALL of the
+    following hold: a well-formed operation; a schema-valid, consistent,
+    unexpired READY gate; operation_ref + target_surface + payload_digest binding
+    to THIS operation; ``execute is True``; the gate's ``canonical_writer`` name
+    resolves in ``writer_registry``; and the assertion_id is first-seen in
+    ``executed_keys``. Every other branch returns without invoking any writer.
+
+    ``executed_keys`` is the idempotency store (a set). Pass a shared set to
+    deduplicate across calls (the FastAPI router does this per-router). When it
+    is None, a throwaway set is used (no cross-call dedup).
+    """
+    # 1. Operation shape (fail-closed).
+    if not isinstance(operation, dict):
+        return _result(
+            mode=_MODE_REJECTED, permitted=False, executed=False,
+            reasons=["MALFORMED_OPERATION"], operation_ref=None, target_surface=None,
+        )
+    op_ref = operation.get("operation_ref")
+    op_surface = operation.get("target_surface")
+    if not (isinstance(op_ref, str) and op_ref and isinstance(op_surface, str) and op_surface):
+        return _result(
+            mode=_MODE_REJECTED, permitted=False, executed=False,
+            reasons=["MALFORMED_OPERATION"],
+            operation_ref=op_ref if isinstance(op_ref, str) else None,
+            target_surface=op_surface if isinstance(op_surface, str) else None,
+        )
+
+    # 2. Gate (schema-valid + READY + consistent + unexpired).
+    permitted, reasons = check_live_write_gate(live_write_ready, now=now)
+    if not permitted:
+        return _result(
+            mode=_MODE_REJECTED, permitted=False, executed=False,
+            reasons=reasons, operation_ref=op_ref, target_surface=op_surface,
+        )
+    gate: dict = live_write_ready  # type: ignore[assignment]  # known dict + READY
+
+    # 3. Operation binding on operation_ref + target_surface.
+    if gate.get("operation_ref") != op_ref or gate.get("target_surface") != op_surface:
+        return _result(
+            mode=_MODE_REJECTED, permitted=True, executed=False,
+            reasons=["GATE_OPERATION_MISMATCH"], operation_ref=op_ref, target_surface=op_surface,
+        )
+
+    # 4. Payload-digest binding (exact operation payload).
+    if _canonical_digest(operation) != gate.get("payload_digest"):
+        return _result(
+            mode=_MODE_REJECTED, permitted=True, executed=False,
+            reasons=["PAYLOAD_DIGEST_MISMATCH"], operation_ref=op_ref, target_surface=op_surface,
+        )
+
+    # 5. Dry-run default — a live write requires ``execute is True`` exactly.
+    if execute is not True:
+        return _result(
+            mode=_MODE_DRY_RUN, permitted=True, executed=False,
+            reasons=[], operation_ref=op_ref, target_surface=op_surface,
+        )
+
+    # 6. Canonical-writer registry resolve (no default writer).
+    registry = writer_registry or {}
+    canonical_writer_name = gate.get("canonical_writer")
+    writer = (
+        registry.get(canonical_writer_name)
+        if isinstance(canonical_writer_name, str)
+        else None
+    )
+    if writer is None:
+        return _result(
+            mode=_MODE_REJECTED, permitted=True, executed=False,
+            reasons=["CANONICAL_WRITER_NOT_REGISTERED"], operation_ref=op_ref, target_surface=op_surface,
+        )
+
+    # 7. Idempotency dedup on assertion_id (record BEFORE the call).
+    store = executed_keys if executed_keys is not None else set()
+    key = gate.get("assertion_id")
+    if key in store:
+        return _result(
+            mode=_MODE_REJECTED, permitted=True, executed=False,
+            reasons=["DUPLICATE_SUPPRESSED"], operation_ref=op_ref, target_surface=op_surface,
+        )
+    store.add(key)
+
+    # 8. Delegate to the canonical writer — the ONLY write path.
+    try:
+        produced = writer(operation)
+    except Exception as exc:  # noqa: BLE001 — fail-closed reporting on writer failure.
+        return _result(
+            mode=_MODE_REJECTED, permitted=True, executed=False,
+            reasons=["WRITER_RAISED:" + type(exc).__name__],
+            operation_ref=op_ref, target_surface=op_surface,
+        )
+    writer_result = produced if isinstance(produced, dict) else {"result": produced}
+    return _result(
+        mode=_MODE_LIVE, permitted=True, executed=True, reasons=[],
+        operation_ref=op_ref, target_surface=op_surface, writer_result=writer_result,
+    )
+
+
+# ---------------------------------------------------------------------------
+# FastAPI surface (thin — all logic lives in route_mutation).
+# ---------------------------------------------------------------------------
+
+class MutateRequest(BaseModel):
+    """Request body for POST /bridge/mutate.
+
+    ``execute`` is a ``StrictBool``: a non-boolean JSON value (e.g. ``1`` or
+    ``"yes"``) is rejected with HTTP 422 rather than coerced to ``True``. This
+    preserves the ``execute is True`` strictness of ``route_mutation`` at the
+    HTTP boundary — a client cannot accidentally trigger a live write by sending
+    a truthy non-boolean.
+    """
+
+    operation: dict
+    live_write_ready: dict | None = None
+    execute: StrictBool = False
+
+
+def create_bridge_router(
+    *, writer_registry: dict[str, Writer] | None = None
+) -> APIRouter:
+    """Build the bridge ``APIRouter``.
+
+    ``writer_registry`` defaults to None, so a deployed app can NEVER perform a
+    live write (every execute attempt resolves no writer and is rejected).
+    Registering a real writer is an explicit, deliberate caller action. The
+    router keeps a private idempotency store so replayed assertion_ids are
+    suppressed across requests.
+    """
+    router = APIRouter(tags=["PCP Bridge"])
+    _executed_keys: set = set()
+
+    @router.post("/bridge/mutate")
+    async def mutate(req: MutateRequest) -> JSONResponse:
+        result = route_mutation(
+            req.operation,
+            live_write_ready=req.live_write_ready,
+            execute=req.execute,
+            writer_registry=writer_registry,
+            executed_keys=_executed_keys,
+        )
+        code = (
+            http_status.HTTP_403_FORBIDDEN
+            if result["mode"] == _MODE_REJECTED
+            else http_status.HTTP_200_OK
+        )
+        return JSONResponse(status_code=code, content=result)
+
+    return router
+
+
+def create_bridge_app(
+    *, writer_registry: dict[str, Writer] | None = None
+) -> FastAPI:
+    """Build a standalone FastAPI app mounting the bridge router.
+
+    Defaults to no writer registry — dry-run / reject only.
+    """
+    app = FastAPI(title="PCP Live-Write Bridge", version="0.1.0")
+    app.include_router(create_bridge_router(writer_registry=writer_registry))
+    return app

--- a/tests/project_control_plane/test_fastapi_bridge.py
+++ b/tests/project_control_plane/test_fastapi_bridge.py
@@ -1,0 +1,498 @@
+"""
+Tests for the Packet 11 FastAPI live-write bridge (dopemux.pcp.bridge.fastapi_bridge).
+
+Proves the bridge is fail-closed: a writer is invoked ONLY behind a schema-valid,
+consistent, unexpired READY gate that is bound (operation_ref + target_surface +
+payload_digest) to the exact operation, with execute is True, a registered
+canonical writer matching the gate's name, and a first-time assertion_id.
+
+Groups:
+  A. check_live_write_gate (pure, incl. TTL)
+  B. route_mutation decision branches (pure)
+  C. gate-operation + payload-digest binding
+  D. canonical-writer registry / substitution
+  E. idempotency dedup
+  F. FastAPI TestClient (thin HTTP layer)
+  G. structural no-write proofs (Red Line #15) + invariants
+"""
+
+from __future__ import annotations
+
+import hashlib
+import inspect
+import json
+import pathlib
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from dopemux.pcp.bridge import fastapi_bridge as bridge
+from dopemux.pcp.bridge.fastapi_bridge import (
+    check_live_write_gate,
+    create_bridge_router,
+    route_mutation,
+)
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+
+# A fixed "now" so TTL tests are deterministic. The default gate valid_until is
+# far in the future relative to this.
+_NOW = datetime(2026, 6, 22, 12, 0, 0, tzinfo=timezone.utc)
+_FAR_FUTURE = "2999-01-01T00:00:00Z"
+_PAST = "2020-01-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _operation(operation_ref: str = "op-merge-pr-42", target_surface: str = "github.pr.merge", **extra) -> dict:
+    op = {"operation_ref": operation_ref, "target_surface": target_surface}
+    op.update(extra)
+    return op
+
+
+def _digest(operation: dict) -> str:
+    canonical = json.dumps(operation, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _ready_gate_for(operation: dict, **overrides) -> dict:
+    """A schema-valid READY assertion bound to *operation* (ref/surface/digest),
+    far-future expiry. Callers may override individual keys."""
+    gate = {
+        "schema_version": "pcp.live_write_ready.v0",
+        "assertion_id": "assert-001",
+        "operation_ref": operation["operation_ref"],
+        "target_surface": operation["target_surface"],
+        "canonical_writer": "dopemux.test_writer",
+        "allowlist": {"paths": ["src/x.py"], "diff_within_allowlist": True},
+        "approval": {"approved": True, "approver": "op", "approval_ref": "ref"},
+        "idempotency": {"idempotent": True, "key": "k1"},
+        "rollback": {"available": True, "plan": "revert the change"},
+        "dry_run_proof": {"performed": True, "proof_ref": "dr"},
+        "independent_audit": {
+            "performed": True,
+            "independent": True,
+            "status": "PASS",
+            "auditor": "auditor",
+        },
+        "post_write_verification": {"planned": True, "performed": False, "verification_ref": "v"},
+        "status": "READY",
+        "blocked_reasons": [],
+        "live_write_performed": False,
+        "created_at": "2026-06-22T00:00:00Z",
+        "valid_until": _FAR_FUTURE,
+        "payload_digest": _digest(operation),
+    }
+    gate.update(overrides)
+    return gate
+
+
+class _SpyWriter:
+    """A fake canonical writer that records calls. Never performs a real write."""
+
+    def __init__(self, result=None, raises: Exception | None = None):
+        self.calls: list = []
+        self._result = result if result is not None else {"ok": True}
+        self._raises = raises
+
+    def __call__(self, operation: dict):
+        self.calls.append(operation)
+        if self._raises is not None:
+            raise self._raises
+        return self._result
+
+
+# ===========================================================================
+# A. check_live_write_gate — pure, fail-closed
+# ===========================================================================
+
+class TestGate:
+    def test_none_denied(self):
+        permitted, reasons = check_live_write_gate(None)
+        assert permitted is False and "GATE_ABSENT" in reasons
+
+    @pytest.mark.parametrize("bad", ["READY", [], 123, 0, True])
+    def test_non_dict_denied(self, bad):
+        permitted, _ = check_live_write_gate(bad)  # type: ignore[arg-type]
+        assert permitted is False
+
+    def test_clean_ready_permitted(self):
+        op = _operation()
+        permitted, reasons = check_live_write_gate(_ready_gate_for(op), now=_NOW)
+        assert permitted is True and reasons == []
+
+    def test_schema_invalid_denied(self):
+        op = _operation()
+        # live_write_performed must be const false -> schema invalid
+        gate = _ready_gate_for(op, live_write_performed=True)
+        permitted, reasons = check_live_write_gate(gate, now=_NOW)
+        assert permitted is False and "GATE_SCHEMA_INVALID" in reasons
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"canonical_writer": None},
+            {"approval": {"approved": False, "approver": None, "approval_ref": None}},
+            {"idempotency": {"idempotent": False, "key": None}},
+            {"rollback": {"available": False, "plan": None}},
+            {"dry_run_proof": {"performed": False, "proof_ref": None}},
+            {"independent_audit": {"performed": True, "independent": False, "status": "PASS", "auditor": "x"}},
+            {"independent_audit": {"performed": True, "independent": True, "status": "FAIL", "auditor": "x"}},
+            {"post_write_verification": {"planned": False, "performed": False, "verification_ref": None}},
+            {"allowlist": {"paths": [], "diff_within_allowlist": True}},
+        ],
+    )
+    def test_each_missing_precondition_denied(self, override):
+        op = _operation()
+        gate = _ready_gate_for(op, status="READY", **override)
+        permitted, _ = check_live_write_gate(gate, now=_NOW)
+        assert permitted is False
+
+    def test_blocked_status_denied_surfaces_reasons(self):
+        op = _operation()
+        gate = _ready_gate_for(op, status="BLOCKED", blocked_reasons=["MISSING_APPROVAL"])
+        permitted, reasons = check_live_write_gate(gate, now=_NOW)
+        assert permitted is False and "MISSING_APPROVAL" in reasons
+
+    def test_needs_supervisor_denied(self):
+        op = _operation()
+        gate = _ready_gate_for(op, status="NEEDS_SUPERVISOR", blocked_reasons=["UNKNOWN"])
+        permitted, _ = check_live_write_gate(gate, now=_NOW)
+        assert permitted is False
+
+    def test_expired_gate_denied(self):
+        op = _operation()
+        gate = _ready_gate_for(op, valid_until=_PAST)
+        permitted, reasons = check_live_write_gate(gate, now=_NOW)
+        assert permitted is False and "GATE_EXPIRED" in reasons
+
+    def test_future_gate_permitted(self):
+        op = _operation()
+        gate = _ready_gate_for(op, valid_until=_FAR_FUTURE)
+        permitted, _ = check_live_write_gate(gate, now=_NOW)
+        assert permitted is True
+
+
+# ===========================================================================
+# B. route_mutation — decision branches (pure)
+# ===========================================================================
+
+class TestRoute:
+    def _writer_reg(self, spy: _SpyWriter) -> dict:
+        return {"dopemux.test_writer": spy}
+
+    def test_no_gate_rejected_no_write(self):
+        spy = _SpyWriter()
+        op = _operation()
+        r = route_mutation(op, live_write_ready=None, execute=True,
+                           writer_registry=self._writer_reg(spy), now=_NOW)
+        assert r["mode"] == "REJECTED" and r["executed"] is False and spy.calls == []
+
+    def test_blocked_gate_rejected_no_write(self):
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op, status="BLOCKED", blocked_reasons=["MISSING_APPROVAL"])
+        r = route_mutation(op, live_write_ready=gate, execute=True,
+                           writer_registry=self._writer_reg(spy), now=_NOW)
+        assert r["mode"] == "REJECTED" and spy.calls == []
+
+    def test_ready_no_execute_is_dry_run_no_write(self):
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op)
+        r = route_mutation(op, live_write_ready=gate, execute=False,
+                           writer_registry=self._writer_reg(spy), now=_NOW)
+        assert r["mode"] == "DRY_RUN" and r["permitted"] is True and r["executed"] is False
+        assert spy.calls == []
+
+    def test_ready_execute_no_registry_rejected(self):
+        op = _operation()
+        gate = _ready_gate_for(op)
+        r = route_mutation(op, live_write_ready=gate, execute=True,
+                           writer_registry=None, now=_NOW)
+        assert r["mode"] == "REJECTED" and "CANONICAL_WRITER_NOT_REGISTERED" in r["reasons"]
+        assert r["executed"] is False
+
+    def test_ready_execute_with_registered_writer_is_live(self):
+        spy = _SpyWriter(result={"merged": True})
+        op = _operation()
+        gate = _ready_gate_for(op)
+        r = route_mutation(op, live_write_ready=gate, execute=True,
+                           writer_registry=self._writer_reg(spy), executed_keys=set(), now=_NOW)
+        assert r["mode"] == "LIVE" and r["executed"] is True
+        assert r["writer_result"] == {"merged": True}
+        assert len(spy.calls) == 1 and spy.calls[0] == op
+
+    @pytest.mark.parametrize("execute_val", [1, "yes", "true", [1], object()])
+    def test_execute_non_bool_truthy_is_dry_run(self, execute_val):
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op)
+        r = route_mutation(op, live_write_ready=gate, execute=execute_val,  # type: ignore[arg-type]
+                           writer_registry=self._writer_reg(spy), now=_NOW)
+        assert r["mode"] == "DRY_RUN" and spy.calls == []
+
+    def test_writer_raises_is_rejected_not_live(self):
+        spy = _SpyWriter(raises=RuntimeError("boom"))
+        op = _operation()
+        gate = _ready_gate_for(op)
+        r = route_mutation(op, live_write_ready=gate, execute=True,
+                           writer_registry=self._writer_reg(spy), executed_keys=set(), now=_NOW)
+        assert r["mode"] == "REJECTED" and r["executed"] is False
+        assert any(reason.startswith("WRITER_RAISED") for reason in r["reasons"])
+
+    @pytest.mark.parametrize("bad_op", [None, "x", 123, [], {}, {"operation_ref": "x"}, {"target_surface": "y"},
+                                        {"operation_ref": "", "target_surface": "y"}])
+    def test_malformed_operation_rejected(self, bad_op):
+        spy = _SpyWriter()
+        gate = _ready_gate_for(_operation())
+        r = route_mutation(bad_op, live_write_ready=gate, execute=True,  # type: ignore[arg-type]
+                           writer_registry=self._writer_reg(spy), now=_NOW)
+        assert r["mode"] == "REJECTED" and spy.calls == []
+
+
+# ===========================================================================
+# C. Binding — ref/surface + payload digest
+# ===========================================================================
+
+class TestBinding:
+    def test_operation_ref_mismatch_rejected(self):
+        spy = _SpyWriter()
+        op = _operation(operation_ref="op-A")
+        # gate authored for a DIFFERENT operation_ref
+        other = _operation(operation_ref="op-B")
+        gate = _ready_gate_for(other)
+        r = route_mutation(op, live_write_ready=gate, execute=True,
+                           writer_registry={"dopemux.test_writer": spy}, now=_NOW)
+        assert r["mode"] == "REJECTED" and "GATE_OPERATION_MISMATCH" in r["reasons"]
+        assert spy.calls == []
+
+    def test_target_surface_mismatch_rejected(self):
+        spy = _SpyWriter()
+        op = _operation(target_surface="github.pr.merge")
+        other = _operation(target_surface="conport.progress_entry")
+        gate = _ready_gate_for(other)
+        # align refs so only surface differs; re-point gate ref to op's ref
+        gate["operation_ref"] = op["operation_ref"]
+        r = route_mutation(op, live_write_ready=gate, execute=True,
+                           writer_registry={"dopemux.test_writer": spy}, now=_NOW)
+        assert r["mode"] == "REJECTED" and "GATE_OPERATION_MISMATCH" in r["reasons"]
+        assert spy.calls == []
+
+    def test_payload_digest_mismatch_rejected(self):
+        spy = _SpyWriter()
+        op = _operation(pr_id=42)
+        gate = _ready_gate_for(op)  # digest bound to pr_id=42
+        tampered = _operation(pr_id=9999)  # same ref+surface, different payload
+        r = route_mutation(tampered, live_write_ready=gate, execute=True,
+                           writer_registry={"dopemux.test_writer": spy}, now=_NOW)
+        assert r["mode"] == "REJECTED" and "PAYLOAD_DIGEST_MISMATCH" in r["reasons"]
+        assert spy.calls == []
+
+    def test_matching_digest_allows_live(self):
+        spy = _SpyWriter()
+        op = _operation(pr_id=42, head_sha="abc123")
+        gate = _ready_gate_for(op)
+        r = route_mutation(op, live_write_ready=gate, execute=True,
+                           writer_registry={"dopemux.test_writer": spy}, executed_keys=set(), now=_NOW)
+        assert r["mode"] == "LIVE" and len(spy.calls) == 1
+
+
+# ===========================================================================
+# D. Canonical-writer registry / substitution
+# ===========================================================================
+
+class TestRegistry:
+    def test_writer_name_not_in_registry_rejected(self):
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op, canonical_writer="dopemux.real_writer")
+        # registry only has a DIFFERENT name
+        r = route_mutation(op, live_write_ready=gate, execute=True,
+                           writer_registry={"dopemux.other_writer": spy}, executed_keys=set(), now=_NOW)
+        assert r["mode"] == "REJECTED" and "CANONICAL_WRITER_NOT_REGISTERED" in r["reasons"]
+        assert spy.calls == []
+
+    def test_registered_name_match_is_live(self):
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op, canonical_writer="dopemux.real_writer")
+        r = route_mutation(op, live_write_ready=gate, execute=True,
+                           writer_registry={"dopemux.real_writer": spy}, executed_keys=set(), now=_NOW)
+        assert r["mode"] == "LIVE" and len(spy.calls) == 1
+
+
+# ===========================================================================
+# E. Idempotency dedup
+# ===========================================================================
+
+class TestDedup:
+    def test_same_assertion_id_executes_once(self):
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op, assertion_id="assert-dedup-1")
+        store: set = set()
+        reg = {"dopemux.test_writer": spy}
+        first = route_mutation(op, live_write_ready=gate, execute=True,
+                               writer_registry=reg, executed_keys=store, now=_NOW)
+        second = route_mutation(op, live_write_ready=gate, execute=True,
+                                writer_registry=reg, executed_keys=store, now=_NOW)
+        assert first["mode"] == "LIVE"
+        assert second["mode"] == "REJECTED" and "DUPLICATE_SUPPRESSED" in second["reasons"]
+        assert len(spy.calls) == 1  # writer called exactly once total
+
+
+# ===========================================================================
+# F. FastAPI TestClient — thin HTTP layer
+# ===========================================================================
+
+class TestHttp:
+    def _client(self, writer_registry=None) -> TestClient:
+        app = FastAPI()
+        app.include_router(create_bridge_router(writer_registry=writer_registry))
+        return TestClient(app)
+
+    def test_no_gate_returns_403(self):
+        client = self._client()
+        op = _operation()
+        resp = client.post("/bridge/mutate", json={"operation": op, "execute": True})
+        assert resp.status_code == 403
+        body = resp.json()
+        assert body["mode"] == "REJECTED" and body["is_authority"] is False
+
+    def test_dry_run_returns_200(self):
+        op = _operation()
+        gate = _ready_gate_for(op)
+        client = self._client()
+        resp = client.post("/bridge/mutate", json={"operation": op, "live_write_ready": gate, "execute": False})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mode"] == "DRY_RUN" and body["executed"] is False
+
+    def test_default_app_cannot_live_write(self):
+        # No writer registry -> execute=True with a valid READY gate is rejected.
+        op = _operation()
+        gate = _ready_gate_for(op)
+        client = self._client()  # no registry
+        resp = client.post("/bridge/mutate", json={"operation": op, "live_write_ready": gate, "execute": True})
+        assert resp.status_code == 403
+        assert "CANONICAL_WRITER_NOT_REGISTERED" in resp.json()["reasons"]
+
+    def test_live_when_writer_registered(self):
+        spy = _SpyWriter(result={"merged": True})
+        op = _operation()
+        gate = _ready_gate_for(op)
+        client = self._client(writer_registry={"dopemux.test_writer": spy})
+        resp = client.post("/bridge/mutate", json={"operation": op, "live_write_ready": gate, "execute": True})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mode"] == "LIVE" and body["executed"] is True
+        assert len(spy.calls) == 1
+
+    def test_http_dedup_suppresses_replay(self):
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op, assertion_id="assert-http-dedup")
+        client = self._client(writer_registry={"dopemux.test_writer": spy})
+        payload = {"operation": op, "live_write_ready": gate, "execute": True}
+        first = client.post("/bridge/mutate", json=payload)
+        second = client.post("/bridge/mutate", json=payload)
+        assert first.status_code == 200 and first.json()["mode"] == "LIVE"
+        assert second.status_code == 403 and "DUPLICATE_SUPPRESSED" in second.json()["reasons"]
+        assert len(spy.calls) == 1
+
+    @pytest.mark.parametrize("bad_val", [1, "yes", "true"])
+    def test_execute_truthy_non_bool_rejected_at_http(self, bad_val):
+        """StrictBool: a truthy non-boolean execute value is rejected at the HTTP
+        boundary (422), never coerced to True and never routed to a live write.
+
+        This closes the Pydantic-coercion gap: without StrictBool, JSON 1/"yes"
+        would coerce to True before route_mutation's `execute is True` check.
+        """
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op)
+        client = self._client(writer_registry={"dopemux.test_writer": spy})
+        resp = client.post(
+            "/bridge/mutate",
+            json={"operation": op, "live_write_ready": gate, "execute": bad_val},
+        )
+        assert resp.status_code == 422
+        assert spy.calls == []
+
+    def test_execute_real_bools_still_work(self):
+        """A genuine JSON boolean still routes correctly under StrictBool."""
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op)
+        client = self._client(writer_registry={"dopemux.test_writer": spy})
+        live = client.post("/bridge/mutate", json={"operation": op, "live_write_ready": gate, "execute": True})
+        assert live.status_code == 200 and live.json()["mode"] == "LIVE"
+        # a fresh gate (new assertion_id) for the dry-run path to avoid dedup
+        gate2 = _ready_gate_for(op, assertion_id="assert-dry")
+        dry = client.post("/bridge/mutate", json={"operation": op, "live_write_ready": gate2, "execute": False})
+        assert dry.status_code == 200 and dry.json()["mode"] == "DRY_RUN"
+
+
+# ===========================================================================
+# G. Structural no-write proofs + invariants
+# ===========================================================================
+
+class TestStructural:
+    def test_module_source_has_no_live_write_wiring(self):
+        """The bridge module must contain no forbidden live-write wiring (Red Line #15)."""
+        src = inspect.getsource(bridge)
+        _eq = "="
+        forbidden = [
+            "subprocess",
+            "gh" + " pr " + "merge",
+            "gh" + " pr " + "ready",
+            "git" + " push",
+            "git" + " commit",
+            "git" + " merge",
+            "queue_drain",
+            "batch_resolve_and_merge",
+            "execute" + _eq + "True",
+        ]
+        for token in forbidden:
+            assert token not in src, f"forbidden live-write token {token!r} in bridge source"
+
+    def test_no_default_writer(self):
+        for fn in (route_mutation, create_bridge_router, bridge.create_bridge_app):
+            params = inspect.signature(fn).parameters
+            if "writer_registry" in params:
+                assert params["writer_registry"].default is None
+
+    def test_is_authority_const_false_across_modes(self):
+        op = _operation()
+        gate = _ready_gate_for(op)
+        spy = _SpyWriter()
+        reg = {"dopemux.test_writer": spy}
+        results = [
+            route_mutation(op, live_write_ready=None, execute=True, writer_registry=reg, now=_NOW),  # REJECTED
+            route_mutation(op, live_write_ready=gate, execute=False, writer_registry=reg, now=_NOW),  # DRY_RUN
+            route_mutation(op, live_write_ready=gate, execute=True, writer_registry=reg, executed_keys=set(), now=_NOW),  # LIVE
+        ]
+        assert {r["mode"] for r in results} == {"REJECTED", "DRY_RUN", "LIVE"}
+        for r in results:
+            assert r["is_authority"] is False
+
+    def test_executed_iff_live(self):
+        op = _operation()
+        gate = _ready_gate_for(op)
+        spy = _SpyWriter()
+        reg = {"dopemux.test_writer": spy}
+        rejected = route_mutation(op, live_write_ready=None, execute=True, writer_registry=reg, now=_NOW)
+        dry = route_mutation(op, live_write_ready=gate, execute=False, writer_registry=reg, now=_NOW)
+        live = route_mutation(op, live_write_ready=gate, execute=True, writer_registry=reg, executed_keys=set(), now=_NOW)
+        for r in (rejected, dry, live):
+            assert r["executed"] is (r["mode"] == "LIVE")
+
+    def test_allowlist_files_only(self):
+        bridge_dir = _REPO_ROOT / "src" / "dopemux" / "pcp" / "bridge"
+        py_files = sorted(p.name for p in bridge_dir.glob("*.py"))
+        assert py_files == ["__init__.py", "fastapi_bridge.py"]

--- a/tests/project_control_plane/test_live_write_gates.py
+++ b/tests/project_control_plane/test_live_write_gates.py
@@ -97,6 +97,8 @@ def _ready_assertion(**overrides) -> dict:
         "blocked_reasons": [],
         "live_write_performed": False,
         "created_at": "2026-06-22T00:00:00Z",
+        "valid_until": "2999-01-01T00:00:00Z",
+        "payload_digest": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     }
     base.update(overrides)
     return base
@@ -403,3 +405,57 @@ def test_ready_rejected_when_rollback_plan_is_empty_string():
         "Expected ≥1 schema error for READY with rollback.plan='' but got none. "
         "Empty-string rollback plan is a fail-open — READY gate must enforce minLength: 1."
     )
+
+
+# ---------------------------------------------------------------------------
+# 9. valid_until + payload_digest READY-gate enforcement (Packet 11 amendment)
+#    These bind a READY assertion to an expiry and an exact operation payload.
+#    The schema enforces presence + format under READY; the consuming bridge
+#    enforces the time comparison and the hash comparison.
+# ---------------------------------------------------------------------------
+
+def test_ready_rejected_when_valid_until_missing():
+    """READY must be rejected when valid_until is absent."""
+    instance = _ready_assertion()
+    del instance["valid_until"]
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_valid_until_is_null():
+    """READY must be rejected when valid_until is null."""
+    instance = _ready_assertion(valid_until=None)
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_payload_digest_missing():
+    """READY must be rejected when payload_digest is absent."""
+    instance = _ready_assertion()
+    del instance["payload_digest"]
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_payload_digest_is_null():
+    """READY must be rejected when payload_digest is null."""
+    instance = _ready_assertion(payload_digest=None)
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_payload_digest_bad_format():
+    """READY must be rejected when payload_digest is not a 64-char sha256 hex."""
+    instance = _ready_assertion(payload_digest="not-a-real-sha256-digest")
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_ready_rejected_when_payload_digest_is_uppercase():
+    """READY must be rejected when payload_digest uses uppercase hex (pattern is [0-9a-f])."""
+    instance = _ready_assertion(payload_digest="A" * 64)
+    assert len(_schema_errors(instance)) >= 1
+
+
+def test_blocked_assertion_may_omit_valid_until_and_payload_digest():
+    """Non-READY (BLOCKED) assertions are additive-compatible: they may omit the
+    new fields entirely (the fields are required only under the READY gate)."""
+    instance = _ready_assertion(status="BLOCKED", blocked_reasons=["MISSING_APPROVAL"])
+    del instance["valid_until"]
+    del instance["payload_digest"]
+    assert _schema_errors(instance) == []


### PR DESCRIPTION
## Packet 11 — FastAPI live-write bridge (fail-closed gated adapter) — FINAL packet

The live-write adapter: routes a mutation to a canonical writer **only behind a satisfied LIVE_WRITE_READY gate**, dry-run first, fail-closed. **Adapter, never authority; no default writer** (a deployed app cannot live-write).

### Process (operator-requested full rigor)
Plan-mode: investigation (3 Explore agents) → design (Plan agent, 8-point fail-open audit) → adversarial red-team (4 HIGH gaps) → operator chose **maximal hardening** → implementation → independent Opus exploit verification → adversarial **diff** review (found + fixed an HTTP bool-coercion fail-open). PAL MCP was down this session → independent subagent reviews + Opus exploit verification as substitute.

### Deliverables
- `src/dopemux/pcp/bridge/{__init__,fastapi_bridge}.py` — `check_live_write_gate` + `route_mutation` (8-step fail-closed) + `create_bridge_router`/`create_bridge_app`.
- `schemas/project_control_plane/live_write_ready.schema.json` — **AMENDED**: `+valid_until` `+payload_digest` (required + format-checked under the READY gate; optional for non-READY; `schema_version` stays `v0`).
- `tests/project_control_plane/{test_fastapi_bridge,test_live_write_gates}.py`.
- `docs/ops/project-control-plane/fastapi-bridge.md`.

### Fail-closed guarantee (8-step; a writer is reached only at the end)
well-formed operation → gate schema-valid + consistent + **UNEXPIRED** READY → bound to THIS op (`operation_ref`+`target_surface`+`payload_digest`) → `execute is True` (**StrictBool**: JSON `1`/`"yes"` → 422, never coerced) → gate's `canonical_writer` name resolves in an explicit registry → first-time `assertion_id` (dedup) → writer. Else `REJECTED`, no write. `is_authority` const false; `executed` iff `mode==LIVE`.

### Validation
| Check | Result |
|---|---|
| pytest (P10 amended + P11 + dcp + dnh) | **PASS — 473** |
| schema valid (Draft 2020-12) | **PASS** |
| pre-commit | **PASS** |
| Independent Opus exploit re-verification | **0 fail-open writer calls** across {no gate, expired, schema-invalid, BLOCKED, ref/digest mismatch, execute=1, unregistered writer, dry-run, HTTP execute=1/"yes"/"true"}; legit path writes once; replay suppressed |

### Review findings actioned
- **Design red-team — 4 HIGH** (payload binding, TTL, idempotency dedup, canonical-writer registry) → all closed maximally.
- **Diff review — HTTP bool-coercion fail-open**: Pydantic coerced JSON `1`→`True`, bypassing `execute is True` at the API boundary → fixed with `StrictBool` (now 422) + verified. + 2 doc nits.

### Residual (documented)
- Deferred: cryptographic assertion signing; distributed dedup (bridge dedups in-process per router; the registered writer must honour `idempotency.key` for multi-replica safety).
- Allowlist expanded to the P10 schema + tests per the operator's maximal-scope choice.
- Red Line #15 enforced (forbidden runtimes can never become the writer); #9 (independent audit) gate-enforced for presence; truthfulness is out-of-band.

Packet: `TP-DMX-PCP-FASTAPI-BRIDGE-LAST-0001` · Branch `claude/pcp-p11-fastapi-bridge` · Plan `witty-dancing-mango.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)