### PR TITLE
🎨 Palette: Copyable AI Insights in Team Dashboard

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -158,3 +158,6 @@
 **Learning:** When refactoring multiple nested tooltips into a single "Card-Level" summary, it's easy to lose critical context like the "AI-generated" nature of suggestions. Explicitly labeling these summaries as "AI Insight" or "AI Recommendation" ensures transparency and maintains the user's understanding of the source of the information, which is crucial for building trust in automated systems.
 **Action:** When consolidating metadata into a single tooltip, ensure that the source and nature of suggestions (especially AI-driven ones) are explicitly labeled.
 
+## 2026-06-01 - [Copyable Insight Surfaces & Tooltip Fighting]
+**Learning:** Converting static AI insights into interactive, copyable button surfaces improves utility and provides positive reinforcement. However, when these surfaces are nested within a larger interactive card, it's critical to remove the insight's description from the parent's `Tooltip` and `aria-label`. This prevents "tooltip fighting" (where the parent tooltip obscures the child's feedback) and avoids redundant, confusing announcements for screen reader users.
+**Action:** When making internal elements like AI Insights copyable, ensure the parent container's accessibility metadata is pruned of the child's text to maintain clarity and focus.

--- a/ui-dashboard/src/components/TeamDashboard.tsx
+++ b/ui-dashboard/src/components/TeamDashboard.tsx
@@ -1,6 +1,7 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Avatar, Box, Chip, LinearProgress, Paper, Tooltip, Typography } from '@mui/material';
 import { alpha } from '@mui/material/styles';
-import { Eye, Zap } from 'lucide-react';
+import { Brain, Check, Copy, Eye, Zap } from 'lucide-react';
 
 import { brandTokens, statusStyles } from '../theme';
 
