### PR TITLE
feat(task-orchestrator): canonical-store read view — live_state banner, filters, doc

### DIFF
--- a/docs/03-reference/systems/task-orchestrator/canonical-read-view.md
+++ b/docs/03-reference/systems/task-orchestrator/canonical-read-view.md
@@ -1,0 +1,101 @@
+---
+id: canonical-read-view
+title: Canonical Reconciliation Read View
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-23'
+last_review: '2026-06-23'
+next_review: '2026-09-21'
+prelude: Canonical Reconciliation Read View (reference) for dopemux documentation and developer
+  workflows.
+---
+# Canonical Reconciliation Read View
+
+A feature-flagged, **read-only** operator view over the **offline** canonical reconciliation SQLite
+artifact produced by `tools/task_orchestrator_reconcile/import_pack.py` (`--output`). It is a **DERIVED,
+point-in-time** view — it is **never** live state, **never** a canonical or PM authority, and **never** a
+Task Orchestrator writer. See [canonical-datastore-contract.md](canonical-datastore-contract.md) for the
+authority boundaries.
+
+## What it is (and is not)
+
+- **Is:** a way to inspect the rows the offline importer materialized (`canonical_current_work_items`) with
+  full source provenance, plus a point-in-time anchor.
+- **Is not:** a connection to any live `current-tasks.db`; a PM authority; a workflow writer; or a
+  registered `canonical_*` runtime authority. `config/runtime_authority_manifest.json` is not touched by
+  this surface.
+
+## Feature flag
+
+The command is gated by the `CANONICAL_STORE_READ_VIEW_ENABLED` environment variable, **default off**.
+When unset/false it **fails closed** (non-zero exit, clear message) and never opens the SQLite file.
+
+```bash
+export CANONICAL_STORE_READ_VIEW_ENABLED=1
+```
+
+## Command
+
+```bash
+dopemux orchestrator canonical-store inspect --db <offline-canonical.sqlite> [options]
+```
+
+The store is opened strictly read-only (`file:<path>?mode=ro`, with the path percent-encoded so URI
+metacharacters cannot bypass `mode=ro`). Note bodies / `summary` and FTS rows are never surfaced.
+
+### Options
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `--db PATH` | (required) | Path to the offline canonical reconciliation SQLite file. |
+| `--limit INT` | none | Cap items returned; the full `item_count` (store total) is still reported. |
+| `--role TEXT` | none | Filter to items with this exact `role`. |
+| `--status TEXT` | none | Filter to items with this exact `status_label`. |
+| `--root TEXT` | none | Filter to items whose `canonical_identity` starts with this prefix. |
+| `--include-terminal` | off | Include terminal-role items (`done`, `cancelled`, `archived`); excluded by default. |
+| `--format [table\|json]` | `table` | Output format. |
+| `--json-output` | off | Alias for `--format json`. |
+
+All filter values are bound as parameterised SQL placeholders — none are interpolated into SQL.
+
+### Output
+
+The human-readable (table) banner makes the non-live nature explicit:
+
+```text
+CANONICAL RECONCILIATION VIEW
+  mode: read-only
+  source: offline sqlite
+  valid_as_of: <MAX(source_mtime_utc) — ISO-8601 UTC, see note below>
+  live_state: false
+  source_dbs=<N> | items=<store total> | showing=<after filters>
+```
+
+Each row carries provenance: `canonical_identity`, `role`, `status_label`, `source_db_slug`,
+`source_row_id` (JSON output additionally includes `title`, `source_mtime_utc`, `import_run_id`,
+`archive_sha256`).
+
+### `valid_as_of` semantics
+
+`valid_as_of` is `MAX(source_mtime_utc)` over `source_databases`. This is a lexicographic string MAX and
+equals the true chronological maximum only because `import_pack` emits zero-padded ISO-8601 UTC mtimes.
+
+## Examples
+
+```bash
+# Default table view (terminal items excluded)
+dopemux orchestrator canonical-store inspect --db /tmp/to-canonical-full-dryrun.sqlite
+
+# JSON, only work items, first 20
+dopemux orchestrator canonical-store inspect --db /tmp/store.sqlite --role work --limit 20 --format json
+
+# Items under a series prefix, including terminal
+dopemux orchestrator canonical-store inspect --db /tmp/store.sqlite --root TP-TO-CANON --include-terminal
+```
+
+## Authority note
+
+This view is **derived/read-only/point-in-time**. It does not own PM truth, does not write workflow state,
+and does not promote the offline store into a live authority. PM authority remains split across Leantime,
+task-orchestrator, ConPort, dope-memory, dope-context, and the dopecon-bridge transport boundary.

