### PR TITLE
fix(pcp): block readiness on incomplete PR steward intake

### DIFF
--- a/docs/ops/project-control-plane/pr-steward-readiness.md
+++ b/docs/ops/project-control-plane/pr-steward-readiness.md
@@ -45,6 +45,7 @@ Module: `src/dopemux/pcp/pr_steward.py`
 
 | Field | Type | Description |
 |---|---|---|
+| `intake_completeness` | object | Category-level completeness states for PR metadata, SHA, diff, review, comment, check, proof, allowlist, and security/release evidence |
 | `changed_files` | array of string | Paths changed in the PR diff |
 | `commits` | array of string | Commit SHAs in the PR |
 | `checks` | array of objects | CI check results with `name`, `conclusion`, `stale_to_head` |
@@ -77,6 +78,7 @@ READY is withheld when **any** of the following conditions holds.
 | `DIFF_OUTSIDE_ALLOWLIST` | `diff_escapes_allowlist == true` |
 | `MISSING_SECURITY_RELEASE_APPROVAL` | `security_release_required == true` and `security_release_approved == false` |
 | `MISSING_REQUIRED_INTAKE` | `intake` is `null`, missing, or `head_sha` is falsy |
+| `INCOMPLETE_INTAKE` | Any `intake_completeness` category is not `COMPLETE` |
 | `UNKNOWN` | Reserved for unclassifiable blocking conditions |
 
 ### Status derivation
@@ -91,7 +93,7 @@ READY is withheld when **any** of the following conditions holds.
 
 The schema enforces these rules structurally via `allOf` if/then constraints:
 
-- **Gate (a)**: `status == READY` requires `blocked_reasons maxItems 0`, `proof_freshness const "FRESH"`, and `diff_escapes_allowlist const false`.
+- **Gate (a)**: `status == READY` requires `blocked_reasons maxItems 0`, every `intake_completeness` category `const "COMPLETE"`, `proof_freshness const "FRESH"`, and `diff_escapes_allowlist const false`.
 - **Gate (b)**: `status` in `{BLOCKED, NEEDS_SUPERVISOR}` requires `blocked_reasons minItems 1`.
 - **Gate (c)**: `proof_freshness` in `{STALE, MISSING, UNKNOWN}` forces `status` to `{BLOCKED, NEEDS_SUPERVISOR}`.
 - **Gate (d)**: `diff_escapes_allowlist == true` forces `status` to `{BLOCKED, NEEDS_SUPERVISOR}`.
@@ -131,7 +133,7 @@ result = harvest_pr_intake(
 
 Read-only harvester using `gh pr view`. Returns `{pr_ref, head_sha, intake}`. The `runner` parameter accepts a callable for injecting a fake in tests — no real subprocess runs in unit tests.
 
-> **Note**: The raw harvest always returns `proof_freshness="MISSING"` because proof artifact references are not available from `gh pr view`. A harvested-only signal therefore can never be `READY` — callers must supply proof freshness externally (e.g., by reading a proof artifact and comparing its recorded `head_sha` against the PR head SHA before calling `assess_merge_readiness`).
+> **Note**: The raw harvest marks proof refs, proof freshness, review comments, issue comments, allowlist, and security/release approval as incomplete because `gh pr view` alone does not prove those categories. A harvested-only signal therefore can never be `READY` — callers must supply complete category evidence externally (for example, by reading proof artifacts, review/comment surfaces, allowlist results, and security/release approvals before calling `assess_merge_readiness`).
 
 > **Note**: `stale_to_head` is derived from check conclusion only (`STALE`, `PENDING`, or `UNKNOWN` conclusions set it to `true`). The `gh statusCheckRollup` response is semantically head-scoped, so per-check SHA comparison is not attempted — `gh` does not expose an individual check-run SHA.
 

--- a/schemas/project_control_plane/merge_readiness.schema.json
+++ b/schemas/project_control_plane/merge_readiness.schema.json
@@ -71,6 +71,7 @@
           "DIFF_OUTSIDE_ALLOWLIST",
           "MISSING_SECURITY_RELEASE_APPROVAL",
           "MISSING_REQUIRED_INTAKE",
+          "INCOMPLETE_INTAKE",
           "UNKNOWN"
         ]
       }
@@ -80,6 +81,7 @@
       "additionalProperties": false,
       "description": "Harvested evidence from the PR at read-only intake time.",
       "required": [
+        "intake_completeness",
         "changed_files",
         "commits",
         "checks",
@@ -94,6 +96,43 @@
         "security_release_approved"
       ],
       "properties": {
+        "intake_completeness": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Completeness classification for every evidence category required before READY. Every category must be COMPLETE before READY can be emitted.",
+          "required": [
+            "pr_metadata",
+            "head_sha",
+            "changed_files",
+            "commits",
+            "reviews",
+            "review_comments",
+            "review_threads",
+            "issue_comments",
+            "checks",
+            "proof_refs",
+            "proof_freshness",
+            "reviewer_classifications",
+            "allowlist",
+            "security_release_approval"
+          ],
+          "properties": {
+            "pr_metadata": { "$ref": "#/$defs/completeness_state" },
+            "head_sha": { "$ref": "#/$defs/completeness_state" },
+            "changed_files": { "$ref": "#/$defs/completeness_state" },
+            "commits": { "$ref": "#/$defs/completeness_state" },
+            "reviews": { "$ref": "#/$defs/completeness_state" },
+            "review_comments": { "$ref": "#/$defs/completeness_state" },
+            "review_threads": { "$ref": "#/$defs/completeness_state" },
+            "issue_comments": { "$ref": "#/$defs/completeness_state" },
+            "checks": { "$ref": "#/$defs/completeness_state" },
+            "proof_refs": { "$ref": "#/$defs/completeness_state" },
+            "proof_freshness": { "$ref": "#/$defs/completeness_state" },
+            "reviewer_classifications": { "$ref": "#/$defs/completeness_state" },
+            "allowlist": { "$ref": "#/$defs/completeness_state" },
+            "security_release_approval": { "$ref": "#/$defs/completeness_state" }
+          }
+        },
         "changed_files": {
           "type": "array",
           "items": { "type": "string" },
@@ -226,6 +265,12 @@
       "description": "ISO 8601 datetime at which this signal was assembled."
     }
   },
