### PR TITLE
chore(pcp): arc loose-ends — Leantime DCP mapping + pluggable bridge dedup store

### DIFF
--- a/docs/03-reference/architecture/air-dmx-pcp-dcp-routing-architecture-0001.md
+++ b/docs/03-reference/architecture/air-dmx-pcp-dcp-routing-architecture-0001.md
@@ -257,6 +257,7 @@ extension_manifest:
 | dopecon-bridge                  | Adapter/proxy/event transport mapping.                              | Any canonical authority.                                     | Upstream authority refs; transport proof.                         | ADAPTER_ONLY             | DCP extension mapping          |
 | ADHD Engine                     | Operator-support/cognitive-state hints.                             | PM/memory/retrieval/DCP authority.                           | Read-only signal proof.                                           | EXTENSION_READ           | DCP extension mapping          |
 | GitHub / CI readiness           | Evidence and checks intake.                                         | Semantic proof, merge authority replacement.                 | Current checks, head SHA, PR state, reviewer classification.      | PARTIAL                  | PR Steward proof-readiness     |
+| Leantime                        | PM metadata + sprint/project snapshot mapping.                      | Workflow legality/transitions, decision context, chronicle, technical context. | PM read receipts (canonical_backend=leantime).                    | PARTIAL                  | DCP extension mapping          |
 
 **OBSERVED_BY_FILE:** Dopemux is a mixed workspace, not a single-service monolith, and authority is split by function across dopemux, dopetask, Leantime, task-orchestrator, ConPort, dope-memory, dope-context, dopecon-bridge, ADHD Engine, and Repo-Truth-Extractor.
 

--- a/docs/03-reference/dcp/dcp-extension-mapping.md
+++ b/docs/03-reference/dcp/dcp-extension-mapping.md
@@ -73,6 +73,7 @@ proxy, never the authority.
 | `execution.external_runner` | map | dopetask | ADAPTER | dcp dopetask execution-mapping adapter |
 | `operator.control` | project | dopemux-cli | PROJECTION | dcp dopemux operator-control projection |
 | `pr.readiness` | read | pr-steward | ADAPTER | dcp pr-steward readiness intake |
+| `pm.metadata` | read | leantime | ADAPTER | dcp leantime PM-metadata read adapter |
 
 All entries share these fail-closed properties:
 
@@ -123,17 +124,18 @@ The following PCP Core schemas are explicitly listed as forbidden overrides:
 
 ## Deferred / Not Mapped in Packet 5
 
-The Packet 5 target maps exactly the ten Dopemux systems in the table above. Two systems named
-elsewhere in the architecture are intentionally **not** mapped here:
+The Packet 5 target maps exactly the ten Dopemux systems in the original table. One additional
+system was mapped as a post-P5 loose-end amendment:
+
+- **Leantime** — added as a `pm.metadata` read ADAPTER (closing the AIR §7 gap; `canonical_authority_owner: leantime`, `surface_class: ADAPTER`, `live_write_allowed: false`). The AIR §7 component table now includes a Leantime row. This brings the total mapped systems to **11**.
+
+One system named elsewhere in the architecture is still intentionally **not** mapped here:
 
 - **GitHub / CI readiness** — named in AIR §7 but assigned there to the *PR Steward
   proof-readiness* packet, not this one. It will be added as an additional read/projection
   (`ci.evidence`) entry by that packet.
-- **Leantime** — named in the AIR system inventory (§4 and §261) but has **no row in the AIR §7
-  component table** and is not in this packet's target. It is therefore not mapped in Packet 5;
-  mapping it requires a §7 extension-role definition first (deferred, tracked as an AIR follow-up).
 
-Adding either later is additive — new authority-map entries, no core schema change.
+Adding entries later remains additive — new authority-map entries, no core schema change.
 
 ---
 

--- a/schemas/dcp_extension/authority_map.dcp.json
+++ b/schemas/dcp_extension/authority_map.dcp.json
@@ -161,6 +161,23 @@
       "approval_required": false,
       "rollback_required": false,
       "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "pm.metadata",
+      "action": "read",
+      "canonical_authority_owner": "leantime",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dcp leantime PM-metadata read adapter (JSON-RPC + leantime-bridge)",
+      "source_truth_refs": [
+        "Leantime JSON-RPC API (projects, tickets, sprints, milestones)",
+        "leantime-bridge MCP gateway"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
     }
   ]
 }

