### PR TITLE
fix(litellm): clear cryptography + vendored-wheel Scout CVEs, document perl base-image risk

### DIFF
--- a/docker/mcp-servers-source/litellm/Dockerfile
+++ b/docker/mcp-servers-source/litellm/Dockerfile
@@ -5,6 +5,13 @@ WORKDIR /app
 
 # Install system dependencies and upgrade OS packages to pick up security patches
 # (openssl CVE-2025-x: fixed in 3.5.6-1~deb13u2)
+#
+# Accepted base-image risk: perl CVE-2026-12087 (critical), CVE-2026-48959,
+# CVE-2026-48962 (high) are marked "Not Fixed" by Debian for trixie. perl-base
+# is an Essential package in Debian and cannot be removed from slim images.
+# CVE-2026-12087 is an OOB heap read in Perl's Socket.xs — exploitable only by
+# running perl code on attacker-controlled input; this container runs no perl
+# at runtime (python entrypoint only). Revisit when Debian ships a fix.
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     netcat-traditional \
@@ -16,18 +23,27 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y \
 #   litellm>=1.83.7          (CVE-2026-35030, critical + 3 high)
 #   starlette>=0.49.1        (high CVE)
 #   python-multipart>=0.0.27 (2 high CVEs)
-#   cryptography>=46.0.5     (high CVE)
-#   wheel>=0.46.2            (high CVE)
+#   wheel>=0.46.2            (CVE-2026-24049, high — standalone copy)
+#   setuptools>=80.10.2      (first release whose VENDORED wheel is >=0.46.2;
+#                             the scanner flags setuptools._vendor.wheel 0.45.1,
+#                             so bumping standalone wheel alone does not clear it)
 #   mcp>=1.23.0              (high CVE)
 RUN pip install --no-cache-dir \
     "litellm[proxy]>=1.83.7" \
     "starlette>=0.49.1" \
     "python-multipart>=0.0.27" \
-    "cryptography>=46.0.5" \
     "wheel>=0.46.2" \
+    "setuptools>=80.10.2" \
     "mcp>=1.23.0" \
     prisma \
     pyyaml
+
+# cryptography>=48.0.1 fixes GHSA-537c-gmf6-5ccf (OOB read in statically-linked
+# OpenSSL, high 7.5). litellm[proxy] pins cryptography<47.0, so this cannot be
+# resolved in the same pip invocation — force-upgrade afterwards. litellm's
+# cryptography usage (Fernet key encryption, JWT signing primitives) is stable
+# across these versions; runtime start is verified in CI/manually after build.
+RUN pip install --no-cache-dir --upgrade "cryptography>=48.0.1"
 
 # Copy configuration and entrypoint from root build context
 COPY docker/mcp-servers-source/litellm/litellm.config.yaml /app/config.yaml

--- a/docker/mcp-servers-source/litellm/Dockerfile
+++ b/docker/mcp-servers-source/litellm/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Install system dependencies and upgrade OS packages to pick up security patches
-# (openssl CVE-2025-x: fixed in 3.5.6-1~deb13u2)
+# (openssl security patch level: 3.5.6-1~deb13u2 via apt upgrade)
 #
 # Accepted base-image risk: perl CVE-2026-12087 (critical), CVE-2026-48959,
 # CVE-2026-48962 (high) are marked "Not Fixed" by Debian for trixie. perl-base

--- a/docker/mcp-servers-source/litellm/README.md
+++ b/docker/mcp-servers-source/litellm/README.md
@@ -123,6 +123,24 @@ If port 4000 is in use:
 - SQLite database for request logging (optional)
 - No PII stored in logs by default
 
