### PR TITLE
Optimize Copilot and LLM agent routing baselines

### DIFF
--- a/.github/agents/dopemux-auditor.agent.md
+++ b/.github/agents/dopemux-auditor.agent.md
@@ -2,7 +2,7 @@
 description: 'Independent strong-lane readiness audit of Dopemux work — read-only, formal verdict, no edits'
 name: 'Dopemux Auditor'
 tools: ['read', 'search']
-model: VERIFY_WITH_VENDOR_DOCS  # self_audit lane — operator must replace with a supported strong Copilot model
+model: 'Claude Sonnet 4.5'  # self_audit lane baseline (repo-established Copilot model)
 target: 'vscode'
 infer: true
 handoffs:

--- a/.github/agents/dopemux-planner.agent.md
+++ b/.github/agents/dopemux-planner.agent.md
@@ -2,7 +2,7 @@
 description: 'Plans Dopemux task-packet work without editing or executing commands'
 name: 'Dopemux Planner'
 tools: ['read', 'search']
-model: VERIFY_WITH_VENDOR_DOCS  # planner_strong lane — operator must replace with a supported strong Copilot model
+model: 'Claude Sonnet 4.5'  # planner_strong lane baseline (repo-established Copilot model)
 target: 'vscode'
 infer: true
 handoffs:

--- a/.github/agents/dopemux-reader.agent.md
+++ b/.github/agents/dopemux-reader.agent.md
@@ -2,7 +2,7 @@
 description: 'Read-only Dopemux repo investigation on the cheap model lane — no edits, exact evidence'
 name: 'Dopemux Reader'
 tools: ['read', 'search']
-model: VERIFY_WITH_VENDOR_DOCS  # cheap_read lane — operator must replace with a supported cheap Copilot model
+model: 'Claude Sonnet 4.5'  # cheap_read lane baseline (repo-established Copilot model)
 target: 'vscode'
 infer: true
 handoffs:

--- a/config/ai/model-routing.policy.yaml
+++ b/config/ai/model-routing.policy.yaml
@@ -1,9 +1,9 @@
 # Dopemux Development Model-Routing Policy
 # ----------------------------------------------------------------------------
 # Machine-readable, repo-governed stage-routing policy for AI development
-# workflows across Codex, GitHub Copilot custom agents, Claude Code / CC,
-# AGY / Google Antigravity, Gemini CLI, xAI / Grok, Moonshot / Kimi,
-# and OpenRouter-backed routes.
+# workflows across Codex, OpenCode, GitHub Copilot custom agents,
+# Claude Code / CC, AGY / Google Antigravity, Gemini CLI, xAI / Grok,
+# Moonshot / Kimi, and OpenRouter-backed routes.
 #
 # STATUS: proposed governance policy. This file is ADVISORY GOVERNANCE, not a
 # runtime router. It records which *stage* (read / investigate / plan /
@@ -199,6 +199,18 @@ provider_routes:
       - "OBSERVED in config/pricing.yaml: gpt-5.5"
       - "Codex CLI model selector format and available model names require VERIFY_WITH_VENDOR_DOCS"
 
+  opencode:
+    cheap_read: VERIFY_WITH_VENDOR_DOCS    # tier intent: cheap_fast
+    investigation: VERIFY_WITH_VENDOR_DOCS  # tier intent: cheap_fast
+    planner_strong: .opencode/agents/pal-planner.md
+    implementer_standard: VERIFY_WITH_VENDOR_DOCS  # tier intent: coding_balanced
+    judge_strong: .opencode/agents/pal-reviewer.md
+    self_audit: .opencode/agents/pal-reviewer.md
+    notes:
+      - "OpenCode loads instruction surfaces from opencode.jsonc (AGENTS.md + config/instructions/pal-opencode-guide.md) — OBSERVED in repo."
+      - "planner_strong and self_audit are delegated through PAL subagents (.opencode/agents/pal-planner.md, .opencode/agents/pal-reviewer.md)."
+      - "OpenCode model selector strings are operator-configurable; exact stage bindings remain VERIFY_WITH_VENDOR_DOCS."
+
   copilot:
     cheap_read: .github/agents/dopemux-reader.agent.md
     investigation: .github/agents/dopemux-reader.agent.md