+  "$defs": {
+    "completeness_state": {
+      "type": "string",
+      "enum": ["COMPLETE", "MISSING", "UNKNOWN", "NOT_REQUIRED"]
+    }
+  },
   "allOf": [
     {
       "description": "Fail-closed gate (a): READY requires zero blocked_reasons, FRESH proof, and diff within allowlist.",
@@ -238,6 +283,40 @@
           "blocked_reasons": { "maxItems": 0 },
           "intake": {
             "properties": {
+              "intake_completeness": {
+                "properties": {
+                  "pr_metadata": { "const": "COMPLETE" },
+                  "head_sha": { "const": "COMPLETE" },
+                  "changed_files": { "const": "COMPLETE" },
+                  "commits": { "const": "COMPLETE" },
+                  "reviews": { "const": "COMPLETE" },
+                  "review_comments": { "const": "COMPLETE" },
+                  "review_threads": { "const": "COMPLETE" },
+                  "issue_comments": { "const": "COMPLETE" },
+                  "checks": { "const": "COMPLETE" },
+                  "proof_refs": { "const": "COMPLETE" },
+                  "proof_freshness": { "const": "COMPLETE" },
+                  "reviewer_classifications": { "const": "COMPLETE" },
+                  "allowlist": { "const": "COMPLETE" },
+                  "security_release_approval": { "const": "COMPLETE" }
+                },
+                "required": [
+                  "pr_metadata",
+                  "head_sha",
+                  "changed_files",
+                  "commits",
+                  "reviews",
+                  "review_comments",
+                  "review_threads",
+                  "issue_comments",
+                  "checks",
+                  "proof_refs",
+                  "proof_freshness",
+                  "reviewer_classifications",
+                  "allowlist",
+                  "security_release_approval"
+                ]
+              },
               "proof_freshness": { "const": "FRESH" },
               "diff_escapes_allowlist": { "const": false }
             }

--- a/schemas/project_control_plane/merge_readiness.schema.json
+++ b/schemas/project_control_plane/merge_readiness.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://dopemux.dev/schemas/project_control_plane/merge_readiness.schema.json",
   "title": "PCP Core PR Steward Merge Readiness Signal",
-  "description": "Generic, project-agnostic MERGE_READINESS signal emitted by the PCP-Core PR Steward readiness intake. This signal is ADVISORY only — it NEVER merges, sets PR ready, or mutates any resource. READY is fail-closed: withheld on ANY blocking condition.",
+  "description": "Generic, project-agnostic MERGE_READINESS signal emitted by the PCP-Core PR Steward readiness intake. This signal is ADVISORY only \u2014 it NEVER merges, sets PR ready, or mutates any resource. READY is fail-closed: withheld on ANY blocking condition.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -24,7 +24,12 @@
     "pr_ref": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repo", "number", "head_ref", "base_ref"],
+      "required": [
+        "repo",
+        "number",
+        "head_ref",
+        "base_ref"
+      ],
       "properties": {
         "repo": {
           "type": "string",
@@ -52,7 +57,11 @@
     },
     "status": {
       "type": "string",
-      "enum": ["READY", "BLOCKED", "NEEDS_SUPERVISOR"],
+      "enum": [
+        "READY",
+        "BLOCKED",
+        "NEEDS_SUPERVISOR"
+      ],
       "description": "Merge readiness verdict. READY is withheld on any blocking condition."
     },
     "blocked_reasons": {
@@ -117,30 +126,62 @@
             "security_release_approval"
           ],
           "properties": {
-            "pr_metadata": { "$ref": "#/$defs/completeness_state" },
-            "head_sha": { "$ref": "#/$defs/completeness_state" },
-            "changed_files": { "$ref": "#/$defs/completeness_state" },
-            "commits": { "$ref": "#/$defs/completeness_state" },
-            "reviews": { "$ref": "#/$defs/completeness_state" },
-            "review_comments": { "$ref": "#/$defs/completeness_state" },
-            "review_threads": { "$ref": "#/$defs/completeness_state" },
-            "issue_comments": { "$ref": "#/$defs/completeness_state" },
-            "checks": { "$ref": "#/$defs/completeness_state" },
-            "proof_refs": { "$ref": "#/$defs/completeness_state" },
-            "proof_freshness": { "$ref": "#/$defs/completeness_state" },
-            "reviewer_classifications": { "$ref": "#/$defs/completeness_state" },
-            "allowlist": { "$ref": "#/$defs/completeness_state" },
-            "security_release_approval": { "$ref": "#/$defs/completeness_state" }
+            "pr_metadata": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "head_sha": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "changed_files": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "commits": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "reviews": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "review_comments": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "review_threads": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "issue_comments": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "checks": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "proof_refs": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "proof_freshness": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "reviewer_classifications": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "allowlist": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "security_release_approval": {
+              "$ref": "#/$defs/completeness_state"
+            }
           }
         },
         "changed_files": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Paths of files changed in the PR diff."
         },
         "commits": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Commit SHAs included in the PR (head-to-merge-base)."
         },
         "checks": {
@@ -149,7 +190,11 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["name", "conclusion", "stale_to_head"],
+            "required": [
+              "name",
+              "conclusion",
+              "stale_to_head"
+            ],
             "properties": {
               "name": {
                 "type": "string",
@@ -157,7 +202,14 @@
               },
               "conclusion": {
                 "type": "string",
-                "enum": ["SUCCESS", "FAILURE", "NEUTRAL", "STALE", "PENDING", "UNKNOWN"],
+                "enum": [
+                  "SUCCESS",
+                  "FAILURE",
+                  "NEUTRAL",
+                  "STALE",
+                  "PENDING",
+                  "UNKNOWN"
+                ],
                 "description": "Normalised check conclusion. STALE = ran against an older SHA; PENDING = not yet complete; UNKNOWN = could not classify."
               },
               "stale_to_head": {
@@ -178,7 +230,10 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["resolved", "blocking"],
+            "required": [
+              "resolved",
+              "blocking"
+            ],
             "properties": {
               "resolved": {
                 "type": "boolean",
@@ -197,7 +252,10 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["actor", "kind"],
+            "required": [
+              "actor",
+              "kind"
+            ],
             "properties": {
               "actor": {
                 "type": "string",
@@ -205,7 +263,11 @@
               },
               "kind": {
                 "type": "string",
-                "enum": ["HUMAN", "KNOWN_BOT", "UNKNOWN"],
+                "enum": [
+                  "HUMAN",
+                  "KNOWN_BOT",
+                  "UNKNOWN"
+                ],
                 "description": "Identity classification. UNKNOWN triggers UNKNOWN_REVIEWER_OR_BOT blocker."
               }
             }
@@ -213,7 +275,9 @@
         },
         "unclassified_review_items": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Review item IDs or references that could not be classified. Non-empty triggers UNCLASSIFIED_REVIEW_ITEM blocker."
         },
         "proof_refs": {
@@ -222,14 +286,20 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["path", "head_sha"],
+            "required": [
+              "path",
+              "head_sha"
+            ],
             "properties": {
               "path": {
                 "type": "string",
                 "description": "Path or URL of the proof artifact."
               },
               "head_sha": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "description": "The head SHA recorded inside the proof artifact, or null if unreadable."
               }
             }
@@ -237,7 +307,12 @@
         },
         "proof_freshness": {
           "type": "string",
-          "enum": ["FRESH", "STALE", "MISSING", "UNKNOWN"],
+          "enum": [
+            "FRESH",
+            "STALE",
+            "MISSING",
+            "UNKNOWN"
+          ],
           "description": "Proof freshness classification. FRESH requires proof_refs[].head_sha == PR head_sha. STALE/MISSING/UNKNOWN withholds READY."
         },
         "diff_escapes_allowlist": {
@@ -257,7 +332,7 @@
     "advisory": {
       "type": "boolean",
       "const": true,
-      "description": "Always true. This signal is advisory only — it is NEVER a merge authority. Green CI is NOT semantic proof. See AIR Red Lines #7/#8."
+      "description": "Always true. This signal is advisory only \u2014 it is NEVER a merge authority. Green CI is NOT semantic proof. See AIR Red Lines #7/#8."
     },
     "created_at": {
       "type": "string",
@@ -268,37 +343,81 @@
   "$defs": {
     "completeness_state": {
       "type": "string",
-      "enum": ["COMPLETE", "MISSING", "UNKNOWN", "NOT_REQUIRED"]
+      "enum": [
+        "COMPLETE",
+        "MISSING",
+        "UNKNOWN",
+        "NOT_REQUIRED"
+      ]
     }
   },
   "allOf": [
     {
       "description": "Fail-closed gate (a): READY requires zero blocked_reasons, FRESH proof, and diff within allowlist.",
       "if": {
-        "properties": { "status": { "const": "READY" } },
-        "required": ["status"]
+        "properties": {
+          "status": {
+            "const": "READY"
+          }
+        },
+        "required": [
+          "status"
+        ]
       },
       "then": {
         "properties": {
-          "blocked_reasons": { "maxItems": 0 },
+          "blocked_reasons": {
+            "maxItems": 0
+          },
           "intake": {
             "properties": {
               "intake_completeness": {
                 "properties": {
-                  "pr_metadata": { "const": "COMPLETE" },
-                  "head_sha": { "const": "COMPLETE" },
-                  "changed_files": { "const": "COMPLETE" },
-                  "commits": { "const": "COMPLETE" },
-                  "reviews": { "const": "COMPLETE" },
-                  "review_comments": { "const": "COMPLETE" },
-                  "review_threads": { "const": "COMPLETE" },
-                  "issue_comments": { "const": "COMPLETE" },
-                  "checks": { "const": "COMPLETE" },
-                  "proof_refs": { "const": "COMPLETE" },
-                  "proof_freshness": { "const": "COMPLETE" },
-                  "reviewer_classifications": { "const": "COMPLETE" },
-                  "allowlist": { "const": "COMPLETE" },
-                  "security_release_approval": { "const": "COMPLETE" }
+                  "pr_metadata": {
+                    "const": "COMPLETE"
+                  },
+                  "head_sha": {
+                    "const": "COMPLETE"
+                  },
+                  "changed_files": {
+                    "const": "COMPLETE"
+                  },
+                  "commits": {
+                    "const": "COMPLETE"
+                  },
+                  "reviews": {
+                    "const": "COMPLETE"
+                  },
+                  "review_comments": {
+                    "const": "COMPLETE"
+                  },
+                  "review_threads": {
+                    "const": "COMPLETE"
+                  },
+                  "issue_comments": {
+                    "const": "COMPLETE"
+                  },
+                  "checks": {
+                    "const": "COMPLETE"
+                  },
+                  "proof_refs": {
+                    "const": "COMPLETE"
+                  },
+                  "proof_freshness": {
+                    "const": "COMPLETE"
+                  },
+                  "reviewer_classifications": {
+                    "const": "COMPLETE"
+                  },
+                  "allowlist": {
+                    "const": "COMPLETE"
+                  },
+                  "security_release_approval": {
+                    "enum": [
+                      "COMPLETE",
+                      "NOT_REQUIRED"
+                    ]
+                  }
                 },
                 "required": [
                   "pr_metadata",
@@ -317,8 +436,12 @@
                   "security_release_approval"
                 ]
               },
-              "proof_freshness": { "const": "FRESH" },
-              "diff_escapes_allowlist": { "const": false }
+              "proof_freshness": {
+                "const": "FRESH"
+              },
+              "diff_escapes_allowlist": {
+                "const": false
+              }
             }
           }
         }
@@ -327,12 +450,23 @@
     {
       "description": "Fail-closed gate (b): BLOCKED or NEEDS_SUPERVISOR requires at least one blocked_reason.",
       "if": {
-        "properties": { "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] } },
-        "required": ["status"]
+        "properties": {
+          "status": {
+            "enum": [
+              "BLOCKED",
+              "NEEDS_SUPERVISOR"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ]
       },
       "then": {
         "properties": {
-          "blocked_reasons": { "minItems": 1 }
+          "blocked_reasons": {
+            "minItems": 1
+          }
         }
       }
     },
@@ -342,16 +476,31 @@
         "properties": {
           "intake": {
             "properties": {
-              "proof_freshness": { "enum": ["STALE", "MISSING", "UNKNOWN"] }
+              "proof_freshness": {
+                "enum": [
+                  "STALE",
+                  "MISSING",
+                  "UNKNOWN"
+                ]
+              }
             },
-            "required": ["proof_freshness"]
+            "required": [
+              "proof_freshness"
+            ]
           }
         },
-        "required": ["intake"]
+        "required": [
+          "intake"
+        ]
       },
       "then": {
         "properties": {
-          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+          "status": {
+            "enum": [
+              "BLOCKED",
+              "NEEDS_SUPERVISOR"
+            ]
+          }
         }
       }
     },
@@ -361,41 +510,72 @@
         "properties": {
           "intake": {
             "properties": {
-              "diff_escapes_allowlist": { "const": true }
+              "diff_escapes_allowlist": {
+                "const": true
+              }
             },
-            "required": ["diff_escapes_allowlist"]
+            "required": [
+              "diff_escapes_allowlist"
+            ]
           }
         },
-        "required": ["intake"]
+        "required": [
+          "intake"
+        ]
       },
       "then": {
         "properties": {
-          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+          "status": {
+            "enum": [
+              "BLOCKED",
+              "NEEDS_SUPERVISOR"
+            ]
+          }
         }
       }
     },
     {
       "description": "Fail-closed gate (e): READY with an unapproved security gate is rejected. If status is READY then intake must have security_release_required=false OR security_release_approved=true.",
       "if": {
-        "properties": { "status": { "const": "READY" } },
-        "required": ["status"]
+        "properties": {
+          "status": {
+            "const": "READY"
+          }
+        },
+        "required": [
+          "status"
+        ]
       },
       "then": {
         "properties": {
           "intake": {
             "anyOf": [
               {
-                "properties": { "security_release_required": { "const": false } },
-                "required": ["security_release_required"]
+                "properties": {
+                  "security_release_required": {
+                    "const": false
+                  }
+                },
+                "required": [
+                  "security_release_required"
+                ]
               },
               {
-                "properties": { "security_release_approved": { "const": true } },
-                "required": ["security_release_approved"]
+                "properties": {
+                  "security_release_approved": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "security_release_approved"
+                ]
               }
             ]
           }
         },
-        "required": ["intake"]
+        "required": [
+          "intake"
+        ]
       }
     }
   ]

--- a/src/dopemux/pcp/_schemas/merge_readiness.schema.json
+++ b/src/dopemux/pcp/_schemas/merge_readiness.schema.json
@@ -71,6 +71,7 @@
           "DIFF_OUTSIDE_ALLOWLIST",
           "MISSING_SECURITY_RELEASE_APPROVAL",
           "MISSING_REQUIRED_INTAKE",
+          "INCOMPLETE_INTAKE",
           "UNKNOWN"
         ]
       }
@@ -80,6 +81,7 @@
       "additionalProperties": false,
       "description": "Harvested evidence from the PR at read-only intake time.",
       "required": [
+        "intake_completeness",
         "changed_files",
         "commits",
         "checks",
@@ -94,6 +96,43 @@
         "security_release_approved"
       ],
       "properties": {
+        "intake_completeness": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Completeness classification for every evidence category required before READY. Every category must be COMPLETE before READY can be emitted.",
+          "required": [
+            "pr_metadata",
+            "head_sha",
+            "changed_files",
+            "commits",
+            "reviews",
+            "review_comments",
+            "review_threads",
+            "issue_comments",
+            "checks",
+            "proof_refs",
+            "proof_freshness",
+            "reviewer_classifications",
+            "allowlist",
+            "security_release_approval"
+          ],
+          "properties": {
+            "pr_metadata": { "$ref": "#/$defs/completeness_state" },
+            "head_sha": { "$ref": "#/$defs/completeness_state" },
+            "changed_files": { "$ref": "#/$defs/completeness_state" },
+            "commits": { "$ref": "#/$defs/completeness_state" },
+            "reviews": { "$ref": "#/$defs/completeness_state" },
+            "review_comments": { "$ref": "#/$defs/completeness_state" },
+            "review_threads": { "$ref": "#/$defs/completeness_state" },
+            "issue_comments": { "$ref": "#/$defs/completeness_state" },
+            "checks": { "$ref": "#/$defs/completeness_state" },
+            "proof_refs": { "$ref": "#/$defs/completeness_state" },
+            "proof_freshness": { "$ref": "#/$defs/completeness_state" },
+            "reviewer_classifications": { "$ref": "#/$defs/completeness_state" },
+            "allowlist": { "$ref": "#/$defs/completeness_state" },
+            "security_release_approval": { "$ref": "#/$defs/completeness_state" }
+          }
+        },
         "changed_files": {
           "type": "array",
           "items": { "type": "string" },
@@ -226,6 +265,12 @@
       "description": "ISO 8601 datetime at which this signal was assembled."
     }
   },
+  "$defs": {
+    "completeness_state": {
+      "type": "string",
+      "enum": ["COMPLETE", "MISSING", "UNKNOWN", "NOT_REQUIRED"]
+    }
+  },
   "allOf": [
     {
       "description": "Fail-closed gate (a): READY requires zero blocked_reasons, FRESH proof, and diff within allowlist.",
@@ -238,6 +283,40 @@
           "blocked_reasons": { "maxItems": 0 },
           "intake": {
             "properties": {
+              "intake_completeness": {
+                "properties": {
+                  "pr_metadata": { "const": "COMPLETE" },
+                  "head_sha": { "const": "COMPLETE" },
+                  "changed_files": { "const": "COMPLETE" },
+                  "commits": { "const": "COMPLETE" },
+                  "reviews": { "const": "COMPLETE" },
+                  "review_comments": { "const": "COMPLETE" },
+                  "review_threads": { "const": "COMPLETE" },
+                  "issue_comments": { "const": "COMPLETE" },
+                  "checks": { "const": "COMPLETE" },
+                  "proof_refs": { "const": "COMPLETE" },
+                  "proof_freshness": { "const": "COMPLETE" },
+                  "reviewer_classifications": { "const": "COMPLETE" },
+                  "allowlist": { "const": "COMPLETE" },
+                  "security_release_approval": { "const": "COMPLETE" }
+                },
+                "required": [
+                  "pr_metadata",
+                  "head_sha",
+                  "changed_files",
+                  "commits",
+                  "reviews",
+                  "review_comments",
+                  "review_threads",
+                  "issue_comments",
+                  "checks",
+                  "proof_refs",
+                  "proof_freshness",
+                  "reviewer_classifications",
+                  "allowlist",
+                  "security_release_approval"
+                ]
+              },
               "proof_freshness": { "const": "FRESH" },
               "diff_escapes_allowlist": { "const": false }
             }

--- a/src/dopemux/pcp/_schemas/merge_readiness.schema.json
+++ b/src/dopemux/pcp/_schemas/merge_readiness.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://dopemux.dev/schemas/project_control_plane/merge_readiness.schema.json",
   "title": "PCP Core PR Steward Merge Readiness Signal",
-  "description": "Generic, project-agnostic MERGE_READINESS signal emitted by the PCP-Core PR Steward readiness intake. This signal is ADVISORY only — it NEVER merges, sets PR ready, or mutates any resource. READY is fail-closed: withheld on ANY blocking condition.",
+  "description": "Generic, project-agnostic MERGE_READINESS signal emitted by the PCP-Core PR Steward readiness intake. This signal is ADVISORY only \u2014 it NEVER merges, sets PR ready, or mutates any resource. READY is fail-closed: withheld on ANY blocking condition.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -24,7 +24,12 @@
     "pr_ref": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repo", "number", "head_ref", "base_ref"],
+      "required": [
+        "repo",
+        "number",
+        "head_ref",
+        "base_ref"
+      ],
       "properties": {
         "repo": {
           "type": "string",
@@ -52,7 +57,11 @@
     },
     "status": {
       "type": "string",
-      "enum": ["READY", "BLOCKED", "NEEDS_SUPERVISOR"],
+      "enum": [
+        "READY",
+        "BLOCKED",
+        "NEEDS_SUPERVISOR"
+      ],
       "description": "Merge readiness verdict. READY is withheld on any blocking condition."
     },
     "blocked_reasons": {
@@ -117,30 +126,62 @@
             "security_release_approval"
           ],
           "properties": {
-            "pr_metadata": { "$ref": "#/$defs/completeness_state" },
-            "head_sha": { "$ref": "#/$defs/completeness_state" },
-            "changed_files": { "$ref": "#/$defs/completeness_state" },
-            "commits": { "$ref": "#/$defs/completeness_state" },
-            "reviews": { "$ref": "#/$defs/completeness_state" },
-            "review_comments": { "$ref": "#/$defs/completeness_state" },
-            "review_threads": { "$ref": "#/$defs/completeness_state" },
-            "issue_comments": { "$ref": "#/$defs/completeness_state" },
-            "checks": { "$ref": "#/$defs/completeness_state" },
-            "proof_refs": { "$ref": "#/$defs/completeness_state" },
-            "proof_freshness": { "$ref": "#/$defs/completeness_state" },
-            "reviewer_classifications": { "$ref": "#/$defs/completeness_state" },
-            "allowlist": { "$ref": "#/$defs/completeness_state" },
-            "security_release_approval": { "$ref": "#/$defs/completeness_state" }
+            "pr_metadata": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "head_sha": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "changed_files": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "commits": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "reviews": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "review_comments": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "review_threads": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "issue_comments": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "checks": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "proof_refs": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "proof_freshness": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "reviewer_classifications": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "allowlist": {
+              "$ref": "#/$defs/completeness_state"
+            },
+            "security_release_approval": {
+              "$ref": "#/$defs/completeness_state"
+            }
           }
         },
         "changed_files": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Paths of files changed in the PR diff."
         },
         "commits": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Commit SHAs included in the PR (head-to-merge-base)."
         },
         "checks": {
@@ -149,7 +190,11 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["name", "conclusion", "stale_to_head"],
+            "required": [
+              "name",
+              "conclusion",
+              "stale_to_head"
+            ],
             "properties": {
               "name": {
                 "type": "string",
@@ -157,7 +202,14 @@
               },
               "conclusion": {
                 "type": "string",
-                "enum": ["SUCCESS", "FAILURE", "NEUTRAL", "STALE", "PENDING", "UNKNOWN"],
+                "enum": [
+                  "SUCCESS",
+                  "FAILURE",
+                  "NEUTRAL",
+                  "STALE",
+                  "PENDING",
+                  "UNKNOWN"
+                ],
                 "description": "Normalised check conclusion. STALE = ran against an older SHA; PENDING = not yet complete; UNKNOWN = could not classify."
               },
               "stale_to_head": {
@@ -178,7 +230,10 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["resolved", "blocking"],
+            "required": [
+              "resolved",
+              "blocking"
+            ],
             "properties": {
               "resolved": {
                 "type": "boolean",
@@ -197,7 +252,10 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["actor", "kind"],
+            "required": [
+              "actor",
+              "kind"
+            ],
             "properties": {
               "actor": {
                 "type": "string",
@@ -205,7 +263,11 @@
               },
               "kind": {
                 "type": "string",
-                "enum": ["HUMAN", "KNOWN_BOT", "UNKNOWN"],
+                "enum": [
+                  "HUMAN",
+                  "KNOWN_BOT",
+                  "UNKNOWN"
+                ],
                 "description": "Identity classification. UNKNOWN triggers UNKNOWN_REVIEWER_OR_BOT blocker."
               }
             }
@@ -213,7 +275,9 @@
         },
         "unclassified_review_items": {
           "type": "array",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "description": "Review item IDs or references that could not be classified. Non-empty triggers UNCLASSIFIED_REVIEW_ITEM blocker."
         },
         "proof_refs": {
@@ -222,14 +286,20 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["path", "head_sha"],
+            "required": [
+              "path",
+              "head_sha"
+            ],
             "properties": {
               "path": {
                 "type": "string",
                 "description": "Path or URL of the proof artifact."
               },
               "head_sha": {
-                "type": ["string", "null"],
+                "type": [
+                  "string",
+                  "null"
+                ],
                 "description": "The head SHA recorded inside the proof artifact, or null if unreadable."
               }
             }
@@ -237,7 +307,12 @@
         },
         "proof_freshness": {
           "type": "string",
-          "enum": ["FRESH", "STALE", "MISSING", "UNKNOWN"],
+          "enum": [
+            "FRESH",
+            "STALE",
+            "MISSING",
+            "UNKNOWN"
+          ],
           "description": "Proof freshness classification. FRESH requires proof_refs[].head_sha == PR head_sha. STALE/MISSING/UNKNOWN withholds READY."
         },
         "diff_escapes_allowlist": {
@@ -257,7 +332,7 @@
     "advisory": {
       "type": "boolean",
       "const": true,
-      "description": "Always true. This signal is advisory only — it is NEVER a merge authority. Green CI is NOT semantic proof. See AIR Red Lines #7/#8."
+      "description": "Always true. This signal is advisory only \u2014 it is NEVER a merge authority. Green CI is NOT semantic proof. See AIR Red Lines #7/#8."
     },
     "created_at": {
       "type": "string",
@@ -268,37 +343,81 @@
   "$defs": {
     "completeness_state": {
       "type": "string",
-      "enum": ["COMPLETE", "MISSING", "UNKNOWN", "NOT_REQUIRED"]
+      "enum": [
+        "COMPLETE",
+        "MISSING",
+        "UNKNOWN",
+        "NOT_REQUIRED"
+      ]
     }
   },
   "allOf": [
     {
       "description": "Fail-closed gate (a): READY requires zero blocked_reasons, FRESH proof, and diff within allowlist.",
       "if": {
-        "properties": { "status": { "const": "READY" } },
-        "required": ["status"]
+        "properties": {
+          "status": {
+            "const": "READY"
+          }
+        },
+        "required": [
+          "status"
+        ]
       },
       "then": {
         "properties": {
-          "blocked_reasons": { "maxItems": 0 },
+          "blocked_reasons": {
+            "maxItems": 0
+          },
           "intake": {
             "properties": {
               "intake_completeness": {
                 "properties": {
-                  "pr_metadata": { "const": "COMPLETE" },
-                  "head_sha": { "const": "COMPLETE" },
-                  "changed_files": { "const": "COMPLETE" },
-                  "commits": { "const": "COMPLETE" },
-                  "reviews": { "const": "COMPLETE" },
-                  "review_comments": { "const": "COMPLETE" },
-                  "review_threads": { "const": "COMPLETE" },
-                  "issue_comments": { "const": "COMPLETE" },
-                  "checks": { "const": "COMPLETE" },
-                  "proof_refs": { "const": "COMPLETE" },
-                  "proof_freshness": { "const": "COMPLETE" },
-                  "reviewer_classifications": { "const": "COMPLETE" },
-                  "allowlist": { "const": "COMPLETE" },
-                  "security_release_approval": { "const": "COMPLETE" }
+                  "pr_metadata": {
+                    "const": "COMPLETE"
+                  },
+                  "head_sha": {
+                    "const": "COMPLETE"
+                  },
+                  "changed_files": {
+                    "const": "COMPLETE"
+                  },
+                  "commits": {
+                    "const": "COMPLETE"
+                  },
+                  "reviews": {
+                    "const": "COMPLETE"
+                  },
+                  "review_comments": {
+                    "const": "COMPLETE"
+                  },
+                  "review_threads": {
+                    "const": "COMPLETE"
+                  },
+                  "issue_comments": {
+                    "const": "COMPLETE"
+                  },
+                  "checks": {
+                    "const": "COMPLETE"
+                  },
+                  "proof_refs": {
+                    "const": "COMPLETE"
+                  },
+                  "proof_freshness": {
+                    "const": "COMPLETE"
+                  },
+                  "reviewer_classifications": {
+                    "const": "COMPLETE"
+                  },
+                  "allowlist": {
+                    "const": "COMPLETE"
+                  },
+                  "security_release_approval": {
+                    "enum": [
+                      "COMPLETE",
+                      "NOT_REQUIRED"
+                    ]
+                  }
                 },
                 "required": [
                   "pr_metadata",
@@ -317,8 +436,12 @@
                   "security_release_approval"
                 ]
               },
-              "proof_freshness": { "const": "FRESH" },
-              "diff_escapes_allowlist": { "const": false }
+              "proof_freshness": {
+                "const": "FRESH"
+              },
+              "diff_escapes_allowlist": {
+                "const": false
+              }
             }
           }
         }
@@ -327,12 +450,23 @@
     {
       "description": "Fail-closed gate (b): BLOCKED or NEEDS_SUPERVISOR requires at least one blocked_reason.",
       "if": {
-        "properties": { "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] } },
-        "required": ["status"]
+        "properties": {
+          "status": {
+            "enum": [
+              "BLOCKED",
+              "NEEDS_SUPERVISOR"
+            ]
+          }
+        },
+        "required": [
+          "status"
+        ]
       },
       "then": {
         "properties": {
-          "blocked_reasons": { "minItems": 1 }
+          "blocked_reasons": {
+            "minItems": 1
+          }
         }
       }
     },
@@ -342,16 +476,31 @@
         "properties": {
           "intake": {
             "properties": {
-              "proof_freshness": { "enum": ["STALE", "MISSING", "UNKNOWN"] }
+              "proof_freshness": {
+                "enum": [
+                  "STALE",
+                  "MISSING",
+                  "UNKNOWN"
+                ]
+              }
             },
-            "required": ["proof_freshness"]
+            "required": [
+              "proof_freshness"
+            ]
           }
         },
-        "required": ["intake"]
+        "required": [
+          "intake"
+        ]
       },
       "then": {
         "properties": {
-          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+          "status": {
+            "enum": [
+              "BLOCKED",
+              "NEEDS_SUPERVISOR"
+            ]
+          }
         }
       }
     },
@@ -361,41 +510,72 @@
         "properties": {
           "intake": {
             "properties": {
-              "diff_escapes_allowlist": { "const": true }
+              "diff_escapes_allowlist": {
+                "const": true
+              }
             },
-            "required": ["diff_escapes_allowlist"]
+            "required": [
+              "diff_escapes_allowlist"
+            ]
           }
         },
-        "required": ["intake"]
+        "required": [
+          "intake"
+        ]
       },
       "then": {
         "properties": {
-          "status": { "enum": ["BLOCKED", "NEEDS_SUPERVISOR"] }
+          "status": {
+            "enum": [
+              "BLOCKED",
+              "NEEDS_SUPERVISOR"
+            ]
+          }
         }
       }
     },
     {
       "description": "Fail-closed gate (e): READY with an unapproved security gate is rejected. If status is READY then intake must have security_release_required=false OR security_release_approved=true.",
       "if": {
-        "properties": { "status": { "const": "READY" } },
-        "required": ["status"]
+        "properties": {
+          "status": {
+            "const": "READY"
+          }
+        },
+        "required": [
+          "status"
+        ]
       },
       "then": {
         "properties": {
           "intake": {
             "anyOf": [
               {
-                "properties": { "security_release_required": { "const": false } },
-                "required": ["security_release_required"]
+                "properties": {
+                  "security_release_required": {
+                    "const": false
+                  }
+                },
+                "required": [
+                  "security_release_required"
+                ]
               },
               {
-                "properties": { "security_release_approved": { "const": true } },
-                "required": ["security_release_approved"]
+                "properties": {
+                  "security_release_approved": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "security_release_approved"
+                ]
               }
             ]
           }
         },
-        "required": ["intake"]
+        "required": [
+          "intake"
+        ]
       }
     }
   ]

--- a/src/dopemux/pcp/pr_steward.py
+++ b/src/dopemux/pcp/pr_steward.py
@@ -45,6 +45,23 @@ _SCHEMA: dict = load_schema("merge_readiness.schema.json")
 
 _VALIDATOR = Draft202012Validator(_SCHEMA)
 
+_INTAKE_COMPLETENESS_CATEGORIES = (
+    "pr_metadata",
+    "head_sha",
+    "changed_files",
+    "commits",
+    "reviews",
+    "review_comments",
+    "review_threads",
+    "issue_comments",
+    "checks",
+    "proof_refs",
+    "proof_freshness",
+    "reviewer_classifications",
+    "allowlist",
+    "security_release_approval",
+)
+
 # ---------------------------------------------------------------------------
 # Write-operation prohibition — this module is READ-ONLY.
 # No merge, push, commit, or PR-state-mutation commands are issued here.
@@ -83,6 +100,20 @@ def _default_runner(args: list[str]) -> str:
             f"gh command failed (exit {result.returncode}): {result.stderr.strip()}"
         )
     return result.stdout.strip()
+
+
+def _derive_intake_completeness(intake: dict) -> dict[str, str]:
+    explicit = intake.get("intake_completeness")
+    if not isinstance(explicit, dict):
+        explicit = {}
+
+    completeness: dict[str, str] = {}
+    for category in _INTAKE_COMPLETENESS_CATEGORIES:
+        value = explicit.get(category, "MISSING")
+        if value not in {"COMPLETE", "MISSING", "UNKNOWN", "NOT_REQUIRED"}:
+            value = "UNKNOWN"
+        completeness[category] = value
+    return completeness
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +168,10 @@ def assess_merge_readiness(
         blocked.append("MISSING_REQUIRED_INTAKE")
     if not isinstance(intake, dict):
         intake = {}
+
+    intake_completeness = _derive_intake_completeness(intake)
+    if any(state != "COMPLETE" for state in intake_completeness.values()):
+        blocked.append("INCOMPLETE_INTAKE")
 
     # ------------------------------------------------------------------
     # Rule 1: proof_freshness != FRESH → STALE_PROOF
@@ -224,6 +259,7 @@ def assess_merge_readiness(
     # ------------------------------------------------------------------
     canonical_intake: dict[str, Any] = {
         "changed_files": intake.get("changed_files", []),
+        "intake_completeness": intake_completeness,
         "commits": intake.get("commits", []),
         "checks": checks,
         "reviews": intake.get("reviews", []),
@@ -378,6 +414,22 @@ def harvest_pr_intake(
     proof_freshness = "MISSING"
 
     intake: dict[str, Any] = {
+        "intake_completeness": {
+            "pr_metadata": "COMPLETE",
+            "head_sha": "COMPLETE",
+            "changed_files": "COMPLETE",
+            "commits": "COMPLETE",
+            "reviews": "COMPLETE",
+            "review_comments": "MISSING",
+            "review_threads": "COMPLETE",
+            "issue_comments": "MISSING",
+            "checks": "COMPLETE",
+            "proof_refs": "MISSING",
+            "proof_freshness": "MISSING",
+            "reviewer_classifications": "COMPLETE",
+            "allowlist": "MISSING",
+            "security_release_approval": "MISSING",
+        },
         "changed_files": changed_files,
         "commits": commits,
         "checks": checks,

--- a/src/dopemux/pcp/pr_steward.py
+++ b/src/dopemux/pcp/pr_steward.py
@@ -102,6 +102,18 @@ def _default_runner(args: list[str]) -> str:
     return result.stdout.strip()
 
 
+_ALLOWED_COMPLETENESS_STATES = frozenset(
+    {"COMPLETE", "MISSING", "UNKNOWN", "NOT_REQUIRED"}
+)
+_SATISFIED_COMPLETENESS_STATES = frozenset({"COMPLETE", "NOT_REQUIRED"})
+
+
+def _normalize_completeness_value(value: object) -> str:
+    if isinstance(value, str) and value in _ALLOWED_COMPLETENESS_STATES:
+        return value
+    return "UNKNOWN"
+
+
 def _derive_intake_completeness(intake: dict) -> dict[str, str]:
     explicit = intake.get("intake_completeness")
     if not isinstance(explicit, dict):
@@ -110,9 +122,7 @@ def _derive_intake_completeness(intake: dict) -> dict[str, str]:
     completeness: dict[str, str] = {}
     for category in _INTAKE_COMPLETENESS_CATEGORIES:
         value = explicit.get(category, "MISSING")
-        if value not in {"COMPLETE", "MISSING", "UNKNOWN", "NOT_REQUIRED"}:
-            value = "UNKNOWN"
-        completeness[category] = value
+        completeness[category] = _normalize_completeness_value(value)
     return completeness
 
 
@@ -170,7 +180,7 @@ def assess_merge_readiness(
         intake = {}
 
     intake_completeness = _derive_intake_completeness(intake)
-    if any(state != "COMPLETE" for state in intake_completeness.values()):
+    if any(state not in _SATISFIED_COMPLETENESS_STATES for state in intake_completeness.values()):
         blocked.append("INCOMPLETE_INTAKE")
 
     # ------------------------------------------------------------------

--- a/task-packets/generated/TP-DMX-PCP-PR-STEWARD-COMPLETENESS-0001.json
+++ b/task-packets/generated/TP-DMX-PCP-PR-STEWARD-COMPLETENESS-0001.json
@@ -1,0 +1,95 @@
+{
+  "id": "TP-DMX-PCP-PR-STEWARD-COMPLETENESS-0001",
+  "project": "dopemux-mvp",
+  "target": "Harden PCP Core PR Steward so READY requires explicit completeness for proof, review/comment, check, allowlist, and security/release evidence categories. PR Steward remains advisory and read-only.",
+  "invariants": [
+    "Runtime, GitHub, and PR truth outrank this packet; re-pull live state before execution.",
+    "PR Steward is advisory only and must not merge, ready, push, or mutate GitHub or repository state.",
+    "Green CI is not semantic proof.",
+    "READY must be withheld when required evidence categories are missing, unknown, or not proven complete.",
+    "Harvested-only gh pr view intake is incomplete by design and must not emit READY.",
+    "Bundled PCP schemas must stay in parity with canonical project-control-plane schemas for installed-wheel behavior."
+  ],
+  "depends_on": [
+    "TP-DMX-PCP-PR-STEWARD-PROOF-READINESS-0001"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-PCP-DCP-ROUTING",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-PCP-PR-STEWARD-PROOF-READINESS-0001",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/pcp-pr-steward-completeness",
+    "base_branch": "main"
+  },
+  "commit": {
+    "message": "fix(pcp): block readiness on incomplete PR Steward intake",
+    "allowlist": [
+      "src/dopemux/pcp/pr_steward.py",
+      "schemas/project_control_plane/merge_readiness.schema.json",
+      "src/dopemux/pcp/_schemas/merge_readiness.schema.json",
+      "tests/project_control_plane/test_pr_steward.py",
+      "docs/ops/project-control-plane/pr-steward-readiness.md",
+      "task-packets/generated/TP-DMX-PCP-PR-STEWARD-COMPLETENESS-0001.json"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/TP-DMX-PCP-PR-STEWARD-COMPLETENESS-0001.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/TP-DMX-PCP-PR-STEWARD-COMPLETENESS-0001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest -q tests/project_control_plane/test_pr_steward.py",
+      "python -m pytest -q tests/project_control_plane",
+      "python -m compileall -q src/dopemux/pcp tests/project_control_plane",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(pcp): block readiness on incomplete PR Steward intake",
+    "body": "Adds intake completeness gating to PCP Core PR Steward. READY remains advisory and is blocked unless required evidence categories are complete. Harvested-only gh pr view intake stays incomplete and cannot become merge authority.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Add tests proving incomplete evidence categories block READY and schema rejects handcrafted READY with incomplete intake.",
+      "validation": [
+        "python -m pytest -q tests/project_control_plane/test_pr_steward.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Add fail-closed intake_completeness derivation to PR Steward runtime and schema, including bundled schema parity.",
+      "validation": [
+        "python -m pytest -q tests/project_control_plane",
+        "python -m compileall -q src/dopemux/pcp tests/project_control_plane"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Document that harvested-only PR Steward intake is incomplete and advisory, not merge authority.",
+      "validation": [
+        "pre-commit run --files src/dopemux/pcp/pr_steward.py schemas/project_control_plane/merge_readiness.schema.json src/dopemux/pcp/_schemas/merge_readiness.schema.json tests/project_control_plane/test_pr_steward.py docs/ops/project-control-plane/pr-steward-readiness.md"
+      ]
+    }
+  ]
+}

--- a/tests/project_control_plane/test_pr_steward.py
+++ b/tests/project_control_plane/test_pr_steward.py
@@ -163,6 +163,28 @@ class TestIntakeCompleteness:
         assert result["intake"]["intake_completeness"][category] == "MISSING"
         assert _schema_errors(result) == []
 
+
+    def test_not_required_intake_category_allows_ready(self) -> None:
+        intake = _clean_intake(
+            intake_completeness=_complete_intake_completeness(
+                security_release_approval="NOT_REQUIRED"
+            )
+        )
+        result = _assess(intake)
+        assert result["status"] == "READY"
+        assert "INCOMPLETE_INTAKE" not in result["blocked_reasons"]
+        assert result["intake"]["intake_completeness"]["security_release_approval"] == "NOT_REQUIRED"
+        assert _schema_errors(result) == []
+
+    def test_unhashable_intake_completeness_value_fails_closed(self) -> None:
+        intake = _clean_intake()
+        intake["intake_completeness"]["proof_refs"] = {"bad": "object"}
+        result = _assess(intake)
+        assert result["status"] == "BLOCKED"
+        assert "INCOMPLETE_INTAKE" in result["blocked_reasons"]
+        assert result["intake"]["intake_completeness"]["proof_refs"] == "UNKNOWN"
+        assert _schema_errors(result) == []
+
     def test_missing_intake_completeness_blocks_ready(self) -> None:
         intake = _clean_intake()
         del intake["intake_completeness"]

--- a/tests/project_control_plane/test_pr_steward.py
+++ b/tests/project_control_plane/test_pr_steward.py
@@ -63,6 +63,7 @@ _HEAD_SHA = "a" * 40
 def _clean_intake(**overrides: Any) -> dict:
     """Return a clean (all-gates-clear) intake dict, with optional field overrides."""
     base: dict[str, Any] = {
+        "intake_completeness": _complete_intake_completeness(),
         "changed_files": ["src/foo.py"],
         "commits": ["deadbeef" * 5],
         "checks": [
@@ -80,6 +81,27 @@ def _clean_intake(**overrides: Any) -> dict:
     }
     base.update(overrides)
     return base
+
+
+def _complete_intake_completeness(**overrides: str) -> dict[str, str]:
+    completeness = {
+        "pr_metadata": "COMPLETE",
+        "head_sha": "COMPLETE",
+        "changed_files": "COMPLETE",
+        "commits": "COMPLETE",
+        "reviews": "COMPLETE",
+        "review_comments": "COMPLETE",
+        "review_threads": "COMPLETE",
+        "issue_comments": "COMPLETE",
+        "checks": "COMPLETE",
+        "proof_refs": "COMPLETE",
+        "proof_freshness": "COMPLETE",
+        "reviewer_classifications": "COMPLETE",
+        "allowlist": "COMPLETE",
+        "security_release_approval": "COMPLETE",
+    }
+    completeness.update(overrides)
+    return completeness
 
 
 def _assess(intake: dict | None = None, **kwargs: Any) -> dict:
@@ -117,6 +139,43 @@ class TestCleanIntakeReady:
     def test_schema_version_sentinel(self) -> None:
         result = _assess()
         assert result["schema_version"] == "pcp.merge_readiness.v0"
+
+
+class TestIntakeCompleteness:
+    @pytest.mark.parametrize(
+        "category",
+        [
+            "proof_refs",
+            "review_comments",
+            "issue_comments",
+            "checks",
+            "allowlist",
+            "security_release_approval",
+        ],
+    )
+    def test_incomplete_intake_category_blocks_ready(self, category: str) -> None:
+        intake = _clean_intake(
+            intake_completeness=_complete_intake_completeness(**{category: "MISSING"})
+        )
+        result = _assess(intake)
+        assert result["status"] == "BLOCKED"
+        assert "INCOMPLETE_INTAKE" in result["blocked_reasons"]
+        assert result["intake"]["intake_completeness"][category] == "MISSING"
+        assert _schema_errors(result) == []
+
+    def test_missing_intake_completeness_blocks_ready(self) -> None:
+        intake = _clean_intake()
+        del intake["intake_completeness"]
+        result = _assess(intake)
+        assert result["status"] == "BLOCKED"
+        assert "INCOMPLETE_INTAKE" in result["blocked_reasons"]
+        assert _schema_errors(result) == []
+
+    def test_handcrafted_ready_with_incomplete_intake_fails_schema(self) -> None:
+        signal = _assess()
+        signal["intake"]["intake_completeness"]["proof_refs"] = "MISSING"
+        errors = _schema_errors(signal)
+        assert errors, "READY with incomplete intake must be schema-invalid"
 
 
 # ---------------------------------------------------------------------------
@@ -425,6 +484,11 @@ class TestHarvestPrIntakeWithFakeRunner:
         )
         errors = _schema_errors(signal)
         assert errors == [], f"Schema errors: {errors}"
+        assert signal["status"] == "BLOCKED"
+        assert "INCOMPLETE_INTAKE" in signal["blocked_reasons"]
+        assert signal["intake"]["intake_completeness"]["proof_refs"] == "MISSING"
+        assert signal["intake"]["intake_completeness"]["review_comments"] == "MISSING"
+        assert signal["intake"]["intake_completeness"]["issue_comments"] == "MISSING"
 
     def test_invalid_pr_number_raises(self) -> None:
         _, fake_runner = self._make_runner()
@@ -499,6 +563,7 @@ class TestSchemaRejectsReadyWithUnapprovedSecurityGate:
                     {"name": "ci/test", "conclusion": "SUCCESS", "stale_to_head": False}
                 ],
                 "reviews": [],
+                "intake_completeness": _complete_intake_completeness(),
                 "review_threads": [],
                 "reviewer_classifications": [{"actor": "alice", "kind": "HUMAN"}],
                 "unclassified_review_items": [],


### PR DESCRIPTION
## Summary
- Adds `intake_completeness` to PCP Core PR Steward merge-readiness intake.
- Blocks advisory `READY` unless required PR metadata, SHA, diff, review/comment, check, proof, allowlist, and security/release evidence categories are `COMPLETE`.
- Marks harvested-only `gh pr view` intake as incomplete for categories it cannot prove, so it cannot become merge authority by itself.
- Syncs the bundled PCP merge-readiness schema with the canonical project-control-plane schema.
- Adds a narrow Task Packet for this follow-up: `TP-DMX-PCP-PR-STEWARD-COMPLETENESS-0001`.

## Authority / Context
- Follow-up to the closed unmerged `#975` meta-packet.
- `#977`, `#978`, `#985`, and `#986` are merged and already cover the activation-gate/proof-family pieces that were accepted from that work.
- This PR only ports the remaining PR Steward completeness guard that was not present on `origin/main`.

## Invariants
- PR Steward remains advisory and read-only.
- No merge, ready, push, or GitHub mutation command is added.
- Green CI is not semantic proof.
- Harvested-only intake is incomplete by design.
- Unknown/missing evidence blocks `READY`.

## Validation
- `python -m pytest -q tests/project_control_plane/test_pr_steward.py` -> PASS, 55 tests.
- `python -m pytest -q tests/project_control_plane` -> PASS, 375 tests, 1 existing FastAPI/Starlette deprecation warning.
- `python -m compileall -q src/dopemux/pcp tests/project_control_plane` -> PASS.
- `python -m json.tool task-packets/generated/TP-DMX-PCP-PR-STEWARD-COMPLETENESS-0001.json >/dev/null` -> PASS.
- `python -m jsonschema -i task-packets/generated/TP-DMX-PCP-PR-STEWARD-COMPLETENESS-0001.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` -> PASS, with jsonschema CLI deprecation warning only.
- `git diff --check` -> PASS.
- `pre-commit run --files ...` on changed files -> PASS.

## Residual Risk
- The worktree has an unstaged `.claude/claude_config.json` auto-context change that is unrelated and intentionally not included.
- This does not implement richer GitHub harvesting for all evidence categories; it fails closed until callers provide complete evidence.
