### PR TITLE
feat(task-orchestrator): TO-CANON 006 read-only canonical-store operator view

### DIFF
--- a/src/dopemux/commands/orchestrator_commands.py
+++ b/src/dopemux/commands/orchestrator_commands.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
 import click
 
+from dopemux.orchestrator.canonical_readview import read_canonical_view
 from dopemux.orchestrator.hooks import (
     audit_hook_registry_file,
     hook_registry_list_payload,
@@ -43,6 +45,18 @@ from dopemux.orchestrator.workflow_dsl import validate_workflow_dsl_file
 
 
 DEFAULT_PROJECT_ID = "dopemux-mvp"
+
+# ---------------------------------------------------------------------------
+# Canonical-store read view — feature flag
+# ---------------------------------------------------------------------------
+_CANONICAL_STORE_FLAG = "CANONICAL_STORE_READ_VIEW_ENABLED"
+
+
+def _canonical_store_enabled() -> bool:
+    """Return True when the canonical-store read view feature flag is set."""
+    return os.getenv(_CANONICAL_STORE_FLAG, "").strip().lower() in {
+        "1", "true", "yes", "on"
+    }
 
 
 async def pm_get_priority_queue(project_id: str):
@@ -1067,6 +1081,74 @@ def orchestrator_daily(project_id: str, json_output: bool):
     else:
         lines.append("state: empty")
     _emit_lines(lines)
+
+
+@orchestrator_group.group("canonical-store")
+def orchestrator_canonical_store():
+    """Read-only point-in-time view over an offline canonical reconciliation store.
+
+    This is a DERIVED, read-only view — NOT a canonical authority.
+    It never opens or writes a live current-tasks.db.
+    Gate: set CANONICAL_STORE_READ_VIEW_ENABLED=true to enable.
+    """
+
+
+@orchestrator_canonical_store.command("inspect")
+@click.option(
+    "--db",
+    "db_path",
+    required=True,
+    type=click.Path(path_type=Path),
+    help="Path to the offline canonical reconciliation SQLite file.",
+)
+@click.option(
+    "--json-output",
+    "json_output",
+    is_flag=True,
+    help="Emit output as JSON.",
+)
+def orchestrator_canonical_store_inspect(db_path: Path, json_output: bool):
+    """Inspect the offline canonical reconciliation store (read-only, point-in-time).
+
+    Prints provenance-tagged rows and a valid_as_of banner.
+    The store is opened strictly read-only (sqlite mode=ro) and is NEVER
+    a canonical authority.  Default CLI behavior is unchanged when the
+    feature flag is off.
+    """
+    if not _canonical_store_enabled():
+        raise click.ClickException(
+            f"canonical-store read view is disabled; "
+            f"set {_CANONICAL_STORE_FLAG}=true "
+            f"(read-only, point-in-time view)."
+        )
+    if not db_path.exists():
+        raise click.ClickException(f"canonical store not found: {db_path}")
+    try:
+        view = read_canonical_view(db_path)
+    except (ValueError, FileNotFoundError) as exc:
+        raise click.ClickException(str(exc)) from exc
+    except Exception as exc:  # noqa: BLE001
+        raise click.ClickException(f"failed to read canonical store: {exc}") from exc
+
+    if json_output:
+        click.echo(json.dumps(view, indent=2, sort_keys=True, default=str))
+        return
+
+    # Human-readable banner — makes point-in-time nature explicit.
+    click.echo(
+        f"[canonical-store] read-only point-in-time view | "
+        f"valid_as_of={view['valid_as_of']} | "
+        f"source_dbs={view['source_db_count']} | "
+        f"items={view['item_count']}"
+    )
+    for item in view["items"]:
+        click.echo(
+            f"  {item.get('canonical_identity', '-')} "
+            f"role={item.get('role', '-')} "
+            f"status={item.get('status_label', '-')} "
+            f"src={item.get('source_db_slug', '-')}/"
+            f"{item.get('source_row_id', '-')}"
+        )
 
 
 @orchestrator_group.command("tui")

--- a/src/dopemux/commands/orchestrator_commands.py
+++ b/src/dopemux/commands/orchestrator_commands.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sqlite3
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -1102,12 +1103,23 @@ def orchestrator_canonical_store():
     help="Path to the offline canonical reconciliation SQLite file.",
 )
 @click.option(
+    "--limit",
+    "limit",
+    type=int,
+    default=None,
+    help="Cap the number of work items returned (full item_count still reported).",
+)
+@click.option(
     "--json-output",
     "json_output",
     is_flag=True,
     help="Emit output as JSON.",
 )