--- a/schemas/dcp_extension/extension_manifest.dcp.json
+++ b/schemas/dcp_extension/extension_manifest.dcp.json
@@ -42,7 +42,8 @@
       "repo-truth-extractor",
       "dopetask",
       "dopemux-cli",
-      "pr-steward"
+      "pr-steward",
+      "leantime"
     ]
   },
   "schemas": {

--- a/src/dopemux/pcp/bridge/__init__.py
+++ b/src/dopemux/pcp/bridge/__init__.py
@@ -9,6 +9,9 @@ an explicitly registered canonical_writer (resolved by the gate's
 """
 
 from dopemux.pcp.bridge.fastapi_bridge import (
+    DedupStore,
+    InProcessDedupStore,
+    RedisDedupStore,
     check_live_write_gate,
     create_bridge_app,
     create_bridge_router,
@@ -16,6 +19,9 @@ from dopemux.pcp.bridge.fastapi_bridge import (
 )
 
 __all__ = [
+    "DedupStore",
+    "InProcessDedupStore",
+    "RedisDedupStore",
     "check_live_write_gate",
     "route_mutation",
     "create_bridge_router",

--- a/src/dopemux/pcp/bridge/fastapi_bridge.py
+++ b/src/dopemux/pcp/bridge/fastapi_bridge.py
@@ -26,7 +26,7 @@ import hashlib
 import json
 import pathlib
 from datetime import datetime, timezone
-from typing import Any, Callable
+from typing import Any, Callable, Protocol
 
 from fastapi import APIRouter, FastAPI
 from fastapi import status as http_status
@@ -57,6 +57,69 @@ _MODE_LIVE = "LIVE"
 _RESULT_SCHEMA_VERSION = "pcp.bridge_result.v0"
 
 Writer = Callable[[dict], Any]
+
+
+# ---------------------------------------------------------------------------
+# Idempotency dedup store — pluggable contract.
+# ---------------------------------------------------------------------------
+
+class DedupStore(Protocol):
+    """Contract for an idempotency dedup store.
+
+    ``check_and_record(key)`` must be atomic:
+      - Returns ``False`` when ``key`` is first-seen (and records it).
+      - Returns ``True`` when ``key`` was already recorded (duplicate).
+    """
+
+    def check_and_record(self, key: str) -> bool: ...
+
+
+class InProcessDedupStore:
+    """In-process dedup store backed by a Python ``set``.
+
+    Atomic within a single synchronous call. Suitable for single-process /
+    single-worker deployments and for testing.
+    """
+
+    def __init__(self) -> None:
+        self._seen: set[str] = set()
+
+    def check_and_record(self, key: str) -> bool:
+        if key in self._seen:
+            return True  # duplicate
+        self._seen.add(key)
+        return False  # first-seen
+
+
+class RedisDedupStore:
+    """Redis-backed dedup store using SET NX semantics.
+
+    The Redis client is injected (duck-typed) — no top-level ``redis`` import
+    so this module remains importable without redis installed.
+
+    ``client.set(name, value, nx=True, ex=ttl_seconds)`` semantics:
+      - Returns ``True`` when the key was newly set (first-seen) → return ``False``.
+      - Returns ``None`` when the key already existed (duplicate) → return ``True``.
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        ttl_seconds: int = 86400,
+        key_prefix: str = "pcp:live_write_ready:",
+    ) -> None:
+        self._client = client
+        self._ttl = ttl_seconds
+        self._prefix = key_prefix
+
+    def check_and_record(self, key: str) -> bool:
+        result = self._client.set(
+            self._prefix + key, "1", nx=True, ex=self._ttl
+        )
+        # True → newly set (first-seen) → not a duplicate.
+        # None → key already existed → duplicate.
+        return result is not True
 
 
 # ---------------------------------------------------------------------------
@@ -166,7 +229,7 @@ def route_mutation(
     live_write_ready: dict | None = None,
     execute: bool = False,
     writer_registry: dict[str, Writer] | None = None,
-    executed_keys: set | None = None,
+    dedup_store: "DedupStore | None" = None,
     now: datetime | None = None,
 ) -> dict:
     """Route a single mutation through the fail-closed live-write gate.
@@ -176,11 +239,11 @@ def route_mutation(
     unexpired READY gate; operation_ref + target_surface + payload_digest binding
     to THIS operation; ``execute is True``; the gate's ``canonical_writer`` name
     resolves in ``writer_registry``; and the assertion_id is first-seen in
-    ``executed_keys``. Every other branch returns without invoking any writer.
+    ``dedup_store``. Every other branch returns without invoking any writer.
 
-    ``executed_keys`` is the idempotency store (a set). Pass a shared set to
-    deduplicate across calls (the FastAPI router does this per-router). When it
-    is None, a throwaway set is used (no cross-call dedup).
+    ``dedup_store`` is a pluggable idempotency store (any object implementing
+    ``check_and_record(key) -> bool``). When None, a throwaway
+    ``InProcessDedupStore`` is used (no cross-call dedup).
     """
     # 1. Operation shape (fail-closed).
     if not isinstance(operation, dict):
@@ -243,14 +306,20 @@ def route_mutation(
         )
 
     # 7. Idempotency dedup on assertion_id (record BEFORE the call).
-    store = executed_keys if executed_keys is not None else set()
     key = gate.get("assertion_id")
-    if key in store:
+    if not isinstance(key, str) or not key:
+        # Unreachable for a schema-valid gate (assertion_id is required, minLength 1);
+        # guarded defensively so a non-str key can never reach a dedup store.
+        return _result(
+            mode=_MODE_REJECTED, permitted=True, executed=False,
+            reasons=["GATE_INCONSISTENT"], operation_ref=op_ref, target_surface=op_surface,
+        )
+    store = dedup_store if dedup_store is not None else InProcessDedupStore()
+    if store.check_and_record(key):
         return _result(
             mode=_MODE_REJECTED, permitted=True, executed=False,
             reasons=["DUPLICATE_SUPPRESSED"], operation_ref=op_ref, target_surface=op_surface,
         )
-    store.add(key)
 
     # 8. Delegate to the canonical writer — the ONLY write path.
     try:
@@ -288,7 +357,9 @@ class MutateRequest(BaseModel):
 
 
 def create_bridge_router(
-    *, writer_registry: dict[str, Writer] | None = None
+    *,
+    writer_registry: dict[str, Writer] | None = None,
+    dedup_store: "DedupStore | None" = None,
 ) -> APIRouter:
     """Build the bridge ``APIRouter``.
 
@@ -297,9 +368,13 @@ def create_bridge_router(
     Registering a real writer is an explicit, deliberate caller action. The
     router keeps a private idempotency store so replayed assertion_ids are
     suppressed across requests.
+
+    ``dedup_store`` defaults to None, in which case a private
+    ``InProcessDedupStore`` is created for this router instance. Pass an
+    external store (e.g. ``RedisDedupStore``) for cross-worker dedup.
     """
     router = APIRouter(tags=["PCP Bridge"])
-    _executed_keys: set = set()
+    _dedup_store: DedupStore = dedup_store if dedup_store is not None else InProcessDedupStore()
 
     @router.post("/bridge/mutate")
     async def mutate(req: MutateRequest) -> JSONResponse:
@@ -308,7 +383,7 @@ def create_bridge_router(
             live_write_ready=req.live_write_ready,
             execute=req.execute,
             writer_registry=writer_registry,
-            executed_keys=_executed_keys,
+            dedup_store=_dedup_store,
         )
         code = (
             http_status.HTTP_403_FORBIDDEN
@@ -321,12 +396,17 @@ def create_bridge_router(
 
 
 def create_bridge_app(
-    *, writer_registry: dict[str, Writer] | None = None
+    *,
+    writer_registry: dict[str, Writer] | None = None,
+    dedup_store: "DedupStore | None" = None,
 ) -> FastAPI:
     """Build a standalone FastAPI app mounting the bridge router.
 
     Defaults to no writer registry — dry-run / reject only.
+    ``dedup_store`` is forwarded to the bridge router.
     """
     app = FastAPI(title="PCP Live-Write Bridge", version="0.1.0")
-    app.include_router(create_bridge_router(writer_registry=writer_registry))
+    app.include_router(
+        create_bridge_router(writer_registry=writer_registry, dedup_store=dedup_store)
+    )
     return app

--- a/tests/dcp_extension/test_dcp_extension_mapping.py
+++ b/tests/dcp_extension/test_dcp_extension_mapping.py
@@ -212,8 +212,9 @@ class TestNegativeTamper:
 # 6. Packet-5 scope lock — exactly the ten target systems, manifest in sync
 # ---------------------------------------------------------------------------
 class TestPacketScope:
-    """Packet 5 maps exactly its ten target systems — not github-ci (deferred to the PR Steward
-    proof-readiness packet) and not Leantime (no AIR §7 row). Guards against scope drift."""
+    """Packet 5 maps its ten original target systems plus Leantime (added as a post-P5 loose-end
+    amendment, closing the AIR §7 gap). GitHub/CI readiness is still deferred to the PR Steward
+    proof-readiness packet. Guards against scope drift."""
 
     EXPECTED_SYSTEMS = {
         "task-orchestrator",
@@ -226,6 +227,7 @@ class TestPacketScope:
         "dopetask",
         "dopemux-cli",
         "pr-steward",
+        "leantime",
     }
 
     def test_mapped_systems_match_packet_target(self):
@@ -242,3 +244,40 @@ class TestPacketScope:
             f"manifest adapter_mappings out of sync with authority-map owners. "
             f"Only in manifest: {adapter_mappings - owners}; only in map: {owners - adapter_mappings}"
         )
+
+
+# ---------------------------------------------------------------------------
+# 7. Leantime entry focused test — post-P5 loose-end amendment
+# ---------------------------------------------------------------------------
+class TestLeantimeEntry:
+    """Focused assertions for the Leantime pm.metadata read ADAPTER entry (AIR §7 gap closure)."""
+
+    @staticmethod
+    def _leantime_entry() -> dict:
+        entries = [
+            e for e in AUTHORITY_INST["entries"]
+            if e["canonical_authority_owner"] == "leantime"
+        ]
+        assert len(entries) == 1, (
+            f"Expected exactly one leantime entry in authority map; found {len(entries)}"
+        )
+        return entries[0]
+
+    def test_leantime_entry_exists(self):
+        entry = self._leantime_entry()
+        assert entry["domain"] == "pm.metadata"
+        assert entry["action"] == "read"
+
+    def test_leantime_surface_class_is_adapter(self):
+        entry = self._leantime_entry()
+        assert entry["surface_class"] == "ADAPTER", (
+            f"Expected ADAPTER, got {entry['surface_class']}"
+        )
+
+    def test_leantime_live_write_not_allowed(self):
+        entry = self._leantime_entry()
+        assert entry["live_write_allowed"] is False
+
+    def test_leantime_canonical_writer_is_null(self):
+        entry = self._leantime_entry()
+        assert entry["canonical_writer"] is None

--- a/tests/project_control_plane/test_fastapi_bridge.py
+++ b/tests/project_control_plane/test_fastapi_bridge.py
@@ -30,6 +30,8 @@ from fastapi.testclient import TestClient
 
 from dopemux.pcp.bridge import fastapi_bridge as bridge
 from dopemux.pcp.bridge.fastapi_bridge import (
+    InProcessDedupStore,
+    RedisDedupStore,
     check_live_write_gate,
     create_bridge_router,
     route_mutation,
@@ -222,7 +224,7 @@ class TestRoute:
         op = _operation()
         gate = _ready_gate_for(op)
         r = route_mutation(op, live_write_ready=gate, execute=True,
-                           writer_registry=self._writer_reg(spy), executed_keys=set(), now=_NOW)
+                           writer_registry=self._writer_reg(spy), dedup_store=InProcessDedupStore(), now=_NOW)
         assert r["mode"] == "LIVE" and r["executed"] is True
         assert r["writer_result"] == {"merged": True}
         assert len(spy.calls) == 1 and spy.calls[0] == op
@@ -241,7 +243,7 @@ class TestRoute:
         op = _operation()
         gate = _ready_gate_for(op)
         r = route_mutation(op, live_write_ready=gate, execute=True,
-                           writer_registry=self._writer_reg(spy), executed_keys=set(), now=_NOW)
+                           writer_registry=self._writer_reg(spy), dedup_store=InProcessDedupStore(), now=_NOW)
         assert r["mode"] == "REJECTED" and r["executed"] is False
         assert any(reason.startswith("WRITER_RAISED") for reason in r["reasons"])
 
@@ -298,7 +300,7 @@ class TestBinding:
         op = _operation(pr_id=42, head_sha="abc123")
         gate = _ready_gate_for(op)
         r = route_mutation(op, live_write_ready=gate, execute=True,
-                           writer_registry={"dopemux.test_writer": spy}, executed_keys=set(), now=_NOW)
+                           writer_registry={"dopemux.test_writer": spy}, dedup_store=InProcessDedupStore(), now=_NOW)
         assert r["mode"] == "LIVE" and len(spy.calls) == 1
 
 
