### PR TITLE
chore(mcp): quarantine dead fleet surfaces

### DIFF
--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/implementation-notes.md
@@ -1,0 +1,69 @@
+# TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE Proof
+
+## Scope
+
+Lane 7 quarantines unresolved MCP fleet surfaces from startable generated config outputs.
+It does not delete service code or compose/registry entries because reverse-dependency
+evidence still shows active references.
+
+## Reverse Dependency Scan
+
+Command:
+
+```bash
+rg -n "desktop-commander|exa|mcp-exa|mcp__exa|mcp__desktop|MCP_DesktopCommander" \
+  mcp_catalog.yaml services/registry.yaml src/dopemux/mcp src/dopemux/commands/mcp_commands.py \
+  docker/mcp-servers-source/services/mcp-client docker/mcp-servers-source/start-profile.sh \
+  docker/mcp-servers-source/start-all-mcp-servers.sh .claude/commands/docs/find.md \
+  .claude/commands/web/triage.md docs/03-reference/mcp/fleet-generated-outputs.md
+```
+
+Observed classification:
+
+- Catalog and bundled catalog still declare `desktop-commander` and `exa` as
+  `decision-required`; these remain source-of-truth audit metadata.
+- `services/registry.yaml`, `src/dopemux/mcp/registry.yaml`, start scripts, and
+  legacy MCP client code still reference the surfaces, so deletion is not proven safe.
+- `.claude/commands/docs/find.md` and `.claude/commands/web/triage.md` mention Exa as a
+  human-facing research tool name, but no `mcp__exa__...` generated tool-surface
+  reference was observed in the command-surface drift gate.
+- `docs/03-reference/mcp/fleet-generated-outputs.md` already states that
+  `desktop-commander` is decision-gated.
+
+## Quarantine Evidence
+
+Generated startable output inspection after implementation:
+
+```text
+decision_required= ['desktop-commander', 'exa']
+local= ['conport', 'dope-memory', 'task-orchestrator']
+claude= ['MCP_DOCKER', 'dope-context', 'gpt-researcher', 'pal', 'pal-stdio', 'serena']
+codex= ['MCP_DOCKER', 'dope-context', 'gpt-researcher', 'pal', 'pal-stdio', 'serena']
+quarantine_errors= []
+```
+
+The static gate `validate_decision_required_generated_config_quarantine` fails if a
+`decision-required` surface appears in:
+
+- `defaults.per_worktree`
+- `local/.mcp.json`
+- `claude/mcpServers.json`
+- `codex/config.toml`
+
+## Validation
+
+PASS:
+
+- `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
+- `python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q`
+- `python -m pytest tests/unit/test_mcp_fleet_catalog.py -q`
+- `python -m py_compile src/dopemux/mcp/fleet_catalog.py`
+- `git diff --check`
+- `pre-commit run --files src/dopemux/mcp/fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_fleet_catalog.py task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/implementation-notes.md`
+
+NOT_RUN:
+
+- Docker/provider/live MCP checks; this lane is a static generated-config quarantine.
+- `scripts/orchestrator/perpacket_codereview.py`; the helper exits before review because
+  this generated Lane 7 packet is not present in `config/orchestrator/perpacket_test_map.yaml`.
+  Manual bounded diff review was performed instead.

--- a/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/implementation-notes.md
+++ b/proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/implementation-notes.md
@@ -50,6 +50,15 @@ The static gate `validate_decision_required_generated_config_quarantine` fails i
 - `claude/mcpServers.json`
 - `codex/config.toml`
 
+Review follow-up:
+
+- `dopemux mcp sync-globals --apply` now uses the same startable singleton
+  renderer as generated Claude global config, so it cannot reintroduce
+  `decision-required` singletons into `~/.claude.json`.
+- The quarantine validator treats caller-provided empty output maps as real
+  validation input and recognizes both mapping-shaped and list-shaped
+  `mcpServers` payloads.
+
 ## Validation
 
 PASS:
@@ -57,9 +66,9 @@ PASS:
 - `python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
 - `python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q`
 - `python -m pytest tests/unit/test_mcp_fleet_catalog.py -q`
