### PR TITLE
feat(mcp): generate fleet config outputs

### DIFF
--- a/docs/03-reference/mcp/fleet-generated-outputs.md
+++ b/docs/03-reference/mcp/fleet-generated-outputs.md
@@ -1,0 +1,41 @@
+---
+id: fleet-generated-outputs
+title: Fleet Generated Outputs
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-07-03'
+last_review: '2026-07-03'
+next_review: '2026-10-01'
+prelude: Fleet Generated Outputs (reference) for dopemux documentation and developer
+  workflows.
+---
+# MCP Fleet Generated Outputs
+
+`dopemux mcp generate` renders reviewable MCP fleet projections from
+`mcp_catalog.yaml`.
+
+Generated paths:
+
+- `local/.mcp.json` mirrors the catalog default per-worktree MCP servers.
+- `claude/mcpServers.json` contains the singleton Claude global fragment.
+- `codex/config.toml` contains singleton stdio and streamable HTTP MCP servers
+  in Codex TOML syntax.
+- `health/mcp-health-probes.json` lists catalog health URLs and compose service
+  bindings for static probe planning.
+- `docs/mcp-fleet.md` renders the catalog doctrine summary.
+
+Dry-run is the default and writes nothing:
+
+```bash
+dopemux mcp generate
+```
+
+Writing generated files requires an explicit bounded directory:
+
+```bash
+dopemux mcp generate --apply --output-dir proof/mcp-generated-preview
+```
+
+The command does not write user-global files. Operators must review generated
+fragments before copying or applying them to global config surfaces.

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS/implementation-notes.md
@@ -1,0 +1,58 @@
+# TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS Implementation Notes
+
+## Scope
+
+Implemented Lane 2 generated MCP fleet projections from the canonical
+`mcp_catalog.yaml` contract introduced in Lane 1.
+
+## Changes
+
+- Added deterministic catalog renderers for:
+  - per-worktree `.mcp.json`
+  - Claude singleton `mcpServers` fragment
+  - Codex `config.toml` fragment
+  - MCP health probe list
+  - generated MCP doctrine doc
+- Added `dopemux mcp generate` with dry-run default behavior.
+- Required `--apply --output-dir <dir>` for writes.
+- Added unit coverage proving dry-run does not write and apply is bounded to
+  the requested output directory.
+- Added reference documentation for generated outputs.
+
+## Validation
+
+PASS:
+
+- `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `python -m pytest tests/unit/test_mcp_commands_catalog.py tests/unit/test_mcp_fleet_catalog.py -q`
+- `python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q`
+- `python -m py_compile src/dopemux/mcp/fleet_catalog.py src/dopemux/commands/mcp_commands.py`
+- `PYTHONPATH=src python -m dopemux.cli mcp --help`
+- `PYTHONPATH=src python -m dopemux.cli mcp generate --output-dir /tmp/dmx-mcp-generated-smoke`
+- `PYTHONPATH=src python -m dopemux.cli mcp generate --apply --output-dir /tmp/dmx-mcp-generated-smoke-lane2`
+- `find /tmp/dmx-mcp-generated-smoke-lane2 -type f | sort`
+- `python -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("/tmp/dmx-mcp-generated-smoke-lane2/codex/config.toml").read_text())'`
+
+FAIL:
+
+- `python -m pytest tests/unit/test_mcp_commands_catalog.py tests/unit/test_mcp_fleet_catalog.py -q`
+  failed before implementation because the tested generator functions and CLI
+  command did not exist yet.
+- `python -m dopemux.cli mcp generate --output-dir /tmp/dmx-mcp-generated-smoke`
+  exercised the installed/imported package instead of this worktree source and
+  did not include the new command. The branch-local smoke was rerun with
+  `PYTHONPATH=src`.
+- `python -m tomllib /tmp/dmx-mcp-generated-smoke-lane2/codex/config.toml`
+  used an invalid invocation form because `tomllib` has no module entry point.
+  The same TOML file parsed successfully with `python -c`.
+
+NOT_RUN:
+
+- Docker health and live MCP initialize/tools-list probes. This lane is static
+  generation only and the packet forbids live MCP or Docker mutation.
+- Provider-backed checks. No provider credentials or network calls are required
+  for this packet.
+
+## Runtime Boundaries
+
+No Docker, live MCP, provider, or user-global config writes were performed.

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS/implementation-notes.md
@@ -18,6 +18,9 @@ Implemented Lane 2 generated MCP fleet projections from the canonical
 - Added unit coverage proving dry-run does not write and apply is bounded to
   the requested output directory.
 - Added reference documentation for generated outputs.
