### PR TITLE
feat(dcp): expose read-only facade packet tools

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md
@@ -45,11 +45,20 @@ prelude: Phase-1 tool contract, allowed/denied routes, and authority labels for 
 
 | Tool | Backing surface | Source | Transport | Authority | Notes |
 | --- | --- | --- | --- | --- | --- |
-| `search_code_docs` | dope-context `search_code` + `docs_search` | `OBSERVED` (inventory) | MCP | DERIVED | **Phase 1: BLOCKED** — MCP JSON-RPC transport not yet bridged in facade (REST-only client). Hits will be DERIVED until transport bridge + exact-source fetch exist. |
-| `get_index_status` | dope-context index status | `PROPOSED` (load-pack 0006 scope; **not** in inventory) | MCP | DERIVED | **Phase 1: BLOCKED** — MCP transport gap + not in inventory. ⚠️ requires formal inventory + classification before allowlist wiring (Phase 2). |
-| `get_workflow_status_snapshot` | task-orchestrator `/queue` + `/blockers` + `/state` (GET) | `OBSERVED` (inventory + TP-0006 gap resolved) | HTTP | CANONICAL | workflow-view only, **not** PM truth; strip identities. `/state` classified CONFIRMED_READ_ONLY in TP-0006 (see note below). |
+| `search_code_docs` | dope-context `search_code` + `docs_search` | `OBSERVED` (inventory) | MCP | DERIVED | Registered on the operator-run stdio facade; **returns BLOCKED in Phase 1** because MCP JSON-RPC transport is not yet bridged in the facade (REST-only client). Hits will be DERIVED until transport bridge + exact-source fetch exist. |
+| `get_index_status` | dope-context index status | `PROPOSED` (load-pack 0006 scope; **not** in inventory) | MCP | DERIVED | Registered on the operator-run stdio facade; **returns BLOCKED in Phase 1** because of the MCP transport gap + missing inventory classification. Requires formal inventory + classification before live allowlist wiring (Phase 2). |
+| `get_workflow_status_snapshot` | task-orchestrator `/queue` + `/blockers` + `/state` (GET) | `OBSERVED` (inventory + TP-0006 gap resolved) | HTTP | CANONICAL | Registered on the operator-run stdio facade; workflow-view only, **not** PM truth; strip identities. `/state` classified CONFIRMED_READ_ONLY in TP-0006 (see note below). |
 
