### PR TITLE
🎨 Palette: Consolidated Dashboard UX (supersedes #987–#994, #1010)

### DIFF
--- a/ui-dashboard/src/components/CognitiveLoadGauge.tsx
+++ b/ui-dashboard/src/components/CognitiveLoadGauge.tsx
@@ -2,7 +2,7 @@ import { Box, LinearProgress, Paper, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import { Brain } from 'lucide-react';
 
-import { brandTokens, statusStyles } from '../theme';
+import { brandTokens, statusStyles, getDynamicRoast } from '../theme';
 
 interface CognitiveLoadGaugeProps {
   load: number;
@@ -17,12 +17,13 @@ export default function CognitiveLoadGauge({
 }: CognitiveLoadGaugeProps) {
   const statusMeta = statusStyles[status];
   const normalizedLoad = Math.max(0, Math.min(100, Math.round(load * 100)));
+  const roast = getDynamicRoast('Cognitive Load', load);
 
   return (
-    <Tooltip title={`Recommendation: ${recommendation}`} arrow>
+    <Tooltip title={`AI Recommendation: ${recommendation}. ${roast}`} arrow>
       <Paper
         tabIndex={0}
-        aria-label={`Cognitive load ${normalizedLoad} percent, ${statusMeta.label}. Recommendation: ${recommendation}`}
+        aria-label={`Cognitive load ${normalizedLoad} percent, ${statusMeta.label}. AI Recommendation: ${recommendation}. ${roast}`}
         sx={{
           p: 3,
           minHeight: 300,
@@ -32,6 +33,15 @@ export default function CognitiveLoadGauge({
           cursor: 'help',
           outline: 'none',
           transition: 'transform 0.2s, box-shadow 0.2s, border-color 0.2s',
+          '@keyframes load-pulse': {
+            '0%': { boxShadow: `0 0 0 0px ${alpha(statusMeta.color, 0.4)}` },
+            '70%': { boxShadow: `0 0 0 12px ${alpha(statusMeta.color, 0)}` },
+            '100%': { boxShadow: `0 0 0 0px ${alpha(statusMeta.color, 0)}` },
+          },
+          animation: status === 'high' || status === 'critical' ? 'load-pulse 2s infinite' : 'none',
+          '@media (prefers-reduced-motion: reduce)': {
+            animation: 'none',
+          },
           '&:hover, &:focus-visible': {
             transform: 'translateY(-4px)',
             borderColor: statusMeta.color,
@@ -64,7 +74,13 @@ export default function CognitiveLoadGauge({
           }}
         />
         <Box sx={{ mt: 3 }}>
-          <Typography variant="h6">{statusMeta.label}</Typography>
+          <Typography variant="h6" sx={{ mb: 0.5 }}>{statusMeta.label}</Typography>
+          <Typography variant="body2" className="dopemux-roast" sx={{ mb: 1 }}>
+            {roast}
+          </Typography>
+          <Typography variant="overline" color="text.secondary" sx={{ display: 'block', mb: 0.5, lineHeight: 1.2 }}>
+            AI Recommendation
+          </Typography>
           <Typography variant="body2" color="text.secondary">
             {recommendation}
           </Typography>

--- a/ui-dashboard/src/components/TeamDashboard.tsx
+++ b/ui-dashboard/src/components/TeamDashboard.tsx
@@ -230,7 +230,15 @@ export default function TeamDashboard() {
           onClick={handleCopy}
           onKeyDown={(e) => {
             if (e.repeat) return;
-            if (e.key === 'Enter' || e.key === ' ') {
+            if (e.key === ' ') e.preventDefault();
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              void handleCopy();
+            }
+          }}
+          onKeyUp={(e) => {
+            if (e.repeat) return;
+            if (e.key === ' ') {
               e.preventDefault();
               void handleCopy();
             }

--- a/ui-dashboard/src/components/TeamDashboard.tsx
+++ b/ui-dashboard/src/components/TeamDashboard.tsx
@@ -229,6 +229,7 @@ export default function TeamDashboard() {
           tabIndex={0}
           onClick={handleCopy}
           onKeyDown={(e) => {
+            if (e.repeat) return;
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
               void handleCopy();

--- a/ui-dashboard/src/components/TeamDashboard.tsx
+++ b/ui-dashboard/src/components/TeamDashboard.tsx
@@ -1,6 +1,7 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Avatar, Box, Chip, LinearProgress, Paper, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
-import { Eye, Zap } from 'lucide-react';
+import { Check, Copy, Eye, Zap } from 'lucide-react';
 
 import { brandTokens, statusStyles } from '../theme';
 
@@ -31,6 +32,33 @@ export default function TeamDashboard() {
   const teamStatusColor = statusStyles[teamStatus].color;
 
   const teamInsight = 'Sequence handoffs while average load is below escalation threshold.';
+
+  const [isCopied, setIsCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = useCallback(async () => {
+    if (!navigator.clipboard?.writeText) return;
+    try {
+      await navigator.clipboard.writeText(teamInsight);
+      setIsCopied(true);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => {
+        setIsCopied(false);
+        copyTimeoutRef.current = null;
+      }, 2000);
+    } catch (err) {
+      console.error('Failed to copy team insight:', err);
+    }
+  }, [teamInsight]);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+        copyTimeoutRef.current = null;
+      }
+    };
+  }, []);
 
   return (
     <Tooltip
@@ -105,6 +133,7 @@ export default function TeamDashboard() {
           <Box
             key={member.name}
             tabIndex={0}
+            aria-label={`${member.name}: ${statusStyles[member.status].label}, ${member.load}% load, ${member.energy}% energy, ${member.attention}% attention`}
             sx={{
               display: 'grid',
               gap: 1,
@@ -131,7 +160,6 @@ export default function TeamDashboard() {
                   size="small"
                   label={statusStyles[member.status].label}
                   aria-label={`${member.name}'s current status: ${statusStyles[member.status].label}`}
-                  tabIndex={0}
                   sx={{ cursor: 'help' }}
                 />
               </Tooltip>
@@ -156,7 +184,6 @@ export default function TeamDashboard() {
               <Tooltip title="Current energy level" arrow>
                 <Chip
                   size="small"
-                  tabIndex={0}
                   icon={<Zap size={14} color={brandTokens.colors.serumMint} aria-hidden="true" />}
                   label={`Energy ${member.energy}%`}
                   aria-label={`${member.name}'s current energy level: ${member.energy}%`}
@@ -176,7 +203,6 @@ export default function TeamDashboard() {
               <Tooltip title="Current attention focus" arrow>
                 <Chip
                   size="small"
-                  tabIndex={0}
                   icon={<Eye size={14} color={brandTokens.colors.ritualCyan} aria-hidden="true" />}
                   label={`Attention ${member.attention}%`}
                   aria-label={`${member.name}'s current attention focus: ${member.attention}%`}
@@ -197,9 +223,55 @@ export default function TeamDashboard() {
           </Box>
         ))}
       </Box>
-      <Typography variant="body2" color="text.secondary" tabIndex={0} sx={{ mb: 2 }}>
-        {teamInsight}
-      </Typography>
+      <Tooltip title={isCopied ? 'Copied!' : 'Copy team insight'} arrow>
+        <Box
+          role="button"
+          tabIndex={0}
+          onClick={handleCopy}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              void handleCopy();
+            }
+          }}
+          aria-label={isCopied ? `Team insight: ${teamInsight} (Copied)` : `Copy team insight: ${teamInsight}`}
+          sx={{
+            mb: 2,
+            p: 2,
+            borderRadius: 2,
+            bgcolor: alpha(brandTokens.colors.ritualCyan, 0.04),
+            border: `1px dashed ${alpha(brandTokens.colors.ritualCyan, 0.3)}`,
+            cursor: 'copy',
+            transition: 'all 0.2s ease',
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 1.5,
+            '&:hover, &:focus-visible': {
+              bgcolor: alpha(brandTokens.colors.ritualCyan, 0.08),
+              borderColor: brandTokens.colors.ritualCyan,
+              transform: 'translateY(-2px)',
+              boxShadow: `0 4px 12px ${alpha(brandTokens.colors.ritualCyan, 0.15)}`,
+            },
+            ...(isCopied && {
+              animation: 'insight-copy-pulse 0.4s ease-out',
+              '@keyframes insight-copy-pulse': {
+                '0%': { transform: 'scale(1)' },
+                '50%': { transform: 'scale(1.02)', boxShadow: `0 0 12px ${alpha(brandTokens.colors.serumMint, 0.4)}` },
+                '100%': { transform: 'scale(1)' },
+              }
+            }),
+          }}
+        >
+          {isCopied ? (
+            <Check size={16} color={brandTokens.colors.serumMint} style={{ marginTop: 2 }} aria-hidden="true" />
+          ) : (
+            <Copy size={16} color={brandTokens.colors.ritualCyan} style={{ marginTop: 2 }} aria-hidden="true" />
+          )}
+          <Typography variant="body2" color="text.secondary">
+            {teamInsight}
+          </Typography>
+        </Box>
+      </Tooltip>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
         {teamSignals.map((signal) => (
           <Tooltip key={signal.label} title={`Team signal: ${signal.label} status`} arrow>

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.tsx
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.tsx
@@ -19,7 +19,10 @@ test('CognitiveLoadGauge.tsx has aria-label for LinearProgress and status Toolti
   const content = fs.readFileSync(filePath, 'utf8');
   expect(content).toContain('aria-label="Cognitive Load Percentage"');
   expect(content).toContain('aria-valuetext');
-  expect(content).toContain('<Tooltip title={`Recommendation: ${recommendation}`} arrow>');
+  expect(content).toContain('<Tooltip title={`AI Recommendation: ${recommendation}. ${roast}`} arrow>');
+  expect(content).toContain('getDynamicRoast');
+  expect(content).toContain('load-pulse');
+  expect(content).toContain('prefers-reduced-motion');
   expect(content).toContain('tabIndex={0}');
 });
 
@@ -67,8 +70,6 @@ test('TeamDashboard.tsx has aria-labels for team and member progress bars and To
   expect(content).toContain('<Tooltip title="Current energy level" arrow>');
   expect(content).toContain('<Tooltip title="Current attention focus" arrow>');
   expect(content).toContain('tabIndex={0}');
-  expect(content).toMatch(/<Tooltip title="Current energy level"[\s\S]*tabIndex=\{0\}/);
-  expect(content).toMatch(/<Tooltip title="Current attention focus"[\s\S]*tabIndex=\{0\}/);
   // Verify team signal chips
   expect(content).toMatch(/<Tooltip key=\{signal\.label\} title=\{`Team signal: \$\{signal\.label\} status`\} arrow>/);
   expect(content).toContain('aria-label={`Team signal: ${signal.label} is ${signal.value}`}');
@@ -82,6 +83,16 @@ test('TeamDashboard.tsx has aria-labels for team and member progress bars and To
   expect(content).toContain('AVG LOAD');
   expect(content).toContain('borderColor: teamStatusColor');
   expect(content).toContain('boxShadow: `0 0 20px ${alpha(teamStatusColor, 0.2)}`');
+
+  // Verify Member Card consolidation
+  expect(content).toMatch(/aria-label=\{\s*`\$\{member\.name\}: \$\{statusStyles\[member\.status\]\.label\}, \$\{member\.load\}% load, \$\{member\.energy\}% energy, \$\{member\.attention\}% attention`\s*\}/);
+
+  // Verify AI Insight Copyable Surface
+  expect(content).toMatch(/<Tooltip title=\{isCopied \? 'Copied!' : 'Copy team insight'\} arrow>/);
+  expect(content).toMatch(/aria-label=\{\s*isCopied \? `Team insight: \$\{teamInsight\} \(Copied\)` : `Copy team insight: \$\{teamInsight\}`\s*\}/);
+  expect(content).toContain('role="button"');
+  expect(content).toContain('onKeyDown=');
+  expect(content).toContain("animation: 'insight-copy-pulse 0.4s ease-out'");
 });
 
 test('App.tsx exposes metric card tooltips with focus indicators and labels', () => {


### PR DESCRIPTION
## Summary

Consolidates all palette dashboard UX intents from the open palette cluster into a single PR to avoid `TeamDashboard.tsx` / `CognitiveLoadGauge.tsx` merge conflicts.

**Supersedes:** #987, #988, #989, #990, #991, #992, #994, #1010

### TeamDashboard
- Copyable AI team insight with keyboard support and tactile copy pulse
- Member card aria-label consolidation (load/energy/attention in one label)
- Removed redundant `tabIndex` on nested chips for cleaner focus order

### CognitiveLoadGauge
- AI Recommendation transparency labels in tooltip and content
- Status-driven pulse animation for high/critical load (respects `prefers-reduced-motion`)
- Personality harmonization via `getDynamicRoast`

## Test plan
- [x] `npx vitest --run src/components/__tests__/Accessibility.test.tsx` (10/10 pass)
- [ ] CI pipeline green

## Close-out plan
After merge, close superseded palette PRs with pointer to this PR.