@@ -313,7 +315,7 @@ class TestRegistry:
         gate = _ready_gate_for(op, canonical_writer="dopemux.real_writer")
         # registry only has a DIFFERENT name
         r = route_mutation(op, live_write_ready=gate, execute=True,
-                           writer_registry={"dopemux.other_writer": spy}, executed_keys=set(), now=_NOW)
+                           writer_registry={"dopemux.other_writer": spy}, dedup_store=InProcessDedupStore(), now=_NOW)
         assert r["mode"] == "REJECTED" and "CANONICAL_WRITER_NOT_REGISTERED" in r["reasons"]
         assert spy.calls == []
 
@@ -322,7 +324,7 @@ class TestRegistry:
         op = _operation()
         gate = _ready_gate_for(op, canonical_writer="dopemux.real_writer")
         r = route_mutation(op, live_write_ready=gate, execute=True,
-                           writer_registry={"dopemux.real_writer": spy}, executed_keys=set(), now=_NOW)
+                           writer_registry={"dopemux.real_writer": spy}, dedup_store=InProcessDedupStore(), now=_NOW)
         assert r["mode"] == "LIVE" and len(spy.calls) == 1
 
 
@@ -335,15 +337,91 @@ class TestDedup:
         spy = _SpyWriter()
         op = _operation()
         gate = _ready_gate_for(op, assertion_id="assert-dedup-1")
