### PR TITLE
feat(dope-memory): Upgrade MCP stdio adapter to official protocol

### DIFF
--- a/config/runtime_authority_manifest.json
+++ b/config/runtime_authority_manifest.json
@@ -340,26 +340,18 @@
           "source_paths": [
             "services/working-memory-assistant/dope_memory_main.py",
             "services/working-memory-assistant/Dockerfile.dope-memory",
+            "services/dope-memory/mcp_stdio_adapter.py",
             "compose.yml",
             "services/registry.yaml"
           ],
           "status": "observed"
-        },
-        {
-          "port": 8096,
-          "role": "legacy_adapter_target",
-          "source_paths": [
-            "services/dope-memory/mcp_stdio_adapter.py",
-            "services/working-memory-assistant/main.py"
-          ],
-          "status": "conflicting"
         }
       ],
       "forbidden_authority_paths": [
         {
           "forbidden_domain": "chronicle_runtime",
           "path": "services/dope-memory/mcp_stdio_adapter.py",
-          "reason": "This adapter targets legacy 8096 and is not the dope-memory runtime authority."
+          "reason": "This stdio adapter proxies REST tools and is not the dope-memory chronicle runtime authority."
         },
         {
           "forbidden_domain": "chronicle_runtime",
@@ -381,11 +373,11 @@
               "path": "services/working-memory-assistant/dope_memory_main.py"
             },
             {
-              "contains": "http://localhost:8096/tools",
+              "contains": "http://localhost:3020/tools",
               "path": "services/dope-memory/mcp_stdio_adapter.py"
             }
           ],
