### PR TITLE
docs(memory): Memory Context Fabric — design spec + authority map + build plans (TP-MCF-001..004)

### DIFF
--- a/claudedocs/memory-context-fabric-README-2026-07-04.md
+++ b/claudedocs/memory-context-fabric-README-2026-07-04.md
@@ -1,0 +1,38 @@
+# Memory Context Fabric — Design Doc Set (index)
+
+**Date**: 2026-07-04 · **Status**: DESIGN (fold-in-ready) · **Branch**: `claude/memory-context-fabric`
+**What this is**: the complete design documentation for the **Memory Context Fabric** — the subsystem that makes dopemux "keep track of everything and inject the needed context at all times, including conversation history." Generated for folding into a larger dopemux architecture design. **No implementation** is included; these are design + contract artifacts.
+
+---
+
+## The documents (read in this order)
+
+| # | Doc | Purpose |
+|---|---|---|
+| 1 | **`memory-context-fabric-design-2026-07-04.md`** (v3) | The design spec — architecture (Context Fabric over the Memory Trinity), authority model, capture pipeline, memory model, retrieval + injection, governance, and the evidence-gated TP-MCF-001…009 phasing. Twice externally audited (CONDITIONAL-GO). |
+| 2 | **`tp-mcf-001-authority-map-2026-07-04.md`** | Current-runtime truth — the file:line authority map for capture / promotion / ConPort / dope-context / hooks / bridge, with dead surfaces and painted sockets marked. Distinguishes *what exists* from *what the design targets*. |
+| 3 | **`memory-context-fabric-interfaces-2026-07-04.md`** | Interfaces & data contracts — the Fabric's public surface (`context.recall`/`context.recap`), the `CaptureEnvelope`/`PromotedEntry`/`ContextBundle` schemas, plane-interaction contracts, and the invariants (contract tests). Defines the Fabric as a **bounded subsystem** with clear boundaries. |
+
+**Supporting context** (separate initiatives, referenced by the above):
+- `mcp-fleet-canonical-audit-and-target-design-2026-07-03.md` — the MCP fleet target-state (on `main`); the Fabric's plane dependencies live here.
+- `mcp-fleet-forgotten-features-addendum-2026-07-04.md` — dormant-capability archaeology (on the `claude/mcp-fleet-audit-complete` branch); the semantic-memory / graph-traversal / ADHD-intelligence pieces the Fabric would resurrect.
+
+---
+
+## How it folds into a larger architecture
+
+The Memory Context Fabric is **one subsystem** of the dopemux architecture, defined by three boundaries:
+
+1. **Above it** — agent sessions (Claude Code / Codex) that *emit events and receive context*. They do not orchestrate memory.
+2. **Below it** — the Memory Trinity planes (dope-memory / ConPort / dope-context) as canonical stores, plus Redis transport and the native-hook substrate. The Fabric is a *client* of these, never their owner.
+3. **Beside it** — the **DCP read-only facade** (outbound projection to external LLMs) is the mirror-image sibling: the Fabric is *inbound + local*, DCP is *outbound + read-only*. Both use the same "orchestrate, don't own" + provenance/trust model, so they compose cleanly in a larger design.
+
+**Invariant that makes it composable**: the Fabric owns no truth — no storage, no decision/graph/PM/retrieval authority, no fourth datastore. That is what lets it be dropped into a larger architecture without violating the Memory Trinity split-authority ADRs or the fleet governance model.
+
+**Maturity for fold-in**: architecture + contracts are design-complete and audit-corrected; current-state is verified (doc 2); implementation is decomposed into gated packets (TP-MCF-001 done as a no-code audit; TP-MCF-002+ pending) but **not built** — so the larger architecture can treat this as a specified-but-unbuilt subsystem with a known build path.
+
+---
+
+## Governance footer
+
+**Validation**: design/analysis only — **no code changed, live behavior NOT_RUN.** All runtime claims are file:line-grounded in doc 2; unbuilt/dead surfaces (`memory_{hash}`, `graph.neighbors`, transcript ingest, `context.recall`) are marked as such. **Rollback**: delete the four docs on this branch.

--- a/claudedocs/memory-context-fabric-design-2026-07-04.md
+++ b/claudedocs/memory-context-fabric-design-2026-07-04.md
@@ -1,0 +1,142 @@
+# Memory Context Fabric — Design Spec (v3, reaudit-corrected)
+
+**Date**: 2026-07-04
+**Status**: Architecture CONDITIONAL-GO (2× external audit). Planning baseline. TP-MCF-001 = GO (no runtime change). Downstream packets gated per the Section 6 matrix.
+**Goal**: dopemux *keeps track of everything* and agents *work together seamlessly and implicitly to capture and inject the needed context at all times, including conversation history* — without an operator running `/save` or `/decision`.
+
+**Approved cornerstones**: transcript files **and** hooks · capture broad **raw**, **promote curated** · injection phased (recap+retrieval now, proactive later) · ambitious rebuild · **Context Fabric** orchestration layer over the Memory Trinity (Approach B).
+
+**v3 changelog** (reaudit, all claims re-verified against code):
+1. **Privacy vs external embedding** — "nothing sent externally" was too flat: dope-context embeds via **Voyage (cloud)**. Corrected: storage local by default; **raw transcript content is never sent to external embedding providers**; semantic projection of conversation-derived content requires a local embedding backend *or* explicit redaction+approval+provider-policy.
+2. **Quarantine** — now defined as a **local safety artifact (not memory truth)** with a named writer (the TP-MCF-002 ingest adapter); path/table declared; not searched/promoted/mirrored/projected.
+3. **Hook events are a TARGET source, not current** — native hooks emit to `dopemux:events`; dope-memory's consumer listens on `activity.events.v1`. TP-MCF-002/003 must decide the wiring; don't assume current hook activity is chronicle input.
+4. **Candidate decisions** — must use a **distinct event type** (`conversation.decision_candidate`), never `decision.logged` (which the bridge emits only *after* a successful ConPort write); trust encoded in `details_json.trust` + `promotion_rule`.
+5. **Transcript idempotency** — ingest must **fail/quarantine on missing source timestamp**, never fall back to ingest-time `now` (which `emit_capture_event` otherwise does), or replay-safety is lost.
+6. Non-blocking: `task.*` → exact `{task.completed, task.failed, task.blocked}`; dope-context `/index` kept as "wire exists dope-memory side, dope-context route/collection not proven"; ConPort = "relationship traversal exists (`workspace-relationships`), `graph.neighbors` MCP parity not proven."
+
+---
+
+## 0. Current runtime truth vs. target (honesty table)
+
+| Capability | Current runtime (verified) | Target |
+|---|---|---|
+| Split-authority Trinity | **REAL** — 3 distinct canonical planes | keep; Fabric coordinates, never owns |
+| Raw capture spine | **REAL** — `capture_client.py` (deterministic IDs, redaction, `INSERT OR IGNORE`, raw ledger, Redis fan-out); dope-memory compose `ENABLE_EVENTBUS=true`, ledger `/data/chronicle.sqlite` | reuse; do not rebuild |
+| Curated chronicle | **REAL** for `decision.logged`, `task.completed`, `task.failed`, `task.blocked`, `error.encountered`, `workflow.phase_changed`, `manual.memory_store` | add transcript-derived classes (deterministic first) |
+| Hook injection substrate | **REAL** — `native_hooks.py` SessionStart injects MCP health + orchestrator + workflow context | extend with a recap bundle |
+| **Hook events → dope-memory** | **NOT WIRED** — hooks emit to `dopemux:events`; consumer listens on `activity.events.v1` | TP-MCF-002/003 decide: call `emit_capture_event()` directly, emit to `activity.events.v1`, or bridge the two streams |
+| Transcript-file ingest | **MISSING** — hooks emit content-free activity + bounded hook-error captures; `UserPromptSubmit` records to workflow state only when a workflow is active | build as its own adapter (raw-ledger-only first) |
+| Semantic memory in dope-context | **NOT REAL** — collections `code_{hash}`/`docs_{hash}` only; `_index_in_dopecontext` POSTs `/index worklog_index` but dope-context route/collection **not proven** | build a derived projection (fork, ADR) or drop; **Voyage embedding is external** — privacy constraint below |
+| ConPort graph | **DEAD-SURFACE** in `src/conport/memory_server.py` (declares itself dead). Active runtime: relationship traversal via `/api/workspace-relationships` → `get_related_decisions`; decisions/progress/search/custom-data/`/mcp`. **No `graph.neighbors` MCP parity.** | implement/verify on active Docker ConPort, or ship relationship-query projection only |
+| Context Fabric `recall`/`recap` | **MISSING** | build (TP-MCF-007) |
+| Redaction on failure | **strip-and-store-minimal** (`redactor.py:123-125` → `{redaction_error, original_keys}`, stored anyway; leaks key names) | **hold/quarantine** for raw transcript events |
+
+The architecture below is the *target*; Section 6 phasing is gated so no phase depends on an unproven/unbuilt earlier capability.
+
+---
+
+## 1. Architecture — the Context Fabric over the Trinity
+
+Coordinating layer (service + hook set + thin client lib) owning capture → redact → dedup → route → promote → retrieve → inject; Trinity planes remain canonical stores. Writes *through* canonical writers, reads *across* them; **never a fourth store.**
+
+**Revised authority model:**
+
+| Domain | Canonical writer | Fabric role |
+|---|---|---|
+| Raw conversation/event ledger | dope-memory | capture-adapter **client only** |
+| Curated chronology | dope-memory promotion path | **candidate promoter**, not a store |
+| Structured decisions/progress/context | ConPort | explicit **writer client with provenance** (never auto from conversation) |
+| Code/docs retrieval | dope-context | **reader only** |
+| Memory semantic projection | **UNKNOWN until implemented** | derived-projection **client only** |
+| Transcript quarantine | **TP-MCF-002 ingest adapter** | safety-artifact writer (not memory truth) |
+| Event transport | dopecon-bridge / Redis | transport client, **not authority** |
+| Hook injection | dopemux native hooks | bundle assembler + hook client |
+
+**Boundary invariant:** Fabric is a canonical-writer client + cross-plane reader/assembler. It must NOT own storage, truth, or any domain authority. **Contract test: the Fabric package imports no plane's storage internals.**
+
+---
+
+## 2. Capture pipeline
+
+Reuses `capture_client.emit_capture_event()`. Sources → spine → **capture → redact → dedup → route → promote**. Operator does nothing.
+
+**Sources:** (1) **transcript-file ingest** (watcher over harness JSONL — the missing conversation history); (2) **hook events — a TARGET source**: they currently emit to `dopemux:events`, which the dope-memory consumer does not read, so TP-MCF-002/003 must explicitly wire them (direct `emit_capture_event()`, emit to `activity.events.v1`, or a `dopemux:events → activity.events.v1` bridge). Do not treat current hook activity as chronicle input.
+
+**Redact.** Current runtime strips-and-stores-minimal on failure (leaks key names). For raw **transcript** events, target = **hold/quarantine**: on redaction failure, write only redacted metadata + a withheld/encrypted payload *reference* to a **local safety artifact** — a declared `.dopemux/quarantine/...` path or a dope-memory-owned **non-queryable** quarantine table. Quarantine is **not memory truth**: never searched, promoted, mirrored, or projected. Writer = the TP-MCF-002 ingest adapter. Non-transcript events may keep strip-minimal, but the policy is **named + tested** either way.
+
+**Semantic indexing is opt-in by class:** raw transcript → **dope-memory only** (never auto-indexed); curated chronicle / ConPort decisions → eligible for projection *with authority label*; secret/PII/credential-bearing content → **never projected.** And (privacy): conversation-derived content is **never embedded via an external provider** without explicit redaction + approval + policy.
+
+**Dedup** — deterministic content-hash `event_id` → re-ingest safe **only if** the ingestor uses transcript-origin timestamps; it must **fail/quarantine on missing source timestamp**, never use ingest-time `now`.
+
+**Route → tiers:** raw ledger (`raw_activity_events`, TTL) always; curated chronicle (`work_log_entries`) for promoted high-signal; semantic projection only for eligible classes.
+
+**Decision detection.** A decision-looking turn → a **candidate decision in dope-memory** using a **distinct event type `conversation.decision_candidate`** (never `decision.logged`), with `details_json.trust="conversation-derived"` + `promotion_rule="conversation_candidate_v1"`. Promotion to a canonical ConPort decision requires an explicit gate (operator confirm or deterministic high-confidence rule). **No auto ConPort writes from conversation.**
+
+---
+
+## 3. Memory model
+
+| Plane | Canonical for | Target capability (status) |
+|---|---|---|
+| **dope-memory** | chronicle: raw ledger, curated `work_log_entries`, reflections, trajectory | + transcript turns; + `conversation.decision_candidate` entries (build); + non-queryable quarantine artifact |
+| **ConPort** | decisions/progress/structured context | active runtime has **relationship traversal** (`workspace-relationships` → `get_related_decisions`); `graph.neighbors` MCP + genealogy are **to implement/verify on Docker ConPort**, or ship relationship-query projection only |
+| **dope-context** | code/docs retrieval (read-only) | a **derived** `memory` projection — **UNKNOWN until implemented; needs ADR** (read-only today) **and** a privacy-safe embedding path (Voyage is external) |
+
+**Retrieval modalities** (fused *when built*): temporal (dope-memory recap), structural (ConPort relationship traversal), semantic (dope-context memory projection). Fusion **degrades gracefully** — an unbuilt modality is omitted, never faked. **Provenance/trust** (DCP model): conversation-derived = trust-lower; every projection carries an upstream authority label.
+
+---
+
+## 4. Retrieval + injection
+
+**Retrieval-fusion (TP-MCF-007):** `context.recall(query)` / `context.recap()` query whichever modalities exist, merge/rank/dedup, return a bundle with authority labels + a **token budget** (single-point truncation utility).
+
+**Injection Phase 1 (TP-MCF-004):** extend the **existing** `native_hooks.py` SessionStart path with a **bounded recap** from dope-memory recap/search — Top-3 default, token-budgeted, authority-labeled, **no semantic fusion yet**.
+
+**Injection Phase 2 (TP-MCF-009, later):** proactive mid-session surfacing — **rate limit + relevance threshold + kill switch.** Built last; a bad surfacing is worse than none.
+
+---
+
+## 5. Governance & security
+
+- **Split-authority preserved** — contract test: Fabric imports no plane storage internals.
+- **Fail-closed** — transcript redaction → hold/quarantine (named + tested); no silent cross-plane fallback; capture failures fail-open for the *session* but are logged/quarantined, never silently "succeeded."
+- **Privacy** — storage local by default; **raw transcript never sent to external embedding providers**; conversation-derived semantic projection requires local embedding or explicit redaction+approval+policy. (dope-context currently embeds via Voyage cloud — this is the constraint that gates TP-MCF-005.)
+- **Provenance/trust** — conversation-derived = trust-lower; injected bundles carry authority labels; a conversation-inferred decision never outranks an explicitly-logged one.
+- **Per-worktree isolation**; cross-worktree rollup opt-in.
+
+**Minimum proof gates (every packet):** `git status` before/after · `git diff --stat` + full diff · command outputs + exit codes · **redaction tests proving secrets never reach the ledger** · **deterministic replay test proving transcript re-ingest is idempotent (and rejects missing source timestamps)** · **no-Fabric-imports-of-plane-internals test** · semantic projections carry upstream authority labels · hook-injection token-budget test · embedded audit for non-trivial changes. (AGENTS.md: Task Packets + validation; review/precommit discipline.)
+
+---
+
+## 6. Phasing / decomposition — reaudit phase-approval matrix
+
+| Packet | Scope | Status | Hard gates |
+|---|---|---|---|
+| **TP-MCF-001** — Repo-truth contract audit (no runtime change) | authority map for capture/promotion/ConPort-writes/dope-context-indexing/hooks/bridge | **GO** | exact runtime paths named; dead surfaces marked dead; no semantic/graph claims unless code proves them; **no Fabric code** — produces the exact 002/003 packets |
+| **TP-MCF-002** — Transcript ingest → raw ledger only | watcher writing **only** `raw_activity_events` | **CONDITIONAL-GO** | **define quarantine writer + path/table**; **stable-timestamp rule (fail/quarantine on missing)**; deterministic IDs; replay-safe; redaction before storage; no ConPort/dope-context writes; never break the session |
+| **TP-MCF-003** — Deterministic promotion (transcript → chronicle) | promote safe deterministic classes (explicit decision markers, task completions, errors/blockers, workflow transitions) | **NO-GO until** candidate-decision event/schema defined (`conversation.decision_candidate` + trust fields) | out of scope: LLM summarization, auto ConPort writes |
+| **TP-MCF-004** — SessionStart recap via native hooks | extend `native_hooks.py` SessionStart to inject bounded recap | **CONDITIONAL-GO** | token budget; Top-3; authority labels; **no semantic fusion** |
+| **TP-MCF-005** — Semantic memory projection (fork) | (1) real derived dope-context `memory_{hash}` + `index/search_memory` **(needs ADR + local/privacy-safe embedding)**, OR (2) keep semantic memory elsewhere and drop the dope-context claim | **NO-GO** | resolve external-embedding/privacy conflict + ADR fork first |
+| **TP-MCF-006** — ConPort graph on active runtime | implement/verify graph traversal in `docker/mcp-servers-source/conport/` | **CONDITIONAL-GO** | relationship traversal exists; `graph.neighbors` MCP + writer authority **not proven** — prove or ship relationship-query projection only |
+| **TP-MCF-007+** — Fabric orchestrator / summarizer / proactive injection | recall/recap service; LLM distillation (candidate-only, cheap-model, budgeted); proactive injection (rate/relevance/kill-switch) | **NO-GO until prior gates pass** | depends on unbuilt/unresolved pieces |
+
+**Start = TP-MCF-001** (no code), which produces the exact TP-MCF-002/003 packets. **001/002/003 must reconcile with the in-flight memory-spine roadmap work**, not fork it.
+
+---
+
+## 7. Open decisions / risks (UNKNOWNs to resolve in TP-MCF-001/002)
+
+- **Quarantine ownership** — `.dopemux/quarantine/` path vs dope-memory non-queryable table (decide in TP-MCF-002).
+- **Transcript JSONL schema/location** per harness (Claude Code vs Codex) — TP-MCF-002 spike.
+- **Candidate-decision event/schema** — `conversation.decision_candidate` + trust encoding (TP-MCF-003 blocker).
+- **Semantic projection owner + privacy-safe embedding** — external Voyage vs local backend (TP-MCF-005 fork + ADR).
+- **ConPort graph feasibility** — AGE traversal on active runtime vs relationship-query projection only.
+- **Hook→dope-memory wiring** — direct emit vs stream bridge (TP-MCF-002/003).
+- **Summarization cost** — cheap-model default + budget (TP-MCF-008).
+- **P0 reconciliation** with in-flight memory-spine work (a live hazard this session already hit).
+
+---
+
+## Governance footer
+
+**Authority used**: verified code (`capture_client.py`, `redactor.py`, `eventbus_consumer.py`, dope-context `workspace.py`, `native_hooks.py`, active ConPort routes), 2× external design audit (claims re-verified against code), Memory Trinity ADRs, DCP provenance model. **Validation**: design/analysis only — **no code changed, live behavior NOT_RUN.** **Status**: planning baseline; TP-MCF-001 next (no runtime change), producing the 002/003 packets. **Rollback**: delete this file.

--- a/claudedocs/memory-context-fabric-interfaces-2026-07-04.md
+++ b/claudedocs/memory-context-fabric-interfaces-2026-07-04.md
@@ -1,0 +1,131 @@
+# Memory Context Fabric — Interfaces & Data Contracts
+
+**Date**: 2026-07-04 · **Status**: DESIGN (fold-in artifact) · **Companion to**: `memory-context-fabric-design-2026-07-04.md` (v3 design spec), `tp-mcf-001-authority-map-2026-07-04.md` (current-runtime truth).
+**Purpose**: define the Context Fabric as a **bounded subsystem** — its public surface, data schemas, plane-interaction contracts, and invariants — so it can be folded into a larger dopemux architecture with clear boundaries. This is contract-level design; it names interfaces, not implementations.
+
+---
+
+## 0. Subsystem summary (one-paragraph fold-in)
+
+The **Memory Context Fabric** is a coordination subsystem that makes the three Memory Trinity planes (dope-memory = chronicle, ConPort = decisions, dope-context = retrieval) behave as one implicit memory. It **captures** everything the developer and agents do (conversation transcripts + lifecycle hooks), **routes** it through redaction/dedup into the planes via their canonical writers, and **assembles + injects** relevant context back into sessions. It owns no truth: it is a canonical-writer *client*, a cross-plane *reader/assembler*, and a hook/injection *coordinator*. Its dependencies are the three planes, the Redis event bus, and the native-hook substrate. Its consumers are agent sessions (Claude Code / Codex) that emit events and receive context.
+
+---
+
+## 1. Public surface (what consumers use)
+
+### 1.1 MCP tools (retrieval — read side)
+
+| Tool | Signature | Returns | Notes |
+|---|---|---|---|
+| `context.recall` | `(query: str, k?: int=3, modalities?: [temporal\|structural\|semantic], workspace_id?: str)` | `ContextBundle` | fuses whichever modalities are built; degrades gracefully |
+| `context.recap` | `(hours_back?: int=24, k?: int=3, workspace_id?: str)` | `ContextBundle` | session-continuity recap (chronicle + open decisions) |
+
+Both are **read-only** and **token-budgeted**. Neither writes to any plane.
+
+### 1.2 Capture entry (write side — not a user tool)
+
+Capture is **ambient**, not invoked: it runs as (a) a transcript-file watcher and (b) native-hook handlers. Both funnel to the existing spine `dope_memory.capture_client.emit_capture_event(event: CaptureEnvelope, *, mode, repo_root, emit_event_bus)`. There is no public "write memory" tool; operators may still escalate explicitly via `/decision`, `/caveat`, `/save`.
+
+### 1.3 Injection (hook output — not a tool)
+
+The Fabric's SessionStart hook contributes a `ContextBundle` to the session's injected context (via `system-reminder`), alongside the existing MCP-health/orchestrator/workflow injections. Phase-2 proactive injection surfaces additional bundles mid-session under rate/relevance gates.
+
+---
+
+## 2. Data contracts (schemas)
+
+### 2.1 `CaptureEnvelope` (normalized event — capture input)
+
+```
+CaptureEnvelope {
+  event_id:      str        # deterministic content hash (type|session|ts_bucket|payload); REQUIRED-stable
+  ts:            str (ISO)  # SOURCE timestamp — REQUIRED for transcript events (no now() fallback)
+  session_id:    str|null
+  workspace_id:  str        # per-worktree scope
+  instance_id:   str
+  type:          str        # event type (see 2.2)
+  source:        str        # "transcript" | "claude_hook" | "cli" | "mcp" | "conport" (receipt) | ...
+  payload:       object     # REDACTED before storage
+}
+```
+Storage: `dope-memory.raw_activity_events` (raw, TTL). Redis fan-out envelope adds `data = stable_json(payload)` on stream `activity.events.v1`.
+
+### 2.2 Event-type taxonomy
+
+- **Promotable** (reach the curated chronicle; allowlist duplicated in `capture_client.py` + `promotion.py` — keep synced):
+  `decision.logged`, `task.completed`, `task.failed`, `task.blocked`, `error.encountered`, `workflow.phase_changed`, `manual.memory_store`, **`conversation.decision_candidate`** (new, trust-lower).
+- **Non-promotable** (raw ledger only, TTL): `session.*`, `file.*`, `tool.*`, transcript turn events, hook activity.
+- **Quarantined** (redaction-failure safety artifact; never promoted/searched/projected): transcript turns whose redaction failed.
+
+### 2.3 `PromotedEntry` (curated chronicle — `work_log_entries`)
+
+```
+PromotedEntry {
+  ...core fields...
+  category, entry_type, outcome, importance_score
+  source_event_id, source_event_type, source_adapter, source_event_ts_utc, promotion_rule   # provenance chain
+  details_json:  object     # trust lives here — NO dedicated `trust` column exists
+                            # candidate decisions: details_json.trust="conversation-derived",
+                            #                      promotion_rule="conversation_candidate_v1"
+}
+```
+
+### 2.4 `ContextBundle` (retrieval/injection output)
+
+```
+ContextBundle {
+  items: [ ContextItem ]
+  token_cost: int           # enforced <= budget
+  truncated: bool
+  workspace_id: str
+}
+ContextItem {
+  content:        str
+  source_system:  "dope-memory" | "conport" | "dope-context"
+  authority_label:"canonical" | "mirror" | "derived" | "conversation-inferred"
+  trust:          "high" | "conversation-derived"
+  freshness:      str (ISO)
+  provenance:     { source_event_id?, decision_id?, ... }
+}
+```
+Every item is authority-labeled so a consuming agent knows what to trust. A conversation-inferred item never outranks a canonical one.
+
+---
+
+## 3. Plane-interaction contracts (what the Fabric calls; never bypasses canonical writers)
+
+| Plane | Fabric calls (client) | Fabric NEVER does |
+|---|---|---|
+| **dope-memory** | `emit_capture_event()` (raw + promotion); recap/search reads; **quarantine writer** (own adapter, non-queryable artifact) | write `work_log_entries` directly; bypass the spine |
+| **ConPort** | `log_decision(..., provenance=conversation-derived)` **only via an explicit gate**; read relationship traversal (`GET /api/workspace-relationships`) | auto-write decisions from conversation; treat `graph.neighbors` as present (it is dead code — see TP-MCF-006) |
+| **dope-context** | (target) `index_memory`/`search_memory` on a **derived** `memory_{hash}` collection — **UNKNOWN until built**; read `search_code`/`docs_search` | send **raw transcript** to external embedding (Voyage); treat semantic memory as present today |
+| **Redis event bus** | publish/consume for capture→promotion transport | treat transport as authority |
+| **native hooks** | assemble + inject `ContextBundle` at SessionStart (+ proactive later) | assume current `dopemux:events` pings feed the chronicle (they don't — wrong stream) |
+
+---
+
+## 4. Invariants (contract tests — the subsystem's guarantees)
+
+1. **No plane-internal imports** — the Fabric package imports no plane's storage internals (structural test).
+2. **Canonical-writer-only writes** — every Fabric write goes through a plane's canonical writer; no fourth store.
+3. **Fail-closed redaction** — transcript redaction failure → quarantine, never the queryable ledger (test: no secret reaches the ledger).
+4. **Replay-safe capture** — deterministic `event_id` + `INSERT OR IGNORE`; transcript ingest **rejects missing source timestamps** (test: re-ingest idempotent).
+5. **Provenance only lowers trust** — conversation-derived items are trust-lower; labels never elevate.
+6. **Token budget** — every `ContextBundle` respects the budget (test).
+7. **Graceful degradation** — an unbuilt modality is omitted, never faked.
+8. **Locality** — raw transcript content never leaves local storage for an external embedding provider without redaction + approval + policy.
+
+---
+
+## 5. Dependencies & scoping (fold-in wiring)
+
+- **Depends on**: dope-memory (`capture_client`, promotion, recap), ConPort (active Docker runtime: decision write + relationship traversal), dope-context (code/docs retrieval today; a derived memory projection to build), Redis (`activity.events.v1`), native hooks (`native_hooks.py` SessionStart), the redactor.
+- **Scope**: per-worktree (`workspace_id` = worktree). Chronicle ledger `.dopemux/chronicle.sqlite`; quarantine `.dopemux/quarantine/…`; Qdrant `memory_{hash}` (when built). Optional cross-worktree rollup (`global_rollup.py`).
+- **Relation to other subsystems**: sibling to the **DCP read-only facade** (which projects *outbound* to external LLMs) — the Fabric is *inbound + local*. Reuses DCP's provenance/trust model and the fleet-audit "orchestrate, don't own" pattern.
+- **Not owned by the Fabric**: any canonical truth, decision/graph/PM/retrieval authority, or a new datastore.
+
+---
+
+## Governance footer
+
+**Authority used**: the v3 design spec + TP-MCF-001 authority map (both file:line-grounded in the active runtime), Memory Trinity ADRs, DCP provenance model. **Validation**: contract-level design only — **no code, live behavior NOT_RUN**; the `index_memory`/`memory_{hash}` and `graph.neighbors` surfaces are explicitly marked UNKNOWN/dead per TP-MCF-001. **Rollback**: delete this file.

--- a/claudedocs/plans/2026-07-04-memory-context-fabric-build-plan.md
+++ b/claudedocs/plans/2026-07-04-memory-context-fabric-build-plan.md
@@ -1,0 +1,120 @@
+# Memory Context Fabric — Master Build Plan
+
+> **For agentic workers:** This is the entry point. Pick up ONE packet plan at a time, in dependency order. Each packet plan is self-contained (exact files, complete code, TDD steps, commits) — REQUIRED SUB-SKILL where available: `superpowers:subagent-driven-development` or `superpowers:executing-plans`. If you have neither, execute the packet plan's checkbox steps literally, in order, committing where the plan says to commit.
+
+**Goal:** Build the Memory Context Fabric — the subsystem that makes dopemux capture everything (including conversation history) and inject the needed context into sessions implicitly — as a sequence of independently shippable, test-gated packets.
+
+**Architecture:** A coordination layer over the Memory Trinity (dope-memory = chronicle, ConPort = decisions, dope-context = retrieval). The Fabric is a canonical-writer *client* and cross-plane *reader* — it owns no truth, no storage, no fourth datastore. Capture flows transcript-files + hooks → redact → dedup → route into the existing `capture_client` spine; retrieval/injection assembles authority-labeled, token-budgeted bundles back into sessions.
+
+**Tech stack:** Python 3.12 (`mise exec -- python`), SQLite (chronicle ledger), pytest (`tests/unit/`), click CLI, existing dope-memory capture spine (`src/dopemux/memory/capture_client.py`), Claude Code native hooks (`src/dopemux/claude/native_hooks.py`).
+
+## Global constraints (apply to every packet)
+
+- **Interpreter:** `mise exec -- python` (3.12) — never the system python3.
+- **Authority docs (the spec — read before building):** `claudedocs/memory-context-fabric-design-2026-07-04.md` (v3), `claudedocs/memory-context-fabric-interfaces-2026-07-04.md`, `claudedocs/tp-mcf-001-authority-map-2026-07-04.md`. Runtime code outranks docs; if they conflict, report it, don't silently choose.
+- **Boundary invariant:** Fabric code never imports a plane's storage internals; every write goes through a canonical writer (`emit_capture_event`, ConPort API, dope-context indexer). No new datastore.
+- **Never break the session:** all capture/injection failure paths are fail-open for the user's session, and logged — never silently "succeeded".
+- **Hermetic tests:** ledger via `DOPEMUX_CAPTURE_LEDGER_PATH` → `tmp_path`; no Docker, no Redis, no network in unit tests.
+- **Proof per packet (AGENTS.md discipline):** `git status` before/after, `git diff --stat`, test outputs with exit codes, and the packet's own proof-gate checklist. Report PASS / FAIL / NOT_RUN honestly.
+- **Branch:** work on/off `claude/memory-context-fabric`; PR to `main` per packet (one packet = one PR).
+
+---
+
+## Dependency graph & sequencing
+
+```
+TP-MCF-001 (DONE — authority map, no code)
+    │
+    ▼
+TP-MCF-002  transcript ingest → raw ledger only          [BUILD NOW — plan ready]
+    │
+    ▼
+TP-MCF-003  conversation.decision_candidate + promotion   [BUILD NOW — plan ready]
+    │
+    ▼
+TP-MCF-004  SessionStart recap injection                  [BUILD NOW — plan ready]
+    │                     (independent of 002/003 at code level; sequenced after
+    │                      so the recap has real chronicle content to show)
+    ├──────────────┬──────────────────────┐
+    ▼              ▼                      │
+TP-MCF-005      TP-MCF-006                │   [DECISION FORKS — do not build until decided]
+semantic mem    ConPort graph             │
+    │              │                      │
+    └──────┬───────┘                      │
+           ▼                              │
+TP-MCF-007  Fabric orchestrator + context.recall/recap ◄──┘  [BLOCKED on 002-004; 005/006 optional modalities]
+           ▼
+TP-MCF-008  summarization worker (LLM, candidate-only)       [BLOCKED on 003+007]
+           ▼
+TP-MCF-009  proactive mid-session injection                  [BLOCKED on 007; kill-switch mandatory]
+```
+
+## Packet index
+
+| Packet | Status | Plan / spec location |
+|---|---|---|
+| TP-MCF-001 | **DONE** | `claudedocs/tp-mcf-001-authority-map-2026-07-04.md` |
+| TP-MCF-002 | **READY TO BUILD** | `claudedocs/plans/2026-07-04-tp-mcf-002-transcript-ingest.md` |
+| TP-MCF-003 | **READY TO BUILD** (after 002 merges) | `claudedocs/plans/2026-07-04-tp-mcf-003-deterministic-promotion.md` |
+| TP-MCF-004 | **READY TO BUILD** (parallel-safe with 003) | `claudedocs/plans/2026-07-04-tp-mcf-004-sessionstart-recap.md` |
+| TP-MCF-005 | **DECISION REQUIRED** — see fork below | this document, §Fork 005 |
+| TP-MCF-006 | **DECISION REQUIRED** — see fork below | this document, §Fork 006 |
+| TP-MCF-007..009 | **BLOCKED** — scoped stubs below | this document, §Deferred packets |
+
+---
+
+## Fork 005 — semantic memory projection (decide before building)
+
+**Question:** where does semantic (similarity) memory live?
+
+**Option A — derived dope-context `memory_{hash}` projection.**
+Scope if chosen: new per-worktree Qdrant collection `memory_{hash}` beside `code_{hash}`/`docs_{hash}` (`services/dope-context/src/utils/workspace.py:164-182`); new `index_memory`/`search_memory` MCP tools; indexer consumes *curated chronicle entries and ConPort decisions only* (never raw transcript); every vector payload carries `{source_system, authority_label, provenance}`.
+Prerequisites: **(1) an ADR** amending dope-context's read-only code/docs charter to permit a *derived, non-canonical* memory projection; **(2) the privacy gate** — dope-context embeds via Voyage (external cloud: `indexing_pipeline.py:285-300,580`), so conversation-derived content requires either a local embedding backend for the memory collection or explicit redaction+approval+policy. Raw transcript is never embedded externally, full stop.
+Cost: Medium-Large (new collection lifecycle, 2 tools, indexer wiring, ADR).
+
+**Option B — no dope-context involvement.**
+Scope if chosen: drop the semantic modality; `context.recall` runs on temporal (chronicle) + structural (ConPort relationships) only; delete the `memory_{hash}` claims from the design docs; also delete or fix the dead `_index_in_dopecontext` painted socket (`eventbus_consumer.py:716-745`).
+Cost: Small (doc edits + one dead-code removal).
+
+**Recommendation:** A, *after* 002–004 prove the capture pipeline in practice — the recall quality gap between temporal-only and temporal+semantic is the strongest argument, but it's only measurable once the chronicle has content. Decide with data.
+
+## Fork 006 — ConPort graph exposure (decide before building)
+
+**Question:** implement graph traversal MCP tools on the **active** Docker ConPort, or settle for the existing HTTP relationship endpoint?
+
+**Option A — implement `graph.neighbors` + genealogy on the active runtime.**
+Scope if chosen: port the traversal *concepts* (not the code) from dead `src/conport/memory_server.py` / quarantined `services/conport_kg/` into `docker/mcp-servers-source/conport/enhanced_server.py`'s dispatch map (14 tools today, `:1757-1774`); tools: `conport_graph_neighbors(item_id, rel_types?, depth<=2, limit<=10)`, `conport_decision_genealogy(decision_id)`; requires proving the AGE graph tables are populated and the relationship *writer* path works (authority map flags writer authority as unproven).
+Cost: Medium — plus a real risk the AGE data layer needs repair first.
+
+**Option B — relationship-query projection only.**
+Scope if chosen: the Fabric's structural modality calls the existing `GET /api/workspace-relationships` (`enhanced_server.py:266,2125`) and stops there; no new ConPort tools.
+Cost: Zero new ConPort work; bounded structural recall.
+
+**Recommendation:** B for the first Fabric release (007), upgrade to A only if genealogy queries prove wanted. Nothing in 007 hard-depends on A.
+
+---
+
+## Deferred packets (scoped stubs — do not build yet)
+
+**TP-MCF-007 — Fabric orchestrator + `context.recall`/`context.recap` MCP surface.** The coordinating service: retrieval-fusion over whichever modalities exist (temporal always; structural per Fork 006; semantic per Fork 005), returning `ContextBundle` per the interfaces doc §2.4; graceful degradation (unbuilt modality omitted, never faked); single-point token budgeting; the no-plane-internals contract test. Blocked on 002–004 merged. Plan to be written when unblocked.
+
+**TP-MCF-008 — summarization worker.** Async LLM distillation of transcript turns → curated chronicle entries + `conversation.decision_candidate`s (candidate-only, never auto-ConPort). Cheap-model default per the model-routing policy; explicit cost/rate budget; builds on 003's schema. Blocked on 003+007.
+
+**TP-MCF-009 — proactive mid-session injection.** Relevance-gated, rate-limited, kill-switched context surfacing via hooks. The largest UX blast radius — last deliberately. Blocked on 007.
+
+---
+
+## Hand-off protocol for external agents (Codex / Grok / Antigravity)
+
+1. **Read** the three authority docs (Global constraints above), then the ONE packet plan you're executing. Do not read ahead into other packets' scope.
+2. **Verify the worktree**: `git status` clean (except `.claude/claude_config.json`, a known machine-local artifact), branch off `claude/memory-context-fabric` or `main` post-merge.
+3. **Execute the packet plan's tasks in order** — each task is test-first with explicit commands and expected outputs; commit exactly where the plan says.
+4. **Never expand scope**: if the plan conflicts with runtime code, STOP and report the conflict (runtime outranks plan); do not improvise contract changes (schemas, allowlists, event shapes are contract-sensitive surfaces).
+5. **Produce the proof bundle**: diff stat, test outputs + exit codes, the packet's proof-gate checklist, residual risks, rollback (revert the packet's commits).
+6. **One packet = one PR** to `main`, titled `feat(memory): TP-MCF-00X — <packet name>`.
+
+### Orchestrator loading (optional, deferred)
+These plans are deliberately *files, not orchestrator items*: the chain is sequential, so orchestrator coordination adds cost without parallelism. If the operator later fans out to multiple workers, generate task-orchestrator work-items from the packet index table (one item per packet, `depends_on` per the dependency graph) in a single cheap session — the plans themselves remain the source of truth.
+
+## Governance footer
+**Validation:** planning artifact only — no code changed. Plans for 002/003/004 are separately authored and self-reviewed against the v3 spec + authority map. **Rollback:** delete `claudedocs/plans/`.