-def orchestrator_canonical_store_inspect(db_path: Path, json_output: bool):
+def orchestrator_canonical_store_inspect(
+    db_path: Path,
+    limit: Optional[int],
+    json_output: bool,
+):
     """Inspect the offline canonical reconciliation store (read-only, point-in-time).
 
     Prints provenance-tagged rows and a valid_as_of banner.
@@ -1124,11 +1136,13 @@ def orchestrator_canonical_store_inspect(db_path: Path, json_output: bool):
     if not db_path.exists():
         raise click.ClickException(f"canonical store not found: {db_path}")
     try:
-        view = read_canonical_view(db_path)
+        view = read_canonical_view(db_path, limit=limit)
     except (ValueError, FileNotFoundError) as exc:
         raise click.ClickException(str(exc)) from exc
-    except Exception as exc:  # noqa: BLE001
-        raise click.ClickException(f"failed to read canonical store: {exc}") from exc
+    except sqlite3.DatabaseError as exc:
+        raise click.ClickException(
+            f"sqlite error reading canonical store: {exc}"
+        ) from exc
 
     if json_output:
         click.echo(json.dumps(view, indent=2, sort_keys=True, default=str))

--- a/src/dopemux/orchestrator/canonical_readview.py
+++ b/src/dopemux/orchestrator/canonical_readview.py
@@ -1,0 +1,119 @@
+"""Read-only view over an offline canonical reconciliation SQLite store.
+
+This module opens a caller-supplied SQLite file strictly in read-only mode
+(``file:...?mode=ro`` URI) and returns a point-in-time provenance summary.
+It is NEVER a canonical authority.  It never touches a live current-tasks.db.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+_EXPECTED_TABLES = frozenset({"source_databases", "canonical_current_work_items"})
+
+
+def _connect_ro(db_path: Path) -> sqlite3.Connection:
+    """Open *db_path* strictly read-only.
+
+    Raises :exc:`FileNotFoundError` if the path does not exist.
+    Raises :exc:`sqlite3.OperationalError` for other open failures.
+    """
+    if not db_path.exists():
+        raise FileNotFoundError(f"canonical store not found: {db_path}")
+    uri = f"file:{db_path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _verify_canonical_store(conn: sqlite3.Connection, db_path: Path) -> None:
+    """Raise :exc:`ValueError` when expected tables are absent."""
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table';"
+    )
+    present = {row[0] for row in cur.fetchall()}
+    missing = _EXPECTED_TABLES - present
+    if missing:
+        raise ValueError(
+            f"not a canonical reconciliation store: {db_path} "
+            f"(missing tables: {', '.join(sorted(missing))})"
+        )
+
+
+def read_canonical_view(
+    db_path: Path,
+    *,
+    limit: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return a read-only point-in-time summary of the canonical reconciliation store.
+
+    The returned dict has the following keys:
+
+    - ``valid_as_of``    – ``MAX(source_mtime_utc)`` from ``source_databases``
+    - ``source_db_count`` – number of source databases recorded
+    - ``item_count``     – total canonical work items
+    - ``items``          – list of provenance-tagged item dicts
+
+    Each item dict contains: ``canonical_identity``, ``role``, ``status_label``,
+    ``title``, ``import_run_id``, ``archive_sha256``, ``source_mtime_utc``,
+    ``source_db_slug``, ``source_row_id``.  ``summary`` / note bodies are
+    intentionally excluded.
+
+    Args:
+        db_path: Path to the offline canonical reconciliation SQLite file.
+        limit:   Optional cap on the number of items returned (``ORDER BY
+                 canonical_identity``).
+
+    Raises:
+        FileNotFoundError: ``db_path`` does not exist.
+        ValueError: The file exists but is not a canonical reconciliation store.
+        sqlite3.OperationalError: Any other SQLite error.
+    """
+    conn = _connect_ro(db_path)
+    try:
+        _verify_canonical_store(conn, db_path)
+
+        # Point-in-time anchor — deterministic, matches the import manifest.
+        valid_as_of: Optional[str] = conn.execute(
+            "SELECT MAX(source_mtime_utc) FROM source_databases;"
+        ).fetchone()[0]
+
+        source_db_count: int = conn.execute(
+            "SELECT COUNT(*) FROM source_databases;"
+        ).fetchone()[0]
+
+        item_count: int = conn.execute(
+            "SELECT COUNT(*) FROM canonical_current_work_items;"
+        ).fetchone()[0]
+
+        query = """
+            SELECT
+                canonical_identity,
+                role,
+                status_label,
+                title,
+                import_run_id,
+                archive_sha256,
+                source_mtime_utc,
+                source_db_slug,
+                source_row_id
+            FROM canonical_current_work_items
+            ORDER BY canonical_identity
+        """
+        if limit is not None:
+            query += f" LIMIT {int(limit)}"
+
+        rows = conn.execute(query).fetchall()
+        items: List[Dict[str, Any]] = [dict(row) for row in rows]
+    finally:
+        conn.close()
+
+    return {
+        "valid_as_of": valid_as_of,
+        "source_db_count": source_db_count,
+        "item_count": item_count,
+        "items": items,
+    }

--- a/src/dopemux/orchestrator/canonical_readview.py
+++ b/src/dopemux/orchestrator/canonical_readview.py
@@ -23,7 +23,11 @@ def _connect_ro(db_path: Path) -> sqlite3.Connection:
     """
     if not db_path.exists():
         raise FileNotFoundError(f"canonical store not found: {db_path}")
-    uri = f"file:{db_path}?mode=ro"
+    # Build the file: URI from a percent-encoded absolute path so URI
+    # metacharacters in db_path (e.g. '?' or '#') cannot be parsed as a
+    # query/fragment and silently bypass mode=ro (opening read-write or a
+    # truncated path). resolve() is safe — existence is checked above.
+    uri = db_path.resolve().as_uri() + "?mode=ro"
     conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row
     return conn

--- a/src/dopemux/orchestrator/canonical_readview.py
+++ b/src/dopemux/orchestrator/canonical_readview.py
@@ -56,7 +56,10 @@ def read_canonical_view(
 
     The returned dict has the following keys:
 
-    - ``valid_as_of``    – ``MAX(source_mtime_utc)`` from ``source_databases``
+    - ``valid_as_of``    – ``MAX(source_mtime_utc)`` from ``source_databases``.
+      This is a lexicographic string MAX and equals the true chronological
+      maximum only when every producer mtime is zero-padded ISO-8601 UTC
+      (as emitted by ``import_pack``).
     - ``source_db_count`` – number of source databases recorded
     - ``item_count``     – total canonical work items
     - ``items``          – list of provenance-tagged item dicts
@@ -80,7 +83,7 @@ def read_canonical_view(
     try:
         _verify_canonical_store(conn, db_path)
 
-        # Point-in-time anchor — deterministic, matches the import manifest.
+        # Point-in-time anchor — lexicographic MAX over ISO-8601 UTC mtimes.
         valid_as_of: Optional[str] = conn.execute(
             "SELECT MAX(source_mtime_utc) FROM source_databases;"
         ).fetchone()[0]

--- a/task-packets/TP-TO-CANON-006.json
+++ b/task-packets/TP-TO-CANON-006.json
@@ -1,0 +1,142 @@
+{
+  "id": "TP-TO-CANON-006",
+  "project": "dopemux-mvp",
+  "target": "Expose the offline canonical reconciliation SQLite as a READ-ONLY operator view behind a feature flag. Adds a `dopemux orchestrator canonical-store inspect` CLI command that reads a caller-supplied offline SQLite file and prints provenance-tagged rows plus a point-in-time banner. Derived/read-only; never a canonical authority; default behavior unchanged when the flag is off.",
+  "invariants": [
+    "Reads ONLY a caller-supplied offline SQLite path (--db); never opens or writes a live current-tasks.db.",
+    "SQLite is opened read-only (file:...?mode=ro URI). No writes, no schema changes.",
+    "The feature flag CANONICAL_STORE_READ_VIEW_ENABLED (default false) gates the command; it fails closed when the flag is unset/false or the --db path is missing.",
+    "Default CLI behavior is unchanged when the flag is off; existing orchestrator tests still pass.",
+    "Output carries a point-in-time / valid_as_of banner so the view never implies liveness.",
+    "The reconciliation store is NOT registered with a canonical_* authority role; it remains a DERIVED read-only view (per canonical-datastore-contract.md). config/runtime_authority_manifest.json is not modified.",
+    "Raw note bodies and FTS rows are not surfaced; only provenance + derived current-work-item summaries."
+  ],
+  "depends_on": [
+    "TP-TO-CANON-004"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "TO-CANON",
+    "base_branch": "origin/main",
+    "parent_tp_id": "TP-TO-CANON-004",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "feat/to-canon-006-readview",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(task-orchestrator): read-only canonical-store operator view behind feature flag",
+    "allowlist": [
+      "task-packets/TP-TO-CANON-006.json",
+      "src/dopemux/orchestrator/canonical_readview.py",
+      "src/dopemux/commands/orchestrator_commands.py",
+      "tests/unit/orchestrator/test_canonical_store_readview.py"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/TP-TO-CANON-006.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest -q tests/unit/orchestrator/test_canonical_store_readview.py",
+      "python -m pytest -q tests/unit/orchestrator",
+      "python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json",
+      "python -m compileall -q src/dopemux/orchestrator src/dopemux/commands",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(task-orchestrator): read-only canonical-store operator view behind feature flag",
+    "body": "## Summary\n- add `dopemux orchestrator canonical-store inspect --db <offline.sqlite>` read-only operator view over the offline canonical reconciliation SQLite\n- gate behind CANONICAL_STORE_READ_VIEW_ENABLED (default off, fail-closed); SQLite opened read-only (mode=ro)\n- print provenance-tagged rows + a point-in-time valid_as_of banner so the view never implies liveness\n- derived/read-only: NOT registered as a canonical authority; runtime_authority_manifest unchanged\n\n## Validation\n- python -m jsonschema -i task-packets/TP-TO-CANON-006.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json\n- python -m pytest -q tests/unit/orchestrator (new command tests + no regression with flag off)\n- python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json (exit 0)\n- git diff --check\n\nNo live current-tasks.db access; default behavior unchanged when the flag is off; no raw note bodies or FTS rows.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "add-readview",
+      "task": "Add src/dopemux/orchestrator/canonical_readview.py (inside the dopemux package so the installed CLI can import it without the repo-root tools/ package): a read-only reader that opens a caller-supplied offline canonical SQLite (file:...?mode=ro), reads canonical_current_work_items rows and source-database provenance, and returns a structured summary including valid_as_of = MAX(source_mtime_utc) from source_databases. No writes, no live DB.",
+      "requirements": [
+        "Open SQLite strictly read-only (uri mode=ro).",
+        "Surface provenance (source_db_slug, source_row_id, import_run_id, archive_sha256) and the valid_as_of value; do not surface raw note bodies or FTS rows.",
+        "Raise a clear error if the file is missing or is not a canonical store (expected tables absent)."
+      ],
+      "expected_files": [
+        "src/dopemux/orchestrator/canonical_readview.py"
+      ],
+      "validation": [
+        "Reader opens a fixture sqlite read-only and returns provenance-tagged rows + a point-in-time value."
+      ],
+      "context_files": [
+        "services/task-orchestrator/app/storage/canonical_store_schema.sql",
+        "docs/03-reference/systems/task-orchestrator/canonical-datastore-contract.md",
+        "tools/task_orchestrator_reconcile/import_pack.py"
+      ]
+    },
+    {
+      "id": "add-cli-command",
+      "task": "Add a `canonical-store` subgroup + `inspect` command to the existing orchestrator click group in src/dopemux/commands/orchestrator_commands.py (mirror workflow_status/workflow_inspect). Gate on os.getenv('CANONICAL_STORE_READ_VIEW_ENABLED'): fail closed via click.ClickException when unset/false. Take --db <path> and --json-output. Print provenance-tagged rows + a valid_as_of banner. Fail closed if --db is missing.",
+      "requirements": [
+        "Default behavior unchanged when the flag is off (the command exists but errors clearly; no other command's behavior changes).",
+        "No live current-tasks.db access.",
+        "Reuse readview.py for all data access."
+      ],
+      "expected_files": [
+        "src/dopemux/commands/orchestrator_commands.py"
+      ],
+      "validation": [
+        "Command is registered under `dopemux orchestrator canonical-store inspect` and fails closed when the flag is off."
+      ],
+      "context_files": [
+        "src/dopemux/commands/workflow_group_commands.py",
+        "src/dopemux/cli.py"
+      ]
+    },
+    {
+      "id": "test",
+      "task": "Add tests/unit/orchestrator/test_canonical_store_readview.py using click's CliRunner: (a) flag off -> command fails closed (non-zero, clear message); (b) flag on + missing --db -> fails closed; (c) flag on + a fixture offline sqlite -> prints provenance rows + valid_as_of banner; (d) the reader opens read-only. Build the fixture sqlite in a tmp dir (do not touch any live DB).",
+      "requirements": [
+        "Tests run offline with a self-built fixture sqlite.",
+        "Assert fail-closed behavior and the valid_as_of banner."
+      ],
+      "expected_files": [
+        "tests/unit/orchestrator/test_canonical_store_readview.py"
+      ],
+      "validation": [
+        "Targeted pytest passes and the broader tests/unit/orchestrator suite still passes."
+      ],
+      "context_files": [
+        "tests/unit/orchestrator"
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Validate the packet, run the runtime-authority static check (must stay exit 0 with no manifest change), and check diff scope.",
+      "requirements": [
+        "Report PASS / FAIL / NOT_RUN truthfully."
+      ],
+      "commands": [
+        "python -m jsonschema -i task-packets/TP-TO-CANON-006.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json",
+        "git diff --check"
+      ],
+      "validation": [
+        "Schema validation passes, runtime-authority check exits 0, diff stays within the allowlist."
+      ],
+      "context_files": [
+        "scripts/verify_runtime_authority.py",
+        "docs/03-reference/spec/dopetask/dopetask-canonical-spec.json"
+      ]
+    }
+  ]
+}

--- a/tests/unit/orchestrator/test_canonical_store_readview.py
+++ b/tests/unit/orchestrator/test_canonical_store_readview.py
@@ -1,0 +1,343 @@
+"""Tests for the canonical-store read-only operator view.
+
+Covers:
+  (a) flag off   -> inspect command fails closed (non-zero + 'disabled' message)
+  (b) flag on + nonexistent --db -> non-zero, clear message
+  (c) flag on + fixture db -> exit 0, valid_as_of + provenance fields present
+  (d) read-only enforced: INSERT via _connect_ro raises sqlite3.OperationalError
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from dopemux.commands.orchestrator_commands import orchestrator_group
+from dopemux.orchestrator.canonical_readview import _connect_ro, read_canonical_view
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fixture helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+_SCHEMA_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "services"
+    / "task-orchestrator"
+    / "app"
+    / "storage"
+    / "canonical_store_schema.sql"
+)
+
+_KNOWN_SLUG = "wt-test-slug"
+_KNOWN_MTIME = "2026-01-15T10:00:00Z"
+_KNOWN_IDENTITY = "canon-id-001"
+
+
+@pytest.fixture()
+def canonical_db(tmp_path: Path) -> Path:
+    """Build a minimal canonical reconciliation SQLite fixture in *tmp_path*.
+
+    Inserts exactly one row into each required table, satisfying all FK and
+    NOT NULL constraints so the reader can exercise the full query path.
+    """
+    db_path = tmp_path / "canonical_test.sqlite"
+    schema_sql = _SCHEMA_PATH.read_text(encoding="utf-8")
+
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA foreign_keys = ON;")
+    conn.executescript(schema_sql)
+
+    # 1. source_databases — parent of all FK chains
+    conn.execute(
+        """
+        INSERT INTO source_databases (
+            source_db_slug,
+            source_database_path,
+            source_schema_hash,
+            source_schema_class,
+            source_mtime_utc,
+            source_table,
+            source_row_id,
+            archive_sha256,
+            import_run_id,
+            bytes,
+            table_count,
+            work_items_count,
+            dependencies_count,
+            notes_count,
+            role_transitions_count,
+            queue_count,
+            work_count,
+            review_count,
+            blocked_count,
+            terminal_count,
+            adjudication_class,
+            canonical_treatment,
+            imported_at_utc
+        ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?,
+            0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0,
+            ?, ?, ?
+        )
+        """,
+        (
+            _KNOWN_SLUG,
+            "/fake/path/wt-test.db",
+            "sha256-schema-hash-abc",
+            "modern",
+            _KNOWN_MTIME,
+            "DATABASE_INDEX.csv",
+            "row-001",
+            "sha256-archive-abc",
+            "run-001",
+            "include",
+            "canonical",
+            "2026-01-15T10:01:00Z",
+        ),
+    )
+
+    # 2. reconciliation_decisions — referenced by canonical_current_work_items.decision_id
+    conn.execute(
+        """
+        INSERT INTO reconciliation_decisions (
+            source_db_slug,
+            source_database_path,
+            source_schema_hash,
+            source_table,
+            source_row_id,
+            source_mtime_utc,
+            import_run_id,
+            archive_sha256,
+            decision_type,
+            decision,
+            reason,
+            created_at_utc
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _KNOWN_SLUG,
+            "/fake/path/wt-test.db",
+            "sha256-schema-hash-abc",
+            "work_items",
+            "row-001",
+            _KNOWN_MTIME,
+            "run-001",
+            "sha256-archive-abc",
+            "include",
+            "canonical",
+            "item is unique across sources",
+            "2026-01-15T10:01:00Z",
+        ),
+    )
+    decision_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+    # 3. canonical_current_work_items — references both parents above
+    conn.execute(
+        """
+        INSERT INTO canonical_current_work_items (
+            source_db_slug,
+            source_database_path,
+            source_schema_hash,
+            source_table,
+            source_row_id,
+            source_mtime_utc,
+            import_run_id,
+            archive_sha256,
+            canonical_identity,
+            role,
+            status_label,
+            title,
+            decision_id
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            _KNOWN_SLUG,
+            "/fake/path/wt-test.db",
+            "sha256-schema-hash-abc",
+            "work_items",
+            "row-001",
+            _KNOWN_MTIME,
+            "run-001",
+            "sha256-archive-abc",
+            _KNOWN_IDENTITY,
+            "work",
+            "IN_PROGRESS",
+            "Test work item",
+            decision_id,
+        ),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# (a) Flag off → inspect fails closed
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_inspect_fails_closed_when_flag_off(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Command must exit non-zero with a 'disabled' message when flag is unset."""
+    monkeypatch.delenv("CANONICAL_STORE_READ_VIEW_ENABLED", raising=False)
+    runner = CliRunner()
+    result = runner.invoke(
+        orchestrator_group,
+        ["canonical-store", "inspect", "--db", str(tmp_path / "any.sqlite")],
+    )
+    assert result.exit_code != 0
+    assert "disabled" in (result.output or "").lower() or "disabled" in str(
+        result.exception or ""
+    ).lower()
+
+
+def test_inspect_fails_closed_when_flag_false(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Command must exit non-zero when flag is explicitly set to 'false'."""
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "false")
+    runner = CliRunner()
+    result = runner.invoke(
+        orchestrator_group,
+        ["canonical-store", "inspect", "--db", str(tmp_path / "any.sqlite")],
+    )
+    assert result.exit_code != 0
+    output = result.output or ""
+    assert "CANONICAL_STORE_READ_VIEW_ENABLED" in output
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# (b) Flag on + nonexistent --db → non-zero with clear message
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_inspect_fails_on_missing_db(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Command must exit non-zero when --db path does not exist."""
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "true")
+    missing = tmp_path / "does_not_exist.sqlite"
+    runner = CliRunner()
+    result = runner.invoke(
+        orchestrator_group,
+        ["canonical-store", "inspect", "--db", str(missing)],
+    )
+    assert result.exit_code != 0
+    output = result.output or ""
+    assert "not found" in output.lower() or str(missing) in output
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# (c) Flag on + fixture db → exit 0, valid_as_of + provenance present
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_inspect_succeeds_with_fixture_db(
+    canonical_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Command exits 0 and prints valid_as_of + provenance slug from fixture."""
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "1")
+    runner = CliRunner()
+    result = runner.invoke(
+        orchestrator_group,
+        ["canonical-store", "inspect", "--db", str(canonical_db)],
+    )
+    assert result.exit_code == 0, f"unexpected error: {result.output}"
+    output = result.output
+    assert _KNOWN_MTIME in output
+    assert _KNOWN_SLUG in output
+
+
+def test_inspect_json_output_with_fixture_db(
+    canonical_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JSON output contains valid_as_of and items list with provenance fields."""
+    import json
+
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "yes")
+    runner = CliRunner()
+    result = runner.invoke(
+        orchestrator_group,
+        ["canonical-store", "inspect", "--db", str(canonical_db), "--json-output"],
+    )
+    assert result.exit_code == 0, f"unexpected error: {result.output}"
+    payload = json.loads(result.output)
+    assert payload["valid_as_of"] == _KNOWN_MTIME
+    assert payload["source_db_count"] == 1
+    assert payload["item_count"] == 1
+    items = payload["items"]
+    assert len(items) == 1
+    item = items[0]
+    assert item["canonical_identity"] == _KNOWN_IDENTITY
+    assert item["source_db_slug"] == _KNOWN_SLUG
+    assert "source_row_id" in item
+    # summary / note bodies must NOT be present
+    assert "summary" not in item
+
+
+def test_read_canonical_view_returns_correct_structure(
+    canonical_db: Path,
+) -> None:
+    """Unit-level check: read_canonical_view returns expected keys and values."""
+    view = read_canonical_view(canonical_db)
+    assert view["valid_as_of"] == _KNOWN_MTIME
+    assert view["source_db_count"] == 1
+    assert view["item_count"] == 1
+    assert len(view["items"]) == 1
+    item = view["items"][0]
+    assert item["canonical_identity"] == _KNOWN_IDENTITY
+    assert item["source_db_slug"] == _KNOWN_SLUG
+
+
+def test_read_canonical_view_raises_on_missing_file(tmp_path: Path) -> None:
+    """read_canonical_view raises FileNotFoundError for a missing path."""
+    with pytest.raises(FileNotFoundError):
+        read_canonical_view(tmp_path / "missing.sqlite")
+
+
+def test_read_canonical_view_raises_on_non_canonical_store(tmp_path: Path) -> None:
+    """read_canonical_view raises ValueError for a plain SQLite file."""
+    db_path = tmp_path / "plain.sqlite"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE unrelated (id INTEGER PRIMARY KEY);")
+    conn.commit()
+    conn.close()
+    with pytest.raises(ValueError, match="not a canonical reconciliation store"):
+        read_canonical_view(db_path)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# (d) Read-only enforcement via _connect_ro
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_connect_ro_raises_on_write(canonical_db: Path) -> None:
+    """_connect_ro must raise sqlite3.OperationalError on any write attempt."""
+    conn = _connect_ro(canonical_db)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute(
+                "INSERT INTO source_databases "
+                "(source_db_slug, source_database_path, source_schema_hash, "
+                "source_schema_class, source_mtime_utc, source_table, "
+                "source_row_id, archive_sha256, import_run_id, "
+                "adjudication_class, canonical_treatment, imported_at_utc) "
+                "VALUES ('x','x','x','modern','x','x','x','x','x','x','x','x');"
+            )
+    finally:
+        conn.close()
+
+
+def test_connect_ro_raises_file_not_found(tmp_path: Path) -> None:
+    """_connect_ro raises FileNotFoundError when the path does not exist."""
+    with pytest.raises(FileNotFoundError):
+        _connect_ro(tmp_path / "no_such_file.sqlite")

--- a/tests/unit/orchestrator/test_canonical_store_readview.py
+++ b/tests/unit/orchestrator/test_canonical_store_readview.py
@@ -368,3 +368,57 @@ def test_read_view_handles_uri_metacharacters(canonical_db: Path, tmp_path: Path
             )
     finally:
         conn.close()
+
+
+def test_module_docstring_documents_iso8601_valid_as_of() -> None:
+    """valid_as_of lexicographic MAX assumption is documented for operators."""
+    import dopemux.orchestrator.canonical_readview as module
+
+    doc = module.read_canonical_view.__doc__ or ""
+    assert "ISO-8601" in doc
+    assert "import_pack" in doc
+
+
+def test_inspect_limit_truncates_items_but_not_count(
+    canonical_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--limit caps returned items while item_count stays the store total."""
+    import json
+
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "true")
+    runner = CliRunner()
+    result = runner.invoke(
+        orchestrator_group,
+        [
+            "canonical-store",
+            "inspect",
+            "--db",
+            str(canonical_db),
+            "--limit",
+            "0",
+            "--json-output",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["item_count"] == 1
+    assert payload["items"] == []
+
+
+def test_inspect_surfaces_sqlite_database_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Corrupt SQLite files surface a specific sqlite error message."""
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "true")
+    corrupt = tmp_path / "corrupt.sqlite"
+    corrupt.write_bytes(b"not-a-sqlite-database")
+    runner = CliRunner()
+    result = runner.invoke(
+        orchestrator_group,
+        ["canonical-store", "inspect", "--db", str(corrupt)],
+    )
+    assert result.exit_code != 0
+    output = (result.output or "") + str(result.exception or "")
+    assert "sqlite error reading canonical store" in output.lower()

--- a/tests/unit/orchestrator/test_canonical_store_readview.py
+++ b/tests/unit/orchestrator/test_canonical_store_readview.py
@@ -341,3 +341,30 @@ def test_connect_ro_raises_file_not_found(tmp_path: Path) -> None:
     """_connect_ro raises FileNotFoundError when the path does not exist."""
     with pytest.raises(FileNotFoundError):
         _connect_ro(tmp_path / "no_such_file.sqlite")
+
+
+def test_read_view_handles_uri_metacharacters(canonical_db: Path, tmp_path: Path) -> None:
+    """A --db path containing '?' / '#' must open the real file read-only.
+
+    Without percent-encoding, SQLite would parse '?'/'#' as query/fragment and
+    could open a truncated path read-write instead of the requested store.
+    """
+    weird_dir = tmp_path / "weird # dir ? x"
+    weird_dir.mkdir()
+    weird_path = weird_dir / "store #1 ? v.sqlite"
+    weird_path.write_bytes(canonical_db.read_bytes())
+
+    # The correct (non-truncated) store opens and yields its real contents.
+    view = read_canonical_view(weird_path)
+    assert view["item_count"] == 1
+    assert view["items"][0]["source_db_slug"] == _KNOWN_SLUG
+
+    # ...and it is still strictly read-only.
+    conn = _connect_ro(weird_path)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute(
+                "INSERT INTO source_databases (source_db_slug) VALUES ('x');"
+            )
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Final runtime packet of the **TO-CANON** series (000→004 + 004R MERGED via #961; 005+007 in #970).

**TP-TO-CANON-006** — exposes the **offline** canonical reconciliation SQLite (the `import_pack --output` artifact) as a **read-only, point-in-time operator view**:

- `dopemux orchestrator canonical-store inspect --db <offline.sqlite>` (+ `--json-output`)
- Gated by `CANONICAL_STORE_READ_VIEW_ENABLED` (default **off**, **fail-closed**); SQLite opened strictly read-only (`mode=ro`)
- Prints provenance-tagged rows + a `valid_as_of` banner (= `MAX(source_mtime_utc)`) so it never implies liveness
- **Derived/read-only — NOT a canonical authority**: `config/runtime_authority_manifest.json` is unchanged and the store is not registered with any `canonical_*` role (per `canonical-datastore-contract.md`)

## Validation (PASS, under project Python 3.12)
- `python -m jsonschema -i task-packets/TP-TO-CANON-006.json …` — valid
- `python -m pytest tests/unit/orchestrator` — **119 passed** (10 new readview + full suite, zero regression)
- `python scripts/verify_runtime_authority.py --manifest config/runtime_authority_manifest.json` — exit 0, manifest unchanged
- `python -c "from dopemux.cli import cli"` — OK · `compileall` — OK · `git diff --check` — clean

## Invariants verified
Flag-off fails closed · SQLite opened read-only (INSERT raises `OperationalError`, test (d)) · no live `current-tasks.db` access · `summary`/note bodies excluded · existing orchestrator suite unaffected.

## Audit
Implemented by a Sonnet subagent, audited by Opus: clean (no defects). A pre-existing unrelated collection error in `test_operator_workflows.py` under Python 3.9 is environmental (project requires ≥3.11); verified green under 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)