### PR TITLE
fix(mcp): fix port allocation bugs + transport docs + user guide + agent awareness

### DIFF
--- a/.claude/claude.md
+++ b/.claude/claude.md
@@ -157,3 +157,30 @@ When you need comprehensive details, refer to:
 **MCP Status**: Fully operational with ConPort auto-initialization
 **Python Standards**: Type hints, pytest, PEP 8 with Black formatting, src/ layout
 **ADHD Support**: Progressive disclosure, gentle guidance, visual progress indicators active
+
+## 🔌 MCP Transport and Setup Rules (see AGENTS.md §12)
+
+**Do not change transport types without reading server source.** The correct types are:
+
+| Server | `type` | Protocol |
+|---|---|---|
+| `conport` | `sse` | SSE — `GET /sse` |
+| `dope-memory`, `task-orchestrator` | `http` | Streamable HTTP — `POST /mcp` |
+| `pal`, `serena`, `dope-context` | `http` | Streamable HTTP — `POST /mcp` |
+
+A `406 Not Acceptable: Client must accept text/event-stream` on `GET /mcp` is
+**correct Streamable HTTP behaviour** — not evidence the server is SSE. Fix: POST with JSON-RPC.
+
+**Setting up MCP in a new repo**:
+```bash
+cd ~/code/target-repo && dopemux mcp init
+source .envrc.dopemux-mcp && dopemux mcp doctor
+```
+
+**Debug sequence**: source envrc → `dopemux mcp doctor` → curl probe → tail docker logs
+→ `./mcp_server_health_report.sh`
+
+**Key docs**:
+- [`docs/02-how-to/mcp-setup-other-repos.md`](docs/02-how-to/mcp-setup-other-repos.md) — user guide for other projects
+- [`docs/02-how-to/mcp-transport-and-port-bugs.md`](docs/02-how-to/mcp-transport-and-port-bugs.md) — bug record + correct analysis
+- `AGENTS.md §12` — canonical MCP rules for all agents

--- a/.claude/mcp-system.md
+++ b/.claude/mcp-system.md
@@ -1,189 +1,136 @@
 # MCP System Reference for Claude Code
 
-**Status**: ✅ Fully Operational - 9 servers, 50+ tools
-**Last Updated**: September 25, 2025
+**Status**: Operational — see `AGENTS.md §12` for transport rules and debug sequence
+**Last Updated**: 2026-07-06
+
+---
 
 ## System Overview
 
-This project has a **fully operational MCP ecosystem** specifically optimized for ADHD developers. The system provides structured access to documentation, context preservation, research, and task management through unified protocols.
+This project uses a Docker-based MCP ecosystem with two tiers:
 
-## Critical Usage Instructions for LLMs
+- **Singleton servers** — shared across all worktrees, declared in `~/.claude.json`
+- **Per-worktree servers** — isolated instances per workspace, declared in `.mcp.json`
 
-### 🚨 MANDATORY Session Start Protocol
-Every Claude Code session MUST begin with:
+The canonical server registry is [`mcp_catalog.yaml`](../mcp_catalog.yaml).
 
-1. **Check Active Context**
-   ```
-   mcp__conport__get_active_context --workspace_id "<repo-root>"
-   ```
+---
 
-2. **Review In-Progress Tasks**
-   ```
-   mcp__conport__get_progress --status_filter "IN_PROGRESS"
-   ```
+## Session Start Protocol
 
-3. **Understand Current State** before proceeding with any work
+Every session **should** begin with:
 
-### 🚨 MANDATORY Documentation-First Pattern
-Before implementing ANY new feature or using unfamiliar libraries:
+```
+mcp__conport__get_active_context --workspace_id "<repo-root>"
+mcp__conport__get_recent_activity_summary --workspace_id "<repo-root>" --hours_ago 24
+```
 
-1. **Resolve Library ID**
-   ```
-   mcp__context7__resolve_library_id "library-name"
-   ```
+Then: log decisions, track progress, preserve context before interruptions.
 
-2. **Get Focused Documentation**
-   ```
-   mcp__context7__get_library_docs "/org/library" --topic "specific-feature" --tokens 2000
-   ```
-
-3. **Never guess** - always get authoritative documentation first
-
-### 🚨 MANDATORY Context Preservation
-This user has ADHD - context loss is devastating:
-
-1. **Before ANY interruption or break**
-   ```
-   mcp__conport__update_active_context --workspace_id "<repo-root>" --patch_content '{"interruption_state": "what I was doing", "mental_model": "current understanding", "next_steps": "what to do next"}'
-   ```
-
-2. **Log ALL important decisions**
-   ```
-   mcp__conport__log_decision --workspace_id "<repo-root>" --summary "decision made" --rationale "why this choice" --implementation_details "how to implement"
-   ```
-
-3. **Track progress for motivation**
-   ```
-   mcp__conport__log_progress --workspace_id "<repo-root>" --status "IN_PROGRESS" --description "current task description"
-   ```
+---
 
 ## Available MCP Servers
 
-### Primary Servers (Always Available)
-- **Context7**: Documentation for 10,000+ libraries
-- **ConPort**: ADHD-optimized context & memory
-- **EXA**: High-signal developer research
+### Per-Worktree (in `.mcp.json`)
 
-### MetaMCP Broker System
-- **Endpoint**: `http://localhost:8090`
-- **Status**: 9 connected servers
-- **Features**: Role-based access, ADHD optimizations
-- **Total Tools**: 50+ specialized capabilities
+| Server | Transport | Port var | Purpose |
+|---|---|---|---|
+| `conport` | `sse` | `CONPORT_MCP_PORT` | Decisions, progress, knowledge graph |
+| `dope-memory` | `http` | `DOPE_MEMORY_PORT` | Temporal chronicle, working context |
+| `task-orchestrator` | `http` | `TASK_ORCHESTRATOR_HTTP_PORT` (fixed `7890`) | Workflow orchestration |
 
-### Role-Based Access Patterns
-- **Developer**: 5 tools max, fast iteration focus
-- **Researcher**: 5 tools max, controlled information gathering
-- **Architect**: 5 tools max, deep analysis (higher token budget)
+### Singleton (in `~/.claude.json`)
 
-## ADHD Accommodation Requirements
+| Server | Transport | Port | Purpose |
+|---|---|---|---|
+| `pal` | `http` | `3003` | Multi-model reasoning (thinkdeep, planner, codereview) |
+| `serena` | `http` | `3006` | Semantic code intelligence (LSP + Tree-sitter) |
+| `dope-context` | `http` | `3010` | Code/docs semantic search |
+| `pal-stdio` | `stdio` | — | PAL via Docker exec (fallback) |
+| `gpt-researcher` | `stdio` | — | Deep multi-source research |
 
-### Cognitive Load Management
-- ✅ Use focused Context7 queries with specific `--topic` and token limits
-- ✅ Never overwhelm with too much information at once
-- ✅ Use role-based tool limits to prevent decision paralysis
-- ✅ Store complex information in ConPort rather than keeping in memory
+---
 
-### Flow State Protection
-- ✅ Check/preserve context before any interruption
-- ✅ Use ConPort progress tracking for visual feedback
-- ✅ Make all decisions explicit and logged
-- ✅ Provide clear, actionable next steps
+## Transport Architecture — Do Not Change Without Verification
 
-### Executive Function Support
-- ✅ Break tasks into 25-minute chunks
-- ✅ Use ConPort task hierarchy for organization
-- ✅ Provide progress visualization
-- ✅ Maintain session continuity across interruptions
+> [!IMPORTANT]
+> `dope-memory` and `task-orchestrator` use `"type": "http"` (Streamable HTTP).
+> They are **not** SSE.  A `406 Not Acceptable` on `GET /mcp` is **correct behaviour**
+> — it means you used the wrong HTTP method.  Always `POST` with JSON-RPC body.
+
+| `type` value | Protocol | Client call |
+|---|---|---|
+| `"http"` | Streamable HTTP | `POST /mcp` + JSON-RPC body |
+| `"sse"` | Server-Sent Events | `GET /sse` + `Accept: text/event-stream` |
+
+---
+
+## Setup in a New Workspace
+
+```bash
+cd ~/code/target-repo        # must be a git repo
+dopemux mcp init             # scaffolds .mcp.json + .envrc.dopemux-mcp
+source .envrc.dopemux-mcp    # load port variables
+dopemux mcp doctor           # verify env + reachability
+```
+
+Full guide: [`docs/02-how-to/mcp-setup-other-repos.md`](../docs/02-how-to/mcp-setup-other-repos.md)
+
+---
+
+## Health Monitoring
+
+```bash
+# Quick status:
+dopemux mcp status
+
+# Port + transport-aware probe:
+./mcp_server_health_report.sh
+
+# Per-server doctor:
+dopemux mcp doctor
+
+# Singleton sync (global ~/.claude.json):
+dopemux mcp sync-globals
+```
+
+---
 
 ## Quick Command Reference
 
-### Documentation Access
-```bash
-mcp__context7__resolve_library_id "library-name"
-mcp__context7__get_library_docs "/org/lib" --topic "feature" --tokens 2000
-```
+### ConPort
 