-> **`get_index_status` (Phase 1 BLOCKED):** dope-context exposes all tools via MCP JSON-RPC at `/mcp` — not REST. The facade's `ReadOnlyHttpClient` speaks REST only; no REST routes exist at `/search/code`, `/search/docs`, or `/index/status`. `get_index_status` is additionally `PROPOSED`-only (not in the discovery inventory). Both gaps must be closed before Phase 2 can expose it: (1) transport bridge from facade to MCP JSON-RPC, (2) formal inventory + classification of `get_index_status` with read-only + side-effect evidence.
+> **dope-context registration is fail-closed.** `search_code_docs` and
+> `get_index_status` are registered on the operator-run stdio MCP facade so
+> clients can discover the full packet 0006 surface, but both return BLOCKED in
+> Phase 1. dope-context exposes tools via MCP JSON-RPC at `/mcp` — not REST. The
+> facade's `ReadOnlyHttpClient` speaks REST only; no REST routes exist at
+> `/search/code`, `/search/docs`, or `/index/status`. `get_index_status` is
+> additionally `PROPOSED`-only (not in the discovery inventory). Both gaps must
+> be closed before Phase 2 can return live data: (1) transport bridge from facade
+> to MCP JSON-RPC, (2) formal inventory + classification of `get_index_status`
+> with read-only + side-effect evidence.
 
 > **`/state` gap resolved (TP-0006):** task-orchestrator exposes `/api/projects/{project_id}/workflow/state` as a first-class GET read endpoint (`project_workflow.py:385`, `@router.get("/state", response_model=WorkflowStateResult)`). Evidence: (1) confirmed GET at line 385; (2) existing PM adapter calls it (`src/dopemux/pm/adapters/orchestrator.py:48`); (3) no write path or side effects observed. **Classified CONFIRMED_READ_ONLY.** Added to `get_workflow_status_snapshot` backing-surface row above. The 0001 inventory gap is noted but not retroactively modified (0001 is a committed artifact).
 

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE/implementation-notes.md
@@ -1,0 +1,52 @@
+# TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE Proof Notes
+
+Date: 2026-07-04
+Branch: `codex/mcp-fleet-dcp-readonly-facade`
+Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/mcp-fleet-dcp-readonly-facade`
+
+## Scope
+
+Expose already implemented DCP packet 0006 read-only facade functions through
+the operator-run stdio MCP server:
+
+- `search_code_docs`
+- `get_index_status`
+- `get_workflow_status_snapshot`
+
+The implementation does not add a dope-context transport bridge and does not add
+write authority. dope-context wrappers remain fail-closed through the pure
+facade functions, returning `BLOCKED` envelopes until MCP JSON-RPC bridge and
+inventory work is completed.
+
+## Authority Used
+
+- `AGENTS.md`
+- `docs/03-reference/dcp/README.md`
+- `docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md`
+- `docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_SURFACE_INVENTORY.md`
+- `services/dcp-readonly-facade/src/dcp_facade/tools.py`
+- `services/dcp-readonly-facade/src/mcp/server.py`
+- `services/dcp-readonly-facade/tests/test_packet_0006.py`
+
+## Validation
+
+- PASS: `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+  - Exit 0. The jsonschema CLI emitted its standard deprecation warning.
+- PASS: `python -m pytest services/dcp-readonly-facade/tests/test_mcp_server.py services/dcp-readonly-facade/tests/test_packet_0006.py -q`
+  - Exit 0. Result: `28 passed`.
+- PASS: `python -m py_compile services/dcp-readonly-facade/src/mcp/server.py`
+  - Exit 0.
+- PASS: `python -m pytest services/dcp-readonly-facade/tests/test_route_denylist.py services/dcp-readonly-facade/tests/test_packet_0008.py -q`
+  - Exit 0. Result: `26 passed`.
+
+## NOT_RUN
+
+- NOT_RUN: live operator MCP initialize/tools-list probe.
+  - Reason: packet scope is static stdio registration and no live MCP client was
+    started in this validation slice.
+- NOT_RUN: live dope-context MCP JSON-RPC bridge.
+  - Reason: the bridge is intentionally not implemented in this packet;
+    dope-context facade tools remain fail-closed.
+- NOT_RUN: Docker/provider/service health validation.
+  - Reason: no Docker or provider service is required to validate the stdio
+    wrapper registration and pure-function delegation path.

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE/implementation-notes.md
@@ -3,6 +3,8 @@
 Date: 2026-07-04
 Branch: `codex/mcp-fleet-dcp-readonly-facade`
 Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/mcp-fleet-dcp-readonly-facade`
+Implementation commit: `b7df66d8e5b4b1e90b32022f19a624f6856ec625`
+PR: `https://github.com/DDD-Enterprises/dopemux-mvp/pull/1000`
 
 ## Scope
 

--- a/services/dcp-readonly-facade/README.md
+++ b/services/dcp-readonly-facade/README.md
@@ -4,9 +4,10 @@ Loopback-only, **read-only** MCP server that projects repository evidence from a
 registered dopemux workspace to ChatGPT. It holds no write authority and is an
 evidence projection layer, not a canonical source.
 
-This is the **TP-DCP-MCP-RO-0004 scaffold**: registry + resolver + envelope +
-redaction + five local/git/proof tools. Backend adapters (ConPort, dope-memory,
-dope-context, task-orchestrator) are added in 0005/0006.
+This started as the **TP-DCP-MCP-RO-0004 scaffold**: registry + resolver +
+envelope + redaction + five local/git/proof tools. Backend adapters and MCP
+stdio registrations now cover ConPort + dope-memory (0005) and dope-context +
+task-orchestrator (0006).
 
 ## Layout
 
