### PR TITLE
fix(services): service-audit P0 fixes + ADHD ignition — chronicle mirror, fail-closed protection, engine default-start

### DIFF
--- a/.claude/hooks/untracked_work_probe.py
+++ b/.claude/hooks/untracked_work_probe.py
@@ -1,0 +1,83 @@
+"""SessionStart untracked-work probe (H5).
+
+Surfaces uncommitted work with a one-line advisory at Claude session start
+and emits a promotable ``work.untracked_detected`` capture event so the
+chronicle records it. Delegates detection/formatting to
+``dopemux.untracked_work`` (lite probe — Serena F001 owns the actionable
+detect→remind→convert lifecycle).
+
+Fail-open: any failure returns None and never blocks the session. Cooldown:
+fires at most once per session id (fallback: 30-minute time cooldown when no
+session id is available), cached under ``.claude/``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_CACHE_FILENAME = ".untracked-work-probe-cache.json"
+_FALLBACK_COOLDOWN_MIN = 30
+
+
+def _cache_path(project_root: Path) -> Path:
+    return project_root / ".claude" / _CACHE_FILENAME
+
+
+def _already_probed(project_root: Path, session_id: Optional[str]) -> bool:
+    try:
+        data = json.loads(_cache_path(project_root).read_text())
+    except Exception:
+        return False
+    if session_id and data.get("session_id") == session_id:
+        return True
+    if not session_id:
+        ts = data.get("written_at", "")
+        try:
+            age_min = (
+                datetime.now(timezone.utc) - datetime.fromisoformat(ts)
+            ).total_seconds() / 60
+            return age_min < _FALLBACK_COOLDOWN_MIN
+        except Exception:
+            return False
+    return False
+
+
+def _save_probe_marker(project_root: Path, session_id: Optional[str]) -> None:
+    try:
+        path = _cache_path(project_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "session_id": session_id or "",
+                    "written_at": datetime.now(timezone.utc).isoformat(),
+                }
+            )
+        )
+    except Exception:
+        pass
+
+
+def emit_untracked_work_advisory(
+    project_root: Path, session_id: Optional[str] = None
+) -> Optional[str]:
+    """Return an advisory line for SessionStart context, or None.
+
+    Never raises.
+    """
+    try:
+        root = Path(project_root)
+        if _already_probed(root, session_id):
+            return None
+        from dopemux.untracked_work import probe_untracked_work
+
+        advisory = probe_untracked_work(
+            str(root), source_probe="session_start", session_id=session_id
+        )
+        _save_probe_marker(root, session_id)
+        return advisory
+    except Exception:
+        return None

--- a/claudedocs/service-audit-2026-07-04-appendix-memory-spine.md
+++ b/claudedocs/service-audit-2026-07-04-appendix-memory-spine.md
@@ -1,0 +1,374 @@
+# Memory Spine Service Cluster Audit — 2026-07-04
+
+**Status**: READ-ONLY AUDIT (no modifications)
+**Worktree**: focused-mahavira-5bd29b @ 8f71ab9af
+**Scope**: dope-memory, ConPort, dope-context, task-orchestrator, capture_client, promotion pipeline
+
+---
+
+## Executive Summary
+
+The memory spine **has correct architecture, partial implementation, and ONE critical blocker** preventing chronicle population. Decision logging is 75% wired; the remaining 25% is a stream-name mismatch that can be fixed with a single-line diff in each of 4 files.
+
+- **Intended**: Decisions → ConPort → dope-memory chronicle via activity.events.v1 promotion
+- **Implemented**: Decisions → ConPort ✅, ConPort → DopeconBridge ✅, DopeconBridge → dopemux:events ❌
+- **Result**: 0 work_log_entries in chronicle (24.5k heartbeat spam events, all non-promotable)
+
+---
+
+## 1. Surface Inventory & Wiring Status
+
+### 1.1 dope-memory (services/working-memory-assistant/)
+
+**Intended**:
+- 10-tool MCP surface (recap, reflection, trajectory, chronicle query, work-log indexing)
+- SQLite canonical ledger + Redis event transport
+- Real-time event ingestion via activity.events.v1 → promotion → chronicle
+- Per-worktree instance isolation
+
+**Implemented**:
+- ✅ 10-tool MCP surface @ /mcp port 3020 (dope_memory_main.py:83–1200)
+- ✅ Canonical SQLite ledger with schema (canonical_ledger.py, chronicle/store.py)
+- ✅ PromotionEngine with 7 promotable event types (promotion.py:18–28)
+- ✅ EventBusConsumer wired & started in lifespan (dope_memory_main.py:956–965)
+- ✅ Instance tracking (eventbus_consumer.py:77–100)
+- ⚠️  WMA prototype (~3.6k lines) still co-resident (unreferenced legacy code)
+- ⚠️  Dead stdio shim on port 8096 (dead code path)
+
+**Wired**:
+- compose.yml: ✅ dope-memory service, ENABLE_EVENTBUS=true, REDIS_URL configured
+- services/registry.yaml: ✅ port 3020, /health endpoint
+- .mcp.json: ✅ dope-memory configured, /mcp transport
+- docker/mcp-servers-source/.../Dockerfile.dope-memory: ✅ HEALTHCHECK
+
+**Quality**: 4/5
+- **Bugs**: None in core path
+- **Debt**: WMA prototype (archive candidate), dead shim
+- **Architecture**: Sound canonical-ledger + promotion approach
+- **Test coverage**: Integration tests exist; promotion logic deterministic
+
+---
+
+### 1.2 ConPort (docker/mcp-servers-source/conport/)
+
+**Intended**:
+- Canonical writer for decisions/progress/context
+- 17-tool SSE surface + REST + JSON-RPC compatibility
+- Knowledge graph queries (append-only decisions)
+- Mirror receipt from dope-memory (Trinity Rule 1)
+
+**Implemented**:
+- ✅ 17-tool SSE surface (server.py:43–210)
+- ✅ HTTP endpoints (enhanced_server.py, port 3004)
+- ✅ Decision logging with timestamp + rationale (enhanced_server.py:671–728)
+- ✅ Decision → DopeconBridge publication (enhanced_server.py:708–717)
+- ✅ Instance detection via SimpleInstanceDetector (enhanced_server.py:710)
+- ⚠️  Knowledge graph = plain table, read-only traversal (no AGE/Cypher at runtime)
+- ⚠️  Worktree isolation inert over SSE (single DOPEMUX_INSTANCE_ID value)
+- ⚠️  GET /api/progress mutates if DOPEMUX_AUTO_FORK_PROGRESS=on
+
+**Wired**:
+- compose.yml: ✅ conport service, REST :3004, SSE :3005, info :4004
+- .mcp.json: ✅ conport configured
+- ~/.claude.json: ⚠️  Duplicated (drifted, 6 nonexistent tool references)
+- services/registry.yaml: ✅ ports/health
+
+**Quality**: 3.5/5
+- **Bugs**: 
+  - `_ensure_schema` fail-open verification (enhanced_server.py: missing rollback on error)
+  - GET mutation on /api/progress (design issue, not enforced off)
+- **Integration gaps**:
+  - decision.logged published to dopemux:events, not activity.events.v1
+  - No emit_capture_event() call (decision.logged never reaches dope-memory)
+- **Debt**: Upstream wrapper path still referenced in some .claude commands; knowledge graph write API unimplemented
+
+---
+
+### 1.3 dope-context (services/dope-context/)
+
+**Intended**:
+- Hybrid dense+sparse code+docs retrieval (Voyage + Qdrant + BM25)
+- Per-worktree Qdrant collections
+- Complexity scoring (0.0–1.0 band shared with Serena)
+- Read-only Phase-1 lexical enforcement
+
+**Implemented**:
+- ✅ 18 real tools (search_code, docs_search, search_all, sync, index, clear)
+- ✅ Voyage embeddings + Qdrant client
+- ✅ Sync via SHA256 change detection
+- ✅ Per-worktree collection detection (workspace_id in requests)
+- ⚠️  Healthcheck fail-open (`|| exit 0`, always passes)
+- ⚠️  Mock simple_server.py fabricates plausible results (if real server unavailable)
+- ⚠️  Complexity claim unvalidated (docstring says "ast, not Tree-sitter")
+- ⚠️  No collection GC (orphaned Qdrant collections for deleted worktrees)
+- ⚠️  No Voyage cost guard (unbounded embedding calls possible)
+
+**Wired**:
+- compose.yml: ✅ dope-context service, HTTP 127.0.0.1:3010
+- .mcp.json: ⚠️  Not present (design gap — should be listed)
+- services/registry.yaml: ✅ port 3010, /health
+
+**Quality**: 3/5
+- **Bugs**:
+  - Healthcheck fail-open (trivial fix)
+  - No collection GC (operational risk: disk bloat)
+  - Complexity contract unvalidated (docstring lies)
+- **Integration gaps**:
+  - dope-context indexing of chronicle is gated off (ENABLE_DOPECONTEXT_INDEX=false)
+  - No per-request complexity score in results (promised but unimplemented)
+- **Debt**: simple_server.py mock should be deleted; complexity scoring should be unified with Serena or claim removed
+
+---
+
+### 1.4 Task Orchestrator (Kotlin MCP jar @ port 7890)
+
+**Intended**:
+- Persistent work-item DAG with role-based queue→work→review→terminal transitions
+- Trigger guards + dependency resolution
+- Note-schema gates + proof-bundle-in-note
+- Repo-scoped singleton (git-common-dir keyed)
+
+**Implemented**:
+- ✅ Kotlin jar v3.8.0 (ghcr.io/jpicklyk/mcp-task-orchestrator)
+- ✅ HTTP singleton via ensure script (excellent lifecycle mgmt)
+- ✅ 14-tool surface (manage_items, query_items, advance_item, etc.)
+- ✅ Repo-scoped keying + worktree awareness
+- ⚠️  NOT auto-started (ensure script optional, no healthcheck enforcement)
+- ⚠️  No auto-ensure in H3 hook (manual startup only)
+- ⚠️  Python services/task-orchestrator/ = unrelated parallel service (name collision)
+
+**Wired**:
+- .mcp.json: ✅ task-orchestrator configured @ 127.0.0.1:7890
+- Codex config: ✅ required=true (hard client dependency)
+- /dx:* commands: ✅ 18 commands consume task-orchestrator
+- ensure script: ✅ exists but not called automatically
+
+**Quality**: 4/5
+- **Bugs**: None in jar itself (upstream maintained)
+- **Integration gaps**:
+  - No task.completed/failed/blocked event emission to dope-memory
+  - No workflow.phase_changed event emission
+  - Workflow transitions don't trigger capture_client.emit_capture_event()
+- **Debt**: Python services/task-orchestrator rename needed (rename to workflow-api or archive)
+
+---
+
+### 1.5 Native Hooks Capture Path (src/dopemux/claude/native_hooks.py)
+
+**Intended**:
+- Hook lifecycle: SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, PostToolUseFailure, Stop, SubagentStart, SessionEnd
+- Emit promotable events (error.encountered on tool failure)
+- Fail-open (never block user due to capture)
+
+**Implemented**:
+- ✅ Imports try_emit_promotable_capture_event (line 78)
+- ✅ _bounded_hook_error_capture() wired to PostToolUseFailure (lines 166–194)
+- ✅ Emits "error.encountered" with error_kind, service, hook_event_name
+- ✅ Fail-open behavior (errors caught, logged, no re-raise)
+- ✅ Source="dopemux.native_hooks", mode="plugin"
+
+**Wired**:
+- .claude/settings.json: ✅ hooks configured
+- src/dopemux/claude/native_hooks.py: ✅ entry point registered
+- H3 hook (mcp_health_probe.py): ⚠️  Emits MCP health, not capture events
+
+**Quality**: 4.5/5
+- **Bugs**: None
+- **Integration gaps**: Only error.encountered is wired; no decision/task/workflow events from here
+
+---
+
+## 2. Promotion Pipeline & Chronicle Flow
+
+### Promotable Event Types (promotion.py:18–28)
+
+```python
+PROMOTABLE_EVENT_TYPES = frozenset([
+    "decision.logged",      # ConPort → dope-memory
+    "task.completed",       # workflow-kernel → dope-memory
+    "task.failed",          # workflow-kernel → dope-memory
+    "task.blocked",         # workflow-kernel → dope-memory
+    "error.encountered",    # native_hooks → dope-memory ✅ wired
+    "workflow.phase_changed", # workflow-kernel → dope-memory
+    "manual.memory_store",  # skill invocation → dope-memory
+])
+```
+
+### Current Wiring Status
+
+| Event Type | Source | Emitter | Stream | Status |
+|---|---|---|---|---|
+| error.encountered | native_hooks.py | try_emit_promotable_capture_event() | activity.events.v1 | ✅ WIRED |
+| decision.logged | ConPort | publish_decision_logged() | dopemux:events | ⚠️ WRONG STREAM |
+| task.completed | workflow-kernel | TBD | TBD | ❌ NOT WIRED |
+| task.failed | workflow-kernel | TBD | TBD | ❌ NOT WIRED |
+| task.blocked | workflow-kernel | TBD | TBD | ❌ NOT WIRED |
+| workflow.phase_changed | workflow-kernel | TBD | TBD | ❌ NOT WIRED |
+| manual.memory_store | /decision, /caveat skills | TBD | activity.events.v1 | ⚠️ SKILL LAYER ONLY |
+
+### Root Cause: Stream Name Mismatch
+
+**Published to** (ConPort → DopeconBridge):
+```python
+# docker/mcp-servers-source/conport/integration_bridge_client.py:94
+stream = "dopemux:events"
+```
+
+**Consumed from** (dope-memory EventBusConsumer):
+```python
+# services/working-memory-assistant/eventbus_consumer.py:36
+INPUT_STREAM = os.getenv("DOPE_MEMORY_INPUT_STREAM", "activity.events.v1")
+```
+
+**Impact**: 24,537 raw events in dopemux:events (including decision.logged) + 0 work_log_entries in chronicle
+
+---
+
+## 3. Critical Integration Points
+
+### Integration Point 1: ConPort Decision Logging → Dope-Memory
+
+**Current path**:
+```
+POST /api/decisions
+  ↓ (enhanced_server.py:671–728)
+INSERT decision DB
+  ↓
+publish_decision_logged() to DopeconBridge (line 711)
+  ↓ (integration_bridge_client.py:122–140)
+POST /events to DopeconBridge
+  ↓ (routes.py:558–564)
+Publish to "dopemux:events" (wrong stream!) 
+  ↓
+[never consumed by dope-memory]
+```
+
+**Missing link**: 
+- dope-memory listens on activity.events.v1 only
+- DopeconBridge publishes decision.logged to dopemux:events
+- No bridge between the two streams
+
+**Fix**: Change stream name from dopemux:events → activity.events.v1 in:
+1. docker/mcp-servers-source/conport/integration_bridge_client.py:94
+2. services/dopecon-bridge/dopecon_bridge/routes.py:321, 558, 603
+
+---
+
+### Integration Point 2: Task Orchestrator Transitions → Dope-Memory
+
+**Current state**: NOT WIRED
+
+**Should emit**:
+- task.completed when work_item advances from work→review→terminal
+- task.failed when work_item transitions to terminal with failure status
+- task.blocked when dependency gate fails
+- workflow.phase_changed when global workflow phase shifts
+
+**Source location** (to-be-identified):
+- Likely: services/task-orchestrator/ (Python) OR task-orchestrator Kotlin jar callbacks
+- Should integrate via: task-orchestrator HTTP endpoint hook → capture_client.emit_capture_event()
+
+**Effort**: Medium (requires identifying transition points, adding event emission)
+
+---
+
+### Integration Point 3: Skills → Manual Memory Store
+
+**Current state**: ASPIRATIONAL
+
+**Intended**: /decision, /caveat, /followup skills append mirror receipt to dope-memory
+
+**Current behavior**: Skills operate independently, no integration to capture pipeline
+
+**Source**: .claude/commands/*/... (skills not visible in this worktree)
+
+---
+
+## 4. Intended vs Implemented Verdict
+
+| System | Intended | Implemented | Wired | Quality | Top Bug |
+|---|---|---|---|---|---|
+| **dope-memory** | 10-tool chronicle sidecar with promotion engine | ✅ Complete | ⚠️ Partial (consumer started, stream mismatch blocks input) | 4/5 | WMA prototype unarchived |
+| **ConPort** | Canonical decision/progress writer with Trinity mirroring | ✅ Core complete | ⚠️ Partial (decision.logged to wrong stream) | 3.5/5 | _ensure_schema fail-open |
+| **dope-context** | Hybrid semantic code+docs retrieval | ✅ Complete | ⚠️ Partial (.mcp.json missing, collection GC absent) | 3/5 | Healthcheck fail-open |
+| **task-orchestrator** | Persistent DAG workflow engine | ✅ Jar complete | ⚠️ Partial (no auto-start, no event emission) | 4/5 | No task.*/workflow.phase_changed emission |
+| **capture_client** | Deterministic event capture to SQLite+Redis | ✅ Complete | ⚠️ Partial (error.encountered wired, decision.logged blocked by stream mismatch) | 4.5/5 | None |
+| **native_hooks** | Lifecycle hook adapter for Claude context injection | ✅ Complete | ✅ Full | 4.5/5 | None |
+
+---
+
+## 5. Chronicle Fill Status
+
+**Expected work_log_entries** (after fixes):
+- error.encountered: 100–1k/session (hook failures)
+- decision.logged: 1–10/session (architect decisions)
+- task.completed: 5–50/session (workflow completions)
+- task.failed/blocked: 1–10/session (errors)
+- workflow.phase_changed: 0–5/session (mode transitions)
+- **Total**: 10–100/session vs current 0
+
+**Blocked by**:
+1. Stream mismatch (HIGH IMPACT): dopemux:events ≠ activity.events.v1
+2. Workflow event emission (MEDIUM IMPACT): task-orchestrator not wired
+3. Skill-layer integration (LOW IMPACT): /decision, /caveat, /followup
+
+---
+
+## 6. Ranked Top 5 Fixes
+
+### P1 (1-hour): Stream Name Alignment
+**Files to change**: 4 files, 1 line each
+1. `docker/mcp-servers-source/conport/integration_bridge_client.py:94`: stream → activity.events.v1
+2. `services/dopecon-bridge/dopecon_bridge/routes.py:321`: stream → activity.events.v1
+3. `services/dopecon-bridge/dopecon_bridge/routes.py:558`: stream → activity.events.v1
+4. `services/dopecon-bridge/dopecon_bridge/routes.py:603`: stream → activity.events.v1
+
+**Impact**: 24.5k heartbeat events + decision.logged now flow to chronicle promotion
+
+### P2 (2-hours): ConPort → capture_client Integration
+**File**: `docker/mcp-servers-source/conport/enhanced_server.py:728` (after decision insert)
+**Add**: `try_emit_promotable_capture_event("decision.logged", { ... }, source="conport", mode="mcp")`
+**Impact**: decision.logged also captured to SQLite canonical ledger (Trinity Rule 1)
+
+### P3 (3-hours): Fix Healthchecks
+1. `services/dope-context/Dockerfile`: Remove `|| exit 0`
+2. `docker/mcp-servers-source/pal/Dockerfile`: Replace `exit 0` with real capability check
+
+### P4 (4-hours): Task Orchestrator Event Wiring
+**File**: `services/task-orchestrator/` (if Python) OR task-orchestrator Kotlin jar callback
+**Add**: Transition hooks → `try_emit_promotable_capture_event()`
+
+### P5 (2-hours): Code Cleanup
+1. Archive WMA prototype (`services/working-memory-assistant/wma_core.py`, etc.)
+2. Delete `services/working-memory-assistant/` stdio shim
+3. Rename Python `services/task-orchestrator/` → `services/workflow-api/`
+
+---
+
+## 7. Architecture Validation
+
+**Memory Trinity design is sound** (per 2026-07-03 audit):
+- ✅ Canonical writer split (ConPort = source, dope-memory = mirror)
+- ✅ Fail-closed routing (provenance labels, untrusted-by-default)
+- ✅ Append-only ledger (SQLite + promotion engine)
+- ✅ Promotion determinism (no LLM in Phase 1)
+
+**Implementation gaps are operational, not architectural**:
+- Stream mismatch: naming/plumbing, not design
+- Event emission: missing wiring, not logic
+- Healthchecks: advisory theater, not critical path
+
+---
+
+## Cluster Verdict (5 bullets)
+
+1. **Design is excellent**: Memory Trinity architecture catches hazards (GET mutation detection, fail-closed routing); adoption of this pattern to other systems would fix systemic issues
+
+2. **Implementation is 75% complete**: error.encountered wired ✅; decision.logged infrastructure built but blocked by stream mismatch ⚠️; task.* and workflow.phase_changed not yet wired ❌
+
+3. **One critical blocker**: dopemux:events ≠ activity.events.v1 prevents 24.5k decision.logged events from reaching promotion; fix = 4 one-line changes
+
+4. **Quality is solid but hides debt**: Core path (canonical ledger, promotion engine, eventbus consumer) is robust; peripheral code (WMA prototype, dead shim, name collisions) should be archived
+
+5. **Integration opportunities are high-value**: (a) Fix stream name → chronicle immediately populates; (b) Wire task-orchestrator transitions → workflow instrumentation complete; (c) Unify complexity scoring → Serena + dope-context alignment; (d) Auto-start task-orchestrator in H3 hook → reliability
+

--- a/claudedocs/service-audit-2026-07-04.md
+++ b/claudedocs/service-audit-2026-07-04.md
@@ -1,0 +1,155 @@
+# Dopemux Full-Service Audit — Planned vs Implemented, Effectiveness, and Integration Design
+
+**Date**: 2026-07-04 · **Worktree**: `focused-mahavira-5bd29b` @ `8f71ab9af` (post-quarantine merge #1001)
+**Method**: 6 parallel read-only cluster auditors (2 Sonnet on focus areas, 4 Haiku on mechanical clusters) + synthesis against the 2026-07-03 MCP fleet audit (`claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md`) and the 2026-05-31 ADHD audit. No files modified except this report + appendix. Runtime NOT probed (static wiring evidence only) — every reachability claim below is compose/registry/import-graph evidence.
+**Companion**: `service-audit-2026-07-04-appendix-memory-spine.md` (full memory-spine agent report).
+
+---
+
+## 1. Executive summary
+
+1. **The untracked-work tracker exists and was built well — then stranded.** Serena v2 "Feature 1: Untracked Work Detection" (`services/serena/untracked_work_detector.py`, `untracked_work_storage.py` (974 lines), `git_detector.py`, `batch_track_tool.py`, six MCP tools in `services/serena/mcp_server.py:1190-1255`) implements the complete lifecycle: detect uncommitted work with no matching ConPort task → confidence-scored → cross-session reminders (exponential backoff, quiet hours, snooze) → auto-track at ≥0.85 confidence into ConPort `progress_entry` → auto-close when a matching commit lands (≥80% file overlap vs last 5 commits). **It is unreachable at runtime**: the deployed Serena container builds `docker/mcp-servers/serena/` (wrapper only), and the session Serena is upstream OSS. Design 4/5, reachability 1/5.
+2. **The ADHD layer made real progress since 2026-05-31 — honesty first, wiring second.** A 36-commit remediation series verifiably fixed the "fabricated telemetry" class (C2/H4/C3: `status --attention` now shows UNAVAILABLE; TrendsPanel labels demo data; React dashboard **builds clean — verified by actual `npm run build` PASS**). But the engine is still `enabled_in_smoke: false` (a default session runs no ADHD engine), its ConPort URL default still points at dope-context's port (`config.py` → :3010, a wrong-service write hazard), the event listener start is gated on a possibly-never-set `event_bus`, and no external activity source exists.
+3. **The chronicle is empty by architecture, not by accident — and the root cause is now precise.** Three independent agents converged: (a) ConPort publishes `decision.logged` to Redis stream `dopemux:events` while dope-memory's consumer listens on `activity.events.v1` (≈4 one-line fixes); (b) the PM plane emits only `task.blocked/completed` + `workflow.phase_changed` with `from_phase` hardcoded `"unknown"` (`src/dopemux/pm/writes.py:325`), never `task.created/failed/assigned`; (c) no untracked-work event type is in the promotion allowlist (`services/working-memory-assistant/promotion/promotion.py:20-27`), and `eventbus_consumer.py:384` handles only `session.ended`.
+4. **Shadow-twin syndrome and dead mass persist post-quarantine.** The #1001 quarantine fences only exa + desktop-commander out of *generated client configs*; compose still builds both, `DEFAULT_MCP_SERVICES` still lists desktop-commander, and the six non-catalog dead surfaces (mcp-client, mcp-integration-bridge, router, task-router, services/serena vendored tree, services/dopemux-gpt-researcher) are untouched — one (`mcp_commands.py:206`) can still *resurrect* the dead integration-bridge. Separately, ~8.2 KLoC of confirmed zero-import dead code sits in services/ (ml-predictions, ml-risk-assessment, intelligence, monitoring, monitoring-dashboard, slack-integration, voice-commands, top-level `dashboard/`) — one big aspirational drop from 2026-04-05.
+5. **The live core is genuinely healthy.** dopecon-bridge (3 consumers), dope-context (loopback-bound), conport, gptr-mcp, task-orchestrator, the PM plane write-routing, `src/dopemux/tui/` (real operator HUD) + `src/dopemux/ui/` (render substrate), voice enforcement layer, profile analytics → all wired, consumed, recently maintained.
+6. **Operational hazard**: the main checkout at `/Users/hue/code/dopemux-mvp` is stale (`dbe34fce5`, ancestor of the quarantine merge) — the fleet-catalog gate, its contract test, and the canonical fleet audit doc are unreachable from main's working copy. "Current state" depends on which worktree you stand in. `git pull` on main is the cheapest fix in this whole report.
+
+---
+
+## 2. Focus answer: the untracked-work tracker
+
+### What was planned and built (Serena v2 Feature 1)
+| Capability | Implementation | Evidence |
+|---|---|---|
+| Detect uncommitted work w/ no ConPort task | multi-signal confidence scoring + ConPort matcher | `services/serena/untracked_work_detector.py` |
+| Persist w/ state machine | `detected → acknowledged → snoozed → converted_to_task → abandoned` | `untracked_work_storage.py:19-25` (ConPort custom_data `"untracked_work"`) |
+| Cross-session reminders | exponential backoff, once-per-session cap, quiet hours, snooze 1h/4h/1d | `untracked_work_storage.py:632-714` |
+| Auto-close on commit | ≥80% file overlap vs last 5 commits | `untracked_work_storage.py:418-536` |
+| Auto-track | confidence ≥0.85 → ConPort `log_progress` | `untracked_work_storage.py:538-630` |
+| Operator surface | 6 MCP tools: detect/track/snooze/ignore/get_config/update_config | `mcp_server.py:1190-1255, 1793-1822, 3338+` |
+
+### Why you can't use it
+Compose `serena` (compose.yml:538-562) builds `docker/mcp-servers/serena/Dockerfile`, which copies only `wrapper.py`/`info_server.py` — never `services/serena/`. The Serena MCP in sessions is upstream OSS (no untracked-work tools). SERVICE_CATALOG itself marks `services/serena` runtime authority "unknown".
+
+### What actually runs today (two narrow slices, both in `dopemux start`)
+- **Dirty-main protection**: `uncommitted_detector.py` → `main_worktree_detector.py` → `protection_interceptor.py` (cli.py:205-206, 1954). Bugs: **fail-open** on git failure (`uncommitted_detector.py:135-144` — "assuming no changes" silently disables protection, violates fail-closed doctrine); rename entries stored as literal `"old -> new"` strings (:169); stash count is repo-wide, not per-worktree (:183-184); NoneType crash path at `main_worktree_detector.py:109`.
+- **Orphaned-worktree recovery**: `worktree_recovery.py` menu at cli.py:1928 (ADHD-conformant: max 3 options, 30s timeout).
+
+### Recommended consolidation (cheap — Feature 1 has no LSP dependency, only git + ConPort)
+1. Lift `git_detector.py` + `untracked_work_detector.py` + `untracked_work_storage.py` out of `services/serena/` into `src/dopemux/` (keep ConPort custom_data as canonical store).
+2. Wire detection into the two live entry points: `dopemux start` (beside the recovery menu) and a SessionStart hook (H1–H4 pattern already exists in `.claude/hooks/`).
+3. Add `work.untracked_detected` / `work.untracked_converted` to the promotion allowlist (`promotion/promotion.py:20`) — or emit via the already-wired `dopemux capture emit` — so untracked work reaches the chronicle.
+4. Bridge the convert path to task-orchestrator `manage_items` so converted work enters the real task system, not just ConPort progress.
+5. Fix the two live bugs in the existing slice (fail-open + NoneType) and quarantine the residue (workspace-watcher — whose README falsely claims "Production" — activity-capture, both session-intelligence twins, services/session-manager).
+
+Also confirmed: **nothing anywhere detects "sessions without task packets"** — genuine gap if you want it; the SessionStart hook in step 2 is the natural home.
+
+---
+
+## 3. ADHD cluster (deep dive vs 2026-05-31 baseline)
+
+### Verified fixed (direct evidence)
+- **C2** fabricated `status --attention` telemetry → honest UNAVAILABLE banding (`cli.py:2711-2774`, `attention_monitor.py:128/482` `data_status` field).
+- **H4** TrendsPanel fake sparklines → real mode prints "UNAVAILABLE no live trend data" (`ui/dashboard.py:385-395, 410-413`); demo data behind explicit `--demo` banner (:487-488); ADHDStatePanel makes a real `GET /api/v1/state` with provenance rows.
+- **C3** React ui-dashboard unbuildable → **builds clean (npm run build PASS, 2306 modules)**; all 4 missing components exist. Residual: dual npm/pnpm lockfiles.
+- **C4/H7** doctrine dishonesty → project CLAUDE.md now explicitly disclaims timers/auto-save/forced breaks as planned-not-observed.
+- **M1** naming inversion → now documented as duplicate in SERVICE_CATALOG/TRUTH_CANONICALS (but stub dirs still on disk).
+
+### Claimed fixed, unverified at runtime (commit + test evidence only)
+Signal-loop series (~20 commits): profile seeding at startup, activity fusion into assessment, hyperfocus latch (`db3977af7`), per-user baselines, idle-forwarding guards + 241-line activity-loop test. Diffs unread; runtime NOT_RUN.
+
+### Still broken / new findings
+| Finding | Location | Severity |
+|---|---|---|
+| Engine excluded from default stack (`enabled_in_smoke: false`) — normal session gets no ADHD engine at all | `services/registry.yaml:192-199` | HIGH (gates everything else) |
+| ConPort URL default = :3010 = **dope-context's port** — wrong-service write hazard, not just dead port | `services/adhd_engine/config.py` (corroborated system-adhdengine.md:204-205) | HIGH |
+| Event listener start gated on `engine.event_bus` that init may never set — signal-loop series conditionally inert | system-adhdengine.md:185,196 | HIGH |
+| task-orchestrator coordinator health-checks ADHD engine at `:8080` (= Leantime) | system-adhdengine.md:202 | MED |
+| Dead triangle unchanged 5+ wks: `workflow_manager.py`, `adhd_orchestrator.py`, `main_orchestrator.py`, `rte_adapter.py` (zero live callers, latent TypeError bugs) | `src/dopemux/adhd/`, `src/dopemux/orchestrator/` | MED (delete or wire) |
+| adhd-dashboard still compose-orphaned (exists only as CORS string, compose.yml:482/522); notifier twins unresolved | services/ | LOW |
+| `interruption_shield/` (repo root) — NEW unaudited surface, 5 files, wiring unknown | repo root | follow-up |
+
+### Highest-leverage ADHD wiring (in order)
+1. Fix `event_bus` init → verify listener starts.
+2. Fix conport_url 3010→3004 (or fail-closed env requirement).
+3. Flip `enabled_in_smoke: true` — the single change that makes the whole remediation series real for a default session.
+4. Wire `native_hooks.py` PostToolUse → engine `/external-activity` (routes `/log-intent`, `/save-context`, `/external-activity`, `/log-git-event`, `/state` already exist server-side) — first always-on signal source, no new services needed.
+5. Delete the dead triangle + hyphen/underscore stub dirs.
+
+---
+
+## 4. Memory spine (chronicle) — root cause and fix
+
+Design (Memory Trinity: ConPort canonical → dope-memory chronicle mirror → dope-context retrieval) validated as sound. Implementation ~75%:
+
+- ✅ `error.encountered` wired (native_hooks → capture_client, shipped in #993 with Redis socket timeouts).
+- ⚠️ `decision.logged` **built but blocked by a stream-name mismatch**: ConPort publishes to `dopemux:events`; dope-memory's EventBusConsumer subscribes to `activity.events.v1`. ≈4 one-line changes (ConPort + DopeconBridge publish targets) unblocks it.
+- ❌ `task.*`/`workflow.phase_changed` partially emitted: PM plane sends `task.blocked/completed` + `workflow.phase_changed` on transitions only, `from_phase` hardcoded `"unknown"` (`src/dopemux/pm/writes.py:325`); `task.created/failed/assigned`, `blocker.cleared` never emitted; dope-memory mirror is best-effort with silently swallowed failures (`writes.py:400-418`).
+- ❌ `eventbus_consumer.py:384` handles only `session.ended`; workspace-watcher/activity-capture event families have no consumer (moot while those services stay unwired).
+- Peripheral debt: WMA legacy `main.py` vs deployed `dope_memory_main.py` twin trap; mcp-capture server implemented but registered nowhere; copilot transcript ingester implemented + consumed as a library but nothing schedules it.
+
+**Chronicle fill sequence** (order matters): stream-name fix → PM event completeness (`task.created/failed`, real `from_phase`) → promotion allowlist additions (untracked-work types) → schedule copilot ingester (SessionEnd hook or cron) → then flip dope-context decision indexing (Trinity Rule 2) once curated entries exist.
+
+## 5. MCP/integration plane
+
+- **Live and healthy**: dopecon-bridge :3016 (consumers: conport, task-orchestrator, adhd-engine — the only multi-consumer event seam; candidate canonical event plane), dope-context :3010 (loopback-bound ✅), serena wrapper :3006, gptr-mcp :3009, conport, task-orchestrator.
+- **Bugs**: dope-context healthcheck `|| exit 0` = always-pass (compose.yml:375 — contradicts the #993 "honest healthchecks" work; change to `|| exit 1`); `mcp_commands.py` drift — `DEFAULT_MCP_SERVICES` still includes quarantined desktop-commander (:36-48), `mcp down` list asymmetric to `up` (leaves dopecon-bridge/dope-memory/task-orchestrator/pal-stdio running, :135-138), start-all fallback resurrects dead integration-bridge (:206), script paths break from wheel installs (:110/:195); exa identity contradiction (catalog = exec-into-litellm stdio vs compose = dedicated :3011 HTTP container); compose.yml:605 comment mislabels exa as "Leantime Bridge".
+- **Quarantine (#1001) is real but thin**: config-generation only; runtime fleet unchanged; six non-catalog dead surfaces untouched; orphan volumes remain (compose.yml:41-44).
+- **Branch hazard**: main checkout stale at `dbe34fce5` → fleet-catalog gate/tests/audit doc unreachable from main's working copy; whether main's `mcp_catalog.yaml` carries the personality/lifecycle fields the contract test requires is UNKNOWN until reconciled.
+
+## 6. Orchestration / PM plane
+
+- **Authority routing works as documented** (PM_PLANE.md): Leantime = metadata, task-orchestrator = transitions, ConPort = progress/decisions, dope-memory = best-effort mirror. All four write paths verified wired.
+- **Gaps**: event emission incompleteness (§4); `services/agents/` family (14 files) orphaned with authority explicitly UNKNOWN in AGENTS.md §6; orchestrator enforcement hooks dormant behind never-set `actor_authentication.enabled`; ConPort access split across :3004/:3005; `services/task-orchestrator/task_orchestrator/` legacy module still in tree beside canonical `app/main.py`; note the Python :8000 service is the PM workflow API — the canonical workflow MCP remains the Kotlin jar :7890 (fleet audit target: rename Python service → `workflow-api` to end the name collision).
+
+## 7. Misc / intelligence cluster
+
+- **Keep-and-invest**: `src/dopemux/tui/` (the real operator dashboard — Textual HUD, 8 orchestrator-data panels), `src/dopemux/ui/` (5.3 KLoC render substrate, most-wired surface; flag: 82KB `cockpit/runtime_contract.py`), `src/dopemux/voice/` (brand enforcement, live), `profile_analytics.py` (+`analytics.py` facade; live via `profile_commands.py:267`), `services/copilot_transcript_ingester` (live library; relocate under src/ — services→src import is a layering smell), `services/shared/mcp/pal_client.py` (sole live piece of a 4 KLoC tree).
+- **Dead (~8.2 KLoC, zero imports, all last-touched 2026-04-05 except noted)**: services/intelligence (306), ml-predictions (1,282), ml-risk-assessment (1,159), monitoring (516), slack-integration (138, with unreachable-code bugs), voice-commands (900), top-level `dashboard/` (2,011), monitoring-dashboard (1,886 — **0.0.0.0:8098 unauth exposure still in tree** at `server.py:1563`, but startup-fatal import at `server.py:78` means it can't boot; deleting the dir retires both), `scorer.py` (16), `suggestion_engine.py` (61).
+
+---
+
+## 8. Cross-cutting patterns (why this keeps happening)
+
+1. **Build-then-strand**: features get implemented to high quality in a service dir, then deployment moves elsewhere (Serena Feature 1, WMA main.py, dcp facade dir-as-pointer). *Countermeasure*: SERVICE_CATALOG tier review at PR time + the fleet catalog's `lifecycle:` field enforced by the contract test (already written — needs to land on main).
+2. **Emit-without-consumer / consumer-without-emitter**: workspace-watcher emits events nothing reads; chronicle reads streams nothing writes to. *Countermeasure*: treat event streams as contract surfaces — a CI check that every subscribed stream has ≥1 publisher and vice versa.
+3. **Fail-open as default reflex** (uncommitted detector, PM memory mirror, all hooks) contradicts the repo's fail-closed doctrine. Acceptable for hooks; not for protection features.
+4. **Honesty debt gets fixed faster than wiring debt** — the ADHD series proves the team culture responds to "stop lying" findings; leverage that: every dashboard/status surface should carry `source/updated/data_status` provenance (the pattern `ui/dashboard.py` now uses).
+
+## 9. Optimal interaction model
+
+The 2026-07-03 fleet audit §6–7 already defines the target (one catalog + codegen, `dopemux mcp ensure`, authority labels, per-request identity, loopback binds, memory-spine wiring). This audit **confirms it and adds four service-layer amendments**:
+
+1. **dopecon-bridge is the event plane** — it's the only seam with 3 live consumers. All promotable events (PM transitions, ConPort decisions, untracked-work detections, ADHD state changes) route through it on **one named stream contract** (`activity.events.v1`), ending the dopemux:events split.
+2. **Untracked-work detection joins the session lifecycle**: SessionStart hook (detect + surface, max-3 ADHD menu) → ConPort custom_data (canonical) → capture event (chronicle) → optional task-orchestrator item (convert). This is the missing "ambient capture" leg of the Trinity.
+3. **ADHD engine consumes hooks, not daemons**: PostToolUse/Stop → engine HTTP routes (already built) → engine assessment → surfaced only in `tui/` + `status` with provenance. Skip the watcher/capture services entirely — hooks are the signal source that actually exists.
+4. **One dashboard family**: `tui/` = operator HUD (live), React ui-dashboard = optional web view (now builds), everything else in the dashboard namespace deleted.
+
+## 10. Prioritized roadmap
+
+**P0 — one-line-ish, high leverage (do first)**
+- [ ] `git pull` the stale main checkout (unblocks the quarantine gate + audit doc visibility).
+- [ ] Stream-name fix: ConPort/DopeconBridge publish → `activity.events.v1` (≈4 lines) → chronicle starts filling.
+- [ ] dope-context healthcheck `|| exit 0` → `|| exit 1` (compose.yml:375).
+- [ ] ADHD `config.py` conport_url :3010 → :3004.
+- [ ] uncommitted_detector fail-open → fail-closed (:135-144) + NoneType guard (main_worktree_detector.py:109).
+
+**P1 — the two focus features (≈ a packet each)**
+- [ ] **Untracked-work rescue**: lift Feature 1 → `src/dopemux/`, wire `dopemux start` + SessionStart hook, promotion allowlist entries, orchestrator convert bridge (§2).
+- [ ] **ADHD ignition**: event_bus init fix → verify listener → `enabled_in_smoke: true` → native_hooks PostToolUse → `/external-activity` (§3).
+
+**P2 — event completeness + CLI drift**
+- [ ] PM plane: emit `task.created/failed/assigned`, `blocker.cleared`; real `from_phase`; surface mirror failures (writes.py).
+- [ ] `mcp_commands.py`: fix DEFAULT list, up/down asymmetry, dead-bridge fallback, wheel-safe paths.
+- [ ] Schedule copilot ingester (SessionEnd hook or cron).
+- [ ] Resolve exa identity (catalog vs compose) — wire-or-retire decision.
+
+**P3 — dead-mass excision (single "graveyard" PR, ~12+ KLoC)**
+- [ ] Delete/SYSTEM_ARCHIVE: the 8.2 KLoC misc set (§7) + router, mcp-client (+ orphan volumes compose.yml:41-44), task-router, services/serena vendored tree, services/dopemux-gpt-researcher, ADHD stub twins, dead triangle, workspace-watcher/activity-capture/session-intelligence ×2/session-manager (or honest lifecycle labels), scorer.py, suggestion_engine.py, WMA legacy main.py.
+- [ ] Then: `services/agents/` authority decision, Serena single-surface ADR, ConPort endpoint unification, interruption_shield audit (still unaudited).
+
+---
+
+## Honesty ledger (NOT_RUN)
+No runtime probing anywhere (docker state unknown; conport/dope-memory were down at session start). ADHD signal-loop commit diffs unread (claimed-fixed only). dcp facade 12-tool verification NOT re-confirmed this session. `.claude/settings.json` hook-dispatch grep for ADHD shell scripts not re-verified. interruption_shield/ unaudited. Two agent contradictions resolved by evidence strength: ui-dashboard build (verified PASS) supersedes "vite.config.ts missing"; `services/activity-capture` existence (direct ls) supersedes one agent's "no such dir".

--- a/config/runtime_authority_manifest.json
+++ b/config/runtime_authority_manifest.json
@@ -685,7 +685,7 @@
           "id": "adhd_conport_default_port_drift",
           "markers": [
             {
-              "contains": "http://localhost:3010",
+              "contains": "http://localhost:3005",
               "path": "services/adhd_engine/config.py"
             },
             {
@@ -693,7 +693,7 @@
               "path": "compose.yml"
             }
           ],
-          "summary": "ADHD Engine config defaults ConPort URL to 3010 while compose exposes ConPort HTTP on 3004."
+          "summary": "ADHD Engine config defaults ConPort MCP URL to localhost:3005 while compose exposes ConPort HTTP health on 3004 (MCP on 3005)."
         }
       ],
       "notes": [

--- a/scripts/smoke_up.sh
+++ b/scripts/smoke_up.sh
@@ -38,6 +38,7 @@ SMOKE_CORE_SERVICES=(
     conport
     dopecon-bridge
     dope-memory
+    adhd-engine
 )
 SMOKE_NO_DEPS_SERVICES=(
     task-orchestrator

--- a/scripts/start-all-mcp-servers.sh
+++ b/scripts/start-all-mcp-servers.sh
@@ -67,9 +67,16 @@ start_service "dope-context" "3010" "mcp-dope-context"
 start_service "serena" "3006" "${SERENA_CONTAINER_NAME:-dopemux-mcp-serena}"
 start_service "leantime-bridge" "3015" "dopemux-mcp-leantime-bridge"
 start_service "gptr-mcp" "3009" "dopemux-mcp-gptr-mcp"
-start_service "exa" "3011" "mcp-exa"
-start_service "desktop-commander" "3012" "dopemux-mcp-desktop-commander"
 start_service "pal" "3003" "mcp-pal"
+# exa + desktop-commander are quarantined (lifecycle: decision-required in
+# mcp_catalog.yaml) and intentionally NOT auto-started. Start explicitly with
+# `dopemux mcp up --services exa` if needed.
+
+# Start workflow + memory + cognitive plane
+echo "=== Workflow, Memory & Cognitive Services ==="
+start_service "task-orchestrator" "8000" "task-orchestrator"
+start_service "dope-memory" "3020" "dope-memory"
+start_service "adhd-engine" "3025" "adhd-engine"
 
 echo
 echo "✅ MCP Server startup complete!"

--- a/services/adhd_engine/config.py
+++ b/services/adhd_engine/config.py
@@ -86,7 +86,9 @@ class Settings:
     log_level: str = os.getenv("LOG_LEVEL", "INFO")
     
     # ConPort / DopeconBridge
-    conport_url: str = os.getenv("CONPORT_URL", "http://localhost:3010")
+    # 3005 = ConPort MCP HTTP (compose sets CONPORT_URL=http://conport:3005);
+    # 3010 is dope-context — never default there.
+    conport_url: str = os.getenv("CONPORT_URL", "http://localhost:3005")
     pal_url: str = os.getenv("PAL_URL", os.getenv("ZEN_URL", "http://localhost:3003"))  # Backward compat with ZEN_URL
     workspace_id: str = os.getenv("ADHD_WORKSPACE_ID", os.getcwd())
     operator_id_path: str = os.getenv(

--- a/services/adhd_engine/conport_mcp_client.py
+++ b/services/adhd_engine/conport_mcp_client.py
@@ -6,6 +6,7 @@ Simple client for ConPort integration with circuit breaker protection.
 
 import asyncio
 import logging
+import os
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timezone
 
@@ -42,7 +43,8 @@ class ConPortMCPClient:
     """
 
     def __init__(self):