-### Context Management
 ```bash
 mcp__conport__get_active_context --workspace_id "<repo-root>"
 mcp__conport__update_active_context --workspace_id "<repo-root>" --patch_content '{}'
 mcp__conport__log_decision --workspace_id "<repo-root>" --summary "" --rationale ""
 mcp__conport__log_progress --workspace_id "<repo-root>" --status "" --description ""
-```
-
-### Knowledge Storage
-```bash
 mcp__conport__log_system_pattern --workspace_id "<repo-root>" --name "" --description ""
-mcp__conport__log_custom_data --workspace_id "<repo-root>" --category "" --key "" --value ""
 ```
-
-## System Health Monitoring
-
-### Check Operational Status
-- Individual servers: `claude mcp list`
-- MetaMCP broker: `curl -s http://localhost:8090/health`
-- ConPort status: `mcp__conport__get_active_context` (should respond)
 
 ### Recovery Commands
+
 ```bash
-# Restart MetaMCP broker if needed
-cd <repo-root> && python3 start_metamcp_minimal.py &
+# Restart all MCP containers
+cd ~/code/dopemux-mvp && dopemux mcp up
 
-# Check broker process
-ps aux | grep python3 | grep start_metamcp
+# Single service restart
+docker compose -f compose.yml restart dope-memory
+
+# Tail logs during a connection attempt
+docker logs -f dopemux-dope-memory-1 2>&1 | grep -i "mcp\|error"
 ```
-
-## Integration Patterns
-
-### New Feature Development
-1. Check current context with ConPort
-2. Get documentation with Context7
-3. Log implementation decision
-4. Implement with context preservation
-5. Update progress and store learnings
-
-### Research Sessions
-1. Use focused Context7 queries
-2. Store findings in ConPort custom data
-3. Log research decisions and rationale
-4. Maintain structured notes for future reference
-
-### Context Switches
-1. Store current state in ConPort before switching
-2. Retrieve relevant context after switching
-3. Bridge between contexts with summaries
-4. Maintain awareness of previous work
-
-## Warning Signs & Responses
-
-### If User Shows Confusion
-- **Immediately check ConPort context**
-- **Review recent progress and decisions**
-- **Provide orientation summary**
-- **Break down next steps clearly**
-
-### If Session Seems Long
-- **Suggest storing current state**
-- **Check token usage and optimize**
-- **Consider role-based tool limiting**
-- **Encourage breaks with context preservation**
-
-### If Information Overwhelming
-- **Use more focused Context7 queries**
-- **Reduce token limits**
-- **Store information in ConPort instead of displaying**
-- **Switch to simpler role (e.g., developer vs architect)**
-
-## Success Metrics
-
-The MCP system is working properly when:
-- ✅ Context is preserved across interruptions
-- ✅ Documentation is accessed before implementation
-- ✅ Decisions are logged with clear rationale
-- ✅ Progress is visible and motivating
-- ✅ Cognitive load remains manageable
-- ✅ User maintains focus and productivity
 
 ---
 
-**Remember**: This system exists to support ADHD developers. Use it proactively and systematically to provide the best possible experience.
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `406 Not Acceptable` | Sent `GET` to Streamable HTTP endpoint | Change to `POST /mcp` with JSON-RPC |
+| Connection refused | Container not running | `dopemux mcp up` |
+| Port collision on `init` | Hash offset hit a singleton port | New version of `_allocate_ports` raises error with guidance |
+| `task-orchestrator` on wrong port | Old `init` applied hash offset to wrapper-singleton | Re-run `dopemux mcp init --force` |
+| Tools unavailable in session | Env vars not set at session start | `source .envrc.dopemux-mcp` before launching client |
+
+Full reference: [`docs/02-how-to/mcp-transport-and-port-bugs.md`](../docs/02-how-to/mcp-transport-and-port-bugs.md)

--- a/.claude/modules/shared/governance-principles.md
+++ b/.claude/modules/shared/governance-principles.md
@@ -289,6 +289,24 @@ Before modifying any of these:
 
 Unknown contract implications = stop and investigate.
 
+### MCP Transport Invariants
+
+`*.yml`/`*.yaml` MCP server manifests and `.mcp.json` are contract-sensitive.
+Before changing any `transport` or `type` field, verify the **server implementation**:
+
+| Server | `.mcp.json` type | Implementation | Probe method |
+|---|---|---|---|
+| `conport` | `sse` | SSE endpoint at `/sse` | `GET /sse` + `Accept: text/event-stream` |
+| `dope-memory` | `http` | FastMCP `http_app()` — Streamable HTTP | `POST /mcp` JSON-RPC |
+| `task-orchestrator` | `http` | Ktor Streamable HTTP | `POST /mcp` JSON-RPC |
+| `pal`, `serena`, `dope-context` | `http` | Streamable HTTP | `POST /mcp` JSON-RPC |
+
+A `406 Not Acceptable: Client must accept text/event-stream` on `GET /mcp` is
+**correct behaviour** for Streamable HTTP. It does NOT mean the server is SSE.
+Do not change `"type": "http"` → `"type": "sse"` based on a 406 response.
+
+See [AGENTS.md §12](../../../AGENTS.md) for the full MCP setup and debug rules.
+
 ---
 
 ## Git / Worktree Discipline

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,3 +180,85 @@ OpenCode does **not** behave like Claude Code regarding instruction files.
   - `AGENTS.md`
   - A file referenced via `"instructions"` in `opencode.jsonc`
 - Never rely on `~/.claude/*.md` files being loaded by OpenCode.
+
+## 12. MCP Setup, Transport, and Debug Rules
+
+### 12.1 Canonical Transport Architecture
+
+Do not change transport types without reading the server source.  The mapping is:
+
+| Server | `type` in .mcp.json | Protocol | Endpoint |
+|---|---|---|---|
+| `conport` | `sse` | Server-Sent Events | `GET /sse` |
+| `dope-memory` | `http` | Streamable HTTP (FastMCP `http_app()`) | `POST /mcp` |
+| `task-orchestrator` | `http` | Streamable HTTP (Ktor) | `POST /mcp` |
+| `pal`, `serena`, `dope-context` | `http` | Streamable HTTP | `POST /mcp` |
+| `desktop-commander` | `sse` | Server-Sent Events | `GET /sse` |
+
+**Critical invariant**: A `406 Not Acceptable: Client must accept text/event-stream`
+response to a `GET /mcp` is **correct server behaviour** for a Streamable HTTP
+endpoint.  It is NOT evidence that the server is SSE.  The fix is to use `POST`
+with a JSON-RPC body — not to change `"type"` to `"sse"`.
+
+### 12.2 Port Allocation Invariants
+
+`dopemux mcp init` computes per-worktree port offsets via:
+```
+port = default_port_base + sha1(workspace_path)[:4] % 100
+```
+
+**Invariants enforced by `_allocate_ports`** (as of 2026-07-06):
+- `wrapper-singleton` services (`management_model: wrapper-singleton`, e.g.
+  `task-orchestrator`) always use `default_port_base` directly — **no hash offset**.
+- All singleton catalog ports are pre-seeded in the collision map so a per-worktree
+  hash cannot silently land on a singleton-reserved port.
+- Collision detection raises an error before writing any config.
+
+### 12.3 Setting Up MCP in a New Repo
+
+```bash
+cd ~/code/target-repo    # must be a git repo
+dopemux mcp init         # generates .mcp.json + .envrc.dopemux-mcp
+source .envrc.dopemux-mcp
+dopemux mcp doctor       # verify env vars + port reachability
+```
+
+For full guidance including manual (non-dopemux) setup and vanilla Claude Code:
+→ `docs/02-how-to/mcp-setup-other-repos.md`
+
+### 12.4 MCP Debug Sequence
+
+When MCP servers fail to connect, follow this sequence in order:
+
+1. **Source the envrc**: `source .envrc.dopemux-mcp` — unset vars fall back to
+   catalog defaults which may not match running containers.
+
+2. **Run doctor**: `dopemux mcp doctor` — checks env vars and port reachability.
+
+3. **Probe with correct transport**:
+   ```bash
+   # Streamable HTTP (dope-memory, task-orchestrator, pal, serena):
+   curl -X POST http://localhost:$DOPE_MEMORY_PORT/mcp \
+     -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}'
+
+   # SSE (conport):
+   curl -N -s http://localhost:$CONPORT_MCP_PORT/sse -H "Accept: text/event-stream"
+   ```
+
+4. **Tail container logs** during connection attempt:
+   ```bash
+   docker logs -f dopemux-dope-memory-1 2>&1 | grep -i "mcp\|error"
+   docker logs -f dopemux-task-orchestrator 2>&1 | grep -i "mcp\|error"
+   ```
+
+5. **Run health report**: `./mcp_server_health_report.sh`
+
+6. **Check for port collisions**: If `dopemux mcp init` raises a collision error,
+   adjust `default_port_base` in `mcp_catalog.yaml` to create more spacing, or
+   use a workspace path with a different hash.
+
+**Reference docs**:
+- `docs/02-how-to/mcp-transport-and-port-bugs.md` — bug record + correct analysis
+- `docs/02-how-to/mcp-setup-other-repos.md` — human user guide for other repos
+- `docs/02-how-to/mcp-troubleshooting.md` — container-level troubleshooting

