### PR TITLE
feat(pcp): extension contract + authority map co-keystones

### DIFF
--- a/docs/03-reference/architecture/pcp-extension-contract-and-authority-map.md
+++ b/docs/03-reference/architecture/pcp-extension-contract-and-authority-map.md
@@ -1,0 +1,170 @@
+---
+id: PCP-EXTENSION-CONTRACT-AND-AUTHORITY-MAP
+title: PCP Extension Contract and Authority Map
+type: reference
+owner: '@hu3mann'
+author: claude
+date: '2026-06-19'
+last_review: '2026-06-19'
+next_review: '2026-09-17'
+prelude: PCP Extension Contract and Authority Map (reference) for dopemux documentation
+  and developer workflows.
+---
+# PCP Extension Contract and Authority Map
+
+## 1. Background
+
+Two JSON schemas are the keystones of the Project Control Plane (PCP) Core, as defined in `AIR-DMX-PCP-DCP-ROUTING-ARCHITECTURE-0001` §6:
+
+- `schemas/project_control_plane/authority_map.schema.json`
+- `schemas/project_control_plane/extension_manifest.schema.json`
+
+Both validate against JSON Schema Draft 2020-12. Neither schema may be modified by extension authors; extensions attach to PCP Core through the extension manifest's additive contribution mechanism only.
+
+## 2. Authority Map Schema
+
+The authority map (`pcp.authority_map.v0`) is a machine-checkable ownership table. For every `(domain, action)` pair it records:
+
+- **`canonical_authority_owner`** — the upstream system that owns the domain. An extension or adapter is a mapper, never the owner.
+- **`canonical_writer`** — the only surface permitted to mutate the domain after all gates have been satisfied. `null` when no writer is authorized at this stage.
+- **`surface_class`** — one of `SOURCE`, `PROJECTION`, `MIRROR`, `CACHE`, `INDEX`, `ADAPTER`, or `UNKNOWN`. Derived surfaces (`PROJECTION`, `MIRROR`, `CACHE`, `INDEX`, `ADAPTER`) are never authoritative; they read from or reflect a `SOURCE`.
+- **`reader_or_projection_surface`** — the surface that exposes the domain without owning it (`null` when none).
+- **`source_truth_refs`** — references to the authoritative source artifacts (paths, schema IDs, proof families).
+- **`proof_required`**, **`live_write_allowed`**, **`approval_required`**, **`rollback_required`** — boolean gates. `live_write_allowed` defaults `false` (fail-closed); it may only be set `true` after the live-write gate contract for that domain is separately satisfied.
+- **`unknown_behavior`** — pinned `const: "BLOCK_OR_ESCALATE"`. This field cannot hold any other value. Unknown ownership must block or escalate; it must never silently proceed.
+
+### Valid authority map example
+
+```json
+{
+  "schema_version": "pcp.authority_map.v0",
+  "project_id": "dopemux-mvp",
+  "entries": [
+    {
+      "domain": "pm.tasks",
+      "action": "write",
+      "canonical_authority_owner": "conport",
+      "canonical_writer": "conport-api",
+      "surface_class": "SOURCE",
+      "reader_or_projection_surface": null,
+      "source_truth_refs": [
+        "schemas/project_control_plane/authority_map.schema.json"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": true,
+      "rollback_required": true,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
+    }
+  ]
+}
+```
+
+## 3. Extension Manifest Schema
+
+The extension manifest (`pcp.extension_manifest.v0`) declares how a named extension attaches to PCP Core. Four `extension_kind` values are recognized: `DOPEMUX_DCP`, `DNH_CRM`, `PROJECT`, and `UNKNOWN`.
+
+Extensions are **additive only**. The manifest does not replace or override core behavior; it names what the extension contributes alongside it:
+
+- **`capabilities`** — six arrays (`authority_map_contributions`, `red_lane_contributions`, `evidence_export_sections`, `proof_status_mappings`, `runtime_mappings`, `adapter_mappings`) listing additive contributions.
+- **`schemas`** — three arrays: `owned_schema_ids` (schemas namespaced under and owned by this extension), `core_schema_extensions` (additive sections attached to core schemas), and `forbidden_core_overrides` (core schema IDs this extension must never override).
+- **`extension_identity`** — `project_id_patterns`, `repo_markers`, and `discovery_hints` used to identify applicable projects.
+
+### Five hard invariants (all pinned `const: true`)
+
+Every valid manifest must affirm all five invariants. The schema pins each to `const: true`, so declaring any of them `false` makes the manifest invalid by construction:
+
+| Invariant | Meaning |
+|-----------|---------|
+| `cannot_override_core_fail_closed` | Extension cannot weaken the core fail-closed default. |
+| `cannot_weaken_proof_gates` | Extension cannot lower or remove proof requirements. |
+| `cannot_weaken_audit_gates` | Extension cannot lower or remove audit trail requirements. |
+| `cannot_promote_adapter_to_authority` | An adapter surface declared by the extension cannot be elevated to a canonical authority owner. |
+| `cannot_require_extension_for_baseline_core` | Baseline PCP Core must function without this extension present. |
+
+These are not policy; they are structural constraints enforced by the schema validator.
+
+### Valid extension manifest examples
+
+**DOPEMUX_DCP:**
+
+```json
+{
+  "schema_version": "pcp.extension_manifest.v0",
+  "extension_id": "dopemux-dcp-v0",
+  "extension_kind": "DOPEMUX_DCP",
+  "extension_identity": {
+    "project_id_patterns": ["dopemux-*"],
+    "repo_markers": [".dopemux"],
+    "discovery_hints": ["look for pyproject.toml with [tool.dopemux]"]
+  },
+  "capabilities": {
+    "authority_map_contributions": [],
+    "red_lane_contributions": [],
+    "evidence_export_sections": [],
+    "proof_status_mappings": [],
+    "runtime_mappings": [],
+    "adapter_mappings": []
+  },
+  "schemas": {
+    "owned_schema_ids": [],
+    "core_schema_extensions": [],
+    "forbidden_core_overrides": []
+  },
+  "invariants": {
+    "cannot_override_core_fail_closed": true,
+    "cannot_weaken_proof_gates": true,
+    "cannot_weaken_audit_gates": true,
+    "cannot_promote_adapter_to_authority": true,
+    "cannot_require_extension_for_baseline_core": true
+  }
+}
+```
+
+**DNH_CRM (with contributions):**
+
+```json
+{
+  "schema_version": "pcp.extension_manifest.v0",
+  "extension_id": "dnh-crm-v0",
+  "extension_kind": "DNH_CRM",
+  "extension_identity": {
+    "project_id_patterns": ["dnh-*"],
+    "repo_markers": [".dnh"],
+    "discovery_hints": []
+  },
+  "capabilities": {
+    "authority_map_contributions": ["crm.contacts.write"],
+    "red_lane_contributions": [],
+    "evidence_export_sections": [],
+    "proof_status_mappings": [],
+    "runtime_mappings": [],
+    "adapter_mappings": ["crm-adapter"]
+  },
+  "schemas": {
+    "owned_schema_ids": ["https://dnh.dev/schemas/crm/contact.schema.json"],
+    "core_schema_extensions": [],
+    "forbidden_core_overrides": [
+      "https://dopemux.dev/schemas/project_control_plane/authority_map.schema.json"
+    ]
+  },
+  "invariants": {
+    "cannot_override_core_fail_closed": true,
+    "cannot_weaken_proof_gates": true,
+    "cannot_weaken_audit_gates": true,
+    "cannot_promote_adapter_to_authority": true,
+    "cannot_require_extension_for_baseline_core": true
+  }
+}
+```
+
+## 4. Scope of These Schemas
+
+These schemas are **contracts only**. They define what a valid authority map document and a valid extension manifest document look like. They do not:
+
+- Export evidence or produce proof artifacts (a later packet).
+- Perform live writes to any store.
+- Move schema files between locations.
+- Enforce any runtime behavior on their own.
+
+Runtime enforcement, exporters, and live-write gate satisfication are addressed in subsequent PCP packets. The schemas here establish the machine-checkable foundation that all later packets build on.