-        self.conport_url = "http://localhost:3010"  # ConPort MCP server
+        # ConPort MCP server; 3010 is dope-context, never default there.
+        self.conport_url = os.getenv("CONPORT_URL", "http://localhost:3005")
         self.session: Optional[Any] = None
 
     async def initialize(self):

--- a/services/adhd_engine/event_emitter.py
+++ b/services/adhd_engine/event_emitter.py
@@ -224,7 +224,11 @@ class ADHDEventEmitter:
                             data_str = msg_data.get(b"data", b"{}").decode("utf-8")
                             
                             event = Event(
-                                type=msg_data.get(b"event_type", b"").decode("utf-8"),
+                                # dopemux producers write "event_type";
+                                # dopecon-bridge Event.to_redis_fields writes
+                                # "type" — accept both so bridge events are
+                                # not dropped.
+                                type=(msg_data.get(b"event_type") or msg_data.get(b"type") or b"").decode("utf-8"),
                                 data=json.loads(data_str),
                                 timestamp=msg_data.get(b"timestamp", b"").decode("utf-8"),
                                 source=msg_data.get(b"source", b"").decode("utf-8")

--- a/services/dopecon-bridge/dopecon_bridge/promotable_mirror.py
+++ b/services/dopecon-bridge/dopecon_bridge/promotable_mirror.py
@@ -28,12 +28,16 @@ logger = logging.getLogger(__name__)
 PROMOTABLE_EVENT_TYPES = frozenset(
     {
         "decision.logged",
+        "task.created",
         "task.completed",
         "task.failed",
         "task.blocked",
+        "blocker.cleared",
         "error.encountered",
         "workflow.phase_changed",
         "manual.memory_store",
+        "work.untracked_detected",
+        "work.untracked_converted",
     }
 )
 

--- a/services/dopecon-bridge/dopecon_bridge/promotable_mirror.py
+++ b/services/dopecon-bridge/dopecon_bridge/promotable_mirror.py
@@ -1,0 +1,100 @@
+"""
+Best-effort mirror of promotable events onto the dope-memory input stream.
+
+The dope-memory EventBusConsumer subscribes only to MEMORY_INPUT_STREAM
+(activity.events.v1, see services/working-memory-assistant/eventbus_consumer.py),
+while the bridge's general event traffic flows on other streams (typically
+dopemux:events, which has its own consumers: DDG pattern detection, ADHD engine
+listener, dashboards). Without this mirror, promotable events published through
+the bridge never reach the chronicle promotion pipeline.
+
+Standalone module (no package-relative imports) so it is unit-testable from the
+root test tree.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from uuid import uuid4
+
+logger = logging.getLogger(__name__)
+
+# Promotable event types accepted by dope-memory's promotion engine
+# (services/working-memory-assistant/promotion/promotion.py PROMOTABLE_EVENT_TYPES).
+PROMOTABLE_EVENT_TYPES = frozenset(
+    {
+        "decision.logged",
+        "task.completed",
+        "task.failed",
+        "task.blocked",
+        "error.encountered",
+        "workflow.phase_changed",
+        "manual.memory_store",
+    }
+)
+
+MEMORY_INPUT_STREAM = os.getenv("DOPE_MEMORY_INPUT_STREAM", "activity.events.v1")
+
+
+def normalize_event_type(event_type: str) -> str:
+    """Canonical dotted form, mirroring dope-memory's normalize_event_type."""
+    t = (event_type or "").strip().lower()
+    if not t:
+        return "unknown"
+    return t if "." in t else t.replace("_", ".")
+
+
+def build_mirror_envelope(
+    event_type: str,
+    data: Dict[str, Any],
+    source: str,
+) -> Optional[Dict[str, str]]:
+    """Build a capture-style envelope for a promotable event, or None.
+
+    Envelope shape matches capture_client._emit_to_event_stream: top-level
+    workspace/instance/session identity fields plus JSON-encoded "data", so the
+    dope-memory consumer attributes the entry to the right ledger.
+    """
+    normalized = normalize_event_type(event_type)
+    if normalized not in PROMOTABLE_EVENT_TYPES:
+        return None
+    return {
+        "id": str(uuid4()),
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "workspace_id": str(data.get("workspace_id") or "default"),
+        "instance_id": str(data.get("instance_id") or "A"),
+        "session_id": str(data.get("session_id") or ""),
+        "type": normalized,
+        "source": source,
+        "data": json.dumps(data, default=str, sort_keys=True),
+    }
+
+
+async def mirror_promotable_event(
+    redis_client: Any,
+    *,
+    stream: str,
+    event_type: str,
+    data: Dict[str, Any],
+    source: str,
+) -> bool:
+    """Mirror a promotable event to MEMORY_INPUT_STREAM. Never raises.
+
+    Returns True when a mirror entry was written. Skips events already
+    published to the memory input stream and non-promotable types.
+    """
+    if stream == MEMORY_INPUT_STREAM:
+        return False
+    envelope = build_mirror_envelope(event_type, data, source)
+    if envelope is None:
+        return False
+    try:
+        await redis_client.xadd(MEMORY_INPUT_STREAM, envelope)
+        return True
+    except Exception as exc:  # best-effort: never fail the primary publish
+        logger.warning("Promotable event mirror to %s failed: %s", MEMORY_INPUT_STREAM, exc)
+        return False

--- a/services/dopecon-bridge/dopecon_bridge/routes.py
+++ b/services/dopecon-bridge/dopecon_bridge/routes.py
@@ -199,6 +199,7 @@ def _normalize_custom_data_read(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 async def _publish_event_internal(request: PublishEventRequest) -> Dict[str, Any]:
     from .event_bus import Event, EventBus
+    from .promotable_mirror import mirror_promotable_event
 
     event_bus = EventBus()
     await event_bus.initialize()
@@ -209,6 +210,15 @@ async def _publish_event_internal(request: PublishEventRequest) -> Dict[str, Any
             source=request.source or settings.service_name,
         )
         msg_id = await event_bus.publish(request.stream, event)
+        # Chronicle mirror: promotable events must also land on the
+        # dope-memory input stream or they never reach the promotion pipeline.
+        await mirror_promotable_event(
+            event_bus.redis_client,
+            stream=request.stream,
+            event_type=request.event_type,
+            data=request.data,
+            source=request.source or settings.service_name,
+        )
         return {
             "status": "published",
             "message_id": msg_id,

--- a/services/registry.yaml
+++ b/services/registry.yaml
@@ -194,7 +194,7 @@ services:
     container_port: 8095
     health_path: /health
     compose_service_name: adhd-engine
-    enabled_in_smoke: false
+    enabled_in_smoke: true
     category: cognitive
     description: "ADHD Engine (Multi-instance)"
 

--- a/services/task-orchestrator/app/api/project_workflow.py
+++ b/services/task-orchestrator/app/api/project_workflow.py
@@ -515,6 +515,9 @@ async def execute_transition_project_workflow(
                 "transition": payload.transition,
                 "canonical_backend": "task-orchestrator",
                 "version_after": pm_task.version,
+                # Prior status so PM capture events can report a real
+                # from_phase instead of "unknown" (additive, free-form dict).
+                "from_status": current_status.value,
             },
             resulting_state={
                 "workflow_id": payload.workflow_id,

--- a/services/task-orchestrator/app/core/coordinator.py
+++ b/services/task-orchestrator/app/core/coordinator.py
@@ -491,10 +491,14 @@ class PlaneCoordinator:
     async def _check_adhd_engine_health(self) -> str:
         """Check ADHD Engine health."""
         try:
-            # Simple HTTP health check
+            # Simple HTTP health check. 8080 is Leantime — the engine listens
+            # on 8095 in-container (host 3025); compose network name wins.
+            import os
+
             import aiohttp
+            base_url = os.getenv("ADHD_ENGINE_URL", "http://adhd-engine:8095")
             async with aiohttp.ClientSession() as session:
-                async with session.get("http://localhost:8080/health") as response:
+                async with session.get(f"{base_url.rstrip('/')}/health") as response:
                     return "healthy" if response.status == 200 else "unhealthy"
         except Exception as e:
             return "unhealthy"

--- a/services/working-memory-assistant/eventbus_consumer.py
+++ b/services/working-memory-assistant/eventbus_consumer.py
@@ -57,12 +57,16 @@ REFLECTION_MAX_WINDOW_HOURS = DOPE_MEMORY_REFLECTION_MAX_WINDOW_HOURS
 # High-signal events that reset last_activity_at
 HIGH_SIGNAL_EVENTS = {
     "decision.logged",
+    "task.created",
     "task.completed",
     "task.failed",
     "task.blocked",
+    "blocker.cleared",
     "error.encountered",
     "manual.memory_store",
     "workflow.phase_changed",
+    "work.untracked_detected",
+    "work.untracked_converted",
 }
 
 # Heartbeat events: reset idle timer but don't trigger reflections

--- a/services/working-memory-assistant/promotion/promotion.py
+++ b/services/working-memory-assistant/promotion/promotion.py
@@ -14,16 +14,25 @@ from chronicle.store import VALID_CATEGORIES, VALID_OUTCOMES, VALID_WORKFLOW_PHA
 
 from .redactor import Redactor
 
-# Phase 1 promotable event types (canonical dotted form)
+# Phase 1 promotable event types (canonical dotted form).
+# Phase 1.1 extension (2026-07-04 service audit): task.created,
+# blocker.cleared, work.untracked_detected, work.untracked_converted.
+# Keep in sync with src/dopemux/memory/capture_client.py
+# PROMOTABLE_CAPTURE_EVENT_TYPES and services/dopecon-bridge/
+# dopecon_bridge/promotable_mirror.py PROMOTABLE_EVENT_TYPES.
 PROMOTABLE_EVENT_TYPES = frozenset(
     [
         "decision.logged",
+        "task.created",
         "task.completed",
         "task.failed",
         "task.blocked",
+        "blocker.cleared",
         "error.encountered",
         "workflow.phase_changed",
         "manual.memory_store",
+        "work.untracked_detected",
+        "work.untracked_converted",
     ]
 )
 
@@ -32,10 +41,14 @@ IMPORTANCE_SCORES = {
     "decision.logged": 7,
     "task.failed": 7,
     "task.blocked": 7,
+    "blocker.cleared": 6,
     "error.encountered": 6,
     "task.completed": 5,
+    "task.created": 4,
     "workflow.phase_changed": 5,
     "manual.memory_store": 6,  # default, can be overridden by payload
+    "work.untracked_detected": 5,
+    "work.untracked_converted": 6,
 }
 
 
@@ -323,6 +336,115 @@ class PromotionEngine:
             outcome="blocked",
             importance_score=7,
             details=self.redactor.redact_payload({"task_id": task_id, "reason": reason}),
+            tags=self._extract_tags(data),
+        )
+
+    def _promote_task_created(self, data: dict[str, Any]) -> Optional[PromotedEntry]:
+        """Promote task.created event."""
+        task_id = data.get("task_id")
+        title = data.get("title", "")
+
+        if not task_id and not title:
+            return None
+
+        return PromotedEntry(
+            category="planning",
+            entry_type="task_event",
+            summary=f"Created: {title or task_id}"[:500],
+            outcome="in_progress",
+            importance_score=4,
+            details=self.redactor.redact_payload({"task_id": task_id}),
+            tags=self._extract_tags(data),
+        )
+
+    def _promote_blocker_cleared(self, data: dict[str, Any]) -> Optional[PromotedEntry]:
+        """Promote blocker.cleared event (task left BLOCKED state)."""
+        task_id = data.get("task_id")
+        title = data.get("title", "")
+        reason = data.get("reason", "")
+
+        if not task_id and not title:
+            return None
+
+        summary = f"Blocker cleared: {title or task_id}"
+        if reason:
+            summary += f" - {reason[:100]}"
+
+        return PromotedEntry(
+            category="implementation",
+            entry_type="resolution",
+            summary=summary[:500],
+            outcome="success",
+            importance_score=6,
+            details=self.redactor.redact_payload({"task_id": task_id, "reason": reason}),
+            tags=self._extract_tags(data),
+        )
+
+    def _promote_work_untracked_detected(
+        self, data: dict[str, Any]
+    ) -> Optional[PromotedEntry]:
+        """Promote work.untracked_detected event.
+
+        Emitted when uncommitted work with no matching tracked task is
+        surfaced (session-start probe, `dopemux start`, or Serena F001).
+        """
+        branch = data.get("branch", "")
+        total_files = data.get("total_files")
+
+        if not branch and total_files is None:
+            return None
+
+        parts = []
+        for key, label in (
+            ("staged_count", "staged"),
+            ("unstaged_count", "unstaged"),
+            ("untracked_count", "untracked"),
+        ):
+            count = data.get(key)
+            if count:
+                parts.append(f"{count} {label}")
+        detail = f" ({', '.join(parts)})" if parts else ""
+        summary = (
+            f"Untracked work detected on {branch or 'unknown branch'}: "
+            f"{total_files if total_files is not None else '?'} files{detail}"
+        )
+
+        return PromotedEntry(
+            category="implementation",
+            entry_type="task_event",
+            summary=summary[:500],
+            outcome="in_progress",
+            importance_score=5,
+            details=self.redactor.redact_payload(
+                {"branch": branch, "total_files": total_files}
+            ),
+            tags=self._extract_tags(data),
+        )
+
+    def _promote_work_untracked_converted(
+        self, data: dict[str, Any]
+    ) -> Optional[PromotedEntry]:
+        """Promote work.untracked_converted event (untracked work → real task)."""
+        task_id = data.get("task_id")
+        title = data.get("title", "")
+        branch = data.get("branch", "")
+
+        if not task_id and not title:
+            return None
+
+        summary = f"Untracked work converted to task: {title or task_id}"
+        if branch:
+            summary += f" (from {branch})"
+
+        return PromotedEntry(
+            category="planning",
+            entry_type="milestone",
+            summary=summary[:500],
+            outcome="success",
+            importance_score=6,
+            details=self.redactor.redact_payload(
+                {"task_id": task_id, "branch": branch}
+            ),
             tags=self._extract_tags(data),
         )
 

--- a/services/working-memory-assistant/tests/test_event_type_normalization.py
+++ b/services/working-memory-assistant/tests/test_event_type_normalization.py
@@ -57,12 +57,16 @@ class TestPromotableEventTypes:
         """All Phase 1 event types should be in the allowlist."""
         expected = {
             "decision.logged",
+            "task.created",
             "task.completed",
             "task.failed",
             "task.blocked",
+            "blocker.cleared",
             "error.encountered",
             "workflow.phase_changed",
             "manual.memory_store",
+            "work.untracked_detected",
+            "work.untracked_converted",
         }
         assert PROMOTABLE_EVENT_TYPES == expected
 

--- a/src/dopemux/claude/native_hooks.py
+++ b/src/dopemux/claude/native_hooks.py
@@ -63,6 +63,11 @@ except ImportError:
     def emit_mcp_health(_root): return None  # type: ignore[misc]
 
 try:
+    from untracked_work_probe import emit_untracked_work_advisory
+except ImportError:
+    def emit_untracked_work_advisory(_root, _sid=None): return None  # type: ignore[misc]
+
+try:
     from dcp_surface_guard import surface_guard_block, surface_guard_warnings
 except ImportError:
     def surface_guard_block(_tool, _inp, _root): return None  # type: ignore[misc]
@@ -336,14 +341,15 @@ class NativeHookAdapter:
         reset_edit_counter(self.project_root, self.session_id)
         mcp_health = emit_mcp_health(self.project_root)
         orch_ctx = emit_session_context(self.project_root)
+        untracked_ctx = emit_untracked_work_advisory(self.project_root, self.session_id)
         state = self._active_state()
         if not state:
-            combined = "\n\n".join(filter(None, [mcp_health, orch_ctx]))
+            combined = "\n\n".join(filter(None, [mcp_health, orch_ctx, untracked_ctx]))
             if combined:
                 return self._allow(additional_context=combined, hook_event_name="SessionStart")
             return self._allow()
         workflow_ctx = _workflow_context_lines(state, include_gates=True)
-        combined = "\n\n".join(filter(None, [mcp_health, orch_ctx, workflow_ctx]))
+        combined = "\n\n".join(filter(None, [mcp_health, orch_ctx, workflow_ctx, untracked_ctx]))
         return self._allow(
             system_message=f"Dopemux workflow mode: {state.mode}",
             additional_context=combined or None,

--- a/src/dopemux/cli.py
+++ b/src/dopemux/cli.py
@@ -1969,6 +1969,19 @@ def start(
         except Exception as e:
             console.print(f"[warning]⚠️ Protection check unavailable: {e}[/warning]")
 
+        # Untracked-work surfacing (lite probe; Serena F001 owns the
+        # actionable lifecycle). Advisory only — no prompt, fail-open.
+        try:
+            from .untracked_work import probe_untracked_work
+
+            advisory = probe_untracked_work(
+                str(project_path), source_probe="dopemux_start"
+            )
+            if advisory:
+                console.logger.info(f"[warning]{advisory}[/warning]")
+        except Exception:
+            logger.debug("untracked-work probe unavailable", exc_info=True)
+
     instance_id = None
     port_base = None
     worktree_path = None

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -204,11 +204,9 @@ def mcp_start_all_cmd(verify: bool):
             console.logger.info("[info]Starting MCP servers...[/info]")
             subprocess.run(["docker", "compose", "-f", "compose.yml", "up", "-d"], check=True)
 
-            console.logger.info("[info]Starting Integration Bridge...[/info]")
-            subprocess.run(
-                ["bash", "-lc", "cd docker/conport-kg && docker-compose up -d --no-deps integration-bridge"],
-                check=True,
-            )
+            # NOTE: the legacy docker/conport-kg integration-bridge is dead
+            # code (kill-list per the MCP fleet audit) and must not be
+            # resurrected here.
 
             console.logger.info("[info]Starting Task Orchestrator...[/info]")
             subprocess.run(

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -33,9 +33,11 @@ from ..mcp.project_identity import ProjectIdentityError, resolve_project_identit
 from ..worktree_commands import get_repo_root
 
 
+# desktop-commander and exa are quarantined (lifecycle: decision-required)
+# and excluded from the default set; start them explicitly via --services.
 DEFAULT_MCP_SERVICES = {
+    "adhd-engine",
     "conport",
-    "desktop-commander",
     "dope-context",
     "dope-memory",
     "dopecon-bridge",
@@ -132,10 +134,11 @@ def mcp_down_cmd():
     and preserving ritual state in the Docker volume ledgers.
     """
     try:
-        mcp_services = [
-            "conport", "pal", "litellm", "dope-context",
-            "serena", "gptr-mcp", "desktop-commander", "leantime-bridge",
-        ]
+        # Derive from the default set so `down` stays symmetric with `up`
+        # (previously a hardcoded list that omitted several running services).
+        mcp_services = sorted(DEFAULT_MCP_SERVICES & _compose_services())
+        if not mcp_services:
+            mcp_services = sorted(DEFAULT_MCP_SERVICES)
         subprocess.run(
             ["docker", "compose", "-f", "compose.yml", "rm", "-f", "-s", "-v"] + mcp_services,
             check=True,

--- a/src/dopemux/main_worktree_detector.py
+++ b/src/dopemux/main_worktree_detector.py
@@ -92,7 +92,9 @@ class MainWorktreeDetector:
             return None
 
         # Determine trigger reason
-        if changes.staged_count > 0:
+        if changes.detection_failed:
+            reason = "could not verify main is clean (git status failed)"
+        elif changes.staged_count > 0:
             reason = "staged changes in main"
         elif changes.unstaged_count > 0:
             reason = "uncommitted modifications in main"
@@ -106,7 +108,7 @@ class MainWorktreeDetector:
         # Create protection trigger
         return ProtectionTrigger(
             workspace_path=str(self.workspace_path),
-            git_branch=self.detector._run_git_command(["branch", "--show-current"]).strip(),
+            git_branch=(self.detector._run_git_command(["branch", "--show-current"]) or "").strip() or "unknown",
             changes=changes,
             trigger_reason=reason,
             suggested_action=(

--- a/src/dopemux/memory/capture_client.py
+++ b/src/dopemux/memory/capture_client.py
@@ -36,15 +36,21 @@ CAPTURE_MODES = {
     CAPTURE_MODE_AUTO,
 }
 
+# Keep in sync with services/working-memory-assistant/promotion/promotion.py
+# PROMOTABLE_EVENT_TYPES (the promotion engine is the canonical contract).
 PROMOTABLE_CAPTURE_EVENT_TYPES = frozenset(
     {
         "decision.logged",
+        "task.created",
         "task.completed",
         "task.failed",
         "task.blocked",
+        "blocker.cleared",
         "error.encountered",
         "workflow.phase_changed",
         "manual.memory_store",
+        "work.untracked_detected",
+        "work.untracked_converted",
     }
 )
 

--- a/src/dopemux/pm/writes.py
+++ b/src/dopemux/pm/writes.py
@@ -366,6 +366,21 @@ def pm_transition_work_item(
                 "reason": reason,
             },
         )
+    if from_status == PMTaskStatus.BLOCKED.value and new_status != PMTaskStatus.BLOCKED:
+        emit_pm_promotable_source_event(
+            "blocker.cleared",
+            project_id=config.project_id,
+            work_item_id=task_id,
+            canonical_system="task-orchestrator",
+            operation_type=PMActionKind.WORKFLOW_TRANSITION.value,
+            payload={
+                "task_id": task_id,
+                "title": f"Workflow item {task_id}",
+                "status": new_status.value,
+                "transition": transition_name,
+                "reason": reason,
+            },
+        )
 
     return CanonicalReceipt(
         canonical_system="task-orchestrator",

--- a/src/dopemux/pm/writes.py
+++ b/src/dopemux/pm/writes.py
@@ -69,10 +69,14 @@ TASK_STATUS_CAPTURE_EVENTS = {
     PMTaskStatus.DONE: "task.completed",
 }
 
+# Values must stay within chronicle VALID_WORKFLOW_PHASES
+# (services/working-memory-assistant/chronicle/store.py).
 WORKFLOW_PHASE_CAPTURE_BY_STATUS = {
+    PMTaskStatus.TODO: "planning",
     PMTaskStatus.IN_PROGRESS: "implementation",
     PMTaskStatus.BLOCKED: "review",
     PMTaskStatus.DONE: "deployment",
+    PMTaskStatus.CANCELED: "maintenance",
 }
 
 
@@ -303,7 +307,7 @@ def pm_transition_work_item(
         )
 
     try:
-        config.orchestrator_client.transition(
+        transition_result = config.orchestrator_client.transition(
             project_id=config.project_id,
             workflow_id=task_id,
             transition_name=transition_name,
@@ -315,6 +319,22 @@ def pm_transition_work_item(
     except Exception as exc:
         raise RuntimeError(f"Canonical write failed: {exc}") from exc
 
+    # Derive the prior phase from the orchestrator's receipt when available;
+    # "unknown" only when the backend didn't report from_status.
+    from_status = None
+    if isinstance(transition_result, dict):
+        receipt = transition_result.get("transition_receipt")
+        if isinstance(receipt, dict):
+            from_status = receipt.get("from_status")
+    from_phase = "unknown"
+    if from_status:
+        try:
+            from_phase = WORKFLOW_PHASE_CAPTURE_BY_STATUS.get(
+                PMTaskStatus(from_status), "unknown"
+            )
+        except ValueError:
+            from_phase = "unknown"
+
     emit_pm_promotable_source_event(
         "workflow.phase_changed",
         project_id=config.project_id,
@@ -322,7 +342,8 @@ def pm_transition_work_item(
         canonical_system="task-orchestrator",
         operation_type=PMActionKind.WORKFLOW_TRANSITION.value,
         payload={
-            "from_phase": "unknown",
+            "from_phase": from_phase,
+            "from_status": from_status,
             "to_phase": WORKFLOW_PHASE_CAPTURE_BY_STATUS.get(new_status, "maintenance"),
             "status": new_status.value,
             "transition": transition_name,

--- a/src/dopemux/uncommitted_detector.py
+++ b/src/dopemux/uncommitted_detector.py
@@ -24,10 +24,12 @@ class ChangesSummary:
     untracked_count: int
     stashed_count: int
     total_files: int
+    detection_failed: bool = False
 
     def is_clean(self) -> bool:
         """Check if worktree is completely clean (no changes, no stash)."""
-        return not self.has_changes and self.stashed_count == 0
+        # Unknown state is never "clean" — fail closed.
+        return not self.detection_failed and not self.has_changes and self.stashed_count == 0
 
     def format_summary(self) -> str:
         """
@@ -65,7 +67,9 @@ class ChangesSummary:
         Returns:
             True if should suggest worktree creation
         """
-        return self.has_changes or self.stashed_count > 0
+        # Fail closed: if we could not determine state, protect rather than
+        # silently assume main is clean.
+        return self.has_changes or self.stashed_count > 0 or self.detection_failed
 
 
 class UncommittedChangeDetector:
@@ -133,14 +137,15 @@ class UncommittedChangeDetector:
         status_output = self._run_git_command(["status", "--porcelain"])
 
         if status_output is None:
-            logger.warning("Failed to get git status - assuming no changes")
+            logger.warning("Failed to get git status - treating state as unknown (fail closed)")
             return ChangesSummary(
                 has_changes=False,
                 staged_count=0,
                 unstaged_count=0,
                 untracked_count=0,
                 stashed_count=0,
-                total_files=0
+                total_files=0,
+                detection_failed=True
             )
 
         # Parse status output
@@ -167,6 +172,9 @@ class UncommittedChangeDetector:
                 x_status = line[0]  # Staged status
                 y_status = line[1]  # Unstaged status
                 filename = line[3:].strip()
+                # Rename entries are "old -> new"; track the new path.
+                if " -> " in filename:
+                    filename = filename.split(" -> ")[-1]
 
                 if filename not in seen_files:
                     seen_files.add(filename)

--- a/src/dopemux/untracked_work.py
+++ b/src/dopemux/untracked_work.py
@@ -1,0 +1,118 @@
+"""Session-level untracked-work surfacing (lite probe).
+
+Detects uncommitted work in the current worktree and (a) returns a gentle
+one-line advisory for session-start surfaces, (b) emits a promotable
+``work.untracked_detected`` capture event so the chronicle records it.
+
+This intentionally does NOT duplicate Serena F001 "Untracked Work Detection"
+(services/serena/untracked_work_*.py — the canonical detect → remind →
+convert → auto-close engine with ConPort-persisted state, being exposed via
+MCP in PR #1007). This module is the always-on, zero-dependency probe at the
+live session entry points (``dopemux start``, SessionStart hook); F001 owns
+the actionable lifecycle, including ``work.untracked_converted``.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import Optional
+
+from .uncommitted_detector import ChangesSummary, UncommittedChangeDetector
+
+logger = logging.getLogger(__name__)
+
+PROBE_SOURCE = "dopemux.untracked_work"
+
+
+def check_untracked_work(workspace_path: str) -> Optional[ChangesSummary]:
+    """Return a ChangesSummary when uncommitted work exists, else None.
+
+    None also covers: not a git repo, clean worktree, and detection failure
+    (detection failure is surfaced by main-worktree protection; this probe
+    is advisory and stays quiet rather than guessing).
+    """
+    try:
+        detector = UncommittedChangeDetector(workspace_path)
+    except ValueError:
+        return None
+    changes = detector.check_changes()
+    if changes.detection_failed or not changes.has_changes:
+        return None
+    return changes
+
+
+def current_branch(workspace_path: str) -> Optional[str]:
+    """Best-effort current branch name."""
+    try:
+        result = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=workspace_path,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        branch = result.stdout.strip()
+        return branch or None
+    except Exception:
+        return None
+
+
+def format_advisory(changes: ChangesSummary, branch: Optional[str]) -> str:
+    """One-line, gentle advisory (no prompt — decision reduction)."""
+    where = f" on [bold]{branch}[/bold]" if branch else ""
+    return (
+        f"📂 Untracked work{where}: {changes.format_summary()}. "
+        "If this is task work, log it (e.g. `dopemux capture note`) so it isn't lost."
+    )
+
+
+def emit_untracked_detected(
+    workspace_path: str,
+    changes: ChangesSummary,
+    branch: Optional[str],
+    *,
+    source_probe: str,
+    session_id: Optional[str] = None,
+) -> bool:
+    """Best-effort promotable capture event; never raises."""
+    try:
+        from .memory.capture_client import try_emit_promotable_capture_event
+    except Exception:  # pragma: no cover - capture stack unavailable
+        return False
+    result = try_emit_promotable_capture_event(
+        "work.untracked_detected",
+        {
+            "branch": branch or "",
+            "workspace_path": workspace_path,
+            "staged_count": changes.staged_count,
+            "unstaged_count": changes.unstaged_count,
+            "untracked_count": changes.untracked_count,
+            "total_files": changes.total_files,
+            "source_probe": source_probe,
+        },
+        source=PROBE_SOURCE,
+        session_id=session_id,
+    )
+    return result is not None
+
+
+def probe_untracked_work(
+    workspace_path: str,
+    *,
+    source_probe: str,
+    session_id: Optional[str] = None,
+) -> Optional[str]:
+    """Full probe: detect, emit capture event, return advisory line (or None)."""
+    changes = check_untracked_work(workspace_path)
+    if changes is None:
+        return None
+    branch = current_branch(workspace_path)
+    emit_untracked_detected(
+        workspace_path,
+        changes,
+        branch,
+        source_probe=source_probe,
+        session_id=session_id,
+    )
+    return format_advisory(changes, branch)

--- a/tests/arch/test_registry_compose_alignment.py
+++ b/tests/arch/test_registry_compose_alignment.py
@@ -57,12 +57,16 @@ def parse_port_mapping(port_str: str) -> Optional[tuple[int, int]]:
     - "3004:3004"
     - "${CONPORT_PORT:-3004}:${CONPORT_CONTAINER_PORT:-3004}"
     - "${CONPORT_PORT:-3004}:3004"
+    - "127.0.0.1:${ADHD_ENGINE_PORT:-3025}:8095" (loopback-bound mappings)
     """
     # Remove env var syntax and extract default values
     cleaned = re.sub(r'\$\{[^:}]+:-([0-9]+)\}', r'\1', port_str)
     cleaned = re.sub(r'\$\{[^}]+\}', '', cleaned)  # Remove remaining vars
-    
+
     parts = cleaned.split(":")
+    if len(parts) == 3:
+        # IP:HOST:CONTAINER form (loopback binds are the fleet target)
+        parts = parts[1:]
     if len(parts) != 2:
         return None
     

--- a/tests/dopemux/test_uncommitted_detector.py
+++ b/tests/dopemux/test_uncommitted_detector.py
@@ -391,3 +391,47 @@ def test_should_protect_main_non_git_repo():
     with tempfile.TemporaryDirectory() as tmpdir:
         # Should not raise, just return False
         assert should_protect_main(tmpdir) is False
+
+
+def test_check_changes_fail_closed_on_git_failure(git_repo, monkeypatch):
+    """Git status failure must NOT be reported as a clean worktree (fail closed)."""
+    detector = UncommittedChangeDetector(str(git_repo))
+    monkeypatch.setattr(detector, "_run_git_command", lambda *a, **kw: None)
+
+    changes = detector.check_changes()
+
+    assert changes.detection_failed is True
+    assert changes.is_clean() is False
+    assert changes.needs_worktree_suggestion() is True
+
+
+def test_changes_summary_detection_failed_defaults_false():
+    """Existing construction sites without the flag keep prior behavior."""
+    clean = ChangesSummary(
+        has_changes=False,
+        staged_count=0,
+        unstaged_count=0,
+        untracked_count=0,
+        stashed_count=0,
+        total_files=0,
+    )
+    assert clean.detection_failed is False
+    assert clean.is_clean() is True
+    assert clean.needs_worktree_suggestion() is False
+
+
+def test_rename_counts_single_staged_change(git_repo):
+    """A staged rename (R old -> new) counts once and tracks the new path."""
+    subprocess.run(
+        ["git", "mv", "README.md", "RENAMED.md"],
+        cwd=git_repo,
+        check=True,
+        capture_output=True,
+    )
+
+    detector = UncommittedChangeDetector(str(git_repo))
+    changes = detector.check_changes()
+
+    assert changes.has_changes is True
+    assert changes.staged_count == 1
+    assert changes.detection_failed is False

--- a/tests/dopemux/test_untracked_work.py
+++ b/tests/dopemux/test_untracked_work.py
@@ -1,0 +1,145 @@
+"""Tests for the lite untracked-work probe (src/dopemux/untracked_work.py)."""
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import src.dopemux.untracked_work as uw
+from src.dopemux.untracked_work import (
+    check_untracked_work,
+    current_branch,
+    format_advisory,
+    probe_untracked_work,
+)
+
+
+@pytest.fixture
+def git_repo():
+    """Temporary git repository with one commit."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        repo_path = Path(tmpdir)
+        subprocess.run(
+            ["git", "init", "-b", "feature/test"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+        (repo_path / "README.md").write_text("# Test Repo")
+        subprocess.run(["git", "add", "."], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+        yield repo_path
+
+
+def test_clean_repo_returns_none(git_repo):
+    assert check_untracked_work(str(git_repo)) is None
+
+
+def test_non_git_dir_returns_none():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        assert check_untracked_work(tmpdir) is None
+
+
+def test_dirty_repo_returns_summary(git_repo):
+    (git_repo / "README.md").write_text("# Modified")
+    (git_repo / "new.py").write_text("x = 1")
+
+    changes = check_untracked_work(str(git_repo))
+
+    assert changes is not None
+    assert changes.unstaged_count == 1
+    assert changes.untracked_count == 1
+
+
+def test_current_branch(git_repo):
+    assert current_branch(str(git_repo)) == "feature/test"
+
+
+def test_format_advisory_mentions_branch_and_counts():
+    from src.dopemux.uncommitted_detector import ChangesSummary
+
+    changes = ChangesSummary(
+        has_changes=True,
+        staged_count=1,
+        unstaged_count=2,
+        untracked_count=3,
+        stashed_count=0,
+        total_files=6,
+    )
+    advisory = format_advisory(changes, "feature/test")
+
+    assert "feature/test" in advisory
+    assert "1 staged" in advisory
+    assert "2 unstaged" in advisory
+    assert "3 untracked" in advisory
+
+
+def test_probe_emits_capture_event_and_returns_advisory(git_repo, monkeypatch):
+    (git_repo / "new.py").write_text("x = 1")
+
+    emitted = []
+    monkeypatch.setattr(
+        uw,
+        "emit_untracked_detected",
+        lambda path, changes, branch, **kw: emitted.append((path, changes, branch, kw)) or True,
+    )
+
+    advisory = probe_untracked_work(str(git_repo), source_probe="test_probe")
+
+    assert advisory is not None
+    assert "feature/test" in advisory
+    assert len(emitted) == 1
+    assert emitted[0][3]["source_probe"] == "test_probe"
+
+
+def test_probe_silent_on_clean_repo(git_repo, monkeypatch):
+    emitted = []
+    monkeypatch.setattr(
+        uw,
+        "emit_untracked_detected",
+        lambda *a, **kw: emitted.append(1) or True,
+    )
+
+    assert probe_untracked_work(str(git_repo), source_probe="test_probe") is None
+    assert emitted == []
+
+
+def test_emit_uses_promotable_event_type(git_repo, monkeypatch):
+    """The probe's event type must be in the capture allowlist."""
+    (git_repo / "new.py").write_text("x = 1")
+
+    captured = {}
+
+    def fake_emit(event_type, payload, **kwargs):
+        captured["event_type"] = event_type
+        captured["payload"] = payload
+        return object()
+
+    import src.dopemux.memory.capture_client as cc
+
+    monkeypatch.setattr(cc, "try_emit_promotable_capture_event", fake_emit)
+    # The module imports lazily inside the function, so patch the source.
+    advisory = probe_untracked_work(str(git_repo), source_probe="test_probe")
+
+    assert advisory is not None
+    assert captured["event_type"] == "work.untracked_detected"
+    assert captured["event_type"] in cc.PROMOTABLE_CAPTURE_EVENT_TYPES
+    assert captured["payload"]["untracked_count"] == 1

--- a/tests/unit/dopemux/pm/test_writes.py
+++ b/tests/unit/dopemux/pm/test_writes.py
@@ -415,3 +415,75 @@ def test_pm_transition_from_phase_unknown_without_receipt(monkeypatch):
     assert len(phase_events) == 1
     assert phase_events[0]["from_phase"] == "unknown"
     assert phase_events[0]["from_status"] is None
+
+
+def test_pm_transition_emits_blocker_cleared_when_leaving_blocked(monkeypatch):
+    """A transition out of BLOCKED emits a promotable blocker.cleared event."""
+    import src.dopemux.pm.writes as writes_module
+
+    emitted = []
+    monkeypatch.setattr(
+        writes_module,
+        "try_emit_promotable_capture_event",
+        lambda event_type, payload, **kwargs: emitted.append((event_type, payload)),
+    )
+
+    class BlockedReceiptClient(MockOrchestratorClient):
+        def transition(self, **kwargs):
+            super().transition(**kwargs)
+            return {"transition_receipt": {"status": "success", "from_status": "BLOCKED"}}
+
+    config = PMWriteConfig(
+        leantime_client=MockLeantimeClient(),
+        orchestrator_client=BlockedReceiptClient(),
+        conport_client=None,
+        memory_client=None,
+        project_id="proj-7",
+    )
+
+    pm_transition_work_item(
+        config=config,
+        task_id="task-9",
+        new_status=PMTaskStatus.IN_PROGRESS,
+        reason="unblocked by fix",
+        idempotency_key="key-5",
+        expected_version=2,
+    )
+
+    types = [t for (t, _p) in emitted]
+    assert "blocker.cleared" in types
+    cleared = [p for (t, p) in emitted if t == "blocker.cleared"][0]
+    assert cleared["task_id"] == "task-9"
+    # from_phase on the phase event should reflect BLOCKED -> review
+    phase = [p for (t, p) in emitted if t == "workflow.phase_changed"][0]
+    assert phase["from_phase"] == "review"
+
+
+def test_pm_transition_no_blocker_cleared_without_blocked_prior(monkeypatch):
+    import src.dopemux.pm.writes as writes_module
+
+    emitted = []
+    monkeypatch.setattr(
+        writes_module,
+        "try_emit_promotable_capture_event",
+        lambda event_type, payload, **kwargs: emitted.append(event_type),
+    )
+
+    config = PMWriteConfig(
+        leantime_client=MockLeantimeClient(),
+        orchestrator_client=MockOrchestratorClient(),
+        conport_client=None,
+        memory_client=None,
+        project_id="proj-7",
+    )
+
+    pm_transition_work_item(
+        config=config,
+        task_id="task-9",
+        new_status=PMTaskStatus.IN_PROGRESS,
+        reason="starting",
+        idempotency_key="key-6",
+        expected_version=1,
+    )
+
+    assert "blocker.cleared" not in emitted

--- a/tests/unit/dopemux/pm/test_writes.py
+++ b/tests/unit/dopemux/pm/test_writes.py
@@ -335,3 +335,83 @@ def test_pm_log_decision_marks_conport_decision_and_memory_mirror():
         )
     ]
     assert receipt.mirror_receipts[0].persisted_id == "chron-1"
+
+
+def test_pm_transition_emits_real_from_phase_from_receipt(monkeypatch):
+    """workflow.phase_changed carries the backend-reported prior phase."""
+    import src.dopemux.pm.writes as writes_module
+
+    emitted = []
+    monkeypatch.setattr(
+        writes_module,
+        "try_emit_promotable_capture_event",
+        lambda event_type, payload, **kwargs: emitted.append((event_type, payload)),
+    )
+
+    class ReceiptOrchestratorClient(MockOrchestratorClient):
+        def transition(self, **kwargs):
+            super().transition(**kwargs)
+            return {
+                "transition_receipt": {
+                    "status": "success",
+                    "from_status": "TODO",
+                    "version_after": 2,
+                }
+            }
+
+    config = PMWriteConfig(
+        leantime_client=MockLeantimeClient(),
+        orchestrator_client=ReceiptOrchestratorClient(),
+        conport_client=None,
+        memory_client=None,
+        project_id="proj-7",
+    )
+
+    pm_transition_work_item(
+        config=config,
+        task_id="task-1",
+        new_status=PMTaskStatus.IN_PROGRESS,
+        reason="starting work",
+        idempotency_key="key-3",
+        expected_version=1,
+    )
+
+    phase_events = [p for (t, p) in emitted if t == "workflow.phase_changed"]
+    assert len(phase_events) == 1
+    assert phase_events[0]["from_phase"] == "planning"
+    assert phase_events[0]["from_status"] == "TODO"
+    assert phase_events[0]["to_phase"] == "implementation"
+
+
+def test_pm_transition_from_phase_unknown_without_receipt(monkeypatch):
+    """Clients that return no receipt keep the honest 'unknown' fallback."""
+    import src.dopemux.pm.writes as writes_module
+
+    emitted = []
+    monkeypatch.setattr(
+        writes_module,
+        "try_emit_promotable_capture_event",
+        lambda event_type, payload, **kwargs: emitted.append((event_type, payload)),
+    )
+
+    config = PMWriteConfig(
+        leantime_client=MockLeantimeClient(),
+        orchestrator_client=MockOrchestratorClient(),
+        conport_client=None,
+        memory_client=None,
+        project_id="proj-7",
+    )
+
+    pm_transition_work_item(
+        config=config,
+        task_id="task-1",
+        new_status=PMTaskStatus.DONE,
+        reason="done",
+        idempotency_key="key-4",
+        expected_version=3,
+    )
+
+    phase_events = [p for (t, p) in emitted if t == "workflow.phase_changed"]
+    assert len(phase_events) == 1
+    assert phase_events[0]["from_phase"] == "unknown"
+    assert phase_events[0]["from_status"] is None

--- a/tests/unit/test_dopecon_bridge_promotable_mirror.py
+++ b/tests/unit/test_dopecon_bridge_promotable_mirror.py
@@ -6,6 +6,8 @@ using a capture_client-compatible envelope.
 """
 
 import importlib.util
+
+import pytest
 import json
 import sys
 from pathlib import Path
@@ -45,6 +47,7 @@ def test_normalize_event_type():
     assert MIRROR.normalize_event_type("decision.logged") == "decision.logged"
     assert MIRROR.normalize_event_type("  Task_Completed ") == "task.completed"
     assert MIRROR.normalize_event_type("") == "unknown"
+    assert MIRROR.normalize_event_type("work_untracked_detected") == "work.untracked.detected"
 
 
 def test_envelope_promotable_underscore_type():
@@ -67,6 +70,8 @@ def test_envelope_non_promotable_returns_none():
     assert MIRROR.build_mirror_envelope("session_started", {}, "bridge") is None
 
 
+
+@pytest.mark.asyncio
 async def test_mirror_writes_to_memory_stream():
     fake = _FakeRedis()
     written = await MIRROR.mirror_promotable_event(
@@ -84,6 +89,8 @@ async def test_mirror_writes_to_memory_stream():
     assert envelope["session_id"] == "s1"
 
 
+
+@pytest.mark.asyncio
 async def test_mirror_skips_when_already_on_memory_stream():
     fake = _FakeRedis()
     written = await MIRROR.mirror_promotable_event(
@@ -97,6 +104,8 @@ async def test_mirror_skips_when_already_on_memory_stream():
     assert fake.calls == []
 
 
+
+@pytest.mark.asyncio
 async def test_mirror_skips_non_promotable():
     fake = _FakeRedis()
     written = await MIRROR.mirror_promotable_event(
@@ -110,6 +119,8 @@ async def test_mirror_skips_non_promotable():
     assert fake.calls == []
 
 
+
+@pytest.mark.asyncio
 async def test_mirror_never_raises_on_redis_failure():
     fake = _FakeRedis(fail=True)
     written = await MIRROR.mirror_promotable_event(

--- a/tests/unit/test_dopecon_bridge_promotable_mirror.py
+++ b/tests/unit/test_dopecon_bridge_promotable_mirror.py
@@ -120,3 +120,18 @@ async def test_mirror_never_raises_on_redis_failure():
         source="conport",
     )
     assert written is False
+
+
+def test_new_contract_types_are_promotable():
+    """Phase 1.1 extension types mirror correctly."""
+    for event_type in (
+        "task.created",
+        "blocker.cleared",
+        "work.untracked_detected",
+        "work.untracked_converted",
+    ):
+        envelope = MIRROR.build_mirror_envelope(
+            event_type, {"workspace_id": "/ws"}, "test"
+        )
+        assert envelope is not None, event_type
+        assert envelope["type"] == event_type

--- a/tests/unit/test_dopecon_bridge_promotable_mirror.py
+++ b/tests/unit/test_dopecon_bridge_promotable_mirror.py
@@ -1,0 +1,122 @@
+"""Tests for the dopecon-bridge promotable-event chronicle mirror.
+
+The mirror copies promotable events (decision.logged, task.*, ...) from the
+general bus stream onto the dope-memory input stream (activity.events.v1),
+using a capture_client-compatible envelope.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "services"
+    / "dopecon-bridge"
+    / "dopecon_bridge"
+    / "promotable_mirror.py"
+)
+MODULE_DIR = MODULE_PATH.parent
+
+if str(MODULE_DIR) not in sys.path:
+    sys.path.insert(0, str(MODULE_DIR))
+
+SPEC = importlib.util.spec_from_file_location("promotable_mirror_for_tests", MODULE_PATH)
+MIRROR = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MIRROR)
+
+
+class _FakeRedis:
+    def __init__(self, fail: bool = False):
+        self.fail = fail
+        self.calls = []
+
+    async def xadd(self, stream, envelope):
+        if self.fail:
+            raise ConnectionError("redis down")
+        self.calls.append((stream, envelope))
+        return b"1-0"
+
+
+def test_normalize_event_type():
+    assert MIRROR.normalize_event_type("decision_logged") == "decision.logged"
+    assert MIRROR.normalize_event_type("decision.logged") == "decision.logged"
+    assert MIRROR.normalize_event_type("  Task_Completed ") == "task.completed"
+    assert MIRROR.normalize_event_type("") == "unknown"
+
+
+def test_envelope_promotable_underscore_type():
+    envelope = MIRROR.build_mirror_envelope(
+        "decision_logged",
+        {"workspace_id": "/ws/repo", "summary": "picked X"},
+        "conport",
+    )
+    assert envelope is not None
+    assert envelope["type"] == "decision.logged"
+    assert envelope["workspace_id"] == "/ws/repo"
+    assert envelope["instance_id"] == "A"  # default when absent
+    assert envelope["session_id"] == ""
+    assert envelope["source"] == "conport"
+    assert json.loads(envelope["data"])["summary"] == "picked X"
+
+
+def test_envelope_non_promotable_returns_none():
+    assert MIRROR.build_mirror_envelope("progress_updated", {}, "conport") is None
+    assert MIRROR.build_mirror_envelope("session_started", {}, "bridge") is None
+
+
+async def test_mirror_writes_to_memory_stream():
+    fake = _FakeRedis()
+    written = await MIRROR.mirror_promotable_event(
+        fake,
+        stream="dopemux:events",
+        event_type="decision.logged",
+        data={"workspace_id": "/ws/repo", "instance_id": "B", "session_id": "s1"},
+        source="conport",
+    )
+    assert written is True
+    assert len(fake.calls) == 1
+    stream, envelope = fake.calls[0]
+    assert stream == MIRROR.MEMORY_INPUT_STREAM
+    assert envelope["instance_id"] == "B"
+    assert envelope["session_id"] == "s1"
+
+
+async def test_mirror_skips_when_already_on_memory_stream():
+    fake = _FakeRedis()
+    written = await MIRROR.mirror_promotable_event(
+        fake,
+        stream=MIRROR.MEMORY_INPUT_STREAM,
+        event_type="decision.logged",
+        data={"workspace_id": "/ws"},
+        source="conport",
+    )
+    assert written is False
+    assert fake.calls == []
+
+
+async def test_mirror_skips_non_promotable():
+    fake = _FakeRedis()
+    written = await MIRROR.mirror_promotable_event(
+        fake,
+        stream="dopemux:events",
+        event_type="progress_updated",
+        data={"workspace_id": "/ws"},
+        source="conport",
+    )
+    assert written is False
+    assert fake.calls == []
+
+
+async def test_mirror_never_raises_on_redis_failure():
+    fake = _FakeRedis(fail=True)
+    written = await MIRROR.mirror_promotable_event(
+        fake,
+        stream="dopemux:events",
+        event_type="decision.logged",
+        data={"workspace_id": "/ws"},
+        source="conport",
+    )
+    assert written is False


### PR DESCRIPTION
## Summary

P0 fixes + the ADHD ignition packet from the 2026-07-04 full service-layer audit (`claudedocs/service-audit-2026-07-04.md`, included in this PR).

### Commit 1 — P0 fixes (`365755cbf`)
- **Chronicle unblocked**: new `services/dopecon-bridge/dopecon_bridge/promotable_mirror.py` mirrors promotable events (`decision.logged`, `task.*`, `error.encountered`, `workflow.phase_changed`, `manual.memory_store`; underscore forms normalized) onto the dope-memory input stream `activity.events.v1` with a capture_client-compatible envelope. Root cause: promotable events were published to `dopemux:events`, but dope-memory's EventBusConsumer subscribes only to `activity.events.v1` → 0 `work_log_entries` ever. A stream rename was rejected: `dopemux:events` has other live consumers (DDG pattern detector, ADHD engine listener). The mirror is additive and best-effort.
- **Untracked-work protection fails closed**: `uncommitted_detector` no longer reports a clean worktree when `git status` fails (`detection_failed` flag → honest protection trigger); rename entries tracked by new path; NoneType guard in `main_worktree_detector`.
- **ADHD engine ConPort URL**: `:3010` (= dope-context, wrong-service hazard) → `:3005` (matches compose); client URL env-driven.

### Commit 3 — ADHD ignition (`b56bf06e9`)
The June signal-loop series is coherent in code (hooks → `dopemux:events` `native_hook_activity` → emitter.subscribe → listener → activity signal) but a default session never ran the engine:
- `start-all-mcp-servers.sh` (the real `dopemux mcp up` path) now starts **task-orchestrator, dope-memory, adhd-engine**; quarantined **exa/desktop-commander no longer auto-start** (still available via `--services`).
- adhd-engine joins the smoke core set (`smoke_up.sh` + `registry.yaml enabled_in_smoke: true`).
- `mcp down` derives from `DEFAULT_MCP_SERVICES ∩ compose` (was a hardcoded list that left bridge/memory/orchestrator running); `adhd-engine` added to / `desktop-commander` dropped from the default set.
- **Event-field drift fix**: `ADHDEventEmitter.subscribe` accepts both `event_type` (dopemux producers) and `type` (dopecon-bridge `Event.to_redis_fields`) — bridge events were parsed as type "" and dropped.
- **Coordinator health check**: was probing `:8080` (= Leantime) for ADHD health; now env-driven `ADHD_ENGINE_URL`, default `adhd-engine:8095`.
- Alignment-test port parser handles loopback-bound `IP:HOST:CONTAINER` mappings.

## Validation

- **PASS**: mirror tests (7 new), uncommitted-detector (22, incl. 3 new), 132 worktree/protection, 33 registry/mcp-catalog/compose-alignment, 34 CLI-startup/provision/event-backbone/native-hooks; `bash -n` on both scripts; `py_compile` on all touched service files.
- **NOT_RUN**: live runtime (docker down during session). Two runtime acceptance checks recommended post-merge: (1) `dopemux mcp up` → adhd-engine healthy on :3025 and listener log shows "ADHD Event Listener started"; (2) log a decision via the bridge → confirm a `work_log_entries` row in the chronicle.

## Notes for reviewers

- `PROMOTABLE_EVENT_TYPES` intentionally duplicates the allowlist in `services/working-memory-assistant/promotion/promotion.py` (services don't share a package); shared-constant refactor deferred.
- Auto-start removal for exa/desktop-commander implements the runtime half of the #1001 quarantine (which was config-generation only). The exa wire-vs-retire decision remains open per the fleet audit.
- Known residual (documented in the audit): PM plane still never emits `task.created/failed/assigned`; `from_phase` hardcoded "unknown".

🤖 Generated with [Claude Code](https://claude.com/claude-code)