--- a/docs/02-how-to/mcp-setup-other-repos.md
+++ b/docs/02-how-to/mcp-setup-other-repos.md
@@ -1,12 +1,15 @@
 ---
 id: mcp-setup-other-repos
-title: "Running Dopemux MCP Servers in Other Projects"
+title: Running Dopemux MCP Servers in Other Projects
 type: how-to
 owner: dopemux-infra
 date: 2026-07-06
 author: '@hu3mann'
+last_review: '2026-07-07'
+next_review: '2026-10-05'
+prelude: Running Dopemux MCP Servers in Other Projects (how-to) for dopemux documentation
+  and developer workflows.
 ---
-
 # Running Dopemux MCP Servers in Other Projects
 
 This guide explains how to connect `conport`, `dope-memory`, and `task-orchestrator`
@@ -358,5 +361,5 @@ The `task-orchestrator` default is always `7890` with no offset.
 
 ---
 
-**Last updated**: 2026-07-06  
+**Last updated**: 2026-07-06
 **See also**: [mcp-transport-and-port-bugs.md](mcp-transport-and-port-bugs.md) · [mcp-troubleshooting.md](mcp-troubleshooting.md)

--- a/docs/02-how-to/mcp-setup-other-repos.md
+++ b/docs/02-how-to/mcp-setup-other-repos.md
@@ -1,0 +1,362 @@
+---
+id: mcp-setup-other-repos
+title: "Running Dopemux MCP Servers in Other Projects"
+type: how-to
+owner: dopemux-infra
+date: 2026-07-06
+author: '@hu3mann'
+---
+
+# Running Dopemux MCP Servers in Other Projects
+
+This guide explains how to connect `conport`, `dope-memory`, and `task-orchestrator`
+MCP servers to any project — a new repo, a git worktree of another project, or a
+plain directory — using **dopemux** or manually (for Claude Code / vanilla code use).
+
+---
+
+## Prerequisites
+
+Before you begin, make sure:
+
+1. **Dopemux services are running** (from the `dopemux-mvp` repo):
+   ```bash
+   cd ~/code/dopemux-mvp
+   dopemux mcp up          # starts Docker Compose MCP stack
+   # or for the full stack:
+   dopemux mcp start-all
+   ```
+
+2. **Docker is running** and the MCP containers are healthy:
+   ```bash
+   docker ps | grep dopemux
+   # or
+   dopemux mcp status
+   ```
+
+3. **Your target workspace directory** is a git repository (required for `dopemux mcp init`).
+   If it is not a git repo yet, `git init` first.
+
+---
+
+## Part 1: Using Dopemux (Recommended)
+
+### Step 1 — Navigate to your project
+
+```bash
+cd ~/code/your-other-project   # must be a git repo
+```
+
+### Step 2 — Initialise MCP config for the workspace
+
+```bash
+dopemux mcp init
+```
+
+This command:
+- Reads `mcp_catalog.yaml` from the `dopemux-mvp` repo
+- Generates a `.mcp.json` in your project root with `conport`, `dope-memory`, and
+  `task-orchestrator` entries using `${VAR}` placeholders
+- Writes `.envrc.dopemux-mcp` with stable, collision-checked port numbers unique
+  to this workspace path
+
+Example output:
+```
+✅ Wrote .mcp.json
+✅ Wrote .envrc.dopemux-mcp
+Worktree:   /Users/hue/code/your-other-project
+Instance:   a3f2
+  CONPORT_HTTP_PORT=3044  (free)
+  CONPORT_MCP_PORT=3045   (free)
+  DOPE_MEMORY_PORT=3064   (free)
+  TASK_ORCHESTRATOR_HTTP_PORT=7890  (wrapper-singleton, fixed)
+```
+
+> [!NOTE]
+> **Port allocation is deterministic**: the same workspace path always gets the same
+> ports.  `wrapper-singleton` services (like `task-orchestrator`) always use their
+> fixed port regardless of workspace.
+
+### Step 3 — Load the port variables into your shell
+
+The quickest way is to source the file directly:
+```bash
+source .envrc.dopemux-mcp
+```
+
+Or, for persistent loading with `direnv`:
+```bash
+# Add to .envrc in your project
+echo 'source .envrc.dopemux-mcp' >> .envrc
+direnv allow
+```
+
+### Step 4 — Start per-worktree containers
+
+The per-worktree services (`conport`, `dope-memory`) need to be started with your
+workspace's port variables:
+
+```bash
+# From the dopemux-mvp directory:
+cd ~/code/dopemux-mvp
+
+# Start the per-worktree services for your project using its env file:
+env $(cat ~/code/your-other-project/.envrc.dopemux-mcp | grep -v '^#' | xargs) \
+  docker compose -f compose.yml up -d conport dope-memory
+
+# Go back to your project
+cd ~/code/your-other-project
+```
+
+### Step 5 — Verify connectivity
+
+```bash
+# Check port reachability and env vars:
+dopemux mcp doctor
+
+# Full health report with transport-aware probing:
+~/code/dopemux-mvp/mcp_server_health_report.sh
+```
+
+### Step 6 — Open Claude Code (or agy)
+
+```bash
+# In your project directory (with envrc sourced):
+claude    # Claude Code
+# or
+agy       # Antigravity CLI
+```
+
+Both clients read `.mcp.json` at session startup. Claude Code expands the `${VAR:-default}`
+placeholders using the environment; `agy` does the same.
+
+---
+
+## Part 2: Manual Setup (Without dopemux CLI)
+
+Use this approach when you cannot or don't want to use `dopemux mcp init`, or when
+you need to wire MCP into a non-git directory, a CI environment, or a vanilla
+Claude Code project.
+
+### Step 1 — Pick ports
+
+Choose ports that don't collide with any running services.  Recommended ranges:
+- `conport`: HTTP `304X`, MCP `304X+1`
+- `dope-memory`: `306X`
+- `task-orchestrator`: always `7890` (fixed singleton)
+
+```bash
+export CONPORT_HTTP_PORT=3044
+export CONPORT_INFO_PORT=4044
+export CONPORT_MCP_PORT=3045
+export DOPE_MEMORY_PORT=3064
+export TASK_ORCHESTRATOR_HTTP_PORT=7890
+export DOPEMUX_WORKSPACE_ID=/Users/hue/code/your-other-project
+export DOPE_MEMORY_WORKSPACE_ID=your-other-project   # short name
+export DOPE_MEMORY_INSTANCE_ID=a3f2                  # any 4-char hash
+```
+
+Save these to `.envrc.dopemux-mcp` in your project root and `source` it.
+
+### Step 2 — Start Docker services
+
+From the `dopemux-mvp` directory:
+```bash
+cd ~/code/dopemux-mvp
+
+# Start conport for your workspace
+CONPORT_HTTP_PORT=3044 CONPORT_INFO_PORT=4044 CONPORT_MCP_PORT=3045 \
+DOPEMUX_WORKSPACE_ID=/Users/hue/code/your-other-project \
+  docker compose -f compose.yml up -d conport
+
+# Start dope-memory for your workspace
+DOPE_MEMORY_PORT=3064 \
+DOPE_MEMORY_WORKSPACE_ID=your-other-project \
+DOPE_MEMORY_INSTANCE_ID=a3f2 \
+  docker compose -f compose.yml up -d dope-memory
+
+# task-orchestrator is a singleton — start it once:
+docker compose -f compose.yml up -d task-orchestrator
+```
+
+### Step 3 — Write `.mcp.json`
+
+Create this file in your **project root** (not in `dopemux-mvp`):
+
+```json
+{
+  "mcpServers": {
+    "conport": {
+      "type": "sse",
+      "url": "http://localhost:${CONPORT_MCP_PORT:-3005}/sse",
+      "env": {
+        "DOPEMUX_WORKSPACE_ID": "${DOPEMUX_WORKSPACE_ID:-}"
+      },
+      "description": "Decisions, progress, knowledge graph (per-workspace)"
+    },
+    "dope-memory": {
+      "type": "http",
+      "url": "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp",
+      "env": {
+        "DOPE_MEMORY_WORKSPACE_ID": "${DOPE_MEMORY_WORKSPACE_ID:-}",
+        "DOPE_MEMORY_INSTANCE_ID": "${DOPE_MEMORY_INSTANCE_ID:-}"
+      },
+      "description": "Temporal chronicle (per-workspace)"
+    },
+    "task-orchestrator": {
+      "type": "http",
+      "url": "http://127.0.0.1:${TASK_ORCHESTRATOR_HTTP_PORT:-7890}/mcp",
+      "env": {
+        "TASK_ORCHESTRATOR_PROJECT_ROOT": "${TASK_ORCHESTRATOR_PROJECT_ROOT:-}",
+        "TASK_ORCHESTRATOR_HTTP_PORT": "${TASK_ORCHESTRATOR_HTTP_PORT:-7890}"
+      },
+      "description": "Task orchestrator (singleton, repo-scoped SQLite)"
+    }
+  }
+}
+```
+
+> [!IMPORTANT]
+> **Transport types are critical:**
+> - `"type": "http"` means **Streamable HTTP** — client sends JSON-RPC POST requests
+> - `"type": "sse"` means **Server-Sent Events** — client opens a GET event stream
+>
+> Do **not** switch `dope-memory` or `task-orchestrator` to `"type": "sse"` — they
+> speak Streamable HTTP.  Getting a `406 Not Acceptable` on a GET probe is **correct**
+> behaviour, not a bug.
+
+### Step 4 — Test connectivity
+
+```bash
+source .envrc.dopemux-mcp
+
+# Test dope-memory (Streamable HTTP — must POST):
+curl -X POST http://localhost:$DOPE_MEMORY_PORT/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}'
+
+# Test conport (SSE — must GET with event-stream header):
+curl -N -s http://localhost:$CONPORT_MCP_PORT/sse \
+  -H "Accept: text/event-stream" &
+sleep 1 && kill %1   # should print event: endpoint
+
+# Test task-orchestrator (Streamable HTTP):
+curl -X POST http://127.0.0.1:$TASK_ORCHESTRATOR_HTTP_PORT/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}'
+```
+
+---
+
+## Part 3: Running in Vanilla Claude Code (no dopemux)
+
+If you are using plain Claude Code without any dopemux tooling:
+
+1. Write the `.mcp.json` manually (see Part 2, Step 3).
+2. Set your environment variables in your shell profile or `.env`:
+   ```bash
+   export CONPORT_MCP_PORT=3045
+   export DOPE_MEMORY_PORT=3064
+   export TASK_ORCHESTRATOR_HTTP_PORT=7890
+   export DOPEMUX_WORKSPACE_ID="$(pwd)"
+   export DOPE_MEMORY_WORKSPACE_ID="$(basename $(pwd))"
+   ```
+3. Make sure the Docker containers are running (see Part 2, Step 2).
+4. Launch `claude` from the project directory — it reads `.mcp.json` at startup.
+5. Verify with `/mcp` in the Claude Code session.
+
+### Singleton singletons (already running)
+
+If `pal`, `serena`, or `dope-context` are running as singletons in your global
+`~/.claude.json`, they are available in any project automatically — no per-project
+configuration needed.  Run:
+
+```bash
+dopemux mcp sync-globals --apply   # adds singletons to ~/.claude.json
+```
+
+Or add them manually to `~/.claude.json`:
+```json
+{
+  "mcpServers": {
+    "pal":       { "type": "http", "url": "http://localhost:3003/mcp" },
+    "serena":    { "type": "http", "url": "http://localhost:3006/mcp" },
+    "dope-context": { "type": "http", "url": "http://localhost:3010/mcp" }
+  }
+}
+```
+
+---
+
+## Troubleshooting
+
+### `Connection refused` on startup
+
+The container is not running on the expected port.
+
+```bash
+docker ps | grep dopemux-dope-memory    # check running
+source .envrc.dopemux-mcp
+echo $DOPE_MEMORY_PORT                  # verify port var is set
+docker logs dopemux-dope-memory-1       # inspect startup logs
+```
+
+### `406 Not Acceptable: Client must accept text/event-stream`
+
+You (or your client) sent a **GET** to a Streamable HTTP endpoint.  This is the
+**correct** server response; the fix is to send a **POST** with a JSON-RPC body.
+Check that `.mcp.json` uses `"type": "http"`, not `"type": "sse"`, for `dope-memory`
+and `task-orchestrator`.
+
+### Port collision on `dopemux mcp init`
+
+```
+Internal port collision: conport.CONPORT_HTTP_PORT and singleton:gpt-researcher both map to :3009
+```
+
+This means the workspace hash offset landed on a singleton's reserved port.  The
+new version of `_allocate_ports` detects this and raises an error instead of
+silently colliding.  Fix: adjust `default_port_base` for the conflicting service
+in `mcp_catalog.yaml`, or use a workspace path that produces a different hash.
+
+### `task-orchestrator` never connects
+
+1. Verify the singleton is running: `docker ps | grep task-orchestrator`
+2. Verify the port is **not** hash-offset: `echo $TASK_ORCHESTRATOR_HTTP_PORT`
+   — it should always be `7890`, never `7890+N`.
+3. Re-run `dopemux mcp init --force` with the fixed dopemux version.
+
+### Session starts but tools show as unavailable
+
+Source the env file *before* starting Claude Code:
+```bash
+source .envrc.dopemux-mcp && claude
+```
+
+Claude Code expands `${VAR:-default}` from the **shell environment** at session
+startup.  If the vars are not set, it uses the defaults (which may not match the
+running containers).
+
+---
+
+## Reference: Port Layout
+
+| Variable | Default | Notes |
+|---|---|---|
+| `CONPORT_HTTP_PORT` | `3004` | Conport REST/health |
+| `CONPORT_INFO_PORT` | `4004` | Conport info page |
+| `CONPORT_MCP_PORT`  | `3005` | Conport SSE endpoint `/sse` |
+| `DOPE_MEMORY_PORT`  | `3020` | Dope-memory Streamable HTTP `/mcp` |
+| `TASK_ORCHESTRATOR_HTTP_PORT` | `7890` | **Always fixed** (wrapper-singleton) |
+| `pal`               | `3003` | Singleton, static |
+| `serena`            | `3006` | Singleton, static |
+| `dope-context`      | `3010` | Singleton, static |
+| `desktop-commander` | `3012` | Singleton, static (SSE) |
+
+Per-worktree ports are offset by `sha1(workspace_path)[:4] % 100` from their base.
+The `task-orchestrator` default is always `7890` with no offset.
+
+---
+
+**Last updated**: 2026-07-06  
+**See also**: [mcp-transport-and-port-bugs.md](mcp-transport-and-port-bugs.md) · [mcp-troubleshooting.md](mcp-troubleshooting.md)