-        store: set = set()
+        store = InProcessDedupStore()
         reg = {"dopemux.test_writer": spy}
         first = route_mutation(op, live_write_ready=gate, execute=True,
-                               writer_registry=reg, executed_keys=store, now=_NOW)
+                               writer_registry=reg, dedup_store=store, now=_NOW)
         second = route_mutation(op, live_write_ready=gate, execute=True,
-                                writer_registry=reg, executed_keys=store, now=_NOW)
+                                writer_registry=reg, dedup_store=store, now=_NOW)
         assert first["mode"] == "LIVE"
         assert second["mode"] == "REJECTED" and "DUPLICATE_SUPPRESSED" in second["reasons"]
         assert len(spy.calls) == 1  # writer called exactly once total
+
+    def test_in_process_dedup_store_first_call_returns_false(self):
+        store = InProcessDedupStore()
+        assert store.check_and_record("key-1") is False  # first-seen
+
+    def test_in_process_dedup_store_second_call_returns_true(self):
+        store = InProcessDedupStore()
+        store.check_and_record("key-1")
+        assert store.check_and_record("key-1") is True  # duplicate
+
+    def test_in_process_dedup_store_different_keys_independent(self):
+        store = InProcessDedupStore()
+        assert store.check_and_record("key-A") is False
+        assert store.check_and_record("key-B") is False  # different key, first-seen
+        assert store.check_and_record("key-A") is True   # key-A is now duplicate
+
+
+class _FakeRedisClient:
+    """Minimal fake redis client implementing SET NX semantics for testing."""
+
+    def __init__(self) -> None:
+        self._store: dict = {}
+        self.set_calls: list = []
+
+    def set(self, name: str, value: str, *, nx: bool = False, ex: int | None = None):
+        self.set_calls.append({"name": name, "value": value, "nx": nx, "ex": ex})
+        if nx:
+            if name in self._store:
+                return None  # key already exists — duplicate
+            self._store[name] = value
+            return True  # newly set — first-seen
+        self._store[name] = value
+        return True
+
+
+class TestRedisDedupStore:
+    def test_first_key_returns_false(self):
+        client = _FakeRedisClient()
+        store = RedisDedupStore(client)
+        assert store.check_and_record("key-1") is False  # first-seen
+
+    def test_second_key_returns_true(self):
+        client = _FakeRedisClient()
+        store = RedisDedupStore(client)
+        store.check_and_record("key-1")
+        assert store.check_and_record("key-1") is True  # duplicate
+
+    def test_set_called_with_nx_true_and_ex(self):
+        client = _FakeRedisClient()
+        store = RedisDedupStore(client, ttl_seconds=3600)
+        store.check_and_record("key-x")
+        assert len(client.set_calls) == 1
+        call = client.set_calls[0]
+        assert call["nx"] is True
+        assert call["ex"] == 3600
+
+    def test_key_prefix_applied(self):
+        client = _FakeRedisClient()
+        store = RedisDedupStore(client, key_prefix="test:prefix:")
+        store.check_and_record("my-key")
+        assert client.set_calls[0]["name"] == "test:prefix:my-key"
+
+    def test_route_mutation_with_redis_store_deduplicates(self):
+        spy = _SpyWriter()
+        op = _operation()
+        gate = _ready_gate_for(op, assertion_id="assert-redis-dedup")
+        client = _FakeRedisClient()
+        redis_store = RedisDedupStore(client)
+        reg = {"dopemux.test_writer": spy}
+        first = route_mutation(op, live_write_ready=gate, execute=True,
+                               writer_registry=reg, dedup_store=redis_store, now=_NOW)
+        second = route_mutation(op, live_write_ready=gate, execute=True,
+                                writer_registry=reg, dedup_store=redis_store, now=_NOW)
+        assert first["mode"] == "LIVE" and first["executed"] is True
+        assert second["mode"] == "REJECTED" and "DUPLICATE_SUPPRESSED" in second["reasons"]
+        assert len(spy.calls) == 1  # writer called exactly once
 
 
 # ===========================================================================
