### PR TITLE
feat(mcp): declare fleet server personalities

### DIFF
--- a/docs/03-reference/mcp/fleet-generated-outputs.md
+++ b/docs/03-reference/mcp/fleet-generated-outputs.md
@@ -22,7 +22,8 @@ Generated paths:
 - `codex/config.toml` contains singleton stdio and streamable HTTP MCP servers
   in Codex TOML syntax.
 - `health/mcp-health-probes.json` lists catalog health URLs and compose service
-  bindings for static probe planning.
+  bindings plus role, lifecycle, identity, management, and follow-on decision
+  metadata for static probe planning.
 - `docs/mcp-fleet.md` renders the catalog doctrine summary.
 
 Dry-run is the default and writes nothing:
@@ -39,3 +40,22 @@ dopemux mcp generate --apply --output-dir proof/mcp-generated-preview
 
 The command does not write user-global files. Operators must review generated
 fragments before copying or applying them to global config surfaces.
+
+## Server Personality Metadata
+
+The canonical catalog records each MCP server's plane, authority role,
+lifecycle, management model, identity scope, and follow-on decision. These
+fields are contract data, not runtime proof.
+
+Static gates currently pin the high-risk fleet roles:
+
+- ConPort remains structured context authority in the memory plane.
+- task-orchestrator remains workflow authority with repo-scoped singleton state.
+- dope-memory remains chronicle authority with per-worktree capture identity.
+- dope-context remains read-only retrieval projection with per-call workspace
+  identity.
+- PAL remains reasoning infrastructure with explicit operator-managed stdio
+  handling.
+- Exa remains decision-gated for a future wire-or-retire scan.
+- desktop-commander remains decision-gated for a future delete-or-host-run
+  decision.

--- a/mcp_catalog.yaml
+++ b/mcp_catalog.yaml
@@ -42,6 +42,12 @@ servers:
   pal:
     scope: singleton
     transport: http
+    plane: reasoning
+    authority_role: reasoning-infrastructure
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: singleton
+    follow_on_decision: none
     url: "http://localhost:3003/mcp"
     docker_compose_service: pal
     description: "Multi-model reasoning suite (thinkdeep, planner, consensus, debug, codereview)"
@@ -49,6 +55,12 @@ servers:
   serena:
     scope: singleton
     transport: http
+    plane: code-intelligence
+    authority_role: code-intelligence
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: per-call-workspace
+    follow_on_decision: none
     url: "http://localhost:3006/mcp"
     docker_compose_service: serena
     description: "Semantic code intelligence (LSP + Tree-sitter); workspace auto-detected from cwd"
@@ -56,6 +68,12 @@ servers:
   dope-context:
     scope: singleton
     transport: http
+    plane: retrieval
+    authority_role: retrieval-projection
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: per-call-workspace
+    follow_on_decision: none
     url: "http://localhost:3010/mcp"
     docker_compose_service: dope-context
     description: "AST-aware semantic code & docs search; per-call workspace_path"
@@ -63,6 +81,12 @@ servers:
   desktop-commander:
     scope: singleton
     transport: sse
+    plane: automation
+    authority_role: desktop-automation
+    lifecycle: decision-required
+    management_model: compose-service
+    identity_scope: host-session
+    follow_on_decision: delete-or-host-run
     url: "http://localhost:3012/sse"
     docker_compose_service: desktop-commander
     description: "Desktop automation (PR #575: pinned fastmcp==2.14.7, Starlette /health)"
@@ -70,6 +94,12 @@ servers:
   gpt-researcher:
     scope: singleton
     transport: stdio
+    plane: research
+    authority_role: deep-research
+    lifecycle: active
+    management_model: docker-exec
+    identity_scope: external-provider
+    follow_on_decision: none
     command: docker
     args: ["exec", "-i", "dopemux-mcp-gptr-mcp", "python", "/app/server.py"]
     docker_compose_service: gptr-mcp
