### PR TITLE
test(mcp): gate canonical fleet catalog drift

### DIFF
--- a/.claude/commands/dx/implement.md
+++ b/.claude/commands/dx/implement.md
@@ -6,7 +6,7 @@ allowed-tools: [
   "mcp__conport__*",
   "mcp__serena__*",
   "mcp__pal__apilookup",
-  "mcp__zen__thinkdeep", "mcp__zen__debug", "mcp__zen__codereview"
+  "mcp__pal__thinkdeep", "mcp__pal__debug", "mcp__pal__codereview"
 ]
 model: "claude-sonnet-4-5-20250929"
 ---

--- a/mcp_catalog.yaml
+++ b/mcp_catalog.yaml
@@ -82,7 +82,7 @@ servers:
     scope: singleton
     transport: stdio
     command: docker
-    args: ["exec", "-i", "mcp-exa", "python", "/app/exa_server.py"]
+    args: ["exec", "-i", "-e", "MCP_RUN_MODE=stdio", "mcp-exa", "python", "/app/exa_server.py"]
     docker_compose_service: exa
     requires_env: ["EXA_API_KEY"]
     description: "Neural web search"

--- a/mcp_catalog.yaml
+++ b/mcp_catalog.yaml
@@ -44,7 +44,6 @@ servers:
     transport: http
     url: "http://localhost:3003/mcp"
     docker_compose_service: pal
-    tool_aliases: ["zen"]
     description: "Multi-model reasoning suite (thinkdeep, planner, consensus, debug, codereview)"
 
   serena:

--- a/mcp_catalog.yaml
+++ b/mcp_catalog.yaml
@@ -44,6 +44,7 @@ servers:
     transport: http
     url: "http://localhost:3003/mcp"
     docker_compose_service: pal
+    tool_aliases: ["zen"]
     description: "Multi-model reasoning suite (thinkdeep, planner, consensus, debug, codereview)"
 
   serena:
@@ -81,7 +82,7 @@ servers:
     scope: singleton
     transport: stdio
     command: docker
-    args: ["exec", "-i", "mcp-litellm", "python", "/app/exa_server.py"]
+    args: ["exec", "-i", "mcp-exa", "python", "/app/exa_server.py"]
     docker_compose_service: exa
     requires_env: ["EXA_API_KEY"]
     description: "Neural web search"

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md
@@ -65,3 +65,6 @@ NOT_RUN:
   - `.claude/commands` MCP tool-surface extraction now includes wildcard references such as `mcp__conport__*`.
   - `exa` stdio catalog entry now passes `MCP_RUN_MODE=stdio` to `docker exec`.
   - Proof preflight records commit SHA and PR URL.
+- PR #995 merge unblock follow-up addressed additional review feedback:
+  - `.claude/commands/dx/implement.md` now references `mcp__pal__*` instead of the unregistered historical `mcp__zen__*` surface.
+  - `mcp_catalog.yaml` no longer suppresses that command-surface drift with a `zen` alias.

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md
@@ -68,3 +68,6 @@ NOT_RUN:
 - PR #995 merge unblock follow-up addressed additional review feedback:
   - `.claude/commands/dx/implement.md` now references `mcp__pal__*` instead of the unregistered historical `mcp__zen__*` surface.
   - `mcp_catalog.yaml` no longer suppresses that command-surface drift with a `zen` alias.
+- PR #995 merge unblock follow-up also synced the bundled fallback catalog:
+  - `src/dopemux/mcp/default_catalog.yaml` matches the root `mcp_catalog.yaml`.
+  - The architecture gate now validates bundled catalog schema, root parity, and compose alignment.

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md
@@ -16,6 +16,8 @@ Implemented Lane 1 of the MCP fleet roadmap: catalog contract, static drift gate
 - Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/mcp-fleet-contract-gates`
 - Branch: `codex/mcp-fleet-contract-gates`
 - Base: `origin/main`
+- Commit SHA: `fa748f585314790e8b18e9ab1f94a9937c29ef2e`
+- PR URL: `https://github.com/DDD-Enterprises/dopemux-mvp/pull/995`
 - PR 993 state observed before implementation: open, blocked; audit content treated as advisory input.
 - Unrelated worktree-generated dirty file observed before scoped edits: `.claude/claude_config.json`.
 
@@ -55,3 +57,11 @@ NOT_RUN:
 - Static gates prove committed-surface parity only; they do not prove services are running or that live MCP tool lists match implementation.
 - `zen` is now an explicit alias for command-surface compatibility, but runtime alias availability still requires later live probe work.
 - Task Orchestrator remains split between compose service port `8000` and per-repo singleton catalog port `7890`; Lane 1 records static boundaries and does not resolve runtime personality convergence.
+
+## Review Follow-up
+
+- PR #995 review unblock addressed static review feedback:
+  - `docker exec` target parsing now skips options with attached or following values before selecting the container token.
+  - `.claude/commands` MCP tool-surface extraction now includes wildcard references such as `mcp__conport__*`.
+  - `exa` stdio catalog entry now passes `MCP_RUN_MODE=stdio` to `docker exec`.
+  - Proof preflight records commit SHA and PR URL.

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md
@@ -1,0 +1,57 @@
+# TP-DMX-MCP-FLEET-ROADMAP-001 Implementation Notes
+
+## Scope
+
+Implemented Lane 1 of the MCP fleet roadmap: catalog contract, static drift gates, and minimal data corrections required for the gates to pass. No live MCP, Docker, provider, GitHub mutation, memory writes, or runtime launch behavior changes were performed.
+
+## Authority Used
+
+- Latest user instruction: implement the PR 993-derived packetized MCP fleet roadmap.
+- Repo authority: `AGENTS.md`, `PROJECT.md`, `ARCHITECTURE.md`, `PM_PLANE.md`.
+- Packet authority: `TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT`.
+- Runtime/config evidence: `mcp_catalog.yaml`, `compose.yml`, `services/registry.yaml`, `src/dopemux/mcp/registry.yaml`, `.mcp.json`, `.claude/commands/**`, `src/dopemux/commands/mcp_commands.py`.
+
+## Observed Preflight
+
+- Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/mcp-fleet-contract-gates`
+- Branch: `codex/mcp-fleet-contract-gates`
+- Base: `origin/main`
+- PR 993 state observed before implementation: open, blocked; audit content treated as advisory input.
+- Unrelated worktree-generated dirty file observed before scoped edits: `.claude/claude_config.json`.
+
+## Changes
+
+- Added seven MCP fleet roadmap task packets and indexed them in task packet status/index docs.
+- Added `schemas/mcp/fleet-catalog.schema.json`.
+- Added `src/dopemux/mcp/fleet_catalog.py` for static duplicate-key loading, schema/compose/registry/generated-config/tool-surface drift checks, and renderer parity helpers.
+- Added unit and architecture tests for the new contract.
+- Fixed current drift detected by the new gates:
+  - `mcp_catalog.yaml`: `exa` Docker exec target now matches compose container `mcp-exa`.
+  - `mcp_catalog.yaml`: `pal` declares historical tool alias `zen` used by `.claude/commands`.
+  - `src/dopemux/mcp/registry.yaml`: duplicate YAML keys removed while preserving current effective last-key behavior.
+
+## Validation
+
+PASS:
+
+- Baseline before new gates: `python -m pytest tests/unit/test_mcp_commands_catalog.py tests/arch/test_registry_compose_alignment.py -q` -> 22 passed.
+- Red path: `python -m pytest tests/unit/test_mcp_fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py -q` failed before implementation on missing `dopemux.mcp.fleet_catalog`.
+- After implementation: `python -m pytest tests/unit/test_mcp_fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py -q` -> 15 passed.
+- Existing focused tests: `python -m pytest tests/unit/test_mcp_commands_catalog.py tests/arch/test_registry_compose_alignment.py -q` -> 22 passed.
+- Packet schemas: all `task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-*.json` validated against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`.
+- Fleet schema self-check: `Draft202012Validator.check_schema(...)` passed.
+- Syntax/diff: `python -m py_compile src/dopemux/mcp/fleet_catalog.py && git diff --check` passed.
+
+NOT_RUN:
+
+- `dopemux mcp ensure --full`: not in Lane 1 and would require live service behavior.
+- Docker health checks: not in Lane 1 and may mutate/start services.
+- Live MCP initialize/tools-list probes: not in Lane 1.
+- Provider/network validation: not in Lane 1.
+- Task Orchestrator/ConPort/dope-memory/dope-context writes: prohibited by Lane 1 invariants.
+
+## Residual Risk
+
+- Static gates prove committed-surface parity only; they do not prove services are running or that live MCP tool lists match implementation.
+- `zen` is now an explicit alias for command-surface compatibility, but runtime alias availability still requires later live probe work.
+- Task Orchestrator remains split between compose service port `8000` and per-repo singleton catalog port `7890`; Lane 1 records static boundaries and does not resolve runtime personality convergence.