-- `python -m py_compile src/dopemux/mcp/fleet_catalog.py`
+- `python -m py_compile src/dopemux/mcp/fleet_catalog.py src/dopemux/commands/mcp_commands.py`
 - `git diff --check`
-- `pre-commit run --files src/dopemux/mcp/fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_fleet_catalog.py task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/implementation-notes.md`
+- `pre-commit run --files src/dopemux/commands/mcp_commands.py src/dopemux/mcp/fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_fleet_catalog.py task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/implementation-notes.md`
 
 NOT_RUN:
 

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -438,6 +438,20 @@ def _render_global_entry(name: str, spec: Dict[str, Any]) -> Dict[str, Any]:
     return entry
 
 
+def _is_startable_global_entry(spec: Dict[str, Any]) -> bool:
+    return spec.get("lifecycle") != "decision-required"
+
+
+def _build_global_mcp_servers(catalog: Dict[str, Any]) -> Dict[str, Any]:
+    """Construct startable singleton MCP entries for global client config."""
+
+    return {
+        name: _render_global_entry(name, spec)
+        for name, spec in catalog["servers"].items()
+        if spec.get("scope") == "singleton" and _is_startable_global_entry(spec)
+    }
+
+
 def _read_json(path: Path) -> Dict[str, Any]:
     if not path.exists():
         return {}