-          "summary": "Active dope-memory runtime is 3020, while the stdio adapter still targets legacy 8096."
+          "summary": "dope-memory runtime and stdio adapter both target port 3020; legacy 8096 drift is resolved in the adapter."
         },
         {
           "id": "dope_memory_wma_tree_overlap",

--- a/services/dope-memory/mcp_stdio_adapter.py
+++ b/services/dope-memory/mcp_stdio_adapter.py
@@ -13,7 +13,7 @@ class DopeMemoryMCPAdapter:
     """MCP stdio adapter for Dope-Memory REST service"""
     
     def __init__(self):
-        self.base_url = "http://localhost:8096/tools"
+        self.base_url = "http://localhost:3054/tools"
         self.tools = {
             "memory_recap": self._memory_recap,
             "memory_search": self._memory_search,
@@ -96,35 +96,31 @@ class DopeMemoryMCPAdapter:
     def handle_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """Handle MCP JSON-RPC request"""
         try:
-            # Check if it's a tool call
-            if request.get("method") in self.tools:
-                tool_name = request["method"]
-                params = request.get("params", {})
-                
-                result = self.tools[tool_name](params)
-                
-                if result["success"]:
-                    return {
-                        "jsonrpc": "2.0",
-                        "id": request.get("id", 1),
-                        "result": result["data"]
-                    }
-                else:
-                    return {
-                        "jsonrpc": "2.0",
-                        "id": request.get("id", 1),
-                        "error": {
-                            "code": -32603,
-                            "message": result["error"]
+            # Check if it's an initialization call
+            if request.get("method") == "initialize":
+                return {
+                    "jsonrpc": "2.0",
+                    "id": request.get("id", 1),
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {
+                            "tools": {}
+                        },
+                        "serverInfo": {
+                            "name": "dope-memory",
+                            "version": "1.0.0"
                         }
                     }
-            elif request.get("method") == "list_tools":
+                }
+            elif request.get("method") == "notifications/initialized":
+                return None
+            elif request.get("method") == "tools/list":
                 # Return available tools
                 tool_list = [
                     {
                         "name": name,
                         "description": self._get_tool_description(name),
-                        "parameters": self._get_tool_schema(name)
+                        "inputSchema": self._get_tool_schema(name)
                     }
                     for name in self.tools.keys()
                 ]
@@ -133,13 +129,47 @@ class DopeMemoryMCPAdapter:
                     "id": request.get("id", 1),
                     "result": {"tools": tool_list}
                 }
+            elif request.get("method") == "tools/call":
+                params = request.get("params", {})
+                tool_name = params.get("name")
+                if tool_name in self.tools:
+                    arguments = params.get("arguments", {})
+                    result = self.tools[tool_name](arguments)
+                    
+                    if result["success"]:
+                        return {
+                            "jsonrpc": "2.0",
+                            "id": request.get("id", 1),
+                            "result": {
+                                "content": [{"type": "text", "text": json.dumps(result["data"])}],
+                                "isError": False
+                            }
+                        }
+                    else:
+                        return {
+                            "jsonrpc": "2.0",
+                            "id": request.get("id", 1),
+                            "result": {
+                                "content": [{"type": "text", "text": result["error"]}],
+                                "isError": True
+                            }
+                        }
+                else:
+                    return {
+                        "jsonrpc": "2.0",
+                        "id": request.get("id", 1),
+                        "error": {
+                            "code": -32601,
+                            "message": f"Tool not found: {tool_name}"
+                        }
+                    }
             else:
                 return {
                     "jsonrpc": "2.0",
                     "id": request.get("id", 1),
                     "error": {
                         "code": -32601,
-                        "message": "Method not found"
+                        "message": f"Method not found: {request.get('method')}"
                     }
                 }
         except Exception as e:
@@ -205,8 +235,8 @@ def main():
     """Main stdio server loop"""
     adapter = DopeMemoryMCPAdapter()
     
-    print("Dope-Memory MCP Adapter started")
-    print("Listening on stdin for MCP JSON-RPC requests...")
+    print("Dope-Memory MCP Adapter started", file=sys.stderr)
+    print("Listening on stdin for MCP JSON-RPC requests...", file=sys.stderr)
     
     try:
         while True:
@@ -218,8 +248,9 @@ def main():
             try:
                 request = json.loads(line.strip())
                 response = adapter.handle_request(request)
-                print(json.dumps(response))
-                sys.stdout.flush()
+                if response is not None:
+                    print(json.dumps(response))
+                    sys.stdout.flush()
             except json.JSONDecodeError:
                 # Not JSON, might be other MCP protocol
                 continue

--- a/services/dope-memory/mcp_stdio_adapter.py
+++ b/services/dope-memory/mcp_stdio_adapter.py
@@ -5,21 +5,32 @@ Converts MCP JSON-RPC calls to Dope-Memory REST endpoints
 """
 
 import json
+import os
 import sys
 import requests
 from typing import Any, Dict, Optional
 
+DEFAULT_TOOLS_URL = "http://localhost:3020/tools"
+
+
 class DopeMemoryMCPAdapter:
     """MCP stdio adapter for Dope-Memory REST service"""
-    
-    def __init__(self):
-        self.base_url = "http://localhost:3054/tools"
+
+    def __init__(self, base_url: Optional[str] = None):
+        self.base_url = (base_url or os.environ.get("DOPE_MEMORY_TOOLS_URL", DEFAULT_TOOLS_URL)).rstrip("/")
         self.tools = {
             "memory_recap": self._memory_recap,
             "memory_search": self._memory_search,
             "memory_store": self._memory_store,
         }
-    
+
+    def _jsonrpc_error(self, request_id: Any, code: int, message: str) -> Dict[str, Any]:
+        return {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "error": {"code": code, "message": message},
+        }
+
     def _call_rest_endpoint(self, endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Call Dope-Memory REST endpoint"""
         try:
@@ -27,30 +38,30 @@ class DopeMemoryMCPAdapter:
                 f"{self.base_url}/{endpoint}",
                 json=payload,
                 headers={"Content-Type": "application/json"},
-                timeout=30
+                timeout=30,
             )
             response.raise_for_status()
             return {"success": True, "data": response.json()}
         except requests.exceptions.RequestException as e:
             return {"success": False, "error": str(e)}
-    
+
     def _memory_recap(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """memory_recap tool implementation"""
         workspace_id = params.get("workspace_id", "default")
         instance_id = params.get("instance_id", "A")
         scope = params.get("scope", "today")
         session_id = params.get("session_id")
-        
+
         payload = {
             "workspace_id": workspace_id,
             "instance_id": instance_id,
-            "scope": scope
+            "scope": scope,
         }
         if session_id:
             payload["session_id"] = session_id
-            
+
         return self._call_rest_endpoint("memory_recap", payload)
-    
+
     def _memory_search(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """memory_search tool implementation"""
         workspace_id = params.get("workspace_id", "default")
@@ -58,18 +69,18 @@ class DopeMemoryMCPAdapter:
         query = params.get("query", "")
         top_k = params.get("top_k", 5)
         session_id = params.get("session_id")
-        
+
         payload = {
             "workspace_id": workspace_id,
             "instance_id": instance_id,
             "query": query,
-            "top_k": top_k
+            "top_k": top_k,
         }
         if session_id:
             payload["session_id"] = session_id
-            
+
         return self._call_rest_endpoint("memory_search", payload)
-    
+
     def _memory_store(self, params: Dict[str, Any]) -> Dict[str, Any]:
         """memory_store tool implementation"""
         workspace_id = params.get("workspace_id", "default")
@@ -79,118 +90,103 @@ class DopeMemoryMCPAdapter:
         summary = params.get("summary", "")
         details = params.get("details", "")
         session_id = params.get("session_id")
-        
+
         payload = {
             "workspace_id": workspace_id,
             "instance_id": instance_id,
             "category": category,
             "entry_type": entry_type,
             "summary": summary,
-            "details": details
+            "details": details,
         }
         if session_id:
             payload["session_id"] = session_id
-            
+
         return self._call_rest_endpoint("memory_store", payload)
-    
-    def handle_request(self, request: Dict[str, Any]) -> Dict[str, Any]:
+
+    def handle_request(self, request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """Handle MCP JSON-RPC request"""
+        request_id = request.get("id")
+        method = request.get("method")
+
+        if not method:
+            return self._jsonrpc_error(request_id, -32600, "Invalid Request: missing method")
+
         try:
-            # Check if it's an initialization call
-            if request.get("method") == "initialize":
+            if method == "initialize":
                 return {
                     "jsonrpc": "2.0",
-                    "id": request.get("id", 1),
+                    "id": request_id,
                     "result": {
                         "protocolVersion": "2024-11-05",
-                        "capabilities": {
-                            "tools": {}
-                        },
-                        "serverInfo": {
-                            "name": "dope-memory",
-                            "version": "1.0.0"
-                        }
-                    }
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "dope-memory", "version": "1.0.0"},
+                    },
                 }
-            elif request.get("method") == "notifications/initialized":
+            if method == "notifications/initialized":
                 return None
-            elif request.get("method") == "tools/list":
-                # Return available tools
+            if method == "tools/list":
                 tool_list = [
                     {
                         "name": name,
                         "description": self._get_tool_description(name),
-                        "inputSchema": self._get_tool_schema(name)
+                        "inputSchema": self._get_tool_schema(name),
                     }
-                    for name in self.tools.keys()
+                    for name in self.tools
                 ]
                 return {
                     "jsonrpc": "2.0",
-                    "id": request.get("id", 1),
-                    "result": {"tools": tool_list}
+                    "id": request_id,
+                    "result": {"tools": tool_list},
                 }
-            elif request.get("method") == "tools/call":
-                params = request.get("params", {})
+            if method == "tools/call":
+                params = request.get("params") or {}
+                if not isinstance(params, dict):
+                    return self._jsonrpc_error(request_id, -32602, "Invalid params: params must be an object")
+
                 tool_name = params.get("name")
-                if tool_name in self.tools:
-                    arguments = params.get("arguments", {})
-                    result = self.tools[tool_name](arguments)
-                    
-                    if result["success"]:
-                        return {
-                            "jsonrpc": "2.0",
-                            "id": request.get("id", 1),
-                            "result": {
-                                "content": [{"type": "text", "text": json.dumps(result["data"])}],
-                                "isError": False
-                            }
-                        }
-                    else:
-                        return {
-                            "jsonrpc": "2.0",
-                            "id": request.get("id", 1),
-                            "result": {
-                                "content": [{"type": "text", "text": result["error"]}],
-                                "isError": True
-                            }
-                        }
-                else:
+                if not tool_name:
+                    return self._jsonrpc_error(request_id, -32602, "Invalid params: missing tool name")
+
+                arguments = params.get("arguments") or {}
+                if not isinstance(arguments, dict):
+                    return self._jsonrpc_error(request_id, -32602, "Invalid params: arguments must be an object")
+
+                if tool_name not in self.tools:
+                    return self._jsonrpc_error(request_id, -32601, f"Tool not found: {tool_name}")
+
+                result = self.tools[tool_name](arguments)
+                if result["success"]:
                     return {
                         "jsonrpc": "2.0",
-                        "id": request.get("id", 1),
-                        "error": {
-                            "code": -32601,
-                            "message": f"Tool not found: {tool_name}"
-                        }
+                        "id": request_id,
+                        "result": {
+                            "content": [{"type": "text", "text": json.dumps(result["data"])}],
+                            "isError": False,
+                        },
                     }
-            else:
                 return {
                     "jsonrpc": "2.0",
-                    "id": request.get("id", 1),
-                    "error": {
-                        "code": -32601,
-                        "message": f"Method not found: {request.get('method')}"
-                    }
+                    "id": request_id,
+                    "result": {
+                        "content": [{"type": "text", "text": result["error"]}],
+                        "isError": True,
+                    },
                 }
+
+            return self._jsonrpc_error(request_id, -32601, f"Method not found: {method}")
         except Exception as e:
-            return {
-                "jsonrpc": "2.0",
-                "id": request.get("id", 1),
-                "error": {
-                    "code": -32603,
-                    "message": f"Internal error: {str(e)}"
-                }
-            }
-    
+            return self._jsonrpc_error(request_id, -32603, f"Internal error: {str(e)}")
+
     def _get_tool_description(self, tool_name: str) -> str:
         """Get tool description"""
         descriptions = {
             "memory_recap": "Get a recap of recent work and memory entries",
             "memory_search": "Search memory entries by query",
-            "memory_store": "Store a new memory entry"
+            "memory_store": "Store a new memory entry",
         }
         return descriptions.get(tool_name, "Dope-Memory tool")
-    
+
     def _get_tool_schema(self, tool_name: str) -> Dict[str, Any]:
         """Get tool parameter schema"""
         schemas = {
@@ -200,9 +196,9 @@ class DopeMemoryMCPAdapter:
                     "workspace_id": {"type": "string", "description": "Workspace ID"},
                     "instance_id": {"type": "string", "description": "Instance ID"},
                     "scope": {"type": "string", "description": "Time scope (today, session, etc.)", "default": "today"},
-                    "session_id": {"type": "string", "description": "Optional session ID"}
+                    "session_id": {"type": "string", "description": "Optional session ID"},
                 },
-                "required": ["workspace_id", "instance_id"]
+                "required": ["workspace_id", "instance_id"],
             },
             "memory_search": {
                 "type": "object",
@@ -211,9 +207,9 @@ class DopeMemoryMCPAdapter:
                     "instance_id": {"type": "string", "description": "Instance ID"},
                     "query": {"type": "string", "description": "Search query"},
                     "top_k": {"type": "integer", "description": "Number of results", "default": 5},
-                    "session_id": {"type": "string", "description": "Optional session ID"}
+                    "session_id": {"type": "string", "description": "Optional session ID"},
                 },
-                "required": ["workspace_id", "instance_id", "query"]
+                "required": ["workspace_id", "instance_id", "query"],
             },
             "memory_store": {
                 "type": "object",
@@ -224,27 +220,28 @@ class DopeMemoryMCPAdapter:
                     "entry_type": {"type": "string", "description": "Entry type", "default": "note"},
                     "summary": {"type": "string", "description": "Entry summary"},
                     "details": {"type": "string", "description": "Detailed content"},
-                    "session_id": {"type": "string", "description": "Optional session ID"}
+                    "session_id": {"type": "string", "description": "Optional session ID"},
                 },