--- a/schemas/mcp/fleet-catalog.schema.json
+++ b/schemas/mcp/fleet-catalog.schema.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.local/schemas/mcp/fleet-catalog.schema.json",
+  "title": "Dopemux MCP Fleet Catalog",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "defaults", "servers"],
+  "properties": {
+    "version": {
+      "const": 1
+    },
+    "defaults": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["per_worktree"],
+      "properties": {
+        "per_worktree": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "servers": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/server"
+      }
+    }
+  },
+  "$defs": {
+    "envVar": {
+      "type": "string",
+      "pattern": "^[A-Z][A-Z0-9_]*$"
+    },
+    "server": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["scope", "transport"],
+      "properties": {
+        "scope": {
+          "enum": ["singleton", "per-worktree"]
+        },
+        "state_scope": {
+          "enum": ["per-repo", "per-worktree"]
+        },
+        "transport": {
+          "enum": ["http", "sse", "stdio"]
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "url_template": {
+          "type": "string",
+          "minLength": 1
+        },
+        "port_var": {
+          "$ref": "#/$defs/envVar"
+        },
+        "default_port_base": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "extra_port_vars": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["var", "base"],
+            "properties": {
+              "var": {
+                "$ref": "#/$defs/envVar"
+              },
+              "base": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 65535
+              }
+            }
+          }
+        },
+        "docker_compose_service": {
+          "type": "string",
+          "minLength": 1
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        },
+        "args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "requires_env": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/envVar"
+          },
+          "uniqueItems": true
+        },
+        "optional_env": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/envVar"
+          },
+          "uniqueItems": true
+        },
+        "doctor_args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env_template": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "description": {
+          "type": "string"
+        },
+        "tool_aliases": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "transport": {
+                "enum": ["http", "sse"]
+              }
+            },
+            "required": ["transport"]
+          },
+          "then": {
+            "anyOf": [
+              {
+                "required": ["url"]
+              },
+              {
+                "required": ["url_template"]
+              }
+            ]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "transport": {
+                "const": "stdio"
+              }
+            },
+            "required": ["transport"]
+          },
+          "then": {
+            "required": ["command"]
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "scope": {
+                "const": "per-worktree"
+              },
+              "default_port_base": {}
+            },
+            "required": ["scope", "default_port_base"]
+          },
+          "then": {
+            "required": ["port_var"]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/src/dopemux/mcp/default_catalog.yaml
+++ b/src/dopemux/mcp/default_catalog.yaml
@@ -1,13 +1,44 @@
-# Bundled default MCP catalog used when a project does not define mcp_catalog.yaml.
+# MCP Server Catalog
+#
+# Registry of MCP servers known to the `dopemux mcp` CLI subcommands.
+# Single source of truth for what `dopemux mcp init`, `dopemux mcp add`,
+# `dopemux mcp sync-globals`, and `dopemux mcp doctor` understand.
+#
+# Scope semantics:
+#   singleton    — one shared instance, declared in ~/.claude.json `mcpServers`.
+#                  Stateless, or routes by per-call workspace_path / cwd auto-detection.
+#                  Does NOT need per-worktree isolation.
+#   per-worktree — declared in each worktree's .mcp.json. Most entries in this
+#                  scope use worktree-isolated ports/volumes; entries may set
+#                  state_scope: per-repo when the MCP process is launched from
+#                  each worktree but stores one DB per local git repository.
+#
+# Transport:
+#   http  — Streamable HTTP (Claude Code "type": "http")
+#   sse   — Server-Sent Events  (Claude Code "type": "sse")
+#   stdio — Local process (Claude Code "type": "stdio") with command + args
+#
+# Env-var conventions for per-worktree servers:
+#   DOPEMUX_PORT_<NAME>      — host port allocated by `dopemux mcp init`
+#   DOPEMUX_WORKSPACE_ID     — worktree absolute path (used as logical workspace key)
+#   DOPEMUX_INSTANCE_ID      — short hash of worktree path (4 hex chars)
+#
+# `dopemux mcp init` will write these into a per-worktree `.envrc` (or `.env.mcp`)
+# and substitute them into `.mcp.json` at session start (Claude Code expands ${VAR}).
+
 version: 1
 
 defaults:
+  # What `dopemux mcp init` scaffolds into a fresh worktree's .mcp.json by default.
   per_worktree:
     - conport
     - dope-memory
     - task-orchestrator
 
 servers:
+
+  # ---------- Singletons (live in ~/.claude.json) ----------
+
   pal:
     scope: singleton
     transport: http
@@ -50,25 +81,40 @@ servers:
     scope: singleton
     transport: stdio
     command: docker
-    args: ["exec", "-i", "mcp-litellm", "python", "/app/exa_server.py"]
+    args: ["exec", "-i", "-e", "MCP_RUN_MODE=stdio", "mcp-exa", "python", "/app/exa_server.py"]
     docker_compose_service: exa
     requires_env: ["EXA_API_KEY"]
     description: "Neural web search"
+
+  pal-stdio:
+    scope: singleton
+    transport: stdio
+    command: docker
+    args: ["exec", "-i", "mcp-pal-stdio", "/app/.venv/bin/python", "server.py"]
+    docker_compose_service: pal-stdio
+    requires_env: ["OPENAI_API_KEY", "GEMINI_API_KEY"]
+    description: "PAL via Docker MCP (thinkdeep, planner, consensus, debug, codereview, precommit)"
 
   MCP_DOCKER:
     scope: singleton
     transport: stdio
     command: docker
     args: ["mcp", "gateway", "run"]
-    description: "Docker MCP gateway - surfaces containerized MCPs from Docker MCP Toolkit"
+    description: "Docker MCP gateway — surfaces containerized MCPs from Docker MCP Toolkit"
+
+  # ---------- Per-worktree (live in <worktree>/.mcp.json) ----------
 
   conport:
     scope: per-worktree
     transport: sse
-    url_template: "http://localhost:${CONPORT_MCP_PORT:-3005}/mcp"
+    # Port var names match compose.yml conventions so `init` writes env that
+    # `docker compose up` reads directly.
+    url_template: "http://localhost:${CONPORT_MCP_PORT:-3005}/sse"
     port_var: CONPORT_MCP_PORT
     default_port_base: 3005
     extra_port_vars:
+      # Conport exposes three host ports (HTTP/health, MCP, info). Per-worktree
+      # isolation requires all three to be unique; same hash offset is reused.
       - var: CONPORT_HTTP_PORT
         base: 3004
       - var: CONPORT_INFO_PORT
@@ -80,7 +126,7 @@ servers:
 
   dope-memory:
     scope: per-worktree
-    transport: sse
+    transport: http
     url_template: "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp"
     port_var: DOPE_MEMORY_PORT
     default_port_base: 3020

--- a/src/dopemux/mcp/fleet_catalog.py
+++ b/src/dopemux/mcp/fleet_catalog.py
@@ -1,0 +1,265 @@
+"""Static MCP fleet catalog contract helpers.
+
+This module intentionally performs no Docker, provider, or MCP network work.
+It validates catalog shape and static drift between committed config surfaces.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import yaml
+
+from dopemux.commands import mcp_commands
+
+
+class MCPFleetCatalogError(ValueError):
+    """Base error for static MCP fleet catalog validation."""
+
+
+class DuplicateKeyError(MCPFleetCatalogError):
+    """Raised when a YAML mapping repeats a key."""
+
+
+_ENV_DEFAULT_RE = re.compile(r"\$\{[^:}]+:-([0-9]+)\}")
+_ENV_RE = re.compile(r"\$\{[^}]+\}")
+_MCP_TOOL_SURFACE_RE = re.compile(r"\bmcp__([A-Za-z0-9_-]+)__[A-Za-z0-9_-]+")
+
+
+def load_yaml_no_duplicate_keys(path: Path) -> Any:
+    """Load YAML while rejecting duplicate mapping keys at any depth."""
+
+    class Loader(yaml.SafeLoader):
+        source_name = str(path)
+
+    def construct_mapping(loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False):
+        mapping: dict[Any, Any] = {}
+        for key_node, value_node in node.value:
+            key = loader.construct_object(key_node, deep=deep)
+            if key in mapping:
+                line = key_node.start_mark.line + 1
+                raise DuplicateKeyError(
+                    f"{Loader.source_name}: duplicate YAML key {key!r} at line {line}"
+                )
+            mapping[key] = loader.construct_object(value_node, deep=deep)
+        return mapping
+
+    Loader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping,
+    )
+
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.load(fh, Loader=Loader)
+
+
+def load_json_schema(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def load_root_catalog(repo_root: Path) -> dict[str, Any]:
+    data = load_yaml_no_duplicate_keys(repo_root / "mcp_catalog.yaml") or {}
+    if data.get("version") != 1:
+        raise MCPFleetCatalogError(f"Unsupported MCP catalog version: {data.get('version')!r}")
+    if not isinstance(data.get("servers"), dict):
+        raise MCPFleetCatalogError("MCP catalog missing required `servers` mapping.")
+    return data
+
+
+def render_per_worktree_mcp_json(
+    server_names: list[str],
+    catalog: dict[str, Any],
+) -> dict[str, Any]:
+    return mcp_commands._build_local_mcp_json(server_names, catalog)
+
+
+def render_singleton_mcp_servers(catalog: dict[str, Any]) -> dict[str, Any]:
+    return {
+        name: mcp_commands._render_global_entry(name, spec)
+        for name, spec in catalog["servers"].items()
+        if spec.get("scope") == "singleton"
+    }
+
+
+def known_tool_surfaces(catalog: dict[str, Any]) -> set[str]:
+    surfaces: set[str] = set(catalog.get("servers", {}))
+    for spec in catalog.get("servers", {}).values():
+        surfaces.update(spec.get("tool_aliases") or [])
+    return surfaces
+
+
+def extract_mcp_tool_surfaces(text: str) -> list[str]:
+    return [match.group(1) for match in _MCP_TOOL_SURFACE_RE.finditer(text)]
+
+
+def find_unknown_command_tool_surfaces(
+    command_dir: Path,
+    catalog: dict[str, Any],
+) -> list[str]:
+    known = known_tool_surfaces(catalog)
+    unknown: list[str] = []
+    for path in sorted(command_dir.rglob("*.md")):
+        for index, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for surface in extract_mcp_tool_surfaces(line):
+                if surface not in known:
+                    unknown.append(f"{path}:{index}:{surface}")
+    return unknown
+
+
+def load_compose(repo_root: Path) -> dict[str, Any]:
+    return load_yaml_no_duplicate_keys(repo_root / "compose.yml") or {}
+
+
+def _defaulted(value: str) -> str:
+    value = _ENV_DEFAULT_RE.sub(r"\1", value)
+    return _ENV_RE.sub("", value)
+
+
+def _parse_port_mapping(value: Any) -> tuple[int, int] | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = _defaulted(value)
+    parts = cleaned.split(":")
+    if len(parts) == 3:
+        host, container = parts[1], parts[2]
+    elif len(parts) == 2:
+        host, container = parts[0], parts[1]
+    else:
+        return None
+    try:
+        return int(host), int(container)
+    except ValueError:
+        return None
+
+
+def _compose_host_ports(service: dict[str, Any]) -> set[int]:
+    ports: set[int] = set()
+    for value in service.get("ports") or []:
+        parsed = _parse_port_mapping(value)
+        if parsed:
+            ports.add(parsed[0])
+    return ports
+
+
+def _container_name(service_name: str, service: dict[str, Any]) -> str:
+    value = str(service.get("container_name") or service_name)
+    return _defaulted(value)
+
+
+def _url_port(value: str | None) -> int | None:
+    if not value:
+        return None
+    parsed = urlparse(_defaulted(value))
+    return parsed.port
+
+
+def _docker_exec_target(args: list[str]) -> str | None:
+    if not args or args[0] != "exec":
+        return None
+    for token in args[1:]:
+        if token.startswith("-"):
+            continue
+        return token
+    return None
+
+
+def validate_catalog_compose_alignment(repo_root: Path) -> list[str]:
+    return validate_catalog_compose_alignment_data(
+        load_root_catalog(repo_root),
+        load_compose(repo_root),
+    )
+
+
+def validate_catalog_compose_alignment_data(
+    catalog: dict[str, Any],
+    compose: dict[str, Any],
+) -> list[str]:
+    errors: list[str] = []
+    compose_services = compose.get("services") or {}
+
+    for name, spec in sorted((catalog.get("servers") or {}).items()):
+        service_name = spec.get("docker_compose_service")
+        if not service_name:
+            continue
+        service = compose_services.get(service_name)
+        if not service:
+            errors.append(f"{name}: docker_compose_service `{service_name}` missing from compose.yml")
+            continue
+
+        host_ports = _compose_host_ports(service)
+        expected_ports = {
+            port
+            for port in (
+                _url_port(spec.get("url")),
+                _url_port(spec.get("url_template")),
+                spec.get("default_port_base"),
+                *[extra.get("base") for extra in spec.get("extra_port_vars") or []],
+            )
+            if port
+        }
+        missing_ports = sorted(expected_ports - host_ports)
+        if missing_ports:
+            errors.append(
+                f"{name}: catalog ports {missing_ports} missing from compose service `{service_name}` ports"
+            )
+
+        if spec.get("command") == "docker":
+            target = _docker_exec_target(list(spec.get("args") or []))
+            if target:
+                allowed_targets = {service_name, _container_name(service_name, service)}
+                if target not in allowed_targets:
+                    errors.append(
+                        f"{name}: docker exec target `{target}` does not match compose service "
+                        f"`{service_name}` container `{_container_name(service_name, service)}`"
+                    )
+
+    return errors
+
+
+def validate_legacy_registry_contract(repo_root: Path) -> list[str]:
+    registry_path = repo_root / "src/dopemux/mcp/registry.yaml"
+    try:
+        registry = load_yaml_no_duplicate_keys(registry_path) or {}
+    except DuplicateKeyError as exc:
+        return [str(exc)]
+
+    compose_services = load_compose(repo_root).get("services") or {}
+    errors: list[str] = []
+    for name, spec in sorted((registry.get("servers") or {}).items()):
+        docker = spec.get("docker") or {}
+        service_name = docker.get("service")
+        if not service_name:
+            continue
+        service = compose_services.get(service_name)
+        if not service:
+            errors.append(f"{name}: docker.service `{service_name}` missing from compose.yml")
+            continue
+        health_url = docker.get("health_url")
+        port = _url_port(health_url)
+        if not health_url or port is None:
+            errors.append(f"{name}: docker.health_url must include an absolute URL with a port")
+        elif port not in _compose_host_ports(service):
+            errors.append(
+                f"{name}: health_url port {port} missing from compose service `{service_name}` ports"
+            )
+        if "healthcheck" not in service:
+            errors.append(f"{name}: compose service `{service_name}` missing healthcheck")
+    return errors
+
+
+def validate_generated_mcp_json_parity(repo_root: Path) -> list[str]:
+    catalog = load_root_catalog(repo_root)
+    defaults = catalog.get("defaults", {}).get("per_worktree") or []
+    expected = render_per_worktree_mcp_json(defaults, catalog)
+    actual_path = repo_root / ".mcp.json"
+    if not actual_path.exists():
+        return [".mcp.json is missing"]
+    actual = json.loads(actual_path.read_text(encoding="utf-8"))
+    if actual != expected:
+        return [".mcp.json does not match catalog defaults renderer"]
+    return []

--- a/src/dopemux/mcp/fleet_catalog.py
+++ b/src/dopemux/mcp/fleet_catalog.py
@@ -27,7 +27,7 @@ class DuplicateKeyError(MCPFleetCatalogError):
 
 _ENV_DEFAULT_RE = re.compile(r"\$\{[^:}]+:-([0-9]+)\}")
 _ENV_RE = re.compile(r"\$\{[^}]+\}")
-_MCP_TOOL_SURFACE_RE = re.compile(r"\bmcp__([A-Za-z0-9_-]+)__[A-Za-z0-9_-]+")
+_MCP_TOOL_SURFACE_RE = re.compile(r"\bmcp__([A-Za-z0-9_-]+)__(?:[A-Za-z0-9_-]+|\*)")
 
 
 def load_yaml_no_duplicate_keys(path: Path) -> Any:
@@ -158,11 +158,37 @@ def _url_port(value: str | None) -> int | None:
     return parsed.port
 
 
+_DOCKER_EXEC_VALUE_FLAGS = {
+    "--detach-keys",
+    "--env",
+    "--env-file",
+    "--user",
+    "--workdir",
+    "-e",
+    "-u",
+    "-w",
+}
+
+
 def _docker_exec_target(args: list[str]) -> str | None:
     if not args or args[0] != "exec":
         return None
+    skip_next = False
     for token in args[1:]:
+        if skip_next:
+            skip_next = False
+            continue
+        if token in _DOCKER_EXEC_VALUE_FLAGS:
+            skip_next = True
+            continue
+        if token.startswith("--"):
+            if "=" in token:
+                continue
+            continue
         if token.startswith("-"):
+            # Short Docker exec flags that take attached values, e.g. -u1000 or -eKEY=VAL.
+            if len(token) > 2 and token[1] in {"e", "u", "w"}:
+                continue
             continue
         return token
     return None

--- a/src/dopemux/mcp/registry.yaml
+++ b/src/dopemux/mcp/registry.yaml
@@ -34,16 +34,6 @@ servers:
 
   dopemux-desktop-commander:
     transport: http
-    default_enabled: true
-    required_for_auto: false
-    docker:
-      service: desktop-commander
-      compose_file: compose.yml
-      port: 3012
-      health_url: http://localhost:3012/health
-
-  dopemux-desktop-commander:
-    transport: http
     default_enabled: false
     required_for_auto: false
     docker:
@@ -54,16 +44,6 @@ servers:
 
   dopemux-gpt-researcher:
     transport: http
-    default_enabled: true
-    required_for_auto: false
-    docker:
-      service: gptr-mcp
-      compose_file: compose.yml
-      port: 3009
-      health_url: http://localhost:3009/health
-
-  dopemux-gpt-researcher:
-    transport: http
     default_enabled: false
     required_for_auto: false
     docker:
@@ -71,16 +51,6 @@ servers:
       compose_file: compose.yml
       port: 3009
       health_url: http://localhost:3009/health
-
-  dopemux-leantime-bridge:
-    transport: http-sse
-    default_enabled: true
-    required_for_auto: false
-    docker:
-      service: leantime-bridge
-      compose_file: compose.yml
-      port: 3015
-      health_url: http://localhost:3015/health
 
   dopemux-leantime-bridge:
     transport: http-sse
@@ -116,16 +86,6 @@ servers:
       compose_file: compose.yml
       port: 3010
       health_url: http://localhost:3010/health
-
-  dopemux-pal:
-    transport: stdio
-    default_enabled: false
-    required_for_auto: false
-    local:
-      command: uvx
-      args:
-        - pal-mcp-server
-        - start
 
   dopemux-pal:
     transport: stdio

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -84,6 +84,13 @@ A packet is superseded by another packet
 | TP-BETA-MCP-02-COMPOSE-HEALTHCHECKS | Infra | Gate core MCP compose dependencies on healthchecked services | Active | N/A |
 | TP-BETA-MCP-03-ADHD-REDIS-ISOLATION | ADHD Engine | Isolate ADHD Engine Redis keys by instance | Active | N/A |
 | TP-DMX-GPTR-MCP-CONTAINER-UPDATE-001 | Infra / MCP | Restore GPT Researcher MCP container entrypoint and update package pin | Active | N/A |
+| TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT | MCP Fleet | Canonical catalog contract and static drift gates | Active | PR #993 audit input |
+| TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS | MCP Fleet | Generated MCP config outputs from canonical catalog | Ready | PR #993 audit input |
+| TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE | MCP Fleet | Add `dopemux mcp ensure --fast/--full` remediation layer | Ready | PR #993 audit input |
+| TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE | MCP Fleet / Memory | Capture promotable source events for chronicle spine | Ready | PR #993 audit input |
+| TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES | MCP Fleet | Converge server personalities after catalog gates | Ready | PR #993 audit input |
+| TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION | DCP / MCP | Activate read-only DCP facade follow-ons | Ready | PR #993 audit input |
+| TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE | MCP Fleet | Quarantine dead MCP surfaces after reverse dependency proof | Ready | PR #993 audit input |
 | TP-SEC-COMPOSE-LITELLM-LOCALHOST-001 | Security | Externalize LiteLLM healthcheck key and localize compose service ports | Active | N/A |
 | TP-SEC-WEAK-DEFAULT-SECRETS-001 | Security | Reject weak default secrets in env template and installer | Active | N/A |
 | TP-DMX-ADHD-SIGNAL-E2E-WIRING-001 | ADHD Engine / Dashboard | Prove synthetic ADHD state updates reach the dashboard UI band | Active | N/A |

--- a/task-packets/STATUS.md
+++ b/task-packets/STATUS.md
@@ -71,6 +71,21 @@ None (design investigation only)
 Notes:
 Ranking determinism flagged for review
 Embedding lifecycle not yet audited
+────────────────────
+MCP Fleet
+Status: 🟡 In Progress
+Active Packets:
+TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT — Canonical catalog contract and static drift gates
+Ready Follow-ons:
+TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS
+TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE
+TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE
+TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES
+TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION
+TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE
+Risk Notes:
+PR #993 remains open and blocked; its audit is advisory input, not merged runtime truth
+Live Docker/MCP/provider validation is not part of the first catalog-gates packet
 ────────────────────────────────────────────────────────────
 ⚠️ Cross-Cutting Risks
 Multi-capture source convergence correctness

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT.json
@@ -35,6 +35,7 @@
       "task-packets/STATUS.md",
       ".claude/commands/dx/implement.md",
       "mcp_catalog.yaml",
+      "src/dopemux/mcp/default_catalog.yaml",
       "src/dopemux/mcp/registry.yaml",
       "schemas/mcp/fleet-catalog.schema.json",
       "src/dopemux/mcp/fleet_catalog.py",

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT.json
@@ -33,6 +33,7 @@
       "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-*.json",
       "task-packets/INDEX.md",
       "task-packets/STATUS.md",
+      ".claude/commands/dx/implement.md",
       "mcp_catalog.yaml",
       "src/dopemux/mcp/registry.yaml",
       "schemas/mcp/fleet-catalog.schema.json",

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT.json
@@ -1,0 +1,142 @@
+{
+  "id": "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
+  "project": "dopemux-mvp",
+  "target": "Establish the first mergeable MCP fleet roadmap slice: a canonical catalog contract and static drift gates that prevent config, compose, registry, and command/tool-surface divergence before later runtime remediation.",
+  "invariants": [
+    "No live MCP server calls, provider calls, Docker mutation, Task Orchestrator writes, ConPort writes, dope-memory writes, dope-context index mutation, or GitHub mutation.",
+    "Do not change runtime server behavior in this packet.",
+    "Do not delete, archive, or deprecate server implementations in this packet.",
+    "Treat PR 993 audit content as advisory evidence unless runtime code, config, tests, or committed docs support the claim.",
+    "Preserve split authority across dopemux, task-orchestrator, ConPort, dope-memory, dope-context, dopecon-bridge, and DCP."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MCP-FLEET-ROADMAP",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/mcp-fleet-contract-gates",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "test(mcp): gate canonical fleet catalog drift",
+    "allowlist": [
+      "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-*.json",
+      "task-packets/INDEX.md",
+      "task-packets/STATUS.md",
+      "mcp_catalog.yaml",
+      "src/dopemux/mcp/registry.yaml",
+      "schemas/mcp/fleet-catalog.schema.json",
+      "src/dopemux/mcp/fleet_catalog.py",
+      "tests/arch/test_mcp_fleet_catalog_contract.py",
+      "tests/unit/test_mcp_fleet_catalog.py",
+      "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/**"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -c \"import json; from pathlib import Path; from jsonschema.validators import Draft202012Validator; Draft202012Validator.check_schema(json.loads(Path('schemas/mcp/fleet-catalog.schema.json').read_text()))\"",
+      "python -m pytest tests/unit/test_mcp_fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "test(mcp): gate canonical fleet catalog drift",
+    "body": "## Summary\n- Adds the MCP fleet roadmap packet series derived from PR 993 investigation.\n- Adds a canonical MCP fleet catalog contract and static drift gates for catalog, compose, registry, and generated config surfaces.\n- Keeps runtime remediation out of this first slice.\n\n## Validation\n- Task packets validate against dopetask-canonical-spec.json.\n- Fleet catalog schema validates.\n- Focused MCP catalog tests pass.\n- git diff --check passes.\n\n## NOT_RUN\n- Live MCP handshakes.\n- Docker health checks.\n- Provider/network validation.\n\n@codex review",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "preflight",
+      "task": "Verify dedicated worktree identity, branch, dirty state, repo marker, PR 993 live state, and relevant catalog/runtime surfaces before editing.",
+      "context_files": [
+        "AGENTS.md",
+        "PROJECT.md",
+        "ARCHITECTURE.md",
+        "PM_PLANE.md",
+        "mcp_catalog.yaml",
+        "services/registry.yaml",
+        "src/dopemux/mcp/registry.yaml",
+        "src/dopemux/commands/mcp_commands.py",
+        "tests/arch/test_registry_compose_alignment.py",
+        "tests/unit/test_mcp_commands_catalog.py"
+      ],
+      "validation": [
+        "Repo identity, branch, worktree path, and PR 993 state are recorded in implementation proof."
+      ]
+    },
+    {
+      "id": "packet_series",
+      "task": "Create the seven-packet MCP fleet roadmap series with packet 001 scoped to catalog contract and static drift gates.",
+      "expected_files": [
+        "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT.json",
+        "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS.json",
+        "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE.json",
+        "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE.json",
+        "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json",
+        "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION.json",
+        "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json"
+      ],
+      "validation": [
+        "All seven packets validate against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json."
+      ]
+    },
+    {
+      "id": "red_tests",
+      "task": "Add failing tests for canonical catalog loading, duplicate-key rejection, compose alignment, legacy registry parity, health URL contract, generated .mcp.json parity, singleton rendering parity, and command/tool-surface drift placeholders.",
+      "expected_files": [
+        "tests/unit/test_mcp_fleet_catalog.py",
+        "tests/arch/test_mcp_fleet_catalog_contract.py"
+      ],
+      "validation": [
+        "Focused tests fail before implementation for missing fleet catalog module/schema."
+      ]
+    },
+    {
+      "id": "contract",
+      "task": "Implement the minimal fleet catalog schema and loader/validator needed to pass static drift-gate tests without changing runtime behavior.",
+      "expected_files": [
+        "schemas/mcp/fleet-catalog.schema.json",
+        "src/dopemux/mcp/fleet_catalog.py"
+      ],
+      "validation": [
+        "Focused tests pass and detect intentionally invalid duplicate or drift fixtures."
+      ]
+    },
+    {
+      "id": "proof",
+      "task": "Create implementation notes and run focused validation plus diff checks.",
+      "expected_files": [
+        "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md"
+      ],
+      "validation": [
+        "Validation output records PASS/FAIL/NOT_RUN truthfully.",
+        "git diff --check passes."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS.json
@@ -1,0 +1,84 @@
+{
+  "id": "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS",
+  "project": "dopemux-mvp",
+  "target": "Generate per-worktree MCP config, Claude globals fragment, Codex config fragment, health probe lists, and MCP doctrine docs from the canonical MCP fleet catalog with dry-run defaults and explicit apply gates.",
+  "invariants": [
+    "Depends on TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT.",
+    "Generators default to dry-run and must not write user-global files without explicit apply.",
+    "No live MCP calls, Docker mutation, provider calls, or destructive config pruning.",
+    "Generated outputs must preserve user-owned descriptions and unknown external entries unless prune is explicitly requested."
+  ],
+  "depends_on": [
+    "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MCP-FLEET-ROADMAP",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/mcp-fleet-generated-outputs",
+    "base_branch": "main",
+    "stacked_because": "Generated outputs require the canonical catalog contract and drift gates from packet 001."
+  },
+  "commit": {
+    "message": "feat(mcp): generate fleet config outputs",
+    "allowlist": [
+      "src/dopemux/commands/mcp_commands.py",
+      "src/dopemux/mcp/fleet_catalog.py",
+      "tests/unit/test_mcp_commands_catalog.py",
+      "tests/unit/test_mcp_fleet_catalog.py",
+      "docs/03-reference/mcp/**",
+      "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS.json",
+      "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS/**"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_mcp_commands_catalog.py tests/unit/test_mcp_fleet_catalog.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(mcp): generate fleet config outputs",
+    "body": "Generate MCP config fragments and docs from the canonical catalog. Dry-run remains the default; explicit apply is required for writes.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "inspect_generators",
+      "task": "Inspect current mcp init/add/sync-globals rendering behavior and identify generated output surfaces.",
+      "validation": [
+        "Existing dry-run/apply behavior and user-preservation semantics are documented."
+      ],
+      "context_files": [
+        "src/dopemux/commands/mcp_commands.py",
+        "tests/unit/test_mcp_commands_catalog.py"
+      ]
+    },
+    {
+      "id": "generate_outputs",
+      "task": "Add catalog-backed dry-run generators for local MCP config, Claude globals, Codex config fragment, health probe list, and MCP doctrine docs.",
+      "validation": [
+        "Golden tests prove generated outputs are deterministic and dry-run by default."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE.json
@@ -1,0 +1,84 @@
+{
+  "id": "TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE",
+  "project": "dopemux-mvp",
+  "target": "Add `dopemux mcp ensure --fast/--full` as an idempotent remediation layer over the catalog after generated config surfaces are stable.",
+  "invariants": [
+    "Depends on packets 001 and 002.",
+    "`doctor` diagnoses and `ensure` remediates; do not collapse the commands.",
+    "`--fast` must not start containers or make network/provider calls.",
+    "`--full` must fail closed when Docker, PAL image, or Task Orchestrator singleton prerequisites are unavailable.",
+    "No secrets may be printed."
+  ],
+  "depends_on": [
+    "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
+    "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MCP-FLEET-ROADMAP",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/mcp-fleet-ensure-command",
+    "base_branch": "main",
+    "stacked_because": "Ensure needs catalog-backed config generation and drift gates."
+  },
+  "commit": {
+    "message": "feat(mcp): add fleet ensure command",
+    "allowlist": [
+      "src/dopemux/commands/mcp_commands.py",
+      "src/dopemux/mcp/fleet_catalog.py",
+      "scripts/mcp-wrappers/ensure-pal.sh",
+      "tests/unit/test_mcp_commands_catalog.py",
+      "tests/unit/test_mcp_fleet_catalog.py",
+      "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE.json",
+      "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE/**"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/test_mcp_commands_catalog.py tests/unit/test_mcp_fleet_catalog.py -q",
+      "bash -n scripts/mcp-wrappers/ensure-pal.sh",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(mcp): add fleet ensure command",
+    "body": "Add idempotent MCP fleet remediation with fast and full modes. Live runtime validation remains separately recorded.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "fast_mode",
+      "task": "Implement `dopemux mcp ensure --fast` for local prerequisite and cached health checks only.",
+      "validation": [
+        "Unit tests prove fast mode does not invoke Docker start or live MCP probes."
+      ]
+    },
+    {
+      "id": "full_mode",
+      "task": "Implement `dopemux mcp ensure --full` with compose startup, PAL ensure, Task Orchestrator singleton ensure, and bounded tool-surface probes.",
+      "validation": [
+        "Unit tests cover command construction and fail-closed prerequisite errors; live Docker validation is recorded separately when available."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE.json
@@ -1,0 +1,83 @@
+{
+  "id": "TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE",
+  "project": "dopemux-mvp",
+  "target": "Repair memory spine capture at source events rather than heartbeat spam, with bounded hook failure capture and promotable decision/task/workflow event emission.",
+  "invariants": [
+    "Depends on packet 001 and must not depend on PR 993 hook fan-out behavior unless corrected or isolated.",
+    "Hooks must fail open and must not synchronously block on unbounded Redis fan-out.",
+    "Only WMA promotion allowlist event types may be emitted as promotable capture events.",
+    "ConPort remains structured decision/progress authority; dope-memory receives chronicle receipts and does not become PM truth."
+  ],
+  "depends_on": [
+    "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MCP-FLEET-ROADMAP",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/mcp-fleet-memory-spine",
+    "base_branch": "main",
+    "stacked_because": "Memory capture repair needs the catalog risk framing but can run parallel to ensure work."
+  },
+  "commit": {
+    "message": "fix(memory): capture promotable source events",
+    "allowlist": [
+      "src/dopemux/claude/native_hooks.py",
+      "src/dopemux/memory/capture_client.py",
+      "src/dopemux/pm/**",
+      "services/working-memory-assistant/**",
+      "docker/mcp-servers-source/conport/**",
+      "tests/unit/test_memory_capture_client.py",
+      "tests/test_native_hooks_workflow.py",
+      "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE.json",
+      "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE/**"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/test_native_hooks_workflow.py tests/unit/test_memory_capture_client.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(memory): capture promotable source events",
+    "body": "Repair source-event capture for chronicle promotion while preserving fail-open hooks and split memory authority.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "bounded_errors",
+      "task": "Emit bounded `error.encountered` from hook failures without unbounded Redis fan-out.",
+      "validation": [
+        "Tests prove Redis blackhole or capture exceptions do not block hook responses."
+      ]
+    },
+    {
+      "id": "source_events",
+      "task": "Emit `decision.logged`, `task.*`, and `workflow.phase_changed` at their authoritative source paths.",
+      "validation": [
+        "Tests prove promotable events are written with correct authority labels and no PM authority escalation."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json
@@ -1,0 +1,86 @@
+{
+  "id": "TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES",
+  "project": "dopemux-mvp",
+  "target": "Converge MCP server personalities after catalog gates exist: ConPort in-repo surface, Kotlin Task Orchestrator as workflow MCP, dope-memory/dope-context identity handling, PAL standalone management, exa wire-or-retire, and desktop commander decision.",
+  "invariants": [
+    "Depends on catalog gates from packet 001 and generated outputs from packet 002.",
+    "No destructive deletion in this packet without reverse dependency proof.",
+    "Do not treat dopecon-bridge as canonical authority.",
+    "Do not widen write surfaces or activate unsanctioned Serena write tools."
+  ],
+  "depends_on": [
+    "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
+    "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MCP-FLEET-ROADMAP",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/mcp-fleet-server-personalities",
+    "base_branch": "main",
+    "stacked_because": "Server convergence must ride on catalog drift gates to avoid resurrecting shadow surfaces."
+  },
+  "commit": {
+    "message": "fix(mcp): converge fleet server personalities",
+    "allowlist": [
+      "mcp_catalog.yaml",
+      "services/registry.yaml",
+      "src/dopemux/mcp/**",
+      "docker/mcp-servers-source/conport/**",
+      "services/dope-context/**",
+      "services/working-memory-assistant/**",
+      "scripts/mcp-wrappers/**",
+      "tests/**/test_mcp*.py",
+      "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json",
+      "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES/**"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_fleet_catalog.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(mcp): converge fleet server personalities",
+    "body": "Converge MCP server personalities behind the canonical catalog without destructive deletion.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "decision_matrix",
+      "task": "Document each server's chosen personality, rejected alternatives, authority label, and residual UNKNOWNs.",
+      "validation": [
+        "Decision matrix preserves Memory Trinity and PM-plane authority boundaries."
+      ]
+    },
+    {
+      "id": "converge_configs",
+      "task": "Apply non-destructive config and wrapper convergence for chosen personalities.",
+      "validation": [
+        "Catalog drift gates pass and no generated config references rejected surfaces."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION.json
@@ -1,0 +1,82 @@
+{
+  "id": "TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION",
+  "project": "dopemux-mvp",
+  "target": "Activate DCP follow-ons: close facade tool-contract gaps, add read-only dope-context bridge, add inventory freshness CI, and register the facade as operator-run stdio.",
+  "invariants": [
+    "Depends on catalog contract and generated outputs.",
+    "DCP facade remains read-only and untrusted-by-default.",
+    "No live writes, provider calls, or secure tunnel mutation without explicit validation authorization.",
+    "dope-context remains retrieval/index authority only and does not become source truth."
+  ],
+  "depends_on": [
+    "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
+    "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MCP-FLEET-ROADMAP",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/mcp-fleet-dcp-activation",
+    "base_branch": "main",
+    "stacked_because": "DCP facade registration depends on canonical catalog generation."
+  },
+  "commit": {
+    "message": "feat(dcp): activate read-only facade follow-ons",
+    "allowlist": [
+      "services/dcp-readonly-facade/**",
+      "src/dopemux/mcp/**",
+      "mcp_catalog.yaml",
+      "tests/dcp/**",
+      "tests/unit/dcp/**",
+      "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION.json",
+      "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION/**"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-ACTIVATION.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/dcp tests/dcp -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): activate read-only facade follow-ons",
+    "body": "Close read-only DCP facade contract gaps and register the facade through the canonical MCP catalog.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "facade_contract",
+      "task": "Close facade exposed-tool contract gaps and add contract equality tests.",
+      "validation": [
+        "DCP facade exposed tools exactly match the declared contract."
+      ]
+    },
+    {
+      "id": "dope_context_bridge",
+      "task": "Add read-only dope-context bridge and register facade as operator-run stdio in catalog.",
+      "validation": [
+        "Tests prove no mutating methods or live-write bypass exists."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json
@@ -1,0 +1,87 @@
+{
+  "id": "TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE",
+  "project": "dopemux-mvp",
+  "target": "Quarantine or deprecate dead MCP fleet surfaces only after reverse dependency scans and CI prove no active generated config references them.",
+  "invariants": [
+    "Depends on catalog gates, generated outputs, and server-personality convergence.",
+    "No destructive deletion without reverse dependency proof.",
+    "Deprecated surfaces must not remain startable from generated configs.",
+    "Security-sensitive dead surfaces must be disabled fail-closed before any archive/delete step."
+  ],
+  "depends_on": [
+    "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
+    "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS",
+    "TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MCP-FLEET-ROADMAP",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/mcp-fleet-dead-surface-quarantine",
+    "base_branch": "main",
+    "stacked_because": "Dead-surface quarantine is unsafe until canonical configs and server personality decisions are enforced."
+  },
+  "commit": {
+    "message": "chore(mcp): quarantine dead fleet surfaces",
+    "allowlist": [
+      "SYSTEM_ARCHIVE/**",
+      "mcp_catalog.yaml",
+      "services/registry.yaml",
+      "src/dopemux/mcp/**",
+      "scripts/mcp/**",
+      "docker/mcp-servers-source/**",
+      "services/**",
+      "tests/arch/test_mcp_fleet_catalog_contract.py",
+      "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json",
+      "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/**"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "chore(mcp): quarantine dead fleet surfaces",
+    "body": "Quarantine dead MCP surfaces after reverse dependency proof and generated-config drift gates.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "reverse_deps",
+      "task": "Run reverse dependency scans for each proposed dead surface and classify references as active, generated, docs-only, or archive.",
+      "validation": [
+        "Proof records zero active generated config references before quarantine."
+      ]
+    },
+    {
+      "id": "quarantine",
+      "task": "Quarantine or deprecate dead surfaces with tests proving generated configs cannot start them.",
+      "validation": [
+        "Catalog drift gates pass and no startable dead surface remains in generated config."
+      ]
+    }
+  ]
+}

--- a/tests/arch/test_mcp_fleet_catalog_contract.py
+++ b/tests/arch/test_mcp_fleet_catalog_contract.py
@@ -1,0 +1,119 @@
+import re
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from dopemux.mcp import fleet_catalog
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_root_catalog_conforms_to_schema():
+    schema = fleet_catalog.load_json_schema(REPO_ROOT / "schemas/mcp/fleet-catalog.schema.json")
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+
+    jsonschema.validate(catalog, schema)
+
+
+def test_root_catalog_defaults_are_declared_per_worktree_servers():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    servers = catalog["servers"]
+
+    invalid = [
+        name
+        for name in catalog["defaults"]["per_worktree"]
+        if name not in servers or servers[name].get("scope") != "per-worktree"
+    ]
+
+    assert invalid == []
+
+
+def test_catalog_compose_service_and_port_alignment():
+    errors = fleet_catalog.validate_catalog_compose_alignment(REPO_ROOT)
+
+    assert errors == []
+
+
+def test_legacy_registry_has_unique_keys_and_compose_health_contracts():
+    errors = fleet_catalog.validate_legacy_registry_contract(REPO_ROOT)
+
+    assert errors == []
+
+
+def test_generated_mcp_json_parity_is_checked_against_catalog_renderer():
+    errors = fleet_catalog.validate_generated_mcp_json_parity(REPO_ROOT)
+
+    assert errors == []
+
+
+def test_claude_command_tool_surfaces_are_catalog_known_or_explicit_aliases():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    command_dir = REPO_ROOT / ".claude/commands"
+
+    unknown = fleet_catalog.find_unknown_command_tool_surfaces(command_dir, catalog)
+
+    assert unknown == []
+
+
+def test_unknown_command_tool_surfaces_are_reported(tmp_path):
+    command_dir = tmp_path / "commands"
+    command_dir.mkdir()
+    (command_dir / "bad.md").write_text("Call `mcp__missing-server__do_work`.\n")
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+
+    unknown = fleet_catalog.find_unknown_command_tool_surfaces(command_dir, catalog)
+
+    assert unknown == [f"{command_dir / 'bad.md'}:1:missing-server"]
+
+
+def test_mcp_tool_surface_regex_rejects_partial_mentions():
+    matches = fleet_catalog.extract_mcp_tool_surfaces("mcp__conport__ok mcp__bad mcp____x")
+
+    assert matches == ["conport"]
+
+
+def test_no_duplicate_catalog_server_names_in_sample_fixture(tmp_path):
+    duplicate = tmp_path / "legacy.yaml"
+    duplicate.write_text(
+        """
+servers:
+  one:
+    transport: http
+  one:
+    transport: stdio
+""".lstrip()
+    )
+
+    with pytest.raises(fleet_catalog.DuplicateKeyError):
+        fleet_catalog.load_yaml_no_duplicate_keys(duplicate)
+
+
+def test_catalog_contract_finds_docker_exec_container_drift(tmp_path):
+    compose = {
+        "services": {
+            "exa": {
+                "container_name": "mcp-exa",
+                "ports": ["${EXA_PORT:-3011}:3011"],
+                "healthcheck": {"test": ["CMD", "true"]},
+            }
+        }
+    }
+    catalog = {
+        "version": 1,
+        "defaults": {"per_worktree": []},
+        "servers": {
+            "exa": {
+                "scope": "singleton",
+                "transport": "stdio",
+                "command": "docker",
+                "args": ["exec", "-i", "mcp-litellm", "python", "/app/exa_server.py"],
+                "docker_compose_service": "exa",
+            }
+        },
+    }
+
+    errors = fleet_catalog.validate_catalog_compose_alignment_data(catalog, compose)
+
+    assert re.search(r"exa.*mcp-litellm.*mcp-exa", "\n".join(errors))

--- a/tests/arch/test_mcp_fleet_catalog_contract.py
+++ b/tests/arch/test_mcp_fleet_catalog_contract.py
@@ -17,6 +17,21 @@ def test_root_catalog_conforms_to_schema():
     jsonschema.validate(catalog, schema)
 
 
+def test_bundled_default_catalog_stays_in_sync_with_root_catalog():
+    schema = fleet_catalog.load_json_schema(REPO_ROOT / "schemas/mcp/fleet-catalog.schema.json")
+    root_catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    bundled_catalog = fleet_catalog.load_yaml_no_duplicate_keys(
+        REPO_ROOT / "src/dopemux/mcp/default_catalog.yaml"
+    )
+
+    jsonschema.validate(bundled_catalog, schema)
+    assert bundled_catalog == root_catalog
+    assert fleet_catalog.validate_catalog_compose_alignment_data(
+        bundled_catalog,
+        fleet_catalog.load_compose(REPO_ROOT),
+    ) == []
+
+
 def test_root_catalog_defaults_are_declared_per_worktree_servers():
     catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
     servers = catalog["servers"]

--- a/tests/arch/test_mcp_fleet_catalog_contract.py
+++ b/tests/arch/test_mcp_fleet_catalog_contract.py
@@ -69,9 +69,11 @@ def test_unknown_command_tool_surfaces_are_reported(tmp_path):
 
 
 def test_mcp_tool_surface_regex_rejects_partial_mentions():
-    matches = fleet_catalog.extract_mcp_tool_surfaces("mcp__conport__ok mcp__bad mcp____x")
+    matches = fleet_catalog.extract_mcp_tool_surfaces(
+        "mcp__conport__ok mcp__dope-memory__* mcp__bad mcp____x"
+    )
 
-    assert matches == ["conport"]
+    assert matches == ["conport", "dope-memory"]
 
 
 def test_no_duplicate_catalog_server_names_in_sample_fixture(tmp_path):
@@ -117,3 +119,43 @@ def test_catalog_contract_finds_docker_exec_container_drift(tmp_path):
     errors = fleet_catalog.validate_catalog_compose_alignment_data(catalog, compose)
 
     assert re.search(r"exa.*mcp-litellm.*mcp-exa", "\n".join(errors))
+
+
+def test_catalog_contract_parses_docker_exec_options_with_values():
+    compose = {
+        "services": {
+            "exa": {
+                "container_name": "mcp-exa",
+                "ports": ["${EXA_PORT:-3011}:3011"],
+                "healthcheck": {"test": ["CMD", "true"]},
+            }
+        }
+    }
+    catalog = {
+        "version": 1,
+        "defaults": {"per_worktree": []},
+        "servers": {
+            "exa": {
+                "scope": "singleton",
+                "transport": "stdio",
+                "command": "docker",
+                "args": [
+                    "exec",
+                    "-i",
+                    "-e",
+                    "MCP_RUN_MODE=stdio",
+                    "--user",
+                    "1000:1000",
+                    "--workdir=/app",
+                    "mcp-exa",
+                    "python",
+                    "/app/exa_server.py",
+                ],
+                "docker_compose_service": "exa",
+            }
+        },
+    }
+
+    errors = fleet_catalog.validate_catalog_compose_alignment_data(catalog, compose)
+
+    assert errors == []

--- a/tests/unit/test_mcp_fleet_catalog.py
+++ b/tests/unit/test_mcp_fleet_catalog.py
@@ -1,0 +1,89 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dopemux.commands import mcp_commands
+from dopemux.mcp import fleet_catalog
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_duplicate_yaml_keys_are_rejected(tmp_path):
+    catalog = tmp_path / "catalog.yaml"
+    catalog.write_text(
+        """
+version: 1
+servers:
+  alpha:
+    scope: singleton
+    transport: http
+    url: http://localhost:3000/mcp
+  alpha:
+    scope: singleton
+    transport: http
+    url: http://localhost:3001/mcp
+""".lstrip()
+    )
+
+    with pytest.raises(fleet_catalog.DuplicateKeyError) as excinfo:
+        fleet_catalog.load_yaml_no_duplicate_keys(catalog)
+
+    assert "alpha" in str(excinfo.value)
+
+
+def test_root_catalog_defaults_render_committed_mcp_json():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    defaults = catalog["defaults"]["per_worktree"]
+
+    expected = fleet_catalog.render_per_worktree_mcp_json(defaults, catalog)
+    actual = json.loads((REPO_ROOT / ".mcp.json").read_text())
+
+    assert actual == expected
+
+
+def test_fleet_renderer_matches_existing_mcp_command_renderer():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    defaults = catalog["defaults"]["per_worktree"]
+
+    assert fleet_catalog.render_per_worktree_mcp_json(
+        defaults,
+        catalog,
+    ) == mcp_commands._build_local_mcp_json(defaults, catalog)
+
+
+def test_singleton_fragment_matches_existing_mcp_command_renderer():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+
+    expected = {
+        name: mcp_commands._render_global_entry(name, spec)
+        for name, spec in catalog["servers"].items()
+        if spec["scope"] == "singleton"
+    }
+
+    assert fleet_catalog.render_singleton_mcp_servers(catalog) == expected
+
+
+def test_known_tool_surfaces_include_catalog_servers_and_explicit_aliases():
+    catalog = yaml.safe_load(
+        """
+version: 1
+servers:
+  pal:
+    scope: singleton
+    transport: http
+    url: http://localhost:3003/mcp
+    tool_aliases:
+      - zen
+  conport:
+    scope: per-worktree
+    transport: sse
+    url_template: http://localhost:${CONPORT_MCP_PORT:-3005}/sse
+    port_var: CONPORT_MCP_PORT
+    default_port_base: 3005
+""".lstrip()
+    )
+
+    assert fleet_catalog.known_tool_surfaces(catalog) == {"conport", "pal", "zen"}

--- a/tests/unit/test_mcp_fleet_catalog.py
+++ b/tests/unit/test_mcp_fleet_catalog.py
@@ -87,3 +87,9 @@ servers:
     )
 
     assert fleet_catalog.known_tool_surfaces(catalog) == {"conport", "pal", "zen"}
+
+
+def test_extract_mcp_tool_surfaces_includes_wildcard_references():
+    assert fleet_catalog.extract_mcp_tool_surfaces(
+        "`mcp__conport__*` and `mcp__task-orchestrator__get_context`"
+    ) == ["conport", "task-orchestrator"]


### PR DESCRIPTION
## Summary
- Adds the MCP fleet roadmap task-packet series derived from PR 993 investigation, with Lane 1 active and later lanes queued as ready follow-ons.
- Adds a canonical MCP fleet catalog schema plus static validators for duplicate YAML keys, compose service/port alignment, Docker exec container parity, generated `.mcp.json` parity, singleton rendering parity, legacy registry health contracts, and `.claude/commands` MCP tool-surface drift.
- Fixes current static drift found by those gates: `exa` now execs into `mcp-exa`, duplicate legacy registry keys are removed preserving last-key behavior, and `pal` declares the historical `zen` command-surface alias.

## Release Notes
- MCP catalog drift is now test-gated before runtime remediation work proceeds.
- The roadmap is packetized so later MCP ensure, generator, memory spine, DCP, and quarantine work can land as separate reviewable slices.

## Documentation / Proof
- Updated `task-packets/INDEX.md` and `task-packets/STATUS.md` with the MCP Fleet series.
- Added proof notes at `proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT/implementation-notes.md`.

## Validation
- PASS: all `task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-*.json` validate against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`.
- PASS: `Draft202012Validator.check_schema(...)` for `schemas/mcp/fleet-catalog.schema.json`.
- PASS: `python -m pytest tests/unit/test_mcp_fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py -q` -> 15 passed.
- PASS: `python -m pytest tests/unit/test_mcp_commands_catalog.py tests/arch/test_registry_compose_alignment.py -q` -> 22 passed.
- PASS: combined focused suite -> 37 passed.
- PASS: `python -m py_compile src/dopemux/mcp/fleet_catalog.py && git diff --check`.
- PASS: scoped `pre-commit run --files ...` exit 0; always-run docs filename audit passed.

## NOT_RUN
- Live MCP initialize/tools-list probes.
- Docker health checks.
- `dopemux mcp ensure --full`.
- Provider/network validation.

@codex review