--- a/docs/02-how-to/mcp-transport-and-port-bugs.md
+++ b/docs/02-how-to/mcp-transport-and-port-bugs.md
@@ -6,8 +6,10 @@ owner: dopemux-infra
 date: 2026-07-06
 author: '@hu3mann'
 last_review: '2026-07-06'
+next_review: '2026-10-05'
+prelude: MCP Transport Misconfiguration and Port Collision Reference (how-to) for
+  dopemux documentation and developer workflows.
 ---
-
 # MCP Transport Misconfiguration and Port Collision Reference
 
 This document describes three confirmed bugs that were discovered during the `dNh_CRM`

--- a/docs/02-how-to/mcp-transport-and-port-bugs.md
+++ b/docs/02-how-to/mcp-transport-and-port-bugs.md
@@ -1,0 +1,181 @@
+---
+id: mcp-transport-and-port-bugs
+title: MCP Transport Misconfiguration and Port Collision Reference
+type: reference
+owner: dopemux-infra
+date: 2026-07-06
+author: '@hu3mann'
+last_review: '2026-07-06'
+---
+
+# MCP Transport Misconfiguration and Port Collision Reference
+
+This document describes three confirmed bugs that were discovered during the `dNh_CRM`
+workspace MCP connectivity investigation (2026-07-06) and the authoritative fixes
+applied to `dopemux-mvp`.
+
+---
+
+## Transport Architecture — What is Correct
+
+> [!IMPORTANT]
+> **The canonical `mcp_catalog.yaml` and `.mcp.json` are CORRECT.**
+> `dope-memory` and `task-orchestrator` use `transport: http` / `"type": "http"` which
+> means **MCP Streamable HTTP** — not legacy SSE.  An earlier hotfix that switched
+> these to `"type": "sse"` was **wrong** and caused connection failures.
+
+| Server | Transport | Protocol | Client call |
+|---|---|---|---|
+| `conport` | `sse` | Server-Sent Events | `GET /sse` with `Accept: text/event-stream` |
+| `dope-memory` | `http` | Streamable HTTP (FastMCP `http_app()`) | `POST /mcp` with JSON-RPC body |
+| `task-orchestrator` | `http` | Streamable HTTP (Ktor) | `POST /mcp` with JSON-RPC body |
+| `pal`, `serena`, `dope-context` | `http` | Streamable HTTP | `POST /mcp` with JSON-RPC body |
+| `desktop-commander` | `sse` | Server-Sent Events | `GET /sse` with `Accept: text/event-stream` |
+
+### Verifying a Streamable HTTP server
+
+```bash
+# dope-memory (replace port with actual DOPE_MEMORY_PORT from .envrc.dopemux-mcp)
+curl -X POST http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}'
+# Expected: JSON-RPC response body (200 OK)
+# NOT expected: 406 Not Acceptable (that happens only on a GET to a Streamable HTTP endpoint)
+
+# task-orchestrator
+curl -X POST http://127.0.0.1:${TASK_ORCHESTRATOR_HTTP_PORT:-7890}/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}'
+```
+
+### Verifying an SSE server
+
+```bash
+# conport
+curl -N -s -X GET http://localhost:${CONPORT_MCP_PORT:-3005}/sse \
+  -H "Accept: text/event-stream"
+# Expected: event stream opens, first event is "endpoint"
+```
+
+### The 406 error explained
+
+A `406 Not Acceptable: Client must accept text/event-stream` response from `/mcp`
+means you sent a **GET** to a **Streamable HTTP** endpoint.  This is **not** a bug
+in the server — it is correct rejection of the wrong method.  The fix is to POST
+JSON-RPC, not to switch the transport type to `sse`.
+
+---
+
+## Bug 1: Transport Mismatch (Mis-applied SSE Hotfix)
+
+**Status**: Root cause identified; canonical files are correct; hotfix reverted.
+
+**What happened**: During the `dNh_CRM` debugging session, `curl -X GET /mcp`
+returned `406`.  This was misinterpreted as "the server is SSE, not HTTP".  A
+`sed` replacement switched all `transport: http` entries in `mcp_catalog.yaml` to
+`transport: sse`, and `.mcp.json` was also patched to `"type": "sse"`.
+
+**Why this was wrong**: The 406 is *expected* for a Streamable HTTP endpoint when
+a GET is sent.  The real protocol (`"type": "http"`) was already correct.  Switching
+to `"type": "sse"` caused the client to open an SSE GET stream against an endpoint
+that expects JSON-RPC POSTs, causing immediate protocol mismatch.
+
+**Correct configuration** (already in repo):
+```json
+{
+  "dope-memory":       { "type": "http", "url": "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp" },
+  "task-orchestrator": { "type": "http", "url": "http://127.0.0.1:${TASK_ORCHESTRATOR_HTTP_PORT:-7890}/mcp" },
+  "conport":           { "type": "sse",  "url": "http://localhost:${CONPORT_MCP_PORT:-3005}/sse" }
+}
+```
+
+---
+
+## Bug 2: Port Collision via Hash Offset (Fixed in mcp_commands.py)
+
+**Status**: **FIXED** — `_allocate_ports` now pre-seeds singleton reserved ports.
+
+**Root cause**: `dopemux mcp init` computes per-worktree ports by hashing the
+workspace path and taking `hash % 100` as an offset added to each service's
+`default_port_base`.  The collision check only detected *intra-worktree*
+collisions; it never checked whether the computed port was already occupied by a
+**singleton** service that has a statically-declared port in the catalog.
+
+For workspace `dNh_CRM`, the hash offset was `+5`:
+- `CONPORT_HTTP_PORT` base `3004` → `3009` → **collides with `gpt-researcher` at `3009`**
+
+**Fix applied** (`src/dopemux/commands/mcp_commands.py`):
+
+The new `_singleton_reserved_ports()` helper collects all singleton-declared ports
+at init time and pre-seeds `seen_ports` before any per-worktree allocation runs.
+Any hash-offset that would land on a singleton port now raises a clear error instead
+of silently colliding at Docker bind time.
+
+**Workaround** (if you hit this in an existing workspace):
+```bash
+# Manually set safe ports in .envrc.dopemux-mcp
+# Then restart the containers with the new ports
+export CONPORT_HTTP_PORT=3040
+export CONPORT_MCP_PORT=3041
+export DOPE_MEMORY_PORT=3060
+```
+
+---
+
+## Bug 3: `wrapper-singleton` Port Offset (Fixed in mcp_commands.py)
+
+**Status**: **FIXED** — `_allocate_ports` skips hash offset for `wrapper-singleton`.
+
+**Root cause**: `task-orchestrator` is declared with `management_model: wrapper-singleton`,
+meaning a single instance runs globally and manages per-repo state internally.  Its
+port is fixed — there is no per-worktree isolation.  However, `dopemux mcp init`
+applied the workspace hash offset anyway, generating `TASK_ORCHESTRATOR_HTTP_PORT=7895`
+(offset `+5`) while the singleton was listening on `7890`.
+
+**Fix applied**: The inner loop in `_allocate_ports` now checks
+`management_model == "wrapper-singleton"` and, when true, uses `default_port_base`
+directly (no `_port_for` hash call) for the primary port variable.  Extra port vars
+are also skipped for wrapper-singletons.
+
+**Workaround** (if you hit this in an existing workspace):
+```bash
+# In .envrc.dopemux-mcp, override back to the fixed port:
+export TASK_ORCHESTRATOR_HTTP_PORT=7890
+```
+
+---
+
+## Quick Diagnosis Checklist
+
+If MCP servers are not connecting:
+
+1. **Check transport type**: Is `.mcp.json` using `"type": "http"` for `dope-memory`
+   and `task-orchestrator`?  (It should be.)
+
+2. **Check port variables**: Source the envrc and verify ports are free:
+   ```bash
+   source .envrc.dopemux-mcp
+   dopemux mcp doctor
+   ```
+
+3. **Probe the server directly** with the correct method:
+   ```bash
+   # Streamable HTTP
+   curl -X POST http://localhost:$DOPE_MEMORY_PORT/mcp \
+     -H "Content-Type: application/json" \
+     -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"0.1"}}}'
+
+   # SSE
+   curl -N -s http://localhost:$CONPORT_MCP_PORT/sse -H "Accept: text/event-stream"
+   ```
+
+4. **Tail container logs** during a connection attempt:
+   ```bash
+   docker logs -f dopemux-dope-memory-1 2>&1 | grep -i "mcp\|error\|exception"
+   docker logs -f dopemux-task-orchestrator 2>&1 | grep -i "mcp\|error\|exception"
+   ```
+
+5. **Run the health report**:
+   ```bash
+   ./mcp_server_health_report.sh
+   ```

