### PR TITLE
feat(pcp): A1 activation gates + STRICT routing residual (carved from #975)

### DIFF
--- a/docs/05-audit-reports/pcp-dcp-conformance-2026-06-23.md
+++ b/docs/05-audit-reports/pcp-dcp-conformance-2026-06-23.md
@@ -12,9 +12,9 @@ prelude: Classification of PCP/DCP conformance findings from external audit + lo
 
 # PCP/DCP Conformance Audit Classification — 2026-06-23
 
-**Audit basis:** External auditor reviewed PCP/DCP at `517e6dd4a` (GitHub API only). Local re-verification performed via 3 Explore agents + direct reads + greps + a real wheel build/clean-venv install. PAL multi-model validation: gpt-5.2, gpt-5.5 (neutral 8/10), gemini-2.5-pro (adversarial 9/10, conceded all facts). Operator + supervisor issued the final classification.
+**Audit basis:** External auditor reviewed PCP/DCP at `517e6dd4a` (GitHub API only). Local re-verification performed via 3 Explore agents + direct reads + greps + real wheel build/clean-venv install. PAL multi-model validation: gpt-5.2, gpt-5.5 (neutral 8/10), gemini-2.5-pro (adversarial 9/10, conceded all facts). Operator + supervisor issued the final classification.
 
-**PR:** `claude/pcp-conformance-repair-0001` (TP-DMX-PCP-CONFORMANCE-REPAIR-0001)
+**PR:** `claude/pcp-conformance-repair-0001` (TP-DMX-PCP-CONFORMANCE-REPAIR-0001). The A4 wheel-safety completion was delivered by **#978** (schema bundling), folded into this branch and independently re-verified.
 
 ---
 
@@ -22,36 +22,31 @@ prelude: Classification of PCP/DCP conformance findings from external audit + lo
 
 | Item | Classification | Status |
 |---|---|---|
-| **A4** `dopemux.pcp` packaging | MUST_FIX | **PARTIAL in PR1** — packaging declared; installed-wheel *import* still blocked (see A4 below) |
-| **A2** DCP proof family | MUST_FIX | **MAPPING DELIVERED in PR1** (authority modeling + exporter-consumption tracked as follow-ups) |
+| **A4** `dopemux.pcp` packaging | MUST_FIX | **FIXED** — packaging declared (#977) + wheel-safe schema loading (#978, folded in) |
+| **A2** DCP proof family | MUST_FIX | **MAPPING DELIVERED in #977** (authority modeling + exporter-consumption tracked as follow-ups) |
 | **A3** "only selected_provider+selected_model" | REJECTED_WITH_REASON | **NOT IN SCOPE** |
-| **Red Line #15** forbidden writer wiring | PASS_WITH_GUARD | **GUARD ADDED in PR1** |
+| **Red Line #15** forbidden writer wiring | PASS_WITH_GUARD | **GUARD ADDED in #977** |
 | A3 narrow residual: `selected_provider:"unknown"` for `SELECTED` | ROUTING_POLICY_RESIDUAL | **Tracked: `#968/#967`** |
 | **A1** unsigned READY gate | ACTIVATION_SCOPED | **Deferred** |
 
 ---
 
-## A4 — MUST_FIX: `dopemux.pcp` Packaging (PARTIAL — packaging declared, wheel-import deferred)
+## A4 — MUST_FIX: `dopemux.pcp` Packaging (FIXED, two steps)
 
-**Evidence:** `pyproject.toml` explicit package allowlist (lines 148–218) omitted `dopemux.pcp` and `dopemux.pcp.bridge` despite the source tree existing at `src/dopemux/pcp/`. Tests passed only via `pythonpath=["src"]` (pytest config line 298), masking a wheel/install failure.
+**Evidence:** `pyproject.toml` explicit package allowlist omitted `dopemux.pcp` and `dopemux.pcp.bridge` despite the source tree existing at `src/dopemux/pcp/`. Tests passed only via `pythonpath=["src"]` (pytest config), masking a wheel/install failure.
 
-**Fix shipped in PR1:** `dopemux.pcp` and `dopemux.pcp.bridge` added to the `[tool.setuptools]` packages list immediately after `dopemux.orchestrator.validation`; `dopemux-pcp = "dopemux.pcp.cli:pcp"` added to `[project.scripts]`.
+**Step 1 — packaging declared (#977):** added `dopemux.pcp` + `dopemux.pcp.bridge` to the `[tool.setuptools]` packages list + `dopemux-pcp = "dopemux.pcp.cli:pcp"` console script. The built wheel ships all 8 `dopemux/pcp/*` modules + the script.
 
-**Proven (wheel contents):** A built wheel now contains all 8 `dopemux/pcp/*` modules (incl. `bridge/fastapi_bridge.py`) and the `dopemux-pcp` console-script entry point — all absent before the fix. **PASS.**
+**Step 2 — wheel-safe schema loading (#978, folded in):** the clean-venv install gate (added in this work) caught that 4 PCP modules (`bridge/fastapi_bridge.py`, `exporter.py`, `negative_cases.py`, `pr_steward.py`) loaded repo-root schema JSON **at import time** via a source-tree-relative path (`parents[N]`), so `import dopemux.pcp.*` crashed from an installed wheel (`FileNotFoundError`). #978:
+- Vendors the 4 loaded schemas under `dopemux/pcp/_schemas/` + a `load_schema()` shim using `importlib.resources` (resolves identically from source tree and installed wheel — single path, no repo-root assumption).
+- Repoints the 4 loaders at `load_schema(...)`; drops the now-dead `json`/`pathlib` imports.
+- Adds `dopemux.pcp._schemas` to `packages` + `package-data = ["*.json"]`.
+- Adds a parity test asserting the vendored copies stay byte-identical to canonical `schemas/project_control_plane/` (drift would ship a stale contract).
+- Declares `jsonschema>=4.20.0` as a **core** dependency (previously only transitive via litellm), so the import chain can't break.
 
-**NOT yet fixed (discovered by the clean-venv install gate):** Four PCP modules load repo-root schema JSON **at import time** via a source-tree-relative path (`_REPO_ROOT = parents[4]` → `schemas/project_control_plane/*.json`):
-- `bridge/fastapi_bridge.py` → `live_write_ready.schema.json`
-- `exporter.py` → `project_evidence_export.schema.json`
-- `negative_cases.py` → `negative_case_result.schema.json` + `project_evidence_export.schema.json`
-- `pr_steward.py` → `merge_readiness.schema.json`
+**Re-verified (merged #977 @ the #978 squash):** wheel bundles all 4 schemas + the loader shim; `jsonschema` appears unconditionally in core `Requires-Dist`; a **clean-venv install + import of all 6 `dopemux.pcp.*` modules + the CLI succeeds from the installed location** (not the repo). The previously-FAILing clean-venv import gate now **PASSES**.
 
-The repo-root `schemas/` directory is **not bundled** in the wheel (`[tool.setuptools.package-data]` covers only `dopemux.templates`), and `parents[4]` resolves to the wrong location once installed. Result: `import dopemux.pcp.*` (and the `dopemux-pcp` CLI) **crashes from an installed wheel** with `FileNotFoundError`. The packages-allowlist fix is **necessary but not sufficient** for clean installed-wheel activation — the audit's A4 framing missed this layer.
-
-**Operator ruling:** ship the surgical packaging fix; track the wheel-safety fix separately (do not expand PR1 into a packaging refactor of the generic exporter).
-
-**Follow-up (tracked):** *PCP wheel-safe schema loading* — bundle the `schemas/project_control_plane` JSON as package data and make the 4 loaders wheel-safe (`importlib.resources` or src-tree/installed dual-path), then the clean-venv import gate passes.
-
-**Tests:** `tests/project_control_plane/test_packaging.py` — 2 tests, PASS.
+**Tests:** `tests/project_control_plane/test_packaging.py` (2) + `tests/project_control_plane/test_schema_bundle_parity.py` (parity) — PASS.
 
 ---
 
@@ -59,28 +54,25 @@ The repo-root `schemas/` directory is **not bundled** in the wheel (`[tool.setup
 
 **Evidence:** `schemas/dcp_extension/extension_manifest.dcp.json` had `proof_status_mappings: []`. Invariant pin existed but no proof-root → PCP-pointer mapping.
 
-**Deliverables in PR1 (contract level):**
-- Created `schemas/dcp_extension/proof_status_map.dcp.json` — maps Dopemux proof roots (`PROOF.json`, `SUMMARY.md`) to `pcp.proof_pointer.v0` entries with honest `UNKNOWN` states. Honesty rule: pointers declare the mapping with `freshness_state/validation_status/auditor_verdict = "UNKNOWN"` and an `unknowns` note ("resolved at export time by the exporter-consumption follow-up").
+**Deliverables in #977 (contract level):**
+- Created `schemas/dcp_extension/proof_status_map.dcp.json` — maps Dopemux proof roots (`PROOF.json`, `SUMMARY.md`) to `pcp.proof_pointer.v0` entries with honest `UNKNOWN` states (resolved at export time by the exporter-consumption follow-up).
 - `extension_manifest.dcp.json` `capabilities.proof_status_mappings`: `[]` → `["schemas/dcp_extension/proof_status_map.dcp.json"]`.
 
-**Dropped from PR1 (operator ruling DROP_FROM_PR1 — preserve Packet-5 scope-lock):** A `proof.dopemux_family` authority-map entry was initially added but collided with the Packet-5 scope-lock (`tests/dcp_extension/test_dcp_extension_mapping.py`: authority owners ≡ manifest `adapter_mappings` ≡ `EXPECTED_SYSTEMS`, all MCP-system adapters). Registering `"dopemux"` as a pseudo-adapter to satisfy the lock blurs adapter-ownership vs proof-family-ownership. The entry, its test, and the `adapter_mappings`/`EXPECTED_SYSTEMS` bumps were reverted; the Packet-5 scope-lock is unchanged.
+**Dropped from #977 (operator ruling DROP_FROM_PR1 — preserve Packet-5 scope-lock):** a `proof.dopemux_family` authority-map entry collided with the Packet-5 scope-lock (authority owners ≡ manifest `adapter_mappings` ≡ `EXPECTED_SYSTEMS`, all MCP-system adapters). Registering `"dopemux"` as a pseudo-adapter blurs adapter-ownership vs proof-family-ownership. Reverted; scope-lock unchanged.
 
-**Follow-ups (NOT in PR1):**
-1. *Proof-family authority modeling* — model `proof.*` ownership cleanly (a plane distinct from MCP adapter mappings) rather than forcing it into the Packet-5 adapter set.
-2. *Exporter-consumption* — an extension-aware seam (NOT the generic `exporter.py`) resolving the proof_status_map at export time (head-SHA + freshness → real CURRENT/STALE/PASS, fail-closed on missing). Until then proof pointers remain honest-UNKNOWN. PR1 must NOT be reported as "proof family fully wired."
+**Follow-ups (NOT in #977):**
+1. *Proof-family authority modeling* — model `proof.*` ownership cleanly (distinct plane from MCP adapter mappings).
+2. *Exporter-consumption* — extension-aware seam (NOT the generic `exporter.py`) resolving the proof_status_map at export time (head-SHA + freshness → real CURRENT/STALE/PASS, fail-closed on missing). Until then proof pointers remain honest-UNKNOWN.
 
-**Tests:** `tests/dcp_extension/test_proof_status_map.py` — 2 tests (manifest declares mapping; pointers validate against `proof_pointer.schema.json`), PASS. Pre-existing manifest/authority schema + Packet-5 scope-lock tests: PASS (unchanged).
+**Tests:** `tests/dcp_extension/test_proof_status_map.py` (2) + pre-existing manifest/authority schema + Packet-5 scope-lock tests — PASS.
 
 ---
 
 ## A3 — REJECTED_WITH_REASON: "only selected_provider+selected_model"
 
-**Claim (auditor):** The DCP extension route-decision schema is thin and effectively requires only `selected_provider` + `selected_model`.
+**Claim (auditor):** the DCP extension route-decision schema is thin and effectively requires only `selected_provider` + `selected_model`.
 
-**Rejection evidence:**
-- The extension schema has **19 required fields** spanning privacy, risk, access path, proof, audit, human-gate, benchmark, and more.
-- `live_write_runner_selected: const false` — the live-write runner is pinned off.
-- Richer `schemas/dcp/*` (runtime) and `contracts/openclaw-dcp-routing/*` (policy) families exist alongside it.
+**Rejection evidence:** the extension schema has **19 required fields** (privacy, risk, access path, proof, audit, human-gate, benchmark, …); `live_write_runner_selected: const false`; richer `schemas/dcp/*` (runtime) and `contracts/openclaw-dcp-routing/*` (policy) families exist.
 
 **Operator + supervisor ruling:** REJECTED. **No change** to `schemas/dcp_extension/routing/route_decision.schema.json`. **Do not merge stale `#974`.**
 
@@ -90,13 +82,13 @@ The repo-root `schemas/` directory is **not bundled** in the wheel (`[tool.setup
 
 **Evidence:** `src/dopemux/pcp/**` contains zero forbidden merge-writer references (`queue_drain`, `batch_resolve_and_merge`, `pr_merge_specialist`). Bridge registry defaults inert (`writer_registry=None`); both factories default to no writer.
 
-**Guard added:** `tests/project_control_plane/test_red_line_15.py` — 3 tests (forbidden-token scan of `src/dopemux/pcp/**`; both factories default `writer_registry=None`; `route_mutation` with `execute=True` and no writer returns `executed=False, permitted=False`). All PASS.
+**Guard added:** `tests/project_control_plane/test_red_line_15.py` — 3 tests (forbidden-token scan; both factories default `writer_registry=None`; `route_mutation` `execute=True` + no writer → `executed=False, permitted=False`). PASS.
 
 ---
 
 ## Routing Residual → `#968/#967`
 
-**Finding:** `selected_provider:"unknown"` is permitted for the `SELECTED` routing branch (the schema forbids `null` but allows the `"unknown"` string). Contracts-only; no runtime consumer.
+**Finding:** `selected_provider:"unknown"` is permitted for the `SELECTED` routing branch (schema forbids `null` but allows the `"unknown"` string). Contracts-only; no runtime consumer.
 
 **Classification:** ROUTING_POLICY_RESIDUAL — tracked under `#968/#967`. **Supervisor recommendation:** CONTEXTUAL now (`"unknown"` permissible for public/read-only/manual lanes); STRICT before runtime routing activation (private/high-risk/security/release/structured-output → block or escalate).
 
@@ -104,43 +96,42 @@ The repo-root `schemas/` directory is **not bundled** in the wheel (`[tool.setup
 
 ## A1 — Activation-Scoped: Unsigned READY Gate (Deferred)
 
-**Finding:** The `LIVE_WRITE_READY` gate enforces schema shape + internal consistency + TTL + operation binding, but not cryptographic signing / authenticated issuer provenance. Gate truth-booleans are unsigned (verified out-of-band per the ops doc).
+**Finding:** the `LIVE_WRITE_READY` gate enforces schema shape + internal consistency + TTL + operation binding, but not cryptographic signing / authenticated issuer provenance.
 
 **Classification:** ACTIVATION_SCOPED — fail-closed in commit-default/in-tree wiring; only exploitable once a real writer is registered (bridge inert today).
 
-**Deferred work (not PR1):** signed/authenticated READY issuer, endpoint authN/Z, cross-process atomic dedup + lease, gate-verifier dependency, tz-aware-strict `_parse_iso8601`, generic `WRITER_RAISED` code, `_canonical_digest allow_nan=False`.
+**Deferred work:** signed/authenticated READY issuer, endpoint authN/Z, cross-process atomic dedup + lease, gate-verifier dependency, tz-aware-strict `_parse_iso8601`, generic `WRITER_RAISED` code, `_canonical_digest allow_nan=False`.
 
 ---
 
 ## PAL Validation
 
-- **gpt-5.2** (neutral): validated the finding set + classification + A3 rejection; sharpened the A3 residual to a contract-integrity concern; confirmed bridge fail-closed.
+- **gpt-5.2** (neutral): validated the finding set + classification + A3 rejection; sharpened the A3 residual; confirmed bridge fail-closed.
 - **gpt-5.5** (neutral, 8/10): corroborated; narrowed A1 to "commit-default state"; flagged A2 faithful-fix > exporter wiring.
-- **gemini-2.5-pro** (adversarial, 9/10): conceded all facts; pushed severity/scope (A2 needs authority + integrity; dedup-before-writer DoS).
+- **gemini-2.5-pro** (adversarial, 9/10): conceded all facts; pushed severity/scope.
 - (grok-4, claude-opus-4.5, gemini-3-pro-preview adversaries were unavailable — provider credit/decommission — and are NOT counted.)
 
 ---
 
-## Validation Buckets (PR1)
+## Validation Buckets
 
 | Bucket | Result |
 |---|---|
-| `tests/project_control_plane/test_packaging.py` (2) | PASS |
-| `tests/dcp_extension/test_proof_status_map.py` (2) | PASS |
-| `tests/project_control_plane/test_red_line_15.py` (3) | PASS |
-| Full `tests/project_control_plane` + `tests/dcp_extension` (incl. Packet-5 scope-lock + schema-validation) | PASS |
-| Wheel build + **contents** (`dopemux/pcp/*` 8 modules + `dopemux-pcp` script present) | PASS |
-| Clean-venv **install + import** of `dopemux.pcp.*` | **FAIL (known)** — repo-root schema loaded at import time; deferred to the *PCP wheel-safe schema loading* follow-up |
-| `rg "queue_drain\|batch_resolve_and_merge\|pr_merge_specialist" src/dopemux/pcp` | PASS (empty) |
+| `tests/project_control_plane` + `tests/dcp_extension` (full, incl. Packet-5 scope-lock + schema-bundle parity) | **PASS** (0 failures) |
+| Wheel **contents** (`dopemux/pcp/*` modules + `dopemux-pcp` script + 4 vendored `_schemas/*.json` + loader shim) | **PASS** |
+| `jsonschema` in core `Requires-Dist` (unconditional) | **PASS** |
+| Clean-venv **install + import** of all 6 `dopemux.pcp.*` modules + CLI from installed wheel | **PASS** (was FAIL before #978; re-verified on merged branch) |
+| `rg "queue_drain\|batch_resolve_and_merge\|pr_merge_specialist" src/dopemux/pcp` | **PASS** (empty) |
 
-**NOT claimed:** SOUND_FOR_ACTIVATION — requires A4 wheel-safety, A2 authority modeling + exporter-consumption, the A1 signing/auth family, and the routing residual to all close first.
+**NOT claimed:** SOUND_FOR_ACTIVATION — requires A2 authority modeling + exporter-consumption, the A1 signing/auth family, and the routing residual to all close first.
 
 ---
 
-## Tracked Follow-ups (out of PR1)
+## Tracked Follow-ups (out of this PR)
 
-1. **PCP wheel-safe schema loading** (A4 completion) — bundle `schemas/project_control_plane` as package data + `importlib.resources`/dual-path loaders for `fastapi_bridge.py`, `exporter.py`, `negative_cases.py`, `pr_steward.py`. Closes the clean-venv import gate.
-2. **A2 proof-family authority modeling** — clean `proof.*` ownership plane (not the MCP adapter set).
-3. **A2 exporter-consumption** — extension-aware seam resolving proof_status_map at export time.
-4. **Routing residual `#968/#967`** — `selected_provider:"unknown"` policy (CONTEXTUAL → STRICT).
-5. **A1 activation-security family** — signing/auth/dedup-lease/etc.
+1. **A2 proof-family authority modeling** — clean `proof.*` ownership plane (not the MCP adapter set).
+2. **A2 exporter-consumption** — extension-aware seam resolving proof_status_map at export time.
+3. **Routing residual `#968/#967`** — `selected_provider:"unknown"` policy (CONTEXTUAL → STRICT).
+4. **A1 activation-security family** — signing/auth/dedup-lease/etc.
+
+*(A4 wheel-safe schema loading — formerly follow-up #1 — was completed by #978.)*

--- a/docs/05-audit-reports/pcp-dcp-conformance-2026-06-23.md
+++ b/docs/05-audit-reports/pcp-dcp-conformance-2026-06-23.md
@@ -1,0 +1,131 @@
+---
+id: AUD-PCP-DCP-CONFORMANCE-2026-06-23
+title: PCP/DCP Conformance Audit Classification — 2026-06-23
+type: audit-report
+owner: '@hu3mann'
+author: claude
+date: '2026-06-23'
+last_review: '2026-06-23'
+next_review: '2026-09-23'
+prelude: Classification of PCP/DCP conformance findings from external audit + local re-verification, with PAL multi-model validation and operator/supervisor rulings.
+---
+
+# PCP/DCP Conformance Audit Classification — 2026-06-23
+
+**Audit basis:** External auditor reviewed PCP/DCP at `517e6dd4a` (GitHub API). Local re-verification performed via 3 Explore agents + direct reads + greps. PAL multi-model validation: gpt-5.2, gpt-5.5 (neutral 8/10), gemini-2.5-pro (adversarial 9/10, conceded all facts). Operator + supervisor issued final classification.
+
+**PR closed by:** `claude/pcp-conformance-repair-0001` (TP-DMX-PCP-CONFORMANCE-REPAIR-0001)
+
+---
+
+## Finding Classification Table
+
+| Item | Classification | Status |
+|---|---|---|
+| **A4** `dopemux.pcp` packaging | MUST_FIX | **FIXED in PR1** |
+| **A2** DCP proof family | MUST_FIX | **MAPPING DELIVERED in PR1** (exporter-consumption tracked as follow-up) |
+| **A3** "only selected_provider+selected_model" | REJECTED_WITH_REASON | **NOT IN SCOPE** |
+| **Red Line #15** forbidden writer wiring | PASS_WITH_GUARD | **GUARD ADDED in PR1** |
+| A3 narrow residual: `selected_provider:"unknown"` for `SELECTED` | ROUTING_POLICY_RESIDUAL | **Tracked: `#968/#967`** |
+| **A1** unsigned READY gate | ACTIVATION_SCOPED | **Deferred** |
+
+---
+
+## A4 — MUST_FIX: `dopemux.pcp` Packaging (FIXED)
+
+**Evidence:** `pyproject.toml` explicit package allowlist (lines 148–218) omitted `dopemux.pcp` and `dopemux.pcp.bridge` despite the source tree existing at `src/dopemux/pcp/`. Tests passed only via `pythonpath=["src"]` (pytest config line 298), masking a wheel/install failure that would surface on any real install.
+
+**Fix:** `dopemux.pcp` and `dopemux.pcp.bridge` added to the `[tool.setuptools]` packages list immediately after `dopemux.orchestrator.validation`. `dopemux-pcp = "dopemux.pcp.cli:pcp"` added to `[project.scripts]`.
+
+**Tests:** `tests/project_control_plane/test_packaging.py` — 2 tests, PASS.
+
+---
+
+## A2 — MUST_FIX: DCP Proof-Family Mapping (MAPPING DELIVERED)
+
+**Evidence:** `schemas/dcp_extension/extension_manifest.dcp.json` had `proof_status_mappings: []`. Invariant pin existed but no proof-root → PCP-pointer mapping. `authority_map.dcp.json` had no `proof` domain entry.
+
+**Deliverables in PR1 (contract level):**
+- Created `schemas/dcp_extension/proof_status_map.dcp.json` — maps Dopemux proof roots (`PROOF.json`, `SUMMARY.md`) to `pcp.proof_pointer.v0` entries with honest `UNKNOWN` states. Honesty rule: pointers declare the mapping with `freshness_state/validation_status/auditor_verdict = "UNKNOWN"` and an `unknowns` note ("resolved at export time by the exporter-consumption follow-up").
+- `extension_manifest.dcp.json` `capabilities.proof_status_mappings` updated: `[]` → `["schemas/dcp_extension/proof_status_map.dcp.json"]`.
+- `authority_map.dcp.json` new entry: `proof.dopemux_family` / action `read` / `canonical_authority_owner: "dopemux"` / `surface_class: "ADAPTER"` / `live_write_allowed: false` / `canonical_writer: null` / `unknown_behavior: "BLOCK_OR_ESCALATE"`.
+- Manifest `adapter_mappings` updated to include `"dopemux"` (required by the scope-sync test `test_manifest_adapter_mappings_match_authority_owners`).
+
+**Follow-up (NOT in PR1):** Exporter-consumption — wire an extension-aware seam (NOT the generic `exporter.py`) to resolve the proof_status_map at export time (head-SHA + freshness → real CURRENT/STALE/PASS states, fail-closed on missing). Until then proof pointers remain honest-UNKNOWN. PR1 must NOT be reported as "proof family fully wired."
+
+**Tests:** `tests/dcp_extension/test_proof_status_map.py` — 3 tests, PASS. Existing schema tests for extension_manifest and authority_map: PASS (all 84 schema-validation tests).
+
+---
+
+## A3 — REJECTED_WITH_REASON: "only selected_provider+selected_model"
+
+**Claim (auditor):** The DCP extension schema should expose only `selected_provider` + `selected_model` fields.
+
+**Rejection evidence:**
+- The extension schema has **19 required fields** spanning privacy, risk, access, proof, audit, human-review, benchmark, and more.
+- The schema has `live_write_runner_selected: const false` — the live-write runner is pinned off.
+- Richer `schemas/dcp/*` families exist alongside OpenClaw families.
+
+**Operator + supervisor ruling:** REJECTED. No change to `schemas/dcp_extension/routing/route_decision.schema.json`.
+
+**Do not merge stale `#974`.**
+
+---
+
+## Red Line #15 — PASS_WITH_GUARD
+
+**Evidence:** `src/dopemux/pcp/**` contains zero forbidden merge-writer references (`queue_drain`, `batch_resolve_and_merge`, `pr_merge_specialist`). The bridge registry defaults inert (`writer_registry=None`). Both factory functions (`create_bridge_router`, `create_bridge_app`) default to no writer.
+
+**Guard added:** `tests/project_control_plane/test_red_line_15.py` — 3 tests:
+1. `test_no_forbidden_writer_wiring_in_pcp` — scans all `*.py` under `src/dopemux/pcp/` for forbidden tokens.
+2. `test_bridge_factories_default_no_writer` — asserts `writer_registry` parameter default is `None` for both factories.
+3. `test_execute_without_writer_is_rejected` — asserts `route_mutation` with `execute=True` and no writer returns `executed=False, permitted=False`.
+
+All 3: PASS.
+
+---
+
+## Routing Residual → `#968/#967`
+
+**Finding:** `selected_provider:"unknown"` is permitted for the `SELECTED` routing branch. The extension schema forbids `null` but allows the `"unknown"` string for `selected_provider`.
+
+**Classification:** ROUTING_POLICY_RESIDUAL — tracked under `#968/#967`.
+
+**Supervisor recommendation:** CONTEXTUAL now (`"unknown"` permissible for public/read-only/manual lanes); STRICT before runtime routing activation (private/high-risk/security/release/structured-output lanes must block or escalate).
+
+---
+
+## A1 — Activation-Scoped: Unsigned READY Gate (Deferred)
+
+**Finding:** The `LIVE_WRITE_READY` gate does not enforce cryptographic signing or authenticated assertion provenance. Gate truth-booleans are unsigned.
+
+**Classification:** ACTIVATION_SCOPED — fail-closed in commit-default/in-tree wiring. Gate truth-booleans unsigned but bridge is inert (no registered writer). This only matters once a writer is registered.
+
+**Deferred work (not PR1):** Signed/authenticated READY issuer, endpoint authN/Z, cross-process atomic dedup + lease, gate-verifier dependency, tz-aware-strict `_parse_iso8601`, generic `WRITER_RAISED`, `_canonical_digest allow_nan=False`.
+
+**Operator ruling:** Scoped this work to A4/A2/Red-Line in PR1; A1 family deferred until a writer is registered for activation.
+
+---
+
+## PAL Validation
+
+- **gpt-5.2**: Validated conformance finding set, classification, and rejection of A3. PASS_WITH_RISKS (acknowledged full-suite NOT_RUN).
+- **gpt-5.5**: Neutral assessment 8/10. Conceded A3 rejection evidence.
+- **gemini-2.5-pro**: Adversarial review 9/10. Conceded all fact assertions.
+
+---
+
+## Validation Buckets (PR1)
+
+| Bucket | Result |
+|---|---|
+| `tests/project_control_plane/test_packaging.py` (2 tests) | PASS |
+| `tests/dcp_extension/test_proof_status_map.py` (3 tests) | PASS |
+| `tests/project_control_plane/test_red_line_15.py` (3 tests) | PASS |
+| `tests/project_control_plane test_extension_manifest_schema.py` (42 tests) | PASS |
+| `tests/project_control_plane test_authority_map_schema.py` (42 tests) | PASS |
+| Full `tests/project_control_plane tests/dcp_extension` (all) | PASS |
+| Wheel build + install | NOT_RUN (run after PR merges per supervisor spec) |
+| `rg -n "queue_drain\|batch_resolve_and_merge\|pr_merge_specialist" src/dopemux/pcp` | PASS (empty — confirmed clean) |
+
+**NOT claimed:** SOUND_FOR_ACTIVATION — A4+A2+signing/auth+routing residual must all close and the exporter-consumption follow-up must be completed first.

--- a/docs/05-audit-reports/pcp-dcp-conformance-2026-06-23.md
+++ b/docs/05-audit-reports/pcp-dcp-conformance-2026-06-23.md
@@ -12,9 +12,9 @@ prelude: Classification of PCP/DCP conformance findings from external audit + lo
 
 # PCP/DCP Conformance Audit Classification — 2026-06-23
 
-**Audit basis:** External auditor reviewed PCP/DCP at `517e6dd4a` (GitHub API). Local re-verification performed via 3 Explore agents + direct reads + greps. PAL multi-model validation: gpt-5.2, gpt-5.5 (neutral 8/10), gemini-2.5-pro (adversarial 9/10, conceded all facts). Operator + supervisor issued final classification.
+**Audit basis:** External auditor reviewed PCP/DCP at `517e6dd4a` (GitHub API only). Local re-verification performed via 3 Explore agents + direct reads + greps + a real wheel build/clean-venv install. PAL multi-model validation: gpt-5.2, gpt-5.5 (neutral 8/10), gemini-2.5-pro (adversarial 9/10, conceded all facts). Operator + supervisor issued the final classification.
 
-**PR closed by:** `claude/pcp-conformance-repair-0001` (TP-DMX-PCP-CONFORMANCE-REPAIR-0001)
+**PR:** `claude/pcp-conformance-repair-0001` (TP-DMX-PCP-CONFORMANCE-REPAIR-0001)
 
 ---
 
@@ -22,8 +22,8 @@ prelude: Classification of PCP/DCP conformance findings from external audit + lo
 
 | Item | Classification | Status |
 |---|---|---|
-| **A4** `dopemux.pcp` packaging | MUST_FIX | **FIXED in PR1** |
-| **A2** DCP proof family | MUST_FIX | **MAPPING DELIVERED in PR1** (exporter-consumption tracked as follow-up) |
+| **A4** `dopemux.pcp` packaging | MUST_FIX | **PARTIAL in PR1** — packaging declared; installed-wheel *import* still blocked (see A4 below) |
+| **A2** DCP proof family | MUST_FIX | **MAPPING DELIVERED in PR1** (authority modeling + exporter-consumption tracked as follow-ups) |
 | **A3** "only selected_provider+selected_model" | REJECTED_WITH_REASON | **NOT IN SCOPE** |
 | **Red Line #15** forbidden writer wiring | PASS_WITH_GUARD | **GUARD ADDED in PR1** |
 | A3 narrow residual: `selected_provider:"unknown"` for `SELECTED` | ROUTING_POLICY_RESIDUAL | **Tracked: `#968/#967`** |
@@ -31,11 +31,25 @@ prelude: Classification of PCP/DCP conformance findings from external audit + lo
 
 ---
 
-## A4 — MUST_FIX: `dopemux.pcp` Packaging (FIXED)
+## A4 — MUST_FIX: `dopemux.pcp` Packaging (PARTIAL — packaging declared, wheel-import deferred)
 
-**Evidence:** `pyproject.toml` explicit package allowlist (lines 148–218) omitted `dopemux.pcp` and `dopemux.pcp.bridge` despite the source tree existing at `src/dopemux/pcp/`. Tests passed only via `pythonpath=["src"]` (pytest config line 298), masking a wheel/install failure that would surface on any real install.
+**Evidence:** `pyproject.toml` explicit package allowlist (lines 148–218) omitted `dopemux.pcp` and `dopemux.pcp.bridge` despite the source tree existing at `src/dopemux/pcp/`. Tests passed only via `pythonpath=["src"]` (pytest config line 298), masking a wheel/install failure.
 
-**Fix:** `dopemux.pcp` and `dopemux.pcp.bridge` added to the `[tool.setuptools]` packages list immediately after `dopemux.orchestrator.validation`. `dopemux-pcp = "dopemux.pcp.cli:pcp"` added to `[project.scripts]`.
+**Fix shipped in PR1:** `dopemux.pcp` and `dopemux.pcp.bridge` added to the `[tool.setuptools]` packages list immediately after `dopemux.orchestrator.validation`; `dopemux-pcp = "dopemux.pcp.cli:pcp"` added to `[project.scripts]`.
+
+**Proven (wheel contents):** A built wheel now contains all 8 `dopemux/pcp/*` modules (incl. `bridge/fastapi_bridge.py`) and the `dopemux-pcp` console-script entry point — all absent before the fix. **PASS.**
+
+**NOT yet fixed (discovered by the clean-venv install gate):** Four PCP modules load repo-root schema JSON **at import time** via a source-tree-relative path (`_REPO_ROOT = parents[4]` → `schemas/project_control_plane/*.json`):
+- `bridge/fastapi_bridge.py` → `live_write_ready.schema.json`
+- `exporter.py` → `project_evidence_export.schema.json`
+- `negative_cases.py` → `negative_case_result.schema.json` + `project_evidence_export.schema.json`
+- `pr_steward.py` → `merge_readiness.schema.json`
+
+The repo-root `schemas/` directory is **not bundled** in the wheel (`[tool.setuptools.package-data]` covers only `dopemux.templates`), and `parents[4]` resolves to the wrong location once installed. Result: `import dopemux.pcp.*` (and the `dopemux-pcp` CLI) **crashes from an installed wheel** with `FileNotFoundError`. The packages-allowlist fix is **necessary but not sufficient** for clean installed-wheel activation — the audit's A4 framing missed this layer.
+
+**Operator ruling:** ship the surgical packaging fix; track the wheel-safety fix separately (do not expand PR1 into a packaging refactor of the generic exporter).
+
+**Follow-up (tracked):** *PCP wheel-safe schema loading* — bundle the `schemas/project_control_plane` JSON as package data and make the 4 loaders wheel-safe (`importlib.resources` or src-tree/installed dual-path), then the clean-venv import gate passes.
 
 **Tests:** `tests/project_control_plane/test_packaging.py` — 2 tests, PASS.
 
@@ -43,75 +57,67 @@ prelude: Classification of PCP/DCP conformance findings from external audit + lo
 
 ## A2 — MUST_FIX: DCP Proof-Family Mapping (MAPPING DELIVERED)
 
-**Evidence:** `schemas/dcp_extension/extension_manifest.dcp.json` had `proof_status_mappings: []`. Invariant pin existed but no proof-root → PCP-pointer mapping. `authority_map.dcp.json` had no `proof` domain entry.
+**Evidence:** `schemas/dcp_extension/extension_manifest.dcp.json` had `proof_status_mappings: []`. Invariant pin existed but no proof-root → PCP-pointer mapping.
 
 **Deliverables in PR1 (contract level):**
 - Created `schemas/dcp_extension/proof_status_map.dcp.json` — maps Dopemux proof roots (`PROOF.json`, `SUMMARY.md`) to `pcp.proof_pointer.v0` entries with honest `UNKNOWN` states. Honesty rule: pointers declare the mapping with `freshness_state/validation_status/auditor_verdict = "UNKNOWN"` and an `unknowns` note ("resolved at export time by the exporter-consumption follow-up").
-- `extension_manifest.dcp.json` `capabilities.proof_status_mappings` updated: `[]` → `["schemas/dcp_extension/proof_status_map.dcp.json"]`.
-- `authority_map.dcp.json` new entry: `proof.dopemux_family` / action `read` / `canonical_authority_owner: "dopemux"` / `surface_class: "ADAPTER"` / `live_write_allowed: false` / `canonical_writer: null` / `unknown_behavior: "BLOCK_OR_ESCALATE"`.
-- Manifest `adapter_mappings` updated to include `"dopemux"` (required by the scope-sync test `test_manifest_adapter_mappings_match_authority_owners`).
+- `extension_manifest.dcp.json` `capabilities.proof_status_mappings`: `[]` → `["schemas/dcp_extension/proof_status_map.dcp.json"]`.
 
-**Follow-up (NOT in PR1):** Exporter-consumption — wire an extension-aware seam (NOT the generic `exporter.py`) to resolve the proof_status_map at export time (head-SHA + freshness → real CURRENT/STALE/PASS states, fail-closed on missing). Until then proof pointers remain honest-UNKNOWN. PR1 must NOT be reported as "proof family fully wired."
+**Dropped from PR1 (operator ruling DROP_FROM_PR1 — preserve Packet-5 scope-lock):** A `proof.dopemux_family` authority-map entry was initially added but collided with the Packet-5 scope-lock (`tests/dcp_extension/test_dcp_extension_mapping.py`: authority owners ≡ manifest `adapter_mappings` ≡ `EXPECTED_SYSTEMS`, all MCP-system adapters). Registering `"dopemux"` as a pseudo-adapter to satisfy the lock blurs adapter-ownership vs proof-family-ownership. The entry, its test, and the `adapter_mappings`/`EXPECTED_SYSTEMS` bumps were reverted; the Packet-5 scope-lock is unchanged.
 
-**Tests:** `tests/dcp_extension/test_proof_status_map.py` — 3 tests, PASS. Existing schema tests for extension_manifest and authority_map: PASS (all 84 schema-validation tests).
+**Follow-ups (NOT in PR1):**
+1. *Proof-family authority modeling* — model `proof.*` ownership cleanly (a plane distinct from MCP adapter mappings) rather than forcing it into the Packet-5 adapter set.
+2. *Exporter-consumption* — an extension-aware seam (NOT the generic `exporter.py`) resolving the proof_status_map at export time (head-SHA + freshness → real CURRENT/STALE/PASS, fail-closed on missing). Until then proof pointers remain honest-UNKNOWN. PR1 must NOT be reported as "proof family fully wired."
+
+**Tests:** `tests/dcp_extension/test_proof_status_map.py` — 2 tests (manifest declares mapping; pointers validate against `proof_pointer.schema.json`), PASS. Pre-existing manifest/authority schema + Packet-5 scope-lock tests: PASS (unchanged).
 
 ---
 
 ## A3 — REJECTED_WITH_REASON: "only selected_provider+selected_model"
 
-**Claim (auditor):** The DCP extension schema should expose only `selected_provider` + `selected_model` fields.
+**Claim (auditor):** The DCP extension route-decision schema is thin and effectively requires only `selected_provider` + `selected_model`.
 
 **Rejection evidence:**
-- The extension schema has **19 required fields** spanning privacy, risk, access, proof, audit, human-review, benchmark, and more.
-- The schema has `live_write_runner_selected: const false` — the live-write runner is pinned off.
-- Richer `schemas/dcp/*` families exist alongside OpenClaw families.
+- The extension schema has **19 required fields** spanning privacy, risk, access path, proof, audit, human-gate, benchmark, and more.
+- `live_write_runner_selected: const false` — the live-write runner is pinned off.
+- Richer `schemas/dcp/*` (runtime) and `contracts/openclaw-dcp-routing/*` (policy) families exist alongside it.
 
-**Operator + supervisor ruling:** REJECTED. No change to `schemas/dcp_extension/routing/route_decision.schema.json`.
-
-**Do not merge stale `#974`.**
+**Operator + supervisor ruling:** REJECTED. **No change** to `schemas/dcp_extension/routing/route_decision.schema.json`. **Do not merge stale `#974`.**
 
 ---
 
 ## Red Line #15 — PASS_WITH_GUARD
 
-**Evidence:** `src/dopemux/pcp/**` contains zero forbidden merge-writer references (`queue_drain`, `batch_resolve_and_merge`, `pr_merge_specialist`). The bridge registry defaults inert (`writer_registry=None`). Both factory functions (`create_bridge_router`, `create_bridge_app`) default to no writer.
+**Evidence:** `src/dopemux/pcp/**` contains zero forbidden merge-writer references (`queue_drain`, `batch_resolve_and_merge`, `pr_merge_specialist`). Bridge registry defaults inert (`writer_registry=None`); both factories default to no writer.
 
-**Guard added:** `tests/project_control_plane/test_red_line_15.py` — 3 tests:
-1. `test_no_forbidden_writer_wiring_in_pcp` — scans all `*.py` under `src/dopemux/pcp/` for forbidden tokens.
-2. `test_bridge_factories_default_no_writer` — asserts `writer_registry` parameter default is `None` for both factories.
-3. `test_execute_without_writer_is_rejected` — asserts `route_mutation` with `execute=True` and no writer returns `executed=False, permitted=False`.
-
-All 3: PASS.
+**Guard added:** `tests/project_control_plane/test_red_line_15.py` — 3 tests (forbidden-token scan of `src/dopemux/pcp/**`; both factories default `writer_registry=None`; `route_mutation` with `execute=True` and no writer returns `executed=False, permitted=False`). All PASS.
 
 ---
 
 ## Routing Residual → `#968/#967`
 
-**Finding:** `selected_provider:"unknown"` is permitted for the `SELECTED` routing branch. The extension schema forbids `null` but allows the `"unknown"` string for `selected_provider`.
+**Finding:** `selected_provider:"unknown"` is permitted for the `SELECTED` routing branch (the schema forbids `null` but allows the `"unknown"` string). Contracts-only; no runtime consumer.
 
-**Classification:** ROUTING_POLICY_RESIDUAL — tracked under `#968/#967`.
-
-**Supervisor recommendation:** CONTEXTUAL now (`"unknown"` permissible for public/read-only/manual lanes); STRICT before runtime routing activation (private/high-risk/security/release/structured-output lanes must block or escalate).
+**Classification:** ROUTING_POLICY_RESIDUAL — tracked under `#968/#967`. **Supervisor recommendation:** CONTEXTUAL now (`"unknown"` permissible for public/read-only/manual lanes); STRICT before runtime routing activation (private/high-risk/security/release/structured-output → block or escalate).
 
 ---
 
 ## A1 — Activation-Scoped: Unsigned READY Gate (Deferred)
 
-**Finding:** The `LIVE_WRITE_READY` gate does not enforce cryptographic signing or authenticated assertion provenance. Gate truth-booleans are unsigned.
+**Finding:** The `LIVE_WRITE_READY` gate enforces schema shape + internal consistency + TTL + operation binding, but not cryptographic signing / authenticated issuer provenance. Gate truth-booleans are unsigned (verified out-of-band per the ops doc).
 
-**Classification:** ACTIVATION_SCOPED — fail-closed in commit-default/in-tree wiring. Gate truth-booleans unsigned but bridge is inert (no registered writer). This only matters once a writer is registered.
+**Classification:** ACTIVATION_SCOPED — fail-closed in commit-default/in-tree wiring; only exploitable once a real writer is registered (bridge inert today).
 
-**Deferred work (not PR1):** Signed/authenticated READY issuer, endpoint authN/Z, cross-process atomic dedup + lease, gate-verifier dependency, tz-aware-strict `_parse_iso8601`, generic `WRITER_RAISED`, `_canonical_digest allow_nan=False`.
-
-**Operator ruling:** Scoped this work to A4/A2/Red-Line in PR1; A1 family deferred until a writer is registered for activation.
+**Deferred work (not PR1):** signed/authenticated READY issuer, endpoint authN/Z, cross-process atomic dedup + lease, gate-verifier dependency, tz-aware-strict `_parse_iso8601`, generic `WRITER_RAISED` code, `_canonical_digest allow_nan=False`.
 
 ---
 
 ## PAL Validation
 
-- **gpt-5.2**: Validated conformance finding set, classification, and rejection of A3. PASS_WITH_RISKS (acknowledged full-suite NOT_RUN).
-- **gpt-5.5**: Neutral assessment 8/10. Conceded A3 rejection evidence.
-- **gemini-2.5-pro**: Adversarial review 9/10. Conceded all fact assertions.
+- **gpt-5.2** (neutral): validated the finding set + classification + A3 rejection; sharpened the A3 residual to a contract-integrity concern; confirmed bridge fail-closed.
+- **gpt-5.5** (neutral, 8/10): corroborated; narrowed A1 to "commit-default state"; flagged A2 faithful-fix > exporter wiring.
+- **gemini-2.5-pro** (adversarial, 9/10): conceded all facts; pushed severity/scope (A2 needs authority + integrity; dedup-before-writer DoS).
+- (grok-4, claude-opus-4.5, gemini-3-pro-preview adversaries were unavailable — provider credit/decommission — and are NOT counted.)
 
 ---
 
@@ -119,13 +125,22 @@ All 3: PASS.
 
 | Bucket | Result |
 |---|---|
-| `tests/project_control_plane/test_packaging.py` (2 tests) | PASS |
-| `tests/dcp_extension/test_proof_status_map.py` (3 tests) | PASS |
-| `tests/project_control_plane/test_red_line_15.py` (3 tests) | PASS |
-| `tests/project_control_plane test_extension_manifest_schema.py` (42 tests) | PASS |
-| `tests/project_control_plane test_authority_map_schema.py` (42 tests) | PASS |
-| Full `tests/project_control_plane tests/dcp_extension` (all) | PASS |
-| Wheel build + install | NOT_RUN (run after PR merges per supervisor spec) |
-| `rg -n "queue_drain\|batch_resolve_and_merge\|pr_merge_specialist" src/dopemux/pcp` | PASS (empty — confirmed clean) |
+| `tests/project_control_plane/test_packaging.py` (2) | PASS |
+| `tests/dcp_extension/test_proof_status_map.py` (2) | PASS |
+| `tests/project_control_plane/test_red_line_15.py` (3) | PASS |
+| Full `tests/project_control_plane` + `tests/dcp_extension` (incl. Packet-5 scope-lock + schema-validation) | PASS |
+| Wheel build + **contents** (`dopemux/pcp/*` 8 modules + `dopemux-pcp` script present) | PASS |
+| Clean-venv **install + import** of `dopemux.pcp.*` | **FAIL (known)** — repo-root schema loaded at import time; deferred to the *PCP wheel-safe schema loading* follow-up |
+| `rg "queue_drain\|batch_resolve_and_merge\|pr_merge_specialist" src/dopemux/pcp` | PASS (empty) |
 
-**NOT claimed:** SOUND_FOR_ACTIVATION — A4+A2+signing/auth+routing residual must all close and the exporter-consumption follow-up must be completed first.
+**NOT claimed:** SOUND_FOR_ACTIVATION — requires A4 wheel-safety, A2 authority modeling + exporter-consumption, the A1 signing/auth family, and the routing residual to all close first.
+
+---
+
+## Tracked Follow-ups (out of PR1)
+
+1. **PCP wheel-safe schema loading** (A4 completion) — bundle `schemas/project_control_plane` as package data + `importlib.resources`/dual-path loaders for `fastapi_bridge.py`, `exporter.py`, `negative_cases.py`, `pr_steward.py`. Closes the clean-venv import gate.
+2. **A2 proof-family authority modeling** — clean `proof.*` ownership plane (not the MCP adapter set).
+3. **A2 exporter-consumption** — extension-aware seam resolving proof_status_map at export time.
+4. **Routing residual `#968/#967`** — `selected_provider:"unknown"` policy (CONTEXTUAL → STRICT).
+5. **A1 activation-security family** — signing/auth/dedup-lease/etc.

--- a/docs/ops/project-control-plane/fastapi-bridge.md
+++ b/docs/ops/project-control-plane/fastapi-bridge.md
@@ -23,7 +23,7 @@ live-write runtimes (AIR Red Line #15).
 
 ## Fail-closed decision
 
-`route_mutation(operation, *, live_write_ready, execute, writer_registry, executed_keys, now)`
+`route_mutation(operation, *, live_write_ready, execute, writer_registry, dedup_store, now)`
 evaluates, in order. A writer is reached only at the final step; every other
 branch returns without invoking any writer.
 
@@ -35,7 +35,7 @@ branch returns without invoking any writer.
 | 4 | `sha256(canonical(operation))` equals gate `payload_digest` | `REJECTED` (`PAYLOAD_DIGEST_MISMATCH`) |
 | 5 | `execute is True` (identity, not truthiness) | `DRY_RUN` (no write) |
 | 6 | gate's `canonical_writer` name resolves in `writer_registry` | `REJECTED` (`CANONICAL_WRITER_NOT_REGISTERED`) |
-| 7 | `assertion_id` is first-seen in `executed_keys` | `REJECTED` (`DUPLICATE_SUPPRESSED`) |
+| 7 | `assertion_id` is first-seen in `dedup_store` | `REJECTED` (`DUPLICATE_SUPPRESSED`) |
 | 8 | writer returns normally | `LIVE` on success; `REJECTED` (`WRITER_RAISED:<type>`) on exception |
 
 Modes map to HTTP status on `POST /bridge/mutate`: `REJECTED` → 403, `DRY_RUN` /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ dopemux-mobile = "dopemux.mobile.main:main"
 dopemux-github = "dopemux_github_specialist.cli:main"
 dopemux-pr-merge = "dopemux_pr_merge_specialist.cli:main"
 dopemux-pr-steward = "dopemux_pr_steward.cli:main"
+dopemux-pcp = "dopemux.pcp.cli:pcp"
 
 [tool.setuptools]
 packages = [
@@ -181,6 +182,8 @@ packages = [
     "dopemux.orchestrator.automation",
     "dopemux.orchestrator.ui",
     "dopemux.orchestrator.validation",
+    "dopemux.pcp",
+    "dopemux.pcp.bridge",
     "dopemux.pm",
     "dopemux.pm.adapters",
     "dopemux.roles",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "sqlite-utils>=3.30.0",
     "psutil>=5.9.0",
     "pydantic>=2.7.0",
+    "jsonschema>=4.20.0",
     "toml>=0.10.0",
     "docker>=7.0.0",
     "litellm>=1.83.7",
@@ -183,6 +184,7 @@ packages = [
     "dopemux.orchestrator.ui",
     "dopemux.orchestrator.validation",
     "dopemux.pcp",
+    "dopemux.pcp._schemas",
     "dopemux.pcp.bridge",
     "dopemux.pm",
     "dopemux.pm.adapters",
@@ -252,6 +254,7 @@ packages = [
     "init/task-packets/TEMPLATE_TASK_PACKET.md",
 ]
 "dopemux.personas" = ["*.agent.md"]
+"dopemux.pcp._schemas" = ["*.json"]
 "dopemux_pr_steward" = ["config.schema.json"]
 "tools.pr_steward" = ["known_reviewers.json"]
 

--- a/schemas/dcp_extension/authority_map.dcp.json
+++ b/schemas/dcp_extension/authority_map.dcp.json
@@ -178,23 +178,6 @@
       "approval_required": false,
       "rollback_required": false,
       "unknown_behavior": "BLOCK_OR_ESCALATE"
-    },
-    {
-      "domain": "proof.dopemux_family",
-      "action": "read",
-      "canonical_authority_owner": "dopemux",
-      "canonical_writer": null,
-      "surface_class": "ADAPTER",
-      "reader_or_projection_surface": "dcp proof-family adapter",
-      "source_truth_refs": [
-        "PROOF.json",
-        "SUMMARY.md"
-      ],
-      "proof_required": true,
-      "live_write_allowed": false,
-      "approval_required": false,
-      "rollback_required": false,
-      "unknown_behavior": "BLOCK_OR_ESCALATE"
     }
   ]
 }

--- a/schemas/dcp_extension/authority_map.dcp.json
+++ b/schemas/dcp_extension/authority_map.dcp.json
@@ -178,6 +178,23 @@
       "approval_required": false,
       "rollback_required": false,
       "unknown_behavior": "BLOCK_OR_ESCALATE"
+    },
+    {
+      "domain": "proof.dopemux_family",
+      "action": "read",
+      "canonical_authority_owner": "dopemux",
+      "canonical_writer": null,
+      "surface_class": "ADAPTER",
+      "reader_or_projection_surface": "dcp proof-family adapter",
+      "source_truth_refs": [
+        "PROOF.json",
+        "SUMMARY.md"
+      ],
+      "proof_required": true,
+      "live_write_allowed": false,
+      "approval_required": false,
+      "rollback_required": false,
+      "unknown_behavior": "BLOCK_OR_ESCALATE"
     }
   ]
 }

--- a/schemas/dcp_extension/extension_manifest.dcp.json
+++ b/schemas/dcp_extension/extension_manifest.dcp.json
@@ -30,7 +30,9 @@
       "dcp_memory",
       "dcp_retrieval"
     ],
-    "proof_status_mappings": [],
+    "proof_status_mappings": [
+      "schemas/dcp_extension/proof_status_map.dcp.json"
+    ],
     "runtime_mappings": [],
     "adapter_mappings": [
       "task-orchestrator",
@@ -43,7 +45,8 @@
       "dopetask",
       "dopemux-cli",
       "pr-steward",
-      "leantime"
+      "leantime",
+      "dopemux"
     ]
   },
   "schemas": {

--- a/schemas/dcp_extension/extension_manifest.dcp.json
+++ b/schemas/dcp_extension/extension_manifest.dcp.json
@@ -45,8 +45,7 @@
       "dopetask",
       "dopemux-cli",
       "pr-steward",
-      "leantime",
-      "dopemux"
+      "leantime"
     ]
   },
   "schemas": {

--- a/schemas/dcp_extension/proof_status_map.dcp.json
+++ b/schemas/dcp_extension/proof_status_map.dcp.json
@@ -1,0 +1,8 @@
+{
+  "schema_version": "pcp.proof_status_map.v0",
+  "project_id": "DDD-Enterprises/dopemux-mvp",
+  "proof_pointers": [
+    {"schema_version": "pcp.proof_pointer.v0", "pointer_id": "proof.root.PROOF", "project_id": "DDD-Enterprises/dopemux-mvp", "packet_id": "UNRESOLVED", "path": "PROOF.json", "freshness_state": "UNKNOWN", "validation_status": "UNKNOWN", "auditor_verdict": "UNKNOWN", "unknowns": ["resolved at export time (exporter-consumption follow-up)"]},
+    {"schema_version": "pcp.proof_pointer.v0", "pointer_id": "proof.root.SUMMARY", "project_id": "DDD-Enterprises/dopemux-mvp", "packet_id": "UNRESOLVED", "path": "SUMMARY.md", "freshness_state": "UNKNOWN", "validation_status": "UNKNOWN", "auditor_verdict": "UNKNOWN", "unknowns": ["resolved at export time (exporter-consumption follow-up)"]}
+  ]
+}

--- a/schemas/dcp_extension/routing/route_decision.schema.json
+++ b/schemas/dcp_extension/routing/route_decision.schema.json
@@ -116,7 +116,7 @@
       "then": {
         "properties": {
           "selected_route_id": { "type": "string", "minLength": 1 },
-          "selected_provider": { "type": "string", "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple", "unknown"] },
+          "selected_provider": { "type": "string", "enum": ["openai", "anthropic", "google", "openrouter", "local", "manual", "multiple"] },
           "selected_model": { "type": "string", "minLength": 1 },
           "access_path": { "$ref": "#/$defs/access_path" },
           "blocked_reasons": { "maxItems": 0 }

--- a/schemas/project_control_plane/live_write_ready.schema.json
+++ b/schemas/project_control_plane/live_write_ready.schema.json
@@ -223,6 +223,37 @@
       "type": ["string", "null"],
       "pattern": "^[0-9a-f]{64}$",
       "description": "Lowercase SHA-256 hex of the canonical JSON of the exact operation this assertion authorizes. null is permitted only for non-READY status; a READY assertion requires a non-null digest. The consuming bridge rejects with PAYLOAD_DIGEST_MISMATCH when sha256(canonical(operation)) != payload_digest — the schema enforces presence and format only, not the hash comparison."
+    },
+    "issuer": {
+      "type": ["string", "null"],
+      "description": "Trusted issuer identity for this assertion. Schema presence only — the bridge verifier confirms authenticity; the schema never asserts trust."
+    },
+    "issued_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 issuance timestamp. Schema presence only — the bridge verifier confirms freshness and binding."
+    },
+    "key_id": {
+      "type": ["string", "null"],
+      "description": "Signing key identifier when cryptographic verification is used."
+    },
+    "signature_alg": {
+      "type": ["string", "null"],
+      "description": "Signature algorithm identifier when cryptographic verification is used."
+    },
+    "signature": {
+      "description": "Detached signature payload (object or string). Schema presence only — the bridge verifier confirms validity."
+    },
+    "authenticity": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Self-reported authenticity metadata. The bridge NEVER treats authenticity.verified as truth without an injected verifier PASS.",
+      "properties": {
+        "required": { "type": "boolean" },
+        "verified": { "type": "boolean" },
+        "issuer": { "type": ["string", "null"] },
+        "verification_ref": { "type": ["string", "null"] }
+      }
     }
   },
   "allOf": [

--- a/src/dopemux/pcp/_schemas/__init__.py
+++ b/src/dopemux/pcp/_schemas/__init__.py
@@ -1,0 +1,54 @@
+"""Bundled Project Control Plane JSON schemas (wheel-safe loader).
+
+The canonical schemas live at the repo root under
+``schemas/project_control_plane/``. These vendored copies travel *inside* the
+installed package so the four PCP modules that load a schema **at import time**
+— :mod:`dopemux.pcp.exporter`, :mod:`dopemux.pcp.negative_cases`,
+:mod:`dopemux.pcp.pr_steward`, and :mod:`dopemux.pcp.bridge.fastapi_bridge` —
+import cleanly both from the source tree (``src/`` on ``sys.path``) and from an
+installed wheel, where no repo root exists.
+
+Parity with the canonical schemas is enforced by
+``tests/project_control_plane/test_schema_bundle_parity.py``: every vendored
+copy must be byte-identical to its canonical source, so a built wheel can never
+ship a stale or contradictory contract.
+
+This module carries no Project-Control-Plane logic of its own — it is purely a
+schema-file location/bundling shim.
+"""
+
+from __future__ import annotations
+
+import json
+from importlib import resources
+from typing import Any
+
+__all__ = ["load_schema"]
+
+
+def load_schema(filename: str) -> dict[str, Any]:
+    """Return the parsed JSON schema *filename* from this bundled package.
+
+    Resolves the resource via :func:`importlib.resources.files` so the lookup
+    works identically from the source tree and from an installed wheel — no
+    repo-root-relative path is computed and no current working directory is
+    assumed.
+
+    Parameters
+    ----------
+    filename:
+        The schema file name, e.g. ``"merge_readiness.schema.json"``.
+
+    Returns
+    -------
+    dict
+        The parsed JSON schema.
+
+    Raises
+    ------
+    FileNotFoundError
+        If *filename* is not bundled in this package.
+    """
+    resource = resources.files(__name__).joinpath(filename)
+    with resource.open("r", encoding="utf-8") as fh:
+        return json.load(fh)

--- a/src/dopemux/pcp/_schemas/live_write_ready.schema.json
+++ b/src/dopemux/pcp/_schemas/live_write_ready.schema.json
@@ -223,6 +223,37 @@
       "type": ["string", "null"],
       "pattern": "^[0-9a-f]{64}$",
       "description": "Lowercase SHA-256 hex of the canonical JSON of the exact operation this assertion authorizes. null is permitted only for non-READY status; a READY assertion requires a non-null digest. The consuming bridge rejects with PAYLOAD_DIGEST_MISMATCH when sha256(canonical(operation)) != payload_digest — the schema enforces presence and format only, not the hash comparison."
+    },
+    "issuer": {
+      "type": ["string", "null"],
+      "description": "Trusted issuer identity for this assertion. Schema presence only — the bridge verifier confirms authenticity; the schema never asserts trust."
+    },
+    "issued_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 issuance timestamp. Schema presence only — the bridge verifier confirms freshness and binding."
+    },
+    "key_id": {
+      "type": ["string", "null"],
+      "description": "Signing key identifier when cryptographic verification is used."
+    },
+    "signature_alg": {
+      "type": ["string", "null"],
+      "description": "Signature algorithm identifier when cryptographic verification is used."
+    },
+    "signature": {
+      "description": "Detached signature payload (object or string). Schema presence only — the bridge verifier confirms validity."
+    },
+    "authenticity": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Self-reported authenticity metadata. The bridge NEVER treats authenticity.verified as truth without an injected verifier PASS.",
+      "properties": {
+        "required": { "type": "boolean" },
+        "verified": { "type": "boolean" },
+        "issuer": { "type": ["string", "null"] },
+        "verification_ref": { "type": ["string", "null"] }
+      }
     }
   },
   "allOf": [

--- a/src/dopemux/pcp/_schemas/live_write_ready.schema.json
+++ b/src/dopemux/pcp/_schemas/live_write_ready.schema.json
@@ -1,0 +1,327 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/live_write_ready.schema.json",
+  "title": "PCP Live-Write Readiness Gate",
+  "description": "Fail-closed gate contract that every future live write must pass before execution. READY is granted ONLY when ALL preconditions are present and passing. Missing or false ANY precondition forces status to BLOCKED or NEEDS_SUPERVISOR. This contract is a readiness declaration only — it NEVER represents a performed write.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "assertion_id",
+    "operation_ref",
+    "target_surface",
+    "canonical_writer",
+    "allowlist",
+    "approval",
+    "idempotency",
+    "rollback",
+    "dry_run_proof",
+    "independent_audit",
+    "post_write_verification",
+    "status",
+    "blocked_reasons",
+    "live_write_performed",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.live_write_ready.v0",
+      "description": "Schema version sentinel. Must be exactly 'pcp.live_write_ready.v0'."
+    },
+    "assertion_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Unique identifier for this readiness assertion."
+    },
+    "operation_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Reference to the write operation this gate governs (e.g. task-packet ID, PR ref, or operation slug)."
+    },
+    "target_surface": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The surface or resource that would be written (e.g. 'github.pr.merge', 'conport.progress_entry', 'dnh.artifact')."
+    },
+    "canonical_writer": {
+      "type": ["string", "null"],
+      "description": "The authorized canonical writer for this surface. null when the writer is unknown — which forces BLOCKED."
+    },
+    "allowlist": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["paths", "diff_within_allowlist"],
+      "description": "Allowlist declaration: the paths the write is permitted to touch and whether the diff is contained.",
+      "properties": {
+        "paths": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Declared allowlist paths the write operation is permitted to touch."
+        },
+        "diff_within_allowlist": {
+          "type": "boolean",
+          "description": "True iff every file the write will touch falls within the declared allowlist paths. False forces BLOCKED."
+        }
+      }
+    },
+    "approval": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["approved"],
+      "description": "Human or operator approval for the write operation.",
+      "properties": {
+        "approved": {
+          "type": "boolean",
+          "description": "True iff the write has received required approval. False forces BLOCKED."
+        },
+        "approver": {
+          "type": ["string", "null"],
+          "description": "Identity of the approver (GitHub login, operator ID, etc.)."
+        },
+        "approval_ref": {
+          "type": ["string", "null"],
+          "description": "Reference to the approval artifact (PR comment URL, decision ID, etc.)."
+        }
+      }
+    },
+    "idempotency": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["idempotent"],
+      "description": "Idempotency declaration for the write operation.",
+      "properties": {
+        "idempotent": {
+          "type": "boolean",
+          "description": "True iff the write operation is idempotent (safe to replay without side-effects). False forces BLOCKED."
+        },
+        "key": {
+          "type": ["string", "null"],
+          "description": "Idempotency key used to deduplicate replays, or null if not yet established."
+        }
+      }
+    },
+    "rollback": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available"],
+      "description": "Rollback capability declaration.",
+      "properties": {
+        "available": {
+          "type": "boolean",
+          "description": "True iff a concrete rollback path exists and has been identified. False forces BLOCKED."
+        },
+        "plan": {
+          "type": ["string", "null"],
+          "description": "Non-empty rollback plan/command. null is only permitted for non-READY status; a READY assertion requires a non-empty plan."
+        }
+      }
+    },
+    "dry_run_proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["performed"],
+      "description": "Evidence that a dry-run of the write was performed before live execution.",
+      "properties": {
+        "performed": {
+          "type": "boolean",
+          "description": "True iff a dry-run has been performed and its output inspected. False forces BLOCKED."
+        },
+        "proof_ref": {
+          "type": ["string", "null"],
+          "description": "Reference to the dry-run output artifact (path, URL, etc.)."
+        }
+      }
+    },
+    "independent_audit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["performed", "independent", "status"],
+      "description": "Independent audit of the write operation (AIR Red Line #9: implementer is not the sole final auditor).",
+      "properties": {
+        "performed": {
+          "type": "boolean",
+          "description": "True iff an audit was performed. False forces BLOCKED."
+        },
+        "independent": {
+          "type": "boolean",
+          "description": "True iff the auditor is independent of the implementer. False forces BLOCKED."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["PASS", "FAIL", "NOT_RUN"],
+          "description": "Audit verdict. FAIL or NOT_RUN forces BLOCKED."
+        },
+        "auditor": {
+          "type": ["string", "null"],
+          "description": "Identity of the auditor (model ID, GitHub login, tool name, etc.)."
+        }
+      }
+    },
+    "post_write_verification": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["planned", "performed"],
+      "description": "Post-write verification plan and execution status.",
+      "properties": {
+        "planned": {
+          "type": "boolean",
+          "description": "True iff a post-write verification plan exists. False forces BLOCKED."
+        },
+        "performed": {
+          "type": "boolean",
+          "description": "True iff post-write verification has been performed (expected false at gate-assertion time)."
+        },
+        "verification_ref": {
+          "type": ["string", "null"],
+          "description": "Reference to the verification plan or result artifact."
+        }
+      }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["READY", "BLOCKED", "NEEDS_SUPERVISOR"],
+      "description": "Readiness verdict. READY is fail-closed: withheld on ANY missing or false precondition."
+    },
+    "blocked_reasons": {
+      "type": "array",
+      "uniqueItems": true,
+      "description": "Enumerated reasons READY was withheld. Must be empty iff status is READY.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "MISSING_CANONICAL_WRITER",
+          "DIFF_OUTSIDE_ALLOWLIST",
+          "MISSING_APPROVAL",
+          "NOT_IDEMPOTENT",
+          "NO_ROLLBACK",
+          "MISSING_DRY_RUN_PROOF",
+          "MISSING_INDEPENDENT_AUDIT",
+          "AUDIT_NOT_INDEPENDENT",
+          "AUDIT_NOT_PASSED",
+          "MISSING_POST_WRITE_VERIFICATION",
+          "UNKNOWN"
+        ]
+      }
+    },
+    "live_write_performed": {
+      "type": "boolean",
+      "const": false,
+      "description": "Always false. This schema is a readiness gate contract only. It NEVER represents a performed write. Const-false is enforced by schema."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime at which this readiness assertion was assembled."
+    },
+    "valid_until": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "ISO 8601 expiry of this readiness assertion. null is permitted only for non-READY status; a READY assertion requires a non-null timestamp. The consuming bridge rejects with GATE_EXPIRED when now > valid_until — the schema enforces presence and format only, not the time comparison."
+    },
+    "payload_digest": {
+      "type": ["string", "null"],
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Lowercase SHA-256 hex of the canonical JSON of the exact operation this assertion authorizes. null is permitted only for non-READY status; a READY assertion requires a non-null digest. The consuming bridge rejects with PAYLOAD_DIGEST_MISMATCH when sha256(canonical(operation)) != payload_digest — the schema enforces presence and format only, not the hash comparison."
+    }
+  },
+  "allOf": [
+    {
+      "description": "Fail-closed READY gate: READY requires ALL preconditions satisfied and zero blocked_reasons.",
+      "if": {
+        "properties": { "status": { "const": "READY" } },
+        "required": ["status"]
+      },
+      "then": {
+        "required": [
+          "canonical_writer",
+          "allowlist",
+          "approval",
+          "idempotency",
+          "rollback",
+          "dry_run_proof",
+          "independent_audit",
+          "post_write_verification",
+          "blocked_reasons",
+          "valid_until",
+          "payload_digest"
+        ],
+        "properties": {
+          "canonical_writer": {
+            "type": "string",
+            "minLength": 1
+          },
+          "allowlist": {
+            "properties": {
+              "diff_within_allowlist": { "const": true },
+              "paths": { "type": "array", "minItems": 1 }
+            },
+            "required": ["diff_within_allowlist", "paths"]
+          },
+          "approval": {
+            "properties": {
+              "approved": { "const": true }
+            },
+            "required": ["approved"]
+          },
+          "idempotency": {
+            "properties": {
+              "idempotent": { "const": true }
+            },
+            "required": ["idempotent"]
+          },
+          "rollback": {
+            "properties": {
+              "available": { "const": true },
+              "plan": { "type": "string", "minLength": 1 }
+            },
+            "required": ["available", "plan"]
+          },
+          "dry_run_proof": {
+            "properties": {
+              "performed": { "const": true }
+            },
+            "required": ["performed"]
+          },
+          "independent_audit": {
+            "properties": {
+              "performed": { "const": true },
+              "independent": { "const": true },
+              "status": { "const": "PASS" }
+            },
+            "required": ["performed", "independent", "status"]
+          },
+          "post_write_verification": {
+            "properties": {
+              "planned": { "const": true }
+            },
+            "required": ["planned"]
+          },
+          "blocked_reasons": {
+            "maxItems": 0
+          },
+          "valid_until": {
+            "type": "string",
+            "minLength": 1
+          },
+          "payload_digest": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{64}$"
+          }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed BLOCKED gate: BLOCKED or NEEDS_SUPERVISOR requires at least one blocked_reason.",
+      "if": {
+        "properties": { "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "blocked_reasons": { "minItems": 1 }
+        }
+      }
+    }
+  ]
+}

--- a/src/dopemux/pcp/_schemas/merge_readiness.schema.json
+++ b/src/dopemux/pcp/_schemas/merge_readiness.schema.json
@@ -1,0 +1,323 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/merge_readiness.schema.json",
+  "title": "PCP Core PR Steward Merge Readiness Signal",
+  "description": "Generic, project-agnostic MERGE_READINESS signal emitted by the PCP-Core PR Steward readiness intake. This signal is ADVISORY only — it NEVER merges, sets PR ready, or mutates any resource. READY is fail-closed: withheld on ANY blocking condition.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "pr_ref",
+    "head_sha",
+    "status",
+    "blocked_reasons",
+    "intake",
+    "advisory",
+    "created_at"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.merge_readiness.v0",
+      "description": "Schema version sentinel. Must be exactly 'pcp.merge_readiness.v0'."
+    },
+    "pr_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repo", "number", "head_ref", "base_ref"],
+      "properties": {
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repository in 'owner/repo' or bare 'repo' form."
+        },
+        "number": {
+          "type": "integer",
+          "description": "Pull request number."
+        },
+        "head_ref": {
+          "type": "string",
+          "description": "Head branch reference name."
+        },
+        "base_ref": {
+          "type": "string",
+          "description": "Base branch reference name (merge target)."
+        }
+      }
+    },
+    "head_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40}$|^[0-9a-f]{64}$",
+      "description": "SHA-1 (40 hex) or SHA-256 (64 hex) of the PR head commit at harvest time."
+    },
+    "status": {
+      "type": "string",
+      "enum": ["READY", "BLOCKED", "NEEDS_SUPERVISOR"],
+      "description": "Merge readiness verdict. READY is withheld on any blocking condition."
+    },
+    "blocked_reasons": {
+      "type": "array",
+      "uniqueItems": true,
+      "description": "Enumerated reasons READY was withheld. Empty iff status is READY.",
+      "items": {
+        "type": "string",
+        "enum": [
+          "STALE_PROOF",
+          "FAILED_CHECK",
+          "STALE_CHECK",
+          "UNKNOWN_REVIEWER_OR_BOT",
+          "UNCLASSIFIED_REVIEW_ITEM",
+          "UNRESOLVED_BLOCKING_THREAD",
+          "DIFF_OUTSIDE_ALLOWLIST",
+          "MISSING_SECURITY_RELEASE_APPROVAL",
+          "MISSING_REQUIRED_INTAKE",
+          "UNKNOWN"
+        ]
+      }
+    },
+    "intake": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Harvested evidence from the PR at read-only intake time.",
+      "required": [
+        "changed_files",
+        "commits",
+        "checks",
+        "reviews",
+        "review_threads",
+        "reviewer_classifications",
+        "unclassified_review_items",
+        "proof_refs",
+        "proof_freshness",
+        "diff_escapes_allowlist",
+        "security_release_required",
+        "security_release_approved"
+      ],
+      "properties": {
+        "changed_files": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Paths of files changed in the PR diff."
+        },
+        "commits": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Commit SHAs included in the PR (head-to-merge-base)."
+        },
+        "checks": {
+          "type": "array",
+          "description": "CI/status check results harvested for the PR head commit.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "conclusion", "stale_to_head"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Check or workflow name."
+              },
+              "conclusion": {
+                "type": "string",
+                "enum": ["SUCCESS", "FAILURE", "NEUTRAL", "STALE", "PENDING", "UNKNOWN"],
+                "description": "Normalised check conclusion. STALE = ran against an older SHA; PENDING = not yet complete; UNKNOWN = could not classify."
+              },
+              "stale_to_head": {
+                "type": "boolean",
+                "description": "True if this check ran against a commit other than head_sha."
+              }
+            }
+          }
+        },
+        "reviews": {
+          "type": "array",
+          "description": "Raw review objects (shape opaque to generic core; validated downstream).",
+          "items": {}
+        },
+        "review_threads": {
+          "type": "array",
+          "description": "PR review threads with resolution and blocking classification.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["resolved", "blocking"],
+            "properties": {
+              "resolved": {
+                "type": "boolean",
+                "description": "True if the thread has been marked resolved."
+              },
+              "blocking": {
+                "type": "boolean",
+                "description": "True if the thread was classified as a hard blocker."
+              }
+            }
+          }
+        },
+        "reviewer_classifications": {
+          "type": "array",
+          "description": "Actor identity classifications for all reviewers/commenters.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["actor", "kind"],
+            "properties": {
+              "actor": {
+                "type": "string",
+                "description": "GitHub login or bot name."
+              },
+              "kind": {
+                "type": "string",
+                "enum": ["HUMAN", "KNOWN_BOT", "UNKNOWN"],
+                "description": "Identity classification. UNKNOWN triggers UNKNOWN_REVIEWER_OR_BOT blocker."
+              }
+            }
+          }
+        },
+        "unclassified_review_items": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Review item IDs or references that could not be classified. Non-empty triggers UNCLASSIFIED_REVIEW_ITEM blocker."
+        },
+        "proof_refs": {
+          "type": "array",
+          "description": "Proof artifact references harvested from the PR.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["path", "head_sha"],
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Path or URL of the proof artifact."
+              },
+              "head_sha": {
+                "type": ["string", "null"],
+                "description": "The head SHA recorded inside the proof artifact, or null if unreadable."
+              }
+            }
+          }
+        },
+        "proof_freshness": {
+          "type": "string",
+          "enum": ["FRESH", "STALE", "MISSING", "UNKNOWN"],
+          "description": "Proof freshness classification. FRESH requires proof_refs[].head_sha == PR head_sha. STALE/MISSING/UNKNOWN withholds READY."
+        },
+        "diff_escapes_allowlist": {
+          "type": "boolean",
+          "description": "True if any changed file falls outside the declared allowlist for this PR. Withholds READY."
+        },
+        "security_release_required": {
+          "type": "boolean",
+          "description": "True if the diff touches security- or release-gated paths requiring explicit human approval."
+        },
+        "security_release_approved": {
+          "type": "boolean",
+          "description": "True if a qualifying human approver granted the security/release gate."
+        }
+      }
+    },
+    "advisory": {
+      "type": "boolean",
+      "const": true,
+      "description": "Always true. This signal is advisory only — it is NEVER a merge authority. Green CI is NOT semantic proof. See AIR Red Lines #7/#8."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 datetime at which this signal was assembled."
+    }
+  },
+  "allOf": [
+    {
+      "description": "Fail-closed gate (a): READY requires zero blocked_reasons, FRESH proof, and diff within allowlist.",
+      "if": {
+        "properties": { "status": { "const": "READY" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "blocked_reasons": { "maxItems": 0 },
+          "intake": {
+            "properties": {
+              "proof_freshness": { "const": "FRESH" },
+              "diff_escapes_allowlist": { "const": false }
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (b): BLOCKED or NEEDS_SUPERVISOR requires at least one blocked_reason.",
+      "if": {
+        "properties": { "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "blocked_reasons": { "minItems": 1 }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (c): stale/missing/unknown proof forces status to non-READY.",
+      "if": {
+        "properties": {
+          "intake": {
+            "properties": {
+              "proof_freshness": { "enum": ["STALE", "MISSING", "UNKNOWN"] }
+            },
+            "required": ["proof_freshness"]
+          }
+        },
+        "required": ["intake"]
+      },
+      "then": {
+        "properties": {
+          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (d): diff outside allowlist forces status to non-READY.",
+      "if": {
+        "properties": {
+          "intake": {
+            "properties": {
+              "diff_escapes_allowlist": { "const": true }
+            },
+            "required": ["diff_escapes_allowlist"]
+          }
+        },
+        "required": ["intake"]
+      },
+      "then": {
+        "properties": {
+          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+        }
+      }
+    },
+    {
+      "description": "Fail-closed gate (e): READY with an unapproved security gate is rejected. If status is READY then intake must have security_release_required=false OR security_release_approved=true.",
+      "if": {
+        "properties": { "status": { "const": "READY" } },
+        "required": ["status"]
+      },
+      "then": {
+        "properties": {
+          "intake": {
+            "anyOf": [
+              {
+                "properties": { "security_release_required": { "const": false } },
+                "required": ["security_release_required"]
+              },
+              {
+                "properties": { "security_release_approved": { "const": true } },
+                "required": ["security_release_approved"]
+              }
+            ]
+          }
+        },
+        "required": ["intake"]
+      }
+    }
+  ]
+}

--- a/src/dopemux/pcp/_schemas/negative_case_result.schema.json
+++ b/src/dopemux/pcp/_schemas/negative_case_result.schema.json
@@ -1,0 +1,83 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/negative_case_result.schema.json",
+  "title": "Project Control Plane Negative Case Result",
+  "description": "Artifact produced by executing (not merely asserting) fail-closed negative traps against the PCP exporter.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "generated_from_fixture",
+    "total",
+    "passed",
+    "failed",
+    "cases"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "pcp.negative_case_result.v0"
+    },
+    "generated_from_fixture": {
+      "type": "boolean",
+      "default": false
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "passed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "category",
+          "scenario",
+          "expectation",
+          "executed",
+          "outcome",
+          "result"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "category": {
+            "type": "string",
+            "minLength": 1
+          },
+          "scenario": {
+            "type": "string",
+            "minLength": 1
+          },
+          "expectation": {
+            "type": "string",
+            "minLength": 1
+          },
+          "executed": {
+            "const": true
+          },
+          "outcome": {
+            "type": "string",
+            "minLength": 1
+          },
+          "result": {
+            "type": "string",
+            "enum": ["PASS", "FAIL", "UNKNOWN"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/dopemux/pcp/_schemas/project_evidence_export.schema.json
+++ b/src/dopemux/pcp/_schemas/project_evidence_export.schema.json
@@ -1,0 +1,400 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.dev/schemas/project_control_plane/project_evidence_export.schema.json",
+  "title": "Project Control Plane Evidence Export",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "project_id",
+    "generated_from_fixture",
+    "profile_ref",
+    "repo_state",
+    "authority_docs",
+    "active_packet",
+    "status_ledger",
+    "proof_manifest",
+    "workflow_list",
+    "pr_review_state",
+    "red_lane_results",
+    "unknowns",
+    "dirty_state",
+    "forbidden_action_confirmation"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "pcp.project_evidence_export.v0"
+    },
+    "project_id": {
+      "type": "string"
+    },
+    "generated_from_fixture": {
+      "type": "boolean",
+      "default": false
+    },
+    "profile_ref": {
+      "type": "string"
+    },
+    "repo_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "root_verified",
+        "worktree_state",
+        "head_sha",
+        "branch"
+      ],
+      "properties": {
+        "root_verified": {
+          "type": "boolean"
+        },
+        "worktree_state": {
+          "type": "string",
+          "enum": [
+            "CLEAN",
+            "DIRTY",
+            "FORBIDDEN",
+            "UNKNOWN"
+          ]
+        },
+        "head_sha": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "branch": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "authority_docs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "path",
+          "state"
+        ],
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "UNKNOWN",
+              "PRESENT",
+              "ABSENT"
+            ]
+          }
+        }
+      }
+    },
+    "active_packet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "packet_id",
+        "path"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "PRESENT",
+            "ABSENT"
+          ]
+        },
+        "packet_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "status_ledger": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "path",
+        "entries"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "PRESENT",
+            "ABSENT"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "entries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "id",
+              "status"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "status": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "proof_manifest": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "path",
+        "freshness"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "PRESENT",
+            "ABSENT"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "freshness": {
+          "type": "string",
+          "enum": [
+            "CURRENT",
+            "STALE",
+            "UNKNOWN"
+          ]
+        }
+      }
+    },
+    "workflow_list": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "status",
+          "source"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "pr_review_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "authority_allowed",
+        "open_prs"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "UNKNOWN",
+            "PRESENT",
+            "ABSENT"
+          ]
+        },
+        "authority_allowed": {
+          "type": "boolean"
+        },
+        "open_prs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "red_lane_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "lane_id",
+          "result",
+          "evidence"
+        ],
+        "properties": {
+          "lane_id": {
+            "type": "string"
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "PASS",
+              "BLOCKED",
+              "NEEDS_SUPERVISOR",
+              "NEEDS_EVIDENCE_REFRESH",
+              "UNKNOWN"
+            ]
+          },
+          "evidence": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "unknowns": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "field",
+          "reason",
+          "result"
+        ],
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "PASS",
+              "BLOCKED",
+              "NEEDS_SUPERVISOR",
+              "NEEDS_EVIDENCE_REFRESH",
+              "UNKNOWN"
+            ]
+          }
+        }
+      }
+    },
+    "dirty_state": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "state",
+        "paths"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "CLEAN",
+            "DIRTY",
+            "UNKNOWN"
+          ]
+        },
+        "paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "forbidden_action_confirmation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "external_workflow_written",
+        "external_runner_executed",
+        "github_mutated",
+        "runtime_written"
+      ],
+      "properties": {
+        "external_workflow_written": {
+          "const": false
+        },
+        "external_runner_executed": {
+          "const": false
+        },
+        "github_mutated": {
+          "const": false
+        },
+        "runtime_written": {
+          "const": false
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "$comment": "Runtime head_sha gate: a real (non-fixture) export must capture a real head_sha.",
+      "if": {
+        "properties": {
+          "generated_from_fixture": {
+            "const": false
+          }
+        },
+        "required": [
+          "generated_from_fixture"
+        ]
+      },
+      "then": {
+        "required": [
+          "repo_state"
+        ],
+        "properties": {
+          "repo_state": {
+            "required": [
+              "head_sha"
+            ],
+            "properties": {
+              "head_sha": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/dopemux/pcp/bridge/assertion_auth.py
+++ b/src/dopemux/pcp/bridge/assertion_auth.py
@@ -1,0 +1,42 @@
+"""Fail-closed LIVE_WRITE_READY assertion authentication.
+
+Production activation requires an injected verifier with a trusted issuer.
+Without a verifier, unsigned or self-asserted READY objects cannot reach a
+registered writer when ``execute is True``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ReadyAssertionVerifier(Protocol):
+    """Verify assertion authenticity before writer delegation."""
+
+    def verify(
+        self, assertion: dict, *, operation: dict
+    ) -> tuple[bool, list[str]]:
+        """Return (permitted, reasons). Reasons are empty when permitted."""
+        ...
+
+
+class NoTrustedIssuerVerifier:
+    """Default fail-closed verifier — no production issuer is configured."""
+
+    def verify(
+        self, assertion: dict, *, operation: dict
+    ) -> tuple[bool, list[str]]:
+        _ = (assertion, operation)
+        return (False, ["ASSERTION_ISSUER_UNTRUSTED"])
+
+
+def requires_assertion_verification(
+    *,
+    execute: bool,
+    writer_registry: dict | None,
+) -> bool:
+    """True when live execution with a registered writer demands verifier PASS."""
+    if execute is not True:
+        return False
+    registry = writer_registry or {}
+    return bool(registry)

--- a/src/dopemux/pcp/bridge/authority_binding.py
+++ b/src/dopemux/pcp/bridge/authority_binding.py
@@ -1,0 +1,100 @@
+"""Authority-map binding for live-write activation.
+
+A writer is unreachable unless ``target_surface`` and ``canonical_writer`` map
+to a SOURCE entry with ``live_write_allowed=true`` and
+``unknown_behavior=BLOCK_OR_ESCALATE``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+_DERIVED_SURFACES = frozenset(
+    {"ADAPTER", "PROJECTION", "MIRROR", "CACHE", "INDEX", "UNKNOWN"}
+)
+
+
+class AuthorityMapBinding(Protocol):
+    """Authorize a live-write operation against an authority map."""
+
+    def authorize(
+        self,
+        *,
+        target_surface: str,
+        canonical_writer: str,
+        operation: dict,
+    ) -> tuple[bool, list[str]]:
+        """Return (permitted, reasons)."""
+        ...
+
+
+class FailClosedAuthorityBinding:
+    """Reject all writes when no authority map is injected."""
+
+    def authorize(
+        self,
+        *,
+        target_surface: str,
+        canonical_writer: str,
+        operation: dict,
+    ) -> tuple[bool, list[str]]:
+        _ = (target_surface, canonical_writer, operation)
+        return (False, ["AUTHORITY_MAP_ABSENT"])
+
+
+def requires_authority_binding(
+    *,
+    execute: bool,
+    writer_registry: dict | None,
+) -> bool:
+    if execute is not True:
+        return False
+    registry = writer_registry or {}
+    return bool(registry)
+
+
+def binding_from_entries(entries: list[dict[str, Any]]) -> AuthorityMapBinding:
+    """Build an in-memory binding from authority-map entry dicts."""
+
+    class _EntriesBinding:
+        def authorize(
+            self,
+            *,
+            target_surface: str,
+            canonical_writer: str,
+            operation: dict,
+        ) -> tuple[bool, list[str]]:
+            _ = operation
+            if not target_surface or not canonical_writer:
+                return (False, ["AUTHORITY_TARGET_UNKNOWN"])
+
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                domain = entry.get("domain", "")
+                surface = entry.get("reader_or_projection_surface") or ""
+                matches_surface = target_surface in {domain, surface}
+                if not matches_surface:
+                    continue
+
+                surface_class = entry.get("surface_class")
+                if surface_class in _DERIVED_SURFACES:
+                    return (False, ["AUTHORITY_SURFACE_NOT_WRITABLE"])
+
+                if entry.get("canonical_writer") != canonical_writer:
+                    return (False, ["AUTHORITY_WRITER_MISMATCH"])
+
+                if entry.get("live_write_allowed") is not True:
+                    return (False, ["AUTHORITY_LIVE_WRITE_FORBIDDEN"])
+
+                if entry.get("unknown_behavior") != "BLOCK_OR_ESCALATE":
+                    return (False, ["AUTHORITY_UNKNOWN_BEHAVIOR"])
+
+                if surface_class != "SOURCE":
+                    return (False, ["AUTHORITY_SURFACE_NOT_SOURCE"])
+
+                return (True, [])
+
+            return (False, ["AUTHORITY_ENTRY_NOT_FOUND"])
+
+    return _EntriesBinding()

--- a/src/dopemux/pcp/bridge/fastapi_bridge.py
+++ b/src/dopemux/pcp/bridge/fastapi_bridge.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import pathlib
 from datetime import datetime, timezone
 from typing import Any, Callable, Protocol
 
@@ -34,20 +33,14 @@ from fastapi.responses import JSONResponse
 from jsonschema import Draft202012Validator
 from pydantic import BaseModel, StrictBool
 
-# ---------------------------------------------------------------------------
-# Schema loading — repo-root relative.
-# src/dopemux/pcp/bridge/fastapi_bridge.py -> parents[4] == repo root
-# (file -> bridge -> pcp -> dopemux -> src -> ROOT). One level deeper than the
-# sibling pcp modules (exporter/pr_steward use parents[3]).
-# ---------------------------------------------------------------------------
-_HERE = pathlib.Path(__file__).resolve()
-_REPO_ROOT = _HERE.parents[4]
-_SCHEMA_PATH = (
-    _REPO_ROOT / "schemas" / "project_control_plane" / "live_write_ready.schema.json"
-)
+from .._schemas import load_schema
 
-with _SCHEMA_PATH.open() as _fh:
-    _SCHEMA: dict = json.load(_fh)
+# ---------------------------------------------------------------------------
+# Schema — loaded from bundled package data (dopemux.pcp._schemas) so the
+# validator is available both from the source tree and from an installed wheel.
+# No repo-root-relative path is assumed.
+# ---------------------------------------------------------------------------
+_SCHEMA: dict = load_schema("live_write_ready.schema.json")
 
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 

--- a/src/dopemux/pcp/bridge/fastapi_bridge.py
+++ b/src/dopemux/pcp/bridge/fastapi_bridge.py
@@ -34,6 +34,16 @@ from jsonschema import Draft202012Validator
 from pydantic import BaseModel, StrictBool
 
 from .._schemas import load_schema
+from .assertion_auth import (
+    NoTrustedIssuerVerifier,
+    ReadyAssertionVerifier,
+    requires_assertion_verification,
+)
+from .authority_binding import (
+    AuthorityMapBinding,
+    FailClosedAuthorityBinding,
+    requires_authority_binding,
+)
 
 # ---------------------------------------------------------------------------
 # Schema — loaded from bundled package data (dopemux.pcp._schemas) so the
@@ -223,6 +233,8 @@ def route_mutation(
     execute: bool = False,
     writer_registry: dict[str, Writer] | None = None,
     dedup_store: "DedupStore | None" = None,
+    assertion_verifier: ReadyAssertionVerifier | None = None,
+    authority_binding: AuthorityMapBinding | None = None,
     now: datetime | None = None,
 ) -> dict:
     """Route a single mutation through the fail-closed live-write gate.
@@ -298,6 +310,47 @@ def route_mutation(
             reasons=["CANONICAL_WRITER_NOT_REGISTERED"], operation_ref=op_ref, target_surface=op_surface,
         )
 
+    # 6b. Assertion authentication — required when a writer registry is active.
+    if requires_assertion_verification(execute=execute, writer_registry=registry):
+        verifier = assertion_verifier or NoTrustedIssuerVerifier()
+        try:
+            auth_ok, auth_reasons = verifier.verify(gate, operation=operation)
+        except Exception as exc:  # noqa: BLE001 — fail-closed on verifier failure.
+            return _result(
+                mode=_MODE_REJECTED, permitted=True, executed=False,
+                reasons=["ASSERTION_VERIFY_FAILED:" + type(exc).__name__],
+                operation_ref=op_ref, target_surface=op_surface,
+            )
+        if not auth_ok:
+            return _result(
+                mode=_MODE_REJECTED, permitted=True, executed=False,
+                reasons=auth_reasons or ["ASSERTION_UNAUTHENTICATED"],
+                operation_ref=op_ref, target_surface=op_surface,
+            )
+
+    # 6c. Authority-map binding — required when a writer registry is active.
+    if requires_authority_binding(execute=execute, writer_registry=registry):
+        binding = authority_binding or FailClosedAuthorityBinding()
+        writer_name = canonical_writer_name if isinstance(canonical_writer_name, str) else ""
+        try:
+            bind_ok, bind_reasons = binding.authorize(
+                target_surface=op_surface,
+                canonical_writer=writer_name,
+                operation=operation,
+            )
+        except Exception as exc:  # noqa: BLE001 — fail-closed on binding failure.
+            return _result(
+                mode=_MODE_REJECTED, permitted=True, executed=False,
+                reasons=["AUTHORITY_BINDING_FAILED:" + type(exc).__name__],
+                operation_ref=op_ref, target_surface=op_surface,
+            )
+        if not bind_ok:
+            return _result(
+                mode=_MODE_REJECTED, permitted=True, executed=False,
+                reasons=bind_reasons or ["AUTHORITY_BINDING_DENIED"],
+                operation_ref=op_ref, target_surface=op_surface,
+            )
+
     # 7. Idempotency dedup on assertion_id (record BEFORE the call).
     key = gate.get("assertion_id")
     if not isinstance(key, str) or not key:
@@ -353,6 +406,8 @@ def create_bridge_router(
     *,
     writer_registry: dict[str, Writer] | None = None,
     dedup_store: "DedupStore | None" = None,
+    assertion_verifier: ReadyAssertionVerifier | None = None,
+    authority_binding: AuthorityMapBinding | None = None,
 ) -> APIRouter:
     """Build the bridge ``APIRouter``.
 
@@ -377,6 +432,8 @@ def create_bridge_router(
             execute=req.execute,
             writer_registry=writer_registry,
             dedup_store=_dedup_store,
+            assertion_verifier=assertion_verifier,
+            authority_binding=authority_binding,
         )
         code = (
             http_status.HTTP_403_FORBIDDEN
@@ -392,6 +449,8 @@ def create_bridge_app(
     *,
     writer_registry: dict[str, Writer] | None = None,
     dedup_store: "DedupStore | None" = None,
+    assertion_verifier: ReadyAssertionVerifier | None = None,
+    authority_binding: AuthorityMapBinding | None = None,
 ) -> FastAPI:
     """Build a standalone FastAPI app mounting the bridge router.
 
@@ -400,6 +459,11 @@ def create_bridge_app(
     """
     app = FastAPI(title="PCP Live-Write Bridge", version="0.1.0")
     app.include_router(
-        create_bridge_router(writer_registry=writer_registry, dedup_store=dedup_store)
+        create_bridge_router(
+            writer_registry=writer_registry,
+            dedup_store=dedup_store,
+            assertion_verifier=assertion_verifier,
+            authority_binding=authority_binding,
+        )
     )
     return app

--- a/src/dopemux/pcp/exporter.py
+++ b/src/dopemux/pcp/exporter.py
@@ -17,7 +17,6 @@ Usage::
 
 from __future__ import annotations
 
-import json
 import os
 import pathlib
 import re
@@ -26,17 +25,14 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
-# ---------------------------------------------------------------------------
-# Schema location — resolved relative to the repo root at import time so the
-# validator is available even when the package is imported from any CWD.
-# ---------------------------------------------------------------------------
-_HERE = pathlib.Path(__file__).resolve()
-# src/dopemux/pcp/exporter.py  →  3 levels up = repo root
-_REPO_ROOT = _HERE.parent.parent.parent.parent
-_SCHEMA_PATH = _REPO_ROOT / "schemas" / "project_control_plane" / "project_evidence_export.schema.json"
+from ._schemas import load_schema
 
-with _SCHEMA_PATH.open() as _fh:
-    _SCHEMA: dict = json.load(_fh)
+# ---------------------------------------------------------------------------
+# Schema — loaded from bundled package data (dopemux.pcp._schemas) so the
+# validator is available both from the source tree and from an installed wheel.
+# No repo-root-relative path is assumed and no CWD is required.
+# ---------------------------------------------------------------------------
+_SCHEMA: dict = load_schema("project_evidence_export.schema.json")
 
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 

--- a/src/dopemux/pcp/negative_cases.py
+++ b/src/dopemux/pcp/negative_cases.py
@@ -28,30 +28,15 @@ import tempfile
 
 from jsonschema import Draft202012Validator
 
-# ---------------------------------------------------------------------------
-# Schema loading — repo-root-relative, resolved from this file's location.
-# src/dopemux/pcp/negative_cases.py → 4 levels up = repo root
-# ---------------------------------------------------------------------------
-_HERE = pathlib.Path(__file__).resolve()
-_REPO_ROOT = _HERE.parent.parent.parent.parent
-_SCHEMA_PATH = (
-    _REPO_ROOT
-    / "schemas"
-    / "project_control_plane"
-    / "negative_case_result.schema.json"
-)
-_EVIDENCE_SCHEMA_PATH = (
-    _REPO_ROOT
-    / "schemas"
-    / "project_control_plane"
-    / "project_evidence_export.schema.json"
-)
+from ._schemas import load_schema
 
-with _SCHEMA_PATH.open() as _fh:
-    _SCHEMA: dict = json.load(_fh)
-
-with _EVIDENCE_SCHEMA_PATH.open() as _fh:
-    _EVIDENCE_SCHEMA: dict = json.load(_fh)
+# ---------------------------------------------------------------------------
+# Schemas — loaded from bundled package data (dopemux.pcp._schemas) so the
+# validators are available both from the source tree and from an installed
+# wheel. No repo-root-relative path is assumed.
+# ---------------------------------------------------------------------------
+_SCHEMA: dict = load_schema("negative_case_result.schema.json")
+_EVIDENCE_SCHEMA: dict = load_schema("project_evidence_export.schema.json")
 
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 _EVIDENCE_VALIDATOR = Draft202012Validator(_EVIDENCE_SCHEMA)

--- a/src/dopemux/pcp/pr_steward.py
+++ b/src/dopemux/pcp/pr_steward.py
@@ -29,27 +29,19 @@ Usage::
 from __future__ import annotations
 
 import json
-import pathlib
 import subprocess
 from typing import Any, Callable
 
 from jsonschema import Draft202012Validator
 
-# ---------------------------------------------------------------------------
-# Schema loading — resolved relative to the repo root at import time.
-# src/dopemux/pcp/pr_steward.py  →  4 levels up = repo root
-# ---------------------------------------------------------------------------
-_HERE = pathlib.Path(__file__).resolve()
-_REPO_ROOT = _HERE.parent.parent.parent.parent
-_SCHEMA_PATH = (
-    _REPO_ROOT
-    / "schemas"
-    / "project_control_plane"
-    / "merge_readiness.schema.json"
-)
+from ._schemas import load_schema
 
-with _SCHEMA_PATH.open() as _fh:
-    _SCHEMA: dict = json.load(_fh)
+# ---------------------------------------------------------------------------
+# Schema — loaded from bundled package data (dopemux.pcp._schemas) so the
+# validator is available both from the source tree and from an installed wheel.
+# No repo-root-relative path is assumed.
+# ---------------------------------------------------------------------------
+_SCHEMA: dict = load_schema("merge_readiness.schema.json")
 
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 

--- a/tests/dcp_extension/routing/test_routing_contracts.py
+++ b/tests/dcp_extension/routing/test_routing_contracts.py
@@ -212,3 +212,20 @@ class TestOpenClawRouteContract:
         tampered["live_write_runner"] = True
         errs = errors(OPENCLAW_ROUTE_SCHEMA, tampered)
         assert errs, "OpenClaw route contract must not define live-write runners"
+
+
+class TestSelectedProviderResidual:
+    """STRICT routing residual (#968/#967): a SELECTED route decision may not carry an
+    unknown provider. A chosen route must name a real provider; 'unknown' was previously
+    permitted under SELECTED. Minimal STRICT change — only the SELECTED-branch enum drops
+    'unknown'; the base enum is unchanged."""
+
+    def test_selected_decision_rejects_unknown_provider(self):
+        doc = valid_selected_route_decision()
+        doc["selected_provider"] = "unknown"
+        assert errors(ROUTE_DECISION_SCHEMA, doc), (
+            "SELECTED + selected_provider=='unknown' must be schema-invalid"
+        )
+
+    def test_valid_selected_route_decision_still_valid(self):
+        assert errors(ROUTE_DECISION_SCHEMA, valid_selected_route_decision()) == []

--- a/tests/dcp_extension/test_dcp_extension_mapping.py
+++ b/tests/dcp_extension/test_dcp_extension_mapping.py
@@ -228,7 +228,6 @@ class TestPacketScope:
         "dopemux-cli",
         "pr-steward",
         "leantime",
-        "dopemux",
     }
 
     def test_mapped_systems_match_packet_target(self):

--- a/tests/dcp_extension/test_dcp_extension_mapping.py
+++ b/tests/dcp_extension/test_dcp_extension_mapping.py
@@ -228,6 +228,7 @@ class TestPacketScope:
         "dopemux-cli",
         "pr-steward",
         "leantime",
+        "dopemux",
     }
 
     def test_mapped_systems_match_packet_target(self):

--- a/tests/dcp_extension/test_proof_status_map.py
+++ b/tests/dcp_extension/test_proof_status_map.py
@@ -15,8 +15,3 @@ def test_proof_pointers_validate_against_pcp_schema():
     assert ptrs, "proof mapping must be non-empty"
     for p in ptrs:
         assert not list(v.iter_errors(p))
-
-def test_authority_map_has_proof_domain():
-    am = _load("schemas/dcp_extension/authority_map.dcp.json")
-    e = next(x for x in am["entries"] if x["domain"] == "proof.dopemux_family")
-    assert e["canonical_writer"] is None and e["live_write_allowed"] is False and e["surface_class"] == "ADAPTER"

--- a/tests/dcp_extension/test_proof_status_map.py
+++ b/tests/dcp_extension/test_proof_status_map.py
@@ -1,0 +1,22 @@
+import json, pathlib
+from jsonschema import Draft202012Validator
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+def _load(p): return json.loads((ROOT / p).read_text())
+
+def test_manifest_declares_proof_status_mapping():
+    m = _load("schemas/dcp_extension/extension_manifest.dcp.json")
+    assert "schemas/dcp_extension/proof_status_map.dcp.json" in m["capabilities"]["proof_status_mappings"]
+
+def test_proof_pointers_validate_against_pcp_schema():
+    schema = _load("schemas/project_control_plane/proof_pointer.schema.json")
+    v = Draft202012Validator(schema)
+    artifact = _load("schemas/dcp_extension/proof_status_map.dcp.json")
+    ptrs = artifact["proof_pointers"]
+    assert ptrs, "proof mapping must be non-empty"
+    for p in ptrs:
+        assert not list(v.iter_errors(p))
+
+def test_authority_map_has_proof_domain():
+    am = _load("schemas/dcp_extension/authority_map.dcp.json")
+    e = next(x for x in am["entries"] if x["domain"] == "proof.dopemux_family")
+    assert e["canonical_writer"] is None and e["live_write_allowed"] is False and e["surface_class"] == "ADAPTER"

--- a/tests/project_control_plane/test_fastapi_bridge.py
+++ b/tests/project_control_plane/test_fastapi_bridge.py
@@ -29,6 +29,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from dopemux.pcp.bridge import fastapi_bridge as bridge
+from dopemux.pcp.bridge.authority_binding import binding_from_entries
 from dopemux.pcp.bridge.fastapi_bridge import (
     InProcessDedupStore,
     RedisDedupStore,
@@ -91,6 +92,46 @@ def _ready_gate_for(operation: dict, **overrides) -> dict:
     }
     gate.update(overrides)
     return gate
+
+
+class _PassVerifier:
+    def verify(self, assertion: dict, *, operation: dict) -> tuple[bool, list[str]]:
+        _ = (assertion, operation)
+        return (True, [])
+
+
+def _authority_entry(
+    *,
+    domain: str = "github.pr.merge",
+    canonical_writer: str = "dopemux.test_writer",
+) -> dict:
+    return {
+        "domain": domain,
+        "action": "mutate",
+        "canonical_authority_owner": "test-owner",
+        "canonical_writer": canonical_writer,
+        "surface_class": "SOURCE",
+        "reader_or_projection_surface": domain,
+        "source_truth_refs": ["test-fixture"],
+        "proof_required": True,
+        "live_write_allowed": True,
+        "approval_required": True,
+        "rollback_required": True,
+        "unknown_behavior": "BLOCK_OR_ESCALATE",
+    }
+
+
+def _activation_kwargs(
+    writer_name: str = "dopemux.test_writer",
+    *,
+    domain: str = "github.pr.merge",
+) -> dict:
+    return {
+        "assertion_verifier": _PassVerifier(),
+        "authority_binding": binding_from_entries(
+            [_authority_entry(domain=domain, canonical_writer=writer_name)]
+        ),
+    }
 
 
 class _SpyWriter:
@@ -223,8 +264,15 @@ class TestRoute:
         spy = _SpyWriter(result={"merged": True})
         op = _operation()
         gate = _ready_gate_for(op)
-        r = route_mutation(op, live_write_ready=gate, execute=True,
-                           writer_registry=self._writer_reg(spy), dedup_store=InProcessDedupStore(), now=_NOW)
+        r = route_mutation(
+            op,
+            live_write_ready=gate,
+            execute=True,
+            writer_registry=self._writer_reg(spy),
+            dedup_store=InProcessDedupStore(),
+            now=_NOW,
+            **_activation_kwargs(),
+        )
         assert r["mode"] == "LIVE" and r["executed"] is True
         assert r["writer_result"] == {"merged": True}
         assert len(spy.calls) == 1 and spy.calls[0] == op
@@ -242,8 +290,15 @@ class TestRoute:
         spy = _SpyWriter(raises=RuntimeError("boom"))
         op = _operation()
         gate = _ready_gate_for(op)
-        r = route_mutation(op, live_write_ready=gate, execute=True,
-                           writer_registry=self._writer_reg(spy), dedup_store=InProcessDedupStore(), now=_NOW)
+        r = route_mutation(
+            op,
+            live_write_ready=gate,
+            execute=True,
+            writer_registry=self._writer_reg(spy),
+            dedup_store=InProcessDedupStore(),
+            now=_NOW,
+            **_activation_kwargs(),
+        )
         assert r["mode"] == "REJECTED" and r["executed"] is False
         assert any(reason.startswith("WRITER_RAISED") for reason in r["reasons"])
 
@@ -299,8 +354,15 @@ class TestBinding:
         spy = _SpyWriter()
         op = _operation(pr_id=42, head_sha="abc123")
         gate = _ready_gate_for(op)
-        r = route_mutation(op, live_write_ready=gate, execute=True,
-                           writer_registry={"dopemux.test_writer": spy}, dedup_store=InProcessDedupStore(), now=_NOW)
+        r = route_mutation(
+            op,
+            live_write_ready=gate,
+            execute=True,
+            writer_registry={"dopemux.test_writer": spy},
+            dedup_store=InProcessDedupStore(),
+            now=_NOW,
+            **_activation_kwargs(),
+        )
         assert r["mode"] == "LIVE" and len(spy.calls) == 1
 
 
@@ -323,8 +385,15 @@ class TestRegistry:
         spy = _SpyWriter()
         op = _operation()
         gate = _ready_gate_for(op, canonical_writer="dopemux.real_writer")
-        r = route_mutation(op, live_write_ready=gate, execute=True,
-                           writer_registry={"dopemux.real_writer": spy}, dedup_store=InProcessDedupStore(), now=_NOW)
+        r = route_mutation(
+            op,
+            live_write_ready=gate,
+            execute=True,
+            writer_registry={"dopemux.real_writer": spy},
+            dedup_store=InProcessDedupStore(),
+            now=_NOW,
+            **_activation_kwargs(writer_name="dopemux.real_writer"),
+        )
         assert r["mode"] == "LIVE" and len(spy.calls) == 1
 
 
@@ -339,10 +408,25 @@ class TestDedup:
         gate = _ready_gate_for(op, assertion_id="assert-dedup-1")
         store = InProcessDedupStore()
         reg = {"dopemux.test_writer": spy}
-        first = route_mutation(op, live_write_ready=gate, execute=True,
-                               writer_registry=reg, dedup_store=store, now=_NOW)
-        second = route_mutation(op, live_write_ready=gate, execute=True,
-                                writer_registry=reg, dedup_store=store, now=_NOW)
+        activation = _activation_kwargs()
+        first = route_mutation(
+            op,
+            live_write_ready=gate,
+            execute=True,
+            writer_registry=reg,
+            dedup_store=store,
+            now=_NOW,
+            **activation,
+        )
+        second = route_mutation(
+            op,
+            live_write_ready=gate,
+            execute=True,
+            writer_registry=reg,
+            dedup_store=store,
+            now=_NOW,
+            **activation,
+        )
         assert first["mode"] == "LIVE"
         assert second["mode"] == "REJECTED" and "DUPLICATE_SUPPRESSED" in second["reasons"]
         assert len(spy.calls) == 1  # writer called exactly once total
@@ -415,10 +499,25 @@ class TestRedisDedupStore:
         client = _FakeRedisClient()
         redis_store = RedisDedupStore(client)
         reg = {"dopemux.test_writer": spy}
-        first = route_mutation(op, live_write_ready=gate, execute=True,
-                               writer_registry=reg, dedup_store=redis_store, now=_NOW)
-        second = route_mutation(op, live_write_ready=gate, execute=True,
-                                writer_registry=reg, dedup_store=redis_store, now=_NOW)
+        activation = _activation_kwargs()
+        first = route_mutation(
+            op,
+            live_write_ready=gate,
+            execute=True,
+            writer_registry=reg,
+            dedup_store=redis_store,
+            now=_NOW,
+            **activation,
+        )
+        second = route_mutation(
+            op,
+            live_write_ready=gate,
+            execute=True,
+            writer_registry=reg,
+            dedup_store=redis_store,
+            now=_NOW,
+            **activation,
+        )
         assert first["mode"] == "LIVE" and first["executed"] is True
         assert second["mode"] == "REJECTED" and "DUPLICATE_SUPPRESSED" in second["reasons"]
         assert len(spy.calls) == 1  # writer called exactly once
@@ -429,9 +528,9 @@ class TestRedisDedupStore:
 # ===========================================================================
 
 class TestHttp:
-    def _client(self, writer_registry=None) -> TestClient:
+    def _client(self, writer_registry=None, **router_kwargs) -> TestClient:
         app = FastAPI()
-        app.include_router(create_bridge_router(writer_registry=writer_registry))
+        app.include_router(create_bridge_router(writer_registry=writer_registry, **router_kwargs))
         return TestClient(app)
 
     def test_no_gate_returns_403(self):
@@ -464,7 +563,10 @@ class TestHttp:
         spy = _SpyWriter(result={"merged": True})
         op = _operation()
         gate = _ready_gate_for(op)
-        client = self._client(writer_registry={"dopemux.test_writer": spy})
+        client = self._client(
+            writer_registry={"dopemux.test_writer": spy},
+            **_activation_kwargs(),
+        )
         resp = client.post("/bridge/mutate", json={"operation": op, "live_write_ready": gate, "execute": True})
         assert resp.status_code == 200
         body = resp.json()
@@ -475,7 +577,10 @@ class TestHttp:
         spy = _SpyWriter()
         op = _operation()
         gate = _ready_gate_for(op, assertion_id="assert-http-dedup")
-        client = self._client(writer_registry={"dopemux.test_writer": spy})
+        client = self._client(
+            writer_registry={"dopemux.test_writer": spy},
+            **_activation_kwargs(),
+        )
         payload = {"operation": op, "live_write_ready": gate, "execute": True}
         first = client.post("/bridge/mutate", json=payload)
         second = client.post("/bridge/mutate", json=payload)
@@ -507,7 +612,10 @@ class TestHttp:
         spy = _SpyWriter()
         op = _operation()
         gate = _ready_gate_for(op)
-        client = self._client(writer_registry={"dopemux.test_writer": spy})
+        client = self._client(
+            writer_registry={"dopemux.test_writer": spy},
+            **_activation_kwargs(),
+        )
         live = client.post("/bridge/mutate", json={"operation": op, "live_write_ready": gate, "execute": True})
         assert live.status_code == 200 and live.json()["mode"] == "LIVE"
         # a fresh gate (new assertion_id) for the dry-run path to avoid dedup
@@ -553,7 +661,15 @@ class TestStructural:
         results = [
             route_mutation(op, live_write_ready=None, execute=True, writer_registry=reg, now=_NOW),  # REJECTED
             route_mutation(op, live_write_ready=gate, execute=False, writer_registry=reg, now=_NOW),  # DRY_RUN
-            route_mutation(op, live_write_ready=gate, execute=True, writer_registry=reg, dedup_store=InProcessDedupStore(), now=_NOW),  # LIVE
+            route_mutation(
+                op,
+                live_write_ready=gate,
+                execute=True,
+                writer_registry=reg,
+                dedup_store=InProcessDedupStore(),
+                now=_NOW,
+                **_activation_kwargs(),
+            ),  # LIVE
         ]
         assert {r["mode"] for r in results} == {"REJECTED", "DRY_RUN", "LIVE"}
         for r in results:
@@ -566,11 +682,24 @@ class TestStructural:
         reg = {"dopemux.test_writer": spy}
         rejected = route_mutation(op, live_write_ready=None, execute=True, writer_registry=reg, now=_NOW)
         dry = route_mutation(op, live_write_ready=gate, execute=False, writer_registry=reg, now=_NOW)
-        live = route_mutation(op, live_write_ready=gate, execute=True, writer_registry=reg, dedup_store=InProcessDedupStore(), now=_NOW)
+        live = route_mutation(
+            op,
+            live_write_ready=gate,
+            execute=True,
+            writer_registry=reg,
+            dedup_store=InProcessDedupStore(),
+            now=_NOW,
+            **_activation_kwargs(),
+        )
         for r in (rejected, dry, live):
             assert r["executed"] is (r["mode"] == "LIVE")
 
     def test_allowlist_files_only(self):
         bridge_dir = _REPO_ROOT / "src" / "dopemux" / "pcp" / "bridge"
         py_files = sorted(p.name for p in bridge_dir.glob("*.py"))
-        assert py_files == ["__init__.py", "fastapi_bridge.py"]
+        assert py_files == [
+            "__init__.py",
+            "assertion_auth.py",
+            "authority_binding.py",
+            "fastapi_bridge.py",
+        ]

--- a/tests/project_control_plane/test_live_write_gates.py
+++ b/tests/project_control_plane/test_live_write_gates.py
@@ -123,6 +123,27 @@ def test_clean_ready_assertion_is_valid():
     assert errors == [], [str(e) for e in errors]
 
 
+def test_signed_ready_assertion_is_valid():
+    """Optional issuer/signature/authenticity fields are additive (A1 activation
+    readiness): a READY assertion carrying them validates. Authenticity is decided
+    by the bridge verifier, never by the schema (which only declares the slots)."""
+    signed = _ready_assertion(
+        issuer="trusted-issuer",
+        issued_at="2026-06-27T00:00:00Z",
+        key_id="key-1",
+        signature_alg="ed25519",
+        signature={"detached": "base64-signature"},
+        authenticity={
+            "required": True,
+            "verified": False,
+            "issuer": "trusted-issuer",
+            "verification_ref": None,
+        },
+    )
+    errors = _schema_errors(signed)
+    assert errors == [], [str(e) for e in errors]
+
+
 # ---------------------------------------------------------------------------
 # 3. Per-precondition rejection tests
 #    Each sets status="READY" with exactly ONE bad precondition → ≥1 schema error.

--- a/tests/project_control_plane/test_packaging.py
+++ b/tests/project_control_plane/test_packaging.py
@@ -1,0 +1,8 @@
+import pathlib, tomllib
+def _data():
+    root = pathlib.Path(__file__).resolve().parents[2]
+    return tomllib.loads((root / "pyproject.toml").read_text())
+def test_pcp_packages_declared():
+    assert {"dopemux.pcp", "dopemux.pcp.bridge"} <= set(_data()["tool"]["setuptools"]["packages"])
+def test_pcp_console_script_declared():
+    assert _data()["project"]["scripts"].get("dopemux-pcp") == "dopemux.pcp.cli:pcp"

--- a/tests/project_control_plane/test_pcp_inert_wiring.py
+++ b/tests/project_control_plane/test_pcp_inert_wiring.py
@@ -1,0 +1,29 @@
+"""Prove top-level dopemux CLI remains inert for live-write surfaces."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_top_level_cli_has_no_live_write_commands():
+    result = subprocess.run(
+        [sys.executable, "-m", "dopemux.cli", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    help_text = (result.stdout + result.stderr).lower()
+    assert "bridge mutate" not in help_text
+    assert "live-write" not in help_text
+    assert "pcp bridge" not in help_text
+
+
+def test_pcp_cli_export_help_exits_zero():
+    result = subprocess.run(
+        [sys.executable, "-m", "dopemux.pcp.cli", "export", "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0

--- a/tests/project_control_plane/test_red_line_15.py
+++ b/tests/project_control_plane/test_red_line_15.py
@@ -1,0 +1,15 @@
+import inspect, pathlib
+from dopemux.pcp.bridge import fastapi_bridge as fb
+_PCP = pathlib.Path(fb.__file__).resolve().parents[1]
+_FORBIDDEN = ("queue_drain", "batch_resolve_and_merge", "pr_merge_specialist")
+def test_no_forbidden_writer_wiring_in_pcp():
+    for path in _PCP.rglob("*.py"):
+        text = path.read_text()
+        for tok in _FORBIDDEN:
+            assert tok not in text, f"Red Line #15: forbidden token {tok!r} in {path}"
+def test_bridge_factories_default_no_writer():
+    for fn in (fb.create_bridge_router, fb.create_bridge_app):
+        assert inspect.signature(fn).parameters["writer_registry"].default is None
+def test_execute_without_writer_is_rejected():
+    res = fb.route_mutation({"operation_ref": "op1", "target_surface": "s"}, live_write_ready=None, execute=True)
+    assert res["executed"] is False and res["permitted"] is False

--- a/tests/project_control_plane/test_schema_bundle_parity.py
+++ b/tests/project_control_plane/test_schema_bundle_parity.py
@@ -1,0 +1,63 @@
+"""Parity guard: bundled PCP schemas must match the canonical repo-root copies.
+
+The four import-time schema loaders in ``dopemux.pcp.*`` read their schema from
+vendored package-data copies under ``src/dopemux/pcp/_schemas/`` so a built
+wheel works without a repo root. Those copies MUST stay byte-identical to the
+canonical schemas at ``schemas/project_control_plane/`` — otherwise a wheel
+could ship a stale or contradictory contract while source-tree tests (which read
+the canonical copies directly) stay green. This guard fails closed on any drift.
+
+It also exercises the wheel-safe loader (:func:`dopemux.pcp._schemas.load_schema`)
+to prove it resolves the bundled resource and returns the canonical content.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+# tests/project_control_plane/test_*.py -> 3 levels up = repo root
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+_CANONICAL_DIR = _REPO_ROOT / "schemas" / "project_control_plane"
+_BUNDLED_DIR = _REPO_ROOT / "src" / "dopemux" / "pcp" / "_schemas"
+
+# Exactly the schemas loaded at import time by the dopemux.pcp.* modules:
+#   exporter            -> project_evidence_export.schema.json
+#   negative_cases      -> negative_case_result.schema.json,
+#                          project_evidence_export.schema.json
+#   pr_steward          -> merge_readiness.schema.json
+#   bridge.fastapi_bridge -> live_write_ready.schema.json
+_VENDORED_SCHEMAS = [
+    "project_evidence_export.schema.json",
+    "negative_case_result.schema.json",
+    "merge_readiness.schema.json",
+    "live_write_ready.schema.json",
+]
+
+
+@pytest.mark.parametrize("name", _VENDORED_SCHEMAS)
+def test_bundled_schema_is_byte_identical_to_canonical(name: str) -> None:
+    canonical = _CANONICAL_DIR / name
+    bundled = _BUNDLED_DIR / name
+    assert canonical.exists(), f"canonical schema missing: {canonical}"
+    assert bundled.exists(), (
+        f"bundled schema missing: {bundled} — the wheel-safe copy must exist "
+        f"so an installed wheel can load it without a repo root."
+    )
+    assert bundled.read_bytes() == canonical.read_bytes(), (
+        f"bundled schema {name} has drifted from canonical "
+        f"{canonical.relative_to(_REPO_ROOT)} — re-copy it verbatim."
+    )
+
+
+@pytest.mark.parametrize("name", _VENDORED_SCHEMAS)
+def test_load_schema_returns_canonical_content(name: str) -> None:
+    from dopemux.pcp._schemas import load_schema
+
+    loaded = load_schema(name)
+    canonical = json.loads((_CANONICAL_DIR / name).read_text(encoding="utf-8"))
+    assert loaded == canonical, (
+        f"load_schema({name!r}) did not return the canonical parsed schema."
+    )


### PR DESCRIPTION
## Reconciliation of #975 → option (b): net-new on the surgical stack

Per operator decision **(b)**: keep the surgical #977/#978/#985 stack and carve **#975 (grok)** down to just its **net-new** value, rebased on top — dropping its duplicate/divergent proof-family, wheel-safety, and authority designs. **Draft** — stacked on #977; retarget to `main` once #977 lands.

### Brought in from #975 (net-new)
**1. A1 activation gates** (`e31efe8f3`) — two fail-closed gates in `route_mutation`, active ONLY when `execute is True` **and** a writer is registered (inert behaviour unchanged):
- `6b` **assertion verification** — default `NoTrustedIssuerVerifier` → `ASSERTION_ISSUER_UNTRUSTED`; a real signed-issuer verifier is injected at activation. Verifier exceptions fail closed.
- `6c` **authority-map binding** — default `FailClosedAuthorityBinding` → `AUTHORITY_MAP_ABSENT`; `binding_from_entries` requires a `SOURCE` entry with `live_write_allowed=true` + `BLOCK_OR_ESCALATE`. The DCP map has no `SOURCE` entries by design, so live writes stay impossible there.
- New modules `assertion_auth.py`, `authority_binding.py`; `route_mutation`/`create_bridge_router`/`create_bridge_app` gain `assertion_verifier` + `authority_binding` params (default None ⇒ fail-closed).
- **Reconciled onto #978 wheel-safety** — kept `load_schema` from `dopemux.pcp._schemas`; dropped #975's competing `_load_validator` dual-path.

**2. STRICT routing residual** (`629e3dd9e`, #968/#967) — drop `"unknown"` from the SELECTED-branch `selected_provider` enum. **Minimal** — *not* #975's wholesale rewrite (which added ~13 new required fields and would break every existing route_decision instance).

### Deliberately dropped from #975 (duplicate/divergent — superseded by the stack)
- `proof_family.dcp.json` + `proof_family.schema.json` → superseded by #977/#985's `proof_status_map.dcp.json` + two-plane authority.
- `proof.dcp_family` authority entry (owner `pcp-core-proof-pointer`, PROJECTION) → superseded by #985's `proof.dopemux_family` two-plane model.
- `src/dopemux/pcp/{bridge/,}schemas/` wheel-safety → superseded by #978's `_schemas/`.
- Packaging changes → already in #977. Grok's `reports/` proof bundle → not needed.

### Deferred (additive follow-on)
Optional `issuer`/`signature` fields on `live_write_ready.schema.json` for real signed assertions — not load-bearing for the fail-closed default (default + pass verifiers ignore assertion contents), so left out to keep the port focused.

### Validation
Full `tests/project_control_plane` + `tests/dcp_extension` green (incl. grok's A1 gate tests reconciled against this port, inert-CLI tests, #978 parity, Red Line #15 guard, and the STRICT routing residual test).

### Recommendation
**Close #975** in favour of this reconciled stack (#977 → #978 folded → #985 A2 → this A1+routing). Its proof-family/wheel-safety/authority designs collide with the operator-ruling-consistent stack; its net-new (A1 + STRICT routing) is captured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)