--- a/docs/ops/pal-mcp-codex-claude-stdio.md
+++ b/docs/ops/pal-mcp-codex-claude-stdio.md
@@ -1,3 +1,15 @@
+---
+id: pal-mcp-codex-claude-stdio
+title: Pal Mcp Codex Claude Stdio
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-06-27'
+last_review: '2026-06-27'
+next_review: '2026-09-25'
+prelude: Pal Mcp Codex Claude Stdio (explanation) for dopemux documentation and developer
+  workflows.
+---
 # PAL MCP — Codex & Claude Code (operator runbook)
 
 Dopemux also ships `mcp-pal` / `mcp-pal-stdio` in `compose.yml` (HTTP :3003 and toolkit

--- a/src/dopemux/commands/orchestrator_commands.py
+++ b/src/dopemux/commands/orchestrator_commands.py
@@ -1110,14 +1110,52 @@ def orchestrator_canonical_store():
     help="Cap the number of work items returned (full item_count still reported).",
 )
 @click.option(
+    "--role",
+    "role",
+    default=None,
+    help="Filter items by exact role value (e.g. work, queue, review).",
+)
+@click.option(
+    "--status",
+    "status",
+    default=None,
+    help="Filter items by exact status_label value (e.g. IN_PROGRESS, DONE).",
+)
+@click.option(
+    "--root",
+    "root",
+    default=None,
+    help="Filter items whose canonical_identity starts with this prefix.",
+)
+@click.option(
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    default="table",
+    show_default=True,
+    help="Output format: table (human-readable) or json.",
+)
+@click.option(
+    "--include-terminal",
+    "include_terminal",
+    is_flag=True,
+    default=False,
+    help="Include terminal-role items (done, cancelled, archived).",
+)
+@click.option(
     "--json-output",
     "json_output",
     is_flag=True,
-    help="Emit output as JSON.",
+    help="Emit output as JSON (alias for --format json).",
 )
 def orchestrator_canonical_store_inspect(
     db_path: Path,
     limit: Optional[int],
+    role: Optional[str],
+    status: Optional[str],
+    root: Optional[str],
+    output_format: str,
+    include_terminal: bool,
     json_output: bool,
 ):
     """Inspect the offline canonical reconciliation store (read-only, point-in-time).
@@ -1136,7 +1174,14 @@ def orchestrator_canonical_store_inspect(
     if not db_path.exists():
         raise click.ClickException(f"canonical store not found: {db_path}")
     try:
-        view = read_canonical_view(db_path, limit=limit)
+        view = read_canonical_view(
+            db_path,
+            limit=limit,
+            role=role,
+            status=status,
+            root=root,
+            include_terminal=include_terminal,
+        )
     except (ValueError, FileNotFoundError) as exc:
         raise click.ClickException(str(exc)) from exc
     except sqlite3.DatabaseError as exc:
@@ -1144,16 +1189,19 @@ def orchestrator_canonical_store_inspect(
             f"sqlite error reading canonical store: {exc}"
         ) from exc
 
-    if json_output:
+    if json_output or output_format.lower() == "json":
         click.echo(json.dumps(view, indent=2, sort_keys=True, default=str))
         return
 
-    # Human-readable banner — makes point-in-time nature explicit.
+    # Human-readable multi-line banner — makes the point-in-time, non-live nature explicit.
+    click.echo("CANONICAL RECONCILIATION VIEW")
+    click.echo("  mode: read-only")
+    click.echo("  source: offline sqlite")
+    click.echo(f"  valid_as_of: {view['valid_as_of']}")
+    click.echo("  live_state: false")
     click.echo(
-        f"[canonical-store] read-only point-in-time view | "
-        f"valid_as_of={view['valid_as_of']} | "
-        f"source_dbs={view['source_db_count']} | "
-        f"items={view['item_count']}"
+        f"  source_dbs={view['source_db_count']} | items={view['item_count']}"
+        f" | showing={len(view['items'])}"
     )
     for item in view["items"]:
         click.echo(

--- a/src/dopemux/orchestrator/canonical_readview.py
+++ b/src/dopemux/orchestrator/canonical_readview.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List, Optional
 _EXPECTED_TABLES = frozenset({"source_databases", "canonical_current_work_items"})
 
 # Roles considered terminal — excluded from the operator view unless requested.
-_TERMINAL_ROLES = frozenset({"done", "cancelled", "archived"})
+_TERMINAL_ROLES = frozenset({"done", "cancelled", "archived", "terminal"})
 
 
 def _connect_ro(db_path: Path) -> sqlite3.Connection:
@@ -57,7 +57,7 @@ def read_canonical_view(
     role: Optional[str] = None,
     status: Optional[str] = None,
     root: Optional[str] = None,
-    include_terminal: bool = True,
+    include_terminal: bool = False,
 ) -> Dict[str, Any]:
     """Return a read-only point-in-time summary of the canonical reconciliation store.
 