--- a/mcp_catalog.yaml
+++ b/mcp_catalog.yaml
@@ -103,6 +103,7 @@ servers:
     command: docker
     args: ["exec", "-i", "dopemux-mcp-gptr-mcp", "python", "/app/server.py"]
     docker_compose_service: gptr-mcp
+    reserved_port: 3009  # gptr-mcp container binds ${GPT_RESEARCHER_PORT:-3009}
     requires_env: ["OPENAI_API_KEY"]
     optional_env: ["TAVILY_API_KEY", "EXA_API_KEY", "PERPLEXITY_API_KEY", "ANTHROPIC_API_KEY"]
     description: "Deep multi-source research (PR #575: gpt-researcher==0.14.8 pinned)"

--- a/mcp_server_health_report.sh
+++ b/mcp_server_health_report.sh
@@ -1,116 +1,191 @@
 #!/bin/bash
 # MCP Server Health Report
-# Checks all dopemux MCP servers and generates status report
-# Usage: ./mcp_server_health_report.sh [--workspace /path/to/workspace]
+#
+# Sources per-worktree port variables from .envrc.dopemux-mcp so that the
+# correct (potentially hash-offset) ports are tested, not hardcoded defaults.
+# Probes each transport type correctly:
+#   - Streamable HTTP ("type": "http"): POST JSON-RPC initialize
+#   - SSE           ("type": "sse"):   GET with Accept: text/event-stream
+#
+# Usage: ./mcp_server_health_report.sh [--workspace /path/to/workspace] [-v]
 
-# Parse arguments
+set -euo pipefail
+
 WORKSPACE_PATH=""
 VERBOSE=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --workspace|-w)
-            WORKSPACE_PATH="$2"
-            shift 2
-            ;;
-        --verbose|-v)
-            VERBOSE=true
-            shift
-            ;;
+        --workspace|-w) WORKSPACE_PATH="$2"; shift 2 ;;
+        --verbose|-v)   VERBOSE=true; shift ;;
         --help|-h)
-            cat << 'HELP'
+            cat <<'HELP'
 Usage: ./mcp_server_health_report.sh [OPTIONS]
 
 OPTIONS:
-    --workspace, -w PATH    Check servers for specific workspace
-    --verbose, -v           Show detailed information
-    --help, -h             Show this help message
+    --workspace, -w PATH    Workspace directory (default: current directory)
+    --verbose, -v           Show detailed curl output
+    --help, -h              Show this help message
 
 EXAMPLES:
-    ./mcp_server_health_report.sh                    # All workspaces
-    ./mcp_server_health_report.sh -w ~/code/project  # Specific workspace
+    ./mcp_server_health_report.sh
+    ./mcp_server_health_report.sh -w ~/code/other-project
 HELP
-            exit 0
-            ;;
-        *)
-            echo "Unknown option: $1"
-            exit 1
-            ;;
+            exit 0 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
     esac
 done
 
-# Determine workspace
-if [ -n "$WORKSPACE_PATH" ]; then
-    WORKSPACE_ID="$WORKSPACE_PATH"
-elif [ -n "$DEFAULT_WORKSPACE_PATH" ]; then
-    WORKSPACE_ID="$DEFAULT_WORKSPACE_PATH"
-else
-    WORKSPACE_ID="$(pwd)"
-fi
+WORKSPACE="${WORKSPACE_PATH:-$(pwd)}"
+ENVRC="$WORKSPACE/.envrc.dopemux-mcp"
 
 echo "=========================================="
 echo "MCP Server Health Report"
-if [ -n "$WORKSPACE_PATH" ]; then
-    echo "Workspace: $WORKSPACE_ID"
-fi
+echo "Workspace: $WORKSPACE"
 echo "=========================================="
 echo ""
 date
 echo ""
 