@@ -208,9 +220,9 @@ provider_routes:
     self_audit: .github/agents/dopemux-auditor.agent.md
     notes:
       - "Copilot routes to .github/agents/*.agent.md custom agents — OBSERVED in this repo"
-      - "Agent model: field is VERIFY_WITH_VENDOR_DOCS for read/plan/audit lanes; implementer uses repo-established Claude Sonnet 4.5"
-      - "Cheap/strong intent is enforced via tool scope: read+search only (reader/planner/auditor) vs read+edit (implementer)"
-      - "Whether VS Code Copilot accepts arbitrary model: strings beyond currently deployed values is UNKNOWN"
+      - "All routed Copilot agents pin model: Claude Sonnet 4.5 (reader, planner, implementer, auditor)."
+      - "Cheap/strong intent is primarily enforced via tool scope: read+search only (reader/planner/auditor) vs read+edit (implementer)."
+      - "Per-agent cheap/strong model tier split in VS Code Copilot remains UNKNOWN without vendor-verified model availability."
 
   claude_code:
     cheap_read: VERIFY_WITH_VENDOR_DOCS      # tier intent: cheap_fast (Haiku / Sonnet-low)

--- a/docs/02-how-to/model-routing-usage.md
+++ b/docs/02-how-to/model-routing-usage.md
@@ -104,10 +104,10 @@ stage slots. These are `OBSERVED` in the repo.
 
 | Stage | Agent file | Tools | Model |
 |-------|-----------|-------|-------|
-| `cheap_read` / `investigation` | `dopemux-reader.agent.md` | read, search | VERIFY_WITH_VENDOR_DOCS |
-| `planner_strong` | `dopemux-planner.agent.md` | read, search | VERIFY_WITH_VENDOR_DOCS |
+| `cheap_read` / `investigation` | `dopemux-reader.agent.md` | read, search | Claude Sonnet 4.5 (OBSERVED) |
+| `planner_strong` | `dopemux-planner.agent.md` | read, search | Claude Sonnet 4.5 (OBSERVED) |
 | `implementer_standard` | `dopemux-implementer.agent.md` | read, edit, search | Claude Sonnet 4.5 (OBSERVED) |
-| `judge_strong` / `self_audit` | `dopemux-auditor.agent.md` | read, search | VERIFY_WITH_VENDOR_DOCS |
+| `judge_strong` / `self_audit` | `dopemux-auditor.agent.md` | read, search | Claude Sonnet 4.5 (OBSERVED) |
 
 **How tool scope enforces stage boundaries:**
 - Reader, planner, and auditor agents have `tools: ['read', 'search']` — they
@@ -115,15 +115,15 @@ stage slots. These are `OBSERVED` in the repo.
 - The implementer has `tools: ['read', 'edit', 'search']` — it can edit, but is
   bound to the Task Packet file allowlist.
 
-**Replacing VERIFY_WITH_VENDOR_DOCS model values:**
-To activate per-agent model tiering, an operator must:
-1. Consult VS Code Copilot documentation for currently supported `model:` values.
-2. Replace `VERIFY_WITH_VENDOR_DOCS` in the agent frontmatter with a supported
-   cheap model (reader/planner) and a supported strong model (auditor).
-3. Verify the replacement does not break existing Copilot agent invocation.
+**Pinned baseline (OBSERVED):**
+Reader, planner, implementer, and auditor all pin `model: 'Claude Sonnet 4.5'`.
+Cheap/strong separation is therefore enforced primarily by tool scope
+(`read/search` vs. `read/edit/search`), not by per-agent model tiering.
 
-Until replaced, `VERIFY_WITH_VENDOR_DOCS` is a sentinel — Copilot will use its
-default model, and cheap/strong differentiation relies on tool scope alone.
+If you want model-tier separation later:
+1. Verify currently supported Copilot `model:` values from vendor docs.
+2. Update the targeted `.github/agents/*.agent.md` frontmatter values.
+3. Verify each updated agent can still be invoked from VS Code.
 
 **Handoffs:**
 The reader agent includes handoffs to `dopemux-planner` (escalate for planning) and
