### PR TITLE
fix(pcp): bundle PCP schemas as package data for wheel-safe imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,6 +183,7 @@ packages = [
     "dopemux.orchestrator.ui",
     "dopemux.orchestrator.validation",
     "dopemux.pcp",
+    "dopemux.pcp._schemas",
     "dopemux.pcp.bridge",
     "dopemux.pm",
     "dopemux.pm.adapters",
@@ -252,6 +253,7 @@ packages = [
     "init/task-packets/TEMPLATE_TASK_PACKET.md",
 ]
 "dopemux.personas" = ["*.agent.md"]
+"dopemux.pcp._schemas" = ["*.json"]
 "dopemux_pr_steward" = ["config.schema.json"]
 "tools.pr_steward" = ["known_reviewers.json"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "sqlite-utils>=3.30.0",
     "psutil>=5.9.0",
     "pydantic>=2.7.0",
+    "jsonschema>=4.20.0",
     "toml>=0.10.0",
     "docker>=7.0.0",
     "litellm>=1.83.7",

--- a/src/dopemux/pcp/_schemas/__init__.py
+++ b/src/dopemux/pcp/_schemas/__init__.py
@@ -1,0 +1,54 @@
+"""Bundled Project Control Plane JSON schemas (wheel-safe loader).
+
+The canonical schemas live at the repo root under
+``schemas/project_control_plane/``. These vendored copies travel *inside* the
+installed package so the four PCP modules that load a schema **at import time**
+— :mod:`dopemux.pcp.exporter`, :mod:`dopemux.pcp.negative_cases`,
+:mod:`dopemux.pcp.pr_steward`, and :mod:`dopemux.pcp.bridge.fastapi_bridge` —
+import cleanly both from the source tree (``src/`` on ``sys.path``) and from an
+installed wheel, where no repo root exists.
+
+Parity with the canonical schemas is enforced by
+``tests/project_control_plane/test_schema_bundle_parity.py``: every vendored
+copy must be byte-identical to its canonical source, so a built wheel can never
+ship a stale or contradictory contract.
+
+This module carries no Project-Control-Plane logic of its own — it is purely a
+schema-file location/bundling shim.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Any
+
+__all__ = ["load_schema"]
+
+
+def load_schema(filename: str) -> dict[str, Any]:
+    """Return the parsed JSON schema *filename* from this bundled package.
+
+    Resolves the resource via :func:`importlib.resources.files` so the lookup
+    works identically from the source tree and from an installed wheel — no
+    repo-root-relative path is computed and no current working directory is
+    assumed.
+
+    Parameters
+    ----------
+    filename:
+        The schema file name, e.g. ``"merge_readiness.schema.json"``.
+
+    Returns
+    -------
+    dict
+        The parsed JSON schema.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *filename* is not bundled in this package.
+    """
+    resource = resources.files(__name__).joinpath(filename)
+    with resource.open("r", encoding="utf-8") as fh:
+        return json.load(fh)

--- a/src/dopemux/pcp/_schemas/live_write_ready.schema.json
+++ b/src/dopemux/pcp/_schemas/live_write_ready.schema.json
@@ -1,0 +1,327 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/live_write_ready.schema.json",
+  "title": "PCP Live-Write Readiness Gate",
+  "description": "Fail-closed gate contract that every future live write must pass before execution. READY is granted ONLY when ALL preconditions are present and passing. Missing or false ANY precondition forces status to BLOCKED or NEEDS_SUPERVISOR. This contract is a readiness declaration only — it NEVER represents a performed write.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assertion_id",
+    "operation_ref",
+    "target_surface",
+    "canonical_writer",
+    "allowlist",
+    "approval",
+    "idempotency",
+    "rollback",
+    "dry_run_proof",
+    "independent_audit",
+    "post_write_verification",
+    "status",
+    "blocked_reasons",
+    "live_write_performed",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.live_write_ready.v0",
+      "description": "Schema version sentinel. Must be exactly 'pcp.live_write_ready.v0'."
+    },
+    "assertion_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this readiness assertion."
+    },
+    "operation_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Reference to the write operation this gate governs (e.g. task-packet ID, PR ref, or operation slug)."
+    },
+    "target_surface": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The surface or resource that would be written (e.g. 'github.pr.merge', 'conport.progress_entry', 'dnh.artifact')."
+    },
+    "canonical_writer": {
+      "type": ["string", "null"],
+      "description": "The authorized canonical writer for this surface. null when the writer is unknown — which forces BLOCKED."
+    },
+    "allowlist": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["paths", "diff_within_allowlist"],
+      "description": "Allowlist declaration: the paths the write is permitted to touch and whether the diff is contained.",
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Declared allowlist paths the write operation is permitted to touch."
+        },
+        "diff_within_allowlist": {
+          "type": "boolean",
+          "description": "True iff every file the write will touch falls within the declared allowlist paths. False forces BLOCKED."
+        }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approved"],
+      "description": "Human or operator approval for the write operation.",
+      "properties": {
+        "approved": {
+          "type": "boolean",
+          "description": "True iff the write has received required approval. False forces BLOCKED."
+        },
+        "approver": {
+          "type": ["string", "null"],
+          "description": "Identity of the approver (GitHub login, operator ID, etc.)."
+        },
+        "approval_ref": {
+          "type": ["string", "null"],
+          "description": "Reference to the approval artifact (PR comment URL, decision ID, etc.)."
+        }
+      }
+    },
+    "idempotency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["idempotent"],
+      "description": "Idempotency declaration for the write operation.",
+      "properties": {
+        "idempotent": {
+          "type": "boolean",
+          "description": "True iff the write operation is idempotent (safe to replay without side-effects). False forces BLOCKED."
+        },
+        "key": {
+          "type": ["string", "null"],
+          "description": "Idempotency key used to deduplicate replays, or null if not yet established."
+        }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available"],
+      "description": "Rollback capability declaration.",
+      "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "True iff a concrete rollback path exists and has been identified. False forces BLOCKED."
+        },
+        "plan": {
+          "type": ["string", "null"],
+          "description": "Non-empty rollback plan/command. null is only permitted for non-READY status; a READY assertion requires a non-empty plan."
+        }
+      }
+    },
+    "dry_run_proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["performed"],
+      "description": "Evidence that a dry-run of the write was performed before live execution.",
+      "properties": {
+        "performed": {
+          "type": "boolean",
+          "description": "True iff a dry-run has been performed and its output inspected. False forces BLOCKED."
+        },
+        "proof_ref": {
+          "type": ["string", "null"],
+          "description": "Reference to the dry-run output artifact (path, URL, etc.)."
+        }
+      }
+    },
+    "independent_audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["performed", "independent", "status"],
+      "description": "Independent audit of the write operation (AIR Red Line #9: implementer is not the sole final auditor).",
+      "properties": {
+        "performed": {
+          "type": "boolean",
+          "description": "True iff an audit was performed. False forces BLOCKED."
+        },
+        "independent": {
+          "type": "boolean",
+          "description": "True iff the auditor is independent of the implementer. False forces BLOCKED."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["PASS", "FAIL", "NOT_RUN"],
+          "description": "Audit verdict. FAIL or NOT_RUN forces BLOCKED."
+        },
+        "auditor": {
+          "type": ["string", "null"],
+          "description": "Identity of the auditor (model ID, GitHub login, tool name, etc.)."
+        }
+      }
+    },
+    "post_write_verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["planned", "performed"],
+      "description": "Post-write verification plan and execution status.",
+      "properties": {
+        "planned": {
+          "type": "boolean",
+          "description": "True iff a post-write verification plan exists. False forces BLOCKED."
+        },
+        "performed": {
+          "type": "boolean",
+          "description": "True iff post-write verification has been performed (expected false at gate-assertion time)."
+        },
+        "verification_ref": {
+          "type": ["string", "null"],
+          "description": "Reference to the verification plan or result artifact."
+        }
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["READY", "BLOCKED", "NEEDS_SUPERVISOR"],
+      "description": "Readiness verdict. READY is fail-closed: withheld on ANY missing or false precondition."
+    },
+    "blocked_reasons": {
+      "type": "array",
+      "uniqueItems": true,
+      "description": "Enumerated reasons READY was withheld. Must be empty iff status is READY.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "MISSING_CANONICAL_WRITER",
+          "DIFF_OUTSIDE_ALLOWLIST",
+          "MISSING_APPROVAL",
+          "NOT_IDEMPOTENT",
+          "NO_ROLLBACK",
+          "MISSING_DRY_RUN_PROOF",
+          "MISSING_INDEPENDENT_AUDIT",
+          "AUDIT_NOT_INDEPENDENT",
+          "AUDIT_NOT_PASSED",
+          "MISSING_POST_WRITE_VERIFICATION",
+          "UNKNOWN"
+        ]
+      }
+    },
+    "live_write_performed": {
+      "type": "boolean",
+      "const": false,
+      "description": "Always false. This schema is a readiness gate contract only. It NEVER represents a performed write. Const-false is enforced by schema."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime at which this readiness assertion was assembled."
+    },
+    "valid_until": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 expiry of this readiness assertion. null is permitted only for non-READY status; a READY assertion requires a non-null timestamp. The consuming bridge rejects with GATE_EXPIRED when now > valid_until — the schema enforces presence and format only, not the time comparison."
+    },
+    "payload_digest": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Lowercase SHA-256 hex of the canonical JSON of the exact operation this assertion authorizes. null is permitted only for non-READY status; a READY assertion requires a non-null digest. The consuming bridge rejects with PAYLOAD_DIGEST_MISMATCH when sha256(canonical(operation)) != payload_digest — the schema enforces presence and format only, not the hash comparison."
+    }
+  },
+  "allOf": [
+    {
+      "description": "Fail-closed READY gate: READY requires ALL preconditions satisfied and zero blocked_reasons.",
+      "if": {
+        "properties": { "status": { "const": "READY" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": [
+          "canonical_writer",
+          "allowlist",
+          "approval",
+          "idempotency",
+          "rollback",
+          "dry_run_proof",
+          "independent_audit",
+          "post_write_verification",
+          "blocked_reasons",
+          "valid_until",
+          "payload_digest"
+        ],
+        "properties": {
+          "canonical_writer": {
+            "type": "string",
+            "minLength": 1
+          },
+          "allowlist": {
+            "properties": {
+              "diff_within_allowlist": { "const": true },
+              "paths": { "type": "array", "minItems": 1 }
+            },
+            "required": ["diff_within_allowlist", "paths"]
+          },
+          "approval": {
+            "properties": {
+              "approved": { "const": true }
+            },
+            "required": ["approved"]
+          },
+          "idempotency": {
+            "properties": {
+              "idempotent": { "const": true }
+            },
+            "required": ["idempotent"]
+          },
+          "rollback": {
+            "properties": {
+              "available": { "const": true },
+              "plan": { "type": "string", "minLength": 1 }
+            },
+            "required": ["available", "plan"]
+          },
+          "dry_run_proof": {
+            "properties": {
+              "performed": { "const": true }
+            },
+            "required": ["performed"]
+          },
+          "independent_audit": {
+            "properties": {
+              "performed": { "const": true },
+              "independent": { "const": true },
+              "status": { "const": "PASS" }
+            },
+            "required": ["performed", "independent", "status"]
+          },
+          "post_write_verification": {
+            "properties": {
+              "planned": { "const": true }
+            },
+            "required": ["planned"]
+          },
+          "blocked_reasons": {
+            "maxItems": 0
+          },
+          "valid_until": {
+            "type": "string",
+            "minLength": 1
+          },
+          "payload_digest": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed BLOCKED gate: BLOCKED or NEEDS_SUPERVISOR requires at least one blocked_reason.",
+      "if": {
+        "properties": { "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "blocked_reasons": { "minItems": 1 }
+        }
+      }
+    }
+  ]
+}

--- a/src/dopemux/pcp/_schemas/merge_readiness.schema.json
+++ b/src/dopemux/pcp/_schemas/merge_readiness.schema.json
@@ -1,0 +1,323 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/merge_readiness.schema.json",
+  "title": "PCP Core PR Steward Merge Readiness Signal",
+  "description": "Generic, project-agnostic MERGE_READINESS signal emitted by the PCP-Core PR Steward readiness intake. This signal is ADVISORY only — it NEVER merges, sets PR ready, or mutates any resource. READY is fail-closed: withheld on ANY blocking condition.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "pr_ref",
+    "head_sha",
+    "status",
+    "blocked_reasons",
+    "intake",
+    "advisory",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.merge_readiness.v0",
+      "description": "Schema version sentinel. Must be exactly 'pcp.merge_readiness.v0'."
+    },
+    "pr_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "number", "head_ref", "base_ref"],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repository in 'owner/repo' or bare 'repo' form."
+        },
+        "number": {
+          "type": "integer",
+          "description": "Pull request number."
+        },
+        "head_ref": {
+          "type": "string",
+          "description": "Head branch reference name."
+        },
+        "base_ref": {
+          "type": "string",
+          "description": "Base branch reference name (merge target)."
+        }
+      }
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$|^[0-9a-f]{64}$",
+      "description": "SHA-1 (40 hex) or SHA-256 (64 hex) of the PR head commit at harvest time."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["READY", "BLOCKED", "NEEDS_SUPERVISOR"],
+      "description": "Merge readiness verdict. READY is withheld on any blocking condition."
+    },
+    "blocked_reasons": {
+      "type": "array",
+      "uniqueItems": true,
+      "description": "Enumerated reasons READY was withheld. Empty iff status is READY.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "STALE_PROOF",
+          "FAILED_CHECK",
+          "STALE_CHECK",
+          "UNKNOWN_REVIEWER_OR_BOT",
+          "UNCLASSIFIED_REVIEW_ITEM",
+          "UNRESOLVED_BLOCKING_THREAD",
+          "DIFF_OUTSIDE_ALLOWLIST",
+          "MISSING_SECURITY_RELEASE_APPROVAL",
+          "MISSING_REQUIRED_INTAKE",
+          "UNKNOWN"
+        ]
+      }
+    },
+    "intake": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Harvested evidence from the PR at read-only intake time.",
+      "required": [
+        "changed_files",
+        "commits",
+        "checks",
+        "reviews",
+        "review_threads",
+        "reviewer_classifications",
+        "unclassified_review_items",
+        "proof_refs",
+        "proof_freshness",
+        "diff_escapes_allowlist",
+        "security_release_required",
+        "security_release_approved"
+      ],
+      "properties": {
+        "changed_files": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Paths of files changed in the PR diff."
+        },
+        "commits": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Commit SHAs included in the PR (head-to-merge-base)."
+        },
+        "checks": {
+          "type": "array",
+          "description": "CI/status check results harvested for the PR head commit.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "conclusion", "stale_to_head"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Check or workflow name."
+              },
+              "conclusion": {
+                "type": "string",
+                "enum": ["SUCCESS", "FAILURE", "NEUTRAL", "STALE", "PENDING", "UNKNOWN"],
+                "description": "Normalised check conclusion. STALE = ran against an older SHA; PENDING = not yet complete; UNKNOWN = could not classify."
+              },
+              "stale_to_head": {
+                "type": "boolean",
+                "description": "True if this check ran against a commit other than head_sha."
+              }
+            }
+          }
+        },
+        "reviews": {
+          "type": "array",
+          "description": "Raw review objects (shape opaque to generic core; validated downstream).",
+          "items": {}
+        },
+        "review_threads": {
+          "type": "array",
+          "description": "PR review threads with resolution and blocking classification.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["resolved", "blocking"],
+            "properties": {
+              "resolved": {
+                "type": "boolean",
+                "description": "True if the thread has been marked resolved."
+              },
+              "blocking": {
+                "type": "boolean",
+                "description": "True if the thread was classified as a hard blocker."
+              }
+            }
+          }
+        },
+        "reviewer_classifications": {
+          "type": "array",
+          "description": "Actor identity classifications for all reviewers/commenters.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["actor", "kind"],
+            "properties": {
+              "actor": {
+                "type": "string",
+                "description": "GitHub login or bot name."
+              },
+              "kind": {
+                "type": "string",
+                "enum": ["HUMAN", "KNOWN_BOT", "UNKNOWN"],
+                "description": "Identity classification. UNKNOWN triggers UNKNOWN_REVIEWER_OR_BOT blocker."
+              }
+            }
+          }
+        },
+        "unclassified_review_items": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Review item IDs or references that could not be classified. Non-empty triggers UNCLASSIFIED_REVIEW_ITEM blocker."
+        },
+        "proof_refs": {
+          "type": "array",
+          "description": "Proof artifact references harvested from the PR.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "head_sha"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path or URL of the proof artifact."
+              },
+              "head_sha": {
+                "type": ["string", "null"],
+                "description": "The head SHA recorded inside the proof artifact, or null if unreadable."
+              }
+            }
+          }
+        },
+        "proof_freshness": {
+          "type": "string",
+          "enum": ["FRESH", "STALE", "MISSING", "UNKNOWN"],
+          "description": "Proof freshness classification. FRESH requires proof_refs[].head_sha == PR head_sha. STALE/MISSING/UNKNOWN withholds READY."
+        },
+        "diff_escapes_allowlist": {
+          "type": "boolean",
+          "description": "True if any changed file falls outside the declared allowlist for this PR. Withholds READY."
+        },
+        "security_release_required": {
+          "type": "boolean",
+          "description": "True if the diff touches security- or release-gated paths requiring explicit human approval."
+        },
+        "security_release_approved": {
+          "type": "boolean",
+          "description": "True if a qualifying human approver granted the security/release gate."
+        }
+      }
+    },
+    "advisory": {
+      "type": "boolean",
+      "const": true,
+      "description": "Always true. This signal is advisory only — it is NEVER a merge authority. Green CI is NOT semantic proof. See AIR Red Lines #7/#8."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime at which this signal was assembled."
+    }
+  },
+  "allOf": [
+    {
+      "description": "Fail-closed gate (a): READY requires zero blocked_reasons, FRESH proof, and diff within allowlist.",
+      "if": {
+        "properties": { "status": { "const": "READY" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "blocked_reasons": { "maxItems": 0 },
+          "intake": {
+            "properties": {
+              "proof_freshness": { "const": "FRESH" },
+              "diff_escapes_allowlist": { "const": false }
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (b): BLOCKED or NEEDS_SUPERVISOR requires at least one blocked_reason.",
+      "if": {
+        "properties": { "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "blocked_reasons": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (c): stale/missing/unknown proof forces status to non-READY.",
+      "if": {
+        "properties": {
+          "intake": {
+            "properties": {
+              "proof_freshness": { "enum": ["STALE", "MISSING", "UNKNOWN"] }
+            },
+            "required": ["proof_freshness"]
+          }
+        },
+        "required": ["intake"]
+      },
+      "then": {
+        "properties": {
+          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (d): diff outside allowlist forces status to non-READY.",
+      "if": {
+        "properties": {
+          "intake": {
+            "properties": {
+              "diff_escapes_allowlist": { "const": true }
+            },
+            "required": ["diff_escapes_allowlist"]
+          }
+        },
+        "required": ["intake"]
+      },
+      "then": {
+        "properties": {
+          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (e): READY with an unapproved security gate is rejected. If status is READY then intake must have security_release_required=false OR security_release_approved=true.",
+      "if": {
+        "properties": { "status": { "const": "READY" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "intake": {
+            "anyOf": [
+              {
+                "properties": { "security_release_required": { "const": false } },
+                "required": ["security_release_required"]
+              },
+              {
+                "properties": { "security_release_approved": { "const": true } },
+                "required": ["security_release_approved"]
+              }
+            ]
+          }
+        },
+        "required": ["intake"]
+      }
+    }
+  ]
+}

--- a/src/dopemux/pcp/_schemas/negative_case_result.schema.json
+++ b/src/dopemux/pcp/_schemas/negative_case_result.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/negative_case_result.schema.json",
+  "title": "Project Control Plane Negative Case Result",
+  "description": "Artifact produced by executing (not merely asserting) fail-closed negative traps against the PCP exporter.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_from_fixture",
+    "total",
+    "passed",
+    "failed",
+    "cases"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "pcp.negative_case_result.v0"
+    },
+    "generated_from_fixture": {
+      "type": "boolean",
+      "default": false
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "passed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "category",
+          "scenario",
+          "expectation",
+          "executed",
+          "outcome",
+          "result"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "type": "string",
+            "minLength": 1
+          },
+          "scenario": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectation": {
+            "type": "string",
+            "minLength": 1
+          },
+          "executed": {
+            "const": true
+          },
+          "outcome": {
+            "type": "string",
+            "minLength": 1
+          },
+          "result": {
+            "type": "string",
+            "enum": ["PASS", "FAIL", "UNKNOWN"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/dopemux/pcp/_schemas/project_evidence_export.schema.json
+++ b/src/dopemux/pcp/_schemas/project_evidence_export.schema.json
@@ -1,0 +1,400 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/project_evidence_export.schema.json",
+  "title": "Project Control Plane Evidence Export",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "project_id",
+    "generated_from_fixture",
+    "profile_ref",
+    "repo_state",
+    "authority_docs",
+    "active_packet",
+    "status_ledger",
+    "proof_manifest",
+    "workflow_list",
+    "pr_review_state",
+    "red_lane_results",
+    "unknowns",
+    "dirty_state",
+    "forbidden_action_confirmation"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.project_evidence_export.v0"
+    },
+    "project_id": {
+      "type": "string"
+    },
+    "generated_from_fixture": {
+      "type": "boolean",
+      "default": false
+    },
+    "profile_ref": {
+      "type": "string"
+    },
+    "repo_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "root_verified",
+        "worktree_state",
+        "head_sha",
+        "branch"
+      ],
+      "properties": {
+        "root_verified": {
+          "type": "boolean"
+        },
+        "worktree_state": {
+          "type": "string",
+          "enum": [
+            "CLEAN",
+            "DIRTY",
+            "FORBIDDEN",
+            "UNKNOWN"
+          ]
+        },
+        "head_sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "authority_docs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "path",
+          "state"
+        ],
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "UNKNOWN",
+              "PRESENT",
+              "ABSENT"
+            ]
+          }
+        }
+      }
+    },
+    "active_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "packet_id",
+        "path"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "PRESENT",
+            "ABSENT"
+          ]
+        },
+        "packet_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "status_ledger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "path",
+        "entries"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "PRESENT",
+            "ABSENT"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "status"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "proof_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "path",
+        "freshness"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "PRESENT",
+            "ABSENT"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "freshness": {
+          "type": "string",
+          "enum": [
+            "CURRENT",
+            "STALE",
+            "UNKNOWN"
+          ]
+        }
+      }
+    },
+    "workflow_list": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "status",
+          "source"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "pr_review_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "authority_allowed",
+        "open_prs"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "PRESENT",
+            "ABSENT"
+          ]
+        },
+        "authority_allowed": {
+          "type": "boolean"
+        },
+        "open_prs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "red_lane_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "lane_id",
+          "result",
+          "evidence"
+        ],
+        "properties": {
+          "lane_id": {
+            "type": "string"
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "PASS",
+              "BLOCKED",
+              "NEEDS_SUPERVISOR",
+              "NEEDS_EVIDENCE_REFRESH",
+              "UNKNOWN"
+            ]
+          },
+          "evidence": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "unknowns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "field",
+          "reason",
+          "result"
+        ],
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "PASS",
+              "BLOCKED",
+              "NEEDS_SUPERVISOR",
+              "NEEDS_EVIDENCE_REFRESH",
+              "UNKNOWN"
+            ]
+          }
+        }
+      }
+    },
+    "dirty_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "paths"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "CLEAN",
+            "DIRTY",
+            "UNKNOWN"
+          ]
+        },
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "forbidden_action_confirmation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "external_workflow_written",
+        "external_runner_executed",
+        "github_mutated",
+        "runtime_written"
+      ],
+      "properties": {
+        "external_workflow_written": {
+          "const": false
+        },
+        "external_runner_executed": {
+          "const": false
+        },
+        "github_mutated": {
+          "const": false
+        },
+        "runtime_written": {
+          "const": false
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Runtime head_sha gate: a real (non-fixture) export must capture a real head_sha.",
+      "if": {
+        "properties": {
+          "generated_from_fixture": {
+            "const": false
+          }
+        },
+        "required": [
+          "generated_from_fixture"
+        ]
+      },
+      "then": {
+        "required": [
+          "repo_state"
+        ],
+        "properties": {
+          "repo_state": {
+            "required": [
+              "head_sha"
+            ],
+            "properties": {
+              "head_sha": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/dopemux/pcp/bridge/fastapi_bridge.py
+++ b/src/dopemux/pcp/bridge/fastapi_bridge.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import pathlib
 from datetime import datetime, timezone
 from typing import Any, Callable, Protocol
 
@@ -34,20 +33,14 @@ from fastapi.responses import JSONResponse
 from jsonschema import Draft202012Validator
 from pydantic import BaseModel, StrictBool
 
-# ---------------------------------------------------------------------------
-# Schema loading — repo-root relative.
-# src/dopemux/pcp/bridge/fastapi_bridge.py -> parents[4] == repo root
-# (file -> bridge -> pcp -> dopemux -> src -> ROOT). One level deeper than the
-# sibling pcp modules (exporter/pr_steward use parents[3]).
-# ---------------------------------------------------------------------------
-_HERE = pathlib.Path(__file__).resolve()
-_REPO_ROOT = _HERE.parents[4]
-_SCHEMA_PATH = (
-    _REPO_ROOT / "schemas" / "project_control_plane" / "live_write_ready.schema.json"
-)
+from .._schemas import load_schema
 
-with _SCHEMA_PATH.open() as _fh:
-    _SCHEMA: dict = json.load(_fh)
+# ---------------------------------------------------------------------------
+# Schema — loaded from bundled package data (dopemux.pcp._schemas) so the
+# validator is available both from the source tree and from an installed wheel.
+# No repo-root-relative path is assumed.
+# ---------------------------------------------------------------------------
+_SCHEMA: dict = load_schema("live_write_ready.schema.json")
 
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 

--- a/src/dopemux/pcp/exporter.py
+++ b/src/dopemux/pcp/exporter.py
@@ -17,7 +17,6 @@ Usage::
 
 from __future__ import annotations
 
-import json
 import os
 import pathlib
 import re
@@ -26,17 +25,14 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
-# ---------------------------------------------------------------------------
-# Schema location — resolved relative to the repo root at import time so the
-# validator is available even when the package is imported from any CWD.
-# ---------------------------------------------------------------------------
-_HERE = pathlib.Path(__file__).resolve()
-# src/dopemux/pcp/exporter.py  →  3 levels up = repo root
-_REPO_ROOT = _HERE.parent.parent.parent.parent
-_SCHEMA_PATH = _REPO_ROOT / "schemas" / "project_control_plane" / "project_evidence_export.schema.json"
+from ._schemas import load_schema
 
-with _SCHEMA_PATH.open() as _fh:
-    _SCHEMA: dict = json.load(_fh)
+# ---------------------------------------------------------------------------
+# Schema — loaded from bundled package data (dopemux.pcp._schemas) so the
+# validator is available both from the source tree and from an installed wheel.
+# No repo-root-relative path is assumed and no CWD is required.
+# ---------------------------------------------------------------------------
+_SCHEMA: dict = load_schema("project_evidence_export.schema.json")
 
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 

--- a/src/dopemux/pcp/negative_cases.py
+++ b/src/dopemux/pcp/negative_cases.py
@@ -28,30 +28,15 @@ import tempfile
 
 from jsonschema import Draft202012Validator
 
-# ---------------------------------------------------------------------------
-# Schema loading — repo-root-relative, resolved from this file's location.
-# src/dopemux/pcp/negative_cases.py → 4 levels up = repo root
-# ---------------------------------------------------------------------------
-_HERE = pathlib.Path(__file__).resolve()
-_REPO_ROOT = _HERE.parent.parent.parent.parent
-_SCHEMA_PATH = (
-    _REPO_ROOT
-    / "schemas"
-    / "project_control_plane"
-    / "negative_case_result.schema.json"
-)
-_EVIDENCE_SCHEMA_PATH = (
-    _REPO_ROOT
-    / "schemas"
-    / "project_control_plane"
-    / "project_evidence_export.schema.json"
-)
+from ._schemas import load_schema
 
-with _SCHEMA_PATH.open() as _fh:
-    _SCHEMA: dict = json.load(_fh)
-
-with _EVIDENCE_SCHEMA_PATH.open() as _fh:
-    _EVIDENCE_SCHEMA: dict = json.load(_fh)
+# ---------------------------------------------------------------------------
+# Schemas — loaded from bundled package data (dopemux.pcp._schemas) so the
+# validators are available both from the source tree and from an installed
+# wheel. No repo-root-relative path is assumed.
+# ---------------------------------------------------------------------------
+_SCHEMA: dict = load_schema("negative_case_result.schema.json")
+_EVIDENCE_SCHEMA: dict = load_schema("project_evidence_export.schema.json")
 
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 _EVIDENCE_VALIDATOR = Draft202012Validator(_EVIDENCE_SCHEMA)

--- a/src/dopemux/pcp/pr_steward.py
+++ b/src/dopemux/pcp/pr_steward.py
@@ -29,27 +29,19 @@ Usage::
 from __future__ import annotations
 
 import json
-import pathlib
 import subprocess
 from typing import Any, Callable
 
 from jsonschema import Draft202012Validator
 
-# ---------------------------------------------------------------------------
-# Schema loading — resolved relative to the repo root at import time.
-# src/dopemux/pcp/pr_steward.py  →  4 levels up = repo root
-# ---------------------------------------------------------------------------
-_HERE = pathlib.Path(__file__).resolve()
-_REPO_ROOT = _HERE.parent.parent.parent.parent
-_SCHEMA_PATH = (
-    _REPO_ROOT
-    / "schemas"
-    / "project_control_plane"
-    / "merge_readiness.schema.json"
-)
+from ._schemas import load_schema
 
-with _SCHEMA_PATH.open() as _fh:
-    _SCHEMA: dict = json.load(_fh)
+# ---------------------------------------------------------------------------
+# Schema — loaded from bundled package data (dopemux.pcp._schemas) so the
+# validator is available both from the source tree and from an installed wheel.
+# No repo-root-relative path is assumed.
+# ---------------------------------------------------------------------------
+_SCHEMA: dict = load_schema("merge_readiness.schema.json")
 
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 

--- a/tests/project_control_plane/test_schema_bundle_parity.py
+++ b/tests/project_control_plane/test_schema_bundle_parity.py
@@ -1,0 +1,63 @@
+"""Parity guard: bundled PCP schemas must match the canonical repo-root copies.
+
+The four import-time schema loaders in ``dopemux.pcp.*`` read their schema from
+vendored package-data copies under ``src/dopemux/pcp/_schemas/`` so a built
+wheel works without a repo root. Those copies MUST stay byte-identical to the
+canonical schemas at ``schemas/project_control_plane/`` — otherwise a wheel
+could ship a stale or contradictory contract while source-tree tests (which read
+the canonical copies directly) stay green. This guard fails closed on any drift.
+
+It also exercises the wheel-safe loader (:func:`dopemux.pcp._schemas.load_schema`)
+to prove it resolves the bundled resource and returns the canonical content.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+# tests/project_control_plane/test_*.py -> 3 levels up = repo root
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_CANONICAL_DIR = _REPO_ROOT / "schemas" / "project_control_plane"
+_BUNDLED_DIR = _REPO_ROOT / "src" / "dopemux" / "pcp" / "_schemas"
+
+# Exactly the schemas loaded at import time by the dopemux.pcp.* modules:
+#   exporter            -> project_evidence_export.schema.json
+#   negative_cases      -> negative_case_result.schema.json,
+#                          project_evidence_export.schema.json
+#   pr_steward          -> merge_readiness.schema.json
+#   bridge.fastapi_bridge -> live_write_ready.schema.json
+_VENDORED_SCHEMAS = [
+    "project_evidence_export.schema.json",
+    "negative_case_result.schema.json",
+    "merge_readiness.schema.json",
+    "live_write_ready.schema.json",
+]
+
+
+@pytest.mark.parametrize("name", _VENDORED_SCHEMAS)
+def test_bundled_schema_is_byte_identical_to_canonical(name: str) -> None:
+    canonical = _CANONICAL_DIR / name
+    bundled = _BUNDLED_DIR / name
+    assert canonical.exists(), f"canonical schema missing: {canonical}"
+    assert bundled.exists(), (
+        f"bundled schema missing: {bundled} — the wheel-safe copy must exist "
+        f"so an installed wheel can load it without a repo root."
+    )
+    assert bundled.read_bytes() == canonical.read_bytes(), (
+        f"bundled schema {name} has drifted from canonical "
+        f"{canonical.relative_to(_REPO_ROOT)} — re-copy it verbatim."
+    )
+
+
+@pytest.mark.parametrize("name", _VENDORED_SCHEMAS)
+def test_load_schema_returns_canonical_content(name: str) -> None:
+    from dopemux.pcp._schemas import load_schema
+
+    loaded = load_schema(name)
+    canonical = json.loads((_CANONICAL_DIR / name).read_text(encoding="utf-8"))
+    assert loaded == canonical, (
+        f"load_schema({name!r}) did not return the canonical parsed schema."
+    )


### PR DESCRIPTION
## What & why
The four `dopemux.pcp` modules (`exporter`, `negative_cases`, `pr_steward`, `bridge.fastapi_bridge`) loaded their JSON Schema **at import time** via a repo-root-relative path (`parents[N]` from `__file__`). That path does not exist in an installed wheel, so importing `dopemux.pcp.*` from a `pip install`-ed dopemux crashed with `FileNotFoundError`.

This completes **Tracked Follow-up #1** (A4 wheel-import) deferred by the conformance repair on this base branch.

## Changes
**1. Bundle PCP schemas as package data**
- Vendor the 4 loaded schemas under `dopemux/pcp/_schemas/` + a `load_schema()` shim using `importlib.resources` (resolves identically from the source tree and an installed wheel — single path, no repo-root assumption).
- Repoint the 4 loaders at `load_schema(...)`; drop the now-dead `json`/`pathlib` imports.
- `pyproject.toml`: add `dopemux.pcp._schemas` to `packages` + `package-data = ["*.json"]`.
- New parity test: vendored copies must stay **byte-identical** to canonical `schemas/project_control_plane/` (the modules validate against their copy, so drift would ship a stale contract).

**2. Declare `jsonschema` as a core dependency**
- The 4 shipped pcp modules `import jsonschema` directly, but it was only in the `test`/`dev` extras — a clean install got it only transitively via `litellm`. Declared `jsonschema>=4.20.0` in core `dependencies` so the import chain cannot break if litellm ever changes. Verified `Requires-Dist: jsonschema>=4.20.0` now appears unconditionally in the wheel METADATA.

No PCP/DCP runtime logic changed.

## Verification
- `tests/project_control_plane` + `tests/dcp_extension`: **435 passed, 0 failed**.
- Parity test: RED (`FileNotFoundError`) → GREEN after vendoring.
- Clean-venv wheel install (`--no-deps` + import-time deps): all 6 `dopemux.pcp.*` imports OK from `site-packages`; schemas resolve from `site-packages/dopemux/pcp/_schemas`; `dopemux-pcp export --help` runs.
- Wheel contents include `dopemux/pcp/*`, all 4 `_schemas/*.json`, and the `dopemux-pcp` entry point; METADATA declares `Requires-Dist: jsonschema>=4.20.0`.

## Base
Rebased onto `claude/pcp-conformance-repair-0001` (which adds the `dopemux.pcp` allowlist + `dopemux-pcp` console script). Targets that branch, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)