--- a/schemas/project_control_plane/authority_map.schema.json
+++ b/schemas/project_control_plane/authority_map.schema.json
@@ -1,0 +1,178 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/authority_map.schema.json",
+  "title": "Project Control Plane Authority Map",
+  "description": "Machine-checkable ownership map. For each (domain, action) it records the canonical authority owner, the canonical writer, the projection/mirror/cache/source distinction, proof and live-write gates, and a fail-closed behavior for unknown ownership. PCP Core keystone; pairs with extension_manifest.schema.json. Adding or extending entries is how extensions contribute ownership without weakening core. Fail-closed by construction: a derived surface can never be writable, a writable entry must be a SOURCE with a named writer, and unknown ownership must block or escalate.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "project_id",
+    "entries"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.authority_map.v0"
+    },
+    "project_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "entries": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/authority_entry"
+      }
+    }
+  },
+  "$defs": {
+    "authority_entry": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "domain",
+        "action",
+        "canonical_authority_owner",
+        "canonical_writer",
+        "surface_class",
+        "reader_or_projection_surface",
+        "source_truth_refs",
+        "proof_required",
+        "live_write_allowed",
+        "approval_required",
+        "rollback_required",
+        "unknown_behavior"
+      ],
+      "properties": {
+        "domain": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The owned domain, e.g. 'pm.tasks', 'memory.decisions', 'routing.lane'."
+        },
+        "action": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The action over the domain, e.g. 'read', 'project', 'write', 'mutate'."
+        },
+        "canonical_authority_owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "The upstream system that OWNS the domain. An extension/adapter is a mapper, never the owner."
+        },
+        "canonical_writer": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The only surface permitted to mutate the owned domain after gates. Null means 'no writer by design' (derived/immutable surface). Must be a non-null name whenever live_write_allowed is true (enforced below)."
+        },
+        "surface_class": {
+          "type": "string",
+          "enum": [
+            "SOURCE",
+            "PROJECTION",
+            "MIRROR",
+            "CACHE",
+            "INDEX",
+            "ADAPTER",
+            "UNKNOWN"
+          ],
+          "description": "Distinguishes the authoritative SOURCE from derived/projected/mirrored/cached/indexed/adapter surfaces. Only SOURCE may be writable; all other classes are fail-closed to read-only (enforced below)."
+        },
+        "reader_or_projection_surface": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "The read/projection surface that exposes this domain without owning it."
+        },
+        "source_truth_refs": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "References to the authoritative source artifacts (paths, schema ids, proof families). At least one is required so every entry cites where truth lives."
+        },
+        "proof_required": {
+          "type": "boolean"
+        },
+        "live_write_allowed": {
+          "type": "boolean",
+          "default": false,
+          "description": "Defaults false (fail-closed). May only be true for a SOURCE surface with a non-null canonical_writer, and only once the live-write gate contract is satisfied for this domain."
+        },
+        "approval_required": {
+          "type": "boolean"
+        },
+        "rollback_required": {
+          "type": "boolean"
+        },
+        "unknown_behavior": {
+          "type": "string",
+          "const": "BLOCK_OR_ESCALATE",
+          "description": "Fail-closed by construction: an unknown owner must block or escalate, never silently proceed."
+        }
+      },
+      "allOf": [
+        {
+          "$comment": "Derived/unknown surfaces are never writable and have no canonical writer.",
+          "if": {
+            "properties": {
+              "surface_class": {
+                "enum": [
+                  "PROJECTION",
+                  "MIRROR",
+                  "CACHE",
+                  "INDEX",
+                  "ADAPTER",
+                  "UNKNOWN"
+                ]
+              }
+            },
+            "required": [
+              "surface_class"
+            ]
+          },
+          "then": {
+            "properties": {
+              "live_write_allowed": {
+                "const": false
+              },
+              "canonical_writer": {
+                "type": "null"
+              }
+            }
+          }
+        },
+        {
+          "$comment": "A writable entry must be a SOURCE surface with a named (non-null) canonical writer.",
+          "if": {
+            "properties": {
+              "live_write_allowed": {
+                "const": true
+              }
+            },
+            "required": [
+              "live_write_allowed"
+            ]
+          },
+          "then": {
+            "properties": {
+              "surface_class": {
+                "const": "SOURCE"
+              },
+              "canonical_writer": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/schemas/project_control_plane/extension_manifest.schema.json
+++ b/schemas/project_control_plane/extension_manifest.schema.json
@@ -1,0 +1,197 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/extension_manifest.schema.json",
+  "title": "PCP Extension Manifest",
+  "description": "Declares how a named extension (Dopemux/DCP, dNh CRM, or any project) attaches to PCP Core. Additive-only: the hard invariants block forbids weakening core fail-closed/proof/audit gates, promoting an adapter to authority, or requiring the extension for baseline PCP. PCP Core keystone; pairs with authority_map.schema.json. The five invariants are pinned const true so a manifest that tries to declare any of them false is invalid by construction (fail-closed).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "extension_id",
+    "extension_kind",
+    "extension_identity",
+    "capabilities",
+    "schemas",
+    "invariants"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.extension_manifest.v0"
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "PROPOSED",
+        "ACTIVE",
+        "DEPRECATED"
+      ],
+      "default": "PROPOSED"
+    },
+    "extension_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "extension_kind": {
+      "type": "string",
+      "enum": [
+        "DOPEMUX_DCP",
+        "DNH_CRM",
+        "PROJECT",
+        "UNKNOWN"
+      ]
+    },
+    "compatible_pcp_core_versions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extension_identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "project_id_patterns",
+        "repo_markers",
+        "discovery_hints"
+      ],
+      "properties": {
+        "project_id_patterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "repo_markers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "discovery_hints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Additive contributions only. Each list names what the extension adds to core; none can remove or override core behavior.",
+      "required": [
+        "authority_map_contributions",
+        "red_lane_contributions",
+        "evidence_export_sections",
+        "proof_status_mappings",
+        "runtime_mappings",
+        "adapter_mappings"
+      ],
+      "properties": {
+        "authority_map_contributions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "red_lane_contributions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "evidence_export_sections": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "proof_status_mappings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "runtime_mappings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "adapter_mappings": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "schemas": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owned_schema_ids",
+        "core_schema_extensions",
+        "forbidden_core_overrides"
+      ],
+      "properties": {
+        "owned_schema_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Schemas namespaced under and owned by this extension."
+        },
+        "core_schema_extensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Additive extension sections attached to core schemas (never replacements)."
+        },
+        "forbidden_core_overrides": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Core schema ids this extension explicitly must never override."
+        }
+      }
+    },
+    "invariants": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Hard invariants pinned const true. A manifest cannot be valid unless it affirms all five; it cannot declare any of them false.",
+      "required": [
+        "cannot_override_core_fail_closed",
+        "cannot_weaken_proof_gates",
+        "cannot_weaken_audit_gates",
+        "cannot_promote_adapter_to_authority",
+        "cannot_require_extension_for_baseline_core"
+      ],
+      "properties": {
+        "cannot_override_core_fail_closed": {
+          "type": "boolean",
+          "const": true
+        },
+        "cannot_weaken_proof_gates": {
+          "type": "boolean",
+          "const": true
+        },
+        "cannot_weaken_audit_gates": {
+          "type": "boolean",
+          "const": true
+        },
+        "cannot_promote_adapter_to_authority": {
+          "type": "boolean",
+          "const": true
+        },
+        "cannot_require_extension_for_baseline_core": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    }
+  }
+}

