### PR TITLE
fix(mcp): route task-orchestrator through HTTP singleton

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -2,13 +2,15 @@
 #
 # CANONICAL DEVELOPMENT ENTRYPOINT
 # This is the single source of truth for running Dopemux services.
+# SINGLETON TASK-ORCHESTRATOR: Only ONE instance should run across all worktrees.
 #
 # Services Included:
 # - Infrastructure: PostgreSQL (AGE), Redis (2x), Qdrant
 # - MCP Servers: ConPort, PAL, LiteLLM, Dope-Context, Serena, GPT-Researcher, Exa, Desktop Commander, Leantime Bridge
-# - Application Services: DopeconBridge, Task Orchestrator, ADHD Engine
+# - Application Services: DopeconBridge, Task Orchestrator (singleton), ADHD Engine
 #
 # Usage:
+#   export COMPOSE_FILE=compose.yml
 #   docker compose up -d                    # Start all services
 #   docker compose ps                       # View running services
 #   docker compose down                     # Stop all services
@@ -16,7 +18,8 @@
 #
 # Guidelines:
 # - `compose.yml` is the canonical runtime file for this repository.
-# - Do not add overlay compose files for normal runtime operation.
+# - DO NOT invoke `docker compose` from worktree subdirectories.
+# - Always use `COMPOSE_FILE=compose.yml` to lock to canonical file and prevent duplicate task-orchestrator instances.
 # - Instance-aware services must be parameterized through env overrides, not duplicated service definitions.
 
 name: dopemux

--- a/src/dopemux/mcp/default_catalog.yaml
+++ b/src/dopemux/mcp/default_catalog.yaml
@@ -91,13 +91,15 @@ servers:
   task-orchestrator:
     scope: per-worktree
     state_scope: per-repo
-    transport: stdio
-    command: scripts/mcp-wrappers/task-orchestrator-current-stdio.sh
-    args: []
+    transport: http
+    url_template: "http://127.0.0.1:${TASK_ORCHESTRATOR_HTTP_PORT:-7890}/mcp"
+    port_var: TASK_ORCHESTRATOR_HTTP_PORT
+    default_port_base: 7890
     doctor_args: ["--print-resolution"]
     requires_env: ["TASK_ORCHESTRATOR_PROJECT_ROOT"]
     env_template:
       DOPEMUX_WORKSPACE_ROOT: "${DOPEMUX_WORKSPACE_ROOT:-}"
       DOPEMUX_PROJECT_ROOT: "${DOPEMUX_PROJECT_ROOT:-}"
       TASK_ORCHESTRATOR_PROJECT_ROOT: "${TASK_ORCHESTRATOR_PROJECT_ROOT:-}"
-    description: "Current 13-tool MCP Task Orchestrator with repo-scoped SQLite state"
+      TASK_ORCHESTRATOR_HTTP_PORT: "${TASK_ORCHESTRATOR_HTTP_PORT:-7890}"
+    description: "HTTP singleton MCP Task Orchestrator with repo-scoped SQLite state"


### PR DESCRIPTION
## Summary

- Align bundled `default_catalog.yaml` with `mcp_catalog.yaml` and `.mcp.json`: task-orchestrator now uses the `:7890` HTTP singleton instead of the stdio docker wrapper.
- Document compose.yml singleton constraints to prevent duplicate task-orchestrator instances across worktrees.

## Context

Gateway-leaked task-orchestrator containers (MCP_DOCKER profile) were overloading the Docker daemon. Prevention is operator-local (gateway profile remove); this PR fixes the tracked catalog/compose guidance so new sessions route through the existing HTTP singleton.

## Test plan

- [x] `git diff --check`
- [x] Cherry-picked onto current `main` (old branch was 142 commits behind)
- [ ] CI green (merging ASAP on operator request)