@@ -475,7 +553,7 @@ class TestStructural:
         results = [
             route_mutation(op, live_write_ready=None, execute=True, writer_registry=reg, now=_NOW),  # REJECTED
             route_mutation(op, live_write_ready=gate, execute=False, writer_registry=reg, now=_NOW),  # DRY_RUN
-            route_mutation(op, live_write_ready=gate, execute=True, writer_registry=reg, executed_keys=set(), now=_NOW),  # LIVE
+            route_mutation(op, live_write_ready=gate, execute=True, writer_registry=reg, dedup_store=InProcessDedupStore(), now=_NOW),  # LIVE
         ]
         assert {r["mode"] for r in results} == {"REJECTED", "DRY_RUN", "LIVE"}
         for r in results:
@@ -488,7 +566,7 @@ class TestStructural:
         reg = {"dopemux.test_writer": spy}
         rejected = route_mutation(op, live_write_ready=None, execute=True, writer_registry=reg, now=_NOW)
         dry = route_mutation(op, live_write_ready=gate, execute=False, writer_registry=reg, now=_NOW)
-        live = route_mutation(op, live_write_ready=gate, execute=True, writer_registry=reg, executed_keys=set(), now=_NOW)
+        live = route_mutation(op, live_write_ready=gate, execute=True, writer_registry=reg, dedup_store=InProcessDedupStore(), now=_NOW)
         for r in (rejected, dry, live):
             assert r["executed"] is (r["mode"] == "LIVE")
 