+- Addressed PR review feedback by rendering Codex stdio environment forwarding
+  with `env_vars`, deduplicating env names, and avoiding literal placeholder
+  env values in generated Codex config.
 
 ## Validation
 
@@ -32,6 +35,10 @@ PASS:
 - `PYTHONPATH=src python -m dopemux.cli mcp generate --apply --output-dir /tmp/dmx-mcp-generated-smoke-lane2`
 - `find /tmp/dmx-mcp-generated-smoke-lane2 -type f | sort`
 - `python -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("/tmp/dmx-mcp-generated-smoke-lane2/codex/config.toml").read_text())'`
+- `python -m pytest tests/unit/test_mcp_fleet_catalog.py tests/unit/test_mcp_commands_catalog.py -q`
+- `python -m py_compile src/dopemux/mcp/fleet_catalog.py src/dopemux/commands/mcp_commands.py`
+- `PYTHONPATH=src python -m dopemux.cli mcp generate --apply --output-dir /tmp/dmx-mcp-generated-smoke-lane2-review`
+- `python -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("/tmp/dmx-mcp-generated-smoke-lane2-review/codex/config.toml").read_text())'`
 
 FAIL:
 

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -574,8 +574,46 @@ def _build_local_mcp_json(server_names: List[str], catalog: Dict[str, Any]) -> D
 
 
 # ---------------------------------------------------------------------------
-# `mcp init` / `add` / `remove` / `list` / `doctor` / `sync-globals`
+# `mcp generate` / `init` / `add` / `remove` / `list` / `doctor` / `sync-globals`
 # ---------------------------------------------------------------------------
+
+
+@mcp.command("generate")
+@click.option("--apply", is_flag=True, help="Write generated outputs. Default is dry-run.")
+@click.option(
+    "--output-dir",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    help="Directory for generated output files when --apply is set.",
+)
+def mcp_generate_cmd(apply: bool, output_dir: Optional[Path]):
+    """
+    🧾 Project Fleet: Render catalog-backed MCP config fragments
+
+    Generates reviewable projections for local .mcp.json, Claude globals,
+    Codex config, health probes, and MCP doctrine docs. Dry-run is the default;
+    writes require both --apply and --output-dir.
+    """
+    from dopemux.mcp import fleet_catalog
+
+    catalog = _load_catalog()
+    outputs = fleet_catalog.generate_fleet_output_files(catalog)
+
+    if not apply:
+        console.logger.info("[info]Dry-run only. No files were written.[/info]")
+        for relative_path, content in outputs.items():
+            line_count = len(content.splitlines())
+            console.logger.info(f"[info]Would write {relative_path} ({line_count} lines)[/info]")
+        return
+
+    if output_dir is None:
+        raise click.ClickException("--apply requires --output-dir to bound generated writes.")
+
+    for relative_path, content in outputs.items():
+        target = output_dir / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+        console.logger.info(f"[success]Wrote {target}[/success]")
+
 
 @mcp.command("init")
 @click.option("--force", is_flag=True, help="Overwrite existing .mcp.json and env file without prompting.")

--- a/src/dopemux/mcp/fleet_catalog.py
+++ b/src/dopemux/mcp/fleet_catalog.py
@@ -98,6 +98,11 @@ def _toml_string_array(values: list[Any]) -> str:
     return "[" + ", ".join(_toml_string(value) for value in values) + "]"
 
 
