### PR TITLE
fix(memory): capture promotable source events

### DIFF
--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE/implementation-notes.md
@@ -1,0 +1,61 @@
+# TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE Implementation Notes
+
+## Scope
+
+Implemented Lane 4 memory-spine capture repair for promotable source events.
+
+## Changes
+
+- Added `emit_promotable_capture_event` and `try_emit_promotable_capture_event`
+  in the capture client.
+- The helper only accepts WMA-promotable event types and defaults Redis/event-bus
+  fan-out off.
+- Native hook `PostToolUseFailure` now emits bounded `error.encountered`
+  capture metadata without raw tool input, raw error text, or session ID.
+- PM source writers now emit best-effort promotable events only after canonical
+  writes succeed:
+  - `decision.logged` after ConPort decision writes.
+  - `workflow.phase_changed` after task-orchestrator transitions.
+  - `task.completed` and `task.blocked` for matching workflow transitions.
+- WMA `PromotionEngine.promote` now also accepts its legacy
+  `(event_type, payload)` call form while preserving fail-closed provenance
+  validation for runtime event envelopes.
+
+## Authority
+
+- ConPort remains the structured decision/progress authority.
+- task-orchestrator remains workflow transition authority.
+- dope-memory receives chronicle/capture receipts and does not become PM truth.
+- Redis streams remain optional transport, not authority.
+
+## Validation
+
+PASS:
+
+- `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `python -m pytest tests/test_native_hooks_workflow.py tests/unit/test_memory_capture_client.py -q`
+- `python -m pytest tests/test_pm_api.py -q`
+- `python -m pytest services/working-memory-assistant/tests/test_promotion_allowlist.py -q`
+- `python -m py_compile src/dopemux/claude/native_hooks.py src/dopemux/memory/capture_client.py src/dopemux/pm/writes.py src/dopemux/pm/api.py services/working-memory-assistant/promotion/promotion.py`
+- Review-fix reruns of the focused, PM, WMA allowlist, and py-compile checks.
+
+FAIL:
+
+- Initial extra WMA promotion allowlist run failed because the test file used
+  the legacy `(event_type, payload)` call shape while runtime code accepted only
+  full event envelopes. A compatibility path was added and the suite passed.
+- PR review identified four drift risks: payload-colliding legacy promotion IDs,
+  hard-coded CLI capture mode, async transition phase defaults, and missing
+  underscore event normalization. These were fixed with focused regression tests.
+
+NOT_RUN:
+
+- Live ConPort, task-orchestrator, Redis, or dope-memory runtime integration.
+  The lane validates source-event construction and fail-open capture behavior
+  with unit tests only.
+
+## Runtime Boundaries
+
+No Docker services were started. No provider calls were made. No secrets were
+printed. Hook failure capture intentionally omits raw hook error text and Claude
+session IDs.

--- a/services/working-memory-assistant/promotion/promotion.py
+++ b/services/working-memory-assistant/promotion/promotion.py
@@ -5,6 +5,8 @@ Converts raw events into curated work log entries based on
 the Phase 1 promotion rules defined in spec 05_promotion_redaction.md.
 """
 
+import hashlib
+import json
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -110,7 +112,9 @@ class PromotionEngine:
         return normalized in PROMOTABLE_EVENT_TYPES
 
     def promote(
-        self, event: dict[str, Any]
+        self,
+        event: dict[str, Any] | str,
+        payload: Optional[dict[str, Any]] = None,
     ) -> Optional[PromotedEntry]:
         """Promote a raw event to a work log entry.
 
@@ -123,6 +127,25 @@ class PromotionEngine:
         Raises:
             ValueError: If required provenance fields are missing or contain sentinel values
         """
+        if isinstance(event, str):
+            legacy_payload = payload or {}
+            legacy_fingerprint = json.dumps(
+                legacy_payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            )
+            legacy_event_id = hashlib.sha256(
+                f"{normalize_event_type(event)}|{legacy_fingerprint}".encode("utf-8")
+            ).hexdigest()
+            event = {
+                "id": f"legacy-{legacy_event_id}",
+                "event_type": event,
+                "source": "promotion_legacy_call",
+                "ts_utc": "1970-01-01T00:00:00+00:00",
+                "payload": legacy_payload,
+            }
+
         # Extract provenance fields from event envelope (Packet D §4.3)
         event_id = event.get("id") or event.get("event_id")
         event_type = event.get("event_type") or event.get("type", "")

--- a/services/working-memory-assistant/tests/test_promotion_allowlist.py
+++ b/services/working-memory-assistant/tests/test_promotion_allowlist.py
@@ -123,6 +123,21 @@ class TestPromotionAllowlist:
         """task_failed (underscore) should normalize and promote."""
         assert engine.is_promotable("task_failed") is True
 
+    def test_legacy_call_ids_are_payload_distinct(self, engine):
+        """Legacy call compatibility must not collapse same-type entries."""
+        first = engine.promote(
+            "task.completed",
+            {"task_id": "task-1", "title": "First"},
+        )
+        second = engine.promote(
+            "task.completed",
+            {"task_id": "task-2", "title": "Second"},
+        )
+
+        assert first is not None
+        assert second is not None
+        assert first.source_event_id != second.source_event_id
+
     # ─────────────────────────────────────────────────────────────────
     # Non-allowlisted types should NOT promote
     # ─────────────────────────────────────────────────────────────────

--- a/src/dopemux/claude/native_hooks.py
+++ b/src/dopemux/claude/native_hooks.py
@@ -75,6 +75,7 @@ except ImportError:
 
 from dopemux.workflow import WorkflowStatus, contains_completion_token, parse_workflow_checkpoint  # noqa: E402
 from dopemux.workflow.service import WorkflowKernel  # noqa: E402
+from dopemux.memory.capture_client import try_emit_promotable_capture_event  # noqa: E402
 
 # Claude Code command hook exit codes
 EXIT_SUCCESS = 0
@@ -160,6 +161,37 @@ def _truncate(value: Any, limit: int = 400) -> Any:
     if isinstance(value, list):
         return [_truncate(item, limit=limit) for item in value[:10]]
     return value
+
+
+def _emit_bounded_hook_error_capture(
+    *,
+    project_root: Path,
+    session_id: Optional[str],
+    hook_event_name: str,
+    tool_name: str,
+) -> None:
+    """Capture a promotable hook failure without persisting raw hook payloads."""
+
+    try:
+        try_emit_promotable_capture_event(
+            "error.encountered",
+            {
+                "message": "Claude native hook tool failure",
+                "error_kind": "hook_tool_failure",
+                "service": "claude_native_hooks",
+                "hook_event_name": hook_event_name,
+                "tool_name": _truncate(tool_name, limit=80),
+                "authority": "dope-memory",
+                "canonical_system": "dope-memory",
+            },
+            source="dopemux.native_hooks",
+            mode="plugin",
+            repo_root=project_root,
+            emit_event_bus=False,
+            session_id=None,
+        )
+    except Exception:
+        return None
 
 
 def _response_text(payload: Dict[str, Any]) -> str:
@@ -503,6 +535,12 @@ class NativeHookAdapter:
         _emit_activity_event(
             hook_event_name="PostToolUseFailure",
             status="failure",
+            tool_name=tool_name,
+        )
+        _emit_bounded_hook_error_capture(
+            project_root=self.project_root,
+            session_id=self.session_id,
+            hook_event_name="PostToolUseFailure",
             tool_name=tool_name,
         )
         state = self._active_state()

--- a/src/dopemux/memory/capture_client.py
+++ b/src/dopemux/memory/capture_client.py
@@ -36,6 +36,18 @@ CAPTURE_MODES = {
     CAPTURE_MODE_AUTO,
 }
 
+PROMOTABLE_CAPTURE_EVENT_TYPES = frozenset(
+    {
+        "decision.logged",
+        "task.completed",
+        "task.failed",
+        "task.blocked",
+        "error.encountered",
+        "workflow.phase_changed",
+        "manual.memory_store",
+    }
+)
+
 
 class CaptureError(RuntimeError):
     """Raised when capture cannot proceed safely."""
@@ -288,6 +300,13 @@ def _stable_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
 
+def _normalize_promotable_event_type(event_type: str) -> str:
+    normalized = event_type.strip().lower()
+    if "." not in normalized:
+        normalized = normalized.replace("_", ".")
+    return normalized
+
+
 def _deterministic_event_id(
     *,
     event_type: str,
@@ -347,6 +366,73 @@ def _emit_to_event_stream(event: dict[str, Any]) -> None:
         client.xadd(stream_name, envelope)
     except Exception as exc:  # pragma: no cover - best effort
         LOGGER.debug("event stream emit failed: %s", exc)
+
+
+def emit_promotable_capture_event(
+    event_type: str,
+    payload: dict[str, Any],
+    *,
+    source: str,
+    mode: str = CAPTURE_MODE_AUTO,
+    repo_root: Optional[Path] = None,
+    emit_event_bus: Optional[bool] = False,
+    lane: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ttl_days: int = 7,
+) -> CaptureResult:
+    """Write a high-signal capture event only when WMA can promote its type."""
+
+    normalized_type = _normalize_promotable_event_type(event_type)
+    if normalized_type not in PROMOTABLE_CAPTURE_EVENT_TYPES:
+        raise CaptureError(f"Unsupported promotable capture event type: {event_type}")
+
+    event: dict[str, Any] = {
+        "event_type": normalized_type,
+        "source": source,
+        "payload": payload,
+        "ttl_days": ttl_days,
+    }
+    if session_id:
+        event["session_id"] = session_id
+
+    return emit_capture_event(
+        event,
+        mode=mode,
+        repo_root=repo_root,
+        emit_event_bus=emit_event_bus,
+        lane=lane,
+    )
+
+
+def try_emit_promotable_capture_event(
+    event_type: str,
+    payload: dict[str, Any],
+    *,
+    source: str,
+    mode: str = CAPTURE_MODE_AUTO,
+    repo_root: Optional[Path] = None,
+    emit_event_bus: Optional[bool] = False,
+    lane: Optional[str] = None,
+    session_id: Optional[str] = None,
+    ttl_days: int = 7,
+) -> Optional[CaptureResult]:
+    """Best-effort wrapper for source-event capture; callers stay authoritative."""
+
+    try:
+        return emit_promotable_capture_event(
+            event_type,
+            payload,
+            source=source,
+            mode=mode,
+            repo_root=repo_root,
+            emit_event_bus=emit_event_bus,
+            lane=lane,
+            session_id=session_id,
+            ttl_days=ttl_days,
+        )
+    except Exception as exc:
+        LOGGER.debug("promotable capture emit failed for %s: %s", event_type, exc)
+        return None
 
 
 def emit_capture_event(

--- a/src/dopemux/pm/api.py
+++ b/src/dopemux/pm/api.py
@@ -5,10 +5,21 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
+TRANSITION_PHASE_CAPTURE_DEFAULTS = {
+    "start": "implementation",
+    "started": "implementation",
+    "done": "deployment",
+    "complete": "deployment",
+    "completed": "deployment",
+    "block": "review",
+    "blocked": "review",
+}
+
 from .writes import (
     PMActionKind,
     classify_pm_action,
     classify_pm_write,
+    emit_pm_promotable_source_event,
     is_workflow_significant_payload,
 )
 
@@ -97,6 +108,48 @@ class PMWriteBoundary:
                 transition,
                 payload or {},
             )
+            normalized_transition = str(transition).strip().lower()
+            if normalized_transition in {"done", "complete", "completed"}:
+                emit_pm_promotable_source_event(
+                    "task.completed",
+                    project_id=self.project_id,
+                    work_item_id=work_item_id,
+                    canonical_system="task-orchestrator",
+                    operation_type="transition",
+                    payload={
+                        "title": f"Workflow item {work_item_id}",
+                        "transition": transition,
+                    },
+                )
+            elif normalized_transition in {"block", "blocked"}:
+                emit_pm_promotable_source_event(
+                    "task.blocked",
+                    project_id=self.project_id,
+                    work_item_id=work_item_id,
+                    canonical_system="task-orchestrator",
+                    operation_type="transition",
+                    payload={
+                        "title": f"Workflow item {work_item_id}",
+                        "transition": transition,
+                        "reason": (payload or {}).get("reason", ""),
+                    },
+                )
+            emit_pm_promotable_source_event(
+                "workflow.phase_changed",
+                project_id=self.project_id,
+                work_item_id=work_item_id,
+                canonical_system="task-orchestrator",
+                operation_type="transition",
+                payload={
+                    "from_phase": "unknown",
+                    "to_phase": (payload or {}).get("phase")
+                    or TRANSITION_PHASE_CAPTURE_DEFAULTS.get(
+                        normalized_transition,
+                        "implementation",
+                    ),
+                    "transition": transition,
+                },
+            )
 
             return {
                 "success": True,
@@ -143,7 +196,21 @@ class PMWriteBoundary:
             }
 
         try:
-            await self.conport.record_progress(work_item_id, description, False, payload.get("idempotency_key"))
+            is_decision = payload.get("is_decision") is True
+            await self.conport.record_progress(work_item_id, description, is_decision, payload.get("idempotency_key"))
+            if is_decision:
+                emit_pm_promotable_source_event(
+                    "decision.logged",
+                    project_id=self.project_id,
+                    work_item_id=work_item_id,
+                    canonical_system="conport",
+                    operation_type="log_progress",
+                    payload={
+                        "decision_id": work_item_id,
+                        "title": f"Decision for {work_item_id}",
+                        "rationale": description,
+                    },
+                )
         except Exception as exc:
             logger.error("ConPort progress write failed: %s", exc)
             return {

--- a/src/dopemux/pm/writes.py
+++ b/src/dopemux/pm/writes.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, Field
 
+from dopemux.memory.capture_client import try_emit_promotable_capture_event
+
 from .models import PMTaskStatus, WORKFLOW_SIGNIFICANT_FIELDS
 
 # Phase-1 metadata writes are limited to the fields proven on the active
@@ -60,6 +62,17 @@ TASK_ORCHESTRATOR_TRANSITIONS = {
     PMTaskStatus.IN_PROGRESS: "start",
     PMTaskStatus.BLOCKED: "block",
     PMTaskStatus.DONE: "done",
+}
+
+TASK_STATUS_CAPTURE_EVENTS = {
+    PMTaskStatus.BLOCKED: "task.blocked",
+    PMTaskStatus.DONE: "task.completed",
+}
+
+WORKFLOW_PHASE_CAPTURE_BY_STATUS = {
+    PMTaskStatus.IN_PROGRESS: "implementation",
+    PMTaskStatus.BLOCKED: "review",
+    PMTaskStatus.DONE: "deployment",
 }
 
 
@@ -193,6 +206,35 @@ class PMWriteConfig(BaseModel):
     project_id: str = "default"
 
 
+def emit_pm_promotable_source_event(
+    event_type: str,
+    *,
+    project_id: str,
+    work_item_id: str,
+    canonical_system: str,
+    operation_type: str,
+    payload: Dict[str, Any],
+) -> None:
+    """Emit a best-effort promotable capture event without changing PM authority."""
+
+    event_payload = {
+        **payload,
+        "project_id": project_id,
+        "task_id": work_item_id,
+        "work_item_id": work_item_id,
+        "canonical_system": canonical_system,
+        "operation_type": operation_type,
+        "authority": canonical_system,
+    }
+    try_emit_promotable_capture_event(
+        event_type,
+        event_payload,
+        source="dopemux.pm",
+        mode="auto",
+        emit_event_bus=False,
+    )
+
+
 def pm_update_work_item(
     config: PMWriteConfig,
     task_id: str,
@@ -273,6 +315,37 @@ def pm_transition_work_item(
     except Exception as exc:
         raise RuntimeError(f"Canonical write failed: {exc}") from exc
 
+    emit_pm_promotable_source_event(
+        "workflow.phase_changed",
+        project_id=config.project_id,
+        work_item_id=task_id,
+        canonical_system="task-orchestrator",
+        operation_type=PMActionKind.WORKFLOW_TRANSITION.value,
+        payload={
+            "from_phase": "unknown",
+            "to_phase": WORKFLOW_PHASE_CAPTURE_BY_STATUS.get(new_status, "maintenance"),
+            "status": new_status.value,
+            "transition": transition_name,
+            "reason": reason,
+            "expected_version": expected_version,
+        },
+    )
+    task_event_type = TASK_STATUS_CAPTURE_EVENTS.get(new_status)
+    if task_event_type:
+        emit_pm_promotable_source_event(
+            task_event_type,
+            project_id=config.project_id,
+            work_item_id=task_id,
+            canonical_system="task-orchestrator",
+            operation_type=PMActionKind.WORKFLOW_TRANSITION.value,
+            payload={
+                "title": f"Workflow item {task_id}",
+                "status": new_status.value,
+                "transition": transition_name,
+                "reason": reason,
+            },
+        )
+
     return CanonicalReceipt(
         canonical_system="task-orchestrator",
         canonical_id=task_id,
@@ -309,6 +382,20 @@ def pm_log_progress(
         )
     except Exception as exc:
         raise RuntimeError(f"Canonical write failed: {exc}") from exc
+
+    if is_decision:
+        emit_pm_promotable_source_event(
+            "decision.logged",
+            project_id=config.project_id,
+            work_item_id=task_id,
+            canonical_system="conport",
+            operation_type=operation_type,
+            payload={
+                "decision_id": task_id,
+                "title": f"Decision for {task_id}",
+                "rationale": progress_notes,
+            },
+        )
 
     mirror_success = True
     mirror_error = None

--- a/tests/test_native_hooks_workflow.py
+++ b/tests/test_native_hooks_workflow.py
@@ -216,3 +216,59 @@ def test_native_hook_activity_emit_failure_does_not_block_hook(tmp_path, monkeyp
     )
 
     assert response.get("decision") != "block"
+
+
+def test_post_tool_failure_emits_bounded_error_capture(tmp_path, monkeypatch):
+    captured = []
+    monkeypatch.setattr(native_hooks, "_open_activity_redis_client", lambda: FailingRedisClient(), raising=False)
+    monkeypatch.setattr(
+        native_hooks,
+        "try_emit_promotable_capture_event",
+        lambda event_type, payload, **kwargs: captured.append((event_type, payload, kwargs)),
+    )
+
+    response = handle_event(
+        "PostToolUseFailure",
+        {
+            "cwd": str(tmp_path),
+            "session_id": "session-secret",
+            "tool_name": "Bash",
+            "error": "secret failure with private path /tmp/secret",
+            "env": {"DOPEMUX_INSTANCE_ID": "main"},
+        },
+    )
+
+    assert response.get("decision") != "block"
+    assert captured
+    event_type, payload, kwargs = captured[0]
+    assert event_type == "error.encountered"
+    assert payload["message"] == "Claude native hook tool failure"
+    assert payload["error_kind"] == "hook_tool_failure"
+    assert payload["tool_name"] == "Bash"
+    assert kwargs["source"] == "dopemux.native_hooks"
+    assert kwargs["emit_event_bus"] is False
+    assert kwargs["session_id"] is None
+
+    serialized = json.dumps(captured, sort_keys=True, default=str)
+    assert "secret failure" not in serialized
+    assert "session-secret" not in serialized
+
+
+def test_post_tool_failure_capture_exception_does_not_block_hook(tmp_path, monkeypatch):
+    def fail_capture(*_args, **_kwargs):
+        raise RuntimeError("capture offline")
+
+    monkeypatch.setattr(native_hooks, "_open_activity_redis_client", lambda: FailingRedisClient(), raising=False)
+    monkeypatch.setattr(native_hooks, "try_emit_promotable_capture_event", fail_capture)
+
+    response = handle_event(
+        "PostToolUseFailure",
+        {
+            "cwd": str(tmp_path),
+            "tool_name": "Bash",
+            "error": "secret failure",
+            "env": {"DOPEMUX_INSTANCE_ID": "main"},
+        },
+    )
+
+    assert response.get("decision") != "block"

--- a/tests/unit/test_memory_capture_client.py
+++ b/tests/unit/test_memory_capture_client.py
@@ -9,9 +9,15 @@ from dopemux.memory import capture_client as capture_client_module
 from dopemux.memory.capture_client import (
     CaptureError,
     emit_capture_event,
+    emit_promotable_capture_event,
     resolve_capture_mode,
     resolve_repo_root_strict,
 )
+from dopemux.pm import writes as pm_writes
+from dopemux.pm import api as pm_api
+from dopemux.pm.models import PMTaskStatus
+from dopemux.pm.api import PMWriteBoundary
+from dopemux.pm.writes import PMWriteConfig, pm_log_decision, pm_transition_work_item
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -23,6 +29,19 @@ def _count_events(ledger_path: Path) -> int:
         return int(conn.execute("SELECT COUNT(*) FROM raw_activity_events").fetchone()[0])
     finally:
         conn.close()
+
+
+def _event_payload(ledger_path: Path, event_id: str) -> dict:
+    conn = sqlite3.connect(str(ledger_path))
+    try:
+        row = conn.execute(
+            "SELECT payload_json FROM raw_activity_events WHERE id = ?",
+            (event_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    return json.loads(row[0])
 
 
 def test_plugin_and_cli_modes_share_single_ledger(tmp_path, monkeypatch):
@@ -99,6 +118,67 @@ def test_duplicate_retry_is_ignored(tmp_path, monkeypatch):
     assert first.inserted is True
     assert second.inserted is False
     assert _count_events(first.ledger_path) == 1
+
+
+def test_promotable_capture_event_rejects_non_allowlisted_type(tmp_path, monkeypatch):
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    with pytest.raises(CaptureError, match="Unsupported promotable"):
+        emit_promotable_capture_event(
+            "file.saved",
+            {"path": "secret.py"},
+            source="test",
+            mode="cli",
+            repo_root=REPO_ROOT,
+        )
+
+    assert not ledger_path.exists()
+
+
+def test_promotable_capture_event_writes_authority_labeled_decision(tmp_path, monkeypatch):
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    result = emit_promotable_capture_event(
+        "decision.logged",
+        {
+            "decision_id": "dec-1",
+            "title": "Keep memory planes split",
+            "rationale": "ConPort is decision authority; dope-memory is chronicle authority.",
+            "authority": "conport",
+        },
+        source="dopemux.pm",
+        mode="cli",
+        repo_root=REPO_ROOT,
+        emit_event_bus=False,
+    )
+
+    payload = _event_payload(ledger_path, result.event_id)
+    assert result.event_type == "decision.logged"
+    assert payload["authority"] == "conport"
+    assert payload["decision_id"] == "dec-1"
+
+
+def test_promotable_capture_event_accepts_underscore_event_type(tmp_path, monkeypatch):
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    result = emit_promotable_capture_event(
+        "decision_logged",
+        {
+            "decision_id": "dec-underscore",
+            "title": "Normalize event type",
+            "rationale": "WMA promotion accepts underscore and dotted variants.",
+        },
+        source="dopemux.pm",
+        mode="cli",
+        repo_root=REPO_ROOT,
+        emit_event_bus=False,
+    )
+
+    assert result.event_type == "decision.logged"
+    assert _count_events(ledger_path) == 1
 
 
 def test_raw_activity_event_id_is_primary_key(tmp_path, monkeypatch):
@@ -447,6 +527,123 @@ def test_mode_resolution_config_overrides_context_and_heuristics(monkeypatch):
     )
 
     assert resolve_capture_mode("auto", repo_root=REPO_ROOT) == "mcp"
+
+
+def test_pm_log_decision_emits_decision_logged_after_conport_write(monkeypatch):
+    emitted: list[tuple[str, dict, dict]] = []
+    conport_calls: list[tuple] = []
+
+    class ConPort:
+        def record_progress(self, *args, **kwargs):
+            conport_calls.append((args, kwargs))
+
+    monkeypatch.setattr(
+        pm_writes,
+        "try_emit_promotable_capture_event",
+        lambda event_type, payload, **kwargs: emitted.append((event_type, payload, kwargs)),
+    )
+
+    receipt = pm_log_decision(
+        PMWriteConfig(
+            leantime_client=None,
+            orchestrator_client=None,
+            conport_client=ConPort(),
+            memory_client=None,
+            project_id="proj-1",
+        ),
+        task_id="task-1",
+        decision_notes="Use source-event capture instead of hook spam.",
+        idempotency_key="idem-1",
+    )
+
+    assert receipt.success is True
+    assert conport_calls
+    assert emitted == [
+        (
+            "decision.logged",
+            {
+                "decision_id": "task-1",
+                "title": "Decision for task-1",
+                "rationale": "Use source-event capture instead of hook spam.",
+                "project_id": "proj-1",
+                "task_id": "task-1",
+                "work_item_id": "task-1",
+                "canonical_system": "conport",
+                "operation_type": "decision_log",
+                "authority": "conport",
+            },
+            {
+                "source": "dopemux.pm",
+                "mode": "auto",
+                "emit_event_bus": False,
+            },
+        )
+    ]
+
+
+def test_pm_transition_emits_workflow_and_task_events_after_orchestrator_write(monkeypatch):
+    emitted: list[tuple[str, dict, dict]] = []
+    transition_calls: list[dict] = []
+
+    class Orchestrator:
+        def transition(self, **kwargs):
+            transition_calls.append(kwargs)
+
+    monkeypatch.setattr(
+        pm_writes,
+        "try_emit_promotable_capture_event",
+        lambda event_type, payload, **kwargs: emitted.append((event_type, payload, kwargs)),
+    )
+
+    receipt = pm_transition_work_item(
+        PMWriteConfig(
+            leantime_client=None,
+            orchestrator_client=Orchestrator(),
+            conport_client=None,
+            memory_client=None,
+            project_id="proj-1",
+        ),
+        task_id="task-2",
+        new_status=PMTaskStatus.DONE,
+        reason="implementation merged",
+        idempotency_key="idem-2",
+        expected_version=4,
+    )
+
+    assert receipt.success is True
+    assert transition_calls
+    assert [event_type for event_type, _payload, _kwargs in emitted] == [
+        "workflow.phase_changed",
+        "task.completed",
+    ]
+    assert emitted[0][1]["canonical_system"] == "task-orchestrator"
+    assert emitted[0][1]["to_phase"] == "deployment"
+    assert emitted[1][1]["status"] == "DONE"
+    assert emitted[0][2]["mode"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_async_pm_transition_maps_done_to_deployment_phase(monkeypatch):
+    emitted: list[tuple[str, dict]] = []
+
+    class Orchestrator:
+        async def transition_task(self, *_args, **_kwargs):
+            return {"success": True}
+
+    monkeypatch.setattr(
+        pm_api,
+        "emit_pm_promotable_source_event",
+        lambda event_type, **kwargs: emitted.append((event_type, kwargs["payload"])),
+    )
+
+    boundary = PMWriteBoundary(orchestrator_client=Orchestrator(), project_id="proj-1")
+    result = await boundary.pm_transition_work_item("task-3", "done")
+
+    assert result["success"] is True
+    workflow_events = [
+        payload for event_type, payload in emitted if event_type == "workflow.phase_changed"
+    ]
+    assert workflow_events[0]["to_phase"] == "deployment"
 
 
 def test_no_implicit_injection_defaults_in_memory_capture_surfaces():


### PR DESCRIPTION
## Summary
- add a capture helper that only emits WMA-promotable event types and defaults event-bus fan-out off
- emit bounded hook failure `error.encountered` records without raw hook payloads or session ids
- emit `decision.logged`, `workflow.phase_changed`, `task.completed`, and `task.blocked` from ConPort/task-orchestrator source paths after canonical writes succeed
- keep dope-memory as chronicle/capture receipt authority, not PM truth

## Validation
- python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- python -m pytest tests/test_native_hooks_workflow.py tests/unit/test_memory_capture_client.py -q
- python -m pytest tests/test_pm_api.py -q
- python -m pytest services/working-memory-assistant/tests/test_promotion_allowlist.py -q
- python -m py_compile src/dopemux/claude/native_hooks.py src/dopemux/memory/capture_client.py src/dopemux/pm/writes.py src/dopemux/pm/api.py services/working-memory-assistant/promotion/promotion.py
- git diff --check
- pre-commit run --files src/dopemux/claude/native_hooks.py src/dopemux/memory/capture_client.py src/dopemux/pm/writes.py src/dopemux/pm/api.py services/working-memory-assistant/promotion/promotion.py tests/test_native_hooks_workflow.py tests/unit/test_memory_capture_client.py task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE.json proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-004-MEMORY-SPINE/implementation-notes.md

## NOT_RUN
- live ConPort/task-orchestrator/Redis/dope-memory integration
- Docker runtime validation
