### PR TITLE
docs(service): audit Dopemux service integration gaps

### DIFF
--- a/docs/06-research/2026-07-04-dopemux-service-investigation/adhd-untracked-work-design.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/adhd-untracked-work-design.md
@@ -1,13 +1,13 @@
 ---
 id: adhd-untracked-work-design
-title: Adhd Untracked Work Design
+title: ADHD Untracked Work Design
 type: reference
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-07-04'
 last_review: '2026-07-04'
 next_review: '2026-10-02'
-prelude: Adhd Untracked Work Design (reference) for dopemux documentation and developer
+prelude: ADHD Untracked Work Design (reference) for dopemux documentation and developer
   workflows.
 ---
 # ADHD + Serena/F001 + Task Orchestrator + Cockpit Integration Design

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/adhd-untracked-work-design.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/adhd-untracked-work-design.md
@@ -1,0 +1,122 @@
+---
+id: adhd-untracked-work-design
+title: Adhd Untracked Work Design
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-07-04'
+last_review: '2026-07-04'
+next_review: '2026-10-02'
+prelude: Adhd Untracked Work Design (reference) for dopemux documentation and developer
+  workflows.
+---
+# ADHD + Serena/F001 + Task Orchestrator + Cockpit Integration Design
+
+## Current Truth
+
+### ADHD Engine
+
+- OBSERVED: `services/adhd_engine/main.py` creates a FastAPI service and FastMCP app named `ADHD-Engine`.
+- OBSERVED: ADHD Engine exposes HTTP root, `/health`, `/metrics`, `/api/v1/*`, `/mcp`, and stdio MCP via `services/adhd_engine/mcp_stdio.py`.
+- OBSERVED: `services/adhd_engine/api/routes.py` exposes cognitive state, task assessment, activity, break, hook, WebSocket, trust, and dashboard-friendly endpoints.
+- OBSERVED: ADHD Engine uses Redis/cache/in-memory state, bridge projections, and event helper modules. A single durable ADHD ledger is not proven.
+- CONCLUSION: ADHD Engine owns current support-state and recommendations only. It does not own PM truth, workflow transitions, chronicle, ConPort, dope-context, or bridge authority.
+
+### Serena/F001
+
+- OBSERVED: `services/serena/untracked_work_detector.py` implements base and enhanced detection through `detect()` and `detect_with_enhancements()`.
+- OBSERVED: Enhanced F001 components exist: false-starts aggregation, design-first detection, revival suggestions, and prioritization context.
+- OBSERVED: `services/serena/mcp_server.py` implements `detect_untracked_work_enhanced_tool()`.
+- OBSERVED: `detect_untracked_work_enhanced` is not registered in `list_tools()` and is not routed in `call_tool()`.
+- CONCLUSION: Enhanced F001 is implemented but not currently callable through Serena MCP by the expected tool name.
+
+### Task Orchestrator / PM Authority
+
+- OBSERVED: Task Orchestrator is canonical for workflow-significant transitions and workflow views.
+- OBSERVED: ConPort is canonical for structured decisions/progress/custom data.
+- OBSERVED: Serena currently uses ConPort-shaped custom-data/progress calls for F001 records.
+- CONCLUSION: F001 can recommend or request tracking, but final workflow item creation/transition needs Task Orchestrator/ConPort authority boundaries.
+
+### Cockpit / Dashboard
+
+- OBSERVED: Cockpit render modes are deterministic, guarded, and no-write.
+- OBSERVED: ADHD dashboard/backend and `ui-dashboard` consume ADHD Engine state separately.
+- UNKNOWN: A live Cockpit data source for Serena F001 or ADHD Engine state is not proven.
+- CONCLUSION: Cockpit should become the unified operator surface for F001/service awareness, but action execution should remain gated and receipt-based.
+
+## Intended Final Design
+
+### Data Flow
+
+```text
+workspace/git state
+  -> Serena F001 detector
+  -> ConPort custom_data: untracked_work
+  -> Cockpit service/F001 data source
+  -> operator quick action
+  -> Task Orchestrator or ConPort canonical writer
+  -> receipt mirrored to dope-memory where appropriate
+
+activity/window/git/hook signals
+  -> workspace-watcher/activity-capture/ADHD hooks
+  -> ADHD Engine current state and recommendations
+  -> dashboard/Cockpit cognitive-state panel
+  -> non-authoritative suggestions only
+```
+
+### Authority Rules
+
+- Serena detects and explains. It does not own PM truth.
+- ADHD Engine assesses cognitive state and suggests accommodations. It does not own PM truth.
+- Cockpit displays, asks, gates, and receipts. It does not silently mutate.
+- Task Orchestrator owns workflow transitions and next-work state.
+- ConPort owns structured progress, decisions, custom data, and F001 record persistence.
+- dope-memory owns historical receipts, not current PM state.
+- dopecon-bridge transports/proxies and must carry provenance.
+
+### F001 Enhanced Tool Contract
+
+PROPOSED MCP tool:
+
+```text
+detect_untracked_work_enhanced(session_number: int = 1, show_details: bool = false)
+```
+
+Minimum response requirements:
+
+- `status`: `all_clear | untracked_work_detected | degraded | error`
+- `work_summary`: name, branch, files changed, confidence, threshold
+- `false_starts_dashboard`: total unfinished, snoozed, abandoned, message, provenance
+- `design_first_recommendation`: optional, with reasons and document type
+- `revival_suggestions`: optional, max 3
+- `prioritization_context`: active counts and risk level
+- `suggested_actions`: inspect, track, design_first, resume_abandoned, snooze, ignore
+- `provenance`: tool version, workspace id, ConPort availability, fallback flags
+
+The existing implementation already produces most content, but the MCP registration and degraded provenance need hardening.
+
+## Implementation Gaps
+
+1. F001 Enhanced tool is not registered/callable through Serena MCP.
+2. F001 fallback behavior returns empty/mock-like summaries without a strong degraded flag.
+3. Cockpit does not have a proven live F001/ADHD/service-state data source.
+4. ADHD dashboard and Cockpit are separate UX surfaces with no shared service-state model.
+5. Service aliases are not normalized into one operator-facing model.
+6. Task Orchestrator integration for F001 quick actions is not clearly defined as a gated write path.
+
+## Proposed Integration Slices
+
+1. Register and test `detect_untracked_work_enhanced` in Serena MCP.
+2. Add explicit degraded/provenance fields to F001 responses when ConPort or pattern history is unavailable.
+3. Add a read-only Cockpit data source for service inventory, ADHD state, and F001 summary.
+4. Add Cockpit UI rows for untracked work: inspect, copy evidence, create Task Packet prompt, and open safe action gate.
+5. Add gated action adapters for track/snooze/ignore/design-first with ConPort/Task Orchestrator receipts.
+6. Add dashboard/Cockpit shared display contract so the web dashboard and terminal Cockpit present the same cognitive/F001 truth states.
+
+## Safety Constraints
+
+- No implicit PM writes.
+- No silent conversion of `UNKNOWN` to OK.
+- No content-bearing hook payloads into ADHD Engine.
+- No bridge-owned authority claims.
+- No service start/stop from Cockpit without typed service id, explicit consent, and proof receipt.

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/implementation-backlog.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/implementation-backlog.md
@@ -1,0 +1,141 @@
+---
+id: implementation-backlog
+title: Implementation Backlog
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-07-04'
+last_review: '2026-07-04'
+next_review: '2026-10-02'
+prelude: Implementation Backlog (reference) for dopemux documentation and developer
+  workflows.
+---
+# Implementation Backlog
+
+This backlog is ordered to reduce authority drift before adding richer UX. Each item is commit-sized and Task-Packet-ready.
+
+## P0: Correctness And Exposure
+
+### TP-DMX-F001-ENHANCED-MCP-REGISTER-001
+
+- Goal: Make the already-implemented Serena enhanced untracked-work detector callable through MCP.
+- Scope: `services/serena/mcp_server.py`, Serena MCP tests.
+- Changes:
+  - Add `detect_untracked_work_enhanced` to `list_tools()`.
+  - Add dispatch to `call_tool()`.
+  - Update tool grouping metadata.
+  - Add tests proving list and call dispatch.
+- Validation:
+  - `pytest -q services/serena/tests/test_mcp_server_local.py services/serena/test_f001_enhanced.py`
+- Risk:
+  - Current implementation may expose degraded ConPort fallback too optimistically; pair with next packet before UX surfacing.
+
+### TP-DMX-F001-PROVENANCE-DEGRADED-001
+
+- Goal: Make F001 fallback/degraded states explicit.
+- Scope: Serena F001 detector/storage/aggregator output shapes and tests.
+- Changes:
+  - Add `provenance` and `degraded` fields to enhanced detection responses.
+  - Distinguish `no data` from `ConPort unavailable`.
+  - Ensure mock/empty dashboard summaries are never rendered as healthy history.
+- Validation:
+  - Serena F001 unit tests plus response-shape regression test.
+
+### TP-DMX-SERVICE-MODEL-ALIASES-001
+
+- Goal: Create a normalized service inventory model that groups directory, compose, registry, and catalog aliases.
+- Scope: new read-only model under `src/dopemux/ui` or `src/dopemux/orchestrator/ui`.
+- Changes:
+  - Group aliases: `qdrant/mcp-qdrant`, `gptr-mcp/gpt-researcher`, `adhd_engine/adhd-engine`, `dope-memory/working-memory-assistant`, `conport-http/conport-mcp/conport`.
+  - Expose classification and action policy.
+- Validation:
+  - Unit tests for alias grouping and classification.
+
+## P1: Cockpit Read-Only Integration
+
+### TP-DMX-COCKPIT-SERVICE-DATA-SOURCE-001
+
+- Goal: Add a read-only Cockpit data source for service inventory and status provenance.
+- Scope: Cockpit data-source layer and services mode.
+- Changes:
+  - Read compose/registry/catalog without starting services.
+  - Display active, support, adapter, duplicate, legacy, unknown.
+  - Preserve `UNKNOWN` and `NOT_PROBED`.
+- Validation:
+  - Cockpit render-mode tests and data-source unit tests.
+
+### TP-DMX-COCKPIT-F001-PANEL-001
+
+- Goal: Surface F001 untracked-work summary in Cockpit without writes.
+- Scope: Cockpit events/services/implementer mode read-only panel.
+- Changes:
+  - Call Serena enhanced MCP when available.
+  - Show degraded state when tool is missing or ConPort is unavailable.
+  - Provide inspect/copy-evidence/copy-task-prompt actions only.
+- Validation:
+  - Unit tests for all-clear, detected, degraded, and unavailable states.
+
+### TP-DMX-COCKPIT-ADHD-STATE-PANEL-001
+
+- Goal: Surface ADHD Engine cognitive state in Cockpit as advisory support.
+- Scope: Cockpit data source and render surface.
+- Changes:
+  - Read ADHD Engine health/state when available.
+  - Never treat cognitive state as workflow authority.
+  - Show stale/unavailable with explicit timestamp and source.
+- Validation:
+  - Unit tests using mocked ADHD Engine responses.
+
+## P2: Gated Actions And Receipts
+
+### TP-DMX-F001-TRACK-WORK-GATE-001
+
+- Goal: Convert F001 track/snooze/ignore/design-first into safe action gates.
+- Scope: Cockpit safe action gate, Serena action adapters, ConPort/Task Orchestrator receipts.
+- Changes:
+  - Require explicit operator confirmation.
+  - Write only through canonical writer for each action.
+  - Return receipts with source, destination, id, timestamp, and rollback/undo guidance.
+- Validation:
+  - Unit tests for receipt shape and blocked writes.
+
+### TP-DMX-F001-TASK-ORCH-ESCALATION-001
+
+- Goal: Escalate detected untracked work into Task Orchestrator when the operator chooses to track work as workflow.
+- Scope: Task Orchestrator client adapter and F001 action flow.
+- Changes:
+  - Map F001 detection to a work item draft.
+  - Keep ConPort custom-data as detection record, not workflow authority.
+  - Link Task Orchestrator item id back to F001 record.
+- Validation:
+  - Adapter tests with fake Task Orchestrator.
+
+## P3: Gorgeous Seamless UX
+
+### TP-DMX-DASHBOARD-COCKPIT-SHARED-STATE-001
+
+- Goal: Align web dashboard and terminal Cockpit display semantics.
+- Scope: shared status model, dashboard mapping, Cockpit rendering.
+- Changes:
+  - Shared state labels: `LIVE`, `DEGRADED`, `NOT_PROBED`, `UNKNOWN`, `BLOCKED`.
+  - Common colors/tokens with low cognitive load and no false green.
+  - F001 summary and ADHD advisory state share provenance language.
+- Validation:
+  - UI tests for mapping, accessibility, and no misleading success state.
+
+### TP-DMX-IMPLICIT-SESSION-START-SURFACING-001
+
+- Goal: At session start, gently surface current untracked work and service drift without blocking.
+- Scope: Dopemux startup/Cockpit session view.
+- Changes:
+  - Show max three high-signal items.
+  - Avoid shame language and avoid modal interruption.
+  - Offer one keystroke to inspect, not mutate.
+- Validation:
+  - Snapshot tests for clean slate, one untracked work item, many false-starts, and unavailable MCP.
+
+## Deferred / Needs Decision
+
+- Whether `activity-capture`, `workspace-watcher`, `adhd-dashboard`, and `adhd-notifier` should be promoted into canonical compose/registry.
+- Whether source-only service directories should be archived after alias model lands.
+- Whether web dashboard should remain separate from Cockpit or become a Cockpit web surface.

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/implementation-notes.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/implementation-notes.md
@@ -18,7 +18,7 @@ Task Packet: `TP-DMX-SERVICE-INVESTIGATION-20260704`.
 
 ## Scope Executed
 