@@ -80,6 +110,12 @@ servers:
   exa:
     scope: singleton
     transport: stdio
+    plane: research
+    authority_role: web-search
+    lifecycle: decision-required
+    management_model: docker-exec
+    identity_scope: external-provider
+    follow_on_decision: wire-or-retire
     command: docker
     args: ["exec", "-i", "-e", "MCP_RUN_MODE=stdio", "mcp-exa", "python", "/app/exa_server.py"]
     docker_compose_service: exa
@@ -89,6 +125,12 @@ servers:
   pal-stdio:
     scope: singleton
     transport: stdio
+    plane: reasoning
+    authority_role: reasoning-infrastructure
+    lifecycle: operator-managed
+    management_model: docker-exec
+    identity_scope: singleton
+    follow_on_decision: none
     command: docker
     args: ["exec", "-i", "mcp-pal-stdio", "/app/.venv/bin/python", "server.py"]
     docker_compose_service: pal-stdio
@@ -98,6 +140,12 @@ servers:
   MCP_DOCKER:
     scope: singleton
     transport: stdio
+    plane: gateway
+    authority_role: docker-gateway
+    lifecycle: operator-managed
+    management_model: docker-mcp-gateway
+    identity_scope: host-session
+    follow_on_decision: none
     command: docker
     args: ["mcp", "gateway", "run"]
     description: "Docker MCP gateway — surfaces containerized MCPs from Docker MCP Toolkit"
@@ -107,6 +155,12 @@ servers:
   conport:
     scope: per-worktree
     transport: sse
+    plane: memory
+    authority_role: structured-context-authority
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: per-worktree
+    follow_on_decision: none
     # Port var names match compose.yml conventions so `init` writes env that
     # `docker compose up` reads directly.
     url_template: "http://localhost:${CONPORT_MCP_PORT:-3005}/sse"
@@ -127,6 +181,12 @@ servers:
   dope-memory:
     scope: per-worktree
     transport: http
+    plane: memory
+    authority_role: chronicle-authority
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: per-worktree
+    follow_on_decision: none
     url_template: "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp"
     port_var: DOPE_MEMORY_PORT
     default_port_base: 3020
@@ -138,6 +198,12 @@ servers:
     scope: per-worktree
     state_scope: per-repo
     transport: http
