### PR TITLE
feat(mcp): add fleet ensure command

### DIFF
--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE/implementation-notes.md
@@ -1,0 +1,60 @@
+# TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE Implementation Notes
+
+## Scope
+
+Implemented Lane 3 `dopemux mcp ensure --fast/--full` over the canonical MCP
+fleet catalog.
+
+## Changes
+
+- Added `dopemux mcp ensure`.
+- `--fast` performs local/static checks only:
+  - filesystem/env-only workspace and project-root detection
+  - catalog default `.mcp.json` parity
+  - generated env file presence
+  - required per-worktree env derivability
+- `--full` runs fast checks first, then fails closed unless Docker and
+  `compose.yml` are available.
+- Full mode starts catalog compose services, runs the PAL ensure wrapper, runs
+  the Task Orchestrator HTTP singleton wrapper, and performs bounded loopback
+  HTTP MCP tools-list probes.
+- Added `scripts/mcp-wrappers/ensure-pal.sh`.
+- Added unit tests proving fast mode does not invoke subprocesses or live MCP
+  probes, full mode fails closed without Docker, and full mode builds the
+  bounded remediation sequence.
+
+## Validation
+
+PASS:
+
+- `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `python -m pytest tests/unit/test_mcp_commands_catalog.py tests/unit/test_mcp_fleet_catalog.py -q`
+- `bash -n scripts/mcp-wrappers/ensure-pal.sh`
+- `python -m py_compile src/dopemux/commands/mcp_commands.py src/dopemux/mcp/fleet_catalog.py`
+- `PYTHONPATH=src python -m dopemux.cli mcp ensure --help`
+- `git diff --check`
+- `python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q`
+
+FAIL:
+
+- Initial TDD red run failed because `mcp_ensure_cmd` and support imports did
+  not exist.
+- First green attempt exposed brittle test expectations around Rich path
+  wrapping and relative wrapper paths; tests and missing-file messages were
+  tightened and rerun successfully.
+- PR review identified that fast mode still used canonical git identity
+  resolution, which could spawn `git rev-parse`; fast mode was split onto a
+  filesystem/env-only context path and rerun successfully.
+
+NOT_RUN:
+
+- `dopemux mcp ensure --full` against live Docker services. This implementation
+  validates command construction and fail-closed behavior; live runtime proof
+  requires Docker/service availability and should be recorded separately.
+- Provider-backed MCP probes. Full mode only probes loopback HTTP MCP URLs from
+  the catalog.
+
+## Runtime Boundaries
+
+No Docker containers were started during implementation validation. No provider
+calls were made. No secrets were printed.

--- a/scripts/mcp-wrappers/ensure-pal.sh
+++ b/scripts/mcp-wrappers/ensure-pal.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd -P)"
+COMPOSE_FILE="${ROOT_DIR}/compose.yml"
+
+die() {
+  printf 'ensure-pal: %s\n' "$*" >&2
+  exit 1
+}
+
+command -v docker >/dev/null 2>&1 || die "docker is required but not found in PATH"
+[[ -f "${COMPOSE_FILE}" ]] || die "missing compose file at ${COMPOSE_FILE}"
+
+docker compose -f "${COMPOSE_FILE}" up -d pal pal-stdio
+printf 'ensure-pal: PAL compose services requested\n' >&2

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -9,10 +9,13 @@ scaffolding driven by repo-local or bundled ``mcp_catalog.yaml`` data
 The ``servers`` group is an alias for ``mcp`` for backward compatibility.
 """
 
+import asyncio
 import hashlib
 import importlib.resources
 import json
 import os
+import re
+import shutil
 import socket
 import sys
 import subprocess
@@ -20,6 +23,7 @@ from datetime import datetime
 from pathlib import Path
 from subprocess import CalledProcessError
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 import click
 import yaml
@@ -574,7 +578,7 @@ def _build_local_mcp_json(server_names: List[str], catalog: Dict[str, Any]) -> D
 
 
 # ---------------------------------------------------------------------------
-# `mcp generate` / `init` / `add` / `remove` / `list` / `doctor` / `sync-globals`
+# `mcp generate` / `ensure` / `init` / `add` / `remove` / `list` / `doctor` / `sync-globals`
 # ---------------------------------------------------------------------------
 
 
@@ -613,6 +617,215 @@ def mcp_generate_cmd(apply: bool, output_dir: Optional[Path]):
         target.parent.mkdir(parents=True, exist_ok=True)
         target.write_text(content, encoding="utf-8")
         console.logger.info(f"[success]Wrote {target}[/success]")
+
+
+def _ensure_context() -> tuple[Path, Any]:
+    repo = get_repo_root(fallback_cwd=False)
+    if not repo:
+        raise click.ClickException("Not inside a git repository.")
+    repo_path = Path(repo)
+    identity_env = dict(os.environ)
+    identity_env["DOPEMUX_WORKSPACE_ROOT"] = repo
+    try:
+        identity = resolve_project_identity(cwd=repo_path, env=identity_env)
+    except ProjectIdentityError as exc:
+        raise click.ClickException(f"Could not resolve project identity: {exc}") from exc
+    return repo_path, identity
+
+
+def _ensure_fast_context() -> tuple[Path, Path]:
+    env_repo = os.environ.get("DOPEMUX_WORKSPACE_ROOT") or os.environ.get("DOPEMUX_PROJECT_ROOT")
+    if env_repo:
+        repo_path = Path(env_repo).expanduser().resolve()
+        if not repo_path.is_dir():
+            raise click.ClickException(f"MCP workspace root does not point to a directory: {repo_path}")
+    else:
+        start = Path.cwd().resolve()
+        repo_path = next(
+            (
+                candidate
+                for candidate in (start, *start.parents)
+                if (candidate / PROJECT_MCP_FILENAME).exists() or (candidate / ".git").exists()
+            ),
+            None,
+        )
+        if repo_path is None:
+            raise click.ClickException(
+                "Could not determine MCP workspace root without subprocess; "
+                "set DOPEMUX_WORKSPACE_ROOT or run from the repository root."
+            )
+
+    project_override = os.environ.get("TASK_ORCHESTRATOR_PROJECT_ROOT") or os.environ.get("DOPEMUX_PROJECT_ROOT")
+    if project_override:
+        project_root = Path(project_override).expanduser().resolve()
+        if not project_root.is_dir():
+            raise click.ClickException(f"MCP project root does not point to a directory: {project_root}")
+    else:
+        project_root = repo_path
+    return repo_path, project_root
+
+
+def _ensure_fast_problems(catalog: Dict[str, Any], repo_path: Path, project_root: Path) -> List[str]:
+    problems: List[str] = []
+    mcp_json_path = repo_path / PROJECT_MCP_FILENAME
+    envrc_path = repo_path / ENVRC_FILENAME
+
+    if not mcp_json_path.exists():
+        problems.append(
+            f"Missing {PROJECT_MCP_FILENAME} at {mcp_json_path} — run `dopemux mcp init`."
+        )
+    else:
+        defaults = catalog.get("defaults", {}).get("per_worktree", []) or []
+        try:
+            expected = _build_local_mcp_json(list(defaults), catalog)
+            actual = _read_json(mcp_json_path)
+        except (json.JSONDecodeError, click.ClickException) as exc:
+            problems.append(f"{mcp_json_path} is not a valid catalog-backed MCP config: {exc}")
+        else:
+            if actual != expected:
+                problems.append(f"{mcp_json_path} does not match catalog defaults.")
+
+    if not envrc_path.exists():
+        problems.append(f"Missing {ENVRC_FILENAME} at {envrc_path} — run `dopemux mcp init`.")
+
+    local_env = {
+        **os.environ,
+        **_project_env_exports(str(repo_path), str(project_root)),
+    }
+    for name in catalog.get("defaults", {}).get("per_worktree", []) or []:
+        spec = catalog.get("servers", {}).get(name) or {}
+        for env_key in spec.get("requires_env", []) or []:
+            if not local_env.get(env_key):
+                problems.append(f"`{name}`: required env `{env_key}` is unavailable.")
+    return problems
+
+
+def _catalog_compose_services(catalog: Dict[str, Any]) -> List[str]:
+    services = {
+        str(spec["docker_compose_service"])
+        for spec in catalog.get("servers", {}).values()
+        if spec.get("docker_compose_service")
+    }
+    return sorted(services)
+
+
+def _run_checked(cmd: List[str], *, cwd: Path, label: str) -> None:
+    console.logger.info(f"[info]{label}: {' '.join(cmd)}[/info]")
+    try:
+        subprocess.run(cmd, cwd=cwd, check=True)
+    except FileNotFoundError as exc:
+        raise click.ClickException(f"{label}: command not found: {cmd[0]}") from exc
+    except CalledProcessError as exc:
+        raise click.ClickException(f"{label} failed with exit code {exc.returncode}.") from exc
+
+
+_ENV_TEMPLATE_RE = re.compile(r"\$\{([A-Z][A-Z0-9_]*)(?::-([^}]*))?\}")
+
+
+def _resolve_env_template(value: str, env: Dict[str, str]) -> str:
+    def repl(match: re.Match[str]) -> str:
+        name = match.group(1)
+        default = match.group(2) or ""
+        return env.get(name) or default
+
+    return _ENV_TEMPLATE_RE.sub(repl, value)
+
+
+def _probeable_http_servers(catalog: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    env = dict(os.environ)
+    servers: Dict[str, Dict[str, Any]] = {}
+    for name, spec in sorted(catalog.get("servers", {}).items()):
+        if spec.get("transport") != "http":
+            continue
+        raw_url = spec.get("url") or spec.get("url_template")
+        if not raw_url:
+            continue
+        url = _resolve_env_template(str(raw_url), env)
+        parsed = urlparse(url)
+        if parsed.hostname not in {"localhost", "127.0.0.1"}:
+            continue
+        servers[name] = {"url": url}
+    return servers
+
+
+def _run_mcp_tools_list_probes(catalog: Dict[str, Any]) -> List[str]:
+    servers = _probeable_http_servers(catalog)
+    if not servers:
+        return []
+    try:
+        from dopemux.mcp.discovery import ToolDiscoveryClient
+    except ModuleNotFoundError as exc:
+        return [f"MCP probe client unavailable: missing dependency `{exc.name}`."]
+
+    report = asyncio.run(ToolDiscoveryClient(timeout=2.0).discover(servers))
+    return [
+        f"`{server['name']}`: MCP tools-list probe failed ({server.get('status', 'unknown')})."
+        for server in report.get("servers", [])
+        if not server.get("reachable")
+    ]
+
+
+def _report_ensure_problems(problems: List[str]) -> None:
+    console.logger.info(f"[warning]{len(problems)} ensure issue(s) found:[/warning]")
+    for problem in problems:
+        console.logger.info(f"  • {problem}")
+    sys.exit(1)
+
+
+@mcp.command("ensure")
+@click.option("--fast", is_flag=True, help="Run local/static prerequisite checks only.")
+@click.option("--full", "full_mode", is_flag=True, help="Run local checks plus bounded service remediation/probes.")
+def mcp_ensure_cmd(fast: bool, full_mode: bool):
+    """
+    🛠️ Stabilize Fleet: Check or remediate catalog-backed MCP prerequisites
+
+    `--fast` performs local/static checks only. `--full` starts catalog compose
+    services, ensures PAL and the Task Orchestrator singleton, then runs bounded
+    local HTTP MCP tools-list probes.
+    """
+    if fast and full_mode:
+        raise click.ClickException("Choose exactly one of --fast or --full.")
+    if not fast and not full_mode:
+        fast = True
+
+    catalog = _load_catalog()
+    if fast:
+        repo_path, project_root = _ensure_fast_context()
+    else:
+        repo_path, identity = _ensure_context()
+        project_root = identity.project_root
+    problems = _ensure_fast_problems(catalog, repo_path, project_root)
+    if problems:
+        _report_ensure_problems(problems)
+
+    if fast:
+        console.logger.info("[success]Fast MCP ensure checks green.[/success]")
+        return
+
+    if shutil.which("docker") is None:
+        raise click.ClickException("docker is required for `dopemux mcp ensure --full`.")
+    if not (repo_path / "compose.yml").exists():
+        raise click.ClickException(f"Missing {repo_path / 'compose.yml'} for compose remediation.")
+
+    compose_services = _catalog_compose_services(catalog)
+    if compose_services:
+        _run_checked(
+            ["docker", "compose", "-f", "compose.yml", "up", "-d", *compose_services],
+            cwd=repo_path,
+            label="compose",
+        )
+
+    _run_checked(["bash", "scripts/mcp-wrappers/ensure-pal.sh"], cwd=repo_path, label="pal")
+    _run_checked(
+        ["bash", "scripts/mcp-wrappers/task-orchestrator-http-singleton.sh"],
+        cwd=repo_path,
+        label="task-orchestrator",
+    )
+
+    probe_problems = _run_mcp_tools_list_probes(catalog)
+    if probe_problems:
+        _report_ensure_problems(probe_problems)
+    console.logger.info("[success]Full MCP ensure checks green.[/success]")
 
 
 @mcp.command("init")

--- a/tests/unit/test_mcp_commands_catalog.py
+++ b/tests/unit/test_mcp_commands_catalog.py
@@ -370,6 +370,141 @@ def test_mcp_generate_apply_writes_only_under_output_dir(tmp_path, monkeypatch):
     }
 
 
+def test_mcp_ensure_fast_uses_local_checks_without_subprocess(tmp_path, monkeypatch):
+    catalog = _catalog()
+    (tmp_path / mcp_commands.PROJECT_MCP_FILENAME).write_text(
+        json.dumps(mcp_commands._build_local_mcp_json(["conport"], catalog), indent=2) + "\n"
+    )
+    (tmp_path / mcp_commands.ENVRC_FILENAME).write_text("export CONPORT_MCP_PORT=3005\n")
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DOPEMUX_WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("DOPEMUX_PROJECT_ROOT", raising=False)
+    monkeypatch.delenv("TASK_ORCHESTRATOR_PROJECT_ROOT", raising=False)
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: catalog)
+    monkeypatch.setattr(
+        mcp_commands,
+        "resolve_project_identity",
+        lambda **_: pytest.fail("fast ensure must not resolve git project identity"),
+    )
+    monkeypatch.setattr(
+        mcp_commands.subprocess,
+        "run",
+        lambda *args, **kwargs: pytest.fail("fast ensure must not run subprocesses"),
+    )
+    monkeypatch.setattr(
+        mcp_commands,
+        "_run_mcp_tools_list_probes",
+        lambda *_args, **_kwargs: pytest.fail("fast ensure must not run live MCP probes"),
+        raising=False,
+    )
+
+    result = CliRunner().invoke(mcp_commands.mcp_ensure_cmd, ["--fast"])
+
+    assert result.exit_code == 0, result.output
+    assert "Fast MCP ensure checks green" in result.output
+
+
+def test_mcp_ensure_fast_reports_missing_local_config(tmp_path, monkeypatch):
+    catalog = _catalog()
+    (tmp_path / ".git").mkdir()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DOPEMUX_WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("DOPEMUX_PROJECT_ROOT", raising=False)
+    monkeypatch.delenv("TASK_ORCHESTRATOR_PROJECT_ROOT", raising=False)
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: catalog)
+    monkeypatch.setattr(
+        mcp_commands,
+        "resolve_project_identity",
+        lambda **_: pytest.fail("fast ensure must not resolve git project identity"),
+    )
+
+    result = CliRunner().invoke(mcp_commands.mcp_ensure_cmd, ["--fast"])
+
+    assert result.exit_code == 1
+    assert "Missing" in result.output
+    assert mcp_commands.PROJECT_MCP_FILENAME in result.output
+    assert mcp_commands.ENVRC_FILENAME in result.output
+
+
+def test_mcp_ensure_full_fails_closed_when_docker_missing(tmp_path, monkeypatch):
+    catalog = _catalog()
+    (tmp_path / mcp_commands.PROJECT_MCP_FILENAME).write_text(
+        json.dumps(mcp_commands._build_local_mcp_json(["conport"], catalog), indent=2) + "\n"
+    )
+    (tmp_path / mcp_commands.ENVRC_FILENAME).write_text("export CONPORT_MCP_PORT=3005\n")
+
+    monkeypatch.setattr(mcp_commands, "get_repo_root", lambda fallback_cwd=False: str(tmp_path))
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: catalog)
+    monkeypatch.setattr(mcp_commands, "resolve_project_identity", lambda **_: _identity(tmp_path))
+    monkeypatch.setattr(mcp_commands.shutil, "which", lambda name: None)
+
+    result = CliRunner().invoke(mcp_commands.mcp_ensure_cmd, ["--full"])
+
+    assert result.exit_code == 1
+    assert "docker is required" in result.output
+
+
+def test_mcp_ensure_full_runs_bounded_remediation_sequence(tmp_path, monkeypatch):
+    catalog = {
+        "version": 1,
+        "defaults": {"per_worktree": ["task-orchestrator"]},
+        "servers": {
+            "pal": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": "http://localhost:3003/mcp",
+                "docker_compose_service": "pal",
+            },
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "state_scope": "per-repo",
+                "transport": "http",
+                "url_template": "http://127.0.0.1:${TASK_ORCHESTRATOR_HTTP_PORT:-7890}/mcp",
+                "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
+                "default_port_base": 7890,
+                "docker_compose_service": "task-orchestrator",
+                "requires_env": ["TASK_ORCHESTRATOR_PROJECT_ROOT"],
+            },
+        },
+    }
+    (tmp_path / "compose.yml").write_text("services: {}\n")
+    (tmp_path / mcp_commands.PROJECT_MCP_FILENAME).write_text(
+        json.dumps(mcp_commands._build_local_mcp_json(["task-orchestrator"], catalog), indent=2) + "\n"
+    )
+    (tmp_path / mcp_commands.ENVRC_FILENAME).write_text("export TASK_ORCHESTRATOR_HTTP_PORT=7890\n")
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs.get("cwd")))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(mcp_commands, "get_repo_root", lambda fallback_cwd=False: str(tmp_path))
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: catalog)
+    monkeypatch.setattr(mcp_commands, "resolve_project_identity", lambda **_: _identity(tmp_path))
+    monkeypatch.setattr(mcp_commands.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(mcp_commands.subprocess, "run", fake_run)
+    monkeypatch.setattr(mcp_commands, "_run_mcp_tools_list_probes", lambda catalog: [])
+
+    result = CliRunner().invoke(mcp_commands.mcp_ensure_cmd, ["--full"])
+
+    assert result.exit_code == 0, result.output
+    assert calls[0][0] == [
+        "docker",
+        "compose",
+        "-f",
+        "compose.yml",
+        "up",
+        "-d",
+        "pal",
+        "task-orchestrator",
+    ]
+    assert calls[1][0][-1].endswith("ensure-pal.sh")
+    assert calls[2][0][-1].endswith("task-orchestrator-http-singleton.sh")
+    assert "Full MCP ensure checks green" in result.output
+
+
 def test_doctor_aggregates_problems_and_exits_nonzero(tmp_path, monkeypatch):
     """`doctor` reports every issue it finds and exits 1 if any are present."""
     catalog = {


### PR DESCRIPTION
## Summary
- add `dopemux mcp ensure --fast/--full`
- keep fast mode local/static only with no subprocess or live MCP probes
- make full mode fail closed before Docker remediation, then run compose, PAL ensure, Task Orchestrator singleton ensure, and bounded loopback HTTP MCP probes
- add `scripts/mcp-wrappers/ensure-pal.sh`

## Authority / Scope
- Implements `TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE`
- Depends on merged Lane 1 catalog gates and merged Lane 2 generated output surfaces
- No secrets are printed; provider-backed probes are not performed

## Validation
PASS:
- `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-003-MCP-ENSURE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `python -m pytest tests/unit/test_mcp_commands_catalog.py tests/unit/test_mcp_fleet_catalog.py -q`
- `bash -n scripts/mcp-wrappers/ensure-pal.sh`
- `python -m py_compile src/dopemux/commands/mcp_commands.py src/dopemux/mcp/fleet_catalog.py`
- `PYTHONPATH=src python -m dopemux.cli mcp ensure --help`
- `git diff --check`
- `python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q`
- scoped `pre-commit run --files ...`

NOT_RUN:
- `dopemux mcp ensure --full` against live Docker services. Unit coverage verifies command construction and fail-closed prerequisite behavior; live runtime proof requires Docker/service availability and should be recorded separately.
- Provider-backed MCP probes. Full mode only probes loopback HTTP MCP URLs from the catalog.