@@ -19,8 +20,17 @@ dope-context, task-orchestrator) are added in 0005/0006.
 ## Phase-1 tools
 
 `list_projects`, `get_project_capabilities`, `get_repo_state_snapshot`,
-`list_proof_bundles`, `fetch_proof_bundle`. Every project-scoped tool requires
-`project_id`; results are wrapped in the canonical envelope and redacted.
+`list_proof_bundles`, `fetch_proof_bundle`, `search_decisions`,
+`search_progress`, `search_chronicle`, `replay_chronicle_session`,
+`search_code_docs`, `get_index_status`, `get_workflow_status_snapshot`.
+Every project-scoped tool requires `project_id`; results are wrapped in the
+canonical envelope and redacted.
+
+dope-context tools are registered for operator-run stdio discovery, but they
+fail closed with `BLOCKED` envelopes until a dope-context MCP JSON-RPC bridge is
+implemented and inventoried. `get_workflow_status_snapshot` reads
+task-orchestrator queue/blockers/state as workflow-view authority only; it is
+not PM metadata truth and exposes no transition/write surface.
 
 ## Run / test
 

--- a/services/dcp-readonly-facade/src/mcp/server.py
+++ b/services/dcp-readonly-facade/src/mcp/server.py
@@ -99,6 +99,48 @@ async def replay_chronicle_session(
     return tools.replay_chronicle_session(_REGISTRY, project_id, session_id, mode, top_k)
 
 
+@mcp.tool()
+async def search_code_docs(
+    project_id: str,
+    query: str,
+    top_k: int = 20,
+    kind: str = "code",
+    profile: Optional[str] = None,
+    filter_doc_type: Optional[str] = None,
+) -> dict:
+    """Search dope-context code/docs through the read-only facade.
+
+    Phase 1 registers the tool for operator-run stdio discovery, but the pure
+    facade function returns BLOCKED until a dope-context MCP JSON-RPC bridge is
+    implemented and inventoried.
+    """
+    return tools.search_code_docs(
+        _REGISTRY,
+        project_id,
+        query,
+        top_k,
+        kind=kind,
+        profile=profile,
+        filter_doc_type=filter_doc_type,
+    )
+
+
+@mcp.tool()
+async def get_index_status(project_id: str) -> dict:
+    """Return dope-context index status envelope.
+
+    Phase 1 fail-closes because the dope-context transport bridge and formal
+    inventory classification are not complete.
+    """
+    return tools.get_index_status(_REGISTRY, project_id)
+
+
+@mcp.tool()
+async def get_workflow_status_snapshot(project_id: str) -> dict:
+    """Read task-orchestrator workflow queue/blockers/state as a snapshot."""
+    return tools.get_workflow_status_snapshot(_REGISTRY, project_id)
+
+
 def main() -> None:
     transport = os.getenv("DCP_FACADE_TRANSPORT", "stdio")
     mcp.run(transport=transport)

--- a/services/dcp-readonly-facade/tests/test_mcp_server.py
+++ b/services/dcp-readonly-facade/tests/test_mcp_server.py
@@ -41,6 +41,7 @@ def server_module(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, "fastmcp", types.SimpleNamespace(FastMCP=RecordingFastMCP))
     sys.modules.pop("mcp.server", None)
     module = importlib.import_module("mcp.server")
+    assert RecordingFastMCP.instances, "mcp.server import did not instantiate FastMCP"
     yield module, RecordingFastMCP.instances[-1]
     sys.modules.pop("mcp.server", None)
 

--- a/services/dcp-readonly-facade/tests/test_mcp_server.py
+++ b/services/dcp-readonly-facade/tests/test_mcp_server.py
@@ -1,0 +1,139 @@
+"""DCP read-only MCP server wiring tests.
+
+These tests replace the optional FastMCP dependency with a recording stub before
+importing ``mcp.server``. That keeps the assertions focused on stdio facade tool
+registration and delegation without opening network or MCP transports.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+
+import pytest
+
+
+class RecordingFastMCP:
+    instances: list["RecordingFastMCP"] = []
+
+    def __init__(self, name: str):
+        self.name = name
+        self.tools: dict[str, object] = {}
+        RecordingFastMCP.instances.append(self)
+
+    def tool(self, *args, **kwargs):
+        def decorator(func):
+            self.tools[func.__name__] = func
+            return func
+
+        return decorator
+
+    def run(self, *args, **kwargs):  # pragma: no cover - main() is not exercised here
+        self.run_args = (args, kwargs)
+
+
+@pytest.fixture()
+def server_module(monkeypatch, tmp_path):
+    RecordingFastMCP.instances = []
+    monkeypatch.setenv("DCP_FACADE_REGISTRY", str(tmp_path / "missing-registry.yaml"))
+    monkeypatch.setitem(sys.modules, "fastmcp", types.SimpleNamespace(FastMCP=RecordingFastMCP))
+    sys.modules.pop("mcp.server", None)
+    module = importlib.import_module("mcp.server")
+    yield module, RecordingFastMCP.instances[-1]
+    sys.modules.pop("mcp.server", None)
+
+
+def test_mcp_server_registers_packet_0006_tools(server_module):
+    _, mcp = server_module
+    assert mcp.name == "dcp-readonly-facade"
+    assert set(mcp.tools) == {
+        "list_projects",
+        "get_project_capabilities",
+        "get_repo_state_snapshot",
+        "list_proof_bundles",
+        "fetch_proof_bundle",
+        "search_decisions",
+        "search_progress",
+        "search_chronicle",
+        "replay_chronicle_session",
+        "search_code_docs",
+        "get_index_status",
+        "get_workflow_status_snapshot",
+    }
+
+
+def test_search_code_docs_delegates_to_pure_facade_function(server_module, monkeypatch):
+    server, _ = server_module
+    captured = {}
+    sentinel = {"status": "BLOCKED", "data": None}
+
+    def fake_search_code_docs(
+        registry,
+        project_id,
+        query,
+        top_k,
+        *,
+        kind,
+        profile,
+        filter_doc_type,
+    ):
+        captured.update(
+            {
+                "registry": registry,
+                "project_id": project_id,
+                "query": query,
+                "top_k": top_k,
+                "kind": kind,
+                "profile": profile,
+                "filter_doc_type": filter_doc_type,
+            }
+        )
+        return sentinel
+
+    monkeypatch.setattr(server.tools, "search_code_docs", fake_search_code_docs)
+    result = asyncio.run(
+        server.search_code_docs(
+            "dopemux",
+            "catalog contract",
+            top_k=7,
+            kind="docs",
+            profile="implementation",
+            filter_doc_type="md",
+        )
+    )
+
+    assert result is sentinel
+    assert captured == {
+        "registry": server._REGISTRY,
+        "project_id": "dopemux",
+        "query": "catalog contract",
+        "top_k": 7,
+        "kind": "docs",
+        "profile": "implementation",
+        "filter_doc_type": "md",
+    }
+
+
+def test_status_wrappers_delegate_to_pure_facade_functions(server_module, monkeypatch):
+    server, _ = server_module
+    captured = []
+
+    def fake_index_status(registry, project_id):
+        captured.append(("index", registry, project_id))
+        return {"status": "BLOCKED"}
+
+    def fake_workflow_snapshot(registry, project_id):
+        captured.append(("workflow", registry, project_id))
+        return {"status": "OK"}
+
+    monkeypatch.setattr(server.tools, "get_index_status", fake_index_status)
+    monkeypatch.setattr(server.tools, "get_workflow_status_snapshot", fake_workflow_snapshot)
+
+    assert asyncio.run(server.get_index_status("dopemux")) == {"status": "BLOCKED"}
+    assert asyncio.run(server.get_workflow_status_snapshot("dopemux")) == {"status": "OK"}
+    assert captured == [
+        ("index", server._REGISTRY, "dopemux"),
+        ("workflow", server._REGISTRY, "dopemux"),
+    ]

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE.json
@@ -1,0 +1,81 @@
+{
+  "id": "TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE",
+  "project": "dopemux-mvp",
+  "target": "Activate DCP read-only facade follow-ons by exposing already implemented packet 0006 tools through the operator-run stdio MCP facade without adding write authority.",
+  "invariants": [
+    "DCP v1 remains read/export/pointer/dry-run only.",
+    "No mutating DCP, task-orchestrator, ConPort, dope-memory, dope-context, GitHub, shell, or event-store route may be exposed.",
+    "dope-context remains fail-closed until a real MCP JSON-RPC bridge is implemented and inventoried.",
+    "task-orchestrator facade results are workflow-view snapshots only, not PM metadata truth."
+  ],
+  "depends_on": [
+    "TP-DMX-MCP-FLEET-ROADMAP-001-CATALOG-CONTRACT",
+    "TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MCP-FLEET-ROADMAP",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-MCP-FLEET-ROADMAP-005-SERVER-PERSONALITIES",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/mcp-fleet-dcp-readonly-facade",
+    "base_branch": "main",
+    "stacked_because": "DCP facade activation follows server-personality catalog gates and stays read-only."
+  },
+  "commit": {
+    "message": "feat(dcp): expose read-only facade packet tools",
+    "allowlist": [
+      "services/dcp-readonly-facade/src/mcp/server.py",
+      "services/dcp-readonly-facade/tests/test_mcp_server.py",
+      "services/dcp-readonly-facade/README.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md",
+      "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE.json",
+      "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE/**"
+    ],
+    "verify": [
+      "python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest services/dcp-readonly-facade/tests/test_mcp_server.py services/dcp-readonly-facade/tests/test_packet_0006.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): expose read-only facade packet tools",
+    "body": "Expose packet 0006 read-only facade tools over the DCP stdio MCP server while preserving fail-closed dope-context behavior and workflow-view-only task-orchestrator snapshots.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "mcp_tool_registration",
+      "task": "Register packet 0006 read-only facade functions in the stdio MCP server.",
+      "validation": [
+        "Tests prove the MCP server exposes the expected tool names and delegates to pure facade functions."
+      ]
+    },
+    {
+      "id": "docs_and_proof",
+      "task": "Document the operator-run stdio registration and preserve dope-context transport limitations.",
+      "validation": [
+        "Focused DCP facade tests and diff checks pass; live MCP/provider checks are explicitly NOT_RUN if not exercised."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- register packet 0006 DCP read-only facade tools on the operator-run stdio MCP server
- add MCP server wiring tests for tool registration and pure-function delegation
- update DCP facade docs/proof to state dope-context remains fail-closed until MCP JSON-RPC bridge/inventory work lands

## Validation
- PASS: `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- PASS: `python -m pytest services/dcp-readonly-facade/tests/test_mcp_server.py services/dcp-readonly-facade/tests/test_packet_0006.py -q`
- PASS: `python -m py_compile services/dcp-readonly-facade/src/mcp/server.py`
- PASS: `python -m pytest services/dcp-readonly-facade/tests/test_route_denylist.py services/dcp-readonly-facade/tests/test_packet_0008.py -q`
- PASS: `git diff --check`
- PASS: `git diff --cached --check`
- PASS: `pre-commit run --files docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md services/dcp-readonly-facade/README.md services/dcp-readonly-facade/src/mcp/server.py services/dcp-readonly-facade/tests/test_mcp_server.py task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE.json proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-006-DCP-READONLY-FACADE/implementation-notes.md`

## NOT_RUN
- live operator MCP initialize/tools-list probe; static stdio registration was tested with a recording FastMCP stub
- live dope-context MCP JSON-RPC bridge; intentionally not implemented in this packet
- Docker/provider/service health checks; not required for this wrapper registration slice

## Residual risk
- live MCP discovery depends on the installed FastMCP runtime, though wrapper registration is covered with a fake FastMCP module
- dope-context still returns BLOCKED until the bridge and inventory work are implemented

## Release Notes
- DCP read-only MCP facade now exposes packet 0006 tool names over stdio without granting write authority.