-echo "=== MCP Servers Status ==="
+# Source per-worktree port variables if available
+if [[ -f "$ENVRC" ]]; then
+    echo "Sourcing port variables from: $ENVRC"
+    # Use set -a so exported variables are available for subshells
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENVRC"
+    set +a
+    echo ""
+else
+    echo "⚠️  No .envrc.dopemux-mcp found at $WORKSPACE — using catalog default ports."
+    echo "   Run: dopemux mcp init  (from inside the workspace)"
+    echo ""
+fi
+
+# Resolve ports (env vars take precedence over defaults)
+CONPORT_HTTP_PORT="${CONPORT_HTTP_PORT:-3004}"
+CONPORT_MCP_PORT="${CONPORT_MCP_PORT:-3005}"
+DOPE_MEMORY_PORT="${DOPE_MEMORY_PORT:-3020}"
+TASK_ORCHESTRATOR_HTTP_PORT="${TASK_ORCHESTRATOR_HTTP_PORT:-7890}"
+
+echo "=== Per-Worktree MCP Servers ==="
 echo ""
 
-# Function to test HTTP endpoint
-test_endpoint() {
-    local port=$1
-    local name=$2
+# ---------------------------------------------------------------------------
+# Helper: probe Streamable HTTP (type: "http") via JSON-RPC initialize POST
+# These servers speak the MCP Streamable HTTP protocol, NOT SSE.
+# A GET request returns 406; the correct probe is a POST.
+# ---------------------------------------------------------------------------
+probe_http() {
+    local name="$1"
+    local port="$2"
+    local path="${3:-/mcp}"
 
-    http_code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:$port/health --max-time 2 2>/dev/null)
+    local response
+    response=$(curl -s --max-time 2 -o /tmp/mcp_probe_$$.json -w "%{http_code}" \
+        -X POST "http://localhost:${port}${path}" \
+        -H "Content-Type: application/json" \
+        -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"health-probe","version":"0.1"}}}' \
+        2>/dev/null) || response="000"
 
-    if [ "$http_code" = "200" ]; then
-        echo "✅ $name (port $port): Healthy (HTTP 200)"
-    elif [ "$http_code" = "404" ]; then
-        echo "✅ $name (port $port): Responding (HTTP 404 - no /health endpoint)"
+    if [[ "$response" =~ ^2 ]]; then
+        echo "✅ $name (port $port, HTTP/Streamable): OK (HTTP $response)"
+        if $VERBOSE; then
+            cat /tmp/mcp_probe_$$.json 2>/dev/null | head -3
+        fi
+    elif [[ "$response" == "000" ]]; then
+        echo "❌ $name (port $port, HTTP/Streamable): Connection refused — is the container running?"
     else
-        echo "⚠️  $name (port $port): Not responding or error"
+        echo "⚠️  $name (port $port, HTTP/Streamable): Unexpected HTTP $response"
+        if $VERBOSE; then
+            cat /tmp/mcp_probe_$$.json 2>/dev/null | head -3
+        fi
+    fi
+    rm -f /tmp/mcp_probe_$$.json
+}
+
+# ---------------------------------------------------------------------------
+# Helper: probe SSE (type: "sse") via GET with Accept: text/event-stream
+# ---------------------------------------------------------------------------
+probe_sse() {
+    local name="$1"
+    local port="$2"
+    local path="${3:-/sse}"
+
+    local response
+    response=$(curl -s --max-time 2 -o /dev/null -w "%{http_code}" \
+        -X GET "http://localhost:${port}${path}" \
+        -H "Accept: text/event-stream" \
+        2>/dev/null) || response="000"
+
+    if [[ "$response" =~ ^2 ]]; then
+        echo "✅ $name (port $port, SSE): OK (HTTP $response)"
+    elif [[ "$response" == "000" ]]; then
+        echo "❌ $name (port $port, SSE): Connection refused — is the container running?"
+    else
+        echo "⚠️  $name (port $port, SSE): Unexpected HTTP $response"
     fi
 }
 
-# Test each MCP server
-test_endpoint 3003 "pal        "
-test_endpoint 3004 "conport         "
-test_endpoint 3006 "serena          "
-test_endpoint 3008 "exa             "
-test_endpoint 3009 "gptr-mcp        "
-test_endpoint 3012 "desktop-commander"
+# ---------------------------------------------------------------------------
+# Helper: probe a /health REST endpoint
+# ---------------------------------------------------------------------------
+probe_health() {
+    local name="$1"
+    local port="$2"
+
+    local response
+    response=$(curl -s --max-time 2 -o /dev/null -w "%{http_code}" \
+        "http://localhost:${port}/health" 2>/dev/null) || response="000"
+
+    if [[ "$response" =~ ^2 ]]; then
+        echo "✅ $name (port $port, /health): OK"
+    elif [[ "$response" == "404" ]]; then
+        echo "✅ $name (port $port, /health): Responding (no /health endpoint)"
+    elif [[ "$response" == "000" ]]; then
+        echo "❌ $name (port $port, /health): Not responding"
+    else
+        echo "⚠️  $name (port $port, /health): HTTP $response"
+    fi
+}
+
+# --- Per-worktree servers ---
+# conport: SSE transport at /sse
+probe_sse "conport      " "$CONPORT_MCP_PORT"
+probe_health "conport (health)" "$CONPORT_HTTP_PORT"
+
+# dope-memory: Streamable HTTP at /mcp  (NOT SSE — POST only)
+probe_http "dope-memory  " "$DOPE_MEMORY_PORT"
+
+# task-orchestrator: Streamable HTTP at /mcp (wrapper-singleton, fixed port)
+probe_http "task-orch    " "$TASK_ORCHESTRATOR_HTTP_PORT"
 
 echo ""
-echo "=== MCP Server Containers ==="
+echo "=== Singleton MCP Servers (shared) ==="
 echo ""
 
-docker ps --filter "name=mcp-" --format "table {{.Names}}\t{{.Status}}"
+# Singletons have hardcoded ports declared in mcp_catalog.yaml
+probe_http "pal          " 3003
+probe_http "serena       " 3006
+probe_http "dope-context " 3010
+probe_sse  "desktop-cmd  " 3012
+
+echo ""
+echo "=== Docker Containers ==="
+echo ""
+docker ps --format "table {{.Names}}\t{{.Status}}" | grep -E "(conport|dope-memory|task-orchestrator|pal|serena|dope-context|desktop)" || echo "(no matching containers running)"
 
 echo ""
 echo "=== Port Listeners ==="
 echo ""
-
-lsof -iTCP -sTCP:LISTEN -n -P | grep -E ":(3001|3003|3004|3006|3007|3008|3009|3012)" | awk '{print $9}' | sort -t: -k2 -n || echo "None found"
+lsof -iTCP -sTCP:LISTEN -n -P 2>/dev/null | \
+    grep -E ":(${CONPORT_HTTP_PORT}|${CONPORT_MCP_PORT}|${DOPE_MEMORY_PORT}|${TASK_ORCHESTRATOR_HTTP_PORT}|3003|3006|3010|3012)" \
+    | awk '{print $9}' | sort -t: -k2 -n || echo "None found"
 
 echo ""
-echo "=== Summary ==="
-echo ""
-
-# Count healthy containers
-healthy_count=$(docker ps --filter "name=mcp-" --filter "health=healthy" | wc -l | tr -d ' ')
-total_count=$(docker ps --filter "name=mcp-" | grep -v "NAMES" | wc -l | tr -d ' ')
-
-echo "Healthy containers: $healthy_count/$total_count"
-echo ""
-
-# List ports listening
-listening_ports=$(lsof -iTCP -sTCP:LISTEN -n -P | grep -E ":(3001|3003|3004|3006|3007|3008|3009|3012)" | awk '{print $9}' | cut -d: -f2 | sort -n | tr '\n' ' ')
-
-echo "Ports listening: $listening_ports"
-echo ""
+echo "=========================================="
+echo "TRANSPORT REMINDER:"
+echo "  dope-memory, task-orchestrator → type: http (Streamable HTTP, POST /mcp)"
+echo "  conport, desktop-commander     → type: sse  (SSE, GET /sse)"
+echo "  pal, serena, dope-context      → type: http (Streamable HTTP, POST /mcp)"
 echo "=========================================="

--- a/schemas/mcp/fleet-catalog.schema.json
+++ b/schemas/mcp/fleet-catalog.schema.json
@@ -120,6 +120,11 @@
           "minimum": 1,
           "maximum": 65535
         },
