### PR TITLE
feat(task-orchestrator): TO-CANON 005 coldstart materialization + 007 cutover plan

### DIFF
--- a/docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md
+++ b/docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md
@@ -1,0 +1,119 @@
+---
+id: canonical-store-cutover-plan
+title: Canonical Store Supervised Cutover Plan
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-22'
+last_review: '2026-06-22'
+next_review: '2026-09-20'
+prelude: Canonical Store Supervised Cutover Plan (reference) for dopemux documentation and developer
+  workflows.
+---
+# Task Orchestrator Canonical Store — Supervised Cutover Plan
+
+> **STATUS: PLAN ONLY — NOT APPROVED FOR EXECUTION.**
+> This document describes how the offline canonical reconciliation datastore *could* be promoted
+> to a runtime-backed store. It authorizes **no** write cutover and performs **no** live mutation.
+> Every step past the approval gate requires explicit operator sign-off and fails closed without it.
+
+## Scope and relationship to the contract
+
+This plan extends [canonical-datastore-contract.md](canonical-datastore-contract.md). Today the canonical
+reconciliation datastore is an **offline artifact** — `tools/task_orchestrator_reconcile/import_pack.py`
+writes it only to a caller-supplied `--output` SQLite path and never opens a live `current-tasks.db`.
+
+This document plans two *future* phases that are intentionally **not** executed here:
+
+1. A read-only runtime shadow of the offline store (the surface built by `TP-TO-CANON-006`, gated by
+   `CANONICAL_STORE_READ_VIEW_ENABLED`, default off).
+2. A possible later **write** cutover. This is explicitly **NOT AUTHORIZED** by this plan and would
+   require a separate ADR (see "Canonical writer" below).
+
+## Authority boundaries (must be preserved through any cutover)
+
+| System | Authority | Cutover rule |
+|--------|-----------|--------------|
+| task-orchestrator | workflow views, roles, transition memory only | remains the live workflow writer |
+| Leantime | passive PM metadata | unchanged; not a target |
+| ConPort | structured decisions / progress / context / custom-data | unchanged; not a target |
+| dope-memory | chronicle / evidence receipts | unchanged; not a target |
+| dopecon-bridge | adapter / proxy / event transport only | **MUST NOT** be promoted to a data authority |
+
+A cutover **must not** flatten these into a single PM datastore. The canonical reconciliation store is a
+**derived, read-only, point-in-time** view — never a replacement for split PM authority.
+
+## Canonical writer
+
+The canonical writer of live workflow transitions remains the **upstream Task Orchestrator MCP service**
+(`config/runtime_authority_manifest.json` → `task-orchestrator`, `authority_status: CONFLICTING`). The
+canonical reconciliation datastore is **DERIVED** and read-only; it is **not** the canonical writer and is
+not registered with a `canonical_*` authority role. Any future write cutover would have to *redefine the
+canonical writer* — an architecture-level change that is out of scope for this plan and requires a
+dedicated ADR plus operator approval before it may even be designed.
+
+## Preconditions (ALL required before any write cutover is even considered)
+
+1. `TP-TO-CANON-006` read-only view is enabled (`CANONICAL_STORE_READ_VIEW_ENABLED=true`) and validated
+   against a freshly regenerated point-in-time snapshot.
+2. Explicit operator approval is recorded (see approval gate).
+3. A full, verified backup exists of **every** live `current-tasks.db` (see Backup).
+4. Replay / idempotency / dedupe behavior is verified against the offline store.
+5. A green dry-run of the cutover steps has been produced with no live writes.
+
+If any precondition is unmet, **STOP** — the plan fails closed.
+
+## Phased plan
+
+### Phase 0 — Read-only shadow (covered by TP-TO-CANON-006)
+Expose the derived view read-only behind the feature flag. Operators compare the derived view against live
+Task Orchestrator state. **No writes.** This is the only phase any current packet builds.
+
+### Phase 1 — Backup (no mutation of source)
+Snapshot every live workspace DB to a timestamped archive directory. Read-only copies; archive, never delete.
+
+```bash
+# For each workspace's live DB (path derived by the stdio/http wrapper):
+#   ~/.local/share/dopemux-mission-control/task-orchestrator/<workspace-id>/current-tasks.db
+ARCHIVE="audit_inputs/task-orchestrator-canon/backups/$(git rev-parse --short HEAD)"
+mkdir -p "$ARCHIVE"
+cp -a "<live current-tasks.db>" "$ARCHIVE/current-tasks.<workspace-id>.db"   # read-only copy
+sqlite3 "$ARCHIVE/current-tasks.<workspace-id>.db" 'PRAGMA integrity_check;'
+```
+
+### Phase 2 — Operator-approval gate
+No step beyond this point may run without explicit, recorded operator approval. Default = denied.
+
+### Phase 3 — Write cutover (**NOT AUTHORIZED — design only, requires ADR + approval**)
+Out of scope for this plan. Documented only so the boundary is explicit: redefining the canonical writer,
+migrating live writes, and decommissioning the stdio/http path would each be separate, approval-gated work.
+
+## Rollback (exact)
+
+```bash
+# 1. Disable the read view (default is already off):
+unset CANONICAL_STORE_READ_VIEW_ENABLED
+
+# 2. Revert any code change introduced by a cutover step:
+git revert <cutover-commit-sha>
+
+# 3. Restore a live DB from backup ONLY under explicit operator direction (only if a write occurred):
+cp -a "$ARCHIVE/current-tasks.<workspace-id>.db" "<live current-tasks.db path>"
+```
+
+## Stale / recovery databases
+
+Stale, legacy, empty-shell, and recovery DBs (per `ADJUDICATION_MANIFEST.json`) are **archived, never
+deleted**, and remain provenance-only per the contract. Cutover does not promote them to active state.
+
+## Out of scope
+
+- Any actual write cutover (this is a plan).
+- Deletion of any database.
+- Promotion of `dopecon-bridge` to a data authority.
+- Flattening PM authority into a single store.
+
+## Risk assessment
+
+See the companion red-team risk doc:
+[canonical-store-cutover-risk.md](../../../05-audit-reports/task-orchestrator/canonical-store-cutover-risk.md).

--- a/docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md
+++ b/docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md
@@ -70,14 +70,18 @@ Expose the derived view read-only behind the feature flag. Operators compare the
 Task Orchestrator state. **No writes.** This is the only phase any current packet builds.
 
 ### Phase 1 — Backup (no mutation of source)
-Snapshot every live workspace DB to a timestamped archive directory. Read-only copies; archive, never delete.
+Snapshot every live workspace DB to a **uniquely timestamped** archive directory using SQLite's online
+backup (WAL/-shm consistent). Archive, never delete.
 
 ```bash
 # For each workspace's live DB (path derived by the stdio/http wrapper):
 #   ~/.local/share/dopemux-mission-control/task-orchestrator/<workspace-id>/current-tasks.db
-ARCHIVE="audit_inputs/task-orchestrator-canon/backups/$(git rev-parse --short HEAD)"
+ARCHIVE="audit_inputs/task-orchestrator-canon/backups/$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD)"
 mkdir -p "$ARCHIVE"
-cp -a "<live current-tasks.db>" "$ARCHIVE/current-tasks.<workspace-id>.db"   # read-only copy
+# Use SQLite's online backup, NOT a bare cp: cp of current-tasks.db alone can miss
+# the -wal/-shm sidecars and capture a torn snapshot under the WAL-lock contention
+# this DB is known for. .backup produces a single consistent file.
+sqlite3 "<live current-tasks.db>" ".backup '$ARCHIVE/current-tasks.<workspace-id>.db'"
 sqlite3 "$ARCHIVE/current-tasks.<workspace-id>.db" 'PRAGMA integrity_check;'
 ```
 