@@ -1151,11 +1165,7 @@ def mcp_sync_globals_cmd(apply: bool, prune: bool):
     Pass --prune to remove existing globals that aren't in the catalog.
     """
     catalog = _load_catalog()
-    desired = {
-        name: _render_global_entry(name, spec)
-        for name, spec in catalog["servers"].items()
-        if spec.get("scope") == "singleton"
-    }
+    desired = _build_global_mcp_servers(catalog)
 
     global_path = _claude_global_path()
     global_data = _read_json(global_path) if global_path.exists() else {}

--- a/src/dopemux/mcp/fleet_catalog.py
+++ b/src/dopemux/mcp/fleet_catalog.py
@@ -28,6 +28,7 @@ class DuplicateKeyError(MCPFleetCatalogError):
 _ENV_DEFAULT_RE = re.compile(r"\$\{[^:}]+:-([0-9]+)\}")
 _ENV_RE = re.compile(r"\$\{[^}]+\}")
 _MCP_TOOL_SURFACE_RE = re.compile(r"\bmcp__([A-Za-z0-9_-]+)__(?:[A-Za-z0-9_-]+|\*)")
+_CODEX_SERVER_HEADING_RE = re.compile(r'^\[mcp_servers\."([^"]+)"\]$', re.MULTILINE)
 
 
 REQUIRED_SERVER_PERSONALITIES: dict[str, dict[str, str]] = {
@@ -146,11 +147,19 @@ def render_per_worktree_mcp_json(
     return mcp_commands._build_local_mcp_json(server_names, catalog)
 
 
+def _is_decision_required(spec: dict[str, Any]) -> bool:
+    return spec.get("lifecycle") == "decision-required"
+
+
+def _is_startable_generated_server(spec: dict[str, Any]) -> bool:
+    return not _is_decision_required(spec)
+
+
 def render_singleton_mcp_servers(catalog: dict[str, Any]) -> dict[str, Any]:
     return {
         name: mcp_commands._render_global_entry(name, spec)
         for name, spec in catalog["servers"].items()
-        if spec.get("scope") == "singleton"
+        if spec.get("scope") == "singleton" and _is_startable_generated_server(spec)
     }
 
 
@@ -184,6 +193,8 @@ def render_codex_config_fragment(catalog: dict[str, Any]) -> str:
     ]
     for name, spec in sorted(catalog.get("servers", {}).items()):
         if spec.get("scope") != "singleton":
+            continue
+        if not _is_startable_generated_server(spec):
             continue
         transport = spec.get("transport", "http")
         if transport not in {"stdio", "http"}:
@@ -245,6 +256,7 @@ def render_mcp_doctrine_doc(catalog: dict[str, Any]) -> str:
         "- Dry-run is the default; writes require `dopemux mcp generate --apply --output-dir <dir>`.",
         "- Generated outputs are projections, not user-global authority.",
         "- Unknown external config entries are preserved by sync flows unless pruning is explicit.",
+        "- `decision-required` servers stay visible in audit outputs but are excluded from startable generated configs.",
         "",
         "## Default Per-Worktree Servers",
         "",
@@ -300,6 +312,49 @@ def generate_fleet_output_files(catalog: dict[str, Any]) -> dict[str, str]:
         "health/mcp-health-probes.json": _json_dumps(render_health_probe_list(catalog)),
         "docs/mcp-fleet.md": render_mcp_doctrine_doc(catalog),
     }
+
+
+def _json_mcp_server_names(payload: str) -> set[str]:
+    data = json.loads(payload)
+    servers = data.get("mcpServers") or {}
+    if not isinstance(servers, dict):
+        return set()
+    return set(servers)
+
+
+def validate_decision_required_generated_config_quarantine(
+    catalog: dict[str, Any],
+    outputs: dict[str, str] | None = None,
+) -> list[str]:
+    """Ensure unresolved MCP surfaces cannot be started from generated configs."""
+
+    errors: list[str] = []
+    servers = catalog.get("servers") or {}
+    decision_required = {
+        name
+        for name, spec in servers.items()
+        if isinstance(spec, dict) and _is_decision_required(spec)
+    }
+
+    for name in catalog.get("defaults", {}).get("per_worktree") or []:
+        if name in decision_required:
+            errors.append(f"defaults.per_worktree includes decision-required server `{name}`")
+
+    rendered = outputs or generate_fleet_output_files(catalog)
+    startable_outputs = {
+        "local/.mcp.json": _json_mcp_server_names(rendered.get("local/.mcp.json", "{}")),
+        "claude/mcpServers.json": _json_mcp_server_names(
+            rendered.get("claude/mcpServers.json", "{}")
+        ),
+        "codex/config.toml": set(
+            _CODEX_SERVER_HEADING_RE.findall(rendered.get("codex/config.toml", ""))
+        ),
+    }
+    for output_path, names in startable_outputs.items():
+        for name in sorted(names & decision_required):
+            errors.append(f"{output_path} includes decision-required server `{name}`")
+
+    return errors
 
 
 def known_tool_surfaces(catalog: dict[str, Any]) -> set[str]:

--- a/src/dopemux/mcp/fleet_catalog.py
+++ b/src/dopemux/mcp/fleet_catalog.py
@@ -151,16 +151,8 @@ def _is_decision_required(spec: dict[str, Any]) -> bool:
     return spec.get("lifecycle") == "decision-required"
 
 
-def _is_startable_generated_server(spec: dict[str, Any]) -> bool:
-    return not _is_decision_required(spec)
-
-
 def render_singleton_mcp_servers(catalog: dict[str, Any]) -> dict[str, Any]:
-    return {
-        name: mcp_commands._render_global_entry(name, spec)
-        for name, spec in catalog["servers"].items()
-        if spec.get("scope") == "singleton" and _is_startable_generated_server(spec)
-    }
+    return mcp_commands._build_global_mcp_servers(catalog)
 
 
 def _json_dumps(data: Any) -> str:
@@ -194,7 +186,7 @@ def render_codex_config_fragment(catalog: dict[str, Any]) -> str:
     for name, spec in sorted(catalog.get("servers", {}).items()):
         if spec.get("scope") != "singleton":
             continue
-        if not _is_startable_generated_server(spec):
+        if _is_decision_required(spec):
             continue
         transport = spec.get("transport", "http")
         if transport not in {"stdio", "http"}:
@@ -317,9 +309,17 @@ def generate_fleet_output_files(catalog: dict[str, Any]) -> dict[str, str]:
 def _json_mcp_server_names(payload: str) -> set[str]:
     data = json.loads(payload)
     servers = data.get("mcpServers") or {}
-    if not isinstance(servers, dict):
-        return set()
-    return set(servers)
+    if isinstance(servers, dict):
+        return set(servers)
+    if isinstance(servers, list):
+        names: set[str] = set()
+        for server in servers:
+            if isinstance(server, str):
+                names.add(server)
+            elif isinstance(server, dict) and isinstance(server.get("name"), str):
+                names.add(server["name"])
+        return names
+    return set()
 
 
 def validate_decision_required_generated_config_quarantine(
@@ -340,7 +340,7 @@ def validate_decision_required_generated_config_quarantine(
         if name in decision_required:
             errors.append(f"defaults.per_worktree includes decision-required server `{name}`")
 
-    rendered = outputs or generate_fleet_output_files(catalog)
+    rendered = outputs if outputs is not None else generate_fleet_output_files(catalog)
     startable_outputs = {
         "local/.mcp.json": _json_mcp_server_names(rendered.get("local/.mcp.json", "{}")),
         "claude/mcpServers.json": _json_mcp_server_names(

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json
@@ -42,6 +42,7 @@
       "docker/mcp-servers-source/**",
       "services/**",
       "tests/arch/test_mcp_fleet_catalog_contract.py",
+      "tests/unit/test_mcp_fleet_catalog.py",
       "task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json",
       "proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/**"
     ],

--- a/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json
+++ b/task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json
@@ -37,6 +37,7 @@
       "SYSTEM_ARCHIVE/**",
       "mcp_catalog.yaml",
       "services/registry.yaml",
+      "src/dopemux/commands/mcp_commands.py",
       "src/dopemux/mcp/**",
       "scripts/mcp/**",
       "docker/mcp-servers-source/**",

--- a/tests/arch/test_mcp_fleet_catalog_contract.py
+++ b/tests/arch/test_mcp_fleet_catalog_contract.py
@@ -1,3 +1,4 @@
+import json
 import re
 from pathlib import Path
 
@@ -97,6 +98,79 @@ def test_generated_mcp_json_parity_is_checked_against_catalog_renderer():
     errors = fleet_catalog.validate_generated_mcp_json_parity(REPO_ROOT)
 
     assert errors == []
+
+
+def test_decision_required_servers_are_quarantined_from_startable_generated_configs():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    outputs = fleet_catalog.generate_fleet_output_files(catalog)
+    decision_required = {
+        name
+        for name, spec in catalog["servers"].items()
+        if spec.get("lifecycle") == "decision-required"
+    }
+
+    local_servers = set(json.loads(outputs["local/.mcp.json"])["mcpServers"])
+    claude_servers = set(json.loads(outputs["claude/mcpServers.json"])["mcpServers"])
+    codex_servers = set(
+        re.findall(r'^\[mcp_servers\."([^"]+)"\]$', outputs["codex/config.toml"], re.MULTILINE)
+    )
+
+    assert decision_required == {"desktop-commander", "exa"}
+    assert local_servers.isdisjoint(decision_required)
+    assert claude_servers.isdisjoint(decision_required)
+    assert codex_servers.isdisjoint(decision_required)
+    assert fleet_catalog.validate_decision_required_generated_config_quarantine(
+        catalog,
+        outputs,
+    ) == []
+
+
+def test_decision_required_quarantine_gate_reports_generated_config_drift():
+    catalog = {
+        "version": 1,
+        "defaults": {"per_worktree": ["quarantined-local"]},
+        "servers": {
+            "active-stdio": {
+                "scope": "singleton",
+                "transport": "stdio",
+                "command": "python",
+                "args": ["server.py"],
+                "lifecycle": "active",
+            },
+            "quarantined-stdio": {
+                "scope": "singleton",
+                "transport": "stdio",
+                "command": "python",
+                "args": ["server.py"],
+                "lifecycle": "decision-required",
+                "follow_on_decision": "wire-or-retire",
+            },
+            "quarantined-local": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "url_template": "http://localhost:3999/mcp",
+                "lifecycle": "decision-required",
+                "follow_on_decision": "delete-or-host-run",
+            },
+        },
+    }
+    outputs = {
+        "local/.mcp.json": json.dumps({"mcpServers": {"quarantined-local": {}}}),
+        "claude/mcpServers.json": json.dumps({"mcpServers": {"quarantined-stdio": {}}}),
+        "codex/config.toml": '[mcp_servers."quarantined-stdio"]\ncommand = "python"\n',
+    }
+
+    errors = fleet_catalog.validate_decision_required_generated_config_quarantine(
+        catalog,
+        outputs,
+    )
+
+    assert errors == [
+        "defaults.per_worktree includes decision-required server `quarantined-local`",
+        "local/.mcp.json includes decision-required server `quarantined-local`",
+        "claude/mcpServers.json includes decision-required server `quarantined-stdio`",
+        "codex/config.toml includes decision-required server `quarantined-stdio`",
+    ]
 
 
 def test_claude_command_tool_surfaces_are_catalog_known_or_explicit_aliases():

--- a/tests/arch/test_mcp_fleet_catalog_contract.py
+++ b/tests/arch/test_mcp_fleet_catalog_contract.py
@@ -115,7 +115,7 @@ def test_decision_required_servers_are_quarantined_from_startable_generated_conf
         re.findall(r'^\[mcp_servers\."([^"]+)"\]$', outputs["codex/config.toml"], re.MULTILINE)
     )
 
-    assert decision_required == {"desktop-commander", "exa"}
+    assert decision_required >= {"desktop-commander", "exa"}
     assert local_servers.isdisjoint(decision_required)
     assert claude_servers.isdisjoint(decision_required)
     assert codex_servers.isdisjoint(decision_required)
@@ -171,6 +171,62 @@ def test_decision_required_quarantine_gate_reports_generated_config_drift():
         "claude/mcpServers.json includes decision-required server `quarantined-stdio`",
         "codex/config.toml includes decision-required server `quarantined-stdio`",
     ]
+
+
+def test_decision_required_quarantine_gate_reads_list_shaped_mcp_servers():
+    catalog = {
+        "version": 1,
+        "defaults": {"per_worktree": []},
+        "servers": {
+            "quarantined-stdio": {
+                "scope": "singleton",
+                "transport": "stdio",
+                "command": "python",
+                "args": ["server.py"],
+                "lifecycle": "decision-required",
+                "follow_on_decision": "wire-or-retire",
+            },
+        },
+    }
+    outputs = {
+        "local/.mcp.json": json.dumps({"mcpServers": []}),
+        "claude/mcpServers.json": json.dumps(
+            {"mcpServers": [{"name": "quarantined-stdio"}]}
+        ),
+        "codex/config.toml": "",
+    }
+
+    errors = fleet_catalog.validate_decision_required_generated_config_quarantine(
+        catalog,
+        outputs,
+    )
+
+    assert errors == [
+        "claude/mcpServers.json includes decision-required server `quarantined-stdio`"
+    ]
+
+
+def test_decision_required_quarantine_gate_validates_provided_empty_outputs():
+    catalog = {
+        "version": 1,
+        "defaults": {"per_worktree": ["quarantined-local"]},
+        "servers": {
+            "quarantined-local": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "url_template": "http://localhost:3999/mcp",
+                "lifecycle": "decision-required",
+                "follow_on_decision": "delete-or-host-run",
+            },
+        },
+    }
+
+    errors = fleet_catalog.validate_decision_required_generated_config_quarantine(
+        catalog,
+        {},
+    )
+
+    assert errors == ["defaults.per_worktree includes decision-required server `quarantined-local`"]
 
 
 def test_claude_command_tool_surfaces_are_catalog_known_or_explicit_aliases():

--- a/tests/unit/test_mcp_fleet_catalog.py
+++ b/tests/unit/test_mcp_fleet_catalog.py
@@ -61,7 +61,7 @@ def test_singleton_fragment_matches_existing_mcp_command_renderer():
     expected = {
         name: mcp_commands._render_global_entry(name, spec)
         for name, spec in catalog["servers"].items()
-        if spec["scope"] == "singleton"
+        if spec["scope"] == "singleton" and spec.get("lifecycle") != "decision-required"
     }
 
     assert fleet_catalog.render_singleton_mcp_servers(catalog) == expected
@@ -98,6 +98,11 @@ def test_extract_mcp_tool_surfaces_includes_wildcard_references():
 
 def test_generate_fleet_output_files_are_deterministic_and_catalog_backed():
     catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+    startable_singletons = {
+        name: spec
+        for name, spec in catalog["servers"].items()
+        if spec.get("scope") == "singleton" and spec.get("lifecycle") != "decision-required"
+    }
 
     outputs = fleet_catalog.generate_fleet_output_files(catalog)
 
@@ -113,7 +118,10 @@ def test_generate_fleet_output_files_are_deterministic_and_catalog_backed():
         catalog,
     )
     assert json.loads(outputs["claude/mcpServers.json"]) == {
-        "mcpServers": fleet_catalog.render_singleton_mcp_servers(catalog)
+        "mcpServers": {
+            name: mcp_commands._render_global_entry(name, spec)
+            for name, spec in startable_singletons.items()
+        }
     }
     assert outputs == fleet_catalog.generate_fleet_output_files(catalog)
 

--- a/tests/unit/test_mcp_fleet_catalog.py
+++ b/tests/unit/test_mcp_fleet_catalog.py
@@ -58,13 +58,18 @@ def test_fleet_renderer_matches_existing_mcp_command_renderer():
 def test_singleton_fragment_matches_existing_mcp_command_renderer():
     catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
 
-    expected = {
-        name: mcp_commands._render_global_entry(name, spec)
-        for name, spec in catalog["servers"].items()
-        if spec["scope"] == "singleton" and spec.get("lifecycle") != "decision-required"
-    }
+    expected = mcp_commands._build_global_mcp_servers(catalog)
 
     assert fleet_catalog.render_singleton_mcp_servers(catalog) == expected
+
+
+def test_global_command_renderer_excludes_decision_required_singletons():
+    catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
+
+    servers = mcp_commands._build_global_mcp_servers(catalog)
+
+    assert {"desktop-commander", "exa"}.isdisjoint(servers)
+    assert servers == fleet_catalog.render_singleton_mcp_servers(catalog)
 
 
 def test_known_tool_surfaces_include_catalog_servers_and_explicit_aliases():
@@ -98,11 +103,6 @@ def test_extract_mcp_tool_surfaces_includes_wildcard_references():
 
 def test_generate_fleet_output_files_are_deterministic_and_catalog_backed():
     catalog = fleet_catalog.load_root_catalog(REPO_ROOT)
-    startable_singletons = {
-        name: spec
-        for name, spec in catalog["servers"].items()
-        if spec.get("scope") == "singleton" and spec.get("lifecycle") != "decision-required"
-    }
 
     outputs = fleet_catalog.generate_fleet_output_files(catalog)
 
@@ -118,10 +118,7 @@ def test_generate_fleet_output_files_are_deterministic_and_catalog_backed():
         catalog,
     )
     assert json.loads(outputs["claude/mcpServers.json"]) == {
-        "mcpServers": {
-            name: mcp_commands._render_global_entry(name, spec)
-            for name, spec in startable_singletons.items()
-        }
+        "mcpServers": fleet_catalog.render_singleton_mcp_servers(catalog)
     }
     assert outputs == fleet_catalog.generate_fleet_output_files(catalog)
 


### PR DESCRIPTION
## Summary
- exclude decision-required MCP fleet surfaces from startable generated Claude and Codex config outputs
- add a static quarantine validator for decision-required surfaces in generated configs
- document reverse-dependency evidence showing exa and desktop-commander are not deletion-safe yet

## Release Notes
- MCP fleet generation now omits unresolved decision-required surfaces from startable generated configs while preserving them in catalog audit outputs.

## Validation
- PASS: python -m jsonschema -i task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
- PASS: python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q
- PASS: python -m pytest tests/unit/test_mcp_fleet_catalog.py -q
- PASS: python -m py_compile src/dopemux/mcp/fleet_catalog.py
- PASS: git diff --check
- PASS: pre-commit run --files src/dopemux/mcp/fleet_catalog.py tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_fleet_catalog.py task-packets/generated/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE.json proof/dmx-mcp-fleet-roadmap/TP-DMX-MCP-FLEET-ROADMAP-007-DEAD-SURFACE-QUARANTINE/implementation-notes.md

## NOT_RUN
- Docker/provider/live MCP checks; lane is static generated-config quarantine.
- scripts/orchestrator/perpacket_codereview.py; generated Lane 7 packet is not in config/orchestrator/perpacket_test_map.yaml, so manual bounded diff review was performed.

## Residual Risk
- Legacy references to exa and desktop-commander remain in compose/service/client surfaces; deletion is intentionally deferred until reverse-dependency proof supports it.
- Worktree has an unstaged local .claude/claude_config.json mutation outside this packet and excluded from the commit.