+### Accepted CVE Risk (base image)
+
+Docker Scout flags three perl CVEs in this image — CVE-2026-12087 (critical),
+CVE-2026-48959 and CVE-2026-48962 (high). These come from `perl-base` in the
+`python:3.11-slim` (Debian trixie) base image and are marked **Not Fixed** by
+Debian. `perl-base` is an `Essential: yes` package and cannot be removed from
+Debian-based images. CVE-2026-12087 is an out-of-bounds heap read in Perl's
+`Socket.xs`, exploitable only by running perl code on attacker-controlled
+input; this container runs no perl at runtime (python entrypoint only), so the
+vulnerable code path is unreachable. **Accepted risk** — re-evaluate when
+Debian publishes fixed packages (`apt-get upgrade` in the Dockerfile will pick
+them up automatically on the next rebuild).
+
+Note on `cryptography`: `litellm[proxy]` pins `cryptography<47.0`, but
+GHSA-537c-gmf6-5ccf is only fixed in 48.0.1, so the Dockerfile force-upgrades
+cryptography in a second `pip install` step. `pip check` inside the image will
+report this mismatch by design; runtime startup is verified after each bump.
+
 ## Monitoring
 
 - Health endpoint: `http://localhost:4000/health`


### PR DESCRIPTION
## Summary

Clears the high/critical Docker Scout findings in the `ddddenterprises/litellm` image (surfaced on #1002, pre-existing on main). Scoped to `docker/mcp-servers-source/litellm/` only.

### 1. cryptography → >=48.0.1 (GHSA-537c-gmf6-5ccf, high 7.5)
The old pin `cryptography>=46.0.5` resolved to 46.0.7, still vulnerable (patched range starts at **48.0.1** — confirmed via the GitHub advisory API). Complication: `litellm[proxy]` (all released versions incl. latest 1.90.3) pins `cryptography<47.0`, so the fix cannot be resolved in the same pip invocation. The Dockerfile now force-upgrades cryptography in a **second** `pip install` step (resolves to 49.0.0). `pip check` will report the litellm constraint mismatch by design; runtime is verified (see below).

### 2. wheel (CVE-2026-24049, high 7.1) → setuptools >=80.10.2
The flagged wheel 0.45.1 is the copy **vendored inside setuptools** (`setuptools/_vendor/wheel`), which the standalone `wheel>=0.46.2` pin can't touch. Inspected setuptools releases on GitHub: **80.10.2 is the first version vendoring the fixed wheel (0.46.3)**; 80.10.1 still vendors 0.45.1. Added `setuptools>=80.10.2` (resolves to 82.0.1, vendored wheel 0.46.3). Standalone wheel pin kept.

### 3. perl CVE-2026-12087 (critical) / CVE-2026-48959 / CVE-2026-48962 (high) — accepted risk
- Marked **Not Fixed** by Debian for trixie; the flagged package is `perl-base 5.40.1-6`, which is `Essential: yes` / `Priority: required` and cannot be removed from any Debian-based image (verified via `dpkg` in the built image — full perl is *not* installed, only perl-base).
- CVE-2026-12087 is an OOB heap read in Perl's `Socket.xs` (`pack_ip_mreq_source()`), reachable only by running perl code on attacker-controlled input — this container runs no perl at runtime (python entrypoint only).
- Alpine was considered and rejected: prisma engines require glibc.
- Documented in the Dockerfile comment + README "Accepted CVE Risk" section; the existing `apt-get upgrade` picks up Debian fixes automatically once published.

## Verification

- **Build**: image builds clean; installed versions confirmed in-image: cryptography 49.0.0, setuptools 82.0.1 (vendored wheel 0.46.3), standalone wheel 0.47.0, litellm 1.90.3.
- **Scout scan** (`docker scout cves --only-severity critical,high`): **only the 3 accepted perl CVEs remain** — cryptography and wheel findings cleared.
- **Runtime**: container run with the real entrypoint against the live `dopemux-postgres-age` DB — prisma client generated, `prisma migrate deploy` completed (127 migrations found, none pending), proxy served `/health/liveliness` → `"I'm alive!"`, and `/v1/models` exercised the DB-backed auth path (expected 401 for an unregistered test key, proving token-table lookup works on cryptography 49).

## Notes for reviewers

- First runtime attempt was OOM-killed (exit 137) — that was Docker VM memory pressure (5.8GB VM, 24 containers), not the image; retried with `--memory 2g` and it started fine.
- `.claude/claude_config.json` local modification deliberately excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)