@@ -16,6 +17,9 @@ const teamSignals = [
 ];
 
 export default function TeamDashboard() {
+  const [isCopied, setIsCopied] = useState(false);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const teamAverageLoad = Math.round(
     teamMembers.reduce((total, member) => total + member.load, 0) / teamMembers.length
   );
@@ -32,14 +36,37 @@ export default function TeamDashboard() {
 
   const teamInsight = 'Sequence handoffs while average load is below escalation threshold.';
 
+  const handleCopy = useCallback(async () => {
+    if (!navigator.clipboard?.writeText) return;
+    try {
+      await navigator.clipboard.writeText(teamInsight);
+      setIsCopied(true);
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => {
+        setIsCopied(false);
+        copyTimeoutRef.current = null;
+      }, 2000);
+    } catch (err) {
+      console.error('Failed to copy team insight', err);
+    }
+  }, [teamInsight]);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) {
+        clearTimeout(copyTimeoutRef.current);
+      }
+    };
+  }, []);
+
   return (
     <Tooltip
-      title={`Average Team Load: ${teamAverageLoad}% • ${statusStyles[teamStatus].label}. AI Insight: ${teamInsight}`}
+      title={`Average Team Load: ${teamAverageLoad}% • ${statusStyles[teamStatus].label}`}
       arrow
     >
       <Paper
         tabIndex={0}
-        aria-label={`Team dashboard signal summary. Average load: ${teamAverageLoad}%. Status: ${statusStyles[teamStatus].label}. AI Insight: ${teamInsight}`}
+        aria-label={`Team dashboard signal summary. Average load: ${teamAverageLoad}%. Status: ${statusStyles[teamStatus].label}`}
         sx={{
           p: 3,
           borderRadius: 3,
@@ -197,9 +224,59 @@ export default function TeamDashboard() {
           </Box>
         ))}
       </Box>
-      <Typography variant="body2" color="text.secondary" tabIndex={0} sx={{ mb: 2 }}>
-        {teamInsight}
-      </Typography>
+      <Box
+        role="button"
+        tabIndex={0}
+        onClick={handleCopy}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleCopy();
+          }
+        }}
+        aria-label={isCopied ? `AI Recommendation: ${teamInsight} (Copied)` : `Copy AI Recommendation: ${teamInsight}`}
+        sx={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          gap: 1.5,
+          mt: 1,
+          mb: 2,
+          p: 1.5,
+          borderRadius: 2,
+          bgcolor: alpha(teamStatusColor, 0.05),
+          border: `1px dashed ${alpha(teamStatusColor, 0.4)}`,
+          cursor: 'copy',
+          transition: 'all 0.2s cubic-bezier(0.4, 0, 0.2, 1)',
+          '&:hover, &:focus-visible': {
+            bgcolor: alpha(teamStatusColor, 0.1),
+            borderColor: teamStatusColor,
+            transform: 'translateY(-2px)',
+            boxShadow: `0 4px 12px ${alpha(teamStatusColor, 0.15)}`,
+          },
+          ...(isCopied && {
+            animation: 'insight-copy-pulse 0.4s ease-out',
+            '@keyframes insight-copy-pulse': {
+              '0%': { transform: 'scale(1)' },
+              '50%': { transform: 'scale(1.02)', boxShadow: `0 0 15px ${alpha(teamStatusColor, 0.4)}` },
+              '100%': { transform: 'scale(1)' },
+            }
+          }),
+        }}
+      >
+        <Box sx={{ mt: 0.25 }}>
+          {isCopied ? (
+            <Check size={16} color={brandTokens.colors.serumMint} aria-hidden="true" />
+          ) : (
+            <Brain size={16} color={teamStatusColor} aria-hidden="true" />
+          )}
+        </Box>
+        <Typography variant="body2" color="text.secondary">
+          {teamInsight}
+        </Typography>
+        <Box sx={{ ml: 'auto', alignSelf: 'center', opacity: 0.5 }}>
+          <Copy size={14} aria-hidden="true" />
+        </Box>
+      </Box>
       <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5 }}>
         {teamSignals.map((signal) => (
           <Tooltip key={signal.label} title={`Team signal: ${signal.label} status`} arrow>

--- a/ui-dashboard/src/components/__tests__/Accessibility.test.tsx
+++ b/ui-dashboard/src/components/__tests__/Accessibility.test.tsx
@@ -76,9 +76,15 @@ test('TeamDashboard.tsx has aria-labels for team and member progress bars and To
 
   // Verify TeamDashboard root interactive surface and summary Tooltip
   expect(content).toContain('tabIndex={0}');
-  expect(content).toMatch(/<Tooltip[^>]*title=\{`Average Team Load: \$\{teamAverageLoad\}% • \$\{statusStyles\[teamStatus\]\.label\}\. AI Insight: \$\{teamInsight\}`\}[^>]*arrow/);
-  expect(content).toContain('aria-label={`Team dashboard signal summary. Average load: ${teamAverageLoad}%. Status: ${statusStyles[teamStatus].label}. AI Insight: ${teamInsight}`}');
+  expect(content).toMatch(/<Tooltip[^>]*title=\{`Average Team Load: \$\{teamAverageLoad\}% • \$\{statusStyles\[teamStatus\]\.label\}`\}[^>]*arrow/);
+  expect(content).toContain('aria-label={`Team dashboard signal summary. Average load: ${teamAverageLoad}%. Status: ${statusStyles[teamStatus].label}`}');
   expect(content).toContain("letterSpacing: '0.16em'");
+
+  // Verify copyable AI Insight block
+  expect(content).toContain('role="button"');
+  expect(content).toContain('aria-label={isCopied ? `AI Recommendation: ${teamInsight} (Copied)` : `Copy AI Recommendation: ${teamInsight}`}');
+  expect(content).toContain('animation: \'insight-copy-pulse 0.4s ease-out\'');
+  expect(content).toContain('cursor: \'copy\'');
   expect(content).toContain('AVG LOAD');
   expect(content).toContain('borderColor: teamStatusColor');
   expect(content).toContain('boxShadow: `0 0 20px ${alpha(teamStatusColor, 0.2)}`');


### PR DESCRIPTION
Converted static AI insights in the Team Dashboard into interactive, copyable blocks with accessibility improvements and visual feedback.

---
*PR created automatically by Jules for task [10679588452890549820](https://jules.google.com/task/10679588452890549820) started by @hu3mann*