--- a/docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md
+++ b/docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md
@@ -102,7 +102,12 @@ unset CANONICAL_STORE_READ_VIEW_ENABLED
 git revert <cutover-commit-sha>
 
 # 3. Restore a live DB from backup ONLY under explicit operator direction (only if a write occurred):
-cp -a "$ARCHIVE/current-tasks.<workspace-id>.db" "<live current-tasks.db path>"
+#    Quiesce writers first (stop task-orchestrator MCP for this workspace).
+#    Use SQLite restore — NOT bare cp — to avoid WAL/-shm inconsistency (same invariant as Phase 1).
+sqlite3 "<live current-tasks.db path>" ".restore '$ARCHIVE/current-tasks.<workspace-id>.db'"
+sqlite3 "<live current-tasks.db path>" 'PRAGMA integrity_check;'
+# Remove stale WAL/SHM sidecars from the pre-restore live file if they remain:
+rm -f "<live current-tasks.db path>"-wal "<live current-tasks.db path>"-shm
 ```
 
 ## Stale / recovery databases

--- a/docs/05-audit-reports/task-orchestrator/canonical-store-cutover-risk.md
+++ b/docs/05-audit-reports/task-orchestrator/canonical-store-cutover-risk.md
@@ -34,7 +34,7 @@ adopting the plan document itself.
 | R5 | Stale / recovery DB rows promoted into active state | Low | Medium | Stale/legacy/recovery DBs stay provenance-only; archive-never-delete |
 | R6 | Operator-approval gate bypass / automation | Low | High | Plan fails closed; default denied; no step past Phase 2 without recorded sign-off |
 | R7 | Stale point-in-time view presented as live | Medium | Medium | Read view (006) carries a `valid_as_of` banner; cutover requires a freshly regenerated snapshot |
-| R8 | Task Orchestrator MCP health / SQLite contention during backup | Medium | Low-Medium | Backup uses read-only `cp -a` copies of the DB files, not live MCP calls |
+| R8 | Task Orchestrator MCP health / SQLite contention during backup | Medium | Low-Medium | Backup and rollback use SQLite online `.backup` / `.restore` to produce a single consistent file; never bare `cp -a` of live DB files (WAL/SHM sidecars can tear snapshots under contention) |
 
 ## Notes
 

--- a/docs/05-audit-reports/task-orchestrator/canonical-store-cutover-risk.md
+++ b/docs/05-audit-reports/task-orchestrator/canonical-store-cutover-risk.md
@@ -1,0 +1,50 @@
+---
+id: canonical-store-cutover-risk
+title: Canonical Store Cutover Risk Assessment
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-22'
+last_review: '2026-06-22'
+next_review: '2026-09-20'
+prelude: Canonical Store Cutover Risk Assessment (reference) for dopemux documentation and developer
+  workflows.
+---
+# Canonical Store Cutover — Red-Team Risk Assessment
+
+Companion to [canonical-store-cutover-plan.md](../../03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md).
+
+## Verdict
+
+**PASS_WITH_RISKS.**
+
+The cutover *plan* is safe to merge because it authorizes **no writes**, performs no live mutation, and
+fails closed at an explicit operator-approval gate. The residual risks below are about **future
+execution** (Phase 3), which this plan deliberately leaves NOT AUTHORIZED. None of them are introduced by
+adopting the plan document itself.
+
+## Risk register
+
+| ID | Risk | Likelihood (at plan stage) | Impact if executed unsafely | Mitigation in the plan |
+|----|------|----------------------------|-----------------------------|------------------------|
+| R1 | Data loss from overwriting a live `current-tasks.db` | None now (no writes) | High | Phase 1 backup + integrity check are mandatory preconditions; Phase 3 is NOT AUTHORIZED |
+| R2 | Authority flattening — treating the derived store as the single PM truth | Low | High (breaks split-authority model) | Authority-boundary table is normative; store is DERIVED/read-only; canonical writer stays the live TO MCP |
+| R3 | `dopecon-bridge` promoted to a data authority | Low | High | Explicit invariant: bridge is transport-only and MUST NOT become an authority |
+| R4 | Replay / idempotency regressions after a write cutover | None now | Medium-High | Precondition 4 requires replay/dedupe verification before any write |
+| R5 | Stale / recovery DB rows promoted into active state | Low | Medium | Stale/legacy/recovery DBs stay provenance-only; archive-never-delete |
+| R6 | Operator-approval gate bypass / automation | Low | High | Plan fails closed; default denied; no step past Phase 2 without recorded sign-off |
+| R7 | Stale point-in-time view presented as live | Medium | Medium | Read view (006) carries a `valid_as_of` banner; cutover requires a freshly regenerated snapshot |
+| R8 | Task Orchestrator MCP health / SQLite contention during backup | Medium | Low-Medium | Backup uses read-only `cp -a` copies of the DB files, not live MCP calls |
+
+## Notes
+
+- The most dangerous step (R1) is gated behind a precondition chain (backup → approval) and is explicitly
+  marked NOT AUTHORIZED in the plan. Merging the plan does not enable it.
+- R7 is the subtlest operational risk: a derived view must never imply liveness. The 006 read surface
+  mitigates this with an explicit `valid_as_of` banner; the cutover plan reinforces it by requiring a fresh
+  snapshot before any cutover.
+
+## Residual uncertainty
+
+- The future write cutover (Phase 3) is intentionally under-specified; it requires a dedicated ADR before it
+  can be designed. This risk doc covers the *plan*, not an executed migration.

--- a/docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md
+++ b/docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md
@@ -1,0 +1,94 @@
+---
+id: coldstart-reconciliation-20260622
+title: Coldstart Reconciliation 20260622
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-22'
+last_review: '2026-06-22'
+next_review: '2026-09-20'
+prelude: Coldstart reconciliation decision report for the DMX-COLDSTART task-packet series as of 2026-06-22.
+---
+
+# Coldstart Reconciliation — 2026-06-22
+
+Offline point-in-time classification of all DMX-COLDSTART work items. This report is generated from the committed reconciliation JSON and is presentation-only — no live database access, no status mutations.
+
+## Point-in-Time Provenance
+
+**valid_as_of_utc**: `2026-06-22T19:28:14Z`
+
+**basis**: June 22 Task Orchestrator safe-pack reconciliation and PR evidence: completed-PR map (#886/#887/#888), high-risk packet set, and the model.py schema-class table-count thresholds are point-in-time facts.
+
+**schema_version**: `task-orchestrator.reconciliation-decision.v0`
+
+**active_db_slug**: `dopemux-mvp-2e346e2084bca021`
+
+**root_decision**: `remain_active_in_progress`
+
+## Item Classifications
+
+### Active Root — In Progress
+
+| Title | Role | Decision | Status Label | Evidence |
+|-------|------|----------|--------------|----------|
+| DMX-COLDSTART task-packet series | work | remain_active_in_progress | in-progress | role=work; status_label=in-progress |
+
+### Repo PR Proof Observed
+
+| Title | Role | Decision | Status Label | Evidence |
+|-------|------|----------|--------------|----------|
+| TP-DMX-COLDSTART-L0-DEP-AUDIT-100 | terminal | accepted_do_not_rerun | in-progress | pr=#886; proof_exists=True; proof_json=/Users/hue/.codex/worktrees/a318/dopemux-mvp/proof/TP-DMX-COLDSTART-L0-DEP-AUDIT-100/PROOF.json |
+| TP-DMX-COLDSTART-ORCH-HTTP-CUTOVER-109 | terminal | accepted_do_not_rerun | done | pr=#888; proof_exists=True; proof_json=/Users/hue/.codex/worktrees/a318/dopemux-mvp/proof/TP-DMX-COLDSTART-ORCH-HTTP-CUTOVER-109/PROOF.json |
+| TP-DMX-COLDSTART-SALVAGE-COLDSTART-LIB-101 | terminal | accepted_do_not_rerun | in-progress | pr=#887; proof_exists=True; proof_json=/Users/hue/.codex/worktrees/a318/dopemux-mvp/proof/TP-DMX-COLDSTART-SALVAGE-COLDSTART-LIB-101/PROOF.json |
+
+### Explicit Blocked
+
+| Title | Role | Decision | Status Label | Evidence |
+|-------|------|----------|--------------|----------|
+| TP-DMX-COLDSTART-INIT-UNIFY-102 | blocked | keep_blocked_until_repo_packet_allowlist_exists | blocked | role=blocked; status_label=blocked |
+
+### Operator Gate
+
+| Title | Role | Decision | Status Label | Evidence |
+|-------|------|----------|--------------|----------|
+| OP-DMX-COLDSTART-PYPI-NAME-000 | queue | operator_only_do_not_automate |  | role=queue |
+
+### Queue Only — Supervisor Required
+
+| Title | Role | Decision | Status Label | Evidence |
+|-------|------|----------|--------------|----------|
+| TP-DMX-COLDSTART-L0-PLUGIN-107 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-LIFECYCLE-118 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-RELEASE-PIPELINE-113 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-SECURITY-GATE-108 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+
+### Queue Only
+
+| Title | Role | Decision | Status Label | Evidence |
+|-------|------|----------|--------------|----------|
+| TP-DMX-COLDSTART-AUTH-SECRETS-103 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-DOCS-GETTINGSTARTED-114 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-DOCTOR-STATUS-105 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-DOCTRINE-SYNC-115 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-EXTRAS-PYPI-111 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-FLEET-IMAGES-110 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-FRESHVM-CI-112 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-GLOBALS-SYNC-106 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-MIGRATION-CLEANUP-116 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-PUBLIC-HYGIENE-119 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-UP-DOWN-104 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+| TP-DMX-COLDSTART-VERSION-CONTRACT-117 | queue | do_not_infer_readiness_from_to_role |  | role=queue |
+
+## Classification Counts
+
+| Classification | Count |
+|----------------|-------|
+| active_root_in_progress | 1 |
+| repo_pr_proof_observed | 3 |
+| explicit_blocked | 1 |
+| operator_gate | 1 |
+| queue_only_supervisor_required | 4 |
+| queue_only | 12 |
+
+**Total items**: 22

--- a/docs/ops/load-plans/load_plan-TO-CANON.json
+++ b/docs/ops/load-plans/load_plan-TO-CANON.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": "1.0.0",
+  "series_id": "TO-CANON",
+  "title": "Task Orchestrator canonical reconciliation series — offline datastore, coldstart materialization, read-only view, supervised cutover plan",
+  "description": "8-packet series over the June 22 Task Orchestrator safe evidence pack. 000-004 (intake/adjudication, datastore contract+schema, importer/validator, resolver/dedupe/coldstart, full dry-run) plus the 004R contract-hardening pass are MERGED via PR #961. 005 materializes the committed coldstart reconciliation JSON into a tracked Markdown decision report (offline). 006 exposes the offline canonical SQLite as a read-only operator view behind the CANONICAL_STORE_READ_VIEW_ENABLED flag (default off, derived/read-only, never a canonical authority). 007 authors a supervised, operator-gated cutover plan + red-team risk doc (docs only; no write cutover).",
+  "authority": "Task packets at task-packets/TP-TO-CANON-*.json conforming to docs/03-reference/spec/dopetask/dopetask-canonical-spec.json. Contract at docs/03-reference/systems/task-orchestrator/canonical-datastore-contract.md. Runtime repo truth outranks this document; verify paths before edit.",
+  "live_task_orchestrator_load": "PENDING_LOAD",
+  "live_load_evidence": "Not loaded into the live task-orchestrator. A query_items call timed out during planning (2026-06-22); 000-004 shipped without a formal live load. Live load is an optional coordination convenience, not a prerequisite. If loaded later via create_work_tree, backfill task_orchestrator_root_id + task_orchestrator_leaf_ids and set live_task_orchestrator_load=LOADED.",
+  "offline_artifact": "CREATED",
+  "loaded": false,
+  "load_mechanism_classified_as": "PENDING_LOAD",
+  "load_mechanism_evidence": "task-orchestrator MCP v3 would use create_work_tree for root, manage_items(operation=create) per node, manage_dependencies for BLOCKS DAG, manage_notes for gate briefs — same as sibling load plans (DMX-CONPORT-OPTIMAL).",
+  "task_orchestrator_root_id": null,
+  "task_orchestrator_leaf_ids": {
+    "TP-TO-CANON-000": null,
+    "TP-TO-CANON-001": null,
+    "TP-TO-CANON-002": null,
+    "TP-TO-CANON-003": null,
+    "TP-TO-CANON-004": null,
+    "TP-TO-CANON-005": null,
+    "TP-TO-CANON-006": null,
+    "TP-TO-CANON-007": null
+  },
+  "workspace_id": "/Users/hue/code/dopemux-mvp",
+  "generated_by": "claude-opus-4-8 authoring session 2026-06-22 on feat/to-canon-tail-005-007. Orchestrator MCP unavailable at generation time — root and leaf UUIDs are PENDING_LOAD.",
+  "executor_defaults": {
+    "primary": "claude-code-sonnet",
+    "auditor": "claude-code-opus",
+    "fallback_auditor": "gemini-cli"
+  },
+  "merged_status": {
+    "TP-TO-CANON-000": "MERGED (PR #961, squash af97290a4)",
+    "TP-TO-CANON-001": "MERGED (PR #961)",
+    "TP-TO-CANON-002": "MERGED (PR #961)",
+    "TP-TO-CANON-003": "MERGED (PR #961)",
+    "TP-TO-CANON-004": "MERGED (PR #961); 004R contract-hardening folded in via commit eae033f21",
+    "TP-TO-CANON-005": "READY (this series tail) — offline coldstart materialization",
+    "TP-TO-CANON-006": "READY — read-only operator view behind CANONICAL_STORE_READ_VIEW_ENABLED",
+    "TP-TO-CANON-007": "READY — supervised cutover plan (docs only)"
+  },
+  "first_unblocked_wave": [
+    "TP-TO-CANON-005",
+    "TP-TO-CANON-006"
+  ],
+  "blocks_dag": {
+    "description": "7 BLOCKS edges. 000 blocks the four datastore packets; 004 (full dry-run) blocks the two consumers 005/006; 006 (read view) blocks 007 (cutover plan, which lists the read view as a precondition).",
+    "edges": [
+      { "predecessor": "TP-TO-CANON-000", "successor": "TP-TO-CANON-001" },
+      { "predecessor": "TP-TO-CANON-000", "successor": "TP-TO-CANON-002" },
+      { "predecessor": "TP-TO-CANON-000", "successor": "TP-TO-CANON-003" },
+      { "predecessor": "TP-TO-CANON-000", "successor": "TP-TO-CANON-004" },
+      { "predecessor": "TP-TO-CANON-004", "successor": "TP-TO-CANON-005" },
+      { "predecessor": "TP-TO-CANON-004", "successor": "TP-TO-CANON-006" },
+      { "predecessor": "TP-TO-CANON-006", "successor": "TP-TO-CANON-007" }
+    ],
+    "edge_count": 7
+  },
+  "nodes": [
+    { "id": "TP-TO-CANON-000", "role": "terminal", "status": "MERGED", "redlane": true, "orchestrator_uuid": null, "objective": "Safe evidence-pack intake + 26-DB adjudication manifest", "depends_on": [], "blocks": ["TP-TO-CANON-001", "TP-TO-CANON-002", "TP-TO-CANON-003", "TP-TO-CANON-004"] },
+    { "id": "TP-TO-CANON-001", "role": "terminal", "status": "MERGED", "redlane": true, "orchestrator_uuid": null, "objective": "Canonical datastore contract + JSON schemas", "depends_on": ["TP-TO-CANON-000"], "blocks": [] },
+    { "id": "TP-TO-CANON-002", "role": "terminal", "status": "MERGED", "redlane": true, "orchestrator_uuid": null, "objective": "Read-only importer + validator", "depends_on": ["TP-TO-CANON-000"], "blocks": [] },
+    { "id": "TP-TO-CANON-003", "role": "terminal", "status": "MERGED", "redlane": true, "orchestrator_uuid": null, "objective": "Resolver + dedupe + coldstart reconciliation engine", "depends_on": ["TP-TO-CANON-000"], "blocks": [] },
+    { "id": "TP-TO-CANON-004", "role": "terminal", "status": "MERGED", "redlane": true, "orchestrator_uuid": null, "objective": "Full dry-run of all 26 DBs + 004R contract hardening", "depends_on": ["TP-TO-CANON-000"], "blocks": ["TP-TO-CANON-005", "TP-TO-CANON-006"] },
+    { "id": "TP-TO-CANON-005", "role": "queue", "status": "READY", "redlane": false, "orchestrator_uuid": null, "objective": "Materialize committed coldstart reconciliation JSON into a tracked Markdown report (offline, deterministic)", "depends_on": ["TP-TO-CANON-004"], "blocks": [] },
+    { "id": "TP-TO-CANON-006", "role": "queue", "status": "READY", "redlane": true, "orchestrator_uuid": null, "objective": "Read-only operator view over the offline canonical SQLite behind a feature flag (derived/read-only)", "depends_on": ["TP-TO-CANON-004"], "blocks": ["TP-TO-CANON-007"] },
+    { "id": "TP-TO-CANON-007", "role": "queue", "status": "READY", "redlane": false, "orchestrator_uuid": null, "objective": "Supervised, operator-gated cutover plan + red-team risk doc (docs only; no write cutover)", "depends_on": ["TP-TO-CANON-006"], "blocks": [] }
+  ],
+  "verification": {
+    "packet_schema": "python -m jsonschema -i task-packets/TP-TO-CANON-<NNN>.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+    "notes": "000-004 verified MERGED via gh pr view 961 (state MERGED, squash af97290a4, ancestor of main). 005/006/007 verified per their packet verify blocks."
+  },
+  "replay_instructions": "To load into a healthy task-orchestrator: create_work_tree for the TO-CANON root, manage_items(create) for each node, manage_dependencies for the 7 BLOCKS edges, then backfill task_orchestrator_root_id + task_orchestrator_leaf_ids and set live_task_orchestrator_load=LOADED."
+}

--- a/task-packets/TP-TO-CANON-005.json
+++ b/task-packets/TP-TO-CANON-005.json
@@ -42,8 +42,8 @@
     ],
     "verify": [
       "python -m jsonschema -i task-packets/TP-TO-CANON-005.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
-      "python -m tools.task_orchestrator_reconcile.coldstart --from-json audit_inputs/task-orchestrator-canon/to-all-dbs-20260622T192814Z/COLDSTART_RECONCILIATION.json --emit-md docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md",
-      "python -m tools.task_orchestrator_reconcile.coldstart --from-json audit_inputs/task-orchestrator-canon/to-all-dbs-20260622T192814Z/COLDSTART_RECONCILIATION.json --emit-md /tmp/coldstart-rerun.md && diff docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md /tmp/coldstart-rerun.md",
+      "python -m tools.task_orchestrator_reconcile.coldstart --from-json audit_inputs/task-orchestrator-canon/to-all-dbs-20260622T192814Z/COLDSTART_RECONCILIATION.json --emit-md /tmp/coldstart-rerun.md",
+      "diff docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md /tmp/coldstart-rerun.md",
       "python -m pytest -q tests/tools/test_task_orchestrator_reconcile_coldstart.py",
       "python -m compileall -q tools/task_orchestrator_reconcile tests/tools",
       "git diff --check"

--- a/task-packets/TP-TO-CANON-005.json
+++ b/task-packets/TP-TO-CANON-005.json
@@ -1,0 +1,130 @@
+{
+  "id": "TP-TO-CANON-005",
+  "project": "dopemux-mvp",
+  "target": "Materialize the coldstart reconciliation decision: deterministically render the committed COLDSTART_RECONCILIATION.json into a tracked Markdown decision report. Offline, presentation-only; no new analysis and no live state mutation.",
+  "invariants": [
+    "No live current-tasks.db reads or writes.",
+    "Renderer input is the committed audit_inputs COLDSTART_RECONCILIATION.json, not the raw evidence pack.",
+    "Markdown output is deterministic and byte-stable across re-runs (stable item ordering, no wall-clock).",
+    "The point_in_time block (valid_as_of_utc 2026-06-22T19:28:14Z) is carried verbatim into the report.",
+    "Do not fix live status-label drift (100/101 terminal-but-in-progress) and do not unblock TP-DMX-COLDSTART-INIT-UNIFY-102 — those are live PM writes outside this packet.",
+    "100, 101, and 109 remain repo/PR/proof observed (accepted_do_not_rerun); 102 remains blocked.",
+    "Raw note bodies and FTS rows must not be emitted."
+  ],
+  "depends_on": [
+    "TP-TO-CANON-004"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "TO-CANON",
+    "base_branch": "origin/main",
+    "parent_tp_id": "TP-TO-CANON-004",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "feat/to-canon-tail-005-007",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(task-orchestrator): materialize coldstart reconciliation report",
+    "allowlist": [
+      "task-packets/TP-TO-CANON-005.json",
+      "tools/task_orchestrator_reconcile/coldstart.py",
+      "tools/task_orchestrator_reconcile/import_pack.py",
+      "tests/tools/test_task_orchestrator_reconcile_coldstart.py",
+      "docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-TO-CANON-005.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m tools.task_orchestrator_reconcile.coldstart --from-json audit_inputs/task-orchestrator-canon/to-all-dbs-20260622T192814Z/COLDSTART_RECONCILIATION.json --emit-md docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md",
+      "python -m tools.task_orchestrator_reconcile.coldstart --from-json audit_inputs/task-orchestrator-canon/to-all-dbs-20260622T192814Z/COLDSTART_RECONCILIATION.json --emit-md /tmp/coldstart-rerun.md && diff docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md /tmp/coldstart-rerun.md",
+      "python -m pytest -q tests/tools/test_task_orchestrator_reconcile_coldstart.py",
+      "python -m compileall -q tools/task_orchestrator_reconcile tests/tools",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(task-orchestrator): materialize coldstart reconciliation report",
+    "body": "## Summary\n- add a deterministic Markdown renderer over the committed COLDSTART_RECONCILIATION.json (offline; no raw pack, no live DB)\n- emit docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md (done/blocked/queue/supervisor/operator-gate + active root, with PR/proof refs)\n- carry the point_in_time provenance banner verbatim\n\n## Validation\n- python -m jsonschema -i task-packets/TP-TO-CANON-005.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- re-render is byte-stable (diff clean)\n- python -m pytest -q tests/tools/test_task_orchestrator_reconcile_coldstart.py\n- git diff --check\n\nNo live current-tasks.db writes; no status-drift fix; no 102 unblock; no raw note bodies or FTS rows.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "add-renderer",
+      "task": "Add a deterministic render_markdown(coldstart: dict) -> str to tools/task_orchestrator_reconcile/coldstart.py that groups items by classification (active_root_in_progress, repo_pr_proof_observed, explicit_blocked, operator_gate, queue_only_supervisor_required, queue_only) with stable ordering, renders the point_in_time banner verbatim, and includes PR/proof evidence refs. Wire a `python -m tools.task_orchestrator_reconcile.coldstart --from-json <path> --emit-md <path>` CLI that reads the committed JSON. Also add an --emit-coldstart-md option to import_pack.py that renders alongside --emit-coldstart during a full import.",
+      "requirements": [
+        "Renderer input is the committed JSON artifact; no raw pack or live DB access.",
+        "Output is byte-stable across re-runs (no wall-clock, deterministic ordering).",
+        "point_in_time.valid_as_of_utc and basis are reproduced verbatim."
+      ],
+      "commands": [
+        "python -m tools.task_orchestrator_reconcile.coldstart --from-json audit_inputs/task-orchestrator-canon/to-all-dbs-20260622T192814Z/COLDSTART_RECONCILIATION.json --emit-md docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md"
+      ],
+      "expected_files": [
+        "tools/task_orchestrator_reconcile/coldstart.py",
+        "tools/task_orchestrator_reconcile/import_pack.py",
+        "docs/05-audit-reports/task-orchestrator/coldstart-reconciliation-20260622.md"
+      ],
+      "validation": [
+        "Re-rendering the report produces a byte-identical file (diff clean)."
+      ],
+      "context_files": [
+        "audit_inputs/task-orchestrator-canon/to-all-dbs-20260622T192814Z/COLDSTART_RECONCILIATION.json",
+        "tools/task_orchestrator_reconcile/coldstart.py",
+        "tools/task_orchestrator_reconcile/resolve.py"
+      ]
+    },
+    {
+      "id": "test-renderer",
+      "task": "Add tests/tools/test_task_orchestrator_reconcile_coldstart.py asserting: render is deterministic (same input -> same output), 100/101/109 are classified accepted_do_not_rerun, 102 stays keep_blocked, the operator gate is preserved, and no live-DB or raw-pack access occurs.",
+      "requirements": [
+        "Tests run offline against a fixture or the committed JSON.",
+        "Assert byte-stability and the do-not-rerun / keep-blocked decisions."
+      ],
+      "commands": [
+        "python -m pytest -q tests/tools/test_task_orchestrator_reconcile_coldstart.py"
+      ],
+      "expected_files": [
+        "tests/tools/test_task_orchestrator_reconcile_coldstart.py"
+      ],
+      "validation": [
+        "Targeted pytest passes."
+      ],
+      "context_files": [
+        "tests/tools/test_task_orchestrator_reconcile_import.py"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate the packet against the canonical spec, confirm byte-stable regeneration, and check diff scope.",
+      "requirements": [
+        "Report PASS / FAIL / NOT_RUN truthfully."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-TO-CANON-005.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "git diff --check"
+      ],
+      "validation": [
+        "Schema validation passes and diff scope is within the allowlist."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    }
+  ]
+}

--- a/task-packets/TP-TO-CANON-007.json
+++ b/task-packets/TP-TO-CANON-007.json
@@ -23,7 +23,7 @@
   "series": {
     "id": "TO-CANON",
     "base_branch": "origin/main",
-    "parent_tp_id": "TP-TO-CANON-004",
+    "parent_tp_id": "TP-TO-CANON-006",
     "final_packet": true
   },
   "execution": {

--- a/task-packets/TP-TO-CANON-007.json
+++ b/task-packets/TP-TO-CANON-007.json
@@ -1,0 +1,116 @@
+{
+  "id": "TP-TO-CANON-007",
+  "project": "dopemux-mvp",
+  "target": "Author (do not execute) a supervised cutover plan for promoting the offline canonical reconciliation datastore to a runtime-backed Task Orchestrator workflow-memory store. Docs-only: a cutover plan plus a red-team risk doc, gated behind explicit operator approval.",
+  "invariants": [
+    "Docs-only. No code, no live current-tasks.db mutation, no actual cutover.",
+    "The plan must require explicit operator approval before any write/cutover.",
+    "Stale/recovery DBs are archived, never deleted.",
+    "Authority boundaries (task-orchestrator views-only, Leantime passive PM, ConPort structured context/decisions, dope-memory chronicle, dopecon-bridge transport-only) are preserved and named.",
+    "dopecon-bridge must not be promoted into a data authority.",
+    "The plan names the canonical writer, a live backup-before-mutation step, and exact rollback commands.",
+    "Enabling and validating the TP-TO-CANON-006 read-only view is listed as a cutover precondition."
+  ],
+  "depends_on": [
+    "TP-TO-CANON-004"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "TO-CANON",
+    "base_branch": "origin/main",
+    "parent_tp_id": "TP-TO-CANON-004",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "feat/to-canon-tail-005-007",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(task-orchestrator): supervised canonical-store cutover plan",
+    "allowlist": [
+      "task-packets/TP-TO-CANON-007.json",
+      "docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md",
+      "docs/05-audit-reports/task-orchestrator/canonical-store-cutover-risk.md"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-TO-CANON-007.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python scripts/docs_validator.py docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md docs/05-audit-reports/task-orchestrator/canonical-store-cutover-risk.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(task-orchestrator): supervised canonical-store cutover plan",
+    "body": "## Summary\n- add a supervised, operator-gated cutover plan for the offline canonical reconciliation datastore (plan only, no execution)\n- add a red-team risk doc (verdict PASS or PASS_WITH_RISKS)\n- preserve task-orchestrator / Leantime / ConPort / dope-memory / dopecon-bridge authority boundaries; bridge stays transport-only\n\n## Validation\n- python -m jsonschema -i task-packets/TP-TO-CANON-007.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python scripts/docs_validator.py <new docs>\n- git diff --check\n\nNo code, no live current-tasks.db mutation, no actual cutover, no stale-DB deletion.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "author-cutover-plan",
+      "task": "Write docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md extending canonical-datastore-contract.md: name the canonical writer, the live backup-before-mutation step, exact rollback commands, the operator-approval gate, and the precondition that the TP-TO-CANON-006 read-only view is enabled and validated first. Archive (never delete) stale DBs.",
+      "requirements": [
+        "Explicit operator-approval gate before any write/cutover.",
+        "Preserve and name the bridge/ConPort/Leantime/dope-memory authority boundaries.",
+        "Include exact backup and rollback commands."
+      ],
+      "expected_files": [
+        "docs/03-reference/systems/task-orchestrator/canonical-store-cutover-plan.md"
+      ],
+      "validation": [
+        "Plan names canonical writer, backup, rollback, approval gate, and 006 precondition."
+      ],
+      "context_files": [
+        "docs/03-reference/systems/task-orchestrator/canonical-datastore-contract.md",
+        "config/runtime_authority_manifest.json"
+      ]
+    },
+    {
+      "id": "author-risk-doc",
+      "task": "Write docs/05-audit-reports/task-orchestrator/canonical-store-cutover-risk.md as a red-team risk assessment of the cutover plan, with an explicit verdict of PASS or PASS_WITH_RISKS.",
+      "requirements": [
+        "Enumerate data-loss, authority-flattening, and replay/idempotency risks with mitigations.",
+        "Verdict must be PASS or PASS_WITH_RISKS."
+      ],
+      "expected_files": [
+        "docs/05-audit-reports/task-orchestrator/canonical-store-cutover-risk.md"
+      ],
+      "validation": [
+        "Risk doc carries an explicit verdict and mitigations."
+      ],
+      "context_files": [
+        "docs/03-reference/systems/task-orchestrator/canonical-datastore-contract.md"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate the packet and run docs gates and diff-scope checks.",
+      "requirements": [
+        "Report PASS / FAIL / NOT_RUN truthfully."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-TO-CANON-007.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "git diff --check"
+      ],
+      "validation": [
+        "Schema validation passes and docs gates pass or blockers are reported."
+      ],
+      "context_files": [
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    }
+  ]
+}

--- a/task-packets/TP-TO-CANON-007.json
+++ b/task-packets/TP-TO-CANON-007.json
@@ -12,7 +12,7 @@
     "Enabling and validating the TP-TO-CANON-006 read-only view is listed as a cutover precondition."
   ],
   "depends_on": [
-    "TP-TO-CANON-004"
+    "TP-TO-CANON-006"
   ],
   "repo_binding": {
     "project_id": "dopemux-mvp",

--- a/tests/tools/test_task_orchestrator_reconcile_coldstart.py
+++ b/tests/tools/test_task_orchestrator_reconcile_coldstart.py
@@ -7,6 +7,7 @@ fixture or inline data. No live database access required.
 """
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -140,3 +141,35 @@ def test_valid_as_of_utc_banner_present():
     assert expected in md, (
         f"valid_as_of_utc '{expected}' not found in rendered Markdown"
     )
+
+
+def test_table_cells_escape_delimiters_and_line_breaks():
+    """Item table cells must not corrupt the Markdown table shape."""
+    data = _load_fixture()
+    data["items"] = [
+        {
+            "title": "TP-DMX-COLDSTART-PIPE|SAFE\nNEXT",
+            "role": "work|review",
+            "classification": "queue_only",
+            "decision": "keep|queued",
+            "status_label": "Queue\nOnly",
+            "evidence": {
+                "pr": "#123|#456",
+                "proof_exists": "yes\nobserved",
+                "role": "queue|work",
+            },
+        }
+    ]
+    data["classification_counts"] = {"queue_only": 1}
+
+    md = _render(data)
+
+    row = next(
+        line for line in md.splitlines() if "TP-DMX-COLDSTART-PIPE" in line
+    )
+    assert len(re.findall(r"(?<!\\)\|", row)) == 6
+    assert "TP-DMX-COLDSTART-PIPE\\|SAFE<br>NEXT" in row
+    assert "work\\|review" in row
+    assert "keep\\|queued" in row
+    assert "Queue<br>Only" in row
+    assert "pr=#123\\|#456; proof_exists=yes<br>observed; role=queue\\|work" in row

--- a/tests/tools/test_task_orchestrator_reconcile_coldstart.py
+++ b/tests/tools/test_task_orchestrator_reconcile_coldstart.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+"""Tests for the coldstart render_markdown function and CLI.
+
+All tests run offline — they load the committed COLDSTART_RECONCILIATION.json
+fixture or inline data. No live database access required.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_JSON = (
+    ROOT
+    / "audit_inputs"
+    / "task-orchestrator-canon"
+    / "to-all-dbs-20260622T192814Z"
+    / "COLDSTART_RECONCILIATION.json"
+)
+GENERATED_MD = (
+    ROOT
+    / "docs"
+    / "05-audit-reports"
+    / "task-orchestrator"
+    / "coldstart-reconciliation-20260622.md"
+)
+
+
+def _load_fixture() -> dict:
+    return json.loads(FIXTURE_JSON.read_text(encoding="utf-8"))
+
+
+def _render(coldstart: dict | None = None) -> str:
+    # Import here so tests get a fresh import each time
+    # (avoids sys.modules caching issues when running in isolation)
+    import importlib
+
+    mod = importlib.import_module("tools.task_orchestrator_reconcile.coldstart")
+    data = coldstart if coldstart is not None else _load_fixture()
+    return mod.render_markdown(data)
+
+
+def _run_cli(from_json: str, emit_md: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tools.task_orchestrator_reconcile.coldstart",
+            "--from-json",
+            from_json,
+            "--emit-md",
+            emit_md,
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+# --- (a) Render determinism ---------------------------------------------------
+
+
+def test_render_is_deterministic():
+    """Calling render_markdown twice on the same input must produce identical output."""
+    data = _load_fixture()
+    first = _render(data)
+    second = _render(data)
+    assert first == second, "render_markdown is not deterministic"
+
+
+# --- (b) CLI byte-identical on re-run ----------------------------------------
+
+
+def test_cli_byte_identical_on_rerun(tmp_path: Path):
+    """Running the CLI twice must produce byte-identical output files."""
+    out1 = tmp_path / "run1.md"
+    out2 = tmp_path / "run2.md"
+
+    r1 = _run_cli(str(FIXTURE_JSON), str(out1))
+    assert r1.returncode == 0, f"CLI run 1 failed: {r1.stderr}"
+
+    r2 = _run_cli(str(FIXTURE_JSON), str(out2))
+    assert r2.returncode == 0, f"CLI run 2 failed: {r2.stderr}"
+
+    assert out1.read_bytes() == out2.read_bytes(), (
+        "CLI output differs between runs — not byte-stable"
+    )
+
+
+# --- (c) Items 100/101/109 render with accepted_do_not_rerun -----------------
+
+
+def test_items_100_101_109_render_accepted_do_not_rerun():
+    """TP-100, TP-101, and TP-109 must appear with decision=accepted_do_not_rerun."""
+    md = _render()
+    expected_titles = [
+        "TP-DMX-COLDSTART-L0-DEP-AUDIT-100",
+        "TP-DMX-COLDSTART-SALVAGE-COLDSTART-LIB-101",
+        "TP-DMX-COLDSTART-ORCH-HTTP-CUTOVER-109",
+    ]
+    for title in expected_titles:
+        assert title in md, f"title not found in rendered output: {title}"
+    # All three must appear alongside accepted_do_not_rerun
+    assert md.count("accepted_do_not_rerun") >= 3, (
+        "expected at least 3 occurrences of accepted_do_not_rerun "
+        f"(one per repo_pr_proof_observed item), got: {md.count('accepted_do_not_rerun')}"
+    )
+
+
+# --- (d) Item 102 renders as keep_blocked_until_repo_packet_allowlist_exists --
+
+
+def test_item_102_renders_keep_blocked():
+    """TP-DMX-COLDSTART-INIT-UNIFY-102 must appear with the correct blocked decision."""
+    md = _render()
+    assert "TP-DMX-COLDSTART-INIT-UNIFY-102" in md
+    assert "keep_blocked_until_repo_packet_allowlist_exists" in md
+
+
+# --- (e) OP-DMX-COLDSTART-PYPI-NAME-000 appears -----------------------------
+
+
+def test_operator_gate_item_appears():
+    """OP-DMX-COLDSTART-PYPI-NAME-000 must appear in the rendered Markdown."""
+    md = _render()
+    assert "OP-DMX-COLDSTART-PYPI-NAME-000" in md
+
+
+# --- (f) valid_as_of_utc banner is present -----------------------------------
+
+
+def test_valid_as_of_utc_banner_present():
+    """The point-in-time valid_as_of_utc value must appear verbatim in the output."""
+    data = _load_fixture()
+    expected = data["point_in_time"]["valid_as_of_utc"]
+    md = _render(data)
+    assert expected in md, (
+        f"valid_as_of_utc '{expected}' not found in rendered Markdown"
+    )

--- a/tools/task_orchestrator_reconcile/coldstart.py
+++ b/tools/task_orchestrator_reconcile/coldstart.py
@@ -45,6 +45,12 @@ def _evidence_cell(evidence: dict[str, Any]) -> str:
     return "; ".join(parts) if parts else ""
 
 
+def _markdown_table_cell(value: Any) -> str:
+    normalized = str(value)
+    normalized = normalized.replace("\r\n", "\n").replace("\r", "\n")
+    return normalized.replace("\n", "<br>").replace("|", r"\|")
+
+
 def render_markdown(coldstart: dict) -> str:
     """Render a coldstart reconciliation dict as a deterministic Markdown report.
 
@@ -130,12 +136,12 @@ def render_markdown(coldstart: dict) -> str:
         lines.append("| Title | Role | Decision | Status Label | Evidence |")
         lines.append("|-------|------|----------|--------------|----------|")
         for item in group_items:
-            title = item.get("title", "")
-            role = item.get("role", "") or ""
-            decision = item.get("decision", "") or ""
-            status_label = item.get("status_label", "") or ""
+            title = _markdown_table_cell(item.get("title", ""))
+            role = _markdown_table_cell(item.get("role", "") or "")
+            decision = _markdown_table_cell(item.get("decision", "") or "")
+            status_label = _markdown_table_cell(item.get("status_label", "") or "")
             evidence = item.get("evidence", {})
-            evidence_str = _evidence_cell(evidence)
+            evidence_str = _markdown_table_cell(_evidence_cell(evidence))
             lines.append(
                 f"| {title} | {role} | {decision} | {status_label} | {evidence_str} |"
             )

--- a/tools/task_orchestrator_reconcile/coldstart.py
+++ b/tools/task_orchestrator_reconcile/coldstart.py
@@ -1,11 +1,204 @@
 from __future__ import annotations
 
+import argparse
+import json
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Any
 
 from .resolve import coldstart_report
 
+# Fixed group order as specified in TP-TO-CANON-005
+_GROUP_ORDER = [
+    "active_root_in_progress",
+    "repo_pr_proof_observed",
+    "explicit_blocked",
+    "operator_gate",
+    "queue_only_supervisor_required",
+    "queue_only",
+]
+
+_GROUP_LABELS = {
+    "active_root_in_progress": "Active Root — In Progress",
+    "repo_pr_proof_observed": "Repo PR Proof Observed",
+    "explicit_blocked": "Explicit Blocked",
+    "operator_gate": "Operator Gate",
+    "queue_only_supervisor_required": "Queue Only — Supervisor Required",
+    "queue_only": "Queue Only",
+}
+
+
+def _evidence_cell(evidence: dict[str, Any]) -> str:
+    """Render evidence dict as a deterministic string. Fixed key order: pr, proof_exists, proof_json, role, status_label."""
+    parts = []
+    if "pr" in evidence:
+        parts.append(f"pr={evidence['pr']}")
+    if "proof_exists" in evidence:
+        parts.append(f"proof_exists={evidence['proof_exists']}")
+    if "proof_json" in evidence:
+        parts.append(f"proof_json={evidence['proof_json']}")
+    if "role" in evidence:
+        parts.append(f"role={evidence['role']}")
+    if "status_label" in evidence:
+        parts.append(f"status_label={evidence['status_label']}")
+    return "; ".join(parts) if parts else ""
+
+
+def render_markdown(coldstart: dict) -> str:
+    """Render a coldstart reconciliation dict as a deterministic Markdown report.
+
+    Takes the dict produced by the offline JSON (or build_coldstart_report).
+    Does NOT call any live DB function. Output is byte-stable across re-runs
+    provided the input dict is identical (no wall-clock timestamps, no randomness).
+    """
+    pit = coldstart["point_in_time"]
+    valid_as_of = pit["valid_as_of_utc"]
+    basis = pit["basis"]
+    counts = coldstart.get("classification_counts", {})
+    items = coldstart.get("items", [])
+    schema_version = coldstart.get("schema_version", "")
+    root_decision = coldstart.get("root_decision", "")
+    active_db_slug = coldstart.get("active_db_slug", "")
+
+    # Group items by classification
+    groups: dict[str, list[dict]] = {g: [] for g in _GROUP_ORDER}
+    for item in items:
+        cls = item.get("classification", "")
+        if cls in groups:
+            groups[cls].append(item)
+    # Sort each group by title for deterministic ordering
+    for cls in _GROUP_ORDER:
+        groups[cls].sort(key=lambda x: x.get("title", ""))
+
+    lines: list[str] = []
+
+    # Frontmatter — static, no wall-clock dates
+    lines.append("---")
+    lines.append("id: coldstart-reconciliation-20260622")
+    lines.append("title: Coldstart Reconciliation 20260622")
+    lines.append("type: reference")
+    lines.append("owner: '@hu3mann'")
+    lines.append("author: '@hu3mann'")
+    lines.append("date: '2026-06-22'")
+    lines.append("last_review: '2026-06-22'")
+    lines.append("next_review: '2026-09-20'")
+    lines.append(
+        "prelude: Coldstart reconciliation decision report for the DMX-COLDSTART"
+        " task-packet series as of 2026-06-22."
+    )
+    lines.append("---")
+    lines.append("")
+
+    # Title and intro
+    lines.append("# Coldstart Reconciliation — 2026-06-22")
+    lines.append("")
+    lines.append(
+        "Offline point-in-time classification of all DMX-COLDSTART work items. "
+        "This report is generated from the committed reconciliation JSON and is "
+        "presentation-only — no live database access, no status mutations."
+    )
+    lines.append("")
+
+    # Point-in-time banner — verbatim from input dict
+    lines.append("## Point-in-Time Provenance")
+    lines.append("")
+    lines.append(f"**valid_as_of_utc**: `{valid_as_of}`")
+    lines.append("")
+    lines.append(f"**basis**: {basis}")
+    lines.append("")
+    lines.append(f"**schema_version**: `{schema_version}`")
+    lines.append("")
+    lines.append(f"**active_db_slug**: `{active_db_slug}`")
+    lines.append("")
+    lines.append(f"**root_decision**: `{root_decision}`")
+    lines.append("")
+
+    # Per-group tables
+    lines.append("## Item Classifications")
+    lines.append("")
+    for cls in _GROUP_ORDER:
+        group_items = groups[cls]
+        label = _GROUP_LABELS.get(cls, cls)
+        lines.append(f"### {label}")
+        lines.append("")
+        if not group_items:
+            lines.append("_No items in this classification._")
+            lines.append("")
+            continue
+        # Table header
+        lines.append("| Title | Role | Decision | Status Label | Evidence |")
+        lines.append("|-------|------|----------|--------------|----------|")
+        for item in group_items:
+            title = item.get("title", "")
+            role = item.get("role", "") or ""
+            decision = item.get("decision", "") or ""
+            status_label = item.get("status_label", "") or ""
+            evidence = item.get("evidence", {})
+            evidence_str = _evidence_cell(evidence)
+            lines.append(
+                f"| {title} | {role} | {decision} | {status_label} | {evidence_str} |"
+            )
+        lines.append("")
+
+    # Counts summary — read from classification_counts, fixed group order
+    lines.append("## Classification Counts")
+    lines.append("")
+    lines.append("| Classification | Count |")
+    lines.append("|----------------|-------|")
+    for cls in _GROUP_ORDER:
+        count = counts.get(cls, 0)
+        lines.append(f"| {cls} | {count} |")
+    lines.append("")
+    total = sum(counts.values())
+    lines.append(f"**Total items**: {total}")
+    lines.append("")
+
+    return "\n".join(lines)
+
 
 def build_coldstart_report(conn: sqlite3.Connection, repo_root: Path) -> dict[str, Any]:
     return coldstart_report(conn, repo_root)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Render a coldstart reconciliation JSON as a deterministic Markdown report."
+        )
+    )
+    parser.add_argument(
+        "--from-json",
+        required=True,
+        type=Path,
+        metavar="PATH",
+        help="path to COLDSTART_RECONCILIATION.json (read-only)",
+    )
+    parser.add_argument(
+        "--emit-md",
+        required=True,
+        type=Path,
+        metavar="PATH",
+        help="output path for the generated Markdown report",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        coldstart = json.loads(args.from_json.read_text(encoding="utf-8"))
+    except OSError as exc:
+        parser.error(f"cannot read --from-json {args.from_json}: {exc}")
+    except json.JSONDecodeError as exc:
+        parser.error(f"invalid JSON in --from-json {args.from_json}: {exc}")
+    md = render_markdown(coldstart)
+    args.emit_md.parent.mkdir(parents=True, exist_ok=True)
+    args.emit_md.write_text(md, encoding="utf-8")
+    print(f"wrote {args.emit_md}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/task_orchestrator_reconcile/import_pack.py
+++ b/tools/task_orchestrator_reconcile/import_pack.py
@@ -11,6 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
+from .coldstart import render_markdown as render_coldstart_markdown
 from .dedupe import build_collision_report
 from .model import (
     ACTIVE_DOPEMUX_DB_SLUG,
@@ -371,6 +372,13 @@ def _write_json(path: Path | None, payload: dict) -> None:
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _write_md(path: Path | None, payload: dict) -> None:
+    if path is None:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_coldstart_markdown(payload), encoding="utf-8")
+
+
 def import_pack(args: argparse.Namespace) -> dict:
     input_dir = args.input.resolve()
     _require_pack(input_dir)
@@ -455,6 +463,7 @@ def import_pack(args: argparse.Namespace) -> dict:
             resolve_report = build_resolve_report(conn, REPO_ROOT)
             report["resolve"] = resolve_report
             _write_json(args.emit_coldstart, resolve_report["coldstart"])
+            _write_md(args.emit_coldstart_md, resolve_report["coldstart"])
             _write_json(args.emit_conflicts, build_collision_report(conn))
         if args.emit_manifest:
             manifest = build_canonical_datastore_manifest(
@@ -492,6 +501,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--resolve-current", action="store_true")
     parser.add_argument("--emit-report", type=Path)
     parser.add_argument("--emit-coldstart", type=Path)
+    parser.add_argument(
+        "--emit-coldstart-md",
+        type=Path,
+        help="(optional) emit a Markdown coldstart reconciliation report alongside --emit-coldstart",
+    )
     parser.add_argument("--emit-conflicts", type=Path)
     parser.add_argument(
         "--emit-manifest",


### PR DESCRIPTION
## Summary

Continues the **TO-CANON** series (TP-TO-CANON-000→004 + 004R already MERGED via #961). This PR lands the two **offline / docs-only** tail packets:

- **TP-TO-CANON-005** — deterministic, offline Markdown renderer over the committed `COLDSTART_RECONCILIATION.json` + the generated decision report. No raw pack, no live `current-tasks.db`.
- **TP-TO-CANON-007** — plan-only, operator-gated canonical-store **cutover plan** + red-team risk doc (verdict PASS_WITH_RISKS).
- Adds `docs/ops/load-plans/load_plan-TO-CANON.json` documenting the full 000→007 DAG.

`TP-TO-CANON-006` (read-only operator view behind a feature flag) ships separately as runtime code.

## Validation (PASS)
- `python -m jsonschema -i task-packets/TP-TO-CANON-00{5,7}.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` — both valid
- `pytest tests/tools/test_task_orchestrator_reconcile_coldstart.py tests/tools/test_task_orchestrator_reconcile_import.py` — **13 passed** (6 new renderer + 7 existing importer regression)
- Byte-stability: re-rendering the report from the committed JSON is byte-identical
- `scripts/docs_validator.py` on all new docs — exit 0
- `pre-commit run` on staged files — all applicable hooks pass
- `git diff --check` — clean

## Audit note
The 005 renderer was implemented by a Sonnet subagent and audited by Opus: an **unreachable-code defect** (dead `return 2` after `parser.exit`, which Pyright flagged) was fixed to use `parser.error()` (`NoReturn`) before commit; verification re-run from scratch.

## Out of scope (by design)
- No live `current-tasks.db` writes; no fix of the 100/101 status-label drift; no unblock of `INIT-UNIFY-102` (its packet was never landed on main).
- No write cutover — 007 is a plan only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)