@@ -85,9 +85,9 @@ def read_canonical_view(
         role:             Filter to items with this exact ``role``.
         status:           Filter to items with this exact ``status_label``.
         root:             Filter to items whose ``canonical_identity`` starts with
-                          this prefix.
+          this prefix.
         include_terminal: When False, exclude terminal-role rows
-                          (``done``/``cancelled``/``archived``). Default True.
+          (``done``/``cancelled``/``archived``/``terminal``). Default False.
 
     Raises:
         FileNotFoundError: ``db_path`` does not exist.

--- a/src/dopemux/orchestrator/canonical_readview.py
+++ b/src/dopemux/orchestrator/canonical_readview.py
@@ -14,6 +14,9 @@ from typing import Any, Dict, List, Optional
 
 _EXPECTED_TABLES = frozenset({"source_databases", "canonical_current_work_items"})
 
+# Roles considered terminal — excluded from the operator view unless requested.
+_TERMINAL_ROLES = frozenset({"done", "cancelled", "archived"})
+
 
 def _connect_ro(db_path: Path) -> sqlite3.Connection:
     """Open *db_path* strictly read-only.
@@ -51,6 +54,10 @@ def read_canonical_view(
     db_path: Path,
     *,
     limit: Optional[int] = None,
+    role: Optional[str] = None,
+    status: Optional[str] = None,
+    root: Optional[str] = None,
+    include_terminal: bool = True,
 ) -> Dict[str, Any]:
     """Return a read-only point-in-time summary of the canonical reconciliation store.
 
@@ -69,10 +76,18 @@ def read_canonical_view(
     ``source_db_slug``, ``source_row_id``.  ``summary`` / note bodies are
     intentionally excluded.
 
+    All filter values are applied as parameterised ``?`` placeholders; no filter
+    value is ever interpolated into SQL.
+
     Args:
-        db_path: Path to the offline canonical reconciliation SQLite file.
-        limit:   Optional cap on the number of items returned (``ORDER BY
-                 canonical_identity``).
+        db_path:          Path to the offline canonical reconciliation SQLite file.
+        limit:            Optional cap on items returned (``ORDER BY canonical_identity``).
+        role:             Filter to items with this exact ``role``.
+        status:           Filter to items with this exact ``status_label``.
+        root:             Filter to items whose ``canonical_identity`` starts with
+                          this prefix.
+        include_terminal: When False, exclude terminal-role rows
+                          (``done``/``cancelled``/``archived``). Default True.
 
     Raises:
         FileNotFoundError: ``db_path`` does not exist.
@@ -96,7 +111,27 @@ def read_canonical_view(
             "SELECT COUNT(*) FROM canonical_current_work_items;"
         ).fetchone()[0]
 
-        query = """
+        # Parameterised filters — no filter value is interpolated into SQL.
+        conditions: List[str] = []
+        params: List[Any] = []
+        if not include_terminal:
+            placeholders = ",".join("?" for _ in _TERMINAL_ROLES)
+            conditions.append(f"role NOT IN ({placeholders})")
+            params.extend(sorted(_TERMINAL_ROLES))
+        if role is not None:
+            conditions.append("role = ?")
+            params.append(role)
+        if status is not None:
+            conditions.append("status_label = ?")
+            params.append(status)
+        if root is not None:
+            conditions.append("canonical_identity LIKE ? ESCAPE '\\'")
+            params.append(
+                root.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_") + "%"
+            )
+        where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+        query = f"""
             SELECT
                 canonical_identity,
                 role,
@@ -108,12 +143,14 @@ def read_canonical_view(
                 source_db_slug,
                 source_row_id
             FROM canonical_current_work_items
+            {where_clause}
             ORDER BY canonical_identity
         """
         if limit is not None:
-            query += f" LIMIT {int(limit)}"
+            query += " LIMIT ?"
+            params.append(int(limit))
 
-        rows = conn.execute(query).fetchall()
+        rows = conn.execute(query, params).fetchall()
         items: List[Dict[str, Any]] = [dict(row) for row in rows]
     finally:
         conn.close()

--- a/tests/unit/orchestrator/test_canonical_store_readview.py
+++ b/tests/unit/orchestrator/test_canonical_store_readview.py
@@ -422,3 +422,131 @@ def test_inspect_surfaces_sqlite_database_error(
     assert result.exit_code != 0
     output = (result.output or "") + str(result.exception or "")
     assert "sqlite error reading canonical store" in output.lower()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Enhancements: live_state banner + filters (--role/--status/--root/--include-terminal/--format)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _add_work_item(
+    db_path: Path,
+    *,
+    identity: str,
+    role: str,
+    status: str = "QUEUED",
+    title: str = "extra",
+) -> None:
+    """Insert an extra canonical_current_work_items row (read-write, test setup only)."""
+    conn = sqlite3.connect(str(db_path))
+    try:
+        decision_id = conn.execute(
+            "SELECT id FROM reconciliation_decisions LIMIT 1"
+        ).fetchone()[0]
+        conn.execute(
+            """
+            INSERT INTO canonical_current_work_items (
+                source_db_slug, source_database_path, source_schema_hash,
+                source_table, source_row_id, source_mtime_utc, import_run_id,
+                archive_sha256, canonical_identity, role, status_label, title, decision_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                _KNOWN_SLUG, "/fake/path/wt-test.db", "sha256-schema-hash-abc",
+                "work_items", identity, _KNOWN_MTIME, "run-001", "sha256-archive-abc",
+                identity, role, status, title, decision_id,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _inspect_json(canonical_db: Path, *extra_args: str) -> dict:
+    monkey_runner = CliRunner()
+    result = monkey_runner.invoke(
+        orchestrator_group,
+        ["canonical-store", "inspect", "--db", str(canonical_db), "--json-output", *extra_args],
+    )
+    assert result.exit_code == 0, result.output
+    import json
+
+    return json.loads(result.output)
+
+
+def test_inspect_table_banner_states_read_only_and_live_state_false(
+    canonical_db: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The default (table) banner must state mode: read-only and live_state: false."""
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "1")
+    runner = CliRunner()
+    result = runner.invoke(
+        orchestrator_group,
+        ["canonical-store", "inspect", "--db", str(canonical_db)],
+    )
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "CANONICAL RECONCILIATION VIEW" in out
+    assert "mode: read-only" in out
+    assert "live_state: false" in out
+    assert f"valid_as_of: {_KNOWN_MTIME}" in out
+
+
+def test_inspect_role_filter(
+    canonical_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "1")
+    match = _inspect_json(canonical_db, "--role", "work")
+    assert [i["canonical_identity"] for i in match["items"]] == [_KNOWN_IDENTITY]
+    miss = _inspect_json(canonical_db, "--role", "nonexistent")
+    assert miss["items"] == []
+    assert miss["item_count"] == 1  # store total unchanged by filter
+
+
+def test_inspect_status_filter(
+    canonical_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "1")
+    assert _inspect_json(canonical_db, "--status", "IN_PROGRESS")["items"]
+    assert _inspect_json(canonical_db, "--status", "NOPE")["items"] == []
+
+
+def test_inspect_root_prefix_filter(
+    canonical_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "1")
+    assert _inspect_json(canonical_db, "--root", "canon-id")["items"]
+    assert _inspect_json(canonical_db, "--root", "zzz-no-match")["items"] == []
+
+
+def test_inspect_excludes_terminal_by_default_includes_with_flag(
+    canonical_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "1")
+    _add_work_item(canonical_db, identity="canon-id-done", role="done")
+    default = _inspect_json(canonical_db)
+    ids_default = {i["canonical_identity"] for i in default["items"]}
+    assert _KNOWN_IDENTITY in ids_default
+    assert "canon-id-done" not in ids_default  # terminal excluded by default
+    assert default["item_count"] == 2  # store total still counts it
+    with_terminal = _inspect_json(canonical_db, "--include-terminal")
+    ids_all = {i["canonical_identity"] for i in with_terminal["items"]}
+    assert "canon-id-done" in ids_all
+
+
+def test_inspect_format_json_matches_json_output(
+    canonical_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("CANONICAL_STORE_READ_VIEW_ENABLED", "1")
+    import json
+
+    runner = CliRunner()
+    res = runner.invoke(
+        orchestrator_group,
+        ["canonical-store", "inspect", "--db", str(canonical_db), "--format", "json"],
+    )
+    assert res.exit_code == 0, res.output
+    payload = json.loads(res.output)
+    assert payload["valid_as_of"] == _KNOWN_MTIME
+    assert "summary" not in payload["items"][0]


### PR DESCRIPTION
## Summary

Follow-up enhancements to the merged TO-CANON-006 read view ([#971](https://github.com/DDD-Enterprises/dopemux-mvp/pull/971)), per the GPT-5.5 supervisor dispatch spec. Layered **on top of** the operator's merged `--limit`/`DatabaseError`/ISO hardening (`0efc4d8919`) — their work is preserved, not reverted.

- **`live_state: false` banner** — multi-line table banner (`CANONICAL RECONCILIATION VIEW / mode: read-only / source: offline sqlite / valid_as_of / live_state: false`) so the view never implies liveness.
- **Filters** — `--role`, `--status`, `--root` (canonical_identity prefix), `--format table|json`, `--include-terminal` (terminal roles excluded by default). All bound as parameterised SQL placeholders; `LIKE` uses `ESCAPE`.
- **Reference doc** — `docs/03-reference/systems/task-orchestrator/canonical-read-view.md`.

Derived/read-only is unchanged: SQLite still `mode=ro`, flag still fail-closed (default off), `config/runtime_authority_manifest.json` untouched, no `canonical_store` role, `summary`/note bodies still excluded.

## Validation (PASS, Python 3.12)
- `pytest tests/unit/orchestrator` — **129 passed** (20 readview incl. operator's + 6 new filter/banner tests; zero regression)
- `verify_runtime_authority.py` — exit 0, manifest unchanged
- `docs_validator.py` on the new doc — exit 0
- `compileall` / `from dopemux.cli import cli` / `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)