-- Created a dedicated worktree at `/Users/hue/code/dopemux-mvp/.worktrees/dopemux-service-investigation-20260704`.
+- Created a dedicated worktree at `<repo-root>/.worktrees/dopemux-service-investigation-20260704` (see `git worktree list`).
 - Created the repo-bound Task Packet for this audit.
 - Wrote the requested read-only investigation package under `docs/06-research/2026-07-04-dopemux-service-investigation/`.
 - Runtime systems were not started for this audit.

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/implementation-notes.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/implementation-notes.md
@@ -1,0 +1,44 @@
+---
+id: implementation-notes
+title: Implementation Notes
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-07-04'
+last_review: '2026-07-04'
+next_review: '2026-10-02'
+prelude: Implementation Notes (reference) for dopemux documentation and developer
+  workflows.
+---
+# Implementation Notes: Dopemux Service Investigation
+
+Status: OBSERVED implementation artifact.
+Date: 2026-07-04.
+Task Packet: `TP-DMX-SERVICE-INVESTIGATION-20260704`.
+
+## Scope Executed
+
+- Created a dedicated worktree at `/Users/hue/code/dopemux-mvp/.worktrees/dopemux-service-investigation-20260704`.
+- Created the repo-bound Task Packet for this audit.
+- Wrote the requested read-only investigation package under `docs/06-research/2026-07-04-dopemux-service-investigation/`.
+- Runtime systems were not started for this audit.
+
+## Artifact Map
+
+- `research.md`: evidence summary, inventory counts, deep-dive findings, validation ledger.
+- `service-gap-matrix.md`: service-by-service matrix across top-level service directories, compose services, registry services, docs, tests, entrypoints, gaps, and recommended next actions.
+- `adhd-untracked-work-design.md`: target integration design for ADHD Engine, Serena/F001, Task Orchestrator, MCP, and Cockpit.
+- `implementation-backlog.md`: commit-sized follow-on slices ordered by dependency and risk.
+- `ux-integration-spec.md`: Cockpit/dashboard UX model, safe actions, receipts, progressive disclosure, and visual quality bar.
+
+## Important Boundaries
+
+- OBSERVED findings are limited to repository source, config, docs, and non-mutating command output.
+- INFERRED design is marked as inference and should not be treated as runtime truth.
+- PROPOSED follow-on work is backlog material, not an implemented feature claim.
+- UNKNOWN items require either service startup, external MCP state, or additional implementation packets.
+
+## Precommit Notes
+
+- `.claude/claude_config.json` may be locally rewritten by worktree-aware tooling and is outside the scoped allowlist for this audit packet.
+- Stage and commit only the Task Packet and investigation files listed in the Task Packet allowlist.

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/research.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/research.md
@@ -13,14 +13,14 @@ prelude: Research (reference) for dopemux documentation and developer workflows.
 
 Date: 2026-07-04
 Task Packet: `TP-DMX-SERVICE-INVESTIGATION-20260704`
-Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/dopemux-service-investigation-20260704`
+Worktree: `<repo-root>/.worktrees/dopemux-service-investigation-20260704` (see `git worktree list`)
 Branch: `codex/dopemux-service-investigation-20260704`
 
 ## Executive Summary
 
 This audit inspected the live repo shape, not only the curated service catalog. The observed service surface is larger than the Tier 1-4 catalog summary:
 
-- OBSERVED: `43` top-level `services/*` directories exist in this checkout, including non-service artifacts such as `services/.claude` and `services/__pycache__`.
+- OBSERVED: `42` tracked top-level `services/*` directories exist in git (`git ls-tree -d --name-only HEAD services/`), including non-service artifacts such as `services/.claude`.
 - OBSERVED: `24` services are declared in `compose.yml`.
 - OBSERVED: `21` service rows exist in `services/registry.yaml`.
 - OBSERVED: `SERVICE_CATALOG.md` already separates canonical systems from support, adapter, duplicate, legacy, drifted, and unknown surfaces.
@@ -40,7 +40,7 @@ The strongest current architecture remains a multi-plane control stack, not a un
 OBSERVED from live tree/config:
 
 ```text
-top-level services directories: 43
+top-level services directories: 42
 compose services: 24
 registry services: 21
 ```
@@ -48,7 +48,7 @@ registry services: 21
 Top-level `services/*` candidates observed:
 
 ```text
-.claude, __pycache__, activity-capture, adhd-dashboard, adhd-engine,
+.claude, activity-capture, adhd-dashboard, adhd-engine,
 adhd-notifier, adhd_engine, adhd_notifier, agents, claude_brain,
 complexity_coordinator, conport_kg, conport_kg_ui, copilot_transcript_ingester,
 dcp-readonly-facade, dddpg, dope-context, dope-memory, dope-query,
@@ -155,7 +155,7 @@ CONCLUSION: The UX needs a naming reconciliation layer that names canonical runt
 PASS:
 
 - `python -m json.tool task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json >/dev/null` exited `0`.
-- `python - <<'PY' ... jsonschema.validate(...) ... PY` exited `0` and printed `schema_ok`.
+- `python - <<'PY' ... jsonschema.validate(...) ... PY` exited `0`.
 - `docker compose -f compose.yml config` exited `0`. Raw output is not reproduced because it rendered sensitive-looking environment values from local compose configuration.
 - `dopemux mcp status` exited `0`. It reported the already-running Dopemux containers, including healthy ConPort, Serena, dope-context, dope-memory, dopecon-bridge, Task Orchestrator, Leantime, PAL, Exa, desktop-commander, Redis, Postgres, and Qdrant surfaces, plus an unhealthy LiteLLM container.
 - `pytest -q tests/mcp tests/unit/dopemux/ui/cockpit` exited `0` with `183` passing tests.

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/research.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/research.md
@@ -1,0 +1,175 @@
+---
+id: research
+title: Research
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-07-04'
+last_review: '2026-07-04'
+next_review: '2026-10-02'
+prelude: Research (reference) for dopemux documentation and developer workflows.
+---
+# Exhaustive Dopemux Service Investigation
+
+Date: 2026-07-04
+Task Packet: `TP-DMX-SERVICE-INVESTIGATION-20260704`
+Worktree: `/Users/hue/code/dopemux-mvp/.worktrees/dopemux-service-investigation-20260704`
+Branch: `codex/dopemux-service-investigation-20260704`
+
+## Executive Summary
+
+This audit inspected the live repo shape, not only the curated service catalog. The observed service surface is larger than the Tier 1-4 catalog summary:
+
+- OBSERVED: `43` top-level `services/*` directories exist in this checkout, including non-service artifacts such as `services/.claude` and `services/__pycache__`.
+- OBSERVED: `24` services are declared in `compose.yml`.
+- OBSERVED: `21` service rows exist in `services/registry.yaml`.
+- OBSERVED: `SERVICE_CATALOG.md` already separates canonical systems from support, adapter, duplicate, legacy, drifted, and unknown surfaces.
+
+The strongest current architecture remains a multi-plane control stack, not a unified platform. `dopemux` is the operator control surface, Task Orchestrator owns workflow transitions, ConPort owns structured decisions/progress/context, dope-memory owns chronicle receipts, dope-context owns code/docs retrieval, dopecon-bridge is transport/proxy, ADHD Engine is operator support, and Serena is code-intelligence/F001 detection support.
+
+## Authority Used
+
+- OBSERVED: `AGENTS.md` defines repo truth order, worktree/Task Packet requirements, PAL chain expectations, proof requirements, and the rule that ADHD Engine is support only.
+- OBSERVED: `PROJECT.md`, `ARCHITECTURE.md`, `PM_PLANE.md`, and `SERVICE_CATALOG.md` describe the current split architecture and known drift.
+- OBSERVED: `compose.yml` is marked the canonical Docker Compose entrypoint and declares the active service stack.
+- OBSERVED: `services/registry.yaml` lists service health and port metadata for the registered operational set.
+- OBSERVED: `services/serena/mcp_server.py`, `services/serena/untracked_work_detector.py`, `services/adhd_engine/main.py`, `services/adhd_engine/api/routes.py`, `src/dopemux/commands/mcp_commands.py`, and `src/dopemux/ui/cockpit/*` are runtime/code evidence for the key deep-dive flows.
+
+## Inventory Counts
+
+OBSERVED from live tree/config:
+
+```text
+top-level services directories: 43
+compose services: 24
+registry services: 21
+```
+
+Top-level `services/*` candidates observed:
+
+```text
+.claude, __pycache__, activity-capture, adhd-dashboard, adhd-engine,
+adhd-notifier, adhd_engine, adhd_notifier, agents, claude_brain,
+complexity_coordinator, conport_kg, conport_kg_ui, copilot_transcript_ingester,
+dcp-readonly-facade, dddpg, dope-context, dope-memory, dope-query,
+dopecon-bridge, dopemux-gpt-researcher, intelligence, mcp-capture,
+mcp-client, mcp-integration-bridge, ml-predictions, ml-risk-assessment,
+monitoring, monitoring-dashboard, repo-truth-extractor, router, serena,
+session-intelligence, session-manager, session_intelligence, shared,
+slack-integration, task-orchestrator, task-router, voice-commands,
+webhook_receiver, working-memory-assistant, workspace-watcher
+```
+
+Compose services observed:
+
+```text
+adhd-engine, conport, desktop-commander, dope-context, dope-memory,
+dopecon-bridge, exa, gptr-mcp, leantime, leantime-bridge, litellm,
+mcp-qdrant, mysql_leantime, pal, pal-stdio, postgres, redis-events,
+redis-primary, redis-ui, redis_leantime, serena, task-orchestrator,
+webhook-poller, webhook-receiver
+```
+
+Registry services observed:
+
+```text
+postgres, redis-events, redis-primary, qdrant, dopecon-bridge,
+dopecon-bridge-alt, pal, conport-http, conport-mcp, serena, gpt-researcher,
+dope-context, exa, desktop-commander, task-orchestrator, leantime-bridge,
+dope-memory, adhd-engine, leantime, webhook-receiver, litellm
+```
+
+## Key Findings
+
+### 1. The service surface is broad, but the active spine is narrower.
+
+OBSERVED: `compose.yml` wires 24 active runtime/container services. `services/registry.yaml` registers 21 health/port rows. Many `services/*` directories are implementation libraries, duplicates, old experiments, support services, or unwired adjacent surfaces.
+
+INFERRED: Operational UX should not show every directory as an equally actionable service. It should show a layered inventory: active stack, registered but indirect services, source-only support surfaces, and drift/unknown candidates.
+
+### 2. Serena F001 Enhanced exists in code but is not exposed as an MCP tool.
+
+OBSERVED: `services/serena/mcp_server.py` implements `detect_untracked_work_enhanced_tool()` around lines where the method is defined.
+
+OBSERVED: The MCP `list_tools()` registration includes `detect_untracked_work`, `track_untracked_work`, `snooze_untracked_work`, `ignore_untracked_work`, config tools, and analytics tools, but no `detect_untracked_work_enhanced` tool name.
+
+OBSERVED: The `call_tool()` dispatch chain routes `detect_untracked_work` but does not route `detect_untracked_work_enhanced`.
+
+CONCLUSION: The enhanced E1-E4 detection path is present but not currently callable through Serena MCP by name. The current callable path is the base `detect_untracked_work` tool.
+
+### 3. Serena F001 storage/action paths are ConPort-shaped but need contract hardening.
+
+OBSERVED: `services/serena/untracked_work_storage.py` stores category `untracked_work` through `conport_client.log_custom_data(...)` and reads via `get_custom_data(...)`.
+
+OBSERVED: `track_untracked_work_tool()` in `services/serena/mcp_server.py` creates progress-like records and links in `untracked_work_links`.
+
+OBSERVED: `FalseStartsAggregator`, `PriorityContextBuilder`, and metrics helpers tolerate missing ConPort clients and return empty/mock-like views.
+
+INFERRED: The fallback behavior is useful for non-blocking UX but currently risks looking healthier than reality unless surfaced as degraded/unknown in Cockpit and dashboard.
+
+### 4. ADHD Engine is active support runtime, not a PM or memory authority.
+
+OBSERVED: `services/adhd_engine/main.py` creates the FastAPI app, mounts FastMCP under `/mcp`, and includes `/api/v1` routes.
+
+OBSERVED: `services/adhd_engine/api/routes.py` exposes state, assessment, break, activity, hook, WebSocket, and trust/customization surfaces.
+
+OBSERVED: Event handling spans Redis stream `dopemux:events`, `event_emitter.py`, `event_listener.py`, `workspace_watcher.py`, dashboard backend, and activity-capture. Startup of some pieces is conditional/degraded.
+
+CONCLUSION: ADHD Engine can produce cognitive state and recommendation signals. It should not directly create PM truth. It should emit support signals, and Task Orchestrator/ConPort should own workflow/progress effects.
+
+### 5. Cockpit currently emphasizes deterministic visibility and guarded actions.
+
+OBSERVED: `src/dopemux/ui/cockpit/render_modes.py` renders PM, Implementer, Overview, Services, and Events modes as deterministic/no-write surfaces.
+
+OBSERVED: `src/dopemux/ui/cockpit/runtime_contract.py` models command palette, safe action gates, settings/admin/runtime, and unknown-drift queues.
+
+OBSERVED: No inspected Cockpit path directly consumes Serena F001 or ADHD Engine live state. Dashboard frontend and ADHD dashboard backend are separate surfaces.
+
+CONCLUSION: Cockpit is the right home for service/F001 visibility, but a separate data-source integration packet is needed before claiming live F001/ADHD surfacing.
+
+### 6. Several service families have naming or deployment drift.
+
+OBSERVED examples:
+
+- `services/adhd_engine` is active; `services/adhd-engine` is duplicate residue.
+- `services/adhd-notifier` exists; `services/adhd_notifier` is only a small Python package-like duplicate.
+- `services/session-intelligence` and `services/session_intelligence` both exist.
+- `services/serena` contains substantial code, while compose builds from `docker/mcp-servers/serena/Dockerfile`.
+- `dope-memory` compose runtime points at `services/working-memory-assistant/Dockerfile.dope-memory`, while `services/dope-memory` contains only an MCP stdio adapter.
+
+CONCLUSION: The UX needs a naming reconciliation layer that names canonical runtime, source-only support tree, and duplicates separately.
+
+## Risk List
+
+- HIGH: Showing directory presence as service health would mislead operators.
+- HIGH: Exposing F001 Enhanced UX before registering/dispatching the MCP tool would create a false affordance.
+- HIGH: Treating ADHD Engine activity/hook state as durable PM truth would violate architecture boundaries.
+- MEDIUM: Mock/fallback dashboard behavior can appear healthy unless degraded provenance is visible.
+- MEDIUM: Compose and registry do not cover all source-only service families, so "all services" needs a multi-layer inventory model.
+- MEDIUM: `docker compose -f compose.yml config` renders sensitive-looking environment values from the local compose configuration. Raw config output should not be copied into reports or UX receipts.
+- MEDIUM: Large service test suites may fail for environment/dependency reasons unrelated to this docs-only audit.
+- LOW: Some adjacent service docs are stale and may overclaim production readiness compared with current runtime wiring.
+
+## Validation Ledger
+
+PASS:
+
+- `python -m json.tool task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json >/dev/null` exited `0`.
+- `python - <<'PY' ... jsonschema.validate(...) ... PY` exited `0` and printed `schema_ok`.
+- `docker compose -f compose.yml config` exited `0`. Raw output is not reproduced because it rendered sensitive-looking environment values from local compose configuration.
+- `dopemux mcp status` exited `0`. It reported the already-running Dopemux containers, including healthy ConPort, Serena, dope-context, dope-memory, dopecon-bridge, Task Orchestrator, Leantime, PAL, Exa, desktop-commander, Redis, Postgres, and Qdrant surfaces, plus an unhealthy LiteLLM container.
+- `pytest -q tests/mcp tests/unit/dopemux/ui/cockpit` exited `0` with `183` passing tests.
+
+FAIL:
+
+- `pytest -q services/serena/test_f001_enhanced.py services/serena/tests/test_mcp_server_local.py` exited `3` during collection. Key output: `Import failed: No module named 'untracked_work_detector'`, then `SystemExit: 1` from `services/serena/test_f001_enhanced.py`.
+- `pytest -q services/adhd_engine/tests tests/unit/test_adhd_*.py` exited `2` during collection. Key output: missing modules including `services.adhd_engine.attention_calibrator`, `ml`, `adhd_engine.feature_flags`, and `services.adhd_engine.voice_assistant`.
+
+NOT_RUN:
+
+- `pnpm --dir ui-dashboard test` was not run because `ui-dashboard/node_modules` is missing in this worktree. The guard command exited `125` with `NOT_RUN: ui-dashboard/node_modules missing`.
+- Live health probes beyond the already-running `dopemux mcp status` container view were not run because this audit did not authorize starting stopped services or mutating runtime state.
+
+PENDING:
+
+- `git diff --check` runs at precommit after final report edits.

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/service-gap-matrix.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/service-gap-matrix.md
@@ -25,7 +25,6 @@ Legend:
 | Candidate | Compose | Registry | Classification | Observed role | Gap / risk | Recommended next action |
 |---|---:|---:|---|---|---|---|
 | `services/.claude` | no | no | non-service artifact | Claude-local service subtree metadata. | Can inflate service counts if treated as runtime. | Exclude from operational health; keep in raw inventory only. |
-| `services/__pycache__` | no | no | non-service artifact | Python bytecode cache directory. | Not a service. | Exclude from operational UX. |
 | `activity-capture` | no | no | support/unknown | FastAPI service consumes `dopemux:events` and sends content-free activity to ADHD Engine. | Not compose/registry wired in canonical stack. | Promote to support service only after compose/registry wiring and smoke tests. |
 | `adhd-dashboard` | no | no | support/unknown | Backend proxies ADHD Engine, activity-capture metrics, Redis state streams, and dashboard WebSocket. | README references stale compose file; not active in canonical compose. | Add explicit registry/compose decision or mark source-only dashboard backend. |
 | `adhd-engine` | `adhd-engine` | `adhd-engine` | duplicate naming drift | Hyphenated tree contains only `auth.py` in inspected max-depth inventory. | Can be confused with active `adhd_engine`. | Retire, redirect, or document as duplicate residue. |

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/service-gap-matrix.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/service-gap-matrix.md
@@ -1,0 +1,96 @@
+---
+id: service-gap-matrix
+title: Service Gap Matrix
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-07-04'
+last_review: '2026-07-04'
+next_review: '2026-10-02'
+prelude: Service Gap Matrix (reference) for dopemux documentation and developer workflows.
+---
+# Dopemux Service Gap Matrix
+
+This matrix classifies every observed top-level `services/*` candidate plus compose-only and registry-only services. It distinguishes active runtime authority from source-only, duplicate, support, adapter, and unknown surfaces.
+
+Legend:
+
+- OBSERVED: directly supported by repo files/config.
+- INFERRED: best interpretation from nearby evidence.
+- UNKNOWN: not proven by inspected runtime/config/tests.
+- PROPOSED: recommended target or follow-up, not current state.
+
+## Directory Candidates
+
+| Candidate | Compose | Registry | Classification | Observed role | Gap / risk | Recommended next action |
+|---|---:|---:|---|---|---|---|
+| `services/.claude` | no | no | non-service artifact | Claude-local service subtree metadata. | Can inflate service counts if treated as runtime. | Exclude from operational health; keep in raw inventory only. |
+| `services/__pycache__` | no | no | non-service artifact | Python bytecode cache directory. | Not a service. | Exclude from operational UX. |
+| `activity-capture` | no | no | support/unknown | FastAPI service consumes `dopemux:events` and sends content-free activity to ADHD Engine. | Not compose/registry wired in canonical stack. | Promote to support service only after compose/registry wiring and smoke tests. |
+| `adhd-dashboard` | no | no | support/unknown | Backend proxies ADHD Engine, activity-capture metrics, Redis state streams, and dashboard WebSocket. | README references stale compose file; not active in canonical compose. | Add explicit registry/compose decision or mark source-only dashboard backend. |
+| `adhd-engine` | `adhd-engine` | `adhd-engine` | duplicate naming drift | Hyphenated tree contains only `auth.py` in inspected max-depth inventory. | Can be confused with active `adhd_engine`. | Retire, redirect, or document as duplicate residue. |
+| `adhd-notifier` | no | no | support/unknown | Break/hyperfocus notification service with Dockerfile and monitor logic. | Not active in canonical compose/registry. | Wire as optional support service or archive. |
+| `adhd_engine` | `adhd-engine` | `adhd-engine` | active canonical support runtime | FastAPI + FastMCP ADHD/operator-support runtime. | Broad routes/event paths; durable store and event listener guarantees remain mixed. | Keep as operator-support authority only; add integration hardening packets. |
+| `adhd_notifier` | no | no | duplicate/support | Minimal import package for mobile push. | Duplicates hyphenated notifier family. | Consolidate import package or document its purpose. |
+| `agents` | no | no | unknown/experimental | Multiple agent implementations and tests. | Repo-wide agent authority remains UNKNOWN. | Keep out of canonical UX until runtime owner is proven. |
+| `claude_brain` | no | no | experimental/unknown | Claude adaptation/proactive intervention service code with Dockerfile. | Not canonical compose/registry. | Archive or define support boundary. |
+| `complexity_coordinator` | no | no | support/unknown | Unified complexity helper. | Not wired as service. | Treat as library unless promoted. |
+| `conport_kg` | no | no | drift/unknown | AGE/KG integration helpers. | Overlaps ConPort authority but not active canonical ConPort runtime. | Keep distinct from ConPort; document as adjacent tooling. |
+| `conport_kg_ui` | no | no | drift/unknown | UI package for KG-adjacent surface. | Not compose/registry canonical. | Mark source-only until deployed. |
+| `copilot_transcript_ingester` | no | no | support/unknown | Transcript ingestion package. | No active runtime wiring found. | Keep as tool/support candidate. |
+| `dcp-readonly-facade` | no | no | adapter/support | Read-only DCP facade with tests. | Not active compose service. | Preserve as read-only adapter; do not promote to authority. |
+| `dddpg` | no | no | experimental/support | Bridge/KG integration helpers and tests. | Not active service. | Archive or document as support library. |
+| `dope-context` | `dope-context` | `dope-context` | canonical retrieval runtime | Dockerized code/docs retrieval and indexing surface. | Derived retrieval can be mistaken for source truth. | Keep retrieval-only in UX. |
+| `dope-memory` | `dope-memory` | `dope-memory` | adapter/drift | Directory only shows MCP stdio adapter; compose uses working-memory-assistant Dockerfile. | Directory name does not contain full runtime. | Label runtime path explicitly in Cockpit/service inventory. |
+| `dope-query` | no | no | legacy | Sparse old retrieval/query surface per catalog. | Could be mistaken for active retrieval. | Archive or add pointer to dope-context/ConPort. |
+| `dopecon-bridge` | `dopecon-bridge` | `dopecon-bridge` / `dopecon-bridge-alt` | active proxy/transport | Bridge/proxy/event routing service. | Broad surface looks authoritative, but is not. | UX must show "proxy only" provenance on all bridge-backed data. |
+| `dopemux-gpt-researcher` | no (`gptr-mcp` compose) | `gpt-researcher` | active-but-drifted/source-only | Research API implementation and tests. | Compose builds separate Docker MCP source. | Reconcile in-repo implementation vs Docker wrapper. |
+| `intelligence` | no | no | support/unknown | Pattern correlation engine. | Not service-wired. | Treat as library unless promoted. |
+| `mcp-capture` | no | no | support/unknown | MCP capture server/test surface. | Not registry/compose active. | Decide if capture belongs in operator observability. |
+| `mcp-client` | no | no | adapter | Utility MCP client. | Owns no domain truth. | Keep as diagnostic tool only. |
+| `mcp-integration-bridge` | no | no | duplicate/adapter drift | KG endpoint/bridge-like code. | Overlaps dopecon-bridge. | Archive or prove active usage. |
+| `ml-predictions` | no | no | support/unknown | LSTM cognitive predictor service code. | ADHD Engine has internal ML modules too. | Consolidate ML prediction ownership. |
+| `ml-risk-assessment` | no | no | support/unknown | Risk assessment engine. | Not active compose/registry. | Treat as future support until wired. |
+| `monitoring` | no | no | support library | Health and Prometheus helper modules. | Not a standalone service. | Use as shared library; exclude from service health rows. |
+| `monitoring-dashboard` | no | no | support/unknown | Monitoring dashboard server with Dockerfile. | Not active canonical compose. | Decide whether Cockpit supersedes it. |
+| `repo-truth-extractor` | no | no | canonical audit subsystem | v5 extraction/audit runtime. | Not compose service; live/provider gates must stay explicit. | Keep as audit runtime, not source truth. |
+| `router` | no | no | package/unknown | Empty/minimal router package. | No service evidence. | Exclude from UX except raw inventory. |
+| `serena` | `serena` | `serena` | active-but-drifted support/MCP | Code intelligence and F001 detection implementation. | Compose uses Docker wrapper; enhanced F001 tool is implemented but not registered/callable. | Add F001 Enhanced registration packet and deployment authority reconciliation. |
+| `session-intelligence` | no | no | support/unknown | README and bridge adapter. | Duplicate with underscore package. | Consolidate naming and authority. |
+| `session-manager` | no | no | support/unknown | Session orchestrator/TUI demo package. | Not canonical service. | Define if it belongs under Cockpit or archive. |
+| `session_intelligence` | no | no | support/unknown | Python coordinator package. | Naming drift with hyphenated service. | Consolidate or document import/runtime split. |
+| `shared` | no | no | support library | Shared brand voice, exceptions, workspace utilities. | Not service runtime. | Keep library-only. |
+| `slack-integration` | no | no | adapter/unknown | Slack notifier. | No active wiring. | Mark optional integration. |
+| `task-orchestrator` | `task-orchestrator` | `task-orchestrator` | active canonical workflow surface with drift | Workflow coordination and PM transition service. | Legacy files and multiple paths still confuse runtime authority. | Keep canonical runtime path explicit; avoid local DB authority overclaims. |
+| `task-router` | no | no | unknown/legacy | Routing/matching helpers. | Not current canonical stack. | Archive or prove active use. |
+| `voice-commands` | no | no | experimental/support | Voice API/task decomposer with Dockerfile. | Not active compose/registry. | Treat as future optional support. |
+| `webhook_receiver` | `webhook-receiver`, `webhook-poller` | `webhook-receiver` | active support | Provider webhook ledger and poller. | Registry omits poller row. | Add poller registry row or document as subordinate worker. |
+| `working-memory-assistant` | `dope-memory` | `dope-memory` | canonical runtime path plus support service | Hosts dope-memory runtime and separate WMA support surface. | Tree layout blurs dope-memory vs WMA. | Split service labels in UX: dope-memory runtime vs WMA support. |
+| `workspace-watcher` | no | no | support/unknown | Active app/workspace event emitter. | Not active canonical compose. | Wire into optional ADHD loop or archive. |
+
+## Compose-Only / Registry-Only Surfaces
+
+| Surface | Source | Classification | Gap / risk | Recommended next action |
+|---|---|---|---|---|
+| `conport` | compose | canonical externalized runtime | Registry splits into `conport-http` and `conport-mcp`. | UX should group both rows under one ConPort service. |
+| `desktop-commander` | compose/registry | adapter/MCP | Docker source outside `services/*`. | Show as MCP tool adapter, not repo-owned domain service. |
+| `exa` | compose/registry | adapter/MCP | External search surface. | Mark external/search adapter with credential state unknown. |
+| `gptr-mcp` | compose | adapter/MCP | Registry calls it `gpt-researcher`. | Normalize display alias. |
+| `leantime` | compose/registry | PM metadata app | External PM app, not repo-owned service code. | Show as PM metadata authority. |
+| `leantime-bridge` | compose/registry | adapter | Bridge to Leantime. | Show upstream authority as Leantime. |
+| `litellm` | compose/registry | model routing support | External/provider-dependent. | Show as routing support, not model authority. |
+| `mcp-qdrant` / `qdrant` | compose/registry alias | infrastructure | Name mismatch. | Normalize alias in service model. |
+| `mysql_leantime` | compose | infrastructure | No registry row. | Decide whether infra rows appear in Cockpit. |
+| `pal` / `pal-stdio` | compose/registry partial | adapter/MCP | `pal-stdio` compose row lacks registry row. | Document as PAL transport variant. |
+| `postgres` | compose/registry | infrastructure | Shared backing store. | Show as infrastructure dependency. |
+| `redis-events` | compose/registry | infrastructure/event bus | Event stream dependency. | Show stream name/provenance in event UX. |
+| `redis-primary` | compose/registry | infrastructure/cache | Shared cache/state. | Show as infra, not domain authority. |
+| `redis-ui` | compose | optional infra UI | No registry row. | Keep hidden or optional. |
+| `redis_leantime` | compose | Leantime infra | No registry row. | Group under Leantime. |
+| `webhook-poller` | compose | worker/adapter | Not registry-listed. | Add registry row if operator-visible. |
+
+## Integration Quality Summary
+
+- Strongest active spine: `dopemux`, Task Orchestrator, ConPort, dope-memory, dope-context, dopecon-bridge, ADHD Engine, Repo Truth Extractor, Leantime, Serena, and core MCP/infrastructure containers.
+- Highest-risk gaps: F001 Enhanced not registered, Cockpit lacks live F001/ADHD data source, source-only service directories overinflate actionable services, and dashboard/fallback surfaces need provenance.
+- Best next UX move: build a normalized service model that groups aliases, exposes provenance, and limits actions to safe inspect/receipt flows until each service has proof gates.

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/ux-integration-spec.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/ux-integration-spec.md
@@ -1,0 +1,156 @@
+---
+id: ux-integration-spec
+title: Ux Integration Spec
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-07-04'
+last_review: '2026-07-04'
+next_review: '2026-10-02'
+prelude: Ux Integration Spec (reference) for dopemux documentation and developer workflows.
+---
+# Seamless Operator UX Integration Spec
+
+## Design Goal
+
+Provide a gorgeous, implicit operator experience that notices unfinished work, service drift, and cognitive-state risk without pretending advisory systems own workflow truth. The UX should reduce cognitive load while preserving determinism, replayability, proof, and explicit write gates.
+
+## First-Screen Model
+
+The first operator surface should be Cockpit, not a marketing or explanatory page. It should show:
+
+- Current work state: active Task Orchestrator item, branch/worktree, dirty state.
+- F001 signal: untracked work summary, false-start count, and highest-value next action.
+- Cognitive advisory: ADHD Engine current state if live, otherwise `NOT_PROBED` or `DEGRADED`.
+- Service spine: active/registered/degraded/unknown service count.
+- Proof rail: latest validation or why no validation exists.
+
+## Status Vocabulary
+
+Use stable, audit-friendly labels:
+
+- `LIVE`: directly probed and healthy.
+- `DEGRADED`: service responded or fallback exists, but some dependency is missing.
+- `NOT_PROBED`: intentionally not checked in this run.
+- `UNKNOWN`: repo/runtime does not prove the claim.
+- `BLOCKED`: known blocker prevents action.
+- `ADVISORY`: support signal that must not mutate workflow truth.
+- `PROXY`: bridge/adapter signal that is not source truth.
+
+Do not collapse `UNKNOWN`, `NOT_PROBED`, and `DEGRADED` into a green state.
+
+## Cockpit Layout
+
+### PM Mode
+
+- Show Task Orchestrator workflow truth.
+- Include F001 detected-work row only as a recommendation unless explicitly tracked.
+- If a F001 item was converted, show Task Orchestrator id and ConPort F001 record id.
+
+### Implementer Mode
+
+- Show current branch/worktree and dirty-state summary.
+- Show untracked work detection with max three files by default.
+- Actions: inspect, copy evidence, copy Task Packet prompt, open safe action gate.
+
+### Services Mode
+
+- Show grouped service model:
+  - Active stack
+  - Registered services
+  - Source-only support surfaces
+  - Duplicates/legacy/unknown
+- Group aliases under canonical names.
+- Show per-service authority: canonical, support, adapter, infra, unknown.
+
+### Events Mode
+
+- Show event-bus state and recent event categories when probed.
+- Mark ADHD events as advisory/support.
+- Mark bridge events as transport/proxy.
+
+## Web Dashboard
+
+The web dashboard can provide richer visualization, but it must use the same state vocabulary as Cockpit.
+
+Required behavior:
+
+- Show ADHD Engine state as advisory.
+- Show F001 summary only when backed by Serena tool response or explicit degraded state.
+- Use compact, scan-friendly layout.
+- No fake healthy mock state; mock/demo data must be visibly marked.
+- Provide receipts and source timestamps.
+
+## F001 Interaction Pattern
+
+When untracked work is detected:
+
+1. Surface a concise summary.
+2. Show why it was detected: branch, changed files count, orphan reason, confidence, grace period.
+3. Show false-start context if available.
+4. Offer low-friction actions:
+   - Inspect
+   - Track as workflow item
+   - Create ADR/RFC first
+   - Snooze
+   - Ignore as experiment
+   - Resume related abandoned work
+5. Require explicit confirmation for any write.
+6. Emit a receipt with canonical writer and target id.
+
+Copy should be factual and non-shaming:
+
+```text
+Untracked work detected: "service integration audit"
+5 files changed on codex/example. No linked workflow item found.
+You can inspect, track, design first, snooze, or ignore this experiment.
+```
+
+Avoid:
+
+- modal blocking by default
+- blame language
+- "production-ready" without proof
+- hidden auto-track
+- action buttons without provenance
+
+## Safe Action Gate
+
+Every mutating action must show:
+
+- action name
+- canonical writer
+- target service
+- expected files/records
+- side effects
+- rollback/undo guidance
+- proof that will be emitted
+- confirmation requirement
+
+Examples:
+
+- Track as workflow item: canonical writer `task-orchestrator`; link F001 record in ConPort.
+- Snooze detection: canonical writer `ConPort custom_data: untracked_work`.
+- Ignore detection: canonical writer `ConPort custom_data: untracked_work`.
+- Create ADR/RFC: canonical writer repo docs path, through a separate Task Packet.
+
+## Visual Quality Bar
+
+- Dense but calm operational UI.
+- No floating-card clutter; use full-width bands, rails, panes, and table rows.
+- Use icons/symbols for actions when rendered in graphical UI.
+- Max three primary recommendations at once.
+- Stable dimensions for rows and counters.
+- Visible provenance on every non-local signal.
+- Button/action labels must not overflow on narrow widths.
+- Degraded states should be visually distinct but not alarming unless action is blocked.
+
+## Acceptance Scenarios
+
+- Clean slate: no untracked work, services not probed, ADHD unavailable. UI shows `NOT_PROBED`/`UNKNOWN` honestly.
+- F001 base only: enhanced tool absent. UI shows base detection available and enhanced unavailable, with no enhanced affordance.
+- F001 enhanced detected: UI shows summary, false-start count, and safe actions.
+- ConPort unavailable: UI shows degraded detection and disables ConPort-backed history/actions.
+- ADHD Engine unavailable: UI hides cognitive recommendations or marks them degraded.
+- Task Orchestrator unavailable: tracking action is blocked, but inspect/copy evidence remains available.
+- Bridge available only: UX marks bridge data as proxy, not authority.

--- a/docs/06-research/2026-07-04-dopemux-service-investigation/ux-integration-spec.md
+++ b/docs/06-research/2026-07-04-dopemux-service-investigation/ux-integration-spec.md
@@ -1,13 +1,13 @@
 ---
 id: ux-integration-spec
-title: Ux Integration Spec
+title: UX Integration Spec
 type: reference
 owner: '@hu3mann'
 author: '@hu3mann'
 date: '2026-07-04'
 last_review: '2026-07-04'
 next_review: '2026-10-02'
-prelude: Ux Integration Spec (reference) for dopemux documentation and developer workflows.
+prelude: UX Integration Spec (reference) for dopemux documentation and developer workflows.
 ---
 # Seamless Operator UX Integration Spec
 

--- a/task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json
+++ b/task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json
@@ -1,0 +1,108 @@
+{
+  "id": "TP-DMX-SERVICE-INVESTIGATION-20260704",
+  "project": "dopemux-mvp",
+  "target": "docs/06-research/2026-07-04-dopemux-service-investigation",
+  "invariants": [
+    "Repo truth outranks historical prose.",
+    "Bridge, adapter, mirror, and retrieval surfaces must not be promoted to authority without runtime evidence.",
+    "ADHD Engine remains operator-support authority only unless runtime code proves stronger ownership.",
+    "Serena/F001 remains detection and code-intelligence support, not PM truth.",
+    "ConPort, dope-memory, and dope-context remain separate authority planes."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-SERVICE-INVESTIGATION",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dopemux-service-investigation-20260704",
+    "base_branch": "main",
+    "stacked_because": ""
+  },
+  "commit": {
+    "message": "docs(service): audit dopemux service integration gaps",
+    "allowlist": [
+      "task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json",
+      "docs/06-research/2026-07-04-dopemux-service-investigation/research.md",
+      "docs/06-research/2026-07-04-dopemux-service-investigation/service-gap-matrix.md",
+      "docs/06-research/2026-07-04-dopemux-service-investigation/adhd-untracked-work-design.md",
+      "docs/06-research/2026-07-04-dopemux-service-investigation/implementation-backlog.md",
+      "docs/06-research/2026-07-04-dopemux-service-investigation/ux-integration-spec.md",
+      "docs/06-research/2026-07-04-dopemux-service-investigation/implementation-notes.md"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json >/dev/null",
+      "python - <<'PY'\nimport json\nfrom pathlib import Path\nfrom jsonschema import validate\nroot = Path.cwd()\nvalidate(json.loads((root / 'task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json').read_text()), json.loads((root / 'docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()))\nPY",
+      "docker compose -f compose.yml config",
+      "dopemux mcp status",
+      "pytest -q services/serena/test_f001_enhanced.py services/serena/tests/test_mcp_server_local.py",
+      "pytest -q services/adhd_engine/tests tests/unit/test_adhd_*.py",
+      "pytest -q tests/mcp tests/unit/dopemux/ui/cockpit",
+      "pnpm --dir ui-dashboard test",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(service): audit Dopemux service integration gaps",
+    "body": "Adds an evidence-backed service inventory, ADHD/F001/Cockpit integration design, UX spec, and Task-Packet-ready backlog for the full Dopemux service surface.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Create the repo-bound service investigation packet and evidence-backed report bundle.",
+      "requirements": [
+        "Inventory every top-level services directory, compose service, and registry service.",
+        "Trace ADHD, Serena/F001, Task Orchestrator, MCP, Cockpit, and dashboard integration gaps.",
+        "Mark observed, inferred, proposed, and unknown claims explicitly."
+      ],
+      "commands": [
+        "find services -mindepth 1 -maxdepth 1 -type d -print | sort",
+        "python - <<'PY'\nfrom pathlib import Path\nimport yaml\nroot = Path.cwd()\nprint(len([p for p in (root / 'services').iterdir() if p.is_dir()]))\nprint(len((yaml.safe_load((root / 'compose.yml').read_text()).get('services') or {})))\nprint(len(yaml.safe_load((root / 'services/registry.yaml').read_text()).get('services', [])))\nPY"
+      ],
+      "expected_files": [
+        "docs/06-research/2026-07-04-dopemux-service-investigation/research.md",
+        "docs/06-research/2026-07-04-dopemux-service-investigation/service-gap-matrix.md",
+        "docs/06-research/2026-07-04-dopemux-service-investigation/adhd-untracked-work-design.md",
+        "docs/06-research/2026-07-04-dopemux-service-investigation/implementation-backlog.md",
+        "docs/06-research/2026-07-04-dopemux-service-investigation/ux-integration-spec.md",
+        "docs/06-research/2026-07-04-dopemux-service-investigation/implementation-notes.md"
+      ],
+      "validation": [
+        "python -m json.tool task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json >/dev/null",
+        "python - <<'PY'\nimport json\nfrom pathlib import Path\nfrom jsonschema import validate\nroot = Path.cwd()\nvalidate(json.loads((root / 'task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json').read_text()), json.loads((root / 'docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()))\nPY",
+        "git diff --check"
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "PROJECT.md",
+        "ARCHITECTURE.md",
+        "PM_PLANE.md",
+        "SERVICE_CATALOG.md",
+        "compose.yml",
+        "services/registry.yaml"
+      ]
+    }
+  ]
+}

--- a/task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json
+++ b/task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json
@@ -42,7 +42,7 @@
     "verify": [
       "python -m json.tool task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json >/dev/null",
       "python - <<'PY'\nimport json\nfrom pathlib import Path\nfrom jsonschema import validate\nroot = Path.cwd()\nvalidate(json.loads((root / 'task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json').read_text()), json.loads((root / 'docs/03-reference/spec/dopetask/dopetask-canonical-spec.json').read_text()))\nPY",
-      "docker compose -f compose.yml config",
+      "docker compose -f compose.yml config >/dev/null",
       "dopemux mcp status",
       "pytest -q services/serena/test_f001_enhanced.py services/serena/tests/test_mcp_server_local.py",
       "pytest -q services/adhd_engine/tests tests/unit/test_adhd_*.py",


### PR DESCRIPTION
## Summary

Adds a repo-grounded Dopemux service investigation package covering all observed service surfaces and the deeper ADHD/F001/Task Orchestrator/MCP/Cockpit integration design.

Artifacts:
- `task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json`
- `docs/06-research/2026-07-04-dopemux-service-investigation/research.md`
- `docs/06-research/2026-07-04-dopemux-service-investigation/service-gap-matrix.md`
- `docs/06-research/2026-07-04-dopemux-service-investigation/adhd-untracked-work-design.md`
- `docs/06-research/2026-07-04-dopemux-service-investigation/implementation-backlog.md`
- `docs/06-research/2026-07-04-dopemux-service-investigation/ux-integration-spec.md`
- `docs/06-research/2026-07-04-dopemux-service-investigation/implementation-notes.md`

## Validation

PASS:
- `python -m json.tool task-packets/TP-DMX-SERVICE-INVESTIGATION-20260704.json >/dev/null`
- `jsonschema.validate(...)` against `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json`
- `docker compose -f compose.yml config` exited 0; raw output intentionally not copied because compose rendered sensitive-looking environment values.
- `dopemux mcp status` exited 0 and showed already-running container state.
- `pytest -q tests/mcp tests/unit/dopemux/ui/cockpit` exited 0 with 183 passing tests.
- `pre-commit run --files ...` exited 0 after frontmatter normalization.
- `git -c core.fsmonitor=false diff --cached --check`

FAIL, recorded in the report:
- `pytest -q services/serena/test_f001_enhanced.py services/serena/tests/test_mcp_server_local.py` exited 3 during collection on missing `untracked_work_detector` import.
- `pytest -q services/adhd_engine/tests tests/unit/test_adhd_*.py` exited 2 during collection on missing ADHD/ML modules.

NOT_RUN:
- `pnpm --dir ui-dashboard test`; `ui-dashboard/node_modules` is missing.
- Live service probes beyond already-running status view; this audit did not authorize starting stopped services.

## Notes

The worktree has an unstaged local rewrite of `.claude/claude_config.json` from worktree-aware tooling. It was not staged or committed.