+    plane: workflow
+    authority_role: workflow-authority
+    lifecycle: active
+    management_model: wrapper-singleton
+    identity_scope: per-repo
+    follow_on_decision: none
     url_template: "http://127.0.0.1:${TASK_ORCHESTRATOR_HTTP_PORT:-7890}/mcp"
     port_var: TASK_ORCHESTRATOR_HTTP_PORT
     default_port_base: 7890

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES/implementation-notes.md
@@ -1,0 +1,59 @@
+# TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES
+
+## Scope
+
+Lane 5 converges MCP server personalities through static catalog contract data.
+It does not delete services, change runtime startup, run Docker, or claim live
+MCP health.
+
+## Changes
+
+- Added schema-backed metadata for MCP plane, authority role, lifecycle,
+  management model, identity scope, and follow-on decision.
+- Declared metadata in both `mcp_catalog.yaml` and the packaged
+  `src/dopemux/mcp/default_catalog.yaml`.
+- Added a static personality drift gate for high-risk surfaces:
+  ConPort, task-orchestrator, dope-memory, dope-context, PAL, PAL stdio, Exa,
+  and desktop-commander.
+- Rendered personality metadata into health probe JSON and the generated
+  doctrine table.
+- Documented that Exa and desktop-commander remain decision-gated until future
+  wire-or-retire and delete-or-host-run scans prove a safe action.
+
+## Review Fixes
+
+- Removed lane-specific wording from the reusable personality validator error
+  message.
+- Changed the generic `decision-required` regression test to use a temporary
+  non-pinned server so it specifically covers the generic rule.
+
+## Authority
+
+- `AGENTS.md`, `PROJECT.md`, `ARCHITECTURE.md`, and `PM_PLANE.md`.
+- Runtime/config surfaces: `mcp_catalog.yaml`, `compose.yml`,
+  `src/dopemux/mcp/default_catalog.yaml`, `src/dopemux/mcp/fleet_catalog.py`,
+  and existing fleet catalog tests.
+
+## Validation
+
+PASS:
+
+- `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `python -m pytest tests/unit/test_mcp_fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py -q`
+- `python - <<'PY' ... jsonschema.validate(yaml.safe_load(...), schema) ... PY` for `mcp_catalog.yaml` and `src/dopemux/mcp/default_catalog.yaml`
+- `python -m py_compile src/dopemux/mcp/fleet_catalog.py`
+- `git diff --check`
+- `pre-commit run --files mcp_catalog.yaml src/dopemux/mcp/default_catalog.yaml schemas/mcp/fleet-catalog.schema.json src/dopemux/mcp/fleet_catalog.py tests/unit/test_mcp_fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py docs/03-reference/mcp/fleet-generated-outputs.md task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES/implementation-notes.md`
+
+FAIL:
+
+- `python -m jsonschema -i mcp_catalog.yaml schemas/mcp/fleet-catalog.schema.json` failed because the `jsonschema` CLI parses JSON input, not YAML input. This was replaced by the YAML-aware validation command above.
+
+## Not Run
+
+- Docker compose startup.
+- Live MCP initialize or tools-list probes.
+- Provider-backed Exa, PAL, or GPT Researcher calls.
+
+Those checks require runtime services and credentials and belong to a bounded
+runtime validation lane.

--- a/schemas/mcp/fleet-catalog.schema.json
+++ b/schemas/mcp/fleet-catalog.schema.json
@@ -51,6 +51,59 @@
         "transport": {
           "enum": ["http", "sse", "stdio"]
         },
+        "plane": {
+          "enum": [
+            "automation",
+            "code-intelligence",
+            "gateway",
+            "memory",
+            "pm",
+            "reasoning",
+            "research",
+            "retrieval",
+            "workflow"
+          ]
+        },
+        "authority_role": {
+          "enum": [
+            "chronicle-authority",
+            "code-intelligence",
+            "deep-research",
+            "desktop-automation",
+            "docker-gateway",
+            "pm-adapter",
+            "reasoning-infrastructure",
+            "retrieval-projection",
+            "structured-context-authority",
+            "web-search",
+            "workflow-authority"
+          ]
+        },
+        "lifecycle": {
+          "enum": ["active", "decision-required", "operator-managed"]
+        },
+        "management_model": {
+          "enum": [
+            "compose-service",
+            "docker-exec",
+            "docker-mcp-gateway",
+            "operator-managed",
+            "wrapper-singleton"
+          ]
+        },
+        "identity_scope": {
+          "enum": [
+            "external-provider",
+            "host-session",
+            "per-call-workspace",
+            "per-repo",
+            "per-worktree",
+            "singleton"
+          ]
+        },
+        "follow_on_decision": {
+          "enum": ["delete-or-host-run", "none", "wire-or-retire"]
+        },
         "url": {
           "type": "string",
           "minLength": 1

--- a/src/dopemux/mcp/default_catalog.yaml
+++ b/src/dopemux/mcp/default_catalog.yaml
@@ -42,6 +42,12 @@ servers:
   pal:
     scope: singleton
     transport: http
+    plane: reasoning
+    authority_role: reasoning-infrastructure
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: singleton
+    follow_on_decision: none
     url: "http://localhost:3003/mcp"
     docker_compose_service: pal
     description: "Multi-model reasoning suite (thinkdeep, planner, consensus, debug, codereview)"
@@ -49,6 +55,12 @@ servers:
   serena:
     scope: singleton
     transport: http
+    plane: code-intelligence
+    authority_role: code-intelligence
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: per-call-workspace
+    follow_on_decision: none
     url: "http://localhost:3006/mcp"
     docker_compose_service: serena
     description: "Semantic code intelligence (LSP + Tree-sitter); workspace auto-detected from cwd"
@@ -56,6 +68,12 @@ servers:
   dope-context:
     scope: singleton
     transport: http
+    plane: retrieval
+    authority_role: retrieval-projection
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: per-call-workspace
+    follow_on_decision: none
     url: "http://localhost:3010/mcp"
     docker_compose_service: dope-context
     description: "AST-aware semantic code & docs search; per-call workspace_path"
@@ -63,6 +81,12 @@ servers:
   desktop-commander:
     scope: singleton
     transport: sse
+    plane: automation
+    authority_role: desktop-automation
+    lifecycle: decision-required
+    management_model: compose-service
+    identity_scope: host-session
+    follow_on_decision: delete-or-host-run
     url: "http://localhost:3012/sse"
     docker_compose_service: desktop-commander
     description: "Desktop automation (PR #575: pinned fastmcp==2.14.7, Starlette /health)"
@@ -70,6 +94,12 @@ servers:
   gpt-researcher:
     scope: singleton
     transport: stdio
+    plane: research
+    authority_role: deep-research
+    lifecycle: active
+    management_model: docker-exec
+    identity_scope: external-provider
+    follow_on_decision: none
     command: docker
     args: ["exec", "-i", "dopemux-mcp-gptr-mcp", "python", "/app/server.py"]
     docker_compose_service: gptr-mcp
@@ -80,6 +110,12 @@ servers:
   exa:
     scope: singleton
     transport: stdio
+    plane: research
+    authority_role: web-search
+    lifecycle: decision-required
+    management_model: docker-exec
+    identity_scope: external-provider
+    follow_on_decision: wire-or-retire
     command: docker
     args: ["exec", "-i", "-e", "MCP_RUN_MODE=stdio", "mcp-exa", "python", "/app/exa_server.py"]
     docker_compose_service: exa
@@ -89,6 +125,12 @@ servers:
   pal-stdio:
     scope: singleton
     transport: stdio
+    plane: reasoning
+    authority_role: reasoning-infrastructure
+    lifecycle: operator-managed
+    management_model: docker-exec
+    identity_scope: singleton
+    follow_on_decision: none
     command: docker
     args: ["exec", "-i", "mcp-pal-stdio", "/app/.venv/bin/python", "server.py"]
     docker_compose_service: pal-stdio
@@ -98,6 +140,12 @@ servers:
   MCP_DOCKER:
     scope: singleton
     transport: stdio
+    plane: gateway
+    authority_role: docker-gateway
+    lifecycle: operator-managed
+    management_model: docker-mcp-gateway
+    identity_scope: host-session
+    follow_on_decision: none
     command: docker
     args: ["mcp", "gateway", "run"]
     description: "Docker MCP gateway — surfaces containerized MCPs from Docker MCP Toolkit"
@@ -107,6 +155,12 @@ servers:
   conport:
     scope: per-worktree
     transport: sse
+    plane: memory
+    authority_role: structured-context-authority
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: per-worktree
+    follow_on_decision: none
     # Port var names match compose.yml conventions so `init` writes env that
     # `docker compose up` reads directly.
     url_template: "http://localhost:${CONPORT_MCP_PORT:-3005}/sse"
@@ -127,6 +181,12 @@ servers:
   dope-memory:
     scope: per-worktree
     transport: http
+    plane: memory
+    authority_role: chronicle-authority
+    lifecycle: active
+    management_model: compose-service
+    identity_scope: per-worktree
+    follow_on_decision: none
     url_template: "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp"
     port_var: DOPE_MEMORY_PORT
     default_port_base: 3020
@@ -138,6 +198,12 @@ servers:
     scope: per-worktree
     state_scope: per-repo
     transport: http
+    plane: workflow
+    authority_role: workflow-authority
+    lifecycle: active
+    management_model: wrapper-singleton
+    identity_scope: per-repo
+    follow_on_decision: none
     url_template: "http://127.0.0.1:${TASK_ORCHESTRATOR_HTTP_PORT:-7890}/mcp"
     port_var: TASK_ORCHESTRATOR_HTTP_PORT
     default_port_base: 7890

--- a/src/dopemux/mcp/fleet_catalog.py
+++ b/src/dopemux/mcp/fleet_catalog.py
@@ -30,6 +30,74 @@ _ENV_RE = re.compile(r"\$\{[^}]+\}")
 _MCP_TOOL_SURFACE_RE = re.compile(r"\bmcp__([A-Za-z0-9_-]+)__(?:[A-Za-z0-9_-]+|\*)")
 
 
+REQUIRED_SERVER_PERSONALITIES: dict[str, dict[str, str]] = {
+    "conport": {
+        "plane": "memory",
+        "authority_role": "structured-context-authority",
+        "lifecycle": "active",
+        "management_model": "compose-service",
+        "identity_scope": "per-worktree",
+        "follow_on_decision": "none",
+    },
+    "dope-memory": {
+        "plane": "memory",
+        "authority_role": "chronicle-authority",
+        "lifecycle": "active",
+        "management_model": "compose-service",
+        "identity_scope": "per-worktree",
+        "follow_on_decision": "none",
+    },
+    "dope-context": {
+        "plane": "retrieval",
+        "authority_role": "retrieval-projection",
+        "lifecycle": "active",
+        "management_model": "compose-service",
+        "identity_scope": "per-call-workspace",
+        "follow_on_decision": "none",
+    },
+    "task-orchestrator": {
+        "plane": "workflow",
+        "authority_role": "workflow-authority",
+        "lifecycle": "active",
+        "management_model": "wrapper-singleton",
+        "identity_scope": "per-repo",
+        "follow_on_decision": "none",
+    },
+    "pal": {
+        "plane": "reasoning",
+        "authority_role": "reasoning-infrastructure",
+        "lifecycle": "active",
+        "management_model": "compose-service",
+        "identity_scope": "singleton",
+        "follow_on_decision": "none",
+    },
+    "pal-stdio": {
+        "plane": "reasoning",
+        "authority_role": "reasoning-infrastructure",
+        "lifecycle": "operator-managed",
+        "management_model": "docker-exec",
+        "identity_scope": "singleton",
+        "follow_on_decision": "none",
+    },
+    "exa": {
+        "plane": "research",
+        "authority_role": "web-search",
+        "lifecycle": "decision-required",
+        "management_model": "docker-exec",
+        "identity_scope": "external-provider",
+        "follow_on_decision": "wire-or-retire",
+    },
+    "desktop-commander": {
+        "plane": "automation",
+        "authority_role": "desktop-automation",
+        "lifecycle": "decision-required",
+        "management_model": "compose-service",
+        "identity_scope": "host-session",
+        "follow_on_decision": "delete-or-host-run",
+    },
+}
+
+
 def load_yaml_no_duplicate_keys(path: Path) -> Any:
     """Load YAML while rejecting duplicate mapping keys at any depth."""
 
@@ -149,8 +217,14 @@ def render_health_probe_list(catalog: dict[str, Any]) -> list[dict[str, Any]]:
             continue
         probes.append(
             {
+                "authority_role": spec.get("authority_role"),
                 "docker_compose_service": spec.get("docker_compose_service"),
+                "follow_on_decision": spec.get("follow_on_decision"),
+                "identity_scope": spec.get("identity_scope"),
+                "lifecycle": spec.get("lifecycle"),
+                "management_model": spec.get("management_model"),
                 "name": name,
+                "plane": spec.get("plane"),
                 "scope": spec.get("scope"),
                 "transport": spec.get("transport", "http"),
                 "url": url,
@@ -187,8 +261,8 @@ def render_mcp_doctrine_doc(catalog: dict[str, Any]) -> str:
             "",
             "## Servers",
             "",
-            "| Server | Scope | Transport | Health URL | Compose Service |",
-            "| --- | --- | --- | --- | --- |",
+            "| Server | Plane | Authority Role | Lifecycle | Identity | Follow-on | Scope | Transport | Health URL | Compose Service |",
+            "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
         ]
     )
     for name, spec in sorted(catalog.get("servers", {}).items()):
@@ -199,6 +273,11 @@ def render_mcp_doctrine_doc(catalog: dict[str, Any]) -> str:
             + " | ".join(
                 [
                     f"`{name}`",
+                    str(spec.get("plane", "")),
+                    str(spec.get("authority_role", "")),
+                    str(spec.get("lifecycle", "")),
+                    str(spec.get("identity_scope", "")),
+                    str(spec.get("follow_on_decision", "")),
                     str(spec.get("scope", "")),
                     str(spec.get("transport", "")),
                     f"`{health_url}`" if health_url else "",
@@ -246,6 +325,38 @@ def find_unknown_command_tool_surfaces(
                 if surface not in known:
                     unknown.append(f"{path}:{index}:{surface}")
     return unknown
+
+
+def validate_catalog_personality_contract(catalog: dict[str, Any]) -> list[str]:
+    """Validate high-risk MCP server role and lifecycle metadata.
+
+    This is a static gate. It does not prove the runtime is healthy; it prevents
+    authority and lifecycle semantics from drifting out of the catalog.
+    """
+
+    errors: list[str] = []
+    servers = catalog.get("servers") or {}
+    for name, expected in REQUIRED_SERVER_PERSONALITIES.items():
+        spec = servers.get(name)
+        if not spec:
+            errors.append(f"{name}: required server missing from catalog")
+            continue
+        for field, expected_value in expected.items():
+            actual = spec.get(field)
+            if actual != expected_value:
+                errors.append(
+                    f"{name}: {field} must be `{expected_value}` for MCP personality contract "
+                    f"(found `{actual}`)"
+                )
+
+    for name, spec in sorted(servers.items()):
+        follow_on_decision = spec.get("follow_on_decision")
+        if spec.get("lifecycle") == "decision-required" and follow_on_decision in {None, "none"}:
+            errors.append(f"{name}: decision-required lifecycle must name a follow_on_decision")
+        if follow_on_decision not in {None, "none"} and spec.get("lifecycle") != "decision-required":
+            errors.append(f"{name}: follow_on_decision requires lifecycle `decision-required`")
+
+    return errors
 
 
 def load_compose(repo_root: Path) -> dict[str, Any]:

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json
@@ -1,16 +1,15 @@
 {
   "id": "TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES",
   "project": "dopemux-mvp",
-  "target": "Converge MCP server personalities after catalog gates exist: ConPort in-repo surface, Kotlin Task Orchestrator as workflow MCP, dope-memory/dope-context identity handling, PAL standalone management, exa wire-or-retire, and desktop commander decision.",
+  "target": "Converge MCP server personality and lifecycle contracts through the canonical fleet catalog without deleting or rewriting runtime surfaces.",
   "invariants": [
-    "Depends on catalog gates from packet 001 and generated outputs from packet 002.",
-    "No destructive deletion in this packet without reverse dependency proof.",
-    "Do not treat dopecon-bridge as canonical authority.",
-    "Do not widen write surfaces or activate unsanctioned Serena write tools."
+    "Depends on packet 001 catalog gates and must not bypass catalog validation.",
+    "ConPort, task-orchestrator, dope-memory, and dope-context roles must preserve repo authority boundaries.",
+    "PAL must remain explicitly operator-managed as standalone reasoning infrastructure.",
+    "Exa and desktop-commander must remain decision-gated until wire-or-retire and host-run/delete decisions are proven by follow-on scans."
   ],
   "depends_on": [
-    "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
-    "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS"
+    "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT"
   ],
   "repo_binding": {
     "project_id": "DDD-Enterprises/dopemux-mvp",
@@ -21,38 +20,37 @@
   "series": {
     "id": "DMX-MCP-FLEET-ROADMAP",
     "base_branch": "main",
-    "parent_tp_id": "TP-DMX-MCP-FLEET-ROADMAP-002-GENERATED-OUTPUTS",
+    "parent_tp_id": "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
     "final_packet": false
   },
   "execution": {
     "agent": "codex",
     "branch": "codex/mcp-fleet-server-personalities",
     "base_branch": "main",
-    "stacked_because": "Server convergence must ride on catalog drift gates to avoid resurrecting shadow surfaces."
+    "stacked_because": "Server personality convergence needs catalog gates from packet 001 and follows memory capture repair."
   },
   "commit": {
-    "message": "fix(mcp): converge fleet server personalities",
+    "message": "feat(mcp): declare fleet server personalities",
     "allowlist": [
       "mcp_catalog.yaml",
-      "services/registry.yaml",
-      "src/dopemux/mcp/**",
-      "docker/mcp-servers-source/conport/**",
-      "services/dope-context/**",
-      "services/working-memory-assistant/**",
-      "scripts/mcp-wrappers/**",
-      "tests/**/test_mcp*.py",
+      "src/dopemux/mcp/default_catalog.yaml",
+      "schemas/mcp/fleet-catalog.schema.json",
+      "src/dopemux/mcp/fleet_catalog.py",
+      "tests/unit/test_mcp_fleet_catalog.py",
+      "tests/arch/test_mcp_fleet_catalog_contract.py",
+      "docs/03-reference/mcp/fleet-generated-outputs.md",
       "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json",
       "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES/**"
     ],
     "verify": [
       "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
-      "python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_fleet_catalog.py -q",
+      "python -m pytest tests/unit/test_mcp_fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py -q",
       "git diff --check"
     ]
   },
   "pr": {
-    "title": "fix(mcp): converge fleet server personalities",
-    "body": "Converge MCP server personalities behind the canonical catalog without destructive deletion.",
+    "title": "feat(mcp): declare fleet server personalities",
+    "body": "Add catalog-backed MCP server role, lifecycle, identity, and decision metadata with static gates for high-risk fleet personalities.",
     "base": "main"
   },
   "pal_chain": {
@@ -62,24 +60,23 @@
       "thinkdeep",
       "challenge",
       "planner",
-      "challenge",
       "codereview",
       "precommit"
     ]
   },
   "steps": [
     {
-      "id": "decision_matrix",
-      "task": "Document each server's chosen personality, rejected alternatives, authority label, and residual UNKNOWNs.",
+      "id": "catalog_personalities",
+      "task": "Add schema-backed server personality metadata for authority role, lifecycle, management model, identity scope, and unresolved follow-on decisions.",
       "validation": [
-        "Decision matrix preserves Memory Trinity and PM-plane authority boundaries."
+        "Catalog schema validation accepts only declared metadata fields and rejects unknown values."
       ]
     },
     {
-      "id": "converge_configs",
-      "task": "Apply non-destructive config and wrapper convergence for chosen personalities.",
+      "id": "drift_gate",
+      "task": "Add static drift checks for required MCP personality contracts and render metadata into generated outputs.",
       "validation": [
-        "Catalog drift gates pass and no generated config references rejected surfaces."
+        "Focused fleet catalog tests prove required role/lifecycle decisions cannot drift silently."
       ]
     }
   ]

--- a/tests/arch/test_mcp_fleet_catalog_contract.py
+++ b/tests/arch/test_mcp_fleet_catalog_contract.py
@@ -51,6 +51,42 @@ def test_catalog_compose_service_and_port_alignment():
     assert errors == []
 
 
+def test_required_server_personalities_are_static_contract():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+
+    errors = fleet_catalog.validate_catalog_personality_contract(catalog)
+
+    assert errors == []
+
+
+def test_personality_contract_catches_authority_role_drift():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    catalog["servers"]["dope-context"]["authority_role"] = "structured-context-authority"
+
+    errors = fleet_catalog.validate_catalog_personality_contract(catalog)
+
+    assert any("dope-context: authority_role" in error for error in errors)
+
+
+def test_decision_required_servers_must_name_follow_on_decision():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    catalog["servers"]["temporary-search"] = {
+        "scope": "singleton",
+        "transport": "http",
+        "plane": "research",
+        "authority_role": "web-search",
+        "lifecycle": "decision-required",
+        "management_model": "compose-service",
+        "identity_scope": "external-provider",
+        "follow_on_decision": "none",
+        "url": "http://localhost:3999/mcp",
+    }
+
+    errors = fleet_catalog.validate_catalog_personality_contract(catalog)
+
+    assert any("temporary-search: decision-required lifecycle" in error for error in errors)
+
+
 def test_legacy_registry_has_unique_keys_and_compose_health_contracts():
     errors = fleet_catalog.validate_legacy_registry_contract(REPO_ROOT)
 

--- a/tests/unit/test_mcp_fleet_catalog.py
+++ b/tests/unit/test_mcp_fleet_catalog.py
@@ -182,17 +182,49 @@ def test_health_probe_list_uses_catalog_urls_and_compose_services():
 
     assert fleet_catalog.render_health_probe_list(catalog) == [
         {
+            "authority_role": None,
             "docker_compose_service": "http-one",
+            "follow_on_decision": None,
+            "identity_scope": None,
+            "lifecycle": None,
+            "management_model": None,
             "name": "http-one",
+            "plane": None,
             "scope": "singleton",
             "transport": "http",
             "url": "http://localhost:1234/mcp",
         },
         {
+            "authority_role": None,
             "docker_compose_service": None,
+            "follow_on_decision": None,
+            "identity_scope": None,
+            "lifecycle": None,
+            "management_model": None,
             "name": "local-one",
+            "plane": None,
             "scope": "per-worktree",
             "transport": "sse",
             "url": "http://localhost:${LOCAL_ONE_PORT:-4321}/sse",
         },
     ]
+
+
+def test_health_probe_list_carries_personality_metadata():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    probes = {
+        probe["name"]: probe
+        for probe in fleet_catalog.render_health_probe_list(catalog)
+    }
+
+    assert probes["conport"]["authority_role"] == "structured-context-authority"
+    assert probes["task-orchestrator"]["identity_scope"] == "per-repo"
+    assert probes["desktop-commander"]["lifecycle"] == "decision-required"
+
+
+def test_mcp_doctrine_doc_carries_decision_gated_servers():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    doc = fleet_catalog.render_mcp_doctrine_doc(catalog)
+
+    assert "`exa` | research | web-search | decision-required" in doc
+    assert "`desktop-commander` | automation | desktop-automation | decision-required" in doc


### PR DESCRIPTION
## Summary
- add schema-backed MCP server personality metadata for plane, authority role, lifecycle, management model, identity scope, and follow-on decision
- pin high-risk server contracts for ConPort, task-orchestrator, dope-memory, dope-context, PAL, Exa, and desktop-commander
- render metadata into generated health/doc projections and document decision-gated services

## Validation
- PASS: python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: python -m pytest tests/unit/test_mcp_fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py -q
- PASS: YAML-aware jsonschema validation for mcp_catalog.yaml and src/dopemux/mcp/default_catalog.yaml
- PASS: python -m py_compile src/dopemux/mcp/fleet_catalog.py
- PASS: git diff --check
- PASS: scoped pre-commit run over changed packet files

## Not Run
- Docker compose startup
- live MCP initialize/tools-list probes
- provider-backed Exa/PAL/GPT Researcher calls

## Release Notes
- MCP fleet catalog now exposes auditable server personality metadata and gates decision-required surfaces before runtime convergence work.