### PR DESCRIPTION
## PCP arc loose-ends

Two follow-ups after the completed PCP/DCP/Routing series (operator chose "finish loose ends, then activate"), resolving documented residuals.

### 1. Leantime mapped as a DCP read-only adapter (closes the AIR §7 gap)
Leantime is the Dopemux **PM-metadata + sprint-snapshot authority** (`src/dopemux/pm/*` via JSON-RPC + `leantime-bridge`) but was missing from the DCP authority map — the code used an authority the contract never recorded. Added:
- `pm.metadata / read / leantime / ADAPTER` entry (`live_write_allowed=false`, `canonical_writer=null`).
- AIR §7 component row (must-not-own: workflow legality/transitions, decision context, chronicle, technical context).
- doc + extension-manifest `adapter_mappings` + scope-lock test (now **11** systems).

### 2. Bridge dedup is now a pluggable store (P11 hardening from the cross-check)
- `DedupStore` Protocol (`check_and_record`) + `InProcessDedupStore` (default, per-router — current behavior) + `RedisDedupStore` (atomic `SET NX` + TTL, duck-typed client, for cross-process/multi-replica).
- `route_mutation`/`create_bridge_router`/`create_bridge_app` take an injectable `dedup_store`; **default stays in-process**, so a deployed app behaves exactly as before until an operator injects Redis.
- Record-before-write preserved (a failed write keeps the key → fail-closed); added a type-safe `assertion_id` guard.

**Cryptographic assertion signing remains deferred to activation** — the multi-model cross-check + the investigation confirmed there's no trusted issuer defined yet (and the repo has no signing utilities), so building it now would invent a trust model around a ghost. It belongs in Phase 1 (activation), which names the issuer.

### Validation
| Check | Result |
|---|---|
| pytest dcp + dnh + pcp | **PASS — 489** |
| jsonschema (authority_map + extension_manifest vs P2 contracts) | **PASS** |
| pre-commit (SKIP=docs-graph-validator) | **PASS** |
| independent exploit verification | fail-closed intact (0 writer calls on no-gate/expired/digest-mismatch/execute=1/unregistered); both stores dedup atomically (LIVE→REJECTED, writer once); Leantime entry read-only, schema-valid |

Branch `claude/pcp-looseends`. These amend already-merged P5 (DCP map) + P11 (bridge) per the operator's authorization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)