+def _codex_env_vars(spec: dict[str, Any]) -> list[str]:
+    env_keys = list(spec.get("requires_env", []) or []) + list(spec.get("optional_env", []) or [])
+    return sorted(set(env_keys))
+
+
 def render_codex_config_fragment(catalog: dict[str, Any]) -> str:
     """Render singleton MCP servers in Codex `config.toml` syntax.
 
@@ -124,17 +129,14 @@ def render_codex_config_fragment(catalog: dict[str, Any]) -> str:
             lines.append(f"command = {_toml_string(command)}")
             if spec.get("args"):
                 lines.append(f"args = {_toml_string_array(list(spec['args']))}")
+            env_vars = _codex_env_vars(spec)
+            if env_vars:
+                lines.append(f"env_vars = {_toml_string_array(env_vars)}")
         else:
             url = spec.get("url")
             if not url:
                 raise MCPFleetCatalogError(f"Singleton `{name}` requires `url` for Codex HTTP.")
             lines.append(f"url = {_toml_string(url)}")
-
-        env_keys = list(spec.get("requires_env", []) or []) + list(spec.get("optional_env", []) or [])
-        if env_keys:
-            lines.extend(["", f"[mcp_servers.{_toml_string(name)}.env]"])
-            for key in sorted(env_keys):
-                lines.append(f"{key} = {_toml_string(f'${{{key}:-}}')}")
 
     return "\n".join(lines) + "\n"
 

--- a/src/dopemux/mcp/fleet_catalog.py
+++ b/src/dopemux/mcp/fleet_catalog.py
@@ -86,6 +86,141 @@ def render_singleton_mcp_servers(catalog: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _json_dumps(data: Any) -> str:
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def _toml_string(value: Any) -> str:
+    return json.dumps(str(value))
+
+
+def _toml_string_array(values: list[Any]) -> str:
+    return "[" + ", ".join(_toml_string(value) for value in values) + "]"
+
+
+def render_codex_config_fragment(catalog: dict[str, Any]) -> str:
+    """Render singleton MCP servers in Codex `config.toml` syntax.
+
+    Codex currently supports stdio and streamable HTTP MCP servers. SSE-only
+    singleton entries stay represented in Claude/global and health outputs.
+    """
+
+    lines = [
+        "# Generated from mcp_catalog.yaml by `dopemux mcp generate`.",
+        "# Dry-run is the default; review before copying into .codex/config.toml.",
+    ]
+    for name, spec in sorted(catalog.get("servers", {}).items()):
+        if spec.get("scope") != "singleton":
+            continue
+        transport = spec.get("transport", "http")
+        if transport not in {"stdio", "http"}:
+            continue
+
+        lines.extend(["", f"[mcp_servers.{_toml_string(name)}]"])
+        if transport == "stdio":
+            command = spec.get("command")
+            if not command:
+                raise MCPFleetCatalogError(f"Singleton `{name}` requires `command` for Codex stdio.")
+            lines.append(f"command = {_toml_string(command)}")
+            if spec.get("args"):
+                lines.append(f"args = {_toml_string_array(list(spec['args']))}")
+        else:
+            url = spec.get("url")
+            if not url:
+                raise MCPFleetCatalogError(f"Singleton `{name}` requires `url` for Codex HTTP.")
+            lines.append(f"url = {_toml_string(url)}")
+
+        env_keys = list(spec.get("requires_env", []) or []) + list(spec.get("optional_env", []) or [])
+        if env_keys:
+            lines.extend(["", f"[mcp_servers.{_toml_string(name)}.env]"])
+            for key in sorted(env_keys):
+                lines.append(f"{key} = {_toml_string(f'${{{key}:-}}')}")
+
+    return "\n".join(lines) + "\n"
+
+
+def render_health_probe_list(catalog: dict[str, Any]) -> list[dict[str, Any]]:
+    probes: list[dict[str, Any]] = []
+    for name, spec in sorted(catalog.get("servers", {}).items()):
+        url = spec.get("url") or spec.get("url_template")
+        if not url:
+            continue
+        probes.append(
+            {
+                "docker_compose_service": spec.get("docker_compose_service"),
+                "name": name,
+                "scope": spec.get("scope"),
+                "transport": spec.get("transport", "http"),
+                "url": url,
+            }
+        )
+    return probes
+
+
+def render_mcp_doctrine_doc(catalog: dict[str, Any]) -> str:
+    lines = [
+        "# MCP Fleet Catalog Outputs",
+        "",
+        "<!-- Generated from mcp_catalog.yaml by `dopemux mcp generate`. -->",
+        "",
+        "## Contract",
+        "",
+        "- `mcp_catalog.yaml` is the source for generated MCP config fragments.",
+        "- Dry-run is the default; writes require `dopemux mcp generate --apply --output-dir <dir>`.",
+        "- Generated outputs are projections, not user-global authority.",
+        "- Unknown external config entries are preserved by sync flows unless pruning is explicit.",
+        "",
+        "## Default Per-Worktree Servers",
+        "",
+    ]
+    defaults = catalog.get("defaults", {}).get("per_worktree") or []
+    if defaults:
+        for name in defaults:
+            lines.append(f"- `{name}`")
+    else:
+        lines.append("- None")
+
+    lines.extend(
+        [
+            "",
+            "## Servers",
+            "",
+            "| Server | Scope | Transport | Health URL | Compose Service |",
+            "| --- | --- | --- | --- | --- |",
+        ]
+    )
+    for name, spec in sorted(catalog.get("servers", {}).items()):
+        health_url = spec.get("url") or spec.get("url_template") or ""
+        compose_service = spec.get("docker_compose_service") or ""
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    f"`{name}`",
+                    str(spec.get("scope", "")),
+                    str(spec.get("transport", "")),
+                    f"`{health_url}`" if health_url else "",
+                    f"`{compose_service}`" if compose_service else "",
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def generate_fleet_output_files(catalog: dict[str, Any]) -> dict[str, str]:
+    defaults = catalog.get("defaults", {}).get("per_worktree") or []
+    return {
+        "local/.mcp.json": _json_dumps(render_per_worktree_mcp_json(defaults, catalog)),
+        "claude/mcpServers.json": _json_dumps(
+            {"mcpServers": render_singleton_mcp_servers(catalog)}
+        ),
+        "codex/config.toml": render_codex_config_fragment(catalog),
+        "health/mcp-health-probes.json": _json_dumps(render_health_probe_list(catalog)),
+        "docs/mcp-fleet.md": render_mcp_doctrine_doc(catalog),
+    }
+
+
 def known_tool_surfaces(catalog: dict[str, Any]) -> set[str]:
     surfaces: set[str] = set(catalog.get("servers", {}))
     for spec in catalog.get("servers", {}).values():

--- a/tests/unit/test_mcp_commands_catalog.py
+++ b/tests/unit/test_mcp_commands_catalog.py
@@ -315,6 +315,61 @@ def test_sync_globals_prune_removes_unknown_entries(tmp_path, monkeypatch):
     assert "exa" in written
 
 
+def test_mcp_generate_dry_run_reports_outputs_without_writing(tmp_path, monkeypatch):
+    catalog = _singleton_catalog()
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: catalog)
+
+    result = CliRunner().invoke(
+        mcp_commands.mcp_generate_cmd,
+        ["--output-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Dry-run only" in result.output
+    assert "local/.mcp.json" in result.output
+    assert "claude/mcpServers.json" in result.output
+    assert not any(tmp_path.iterdir())
+
+
+def test_mcp_generate_apply_requires_output_dir(monkeypatch):
+    catalog = _singleton_catalog()
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: catalog)
+
+    result = CliRunner().invoke(mcp_commands.mcp_generate_cmd, ["--apply"])
+
+    assert result.exit_code != 0
+    assert "--apply requires --output-dir" in result.output
+
+
+def test_mcp_generate_apply_writes_only_under_output_dir(tmp_path, monkeypatch):
+    catalog = _singleton_catalog()
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: catalog)
+
+    result = CliRunner().invoke(
+        mcp_commands.mcp_generate_cmd,
+        ["--apply", "--output-dir", str(tmp_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    expected = {
+        "local/.mcp.json",
+        "claude/mcpServers.json",
+        "codex/config.toml",
+        "health/mcp-health-probes.json",
+        "docs/mcp-fleet.md",
+    }
+    written = {
+        str(path.relative_to(tmp_path))
+        for path in tmp_path.rglob("*")
+        if path.is_file()
+    }
+    assert written == expected
+    assert json.loads((tmp_path / "claude/mcpServers.json").read_text())["mcpServers"].keys() == {
+        "exa",
+        "gpt-researcher",
+    }
+
+
 def test_doctor_aggregates_problems_and_exits_nonzero(tmp_path, monkeypatch):
     """`doctor` reports every issue it finds and exits 1 if any are present."""
     catalog = {

--- a/tests/unit/test_mcp_fleet_catalog.py
+++ b/tests/unit/test_mcp_fleet_catalog.py
@@ -1,4 +1,5 @@
 import json
+import tomllib
 from pathlib import Path
 
 import pytest
@@ -128,11 +129,13 @@ def test_codex_fragment_renders_stdio_and_streamable_http_servers():
                 "command": "docker",
                 "args": ["exec", "-i", "stdio-one", "server"],
                 "requires_env": ["TOKEN"],
+                "optional_env": ["TOKEN", "OPTIONAL_TOKEN"],
             },
             "http-one": {
                 "scope": "singleton",
                 "transport": "http",
                 "url": "http://localhost:1234/mcp",
+                "requires_env": ["HTTP_TOKEN"],
             },
             "sse-one": {
                 "scope": "singleton",
@@ -147,10 +150,12 @@ def test_codex_fragment_renders_stdio_and_streamable_http_servers():
     assert '[mcp_servers."stdio-one"]' in fragment
     assert 'command = "docker"' in fragment
     assert 'args = ["exec", "-i", "stdio-one", "server"]' in fragment
-    assert '[mcp_servers."stdio-one".env]' in fragment
-    assert 'TOKEN = "${TOKEN:-}"' in fragment
+    assert 'env_vars = ["OPTIONAL_TOKEN", "TOKEN"]' in fragment
+    assert fragment.count('"TOKEN"') == 1
+    assert "${TOKEN:-}" not in fragment
     assert '[mcp_servers."http-one"]' in fragment
     assert 'url = "http://localhost:1234/mcp"' in fragment
+    assert "HTTP_TOKEN" not in tomllib.loads(fragment)["mcp_servers"]["http-one"]
     assert "sse-one" not in fragment
 
 

--- a/tests/unit/test_mcp_fleet_catalog.py
+++ b/tests/unit/test_mcp_fleet_catalog.py
@@ -93,3 +93,101 @@ def test_extract_mcp_tool_surfaces_includes_wildcard_references():
     assert fleet_catalog.extract_mcp_tool_surfaces(
         "`mcp__conport__*` and `mcp__task-orchestrator__get_context`"
     ) == ["conport", "task-orchestrator"]
+
+
+def test_generate_fleet_output_files_are_deterministic_and_catalog_backed():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+
+    outputs = fleet_catalog.generate_fleet_output_files(catalog)
+
+    assert list(outputs) == [
+        "local/.mcp.json",
+        "claude/mcpServers.json",
+        "codex/config.toml",
+        "health/mcp-health-probes.json",
+        "docs/mcp-fleet.md",
+    ]
+    assert json.loads(outputs["local/.mcp.json"]) == fleet_catalog.render_per_worktree_mcp_json(
+        catalog["defaults"]["per_worktree"],
+        catalog,
+    )
+    assert json.loads(outputs["claude/mcpServers.json"]) == {
+        "mcpServers": fleet_catalog.render_singleton_mcp_servers(catalog)
+    }
+    assert outputs == fleet_catalog.generate_fleet_output_files(catalog)
+
+
+def test_codex_fragment_renders_stdio_and_streamable_http_servers():
+    catalog = {
+        "version": 1,
+        "defaults": {"per_worktree": []},
+        "servers": {
+            "stdio-one": {
+                "scope": "singleton",
+                "transport": "stdio",
+                "command": "docker",
+                "args": ["exec", "-i", "stdio-one", "server"],
+                "requires_env": ["TOKEN"],
+            },
+            "http-one": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": "http://localhost:1234/mcp",
+            },
+            "sse-one": {
+                "scope": "singleton",
+                "transport": "sse",
+                "url": "http://localhost:5678/sse",
+            },
+        },
+    }
+
+    fragment = fleet_catalog.render_codex_config_fragment(catalog)
+
+    assert '[mcp_servers."stdio-one"]' in fragment
+    assert 'command = "docker"' in fragment
+    assert 'args = ["exec", "-i", "stdio-one", "server"]' in fragment
+    assert '[mcp_servers."stdio-one".env]' in fragment
+    assert 'TOKEN = "${TOKEN:-}"' in fragment
+    assert '[mcp_servers."http-one"]' in fragment
+    assert 'url = "http://localhost:1234/mcp"' in fragment
+    assert "sse-one" not in fragment
+
+
+def test_health_probe_list_uses_catalog_urls_and_compose_services():
+    catalog = {
+        "version": 1,
+        "defaults": {"per_worktree": []},
+        "servers": {
+            "http-one": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": "http://localhost:1234/mcp",
+                "docker_compose_service": "http-one",
+            },
+            "local-one": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "url_template": "http://localhost:${LOCAL_ONE_PORT:-4321}/sse",
+                "port_var": "LOCAL_ONE_PORT",
+                "default_port_base": 4321,
+            },
+        },
+    }
+
+    assert fleet_catalog.render_health_probe_list(catalog) == [
+        {
+            "docker_compose_service": "http-one",
+            "name": "http-one",
+            "scope": "singleton",
+            "transport": "http",
+            "url": "http://localhost:1234/mcp",
+        },
+        {
+            "docker_compose_service": None,
+            "name": "local-one",
+            "scope": "per-worktree",
+            "transport": "sse",
+            "url": "http://localhost:${LOCAL_ONE_PORT:-4321}/sse",
+        },
+    ]


### PR DESCRIPTION
## Summary
- add deterministic MCP fleet output renderers backed by `mcp_catalog.yaml`
- add `dopemux mcp generate` with dry-run as the default and `--apply --output-dir` required for writes
- document generated output surfaces and record Lane 2 proof notes

## Authority / Scope
- Implements `TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS`
- Depends on merged Lane 1 catalog contract and drift gates
- Static generation only: no Docker mutation, live MCP probes, provider calls, or user-global writes

## Validation
PASS:
- `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `python -m pytest tests/unit/test_mcp_commands_catalog.py tests/unit/test_mcp_fleet_catalog.py -q`
- `python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q`
- `python -m py_compile src/dopemux/mcp/fleet_catalog.py src/dopemux/commands/mcp_commands.py`
- `PYTHONPATH=src python -m dopemux.cli mcp --help`
- `PYTHONPATH=src python -m dopemux.cli mcp generate --output-dir /tmp/dmx-mcp-generated-smoke`
- `PYTHONPATH=src python -m dopemux.cli mcp generate --apply --output-dir /tmp/dmx-mcp-generated-smoke-lane2`
- `find /tmp/dmx-mcp-generated-smoke-lane2 -type f | sort`
- `python -c 'import pathlib, tomllib; tomllib.loads(pathlib.Path("/tmp/dmx-mcp-generated-smoke-lane2/codex/config.toml").read_text())'`
- `git diff --check`
- `pre-commit run --files src/dopemux/commands/mcp_commands.py src/dopemux/mcp/fleet_catalog.py tests/unit/test_mcp_commands_catalog.py tests/unit/test_mcp_fleet_catalog.py docs/03-reference/mcp/fleet-generated-outputs.md task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS.json proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS/implementation-notes.md`

NOT_RUN:
- Docker health and live MCP initialize/tools-list probes; this packet is static generation only.
- Provider-backed checks; no provider calls are required for this lane.