@@ -132,7 +132,29 @@ The reader agent includes handoffs to `dopemux-planner` (escalate for planning) 
 
 ---
 
-## 4. How to use the policy in AGY / Gemini audit flows
+## 4. How to use the policy in OpenCode
+
+OpenCode in this repo is configured by `opencode.jsonc` and two PAL subagents in
+`.opencode/agents/`.
+
+**Stage mapping (repo baseline):**
+
+| Stage | Route |
+|-------|-------|
+| `cheap_read` / `investigation` | Main OpenCode session model (operator-configured, `VERIFY_WITH_VENDOR_DOCS`) |
+| `planner_strong` | `.opencode/agents/pal-planner.md` |
+| `implementer_standard` | Main OpenCode session model with `AGENTS.md` + Task Packet allowlist discipline |
+| `judge_strong` / `self_audit` | `.opencode/agents/pal-reviewer.md` |
+
+**Usage pattern:**
+1. Perform read-only inventory in the main OpenCode session.
+2. Delegate non-trivial planning to `pal-planner`.
+3. Implement in the main session under packet allowlist constraints.
+4. Run `pal-reviewer` for codereview/precommit before readiness claims.
+
+---
+
+## 5. How to use the policy in AGY / Gemini audit flows
 
 AGY (Antigravity) and Gemini CLI route through Google's Gemini model family.
 All model selector strings require `VERIFY_WITH_VENDOR_DOCS`.
@@ -170,7 +192,7 @@ The `auditor_verdict` field in `PROOF.json` aligns with the verdict enum in
 
 ---
 
-## 5. Example Task Packet model_routing block
+## 6. Example Task Packet model_routing block
 
 Include this section in every Task Packet before implementation begins.
 Operators fill in the actual model/tier used per stage; entries that are not yet
@@ -196,7 +218,7 @@ Escalate to strong model if:
 
 ---
 
-## 6. Example proof block
+## 7. Example proof block
 
 This is the structure required in `proof/<TP-ID>/PROOF.json` for a substantive
 run. Fields marked `actual_*` capture what was used, not just what was intended.

--- a/docs/03-reference/governance/model-routing.md
+++ b/docs/03-reference/governance/model-routing.md
@@ -29,8 +29,8 @@ does not dispatch model calls.
 
 This policy assigns a **stage slot** (cheap_read → investigation → planner_strong →
 implementer_standard → judge_strong → self_audit) and an appropriate model tier to
-each AI development tool (Codex, Copilot, Claude Code, AGY, Gemini CLI, xAI,
-Moonshot, OpenRouter) operating on this repo.
+each AI development tool (Codex, OpenCode, Copilot, Claude Code, AGY, Gemini CLI,
+xAI, Moonshot, OpenRouter) operating on this repo.
 
 The goal is to ensure cheap models gather facts but never make architecture or
 security decisions, and that implementation and judgment always operate under approved
@@ -76,6 +76,7 @@ Verdict values for `self_audit`: `PASS` · `PASS_WITH_RISKS` · `FAIL` ·
 | Provider | cheap_read | planner_strong | implementer_standard | judge_strong / self_audit |
 |----------|-----------|---------------|---------------------|--------------------------|
 | Codex | VERIFY_WITH_VENDOR_DOCS (cheap_fast tier) | VERIFY_WITH_VENDOR_DOCS (strong_reasoning) | VERIFY_WITH_VENDOR_DOCS (coding_balanced) | VERIFY_WITH_VENDOR_DOCS (strong_reasoning / audit_strong) |
+| OpenCode | VERIFY_WITH_VENDOR_DOCS (session model / cheap_fast intent) | `.opencode/agents/pal-planner.md` | VERIFY_WITH_VENDOR_DOCS (session model / coding_balanced intent) | `.opencode/agents/pal-reviewer.md` |
 | Copilot | `dopemux-reader.agent.md` | `dopemux-planner.agent.md` | `dopemux-implementer.agent.md` | `dopemux-auditor.agent.md` |
 | Claude Code | VERIFY_WITH_VENDOR_DOCS (Haiku / Sonnet-low) | VERIFY_WITH_VENDOR_DOCS (opusplan: Opus plans, Sonnet implements) | VERIFY_WITH_VENDOR_DOCS (Sonnet) | VERIFY_WITH_VENDOR_DOCS (Opus) |
 | AGY | VERIFY_WITH_VENDOR_DOCS (Flash tier) | VERIFY_WITH_VENDOR_DOCS (Pro-high tier) | VERIFY_WITH_VENDOR_DOCS (Claude Sonnet in-AGY) | VERIFY_WITH_VENDOR_DOCS (Pro-high) |