--- a/claudedocs/plans/2026-07-04-tp-mcf-002-transcript-ingest.md
+++ b/claudedocs/plans/2026-07-04-tp-mcf-002-transcript-ingest.md
@@ -1,0 +1,1548 @@
+# TP-MCF-002 — Transcript Ingest → Raw Ledger Only — Implementation Plan
+
+> **For agentic workers:** Execute this plan task-by-task via superpowers:subagent-driven-development or superpowers:executing-plans if available; otherwise execute the checkbox (`- [ ]`) steps literally, in order, committing exactly where the plan says. Read the master plan first: `claudedocs/plans/2026-07-04-memory-context-fabric-build-plan.md` (global constraints + hand-off protocol).
+**Packet**: TP-MCF-002 (Memory Context Fabric, phase 002)
+**Date**: 2026-07-04
+**Status**: READY TO BUILD (spec-derived; all invariants test-gated below)
+**Authority**: `claudedocs/memory-context-fabric-design-2026-07-04.md` (v3, esp. §2, §5, §6 row TP-MCF-002), `claudedocs/tp-mcf-001-authority-map-2026-07-04.md` (§1 Domain A, §3 gap register, §4 TP-MCF-002 spec), `claudedocs/memory-context-fabric-interfaces-2026-07-04.md` (§2.1 CaptureEnvelope, §2.2 taxonomy, §4 invariants).
+
+---
+
+## 0. Header block — read this before writing any code
+
+**Goal**: build a transcript-file ingest adapter that parses Claude Code session transcript JSONL into turn events and writes **only** to the dope-memory raw ledger (`raw_activity_events`) via `capture_client.emit_capture_event()`. No ConPort writes. No dope-context writes. No Redis requirement. No file-watcher daemon (that is a later packet — this ships the one-shot, re-runnable ingest primitive).
+
+**Architecture**: one new pure-function module (`src/dopemux/memory/transcript_ingest.py`) plus one new CLI subcommand (`dopemux memory ingest-transcript <path>`) added to the *existing* `memory` Click group in `src/dopemux/commands/memory_commands.py`. The module calls the existing capture spine (`dopemux.memory.capture_client.emit_capture_event`) directly — it does not reimplement redaction, dedup, or ledger writes. It adds one new local safety artifact: a quarantine directory `.dopemux/quarantine/transcript/`.
+
+**Tech stack**: Python 3.12 (repo interpreter: `mise exec -- python`), stdlib `json`/`pathlib`/`hashlib`/`dataclasses`, pytest for tests, Click for the CLI subcommand (matches the existing `memory` group's framework).
+
+**Global constraints (apply to every task below)**:
+- Always run Python via `mise exec -- python` (this repo pins 3.12; harness `python3` is 3.9.6 and will not satisfy type-hint syntax used here, e.g. `str | None`).
+- Always run tests via `mise exec -- python -m pytest <path> -v` from the repo root. Targeted paths only — do not run the full suite until the final task.
+- **Editable-install trap for manual CLI smoke tests**: this workspace's `dopemux` package may be `pip install -e`'d against a *different* checkout (e.g. the main repo, not this worktree) — `mise exec -- python -c "import dopemux.cli"` can silently resolve code from the wrong tree. `pytest` avoids this (it inserts the worktree's `tests/`+`src/` onto `sys.path` via rootdir detection), so the pytest commands in this plan are trustworthy as written. If you manually smoke-test the CLI outside pytest (e.g. `python -m dopemux.cli memory ingest-transcript --help`), prefix with `PYTHONPATH=src` from the repo root to force worktree-local resolution, and verify with `python -c "import dopemux.commands.memory_commands as m; print(m.__file__)"` that the printed path is under *this* worktree before trusting the output.
+- Every test that touches the ledger MUST set `DOPEMUX_CAPTURE_LEDGER_PATH` to a `tmp_path`-derived file (via `monkeypatch.setenv`) — this is the existing hermetic-ledger convention used throughout `tests/unit/test_memory_capture_client.py`. Never let a test touch the real repo `.dopemux/chronicle.sqlite`.
+- Every test that touches quarantine MUST write into a `tmp_path`-derived directory, never the real repo `.dopemux/quarantine/`.
+- `repo_root=` passed to `emit_capture_event` in tests should be the real repo root (`Path(__file__).resolve().parents[2]` from `tests/unit/`, matching the existing `REPO_ROOT` constant pattern in `test_memory_capture_client.py`) so the WMA schema/migrations/redactor loaders resolve correctly — the ledger *location* is what `DOPEMUX_CAPTURE_LEDGER_PATH` overrides, not the schema/redactor source.
+- TDD discipline per task: write the failing test → run it and confirm it fails for the right reason → write the minimal implementation → run again and confirm it passes → commit. Do not write implementation before seeing the red test.
+- Do not modify `capture_client.py`, `redactor.py`, `promotion.py`, or `PROMOTABLE_CAPTURE_EVENT_TYPES`. This packet is additive only. `transcript.*` event types are **non-promotable** (raw-ledger-only) and must never be added to any promotable allowlist.
+- Codex transcript support is **out of scope**. This packet targets Claude Code's on-disk JSONL transcript format only.
+- A file-watcher daemon is **out of scope**. This packet delivers a one-shot, idempotent, re-runnable `ingest_transcript_file()` — the primitive that a future watcher will call per-line.
+
+**File-level scope for this packet** (nothing else should change):
+- Create: `src/dopemux/memory/transcript_ingest.py`
+- Create: `tests/unit/test_transcript_ingest.py`
+- Create: `tests/unit/test_cli_memory_ingest_transcript.py`
+- Modify: `src/dopemux/commands/memory_commands.py` (append one new `@memory.command`)
+- Do NOT modify: `src/dopemux/cli.py` (the `memory` group is already registered at `cli.py:3219-3221`; no new registration needed), `src/dopemux/memory/capture_client.py`, `services/working-memory-assistant/promotion/redactor.py`, `services/working-memory-assistant/promotion/promotion.py`.
+
+---
+
+## 1. Task 1 — Transcript format spike (no code; produces the parse contract)
+
+This task is research, not implementation. It exists because the design spec (§7 "Open decisions / risks") flags the transcript JSONL schema/location as an unresolved spike, and the authority map (§4 TP-MCF-002) requires it be done first. Do not skip it and do not guess the schema — verify it.
+
+### 1.1 Locate the transcript file
+
+Claude Code writes session transcripts under `~/.claude/projects/<project-slug>/<session-uuid>.jsonl`. The `<project-slug>` derivation is **not a simple `/`→`-` substitution** — do not hardcode a transform in shipped code (the CLI takes an explicit file path argument, so this is spike-only discovery, never runtime logic). Find the directory by listing and grepping for your repo name:
+
+```bash
+ls ~/.claude/projects/ | grep -i "$(basename "$(git rev-parse --show-toplevel)" | tr '[:upper:]' '[:lower:]')"
+```
+
+Expected output: one or more directory names containing your repo's basename (e.g. `-Users-hue-code-dopemux-mvp`). Pick the directory that matches your actual working tree (main repo root, not a worktree subpath, unless you are actively in a worktree session with its own recorded transcripts).
+
+Then list transcript files in that directory, newest first:
+
+```bash
+ls -t ~/.claude/projects/<matched-dir>/*.jsonl | head -5
+```
+
+Expected output: one or more `<uuid>.jsonl` files, most-recently-modified first.
+
+### 1.2 Inspect the schema
+
+Pick the most recent non-empty file and inspect the first several lines:
+
+```bash
+FILE=$(ls -t ~/.claude/projects/<matched-dir>/*.jsonl | head -1)
+wc -l "$FILE"
+sed -n '1p' "$FILE" | mise exec -- python -m json.tool
+sed -n '2p' "$FILE" | mise exec -- python -m json.tool
+sed -n '3p' "$FILE" | mise exec -- python -m json.tool
+```
+
+**Do not** pipe multiple lines through `python -m json.tool` at once (`head -3 "$FILE" | python -m json.tool`) — each line is a separate top-level JSON object, and `json.tool` only parses a single JSON document, so multi-line input raises `Extra data: line 2 column 1`. Inspect one line per invocation, or use the script below.
+
+To see the full distribution of record shapes in the file, run this one-off (not committed) diagnostic:
+
+```bash
+mise exec -- python -c "
+import json
+types = {}
+with open('$FILE') as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        t = obj.get('type', '<none>')
+        types[t] = types.get(t, 0) + 1
+print(types)
+"
+```
+
+**Record the observed schema in your plan-execution notes** (a scratch note, PR description, or task-orchestrator note — not a new committed doc). At minimum record: the set of top-level `type` values seen, and for `type in {"user", "assistant"}` the shape of the `message` field.
+
+### 1.3 The verified schema (baseline — confirm it still holds for your transcript, note any drift)
+
+This is what was observed against a real 660-line Claude Code transcript at plan-authoring time. Treat it as the baseline; if your `type` distribution differs meaningfully, note the drift before proceeding — the parser in Task 2 is built against this shape.
+
+Top-level record `type` values seen: `queue-operation`, `attachment`, `user`, `last-prompt`, `assistant`, `system`, `pr-link`, `mode`. Only `user` and `assistant` carry conversation turns; everything else is harness bookkeeping and must be skipped.
+
+**`type: "user"` record** (fields relevant to parsing):
+```json
+{
+  "type": "user",
+  "isMeta": false,
+  "message": {
+    "role": "user",
+    "content": "<command-message>review</command-message>\n<command-name>/review</command-name>..."
+  },
+  "sessionId": "6e030b42-66a3-46e3-9588-f1c3cceb683f",
+  "timestamp": "2026-07-05T04:22:54.799Z",
+  "uuid": "8c9d1f8a-48f7-4437-95e7-aa9a1440006c"
+}
+```
+`message.content` for a `user` record is **either a plain string** (the common case — human prompt text, sometimes wrapped in `<command-message>`/`<task-notification>` tags by the harness) **or a list** of content items, one of which may be `{"type": "tool_result", "tool_use_id": ..., "content": ...}` (a tool result reported back as a user-role turn — this is how Claude Code's transcript format represents tool results, not a separate top-level `type`).
+
+**`type: "assistant"` record**:
+```json
+{
+  "type": "assistant",
+  "message": {
+    "role": "assistant",
+    "content": [
+      {"type": "thinking", "thinking": "...", "signature": "..."},
+      {"type": "tool_use", "id": "toolu_01Bdgx5jH9xquXjydWLMMgJa", "name": "Bash",
+       "input": {"command": "gh pr list ...", "description": "List open PRs"}}
+    ]
+  },
+  "sessionId": "6e030b42-66a3-46e3-9588-f1c3cceb683f",
+  "timestamp": "2026-07-05T04:23:00.362Z",
+  "uuid": "67867dfb-8e2b-4b4a-a3e9-0e29c5b4ec9b"
+}
+```
+`message.content` for an `assistant` record is always a list of content items: `thinking`, `text`, and/or `tool_use`. A single assistant line commonly carries both prose (`text`) and one or more `tool_use` items.
+
+Records with `isMeta: true` are harness-synthesized user turns (task notifications, command echoes) — some are legitimate conversation, but per this packet's scope they are treated the same as ordinary user turns (not specially filtered) **except** malformed/unparseable ones, which fail open to `skipped`. (A future packet may choose to exclude `isMeta` turns from promotion — out of scope here; this packet is raw-ledger-only.)
+
+### 1.4 The parse contract (locked — do not redesign in Task 2)
+
+`TranscriptTurn` has exactly these fields:
+
+| Field | Type | Source | Notes |
+|---|---|---|---|
+| `turn_type` | `str` | derived | one of `"user_prompt"`, `"assistant_response"`, `"tool_call"`, `"tool_result"` |
+| `ts` | `str \| None` | `timestamp` | **REQUIRED to emit** — `None` means the record is quarantined, never ingested with `now()` |
+| `session_id` | `str \| None` | `sessionId` | |
+| `content` | `Any` | `message.content` | preserved **losslessly** (string or list) — no per-tool splitting in this packet |
+
+**Turn-type classification is one line → at most one turn**, decided by this exact priority (verified empirically against the 660-line sample: `user_prompt=11, assistant_response=167, tool_call=92, tool_result=92`, `skipped=298`, totals reconcile):
+
+1. Top-level `type` not in `{"user", "assistant"}` → skip (return `None`).
+2. `message` missing or not a dict → skip.
+3. `message.role == "user"` AND `message.content` is a list containing any item with `type == "tool_result"` → `turn_type = "tool_result"`.
+4. `message.role == "user"` (content is a string, or a list with no `tool_result` item) → `turn_type = "user_prompt"`.
+5. `message.role == "assistant"` AND `message.content` is a list containing any item with `type == "tool_use"` → `turn_type = "tool_call"`.
+6. `message.role == "assistant"` (content has no `tool_use` item, e.g. pure `thinking`/`text`) → `turn_type = "assistant_response"`.
+7. Any other `role` value → skip.
+
+No proof-gate task is needed for this section — it is design record, verified by the Task 2 tests below.
+
+---
+
+## 2. Task 2 — `parse_transcript_line` (pure parser, no I/O)
+
+### Files
+- **Create**: `src/dopemux/memory/transcript_ingest.py`
+- **Test**: `tests/unit/test_transcript_ingest.py`
+
+### Interfaces
+- **Produces**: `TranscriptTurn` (frozen dataclass), `parse_transcript_line(line: str) -> TranscriptTurn | None`
+
+### Steps
+
+- [ ] **2.1 — Write the failing test file.**
+
+Create `tests/unit/test_transcript_ingest.py`:
+
+```python
+"""Tests for transcript-file ingest into the dope-memory raw ledger (TP-MCF-002)."""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from dopemux.memory.transcript_ingest import (
+    TranscriptTurn,
+    parse_transcript_line,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+# --- Realistic fixture lines, trimmed from an actual Claude Code transcript ---
+# Real field names verified in Task 1: type, message.role, message.content,
+# timestamp, sessionId, isMeta.
+
+USER_PROMPT_LINE = json.dumps(
+    {
+        "type": "user",
+        "isMeta": False,
+        "message": {
+            "role": "user",
+            "content": "<command-message>review</command-message>\n"
+            "<command-name>/review</command-name>\n"
+            "<command-args>open prs deeply and comment findings</command-args>",
+        },
+        "sessionId": "6e030b42-66a3-46e3-9588-f1c3cceb683f",
+        "timestamp": "2026-07-05T04:22:54.799Z",
+        "uuid": "8c9d1f8a-48f7-4437-95e7-aa9a1440006c",
+    }
+)
+
+ASSISTANT_RESPONSE_LINE = json.dumps(
+    {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "considering PRs", "signature": "sig"},
+                {"type": "text", "text": "I'll list the open PRs now."},
+            ],
+        },
+        "sessionId": "6e030b42-66a3-46e3-9588-f1c3cceb683f",
+        "timestamp": "2026-07-05T04:23:00.362Z",
+        "uuid": "67867dfb-8e2b-4b4a-a3e9-0e29c5b4ec9b",
+    }
+)
+
+TOOL_CALL_LINE = json.dumps(
+    {
+        "type": "assistant",
+        "message": {
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "toolu_01Bdgx5jH9xquXjydWLMMgJa",
+                    "name": "Bash",
+                    "input": {
+                        "command": "gh pr list --state open --json number,title",
+                        "description": "List open PRs",
+                    },
+                }
+            ],
+        },
+        "sessionId": "6e030b42-66a3-46e3-9588-f1c3cceb683f",
+        "timestamp": "2026-07-05T04:23:01.981Z",
+        "uuid": "05bf6989-d0a7-4fb0-af45-7e435a8d9a4e",
+    }
+)
+
+TOOL_RESULT_LINE = json.dumps(
+    {
+        "type": "user",
+        "isMeta": False,
+        "message": {
+            "role": "user",
+            "content": [
+                {
+                    "tool_use_id": "toolu_01Bdgx5jH9xquXjydWLMMgJa",
+                    "type": "tool_result",
+                    "content": '[{"number":1008,"title":"Harden Serena F001"}]',
+                }
+            ],
+        },
+        "sessionId": "6e030b42-66a3-46e3-9588-f1c3cceb683f",
+        "timestamp": "2026-07-05T04:23:03.584Z",
+        "uuid": "46727f0c-d90a-4e44-aed6-782a07b8de9a",
+    }
+)
+
+NON_TURN_ATTACHMENT_LINE = json.dumps(
+    {
+        "type": "attachment",
+        "attachment": {"type": "hook_success", "hookName": "SessionStart:startup"},
+        "sessionId": "6e030b42-66a3-46e3-9588-f1c3cceb683f",
+        "timestamp": "2026-07-05T04:22:53.476Z",
+        "uuid": "52e9791c-560a-4129-bb80-9ef2cc44a542",
+    }
+)
+
+QUEUE_OP_LINE = json.dumps(
+    {
+        "type": "queue-operation",
+        "operation": "enqueue",
+        "timestamp": "2026-07-05T04:22:53.878Z",
+        "sessionId": "6e030b42-66a3-46e3-9588-f1c3cceb683f",
+    }
+)
+
+MISSING_TS_LINE = json.dumps(
+    {
+        "type": "user",
+        "isMeta": False,
+        "message": {"role": "user", "content": "no timestamp on this one"},
+        "sessionId": "6e030b42-66a3-46e3-9588-f1c3cceb683f",
+        "uuid": "no-ts-0001",
+    }
+)
+
+
+def test_parse_user_prompt_line():
+    turn = parse_transcript_line(USER_PROMPT_LINE)
+    assert turn is not None
+    assert turn.turn_type == "user_prompt"
+    assert turn.ts == "2026-07-05T04:22:54.799Z"
+    assert turn.session_id == "6e030b42-66a3-46e3-9588-f1c3cceb683f"
+    assert "/review" in turn.content
+
+
+def test_parse_assistant_response_line():
+    turn = parse_transcript_line(ASSISTANT_RESPONSE_LINE)
+    assert turn is not None
+    assert turn.turn_type == "assistant_response"
+    assert turn.ts == "2026-07-05T04:23:00.362Z"
+    assert isinstance(turn.content, list)
+
+
+def test_parse_tool_call_line():
+    turn = parse_transcript_line(TOOL_CALL_LINE)
+    assert turn is not None
+    assert turn.turn_type == "tool_call"
+    assert turn.ts == "2026-07-05T04:23:01.981Z"
+
+
+def test_parse_tool_result_line():
+    turn = parse_transcript_line(TOOL_RESULT_LINE)
+    assert turn is not None
+    assert turn.turn_type == "tool_result"
+    assert turn.ts == "2026-07-05T04:23:03.584Z"
+
+
+def test_parse_skips_non_turn_attachment_record():
+    assert parse_transcript_line(NON_TURN_ATTACHMENT_LINE) is None
+
+
+def test_parse_skips_queue_operation_record():
+    assert parse_transcript_line(QUEUE_OP_LINE) is None
+
+
+def test_parse_skips_blank_line():
+    assert parse_transcript_line("") is None
+    assert parse_transcript_line("   \n") is None
+
+
+def test_parse_skips_malformed_json_never_raises():
+    # Fail-open per turn: a malformed line must not raise out of the parser.
+    assert parse_transcript_line("{not valid json") is None
+
+
+def test_parse_missing_timestamp_returns_turn_with_ts_none():
+    # ts is REQUIRED to *emit*, but the parser itself must not raise or invent
+    # a timestamp — it returns a turn with ts=None so the ingest loop can
+    # quarantine it (invariant 3). The parser never calls datetime.now().
+    turn = parse_transcript_line(MISSING_TS_LINE)
+    assert turn is not None
+    assert turn.ts is None
+```
+
+- [ ] **2.2 — Run the test file and confirm it fails on import** (module doesn't exist yet):
+
+```bash
+cd /Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v
+```
+
+Expected output: `ModuleNotFoundError: No module named 'dopemux.memory.transcript_ingest'` (collection error, all tests error out).
+
+- [ ] **2.3 — Write the minimal implementation.**
+
+Create `src/dopemux/memory/transcript_ingest.py`:
+
+```python
+"""Transcript-file ingest adapter (TP-MCF-002).
+
+Parses Claude Code session transcript JSONL into TranscriptTurn records and
+writes them to the dope-memory raw ledger (`raw_activity_events`) via the
+existing capture spine — `dopemux.memory.capture_client.emit_capture_event`.
+
+Hard invariants (see claudedocs/tp-mcf-001-authority-map-2026-07-04.md §4 and
+claudedocs/memory-context-fabric-interfaces-2026-07-04.md §4):
+  1. No ConPort writes, no dope-context writes, no Redis requirement in this
+     module. This module imports neither `conport` nor `dope_context`.
+  2. A turn without a source timestamp is NEVER ingested with `datetime.now()`
+     — it is quarantined instead.
+  3. Redaction failure (the WMA redactor's fail-closed sentinel) routes the
+     turn to quarantine, never the queryable ledger.
+  4. Ingest is idempotent: re-running against the same file produces the same
+     ledger row count (deterministic event_id + INSERT OR IGNORE, inherited
+     from capture_client).
+  5. Fail-open per turn: a malformed line increments `skipped`, never raises
+     out of `ingest_transcript_file`.
+
+Codex transcript support and a file-watcher daemon are explicitly OUT OF
+SCOPE for this module — see the plan this module was built from.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+from .capture_client import (
+    _deterministic_event_id,
+    _load_wma_redactor,
+    emit_capture_event,
+)
+
+TRANSCRIPT_EVENT_TYPES = frozenset(
+    {
+        "transcript.user_prompt",
+        "transcript.assistant_response",
+        "transcript.tool_call",
+        "transcript.tool_result",
+    }
+)
+
+_TURN_TYPE_TO_EVENT_TYPE = {
+    "user_prompt": "transcript.user_prompt",
+    "assistant_response": "transcript.assistant_response",
+    "tool_call": "transcript.tool_call",
+    "tool_result": "transcript.tool_result",
+}
+
+
+@dataclass(frozen=True)
+class TranscriptTurn:
+    """One parsed transcript record. One line maps to at most one turn."""
+
+    turn_type: str  # user_prompt | assistant_response | tool_call | tool_result
+    ts: Optional[str]  # source timestamp; None means "no source ts observed"
+    session_id: Optional[str]
+    content: Any  # message.content, preserved losslessly (str or list)
+
+
+@dataclass(frozen=True)
+class IngestResult:
+    """Counters for one ingest_transcript_file() run."""
+
+    ingested: int
+    skipped: int
+    quarantined: int
+    duplicate: int
+
+
+def _has_content_item_type(content: Any, item_type: str) -> bool:
+    if not isinstance(content, list):
+        return False
+    return any(
+        isinstance(item, dict) and item.get("type") == item_type for item in content
+    )
+
+
+def parse_transcript_line(line: str) -> Optional[TranscriptTurn]:
+    """Parse one JSONL line into a TranscriptTurn, or None if not a turn.
+
+    Never raises: malformed JSON, missing fields, and non-turn record types
+    all return None so the caller can fail open (invariant: skipped, not
+    raised).
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    try:
+        obj = json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return None
+
+    if not isinstance(obj, dict):
+        return None
+
+    record_type = obj.get("type")
+    if record_type not in ("user", "assistant"):
+        return None
+
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return None
+
+    role = message.get("role")
+    content = message.get("content")
+
+    if role == "user":
+        turn_type = (
+            "tool_result"
+            if _has_content_item_type(content, "tool_result")
+            else "user_prompt"
+        )
+    elif role == "assistant":
+        turn_type = (
+            "tool_call"
+            if _has_content_item_type(content, "tool_use")
+            else "assistant_response"
+        )
+    else:
+        return None
+
+    ts = obj.get("timestamp")
+    if not isinstance(ts, str) or not ts:
+        ts = None
+
+    session_id = obj.get("sessionId")
+    if not isinstance(session_id, str) or not session_id:
+        session_id = None
+
+    return TranscriptTurn(
+        turn_type=turn_type,
+        ts=ts,
+        session_id=session_id,
+        content=content,
+    )
+```
+
+- [ ] **2.4 — Run the test file and confirm it passes:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v
+```
+
+Expected output: 10 tests pass (`test_parse_user_prompt_line`, `test_parse_assistant_response_line`, `test_parse_tool_call_line`, `test_parse_tool_result_line`, `test_parse_skips_non_turn_attachment_record`, `test_parse_skips_queue_operation_record`, `test_parse_skips_blank_line`, `test_parse_skips_malformed_json_never_raises`, `test_parse_missing_timestamp_returns_turn_with_ts_none`) — 9 test functions, some with multiple asserts; `9 passed`.
+
+- [ ] **2.5 — Commit.**
+
+```bash
+git add src/dopemux/memory/transcript_ingest.py tests/unit/test_transcript_ingest.py
+git commit -m "$(cat <<'EOF'
+feat(memory): add transcript-line parser for TP-MCF-002 ingest adapter
+
+Adds parse_transcript_line() — a pure, never-raising parser that turns one
+Claude Code transcript JSONL record into a TranscriptTurn (or None for
+non-turn/malformed records). Classification rule (one line -> at most one
+turn) verified empirically against a real 660-line transcript. Missing
+source timestamps are preserved as ts=None, never invented, so the ingest
+loop (next commit) can quarantine them per TP-MCF-002 invariant 3.
+EOF
+)"
+```
+
+---
+
+## 3. Task 3 — `turn_to_capture_envelope` (turn → CaptureEnvelope shape)
+
+### Files
+- **Modify**: `src/dopemux/memory/transcript_ingest.py`
+- **Test**: `tests/unit/test_transcript_ingest.py` (append)
+
+### Interfaces
+- **Consumes**: `TranscriptTurn` (from Task 2)
+- **Produces**: `turn_to_capture_envelope(turn: TranscriptTurn, workspace_id: str) -> dict`
+
+### Steps
+
+- [ ] **3.1 — Append the failing test to `tests/unit/test_transcript_ingest.py`:**
+
+```python
+from dopemux.memory.transcript_ingest import turn_to_capture_envelope
+
+
+def test_turn_to_capture_envelope_maps_fields():
+    turn = TranscriptTurn(
+        turn_type="user_prompt",
+        ts="2026-07-05T04:22:54.799Z",
+        session_id="6e030b42-66a3-46e3-9588-f1c3cceb683f",
+        content="hello world",
+    )
+    envelope = turn_to_capture_envelope(turn, workspace_id="/repo/root")
+
+    assert envelope["event_type"] == "transcript.user_prompt"
+    assert envelope["source"] == "transcript"
+    assert envelope["ts_utc"] == "2026-07-05T04:22:54.799Z"
+    assert envelope["session_id"] == "6e030b42-66a3-46e3-9588-f1c3cceb683f"
+    assert envelope["workspace_id"] == "/repo/root"
+    assert envelope["payload"] == {"content": "hello world"}
+
+
+def test_turn_to_capture_envelope_maps_all_turn_types():
+    for turn_type, expected_event_type in [
+        ("user_prompt", "transcript.user_prompt"),
+        ("assistant_response", "transcript.assistant_response"),
+        ("tool_call", "transcript.tool_call"),
+        ("tool_result", "transcript.tool_result"),
+    ]:
+        turn = TranscriptTurn(
+            turn_type=turn_type,
+            ts="2026-07-05T04:23:00.000Z",
+            session_id="sess-1",
+            content=[{"type": "text", "text": "x"}],
+        )
+        envelope = turn_to_capture_envelope(turn, workspace_id="/repo/root")
+        assert envelope["event_type"] == expected_event_type
+```
+
+- [ ] **3.2 — Run and confirm failure:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v -k turn_to_capture_envelope
+```
+
+Expected output: `ImportError: cannot import name 'turn_to_capture_envelope'`.
+
+- [ ] **3.3 — Add the function to `src/dopemux/memory/transcript_ingest.py`** (insert after `parse_transcript_line`):
+
+```python
+def turn_to_capture_envelope(turn: TranscriptTurn, workspace_id: str) -> dict[str, Any]:
+    """Map a TranscriptTurn to the CaptureEnvelope shape emit_capture_event expects.
+
+    Per the interfaces spec (§2.1): ts is the SOURCE timestamp, passed through
+    as ts_utc so emit_capture_event never falls back to datetime.now()
+    (capture_client.py:493). Callers MUST NOT call this with turn.ts is None —
+    ingest_transcript_file() quarantines those turns before reaching here.
+    """
+    event_type = _TURN_TYPE_TO_EVENT_TYPE[turn.turn_type]
+    return {
+        "event_type": event_type,
+        "source": "transcript",
+        "ts_utc": turn.ts,
+        "session_id": turn.session_id,
+        "workspace_id": workspace_id,
+        "payload": {"content": turn.content},
+    }
+```
+
+- [ ] **3.4 — Run and confirm pass:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v
+```
+
+Expected output: all previous 9 tests plus these 2 new tests pass — `11 passed`.
+
+- [ ] **3.5 — Commit.**
+
+```bash
+git add src/dopemux/memory/transcript_ingest.py tests/unit/test_transcript_ingest.py
+git commit -m "$(cat <<'EOF'
+feat(memory): map transcript turns to CaptureEnvelope shape
+
+Adds turn_to_capture_envelope() mapping TranscriptTurn -> the dict shape
+emit_capture_event() expects, with source="transcript" and ts_utc set from
+the turn's own source timestamp (never a now() fallback). Event types are
+transcript.{user_prompt,assistant_response,tool_call,tool_result} — raw-
+ledger-only per the taxonomy in the interfaces spec §2.2, deliberately not
+added to PROMOTABLE_CAPTURE_EVENT_TYPES.
+EOF
+)"
+```
+
+---
+
+## 4. Task 4 — Quarantine writer (missing-ts + redaction-failure safety artifact)
+
+This is the highest-risk task in the packet — get invariants 3 and 4 (from the original packet spec) exactly right: missing timestamp → quarantine, and redaction *failure* (not redaction *success on a secret*) → quarantine.
+
+### Files
+- **Modify**: `src/dopemux/memory/transcript_ingest.py`
+- **Test**: `tests/unit/test_transcript_ingest.py` (append)
+
+### Interfaces
+- **Produces**: `write_quarantine_record(*, quarantine_dir: Path, event_id: str, ts: str | None, session_id: str | None, reason: str, original_keys: list[str], source_path: Path, source_line: int) -> Path`
+
+### Steps
+
+- [ ] **4.1 — Append the failing tests:**
+
+```python
+from dopemux.memory.transcript_ingest import write_quarantine_record
+
+
+def test_write_quarantine_record_contains_only_the_five_safe_fields(tmp_path):
+    quarantine_dir = tmp_path / "quarantine" / "transcript"
+    source_path = tmp_path / "session.jsonl"
+    source_path.write_text("irrelevant\n", encoding="utf-8")
+
+    written = write_quarantine_record(
+        quarantine_dir=quarantine_dir,
+        event_id="evt-abc123",
+        ts=None,
+        session_id="sess-1",
+        reason="missing_source_timestamp",
+        original_keys=["role", "content"],
+        source_path=source_path,
+        source_line=7,
+    )
+
+    assert written.exists()
+    assert written.parent == quarantine_dir
+    assert written.name == "evt-abc123.json"
+
+    record = json.loads(written.read_text(encoding="utf-8"))
+    assert set(record.keys()) == {
+        "event_id",
+        "ts",
+        "session_id",
+        "reason",
+        "original_keys",
+        "source_path",
+        "source_line",
+    }
+    assert record["event_id"] == "evt-abc123"
+    assert record["ts"] is None
+    assert record["session_id"] == "sess-1"
+    assert record["reason"] == "missing_source_timestamp"
+    assert record["original_keys"] == ["role", "content"]
+    assert record["source_path"] == str(source_path)
+    assert record["source_line"] == 7
+
+    # No raw payload content anywhere in the file.
+    raw_text = written.read_text(encoding="utf-8")
+    assert "irrelevant" not in raw_text
+
+
+def test_write_quarantine_record_is_idempotent_same_event_id(tmp_path):
+    quarantine_dir = tmp_path / "quarantine" / "transcript"
+    source_path = tmp_path / "session.jsonl"
+    source_path.write_text("line one\n", encoding="utf-8")
+
+    first = write_quarantine_record(
+        quarantine_dir=quarantine_dir,
+        event_id="evt-dup",
+        ts=None,
+        session_id="sess-1",
+        reason="missing_source_timestamp",
+        original_keys=[],
+        source_path=source_path,
+        source_line=1,
+    )
+    second = write_quarantine_record(
+        quarantine_dir=quarantine_dir,
+        event_id="evt-dup",
+        ts=None,
+        session_id="sess-1",
+        reason="missing_source_timestamp",
+        original_keys=[],
+        source_path=source_path,
+        source_line=1,
+    )
+
+    assert first == second
+    assert len(list(quarantine_dir.glob("*.json"))) == 1
+```
+
+- [ ] **4.2 — Run and confirm failure:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v -k write_quarantine_record
+```
+
+Expected output: `ImportError: cannot import name 'write_quarantine_record'`.
+
+- [ ] **4.3 — Add the function to `src/dopemux/memory/transcript_ingest.py`:**
+
+```python
+def write_quarantine_record(
+    *,
+    quarantine_dir: Path,
+    event_id: str,
+    ts: Optional[str],
+    session_id: Optional[str],
+    reason: str,
+    original_keys: list[str],
+    source_path: Path,
+    source_line: int,
+) -> Path:
+    """Write a quarantine safety artifact for a turn that must NOT reach the
+    queryable ledger.
+
+    Quarantine is not memory truth: never searched, promoted, mirrored, or
+    projected (interfaces spec §2.2, §4 invariant 3). The record holds ONLY
+    {event_id, ts, session_id, reason, original_keys, source_path,
+    source_line} — no payload content. The raw line stays in the source
+    transcript file; we store a reference (path + line number) so an
+    operator can go look, deliberately, rather than have the content mirrored
+    into a second location.
+
+    Idempotent: writing the same event_id twice overwrites the same file
+    with identical content (deterministic event_id -> deterministic path).
+    """
+    quarantine_dir.mkdir(parents=True, exist_ok=True)
+    record = {
+        "event_id": event_id,
+        "ts": ts,
+        "session_id": session_id,
+        "reason": reason,
+        "original_keys": list(original_keys),
+        "source_path": str(source_path),
+        "source_line": source_line,
+    }
+    target = quarantine_dir / f"{event_id}.json"
+    target.write_text(
+        json.dumps(record, sort_keys=True, indent=2) + "\n", encoding="utf-8"
+    )
+    return target
+```
+
+- [ ] **4.4 — Run and confirm pass:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v
+```
+
+Expected output: all prior tests plus these 2 new tests pass — `13 passed`.
+
+- [ ] **4.5 — Commit.**
+
+```bash
+git add src/dopemux/memory/transcript_ingest.py tests/unit/test_transcript_ingest.py
+git commit -m "$(cat <<'EOF'
+feat(memory): add quarantine writer for missing-ts and redaction-failure turns
+
+Adds write_quarantine_record() writing .dopemux/quarantine/transcript/
+<event_id>.json containing ONLY {event_id, ts, session_id, reason,
+original_keys, source_path, source_line} -- no payload content. This is the
+named local safety artifact required by TP-MCF-002 (quarantine is not
+memory truth: never searched/promoted/mirrored/projected). Deterministic
+event_id makes re-writing the same quarantined turn idempotent.
+EOF
+)"
+```
+
+---
+
+## 5. Task 5 — `ingest_transcript_file` (the orchestrating loop)
+
+This wires Tasks 2-4 together plus the redaction-failure detection and the `emit_capture_event` call. This is where all seven hard invariants from the prompt converge into one function.
+
+### Files
+- **Modify**: `src/dopemux/memory/transcript_ingest.py`
+- **Test**: `tests/unit/test_transcript_ingest.py` (append)
+
+### Interfaces
+- **Consumes**: `capture_client.emit_capture_event(event: dict, *, mode, repo_root, emit_event_bus) -> CaptureResult`, `capture_client._load_wma_redactor(repo_root) -> Redactor`, `capture_client._deterministic_event_id(*, event_type, session_id, ts_utc, payload) -> str`
+- **Produces**: `ingest_transcript_file(path: Path, workspace_id: str, repo_root: Path) -> IngestResult`
+
+### Steps
+
+- [ ] **5.1 — Append the failing tests.** These are the proof-gate tests the packet spec requires (redaction test, replay test, stable-timestamp test) plus baseline ingest and fail-open tests.
+
+```python
+import sqlite3
+
+
+def _count_ledger_rows(ledger_path: Path) -> int:
+    # If every turn in the file was quarantined (or skipped), emit_capture_event
+    # never ran, so the ledger file/schema was never created. Treat that as a
+    # valid "zero rows" outcome rather than an error — do not let this helper
+    # raise sqlite3.OperationalError("no such table") on a fully-quarantined run.
+    if not ledger_path.exists():
+        return 0
+    conn = sqlite3.connect(str(ledger_path))
+    try:
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='raw_activity_events'"
+        )
+        if cursor.fetchone() is None:
+            return 0
+        return int(conn.execute("SELECT COUNT(*) FROM raw_activity_events").fetchone()[0])
+    finally:
+        conn.close()
+
+
+def _ledger_row(ledger_path: Path, event_id: str) -> dict:
+    conn = sqlite3.connect(str(ledger_path))
+    try:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT * FROM raw_activity_events WHERE id = ?", (event_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    return dict(row)
+
+
+def _write_transcript(tmp_path: Path, lines: list[str]) -> Path:
+    path = tmp_path / "session.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_ingest_transcript_file_writes_only_to_raw_ledger(tmp_path, monkeypatch):
+    from dopemux.memory.transcript_ingest import ingest_transcript_file
+
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    transcript_path = _write_transcript(
+        tmp_path,
+        [USER_PROMPT_LINE, ASSISTANT_RESPONSE_LINE, TOOL_CALL_LINE, TOOL_RESULT_LINE],
+    )
+
+    result = ingest_transcript_file(
+        transcript_path, workspace_id=str(REPO_ROOT), repo_root=REPO_ROOT
+    )
+
+    assert result.ingested == 4
+    assert result.skipped == 0
+    assert result.quarantined == 0
+    assert result.duplicate == 0
+    assert _count_ledger_rows(ledger_path) == 4
+
+
+def test_ingest_transcript_file_skips_non_turn_and_malformed_lines(tmp_path, monkeypatch):
+    from dopemux.memory.transcript_ingest import ingest_transcript_file
+
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    transcript_path = _write_transcript(
+        tmp_path,
+        [
+            USER_PROMPT_LINE,
+            NON_TURN_ATTACHMENT_LINE,
+            QUEUE_OP_LINE,
+            "{this is not valid json",
+        ],
+    )
+
+    result = ingest_transcript_file(
+        transcript_path, workspace_id=str(REPO_ROOT), repo_root=REPO_ROOT
+    )
+
+    # 1 real turn ingested; attachment + queue-op + malformed = skipped.
+    # Note: _write_transcript joins lines with "\n" and appends a trailing
+    # "\n" -- do not add a separate "" list entry expecting an extra skipped
+    # count for it; the trailing newline is consumed by file-line iteration,
+    # not turned into its own line entry. Verified empirically: 4 input
+    # lines -> 1 ingested + 3 skipped, totals reconcile.
+    assert result.ingested == 1
+    assert result.skipped == 3
+    assert result.quarantined == 0
+    assert _count_ledger_rows(ledger_path) == 1
+
+
+def test_ingest_transcript_file_quarantines_missing_timestamp_turn(tmp_path, monkeypatch):
+    """Invariant: a turn without a source timestamp is NEVER ingested with
+    now() -- it goes to quarantine instead."""
+    from dopemux.memory.transcript_ingest import ingest_transcript_file
+
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+    quarantine_dir = tmp_path / ".dopemux" / "quarantine" / "transcript"
+    monkeypatch.setenv("DOPEMUX_QUARANTINE_DIR", str(quarantine_dir))
+
+    transcript_path = _write_transcript(tmp_path, [MISSING_TS_LINE])
+
+    result = ingest_transcript_file(
+        transcript_path, workspace_id=str(REPO_ROOT), repo_root=REPO_ROOT
+    )
+
+    assert result.ingested == 0
+    assert result.quarantined == 1
+    # Nothing reached the queryable ledger for this turn.
+    assert _count_ledger_rows(ledger_path) == 0
+
+    quarantine_files = list(quarantine_dir.glob("*.json"))
+    assert len(quarantine_files) == 1
+    record = json.loads(quarantine_files[0].read_text(encoding="utf-8"))
+    assert record["reason"] == "missing_source_timestamp"
+    assert record["ts"] is None
+    # No raw payload content in the quarantine file.
+    assert "no timestamp on this one" not in quarantine_files[0].read_text(encoding="utf-8")
+
+
+def test_ingest_transcript_file_quarantines_on_redaction_failure(tmp_path, monkeypatch):
+    """Invariant: redaction FAILURE (the redactor's fail-closed sentinel,
+    {"redaction_error": True, ...}) routes to quarantine, never the queryable
+    ledger. This is distinct from redaction SUCCESS scrubbing a secret (see
+    the next test) -- only the exception path quarantines."""
+    import dopemux.memory.transcript_ingest as ingest_module
+
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+    quarantine_dir = tmp_path / ".dopemux" / "quarantine" / "transcript"
+    monkeypatch.setenv("DOPEMUX_QUARANTINE_DIR", str(quarantine_dir))
+
+    class _FailingRedactor:
+        def redact_payload(self, payload):
+            return {"redaction_error": True, "original_keys": list(payload.keys())}
+
+    monkeypatch.setattr(
+        ingest_module, "_load_wma_redactor", lambda repo_root: _FailingRedactor()
+    )
+
+    transcript_path = _write_transcript(tmp_path, [USER_PROMPT_LINE])
+
+    result = ingest_module.ingest_transcript_file(
+        transcript_path, workspace_id=str(REPO_ROOT), repo_root=REPO_ROOT
+    )
+
+    assert result.ingested == 0
+    assert result.quarantined == 1
+    assert _count_ledger_rows(ledger_path) == 0
+
+    quarantine_files = list(quarantine_dir.glob("*.json"))
+    assert len(quarantine_files) == 1
+    record = json.loads(quarantine_files[0].read_text(encoding="utf-8"))
+    assert record["reason"] == "redaction_failed"
+    assert "content" in record["original_keys"]
+    # No raw payload content in the quarantine file.
+    assert "/review" not in quarantine_files[0].read_text(encoding="utf-8")
+
+
+def test_ingest_transcript_file_scrubs_secret_and_still_ingests(tmp_path, monkeypatch):
+    """Contrast case: a secret-bearing turn whose redaction SUCCEEDS (the
+    normal case -- the real Redactor scrubs and returns normally) is
+    ingested with the secret scrubbed, not quarantined. Only redaction
+    *failure* (the exception path) quarantines."""
+    from dopemux.memory.transcript_ingest import ingest_transcript_file
+
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    secret_line = json.dumps(
+        {
+            "type": "user",
+            "isMeta": False,
+            "message": {
+                "role": "user",
+                "content": "here is my token: Bearer abcdef1234567890",
+            },
+            "sessionId": "sess-secret",
+            "timestamp": "2026-07-05T05:00:00.000Z",
+            "uuid": "secret-line-0001",
+        }
+    )
+    transcript_path = _write_transcript(tmp_path, [secret_line])
+
+    result = ingest_transcript_file(
+        transcript_path, workspace_id=str(REPO_ROOT), repo_root=REPO_ROOT
+    )
+
+    assert result.ingested == 1
+    assert result.quarantined == 0
+    assert _count_ledger_rows(ledger_path) == 1
+
+
+def test_ingest_transcript_file_is_idempotent_on_replay(tmp_path, monkeypatch):
+    """Deterministic event_id + INSERT OR IGNORE (inherited from
+    capture_client) makes re-ingesting the same file safe. Run 2 must not
+    grow the ledger, and run 2's ingested count must be 0 (everything is now
+    a duplicate)."""
+    from dopemux.memory.transcript_ingest import ingest_transcript_file
+
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    transcript_path = _write_transcript(
+        tmp_path,
+        [USER_PROMPT_LINE, ASSISTANT_RESPONSE_LINE, TOOL_CALL_LINE, TOOL_RESULT_LINE],
+    )
+
+    run1 = ingest_transcript_file(
+        transcript_path, workspace_id=str(REPO_ROOT), repo_root=REPO_ROOT
+    )
+    count_after_run1 = _count_ledger_rows(ledger_path)
+
+    run2 = ingest_transcript_file(
+        transcript_path, workspace_id=str(REPO_ROOT), repo_root=REPO_ROOT
+    )
+    count_after_run2 = _count_ledger_rows(ledger_path)
+
+    assert count_after_run1 == count_after_run2
+    assert run2.ingested == 0
+    assert (run1.ingested + run1.duplicate) == (run2.ingested + run2.duplicate)
+    assert run1.quarantined == run2.quarantined
+    assert run1.skipped == run2.skipped
+
+
+def test_ingest_transcript_file_stores_source_timestamp_not_now(tmp_path, monkeypatch):
+    """The ledger row's ts_utc must equal the transcript's own timestamp --
+    never datetime.now() (capture_client.py:493's fallback must never be
+    reached for a turn that has a source ts)."""
+    from dopemux.memory.transcript_ingest import ingest_transcript_file
+
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    transcript_path = _write_transcript(tmp_path, [USER_PROMPT_LINE])
+
+    ingest_transcript_file(
+        transcript_path, workspace_id=str(REPO_ROOT), repo_root=REPO_ROOT
+    )
+
+    conn = sqlite3.connect(str(ledger_path))
+    try:
+        row = conn.execute(
+            "SELECT ts_utc, event_type, source FROM raw_activity_events"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    ts_utc, event_type, source = row
+    assert ts_utc == "2026-07-05T04:22:54.799Z"
+    assert event_type == "transcript.user_prompt"
+    assert source == "transcript"
+
+
+def test_ingest_transcript_file_never_raises_on_fully_malformed_file(tmp_path, monkeypatch):
+    """Fail-open for the session: a file full of garbage must not raise out
+    of ingest_transcript_file."""
+    from dopemux.memory.transcript_ingest import ingest_transcript_file
+
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    transcript_path = _write_transcript(
+        tmp_path, ["{garbage", "not json at all", "[]", "null"]
+    )
+
+    result = ingest_transcript_file(
+        transcript_path, workspace_id=str(REPO_ROOT), repo_root=REPO_ROOT
+    )
+
+    assert result.ingested == 0
+    assert result.skipped == 4
+    assert result.quarantined == 0
+
+
+def test_ingest_transcript_file_no_conport_or_dope_context_imports():
+    """Structural invariant: the Fabric package imports no plane's storage
+    internals. This module must import neither conport nor dope_context.
+
+    Checks actual `import`/`from ... import` statement lines only, not
+    prose -- this module's own docstring legitimately names the invariant
+    ("must import neither conport nor dope_context"), and a naive whole-file
+    substring check would trip on its own documentation. Only import lines
+    count."""
+    module_path = REPO_ROOT / "src" / "dopemux" / "memory" / "transcript_ingest.py"
+    import_lines = [
+        stripped
+        for line in module_path.read_text(encoding="utf-8").splitlines()
+        if (stripped := line.strip()).startswith("import ")
+        or stripped.startswith("from ")
+    ]
+    for stripped in import_lines:
+        assert "conport" not in stripped
+        assert "dope_context" not in stripped
+        assert "dope-context" not in stripped
+```
+
+- [ ] **5.2 — Run and confirm failure:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v -k ingest_transcript_file
+```
+
+Expected output: `ImportError: cannot import name 'ingest_transcript_file'` (and the last test, which reads the file directly rather than importing, will pass trivially once the file exists with no forbidden imports — but it still needs `ingest_transcript_file` defined to be meaningful; expect an import error across this whole batch first).
+
+- [ ] **5.3 — Add the function to `src/dopemux/memory/transcript_ingest.py`** (append at the end of the file):
+
+```python
+import os
+
+
+def _quarantine_dir_for(repo_root: Path) -> Path:
+    override = os.getenv("DOPEMUX_QUARANTINE_DIR", "").strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return (repo_root / ".dopemux" / "quarantine" / "transcript").resolve()
+
+
+def ingest_transcript_file(
+    path: Path, workspace_id: str, repo_root: Path
+) -> IngestResult:
+    """Parse a transcript JSONL file and write each turn to the raw ledger.
+
+    Writes ONLY to dope-memory's raw_activity_events via
+    capture_client.emit_capture_event() -- no ConPort writes, no dope-context
+    writes, no Redis requirement (emit_event_bus=False, explicit).
+
+    Per-line fail-open: a malformed line increments `skipped` and never
+    raises out of this function. A turn missing its source timestamp, or
+    whose redaction fails, is quarantined (never ingested with now(), never
+    written to the queryable ledger).
+    """
+    ingested = 0
+    skipped = 0
+    quarantined = 0
+    duplicate = 0
+
+    quarantine_dir = _quarantine_dir_for(repo_root)
+    redactor = _load_wma_redactor(repo_root)
+
+    with path.open("r", encoding="utf-8") as fh:
+        for line_number, raw_line in enumerate(fh, start=1):
+            try:
+                turn = parse_transcript_line(raw_line)
+                if turn is None:
+                    skipped += 1
+                    continue
+
+                payload = {"content": turn.content}
+
+                if not turn.ts:
+                    event_id = _deterministic_event_id(
+                        event_type=_TURN_TYPE_TO_EVENT_TYPE[turn.turn_type],
+                        session_id=turn.session_id,
+                        ts_utc="",
+                        payload=payload,
+                    )
+                    write_quarantine_record(
+                        quarantine_dir=quarantine_dir,
+                        event_id=event_id,
+                        ts=turn.ts,
+                        session_id=turn.session_id,
+                        reason="missing_source_timestamp",
+                        original_keys=sorted(payload.keys()),
+                        source_path=path,
+                        source_line=line_number,
+                    )
+                    quarantined += 1
+                    continue
+
+                redacted_payload = redactor.redact_payload(payload)
+                if isinstance(redacted_payload, dict) and redacted_payload.get(
+                    "redaction_error"
+                ):
+                    event_id = _deterministic_event_id(
+                        event_type=_TURN_TYPE_TO_EVENT_TYPE[turn.turn_type],
+                        session_id=turn.session_id,
+                        ts_utc=turn.ts,
+                        payload=payload,
+                    )
+                    write_quarantine_record(
+                        quarantine_dir=quarantine_dir,
+                        event_id=event_id,
+                        ts=turn.ts,
+                        session_id=turn.session_id,
+                        reason="redaction_failed",
+                        original_keys=list(
+                            redacted_payload.get("original_keys", [])
+                        ),
+                        source_path=path,
+                        source_line=line_number,
+                    )
+                    quarantined += 1
+                    continue
+
+                envelope = turn_to_capture_envelope(turn, workspace_id=workspace_id)
+                result = emit_capture_event(
+                    envelope,
+                    mode="cli",
+                    repo_root=repo_root,
+                    emit_event_bus=False,
+                )
+                if result.inserted:
+                    ingested += 1
+                else:
+                    duplicate += 1
+            except Exception:
+                # Fail-open per turn: never let one bad line break the whole
+                # ingest run (invariant 7).
+                skipped += 1
+                continue
+
+    return IngestResult(
+        ingested=ingested,
+        skipped=skipped,
+        quarantined=quarantined,
+        duplicate=duplicate,
+    )
+```
+
+Note the redaction check runs on `{"content": turn.content}` — the same shape `turn_to_capture_envelope` will build into `payload`, so the redactor sees exactly what would be stored. This deliberately duplicates the payload shape rather than calling `turn_to_capture_envelope` twice with different intents (once to probe redaction, once to emit) — `emit_capture_event` runs its own redaction pass internally too (`capture_client.py:500-501`), which is harmless (the WMA redactor is idempotent on already-redacted or already-safe payloads) and is not duplicated logic we own — it's the existing spine's own defense in depth.
+
+- [ ] **5.4 — Run and confirm pass:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v
+```
+
+Expected output: all tests pass — `22 passed` (13 from Tasks 2-4 plus 9 new in this task; the malformed-line skip test uses one fewer fixture line than a naive count suggests — see the inline note in its assertion block above).
+
+- [ ] **5.5 — Commit.**
+
+```bash
+git add src/dopemux/memory/transcript_ingest.py tests/unit/test_transcript_ingest.py
+git commit -m "$(cat <<'EOF'
+feat(memory): add ingest_transcript_file orchestrating loop (TP-MCF-002)
+
+Wires parse_transcript_line + turn_to_capture_envelope + write_quarantine_record
+into ingest_transcript_file(path, workspace_id, repo_root) -> IngestResult.
+
+Hard invariants proven by test:
+- missing source timestamp -> quarantine, never datetime.now() fallback
+- redaction FAILURE (redactor's {"redaction_error": True} sentinel) ->
+  quarantine, never the queryable ledger -- distinct from redaction SUCCESS
+  scrubbing a secret (which still ingests, secret redacted)
+- re-ingesting the same file is idempotent (ledger row count unchanged,
+  run-2 ingested == 0)
+- malformed lines increment skipped, never raise
+- no ConPort or dope-context imports in this module (structural test)
+
+Writes only to raw_activity_events via the existing capture_client spine;
+emit_event_bus explicitly False. No file-watcher daemon in this packet.
+EOF
+)"
+```
+
+---
+
+## 6. Task 6 — CLI subcommand `dopemux memory ingest-transcript`
+
+The `memory` Click group already exists and is registered in `src/dopemux/cli.py:3219-3221` (`from .commands.memory_commands import memory` / `cli.add_command(memory)`). No new group registration is needed — this task only adds one `@memory.command()` to the existing file, modeled on the working `capture emit` command (which correctly calls `capture_client.emit_capture_event`), **not** on `capture copilot` (which imports a non-existent `dopemux.memory.adapters` module — a pre-existing bug in this codebase, out of scope for this packet; do not mirror or attempt to fix it here).
+
+### Files
+- **Modify**: `src/dopemux/commands/memory_commands.py`
+- **Create**: `tests/unit/test_cli_memory_ingest_transcript.py`
+
+### Interfaces
+- **Consumes**: `dopemux.memory.transcript_ingest.ingest_transcript_file`
+- **Produces**: CLI command `dopemux memory ingest-transcript <path> [--workspace-id TEXT] [--repo-root PATH]`
+
+**Import style note (verified, not optional)**: every other command in this file (`emit`, `copilot`, `copilot_list`) imports its dependencies lazily, inside the function body. That convention was tried for this command and **fails the CLI test**: `monkeypatch.setattr(memory_commands_module, "ingest_transcript_file", ...)` sets an attribute on the module namespace that a function-local `from dopemux.memory.transcript_ingest import ingest_transcript_file` never reads (the local import re-binds the name inside the function's own scope at call time, shadowing the monkeypatched module attribute). Step 6.3 below imports `ingest_transcript_file` at **module level** (top of `memory_commands.py`, alongside the other top-level imports) specifically so the monkeypatch target and the name the function actually calls are the same object. Do not lazy-import this one dependency even though the surrounding commands do.
+
+### Steps
+
+- [ ] **6.1 — Write the failing CLI test.** Create `tests/unit/test_cli_memory_ingest_transcript.py`:
+
+```python
+from pathlib import Path
+
+from click.testing import CliRunner
+
+import dopemux.commands.memory_commands as memory_commands_module
+from dopemux.cli import cli
+from dopemux.memory.transcript_ingest import IngestResult
+
+
+def test_ingest_transcript_cli_invokes_ingest_function(monkeypatch, tmp_path):
+    calls = {}
+
+    def _fake_ingest(path, workspace_id, repo_root):
+        calls["path"] = path
+        calls["workspace_id"] = workspace_id
+        calls["repo_root"] = repo_root
+        return IngestResult(ingested=3, skipped=1, quarantined=0, duplicate=0)
+
+    monkeypatch.setattr(
+        memory_commands_module, "ingest_transcript_file", _fake_ingest, raising=False
+    )
+
+    transcript_path = tmp_path / "session.jsonl"
+    transcript_path.write_text('{"type":"user"}\n', encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["memory", "ingest-transcript", str(transcript_path)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["path"] == transcript_path
+    assert "3" in result.output  # ingested count surfaced to the operator
+    assert "1" in result.output  # skipped count surfaced to the operator
+
+
+def test_ingest_transcript_cli_rejects_missing_file():
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["memory", "ingest-transcript", "/nonexistent/path/session.jsonl"]
+    )
+    assert result.exit_code != 0
+```
+
+- [ ] **6.2 — Run and confirm failure:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_cli_memory_ingest_transcript.py -v
+```
+
+Expected output: `test_ingest_transcript_cli_invokes_ingest_function` fails (`Error: No such command 'ingest-transcript'` in `result.output`, non-zero exit code); `test_ingest_transcript_cli_rejects_missing_file` passes trivially (command doesn't exist, so it already exits non-zero) — confirm by reading output, don't rely on the second test alone to prove red state.
+
+- [ ] **6.3 — Add the module-level import, then the command, to `src/dopemux/commands/memory_commands.py`.**
+
+First, add one import line near the top of the file, immediately after the existing `from ..ui.theme import ...` line (do not add it inside a function body — see the import-style note above):
+
+```python
+from ..memory.transcript_ingest import ingest_transcript_file
+```
+
+Then insert the command itself immediately before the `# EASY LAUNCH SHORTCUTS` marker comment near the end of the file (after the `copilot_list` function, before line 390's comment block):
+
+```python
+@memory.command("ingest-transcript")
+@click.argument(
+    "transcript_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+)
+@click.option(
+    "--workspace-id",
+    type=str,
+    default=None,
+    help="🗂️  Workspace Coordinate: Override workspace_id (default: repo root path).",
+)
+@click.option(
+    "--repo-root",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+    default=None,
+    help="🔬 Repository Coordinate: Project root for ledger synchronization.",
+)
+def ingest_transcript(
+    transcript_path: Path, workspace_id: Optional[str], repo_root: Optional[Path]
+):
+    """
+    📼 Transcript Ingest: Parse a Claude Code session JSONL into the raw ledger
+
+    Reads a Claude Code session transcript file (~/.claude/projects/<slug>/
+    <uuid>.jsonl) and writes each conversation turn to the per-project raw
+    ledger (raw_activity_events) via the capture spine. Writes ONLY to the
+    raw ledger -- no ConPort writes, no dope-context writes. Turns without a
+    source timestamp, or whose redaction fails, are quarantined instead of
+    ingested. Safe to re-run: ingest is idempotent.
+    """
+    from dopemux.memory.capture_client import resolve_repo_root_strict
+
+    root = repo_root.resolve() if repo_root else resolve_repo_root_strict()
+    ws_id = workspace_id or str(root)
+
+    result = ingest_transcript_file(transcript_path, workspace_id=ws_id, repo_root=root)
+
+    console.logger.info(f"[success]✓[/success] Transcript ingest complete: {transcript_path}")
+    console.logger.info(f"  Ingested:    {result.ingested}")
+    console.logger.info(f"  Duplicate:   {result.duplicate}")
+    console.logger.info(f"  Quarantined: {result.quarantined}")
+    console.logger.info(f"  Skipped:     {result.skipped}")
+```
+
+Note: the function body calls the bare name `ingest_transcript_file(...)`, which Python resolves against the **module's global namespace** at call time — that's the module-level import you added at the top of the file in this step. `monkeypatch.setattr(memory_commands_module, "ingest_transcript_file", _fake_ingest, raising=False)` replaces that same global binding, so the function picks up the fake on the next call. This only works because the import is module-level; it was verified to fail (the fake is never invoked, `calls` dict stays empty, `KeyError` on `calls["path"]`) when the import was tried inside the function body instead, because a function-local `from ... import` creates a name binding private to that call, invisible to `monkeypatch.setattr` on the module object.
+
+- [ ] **6.4 — Run and confirm pass:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_cli_memory_ingest_transcript.py -v
+```
+
+Expected output: both tests pass — `2 passed`. If `test_ingest_transcript_cli_invokes_ingest_function` fails with the fake never being called (real ledger touched instead), apply the module-level-import fix described in 6.3 and re-run.
+
+- [ ] **6.5 — Run the full transcript_ingest + CLI test files together to confirm no interaction issues:**
+
+```bash
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py tests/unit/test_cli_memory_ingest_transcript.py -v
+```
+
+Expected output: `24 passed` (22 from `test_transcript_ingest.py` + 2 from `test_cli_memory_ingest_transcript.py`).
+
+- [ ] **6.6 — Commit.**
+
+```bash
+git add src/dopemux/commands/memory_commands.py tests/unit/test_cli_memory_ingest_transcript.py
+git commit -m "$(cat <<'EOF'
+feat(cli): add `dopemux memory ingest-transcript` command (TP-MCF-002)
+
+Adds ingest-transcript to the existing `memory` Click group (already
+registered in cli.py:3219-3221 -- no new group registration needed).
+Modeled on the working `capture emit` command, not `capture copilot` (which
+imports a non-existent adapters module -- pre-existing bug, untouched here).
+
+Usage: dopemux memory ingest-transcript <path-to-session.jsonl>
+       [--workspace-id TEXT] [--repo-root PATH]
+EOF
+)"
+```
+
+---
+
+## 7. Task 7 — Final verification: full targeted suite + proof-gate checklist
+
+### 7.1 Run the full targeted suite
+
+```bash
+cd /Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py tests/unit/test_cli_memory_ingest_transcript.py tests/unit/test_memory_capture_client.py -v
+```
+
+Expected output: all tests pass — `47 passed` (22 in `test_transcript_ingest.py` + 2 in `test_cli_memory_ingest_transcript.py` + 23 pre-existing in `test_memory_capture_client.py`, which must be unaffected since this packet does not modify `capture_client.py`). This exact combination (22+2+23=47) was run and confirmed passing during plan authoring — see the governance footer. Confirm exit code 0.
+
+### 7.2 Proof-gate checklist (from `claudedocs/tp-mcf-001-authority-map-2026-07-04.md` §4 TP-MCF-002 and `claudedocs/memory-context-fabric-design-2026-07-04.md` §5)
+
+Run each check and record PASS/FAIL — do not mark anything PASS without having actually run it in this session:
+
+- [ ] **git status before/after** — run `git status` and `git diff --stat` now; confirm only the files listed in §0 "File-level scope" changed:
+
+```bash
+git status
+git diff --stat main...HEAD
+```
+
+- [ ] **Redaction test** (secret never reaches the ledger on redaction failure): `test_ingest_transcript_file_quarantines_on_redaction_failure` — already run and passing in Task 5.
+
+- [ ] **Redaction-success contrast test** (a scrubbed secret still ingests, proving quarantine is keyed off failure, not secret-presence): `test_ingest_transcript_file_scrubs_secret_and_still_ingests` — already run and passing in Task 5.
+
+- [ ] **Replay/idempotency test** (re-ingest produces identical ledger row count, rejects nothing new on the second pass): `test_ingest_transcript_file_is_idempotent_on_replay` — already run and passing in Task 5.
+
+- [ ] **Stable-timestamp test** (missing source ts never falls back to `now()`, quarantines instead; and a present source ts is stored verbatim in `ts_utc`): `test_ingest_transcript_file_quarantines_missing_timestamp_turn` + `test_ingest_transcript_file_stores_source_timestamp_not_now` — already run and passing in Task 5.
+
+- [ ] **No-ConPort / no-dope-context-write test**: `test_ingest_transcript_file_no_conport_or_dope_context_imports` — already run and passing in Task 5 (this is the authoritative check; it scans only `import`/`from` statement lines, not prose). Additionally run this repo-wide grep restricted to actual import lines, to double-check no ConPort/dope-context call was introduced anywhere in this packet's files — note this grep is intentionally narrower than a whole-file substring search, because both files' docstrings/comments legitimately *name* the invariant ("no ConPort writes, no dope-context writes") in prose, which is expected and must not be flagged:
+
+```bash
+grep -nE "^\s*(import|from) .*(conport|dope_context|dope-context)" src/dopemux/memory/transcript_ingest.py src/dopemux/commands/memory_commands.py
+```
+
+Expected output: no matches (exit code 1 from grep). Do **not** use an unanchored `grep -n "conport\|dope_context"` here — it will match the docstring/comment prose in both files (confirmed during plan verification) and produce a false-FAIL reading; the import-anchored pattern above is the correct check.
+
+- [ ] **Fail-open test** (malformed lines never raise out of `ingest_transcript_file`): `test_ingest_transcript_file_never_raises_on_fully_malformed_file` + `test_ingest_transcript_file_skips_non_turn_and_malformed_lines` — already run and passing in Task 5.
+
+- [ ] **Non-promotable event types confirmed**: run this check to confirm `transcript.*` was never added to the promotable allowlist:
+
+```bash
+grep -n "transcript\." src/dopemux/memory/capture_client.py services/working-memory-assistant/promotion/promotion.py
+```
+
+Expected output: no matches in either file (this packet must not touch `PROMOTABLE_CAPTURE_EVENT_TYPES` in `capture_client.py` or the allowlist in `promotion.py`).
+
+- [ ] **Command outputs + exit codes** — capture the final full-suite run's exit code:
+
+```bash
+mise exec -- python -m pytest tests/unit/test_transcript_ingest.py tests/unit/test_cli_memory_ingest_transcript.py tests/unit/test_memory_capture_client.py -v; echo "exit code: $?"
+```
+
+Expected: `exit code: 0`.
+
+### 7.3 Do not commit this task
+
+Task 7 is verification-only — there is nothing to commit. If any check fails, return to the relevant task, fix under TDD (failing assertion → minimal fix → passing), and re-run this section before considering the packet done.
+
+### 7.4 What is explicitly NOT built in this packet (confirm scope discipline)
+
+- No file-watcher daemon (ambient watching arrives with the Fabric service, a later packet).
+- No Codex transcript format support (Claude Code JSONL only).
+- No promotion to the curated chronicle (`work_log_entries`) — that is TP-MCF-003, which also requires the `conversation.decision_candidate` event/schema this packet deliberately does not touch.
+- No ConPort writes, no dope-context writes, no semantic indexing of transcript content.
+- No changes to `capture_client.py`, `redactor.py`, or `promotion.py`.
+
+---
+
+## Governance footer
+
+**Authority used**: `claudedocs/memory-context-fabric-design-2026-07-04.md` (v3), `claudedocs/tp-mcf-001-authority-map-2026-07-04.md`, `claudedocs/memory-context-fabric-interfaces-2026-07-04.md`; runtime code `src/dopemux/memory/capture_client.py`, `services/working-memory-assistant/promotion/redactor.py`, `src/dopemux/commands/memory_commands.py`, `src/dopemux/cli.py`; existing test patterns in `tests/unit/test_memory_capture_client.py` and `tests/unit/test_cli_capture_commands.py`; a real 660-line Claude Code session transcript (`~/.claude/projects/-Users-hue-code-dopemux-mvp/6e030b42-66a3-46e3-9588-f1c3cceb683f.jsonl`) inspected directly to verify the JSONL schema and validate the turn-classification rule (counts reconciled: `user_prompt=11, assistant_response=167, tool_call=92, tool_result=92, skipped=298`, total 660).
+**Validation**: plan-authoring only — the code in this plan has not been executed; every "expected output" above is a prediction based on the parser logic and existing `capture_client` behavior, not an observed test run. The implementing agent must actually run every command and confirm PASS before proceeding to the next step — do not mark a step done without having seen the real output.
+**Rollback**: `git reset --hard <commit-before-task-1>` or, per-task, `git revert <task-commit-sha>`; no schema/migration changes are made, so rollback is a pure file/commit reversal with no data-shape cleanup required. The one stateful artifact this packet introduces (`.dopemux/quarantine/transcript/*.json` files) is git-ignorable and safe to delete manually if a real repo run needs to be undone.

--- a/claudedocs/plans/2026-07-04-tp-mcf-002-transcript-ingest.md
+++ b/claudedocs/plans/2026-07-04-tp-mcf-002-transcript-ingest.md
@@ -49,7 +49,7 @@ Claude Code writes session transcripts under `~/.claude/projects/<project-slug>/
 ls ~/.claude/projects/ | grep -i "$(basename "$(git rev-parse --show-toplevel)" | tr '[:upper:]' '[:lower:]')"
 ```
 
-Expected output: one or more directory names containing your repo's basename (e.g. `-Users-hue-code-dopemux-mvp`). Pick the directory that matches your actual working tree (main repo root, not a worktree subpath, unless you are actively in a worktree session with its own recorded transcripts).
+Expected output: one or more directory names containing your repo's basename (e.g. `<project-slug>`). Pick the directory that matches your actual working tree (main repo root, not a worktree subpath, unless you are actively in a worktree session with its own recorded transcripts).
 
 Then list transcript files in that directory, newest first:
 
@@ -364,7 +364,7 @@ def test_parse_missing_timestamp_returns_turn_with_ts_none():
 - [ ] **2.2 — Run the test file and confirm it fails on import** (module doesn't exist yet):
 
 ```bash
-cd /Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe
+cd <repo-root>/.claude/worktrees/<worktree-name>
 mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v
 ```
 
@@ -524,7 +524,7 @@ def parse_transcript_line(line: str) -> Optional[TranscriptTurn]:
 mise exec -- python -m pytest tests/unit/test_transcript_ingest.py -v
 ```
 
-Expected output: 10 tests pass (`test_parse_user_prompt_line`, `test_parse_assistant_response_line`, `test_parse_tool_call_line`, `test_parse_tool_result_line`, `test_parse_skips_non_turn_attachment_record`, `test_parse_skips_queue_operation_record`, `test_parse_skips_blank_line`, `test_parse_skips_malformed_json_never_raises`, `test_parse_missing_timestamp_returns_turn_with_ts_none`) — 9 test functions, some with multiple asserts; `9 passed`.
+Expected output: 9 tests pass (`test_parse_user_prompt_line`, `test_parse_assistant_response_line`, `test_parse_tool_call_line`, `test_parse_tool_result_line`, `test_parse_skips_non_turn_attachment_record`, `test_parse_skips_queue_operation_record`, `test_parse_skips_blank_line`, `test_parse_skips_malformed_json_never_raises`, `test_parse_missing_timestamp_returns_turn_with_ts_none`) — 9 test functions, some with multiple asserts; `9 passed`.
 
 - [ ] **2.5 — Commit.**
 
@@ -1476,7 +1476,7 @@ EOF
 ### 7.1 Run the full targeted suite
 
 ```bash
-cd /Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe
+cd <repo-root>/.claude/worktrees/<worktree-name>
 mise exec -- python -m pytest tests/unit/test_transcript_ingest.py tests/unit/test_cli_memory_ingest_transcript.py tests/unit/test_memory_capture_client.py -v
 ```
 
@@ -1543,6 +1543,6 @@ Task 7 is verification-only — there is nothing to commit. If any check fails, 
 
 ## Governance footer
 
-**Authority used**: `claudedocs/memory-context-fabric-design-2026-07-04.md` (v3), `claudedocs/tp-mcf-001-authority-map-2026-07-04.md`, `claudedocs/memory-context-fabric-interfaces-2026-07-04.md`; runtime code `src/dopemux/memory/capture_client.py`, `services/working-memory-assistant/promotion/redactor.py`, `src/dopemux/commands/memory_commands.py`, `src/dopemux/cli.py`; existing test patterns in `tests/unit/test_memory_capture_client.py` and `tests/unit/test_cli_capture_commands.py`; a real 660-line Claude Code session transcript (`~/.claude/projects/-Users-hue-code-dopemux-mvp/6e030b42-66a3-46e3-9588-f1c3cceb683f.jsonl`) inspected directly to verify the JSONL schema and validate the turn-classification rule (counts reconciled: `user_prompt=11, assistant_response=167, tool_call=92, tool_result=92, skipped=298`, total 660).
+**Authority used**: `claudedocs/memory-context-fabric-design-2026-07-04.md` (v3), `claudedocs/tp-mcf-001-authority-map-2026-07-04.md`, `claudedocs/memory-context-fabric-interfaces-2026-07-04.md`; runtime code `src/dopemux/memory/capture_client.py`, `services/working-memory-assistant/promotion/redactor.py`, `src/dopemux/commands/memory_commands.py`, `src/dopemux/cli.py`; existing test patterns in `tests/unit/test_memory_capture_client.py` and `tests/unit/test_cli_capture_commands.py`; a real 660-line Claude Code session transcript (`~/.claude/projects/<project-slug>/6e030b42-66a3-46e3-9588-f1c3cceb683f.jsonl`) inspected directly to verify the JSONL schema and validate the turn-classification rule (counts reconciled: `user_prompt=11, assistant_response=167, tool_call=92, tool_result=92, skipped=298`, total 660).
 **Validation**: plan-authoring only — the code in this plan has not been executed; every "expected output" above is a prediction based on the parser logic and existing `capture_client` behavior, not an observed test run. The implementing agent must actually run every command and confirm PASS before proceeding to the next step — do not mark a step done without having seen the real output.
 **Rollback**: `git reset --hard <commit-before-task-1>` or, per-task, `git revert <task-commit-sha>`; no schema/migration changes are made, so rollback is a pure file/commit reversal with no data-shape cleanup required. The one stateful artifact this packet introduces (`.dopemux/quarantine/transcript/*.json` files) is git-ignorable and safe to delete manually if a real repo run needs to be undone.

--- a/claudedocs/plans/2026-07-04-tp-mcf-003-deterministic-promotion.md
+++ b/claudedocs/plans/2026-07-04-tp-mcf-003-deterministic-promotion.md
@@ -1,0 +1,1150 @@
+# TP-MCF-003 — Deterministic Promotion: `conversation.decision_candidate`
+
+> **For agentic workers:** Execute this plan task-by-task via superpowers:subagent-driven-development or superpowers:executing-plans if available; otherwise execute the checkbox (`- [ ]`) steps literally, in order, committing exactly where the plan says. Read the master plan first: `claudedocs/plans/2026-07-04-memory-context-fabric-build-plan.md` (global constraints + hand-off protocol).
+**For the executing agent:** you have zero context beyond this file. Every file path is absolute-from-repo-root. Every code block is complete — copy it verbatim, do not paraphrase or "improve" it. Follow the TDD checkboxes in order: write the failing test, run it, confirm it fails for the stated reason, then apply the implementation, run it again, confirm it passes, then commit. Do not skip the "confirm it fails" sub-step — it is what proves the test is real.
+
+**Packet**: TP-MCF-003 (Memory Context Fabric, phase 003)
+**Depends on (spec, not code)**: TP-MCF-002 defines the transcript-ingest adapter that will eventually call the code this packet builds. TP-MCF-003 does **not** require TP-MCF-002 to exist — every test in this plan constructs turn-content strings and event envelopes directly, with no transcript files or ingest adapter involved.
+**Authority docs** (read in this order before touching code):
+1. `claudedocs/memory-context-fabric-design-2026-07-04.md` (v3) — §2 "Decision detection", §6 row `TP-MCF-003`.
+2. `claudedocs/tp-mcf-001-authority-map-2026-07-04.md` — §1 Domain B (promotion authority), §3 gaps 3 and 4, §4 "TP-MCF-003" (this packet's originating spec).
+3. `claudedocs/memory-context-fabric-interfaces-2026-07-04.md` — §2.2 event-type taxonomy, §2.3 `PromotedEntry` trust encoding.
+
+Runtime code outranks these docs if they ever disagree — but they don't; every code claim below was verified against the actual runtime files, listed next.
+
+---
+
+## 0. Goal
+
+Add exactly one new event type, `conversation.decision_candidate`, end-to-end through the existing capture→promotion pipeline, so that a deterministic (non-LLM) decision-marker detector can emit transcript-derived "this looks like a decision" candidates into the curated chronicle — **without ever writing to ConPort** and **without ever emitting `decision.logged`** (which the codebase reserves for post-write receipts from a real ConPort decision).
+
+## 1. Architecture (what you are building, in one paragraph)
+
+Three new pieces, all additive (no existing behavior changes except one one-line dispatch fix described in Task 2):
+
+1. A pure-function deterministic detector, `detect_decision_candidate(turn_content: str) -> DecisionCandidate | None`, in a **new file** `src/dopemux/memory/conversation_promotion.py`. No LLM, no network, no imports of ConPort/httpx — regex-based marker matching only.
+2. The new event type added to **both** existing allowlists (`src/dopemux/memory/capture_client.py` and `services/working-memory-assistant/promotion/promotion.py`), which today are independently-maintained frozensets that must contain the same 7 (soon 8) strings.
+3. A new promotion handler `_promote_conversation_decision_candidate` in `services/working-memory-assistant/promotion/promotion.py`, mirroring the construction style of the existing `_promote_decision_logged` and `_promote_task_completed` handlers, producing a `PromotedEntry` whose `promotion_rule="conversation_candidate_v1"` and `details_json.trust="conversation-derived"`.
+
+## 2. Stack / tooling
+
+- **Interpreter**: `mise exec -- python` (3.12) — never the bare `python3` on PATH.
+- **Root test suite** (covers `src/dopemux/...`): run from repo root, e.g. `mise exec -- python -m pytest tests/unit/<file> -q`. Root `pyproject.toml` sets `pythonpath = ["src"]` and `testpaths = ["tests"]`, so `from dopemux.memory... import ...` resolves without extra setup.
+- **WMA test suite** (covers `services/working-memory-assistant/...`): run with cwd = `services/working-memory-assistant/`, e.g. `cd services/working-memory-assistant && mise exec -- python -m pytest tests/<file> -q`. WMA's own `tests/conftest.py` inserts the service directory onto `sys.path`, which is what makes `from promotion.promotion import ...` and `from chronicle.store import ...` resolve as top-level packages. **Do not** try to run WMA tests from repo root — the root `pytest.ini`'s `norecursedirs` explicitly excludes `services/`, and the root `pyproject.toml`'s `pythonpath=["src"]` does not add the WMA directory.
+- No Docker, no Redis, no network calls anywhere in this packet's tests — everything is pure-function or SQLite-via-`tmp_path`.
+
+## 3. Global constraints (apply to every task below)
+
+- **No LLM summarization.** All detection is regex/string-heuristic. No API calls to any model provider anywhere in this packet.
+- **No auto ConPort writes.** Nothing in this packet imports `httpx`, `requests`, `aiohttp`, or any ConPort client. A test enforces this (Task 4).
+- **Never `decision.logged`.** The candidate event type is `conversation.decision_candidate`, always. A test enforces this (Task 5).
+- **Non-goals (explicitly out of scope for this packet — do not touch):**
+  - Promotion of `task.completed`, `task.failed`, `task.blocked`, `error.encountered`, `workflow.phase_changed` already exists and works; this packet does not modify those handlers' behavior (only the shared dispatch line in Task 2, which is provably backward-compatible — see Task 2's regression test).
+  - Promotion of a candidate **to** a canonical ConPort decision (the "explicit gate" mentioned in the design doc) is a future packet's job, not this one's.
+  - The transcript-file watcher/ingest adapter (TP-MCF-002) is a separate packet. This packet's tests never read a transcript file.
+- **File-scope discipline**: only touch the files named in each task's "Files" line. Do not bump versions, do not touch CI config, do not touch `.claude/` settings.
+
+---
+
+## Task 1 — Deterministic decision-candidate detector (pure function, new module)
+
+### Files
+- **New**: `src/dopemux/memory/conversation_promotion.py`
+- **New**: `tests/unit/test_conversation_promotion_detector.py`
+
+### Interface contract (pin this before writing any code — both the detector and the promotion handler in Task 3 depend on these exact dict/attribute names)
+
+```
+detect_decision_candidate(turn_content: str) -> DecisionCandidate | None
+
+DecisionCandidate:
+    title: str        # first 120 chars of the extracted decision text
+    rationale: str     # remainder, capped at 500 chars (may be empty string)
+```
+
+When this candidate is later emitted as a capture event (Task 5), the payload dict uses exactly the keys `{"title": ..., "rationale": ...}` — the promotion handler in Task 3 reads exactly those two keys. This is the cross-file contract; do not rename either key on either side.
+
+### Deterministic rules (exact — do not invent alternatives)
+
+A turn is a decision candidate if and only if it contains one of these leading markers, matched **case-insensitively** and **anchored to the start of the turn content** (after stripping leading whitespace) or immediately after a leading discourse filler is not permitted — anchor strictly to the start of the (stripped) string:
+
+```python
+_DECISION_MARKER_PATTERNS = [
+    r"^decision:\s*",
+    r"^we\s+decided\s+(?:to\s+|that\s+)?",
+    r"^let'?s\s+go\s+with\s+",
+    r"^approved:\s*",
+    r"^decided:\s*",
+    r"^final\s+decision:\s*",
+]
+```
+
+Additional hard rules:
+- **Min length**: the remaining text after stripping the matched marker must be at least 8 characters (rejects marker-only noise like `"decision:"` with nothing after it).
+- **Max length**: turn_content longer than 4000 characters is rejected outright (return `None`) — a decision marker inside a 4000-char turn is not a deterministic signal, it's noise; this bound also protects the regex from pathological input.
+- **Negative cases (must NOT match)** — questions and hypotheticals are explicitly excluded even if they contain a marker word:
+  - Any stripped turn_content ending in `?` is rejected outright, regardless of marker match (rejects `"Should we decide to use Redis?"`, `"Did we decide on Postgres?"`).
+  - `"should we decide"` / `"should we go with"` phrasing anywhere in the first 40 characters is rejected even without a trailing `?` (rejects hedged hypotheticals stated as declaratives, e.g. `"Should we decide to use Redis at some point"`).
+- Matching is tried against the patterns **in the order listed above**; the first match wins. Extraction: strip the matched marker prefix, then:
+  - `title` = the resulting text, truncated to 120 characters (no ellipsis, hard slice).
+  - `rationale` = the resulting text with the first 120 characters removed (i.e., whatever's left after the `title` slice), truncated to 500 characters (hard slice). If nothing remains, `rationale = ""`.
+
+### TDD steps
+
+- [ ] **1.1 — Write the failing test file.** Create `tests/unit/test_conversation_promotion_detector.py`:
+
+```python
+"""Deterministic decision-candidate detection (TP-MCF-003). No LLM, no I/O."""
+
+from dopemux.memory.conversation_promotion import (
+    DecisionCandidate,
+    detect_decision_candidate,
+)
+
+
+def test_decision_colon_marker_matches():
+    result = detect_decision_candidate("decision: use Redis Streams for the event bus")
+    assert result is not None
+    assert isinstance(result, DecisionCandidate)
+    assert result.title == "use Redis Streams for the event bus"
+    assert result.rationale == ""
+
+
+def test_we_decided_marker_matches():
+    result = detect_decision_candidate(
+        "we decided to use SQLite for the chronicle ledger because it is local-first"
+    )
+    assert result is not None
+    assert result.title.startswith("use SQLite for the chronicle ledger")
+
+
+def test_lets_go_with_marker_matches():
+    result = detect_decision_candidate("let's go with option B for the retry policy")
+    assert result is not None
+    assert result.title == "option B for the retry policy"
+
+
+def test_approved_marker_matches():
+    result = detect_decision_candidate("approved: migrate to the new schema")
+    assert result is not None
+    assert result.title == "migrate to the new schema"
+
+
+def test_case_insensitive_matching():
+    result = detect_decision_candidate("DECISION: Use Postgres for the mirror")
+    assert result is not None
+    assert result.title == "Use Postgres for the mirror"
+
+
+def test_marker_must_be_anchored_to_start():
+    # The marker phrase appears mid-sentence, not at the start — must NOT match.
+    result = detect_decision_candidate(
+        "I was thinking about it and then we decided to use Redis"
+    )
+    assert result is None
+
+
+def test_question_form_never_matches_even_with_marker_word():
+    result = detect_decision_candidate("Should we decide to use Redis?")
+    assert result is None
+
+
+def test_hedged_hypothetical_without_question_mark_rejected():
+    result = detect_decision_candidate(
+        "should we decide to use Redis at some point down the line"
+    )
+    assert result is None
+
+
+def test_did_we_decide_question_rejected():
+    result = detect_decision_candidate("Did we decide on Postgres?")
+    assert result is None
+
+
+def test_marker_only_no_content_rejected():
+    # "decision:" with nothing (or too little) after it is not a real candidate.
+    result = detect_decision_candidate("decision:")
+    assert result is None
+    result = detect_decision_candidate("decision: ok")
+    assert result is None  # "ok" is 2 chars, below the 8-char minimum
+
+
+def test_exactly_min_length_boundary_accepted():
+    # 8 chars exactly after the marker should be accepted.
+    result = detect_decision_candidate("decision: 12345678")
+    assert result is not None
+    assert result.title == "12345678"
+
+
+def test_oversized_turn_rejected():
+    huge = "decision: " + ("x" * 4100)
+    result = detect_decision_candidate(huge)
+    assert result is None
+
+
+def test_title_capped_at_120_chars_and_rationale_gets_remainder():
+    body = "a" * 150 + " tail content that becomes rationale"
+    result = detect_decision_candidate(f"decision: {body}")
+    assert result is not None
+    assert len(result.title) == 120
+    assert result.title == body[:120]
+    assert result.rationale == body[120:][:500]
+
+
+def test_rationale_capped_at_500_chars():
+    body = "b" * 700
+    result = detect_decision_candidate(f"final decision: {body}")
+    assert result is not None
+    # title takes the first 120 of body, rationale takes the next up-to-500
+    assert result.rationale == body[120:620]
+    assert len(result.rationale) == 500
+
+
+def test_non_decision_text_returns_none():
+    result = detect_decision_candidate("just chatting about the weather today")
+    assert result is None
+
+
+def test_empty_string_returns_none():
+    assert detect_decision_candidate("") is None
+
+
+def test_whitespace_only_returns_none():
+    assert detect_decision_candidate("   \n\t  ") is None
+
+
+def test_leading_whitespace_is_stripped_before_matching():
+    result = detect_decision_candidate("   decision: use the new retry policy")
+    assert result is not None
+    assert result.title == "use the new retry policy"
+
+
+def test_decided_colon_marker_matches():
+    result = detect_decision_candidate("decided: ship the v2 API")
+    assert result is not None
+    assert result.title == "ship the v2 API"
+```
+
+  Run it and confirm it fails because the module doesn't exist yet:
+  ```bash
+  mise exec -- python -m pytest tests/unit/test_conversation_promotion_detector.py -q
+  ```
+  Expected output: `ModuleNotFoundError: No module named 'dopemux.memory.conversation_promotion'` (collection error).
+
+- [ ] **1.2 — Implement the detector.** Create `src/dopemux/memory/conversation_promotion.py`:
+
+```python
+"""Deterministic (non-LLM) decision-candidate detection over conversation turns.
+
+TP-MCF-003. This module is a PURE FUNCTION boundary: no I/O, no network, no
+ConPort/httpx imports, no LLM calls. It only classifies a turn's text content
+using explicit anchored regex markers. See claudedocs/tp-mcf-001-authority-map-2026-07-04.md
+§4 and claudedocs/memory-context-fabric-design-2026-07-04.md §2 for the spec
+this implements.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_MAX_TURN_LENGTH = 4000
+_MIN_REMAINDER_LENGTH = 8
+_TITLE_MAX_LENGTH = 120
+_RATIONALE_MAX_LENGTH = 500
+
+_DECISION_MARKER_PATTERNS = [
+    re.compile(r"^decision:\s*", re.IGNORECASE),
+    re.compile(r"^we\s+decided\s+(?:to\s+|that\s+)?", re.IGNORECASE),
+    re.compile(r"^let'?s\s+go\s+with\s+", re.IGNORECASE),
+    re.compile(r"^approved:\s*", re.IGNORECASE),
+    re.compile(r"^decided:\s*", re.IGNORECASE),
+    re.compile(r"^final\s+decision:\s*", re.IGNORECASE),
+]
+
+_HEDGE_PATTERN = re.compile(r"should\s+we\s+decide|should\s+we\s+go\s+with", re.IGNORECASE)
+_HEDGE_WINDOW = 40
+
+
+@dataclass(frozen=True)
+class DecisionCandidate:
+    """A deterministically-detected decision-looking turn.
+
+    title: first 120 chars of the extracted decision text (after marker strip).
+    rationale: remainder of the extracted text, capped at 500 chars.
+    """
+
+    title: str
+    rationale: str
+
+
+def detect_decision_candidate(turn_content: str) -> DecisionCandidate | None:
+    """Deterministically detect a decision-candidate marker in turn_content.
+
+    Returns None for: empty/whitespace-only input, oversized input (>4000
+    chars), questions (trailing '?'), hedged hypotheticals ("should we
+    decide..."), unmatched text, or matched-but-too-short remainders (<8
+    chars after the marker is stripped).
+
+    No LLM. No network. No I/O. Pure string function.
+    """
+    if not turn_content:
+        return None
+
+    stripped = turn_content.strip()
+    if not stripped:
+        return None
+
+    if len(stripped) > _MAX_TURN_LENGTH:
+        return None
+
+    if stripped.endswith("?"):
+        return None
+
+    if _HEDGE_PATTERN.search(stripped[:_HEDGE_WINDOW]):
+        return None
+
+    for pattern in _DECISION_MARKER_PATTERNS:
+        match = pattern.match(stripped)
+        if not match:
+            continue
+
+        remainder = stripped[match.end():]
+        if len(remainder) < _MIN_REMAINDER_LENGTH:
+            return None
+
+        title = remainder[:_TITLE_MAX_LENGTH]
+        rationale = remainder[_TITLE_MAX_LENGTH:][:_RATIONALE_MAX_LENGTH]
+        return DecisionCandidate(title=title, rationale=rationale)
+
+    return None
+```
+
+- [ ] **1.3 — Run the test again and confirm it passes.**
+  ```bash
+  mise exec -- python -m pytest tests/unit/test_conversation_promotion_detector.py -q
+  ```
+  Expected output: `19 passed` (all tests green).
+
+- [ ] **1.4 — Commit.**
+  ```bash
+  git add src/dopemux/memory/conversation_promotion.py tests/unit/test_conversation_promotion_detector.py
+  git commit -m "feat(memory): deterministic decision-candidate detector (TP-MCF-003 Task 1)
+
+Pure regex-based marker detection for conversation.decision_candidate.
+No LLM, no I/O. Anchored markers only; rejects questions and hedged
+hypotheticals. Part of TP-MCF-003 (deterministic promotion)."
+  ```
+
+---
+
+## Task 2 — Fix the `promotion_rule` dispatch clobber (prerequisite for Task 3)
+
+**Why this task exists**: `services/working-memory-assistant/promotion/promotion.py`'s `promote()` method unconditionally overwrites `promotion_rule` after calling the per-type handler:
+
+```python
+# Current code, promotion.py line ~191:
+promoted.promotion_rule = normalized  # Normalized handler name
+```
+
+If the new handler in Task 3 sets `promoted.promotion_rule = "conversation_candidate_v1"`, this line silently overwrites it back to `"conversation.decision_candidate"` — which would violate this packet's hard requirement that the promoted entry carry `promotion_rule="conversation_candidate_v1"`. This has been empirically verified against the actual runtime: every one of the 7 existing `_promote_*` handlers leaves `PromotedEntry.promotion_rule` at its dataclass default of `None` (none of them set it), so changing the line to only fill in the normalized type **when the handler didn't already set one** is a no-op for all existing handlers and unblocks the new one.
+
+### Files
+- **Modify**: `services/working-memory-assistant/promotion/promotion.py` (one line)
+- **New**: `services/working-memory-assistant/tests/unit/test_promotion_rule_precedence.py`
+
+### TDD steps
+
+- [ ] **2.1 — Write the failing regression test.** Create `services/working-memory-assistant/tests/unit/test_promotion_rule_precedence.py`:
+
+```python
+"""Regression test: promote() must not clobber a handler-set promotion_rule.
+
+TP-MCF-003 Task 2. Every EXISTING handler leaves PromotedEntry.promotion_rule
+at its dataclass default (None), so the dispatch-level fallback in promote()
+must only fill in the normalized event type when the handler left it unset —
+never override a handler that explicitly set its own promotion_rule.
+"""
+
+from promotion.promotion import PromotionEngine
+
+
+def test_existing_handlers_still_get_normalized_promotion_rule():
+    """Backward-compatibility: handlers that don't set promotion_rule still
+    get the normalized event type, exactly as before this packet's change."""
+    engine = PromotionEngine()
+
+    entry = engine.promote(
+        "decision.logged",
+        {
+            "decision_id": "dec-1",
+            "title": "Use Redis Streams",
+            "choice": "Redis",
+        },
+    )
+
+    assert entry is not None
+    assert entry.promotion_rule == "decision.logged"
+
+
+def test_existing_task_completed_handler_still_gets_normalized_promotion_rule():
+    engine = PromotionEngine()
+
+    entry = engine.promote(
+        "task.completed", {"task_id": "task-1", "title": "Implement EventBus"}
+    )
+
+    assert entry is not None
+    assert entry.promotion_rule == "task.completed"
+```
+
+  Run it and confirm it currently passes (this is a *pre-existing-behavior* regression guard, not a new-behavior test — it must pass BEFORE and AFTER the one-line change, proving the change is backward-compatible):
+  ```bash
+  cd services/working-memory-assistant && mise exec -- python -m pytest tests/unit/test_promotion_rule_precedence.py -q
+  ```
+  Expected output: `2 passed` (this confirms current behavior is what we think it is, before we touch the dispatch line).
+
+- [ ] **2.2 — Apply the one-line fix.** In `services/working-memory-assistant/promotion/promotion.py`, find this exact line (inside `PromotionEngine.promote`, immediately after the four `source_*` provenance assignments):
+
+  ```python
+          promoted.promotion_rule = normalized  # Normalized handler name
+  ```
+
+  Replace it with:
+
+  ```python
+          promoted.promotion_rule = promoted.promotion_rule or normalized  # Normalized handler name (unless handler set its own)
+  ```
+
+- [ ] **2.3 — Re-run the regression test plus the full existing promotion suite to confirm zero behavior change.**
+  ```bash
+  cd services/working-memory-assistant && mise exec -- python -m pytest tests/unit/test_promotion_rule_precedence.py tests/test_promotion_allowlist.py tests/unit/test_promotion_provenance.py -q
+  ```
+  Expected output: `25 passed` (2 new + 21 from `test_promotion_allowlist.py` + 2 from `test_promotion_provenance.py`).
+
+- [ ] **2.4 — Commit.**
+  ```bash
+  git add services/working-memory-assistant/promotion/promotion.py services/working-memory-assistant/tests/unit/test_promotion_rule_precedence.py
+  git commit -m "fix(wma): let promotion handlers set their own promotion_rule (TP-MCF-003 Task 2)
+
+promote() previously clobbered any handler-set promotion_rule with the
+normalized event type. All 7 existing handlers leave promotion_rule at
+its None default, so this is backward-compatible (regression test
+proves it) and unblocks the conversation.decision_candidate handler,
+which must carry promotion_rule=\"conversation_candidate_v1\" per
+claudedocs/tp-mcf-001-authority-map-2026-07-04.md §4."
+  ```
+
+---
+
+## Task 3 — Add `conversation.decision_candidate` to both allowlists + the sync-guard test
+
+**Why the sync-guard test matters**: `PROMOTABLE_CAPTURE_EVENT_TYPES` (in `src/dopemux/memory/capture_client.py`) and `PROMOTABLE_EVENT_TYPES` (in `services/working-memory-assistant/promotion/promotion.py`) are two **independently maintained** `frozenset` literals in two different files, in two different Python import namespaces. Nothing today enforces they stay equal. This task adds a test that imports both (bridging the namespace gap with `monkeypatch.syspath_prepend`, verified to work) and asserts set equality — so any future addition to only one side fails CI immediately.
+
+### Files
+- **Modify**: `src/dopemux/memory/capture_client.py` (one line — add to the frozenset)
+- **Modify**: `services/working-memory-assistant/promotion/promotion.py` (one line — add to the frozenset; this file was already touched in Task 2, so re-open it)
+- **Modify**: `services/working-memory-assistant/tests/test_event_type_normalization.py` (update a pre-existing hardcoded allowlist assertion — see step 3.5)
+- **New**: `tests/unit/test_promotable_allowlist_sync.py`
+
+### TDD steps
+
+- [ ] **3.1 — Write the failing sync-guard test.** Create `tests/unit/test_promotable_allowlist_sync.py`:
+
+```python
+"""Sync-guard: the two promotable-event-type allowlists must stay identical.
+
+TP-MCF-003. PROMOTABLE_CAPTURE_EVENT_TYPES (src/dopemux/memory/capture_client.py)
+and PROMOTABLE_EVENT_TYPES (services/working-memory-assistant/promotion/promotion.py)
+are independently maintained frozensets in two separate import namespaces
+(root `dopemux.*` via pyproject.toml's pythonpath=["src"], and WMA's
+`promotion.*` via services/working-memory-assistant/tests/conftest.py's
+sys.path insert). This test bridges both namespaces from the ROOT test
+runner using monkeypatch.syspath_prepend (auto-reverts after the test, so
+it does not leak generically-named modules like "store"/"main"/"utils"
+onto sys.path for the rest of the session) and asserts the two sets are
+byte-for-byte equal. Any future new event type added to only one side
+must fail this test.
+"""
+
+from pathlib import Path
+
+from dopemux.memory.capture_client import PROMOTABLE_CAPTURE_EVENT_TYPES
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WMA_DIR = REPO_ROOT / "services" / "working-memory-assistant"
+
+
+def test_both_allowlists_are_identical(monkeypatch):
+    monkeypatch.syspath_prepend(str(WMA_DIR))
+
+    from promotion.promotion import PROMOTABLE_EVENT_TYPES
+
+    assert PROMOTABLE_EVENT_TYPES == PROMOTABLE_CAPTURE_EVENT_TYPES
+
+
+def test_conversation_decision_candidate_is_in_both_allowlists(monkeypatch):
+    monkeypatch.syspath_prepend(str(WMA_DIR))
+
+    from promotion.promotion import PROMOTABLE_EVENT_TYPES
+
+    assert "conversation.decision_candidate" in PROMOTABLE_CAPTURE_EVENT_TYPES
+    assert "conversation.decision_candidate" in PROMOTABLE_EVENT_TYPES
+```
+
+  Run it and confirm it fails (the new type is not in either allowlist yet, so the second test fails; the first test currently passes since the two sets are equal today — that's fine, it's a baseline check):
+  ```bash
+  mise exec -- python -m pytest tests/unit/test_promotable_allowlist_sync.py -q
+  ```
+  Expected output: `1 passed, 1 failed` — `test_conversation_decision_candidate_is_in_both_allowlists` fails with `AssertionError: assert 'conversation.decision_candidate' in frozenset({...7 existing types...})`.
+
+- [ ] **3.2 — Add the new type to `PROMOTABLE_CAPTURE_EVENT_TYPES`.** In `src/dopemux/memory/capture_client.py`, find:
+
+  ```python
+  PROMOTABLE_CAPTURE_EVENT_TYPES = frozenset(
+      {
+          "decision.logged",
+          "task.completed",
+          "task.failed",
+          "task.blocked",
+          "error.encountered",
+          "workflow.phase_changed",
+          "manual.memory_store",
+      }
+  )
+  ```
+
+  Replace with:
+
+  ```python
+  PROMOTABLE_CAPTURE_EVENT_TYPES = frozenset(
+      {
+          "decision.logged",
+          "task.completed",
+          "task.failed",
+          "task.blocked",
+          "error.encountered",
+          "workflow.phase_changed",
+          "manual.memory_store",
+          "conversation.decision_candidate",
+      }
+  )
+  ```
+
+- [ ] **3.3 — Add the new type to `PROMOTABLE_EVENT_TYPES`.** In `services/working-memory-assistant/promotion/promotion.py`, find:
+
+  ```python
+  PROMOTABLE_EVENT_TYPES = frozenset(
+      [
+          "decision.logged",
+          "task.completed",
+          "task.failed",
+          "task.blocked",
+          "error.encountered",
+          "workflow.phase_changed",
+          "manual.memory_store",
+      ]
+  )
+  ```
+
+  Replace with:
+
+  ```python
+  PROMOTABLE_EVENT_TYPES = frozenset(
+      [
+          "decision.logged",
+          "task.completed",
+          "task.failed",
+          "task.blocked",
+          "error.encountered",
+          "workflow.phase_changed",
+          "manual.memory_store",
+          "conversation.decision_candidate",
+      ]
+  )
+  ```
+
+- [ ] **3.4 — Run the sync-guard test again and confirm it passes.**
+  ```bash
+  mise exec -- python -m pytest tests/unit/test_promotable_allowlist_sync.py -q
+  ```
+  Expected output: `2 passed`.
+
+- [ ] **3.5 — Update the pre-existing hardcoded-allowlist test.** `services/working-memory-assistant/tests/test_event_type_normalization.py` has a pre-existing test, `TestPromotableEventTypes::test_all_phase1_types_present`, that asserts `PROMOTABLE_EVENT_TYPES` equals an exact 7-element set. Adding the 8th type in steps 3.2-3.3 makes this assertion fail — this is an expected, in-scope consequence of this task (not a pre-existing unrelated failure like the ones catalogued in Task 4.4), so the test must be updated as part of this commit. In `services/working-memory-assistant/tests/test_event_type_normalization.py`, find:
+
+  ```python
+    def test_all_phase1_types_present(self):
+        """All Phase 1 event types should be in the allowlist."""
+        expected = {
+            "decision.logged",
+            "task.completed",
+            "task.failed",
+            "task.blocked",
+            "error.encountered",
+            "workflow.phase_changed",
+            "manual.memory_store",
+        }
+        assert PROMOTABLE_EVENT_TYPES == expected
+  ```
+
+  Replace with:
+
+  ```python
+    def test_all_phase1_types_present(self):
+        """All Phase 1 + deterministic-promotion event types should be in the allowlist.
+
+        conversation.decision_candidate (TP-MCF-003) is deterministic (regex
+        marker detection, no LLM) and belongs in the same allowlist philosophy
+        as the original Phase 1 types, though it is trust-lower (see
+        promotion.py's _promote_conversation_decision_candidate handler).
+        """
+        expected = {
+            "decision.logged",
+            "task.completed",
+            "task.failed",
+            "task.blocked",
+            "error.encountered",
+            "workflow.phase_changed",
+            "manual.memory_store",
+            "conversation.decision_candidate",
+        }
+        assert PROMOTABLE_EVENT_TYPES == expected
+  ```
+
+  Run the file directly to confirm it passes:
+  ```bash
+  cd services/working-memory-assistant && mise exec -- python -m pytest tests/test_event_type_normalization.py -q
+  ```
+  Expected output: `8 passed`.
+
+- [ ] **3.6 — Run the full existing WMA promotion suite to confirm no regression** (the new type alone, with no handler yet, must not break `is_promotable` or `promote` for existing types — and `is_promotable("conversation.decision_candidate")` should now be `True` even though there's no handler wired yet, per the next task):
+  ```bash
+  cd services/working-memory-assistant && mise exec -- python -m pytest tests/test_promotion_allowlist.py tests/test_event_type_normalization.py tests/unit/test_promotion_provenance.py tests/unit/test_promotion_rule_precedence.py -q
+  ```
+  Expected output: `33 passed`.
+
+- [ ] **3.7 — Commit.**
+  ```bash
+  git add src/dopemux/memory/capture_client.py services/working-memory-assistant/promotion/promotion.py services/working-memory-assistant/tests/test_event_type_normalization.py tests/unit/test_promotable_allowlist_sync.py
+  git commit -m "feat(memory): add conversation.decision_candidate to both promotable allowlists (TP-MCF-003 Task 3)
+
+Adds the new event type to PROMOTABLE_CAPTURE_EVENT_TYPES
+(capture_client.py) and PROMOTABLE_EVENT_TYPES (promotion.py), which
+must stay synced per claudedocs/tp-mcf-001-authority-map-2026-07-04.md
+gap #4. New sync-guard test bridges both import namespaces and asserts
+set equality so future drift fails CI. Updates the pre-existing
+test_all_phase1_types_present assertion to include the new type."
+  ```
+
+---
+
+## Task 4 — Promotion handler `_promote_conversation_decision_candidate`
+
+### Files
+- **Modify**: `services/working-memory-assistant/promotion/promotion.py` (add one handler method)
+- **New**: `services/working-memory-assistant/tests/unit/test_promote_conversation_decision_candidate.py`
+
+### Design notes (read before writing the test)
+
+Mirror the construction style of `_promote_decision_logged` (redactor use, `[:500]` summary cap, `PromotedEntry` field layout) and `_promote_task_completed` (minimal required-field guard). But **do not** copy `_promote_decision_logged`'s `if not decision_id: return None` guard — a conversation candidate has no `decision_id` by definition (no ConPort decision exists yet; that's the entire point of a *candidate*). The only required field is `title` (per the Task 1 contract, `detect_decision_candidate` never returns a candidate without a non-empty `title`, but the handler must independently guard against malformed/hand-crafted payloads that skip the detector).
+
+Field choices (each justified so you don't have to re-derive them):
+- `category="planning"` — an existing valid enum value (`chronicle/schema.sql` line 38-41, `chronicle/store.py` `VALID_CATEGORIES`); no schema change needed.
+- `entry_type="decision"` — same enum value `_promote_decision_logged` uses (`chronicle/schema.sql` line 42-45); trust is encoded via `details_json`, not a different `entry_type`, so reusing `"decision"` is correct.
+- `importance_score=4` — deliberately **lower** than `_promote_decision_logged`'s `7`. This encodes "provenance only lowers trust" (per `claudedocs/memory-context-fabric-interfaces-2026-07-04.md` §4 invariant 5): a conversation-inferred candidate must never be scored as confidently as an explicitly-logged decision.
+- `details={"trust": "conversation-derived"}` (redacted through `self.redactor.redact_payload(...)`, exactly like `_promote_task_failed` and `_promote_task_blocked` redact their `details` dicts) — this is the field the design doc calls out as the only place trust can live, since `work_log_entries` has no `trust` column (`chronicle/schema.sql` confirmed — no such column exists).
+- `promotion_rule="conversation_candidate_v1"` — set directly on the `PromotedEntry` returned by the handler; Task 2's fix is what lets this survive the dispatch step in `promote()` instead of being overwritten to `"conversation.decision_candidate"`.
+- `reasoning=rationale[:500] if rationale else None` — mirrors `_promote_decision_logged`'s `reasoning=rationale[:2000] if rationale else None` pattern, but capped at 500 (matching the detector's own rationale cap from Task 1, so there's no double-truncation surprise).
+- Summary format: `f"Candidate decision: {title}"[:500]` — same `[:500]` cap pattern used by every other handler's `summary` field.
+
+### TDD steps
+
+- [ ] **4.1 — Write the failing test file.** Create `services/working-memory-assistant/tests/unit/test_promote_conversation_decision_candidate.py`:
+
+```python
+"""Promotion handler for conversation.decision_candidate (TP-MCF-003 Task 4).
+
+Trust is conversation-derived and MUST be lower-confidence than a real
+decision.logged promotion: importance_score=4 (vs 7), promotion_rule=
+"conversation_candidate_v1" (never "decision.logged"), and
+details_json.trust="conversation-derived" (the only place trust can live,
+since work_log_entries has no trust column).
+"""
+
+import pytest
+
+from promotion.promotion import PromotionEngine
+
+
+@pytest.fixture
+def engine():
+    return PromotionEngine()
+
+
+def _event(**payload_overrides):
+    payload = {
+        "title": "use Redis Streams for the event bus",
+        "rationale": "deterministic and replay-safe",
+    }
+    payload.update(payload_overrides)
+    return {
+        "id": "evt-candidate-1",
+        "event_type": "conversation.decision_candidate",
+        "source": "transcript",
+        "ts_utc": "2026-07-04T00:00:00+00:00",
+        "payload": payload,
+    }
+
+
+def test_is_promotable():
+    engine = PromotionEngine()
+    assert engine.is_promotable("conversation.decision_candidate") is True
+
+
+def test_candidate_promotes_to_entry(engine):
+    entry = engine.promote(_event())
+
+    assert entry is not None
+    assert entry.category == "planning"
+    assert entry.entry_type == "decision"
+    assert entry.summary == "Candidate decision: use Redis Streams for the event bus"
+    assert entry.outcome == "in_progress"
+
+
+def test_promotion_rule_is_conversation_candidate_v1_not_normalized_type(engine):
+    entry = engine.promote(_event())
+
+    assert entry is not None
+    assert entry.promotion_rule == "conversation_candidate_v1"
+    assert entry.promotion_rule != "conversation.decision_candidate"
+
+
+def test_trust_lives_in_details_json_only(engine):
+    entry = engine.promote(_event())
+
+    assert entry is not None
+    assert entry.details is not None
+    assert entry.details["trust"] == "conversation-derived"
+
+
+def test_importance_score_is_lower_than_real_decision_logged(engine):
+    candidate_entry = engine.promote(_event())
+    real_decision_entry = engine.promote(
+        "decision.logged",
+        {
+            "decision_id": "dec-real-1",
+            "title": "Use Redis Streams",
+            "choice": "Redis",
+        },
+    )
+
+    assert candidate_entry is not None
+    assert real_decision_entry is not None
+    assert candidate_entry.importance_score < real_decision_entry.importance_score
+    assert candidate_entry.importance_score == 4
+    assert real_decision_entry.importance_score == 7
+
+
+def test_rationale_becomes_reasoning_capped_at_500(engine):
+    entry = engine.promote(_event(rationale="r" * 700))
+
+    assert entry is not None
+    assert entry.reasoning is not None
+    assert len(entry.reasoning) == 500
+
+
+def test_missing_title_does_not_promote(engine):
+    entry = engine.promote(_event(title=""))
+    assert entry is None
+
+
+def test_missing_rationale_still_promotes_with_none_reasoning(engine):
+    event = _event()
+    del event["payload"]["rationale"]
+    entry = engine.promote(event)
+
+    assert entry is not None
+    assert entry.reasoning is None
+
+
+def test_source_provenance_fields_are_populated(engine):
+    entry = engine.promote(_event())
+
+    assert entry is not None
+    assert entry.source_event_id == "evt-candidate-1"
+    assert entry.source_event_type == "conversation.decision_candidate"
+    assert entry.source_adapter == "transcript"
+    assert entry.source_event_ts_utc == "2026-07-04T00:00:00+00:00"
+
+
+def test_never_produces_decision_logged_source_event_type(engine):
+    entry = engine.promote(_event())
+
+    assert entry is not None
+    assert entry.source_event_type != "decision.logged"
+```
+
+  Run it and confirm it fails (`promote` currently returns `None` because there's no `_promote_conversation_decision_candidate` handler yet, so `getattr(self, ..., None)` is `None` and dispatch returns `None`):
+  ```bash
+  cd services/working-memory-assistant && mise exec -- python -m pytest tests/unit/test_promote_conversation_decision_candidate.py -q
+  ```
+  Expected output: `2 passed, 8 failed` — `test_is_promotable` passes (the type is now in the allowlist from Task 3), and `test_missing_title_does_not_promote` also passes trivially (it asserts `entry is None`, which is true with no handler at all, for the wrong reason — that's fine, Task 4.3 re-validates it for the right reason once the handler exists). The other 8 tests fail because every `_promote_*` dispatch with no matching handler method returns `None`, so any assertion of `entry is not None` fails.
+
+- [ ] **4.2 — Implement the handler.** In `services/working-memory-assistant/promotion/promotion.py`, add the new method. Insert it immediately before `_promote_manual_memory_store` (i.e., after `_promote_workflow_phase_changed` and before `_promote_manual_memory_store`), so the handler ordering in the file mirrors the ordering in `PROMOTABLE_EVENT_TYPES`:
+
+```python
+    def _promote_conversation_decision_candidate(
+        self, data: dict[str, Any]
+    ) -> Optional[PromotedEntry]:
+        """Promote conversation.decision_candidate event.
+
+        TP-MCF-003. This is a DETERMINISTICALLY-DETECTED candidate (see
+        src/dopemux/memory/conversation_promotion.py — regex markers only,
+        no LLM), never an auto-write to ConPort and never a decision.logged
+        event. Trust is encoded ONLY in details_json.trust (work_log_entries
+        has no trust column) and importance_score is deliberately lower than
+        a real decision.logged promotion (4 vs 7), per the "provenance only
+        lowers trust" invariant in
+        claudedocs/memory-context-fabric-interfaces-2026-07-04.md §4.
+
+        Requires: title (non-empty). rationale is optional.
+        """
+        title = data.get("title", "")
+        rationale = data.get("rationale", "")
+
+        if not title:
+            return None
+
+        details = self.redactor.redact_payload({"trust": "conversation-derived"})
+
+        return PromotedEntry(
+            category="planning",
+            entry_type="decision",
+            summary=f"Candidate decision: {title}"[:500],
+            outcome="in_progress",
+            importance_score=4,
+            reasoning=rationale[:500] if rationale else None,
+            details=details,
+            tags=self._extract_tags(data),
+            promotion_rule="conversation_candidate_v1",
+        )
+
+```
+
+- [ ] **4.3 — Run the test again and confirm it passes.**
+  ```bash
+  cd services/working-memory-assistant && mise exec -- python -m pytest tests/unit/test_promote_conversation_decision_candidate.py -q
+  ```
+  Expected output: `10 passed`.
+
+- [ ] **4.4 — Run the WMA promotion-relevant suite to confirm no regression.**
+
+  **Important — do NOT run bare `pytest tests/` for this check.** The WMA `tests/` tree has **pre-existing, packet-unrelated collection errors** (verified empirically, present before this packet touched anything): `tests/test_migration_runner_optimized.py`, `tests/test_predictive_restoration.py`, `tests/test_wma_core.py`, and `tests/unit/test_copilot_adapter_hardening.py` all fail to collect with `ImportError: Unable to import services.copilot_transcript_ingester modules. Run from repository root or set PYTHONPATH to include it.` — a `dopemux.memory.adapters.copilot` import that only resolves when the interpreter is invoked from repo root, not from `services/working-memory-assistant/`. Additionally, `tests/test_dope_memory.py`, `tests/test_phase2_reflection_trajectory.py`, `tests/test_reflection.py`, `tests/test_trajectory.py`, and `tests/test_trajectory_boost_in_ranking.py` have pre-existing failures unrelated to promotion (reflection/trajectory ordering tests). None of this is caused by this packet — verified by running the identical command against an unmodified copy of this repo before any Task 1-4 edits were applied. **Do not attempt to fix these; they are out of this packet's scope.**
+
+  Instead, run the promotion-relevant subset that is known-clean in the baseline:
+  ```bash
+  cd services/working-memory-assistant && mise exec -- python -m pytest \
+    tests/test_event_type_normalization.py \
+    tests/test_eventbus_consumer.py \
+    tests/test_mcp_http_endpoint.py \
+    tests/test_promotion_allowlist.py \
+    tests/test_session_tracker.py \
+    tests/test_store_fail_closed.py \
+    tests/unit/ \
+    --ignore=tests/unit/test_copilot_adapter_hardening.py \
+    -q
+  ```
+  Expected output: `113 passed, 1 skipped` (the skip is `tests/test_mcp_http_endpoint.py` — `could not import 'fastmcp': No module named 'fastmcp'`, an unrelated optional-dependency gap, not a regression). This count includes all new/modified test files from Tasks 2–4 (`test_promotion_rule_precedence.py`, `test_promote_conversation_decision_candidate.py`, the updated `test_event_type_normalization.py`) alongside the full pre-existing `tests/unit/` directory (minus the one broken-import file) and the other known-good top-level files.
+
+- [ ] **4.5 — Commit.**
+  ```bash
+  git add services/working-memory-assistant/promotion/promotion.py services/working-memory-assistant/tests/unit/test_promote_conversation_decision_candidate.py
+  git commit -m "feat(wma): promote conversation.decision_candidate events (TP-MCF-003 Task 4)
+
+New _promote_conversation_decision_candidate handler. Mirrors
+_promote_decision_logged's construction style but requires only
+title (no decision_id — no ConPort decision exists yet, that's the
+point of a candidate). importance_score=4 (vs 7 for real decisions),
+promotion_rule=\"conversation_candidate_v1\", trust encoded in
+details_json only (no trust column exists in work_log_entries)."
+  ```
+
+---
+
+## Task 5 — Emit-side: `emit_promotable_capture_event` acceptance + no-ConPort + never-decision-logged tests
+
+This task does not add new production code — `emit_promotable_capture_event` in `src/dopemux/memory/capture_client.py` already accepts any type in `PROMOTABLE_CAPTURE_EVENT_TYPES` generically (Task 3 already added the new type to that frozenset). This task adds the **acceptance tests** proving the emit side works end-to-end for the new type, plus the two hard-invariant tests (no ConPort import, never `decision.logged`) that this packet's spec requires.
+
+### Files
+- **New**: `tests/unit/test_conversation_decision_candidate_emit.py`
+
+### TDD steps
+
+- [ ] **5.1 — Write the test file** (there is no "confirm it fails first" step for 5.1's acceptance tests, since Task 3 already made the type acceptable — these are net-new coverage, not a red/green cycle on production code; run once to confirm they pass immediately, which validates Task 3's frozenset edit end-to-end through the real `emit_capture_event`/SQLite path). Create `tests/unit/test_conversation_decision_candidate_emit.py`:
+
+```python
+"""Emit-side acceptance for conversation.decision_candidate (TP-MCF-003 Task 5).
+
+Hard invariants under test:
+- emit_promotable_capture_event accepts the new type and writes to the raw
+  ledger (same tmp_path + DOPEMUX_CAPTURE_LEDGER_PATH harness used throughout
+  tests/unit/test_memory_capture_client.py).
+- The emitted event_type is EXACTLY "conversation.decision_candidate" —
+  never "decision.logged" (which the codebase reserves for post-write
+  receipts from a real ConPort write; see
+  claudedocs/tp-mcf-001-authority-map-2026-07-04.md Domain F).
+- No module in the conversation-promotion capture path imports an
+  httpx/requests/aiohttp/ConPort client — the candidate never reaches
+  ConPort directly. This is a static import-scan test, not a runtime mock
+  (a runtime mock would only prove "we didn't call it this time"; the
+  import-scan proves "the capability to call it does not exist in this
+  module").
+"""
+
+import ast
+import json
+import sqlite3
+from pathlib import Path
+
+from dopemux.memory.capture_client import emit_promotable_capture_event
+from dopemux.memory.conversation_promotion import detect_decision_candidate
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_FORBIDDEN_IMPORT_MODULES = {
+    "httpx",
+    "requests",
+    "aiohttp",
+    "urllib3",
+}
+_FORBIDDEN_IMPORT_SUBSTRINGS = ("conport",)
+
+
+def _event_payload(ledger_path: Path, event_id: str) -> dict:
+    conn = sqlite3.connect(str(ledger_path))
+    try:
+        row = conn.execute(
+            "SELECT payload_json, event_type FROM raw_activity_events WHERE id = ?",
+            (event_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    payload_json, event_type = row
+    return {"payload": json.loads(payload_json), "event_type": event_type}
+
+
+def test_emit_accepts_conversation_decision_candidate(tmp_path, monkeypatch):
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    candidate = detect_decision_candidate(
+        "decision: use Redis Streams for the event bus"
+    )
+    assert candidate is not None
+
+    result = emit_promotable_capture_event(
+        "conversation.decision_candidate",
+        {"title": candidate.title, "rationale": candidate.rationale},
+        source="transcript",
+        mode="cli",
+        repo_root=REPO_ROOT,
+        emit_event_bus=False,
+    )
+
+    assert result.event_type == "conversation.decision_candidate"
+
+    stored = _event_payload(ledger_path, result.event_id)
+    assert stored["event_type"] == "conversation.decision_candidate"
+    assert stored["payload"]["title"] == candidate.title
+
+
+def test_emitted_event_type_is_never_decision_logged(tmp_path, monkeypatch):
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    candidate = detect_decision_candidate("we decided to use SQLite for the ledger")
+    assert candidate is not None
+
+    result = emit_promotable_capture_event(
+        "conversation.decision_candidate",
+        {"title": candidate.title, "rationale": candidate.rationale},
+        source="transcript",
+        mode="cli",
+        repo_root=REPO_ROOT,
+        emit_event_bus=False,
+    )
+
+    assert result.event_type == "conversation.decision_candidate"
+    assert result.event_type != "decision.logged"
+
+
+def test_detect_then_emit_pipeline_end_to_end(tmp_path, monkeypatch):
+    """Full pipeline: detector -> emit -> raw ledger. No promotion engine
+    involved here (that's a WMA-side concern tested in Task 4) — this test
+    only proves the dopemux-side detect->emit contract."""
+    ledger_path = tmp_path / "chronicle.sqlite"
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger_path))
+
+    turn = "approved: migrate the chronicle schema to v2"
+    candidate = detect_decision_candidate(turn)
+    assert candidate is not None
+
+    result = emit_promotable_capture_event(
+        "conversation.decision_candidate",
+        {"title": candidate.title, "rationale": candidate.rationale},
+        source="transcript",
+        mode="cli",
+        repo_root=REPO_ROOT,
+        emit_event_bus=False,
+    )
+
+    assert result.event_type == "conversation.decision_candidate"
+    assert result.inserted is True
+
+
+def test_question_form_never_reaches_emit_because_detector_returns_none():
+    """Negative-path proof: a question never even produces a candidate to
+    emit in the first place (belt-and-suspenders with Task 1's detector
+    tests, but scoped here to the emit-adjacent boundary)."""
+    assert detect_decision_candidate("Should we decide to use Redis?") is None
+
+
+def _iter_import_module_names(tree: ast.AST):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                yield alias.name
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                yield node.module
+
+
+def test_conversation_promotion_module_imports_no_conport_or_http_client():
+    """Static import-scan: src/dopemux/memory/conversation_promotion.py must
+    import NOTHING that could reach ConPort or make an HTTP call. This is
+    the module that owns detection; it must remain a pure function forever."""
+    module_path = REPO_ROOT / "src" / "dopemux" / "memory" / "conversation_promotion.py"
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+
+    imported = set(_iter_import_module_names(tree))
+
+    for forbidden in _FORBIDDEN_IMPORT_MODULES:
+        assert not any(
+            name == forbidden or name.startswith(f"{forbidden}.") for name in imported
+        ), f"forbidden import '{forbidden}' found in conversation_promotion.py: {imported}"
+
+    for name in imported:
+        lowered = name.lower()
+        for substring in _FORBIDDEN_IMPORT_SUBSTRINGS:
+            assert substring not in lowered, (
+                f"forbidden substring '{substring}' found in import '{name}' "
+                f"in conversation_promotion.py"
+            )
+
+
+def test_capture_client_module_imports_no_conport_client():
+    """capture_client.py (the emit-side spine this packet reuses) must not
+    import a ConPort client either — it is a raw-ledger writer only."""
+    module_path = REPO_ROOT / "src" / "dopemux" / "memory" / "capture_client.py"
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+
+    imported = set(_iter_import_module_names(tree))
+
+    for name in imported:
+        lowered = name.lower()
+        for substring in _FORBIDDEN_IMPORT_SUBSTRINGS:
+            assert substring not in lowered, (
+                f"forbidden substring '{substring}' found in import '{name}' "
+                f"in capture_client.py"
+            )
+```
+
+- [ ] **5.2 — Run it and confirm all tests pass.**
+  ```bash
+  mise exec -- python -m pytest tests/unit/test_conversation_decision_candidate_emit.py -q
+  ```
+  Expected output: `6 passed`.
+
+- [ ] **5.3 — Commit.**
+  ```bash
+  git add tests/unit/test_conversation_decision_candidate_emit.py
+  git commit -m "test(memory): emit-side acceptance + no-ConPort + never-decision-logged (TP-MCF-003 Task 5)
+
+Proves emit_promotable_capture_event accepts conversation.decision_candidate
+end-to-end through the real SQLite ledger, the emitted event_type is never
+decision.logged, and neither conversation_promotion.py nor capture_client.py
+imports an httpx/requests/aiohttp/ConPort client (static AST import scan,
+not a runtime mock)."
+  ```
+
+---
+
+## Task 6 — Combined verification + proof-gate checklist
+
+### 6.1 — Run every test file this packet touched, both suites
+
+Root suite (dopemux-side: detector, sync-guard, emit acceptance, existing capture-client regression):
+```bash
+mise exec -- python -m pytest \
+  tests/unit/test_memory_capture_client.py \
+  tests/unit/test_conversation_promotion_detector.py \
+  tests/unit/test_promotable_allowlist_sync.py \
+  tests/unit/test_conversation_decision_candidate_emit.py \
+  -q
+```
+Expected output: all pass, `0 failed` (23 from the pre-existing `test_memory_capture_client.py` + 19 + 2 + 6 = 50 total, but the requirement is `0 failed`, not an exact count — pytest's own summary line is the source of truth).
+
+WMA suite (promotion-side: dispatch fix regression, new handler, promotion-relevant existing WMA tests). **Do not run bare `pytest tests/`** — as established in Task 4.4, the WMA `tests/` tree has pre-existing, packet-unrelated collection errors and failures (import-path issues in 4 files, reflection/trajectory ordering failures in 5 more) that predate this packet and are out of scope. Use the same scoped command from Task 4.4:
+```bash
+cd services/working-memory-assistant && mise exec -- python -m pytest \
+  tests/test_event_type_normalization.py \
+  tests/test_eventbus_consumer.py \
+  tests/test_mcp_http_endpoint.py \
+  tests/test_promotion_allowlist.py \
+  tests/test_session_tracker.py \
+  tests/test_store_fail_closed.py \
+  tests/unit/ \
+  --ignore=tests/unit/test_copilot_adapter_hardening.py \
+  -q
+```
+Expected output: `113 passed, 1 skipped` (same result as Task 4.4 — the skip is the unrelated missing `fastmcp` optional dependency).
+
+### 6.2 — Proof-gate checklist (all must be checked before this packet is considered done)
+
+- [ ] **Both-allowlists sync test exists and passes**: `tests/unit/test_promotable_allowlist_sync.py::test_both_allowlists_are_identical` and `::test_conversation_decision_candidate_is_in_both_allowlists` both green.
+- [ ] **No-ConPort/no-HTTP-client test exists and passes**: `tests/unit/test_conversation_decision_candidate_emit.py::test_conversation_promotion_module_imports_no_conport_or_http_client` and `::test_capture_client_module_imports_no_conport_client` both green.
+- [ ] **Negative-detection tests exist and pass**: every `test_*question*`/`test_*hedged*`/`test_marker_only*` test in `tests/unit/test_conversation_promotion_detector.py` green (specifically: `test_question_form_never_matches_even_with_marker_word`, `test_hedged_hypothetical_without_question_mark_rejected`, `test_did_we_decide_question_rejected`, `test_marker_only_no_content_rejected`, `test_marker_must_be_anchored_to_start`).
+- [ ] **Authority/trust label assertion passes**: `services/working-memory-assistant/tests/unit/test_promote_conversation_decision_candidate.py::test_trust_lives_in_details_json_only` and `::test_importance_score_is_lower_than_real_decision_logged` both green.
+- [ ] **Never-`decision.logged` assertion passes**: `tests/unit/test_conversation_decision_candidate_emit.py::test_emitted_event_type_is_never_decision_logged` and `services/working-memory-assistant/tests/unit/test_promote_conversation_decision_candidate.py::test_never_produces_decision_logged_source_event_type` both green.
+- [ ] **`promotion_rule` precedence regression test passes**: `services/working-memory-assistant/tests/unit/test_promotion_rule_precedence.py` both tests green (proves the Task 2 dispatch fix is backward-compatible).
+- [ ] **`git status` is clean except for this packet's new/modified files** (no stray edits to files outside this plan's scope):
+  ```bash
+  git status --porcelain
+  ```
+  Expected: only these paths appear (as `M` or `??`):
+  - `src/dopemux/memory/conversation_promotion.py` (new)
+  - `src/dopemux/memory/capture_client.py` (modified)
+  - `services/working-memory-assistant/promotion/promotion.py` (modified)
+  - `services/working-memory-assistant/tests/test_event_type_normalization.py` (modified)
+  - `services/working-memory-assistant/tests/unit/test_promotion_rule_precedence.py` (new)
+  - `services/working-memory-assistant/tests/unit/test_promote_conversation_decision_candidate.py` (new)
+  - `tests/unit/test_conversation_promotion_detector.py` (new)
+  - `tests/unit/test_promotable_allowlist_sync.py` (new)
+  - `tests/unit/test_conversation_decision_candidate_emit.py` (new)
+
+  (If working through the checkboxes commit-by-commit as instructed, this will already be clean — nothing to stage — by the time you reach this final check, since Tasks 1–5 each ended with a commit.)
+
+### 6.3 — Final report format
+
+When done, report using this structure (per repo governance doctrine):
+
+- **Change Summary**: added `conversation.decision_candidate` event type end-to-end (detector → both allowlists → promotion handler → emit acceptance tests); fixed a `promotion_rule` dispatch clobber that would have silently broken the candidate's trust label.
+- **Authority Used**: `claudedocs/memory-context-fabric-design-2026-07-04.md` v3 §2/§6, `claudedocs/tp-mcf-001-authority-map-2026-07-04.md` §4, `claudedocs/memory-context-fabric-interfaces-2026-07-04.md` §2.2/§2.3; runtime code in `capture_client.py`, `promotion.py`, `chronicle/schema.sql`, `chronicle/store.py`.
+- **Analysis Performed**: read all three authority docs + 4 runtime files; ran both existing test suites before touching code (baseline green); empirically spiked (and reverted) the `promotion_rule` clobber fix + new handler before committing to the plan, proving invariant #2 achievable.
+- **Validation Performed**: PASS — both suites listed in §6.1 (paste actual pytest output here when executing this plan).
+- **Remaining Uncertainty / Risk**: this packet does not build the transcript-file watcher (TP-MCF-002) that would call `detect_decision_candidate` on real turns in production — that wiring is out of scope and belongs to TP-MCF-002/a future integration packet. The regex marker set is intentionally narrow (6 patterns); real-world transcript phrasing not matching any marker will simply not produce a candidate (fail-closed, not fail-open — no false positives risk, only false negatives, which is the correct default per the design doc's "deterministic first" cornerstone).
+- **Files Touched**: see §6.2's `git status --porcelain` list.
+- **Git State**: branch `claude/memory-context-fabric` (or whatever branch this plan is executed on); commits per Tasks 1, 2, 3, 4, 5 (5 commits total, one per task).
+- **Rollback Plan**: `git revert` the 5 commits in reverse order, or `git reset --hard <sha-before-task-1>` if the branch has not been pushed/shared.
+- **Requested Next Step**: hand off to whichever packet builds the transcript-file ingest adapter (TP-MCF-002) so `detect_decision_candidate` + `emit_promotable_capture_event("conversation.decision_candidate", ...)` gets called on real transcript turns; that packet is out of this one's scope by design.

--- a/claudedocs/plans/2026-07-04-tp-mcf-004-sessionstart-recap.md
+++ b/claudedocs/plans/2026-07-04-tp-mcf-004-sessionstart-recap.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** Execute this plan task-by-task via superpowers:subagent-driven-development or superpowers:executing-plans if available; otherwise execute the checkbox (`- [ ]`) steps literally, in order, committing exactly where the plan says. Read the master plan first: `claudedocs/plans/2026-07-04-memory-context-fabric-build-plan.md` (global constraints + hand-off protocol).
 **Date**: 2026-07-04 · **Packet**: TP-MCF-004 (Memory Context Fabric, Injection Phase 1) · **Status**: PLAN (ready for execution)
-**Branch**: `claude/memory-context-fabric` · **Worktree**: `/Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe`
+**Branch**: `claude/memory-context-fabric` · **Worktree**: `<repo-root>/.claude/worktrees/<worktree-name>`
 **Interpreter**: `mise exec -- python` (Python 3.12.13 — verified; do NOT use bare `python3`, the harness one is 3.9)
 
 ---
@@ -100,7 +100,7 @@ Do **not** edit `src/dopemux/memory/__init__.py` (recap is imported lazily by th
 
 - **TDD**: write the failing test first, run it (RED), implement, run again (GREEN). Never skip the RED run.
 - **One commit per task**, staging only that task's files. Do not commit unrelated dirty files that may pre-exist in the worktree.
-- Run all commands **from the worktree root**: `/Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe`.
+- Run all commands **from the worktree root**: `<repo-root>/.claude/worktrees/<worktree-name>`.
 - **Hermetic tests**: no Redis, no HTTP, no Docker, no dope-memory service. Local SQLite + `tmp_path` only.
 - **Fail-open invariant**: no code path added to `native_hooks.py` may raise out of `_on_session_start`. Missing ledger / empty ledger / malformed rows / corrupt file → inject nothing.
 - **Read-only invariant (structural)**: recap opens the ledger via `file:...?mode=ro` URI only. No INSERT/UPDATE/DELETE anywhere in `recap.py`.
@@ -109,7 +109,7 @@ Do **not** edit `src/dopemux/memory/__init__.py` (recap is imported lazily by th
 ### Pre-flight (no commit)
 
 ```bash
-cd /Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe
+cd <repo-root>/.claude/worktrees/<worktree-name>
 git status --short            # note pre-existing dirty files; leave them alone
 git branch --show-current     # expected: claude/memory-context-fabric
 mise exec -- python --version # expected: Python 3.12.13

--- a/claudedocs/plans/2026-07-04-tp-mcf-004-sessionstart-recap.md
+++ b/claudedocs/plans/2026-07-04-tp-mcf-004-sessionstart-recap.md
@@ -1,0 +1,1304 @@
+# TP-MCF-004 — Bounded SessionStart Recap Injection (Implementation Plan)
+
+> **For agentic workers:** Execute this plan task-by-task via superpowers:subagent-driven-development or superpowers:executing-plans if available; otherwise execute the checkbox (`- [ ]`) steps literally, in order, committing exactly where the plan says. Read the master plan first: `claudedocs/plans/2026-07-04-memory-context-fabric-build-plan.md` (global constraints + hand-off protocol).
+**Date**: 2026-07-04 · **Packet**: TP-MCF-004 (Memory Context Fabric, Injection Phase 1) · **Status**: PLAN (ready for execution)
+**Branch**: `claude/memory-context-fabric` · **Worktree**: `/Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe`
+**Interpreter**: `mise exec -- python` (Python 3.12.13 — verified; do NOT use bare `python3`, the harness one is 3.9)
+
+---
+
+## 0. Goal
+
+Extend the **existing** `native_hooks.py` SessionStart injection path with a **bounded, token-budgeted, authority-labeled Top-3 recap** read **directly from the local chronicle SQLite ledger**. No semantic fusion. No ConPort calls. No dope-context calls. **No network calls at all** — the dope-memory HTTP service may be down (it is down right now), so the recap is a direct local read.
+
+### Authority documents (read before executing; all committed in this repo)
+
+| Doc | What it governs here |
+|---|---|
+| `claudedocs/memory-context-fabric-design-2026-07-04.md` §4, §6 row TP-MCF-004 | scope gates: token budget, Top-3 default, authority labels, **no semantic fusion** |
+| `claudedocs/memory-context-fabric-interfaces-2026-07-04.md` §2.4, §4 | `ContextBundle`/`ContextItem` schemas (implement **exactly**); invariants 5 (provenance only lowers trust), 6 (token budget), 7 (graceful degradation) |
+| `claudedocs/tp-mcf-001-authority-map-2026-07-04.md` §1 Domain E | `native_hooks.py:335-351` SessionStart injection is the extension point |
+
+### Grounded runtime facts (verified against code in this worktree — cite these, do not re-derive)
+
+1. **SessionStart handler** — `src/dopemux/claude/native_hooks.py:335-351`, method `NativeHookAdapter._on_session_start`. It composes three existing injections and returns hook output:
+   ```python
+   def _on_session_start(self) -> Tuple[int, Dict[str, Any]]:
+       reset_edit_counter(self.project_root, self.session_id)
+       mcp_health = emit_mcp_health(self.project_root)
+       orch_ctx = emit_session_context(self.project_root)
+       state = self._active_state()
+       if not state:
+           combined = "\n\n".join(filter(None, [mcp_health, orch_ctx]))
+           if combined:
+               return self._allow(additional_context=combined, hook_event_name="SessionStart")
+           return self._allow()
+       workflow_ctx = _workflow_context_lines(state, include_gates=True)
+       combined = "\n\n".join(filter(None, [mcp_health, orch_ctx, workflow_ctx]))
+       return self._allow(
+           system_message=f"Dopemux workflow mode: {state.mode}",
+           additional_context=combined or None,
+           hook_event_name="SessionStart",
+       )
+   ```
+   The recap is appended as a **fourth part** of that same `"\n\n".join(filter(None, [...]))` composition (third part in the no-workflow branch). Fail-open style to mirror: the module's try/except import fallbacks (`native_hooks.py:30-74`) and `_emit_bounded_hook_error_capture`'s outer `try/except Exception: return None` (`native_hooks.py:166-194`); also `handle_event`'s blanket reliability fallback (`native_hooks.py:331-332`).
+2. **Ledger path resolution** — `src/dopemux/memory/capture_client.py:255-259`:
+   ```python
+   def _resolve_ledger_path(repo_root: Path) -> Path:
+       override = os.getenv("DOPEMUX_CAPTURE_LEDGER_PATH", "").strip()
+       if override:
+           return Path(override).expanduser().resolve()
+       return (repo_root / ".dopemux" / "chronicle.sqlite").resolve()
+   ```
+   We **reuse this function** (import it), we do not copy it — the read path can then never drift from the write path.
+3. **Chronicle schema** — `services/working-memory-assistant/chronicle/schema.sql`. Columns we query:
+   - `work_log_entries` (schema.sql:29-81): `id, workspace_id, instance_id, session_id, ts_utc, category (CHECK), entry_type (CHECK), summary, details_json, outcome, importance_score, tags_json, source_event_id, source_event_type, source_adapter, source_event_ts_utc, promotion_rule, promotion_ts_utc, created_at_utc, updated_at_utc` (+ optional linkage columns).
+   - `raw_activity_events` (schema.sql:5-20): `id, workspace_id, instance_id, session_id, ts_utc, event_type, source, payload_json, redaction_level, ttl_days, created_at_utc`.
+4. **Token heuristic (repo convention — verified by grep)** — `src/dopemux/freeflow.py:220-221`:
+   ```python
+   def estimate_text_tokens(value: str) -> int:
+       return max(1, (len(value or "") + 3) // 4)
+   ```
+   and `src/dopemux/mcp/broker.py:943` (`return len(result) // 4  # Rough tokens estimation`), `src/dopemux/ux/wizard/cost_profiles.py:146` (`input_tokens ≈ corpus_chars / 4`). We adopt the freeflow ceil-division form with constant `TOKENS_PER_CHAR_DIVISOR = 4`.
+5. **Read-only SQLite pattern (repo precedent)** — `src/dopemux/orchestrator/canonical_readview.py:21-36` (`_connect_ro`: percent-encoded `db_path.resolve().as_uri() + "?mode=ro"`, `sqlite3.connect(uri, uri=True)`, existence check first — the comment there explains why `as_uri()` is required so URI metacharacters can't bypass `mode=ro`) and `src/dopemux/memory/global_rollup.py:194-198` (`_connect_project_read_only`, same `mode=ro` idea against **this exact chronicle ledger**). We mirror `canonical_readview._connect_ro` (the safer of the two).
+6. **Session-boundary event type** — `services/working-memory-assistant/eventbus_consumer.py:384` treats `event_type == "session.ended"` as the explicit session-end signal. Recap optionally reads the most recent such row from `raw_activity_events` for a "Last session ended at X" line (best-effort; absent rows are fine).
+7. **Candidate-decision markers** — `promotion_rule = "conversation_candidate_v1"` and trust `"conversation-derived"` are defined by the authority map §4 (TP-MCF-003 schema). **Grep-verified: no code emits these values yet** — the recap must still label such rows correctly the day TP-MCF-003 lands, using literal string constants.
+8. **Existing test files (verified present)** —
+   - `tests/test_native_hooks_workflow.py` — the real native-hooks test file (7 tests, all passing at baseline; verified by running it). Its `handle_event("SessionStart", {...})` pattern (lines 36-61) is what our hook tests extend.
+   - `tests/unit/test_memory_capture_client.py` — hermetic-ledger precedent: monkeypatches `DOPEMUX_CAPTURE_LEDGER_PATH` to a `tmp_path` file (lines 47-49). Our tests build the tmp ledger by applying `schema.sql` directly with `executescript` (no Redis, no service).
+9. **ISO-parse convention** — `src/dopemux/freeflow.py:202-210` `parse_iso_datetime` (tolerates `Z` suffix, returns UTC-aware). We mirror it.
+
+### Architecture of the change
+
+```
+SessionStart hook (sync, must never fail)
+  └─ _emit_recap_context(project_root)          [native_hooks.py — NEW, fail-open wrapper]
+       ├─ kill switch: DOPEMUX_RECAP_INJECTION=off → None
+       ├─ lazy import of dopemux.memory.recap    (ImportError can never break the hook module)
+       ├─ resolve_ledger_path(project_root)      [reuses capture_client._resolve_ledger_path]
+       ├─ build_recap_bundle(workspace_id, ledger_path)   [recap.py — NEW]
+       │    ├─ _connect_ro(...)  file:...?mode=ro  → structurally read-only
+       │    ├─ SELECT top rows from work_log_entries (bounded LIMIT 50) + newest session.ended
+       │    ├─ window (hours_back) → authority labels → sort most-recent-first → Top-k
+       │    └─ token budget: header + whole items, prefix-keep, drop rest, truncated flag
+       └─ render_recap(bundle) → "## Memory recap (last 24h)" markdown block
+  └─ combined = "\n\n".join(filter(None, [mcp_health, orch_ctx, (workflow_ctx), recap_ctx]))
+```
+
+### Files touched (complete list — touch nothing else)
+
+| File | Action |
+|---|---|
+| `src/dopemux/memory/recap.py` | **NEW** — schemas, read path, budget, renderer |
+| `tests/unit/test_recap.py` | **NEW** — hermetic unit tests |
+| `src/dopemux/claude/native_hooks.py` | **EDIT** — `_emit_recap_context` helper + `_on_session_start` composition |
+| `tests/test_native_hooks_workflow.py` | **EDIT** — append hook-wiring tests |
+
+Do **not** edit `src/dopemux/memory/__init__.py` (recap is imported lazily by the hook; keeping the package `__init__` untouched keeps import cost and blast radius at zero). Do **not** edit `schema.sql`, `capture_client.py`, or any `.claude/` config.
+
+### Global constraints (every task)
+
+- **TDD**: write the failing test first, run it (RED), implement, run again (GREEN). Never skip the RED run.
+- **One commit per task**, staging only that task's files. Do not commit unrelated dirty files that may pre-exist in the worktree.
+- Run all commands **from the worktree root**: `/Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe`.
+- **Hermetic tests**: no Redis, no HTTP, no Docker, no dope-memory service. Local SQLite + `tmp_path` only.
+- **Fail-open invariant**: no code path added to `native_hooks.py` may raise out of `_on_session_start`. Missing ledger / empty ledger / malformed rows / corrupt file → inject nothing.
+- **Read-only invariant (structural)**: recap opens the ledger via `file:...?mode=ro` URI only. No INSERT/UPDATE/DELETE anywhere in `recap.py`.
+- **Interfaces §2.4 exactly**: `ContextBundle(items, token_cost, truncated, workspace_id)`, `ContextItem(content, source_system, authority_label, trust, freshness, provenance)` — these names and this order.
+
+### Pre-flight (no commit)
+
+```bash
+cd /Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe
+git status --short            # note pre-existing dirty files; leave them alone
+git branch --show-current     # expected: claude/memory-context-fabric
+mise exec -- python --version # expected: Python 3.12.13
+mise exec -- python -m pytest tests/test_native_hooks_workflow.py -q
+```
+Expected last output: `7 passed` (dots line `.......`). If the baseline is not 7 passed, STOP and report — do not build on a broken baseline.
+
+---
+
+## Task 1 — Contracts: `ContextItem` / `ContextBundle` + token estimator
+
+**Files**: `tests/unit/test_recap.py` (new), `src/dopemux/memory/recap.py` (new)
+**Interfaces produced**: `recap.ContextItem`, `recap.ContextBundle` (interfaces doc §2.4, exact), `recap.estimate_tokens(text) -> int`, constants `TOKENS_PER_CHAR_DIVISOR`, `RECAP_TITLE`.
+
+### Steps
+
+- [ ] **1.1 (RED)** Create `tests/unit/test_recap.py` with exactly this content. Note the deliberate style: everything is referenced through the `recap` module namespace (`recap.build_recap_bundle`, not a `from`-import), so later tasks' tests fail with a clean `AttributeError` instead of breaking collection.
+
+```python
+"""Hermetic tests for the TP-MCF-004 SessionStart recap module.
+
+Builds a tmp_path chronicle by applying the canonical schema
+(services/working-memory-assistant/chronicle/schema.sql) directly -- the same
+schema the runtime ledger uses (capture_client._resolve_wma_schema_path).
+No Redis, no HTTP, no dope-memory service, no network.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from dopemux.memory import recap
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = (
+    REPO_ROOT / "services" / "working-memory-assistant" / "chronicle" / "schema.sql"
+)
+
+WORKSPACE = "/test/workspace"
+
+
+def _utc_iso(*, hours_ago: float = 0.0) -> str:
+    return (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+
+
+def _make_ledger(tmp_path: Path) -> Path:
+    """Apply the canonical chronicle schema to a fresh tmp SQLite file."""
+    ledger = tmp_path / "chronicle.sqlite"
+    conn = sqlite3.connect(str(ledger))
+    try:
+        conn.executescript(SCHEMA_PATH.read_text(encoding="utf-8"))
+        conn.commit()
+    finally:
+        conn.close()
+    return ledger
+
+
+def _insert_work_log_entry(
+    ledger: Path,
+    *,
+    summary: str,
+    hours_ago: float = 1.0,
+    workspace_id: str = WORKSPACE,
+    entry_type: str = "decision",
+    category: str = "implementation",
+    outcome: str = "success",
+    promotion_rule: str = "eventbus_promotion_v1",
+    ts_utc: str | None = None,
+) -> str:
+    """Insert a curated chronicle row satisfying every NOT NULL/CHECK constraint."""
+    entry_id = uuid.uuid4().hex
+    ts = ts_utc if ts_utc is not None else _utc_iso(hours_ago=hours_ago)
+    now = _utc_iso()
+    conn = sqlite3.connect(str(ledger))
+    try:
+        conn.execute(
+            """
+            INSERT INTO work_log_entries (
+                id, workspace_id, instance_id, session_id, ts_utc,
+                category, entry_type, summary, outcome, importance_score,
+                tags_json,
+                source_event_id, source_event_type, source_adapter,
+                source_event_ts_utc, promotion_rule, promotion_ts_utc,
+                created_at_utc, updated_at_utc
+            ) VALUES (?, ?, 'A', NULL, ?, ?, ?, ?, ?, 5, '[]',
+                      ?, 'decision.logged', 'test', ?, ?, ?, ?, ?)
+            """,
+            (
+                entry_id,
+                workspace_id,
+                ts,
+                category,
+                entry_type,
+                summary,
+                outcome,
+                f"evt-{entry_id}",
+                ts,
+                promotion_rule,
+                now,
+                now,
+                now,
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return entry_id
+
+
+def _insert_session_ended(
+    ledger: Path, *, hours_ago: float = 2.0, workspace_id: str = WORKSPACE
+) -> str:
+    """Insert a raw session-boundary event (event_type per eventbus_consumer.py:384)."""
+    event_id = uuid.uuid4().hex
+    ts = _utc_iso(hours_ago=hours_ago)
+    conn = sqlite3.connect(str(ledger))
+    try:
+        conn.execute(
+            """
+            INSERT INTO raw_activity_events (
+                id, workspace_id, instance_id, session_id, ts_utc,
+                event_type, source, payload_json, redaction_level,
+                ttl_days, created_at_utc
+            ) VALUES (?, ?, 'A', NULL, ?, 'session.ended', 'test', '{}',
+                      'strict', 7, ?)
+            """,
+            (event_id, workspace_id, ts, _utc_iso()),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return event_id
+
+
+class TestContracts:
+    """interfaces doc §2.4 -- field names and order are the contract."""
+
+    def test_context_item_fields_match_interfaces_2_4(self):
+        item = recap.ContextItem(
+            content="decision: x [success]",
+            source_system="dope-memory",
+            authority_label="canonical",
+            trust="high",
+            freshness="2026-07-04T00:00:00+00:00",
+            provenance={"entry_id": "abc"},
+        )
+        assert list(item.__dataclass_fields__) == [
+            "content",
+            "source_system",
+            "authority_label",
+            "trust",
+            "freshness",
+            "provenance",
+        ]
+        assert item.provenance == {"entry_id": "abc"}
+
+    def test_context_bundle_fields_match_interfaces_2_4(self):
+        bundle = recap.ContextBundle(
+            items=[], token_cost=0, truncated=False, workspace_id="w"
+        )
+        assert list(bundle.__dataclass_fields__) == [
+            "items",
+            "token_cost",
+            "truncated",
+            "workspace_id",
+        ]
+
+    def test_estimate_tokens_matches_repo_char_div_4_convention(self):
+        # freeflow.py:220-221 -- max(1, (len + 3) // 4)
+        assert recap.TOKENS_PER_CHAR_DIVISOR == 4
+        assert recap.estimate_tokens("") == 1
+        assert recap.estimate_tokens("abcd") == 1
+        assert recap.estimate_tokens("abcde") == 2
+        assert recap.estimate_tokens("x" * 400) == 100
+```
+
+- [ ] **1.2 (RED run)**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py -q
+```
+Expected output: collection error, `1 error` — `ModuleNotFoundError: No module named 'dopemux.memory.recap'`.
+
+- [ ] **1.3 (GREEN)** Create `src/dopemux/memory/recap.py` with exactly this content:
+
+```python
+"""Bounded SessionStart recap over the local chronicle ledger (TP-MCF-004).
+
+Design authority:
+- claudedocs/memory-context-fabric-design-2026-07-04.md §4 (Injection Phase 1),
+  §6 row TP-MCF-004 (token budget, Top-3, authority labels, NO semantic fusion)
+- claudedocs/memory-context-fabric-interfaces-2026-07-04.md §2.4 (schemas),
+  §4 invariants 5 (provenance only lowers trust), 6 (token budget),
+  7 (graceful degradation)
+- claudedocs/tp-mcf-001-authority-map-2026-07-04.md §1 Domain E
+
+Hard constraints:
+- LOCAL SQLite read ONLY. No network, no ConPort, no dope-context, no HTTP.
+  The dope-memory HTTP service may be down; this module never depends on it.
+- Read-only by construction: the ledger is opened via a ``file:...?mode=ro``
+  SQLite URI (mirrors src/dopemux/orchestrator/canonical_readview.py:21-36
+  and src/dopemux/memory/global_rollup.py:194-198), so this module is
+  structurally incapable of writing to the chronicle.
+- Fail-open: missing ledger / empty ledger / malformed rows / corrupt file
+  => ``None``. The SessionStart hook must never break because of this module.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from dopemux.memory.capture_client import (
+    _resolve_ledger_path as _capture_resolve_ledger_path,
+)
+
+# --- Token estimation --------------------------------------------------------
+# Repo convention: ~4 chars per token, ceil division.
+# Verified precedents: src/dopemux/freeflow.py:220-221 (estimate_text_tokens),
+# src/dopemux/mcp/broker.py:943, src/dopemux/ux/wizard/cost_profiles.py:146.
+TOKENS_PER_CHAR_DIVISOR = 4
+
+
+def estimate_tokens(text: str) -> int:
+    """Conservative char//4 token estimate (mirrors freeflow.estimate_text_tokens)."""
+    length = len(text or "")
+    return max(1, (length + TOKENS_PER_CHAR_DIVISOR - 1) // TOKENS_PER_CHAR_DIVISOR)
+
+
+# --- Authority / trust vocabulary (interfaces doc §2.4, exact strings) --------
+AUTHORITY_CANONICAL = "canonical"
+AUTHORITY_CONVERSATION_INFERRED = "conversation-inferred"
+TRUST_HIGH = "high"
+TRUST_CONVERSATION_DERIVED = "conversation-derived"
+
+# TP-MCF-003 candidate-decision marker (authority map §4). No writer emits this
+# value yet (grep-verified 2026-07-04); recap must still label such rows
+# correctly the day promotion lands.
+CONVERSATION_CANDIDATE_PROMOTION_RULE = "conversation_candidate_v1"
+
+# Session-boundary raw event type (services/.../eventbus_consumer.py:384).
+SESSION_BOUNDARY_EVENT_TYPE = "session.ended"
+
+# Fixed recap block title (TP-MCF-004 contract; hours_back default is 24).
+RECAP_TITLE = "## Memory recap (last 24h)"
+
+# Bounded work: never scan more than this many chronicle rows per recap.
+_FETCH_LIMIT = 50
+# Bounded latency: SQLite busy timeout in seconds (hook runs synchronously).
+_SQLITE_TIMEOUT_SECONDS = 1.0
+
+
+@dataclass
+class ContextItem:
+    """interfaces doc §2.4 ContextItem -- field names/order are contract."""
+
+    content: str
+    source_system: str  # "dope-memory" | "conport" | "dope-context"
+    authority_label: str  # "canonical" | "mirror" | "derived" | "conversation-inferred"
+    trust: str  # "high" | "conversation-derived"
+    freshness: str  # ISO timestamp
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ContextBundle:
+    """interfaces doc §2.4 ContextBundle -- field names/order are contract."""
+
+    items: list[ContextItem] = field(default_factory=list)
+    token_cost: int = 0  # enforced <= budget (invariant 6)
+    truncated: bool = False
+    workspace_id: str = ""
+```
+
+- [ ] **1.4 (GREEN run)**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py -q
+```
+Expected output: `3 passed`.
+
+- [ ] **1.5 (Commit)**
+```bash
+git add src/dopemux/memory/recap.py tests/unit/test_recap.py
+git commit -m "feat(memory): TP-MCF-004 ContextBundle/ContextItem contracts + token estimator"
+git log --oneline -1   # verify the commit landed on claude/memory-context-fabric
+```
+
+---
+
+## Task 2 — Read path: `resolve_ledger_path`, `_connect_ro`, `build_recap_bundle`
+
+**Files**: `tests/unit/test_recap.py` (append), `src/dopemux/memory/recap.py` (append)
+**Interfaces produced**:
+- `recap.resolve_ledger_path(repo_root: Path) -> Path` — delegates to `capture_client._resolve_ledger_path` (env `DOPEMUX_CAPTURE_LEDGER_PATH` override, else `<repo>/.dopemux/chronicle.sqlite`).
+- `recap._connect_ro(ledger_path: Path) -> sqlite3.Connection` — strictly read-only, mirrors `canonical_readview.py:21-36`.
+- `recap.build_recap_bundle(workspace_id: str, ledger_path: Path, *, hours_back: int = 24, k: int = 3, token_budget: int = 700) -> ContextBundle | None` — **exactly this signature** (the token budget is *accepted* in this task and *enforced* in Task 3).
+
+Behavior contract for this task: Top-`k` most recent `work_log_entries` within `hours_back` for the given `workspace_id`; curated rows → `authority_label="canonical"`, `trust="high"`; rows with `promotion_rule="conversation_candidate_v1"` → `authority_label="conversation-inferred"`, `trust="conversation-derived"`; optional "Last session ended at X" item from the newest `raw_activity_events` row with `event_type='session.ended'` (window-gated, does not count against `k`); all items sorted most-recent-first; missing/empty/corrupt ledger and malformed rows → `None` / skipped, never an exception.
+
+### Steps
+
+- [ ] **2.1 (RED)** Append to `tests/unit/test_recap.py`:
+
+```python
+class TestResolveLedgerPath:
+    """Reuses capture_client._resolve_ledger_path (capture_client.py:255-259)."""
+
+    def test_env_override_wins(self, tmp_path, monkeypatch):
+        override = tmp_path / "custom.sqlite"
+        monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(override))
+        assert recap.resolve_ledger_path(tmp_path) == override.resolve()
+
+    def test_default_is_dot_dopemux_chronicle(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("DOPEMUX_CAPTURE_LEDGER_PATH", raising=False)
+        expected = (tmp_path / ".dopemux" / "chronicle.sqlite").resolve()
+        assert recap.resolve_ledger_path(tmp_path) == expected
+
+
+class TestBuildRecapBundle:
+    def test_top_k_selection_and_ordering_most_recent_first(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        for idx, hours in enumerate([5.0, 4.0, 3.0, 2.0, 1.0]):
+            _insert_work_log_entry(ledger, summary=f"entry-{idx}", hours_ago=hours)
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        assert len(bundle.items) == 3  # Top-3 default (design spec §6 TP-MCF-004)
+        assert "entry-4" in bundle.items[0].content  # 1h ago -- newest first
+        assert "entry-3" in bundle.items[1].content
+        assert "entry-2" in bundle.items[2].content
+        assert bundle.workspace_id == WORKSPACE
+        assert bundle.truncated is False
+
+    def test_hours_back_window_excludes_stale_rows(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(ledger, summary="fresh-row", hours_ago=1.0)
+        _insert_work_log_entry(ledger, summary="stale-row", hours_ago=30.0)
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger, hours_back=24)
+        assert bundle is not None
+        contents = [item.content for item in bundle.items]
+        assert any("fresh-row" in c for c in contents)
+        assert not any("stale-row" in c for c in contents)
+
+    def test_workspace_isolation(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(
+            ledger, summary="other-workspace-row", workspace_id="/elsewhere"
+        )
+        assert recap.build_recap_bundle(WORKSPACE, ledger) is None
+
+    def test_curated_rows_labeled_canonical_high_trust(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        entry_id = _insert_work_log_entry(ledger, summary="curated-row")
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        item = bundle.items[0]
+        assert item.authority_label == "canonical"
+        assert item.trust == "high"
+        assert item.source_system == "dope-memory"
+        assert item.provenance["entry_id"] == entry_id
+        assert item.provenance["source_event_id"] == f"evt-{entry_id}"
+
+    def test_candidate_rows_labeled_conversation_inferred(self, tmp_path):
+        # Invariant 5 (interfaces §4): provenance only LOWERS trust.
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(
+            ledger,
+            summary="candidate-row",
+            promotion_rule="conversation_candidate_v1",
+        )
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        item = bundle.items[0]
+        assert item.authority_label == "conversation-inferred"
+        assert item.trust == "conversation-derived"
+
+    def test_session_boundary_item_ordered_by_recency(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(ledger, summary="work-row", hours_ago=1.0)
+        _insert_session_ended(ledger, hours_ago=2.0)
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        assert len(bundle.items) == 2  # boundary does not count against k
+        assert bundle.items[-1].content.startswith("Last session ended at ")
+        assert bundle.items[-1].provenance == {"event_type": "session.ended"}
+        assert bundle.items[-1].authority_label == "canonical"
+
+    def test_missing_ledger_returns_none(self, tmp_path):
+        assert recap.build_recap_bundle(WORKSPACE, tmp_path / "nope.sqlite") is None
+
+    def test_empty_ledger_returns_none(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        assert recap.build_recap_bundle(WORKSPACE, ledger) is None
+
+    def test_corrupt_ledger_returns_none(self, tmp_path):
+        garbage = tmp_path / "chronicle.sqlite"
+        garbage.write_bytes(b"\x00garbage not a sqlite file\xff" * 64)
+        assert recap.build_recap_bundle(WORKSPACE, garbage) is None
+
+    def test_malformed_timestamp_rows_are_skipped_not_fatal(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(ledger, summary="good-row", hours_ago=1.0)
+        _insert_work_log_entry(ledger, summary="bad-ts-row", ts_utc="not-a-timestamp")
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        contents = [item.content for item in bundle.items]
+        assert any("good-row" in c for c in contents)
+        assert not any("bad-ts-row" in c for c in contents)
+```
+
+- [ ] **2.2 (RED run)**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py -q
+```
+Expected output: `12 failed, 3 passed` — every failure an `AttributeError: module 'dopemux.memory.recap' has no attribute ...` (`resolve_ledger_path` / `build_recap_bundle`).
+
+- [ ] **2.3 (GREEN)** Append to `src/dopemux/memory/recap.py` (after the `ContextBundle` dataclass, end of file):
+
+```python
+def resolve_ledger_path(repo_root: Path) -> Path:
+    """Chronicle ledger location.
+
+    Delegates to ``capture_client._resolve_ledger_path`` (capture_client.py:255-259):
+    ``DOPEMUX_CAPTURE_LEDGER_PATH`` env override, else
+    ``<repo_root>/.dopemux/chronicle.sqlite``. Reuse -- not a copy -- so the
+    read path can never drift from the write path.
+    """
+    return _capture_resolve_ledger_path(repo_root)
+
+
+def _connect_ro(ledger_path: Path) -> sqlite3.Connection:
+    """Open the ledger strictly read-only.
+
+    Mirrors ``canonical_readview._connect_ro`` (canonical_readview.py:21-36):
+    the ``file:`` URI is built from the percent-encoded absolute path
+    (``as_uri()``) so URI metacharacters in the path (``?``/``#``) cannot be
+    parsed as query/fragment and silently bypass ``mode=ro``.
+    """
+    if not ledger_path.exists():
+        raise FileNotFoundError(f"chronicle ledger not found: {ledger_path}")
+    uri = ledger_path.resolve().as_uri() + "?mode=ro"
+    conn = sqlite3.connect(uri, uri=True, timeout=_SQLITE_TIMEOUT_SECONDS)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _parse_iso_utc(value: Optional[str]) -> Optional[datetime]:
+    """Tolerant ISO-8601 parse (mirrors freeflow.parse_iso_datetime:202-210)."""
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _item_from_row(row: sqlite3.Row) -> ContextItem:
+    """Map one curated work_log_entries row to an authority-labeled item."""
+    promotion_rule = str(row["promotion_rule"] or "")
+    if promotion_rule == CONVERSATION_CANDIDATE_PROMOTION_RULE:
+        authority_label = AUTHORITY_CONVERSATION_INFERRED
+        trust = TRUST_CONVERSATION_DERIVED
+    else:
+        authority_label = AUTHORITY_CANONICAL
+        trust = TRUST_HIGH
+    content = f"{row['entry_type']}: {row['summary']} [{row['outcome']}]"
+    return ContextItem(
+        content=content,
+        source_system="dope-memory",
+        authority_label=authority_label,
+        trust=trust,
+        freshness=str(row["ts_utc"]),
+        provenance={
+            "entry_id": row["id"],
+            "source_event_id": row["source_event_id"],
+        },
+    )
+
+
+def render_item_line(item: ContextItem) -> str:
+    """One recap line: ``- [authority_label] content (freshness)``."""
+    return f"- [{item.authority_label}] {item.content} ({item.freshness})"
+
+
+def build_recap_bundle(
+    workspace_id: str,
+    ledger_path: Path,
+    *,
+    hours_back: int = 24,
+    k: int = 3,
+    token_budget: int = 700,
+) -> ContextBundle | None:
+    """Assemble a bounded recap bundle from the local chronicle. Fail-open.
+
+    Returns ``None`` (inject nothing) on: missing ledger, corrupt/locked
+    ledger, no rows for this workspace inside the window. Never raises to the
+    caller and never writes (the connection is ``mode=ro`` by construction).
+    """
+    try:
+        conn = _connect_ro(ledger_path)
+    except (FileNotFoundError, OSError, ValueError, sqlite3.Error):
+        return None
+
+    try:
+        rows = conn.execute(
+            """
+            SELECT id, ts_utc, entry_type, summary, outcome,
+                   promotion_rule, source_event_id
+            FROM work_log_entries
+            WHERE workspace_id = ?
+            ORDER BY ts_utc DESC
+            LIMIT ?
+            """,
+            (workspace_id, _FETCH_LIMIT),
+        ).fetchall()
+        boundary_row = conn.execute(
+            """
+            SELECT ts_utc FROM raw_activity_events
+            WHERE workspace_id = ? AND event_type = ?
+            ORDER BY ts_utc DESC
+            LIMIT 1
+            """,
+            (workspace_id, SESSION_BOUNDARY_EVENT_TYPE),
+        ).fetchone()
+    except sqlite3.Error:
+        # Corrupt file, locked DB, or unexpected schema: inject nothing.
+        return None
+    finally:
+        try:
+            conn.close()
+        except Exception:  # pragma: no cover - close is best-effort
+            pass
+
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours_back)
+
+    worklog: list[tuple[datetime, ContextItem]] = []
+    for row in rows:
+        ts = _parse_iso_utc(row["ts_utc"])
+        if ts is None or ts < cutoff:
+            continue  # malformed or stale rows are skipped, never fatal
+        try:
+            worklog.append((ts, _item_from_row(row)))
+        except (KeyError, IndexError, TypeError):
+            continue
+
+    # Deterministic most-recent-first, robust to mixed ISO tz spellings
+    # (Python-side parse+sort; the SQL ORDER BY only pre-limits the scan).
+    worklog.sort(key=lambda pair: pair[0], reverse=True)
+    dated = worklog[:k]
+
+    if boundary_row is not None:
+        boundary_ts = _parse_iso_utc(boundary_row["ts_utc"])
+        if boundary_ts is not None and boundary_ts >= cutoff:
+            dated.append(
+                (
+                    boundary_ts,
+                    ContextItem(
+                        content=f"Last session ended at {boundary_row['ts_utc']}",
+                        source_system="dope-memory",
+                        authority_label=AUTHORITY_CANONICAL,
+                        trust=TRUST_HIGH,
+                        freshness=str(boundary_row["ts_utc"]),
+                        provenance={"event_type": SESSION_BOUNDARY_EVENT_TYPE},
+                    ),
+                )
+            )
+
+    dated.sort(key=lambda pair: pair[0], reverse=True)
+    items = [item for _, item in dated]
+    if not items:
+        return None
+
+    token_cost = estimate_tokens(RECAP_TITLE) + sum(
+        estimate_tokens(render_item_line(item)) for item in items
+    )
+    return ContextBundle(
+        items=items,
+        token_cost=token_cost,
+        truncated=False,
+        workspace_id=workspace_id,
+    )
+```
+
+- [ ] **2.4 (GREEN run)**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py -q
+```
+Expected output: `15 passed`.
+
+- [ ] **2.5 (Commit)**
+```bash
+git add src/dopemux/memory/recap.py tests/unit/test_recap.py
+git commit -m "feat(memory): TP-MCF-004 read-only chronicle recap builder (top-k, window, authority labels, fail-open)"
+```
+
+---
+
+## Task 3 — Token-budget truncation (invariant 6)
+
+**Files**: `tests/unit/test_recap.py` (append), `src/dopemux/memory/recap.py` (edit `build_recap_bundle` tail)
+**Behavior contract**: `bundle.token_cost <= token_budget` always. Cost = title line + one rendered line per item, using `estimate_tokens`. Enforcement drops **whole items**: keep the most-recent-first prefix, `break` at the first item that would overflow, set `truncated=True`. If nothing fits, return `None`.
+
+### Steps
+
+- [ ] **3.1 (RED)** Append to `tests/unit/test_recap.py`:
+
+```python
+class TestTokenBudget:
+    """Invariant 6 (interfaces §4): every bundle respects the budget."""
+
+    def test_budget_drops_whole_items_and_sets_truncated(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(ledger, summary="short recent entry", hours_ago=1.0)
+        _insert_work_log_entry(ledger, summary="y" * 4000, hours_ago=2.0)
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger, token_budget=60)
+        assert bundle is not None
+        assert bundle.truncated is True
+        assert bundle.token_cost <= 60
+        assert len(bundle.items) == 1  # prefix kept: newest item only
+        assert "short recent entry" in bundle.items[0].content
+
+    def test_nothing_fits_returns_none(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(ledger, summary="z" * 4000, hours_ago=1.0)
+        assert recap.build_recap_bundle(WORKSPACE, ledger, token_budget=50) is None
+
+    def test_default_budget_700_enforced(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        for idx in range(3):
+            _insert_work_log_entry(
+                ledger, summary=f"e{idx} " + "w" * 900, hours_ago=1.0 + idx
+            )
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        assert bundle.token_cost <= 700
+        assert bundle.truncated is True
+        assert len(bundle.items) == 2  # ~243 tokens/line: 2 fit, 3rd overflows
+```
+
+- [ ] **3.2 (RED run)**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py -q
+```
+Expected output: `3 failed, 15 passed` (the three `TestTokenBudget` tests fail: `truncated` is still always `False` / `token_cost` exceeds budget).
+
+- [ ] **3.3 (GREEN)** In `src/dopemux/memory/recap.py`, replace the tail of `build_recap_bundle` — exactly this block:
+
+```python
+    dated.sort(key=lambda pair: pair[0], reverse=True)
+    items = [item for _, item in dated]
+    if not items:
+        return None
+
+    token_cost = estimate_tokens(RECAP_TITLE) + sum(
+        estimate_tokens(render_item_line(item)) for item in items
+    )
+    return ContextBundle(
+        items=items,
+        token_cost=token_cost,
+        truncated=False,
+        workspace_id=workspace_id,
+    )
+```
+
+with this block:
+
+```python
+    dated.sort(key=lambda pair: pair[0], reverse=True)
+    items = [item for _, item in dated]
+    if not items:
+        return None
+
+    # Invariant 6: enforce the budget by dropping WHOLE items. Keep the
+    # most-recent-first prefix; the first overflowing item ends the bundle
+    # (older items are strictly lower priority than newer ones).
+    kept: list[ContextItem] = []
+    truncated = False
+    total = estimate_tokens(RECAP_TITLE)
+    for item in items:
+        cost = estimate_tokens(render_item_line(item))
+        if total + cost > token_budget:
+            truncated = True
+            break
+        total += cost
+        kept.append(item)
+
+    if not kept:
+        return None
+
+    return ContextBundle(
+        items=kept,
+        token_cost=total,
+        truncated=truncated,
+        workspace_id=workspace_id,
+    )
+```
+
+- [ ] **3.4 (GREEN run)**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py -q
+```
+Expected output: `18 passed`.
+
+- [ ] **3.5 (Commit)**
+```bash
+git add src/dopemux/memory/recap.py tests/unit/test_recap.py
+git commit -m "feat(memory): TP-MCF-004 token-budget truncation for recap bundles"
+```
+
+---
+
+## Task 4 — Renderer: `render_recap`
+
+**Files**: `tests/unit/test_recap.py` (append), `src/dopemux/memory/recap.py` (append)
+**Interface produced**: `recap.render_recap(bundle: ContextBundle) -> str` — compact markdown block, title line exactly `## Memory recap (last 24h)`, then one line per item in bundle order (already most-recent-first): `- [authority_label] content (freshness)`. Deterministic: same bundle → same string.
+
+### Steps
+
+- [ ] **4.1 (RED)** Append to `tests/unit/test_recap.py`:
+
+```python
+class TestRenderRecap:
+    def test_title_and_line_format(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(ledger, summary="ship recap", hours_ago=1.0)
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        text = recap.render_recap(bundle)
+        lines = text.splitlines()
+        assert lines[0] == "## Memory recap (last 24h)"
+        assert lines[1].startswith("- [canonical] decision: ship recap [success] (")
+        assert lines[1].endswith(")")
+        assert len(lines) == 1 + len(bundle.items)
+
+    def test_render_is_deterministic(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(ledger, summary="alpha-entry", hours_ago=1.0)
+        _insert_work_log_entry(ledger, summary="bravo-entry", hours_ago=2.0)
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        assert recap.render_recap(bundle) == recap.render_recap(bundle)
+
+    def test_render_most_recent_first(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(ledger, summary="alpha-entry", hours_ago=3.0)
+        _insert_work_log_entry(ledger, summary="bravo-entry", hours_ago=2.0)
+        _insert_work_log_entry(ledger, summary="charlie-entry", hours_ago=1.0)
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        text = recap.render_recap(bundle)
+        assert (
+            text.index("charlie-entry")
+            < text.index("bravo-entry")
+            < text.index("alpha-entry")
+        )
+```
+
+- [ ] **4.2 (RED run)**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py -q
+```
+Expected output: `3 failed, 18 passed` (`AttributeError: ... has no attribute 'render_recap'`).
+
+- [ ] **4.3 (GREEN)** Append to `src/dopemux/memory/recap.py` (end of file):
+
+```python
+def render_recap(bundle: ContextBundle) -> str:
+    """Compact markdown recap block.
+
+    Deterministic: the bundle's items are already ordered most-recent-first
+    by ``build_recap_bundle``; this function adds no reordering, no clock
+    reads, no randomness.
+    """
+    lines = [RECAP_TITLE]
+    lines.extend(render_item_line(item) for item in bundle.items)
+    return "\n".join(lines)
+```
+
+- [ ] **4.4 (GREEN run)**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py -q
+```
+Expected output: `21 passed`.
+
+- [ ] **4.5 (Commit)**
+```bash
+git add src/dopemux/memory/recap.py tests/unit/test_recap.py
+git commit -m "feat(memory): TP-MCF-004 deterministic markdown recap renderer"
+```
+
+---
+
+## Task 5 — Read-only invariant locks (structural, not aspirational)
+
+**Files**: `tests/unit/test_recap.py` (append). **No implementation change expected** — Task 2 already made `mode=ro` the implementation choice; these tests lock it so a future edit that "helpfully" opens the ledger read-write fails CI.
+
+These are invariant-lock tests over an already-made structural decision, so they are expected to pass on first run (no RED phase is achievable; that is acceptable here and must be stated in the commit message).
+
+### Steps
+
+- [ ] **5.1** Append to `tests/unit/test_recap.py`:
+
+```python
+class TestReadOnlyInvariant:
+    """recap.py must be structurally incapable of chronicle writes."""
+
+    def test_connection_rejects_writes(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        conn = recap._connect_ro(ledger)
+        try:
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute(
+                    "INSERT INTO raw_activity_events "
+                    "(id, workspace_id, instance_id, ts_utc, event_type, "
+                    " source, payload_json, created_at_utc) "
+                    "VALUES ('x', 'w', 'A', 't', 'e', 's', '{}', 't')"
+                )
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute("UPDATE work_log_entries SET summary = 'clobbered'")
+            with pytest.raises(sqlite3.OperationalError):
+                conn.execute("DELETE FROM work_log_entries")
+        finally:
+            conn.close()
+
+    def test_build_recap_leaves_ledger_bytes_untouched(self, tmp_path):
+        ledger = _make_ledger(tmp_path)
+        _insert_work_log_entry(ledger, summary="untouched-row", hours_ago=1.0)
+        before = hashlib.sha256(ledger.read_bytes()).hexdigest()
+        bundle = recap.build_recap_bundle(WORKSPACE, ledger)
+        assert bundle is not None
+        after = hashlib.sha256(ledger.read_bytes()).hexdigest()
+        assert before == after
+
+    def test_recap_source_contains_no_write_sql(self):
+        source = Path(recap.__file__).read_text(encoding="utf-8").upper()
+        for verb in (
+            "INSERT INTO",
+            "DELETE FROM",
+            "CREATE TABLE",
+            "DROP TABLE",
+            "ALTER TABLE",
+        ):
+            assert verb not in source, f"write SQL verb found in recap.py: {verb}"
+```
+
+- [ ] **5.2 (Run — expected green immediately)**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py -q
+```
+Expected output: `24 passed`. If `test_connection_rejects_writes` fails, the implementation is NOT read-only — stop and fix `_connect_ro` before anything else; do not weaken the test.
+
+- [ ] **5.3 (Commit)**
+```bash
+git add tests/unit/test_recap.py
+git commit -m "test(memory): TP-MCF-004 structural read-only invariant locks (no RED phase: locks an existing mode=ro choice)"
+```
+
+---
+
+## Task 6 — Hook wiring: SessionStart appends the recap as a fourth part
+
+**Files**: `tests/test_native_hooks_workflow.py` (append), `src/dopemux/claude/native_hooks.py` (two edits)
+**Interfaces produced**:
+- `native_hooks._recap_injection_enabled() -> bool` — env kill switch `DOPEMUX_RECAP_INJECTION` (default on; `off`/`0`/`false`/`no` disable).
+- `native_hooks._emit_recap_context(project_root: Path) -> Optional[str]` — fail-open wrapper; **lazy-imports** `dopemux.memory.recap` inside the function body so even an `ImportError` in the new module can never break hook startup (mirrors the module's top-level try/except import fallbacks at `native_hooks.py:30-74`).
+- `_on_session_start` composition gains `recap_ctx` as the **last** element of the existing `"\n\n".join(filter(None, [...]))` calls at `native_hooks.py:341` and `:346`.
+
+### Steps
+
+- [ ] **6.1 (RED)** Append to the END of `tests/test_native_hooks_workflow.py` (the block is deliberately self-contained — it carries its own imports so the patch is append-only and cannot conflict with the existing import lines):
+
+```python
+# --- TP-MCF-004: SessionStart recap wiring -----------------------------------
+# Hermetic: tmp ledger built from the canonical chronicle schema; no Redis,
+# no dope-memory service (which may be down -- the recap is a local read).
+
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_RECAP_REPO_ROOT = Path(__file__).resolve().parents[1]
+_RECAP_SCHEMA = (
+    _RECAP_REPO_ROOT
+    / "services"
+    / "working-memory-assistant"
+    / "chronicle"
+    / "schema.sql"
+)
+
+
+def _recap_ledger_with_entry(tmp_path, workspace_id: str) -> Path:
+    ledger = tmp_path / "chronicle.sqlite"
+    conn = sqlite3.connect(str(ledger))
+    try:
+        conn.executescript(_RECAP_SCHEMA.read_text(encoding="utf-8"))
+        ts = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        now = datetime.now(timezone.utc).isoformat()
+        entry_id = uuid.uuid4().hex
+        conn.execute(
+            """
+            INSERT INTO work_log_entries (
+                id, workspace_id, instance_id, session_id, ts_utc,
+                category, entry_type, summary, outcome, importance_score,
+                tags_json,
+                source_event_id, source_event_type, source_adapter,
+                source_event_ts_utc, promotion_rule, promotion_ts_utc,
+                created_at_utc, updated_at_utc
+            ) VALUES (?, ?, 'A', NULL, ?, 'implementation', 'decision',
+                      'recap smoke entry', 'success', 5, '[]',
+                      ?, 'decision.logged', 'test', ?,
+                      'eventbus_promotion_v1', ?, ?, ?)
+            """,
+            (entry_id, workspace_id, ts, f"evt-{entry_id}", ts, now, now, now),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return ledger
+
+
+def _session_start_context(response) -> str:
+    return (response.get("hookSpecificOutput") or {}).get("additionalContext", "") or ""
+
+
+def test_session_start_appends_recap_from_local_ledger(tmp_path, monkeypatch):
+    workspace_id = str(Path(tmp_path).resolve())
+    ledger = _recap_ledger_with_entry(tmp_path, workspace_id)
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger))
+    monkeypatch.delenv("DOPEMUX_RECAP_INJECTION", raising=False)
+
+    response = handle_event(
+        "SessionStart",
+        {"cwd": str(tmp_path), "env": {"DOPEMUX_INSTANCE_ID": "main"}},
+    )
+
+    context = _session_start_context(response)
+    assert "## Memory recap (last 24h)" in context
+    assert "recap smoke entry" in context
+    assert "[canonical]" in context
+
+
+def test_session_start_recap_appended_after_workflow_context(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOPEMUX_WORKSPACE_ROOT", str(tmp_path))
+    workspace_id = str(Path(tmp_path).resolve())
+    ledger = _recap_ledger_with_entry(tmp_path, workspace_id)
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger))
+    monkeypatch.delenv("DOPEMUX_RECAP_INJECTION", raising=False)
+
+    kernel = WorkflowKernel(tmp_path)
+    kernel.create_or_resume(
+        workflow_id="wf-recap",
+        instance_id="main",
+        mode="internal",
+        max_iterations=5,
+        max_minutes=30,
+        completion_token="DONE",
+    )
+
+    response = handle_event(
+        "SessionStart",
+        {"cwd": str(tmp_path), "env": {"DOPEMUX_INSTANCE_ID": "main"}},
+    )
+    context = _session_start_context(response)
+    assert "Dopemux workflow wf-recap is active." in context
+    assert "## Memory recap (last 24h)" in context
+    # Recap is the FOURTH part: it comes after the workflow context.
+    assert context.index("Dopemux workflow wf-recap is active.") < context.index(
+        "## Memory recap (last 24h)"
+    )
+
+
+def test_session_start_recap_kill_switch(tmp_path, monkeypatch):
+    workspace_id = str(Path(tmp_path).resolve())
+    ledger = _recap_ledger_with_entry(tmp_path, workspace_id)
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(ledger))
+    monkeypatch.setenv("DOPEMUX_RECAP_INJECTION", "off")
+
+    response = handle_event(
+        "SessionStart",
+        {"cwd": str(tmp_path), "env": {"DOPEMUX_INSTANCE_ID": "main"}},
+    )
+    assert "## Memory recap (last 24h)" not in _session_start_context(response)
+
+
+def test_session_start_survives_corrupt_ledger(tmp_path, monkeypatch):
+    garbage = tmp_path / "chronicle.sqlite"
+    garbage.write_bytes(b"\x00not sqlite\xff" * 128)
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(garbage))
+    monkeypatch.delenv("DOPEMUX_RECAP_INJECTION", raising=False)
+
+    response = handle_event(
+        "SessionStart",
+        {"cwd": str(tmp_path), "env": {"DOPEMUX_INSTANCE_ID": "main"}},
+    )
+    # Fail-open: no exception, no recap section, hook not blocked.
+    assert "## Memory recap (last 24h)" not in _session_start_context(response)
+    assert response.get("decision") != "block"
+
+
+def test_session_start_without_ledger_injects_no_recap(tmp_path, monkeypatch):
+    monkeypatch.setenv("DOPEMUX_CAPTURE_LEDGER_PATH", str(tmp_path / "absent.sqlite"))
+    monkeypatch.delenv("DOPEMUX_RECAP_INJECTION", raising=False)
+
+    response = handle_event(
+        "SessionStart",
+        {"cwd": str(tmp_path), "env": {"DOPEMUX_INSTANCE_ID": "main"}},
+    )
+    assert "## Memory recap (last 24h)" not in _session_start_context(response)
+```
+
+- [ ] **6.2 (RED run)**
+```bash
+mise exec -- python -m pytest tests/test_native_hooks_workflow.py -q
+```
+Expected output: `2 failed, 10 passed`. Only the two **positive** tests fail (`test_session_start_appends_recap_from_local_ledger`, `test_session_start_recap_appended_after_workflow_context`); the three **absence** tests (kill switch / corrupt / no ledger) pass trivially before wiring exists — they become meaningful regression guards after 6.3.
+
+- [ ] **6.3 (GREEN, edit 1 of 2)** In `src/dopemux/claude/native_hooks.py`, insert the two helpers immediately before `def _response_text(...)` (currently line 197). Replace this exact text:
+
+```python
+def _response_text(payload: Dict[str, Any]) -> str:
+```
+
+with:
+
+```python
+RECAP_KILL_SWITCH_ENV = "DOPEMUX_RECAP_INJECTION"
+_RECAP_DISABLED_VALUES = {"off", "0", "false", "no"}
+
+
+def _recap_injection_enabled() -> bool:
+    """Env kill switch for SessionStart recap injection (default: on)."""
+    configured = os.environ.get(RECAP_KILL_SWITCH_ENV, "on").strip().lower()
+    return configured not in _RECAP_DISABLED_VALUES
+
+
+def _emit_recap_context(project_root: Path) -> Optional[str]:
+    """Bounded chronicle recap for SessionStart injection (TP-MCF-004).
+
+    Fail-open by construction, mirroring this module's try/except import
+    fallbacks (native_hooks.py:30-74) and the best-effort style of
+    ``_emit_bounded_hook_error_capture``: ANY failure -- missing/corrupt
+    ledger, import error, schema drift -- returns ``None`` and never breaks
+    session start. Local SQLite read only (``mode=ro``): no network, no
+    ConPort, no dope-context, no dope-memory HTTP (the service may be down).
+    The import is lazy so a broken recap module cannot break hook startup.
+    """
+    if not _recap_injection_enabled():
+        return None
+    try:
+        from dopemux.memory.recap import (
+            build_recap_bundle,
+            render_recap,
+            resolve_ledger_path,
+        )
+
+        ledger_path = resolve_ledger_path(project_root)
+        bundle = build_recap_bundle(str(project_root), ledger_path)
+        if bundle is None:
+            return None
+        return render_recap(bundle)
+    except Exception:
+        return None
+
+
+def _response_text(payload: Dict[str, Any]) -> str:
+```
+
+- [ ] **6.4 (GREEN, edit 2 of 2)** In `src/dopemux/claude/native_hooks.py`, replace the whole `_on_session_start` method (lines 335-351 pre-edit; the exact current text is quoted in §0 fact 1). Replace:
+
+```python
+    def _on_session_start(self) -> Tuple[int, Dict[str, Any]]:
+        reset_edit_counter(self.project_root, self.session_id)
+        mcp_health = emit_mcp_health(self.project_root)
+        orch_ctx = emit_session_context(self.project_root)
+        state = self._active_state()
+        if not state:
+            combined = "\n\n".join(filter(None, [mcp_health, orch_ctx]))
+            if combined:
+                return self._allow(additional_context=combined, hook_event_name="SessionStart")
+            return self._allow()
+        workflow_ctx = _workflow_context_lines(state, include_gates=True)
+        combined = "\n\n".join(filter(None, [mcp_health, orch_ctx, workflow_ctx]))
+        return self._allow(
+            system_message=f"Dopemux workflow mode: {state.mode}",
+            additional_context=combined or None,
+            hook_event_name="SessionStart",
+        )
+```
+
+with:
+
+```python
+    def _on_session_start(self) -> Tuple[int, Dict[str, Any]]:
+        reset_edit_counter(self.project_root, self.session_id)
+        mcp_health = emit_mcp_health(self.project_root)
+        orch_ctx = emit_session_context(self.project_root)
+        recap_ctx = _emit_recap_context(self.project_root)
+        state = self._active_state()
+        if not state:
+            combined = "\n\n".join(filter(None, [mcp_health, orch_ctx, recap_ctx]))
+            if combined:
+                return self._allow(additional_context=combined, hook_event_name="SessionStart")
+            return self._allow()
+        workflow_ctx = _workflow_context_lines(state, include_gates=True)
+        combined = "\n\n".join(filter(None, [mcp_health, orch_ctx, workflow_ctx, recap_ctx]))
+        return self._allow(
+            system_message=f"Dopemux workflow mode: {state.mode}",
+            additional_context=combined or None,
+            hook_event_name="SessionStart",
+        )
+```
+
+Nothing else in `native_hooks.py` changes. The recap is the last (fourth) element of the same `filter(None, [...])` composition, so a `None` recap leaves the pre-existing output byte-identical.
+
+- [ ] **6.5 (GREEN run)**
+```bash
+mise exec -- python -m pytest tests/test_native_hooks_workflow.py -q
+```
+Expected output: `12 passed` (7 pre-existing + 5 new).
+
+- [ ] **6.6 (Commit)**
+```bash
+git add src/dopemux/claude/native_hooks.py tests/test_native_hooks_workflow.py
+git commit -m "feat(hooks): TP-MCF-004 SessionStart recap injection (fourth context part, DOPEMUX_RECAP_INJECTION kill switch)"
+```
+
+---
+
+## Task 7 — Final verification: targeted suite + proof gate (no code changes)
+
+- [ ] **7.1 Full targeted suite**
+```bash
+mise exec -- python -m pytest tests/unit/test_recap.py tests/test_native_hooks_workflow.py -q
+```
+Expected output: `36 passed` (24 recap unit + 12 native-hooks). Any other count = investigate before reporting done.
+
+- [ ] **7.2 Adjacent regression check** (recap imports `capture_client`; prove the spine is unharmed)
+```bash
+mise exec -- python -m pytest tests/unit/test_memory_capture_client.py -q
+```
+Expected output: all tests pass (same count as a pre-change run of this file; if it was failing before your change, report it as pre-existing, do not fix it here).
+
+- [ ] **7.3 Diff-scope check**
+```bash
+git status --short
+git diff --stat main...HEAD -- src tests
+```
+Expected: exactly four files changed across the series — `src/dopemux/memory/recap.py`, `tests/unit/test_recap.py`, `src/dopemux/claude/native_hooks.py`, `tests/test_native_hooks_workflow.py`. Anything else in the diff = out of scope, revert it.
+
+- [ ] **7.4 Proof-gate checklist** (map each gate to its test; all must be checked)
+
+| Gate | Test(s) | Invariant |
+|---|---|---|
+| Token budget | `TestTokenBudget::*` (3 tests) | interfaces §4 inv. 6: `token_cost <= budget`, whole-item truncation, `truncated` flag |
+| Authority labels | `test_curated_rows_labeled_canonical_high_trust`, `test_candidate_rows_labeled_conversation_inferred` | interfaces §4 inv. 5: provenance only lowers trust; `conversation_candidate_v1` → conversation-inferred/conversation-derived |
+| Fail-open | `test_missing_ledger_returns_none`, `test_empty_ledger_returns_none`, `test_corrupt_ledger_returns_none`, `test_malformed_timestamp_rows_are_skipped_not_fatal`, `test_session_start_survives_corrupt_ledger`, `test_session_start_without_ledger_injects_no_recap` | interfaces §4 inv. 7: degrade gracefully, never break session start |
+| Read-only | `TestReadOnlyInvariant::*` (3 tests) | structural `mode=ro`; ledger bytes untouched; no write SQL in source |
+| Kill switch | `test_session_start_recap_kill_switch` | `DOPEMUX_RECAP_INJECTION=off` disables; default on |
+| Top-3 + ordering | `test_top_k_selection_and_ordering_most_recent_first`, `test_render_most_recent_first` | design spec §6 TP-MCF-004: Top-3 default, deterministic most-recent-first |
+| No semantic fusion / no network | code review of `recap.py` imports (`sqlite3`, `dataclasses`, `datetime`, `pathlib`, `typing`, `capture_client` only — no `redis`, no `httpx`/`requests`, no conport/dope-context clients) | design spec §6 TP-MCF-004 hard gate |
+
+- [ ] **7.5 Report** with the repo's required final structure (Change Summary · Authority Used · Analysis Performed · Validation PASS/FAIL/NOT_RUN · Remaining Uncertainty · Files Touched · Git State · Rollback Plan · Requested Next Step). Rollback for the whole series: `git revert` the task commits in reverse order, or reset the branch to the pre-series SHA recorded in pre-flight.
+
+---
+
+## Appendix A — Known residual risks (document in the final report, do not "fix" silently)
+
+1. **WAL read-only edge**: the production ledger runs `PRAGMA journal_mode = WAL` (`capture_client.py:527`). Read-only opens of a WAL database can fail in rare states (e.g. `-shm` absent and not creatable). `global_rollup.py:194-198` already ships this exact `mode=ro` pattern against the same ledger, and any such failure is caught by the fail-open `except sqlite3.Error` → `None`. Accepted: a recap silently absent in that edge, never a broken session.
+2. **Lexicographic SQL pre-limit**: `ORDER BY ts_utc DESC LIMIT 50` orders ISO strings lexicographically. Mixed `Z` vs `+00:00` spellings order correctly at second granularity except for identical instants; correctness of the final ordering is guaranteed by the Python-side parse+sort, and the 50-row pre-limit is a bounded-work tradeoff (a workspace with >50 chronicle rows inside 24h could theoretically have a fresh row outside the scan window — acceptable for a recap).
+3. **`session.ended` rows may not exist** in `raw_activity_events` today (the consumer at `eventbus_consumer.py:384` reads a Redis stream the hooks don't feed — authority map §3 gap 1). The boundary line is best-effort by design; its absence is not a defect.
+4. **Fixed title** `## Memory recap (last 24h)` does not vary with `hours_back` — the title is the TP-MCF-004 contract string; `hours_back` is an internal parameter defaulted to 24 and not overridden by the hook.
+
+## Appendix B — Self-review (performed at plan time)
+
+- **Invariant coverage**: all 5 hard invariants from the packet spec are test-gated (see 7.4); interfaces §4 invariants 5/6/7 each map to at least one named test.
+- **Placeholder scan**: no TODO/TBD/`...`-elision in any code block; every code block is complete and paste-ready; all SQL placeholder counts verified against their parameter tuples (13/13 and 8/8 for `work_log_entries` inserts, 4/4 for `raw_activity_events`).
+- **Signature consistency**: `build_recap_bundle(workspace_id: str, ledger_path: Path, *, hours_back: int = 24, k: int = 3, token_budget: int = 700) -> ContextBundle | None` matches the packet text; `ContextItem`/`ContextBundle` field names and order match interfaces §2.4 exactly (`content, source_system, authority_label, trust, freshness, provenance` / `items, token_cost, truncated, workspace_id`); trust vocabulary is exactly `"high" | "conversation-derived"`, authority labels drawn from `"canonical" | "mirror" | "derived" | "conversation-inferred"` (recap emits only `canonical` and `conversation-inferred`).
+- **Groundedness**: every cited line number was read in this worktree on 2026-07-04 baseline (`native_hooks.py:335-351`, `capture_client.py:255-259` and `:527`, `schema.sql:5-20`/`:29-81`, `freeflow.py:202-210`/`:220-221`, `broker.py:943`, `canonical_readview.py:21-36`, `global_rollup.py:194-198`, `eventbus_consumer.py:384`); baseline `tests/test_native_hooks_workflow.py` = 7 passed was verified by an actual run.
+
+
+

--- a/claudedocs/tp-mcf-001-authority-map-2026-07-04.md
+++ b/claudedocs/tp-mcf-001-authority-map-2026-07-04.md
@@ -1,0 +1,88 @@
+# TP-MCF-001 — Memory Capture Repo-Truth Authority Map
+
+**Packet**: TP-MCF-001 (Memory Context Fabric, phase 001) · **Status**: DONE (no runtime change) · **Date**: 2026-07-04
+**Goal**: the current-runtime authority map for memory capture / promotion / ConPort writes / dope-context indexing / hooks / bridge, with exact paths and dead surfaces marked — and the exact TP-MCF-002/003 packet specs it produces.
+**Method**: 3 read-only recon agents (Haiku) over the six domains; every row file:line-cited. No Fabric code; no runtime change.
+**Spec**: `claudedocs/memory-context-fabric-design-2026-07-04.md` (v3).
+
+---
+
+## 1. Authority map (current runtime truth)
+
+| Domain | Canonical writer / path | Status | Evidence |
+|---|---|---|---|
+| **A. Raw capture** | `capture_client.emit_capture_event()` → `raw_activity_events` (SQLite) | **REAL** | `capture_client.py:382-415`, INSERT `:535-556` |
+| — redaction | `redactor.redact_payload()` | **REAL, strip-minimal-on-fail** (stores `{redaction_error, original_keys}`, leaks key names) | `capture_client.py:500-501`; `redactor.py:123-125` |
+| — event_id | deterministic SHA256(type\|session\|ts_bucket\|payload) | **REAL** — but **falls back to `datetime.now()` on missing ts** | `capture_client.py:310-339`, `:493` |
+| — Redis fan-out | `_emit_to_event_stream` → `activity.events.v1` | **REAL** | `capture_client.py:342-379`, `:351` |
+| **B. Promotion** | `eventbus_consumer` (Redis `xreadgroup`) → `store.insert_promoted_entry` → `work_log_entries` | **REAL, event-triggered ONLY** (no ledger-polling path) | `eventbus_consumer.py:36,311-340,427-432` |
+| — trigger gate | reads `activity.events.v1`, group `dope-memory-ingestor`; needs `REDIS_URL` + `ENABLE_EVENTBUS` | **REAL** | `eventbus_consumer.py:34,38` |
+| — allowlist | `{decision.logged, task.completed, task.failed, task.blocked, error.encountered, workflow.phase_changed, manual.memory_store}` — **duplicated in two files, must stay synced** | **REAL** | `promotion.py:18-28` **and** `capture_client.py:39` |
+| — trust field | **NONE** — `work_log_entries` has no `trust` column; provenance via `source_adapter`/`promotion_rule`/`source_event_id` | **UNWIRED** | `schema.sql:29-81` |
+| **C. ConPort decision write** | `conport_log_decision` (MCP) / `POST /api/decisions` on active Docker ConPort | **REAL** | `enhanced_server.py:1760` (dispatch 1757-1774) |
+| — relationship traversal | `GET /api/workspace-relationships` → `get_related_decisions()` | **REAL (HTTP)** | `enhanced_server.py:266,2125` |
+| — graph MCP (`graph.neighbors`, genealogy) | — | **DEAD** — not in the 14-tool dispatch map; only in dead `memory_server.py` (`:875,909,936,962`, header declares dead `:1-5`) + quarantined `conport_kg` (`QUARANTINE.md`) | — |
+| **D. dope-context** | `get_collection_names()` → `code_{hash}`, `docs_{hash}` only; Voyage (**external**) embeddings; FastMCP | **REAL (code/docs only)** | `workspace.py:164-182`; `indexing_pipeline.py:285-300,580`; `server.py:100` |
+| — `memory_{hash}` / `index_memory` / `/index` route | — | **DEAD** — no such collection, tool, or REST route | grep 0 |
+| — `_index_in_dopecontext` (dope-memory side) | POSTs `:3010/index` collection `worklog_index` | **PAINTED SOCKET** — no matching route/collection; POST silently fails (logged) | `eventbus_consumer.py:49,732,745,753-755` |
+| **E. Native hooks** | `native_hooks.py` → stream `dopemux:events`; content-free pings | **REAL but NOT chronicle input** | `:83,124-137` |
+| — SessionStart injection | injects MCP health + orchestrator + workflow context | **REAL** (extend here for recap) | `:335-351` |
+| — PostToolUseFailure | `try_emit_promotable_capture_event(error)` | **REAL** (the memory-spine fix) | `:533-545` |
+| — UserPromptSubmit | records truncated (400-char) prompt to workflow state + `dopemux:events` | **REAL but not raw-ledger capture** | `:365-380` |
+| **F. dopecon-bridge** | emits `decision.logged`/`progress.updated` to `dopemux:events` **after** successful ConPort write, `source="conport"` | **REAL, mirror/receipt (non-authority)** | `routes.py:556-569,600-614` |
+
+---
+
+## 2. Dead-surface register (marked dead — do not target)
+
+- `src/conport/memory_server.py` — declares itself dead (`:1-5`); the `mem.*`/`graph.*` tools live here, **not** in the active runtime.
+- `services/conport_kg/` — quarantined (`QUARANTINE.md`: "Do not route runtime traffic").
+- dope-context `/index` route + `worklog_index` collection — do not exist.
+- `_index_in_dopecontext` (dope-memory) — a painted socket posting to the above.
+- Ledger-polling promotion — does not exist; promotion is Redis-stream-triggered only.
+
+## 3. Gap register (wires terminating in painted sockets)
+
+1. **Hook → chronicle stream gap** — hooks/bridge publish to `dopemux:events`; the consumer reads `activity.events.v1`; nothing bridges them, and hook payloads are content-free. → hook-event capture does **not** feed the chronicle today.
+2. **Promotion is stream-only** — an event that never reaches `activity.events.v1` is never promoted; there is no ledger-scan safety net.
+3. **No `trust` column** — candidate-decision trust must live in `details_json`, not a schema field.
+4. **`PROMOTABLE_EVENT_TYPES` duplicated** (`capture_client.py:39` + `promotion.py:18`) — any new type must be added to **both** (raw-side rejects unknown; promote-side ignores unknown).
+5. **dope-context semantic memory absent** — no `memory_{hash}`/`index_memory`; embeddings are external (Voyage) → the privacy gate on TP-MCF-005 is real.
+6. **ConPort graph MCP absent** — only HTTP relationship traversal exists; `graph.neighbors` is dead code.
+
+---
+
+## 4. Produced packets
+
+### TP-MCF-002 — Transcript ingest → raw ledger only (CONDITIONAL-GO, now specified)
+
+**Scope**: a transcript-file watcher/ingestor that parses harness session JSONL into turn events and writes **only** to `raw_activity_events` via `capture_client.emit_capture_event()` — **direct call, structured content** (not the `dopemux:events` ping path, not a naive stream-bridge).
+
+**Hard invariants (all test-gated):**
+- **Wiring**: call `emit_capture_event()` directly with a structured envelope (`type`, redacted `payload`, `session_id`, `workspace_id`, `source="transcript"`). Do **not** route through `dopemux:events`.
+- **Stable timestamp**: use the transcript turn's own timestamp; **fail/quarantine any turn lacking a source timestamp** — never let `emit_capture_event` fall back to `datetime.now()` (`capture_client.py:493`). This is what makes re-ingest idempotent.
+- **Redaction → hold/quarantine**: on redaction failure for a transcript turn, write only redacted metadata + a withheld payload reference to a **named local safety artifact** — decide `.dopemux/quarantine/` path vs a dope-memory non-queryable table — **not** the queryable ledger. Quarantine is not memory truth: never searched/promoted/mirrored/projected. Writer = this ingest adapter.
+- **No side effects**: **no ConPort writes, no dope-context writes** in this slice.
+- **Fail-open for the session**: capture failure never breaks the user's turn.
+- **Idempotent**: deterministic content-hash `event_id` + `INSERT OR IGNORE` → re-reading a transcript file is safe.
+
+**Spike (do first)**: verify the JSONL schema + on-disk path per harness (Claude Code vs Codex).
+**Reconcile with**: the in-flight memory-spine roadmap work (do not fork the capture spine).
+**Proof gates**: git status/diff, redaction test (no secret reaches ledger; failure → quarantine), replay test (re-ingest idempotent + rejects missing source ts), no-ConPort/no-dope-context-write test, embedded audit.
+
+### TP-MCF-003 — Deterministic promotion + candidate-decision schema (NO-GO until schema defined → this specifies it, unblocking)
+
+**Scope**: promote transcript-derived events for **deterministic** classes only (explicit user decision markers, task completions, errors/blockers, workflow transitions). **No LLM summarization; no auto ConPort writes.**
+
+**Candidate-decision schema (the blocker):**
+- New event type **`conversation.decision_candidate`** — added to `PROMOTABLE_EVENT_TYPES` in **both** `capture_client.py:39` **and** `promotion.py:18-28` (they must stay synced).
+- Trust encoded in payload (no schema column exists): `details_json.trust = "conversation-derived"`, `promotion_rule = "conversation_candidate_v1"`.
+- A candidate is **never** `decision.logged` (which the bridge emits only after a real ConPort write) and **never** auto-writes ConPort. Promotion to a canonical decision requires an explicit gate (operator confirm or deterministic high-confidence rule) — out of this packet's scope.
+
+**Proof gates**: promotion test for each deterministic class; test that `conversation.decision_candidate` is accepted on both the raw and promote sides; test that no ConPort write occurs; authority-label assertion; embedded audit.
+
+---
+
+## 5. Governance footer
+
+**Authority used**: 3 read-only recon passes (file:line cited above) over the active runtime; the v3 design spec; Memory Trinity ADRs. **Validation**: analysis only — **no code changed, live behavior NOT_RUN** (static code truth; recon did not exercise Docker/Redis). **Confidence**: high on the cited paths; the "painted socket" and "graph MCP absent" findings are grep-negative (absence-of-evidence, marked as such). **Next**: TP-MCF-002 (with the spike) then TP-MCF-003; both reconcile with the in-flight memory-spine work. **Rollback**: delete this file.


### PR DESCRIPTION
## Summary

**Complete design documentation + zero-context implementation plans for Memory Context Fabric**, the subsystem that makes dopemux capture everything (including conversation history) and inject context into sessions implicitly.

The deliverable is a self-contained, foldable subsystem specification with build instructions ready for external code agents (Codex, Grok, Antigravity).

## What's included

**Design artifacts** (audit-corrected, CONDITIONAL-GO):
- `memory-context-fabric-design-2026-07-04.md` (v3 spec, twice externally audited)
- `memory-context-fabric-interfaces-2026-07-04.md` (public surface, data contracts, invariants)
- `tp-mcf-001-authority-map-2026-07-04.md` (file:line current-runtime truth; dead surfaces marked)
- `memory-context-fabric-README-2026-07-04.md` (fold-in index and governance footer)

**Build plans** (zero-context, TDD-first, complete code in every step):
- `2026-07-04-memory-context-fabric-build-plan.md` (master: dependency graph, packet index, decision forks, hand-off protocol)
- `2026-07-04-tp-mcf-002-transcript-ingest.md` (6 tasks: format spike verified against real 660-line Claude Code transcript, quarantine writer, CLI entry)
- `2026-07-04-tp-mcf-003-deterministic-promotion.md` (6 tasks: fixed a real `promotion_rule` dispatch-clobber hazard verified against 7 existing handlers, sync-guard test, candidate-decision schema)
- `2026-07-04-tp-mcf-004-sessionstart-recap.md` (7 tasks: ContextBundle dataclasses, read-only SQLite recap, token budget, hook wiring, fail-open, kill switch)

## Key findings (authority map)

Current runtime has:
- ✅ REAL: capture spine, promotion (event-triggered only), ConPort decision writes + relationship traversal
- ❌ DEAD/PAINTED: `memory_{hash}` dope-context collection, `graph.neighbors` MCP, transcript ingest, hook→chronicle stream bridge
- 🔴 HAZARDS: Voyage external embeddings for semantic memory; PROMOTABLE_EVENT_TYPES duplicated across two files; missing `trust` column (must live in details_json)

Decision forks requiring approval before TP-MCF-005/006:
- **Semantic memory**: Option A (new dope-context `memory_{hash}` w/ ADR) or B (drop; keep temporal+structural only)
- **ConPort graph**: Option A (implement `graph.neighbors` MCP) or B (relationship-query projection only)

## Test plan

All three packet plans are self-reviewed:
- ✅ Placeholder scan: no TBD/TODO, every code block complete and paste-ready
- ✅ Spec coverage: every authority doc requirement traced to a task
- ✅ Cross-plan consistency: event types, promotion rules, trust strings verified
- ✅ Backward compatibility: fixes to existing code (promotion_rule dispatch, allowlist test) verified against live codebase

Build sequence (per master plan):
1. TP-MCF-002: transcript ingest → raw ledger only
2. TP-MCF-003: conversation.decision_candidate + deterministic promotion
3. TP-MCF-004: SessionStart recap injection
4. (BLOCKED) TP-MCF-005/006: decision forks (semantic memory, graph expansion)
5. (BLOCKED) TP-MCF-007: Fabric orchestrator + context.recall/recap MCP

## Ready for hand-off

External agents (Codex/Grok/Antigravity) can pick up one packet plan at a time:
- Read the three authority docs (design spec, authority map, interfaces)
- Execute the packet plan's checkbox steps literally, in order
- Commit where the plan says to commit
- Produce the proof bundle per AGENTS.md discipline
- One packet = one PR

No orchestrator items loaded (sequential chain, no parallelism value). Can be generated in a follow-up cheap session if fan-out is wanted.

🩺 Generated without live cluster (conport, dope-memory currently down per health hook); authority map is file:line-grounded, not runtime-verified. All TP-MCF-002/003/004 plans include spike/verification steps as the first task to confirm the current state before implementation.