+        "reserved_port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
         "extra_port_vars": {
           "type": "array",
           "items": {

--- a/src/dopemux/commands/extractor_validation.py
+++ b/src/dopemux/commands/extractor_validation.py
@@ -21,7 +21,6 @@ import yaml
 from .extractor_commands import _extractor_runner_path, _resolve_extractor_root
 from .extractor_validation_ui import BatchValidationUI
 from dopemux.error_handling import CircuitBreaker, CircuitBreakerConfig, CircuitBreakerState
-from services.shared.mcp.pal_client import PALClient
 
 
 DEFAULT_REPORT_ROOT = Path("reports/repo-truth-extractor/validation")
@@ -909,6 +908,13 @@ class LiveValidationRunner:
         return {provider: sorted(models) for provider, models in inventory.items()}
 
     async def _call_pal_tool(self, tool_name: str, prompt: str) -> Dict[str, Any]:
+        try:
+            from services.shared.mcp.pal_client import PALClient  # lazy: only available in dopemux-mvp checkout
+        except ImportError as exc:
+            raise RuntimeError(
+                "PALClient is only available when running from the dopemux-mvp checkout. "
+                "Ensure services/shared/mcp/pal_client.py is on sys.path."
+            ) from exc
         async with PALClient(
             self.pal_base_url,
             SimpleNamespace(api_key=os.getenv("PAL_API_KEY", "")),
@@ -926,6 +932,13 @@ class LiveValidationRunner:
         return result
 
     async def _call_pal_consensus(self, prompt: str) -> Dict[str, Any]:
+        try:
+            from services.shared.mcp.pal_client import PALClient  # lazy: only available in dopemux-mvp checkout
+        except ImportError as exc:
+            raise RuntimeError(
+                "PALClient is only available when running from the dopemux-mvp checkout. "
+                "Ensure services/shared/mcp/pal_client.py is on sys.path."
+            ) from exc
         async with PALClient(
             self.pal_base_url,
             SimpleNamespace(api_key=os.getenv("PAL_API_KEY", "")),

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -477,6 +477,30 @@ def _backup_path(path: Path) -> Path:
     return path.with_suffix(path.suffix + f".backup-{stamp}")
 
 
+def _singleton_reserved_ports(catalog: Dict[str, Any]) -> Dict[int, str]:
+    """
+    Return a map of {port: server_name} for all singleton servers that have a
+    statically-declared port in the catalog.  These ports must never be assigned
+    to per-worktree services regardless of what hash offset `_port_for` produces.
+    """
+    reserved: Dict[int, str] = {}
+    for name, spec in catalog.get("servers", {}).items():
+        if spec.get("scope") != "singleton":
+            continue
+        raw_url = spec.get("url")
+        if not raw_url:
+            continue
+        # Parse the port from a bare URL like "http://localhost:3009/mcp"
+        try:
+            from urllib.parse import urlparse as _up
+            port = _up(str(raw_url)).port
+            if port:
+                reserved[port] = name
+        except Exception:
+            pass
+    return reserved
+
+
 def _allocate_ports(
     worktree: str,
     names: List[str],
@@ -488,15 +512,26 @@ def _allocate_ports(
     Compute ports for each per-worktree server, including any `extra_port_vars`
     declared by the spec (e.g. conport exposes three host ports for one service).
     Same hash offset is reused across a single server's primary + extras.
+
+    Safety rules:
+    - ``wrapper-singleton`` services (one global instance, fixed port) are
+      assigned their ``default_port_base`` directly without any hash offset.
+    - All singleton-catalog reserved ports are pre-seeded into the collision
+      map so per-worktree hash offsets cannot land on them.
     """
     assignments: Dict[str, int] = {}
-    seen_ports: Dict[int, str] = {}
+    # Pre-seed with singleton reserved ports so per-worktree allocations
+    # cannot collide with statically-assigned singleton ports (e.g. gptr-mcp).
+    seen_ports: Dict[int, str] = {
+        port: f"singleton:{name}"
+        for port, name in _singleton_reserved_ports(catalog).items()
+    }
 
-    def _claim(var: str, base: int, owner: str, key_path: str) -> None:
-        port = _port_for(key_path, base)
+    def _claim(var: str, base: int, owner: str, key_path: str, *, fixed: bool = False) -> None:
+        port = base if fixed else _port_for(key_path, base)
         if port in seen_ports:
             raise click.ClickException(
-                f"Internal port collision: {owner}.{var} and {seen_ports[port]} both hashed to :{port}. "
+                f"Internal port collision: {owner}.{var} and {seen_ports[port]} both map to :{port}. "
                 f"Adjust the `default_port_base` for one of them in {CATALOG_FILENAME}."
             )
         seen_ports[port] = f"{owner}.{var}"
@@ -506,12 +541,15 @@ def _allocate_ports(
         spec = catalog["servers"].get(name)
         if not spec or spec.get("scope") != "per-worktree":
             continue
+        # wrapper-singleton: one global instance at a fixed port — no hash offset.
+        is_wrapper_singleton = spec.get("management_model") == "wrapper-singleton"
         key_path = project_root if spec.get("state_scope") == "per-repo" and project_root else worktree
         base = spec.get("default_port_base")
         if base:
-            _claim(spec["port_var"], base, name, key_path)
-        for extra in spec.get("extra_port_vars", []) or []:
-            _claim(extra["var"], extra["base"], name, key_path)
+            _claim(spec["port_var"], base, name, key_path, fixed=is_wrapper_singleton)
+        if not is_wrapper_singleton:
+            for extra in spec.get("extra_port_vars", []) or []:
+                _claim(extra["var"], extra["base"], name, key_path)
     return assignments
 
 

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -482,22 +482,44 @@ def _singleton_reserved_ports(catalog: Dict[str, Any]) -> Dict[int, str]:
     Return a map of {port: server_name} for all singleton servers that have a
     statically-declared port in the catalog.  These ports must never be assigned
     to per-worktree services regardless of what hash offset `_port_for` produces.
+
+    Two sources of port reservation are recognised:
+
+    1. ``url`` field — parsed via urllib (e.g. ``http://localhost:3009/mcp``).
+    2. ``reserved_port`` field — an explicit integer for singletons whose MCP
+       transport is ``stdio`` (e.g. ``gpt-researcher``) but whose Docker service
+       still binds a host port that per-worktree services must not shadow.
     """
+    from urllib.parse import urlparse as _urlparse
+
     reserved: Dict[int, str] = {}
     for name, spec in catalog.get("servers", {}).items():
         if spec.get("scope") != "singleton":
             continue
+
+        # Source 1: explicit reserved_port (stdio singletons that still bind a host port)
+        explicit = spec.get("reserved_port")
+        if explicit is not None:
+            try:
+                reserved[int(explicit)] = name
+            except (TypeError, ValueError):
+                console.logger.warning(
+                    f"[warning]mcp_catalog: singleton '{name}' has a non-integer "
+                    f"reserved_port value ({explicit!r}); skipping port reservation.[/warning]"
+                )
+
+        # Source 2: url field (HTTP/SSE singletons)
         raw_url = spec.get("url")
-        if not raw_url:
-            continue
-        # Parse the port from a bare URL like "http://localhost:3009/mcp"
-        try:
-            from urllib.parse import urlparse as _up
-            port = _up(str(raw_url)).port
-            if port:
-                reserved[port] = name
-        except Exception:
-            pass
+        if raw_url:
+            try:
+                port = _urlparse(str(raw_url)).port
+                if port:
+                    reserved[port] = name
+            except Exception as exc:  # noqa: BLE001
+                console.logger.warning(
+                    f"[warning]mcp_catalog: singleton '{name}' has an unparseable "
+                    f"url ({raw_url!r}); skipping port reservation. ({exc})[/warning]"
+                )
     return reserved
 
 
@@ -527,11 +549,14 @@ def _allocate_ports(
         for port, name in _singleton_reserved_ports(catalog).items()
     }
 
-    def _claim(var: str, base: int, owner: str, key_path: str, *, fixed: bool = False) -> None:
+    def _claim(
+        var: str, base: int, owner: str, key_path: str, *, fixed: bool = False
+    ) -> None:
         port = base if fixed else _port_for(key_path, base)
         if port in seen_ports:
             raise click.ClickException(
-                f"Internal port collision: {owner}.{var} and {seen_ports[port]} both map to :{port}. "
+                f"Internal port collision: {owner}.{var} and "
+                f"{seen_ports[port]} both map to :{port}. "
                 f"Adjust the `default_port_base` for one of them in {CATALOG_FILENAME}."
             )
         seen_ports[port] = f"{owner}.{var}"
@@ -543,7 +568,11 @@ def _allocate_ports(
             continue
         # wrapper-singleton: one global instance at a fixed port — no hash offset.
         is_wrapper_singleton = spec.get("management_model") == "wrapper-singleton"
-        key_path = project_root if spec.get("state_scope") == "per-repo" and project_root else worktree
+        key_path = (
+            project_root
+            if spec.get("state_scope") == "per-repo" and project_root
+            else worktree
+        )
         base = spec.get("default_port_base")
         if base:
             _claim(spec["port_var"], base, name, key_path, fixed=is_wrapper_singleton)

--- a/src/dopemux/mcp/default_catalog.yaml
+++ b/src/dopemux/mcp/default_catalog.yaml
@@ -103,6 +103,7 @@ servers:
     command: docker
     args: ["exec", "-i", "dopemux-mcp-gptr-mcp", "python", "/app/server.py"]
     docker_compose_service: gptr-mcp
+    reserved_port: 3009  # gptr-mcp container binds ${GPT_RESEARCHER_PORT:-3009}
     requires_env: ["OPENAI_API_KEY"]
     optional_env: ["TAVILY_API_KEY", "EXA_API_KEY", "PERPLEXITY_API_KEY", "ANTHROPIC_API_KEY"]
     description: "Deep multi-source research (PR #575: gpt-researcher==0.14.8 pinned)"

--- a/tests/unit/test_mcp_commands_catalog.py
+++ b/tests/unit/test_mcp_commands_catalog.py
@@ -185,18 +185,19 @@ def test_allocate_ports_raises_on_singleton_port_collision(monkeypatch):
     This is the bug that caused CONPORT_HTTP_PORT=3009 to collide with gpt-researcher
     at port 3009 in the dNh_CRM workspace.
 
-    We monkeypatch _port_for to return a deterministic value equal to the singleton port
-    so the test is independent of hash implementation details.
+    gpt-researcher is a stdio singleton (no url) whose Docker container still binds
+    port 3009; the catalog declares this via ``reserved_port: 3009``.  The test
+    monkeypatches _port_for to guarantee the collision deterministically.
     """
     SINGLETON_PORT = 3009
     catalog = {
         "version": 1,
         "servers": {
-            # Singleton that statically owns port 3009
+            # Matches the real gpt-researcher catalog entry: stdio, no url, reserved_port
             "gpt-researcher": {
                 "scope": "singleton",
-                "transport": "http",
-                "url": f"http://localhost:{SINGLETON_PORT}/mcp",
+                "transport": "stdio",
+                "reserved_port": SINGLETON_PORT,
             },
             # Per-worktree service whose hash-derived port happens to land on 3009
             "conport": {
@@ -221,6 +222,34 @@ def test_allocate_ports_raises_on_singleton_port_collision(monkeypatch):
     msg = str(excinfo.value.message)
     assert "collision" in msg.lower()
     assert str(SINGLETON_PORT) in msg or "gpt-researcher" in msg or "singleton" in msg
+
+
+def test_allocate_ports_raises_on_url_singleton_port_collision(monkeypatch):
+    """Same collision guard applies to HTTP/SSE singletons whose port comes from url."""
+    SINGLETON_PORT = 3003
+    catalog = {
+        "version": 1,
+        "servers": {
+            "pal": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": f"http://localhost:{SINGLETON_PORT}/mcp",
+            },
+            "conport": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "port_var": "CONPORT_HTTP_PORT",
+                "default_port_base": 3000,
+            },
+        },
+    }
+
+    monkeypatch.setattr(mcp_commands, "_port_for", lambda _path, _base: SINGLETON_PORT)
+
+    with pytest.raises(click.ClickException) as excinfo:
+        mcp_commands._allocate_ports("/tmp/wt", ["conport"], catalog)
+
+    assert "collision" in str(excinfo.value.message).lower()
 
 
 def test_allocate_ports_uses_project_root_for_per_repo_state():

--- a/tests/unit/test_mcp_commands_catalog.py
+++ b/tests/unit/test_mcp_commands_catalog.py
@@ -1,4 +1,5 @@
 import json
+import re
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -732,8 +733,9 @@ def test_doctor_aggregates_problems_and_exits_nonzero(tmp_path, monkeypatch):
     assert result.exit_code == 1, result.output
     # Doctor reports multiple problems in a single run (envrc missing + ghost server +
     # missing required env + missing port var). Assert each surfaces, ignoring the
-    # logger's line-wrapping of long absolute paths.
-    assert "issue(s) found" in result.output
+    # logger's line-wrapping of long absolute paths and Rich ANSI markup.
+    plain_output = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "issue(s) found" in plain_output
     assert ".envrc" in result.output
     assert "ghost" in result.output
     assert "DOPEMUX_WORKSPACE_ID" in result.output

--- a/tests/unit/test_mcp_commands_catalog.py
+++ b/tests/unit/test_mcp_commands_catalog.py
@@ -141,6 +141,88 @@ def test_allocate_ports_raises_on_cross_server_collision():
     assert "beta" in msg
 
 
+def test_allocate_ports_wrapper_singleton_uses_fixed_base_port():
+    """wrapper-singleton services must NOT have a workspace hash offset applied.
+
+    task-orchestrator is the canonical wrapper-singleton; its port must always
+    equal default_port_base regardless of the workspace path hash.
+    """
+    catalog = {
+        "version": 1,
+        "servers": {
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "state_scope": "per-repo",
+                "management_model": "wrapper-singleton",
+                "transport": "http",
+                "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
+                "default_port_base": 7890,
+            },
+        },
+    }
+
+    # Two completely different workspace paths must yield the same fixed port
+    result_a = mcp_commands._allocate_ports(
+        "/Users/alice/code/project-a",
+        ["task-orchestrator"],
+        catalog,
+        project_root="/Users/alice/code/project-a",
+    )
+    result_b = mcp_commands._allocate_ports(
+        "/Users/bob/totally-different-path/zyx",
+        ["task-orchestrator"],
+        catalog,
+        project_root="/Users/bob/totally-different-path/zyx",
+    )
+
+    assert result_a["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
+    assert result_b["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
+
+
+def test_allocate_ports_raises_on_singleton_port_collision(monkeypatch):
+    """Per-worktree hash offset must not silently land on a singleton's reserved port.
+
+    This is the bug that caused CONPORT_HTTP_PORT=3009 to collide with gpt-researcher
+    at port 3009 in the dNh_CRM workspace.
+
+    We monkeypatch _port_for to return a deterministic value equal to the singleton port
+    so the test is independent of hash implementation details.
+    """
+    SINGLETON_PORT = 3009
+    catalog = {
+        "version": 1,
+        "servers": {
+            # Singleton that statically owns port 3009
+            "gpt-researcher": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": f"http://localhost:{SINGLETON_PORT}/mcp",
+            },
+            # Per-worktree service whose hash-derived port happens to land on 3009
+            "conport": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "port_var": "CONPORT_HTTP_PORT",
+                "default_port_base": 3004,  # realistic value
+            },
+        },
+    }
+
+    # Force _port_for to return the singleton port regardless of input
+    monkeypatch.setattr(mcp_commands, "_port_for", lambda _path, _base: SINGLETON_PORT)
+
+    with pytest.raises(click.ClickException) as excinfo:
+        mcp_commands._allocate_ports(
+            "/Users/hue/code/dNh_CRM",
+            ["conport"],
+            catalog,
+        )
+
+    msg = str(excinfo.value.message)
+    assert "collision" in msg.lower()
+    assert str(SINGLETON_PORT) in msg or "gpt-researcher" in msg or "singleton" in msg
+
+
 def test_allocate_ports_uses_project_root_for_per_repo_state():
     catalog = {
         "version": 1,


### PR DESCRIPTION
## Summary

Fixes two confirmed port allocation bugs in `dopemux mcp init`, adds a human user guide for running MCP in other repos/projects, documents the correct HTTP vs SSE transport architecture, and updates all agent instruction files.

---

## Bugs Fixed

### Bug 1: `wrapper-singleton` port offset applied when it must not be

**Root cause**: `_allocate_ports` applied a workspace-path hash offset to services with `management_model: wrapper-singleton` (e.g. `task-orchestrator`), which must have a single fixed global port.

**Symptom**: `TASK_ORCHESTRATOR_HTTP_PORT=7895` generated for a workspace with hash offset +5, while the singleton listens on `7890`. Connection refused on every init.

**Fix**: `_claim()` now receives a `fixed=True` flag when `management_model == "wrapper-singleton"` and uses `default_port_base` verbatim.

### Bug 2: Per-worktree hash offset silently collides with singleton reserved ports

**Root cause**: The collision detection map (`seen_ports`) was only populated with intra-worktree allocations, never with singleton-declared ports.

**Symptom**: `CONPORT_HTTP_PORT=3009` (offset +5 from base 3004) silently collided with `gpt-researcher` at port 3009. Docker bind failed with no actionable error.

**Fix**: New `_singleton_reserved_ports()` helper extracts all singleton catalog URL ports and pre-seeds `seen_ports` before per-worktree allocation runs. Collision now raises a clear error.

---

## Transport Architecture Clarification

The SSE hotfix applied during the `dNh_CRM` debugging session (switching `type: http` → `type: sse` in `mcp_catalog.yaml`) was wrong and caused connection failures. The canonical files are correct:

| Server | type | Protocol |
|---|---|---|
| `dope-memory`, `task-orchestrator` | `http` | Streamable HTTP — POST /mcp |
| `conport`, `desktop-commander` | `sse` | Server-Sent Events — GET /sse |

A `406 Not Acceptable: Client must accept text/event-stream` on `GET /mcp` is **correct server behaviour** for Streamable HTTP — not evidence the server is SSE.

---

## New: Human User Guide

`docs/02-how-to/mcp-setup-other-repos.md` — step-by-step guide for:
- Part 1: Setting up MCP in another repo using `dopemux mcp init`
- Part 2: Manual setup without dopemux CLI
- Part 3: Vanilla Claude Code (no dopemux)
- Troubleshooting table

---

## Agent Files Updated

All agent instruction files now include the transport table, port invariants, setup steps, and debug sequence:

- `AGENTS.md` §12 (Codex/OpenCode authority)
- `.claude/claude.md` (Claude Code authority)
- `.claude/modules/shared/governance-principles.md` (canonical doctrine)
- `.claude/mcp-system.md` (rewritten with current accurate server inventory)

---

## Validation

- **23/23 tests pass** including 2 new regression tests
- `git diff --check` clean
- Python syntax verified (`ast.parse`)
- `mcp_server_health_report.sh` rewritten to source `.envrc.dopemux-mcp` and use correct POST/GET probing per transport type

## Files Changed
```
M src/dopemux/commands/mcp_commands.py
M tests/unit/test_mcp_commands_catalog.py
M mcp_server_health_report.sh
A docs/02-how-to/mcp-setup-other-repos.md   ← NEW
M docs/02-how-to/mcp-transport-and-port-bugs.md
M AGENTS.md
M .claude/claude.md
M .claude/mcp-system.md
M .claude/modules/shared/governance-principles.md
```