--- a/task-packets/generated/TP-DMX-PCP-EXTENSION-CONTRACT-AUTHORITY-MAP-0001.json
+++ b/task-packets/generated/TP-DMX-PCP-EXTENSION-CONTRACT-AUTHORITY-MAP-0001.json
@@ -1,0 +1,95 @@
+{
+  "id": "TP-DMX-PCP-EXTENSION-CONTRACT-AUTHORITY-MAP-0001",
+  "project": "dopemux-mvp",
+  "target": "Add extension_manifest.schema.json and authority_map.schema.json as PCP Core co-keystones, with tests proving extensions are additive-only and fail closed on unknown ownership. No exporter, no schema moves yet.",
+  "invariants": [
+    "Runtime, GitHub, and PR truth outrank this packet; re-pull live state before execution (AGENTS.md \u00a72).",
+    "Authority model is fixed: PCP Core is the parent substrate; DCP and dNh are extensions. No 'DCP parent' framing.",
+    "No live writes, Dopetask execution, Task Orchestrator MCP writes, dNh runtime mutation, PR ready/merge, or OpenClaw production routing unless this packet's gates explicitly authorize it.",
+    "Execution is gated by depends_on: do not start until every blocker item is terminal or a supervisor waives sequencing.",
+    "Implementer is not the sole final auditor; embedded audit must be independent (AIR Red Lines #9).",
+    "Allowlist paths are proposed targets and may be refined by upstream packet outputs; keep changes within the declared allowlist.",
+    "Both schemas ship together; neither is optional 'later garnish' (AIR \u00a75/\u00a76).",
+    "Extensions cannot override core fail-closed behavior, weaken proof/audit gates, promote an adapter to authority, or be required for baseline PCP.",
+    "authority_map unknown owner behavior must be BLOCK_OR_ESCALATE (fail closed).",
+    "Correct the proposed enum value to DOPEMUX_DCP (not DOPMUX_DCP)."
+  ],
+  "depends_on": [
+    "TP-DMX-PCP-PR925-FRAMING-PROOF-REPAIR-0002"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-PCP-DCP-ROUTING",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-PCP-PR925-FRAMING-PROOF-REPAIR-0002",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/tp-dmx-pcp-extension-contract-authority-map-0001",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "feat(pcp): extension contract + authority map co-keystones",
+    "allowlist": [
+      "schemas/project_control_plane/authority_map.schema.json",
+      "schemas/project_control_plane/extension_manifest.schema.json",
+      "tests/project_control_plane/test_authority_map_schema.py",
+      "tests/project_control_plane/test_extension_manifest_schema.py",
+      "docs/03-reference/architecture/pcp-extension-contract-and-authority-map.md",
+      "task-packets/generated/TP-DMX-PCP-EXTENSION-CONTRACT-AUTHORITY-MAP-0001.json"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-PCP-EXTENSION-CONTRACT-AUTHORITY-MAP-0001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-PCP-EXTENSION-CONTRACT-AUTHORITY-MAP-0001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "git diff --check",
+      "git diff --stat",
+      "python -m json.tool schemas/project_control_plane/authority_map.schema.json >/dev/null",
+      "python -m json.tool schemas/project_control_plane/extension_manifest.schema.json >/dev/null",
+      "pytest -q tests/project_control_plane/test_authority_map_schema.py tests/project_control_plane/test_extension_manifest_schema.py"
+    ]
+  },
+  "pr": {
+    "title": "feat(pcp): extension contract + authority map co-keystones",
+    "body": "Adds the PCP Core extension-manifest and authority-map schemas as co-keystones with additive-only and fail-closed-unknown tests. Draft / NEEDS_SUPERVISOR. Depends on Packet 1 (PR #925 repair) proof or supervisor waiver.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Author authority_map.schema.json (domain, action, canonical_authority_owner, canonical_writer, reader_or_projection_surface, mirror/cache/index status, source_truth_refs, proof_required, live_write_allowed, approval_required, rollback_required, unknown_behavior=BLOCK_OR_ESCALATE).",
+      "validation": [
+        "python -m json.tool schemas/project_control_plane/authority_map.schema.json >/dev/null"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Author extension_manifest.schema.json (extension_kind enum DOPEMUX_DCP/DNH_CRM/PROJECT/UNKNOWN, additive capabilities, hard invariants cannot_override_core_fail_closed/weaken_proof_gates/weaken_audit_gates/promote_adapter_to_authority/require_extension_for_baseline_core).",
+      "validation": [
+        "python -m json.tool schemas/project_control_plane/extension_manifest.schema.json >/dev/null",
+        "rg -n DOPEMUX_DCP schemas/project_control_plane/extension_manifest.schema.json"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Add tests proving additive-only behavior, fail-closed on unknown owner, and that an extension cannot weaken core gates.",
+      "validation": [
+        "pytest -q tests/project_control_plane/test_authority_map_schema.py tests/project_control_plane/test_extension_manifest_schema.py"
+      ]
+    }
+  ]
+}

--- a/tests/project_control_plane/test_authority_map_schema.py
+++ b/tests/project_control_plane/test_authority_map_schema.py
@@ -1,0 +1,384 @@
+"""
+Tests for schemas/project_control_plane/authority_map.schema.json
+
+Validates the schema itself meta-validates (Draft2020-12), exercises a fully-valid
+instance, and confirms each fail-closed rule rejects invalid instances.
+"""
+
+import json
+import pathlib
+from jsonschema import Draft202012Validator
+
+# ---------------------------------------------------------------------------
+# Schema loading — CWD-independent, resolved relative to THIS file.
+# Repository root is 3 levels up: tests/project_control_plane/test_*.py
+# ---------------------------------------------------------------------------
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_SCHEMA_PATH = _REPO_ROOT / "schemas" / "project_control_plane" / "authority_map.schema.json"
+
+
+def _load_schema() -> dict:
+    with _SCHEMA_PATH.open() as fh:
+        return json.load(fh)
+
+
+SCHEMA = _load_schema()
+
+
+def errors(schema, inst):
+    """Return all validation errors produced by Draft202012Validator."""
+    return list(Draft202012Validator(schema).iter_errors(inst))
+
+
+# ---------------------------------------------------------------------------
+# Minimal valid SOURCE entry (read-only SOURCE — live_write_allowed false)
+# ---------------------------------------------------------------------------
+_VALID_ENTRY = {
+    "domain": "pm.tasks",
+    "action": "write",
+    "canonical_authority_owner": "conport",
+    "canonical_writer": None,
+    "surface_class": "SOURCE",
+    "reader_or_projection_surface": None,
+    "source_truth_refs": ["schemas/project_control_plane/authority_map.schema.json"],
+    "proof_required": True,
+    "live_write_allowed": False,
+    "approval_required": True,
+    "rollback_required": True,
+    "unknown_behavior": "BLOCK_OR_ESCALATE",
+}
+
+_VALID_INSTANCE = {
+    "schema_version": "pcp.authority_map.v0",
+    "project_id": "dopemux-mvp",
+    "entries": [_VALID_ENTRY],
+}
+
+# Derived (non-SOURCE) entry — must have live_write_allowed=false and canonical_writer=null
+_VALID_DERIVED_ENTRY = {
+    **_VALID_ENTRY,
+    "surface_class": "CACHE",
+    "live_write_allowed": False,
+    "canonical_writer": None,
+}
+
+# Writable SOURCE entry — live_write_allowed=true requires surface_class=SOURCE and non-null canonical_writer
+_VALID_WRITABLE_ENTRY = {
+    **_VALID_ENTRY,
+    "surface_class": "SOURCE",
+    "live_write_allowed": True,
+    "canonical_writer": "conport-api",
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Meta-validation: the schema itself must be a valid Draft 2020-12 schema.
+# ---------------------------------------------------------------------------
+class TestSchemaMetaValidation:
+    def test_schema_meta_validates(self):
+        """Draft202012Validator.check_schema must not raise for a valid schema."""
+        Draft202012Validator.check_schema(SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# 2. Valid instance: no errors expected.
+# ---------------------------------------------------------------------------
+class TestValidInstance:
+    def test_fully_valid_instance_produces_zero_errors(self):
+        errs = errors(SCHEMA, _VALID_INSTANCE)
+        assert errs == [], f"Unexpected validation errors: {errs}"
+
+    def test_reader_projection_surface_can_be_null(self):
+        instance = {**_VALID_INSTANCE, "entries": [{**_VALID_ENTRY, "reader_or_projection_surface": None}]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_reader_projection_surface_can_be_string(self):
+        instance = {**_VALID_INSTANCE, "entries": [{**_VALID_ENTRY, "reader_or_projection_surface": "dashboard"}]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_surface_class_projection_is_valid(self):
+        """PROJECTION with live_write_allowed=false and canonical_writer=null is valid."""
+        entry = {**_VALID_ENTRY, "surface_class": "PROJECTION", "live_write_allowed": False, "canonical_writer": None}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_surface_class_mirror_is_valid(self):
+        """MIRROR with live_write_allowed=false and canonical_writer=null is valid."""
+        entry = {**_VALID_ENTRY, "surface_class": "MIRROR", "live_write_allowed": False, "canonical_writer": None}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_surface_class_cache_is_valid(self):
+        """CACHE with live_write_allowed=false and canonical_writer=null is valid."""
+        instance = {**_VALID_INSTANCE, "entries": [_VALID_DERIVED_ENTRY]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_surface_class_index_is_valid(self):
+        """INDEX with live_write_allowed=false and canonical_writer=null is valid."""
+        entry = {**_VALID_ENTRY, "surface_class": "INDEX", "live_write_allowed": False, "canonical_writer": None}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_surface_class_adapter_is_valid(self):
+        """ADAPTER with live_write_allowed=false and canonical_writer=null is valid."""
+        entry = {**_VALID_ENTRY, "surface_class": "ADAPTER", "live_write_allowed": False, "canonical_writer": None}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_surface_class_unknown_is_valid(self):
+        """UNKNOWN with live_write_allowed=false and canonical_writer=null is valid."""
+        entry = {**_VALID_ENTRY, "surface_class": "UNKNOWN", "live_write_allowed": False, "canonical_writer": None}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_canonical_writer_can_be_null_on_source_readonly(self):
+        """SOURCE with live_write_allowed=false may have canonical_writer=null."""
+        instance = {**_VALID_INSTANCE, "entries": [{**_VALID_ENTRY, "canonical_writer": None}]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_source_writable_with_nonnull_canonical_writer_is_valid(self):
+        """SOURCE with live_write_allowed=true and a non-null canonical_writer is valid."""
+        instance = {**_VALID_INSTANCE, "entries": [_VALID_WRITABLE_ENTRY]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_cache_readonly_null_canonical_writer_is_valid(self):
+        """CACHE with live_write_allowed=false and canonical_writer=null is valid."""
+        entry = {**_VALID_ENTRY, "surface_class": "CACHE", "live_write_allowed": False, "canonical_writer": None}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Fail-closed rejection tests — each must produce at least one error.
+# ---------------------------------------------------------------------------
+class TestFailClosedRejections:
+    def test_rejects_unknown_behavior_warn(self):
+        """unknown_behavior must be const 'BLOCK_OR_ESCALATE'; 'WARN' must be rejected."""
+        entry = {**_VALID_ENTRY, "unknown_behavior": "WARN"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for unknown_behavior='WARN'"
+
+    def test_rejects_unknown_behavior_ignore(self):
+        """Any value other than the pinned const must be rejected."""
+        entry = {**_VALID_ENTRY, "unknown_behavior": "IGNORE"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for unknown_behavior='IGNORE'"
+
+    def test_rejects_missing_canonical_writer(self):
+        """Removing required key 'canonical_writer' must produce errors."""
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "canonical_writer"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'canonical_writer'"
+
+    def test_rejects_missing_domain(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "domain"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'domain'"
+
+    def test_rejects_missing_action(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "action"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'action'"
+
+    def test_rejects_missing_canonical_authority_owner(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "canonical_authority_owner"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'canonical_authority_owner'"
+
+    def test_rejects_missing_surface_class(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "surface_class"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'surface_class'"
+
+    def test_rejects_missing_reader_or_projection_surface(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "reader_or_projection_surface"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'reader_or_projection_surface'"
+
+    def test_rejects_missing_source_truth_refs(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "source_truth_refs"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'source_truth_refs'"
+
+    def test_rejects_missing_proof_required(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "proof_required"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'proof_required'"
+
+    def test_rejects_missing_live_write_allowed(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "live_write_allowed"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'live_write_allowed'"
+
+    def test_rejects_missing_approval_required(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "approval_required"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'approval_required'"
+
+    def test_rejects_missing_rollback_required(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "rollback_required"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'rollback_required'"
+
+    def test_rejects_missing_unknown_behavior(self):
+        entry = {k: v for k, v in _VALID_ENTRY.items() if k != "unknown_behavior"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'unknown_behavior'"
+
+    def test_rejects_wrong_schema_version(self):
+        """schema_version const must be 'pcp.authority_map.v0'; any other value rejected."""
+        instance = {**_VALID_INSTANCE, "schema_version": "v1"}
+        assert errors(SCHEMA, instance), "Expected rejection for schema_version='v1'"
+
+    def test_rejects_schema_version_wrong_prefix(self):
+        instance = {**_VALID_INSTANCE, "schema_version": "pcp.authority_map.v1"}
+        assert errors(SCHEMA, instance), "Expected rejection for schema_version with wrong version"
+
+    def test_rejects_surface_class_invalid_value(self):
+        """'BOSS' is not in the enum; must be rejected."""
+        entry = {**_VALID_ENTRY, "surface_class": "BOSS"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for surface_class='BOSS'"
+
+    def test_rejects_surface_class_lowercase(self):
+        """'source' (lowercase) is not in the enum; must be rejected."""
+        entry = {**_VALID_ENTRY, "surface_class": "source"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for surface_class='source'"
+
+    def test_rejects_extra_top_level_key(self):
+        """additionalProperties is false at the top level; extra keys must be rejected."""
+        instance = {**_VALID_INSTANCE, "unexpected_field": "should_fail"}
+        assert errors(SCHEMA, instance), "Expected rejection for top-level extra key"
+
+    def test_rejects_extra_entry_key(self):
+        """additionalProperties is false on authority_entry; extra keys must be rejected."""
+        entry = {**_VALID_ENTRY, "rogue_field": "bad"}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for extra entry key"
+
+    def test_rejects_missing_schema_version(self):
+        instance = {k: v for k, v in _VALID_INSTANCE.items() if k != "schema_version"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'schema_version'"
+
+    def test_rejects_missing_project_id(self):
+        instance = {k: v for k, v in _VALID_INSTANCE.items() if k != "project_id"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'project_id'"
+
+    def test_rejects_missing_entries(self):
+        instance = {k: v for k, v in _VALID_INSTANCE.items() if k != "entries"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'entries'"
+
+    # -----------------------------------------------------------------------
+    # Hardened schema: new rejection tests
+    # -----------------------------------------------------------------------
+
+    def test_rejects_empty_entries_array(self):
+        """entries now has minItems:1; an empty array must be rejected."""
+        instance = {**_VALID_INSTANCE, "entries": []}
+        assert errors(SCHEMA, instance), "Expected rejection for empty entries array"
+
+    def test_rejects_generated_from_fixture_field(self):
+        """generated_from_fixture was removed from schema; additionalProperties:false rejects it."""
+        instance = {**_VALID_INSTANCE, "generated_from_fixture": True}
+        assert errors(SCHEMA, instance), "Expected rejection for unknown property 'generated_from_fixture'"
+
+    def test_rejects_empty_string_project_id(self):
+        """project_id now has minLength:1; empty string must be rejected."""
+        instance = {**_VALID_INSTANCE, "project_id": ""}
+        assert errors(SCHEMA, instance), "Expected rejection for empty string project_id"
+
+    def test_rejects_empty_source_truth_refs(self):
+        """source_truth_refs now has minItems:1; empty list must be rejected."""
+        entry = {**_VALID_ENTRY, "source_truth_refs": []}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for empty source_truth_refs"
+
+    def test_rejects_cache_with_live_write_allowed_true(self):
+        """CACHE is a derived surface; live_write_allowed=true must be rejected."""
+        entry = {**_VALID_ENTRY, "surface_class": "CACHE", "live_write_allowed": True, "canonical_writer": None}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for CACHE with live_write_allowed=true"
+
+    def test_rejects_cache_with_nonnull_canonical_writer(self):
+        """CACHE is a derived surface; canonical_writer must be null; non-null must be rejected."""
+        entry = {
+            **_VALID_ENTRY,
+            "surface_class": "CACHE",
+            "live_write_allowed": False,
+            "canonical_writer": "some-writer",
+        }
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for CACHE with non-null canonical_writer"
+
+    def test_rejects_source_writable_with_null_canonical_writer(self):
+        """SOURCE with live_write_allowed=true but canonical_writer=null must be rejected."""
+        entry = {**_VALID_ENTRY, "surface_class": "SOURCE", "live_write_allowed": True, "canonical_writer": None}
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for SOURCE writable with null canonical_writer"
+
+    def test_rejects_projection_with_live_write_allowed_true(self):
+        """PROJECTION is a derived surface; live_write_allowed=true must be rejected."""
+        entry = {
+            **_VALID_ENTRY,
+            "surface_class": "PROJECTION",
+            "live_write_allowed": True,
+            "canonical_writer": None,
+        }
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for PROJECTION with live_write_allowed=true"
+
+    def test_rejects_mirror_with_live_write_allowed_true(self):
+        """MIRROR is a derived surface; live_write_allowed=true must be rejected."""
+        entry = {
+            **_VALID_ENTRY,
+            "surface_class": "MIRROR",
+            "live_write_allowed": True,
+            "canonical_writer": None,
+        }
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for MIRROR with live_write_allowed=true"
+
+    def test_rejects_index_with_live_write_allowed_true(self):
+        """INDEX is a derived surface; live_write_allowed=true must be rejected."""
+        entry = {
+            **_VALID_ENTRY,
+            "surface_class": "INDEX",
+            "live_write_allowed": True,
+            "canonical_writer": None,
+        }
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for INDEX with live_write_allowed=true"
+
+    def test_rejects_adapter_with_live_write_allowed_true(self):
+        """ADAPTER is a derived surface; live_write_allowed=true must be rejected."""
+        entry = {
+            **_VALID_ENTRY,
+            "surface_class": "ADAPTER",
+            "live_write_allowed": True,
+            "canonical_writer": None,
+        }
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for ADAPTER with live_write_allowed=true"
+
+    def test_rejects_unknown_surface_with_live_write_allowed_true(self):
+        """UNKNOWN is a derived surface; live_write_allowed=true must be rejected."""
+        entry = {
+            **_VALID_ENTRY,
+            "surface_class": "UNKNOWN",
+            "live_write_allowed": True,
+            "canonical_writer": None,
+        }
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for UNKNOWN with live_write_allowed=true"
+
+    def test_rejects_projection_with_nonnull_canonical_writer(self):
+        """PROJECTION is a derived surface; canonical_writer must be null."""
+        entry = {
+            **_VALID_ENTRY,
+            "surface_class": "PROJECTION",
+            "live_write_allowed": False,
+            "canonical_writer": "some-writer",
+        }
+        instance = {**_VALID_INSTANCE, "entries": [entry]}
+        assert errors(SCHEMA, instance), "Expected rejection for PROJECTION with non-null canonical_writer"

--- a/tests/project_control_plane/test_extension_manifest_schema.py
+++ b/tests/project_control_plane/test_extension_manifest_schema.py
@@ -1,0 +1,296 @@
+"""
+Tests for schemas/project_control_plane/extension_manifest.schema.json
+
+Validates the schema itself meta-validates (Draft2020-12), exercises fully-valid
+instances for DOPEMUX_DCP and DNH_CRM extension kinds, and confirms each
+fail-closed invariant and required-field rule rejects invalid instances.
+"""
+
+import json
+import pathlib
+from jsonschema import Draft202012Validator
+
+# ---------------------------------------------------------------------------
+# Schema loading — CWD-independent, resolved relative to THIS file.
+# Repository root is 3 levels up: tests/project_control_plane/test_*.py
+# ---------------------------------------------------------------------------
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_SCHEMA_PATH = _REPO_ROOT / "schemas" / "project_control_plane" / "extension_manifest.schema.json"
+
+
+def _load_schema() -> dict:
+    with _SCHEMA_PATH.open() as fh:
+        return json.load(fh)
+
+
+SCHEMA = _load_schema()
+
+
+def errors(schema, inst):
+    """Return all validation errors produced by Draft202012Validator."""
+    return list(Draft202012Validator(schema).iter_errors(inst))
+
+
+# ---------------------------------------------------------------------------
+# Minimal valid instances
+# ---------------------------------------------------------------------------
+_VALID_INVARIANTS = {
+    "cannot_override_core_fail_closed": True,
+    "cannot_weaken_proof_gates": True,
+    "cannot_weaken_audit_gates": True,
+    "cannot_promote_adapter_to_authority": True,
+    "cannot_require_extension_for_baseline_core": True,
+}
+
+_VALID_CAPABILITIES = {
+    "authority_map_contributions": [],
+    "red_lane_contributions": [],
+    "evidence_export_sections": [],
+    "proof_status_mappings": [],
+    "runtime_mappings": [],
+    "adapter_mappings": [],
+}
+
+_VALID_EXTENSION_IDENTITY = {
+    "project_id_patterns": ["dopemux-*"],
+    "repo_markers": [".dopemux"],
+    "discovery_hints": ["look for pyproject.toml with [tool.dopemux]"],
+}
+
+_VALID_SCHEMAS = {
+    "owned_schema_ids": [],
+    "core_schema_extensions": [],
+    "forbidden_core_overrides": [],
+}
+
+_VALID_DCP_INSTANCE = {
+    "schema_version": "pcp.extension_manifest.v0",
+    "extension_id": "dopemux-dcp-v0",
+    "extension_kind": "DOPEMUX_DCP",
+    "extension_identity": _VALID_EXTENSION_IDENTITY,
+    "capabilities": _VALID_CAPABILITIES,
+    "schemas": _VALID_SCHEMAS,
+    "invariants": _VALID_INVARIANTS,
+}
+
+_VALID_CRM_INSTANCE = {
+    "schema_version": "pcp.extension_manifest.v0",
+    "extension_id": "dnh-crm-v0",
+    "extension_kind": "DNH_CRM",
+    "extension_identity": {
+        "project_id_patterns": ["dnh-*"],
+        "repo_markers": [".dnh"],
+        "discovery_hints": [],
+    },
+    "capabilities": {
+        **_VALID_CAPABILITIES,
+        "authority_map_contributions": ["crm.contacts.write"],
+        "adapter_mappings": ["crm-adapter"],
+    },
+    "schemas": {
+        "owned_schema_ids": ["https://dnh.dev/schemas/crm/contact.schema.json"],
+        "core_schema_extensions": [],
+        "forbidden_core_overrides": [
+            "https://dopemux.dev/schemas/project_control_plane/authority_map.schema.json"
+        ],
+    },
+    "invariants": _VALID_INVARIANTS,
+}
+
+
+# ---------------------------------------------------------------------------
+# 1. Meta-validation
+# ---------------------------------------------------------------------------
+class TestSchemaMetaValidation:
+    def test_schema_meta_validates(self):
+        """Draft202012Validator.check_schema must not raise for a valid schema."""
+        Draft202012Validator.check_schema(SCHEMA)
+
+
+# ---------------------------------------------------------------------------
+# 2. Valid instances
+# ---------------------------------------------------------------------------
+class TestValidInstances:
+    def test_fully_valid_dopemux_dcp_instance(self):
+        errs = errors(SCHEMA, _VALID_DCP_INSTANCE)
+        assert errs == [], f"Unexpected errors for DOPEMUX_DCP: {errs}"
+
+    def test_fully_valid_dnh_crm_instance(self):
+        errs = errors(SCHEMA, _VALID_CRM_INSTANCE)
+        assert errs == [], f"Unexpected errors for DNH_CRM: {errs}"
+
+    def test_project_extension_kind_valid(self):
+        instance = {**_VALID_DCP_INSTANCE, "extension_kind": "PROJECT"}
+        assert errors(SCHEMA, instance) == []
+
+    def test_unknown_extension_kind_valid(self):
+        instance = {**_VALID_DCP_INSTANCE, "extension_kind": "UNKNOWN"}
+        assert errors(SCHEMA, instance) == []
+
+    def test_optional_status_proposed(self):
+        instance = {**_VALID_DCP_INSTANCE, "status": "PROPOSED"}
+        assert errors(SCHEMA, instance) == []
+
+    def test_optional_status_active(self):
+        instance = {**_VALID_DCP_INSTANCE, "status": "ACTIVE"}
+        assert errors(SCHEMA, instance) == []
+
+    def test_optional_status_deprecated(self):
+        instance = {**_VALID_DCP_INSTANCE, "status": "DEPRECATED"}
+        assert errors(SCHEMA, instance) == []
+
+    def test_optional_compatible_pcp_core_versions(self):
+        instance = {**_VALID_DCP_INSTANCE, "compatible_pcp_core_versions": ["pcp.core.v0"]}
+        assert errors(SCHEMA, instance) == []
+
+    def test_non_empty_capabilities_arrays(self):
+        caps = {
+            **_VALID_CAPABILITIES,
+            "authority_map_contributions": ["pm.tasks.read"],
+            "red_lane_contributions": ["pm.tasks.red"],
+            "evidence_export_sections": ["pm_evidence"],
+            "proof_status_mappings": ["pm.proof.v0"],
+            "runtime_mappings": ["pm.runtime.v0"],
+            "adapter_mappings": ["pm.adapter.v0"],
+        }
+        instance = {**_VALID_DCP_INSTANCE, "capabilities": caps}
+        assert errors(SCHEMA, instance) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Fail-closed invariant rejections
+# ---------------------------------------------------------------------------
+class TestInvariantRejections:
+    def _instance_with_invariant(self, key: str, value: object) -> dict:
+        inv = {**_VALID_INVARIANTS, key: value}
+        return {**_VALID_DCP_INSTANCE, "invariants": inv}
+
+    def test_rejects_cannot_override_core_fail_closed_false(self):
+        instance = self._instance_with_invariant("cannot_override_core_fail_closed", False)
+        assert errors(SCHEMA, instance), "Expected rejection: cannot_override_core_fail_closed=False"
+
+    def test_rejects_cannot_weaken_proof_gates_false(self):
+        instance = self._instance_with_invariant("cannot_weaken_proof_gates", False)
+        assert errors(SCHEMA, instance), "Expected rejection: cannot_weaken_proof_gates=False"
+
+    def test_rejects_cannot_weaken_audit_gates_false(self):
+        instance = self._instance_with_invariant("cannot_weaken_audit_gates", False)
+        assert errors(SCHEMA, instance), "Expected rejection: cannot_weaken_audit_gates=False"
+
+    def test_rejects_cannot_promote_adapter_to_authority_false(self):
+        instance = self._instance_with_invariant("cannot_promote_adapter_to_authority", False)
+        assert errors(SCHEMA, instance), "Expected rejection: cannot_promote_adapter_to_authority=False"
+
+    def test_rejects_cannot_require_extension_for_baseline_core_false(self):
+        instance = self._instance_with_invariant("cannot_require_extension_for_baseline_core", False)
+        assert errors(SCHEMA, instance), "Expected rejection: cannot_require_extension_for_baseline_core=False"
+
+    def test_rejects_invariant_string_true(self):
+        """String 'true' is not boolean true — const:true must reject it."""
+        instance = self._instance_with_invariant("cannot_override_core_fail_closed", "true")
+        assert errors(SCHEMA, instance), "Expected rejection for string 'true' in invariant"
+
+    def test_rejects_invariant_integer_one(self):
+        """Integer 1 is not boolean true — const:true must reject it."""
+        instance = self._instance_with_invariant("cannot_weaken_proof_gates", 1)
+        assert errors(SCHEMA, instance), "Expected rejection for integer 1 in invariant"
+
+    def test_rejects_extra_invariant_key(self):
+        """additionalProperties false on invariants block rejects unknown keys."""
+        inv = {**_VALID_INVARIANTS, "sneaky_override": True}
+        instance = {**_VALID_DCP_INSTANCE, "invariants": inv}
+        assert errors(SCHEMA, instance), "Expected rejection for extra invariant key"
+
+
+# ---------------------------------------------------------------------------
+# 4. Extension kind rejections
+# ---------------------------------------------------------------------------
+class TestExtensionKindRejections:
+    def test_rejects_typo_dopmux_dcp(self):
+        """'DOPMUX_DCP' is a typo — not in the enum — must be rejected."""
+        instance = {**_VALID_DCP_INSTANCE, "extension_kind": "DOPMUX_DCP"}
+        assert errors(SCHEMA, instance), "Expected rejection for typo 'DOPMUX_DCP'"
+
+    def test_rejects_lowercase_extension_kind(self):
+        instance = {**_VALID_DCP_INSTANCE, "extension_kind": "dopemux_dcp"}
+        assert errors(SCHEMA, instance), "Expected rejection for lowercase extension_kind"
+
+    def test_rejects_arbitrary_extension_kind(self):
+        instance = {**_VALID_DCP_INSTANCE, "extension_kind": "CUSTOM_EXTENSION"}
+        assert errors(SCHEMA, instance), "Expected rejection for arbitrary extension_kind"
+
+    def test_rejects_missing_extension_kind(self):
+        instance = {k: v for k, v in _VALID_DCP_INSTANCE.items() if k != "extension_kind"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'extension_kind'"
+
+
+# ---------------------------------------------------------------------------
+# 5. Required top-level key rejections
+# ---------------------------------------------------------------------------
+class TestRequiredKeyRejections:
+    def test_rejects_missing_schema_version(self):
+        instance = {k: v for k, v in _VALID_DCP_INSTANCE.items() if k != "schema_version"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'schema_version'"
+
+    def test_rejects_wrong_schema_version(self):
+        instance = {**_VALID_DCP_INSTANCE, "schema_version": "pcp.extension_manifest.v1"}
+        assert errors(SCHEMA, instance), "Expected rejection for wrong schema_version const"
+
+    def test_rejects_missing_extension_id(self):
+        instance = {k: v for k, v in _VALID_DCP_INSTANCE.items() if k != "extension_id"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'extension_id'"
+
+    def test_rejects_missing_extension_identity(self):
+        instance = {k: v for k, v in _VALID_DCP_INSTANCE.items() if k != "extension_identity"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'extension_identity'"
+
+    def test_rejects_missing_capabilities(self):
+        instance = {k: v for k, v in _VALID_DCP_INSTANCE.items() if k != "capabilities"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'capabilities'"
+
+    def test_rejects_missing_schemas(self):
+        instance = {k: v for k, v in _VALID_DCP_INSTANCE.items() if k != "schemas"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'schemas'"
+
+    def test_rejects_missing_invariants(self):
+        instance = {k: v for k, v in _VALID_DCP_INSTANCE.items() if k != "invariants"}
+        assert errors(SCHEMA, instance), "Expected rejection for missing 'invariants'"
+
+
+# ---------------------------------------------------------------------------
+# 6. additionalProperties rejections
+# ---------------------------------------------------------------------------
+class TestAdditionalPropertiesRejections:
+    def test_rejects_extra_top_level_key(self):
+        instance = {**_VALID_DCP_INSTANCE, "rogue_top_level": "bad"}
+        assert errors(SCHEMA, instance), "Expected rejection for extra top-level key"
+
+    def test_rejects_extra_capabilities_key(self):
+        caps = {**_VALID_CAPABILITIES, "undeclared_cap": []}
+        instance = {**_VALID_DCP_INSTANCE, "capabilities": caps}
+        assert errors(SCHEMA, instance), "Expected rejection for extra capabilities key"
+
+    def test_rejects_extra_schemas_key(self):
+        schemas = {**_VALID_SCHEMAS, "sneaky_schema_list": []}
+        instance = {**_VALID_DCP_INSTANCE, "schemas": schemas}
+        assert errors(SCHEMA, instance), "Expected rejection for extra schemas key"
+
+    def test_rejects_extra_extension_identity_key(self):
+        identity = {**_VALID_EXTENSION_IDENTITY, "extra_hint": "nope"}
+        instance = {**_VALID_DCP_INSTANCE, "extension_identity": identity}
+        assert errors(SCHEMA, instance), "Expected rejection for extra extension_identity key"
+
+    def test_rejects_status_not_in_enum(self):
+        """'ACTIVE_BETA' is not in the status enum."""
+        instance = {**_VALID_DCP_INSTANCE, "status": "ACTIVE_BETA"}
+        assert errors(SCHEMA, instance), "Expected rejection for status='ACTIVE_BETA'"
+
+
+# ---------------------------------------------------------------------------
+# 7. Hardened schema: new rejection tests
+# ---------------------------------------------------------------------------
+class TestHardenedSchemaRejections:
+    def test_rejects_empty_string_extension_id(self):
+        """extension_id now has minLength:1; empty string must be rejected."""
+        instance = {**_VALID_DCP_INSTANCE, "extension_id": ""}
+        assert errors(SCHEMA, instance), "Expected rejection for empty string extension_id"


### PR DESCRIPTION
Adds the PCP Core extension-manifest and authority-map schemas as co-keystones with additive-only and fail-closed-unknown tests.

Draft / NEEDS_SUPERVISOR. Depends on Packet 1 (PR #925 repair) proof or supervisor waiver.

Validation performed:
- PASS: `git diff --check origin/main...HEAD`
- PASS: `python -m json.tool task-packets/generated/TP-DMX-PCP-EXTENSION-CONTRACT-AUTHORITY-MAP-0001.json >/dev/null`
- PASS: `python -m jsonschema -i task-packets/generated/TP-DMX-PCP-EXTENSION-CONTRACT-AUTHORITY-MAP-0001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` (jsonschema CLI deprecation warning only)
- PASS: `python -m json.tool schemas/project_control_plane/authority_map.schema.json >/dev/null`
- PASS: `python -m json.tool schemas/project_control_plane/extension_manifest.schema.json >/dev/null`
- PASS: `rg -n DOPEMUX_DCP schemas/project_control_plane/extension_manifest.schema.json`
- PASS: `python -m pytest tests/project_control_plane/test_authority_map_schema.py tests/project_control_plane/test_extension_manifest_schema.py` (84 passed)
- PASS: `pre-commit run --files ...` on all changed files

PAL / audit notes:
- PAL codereview workflow reported zero issues in its completion summary, but the expert payload also requested embedded file contents; treat it as limited, not merge-ready proof.
- PAL precommit workflow completed three steps with zero issues in its completion summary, but the expert payload similarly could not inspect embedded files; local validation above remains the concrete evidence.
- PAL clink external reviewer attempts for `gemini` and `claude` failed because those executables were not in PATH.

Residual risk:
- Branch was 29 commits behind `origin/main` before push; GitHub CI and mergeability have not yet been observed.
- This PR is draft publication only, not ready-for-review or merge-ready.
