### PR TITLE
Harden Serena F001 provenance and degraded-state output

### DIFF
--- a/services/serena/mcp_server.py
+++ b/services/serena/mcp_server.py
@@ -3762,18 +3762,25 @@ class SerenaV2MCPServer:
 
         except ImportError as e:
             # Feature 1 enhanced components not available
-            envelope = _f001_provenance(
-                status="DEGRADED",
-                data_state="unavailable",
-                degraded=True,
-                reason="dependency_unavailable",
-                fallback_used=False
-            )
-            envelope["result"] = {
-                "error": "F001 Enhanced components not fully integrated",
-                "message": "Missing enhancement modules (E1-E4)",
-                "details": str(e),
-                "fallback": "Use detect_untracked_work_tool instead"
+            from datetime import datetime, timezone
+            envelope = {
+                "status": "DEGRADED",
+                "authority": "serena",
+                "authority_role": "advisory",
+                "data_state": "unavailable",
+                "provenance": {
+                    "degraded": True,
+                    "reason": "dependency_unavailable",
+                    "fallback_used": False,
+                    "source": "serena-f001-enhanced",
+                    "checked_at": datetime.now(timezone.utc).isoformat()
+                },
+                "result": {
+                    "error": "F001 Enhanced components not fully integrated",
+                    "message": "Missing enhancement modules (E1-E4)",
+                    "details": str(e),
+                    "fallback": "Use detect_untracked_work_tool instead"
+                }
             }
             return json.dumps(envelope, indent=2)
         except (OSError, RuntimeError) as e:

--- a/services/serena/mcp_server.py
+++ b/services/serena/mcp_server.py
@@ -3727,67 +3727,46 @@ class SerenaV2MCPServer:
 
         except ImportError as e:
             # Feature 1 enhanced components not available
-            from datetime import datetime, timezone
-            envelope = {
-                "status": "DEGRADED",
-                "authority": "serena",
-                "authority_role": "advisory",
-                "data_state": "unavailable",
-                "provenance": {
-                    "degraded": True,
-                    "reason": "dependency_unavailable",
-                    "fallback_used": False,
-                    "source": "serena-f001-enhanced",
-                    "checked_at": datetime.now(timezone.utc).isoformat()
-                },
-                "result": {
-                    "error": "F001 Enhanced components not fully integrated",
-                    "message": "Missing enhancement modules (E1-E4)",
-                    "details": str(e),
-                    "fallback": "Use detect_untracked_work_tool instead"
-                }
+            envelope = _f001_provenance(
+                status="DEGRADED",
+                data_state="unavailable",
+                degraded=True,
+                reason="dependency_unavailable",
+                fallback_used=False
+            )
+            envelope["result"] = {
+                "error": "F001 Enhanced components not fully integrated",
+                "message": "Missing enhancement modules (E1-E4)",
+                "details": str(e),
+                "fallback": "Use detect_untracked_work_tool instead"
             }
             return json.dumps(envelope, indent=2)
         except (OSError, RuntimeError) as e:
             logger.error(f"detect_untracked_work_enhanced failed: {e}")
-            from datetime import datetime, timezone
-            envelope = {
-                "status": "DEGRADED",
-                "authority": "serena",
-                "authority_role": "advisory",
-                "data_state": "unknown",
-                "provenance": {
-                    "degraded": True,
-                    "reason": "unknown_error",
-                    "fallback_used": False,
-                    "source": "serena-f001-enhanced",
-                    "checked_at": datetime.now(timezone.utc).isoformat()
-                },
-                "result": {
-                    "error": str(e),
-                    "fallback": "Use base detect_untracked_work_tool"
-                }
+            envelope = _f001_provenance(
+                status="DEGRADED",
+                data_state="unknown",
+                degraded=True,
+                reason="unknown_error",
+                fallback_used=False
+            )
+            envelope["result"] = {
+                "error": str(e),
+                "fallback": "Use base detect_untracked_work_tool"
             }
             return json.dumps(envelope, indent=2)
         except Exception as e:
             logger.exception("detect_untracked_work_enhanced unexpected error")
-            from datetime import datetime, timezone
-            envelope = {
-                "status": "UNKNOWN",
-                "authority": "serena",
-                "authority_role": "advisory",
-                "data_state": "unknown",
-                "provenance": {
-                    "degraded": True,
-                    "reason": "unknown_error",
-                    "fallback_used": False,
-                    "source": "serena-f001-enhanced",
-                    "checked_at": datetime.now(timezone.utc).isoformat()
-                },
-                "result": {
-                    "error": "unexpected error",
-                    "fallback": "manual investigation"
-                }
+            envelope = _f001_provenance(
+                status="UNKNOWN",
+                data_state="unknown",
+                degraded=True,
+                reason="unknown_error",
+                fallback_used=False
+            )
+            envelope["result"] = {
+                "error": "unexpected error",
+                "fallback": "manual investigation"
             }
             return json.dumps(envelope, indent=2)
 

--- a/services/serena/mcp_server.py
+++ b/services/serena/mcp_server.py
@@ -3588,11 +3588,15 @@ class SerenaV2MCPServer:
                                         async def await_result():
                                             try:
                                                 return await result
+                                            except TypeError:
+                                                raise
                                             except Exception:
                                                 self.had_error = True
                                                 raise
                                         return await_result()
                                     return result
+                                except TypeError:
+                                    raise
                                 except Exception:
                                     self.had_error = True
                                     raise

--- a/services/serena/mcp_server.py
+++ b/services/serena/mcp_server.py
@@ -3569,12 +3569,47 @@ class SerenaV2MCPServer:
             # Ensure ConPort client connected
             await self._ensure_conport_client()
             conport_available = self.conport_client is not None
+            proxy_client = None
+            conport_query_failed = False
+
+            if conport_available:
+                class ConPortClientProxy:
+                    def __init__(self, client):
+                        self._client = client
+                        self.had_error = False
+
+                    def __getattr__(self, name):
+                        attr = getattr(self._client, name)
+                        if callable(attr):
+                            def wrapper(*args, **kwargs):
+                                try:
+                                    result = attr(*args, **kwargs)
+                                    if hasattr(result, "__await__"):
+                                        async def await_result():
+                                            try:
+                                                return await result
+                                            except Exception:
+                                                self.had_error = True
+                                                raise
+                                        return await_result()
+                                    return result
+                                except Exception:
+                                    self.had_error = True
+                                    raise
+                            return wrapper
+                        return attr
+
+                proxy_client = ConPortClientProxy(self.conport_client)
 
             # Run enhanced detection with ConPort integration
             detection = await detector.detect_with_enhancements(
-                conport_client=self.conport_client,
+                conport_client=proxy_client if conport_available else None,
                 session_number=session_number
             )
+            
+            if proxy_client and proxy_client.had_error:
+                conport_available = False
+                conport_query_failed = True
             enhancements = detection.get("enhancements", {})
 
             elapsed_ms = (datetime.now() - start_time).total_seconds() * 1000

--- a/services/serena/mcp_server.py
+++ b/services/serena/mcp_server.py
@@ -587,6 +587,8 @@ class SerenaV2MCPServer:
 
         except (ImportError, ConnectionError, OSError) as e:
             logger.warning(f"ConPort client initialization failed: {e}")
+            self.initialization_errors["conport"] = str(e)
+            self.conport_client = None
         except Exception as exc:
             logger.exception("Unexpected ConPort client initialization error")
             self.initialization_errors["conport"] = str(exc)

--- a/services/serena/mcp_server.py
+++ b/services/serena/mcp_server.py
@@ -3766,7 +3766,10 @@ class SerenaV2MCPServer:
 
         except ImportError as e:
             # Feature 1 enhanced components not available
-            from datetime import datetime, timezone
+            # NOTE: import only `timezone` — a local `from datetime import datetime`
+            # here would make `datetime` function-local, breaking `start_time =
+            # datetime.now()` above with UnboundLocalError. `datetime` is module-level.
+            from datetime import timezone
             envelope = {
                 "status": "DEGRADED",
                 "authority": "serena",

--- a/services/serena/mcp_server.py
+++ b/services/serena/mcp_server.py
@@ -413,7 +413,7 @@ class SerenaV2MCPServer:
             "adhd_features": False,
             "conport": False,  # F001/F002: ConPort connection tracking
         }
-        
+
         # dopeCode Layers
         self.dopecode_runtime = None
         self.ast_engine = None
@@ -490,7 +490,7 @@ class SerenaV2MCPServer:
 
         # Enhanced: Start background services (file watcher)
         await self._ensure_component("file_watcher")
-        
+
         # Initialize dopeCode Layers
         from dopecode.runtime import DopeCodeRuntime
         workspace_id = os.environ.get("DOPEMUX_WORKSPACE_ID", "default_workspace")
@@ -3086,7 +3086,7 @@ class SerenaV2MCPServer:
 
         # Single workspace mode
         start_time = datetime.now()
-        
+
         # Ensure database is available
         if not await self._ensure_component("database"):
             return json.dumps({
@@ -3103,14 +3103,14 @@ class SerenaV2MCPServer:
                 },
                 "error": "Intelligence database unavailable. Please ensure PostgreSQL is running.",
             })
-            
+
         from intelligence import NavigationMode
 
         relationships = []
         try:
             # 1. Resolve symbol to element ID
             search_results = await self.graph_operations.find_elements_by_name(symbol)
-            
+
             if not search_results:
                 elapsed_ms = (datetime.now() - start_time).total_seconds() * 1000
                 return json.dumps({
@@ -3120,10 +3120,10 @@ class SerenaV2MCPServer:
                     "note": f"Symbol '{symbol}' not found in intelligence graph. Use sync_codebase_to_graph to populate.",
                     "performance": {"latency_ms": round(elapsed_ms, 2)}
                 })
-                
+
             # Use the most relevant matching element
             element = search_results[0]
-            
+
             # 2. Get relationships from graph (ADHD optimized by default)
             related_elements = await self.graph_operations.get_related_elements(
                 element.id,
@@ -3131,7 +3131,7 @@ class SerenaV2MCPServer:
                 mode=NavigationMode.EXPLORE,
                 max_results=10
             )
-            
+
             # 3. Format results
             for rel_element, edge in related_elements:
                 relationships.append({
@@ -3215,7 +3215,7 @@ class SerenaV2MCPServer:
                 },
                 "error": "Intelligence database unavailable. Please ensure PostgreSQL is running.",
             })
-            
+
         start_time = datetime.now()
 
         try:
@@ -3234,9 +3234,9 @@ class SerenaV2MCPServer:
                 ORDER BY frequency DESC, avg_effectiveness DESC
                 LIMIT 10
             """
-            
+
             pattern_results = await self.database.execute_query(query, (days_back,), complexity_filter=False)
-            
+
             patterns = []
             for row in pattern_results:
                 patterns.append({
@@ -3246,7 +3246,7 @@ class SerenaV2MCPServer:
                     "cognitive_fatigue": round(row["avg_fatigue"], 2) if row["avg_fatigue"] else 0.0,
                     "last_seen": row["last_seen"].isoformat() if row["last_seen"] else None
                 })
-                
+
             elapsed_ms = (datetime.now() - start_time).total_seconds() * 1000
 
             result = {
@@ -3265,7 +3265,7 @@ class SerenaV2MCPServer:
 
             logger.info(f"get_navigation_patterns: found {len(patterns)} patterns ({elapsed_ms:.1f}ms)")
             return json.dumps(result, indent=2)
-            
+
         except Exception as e:
             logger.error(f"get_navigation_patterns failed: {e}")
             return json.dumps({"error": str(e)})
@@ -3289,7 +3289,7 @@ class SerenaV2MCPServer:
             JSON with updated focus state
         """
         start_time = datetime.now()
-        
+
         # Update in-memory state
         old_mode = self.current_focus_mode
         self.current_focus_mode = mode
@@ -3300,12 +3300,12 @@ class SerenaV2MCPServer:
             "scattered": 3,
             "transitioning": 5
         }
-        
+
         limit = limits.get(mode, 10)
         complexity_pref = "complex" if mode == "focused" else "simple" if mode == "scattered" else "moderate"
-        
+
         db_persisted = False
-        
+
         # Persist to database if available
         if await self._ensure_component("database"):
             try:
@@ -3556,7 +3556,7 @@ class SerenaV2MCPServer:
 
         try:
             # Import Feature 1 enhanced components
-            from .untracked_work_detector import UntrackedWorkDetector
+            from .untracked_work_detector import UntrackedWorkDetector, _f001_provenance
 
             # Initialize detector (includes E1-E4)
             detector = UntrackedWorkDetector(
@@ -3566,6 +3566,7 @@ class SerenaV2MCPServer:
 
             # Ensure ConPort client connected
             await self._ensure_conport_client()
+            conport_available = self.conport_client is not None
 
             # Run enhanced detection with ConPort integration
             detection = await detector.detect_with_enhancements(
@@ -3691,25 +3692,102 @@ class SerenaV2MCPServer:
                 f"E4={bool(enhancements.get('priority'))}, "
                 f"{elapsed_ms:.1f}ms)"
             )
-            return json.dumps(result, indent=2)
+
+            # Determine provenance state
+            prov_status = "LIVE"
+            degraded = False
+            fallback_used = False
+            reason = None
+
+            if not conport_available:
+                prov_status = "DEGRADED"
+                data_state = "unavailable"
+                degraded = True
+                fallback_used = True
+                reason = "conport_unavailable"
+            elif not detection["has_untracked_work"]:
+                data_state = "no_data"
+            else:
+                data_state = "available"
+
+            provenance_envelope = _f001_provenance(
+                status=prov_status,
+                data_state=data_state,
+                degraded=degraded,
+                reason=reason,
+                fallback_used=fallback_used
+            )
+
+            # Wrap the original result inside the provenance envelope to preserve backward compatibility
+            provenance_envelope["result"] = result
+
+            return json.dumps(provenance_envelope, indent=2)
 
         except ImportError as e:
             # Feature 1 enhanced components not available
-            return json.dumps({
-                "error": "F001 Enhanced components not fully integrated",
-                "message": "Missing enhancement modules (E1-E4)",
-                "details": str(e),
-                "fallback": "Use detect_untracked_work_tool instead"
-            }, indent=2)
-        except ImportError as e:
-            logger.error(f"detect_untracked_work_enhanced missing dependency: {e}")
-            return json.dumps({"error": str(e), "fallback": "Install enhancement modules"}, indent=2)
+            from datetime import datetime, timezone
+            envelope = {
+                "status": "DEGRADED",
+                "authority": "serena",
+                "authority_role": "advisory",
+                "data_state": "unavailable",
+                "provenance": {
+                    "degraded": True,
+                    "reason": "dependency_unavailable",
+                    "fallback_used": False,
+                    "source": "serena-f001-enhanced",
+                    "checked_at": datetime.now(timezone.utc).isoformat()
+                },
+                "result": {
+                    "error": "F001 Enhanced components not fully integrated",
+                    "message": "Missing enhancement modules (E1-E4)",
+                    "details": str(e),
+                    "fallback": "Use detect_untracked_work_tool instead"
+                }
+            }
+            return json.dumps(envelope, indent=2)
         except (OSError, RuntimeError) as e:
             logger.error(f"detect_untracked_work_enhanced failed: {e}")
-            return json.dumps({"error": str(e), "fallback": "Use base detect_untracked_work_tool"}, indent=2)
-        except Exception:
+            from datetime import datetime, timezone
+            envelope = {
+                "status": "DEGRADED",
+                "authority": "serena",
+                "authority_role": "advisory",
+                "data_state": "unknown",
+                "provenance": {
+                    "degraded": True,
+                    "reason": "unknown_error",
+                    "fallback_used": False,
+                    "source": "serena-f001-enhanced",
+                    "checked_at": datetime.now(timezone.utc).isoformat()
+                },
+                "result": {
+                    "error": str(e),
+                    "fallback": "Use base detect_untracked_work_tool"
+                }
+            }
+            return json.dumps(envelope, indent=2)
+        except Exception as e:
             logger.exception("detect_untracked_work_enhanced unexpected error")
-            return json.dumps({"error": "unexpected error", "fallback": "manual investigation"}, indent=2)
+            from datetime import datetime, timezone
+            envelope = {
+                "status": "UNKNOWN",
+                "authority": "serena",
+                "authority_role": "advisory",
+                "data_state": "unknown",
+                "provenance": {
+                    "degraded": True,
+                    "reason": "unknown_error",
+                    "fallback_used": False,
+                    "source": "serena-f001-enhanced",
+                    "checked_at": datetime.now(timezone.utc).isoformat()
+                },
+                "result": {
+                    "error": "unexpected error",
+                    "fallback": "manual investigation"
+                }
+            }
+            return json.dumps(envelope, indent=2)
 
     async def initialize_session_tool(
         self,

--- a/services/serena/tests/test_f001_provenance_degraded.py
+++ b/services/serena/tests/test_f001_provenance_degraded.py
@@ -125,7 +125,7 @@ async def test_detect_enhanced_unknown_exception(MockDetector, mcp_server):
 @patch('services.serena.untracked_work_detector.UntrackedWorkDetector')
 async def test_detect_enhanced_conport_query_failure(MockDetector, mcp_server):
     mock_instance = MockDetector.return_value
-    
+
     # Emulate the real detector path: the E1/E3/E4 aggregators call a ConPort
     # client method through ConPortClientProxy and fail-open on error. The proxy
     # records had_error before the aggregator swallows the exception, so detection
@@ -143,21 +143,63 @@ async def test_detect_enhanced_conport_query_failure(MockDetector, mcp_server):
             "confidence_score": 0.0,
             "threshold_used": 0.5
         }
-        
+
     mock_instance.detect_with_enhancements = AsyncMock(side_effect=side_effect_detect)
-    
+
     # Mock ConPort client so the wrapped query raises. Target get_custom_data,
     # the method the real aggregator issues through the proxy (get_tasks is never
     # called by F001), so the proxy's had_error path is genuinely exercised.
     mcp_server.conport_client = MagicMock()
     mcp_server.conport_client.get_custom_data = AsyncMock(side_effect=RuntimeError("Query failed"))
     mcp_server._ensure_conport_client = AsyncMock()
-    
+
     result_str = await mcp_server.detect_untracked_work_enhanced_tool()
     result = json.loads(result_str)
-    
+
     # Assert degraded state because the query failed
     assert result["status"] == "DEGRADED"
     assert result["data_state"] == "unavailable"
     assert result["provenance"]["degraded"] is True
     assert result["provenance"]["reason"] == "conport_unavailable"
+
+@pytest.mark.asyncio
+@patch('services.serena.untracked_work_detector.UntrackedWorkDetector')
+async def test_detect_enhanced_conport_typeerror_fallback(MockDetector, mcp_server):
+    mock_instance = MockDetector.return_value
+
+    # We simulate that detector calls some method on conport_client which raises TypeError first, then succeeds
+    async def side_effect_detect(conport_client=None, session_number=1):
+        if conport_client:
+            # Simulate the detector calling a client method with unsupported args
+            try:
+                await conport_client.get_tasks(status_filter="IN_PROGRESS")
+            except TypeError:
+                # Retry with fallback signature
+                await conport_client.get_tasks()
+
+        return {
+            "has_untracked_work": False,
+            "confidence_score": 0.0,
+            "threshold_used": 0.5
+        }
+
+    mock_instance.detect_with_enhancements = AsyncMock(side_effect=side_effect_detect)
+
+    # Mock ConPort client so it raises TypeError when called with status_filter
+    mcp_server.conport_client = MagicMock()
+
+    async def mock_get_tasks(*args, **kwargs):
+        if "status_filter" in kwargs:
+            raise TypeError("status_filter is not an unexpected keyword argument")
+        return []
+
+    mcp_server.conport_client.get_tasks = AsyncMock(side_effect=mock_get_tasks)
+    mcp_server._ensure_conport_client = AsyncMock()
+
+    result_str = await mcp_server.detect_untracked_work_enhanced_tool()
+    result = json.loads(result_str)
+
+    # Assert LIVE state because the TypeError fallback succeeded
+    assert result["status"] == "LIVE"
+    assert result["data_state"] == "no_data"
+    assert "provenance" not in result or not result.get("provenance", {}).get("degraded", False)

--- a/services/serena/tests/test_f001_provenance_degraded.py
+++ b/services/serena/tests/test_f001_provenance_degraded.py
@@ -1,0 +1,119 @@
+import json
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from services.serena.mcp_server import SerenaV2MCPServer
+
+@pytest.fixture
+def mcp_server():
+    server = SerenaV2MCPServer()
+    # Mock workspace resolving to avoid filesystem issues
+    server.workspace = "/Users/hue/code/dopemux-mvp"
+    return server
+
+@pytest.mark.asyncio
+@patch('services.serena.mcp_server.UntrackedWorkDetector')
+async def test_detect_enhanced_success_with_findings(MockDetector, mcp_server):
+    # Setup mock detector
+    mock_instance = MockDetector.return_value
+    mock_instance.detect_with_enhancements = AsyncMock(return_value={
+        "has_untracked_work": True,
+        "work_name": "Test Work",
+        "confidence_score": 0.9,
+        "threshold_used": 0.5,
+        "git_detection": {"files": ["a.py"], "branch": "main"},
+        "enhancements": {}
+    })
+    
+    # Mock ConPort client
+    mcp_server.conport_client = MagicMock()
+    mcp_server._ensure_conport_client = AsyncMock()
+    
+    result_str = await mcp_server.detect_untracked_work_enhanced_tool()
+    result = json.loads(result_str)
+    
+    assert result["status"] == "LIVE"
+    assert result["data_state"] == "available"
+    assert result["provenance"]["degraded"] is False
+    assert result["provenance"]["fallback_used"] is False
+    assert result["result"]["status"] == "untracked_work_detected"
+    assert result["authority"] == "serena"
+    assert result["authority_role"] == "advisory"
+
+@pytest.mark.asyncio
+@patch('services.serena.mcp_server.UntrackedWorkDetector')
+async def test_detect_enhanced_success_no_findings(MockDetector, mcp_server):
+    # Setup mock detector
+    mock_instance = MockDetector.return_value
+    mock_instance.detect_with_enhancements = AsyncMock(return_value={
+        "has_untracked_work": False,
+        "confidence_score": 0.1,
+        "threshold_used": 0.5
+    })
+    
+    # Mock ConPort client
+    mcp_server.conport_client = MagicMock()
+    mcp_server._ensure_conport_client = AsyncMock()
+    
+    result_str = await mcp_server.detect_untracked_work_enhanced_tool()
+    result = json.loads(result_str)
+    
+    assert result["status"] == "LIVE"
+    assert result["data_state"] == "no_data"
+    assert result["provenance"]["degraded"] is False
+    assert result["result"]["status"] == "all_clear"
+
+@pytest.mark.asyncio
+@patch('services.serena.mcp_server.UntrackedWorkDetector')
+async def test_detect_enhanced_conport_unavailable(MockDetector, mcp_server):
+    # Setup mock detector
+    mock_instance = MockDetector.return_value
+    mock_instance.detect_with_enhancements = AsyncMock(return_value={
+        "has_untracked_work": False,
+        "confidence_score": 0.0,
+        "threshold_used": 0.5
+    })
+    
+    # ConPort is unavailable
+    mcp_server.conport_client = None
+    mcp_server._ensure_conport_client = AsyncMock()
+    
+    result_str = await mcp_server.detect_untracked_work_enhanced_tool()
+    result = json.loads(result_str)
+    
+    assert result["status"] == "DEGRADED"
+    assert result["data_state"] == "unavailable"
+    assert result["provenance"]["degraded"] is True
+    assert result["provenance"]["reason"] == "conport_unavailable"
+    assert result["result"]["status"] == "all_clear"
+
+@pytest.mark.asyncio
+@patch('services.serena.mcp_server.UntrackedWorkDetector')
+async def test_detect_enhanced_unknown_exception(MockDetector, mcp_server):
+    # Setup mock detector to raise an exception
+    mock_instance = MockDetector.return_value
+    mock_instance.detect_with_enhancements.side_effect = RuntimeError("Database timeout")
+    
+    mcp_server.conport_client = MagicMock()
+    mcp_server._ensure_conport_client = AsyncMock()
+    
+    result_str = await mcp_server.detect_untracked_work_enhanced_tool()
+    result = json.loads(result_str)
+    
+    assert result["status"] == "DEGRADED"
+    assert result["data_state"] == "unknown"
+    assert result["provenance"]["degraded"] is True
+    assert result["provenance"]["reason"] == "unknown_error"
+    assert "error" in result["result"]
+
+@pytest.mark.asyncio
+@patch('services.serena.mcp_server.UntrackedWorkDetector')
+async def test_detect_enhanced_no_write_actions(MockDetector, mcp_server):
+    mock_instance = MockDetector.return_value
+    mock_instance.detect_with_enhancements = AsyncMock(return_value={"has_untracked_work": False, "confidence_score": 0, "threshold_used": 0})
+    mcp_server.conport_client = MagicMock()
+    mcp_server._ensure_conport_client = AsyncMock()
+    
+    await mcp_server.detect_untracked_work_enhanced_tool()
+    
+    # Ensure no logging or writing was performed
+    mcp_server.conport_client.log_custom_data.assert_not_called()

--- a/services/serena/tests/test_f001_provenance_degraded.py
+++ b/services/serena/tests/test_f001_provenance_degraded.py
@@ -1,19 +1,41 @@
+"""
+MIGRATION NOTE:
+The enhanced F001 MCP payload shape has changed to include a top-level provenance envelope.
+- The old flat payload (e.g. status: "all_clear") is now nested under the `result` key.
+- The new top-level `status` is the envelope status: LIVE, DEGRADED, UNKNOWN, BLOCKED, or NOT_PROBED.
+- Legacy fields remain available under `result` for backward compatibility.
+"""
+
+import sys
 import json
 import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 from services.serena.mcp_server import SerenaV2MCPServer
 
 @pytest.fixture
-def mcp_server():
+def mcp_server(tmp_path):
     server = SerenaV2MCPServer()
-    # Mock workspace resolving to avoid filesystem issues
-    server.workspace = "/Users/hue/code/dopemux-mvp"
+    server.workspace = str(tmp_path)
     return server
 
+@pytest.fixture
+def mock_conport_failing_module():
+    mock_module = MagicMock()
+    mock_class = MagicMock()
+    mock_instance = AsyncMock()
+    # Simulate ConnectionError during connect
+    mock_instance.connect.side_effect = ConnectionError("Simulated connection error")
+    mock_class.return_value = mock_instance
+    mock_module.ConPortDBClient = mock_class
+
+    sys.modules['conport_client_unified'] = mock_module
+    yield mock_instance
+    if 'conport_client_unified' in sys.modules:
+        del sys.modules['conport_client_unified']
+
 @pytest.mark.asyncio
-@patch('services.serena.mcp_server.UntrackedWorkDetector')
+@patch('services.serena.untracked_work_detector.UntrackedWorkDetector')
 async def test_detect_enhanced_success_with_findings(MockDetector, mcp_server):
-    # Setup mock detector
     mock_instance = MockDetector.return_value
     mock_instance.detect_with_enhancements = AsyncMock(return_value={
         "has_untracked_work": True,
@@ -21,65 +43,60 @@ async def test_detect_enhanced_success_with_findings(MockDetector, mcp_server):
         "confidence_score": 0.9,
         "threshold_used": 0.5,
         "git_detection": {"files": ["a.py"], "branch": "main"},
+        "detection_signals": [],
         "enhancements": {}
     })
-    
-    # Mock ConPort client
+
     mcp_server.conport_client = MagicMock()
     mcp_server._ensure_conport_client = AsyncMock()
-    
+
     result_str = await mcp_server.detect_untracked_work_enhanced_tool()
     result = json.loads(result_str)
-    
+
     assert result["status"] == "LIVE"
     assert result["data_state"] == "available"
     assert result["provenance"]["degraded"] is False
-    assert result["provenance"]["fallback_used"] is False
     assert result["result"]["status"] == "untracked_work_detected"
-    assert result["authority"] == "serena"
-    assert result["authority_role"] == "advisory"
 
 @pytest.mark.asyncio
-@patch('services.serena.mcp_server.UntrackedWorkDetector')
+@patch('services.serena.untracked_work_detector.UntrackedWorkDetector')
 async def test_detect_enhanced_success_no_findings(MockDetector, mcp_server):
-    # Setup mock detector
     mock_instance = MockDetector.return_value
     mock_instance.detect_with_enhancements = AsyncMock(return_value={
         "has_untracked_work": False,
         "confidence_score": 0.1,
         "threshold_used": 0.5
     })
-    
-    # Mock ConPort client
+
     mcp_server.conport_client = MagicMock()
     mcp_server._ensure_conport_client = AsyncMock()
-    
+
     result_str = await mcp_server.detect_untracked_work_enhanced_tool()
     result = json.loads(result_str)
-    
+
     assert result["status"] == "LIVE"
     assert result["data_state"] == "no_data"
     assert result["provenance"]["degraded"] is False
     assert result["result"]["status"] == "all_clear"
 
 @pytest.mark.asyncio
-@patch('services.serena.mcp_server.UntrackedWorkDetector')
-async def test_detect_enhanced_conport_unavailable(MockDetector, mcp_server):
-    # Setup mock detector
+@patch('services.serena.untracked_work_detector.UntrackedWorkDetector')
+async def test_detect_enhanced_conport_connect_failure(MockDetector, mcp_server, mock_conport_failing_module):
     mock_instance = MockDetector.return_value
     mock_instance.detect_with_enhancements = AsyncMock(return_value={
         "has_untracked_work": False,
         "confidence_score": 0.0,
         "threshold_used": 0.5
     })
-    
-    # ConPort is unavailable
-    mcp_server.conport_client = None
-    mcp_server._ensure_conport_client = AsyncMock()
-    
+
+    # We do NOT mock _ensure_conport_client here, so it executes and fails
     result_str = await mcp_server.detect_untracked_work_enhanced_tool()
     result = json.loads(result_str)
-    
+
+    # Assert conport_client was nullified
+    assert mcp_server.conport_client is None
+
+    # Assert degraded state
     assert result["status"] == "DEGRADED"
     assert result["data_state"] == "unavailable"
     assert result["provenance"]["degraded"] is True
@@ -87,33 +104,19 @@ async def test_detect_enhanced_conport_unavailable(MockDetector, mcp_server):
     assert result["result"]["status"] == "all_clear"
 
 @pytest.mark.asyncio
-@patch('services.serena.mcp_server.UntrackedWorkDetector')
+@patch('services.serena.untracked_work_detector.UntrackedWorkDetector')
 async def test_detect_enhanced_unknown_exception(MockDetector, mcp_server):
-    # Setup mock detector to raise an exception
     mock_instance = MockDetector.return_value
     mock_instance.detect_with_enhancements.side_effect = RuntimeError("Database timeout")
-    
+
     mcp_server.conport_client = MagicMock()
     mcp_server._ensure_conport_client = AsyncMock()
-    
+
     result_str = await mcp_server.detect_untracked_work_enhanced_tool()
     result = json.loads(result_str)
-    
+
     assert result["status"] == "DEGRADED"
     assert result["data_state"] == "unknown"
     assert result["provenance"]["degraded"] is True
     assert result["provenance"]["reason"] == "unknown_error"
     assert "error" in result["result"]
-
-@pytest.mark.asyncio
-@patch('services.serena.mcp_server.UntrackedWorkDetector')
-async def test_detect_enhanced_no_write_actions(MockDetector, mcp_server):
-    mock_instance = MockDetector.return_value
-    mock_instance.detect_with_enhancements = AsyncMock(return_value={"has_untracked_work": False, "confidence_score": 0, "threshold_used": 0})
-    mcp_server.conport_client = MagicMock()
-    mcp_server._ensure_conport_client = AsyncMock()
-    
-    await mcp_server.detect_untracked_work_enhanced_tool()
-    
-    # Ensure no logging or writing was performed
-    mcp_server.conport_client.log_custom_data.assert_not_called()

--- a/services/serena/tests/test_f001_provenance_degraded.py
+++ b/services/serena/tests/test_f001_provenance_degraded.py
@@ -126,11 +126,18 @@ async def test_detect_enhanced_unknown_exception(MockDetector, mcp_server):
 async def test_detect_enhanced_conport_query_failure(MockDetector, mcp_server):
     mock_instance = MockDetector.return_value
     
-    # We simulate that detector calls some method on conport_client which fails
+    # Emulate the real detector path: the E1/E3/E4 aggregators call a ConPort
+    # client method through ConPortClientProxy and fail-open on error. The proxy
+    # records had_error before the aggregator swallows the exception, so detection
+    # still returns normally (mirrors false_starts_aggregator._load_records).
     async def side_effect_detect(conport_client=None, session_number=1):
         if conport_client:
-            # Simulate the detector calling a client method that fails
-            await conport_client.get_tasks()
+            try:
+                await conport_client.get_custom_data(
+                    workspace_id="ws", category="untracked_work"
+                )
+            except Exception:
+                pass  # aggregator fail-open; proxy has already flagged had_error
         return {
             "has_untracked_work": False,
             "confidence_score": 0.0,
@@ -139,9 +146,11 @@ async def test_detect_enhanced_conport_query_failure(MockDetector, mcp_server):
         
     mock_instance.detect_with_enhancements = AsyncMock(side_effect=side_effect_detect)
     
-    # Mock ConPort client so it raises an exception when get_tasks is called
+    # Mock ConPort client so the wrapped query raises. Target get_custom_data,
+    # the method the real aggregator issues through the proxy (get_tasks is never
+    # called by F001), so the proxy's had_error path is genuinely exercised.
     mcp_server.conport_client = MagicMock()
-    mcp_server.conport_client.get_tasks = AsyncMock(side_effect=RuntimeError("Query failed"))
+    mcp_server.conport_client.get_custom_data = AsyncMock(side_effect=RuntimeError("Query failed"))
     mcp_server._ensure_conport_client = AsyncMock()
     
     result_str = await mcp_server.detect_untracked_work_enhanced_tool()

--- a/services/serena/tests/test_f001_provenance_degraded.py
+++ b/services/serena/tests/test_f001_provenance_degraded.py
@@ -120,3 +120,35 @@ async def test_detect_enhanced_unknown_exception(MockDetector, mcp_server):
     assert result["provenance"]["degraded"] is True
     assert result["provenance"]["reason"] == "unknown_error"
     assert "error" in result["result"]
+
+@pytest.mark.asyncio
+@patch('services.serena.untracked_work_detector.UntrackedWorkDetector')
+async def test_detect_enhanced_conport_query_failure(MockDetector, mcp_server):
+    mock_instance = MockDetector.return_value
+    
+    # We simulate that detector calls some method on conport_client which fails
+    async def side_effect_detect(conport_client=None, session_number=1):
+        if conport_client:
+            # Simulate the detector calling a client method that fails
+            await conport_client.get_tasks()
+        return {
+            "has_untracked_work": False,
+            "confidence_score": 0.0,
+            "threshold_used": 0.5
+        }
+        
+    mock_instance.detect_with_enhancements = AsyncMock(side_effect=side_effect_detect)
+    
+    # Mock ConPort client so it raises an exception when get_tasks is called
+    mcp_server.conport_client = MagicMock()
+    mcp_server.conport_client.get_tasks = AsyncMock(side_effect=RuntimeError("Query failed"))
+    mcp_server._ensure_conport_client = AsyncMock()
+    
+    result_str = await mcp_server.detect_untracked_work_enhanced_tool()
+    result = json.loads(result_str)
+    
+    # Assert degraded state because the query failed
+    assert result["status"] == "DEGRADED"
+    assert result["data_state"] == "unavailable"
+    assert result["provenance"]["degraded"] is True
+    assert result["provenance"]["reason"] == "conport_unavailable"

--- a/services/serena/untracked_work_detector.py
+++ b/services/serena/untracked_work_detector.py
@@ -39,6 +39,30 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _f001_provenance(
+    *,
+    status: str,
+    data_state: str,
+    degraded: bool,
+    reason: Optional[str] = None,
+    fallback_used: bool = False,
+) -> Dict[str, Any]:
+    from datetime import timezone
+    return {
+        "status": status,
+        "authority": "serena",
+        "authority_role": "advisory",
+        "data_state": data_state,
+        "provenance": {
+            "degraded": degraded,
+            "reason": reason,
+            "fallback_used": fallback_used,
+            "source": "serena-f001-enhanced",
+            "checked_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }
+
+
 class UntrackedWorkDetector:
     """Detect untracked work and provide ADHD-friendly recommendation signals."""
 


### PR DESCRIPTION
## Summary
Adds explicit provenance/degraded/data_state envelope semantics to enhanced Serena F001 detection output.
The enhanced F001 MCP response now distinguishes:
- `available`
- `no_data`
- `unavailable`
- `unknown`
- degraded/fallback paths
The legacy enhanced output is preserved under `result` for backward compatibility.
## Guardrails
- F001 remains read-only/advisory.
- No PM/ConPort/Task Orchestrator/Cockpit/compose/registry/catalog changes.
- No ConPort schema changes.
- Empty dependency fallback is not all-clear.
- `no_data` only means detection actually ran.
- This PR is stacked on PR #1007 and must not merge before #1007.
## Validation
```text
python -m pytest -q services/serena/test_f001_enhanced.py -> exit_code=0
python -m pytest -q services/serena/tests/test_f001_provenance_degraded.py -> exit_code=2
python -m pytest -q services/serena/tests/test_mcp_server_local.py -> exit_code=2
python -m pytest -q services/serena/test_f001_enhanced.py services/serena/tests/test_f001_provenance_degraded.py services/serena/tests/test_mcp_server_local.py -> exit_code=2
python -m compileall -q services/serena -> exit_code=0
git diff --check -> exit_code=0
```

Known native failure:

ModuleNotFoundError: No module named 'mcp'

This is preserved and not claimed green.

## Embedded Audit

```json
{
  "auditor_tool": "AGY CLI",
  "auditor_model": "Gemini 3.1 Pro",
  "invocation": "Local Manual Audit",
  "exit_code": null,
  "auditor_verdict": "PASS_WITH_RISKS",
  "auditor_findings": [
    "Only allowed services/serena files changed.",
    "F001 remains read-only/advisory.",
    "Enhanced F001 output differentiates available/no_data/unavailable/unknown/degraded statuses using the provenance envelope.",
    "Empty dependency fallback triggers DEGRADED status with unavailable data_state.",
    "No PM, ConPort schema, Task Orchestrator, Cockpit, compose, registry, catalog, docs, or .claude files were modified.",
    "Tests use mocks and do not require live ConPort/Docker/Redis.",
    "Tests honestly preserve missing mcp dependency failure.",
    "Existing enhanced MCP registration remains backward compatible by nesting legacy output in result."
  ],
  "fixes_applied_from_audit": [
    "Removed trailing whitespace from services/serena/mcp_server.py."
  ],
  "remaining_risks": [
    "test_f001_provenance_degraded.py and test_mcp_server_local.py natively fail during pytest collection due to missing mcp dependency.",
    "This implementation is stacked on codex/f001-enhanced-mcp-register-001 / PR #1007."
  ],
  "skip_reason": null
}
```

## Residual Risks

* Native pytest collection for MCP-server tests fails due missing mcp dependency.
* This PR is stacked on PR #1007 and must be rebased or retargeted after #1007 merges.

## F001 Output Contract Note
This PR intentionally changes the enhanced F001 MCP response envelope:
- Top-level `status` now represents transport/provenance state: `LIVE`, `DEGRADED`, `UNKNOWN`, etc.
- The previous enhanced F001 payload is preserved under `result`.
- Existing top-level fields such as prior `status`, `message`, `confidence_score`, and action details should be read from `result`.
- This is required so callers can distinguish true no-data from unavailable/degraded backing data.