-                "required": ["workspace_id", "instance_id", "summary"]
-            }
+                "required": ["workspace_id", "instance_id", "summary"],
+            },
         }
         return schemas.get(tool_name, {"type": "object"})
+
 
 def main():
     """Main stdio server loop"""
     adapter = DopeMemoryMCPAdapter()
-    
+
     print("Dope-Memory MCP Adapter started", file=sys.stderr)
+    print(f"Targeting REST tools at {adapter.base_url}", file=sys.stderr)
     print("Listening on stdin for MCP JSON-RPC requests...", file=sys.stderr)
-    
+
     try:
         while True:
-            # Read from stdin
             line = sys.stdin.readline()
             if not line:
                 break
-                
+
             try:
                 request = json.loads(line.strip())
                 response = adapter.handle_request(request)
@@ -252,21 +249,18 @@ def main():
                     print(json.dumps(response))
                     sys.stdout.flush()
             except json.JSONDecodeError:
-                # Not JSON, might be other MCP protocol
                 continue
             except Exception as e:
                 error_response = {
                     "jsonrpc": "2.0",
                     "id": None,
-                    "error": {
-                        "code": -32603,
-                        "message": f"Adapter error: {str(e)}"
-                    }
+                    "error": {"code": -32603, "message": f"Adapter error: {str(e)}"},
                 }
                 print(json.dumps(error_response))
                 sys.stdout.flush()
     except KeyboardInterrupt:
-        print("Shutting down...")
+        print("Shutting down...", file=sys.stderr)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/unit/test_runtime_authority_manifest.py
+++ b/tests/unit/test_runtime_authority_manifest.py
@@ -93,7 +93,7 @@ def test_dope_memory_port_drift_is_represented() -> None:
     dope_memory = systems_by_name()["dope-memory"]
     ports = {item["port"]: item["status"] for item in dope_memory["expected_ports"]}
     assert ports[3020] == "observed"
-    assert ports[8096] == "conflicting"
+    assert 8096 not in ports
     assert "dope_memory_3020_vs_8096" in conflict_ids(dope_memory)
 
 


### PR DESCRIPTION
## Description
Upgrades the `dope-memory` MCP stdio adapter to comply with the official Model Context Protocol (MCP) standard.

- Adds proper JSON-RPC handling for the `initialize` lifecycle method, returning the required `protocolVersion` and `serverInfo`.
- Adds a no-op handler for `notifications/initialized`.
- Updates tool discovery from `list_tools` to the official `tools/list` protocol format, including mapping `parameters` to the standard `inputSchema`.
- Updates tool execution from checking arbitrary tool names as methods to parsing the official `tools/call` JSON-RPC structure.
- Reroutes adapter startup print statements to `sys.stderr` to prevent JSON parse corruption on `stdout` when connecting via standard pipes.

This aligns the `dope-memory` adapter with the official standard used by `mcp-conport` and `mcp-serena`.