@@ -84,6 +85,15 @@ Verdict values for `self_audit`: `PASS` · `PASS_WITH_RISKS` · `FAIL` ·
 | Moonshot | VERIFY_WITH_VENDOR_DOCS (Kimi thinking=off) | VERIFY_WITH_VENDOR_DOCS (Kimi thinking=on) | VERIFY_WITH_VENDOR_DOCS (coding_balanced) | VERIFY_WITH_VENDOR_DOCS (Kimi thinking=on) |
 | OpenRouter | VERIFY_WITH_VENDOR_DOCS (broker, pinned cheap) | VERIFY_WITH_VENDOR_DOCS (broker, pinned strong) | VERIFY_WITH_VENDOR_DOCS (broker, pinned coding) | VERIFY_WITH_VENDOR_DOCS (broker, pinned strong + deterministic provider) |
 
+> **Copilot baseline (OBSERVED):** all routed agents (`reader`, `planner`,
+> `implementer`, `auditor`) pin `model: 'Claude Sonnet 4.5'`; lane separation is
+> enforced by tool scope.
+>
+> **OpenCode baseline (OBSERVED):** `opencode.jsonc` loads `AGENTS.md` +
+> `config/instructions/pal-opencode-guide.md`; strong planning and self-audit are
+> routed through `.opencode/agents/pal-planner.md` and
+> `.opencode/agents/pal-reviewer.md`.
+>
 > **Note on OBSERVED model ids**: `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2`,
 > `grok-code-fast-1`, `grok-4-1-fast` are OBSERVED in `model_map_v2_tp008.yaml` /
 > `tests/test_routing_config.py` as **RTE extraction lane selectors**. `gpt-5.5` is
@@ -207,10 +217,13 @@ same verdict space.
 
 ## 9. Known limitations / unresolved facts
 
-- **Copilot model tiers**: Whether VS Code Copilot accepts `model:` strings beyond
-  the repo's current `'Claude Sonnet 4.5'` (implementer) and what cheap/strong
-  alternatives are available is **UNKNOWN**. Cheap/strong intent is enforced via
-  tool scope (read+search vs. edit) rather than per-agent model selection.
+- **Copilot model tiers**: All four routed Copilot agents now pin
+  `'Claude Sonnet 4.5'` (**OBSERVED**). A distinct cheap-vs-strong model split in
+  VS Code Copilot remains **UNKNOWN** until vendor-verified alternatives are wired.
+
+- **OpenCode stage model binding**: OpenCode planner/audit stages are explicitly
+  routed through PAL subagents, but stage-specific model selector strings are still
+  operator-configurable and remain **VERIFY_WITH_VENDOR_DOCS**.
 
 - **Agent model naming drift**: The `auditor_model` schema enum lists
   `claude-sonnet-4.6` (`schemas/proof/embedded_audit.schema.json:45-54`) while


### PR DESCRIPTION
## Summary\n- pin Dopemux Copilot reader/planner/auditor agents to the repo-established `Claude Sonnet 4.5` baseline\n- add OpenCode stage routing to `config/ai/model-routing.policy.yaml` with PAL planner/reviewer mapping\n- update governance/how-to docs to reflect pinned Copilot baselines and OpenCode routing usage\n\n## Validation\n- python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('config/ai/model-routing.policy.yaml').read_text()); print('model-routing.policy.yaml: OK')"\n- pytest tests/test_routing_config.py -q\n- python scripts/docs_validator.py docs/02-how-to/model-routing-usage.md docs/03-reference/governance/model-routing.md\n- python scripts/docs_frontmatter_guard.py docs/02-how-to/model-routing-usage.md docs/03-reference/governance/model-routing.md\n- git --no-pager diff --check