### PR TITLE
docs(backlog): 52 Task Packets + orchestrator load-plan from thread + PR findings

### DIFF
--- a/claudedocs/backlog/ORCHESTRATOR_LOADPLAN.md
+++ b/claudedocs/backlog/ORCHESTRATOR_LOADPLAN.md
@@ -1,0 +1,145 @@
+# Orchestrator Load-Plan — DMX-BACKLOG-2026-07-07
+
+**Status**: LOAD-PLAN ONLY — **not executed against the live task-orchestrator** (per operator decision). Machine-readable source: [`loadplan.json`](loadplan.json). Packets: [`README.md`](README.md). Decisions: [`decisions-ledger.md`](decisions-ledger.md).
+
+**Contents**: 1 root · 9 epics (series) · 52 leaves (packets) · 28 BLOCKS edges. Items load as `QUEUE`; the BLOCKS DAG makes `get_blocked_items` derive blocked state — no pre-set BLOCKED role needed.
+
+## How to load (operator runs these against the task-orchestrator MCP)
+
+```
+1. create_work_tree  ← root + epics + leaves from loadplan.json (root→epics→leaves via parent refs)
+2. manage_dependencies (action=create) ← one BLOCKS edge per pair in loadplan.json.blocks: [blocker, blocked]
+3. verify: query_items (count==52) · query_dependencies (==28) · get_blocked_items (decision/dep-gated show blocked) · get_next_item (returns a ready Tier-B leaf)
+```
+
+## Epics (series) & leaves
+
+### DMX-MCF (8)
+
+| Packet | disp | Target |
+|---|---|---|
+| `DMX-MCF-002-transcript-ingest` | BUILD | Build a one-shot, idempotent transcript-file ingest adapter that parses Claude Code session transcript JSONL into turn e |
+| `DMX-MCF-003-decision-candidate` | BUILD | Add the conversation.decision_candidate event type end-to-end through the existing capture-to-promotion pipeline (both a |
+| `DMX-MCF-004-sessionstart-recap` | BUILD | Extend the existing native_hooks.py SessionStart injection path with a bounded, token-budgeted, authority-labeled Top-3  |
+| `DMX-MCF-005-semantic-projection-spec` | SPEC | Produce the semantic-memory projection spec for a derived dope-context memory_{hash} collection (privacy-safe embedding  |
+| `DMX-MCF-006-conport-graph-spike-spec` | SPEC | Run the mandatory AGE data-layer spike against the active Docker ConPort runtime, then produce the spec for graph.neighb |
+| `DMX-MCF-007-fabric-orchestrator-spec` | SPEC | Spec the Fabric orchestrator and its context.recall / context.recap MCP surface, fusing whichever retrieval modalities ( |
+| `DMX-MCF-008-summarizer-spec` | SPEC | Spec the LLM summarization worker that distills candidate-only conversation-derived content using a cheap default model  |
+| `DMX-MCF-009-proactive-injection-spec` | SPEC | Spec proactive mid-session context injection (Injection Phase 2) built on top of the Fabric orchestrator, gated by a rat |
+
+### DMX-FLEET-P0 (7)
+
+| Packet | disp | Target |
+|---|---|---|
+| `DMX-FLEET-P0-001-real-healthchecks` | BUILD | Prove that every MCP server healthcheck in the fleet is a real capability probe (non-2xx/unreachable = unhealthy) and ad |
+| `DMX-FLEET-P0-002-ensure-pal-managed` | BUILD | Bring the load-bearing off-compose pal-mcp-server container fully under managed startup: add a real MCP capability healt |
+| `DMX-FLEET-P0-003-conport-schema-verify-failclosed` | WIRE | Verify that ConPort's _ensure_schema post-apply verification is fail-closed (raises, does not silently proceed, on an un |
+| `DMX-FLEET-P0-004-registry-dedup` | DELETE | Remove the competing PAL registry entries in src/dopemux/mcp/registry.yaml (dopemux-pal via uvx pal-mcp-server vs dopemu |
+| `DMX-FLEET-P0-005-wrapper-path-fixes` | BUILD | Fix the three broken MCP stdio wrapper scripts under scripts/mcp-wrappers/: conport-wrapper.sh and conport-codex-wrapper |
+| `DMX-FLEET-P0-006-quarantine-killlist` | BUILD | Quarantine the remaining startable kill-list dead code (services/mcp-integration-bridge, services/router, services/mcp-c |
+| `DMX-FLEET-P0-007-desktop-commander-upstream` | REBUILD | Replace the broken desktop-commander container facade (docker/mcp-servers-source/desktop-commander/server.py, which call |
+
+### DMX-FLEET-P1 (7)
+
+| Packet | disp | Target |
+|---|---|---|
+| `DMX-FLEET-P1-001-unified-catalog-spec` | SPEC | Produce a spec that closes the residual multi-registry drift: current origin/main already has a schema-validated fleet c |
+| `DMX-FLEET-P1-002-codegen-pipeline-spec` | SPEC | Produce a spec that closes the residual codegen gap: src/dopemux/mcp/fleet_catalog.py already renders .mcp.json, a Codex |
+| `DMX-FLEET-P1-003-mcp-ensure-command` | SPEC | Produce a spec that closes the residual gap in `dopemux mcp ensure`: the command already exists on origin/main (src/dope |
+| `DMX-FLEET-P1-004-ci-drift-gates` | BUILD | Close the residual CI-drift-gate gap: tests/arch/test_mcp_fleet_catalog_contract.py already gates catalog-schema conform |
+| `DMX-FLEET-P1-005-orchestrator-autostart` | SPEC | Spec auto-starting the task-orchestrator singleton at session start and refreshing its repo truth-pack to the deployed v |
+| `DMX-FLEET-P1-006-exa-retire-cleanup` | RETIRE | Finish the exa retirement (ADR-223, already merged to origin/main via commit 65313194a and enforced by tests/arch/test_m |
+| `DMX-FLEET-P1-007-token-truncation-utility-spec` | SPEC | Spec restoring the lost progressive-token-truncation pattern (docs/archive/mcp-servers/CONPORT_TOKEN_LIMIT_FIX.md: item- |
+
+### DMX-FLEET-P2 (5)
+
+| Packet | disp | Target |
+|---|---|---|
+| `DMX-FLEET-P2-001-event-source-wiring` | WIRE | Produce the spec for wiring decision.logged/task.*/workflow.phase_changed at their real emission sources (ConPort decisi |
+| `DMX-FLEET-P2-002-heartbeat-ratelimit` | BUILD | Rate-limit session-active heartbeat events in the dope-memory eventbus consumer to stop chronicle spam, and normalize/ba |
+| `DMX-FLEET-P2-003-instance-identity-propagation` | SPEC | Produce the spec for moving workspace/instance identity into per-request parameters (tool arguments or headers) so workt |
+| `DMX-FLEET-P2-004-skill-mirror-receipts` | BUILD | Append a dope-memory mirror-receipt confirmation to the /decision, /caveat, and /followup skill commands so each ConPort |
+| `DMX-FLEET-P2-005-dopecontext-indexing-enable` | BUILD | Flip ENABLE_DOPECONTEXT_INDEX=true with provenance pointers once the chronicle holds real curated content, completing th |
+
+### DMX-FLEET-P3 (6)
+
+| Packet | disp | Target |
+|---|---|---|
+| `DMX-FLEET-P3-001-conport-jsonrpc-parity` | SPEC | Produce a spec for ConPort packets 106/107/201/202 that closes JSON-RPC tool parity (13 of 17 SSE tools currently advert |
+| `DMX-FLEET-P3-002-serena-promotion` | WIRE | Produce a spec that promotes the local 45-tool Serena candidate (services/serena/) to the canonical Serena surface per D |
+| `DMX-FLEET-P3-003-complexity-unify-spec` | SPEC | Produce a spec that picks the canonical complexity scorer among the three unwired implementations (Serena's CodeComplexi |
+| `DMX-FLEET-P3-004-qdrant-gc` | DELETE | Add garbage collection for orphaned dope-context Qdrant collections (code_{workspace_hash}/docs_{workspace_hash}) whose  |
+| `DMX-FLEET-P3-005-voyage-cost-guard` | WIRE | Wire the existing but dead rate_limits.voyage_api config (multi_index_config.yaml) into VoyageEmbedder and VoyageReranke |
+| `DMX-FLEET-P3-006-loopback-binds` | BUILD | Close 0.0.0.0 exposure fleet-wide for conport, dope-memory, serena, and gptr-mcp by adding loopback-bind port publishing |
+
+### DMX-FLEET-P4 (5)
+
+| Packet | disp | Target |
+|---|---|---|
+| `DMX-FLEET-P4-001-facade-g1-contract-test` | WIRE | Close DCP read-only facade gap G1 by adding a CI contract test that asserts the MCP-registered tool set equals TOOL_CONT |
+| `DMX-FLEET-P4-002-dopecontext-bridge-spec` | SPEC | Spec a minimal MCP-JSON-RPC read bridge that lets the DCP read-only facade's dope-context adapter issue real search_code |
+| `DMX-FLEET-P4-003-lane-engine-wire` | WIRE | Wire the currently dead-code decide_lane() function into a real dispatch point (a `dopemux dcp lane` CLI subcommand plus |
+| `DMX-FLEET-P4-004-inventory-freshness-gate` | WIRE | Add a CI verification that fails when the DCP facade's backend-surface inventory (RUNTIME_SURFACE_INVENTORY.md / READ_ON |
+| `DMX-FLEET-P4-005-facade-catalog-register` | WIRE | Register dcp-readonly-facade as an operator-run stdio entry in the unified MCP catalog, closing the gap where the facade |
+
+### DMX-FLEET-P5 (3)
+
+| Packet | disp | Target |
+|---|---|---|
+| `DMX-FLEET-P5-001-e2e-acceptance` | SPEC | Spec the end-to-end fleet acceptance test: from a fresh worktree, `dopemux mcp ensure` brings every plane green, a decis |
+| `DMX-FLEET-P5-002-docs-reconciliation` | WIRE | Regenerate the fleet's per-server doctrine docs (~/.claude/MCP_*.md sources and their in-repo equivalents) to match live |
+| `DMX-FLEET-P5-003-proof-discipline` | BUILD | Establish a per-packet proof-bundle template and a checker script under proof/ that verifies every proof bundle contains |
+
+### DMX-ADHD-WIRE (6)
+
+| Packet | disp | Target |
+|---|---|---|
+| `DMX-ADHD-WIRE-001-predictive-risk-hook` | WIRE | Wire the built-but-dormant predictive_risk_assessment.py into the task-orchestrator runtime path so its 8 risk categorie |
+| `DMX-ADHD-WIRE-002-context-preservation-display` | WIRE | Surface the live adhd_engine/domains/attention/context_preserver.py output (pre-break mental-model snapshots) on a real  |
+| `DMX-ADHD-WIRE-003-overwhelm-snapshot` | WIRE | Expose the existing overwhelm-detection telemetry already computed inside event_coordinator.py as a queryable snapshot o |
+| `DMX-ADHD-WIRE-004-relationship-vocab-widening` | WIRE | Widen the active ConPort MCP server's exposed relationship vocabulary beyond the current link_conport_items generic edge |
+| `DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec` | SPEC | Produce a spec for resurrecting the dormant Serena Adaptive Learning Engine foundation (per-user attention patterns, cro |
+| `DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec` | SPEC | Produce a spec for resurrecting the dormant Serena Fatigue Detection Engine, Context Switching Optimizer, Untracked Work |
+
+### DMX-ADR (5)
+
+| Packet | disp | Target |
+|---|---|---|
+| `DMX-ADR-001-semantic-memory-home` | ADR | Author docs/90-adr/adr-224-semantic-memory-home.md recording the accepted decision that semantic memory lives in dope-co |
+| `DMX-ADR-002-serena-promotion` | ADR | Author docs/90-adr/adr-225-serena-promotion.md recording the accepted decision to promote the local 45-tool Serena surfa |
+| `DMX-ADR-003-lane-engine-dispatch` | ADR | Author docs/90-adr/adr-226-lane-engine-dispatch.md recording the accepted decision to wire decide_lane() as the real DCP |
+| `DMX-ADR-004-complexity-scorer` | ADR | Author docs/90-adr/adr-227-complexity-scorer.md recording the accepted decision to unify the three unwired complexity-sc |
+| `DMX-ADR-005-conport-graph-exposure` | ADR | Author docs/90-adr/adr-228-conport-graph-exposure.md recording the accepted decision to expose graph.neighbors plus deci |
+
+## Dependency edges (BLOCKS: blocker → blocked)
+
+```
+DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec  →  DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec
+DMX-ADR-001-semantic-memory-home  →  DMX-MCF-005-semantic-projection-spec
+DMX-ADR-002-serena-promotion  →  DMX-FLEET-P3-002-serena-promotion
+DMX-ADR-003-lane-engine-dispatch  →  DMX-FLEET-P4-003-lane-engine-wire
+DMX-ADR-004-complexity-scorer  →  DMX-FLEET-P3-003-complexity-unify-spec
+DMX-ADR-005-conport-graph-exposure  →  DMX-MCF-006-conport-graph-spike-spec
+DMX-FLEET-P0-002-ensure-pal-managed  →  DMX-FLEET-P1-003-mcp-ensure-command
+DMX-FLEET-P0-004-registry-dedup  →  DMX-FLEET-P1-001-unified-catalog-spec
+DMX-FLEET-P1-001-unified-catalog-spec  →  DMX-FLEET-P1-002-codegen-pipeline-spec
+DMX-FLEET-P1-001-unified-catalog-spec  →  DMX-FLEET-P1-003-mcp-ensure-command
+DMX-FLEET-P1-001-unified-catalog-spec  →  DMX-FLEET-P4-005-facade-catalog-register
+DMX-FLEET-P1-002-codegen-pipeline-spec  →  DMX-FLEET-P1-004-ci-drift-gates
+DMX-FLEET-P1-003-mcp-ensure-command  →  DMX-FLEET-P5-001-e2e-acceptance
+DMX-FLEET-P2-001-event-source-wiring  →  DMX-FLEET-P2-005-dopecontext-indexing-enable
+DMX-FLEET-P2-005-dopecontext-indexing-enable  →  DMX-FLEET-P5-001-e2e-acceptance
+DMX-FLEET-P3-001-conport-jsonrpc-parity  →  DMX-ADHD-WIRE-004-relationship-vocab-widening
+DMX-FLEET-P3-002-serena-promotion  →  DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec
+DMX-FLEET-P3-002-serena-promotion  →  DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec
+DMX-FLEET-P4-001-facade-g1-contract-test  →  DMX-FLEET-P4-004-inventory-freshness-gate
+DMX-MCF-002-transcript-ingest  →  DMX-MCF-003-decision-candidate
+DMX-MCF-002-transcript-ingest  →  DMX-MCF-007-fabric-orchestrator-spec
+DMX-MCF-003-decision-candidate  →  DMX-MCF-004-sessionstart-recap
+DMX-MCF-003-decision-candidate  →  DMX-MCF-007-fabric-orchestrator-spec
+DMX-MCF-003-decision-candidate  →  DMX-MCF-008-summarizer-spec
+DMX-MCF-004-sessionstart-recap  →  DMX-MCF-005-semantic-projection-spec
+DMX-MCF-004-sessionstart-recap  →  DMX-MCF-007-fabric-orchestrator-spec
+DMX-MCF-007-fabric-orchestrator-spec  →  DMX-MCF-008-summarizer-spec
+DMX-MCF-007-fabric-orchestrator-spec  →  DMX-MCF-009-proactive-injection-spec
+```

--- a/claudedocs/backlog/README.md
+++ b/claudedocs/backlog/README.md
@@ -1,0 +1,144 @@
+# Backlog — Task-Packet Master Manifest & Traceability
+
+**Date**: 2026-07-07 · **Branch**: `claude/backlog-taskpackets` · **Status**: authored (this pass = author + validate + index + load-plan; **no implementation, no live orchestrator mutation**)
+
+Converts every actionable finding from this thread + the three merged PRs (#1011 Memory Context Fabric, #1002 MCP fleet audit, #1009 service P0) into schema-valid Task Packets (`task-packets/generated/<SERIES>/`) and a task-orchestrator load-plan (`ORCHESTRATOR_LOADPLAN.md` + `loadplan.json`). Decisions frozen in [`decisions-ledger.md`](decisions-ledger.md).
+
+**Tiers**: **B** = implementation (frozen/plan-ready, mechanical steps) · **C** = planning (deliverable = a spec/plan, as TP-MCF-001 produced 002/003) · **A** = ADR (author the decision record). Every packet is a valid TP and an orchestrator item.
+
+**Disposition** (load-plan `disp`): BUILD · WIRE · HARDEN · DELETE · RETIRE · CONSOLIDATE · REBUILD · SPEC · ADR.
+
+**Artifacts in this dir**: `decisions-ledger.md` (frozen decisions) · `README.md` (this manifest) · `_AUTHORING_CONTRACT.md` (packet-authoring rules) · `loadplan.json` (machine-readable orchestrator load-plan) · `ORCHESTRATOR_LOADPLAN.md` (human-readable + MCP call recipe). Packets: `task-packets/generated/DMX-*/`. Index: `task-packets/INDEX.md`.
+
+---
+
+## Reconciliation with current `main` (important — runtime outranks the audit)
+
+The MCP fleet audit is dated **2026-07-03**; `main` moved since. During authoring, agents cross-checked every audit claim against **live `origin/main`** (per the repo Truth Order) and found parts of Phase 0/1 **already shipped** — a schema-validated unified fleet catalog (`src/dopemux/mcp/fleet_catalog.py` + `schemas/mcp/fleet-catalog.schema.json`) with a 20+-test CI drift suite, a working `dopemux mcp ensure --fast/--full`, exa retirement via **ADR-223**, and P0 fixes (`4974015c3`, `b63b4b4a7`). Affected packets were **kept in the matrix but reframed to the verified residual gap**, not authored as greenfield:
+- `DMX-FLEET-P0-001` / `-003` → **regression-lock** packets (bug already fixed; lock it in + wire the existing test into the discoverable path).
+- `DMX-FLEET-P0-004` → the real issue is a **semantic** duplicate (`dopemux-pal`/`dopemux-zen`), not literal YAML key collision.
+- `DMX-FLEET-P1-001/002/003/004/006` → close the residual gap (fold last legacy registries, close dry-run-only codegen, wire the advisory hook to the built `mcp ensure`, delete 5 stale exa refs); `P1-005`/`P1-007` confirmed genuinely unbuilt.
+- New drift surfaced: `PROMOTABLE_EVENT_TYPES` is now duplicated across **3** files (`capture_client.py`, `promotion.py`, `dopecon_bridge/promotable_mirror.py`), not the 2 the audit recorded → `DMX-FLEET-P2-001` requires reconciling all three.
+
+**Implication**: this backlog reflects *verified residual work as of 2026-07-07*, not the audit's original framing. Each affected packet's first step re-verifies current state before acting, so an executor never re-fixes a solved bug. **`bd85e784c`** (MCF fork decisions) also remains unmerged on `claude/memory-context-fabric` — land it or fold into a follow-up.
+
+---
+
+## Series DMX-MCF — Memory Context Fabric (8)
+Source: `claudedocs/memory-context-fabric-*.md`, `claudedocs/plans/2026-07-04-*.md`, `claudedocs/tp-mcf-001-authority-map-2026-07-04.md`.
+
+| ID | Tier | disp | Target (one sentence) | depends_on |
+|---|---|---|---|---|
+| `DMX-MCF-002-transcript-ingest` | B | BUILD | Ingest Claude Code transcript JSONL → dope-memory raw ledger only, with deterministic ids, stable-timestamp-or-quarantine, and a **non-queryable quarantine table** (schema migration) for redaction failures. | — |
+| `DMX-MCF-003-decision-candidate` | B | BUILD | Add `conversation.decision_candidate` to both allowlists (sync-guard) + a deterministic promotion handler; never auto-writes ConPort. | `DMX-MCF-002` |
+| `DMX-MCF-004-sessionstart-recap` | B | BUILD | Bounded SessionStart recap injection via native hooks (read-only SQLite, token budget, authority labels, kill switch). | `DMX-MCF-003` |
+| `DMX-MCF-005-semantic-projection-spec` | C | SPEC | Produce the semantic-memory projection spec (dope-context `memory_{hash}`, privacy-safe embedding) — deferred go/no-go after 004. | `DMX-MCF-004`, `DMX-ADR-001-semantic-memory-home` |
+| `DMX-MCF-006-conport-graph-spike-spec` | C | SPEC | Run the AGE data-layer spike, then spec `graph.neighbors`+genealogy tools; fall back to relationship-query if spike fails. | `DMX-ADR-005-conport-graph-exposure` |
+| `DMX-MCF-007-fabric-orchestrator-spec` | C | SPEC | Spec the Fabric orchestrator + `context.recall`/`context.recap` MCP surface with graceful modality degradation. | `DMX-MCF-002`, `DMX-MCF-003`, `DMX-MCF-004` |
+| `DMX-MCF-008-summarizer-spec` | C | SPEC | Spec the LLM summarization worker (candidate-only, cheap-model default, budgeted). | `DMX-MCF-003`, `DMX-MCF-007` |
+| `DMX-MCF-009-proactive-injection-spec` | C | SPEC | Spec proactive mid-session injection (rate limit + relevance threshold + kill switch). | `DMX-MCF-007` |
+
+## Series DMX-FLEET-P0 — Stop the bleeding (7, all B)
+Source: fleet audit §8 Phase 0 + §7.1 kill list; runtime bugs (Category 5).
+
+| ID | Tier | disp | Target | depends_on |
+|---|---|---|---|---|
+| `DMX-FLEET-P0-001-real-healthchecks` | B | HARDEN | Replace fake `exit 0` healthchecks (pal, dope-context) with real capability probes (MCP initialize + tools/list). | — |
+| `DMX-FLEET-P0-002-ensure-pal-managed` | B | WIRE | Bring load-bearing PAL under managed startup: `ensure-pal.sh` + real healthcheck + compose integration. | — |
+| `DMX-FLEET-P0-003-conport-schema-verify-failclosed` | B | HARDEN | Fix `_ensure_schema` verify to fail-closed on migration failure (currently a no-op). | — |
+| `DMX-FLEET-P0-004-registry-dedup` | B | HARDEN | Dedupe duplicate YAML keys in `src/dopemux/mcp/registry.yaml` (last-wins silently disables servers). | — |
+| `DMX-FLEET-P0-005-wrapper-path-fixes` | B | HARDEN | Fix broken MCP wrappers (conport→in-repo, dope-context env/path, serena phantom path). | — |
+| `DMX-FLEET-P0-006-quarantine-killlist` | B | DELETE | Remove kill-list dead code + rename the Python task-orchestrator shadow-twin → `workflow-api`. | — |
+| `DMX-FLEET-P0-007-desktop-commander-upstream` | B | REBUILD | Replace the broken desktop-commander container facade with real upstream DesktopCommanderMCP on the host. | — |
+
+## Series DMX-FLEET-P1 — Single source of truth (7, mostly C)
+Source: fleet audit §8 Phase 1 + §6.1; lost-pattern restorations (forgotten-features §3b).
+
+| ID | Tier | disp | Target | depends_on |
+|---|---|---|---|---|
+| `DMX-FLEET-P1-001-unified-catalog-spec` | C | SPEC | Spec one schema-validated catalog merging `mcp_catalog.yaml` + `registry.yaml` + `services/registry.yaml` (canonical: dopemux). | `DMX-FLEET-P0-004` |
+| `DMX-FLEET-P1-002-codegen-pipeline-spec` | C | SPEC | Spec codegen from the unified catalog → `.mcp.json`, `~/.claude.json`, `~/.codex/config.toml`, compose port/env, health lists, doctrine. | `DMX-FLEET-P1-001` |
+| `DMX-FLEET-P1-003-mcp-ensure-command` | C | BUILD | `dopemux mcp ensure` + `--fast`: idempotent <2s daemon→compose→pal-recreate→orchestrator-singleton→capability-verify. | `DMX-FLEET-P1-001`, `DMX-FLEET-P0-002` |
+| `DMX-FLEET-P1-004-ci-drift-gates` | B | HARDEN | CI drift gates: catalog↔generated-configs, commands↔tool-surfaces, compose-ports↔registry. | `DMX-FLEET-P1-002` |
+| `DMX-FLEET-P1-005-orchestrator-autostart` | C | WIRE | Auto-start the task-orchestrator + refresh its truth-pack to the deployed version. | — |
+| `DMX-FLEET-P1-006-exa-retire-cleanup` | B | RETIRE | Finish exa retirement: doctrine update (WebSearch fallback) + remove dead config writers/surfaces. | — |
+| `DMX-FLEET-P1-007-token-truncation-utility-spec` | C | SPEC | Restore the lost progressive-token-truncation + MCP-boundary-enforcement pattern as one shared utility at the `call_tool()` boundary. | — |
+
+## Series DMX-FLEET-P2 — Memory spine (5, B/C)
+Source: fleet audit §7.2; PR #1009; forgotten-features (mcp-capture, event-bus triggers).
+
+| ID | Tier | disp | Target | depends_on |
+|---|---|---|---|---|
+| `DMX-FLEET-P2-001-event-source-wiring` | C | WIRE | Wire `decision.logged`/`task.*`/`workflow.phase_changed` at their real emission sources (ConPort decision-write + workflow-kernel transitions); **fold mcp-capture into `capture_client.py`**. | — |
+| `DMX-FLEET-P2-002-heartbeat-ratelimit` | B | HARDEN | Rate-limit `session-active` heartbeat spam and normalize/backfill `instance_id`. | — |
+| `DMX-FLEET-P2-003-instance-identity-propagation` | C | SPEC | Move workspace/instance identity into per-request parameters (tool args/headers) so worktree scoping is real over shared HTTP servers. | — |
+| `DMX-FLEET-P2-004-skill-mirror-receipts` | B | WIRE | `/decision`, `/caveat`, `/followup` append dope-memory mirror-receipt confirmations (Trinity Rule 1). | — |
+| `DMX-FLEET-P2-005-dopecontext-indexing-enable` | B | WIRE | Flip `ENABLE_DOPECONTEXT_INDEX=true` with provenance pointers once the chronicle holds real content. | `DMX-FLEET-P2-001` |
+
+## Series DMX-FLEET-P3 — Canonical surfaces (6, C/A/B)
+Source: fleet audit §7.1/§7.3 + §8 Phase 3; forgotten-features §2.5–2.6.
+
+| ID | Tier | disp | Target | depends_on |
+|---|---|---|---|---|
+| `DMX-FLEET-P3-001-conport-jsonrpc-parity` | C | SPEC | Spec ConPort packets 106/107/201/202: JSON-RPC tool parity (13→17), kill GET-mutation side-effect, product context, relationship write API. | — |
+| `DMX-FLEET-P3-002-serena-promotion` | C | CONSOLIDATE | Promote the local 45-tool Serena surface to canonical per ADR (6 write tools out of default profile); archive/retire the wrapper split. | `DMX-ADR-002-serena-promotion` |
+| `DMX-FLEET-P3-003-complexity-unify-spec` | C | SPEC | Pick the canonical complexity scorer among the three unwired implementations and spec wiring it everywhere. | `DMX-ADR-004-complexity-scorer` |
+| `DMX-FLEET-P3-004-qdrant-gc` | B | HARDEN | Garbage-collect orphaned Qdrant collections per deleted worktree. | — |
+| `DMX-FLEET-P3-005-voyage-cost-guard` | B | HARDEN | Add an external-embedding (Voyage) spend cap / cost guard to dope-context. | — |
+| `DMX-FLEET-P3-006-loopback-binds` | B | HARDEN | Close `0.0.0.0` exposure fleet-wide (conport/dope-memory/serena/gptr loopback-bind). | — |
+
+## Series DMX-FLEET-P4 — DCP activation (5, B/C)
+Source: fleet audit §4 (DCP verdict) + §8 Phase 4.
+
+| ID | Tier | disp | Target | depends_on |
+|---|---|---|---|---|
+| `DMX-FLEET-P4-001-facade-g1-contract-test` | B | WIRE | Close DCP facade G1: wire the 3 unwired tools + a CI contract test asserting `exposed == TOOL_CONTRACT`. | — |
+| `DMX-FLEET-P4-002-dopecontext-bridge-spec` | C | SPEC | Spec the dope-context MCP-JSON-RPC bridge that unblocks the facade's dope-context adapter. | — |
+| `DMX-FLEET-P4-003-lane-engine-wire` | B | WIRE | Wire `decide_lane()` as a real dispatch point (`dopemux dcp lane` + task-packet intake). | `DMX-ADR-003-lane-engine-dispatch` |
+| `DMX-FLEET-P4-004-inventory-freshness-gate` | B | HARDEN | Add a facade inventory-freshness CI verification. | `DMX-FLEET-P4-001` |
+| `DMX-FLEET-P4-005-facade-catalog-register` | B | WIRE | Register `dcp-readonly-facade` in the unified catalog (currently operator-run, unregistered). | `DMX-FLEET-P1-001` |
+
+## Series DMX-FLEET-P5 — Prove it (3, B/C)
+Source: fleet audit §8 Phase 5.
+
+| ID | Tier | disp | Target | depends_on |
+|---|---|---|---|---|
+| `DMX-FLEET-P5-001-e2e-acceptance` | C | SPEC | Spec + build the end-to-end acceptance: fresh worktree → `mcp ensure` → all planes green → decision logged → mirrored → recapped → retrieved. | `DMX-FLEET-P1-003`, `DMX-FLEET-P2-005` |
+| `DMX-FLEET-P5-002-docs-reconciliation` | B | HARDEN | Regenerate fleet doctrine; mark aspirational ADHD automation as specification-only. | — |
+| `DMX-FLEET-P5-003-proof-discipline` | B | HARDEN | Establish the per-packet proof-bundle template + checker under `proof/`. | — |
+
+## Series DMX-ADHD-WIRE — Forgotten-features wire-existing (6, B/C)
+Source: `claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md` §3a/§3c.
+
+| ID | Tier | disp | Target | depends_on |
+|---|---|---|---|---|
+| `DMX-ADHD-WIRE-001-predictive-risk-hook` | B | WIRE | Wire the built-but-dormant `predictive_risk_assessment.py` into the task-orchestrator (8 risk categories incl. hyperfocus burnout). | — |
+| `DMX-ADHD-WIRE-002-context-preservation-display` | B | WIRE | Surface `adhd_engine/context_preserver.py` output on a PM display (backend already live). | — |
+| `DMX-ADHD-WIRE-003-overwhelm-snapshot` | B | WIRE | Expose `event_coordinator.py` overwhelm telemetry on a PM surface. | — |
+| `DMX-ADHD-WIRE-004-relationship-vocab-widening` | B | WIRE | Expose ConPort's richer relationship vocabulary (affects/depends_on/implemented_by/…) beyond `link_conport_items`. | `DMX-FLEET-P3-001` |
+| `DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec` | C | SPEC | Spec resurrecting the Adaptive Learning engine foundation (unblocked by Serena promotion). | `DMX-FLEET-P3-002` |
+| `DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec` | C | SPEC | Spec resurrecting the Fatigue + Context-Switch + Untracked-Work modules (Serena-surface dependent). | `DMX-FLEET-P3-002`, `DMX-ADHD-WIRE-005` |
+
+## Series DMX-ADR — Decision records (5, all A)
+Source: `decisions-ledger.md`.
+
+| ID | Tier | disp | Target | depends_on |
+|---|---|---|---|---|
+| `DMX-ADR-001-semantic-memory-home` | A | ADR | Author the ADR: semantic memory lives in dope-context (`memory_{hash}`, provisionally, deferred); ConPort does not own semantic. | — |
+| `DMX-ADR-002-serena-promotion` | A | ADR | Author the ADR: promote the local 45-tool Serena surface to canonical (6 write tools out of default profile). | — |
+| `DMX-ADR-003-lane-engine-dispatch` | A | ADR | Author the ADR: wire `decide_lane()` as the real DCP routing dispatch point. | — |
+| `DMX-ADR-004-complexity-scorer` | A | ADR | Author the ADR: unify complexity scoring onto one canonical scorer (which one = P3-003's investigation). | — |
+| `DMX-ADR-005-conport-graph-exposure` | A | ADR | Author the ADR: expose `graph.neighbors`+genealogy on active ConPort, spike-gated. | — |
+
+---
+
+## Coverage cross-check (finding → packet)
+
+- **MCF 002–009 + forks** → `DMX-MCF-*` + `DMX-ADR-001/005`. ✓
+- **Fleet Phase 0–5 (~30 items)** → `DMX-FLEET-P0..P5-*`. ✓
+- **Forgotten-features wire-existing/resurrect** → `DMX-ADHD-WIRE-*` + folded (mcp-capture→P2-001, ConPort graph→ADR-005/MCF-006, relationship-vocab→WIRE-004, token-truncation→P1-007). ✓
+- **10 decisions** → `decisions-ledger.md` + `DMX-ADR-*`. ✓
+- **~20 runtime bugs (Category 5)** → each folded into a packet: wrong-stream→P2-001 · schema-verify→P0-003 · painted-socket→MCF-005 · PROMOTABLE dup→MCF-003 · wrapper paths→P0-005 · instance-identity→P2-003 · fake-healthchecks→P0-001 · dup-YAML→P0-004 · no-ensure→P1-003 · orchestrator-autostart→P1-005 · shadow-twin rename→P0-006 · GET-mutations→P3-001 · Qdrant-orphans→P3-004 · Voyage-guard→P3-005 · desktop-commander→P0-007 · 3-registries→P1-001 · dead-config→P1-006. ✓
+- **Settled "don't do"** → no packets (listed in `decisions-ledger.md`). ✓
+
+**Total: 52 packets** (8 MCF + 7 P0 + 7 P1 + 5 P2 + 6 P3 + 5 P4 + 3 P5 + 6 ADHD-WIRE + 5 ADR). No inventory item dropped.

--- a/claudedocs/backlog/_AUTHORING_CONTRACT.md
+++ b/claudedocs/backlog/_AUTHORING_CONTRACT.md
@@ -35,7 +35,7 @@ Author schema-valid dopeTask JSON packets. Schema: `docs/03-reference/spec/dopet
 - Every packet: "This packet must run from a fresh dedicated worktree based on origin/main." and "This packet must only touch files in its commit.allowlist."
 - Planning/ADR packets: "This packet must not change runtime code." Implementation packets touching contract surfaces (schemas, MCP manifests, event payloads, allowlists): "This packet must preserve the canonical writer and add a contract test."
 
-## Validate every packet you write (from repo root `/Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe`)
+## Validate every packet you write (from the repository root)
 ```bash
 mise exec -- python -m jsonschema -i task-packets/generated/<SERIES>/<id>.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json && echo "PASS <id>"
 ```

--- a/claudedocs/backlog/_AUTHORING_CONTRACT.md
+++ b/claudedocs/backlog/_AUTHORING_CONTRACT.md
@@ -1,0 +1,42 @@
+# Backlog Packet Authoring Contract (for authoring agents)
+
+Author schema-valid dopeTask JSON packets. Schema: `docs/03-reference/spec/dopetask/dopetask-canonical-spec.json` (draft-07, `additionalProperties:false` everywhere). Full reference: `task-packets/generated/DMX-CONPORT-OPTIMAL/_AUTHORING_KIT.md`. Frozen inputs: `claudedocs/backlog/decisions-ledger.md`. Your packet list + targets + deps: `claudedocs/backlog/README.md` (your series' table).
+
+## Placement & naming
+- One file per packet at `task-packets/generated/<SERIES>/<id>.json` where `<SERIES>` is the series dir (e.g. `DMX-FLEET-P0`) and `<id>` is the packet id.
+- `id` field MUST equal the filename stem exactly (e.g. file `DMX-FLEET-P0-001-real-healthchecks.json` → `"id": "DMX-FLEET-P0-001-real-healthchecks"`).
+
+## Required root fields (exactly these keys allowed; no `status`/`notes`/`tags`/`author`/`date`)
+`id, project, target, repo_binding, series, commit, pr, steps` (required) + optional `invariants, depends_on, execution, pal_chain`.
+
+### Reusable scaffolds — copy verbatim, adjust only where noted
+```json
+"project": "dopemux-mvp",
+"repo_binding": { "project_id": "dopemux-mvp", "repo_marker": ".dopetaskroot", "origin_hint": "DDD-Enterprises/dopemux-mvp", "require_identity_match": true },
+"series": { "id": "<series-slug-kebab>", "base_branch": "origin/main", "parent_tp_id": <null-or-prior-id-in-series>, "final_packet": <true only for the last packet in the series> },
+"execution": { "agent": "codex", "branch": "codex/<series>-<nnn>-<slug>", "base_branch": "origin/main" }
+```
+- `series.id` = kebab of the series (e.g. `dmx-fleet-p0`). `parent_tp_id`: `null` for the first packet in the series, else the previous packet's id (chain them in numeric order). `final_packet`: `true` only on the highest-numbered packet of the series.
+- `commit`: `{ "message": "<conventional commit>", "allowlist": [<every file the packet may touch>, "task-packets/generated/<SERIES>/<id>.json", "task-packets/INDEX.md", "proof/<id>/**"], "verify": ["python -m json.tool task-packets/generated/<SERIES>/<id>.json >/dev/null", "python -m jsonschema -i task-packets/generated/<SERIES>/<id>.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json", "git diff --check"] }`
+- `pr`: `{ "title": "<short>", "body": "<1-3 sentence description referencing the source finding>", "base": "main" }` (all three required — `body` is NOT optional).
+- `depends_on`: array of packet ids from the README (may reference other series, e.g. an ADR id). Use `[]` if none.
+
+## PAL chain
+- Tier B implementation packets touching runtime/schema/contract surfaces: include `"pal_chain": {"enabled": false, "steps": ["analyze","planner","codereview","precommit"]}` (Codex minimum).
+- Architecture-risky packets (schema migrations, MCP surface changes, catalog/codegen, lane-engine, Serena promotion, event-source wiring): use the risky chain `["analyze","thinkdeep","challenge","planner","challenge","implement","codereview","precommit","challenge"]` with `"enabled": false` (Codex).
+- Tier A (ADR) / Tier C (spec-only) packets: `pal_chain` optional; if included use the minimum chain.
+
+## Steps by tier (each step: `id`, `task`, non-empty `validation`; optional `requirements`, `commands`, `expected_files`, `context_files`)
+- **Tier B (implementation)** — mechanical: S1 preflight (fresh worktree, repo marker, clean baseline recorded in proof); S2 write failing test(s) before code where code is testable; S3 minimal implementation; S4 materialize packet + update INDEX + proof + validate + commit + PR + move orchestrator item to review. Reference the source build plan / audit section in `context_files`. Name concrete files in `expected_files` where known from the README/source.
+- **Tier C (planning/spec)** — deliverable is a spec doc, not code: S1 read the named source docs + inspect the current runtime paths (read-only); S2 produce the spec at `claudedocs/specs/<id>.md` (or `docs/03-reference/...`) covering scope/invariants/interfaces/acceptance/phasing; S3 self-review vs the source + validate the packet + commit. Validation asserts the spec file exists and covers the required sections. **No runtime code.**
+- **Tier A (ADR)** — deliverable is an ADR: S1 author `docs/90-adr/adr-<slug>.md` with status `accepted`, the decision, rationale, and consequences (copy the decision + rationale verbatim from `decisions-ledger.md`); S2 validate + commit. Validation asserts `grep -q 'status: accepted'` (or the repo's ADR frontmatter convention — check an existing file in `docs/90-adr/`).
+
+## Invariants (add where relevant)
+- Every packet: "This packet must run from a fresh dedicated worktree based on origin/main." and "This packet must only touch files in its commit.allowlist."
+- Planning/ADR packets: "This packet must not change runtime code." Implementation packets touching contract surfaces (schemas, MCP manifests, event payloads, allowlists): "This packet must preserve the canonical writer and add a contract test."
+
+## Validate every packet you write (from repo root `/Users/hue/code/dopemux-mvp/.claude/worktrees/trusting-engelbart-d2fbfe`)
+```bash
+mise exec -- python -m jsonschema -i task-packets/generated/<SERIES>/<id>.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json && echo "PASS <id>"
+```
+Fix any packet that does not exit 0. Do NOT commit (the parent session commits). Return: the list of files you wrote + PASS/FAIL per packet.

--- a/claudedocs/backlog/decisions-ledger.md
+++ b/claudedocs/backlog/decisions-ledger.md
@@ -1,0 +1,23 @@
+# Backlog Decisions Ledger
+
+**Date**: 2026-07-07 · **Owner**: operator (houston@krohman.org) · **Status**: RESOLVED (frozen inputs for packet authoring)
+**Purpose**: the frozen decisions that convert thread + PR findings into Task Packets. Every gate below is resolved; each row names the resulting packet(s). This ledger is authoritative for the `DMX-*` backlog series; where a formal ADR is warranted, a `DMX-ADR-*` packet authors it.
+
+**Provenance loose-end**: MCF-005/006 were also recorded in commit `bd85e784c` on branch `claude/memory-context-fabric`, which is **unmerged** (PR #1011 merged an earlier commit). Main's `claudedocs/plans/2026-07-04-memory-context-fabric-build-plan.md` still shows "DECISION REQUIRED" for 005/006. This ledger supersedes that; `bd85e784c` should also be landed or folded into a follow-up.
+
+| # | Gate | Decision | Rationale | Resulting packet(s) |
+|---|---|---|---|---|
+| MCF-005 | Semantic memory home | **Defer, provisionally Option A** (dope-context `memory_{hash}` projection); decide after 002–004 with real chronicle data | Recall-quality gap only measurable once chronicle has content; Voyage is external → privacy gate | `DMX-ADR-001`, `DMX-MCF-005` (planning, deferred) |
+| MCF-006 | ConPort graph exposure | **Option A** — `graph.neighbors` + genealogy on active Docker ConPort, **spike-gated** (AGE data-layer spike is mandatory Task 1) | Decision-genealogy provenance is worth it; AGE writer path unproven → de-risk first | `DMX-ADR-005`, `DMX-MCF-006` (spike+spec) |
+| MCF-002 | Redaction-failure quarantine location | **Non-queryable dope-memory table** (not a file path) | Keeps quarantine inside the store; requires a schema migration + non-searchable guardrail | `DMX-MCF-002` (adds migration sub-step) |
+| FLEET | Canonical PAL management | **Manage** via `ensure-pal.sh` + real capability healthcheck + compose integration | PAL is load-bearing (`required=true`); must not stay off-compose/unmanaged | `DMX-FLEET-P0-002` |
+| FLEET | exa | **Retire** (already shipped in #1002) | Zero consumers, broken catalog target; WebSearch fallback in place | `DMX-FLEET-P1-006` (doctrine + dead-config cleanup) |
+| FLEET | Complexity scoring (3 unwired scorers) | **Unify** onto one canonical scorer | Keeps ADHD complexity-aware UX alive; which scorer = the planning packet's investigation | `DMX-ADR-004`, `DMX-FLEET-P3-003` (planning) |
+| FLEET | Serena surface | **Promote local 45-tool candidate** via ADR (6 write tools out of default profile) | Canonicalizes the richer surface; **unblocks dormant ADHD-module resurrections** | `DMX-ADR-002`, `DMX-FLEET-P3-002`, `DMX-ADHD-WIRE-005/006` |
+| FLEET | ConPort vector search (`mem.*` in `memory_server.py`) | **Do not build in ConPort** — dope-context owns semantic (per MCF-005) | Trinity law assigns semantic retrieval to dope-context; avoid a second authority | closed; no packet (noted in `DMX-ADR-001`) |
+| DCP | Lane engine `decide_lane()` | **Wire as real dispatch** (`dopemux dcp lane` + task-packet intake) | "Latent security is not security"; wiring makes the routing design real | `DMX-ADR-003`, `DMX-FLEET-P4-003` |
+| FLEET | desktop-commander (broken container facade) | **Run real upstream DesktopCommanderMCP on the host** (replace facade) | osascript-in-Linux facade fails every call while healthcheck lies; operator uses desktop tooling | `DMX-FLEET-P0-007` |
+| FEAT | mcp-capture (built, unregistered) | **Fold into `capture_client.py`** (no separate server) | Memory-spine already routes capture through capture_client; one capture path, less fleet surface | folded into `DMX-FLEET-P2-001` |
+
+## Out of scope by prior settlement (no packets)
+documentation_search (drop) · Mem0 hosted-cloud memory (forbidden) · PRD→tasks auto-gen (disabled by design; `/dx:prd-parse` is sanctioned) · Leantime bidirectional write-sync (PM-authority-gated) · mcp-integration-bridge revival (secret-leaking; clean-rewrite only) · Multi-Team Coordination (dormant-by-design for single-operator MVP) · Sprint auto-planning (ConPort half unbuilt; revisit on need).

--- a/claudedocs/backlog/loadplan.json
+++ b/claudedocs/backlog/loadplan.json
@@ -1,0 +1,592 @@
+{
+  "program": "DMX-BACKLOG-2026-07-07",
+  "date": "2026-07-07",
+  "source_plan": "claudedocs/backlog/README.md",
+  "validation": "52/52 schema PASS; DAG acyclic=True; dangling=0",
+  "tag": "dmx-backlog,series,supervised-only,load-plan-only",
+  "note": "LOAD-PLAN ONLY \u2014 do not execute against the live task-orchestrator without operator confirmation. Items load as QUEUE; blocks encode the readiness DAG (get_blocked_items derives blocked state).",
+  "root": {
+    "ref": "root",
+    "title": "DMX Backlog \u2014 thread + PR findings (52 packets)",
+    "summary": "Task Packets converting all Memory Context Fabric + MCP fleet audit + forgotten-features + runtime-bug findings into governed execution units across 9 series."
+  },
+  "epics": [
+    {
+      "ref": "DMX-MCF",
+      "title": "DMX-MCF",
+      "phase": 1
+    },
+    {
+      "ref": "DMX-FLEET-P0",
+      "title": "DMX-FLEET-P0",
+      "phase": 2
+    },
+    {
+      "ref": "DMX-FLEET-P1",
+      "title": "DMX-FLEET-P1",
+      "phase": 3
+    },
+    {
+      "ref": "DMX-FLEET-P2",
+      "title": "DMX-FLEET-P2",
+      "phase": 4
+    },
+    {
+      "ref": "DMX-FLEET-P3",
+      "title": "DMX-FLEET-P3",
+      "phase": 5
+    },
+    {
+      "ref": "DMX-FLEET-P4",
+      "title": "DMX-FLEET-P4",
+      "phase": 6
+    },
+    {
+      "ref": "DMX-FLEET-P5",
+      "title": "DMX-FLEET-P5",
+      "phase": 7
+    },
+    {
+      "ref": "DMX-ADHD-WIRE",
+      "title": "DMX-ADHD-WIRE",
+      "phase": 8
+    },
+    {
+      "ref": "DMX-ADR",
+      "title": "DMX-ADR",
+      "phase": 9
+    }
+  ],
+  "leaves": [
+    {
+      "ref": "DMX-MCF-002-transcript-ingest",
+      "parent": "DMX-MCF",
+      "title": "Build a one-shot, idempotent transcript-file ingest adapter that parses Claude Code session transcript JSONL into turn events and writes only to the dope-memory raw ledger (raw_activity_events) via th",
+      "disp": "BUILD",
+      "accept": "Packet DMX-MCF-002-transcript-ingest executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-MCF/DMX-MCF-002-transcript-ingest.json"
+    },
+    {
+      "ref": "DMX-MCF-003-decision-candidate",
+      "parent": "DMX-MCF",
+      "title": "Add the conversation.decision_candidate event type end-to-end through the existing capture-to-promotion pipeline (both allowlists kept in sync, a sync-guard test, and a deterministic non-LLM promotion",
+      "disp": "BUILD",
+      "accept": "Packet DMX-MCF-003-decision-candidate executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-MCF/DMX-MCF-003-decision-candidate.json"
+    },
+    {
+      "ref": "DMX-MCF-004-sessionstart-recap",
+      "parent": "DMX-MCF",
+      "title": "Extend the existing native_hooks.py SessionStart injection path with a bounded, token-budgeted, authority-labeled Top-3 recap read directly from the local chronicle SQLite ledger, with a kill switch a",
+      "disp": "BUILD",
+      "accept": "Packet DMX-MCF-004-sessionstart-recap executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-MCF/DMX-MCF-004-sessionstart-recap.json"
+    },
+    {
+      "ref": "DMX-MCF-005-semantic-projection-spec",
+      "parent": "DMX-MCF",
+      "title": "Produce the semantic-memory projection spec for a derived dope-context memory_{hash} collection (privacy-safe embedding path), deferring the final go/no-go until real chronicle data exists from packet",
+      "disp": "SPEC",
+      "accept": "Packet DMX-MCF-005-semantic-projection-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-MCF/DMX-MCF-005-semantic-projection-spec.json"
+    },
+    {
+      "ref": "DMX-MCF-006-conport-graph-spike-spec",
+      "parent": "DMX-MCF",
+      "title": "Run the mandatory AGE data-layer spike against the active Docker ConPort runtime, then produce the spec for graph.neighbors plus decision-genealogy MCP tools, falling back to a relationship-query proj",
+      "disp": "SPEC",
+      "accept": "Packet DMX-MCF-006-conport-graph-spike-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-MCF/DMX-MCF-006-conport-graph-spike-spec.json"
+    },
+    {
+      "ref": "DMX-MCF-007-fabric-orchestrator-spec",
+      "parent": "DMX-MCF",
+      "title": "Spec the Fabric orchestrator and its context.recall / context.recap MCP surface, fusing whichever retrieval modalities (temporal, structural, semantic) exist at build time and degrading gracefully whe",
+      "disp": "SPEC",
+      "accept": "Packet DMX-MCF-007-fabric-orchestrator-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-MCF/DMX-MCF-007-fabric-orchestrator-spec.json"
+    },
+    {
+      "ref": "DMX-MCF-008-summarizer-spec",
+      "parent": "DMX-MCF",
+      "title": "Spec the LLM summarization worker that distills candidate-only conversation-derived content using a cheap default model under an explicit token/cost budget, never touching canonical ConPort decisions ",
+      "disp": "SPEC",
+      "accept": "Packet DMX-MCF-008-summarizer-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-MCF/DMX-MCF-008-summarizer-spec.json"
+    },
+    {
+      "ref": "DMX-MCF-009-proactive-injection-spec",
+      "parent": "DMX-MCF",
+      "title": "Spec proactive mid-session context injection (Injection Phase 2) built on top of the Fabric orchestrator, gated by a rate limit, a relevance threshold, and an operator kill switch, so a bad surfacing ",
+      "disp": "SPEC",
+      "accept": "Packet DMX-MCF-009-proactive-injection-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-MCF/DMX-MCF-009-proactive-injection-spec.json"
+    },
+    {
+      "ref": "DMX-FLEET-P0-001-real-healthchecks",
+      "parent": "DMX-FLEET-P0",
+      "title": "Prove that every MCP server healthcheck in the fleet is a real capability probe (non-2xx/unreachable = unhealthy) and add a regression test that fails closed if a fake exit-0-style healthcheck is rein",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P0-001-real-healthchecks executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-001-real-healthchecks.json"
+    },
+    {
+      "ref": "DMX-FLEET-P0-002-ensure-pal-managed",
+      "parent": "DMX-FLEET-P0",
+      "title": "Bring the load-bearing off-compose pal-mcp-server container fully under managed startup: add a real MCP capability healthcheck (initialize + tools/list, not just `docker ps` running-state) to scripts/",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P0-002-ensure-pal-managed executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-002-ensure-pal-managed.json"
+    },
+    {
+      "ref": "DMX-FLEET-P0-003-conport-schema-verify-failclosed",
+      "parent": "DMX-FLEET-P0",
+      "title": "Verify that ConPort's _ensure_schema post-apply verification is fail-closed (raises, does not silently proceed, on an unverifiable schema), and wire its existing regression test suite into the repo's ",
+      "disp": "WIRE",
+      "accept": "Packet DMX-FLEET-P0-003-conport-schema-verify-failclosed executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-003-conport-schema-verify-failclosed.json"
+    },
+    {
+      "ref": "DMX-FLEET-P0-004-registry-dedup",
+      "parent": "DMX-FLEET-P0",
+      "title": "Remove the competing PAL registry entries in src/dopemux/mcp/registry.yaml (dopemux-pal via uvx pal-mcp-server vs dopemux-zen via npx zen-mcp -- two definitions for one logical server) and add a CI-en",
+      "disp": "DELETE",
+      "accept": "Packet DMX-FLEET-P0-004-registry-dedup executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-004-registry-dedup.json"
+    },
+    {
+      "ref": "DMX-FLEET-P0-005-wrapper-path-fixes",
+      "parent": "DMX-FLEET-P0",
+      "title": "Fix the three broken MCP stdio wrapper scripts under scripts/mcp-wrappers/: conport-wrapper.sh and conport-codex-wrapper.sh exec the upstream context-portal-mcp package instead of bridging to the in-r",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P0-005-wrapper-path-fixes executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-005-wrapper-path-fixes.json"
+    },
+    {
+      "ref": "DMX-FLEET-P0-006-quarantine-killlist",
+      "parent": "DMX-FLEET-P0",
+      "title": "Quarantine the remaining startable kill-list dead code (services/mcp-integration-bridge, services/router, services/mcp-client, services/dope-context/src/mcp/simple_server.py) by removing their Dockerf",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P0-006-quarantine-killlist executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-006-quarantine-killlist.json"
+    },
+    {
+      "ref": "DMX-FLEET-P0-007-desktop-commander-upstream",
+      "parent": "DMX-FLEET-P0",
+      "title": "Replace the broken desktop-commander container facade (docker/mcp-servers-source/desktop-commander/server.py, which calls macOS osascript from inside a Linux container so every tool call fails while i",
+      "disp": "REBUILD",
+      "accept": "Packet DMX-FLEET-P0-007-desktop-commander-upstream executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-007-desktop-commander-upstream.json"
+    },
+    {
+      "ref": "DMX-FLEET-P1-001-unified-catalog-spec",
+      "parent": "DMX-FLEET-P1",
+      "title": "Produce a spec that closes the residual multi-registry drift: current origin/main already has a schema-validated fleet catalog (src/dopemux/mcp/fleet_catalog.py, schemas/mcp/fleet-catalog.schema.json,",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P1-001-unified-catalog-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-001-unified-catalog-spec.json"
+    },
+    {
+      "ref": "DMX-FLEET-P1-002-codegen-pipeline-spec",
+      "parent": "DMX-FLEET-P1",
+      "title": "Produce a spec that closes the residual codegen gap: src/dopemux/mcp/fleet_catalog.py already renders .mcp.json, a Codex config.toml fragment, health-probe lists, and a doctrine doc from the canonical",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P1-002-codegen-pipeline-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-002-codegen-pipeline-spec.json"
+    },
+    {
+      "ref": "DMX-FLEET-P1-003-mcp-ensure-command",
+      "parent": "DMX-FLEET-P1",
+      "title": "Produce a spec that closes the residual gap in `dopemux mcp ensure`: the command already exists on origin/main (src/dopemux/commands/mcp_commands.py, mcp_ensure_cmd) with --fast (static prerequisite c",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P1-003-mcp-ensure-command executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-003-mcp-ensure-command.json"
+    },
+    {
+      "ref": "DMX-FLEET-P1-004-ci-drift-gates",
+      "parent": "DMX-FLEET-P1",
+      "title": "Close the residual CI-drift-gate gap: tests/arch/test_mcp_fleet_catalog_contract.py already gates catalog-schema conformance, catalog-to-compose port alignment, personality-contract drift, dead-surfac",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P1-004-ci-drift-gates executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-004-ci-drift-gates.json"
+    },
+    {
+      "ref": "DMX-FLEET-P1-005-orchestrator-autostart",
+      "parent": "DMX-FLEET-P1",
+      "title": "Spec auto-starting the task-orchestrator singleton at session start and refreshing its repo truth-pack to the deployed version: scripts/mcp-wrappers/task-orchestrator-http-singleton.sh already impleme",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P1-005-orchestrator-autostart executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-005-orchestrator-autostart.json"
+    },
+    {
+      "ref": "DMX-FLEET-P1-006-exa-retire-cleanup",
+      "parent": "DMX-FLEET-P1",
+      "title": "Finish the exa retirement (ADR-223, already merged to origin/main via commit 65313194a and enforced by tests/arch/test_mcp_fleet_catalog_contract.py's dead_service_names/quarantine assertions) by remo",
+      "disp": "RETIRE",
+      "accept": "Packet DMX-FLEET-P1-006-exa-retire-cleanup executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-006-exa-retire-cleanup.json"
+    },
+    {
+      "ref": "DMX-FLEET-P1-007-token-truncation-utility-spec",
+      "parent": "DMX-FLEET-P1",
+      "title": "Spec restoring the lost progressive-token-truncation pattern (docs/archive/mcp-servers/CONPORT_TOKEN_LIMIT_FIX.md: item-by-item token estimation, 9K budget stop, Zen-validated) as one shared fleet-wid",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P1-007-token-truncation-utility-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-007-token-truncation-utility-spec.json"
+    },
+    {
+      "ref": "DMX-FLEET-P2-001-event-source-wiring",
+      "parent": "DMX-FLEET-P2",
+      "title": "Produce the spec for wiring decision.logged/task.*/workflow.phase_changed at their real emission sources (ConPort decision-write path, workflow-kernel/task-orchestrator transitions) and for folding th",
+      "disp": "WIRE",
+      "accept": "Packet DMX-FLEET-P2-001-event-source-wiring executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-001-event-source-wiring.json"
+    },
+    {
+      "ref": "DMX-FLEET-P2-002-heartbeat-ratelimit",
+      "parent": "DMX-FLEET-P2",
+      "title": "Rate-limit session-active heartbeat events in the dope-memory eventbus consumer to stop chronicle spam, and normalize/backfill instance_id so heartbeat and promotable events carry a consistent, non-de",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P2-002-heartbeat-ratelimit executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-002-heartbeat-ratelimit.json"
+    },
+    {
+      "ref": "DMX-FLEET-P2-003-instance-identity-propagation",
+      "parent": "DMX-FLEET-P2",
+      "title": "Produce the spec for moving workspace/instance identity into per-request parameters (tool arguments or headers) so worktree scoping is real for ConPort and dope-memory over shared HTTP servers, replac",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P2-003-instance-identity-propagation executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-003-instance-identity-propagation.json"
+    },
+    {
+      "ref": "DMX-FLEET-P2-004-skill-mirror-receipts",
+      "parent": "DMX-FLEET-P2",
+      "title": "Append a dope-memory mirror-receipt confirmation to the /decision, /caveat, and /followup skill commands so each ConPort write is visibly mirrored into the chronicle at the point of use, closing Memor",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P2-004-skill-mirror-receipts executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-004-skill-mirror-receipts.json"
+    },
+    {
+      "ref": "DMX-FLEET-P2-005-dopecontext-indexing-enable",
+      "parent": "DMX-FLEET-P2",
+      "title": "Flip ENABLE_DOPECONTEXT_INDEX=true with provenance pointers once the chronicle holds real curated content, completing the Memory Trinity loop by making decision/work-log entries semantically searchabl",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P2-005-dopecontext-indexing-enable executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-005-dopecontext-indexing-enable.json"
+    },
+    {
+      "ref": "DMX-FLEET-P3-001-conport-jsonrpc-parity",
+      "parent": "DMX-FLEET-P3",
+      "title": "Produce a spec for ConPort packets 106/107/201/202 that closes JSON-RPC tool parity (13 of 17 SSE tools currently advertised), eliminates the GET /api/progress side-effect mutation, and adds a product",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P3-001-conport-jsonrpc-parity executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-001-conport-jsonrpc-parity.json"
+    },
+    {
+      "ref": "DMX-FLEET-P3-002-serena-promotion",
+      "parent": "DMX-FLEET-P3",
+      "title": "Produce a spec that promotes the local 45-tool Serena candidate (services/serena/) to the canonical Serena surface per DMX-ADR-002, keeping the 6 write tools out of the default profile, and defines th",
+      "disp": "WIRE",
+      "accept": "Packet DMX-FLEET-P3-002-serena-promotion executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-002-serena-promotion.json"
+    },
+    {
+      "ref": "DMX-FLEET-P3-003-complexity-unify-spec",
+      "parent": "DMX-FLEET-P3",
+      "title": "Produce a spec that picks the canonical complexity scorer among the three unwired implementations (Serena's CodeComplexityAnalyzer, dope-context's scorer, and the orchestrator's ADR-207 ML risk module",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P3-003-complexity-unify-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-003-complexity-unify-spec.json"
+    },
+    {
+      "ref": "DMX-FLEET-P3-004-qdrant-gc",
+      "parent": "DMX-FLEET-P3",
+      "title": "Add garbage collection for orphaned dope-context Qdrant collections (code_{workspace_hash}/docs_{workspace_hash}) whose source worktree no longer exists, so deleted worktrees stop leaking permanent co",
+      "disp": "DELETE",
+      "accept": "Packet DMX-FLEET-P3-004-qdrant-gc executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-004-qdrant-gc.json"
+    },
+    {
+      "ref": "DMX-FLEET-P3-005-voyage-cost-guard",
+      "parent": "DMX-FLEET-P3",
+      "title": "Wire the existing but dead rate_limits.voyage_api config (multi_index_config.yaml) into VoyageEmbedder and VoyageReranker and add an enforced spend/request cap on top of the existing unenforced CostTr",
+      "disp": "WIRE",
+      "accept": "Packet DMX-FLEET-P3-005-voyage-cost-guard executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-005-voyage-cost-guard.json"
+    },
+    {
+      "ref": "DMX-FLEET-P3-006-loopback-binds",
+      "parent": "DMX-FLEET-P3",
+      "title": "Close 0.0.0.0 exposure fleet-wide for conport, dope-memory, serena, and gptr-mcp by adding loopback-bind port publishing in compose.yml, matching the pattern already used by dope-context, adhd-engine,",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P3-006-loopback-binds executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-006-loopback-binds.json"
+    },
+    {
+      "ref": "DMX-FLEET-P4-001-facade-g1-contract-test",
+      "parent": "DMX-FLEET-P4",
+      "title": "Close DCP read-only facade gap G1 by adding a CI contract test that asserts the MCP-registered tool set equals TOOL_CONTRACT.md's 12-tool contract, and by making the two transport-blocked tools (searc",
+      "disp": "WIRE",
+      "accept": "Packet DMX-FLEET-P4-001-facade-g1-contract-test executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-001-facade-g1-contract-test.json"
+    },
+    {
+      "ref": "DMX-FLEET-P4-002-dopecontext-bridge-spec",
+      "parent": "DMX-FLEET-P4",
+      "title": "Spec a minimal MCP-JSON-RPC read bridge that lets the DCP read-only facade's dope-context adapter issue real search_code/docs_search/index-status calls instead of permanently fail-closing to BLOCKED, ",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P4-002-dopecontext-bridge-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-002-dopecontext-bridge-spec.json"
+    },
+    {
+      "ref": "DMX-FLEET-P4-003-lane-engine-wire",
+      "parent": "DMX-FLEET-P4",
+      "title": "Wire the currently dead-code decide_lane() function into a real dispatch point (a `dopemux dcp lane` CLI subcommand plus task-packet intake) so DCP lane routing has at least one non-test consumer, per",
+      "disp": "WIRE",
+      "accept": "Packet DMX-FLEET-P4-003-lane-engine-wire executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-003-lane-engine-wire.json"
+    },
+    {
+      "ref": "DMX-FLEET-P4-004-inventory-freshness-gate",
+      "parent": "DMX-FLEET-P4",
+      "title": "Add a CI verification that fails when the DCP facade's backend-surface inventory (RUNTIME_SURFACE_INVENTORY.md / READ_ONLY_SURFACE_INVENTORY.json) is stale relative to the facade's actual route_manife",
+      "disp": "WIRE",
+      "accept": "Packet DMX-FLEET-P4-004-inventory-freshness-gate executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-004-inventory-freshness-gate.json"
+    },
+    {
+      "ref": "DMX-FLEET-P4-005-facade-catalog-register",
+      "parent": "DMX-FLEET-P4",
+      "title": "Register dcp-readonly-facade as an operator-run stdio entry in the unified MCP catalog, closing the gap where the facade is confirmed absent from mcp_catalog.yaml, services/registry.yaml, and src/dope",
+      "disp": "WIRE",
+      "accept": "Packet DMX-FLEET-P4-005-facade-catalog-register executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-005-facade-catalog-register.json"
+    },
+    {
+      "ref": "DMX-FLEET-P5-001-e2e-acceptance",
+      "parent": "DMX-FLEET-P5",
+      "title": "Spec the end-to-end fleet acceptance test: from a fresh worktree, `dopemux mcp ensure` brings every plane green, a decision logged in ConPort is mirrored to dope-memory and later recapped, and the chr",
+      "disp": "SPEC",
+      "accept": "Packet DMX-FLEET-P5-001-e2e-acceptance executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-001-e2e-acceptance.json"
+    },
+    {
+      "ref": "DMX-FLEET-P5-002-docs-reconciliation",
+      "parent": "DMX-FLEET-P5",
+      "title": "Regenerate the fleet's per-server doctrine docs (~/.claude/MCP_*.md sources and their in-repo equivalents) to match live tools/list surfaces, and explicitly mark aspirational ADHD automation claims (b",
+      "disp": "WIRE",
+      "accept": "Packet DMX-FLEET-P5-002-docs-reconciliation executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-002-docs-reconciliation.json"
+    },
+    {
+      "ref": "DMX-FLEET-P5-003-proof-discipline",
+      "parent": "DMX-FLEET-P5",
+      "title": "Establish a per-packet proof-bundle template and a checker script under proof/ that verifies every proof bundle contains the fields AGENTS.md sections 8 and 9 require (TP path/ID, worktree path, branc",
+      "disp": "BUILD",
+      "accept": "Packet DMX-FLEET-P5-003-proof-discipline executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-003-proof-discipline.json"
+    },
+    {
+      "ref": "DMX-ADHD-WIRE-001-predictive-risk-hook",
+      "parent": "DMX-ADHD-WIRE",
+      "title": "Wire the built-but-dormant predictive_risk_assessment.py into the task-orchestrator runtime path so its 8 risk categories (including hyperfocus burnout and context-switching) are actually evaluated an",
+      "disp": "WIRE",
+      "accept": "Packet DMX-ADHD-WIRE-001-predictive-risk-hook executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-001-predictive-risk-hook.json"
+    },
+    {
+      "ref": "DMX-ADHD-WIRE-002-context-preservation-display",
+      "parent": "DMX-ADHD-WIRE",
+      "title": "Surface the live adhd_engine/domains/attention/context_preserver.py output (pre-break mental-model snapshots) on a real PM/operator-facing display surface, so the existing backend capability stops bei",
+      "disp": "WIRE",
+      "accept": "Packet DMX-ADHD-WIRE-002-context-preservation-display executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-002-context-preservation-display.json"
+    },
+    {
+      "ref": "DMX-ADHD-WIRE-003-overwhelm-snapshot",
+      "parent": "DMX-ADHD-WIRE",
+      "title": "Expose the existing overwhelm-detection telemetry already computed inside event_coordinator.py as a queryable snapshot on a PM/operator-facing surface, matching the same wire-existing shape as the con",
+      "disp": "WIRE",
+      "accept": "Packet DMX-ADHD-WIRE-003-overwhelm-snapshot executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-003-overwhelm-snapshot.json"
+    },
+    {
+      "ref": "DMX-ADHD-WIRE-004-relationship-vocab-widening",
+      "parent": "DMX-ADHD-WIRE",
+      "title": "Widen the active ConPort MCP server's exposed relationship vocabulary beyond the current link_conport_items generic edge, so callers can express modeled-but-unexposed relationship types (affects, depe",
+      "disp": "WIRE",
+      "accept": "Packet DMX-ADHD-WIRE-004-relationship-vocab-widening executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-004-relationship-vocab-widening.json"
+    },
+    {
+      "ref": "DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec",
+      "parent": "DMX-ADHD-WIRE",
+      "title": "Produce a spec for resurrecting the dormant Serena Adaptive Learning Engine foundation (per-user attention patterns, cross-session personalization) plus its Personal Learning Profile dependent, gated ",
+      "disp": "SPEC",
+      "accept": "Packet DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.json"
+    },
+    {
+      "ref": "DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec",
+      "parent": "DMX-ADHD-WIRE",
+      "title": "Produce a spec for resurrecting the dormant Serena Fatigue Detection Engine, Context Switching Optimizer, Untracked Work Detector, and Abandonment Tracker modules, sequenced after the Adaptive Learnin",
+      "disp": "SPEC",
+      "accept": "Packet DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.json"
+    },
+    {
+      "ref": "DMX-ADR-001-semantic-memory-home",
+      "parent": "DMX-ADR",
+      "title": "Author docs/90-adr/adr-224-semantic-memory-home.md recording the accepted decision that semantic memory lives in dope-context (memory_{hash} projection, provisionally Option A, deferred final go/no-go",
+      "disp": "ADR",
+      "accept": "Packet DMX-ADR-001-semantic-memory-home executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADR/DMX-ADR-001-semantic-memory-home.json"
+    },
+    {
+      "ref": "DMX-ADR-002-serena-promotion",
+      "parent": "DMX-ADR",
+      "title": "Author docs/90-adr/adr-225-serena-promotion.md recording the accepted decision to promote the local 45-tool Serena surface to canonical, with 6 write tools carved out of the default profile.",
+      "disp": "ADR",
+      "accept": "Packet DMX-ADR-002-serena-promotion executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADR/DMX-ADR-002-serena-promotion.json"
+    },
+    {
+      "ref": "DMX-ADR-003-lane-engine-dispatch",
+      "parent": "DMX-ADR",
+      "title": "Author docs/90-adr/adr-226-lane-engine-dispatch.md recording the accepted decision to wire decide_lane() as the real DCP routing dispatch point (dopemux dcp lane + task-packet intake), replacing laten",
+      "disp": "ADR",
+      "accept": "Packet DMX-ADR-003-lane-engine-dispatch executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADR/DMX-ADR-003-lane-engine-dispatch.json"
+    },
+    {
+      "ref": "DMX-ADR-004-complexity-scorer",
+      "parent": "DMX-ADR",
+      "title": "Author docs/90-adr/adr-227-complexity-scorer.md recording the accepted decision to unify the three unwired complexity-scoring implementations onto one canonical scorer, with the specific scorer choice",
+      "disp": "ADR",
+      "accept": "Packet DMX-ADR-004-complexity-scorer executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADR/DMX-ADR-004-complexity-scorer.json"
+    },
+    {
+      "ref": "DMX-ADR-005-conport-graph-exposure",
+      "parent": "DMX-ADR",
+      "title": "Author docs/90-adr/adr-228-conport-graph-exposure.md recording the accepted decision to expose graph.neighbors plus decision genealogy on the active Docker ConPort instance, gated on a mandatory AGE d",
+      "disp": "ADR",
+      "accept": "Packet DMX-ADR-005-conport-graph-exposure executed per its steps; proof bundle attached.",
+      "packet": "task-packets/generated/DMX-ADR/DMX-ADR-005-conport-graph-exposure.json"
+    }
+  ],
+  "blocks": [
+    [
+      "DMX-MCF-002-transcript-ingest",
+      "DMX-MCF-003-decision-candidate"
+    ],
+    [
+      "DMX-MCF-003-decision-candidate",
+      "DMX-MCF-004-sessionstart-recap"
+    ],
+    [
+      "DMX-MCF-004-sessionstart-recap",
+      "DMX-MCF-005-semantic-projection-spec"
+    ],
+    [
+      "DMX-ADR-001-semantic-memory-home",
+      "DMX-MCF-005-semantic-projection-spec"
+    ],
+    [
+      "DMX-ADR-005-conport-graph-exposure",
+      "DMX-MCF-006-conport-graph-spike-spec"
+    ],
+    [
+      "DMX-MCF-002-transcript-ingest",
+      "DMX-MCF-007-fabric-orchestrator-spec"
+    ],
+    [
+      "DMX-MCF-003-decision-candidate",
+      "DMX-MCF-007-fabric-orchestrator-spec"
+    ],
+    [
+      "DMX-MCF-004-sessionstart-recap",
+      "DMX-MCF-007-fabric-orchestrator-spec"
+    ],
+    [
+      "DMX-MCF-003-decision-candidate",
+      "DMX-MCF-008-summarizer-spec"
+    ],
+    [
+      "DMX-MCF-007-fabric-orchestrator-spec",
+      "DMX-MCF-008-summarizer-spec"
+    ],
+    [
+      "DMX-MCF-007-fabric-orchestrator-spec",
+      "DMX-MCF-009-proactive-injection-spec"
+    ],
+    [
+      "DMX-FLEET-P0-004-registry-dedup",
+      "DMX-FLEET-P1-001-unified-catalog-spec"
+    ],
+    [
+      "DMX-FLEET-P1-001-unified-catalog-spec",
+      "DMX-FLEET-P1-002-codegen-pipeline-spec"
+    ],
+    [
+      "DMX-FLEET-P1-001-unified-catalog-spec",
+      "DMX-FLEET-P1-003-mcp-ensure-command"
+    ],
+    [
+      "DMX-FLEET-P0-002-ensure-pal-managed",
+      "DMX-FLEET-P1-003-mcp-ensure-command"
+    ],
+    [
+      "DMX-FLEET-P1-002-codegen-pipeline-spec",
+      "DMX-FLEET-P1-004-ci-drift-gates"
+    ],
+    [
+      "DMX-FLEET-P2-001-event-source-wiring",
+      "DMX-FLEET-P2-005-dopecontext-indexing-enable"
+    ],
+    [
+      "DMX-ADR-002-serena-promotion",
+      "DMX-FLEET-P3-002-serena-promotion"
+    ],
+    [
+      "DMX-ADR-004-complexity-scorer",
+      "DMX-FLEET-P3-003-complexity-unify-spec"
+    ],
+    [
+      "DMX-ADR-003-lane-engine-dispatch",
+      "DMX-FLEET-P4-003-lane-engine-wire"
+    ],
+    [
+      "DMX-FLEET-P4-001-facade-g1-contract-test",
+      "DMX-FLEET-P4-004-inventory-freshness-gate"
+    ],
+    [
+      "DMX-FLEET-P1-001-unified-catalog-spec",
+      "DMX-FLEET-P4-005-facade-catalog-register"
+    ],
+    [
+      "DMX-FLEET-P1-003-mcp-ensure-command",
+      "DMX-FLEET-P5-001-e2e-acceptance"
+    ],
+    [
+      "DMX-FLEET-P2-005-dopecontext-indexing-enable",
+      "DMX-FLEET-P5-001-e2e-acceptance"
+    ],
+    [
+      "DMX-FLEET-P3-001-conport-jsonrpc-parity",
+      "DMX-ADHD-WIRE-004-relationship-vocab-widening"
+    ],
+    [
+      "DMX-FLEET-P3-002-serena-promotion",
+      "DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec"
+    ],
+    [
+      "DMX-FLEET-P3-002-serena-promotion",
+      "DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec"
+    ],
+    [
+      "DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec",
+      "DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec"
+    ]
+  ]
+}

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -163,3 +163,64 @@ Superseded packets must reference the replacing packet
 ────────────────────────────────────────────────────────────
 Final Rule
 If it’s not indexed here, it didn’t happen.
+
+────────────────────────────────────────────────────────────
+
+## 🟡 Active Task Packets — DMX-BACKLOG-2026-07-07 (52)
+
+Backlog conversion of Memory Context Fabric + MCP fleet audit + forgotten-features + runtime-bug findings (PRs #1011/#1002/#1009). Decisions: `claudedocs/backlog/decisions-ledger.md`. Traceability: `claudedocs/backlog/README.md`. Load-plan: `claudedocs/backlog/loadplan.json`. All schema-valid; authored, not executed.
+
+| Packet ID | Series | Disp | Status | Depends On |
+| --- | --- | --- | --- | --- |
+| DMX-MCF-002-transcript-ingest | DMX-MCF | BUILD | Ready | — |
+| DMX-MCF-003-decision-candidate | DMX-MCF | BUILD | Ready | DMX-MCF-002-transcript-ingest |
+| DMX-MCF-004-sessionstart-recap | DMX-MCF | BUILD | Ready | DMX-MCF-003-decision-candidate |
+| DMX-MCF-005-semantic-projection-spec | DMX-MCF | SPEC | Ready | DMX-MCF-004-sessionstart-recap, DMX-ADR-001-semantic-memory-home |
+| DMX-MCF-006-conport-graph-spike-spec | DMX-MCF | SPEC | Ready | DMX-ADR-005-conport-graph-exposure |
+| DMX-MCF-007-fabric-orchestrator-spec | DMX-MCF | SPEC | Ready | DMX-MCF-002-transcript-ingest, DMX-MCF-003-decision-candidate, DMX-MCF-004-sessionstart-recap |
+| DMX-MCF-008-summarizer-spec | DMX-MCF | SPEC | Ready | DMX-MCF-003-decision-candidate, DMX-MCF-007-fabric-orchestrator-spec |
+| DMX-MCF-009-proactive-injection-spec | DMX-MCF | SPEC | Ready | DMX-MCF-007-fabric-orchestrator-spec |
+| DMX-FLEET-P0-001-real-healthchecks | DMX-FLEET-P0 | BUILD | Ready | — |
+| DMX-FLEET-P0-002-ensure-pal-managed | DMX-FLEET-P0 | BUILD | Ready | — |
+| DMX-FLEET-P0-003-conport-schema-verify-failclosed | DMX-FLEET-P0 | WIRE | Ready | — |
+| DMX-FLEET-P0-004-registry-dedup | DMX-FLEET-P0 | DELETE | Ready | — |
+| DMX-FLEET-P0-005-wrapper-path-fixes | DMX-FLEET-P0 | BUILD | Ready | — |
+| DMX-FLEET-P0-006-quarantine-killlist | DMX-FLEET-P0 | BUILD | Ready | — |
+| DMX-FLEET-P0-007-desktop-commander-upstream | DMX-FLEET-P0 | REBUILD | Ready | — |
+| DMX-FLEET-P1-001-unified-catalog-spec | DMX-FLEET-P1 | SPEC | Ready | DMX-FLEET-P0-004-registry-dedup |
+| DMX-FLEET-P1-002-codegen-pipeline-spec | DMX-FLEET-P1 | SPEC | Ready | DMX-FLEET-P1-001-unified-catalog-spec |
+| DMX-FLEET-P1-003-mcp-ensure-command | DMX-FLEET-P1 | SPEC | Ready | DMX-FLEET-P1-001-unified-catalog-spec, DMX-FLEET-P0-002-ensure-pal-managed |
+| DMX-FLEET-P1-004-ci-drift-gates | DMX-FLEET-P1 | BUILD | Ready | DMX-FLEET-P1-002-codegen-pipeline-spec |
+| DMX-FLEET-P1-005-orchestrator-autostart | DMX-FLEET-P1 | SPEC | Ready | — |
+| DMX-FLEET-P1-006-exa-retire-cleanup | DMX-FLEET-P1 | RETIRE | Ready | — |
+| DMX-FLEET-P1-007-token-truncation-utility-spec | DMX-FLEET-P1 | SPEC | Ready | — |
+| DMX-FLEET-P2-001-event-source-wiring | DMX-FLEET-P2 | WIRE | Ready | — |
+| DMX-FLEET-P2-002-heartbeat-ratelimit | DMX-FLEET-P2 | BUILD | Ready | — |
+| DMX-FLEET-P2-003-instance-identity-propagation | DMX-FLEET-P2 | SPEC | Ready | — |
+| DMX-FLEET-P2-004-skill-mirror-receipts | DMX-FLEET-P2 | BUILD | Ready | — |
+| DMX-FLEET-P2-005-dopecontext-indexing-enable | DMX-FLEET-P2 | BUILD | Ready | DMX-FLEET-P2-001-event-source-wiring |
+| DMX-FLEET-P3-001-conport-jsonrpc-parity | DMX-FLEET-P3 | SPEC | Ready | — |
+| DMX-FLEET-P3-002-serena-promotion | DMX-FLEET-P3 | WIRE | Ready | DMX-ADR-002-serena-promotion |
+| DMX-FLEET-P3-003-complexity-unify-spec | DMX-FLEET-P3 | SPEC | Ready | DMX-ADR-004-complexity-scorer |
+| DMX-FLEET-P3-004-qdrant-gc | DMX-FLEET-P3 | DELETE | Ready | — |
+| DMX-FLEET-P3-005-voyage-cost-guard | DMX-FLEET-P3 | WIRE | Ready | — |
+| DMX-FLEET-P3-006-loopback-binds | DMX-FLEET-P3 | BUILD | Ready | — |
+| DMX-FLEET-P4-001-facade-g1-contract-test | DMX-FLEET-P4 | WIRE | Ready | — |
+| DMX-FLEET-P4-002-dopecontext-bridge-spec | DMX-FLEET-P4 | SPEC | Ready | — |
+| DMX-FLEET-P4-003-lane-engine-wire | DMX-FLEET-P4 | WIRE | Ready | DMX-ADR-003-lane-engine-dispatch |
+| DMX-FLEET-P4-004-inventory-freshness-gate | DMX-FLEET-P4 | WIRE | Ready | DMX-FLEET-P4-001-facade-g1-contract-test |
+| DMX-FLEET-P4-005-facade-catalog-register | DMX-FLEET-P4 | WIRE | Ready | DMX-FLEET-P1-001-unified-catalog-spec |
+| DMX-FLEET-P5-001-e2e-acceptance | DMX-FLEET-P5 | SPEC | Ready | DMX-FLEET-P1-003-mcp-ensure-command, DMX-FLEET-P2-005-dopecontext-indexing-enable |
+| DMX-FLEET-P5-002-docs-reconciliation | DMX-FLEET-P5 | WIRE | Ready | — |
+| DMX-FLEET-P5-003-proof-discipline | DMX-FLEET-P5 | BUILD | Ready | — |
+| DMX-ADHD-WIRE-001-predictive-risk-hook | DMX-ADHD-WIRE | WIRE | Ready | — |
+| DMX-ADHD-WIRE-002-context-preservation-display | DMX-ADHD-WIRE | WIRE | Ready | — |
+| DMX-ADHD-WIRE-003-overwhelm-snapshot | DMX-ADHD-WIRE | WIRE | Ready | — |
+| DMX-ADHD-WIRE-004-relationship-vocab-widening | DMX-ADHD-WIRE | WIRE | Ready | DMX-FLEET-P3-001-conport-jsonrpc-parity |
+| DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec | DMX-ADHD-WIRE | SPEC | Ready | DMX-FLEET-P3-002-serena-promotion |
+| DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec | DMX-ADHD-WIRE | SPEC | Ready | DMX-FLEET-P3-002-serena-promotion, DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec |
+| DMX-ADR-001-semantic-memory-home | DMX-ADR | ADR | Ready | — |
+| DMX-ADR-002-serena-promotion | DMX-ADR | ADR | Ready | — |
+| DMX-ADR-003-lane-engine-dispatch | DMX-ADR | ADR | Ready | — |
+| DMX-ADR-004-complexity-scorer | DMX-ADR | ADR | Ready | — |
+| DMX-ADR-005-conport-graph-exposure | DMX-ADR | ADR | Ready | — |

--- a/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-001-predictive-risk-hook.json
+++ b/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-001-predictive-risk-hook.json
@@ -1,0 +1,118 @@
+{
+  "id": "DMX-ADHD-WIRE-001-predictive-risk-hook",
+  "project": "dopemux-mvp",
+  "target": "Wire the built-but-dormant predictive_risk_assessment.py into the task-orchestrator runtime path so its 8 risk categories (including hyperfocus burnout and context-switching) are actually evaluated and surfaced, instead of being imported and never instantiated.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not introduce a second competing complexity or risk scorer; it wires the existing PredictiveRiskAssessmentEngine only.",
+    "This packet must fail closed (log + skip risk assessment, do not crash orchestration) if the risk engine raises on a given task."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adhd-wire",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adhd-wire-001-predictive-risk-hook",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(task-orchestrator): wire dormant predictive risk assessment engine",
+    "allowlist": [
+      "services/task-orchestrator/enhanced_orchestrator.py",
+      "services/task-orchestrator/predictive_risk_assessment.py",
+      "services/task-orchestrator/tests/test_predictive_risk_hook.py",
+      "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-001-predictive-risk-hook.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adhd-wire-001-predictive-risk-hook/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-001-predictive-risk-hook.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-001-predictive-risk-hook.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m py_compile services/task-orchestrator/enhanced_orchestrator.py services/task-orchestrator/predictive_risk_assessment.py",
+      "python -m pytest -q services/task-orchestrator/tests/test_predictive_risk_hook.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(task-orchestrator): wire dormant predictive risk assessment engine",
+    "body": "Instantiates PredictiveRiskAssessmentEngine (services/task-orchestrator/predictive_risk_assessment.py, 527 lines, 8 risk categories incl. hyperfocus burnout) inside enhanced_orchestrator.py, which currently only imports it at line 23 and never calls it. Per claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md section 3a item 1, this is the single highest-ROI wire-existing item in the fleet audit ('~3 lines to hook'). No new risk logic is written; this packet only connects the existing engine to a real call site and surfaces its output on the task record.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean status.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Read predictive_risk_assessment.py in full to confirm PredictiveRiskAssessmentEngine's public entrypoint (e.g. assess_risk / evaluate) and its RiskProfile/RiskLevel return shape. Read enhanced_orchestrator.py's SPECIALIZED_ENGINES_AVAILABLE guard (line ~23) and the task lifecycle methods where a risk check should run (task creation and status-transition paths).",
+      "validation": [
+        "Proof documents the engine's exact call signature and the chosen call site(s) in enhanced_orchestrator.py with line references.",
+        "Proof confirms no existing call to PredictiveRiskAssessmentEngine exists prior to this change (grep evidence)."
+      ],
+      "context_files": [
+        "services/task-orchestrator/predictive_risk_assessment.py",
+        "services/task-orchestrator/enhanced_orchestrator.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Write a failing test in services/task-orchestrator/tests/test_predictive_risk_hook.py asserting that creating/updating an orchestration task with hyperfocus-risk-shaped signals (e.g. long uninterrupted session duration) produces a non-null risk assessment result attached to the task, when SPECIALIZED_ENGINES_AVAILABLE is True.",
+      "validation": [
+        "New test fails against current HEAD (engine not wired) before implementation.",
+        "Test asserts on the RiskProfile/RiskLevel shape returned by the engine, not a placeholder."
+      ],
+      "expected_files": [
+        "services/task-orchestrator/tests/test_predictive_risk_hook.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "In enhanced_orchestrator.py, instantiate PredictiveRiskAssessmentEngine once (module- or orchestrator-instance-level) when SPECIALIZED_ENGINES_AVAILABLE is True, call it at the identified task lifecycle point(s), and attach its RiskProfile output to the OrchestrationTask record. Guard the call with try/except so an engine failure logs and skips assessment rather than raising into the orchestration path (fail-closed, non-fatal).",
+      "validation": [
+        "New test from S3 passes.",
+        "Existing task-orchestrator test suite still passes (no regression).",
+        "When SPECIALIZED_ENGINES_AVAILABLE is False, orchestration proceeds unchanged (no crash, no assessment attempted)."
+      ],
+      "expected_files": [
+        "services/task-orchestrator/enhanced_orchestrator.py"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Run packet validation, PAL analyze/planner/codereview/precommit per the Codex minimum chain, and finalize proof.",
+      "validation": [
+        "TP JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "PAL codereview and precommit outputs are saved to proof, or recorded NOT_RUN with the exact tool error if PAL is unavailable.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-002-context-preservation-display.json
+++ b/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-002-context-preservation-display.json
@@ -1,0 +1,119 @@
+{
+  "id": "DMX-ADHD-WIRE-002-context-preservation-display",
+  "project": "dopemux-mvp",
+  "target": "Surface the live adhd_engine/domains/attention/context_preserver.py output (pre-break mental-model snapshots) on a real PM/operator-facing display surface, so the existing backend capability stops being invisible to the user.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not fabricate a consuming display surface path; it must locate the actual PM/dashboard consumer before wiring, or add a minimal read endpoint if none exists.",
+    "This packet must not change context_preserver.py's snapshot data model; it only adds a consumer/read path."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adhd-wire",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-ADHD-WIRE-001-predictive-risk-hook",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adhd-wire-002-context-preservation-display",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(adhd-engine): surface context preservation snapshots on PM display",
+    "allowlist": [
+      "services/adhd_engine/api/routes.py",
+      "services/adhd_engine/domains/attention/context_preserver.py",
+      "services/adhd_engine/tests/test_context_preserver.py",
+      "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-002-context-preservation-display.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adhd-wire-002-context-preservation-display/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-002-context-preservation-display.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-002-context-preservation-display.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m py_compile services/adhd_engine/api/routes.py services/adhd_engine/domains/attention/context_preserver.py",
+      "python -m pytest -q services/adhd_engine/tests/test_context_preserver.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(adhd-engine): surface context preservation snapshots on PM display",
+    "body": "context_preserver.py (services/adhd_engine/domains/attention/) is LIVE and already consumed internally by services/adhd_engine/engine.py and api/routes.py, but per claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md section 3a item 3, no operator-facing display surface exposes its 'what was I doing?' snapshots. This packet adds or confirms a read endpoint/route that returns the latest PreservedContext for a session, closing the cheap UI/display hookup the addendum flags.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean status.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Read services/adhd_engine/domains/attention/context_preserver.py in full and read services/adhd_engine/api/routes.py to determine whether a route already returns PreservedContext data, and if so whether any PM/operator display (dashboard, CLI, TUI) actually calls it. Do not assume a consumer exists; verify with grep/read.",
+      "validation": [
+        "Proof states, with file:line evidence, whether an operator-facing route/consumer already exists for PreservedContext.",
+        "If a real gap is found, proof names the exact minimal addition (new route, or wiring an existing route into an existing display) rather than inventing a new display surface."
+      ],
+      "context_files": [
+        "services/adhd_engine/domains/attention/context_preserver.py",
+        "services/adhd_engine/api/routes.py",
+        "services/adhd_engine/engine.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Write a failing test in services/adhd_engine/tests/test_context_preserver.py (extend the existing test file) asserting that the identified read endpoint/route returns the most recent PreservedContext snapshot for a given session/workspace.",
+      "validation": [
+        "New or extended test fails against current HEAD before implementation.",
+        "Test asserts on real PreservedContext fields (active_files, mental_model_summary, recent_decisions), not a stub."
+      ],
+      "expected_files": [
+        "services/adhd_engine/tests/test_context_preserver.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Add the minimal route/handler in services/adhd_engine/api/routes.py that exposes the latest PreservedContext snapshot as a read-only JSON response, reusing context_preserver.py's existing retrieval method (no new snapshot logic).",
+      "validation": [
+        "New test from S3 passes.",
+        "Existing adhd_engine test suite still passes (no regression).",
+        "Endpoint is read-only; no new write path is introduced to context_preserver.py."
+      ],
+      "expected_files": [
+        "services/adhd_engine/api/routes.py"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Run packet validation, PAL analyze/planner/codereview/precommit per the Codex minimum chain, and finalize proof.",
+      "validation": [
+        "TP JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "PAL codereview and precommit outputs are saved to proof, or recorded NOT_RUN with the exact tool error if PAL is unavailable.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-003-overwhelm-snapshot.json
+++ b/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-003-overwhelm-snapshot.json
@@ -1,0 +1,118 @@
+{
+  "id": "DMX-ADHD-WIRE-003-overwhelm-snapshot",
+  "project": "dopemux-mvp",
+  "target": "Expose the existing overwhelm-detection telemetry already computed inside event_coordinator.py as a queryable snapshot on a PM/operator-facing surface, matching the same wire-existing shape as the context-preservation display.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not fabricate a consuming display surface path; it must locate the actual PM/dashboard consumer before wiring, or add a minimal read endpoint if none exists.",
+    "This packet must not change event_coordinator.py's telemetry computation; it only adds a read/snapshot path."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adhd-wire",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-ADHD-WIRE-002-context-preservation-display",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adhd-wire-003-overwhelm-snapshot",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(task-orchestrator): expose overwhelm telemetry snapshot",
+    "allowlist": [
+      "services/task-orchestrator/event_coordinator.py",
+      "services/task-orchestrator/tests/test_suppression_telemetry.py",
+      "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-003-overwhelm-snapshot.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adhd-wire-003-overwhelm-snapshot/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-003-overwhelm-snapshot.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-003-overwhelm-snapshot.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m py_compile services/task-orchestrator/event_coordinator.py",
+      "python -m pytest -q services/task-orchestrator/tests/test_suppression_telemetry.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(task-orchestrator): expose overwhelm telemetry snapshot",
+    "body": "event_coordinator.py (services/task-orchestrator/, 764 lines) already computes overwhelm-detection/suppression telemetry (see existing services/task-orchestrator/tests/test_suppression_telemetry.py and examples/telemetry_demo.py) but per claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md section 3a item 4, no PM surface exposes a queryable snapshot of it. This packet adds a minimal read accessor so the existing telemetry can be surfaced, without changing how overwhelm is computed.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean status.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Read event_coordinator.py in full to identify the exact class/method that computes or stores overwhelm-detection/suppression telemetry, and read services/task-orchestrator/examples/telemetry_demo.py and tests/test_suppression_telemetry.py to confirm current consumers. Determine whether any PM-facing surface (dashboard, CLI, API route) already queries this telemetry.",
+      "validation": [
+        "Proof documents, with file:line evidence, the exact telemetry accessor(s) in event_coordinator.py and confirms whether a PM-facing consumer already exists.",
+        "If a real gap is found, proof names the exact minimal addition (a get_overwhelm_snapshot()-style accessor plus its call site) rather than inventing a new display surface."
+      ],
+      "context_files": [
+        "services/task-orchestrator/event_coordinator.py",
+        "services/task-orchestrator/examples/telemetry_demo.py",
+        "services/task-orchestrator/tests/test_suppression_telemetry.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Extend services/task-orchestrator/tests/test_suppression_telemetry.py with a failing test asserting that a snapshot accessor returns the current overwhelm/suppression state (e.g. active suppression flags, recent trigger counts) in a stable, queryable shape.",
+      "validation": [
+        "New test fails against current HEAD before implementation.",
+        "Test asserts on real telemetry fields already computed by event_coordinator.py, not placeholders."
+      ],
+      "expected_files": [
+        "services/task-orchestrator/tests/test_suppression_telemetry.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Add the minimal snapshot accessor to event_coordinator.py (or wire the identified existing accessor to the located PM-facing consumer from S2) so overwhelm telemetry is queryable without changing its computation logic.",
+      "validation": [
+        "New test from S3 passes.",
+        "Existing task-orchestrator test suite still passes (no regression).",
+        "No change to overwhelm-detection thresholds or suppression logic itself."
+      ],
+      "expected_files": [
+        "services/task-orchestrator/event_coordinator.py"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Run packet validation, PAL analyze/planner/codereview/precommit per the Codex minimum chain, and finalize proof.",
+      "validation": [
+        "TP JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "PAL codereview and precommit outputs are saved to proof, or recorded NOT_RUN with the exact tool error if PAL is unavailable.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-004-relationship-vocab-widening.json
+++ b/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-004-relationship-vocab-widening.json
@@ -1,0 +1,139 @@
+{
+  "id": "DMX-ADHD-WIRE-004-relationship-vocab-widening",
+  "project": "dopemux-mvp",
+  "target": "Widen the active ConPort MCP server's exposed relationship vocabulary beyond the current link_conport_items generic edge, so callers can express modeled-but-unexposed relationship types (affects, depends_on, implements, discussed_in, produced_by, belongs_to_thread) without a client-side workaround.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must preserve docker/mcp-servers-source/conport/enhanced_server.py as the canonical writer for ConPort relationships and add a contract test.",
+    "This packet must not introduce a second relationship-write path outside the canonical ConPort MCP server (e.g. must not resurrect the quarantined services/conport_kg write path).",
+    "This packet must remain backward compatible: existing link_conport_items calls without an explicit relationship type must continue to work unchanged.",
+    "This packet must fail closed on an unrecognized relationship type (explicit validation error, not silent acceptance)."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P3-001-conport-jsonrpc-parity"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adhd-wire",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-ADHD-WIRE-003-overwhelm-snapshot",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adhd-wire-004-relationship-vocab-widening",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(conport): widen relationship vocabulary beyond generic link",
+    "allowlist": [
+      "docker/mcp-servers-source/conport/enhanced_server.py",
+      "docker/mcp-servers-source/conport/schema.sql",
+      "docker/mcp-servers-source/conport/tests/test_relationship_vocabulary.py",
+      "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-004-relationship-vocab-widening.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adhd-wire-004-relationship-vocab-widening/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-004-relationship-vocab-widening.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-004-relationship-vocab-widening.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m py_compile docker/mcp-servers-source/conport/enhanced_server.py",
+      "python -m pytest -q docker/mcp-servers-source/conport/tests/test_relationship_vocabulary.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(conport): widen relationship vocabulary beyond generic link",
+    "body": "Today only link_conport_items is exposed on the canonical ConPort MCP server (docker/mcp-servers-source/conport/enhanced_server.py), while a richer relationship vocabulary (BUILDS_UPON, VALIDATES, affects, depends_on, implements, discussed_in, produced_by, belongs_to_thread) is already modeled in the quarantined services/conport_kg/queries/models.py Relationship/DecisionChainNode dataclasses and never surfaced on the live server. Per claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md section 3a item 7 and the parent fleet audit's Phase 3 packets 106/107/201/202 (relationship-write-API scope), this packet adds an explicit relationship_type parameter to the canonical writer with validation, depending on DMX-FLEET-P3-001's JSON-RPC parity work landing first. This is an MCP tool-surface/contract change and runs the architecture-risky PAL chain accordingly.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, clean status, and confirm DMX-FLEET-P3-001's JSON-RPC parity work is present on the base branch (this packet's dependency).",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Proof confirms the DMX-FLEET-P3-001 dependency is satisfied on the base branch, or records NOT_RUN/BLOCKED with the exact gap if it is not."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Run PAL analyze, thinkdeep, and a first challenge pass before touching the MCP contract surface. Read enhanced_server.py's link_conport_items implementation and schema.sql's relationship table, and read services/conport_kg/queries/models.py's Relationship/DecisionChainNode dataclasses to enumerate the exact modeled-but-unexposed relationship types.",
+      "validation": [
+        "PAL analyze/thinkdeep/challenge outputs are saved to proof, or recorded NOT_RUN with the exact tool error if PAL is unavailable.",
+        "Proof lists the exact relationship type strings to expose and confirms services/conport_kg is cited as reference only, not as a write path to reuse."
+      ],
+      "context_files": [
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docker/mcp-servers-source/conport/schema.sql",
+        "services/conport_kg/queries/models.py"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Run PAL planner to scope the minimal schema/API change, then a second challenge pass to attack the plan's assumptions (backward compatibility, validation of unrecognized types, migration safety).",
+      "validation": [
+        "PAL planner and challenge outputs are saved to proof, or recorded NOT_RUN with the exact tool error.",
+        "Plan explicitly preserves existing link_conport_items callers with no relationship_type argument."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Write a failing contract test in docker/mcp-servers-source/conport/tests/test_relationship_vocabulary.py asserting that link_conport_items accepts an explicit relationship_type from the widened vocabulary, persists it correctly, and rejects an unrecognized type with a clear error.",
+      "validation": [
+        "New test fails against current HEAD before implementation.",
+        "Test covers at least one new relationship type plus the unrecognized-type rejection case."
+      ],
+      "expected_files": [
+        "docker/mcp-servers-source/conport/tests/test_relationship_vocabulary.py"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Implement the minimal schema and enhanced_server.py changes to accept and validate the widened relationship_type vocabulary on link_conport_items, keeping the canonical writer as the single write path.",
+      "validation": [
+        "New test from S4 passes.",
+        "Existing ConPort MCP server test suite still passes (no regression).",
+        "Unrecognized relationship types fail closed with an explicit validation error."
+      ],
+      "expected_files": [
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docker/mcp-servers-source/conport/schema.sql"
+      ]
+    },
+    {
+      "id": "S6",
+      "task": "Run packet validation, PAL codereview, PAL precommit, and a final PAL challenge per the architecture-risky chain, and finalize proof.",
+      "validation": [
+        "TP JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "PAL codereview, precommit, and final challenge outputs are saved to proof, or recorded NOT_RUN with the exact tool error if PAL is unavailable.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.json
+++ b/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.json
@@ -1,0 +1,103 @@
+{
+  "id": "DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec",
+  "project": "dopemux-mvp",
+  "target": "Produce a spec for resurrecting the dormant Serena Adaptive Learning Engine foundation (per-user attention patterns, cross-session personalization) plus its Personal Learning Profile dependent, gated on the Serena single-surface promotion decision landing first.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not resurrect the module into the local Serena candidate before the Serena promotion ADR/packet has landed; the spec must state this precondition explicitly and mark itself blocked until then."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P3-002-serena-promotion"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adhd-wire",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-ADHD-WIRE-004-relationship-vocab-widening",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adhd-wire-005-adaptive-learning-resurrect-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(specs): adaptive learning engine resurrection spec",
+    "allowlist": [
+      "claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md",
+      "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adhd-wire-005-adaptive-learning-resurrect-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md",
+      "grep -q '## Scope' claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md",
+      "grep -q '## Invariants' claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md",
+      "grep -q '## Interfaces' claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md",
+      "grep -q '## Acceptance' claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md",
+      "grep -q '## Phasing' claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(specs): adaptive learning engine resurrection spec",
+    "body": "Adds a resurrection spec for services/serena/intelligence/adaptive_learning.py and its Personal Learning Profile dependent (services/serena/intelligence/learning_profile_manager.py), currently dormant in the local Serena candidate that the deployed wrapper cannot reach. Per claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md sections 2.5 and 3c, the source estimates a ~6h foundation build that other dormant modules (fatigue detection, context-switch optimizer, untracked work detector) build on, but resurrection is explicitly blocked on the Serena single-surface promotion (DMX-FLEET-P3-002) landing first, to avoid building into a candidate the wrapper cannot reach. This packet is spec-only; no runtime code changes.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read the named source docs and inspect the current runtime paths read-only: the forgotten-features addendum sections 2.5 and 3c, the fleet audit's Serena single-surface promotion decision (parent audit section 7.1), and the dormant adaptive_learning.py plus learning_profile_manager.py implementations in both services/serena/intelligence/ and services/serena/v2/intelligence/.",
+      "validation": [
+        "Proof confirms both copies (services/serena/intelligence and services/serena/v2/intelligence) were read and compared for drift.",
+        "Proof confirms the Serena wrapper's current mcp_server.py path mismatch (cited in the addendum) is independently verified, not merely cited."
+      ],
+      "context_files": [
+        "claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md",
+        "services/serena/intelligence/adaptive_learning.py",
+        "services/serena/v2/intelligence/adaptive_learning.py",
+        "services/serena/intelligence/learning_profile_manager.py",
+        "services/serena/v2/intelligence/learning_profile_manager.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce the spec at claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md covering: Scope (what the Adaptive Learning Engine + Personal Learning Profile do and don't do), Invariants (no build before Serena promotion lands; per-user data stays local; no cross-workspace leakage), Interfaces (how other dormant modules, e.g. fatigue detection and context-switch optimizer, would consume this foundation), Acceptance (concrete, testable criteria for 'foundation resurrected'), and Phasing (foundation first, dependents in DMX-ADHD-WIRE-006 second, explicitly sequenced after DMX-FLEET-P3-002).",
+      "validation": [
+        "Spec file exists at claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md.",
+        "Spec contains all five required sections (Scope, Invariants, Interfaces, Acceptance, Phasing).",
+        "Spec explicitly states the DMX-FLEET-P3-002 precondition and marks this packet's runtime work as blocked until that lands."
+      ],
+      "expected_files": [
+        "claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the addendum source and against the current runtime read in S1, run packet validation, and run the Codex minimum PAL chain (analyze, planner, codereview, precommit) over the spec deliverable.",
+      "validation": [
+        "TP JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "PAL outputs are saved to proof, or recorded NOT_RUN with the exact tool error if PAL is unavailable.",
+        "Only allowlisted files are staged and committed; no runtime code is touched."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.json
+++ b/task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.json
@@ -1,0 +1,108 @@
+{
+  "id": "DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec",
+  "project": "dopemux-mvp",
+  "target": "Produce a spec for resurrecting the dormant Serena Fatigue Detection Engine, Context Switching Optimizer, Untracked Work Detector, and Abandonment Tracker modules, sequenced after the Adaptive Learning Engine foundation and gated on the Serena single-surface promotion decision.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not resurrect these modules into the local Serena candidate before both the Serena promotion (DMX-FLEET-P3-002) and the Adaptive Learning foundation spec (DMX-ADHD-WIRE-005) have landed; the spec must state this precondition explicitly and mark itself blocked until then."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P3-002-serena-promotion",
+    "DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adhd-wire",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adhd-wire-006-fatigue-contextswitch-resurrect-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(specs): fatigue and context-switch modules resurrection spec",
+    "allowlist": [
+      "claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md",
+      "task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adhd-wire-006-fatigue-contextswitch-resurrect-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-ADHD-WIRE/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md",
+      "grep -q '## Scope' claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md",
+      "grep -q '## Invariants' claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md",
+      "grep -q '## Interfaces' claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md",
+      "grep -q '## Acceptance' claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md",
+      "grep -q '## Phasing' claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(specs): fatigue and context-switch modules resurrection spec",
+    "body": "Adds a resurrection spec for the remaining Serena TOP-3/HIGH-priority dormant modules named in claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md sections 2.5 and 3c: the Fatigue Detection Engine (services/serena/intelligence/fatigue_detection_engine.py, 8 indicators + 8 adaptive responses), the Context Switching Optimizer (services/serena/intelligence/context_switching_optimizer.py), the Untracked Work Detector (services/serena/untracked_work_detector.py, 6 sub-detectors), and the Abandonment Tracker (services/serena/abandonment_tracker.py). Source estimates ~8h for fatigue+context-switch and ~4h for untracked+abandonment, all consuming the Adaptive Learning Engine foundation spec'd in DMX-ADHD-WIRE-005. This packet is spec-only, is the final packet in the DMX-ADHD-WIRE series, and makes no runtime code changes.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read the named source docs and inspect the current runtime paths read-only: the forgotten-features addendum sections 2.5 and 3c, the DMX-ADHD-WIRE-005 adaptive-learning spec deliverable (for the foundation interface this packet builds on), and the dormant fatigue_detection_engine.py, context_switching_optimizer.py, untracked_work_detector.py, and abandonment_tracker.py implementations.",
+      "validation": [
+        "Proof confirms all four dormant module files were located and read (both services/serena/intelligence and services/serena/v2/intelligence copies where duplicated).",
+        "Proof confirms the DMX-ADHD-WIRE-005 spec's Interfaces section was read to align this spec's consumption contract with the foundation."
+      ],
+      "context_files": [
+        "claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md",
+        "claudedocs/specs/DMX-ADHD-WIRE-005-adaptive-learning-resurrect-spec.md",
+        "services/serena/intelligence/fatigue_detection_engine.py",
+        "services/serena/v2/intelligence/fatigue_detection_engine.py",
+        "services/serena/intelligence/context_switching_optimizer.py",
+        "services/serena/v2/intelligence/context_switching_optimizer.py",
+        "services/serena/untracked_work_detector.py",
+        "services/serena/abandonment_tracker.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce the spec at claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md covering: Scope (what each of the four modules does and their TOP-3/HIGH source priority per the addendum), Invariants (no build before DMX-FLEET-P3-002 and DMX-ADHD-WIRE-005 land; per-user data stays local; guilt-free framing for abandonment per source), Interfaces (how each module consumes the Adaptive Learning foundation and how Untracked Work Detector's ConPort-mismatch sub-detectors relate to existing ConPort tooling), Acceptance (concrete, testable criteria per module), and Phasing (fatigue+context-switch first per source's TOP-3 estimate, untracked+abandonment second).",
+      "validation": [
+        "Spec file exists at claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md.",
+        "Spec contains all five required sections (Scope, Invariants, Interfaces, Acceptance, Phasing).",
+        "Spec explicitly states both the DMX-FLEET-P3-002 and DMX-ADHD-WIRE-005 preconditions and marks this packet's runtime work as blocked until both land."
+      ],
+      "expected_files": [
+        "claudedocs/specs/DMX-ADHD-WIRE-006-fatigue-contextswitch-resurrect-spec.md"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the addendum source and against the current runtime read in S1, run packet validation, and run the Codex minimum PAL chain (analyze, planner, codereview, precommit) over the spec deliverable. As the final packet in the DMX-ADHD-WIRE series, confirm the full chain (001 through 006) is internally consistent before closing.",
+      "validation": [
+        "TP JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "PAL outputs are saved to proof, or recorded NOT_RUN with the exact tool error if PAL is unavailable.",
+        "Only allowlisted files are staged and committed; no runtime code is touched.",
+        "Proof confirms this packet's series.final_packet=true is consistent with it being the highest-numbered packet in DMX-ADHD-WIRE."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADR/DMX-ADR-001-semantic-memory-home.json
+++ b/task-packets/generated/DMX-ADR/DMX-ADR-001-semantic-memory-home.json
@@ -1,0 +1,81 @@
+{
+  "id": "DMX-ADR-001-semantic-memory-home",
+  "project": "dopemux-mvp",
+  "target": "Author docs/90-adr/adr-224-semantic-memory-home.md recording the accepted decision that semantic memory lives in dope-context (memory_{hash} projection, provisionally Option A, deferred final go/no-go until after DMX-MCF-002..004 land) and that ConPort does not own semantic vector search (mem.* in memory_server.py is closed, not to be built).",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adr",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adr-001-semantic-memory-home",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(adr): ADR-224 semantic memory home (dope-context, deferred)",
+    "allowlist": [
+      "docs/90-adr/adr-224-semantic-memory-home.md",
+      "task-packets/generated/DMX-ADR/DMX-ADR-001-semantic-memory-home.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adr-001-semantic-memory-home/DMX-ADR-001-semantic-memory-home/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-ADR/DMX-ADR-001-semantic-memory-home.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-001-semantic-memory-home.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "grep -q 'status: accepted' docs/90-adr/adr-224-semantic-memory-home.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(adr): ADR-224 semantic memory home (dope-context, deferred)",
+    "body": "Authors ADR-224 recording the backlog decisions-ledger MCF-005 gate: semantic memory home is dope-context's memory_{hash} projection (provisionally Option A, deferred final go/no-go until DMX-MCF-002..004 land with real chronicle data), and closes the ConPort vector-search question (mem.* in memory_server.py is not to be built; dope-context owns semantic per the Memory Trinity). No runtime change.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Author docs/90-adr/adr-224-semantic-memory-home.md with frontmatter matching the repo's accepted-ADR convention (see docs/90-adr/adr-223-retire-exa-mcp-server.md for the exact key set: id, title, type: adr, owner, author, date, last_review, next_review, status: accepted, prelude, graph_metadata). Body must record, copied verbatim from claudedocs/backlog/decisions-ledger.md row 'MCF-005 | Semantic memory home': Decision = 'Defer, provisionally Option A (dope-context memory_{hash} projection); decide after 002-004 with real chronicle data' and Rationale = 'Recall-quality gap only measurable once chronicle has content; Voyage is external -> privacy gate'. Also copy verbatim from the 'FLEET | ConPort vector search (mem.* in memory_server.py)' row: Decision = 'Do not build in ConPort -- dope-context owns semantic (per MCF-005)' and Rationale = 'Trinity law assigns semantic retrieval to dope-context; avoid a second authority'. Author (not copied, since the ledger has no consequences column) a Consequences section describing: dope-context remains provisional/deferred pending real chronicle data from DMX-MCF-002..004; ConPort must not grow a mem.* vector-search surface; this ADR supersedes 'DECISION REQUIRED' language in claudedocs/plans/2026-07-04-memory-context-fabric-build-plan.md for gates 005/006 as it pertains to gate 005 only (006 is ADR-005's scope). Also author an Alternatives Considered section noting Option B/C semantic-memory-home candidates were not selected pending real usage data.",
+      "validation": [
+        "docs/90-adr/adr-224-semantic-memory-home.md exists.",
+        "grep -q 'status: accepted' docs/90-adr/adr-224-semantic-memory-home.md exits 0.",
+        "The Decision section contains the MCF-005 decision string verbatim and the ConPort-vector-search closure string verbatim from decisions-ledger.md.",
+        "The Rationale text for both rows is present verbatim.",
+        "A Consequences section is present and is authored prose, not a ledger copy."
+      ],
+      "context_files": [
+        "claudedocs/backlog/decisions-ledger.md",
+        "claudedocs/backlog/README.md",
+        "docs/90-adr/adr-223-retire-exa-mcp-server.md",
+        "claudedocs/plans/2026-07-04-memory-context-fabric-build-plan.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Validate the packet JSON against the dopeTask canonical schema, add a row for DMX-ADR-001-semantic-memory-home to task-packets/INDEX.md's active packets table (Packet ID, subsystem 'Memory / ADR', title, status 'Ready', related ADR = adr-224-semantic-memory-home), then stage only the allowlisted files and commit.",
+      "validation": [
+        "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-001-semantic-memory-home.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "task-packets/INDEX.md contains a row referencing DMX-ADR-001-semantic-memory-home.",
+        "git diff --check reports no whitespace errors.",
+        "Only allowlisted paths appear in the commit."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADR/DMX-ADR-002-serena-promotion.json
+++ b/task-packets/generated/DMX-ADR/DMX-ADR-002-serena-promotion.json
@@ -1,0 +1,80 @@
+{
+  "id": "DMX-ADR-002-serena-promotion",
+  "project": "dopemux-mvp",
+  "target": "Author docs/90-adr/adr-225-serena-promotion.md recording the accepted decision to promote the local 45-tool Serena surface to canonical, with 6 write tools carved out of the default profile.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adr",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-ADR-001-semantic-memory-home",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adr-002-serena-promotion",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(adr): ADR-225 Serena local surface promotion",
+    "allowlist": [
+      "docs/90-adr/adr-225-serena-promotion.md",
+      "task-packets/generated/DMX-ADR/DMX-ADR-002-serena-promotion.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adr-002-serena-promotion/DMX-ADR-002-serena-promotion/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-ADR/DMX-ADR-002-serena-promotion.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-002-serena-promotion.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "grep -q 'status: accepted' docs/90-adr/adr-225-serena-promotion.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(adr): ADR-225 Serena local surface promotion",
+    "body": "Authors ADR-225 recording the backlog decisions-ledger 'Serena surface' gate: promote the local 45-tool Serena candidate to canonical, carving 6 write tools out of the default profile. Unblocks DMX-FLEET-P3-002 (consolidation) and DMX-ADHD-WIRE-005/006 (dormant ADHD module resurrection). No runtime change.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Author docs/90-adr/adr-225-serena-promotion.md with frontmatter matching the repo's accepted-ADR convention (see docs/90-adr/adr-223-retire-exa-mcp-server.md for the exact key set: id, title, type: adr, owner, author, date, last_review, next_review, status: accepted, prelude, graph_metadata). Body must record, copied verbatim from claudedocs/backlog/decisions-ledger.md row 'FLEET | Serena surface': Decision = 'Promote local 45-tool candidate via ADR (6 write tools out of default profile)' and Rationale = 'Canonicalizes the richer surface; unblocks dormant ADHD-module resurrections'. Author (not copied) a Consequences section describing: the wrapper split (local candidate vs whatever surface is currently canonical) must be archived/retired per DMX-FLEET-P3-002; the 6 write tools carved out of the default profile must be named and profile-gated (do not silently expose write tools by default); DMX-ADHD-WIRE-005 (Adaptive Learning resurrect-spec) and DMX-ADHD-WIRE-006 (Fatigue/Context-Switch/Untracked-Work resurrect-spec) are unblocked by this decision and depend on it. Author an Alternatives Considered section noting: keep the narrower canonical surface and drop the local 45-tool candidate (rejected -- would strand the richer surface and keep ADHD module resurrection blocked).",
+      "validation": [
+        "docs/90-adr/adr-225-serena-promotion.md exists.",
+        "grep -q 'status: accepted' docs/90-adr/adr-225-serena-promotion.md exits 0.",
+        "The Decision and Rationale text for the 'Serena surface' ledger row is present verbatim.",
+        "A Consequences section is present and is authored prose, not a ledger copy, and names the 6-write-tool profile carve-out.",
+        "The ADR text references DMX-FLEET-P3-002 and DMX-ADHD-WIRE-005/006 as downstream-unblocked packets."
+      ],
+      "context_files": [
+        "claudedocs/backlog/decisions-ledger.md",
+        "claudedocs/backlog/README.md",
+        "docs/90-adr/adr-223-retire-exa-mcp-server.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Validate the packet JSON against the dopeTask canonical schema, add a row for DMX-ADR-002-serena-promotion to task-packets/INDEX.md's active packets table (Packet ID, subsystem 'Cognitive Plane / ADR', title, status 'Ready', related ADR = adr-225-serena-promotion), then stage only the allowlisted files and commit.",
+      "validation": [
+        "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-002-serena-promotion.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "task-packets/INDEX.md contains a row referencing DMX-ADR-002-serena-promotion.",
+        "git diff --check reports no whitespace errors.",
+        "Only allowlisted paths appear in the commit."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADR/DMX-ADR-003-lane-engine-dispatch.json
+++ b/task-packets/generated/DMX-ADR/DMX-ADR-003-lane-engine-dispatch.json
@@ -1,0 +1,80 @@
+{
+  "id": "DMX-ADR-003-lane-engine-dispatch",
+  "project": "dopemux-mvp",
+  "target": "Author docs/90-adr/adr-226-lane-engine-dispatch.md recording the accepted decision to wire decide_lane() as the real DCP routing dispatch point (dopemux dcp lane + task-packet intake), replacing latent/unwired routing logic.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adr",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-ADR-002-serena-promotion",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adr-003-lane-engine-dispatch",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(adr): ADR-226 lane engine real dispatch",
+    "allowlist": [
+      "docs/90-adr/adr-226-lane-engine-dispatch.md",
+      "task-packets/generated/DMX-ADR/DMX-ADR-003-lane-engine-dispatch.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adr-003-lane-engine-dispatch/DMX-ADR-003-lane-engine-dispatch/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-ADR/DMX-ADR-003-lane-engine-dispatch.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-003-lane-engine-dispatch.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "grep -q 'status: accepted' docs/90-adr/adr-226-lane-engine-dispatch.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(adr): ADR-226 lane engine real dispatch",
+    "body": "Authors ADR-226 recording the backlog decisions-ledger DCP gate: wire decide_lane() as a real dispatch point via 'dopemux dcp lane' plus task-packet intake, rather than leaving it as latent/unexercised routing logic. Unblocks DMX-FLEET-P4-003 (lane-engine-wire implementation). No runtime change.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Author docs/90-adr/adr-226-lane-engine-dispatch.md with frontmatter matching the repo's accepted-ADR convention (see docs/90-adr/adr-223-retire-exa-mcp-server.md for the exact key set: id, title, type: adr, owner, author, date, last_review, next_review, status: accepted, prelude, graph_metadata). Body must record, copied verbatim from claudedocs/backlog/decisions-ledger.md row 'DCP | Lane engine decide_lane()': Decision = 'Wire as real dispatch (dopemux dcp lane + task-packet intake)' and Rationale = '\"Latent security is not security\"; wiring makes the routing design real'. Author (not copied) a Consequences section describing: decide_lane() must be invoked from an actual CLI entry point (dopemux dcp lane) and from task-packet intake, not merely unit-tested in isolation; the DCP read-only facade's lane-related surface must reflect the wired dispatch; DMX-FLEET-P4-003 (lane-engine-wire) is the implementation packet this ADR unblocks and must cite this ADR. Author an Alternatives Considered section noting: leave decide_lane() as a library function invoked ad hoc by callers (rejected -- perpetuates 'latent security is not security'; no enforceable single dispatch point).",
+      "validation": [
+        "docs/90-adr/adr-226-lane-engine-dispatch.md exists.",
+        "grep -q 'status: accepted' docs/90-adr/adr-226-lane-engine-dispatch.md exits 0.",
+        "The Decision and Rationale text for the 'Lane engine decide_lane()' ledger row is present verbatim.",
+        "A Consequences section is present and is authored prose, not a ledger copy, and names the 'dopemux dcp lane' CLI entry point.",
+        "The ADR text references DMX-FLEET-P4-003 as the downstream-unblocked implementation packet."
+      ],
+      "context_files": [
+        "claudedocs/backlog/decisions-ledger.md",
+        "claudedocs/backlog/README.md",
+        "docs/90-adr/adr-223-retire-exa-mcp-server.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Validate the packet JSON against the dopeTask canonical schema, add a row for DMX-ADR-003-lane-engine-dispatch to task-packets/INDEX.md's active packets table (Packet ID, subsystem 'DCP / ADR', title, status 'Ready', related ADR = adr-226-lane-engine-dispatch), then stage only the allowlisted files and commit.",
+      "validation": [
+        "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-003-lane-engine-dispatch.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "task-packets/INDEX.md contains a row referencing DMX-ADR-003-lane-engine-dispatch.",
+        "git diff --check reports no whitespace errors.",
+        "Only allowlisted paths appear in the commit."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADR/DMX-ADR-004-complexity-scorer.json
+++ b/task-packets/generated/DMX-ADR/DMX-ADR-004-complexity-scorer.json
@@ -1,0 +1,80 @@
+{
+  "id": "DMX-ADR-004-complexity-scorer",
+  "project": "dopemux-mvp",
+  "target": "Author docs/90-adr/adr-227-complexity-scorer.md recording the accepted decision to unify the three unwired complexity-scoring implementations onto one canonical scorer, with the specific scorer choice deferred to DMX-FLEET-P3-003's investigation.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adr",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-ADR-003-lane-engine-dispatch",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adr-004-complexity-scorer",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(adr): ADR-227 unify complexity scorer",
+    "allowlist": [
+      "docs/90-adr/adr-227-complexity-scorer.md",
+      "task-packets/generated/DMX-ADR/DMX-ADR-004-complexity-scorer.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adr-004-complexity-scorer/DMX-ADR-004-complexity-scorer/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-ADR/DMX-ADR-004-complexity-scorer.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-004-complexity-scorer.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "grep -q 'status: accepted' docs/90-adr/adr-227-complexity-scorer.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(adr): ADR-227 unify complexity scorer",
+    "body": "Authors ADR-227 recording the backlog decisions-ledger 'Complexity scoring' gate: unify the three unwired complexity scorers onto one canonical implementation, keeping ADHD complexity-aware UX alive, with the specific scorer choice deferred to DMX-FLEET-P3-003's investigation. No runtime change; no scorer is selected by this ADR.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Author docs/90-adr/adr-227-complexity-scorer.md with frontmatter matching the repo's accepted-ADR convention (see docs/90-adr/adr-223-retire-exa-mcp-server.md for the exact key set: id, title, type: adr, owner, author, date, last_review, next_review, status: accepted, prelude, graph_metadata). Body must record, copied verbatim from claudedocs/backlog/decisions-ledger.md row 'FLEET | Complexity scoring (3 unwired scorers)': Decision = 'Unify onto one canonical scorer' and Rationale = 'Keeps ADHD complexity-aware UX alive; which scorer = the planning packet's investigation'. Author (not copied) a Consequences section describing: this ADR accepts the unification principle but explicitly does NOT select which of the three existing scorer implementations becomes canonical -- that selection is DMX-FLEET-P3-003's investigation and must be recorded there (or in a follow-up ADR amendment) before implementation; all call sites currently using any of the three scorers must eventually converge on the chosen one; the 0.0-1.0 complexity band convention (documented in ~/.claude/MCP_Serena.md and MCP_DopeContext.md) is retained regardless of which implementation wins. Author an Alternatives Considered section noting: keep three parallel scorers (rejected -- drift risk, inconsistent ADHD-band thresholds across surfaces); pick a scorer now without investigation (rejected -- no evidence basis yet, deferred to DMX-FLEET-P3-003 by design).",
+      "validation": [
+        "docs/90-adr/adr-227-complexity-scorer.md exists.",
+        "grep -q 'status: accepted' docs/90-adr/adr-227-complexity-scorer.md exits 0.",
+        "The Decision and Rationale text for the 'Complexity scoring' ledger row is present verbatim.",
+        "A Consequences section is present and is authored prose, not a ledger copy, and explicitly defers the scorer choice to DMX-FLEET-P3-003.",
+        "The ADR does not name a winning scorer implementation."
+      ],
+      "context_files": [
+        "claudedocs/backlog/decisions-ledger.md",
+        "claudedocs/backlog/README.md",
+        "docs/90-adr/adr-223-retire-exa-mcp-server.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Validate the packet JSON against the dopeTask canonical schema, add a row for DMX-ADR-004-complexity-scorer to task-packets/INDEX.md's active packets table (Packet ID, subsystem 'Cognitive Plane / ADR', title, status 'Ready', related ADR = adr-227-complexity-scorer), then stage only the allowlisted files and commit.",
+      "validation": [
+        "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-004-complexity-scorer.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "task-packets/INDEX.md contains a row referencing DMX-ADR-004-complexity-scorer.",
+        "git diff --check reports no whitespace errors.",
+        "Only allowlisted paths appear in the commit."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-ADR/DMX-ADR-005-conport-graph-exposure.json
+++ b/task-packets/generated/DMX-ADR/DMX-ADR-005-conport-graph-exposure.json
@@ -1,0 +1,80 @@
+{
+  "id": "DMX-ADR-005-conport-graph-exposure",
+  "project": "dopemux-mvp",
+  "target": "Author docs/90-adr/adr-228-conport-graph-exposure.md recording the accepted decision to expose graph.neighbors plus decision genealogy on the active Docker ConPort instance, gated on a mandatory AGE data-layer spike.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-adr",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-ADR-004-complexity-scorer",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-adr-005-conport-graph-exposure",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(adr): ADR-228 ConPort graph exposure (spike-gated)",
+    "allowlist": [
+      "docs/90-adr/adr-228-conport-graph-exposure.md",
+      "task-packets/generated/DMX-ADR/DMX-ADR-005-conport-graph-exposure.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-adr-005-conport-graph-exposure/DMX-ADR-005-conport-graph-exposure/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-ADR/DMX-ADR-005-conport-graph-exposure.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-005-conport-graph-exposure.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "grep -q 'status: accepted' docs/90-adr/adr-228-conport-graph-exposure.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(adr): ADR-228 ConPort graph exposure (spike-gated)",
+    "body": "Authors ADR-228 recording the backlog decisions-ledger MCF-006 gate: expose graph.neighbors plus decision genealogy on the active Docker ConPort instance (Option A), gated on a mandatory AGE data-layer spike as Task 1 of DMX-MCF-006 since the AGE writer path is unproven. Falls back to relationship-query if the spike fails. No runtime change.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Author docs/90-adr/adr-228-conport-graph-exposure.md with frontmatter matching the repo's accepted-ADR convention (see docs/90-adr/adr-223-retire-exa-mcp-server.md for the exact key set: id, title, type: adr, owner, author, date, last_review, next_review, status: accepted, prelude, graph_metadata). Body must record, copied verbatim from claudedocs/backlog/decisions-ledger.md row 'MCF-006 | ConPort graph exposure': Decision = 'Option A -- graph.neighbors + genealogy on active Docker ConPort, spike-gated (AGE data-layer spike is mandatory Task 1)' and Rationale = 'Decision-genealogy provenance is worth it; AGE writer path unproven -> de-risk first'. Author (not copied) a Consequences section describing: DMX-MCF-006 must run the AGE data-layer spike as its first task before any graph.neighbors or genealogy tool is implemented; if the spike fails, the fallback is a relationship-query-based approach (not full graph traversal) per the ledger; this ADR does not itself authorize implementation -- DMX-MCF-006 remains a spec/spike packet gated on this decision; DMX-ADHD-WIRE-004 (relationship vocabulary widening) is a related but separately-scoped packet building on ConPort's existing link_conport_items surface, not on this graph exposure. Author an Alternatives Considered section noting: build a new bespoke graph store outside ConPort's Postgres+AGE (rejected -- second authority, violates Memory Trinity boundaries); skip the spike and implement directly (rejected -- AGE writer path unproven, ledger explicitly requires de-risking first).",
+      "validation": [
+        "docs/90-adr/adr-228-conport-graph-exposure.md exists.",
+        "grep -q 'status: accepted' docs/90-adr/adr-228-conport-graph-exposure.md exits 0.",
+        "The Decision and Rationale text for the 'ConPort graph exposure' ledger row is present verbatim.",
+        "A Consequences section is present and is authored prose, not a ledger copy, and states the AGE spike is a mandatory precondition.",
+        "The ADR text references DMX-MCF-006 as the gated spike/spec packet."
+      ],
+      "context_files": [
+        "claudedocs/backlog/decisions-ledger.md",
+        "claudedocs/backlog/README.md",
+        "docs/90-adr/adr-223-retire-exa-mcp-server.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Validate the packet JSON against the dopeTask canonical schema, add a row for DMX-ADR-005-conport-graph-exposure to task-packets/INDEX.md's active packets table (Packet ID, subsystem 'Memory / ADR', title, status 'Ready', related ADR = adr-228-conport-graph-exposure), then stage only the allowlisted files and commit.",
+      "validation": [
+        "python3 -m jsonschema -i task-packets/generated/DMX-ADR/DMX-ADR-005-conport-graph-exposure.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "task-packets/INDEX.md contains a row referencing DMX-ADR-005-conport-graph-exposure.",
+        "git diff --check reports no whitespace errors.",
+        "Only allowlisted paths appear in the commit."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-001-real-healthchecks.json
+++ b/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-001-real-healthchecks.json
@@ -1,0 +1,111 @@
+{
+  "id": "DMX-FLEET-P0-001-real-healthchecks",
+  "project": "dopemux-mvp",
+  "target": "Prove that every MCP server healthcheck in the fleet is a real capability probe (non-2xx/unreachable = unhealthy) and add a regression test that fails closed if a fake exit-0-style healthcheck is reintroduced for pal or dope-context.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not weaken any existing healthcheck to pass trivially (no reintroducing `|| exit 0` or bare `exit 0`).",
+    "This packet must fail closed: the regression test must fail if any compose service or MCP-server Dockerfile healthcheck can report healthy without a real reachability/response check."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p0",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p0-001-real-healthchecks",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "test(mcp): add regression gate against fake exit-0 healthchecks",
+    "allowlist": [
+      "docker/mcp-servers-source/pal/Dockerfile",
+      "services/dope-context/Dockerfile",
+      "compose.yml",
+      "tests/mcp/test_no_fake_healthchecks.py",
+      "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-001-real-healthchecks.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P0-001-real-healthchecks/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-001-real-healthchecks.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-001-real-healthchecks.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "pytest -q tests/mcp/test_no_fake_healthchecks.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "test(mcp): lock in real healthchecks for pal and dope-context",
+    "body": "Fleet audit (claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md §8 Phase 0.1) flagged fake `exit 0` / `|| exit 0` healthchecks for pal and dope-context. Direct inspection at authoring time shows both Dockerfiles already carry a real `curl -f ... || exit 1` HEALTHCHECK (docker/mcp-servers-source/pal/Dockerfile:28-29, services/dope-context/Dockerfile:39-40, fixed by prior commits 4974015c3/b63b4b4a7 area). This packet adds a permanent regression test asserting no fake healthcheck pattern exists for any MCP server Dockerfile or compose healthcheck block, so the bug the audit found cannot silently return.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: create a fresh dedicated worktree based on origin/main, verify the .dopetaskroot repo marker, origin identity, and a clean baseline status. Record the baseline HEAD SHA in proof.",
+      "validation": [
+        "Worktree path, branch, origin remote, repo marker, and base HEAD SHA are recorded in proof/DMX-FLEET-P0-001-real-healthchecks/preflight.md.",
+        "git status --porcelain is empty before any edit."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test at tests/mcp/test_no_fake_healthchecks.py that scans docker/mcp-servers-source/**/Dockerfile, docker/mcp-servers/**/Dockerfile, services/*/Dockerfile, and compose.yml for HEALTHCHECK/healthcheck blocks and asserts none of them use a fake pattern (bare `exit 0` as the sole check, or `|| exit 0` suffix masking curl failure). Confirm the test currently passes against the pal and dope-context Dockerfiles (already fixed) but would fail if either regressed; add one deliberately-broken fixture case inline in the test (a string literal, not a file) to prove the detector actually triggers on the fake pattern before asserting the real files are clean.",
+      "commands": [
+        "grep -rn 'HEALTHCHECK' docker/mcp-servers-source/pal/Dockerfile services/dope-context/Dockerfile",
+        "grep -rn 'exit 0' docker/mcp-servers-source/*/Dockerfile services/*/Dockerfile compose.yml || true"
+      ],
+      "expected_files": [
+        "tests/mcp/test_no_fake_healthchecks.py"
+      ],
+      "validation": [
+        "The self-test fixture case inside test_no_fake_healthchecks.py demonstrably fails the fake-pattern check (proves the detector is not a no-op).",
+        "Running pytest against the real repo files (pal, dope-context Dockerfiles, compose.yml) passes because no fake pattern is present."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "If any Dockerfile or compose healthcheck for pal or dope-context still contains a fake exit-0 pattern (re-verify at implementation time; do not assume the S1 finding is unchanged), replace it with a real capability probe following the pattern already used in services/dope-context/Dockerfile:39-40 (curl -f <health_url> || exit 1). If both are already fixed, this step is a no-op and proof must state so explicitly with file:line citations.",
+      "validation": [
+        "Every pal and dope-context healthcheck (Dockerfile HEALTHCHECK and any compose.yml healthcheck: block) performs a real request and treats non-2xx/unreachable as failure.",
+        "Proof states PASS/NO-OP per file with exact file:line evidence; no claim is made without a citation."
+      ],
+      "context_files": [
+        "docker/mcp-servers-source/pal/Dockerfile",
+        "services/dope-context/Dockerfile",
+        "compose.yml"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet: finalize this TP JSON, add it to task-packets/INDEX.md, run schema validation, write the proof bundle (preflight, test output, file:line evidence, PAL step outputs), commit only allowlisted files, open the PR, and move the corresponding task-orchestrator item to review.",
+      "validation": [
+        "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-001-real-healthchecks.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "pytest -q tests/mcp/test_no_fake_healthchecks.py exits 0.",
+        "Only files in commit.allowlist are staged.",
+        "Proof bundle exists under proof/DMX-FLEET-P0-001-real-healthchecks/ with PASS/FAIL/NOT_RUN per validation item."
+      ],
+      "context_files": [
+        "task-packets/generated/DMX-CONPORT-OPTIMAL/_AUTHORING_KIT.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-002-ensure-pal-managed.json
+++ b/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-002-ensure-pal-managed.json
@@ -1,0 +1,108 @@
+{
+  "id": "DMX-FLEET-P0-002-ensure-pal-managed",
+  "project": "dopemux-mvp",
+  "target": "Bring the load-bearing off-compose pal-mcp-server container fully under managed startup: add a real MCP capability healthcheck (initialize + tools/list, not just `docker ps` running-state) to scripts/mcp-wrappers/ensure-pal.sh, and wire it into the H3 SessionStart remediation pointer so Codex's required=true PAL dependency is verified, not just started.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change the container name, image tag, or entrypoint contract that scripts/mcp-wrappers/ensure-pal.sh and ~/.codex/config.toml already depend on.",
+    "This packet must fail closed: ensure-pal.sh must exit non-zero if the container is running but does not respond to a real MCP tools/list call.",
+    "This packet must not silently swallow a PAL capability-check failure as success."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p0",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P0-001-real-healthchecks",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p0-002-ensure-pal-managed",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(mcp): add real capability healthcheck to ensure-pal.sh",
+    "allowlist": [
+      "scripts/mcp-wrappers/ensure-pal.sh",
+      "tests/mcp_wrappers/test_ensure_pal.sh",
+      "tests/mcp_wrappers/test_ensure_pal_healthcheck.py",
+      "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-002-ensure-pal-managed.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P0-002-ensure-pal-managed/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-002-ensure-pal-managed.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-002-ensure-pal-managed.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "bash -n scripts/mcp-wrappers/ensure-pal.sh",
+      "pytest -q tests/mcp_wrappers/test_ensure_pal_healthcheck.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(mcp): add real PAL capability healthcheck to ensure-pal.sh",
+    "body": "Decisions ledger (claudedocs/backlog/decisions-ledger.md, row 'FLEET / Canonical PAL management') resolves PAL management as: manage via ensure-pal.sh + real capability healthcheck + compose integration, because PAL is required=true for Codex and must not stay unmanaged. scripts/mcp-wrappers/ensure-pal.sh already exists and correctly creates/recreates the off-compose pal-mcp-server container, but only checks `docker ps` running-state (line 66-70, 82-85) -- a container can be 'running' while its stdio MCP process is wedged. This packet adds a real MCP initialize+tools/list probe as the definition of healthy, exercised via `docker exec` against the running container, and wires the check into ensure-pal.sh's exit status so a wedged container is treated as a failure, not a success.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: fresh dedicated worktree from origin/main, verify repo marker/origin/clean baseline, and re-read scripts/mcp-wrappers/ensure-pal.sh end to end to confirm current behavior (creates/recreates pal-mcp-server container, checks docker ps running-state only, no MCP-level probe).",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Proof states, with file:line citation, that ensure-pal.sh currently has no MCP-level capability check (only docker ps)."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "scripts/mcp-wrappers/ensure-pal.sh",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test at tests/mcp_wrappers/test_ensure_pal_healthcheck.py that stubs/mocks `docker exec pal-mcp-server ...` to simulate (a) a container that responds to an MCP initialize+tools/list call, and (b) a wedged container that is running but does not respond or returns an error. Assert the new healthcheck function distinguishes these two cases (must fail on (b)). Run it now to confirm it fails because the check does not yet exist.",
+      "expected_files": [
+        "tests/mcp_wrappers/test_ensure_pal_healthcheck.py"
+      ],
+      "validation": [
+        "pytest -q tests/mcp_wrappers/test_ensure_pal_healthcheck.py fails before implementation with a clear assertion (no such check / import error), proving the test targets real missing behavior."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement a real capability healthcheck in scripts/mcp-wrappers/ensure-pal.sh: after confirming the container is running (existing docker ps checks at lines 66-70 and 82-85), issue a minimal MCP JSON-RPC `initialize` followed by `tools/list` via `docker exec -i pal-mcp-server ...` (matching the existing stdio invocation contract documented in the script's header comment), with a bounded timeout. Treat a non-responding, malformed, or error response as unhealthy and exit non-zero with a clear diagnostic message (matching the script's existing `die`/printf error style). Preserve all existing idempotent create/recreate/--recreate behavior unchanged.",
+      "validation": [
+        "ensure-pal.sh still exits 0 (no-op) when the container is already up and responds to tools/list.",
+        "ensure-pal.sh exits non-zero with a clear diagnostic when the container is running but not responding to MCP calls (wedged case).",
+        "bash -n scripts/mcp-wrappers/ensure-pal.sh passes (no syntax errors).",
+        "No change to the container name, image tag, entrypoint, or --recreate contract."
+      ],
+      "context_files": [
+        "scripts/mcp-wrappers/ensure-pal.sh"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet: finalize this TP JSON, add it to task-packets/INDEX.md, run schema validation, write the proof bundle (preflight, before/after test evidence, PAL step outputs), commit only allowlisted files, open the PR, and move the corresponding task-orchestrator item to review. Note in proof that H3 SessionStart hook wiring to call this healthcheck via `ensure --fast` is tracked separately in DMX-FLEET-P1-003 (mcp ensure command) and is out of scope here.",
+      "validation": [
+        "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-002-ensure-pal-managed.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "pytest -q tests/mcp_wrappers/test_ensure_pal_healthcheck.py exits 0.",
+        "Only files in commit.allowlist are staged.",
+        "Proof bundle exists under proof/DMX-FLEET-P0-002-ensure-pal-managed/ with PASS/FAIL/NOT_RUN per validation item."
+      ],
+      "context_files": [
+        "task-packets/generated/DMX-CONPORT-OPTIMAL/_AUTHORING_KIT.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-003-conport-schema-verify-failclosed.json
+++ b/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-003-conport-schema-verify-failclosed.json
@@ -1,0 +1,113 @@
+{
+  "id": "DMX-FLEET-P0-003-conport-schema-verify-failclosed",
+  "project": "dopemux-mvp",
+  "target": "Verify that ConPort's _ensure_schema post-apply verification is fail-closed (raises, does not silently proceed, on an unverifiable schema), and wire its existing regression test suite into the repo's default pytest discovery path so a future regression is caught by ordinary `pytest -q` / CI runs instead of only by a test file nobody collects.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must preserve the canonical writer and add a contract test.",
+    "This packet must not reintroduce a warn-and-proceed path in _ensure_schema's post-apply verification.",
+    "This packet must not change idempotent 'already exists' apply behavior."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p0",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P0-002-ensure-pal-managed",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p0-003-conport-schema-verify-failclosed",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "test(conport): wire schema fail-closed regression into default pytest path",
+    "allowlist": [
+      "docker/mcp-servers-source/conport/enhanced_server.py",
+      "docker/mcp-servers-source/conport/tests/test_ensure_schema.py",
+      "tests/mcp/test_conport_schema_verify_failclosed.py",
+      "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-003-conport-schema-verify-failclosed.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P0-003-conport-schema-verify-failclosed/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-003-conport-schema-verify-failclosed.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-003-conport-schema-verify-failclosed.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m py_compile docker/mcp-servers-source/conport/enhanced_server.py",
+      "pytest -q tests/mcp/test_conport_schema_verify_failclosed.py docker/mcp-servers-source/conport/tests/test_ensure_schema.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "test(conport): lock in fail-closed schema verify + wire into default pytest path",
+    "body": "Fleet audit (claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md, section 4 ConPort verdict and section 8 Phase 0.3) flagged `_ensure_schema` post-apply verification as fail-open. Direct inspection at authoring time shows this was already fixed in commit 4974015c3 ('fix(conport): fail closed on unverifiable schema post-apply check'), which raises RuntimeError on verification failure and ships docker/mcp-servers-source/conport/tests/test_ensure_schema.py. However, the repo's testpaths (pyproject.toml:303, pytest.ini:8) point only at `tests/`, so this regression suite is never collected by a default `pytest -q` or CI run. This packet re-verifies the fail-closed behavior with a fresh assertion at tests/mcp/test_conport_schema_verify_failclosed.py (imports/exercises the same _ensure_schema code path) so the fix is protected inside the discoverable test path going forward.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: fresh dedicated worktree from origin/main, verify repo marker/origin/clean baseline. Re-read docker/mcp-servers-source/conport/enhanced_server.py:408-489 (_ensure_schema) and docker/mcp-servers-source/conport/tests/test_ensure_schema.py to confirm the fail-closed fix from commit 4974015c3 is present and unmodified, and confirm testpaths in pyproject.toml/pytest.ini do not include docker/mcp-servers-source/conport/tests.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Proof cites enhanced_server.py:473-482 showing RuntimeError is raised when the post-apply table check fails, with commit 4974015c3 referenced as the source of the fix.",
+        "Proof confirms, by grepping pyproject.toml and pytest.ini, that docker/mcp-servers-source/conport/tests/ is outside default testpaths."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docker/mcp-servers-source/conport/tests/test_ensure_schema.py",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a new failing/no-op-proving test at tests/mcp/test_conport_schema_verify_failclosed.py that imports the ConPort server module (via sys.path manipulation to docker/mcp-servers-source/conport/) and exercises _ensure_schema with a fake db pool + fake subprocess where the post-apply verification query returns no row, asserting RuntimeError is raised (not swallowed). Run it before any implementation change to confirm it currently fails only because the test file/module wiring does not exist yet, not because the underlying fix is missing.",
+      "commands": [
+        "pytest -q docker/mcp-servers-source/conport/tests/test_ensure_schema.py -k fail_closed || true"
+      ],
+      "expected_files": [
+        "tests/mcp/test_conport_schema_verify_failclosed.py"
+      ],
+      "validation": [
+        "The new test file exists and, once import wiring is correct, exercises the real _ensure_schema function (not a reimplementation).",
+        "Proof states explicitly whether the underlying fail-closed behavior was already correct (expected: yes, per commit 4974015c3) versus newly implemented in this packet."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "If the fail-closed behavior in _ensure_schema is confirmed intact (expected outcome), make no functional change to enhanced_server.py. If re-verification instead reveals a regression (the RuntimeError path was reverted or weakened since the audit), restore the fail-closed raise exactly as implemented in commit 4974015c3 and document the discrepancy in proof. Either way, ensure tests/mcp/test_conport_schema_verify_failclosed.py and docker/mcp-servers-source/conport/tests/test_ensure_schema.py both pass.",
+      "validation": [
+        "pytest -q tests/mcp/test_conport_schema_verify_failclosed.py docker/mcp-servers-source/conport/tests/test_ensure_schema.py passes with exit 0.",
+        "Proof states PASS (no regression found) or FAIL-THEN-FIXED (regression found and restored) with file:line evidence for whichever occurred.",
+        "No change to idempotent 'already exists' apply handling (enhanced_server.py:456-459)."
+      ],
+      "context_files": [
+        "docker/mcp-servers-source/conport/enhanced_server.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet: finalize this TP JSON, add it to task-packets/INDEX.md, run schema validation, write the proof bundle (preflight, test evidence, PAL step outputs), commit only allowlisted files, open the PR, and move the corresponding task-orchestrator item to review.",
+      "validation": [
+        "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-003-conport-schema-verify-failclosed.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "pytest -q tests/mcp/test_conport_schema_verify_failclosed.py docker/mcp-servers-source/conport/tests/test_ensure_schema.py exits 0.",
+        "Only files in commit.allowlist are staged.",
+        "Proof bundle exists under proof/DMX-FLEET-P0-003-conport-schema-verify-failclosed/ with PASS/FAIL/NOT_RUN per validation item."
+      ],
+      "context_files": [
+        "task-packets/generated/DMX-CONPORT-OPTIMAL/_AUTHORING_KIT.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-004-registry-dedup.json
+++ b/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-004-registry-dedup.json
@@ -1,0 +1,108 @@
+{
+  "id": "DMX-FLEET-P0-004-registry-dedup",
+  "project": "dopemux-mvp",
+  "target": "Remove the competing PAL registry entries in src/dopemux/mcp/registry.yaml (dopemux-pal via uvx pal-mcp-server vs dopemux-zen via npx zen-mcp -- two definitions for one logical server) and add a CI-enforced uniqueness gate so no future duplicate/competing server key can silently disable or shadow another.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must preserve the canonical writer and add a contract test.",
+    "This packet must not remove a registry entry that has a live, distinct, currently-consumed transport (verify consumers before deleting)."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p0",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P0-003-conport-schema-verify-failclosed",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p0-004-registry-dedup",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "fix(mcp): dedupe competing PAL registry entries in registry.yaml",
+    "allowlist": [
+      "src/dopemux/mcp/registry.yaml",
+      "tests/unit/mcp/test_registry_no_duplicate_servers.py",
+      "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-004-registry-dedup.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P0-004-registry-dedup/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-004-registry-dedup.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-004-registry-dedup.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -c \"import yaml; yaml.safe_load(open('src/dopemux/mcp/registry.yaml'))\"",
+      "pytest -q tests/unit/mcp/test_registry_no_duplicate_servers.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(mcp): dedupe competing PAL entries in registry.yaml",
+    "body": "Fleet audit (claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md section 1 finding 1 'shadow-twin syndrome' and section 8 Phase 0.4) flagged src/dopemux/mcp/registry.yaml as having duplicate YAML keys that silently disable servers via last-wins. Direct inspection at authoring time finds no literal duplicate top-level key, but two distinct keys (dopemux-pal: uvx pal-mcp-server, line 90-98; dopemux-zen: npx zen-mcp, line 99-107) both claim to be the local/stdio launcher for the same logical PAL server -- the same shadow-twin pattern the audit describes, expressed as two keys instead of one repeated key. This packet keeps exactly one PAL registry entry (dopemux-pal, matching the actually-consumed pal-mcp-server per decisions-ledger.md's 'Canonical PAL management' row and ensure-pal.sh), removes dopemux-zen, and adds a CI test asserting no two server entries in the registry share the same docker.service/port or local.command target.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: fresh dedicated worktree from origin/main, verify repo marker/origin/clean baseline. Re-read src/dopemux/mcp/registry.yaml in full and grep the codebase for any consumer referencing the 'dopemux-zen' registry key by name before deciding to remove it.",
+      "commands": [
+        "grep -rn 'dopemux-zen' --include='*.py' --include='*.sh' --include='*.yaml' --include='*.yml' --include='*.json' . 2>/dev/null | grep -v node_modules | grep -v '\\.git/'"
+      ],
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Proof lists every consumer (if any) of the 'dopemux-zen' key found by the grep, with file:line citations, before deletion is attempted."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "src/dopemux/mcp/registry.yaml",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test at tests/unit/mcp/test_registry_no_duplicate_servers.py that loads src/dopemux/mcp/registry.yaml and asserts (a) no two top-level server keys are byte-identical (guards against literal YAML duplicate-key silent overwrite), and (b) no two server entries resolve to the same effective launch target (same docker.service+port pair, or same local.command+args pair). Run it now to confirm it fails on the current file because dopemux-pal and dopemux-zen both target a PAL stdio launcher.",
+      "expected_files": [
+        "tests/unit/mcp/test_registry_no_duplicate_servers.py"
+      ],
+      "validation": [
+        "pytest -q tests/unit/mcp/test_registry_no_duplicate_servers.py fails against the current registry.yaml, citing dopemux-pal/dopemux-zen as the collision."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Remove the dopemux-zen entry from src/dopemux/mcp/registry.yaml (lines 99-107), keeping dopemux-pal as the single canonical PAL registry entry per decisions-ledger.md. If S1's grep found live consumers of dopemux-zen, do not delete; instead rename the entry to remove the collision (e.g. distinguish it as a genuinely separate, currently-consumed transport) and document the deviation in proof with the exact consumer citation.",
+      "validation": [
+        "Exactly one PAL-related server key remains in src/dopemux/mcp/registry.yaml, or a documented deviation explains why two remain.",
+        "python -c \"import yaml; yaml.safe_load(open('src/dopemux/mcp/registry.yaml'))\" parses without error.",
+        "No other server entry (conport, serena, desktop-commander, gpt-researcher, leantime-bridge, claude-context, dope-context) is altered."
+      ],
+      "context_files": [
+        "src/dopemux/mcp/registry.yaml"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet: finalize this TP JSON, add it to task-packets/INDEX.md, run schema validation, write the proof bundle (preflight, consumer grep, before/after test evidence, PAL step outputs), commit only allowlisted files, open the PR, and move the corresponding task-orchestrator item to review.",
+      "validation": [
+        "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-004-registry-dedup.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "pytest -q tests/unit/mcp/test_registry_no_duplicate_servers.py exits 0.",
+        "Only files in commit.allowlist are staged.",
+        "Proof bundle exists under proof/DMX-FLEET-P0-004-registry-dedup/ with PASS/FAIL/NOT_RUN per validation item."
+      ],
+      "context_files": [
+        "task-packets/generated/DMX-CONPORT-OPTIMAL/_AUTHORING_KIT.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-005-wrapper-path-fixes.json
+++ b/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-005-wrapper-path-fixes.json
@@ -1,0 +1,127 @@
+{
+  "id": "DMX-FLEET-P0-005-wrapper-path-fixes",
+  "project": "dopemux-mvp",
+  "target": "Fix the three broken MCP stdio wrapper scripts under scripts/mcp-wrappers/: conport-wrapper.sh and conport-codex-wrapper.sh exec the upstream context-portal-mcp package instead of bridging to the in-repo ConPort SSE server; dope-context-wrapper.sh execs a nonexistent /app/server.py path and exports the wrong workspace env var (DOPEMUX_WORKSPACE_ID instead of WORKSPACE_ID); serena-wrapper.sh points at a nonexistent services/serena/v2/mcp_server.py phantom path instead of the real services/serena/mcp_server.py.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must preserve the canonical writer and add a contract test.",
+    "This packet must fail closed with a clear diagnostic (not a silent wrong-target exec) if the target container/process is unavailable.",
+    "This packet must not change the compose-deployed SSE/HTTP surfaces for conport, dope-context, or serena -- only the stdio wrapper scripts that bridge to them."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p0",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P0-004-registry-dedup",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p0-005-wrapper-path-fixes",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "fix(mcp): repair conport, dope-context, and serena stdio wrappers",
+    "allowlist": [
+      "scripts/mcp-wrappers/conport-wrapper.sh",
+      "scripts/mcp-wrappers/conport-codex-wrapper.sh",
+      "scripts/mcp-wrappers/dope-context-wrapper.sh",
+      "scripts/mcp-wrappers/serena-wrapper.sh",
+      "tests/mcp_wrappers/test_conport_wrapper_targets_inrepo_server.py",
+      "tests/mcp_wrappers/test_dope_context_wrapper_paths.py",
+      "tests/mcp_wrappers/test_serena_wrapper_real_path.py",
+      "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-005-wrapper-path-fixes.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P0-005-wrapper-path-fixes/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-005-wrapper-path-fixes.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-005-wrapper-path-fixes.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "bash -n scripts/mcp-wrappers/conport-wrapper.sh scripts/mcp-wrappers/conport-codex-wrapper.sh scripts/mcp-wrappers/dope-context-wrapper.sh scripts/mcp-wrappers/serena-wrapper.sh",
+      "pytest -q tests/mcp_wrappers/test_conport_wrapper_targets_inrepo_server.py tests/mcp_wrappers/test_dope_context_wrapper_paths.py tests/mcp_wrappers/test_serena_wrapper_real_path.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(mcp): repair broken conport/dope-context/serena stdio wrappers",
+    "body": "Fleet audit (claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md section 1 finding 1 and section 8 Phase 0.6) flagged three broken wrappers. Direct inspection confirms all three: (1) scripts/mcp-wrappers/conport-wrapper.sh:38-42 and conport-codex-wrapper.sh:25-29 both exec `uvx --from context-portal-mcp conport-mcp` -- the upstream shadow-twin -- against the in-repo ConPort container, which actually runs enhanced_server.py (aiohttp/SSE only, no stdio entrypoint), so `.claude/commands/*` referencing the real 17-tool surface get the wrong 6-tool upstream surface instead; (2) scripts/mcp-wrappers/dope-context-wrapper.sh:37-40 execs `/app/server.py`, which does not exist in the built image (the real module lives at /app/src/mcp/server.py per services/dope-context/Dockerfile:9,23), and exports DOPEMUX_WORKSPACE_ID while the server code (services/dope-context/src/mcp/server.py:871,899) reads WORKSPACE_ID; (3) scripts/mcp-wrappers/serena-wrapper.sh:13 points at services/serena/v2/mcp_server.py, which does not exist (services/serena/v2/ has no mcp_server.py; the real 45-tool candidate lives at services/serena/mcp_server.py). This packet repairs all three targets using the mcp-proxy stdio-to-SSE bridge pattern already established for serena's compose deployment (docker/mcp-servers-source/serena/wrapper.py) as the reference shape for the conport fix, corrects the dope-context exec path and env var name, and corrects the serena local-path fallback.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: fresh dedicated worktree from origin/main, verify repo marker/origin/clean baseline. Re-confirm all three wrapper bugs by direct file inspection: conport-wrapper.sh/conport-codex-wrapper.sh exec target, dope-context-wrapper.sh exec path and env var name vs services/dope-context/src/mcp/server.py's actual os.getenv() calls, and serena-wrapper.sh's serena_path variable vs the actual filesystem layout under services/serena/.",
+      "commands": [
+        "grep -n 'conport-mcp' scripts/mcp-wrappers/conport-wrapper.sh scripts/mcp-wrappers/conport-codex-wrapper.sh",
+        "grep -n 'server.py\\|WORKSPACE_ID' scripts/mcp-wrappers/dope-context-wrapper.sh services/dope-context/src/mcp/server.py",
+        "grep -n 'serena_path' scripts/mcp-wrappers/serena-wrapper.sh; find services/serena/v2 -iname 'mcp_server.py'; find services/serena -maxdepth 1 -iname 'mcp_server.py'"
+      ],
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Proof cites exact file:line evidence for all three bugs before any edit is made."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "scripts/mcp-wrappers/conport-wrapper.sh",
+        "scripts/mcp-wrappers/conport-codex-wrapper.sh",
+        "scripts/mcp-wrappers/dope-context-wrapper.sh",
+        "scripts/mcp-wrappers/serena-wrapper.sh",
+        "docker/mcp-servers-source/serena/wrapper.py",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write failing tests before any wrapper edit: tests/mcp_wrappers/test_conport_wrapper_targets_inrepo_server.py asserts the wrapper scripts do not contain 'context-portal-mcp' or 'conport-mcp' (the upstream package invocation) and do reference a stdio bridge to the in-repo server; tests/mcp_wrappers/test_dope_context_wrapper_paths.py asserts dope-context-wrapper.sh execs a path that matches the real Dockerfile-copied location (src/mcp/server.py under /app) and exports WORKSPACE_ID (not only DOPEMUX_WORKSPACE_ID); tests/mcp_wrappers/test_serena_wrapper_real_path.py asserts serena-wrapper.sh's local fallback path exists on disk relative to repo root. Run all three now to confirm they fail against the current (broken) wrapper scripts.",
+      "expected_files": [
+        "tests/mcp_wrappers/test_conport_wrapper_targets_inrepo_server.py",
+        "tests/mcp_wrappers/test_dope_context_wrapper_paths.py",
+        "tests/mcp_wrappers/test_serena_wrapper_real_path.py"
+      ],
+      "validation": [
+        "All three new tests fail against the current wrapper scripts, each with an assertion message naming the specific broken target (upstream package name, wrong exec path, or nonexistent phantom path)."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Fix conport-wrapper.sh and conport-codex-wrapper.sh to bridge stdio to the in-repo ConPort SSE server (container mcp-conport / dopemux-mcp-conport, aiohttp SSE on :3005 per docker/mcp-servers-source/conport/enhanced_server.py) using the same mcp-proxy-based stdio<->SSE bridging pattern already used for serena (docker/mcp-servers-source/serena/wrapper.py), instead of exec'ing the upstream context-portal-mcp package. Fix dope-context-wrapper.sh to exec the real module path (python /app/src/mcp/server.py, matching services/dope-context/Dockerfile's COPY src/ src/ under WORKDIR /app) and export WORKSPACE_ID alongside the existing DOPEMUX_WORKSPACE_ID (keep the latter for any other consumer, add the former because that is what services/dope-context/src/mcp/server.py actually reads). Fix serena-wrapper.sh's serena_path to point at the real services/serena/mcp_server.py (remove the phantom v2/ segment), preserving the existing not-found error-and-exit behavior for genuinely missing files.",
+      "validation": [
+        "None of the four wrapper scripts references 'context-portal-mcp' or upstream 'conport-mcp' as the executed target after the fix.",
+        "dope-context-wrapper.sh execs a path that exists inside the built image per the Dockerfile's COPY instructions, and exports WORKSPACE_ID.",
+        "serena-wrapper.sh's local fallback path resolves to an existing file (services/serena/mcp_server.py) at authoring time.",
+        "bash -n passes on all four edited scripts (no syntax errors)."
+      ],
+      "context_files": [
+        "scripts/mcp-wrappers/conport-wrapper.sh",
+        "scripts/mcp-wrappers/conport-codex-wrapper.sh",
+        "scripts/mcp-wrappers/dope-context-wrapper.sh",
+        "scripts/mcp-wrappers/serena-wrapper.sh",
+        "docker/mcp-servers-source/serena/wrapper.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet: finalize this TP JSON, add it to task-packets/INDEX.md, run schema validation, write the proof bundle (preflight evidence, before/after test results, PAL step outputs), commit only allowlisted files, open the PR, and move the corresponding task-orchestrator item to review. Note in proof that live end-to-end stdio session verification against a running Docker stack is NOT_RUN if the daemon is unavailable in this execution context, and that this is a known residual risk consistent with the source audit's own NOT_RUN labeling for live-runtime claims.",
+      "validation": [
+        "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-005-wrapper-path-fixes.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "pytest -q tests/mcp_wrappers/test_conport_wrapper_targets_inrepo_server.py tests/mcp_wrappers/test_dope_context_wrapper_paths.py tests/mcp_wrappers/test_serena_wrapper_real_path.py exits 0.",
+        "Only files in commit.allowlist are staged.",
+        "Proof bundle exists under proof/DMX-FLEET-P0-005-wrapper-path-fixes/ with PASS/FAIL/NOT_RUN per validation item."
+      ],
+      "context_files": [
+        "task-packets/generated/DMX-CONPORT-OPTIMAL/_AUTHORING_KIT.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-006-quarantine-killlist.json
+++ b/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-006-quarantine-killlist.json
@@ -1,0 +1,121 @@
+{
+  "id": "DMX-FLEET-P0-006-quarantine-killlist",
+  "project": "dopemux-mvp",
+  "target": "Quarantine the remaining startable kill-list dead code (services/mcp-integration-bridge, services/router, services/mcp-client, services/dope-context/src/mcp/simple_server.py) by removing their Dockerfiles and adding DEPRECATED headers, and rename the compose Python task-orchestrator service's container_name away from the shared 'task-orchestrator' name so it no longer collides with the real Kotlin-jar MCP task-orchestrator that /dx:* commands and the singleton launcher consume.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not delete source code outright where an existing test or doc still asserts on its content; add DEPRECATED markers and remove build entrypoints (Dockerfile) instead of deleting the directory, unless the source doc's kill-list explicitly says delete.",
+    "This packet must not change the real Kotlin-jar MCP task-orchestrator (external image ghcr.io/jpicklyk, HTTP singleton 127.0.0.1:7890) in any way.",
+    "This packet must not break any existing consumer of the in-repo Python task-orchestrator FastAPI service (services/task-orchestrator/) other than its container name/label."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p0",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P0-005-wrapper-path-fixes",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p0-006-quarantine-killlist",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "chore(mcp): quarantine dead kill-list code and rename workflow-api service",
+    "allowlist": [
+      "services/mcp-integration-bridge/Dockerfile",
+      "services/router/Dockerfile",
+      "services/mcp-client/Dockerfile",
+      "services/dope-context/src/mcp/simple_server.py",
+      "compose.yml",
+      "services/task-orchestrator/README.md",
+      "tests/arch/test_mcp_fleet_catalog_contract.py",
+      "tests/arch/test_workflow_api_service_naming.py",
+      "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-006-quarantine-killlist.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P0-006-quarantine-killlist/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-006-quarantine-killlist.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-006-quarantine-killlist.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "pytest -q tests/arch/test_mcp_fleet_catalog_contract.py tests/arch/test_workflow_api_service_naming.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "chore(mcp): quarantine kill-list dead code, rename workflow-api",
+    "body": "Fleet audit (claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md section 7.1 kill list and section 8 Phase 0.5) names services/mcp-integration-bridge, services/router, services/mcp-client, services/dope-context/src/mcp/simple_server.py, and the task-orchestrator Python/Kotlin name collision as dead-but-startable code. Direct inspection at authoring time finds tests/arch/test_mcp_fleet_catalog_contract.py already asserts generated fleet outputs never reference these paths and that services/mcp-integration-bridge/Dockerfile is absent -- both pass today -- but services/router/Dockerfile and services/mcp-client/Dockerfile still exist (buildable), and no DEPRECATED marker exists on any of the four dead modules. Separately, compose.yml:424 sets container_name: task-orchestrator for the in-repo Python FastAPI service (services/task-orchestrator/, REST :8000), which shares its name with the real Kotlin-jar MCP task-orchestrator (external image ghcr.io/jpicklyk, HTTP singleton 127.0.0.1:7890) consumed by 18 /dx:* commands -- exactly the audit's 'name collision' finding. This packet removes the two remaining live Dockerfiles, adds DEPRECATED headers to all four dead modules, and renames the compose service's container_name to workflow-api (matching the audit's target-state recommendation in section 7.1) without touching the real MCP task-orchestrator.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: fresh dedicated worktree from origin/main, verify repo marker/origin/clean baseline. Re-confirm the kill-list state: which of services/mcp-integration-bridge, services/router, services/mcp-client still have a Dockerfile; whether services/dope-context/src/mcp/simple_server.py is referenced by any live import; and confirm compose.yml's task-orchestrator service container_name collides in name (not in port/transport) with the real MCP task-orchestrator per the fleet inventory table.",
+      "commands": [
+        "find services/mcp-integration-bridge services/router services/mcp-client -iname 'Dockerfile*'",
+        "grep -rln 'simple_server' --include='*.py' services/dope-context/ | grep -v __pycache__",
+        "grep -n 'container_name: task-orchestrator' compose.yml",
+        "pytest -q tests/arch/test_mcp_fleet_catalog_contract.py"
+      ],
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Proof records exact file:line evidence for each kill-list item's current state (Dockerfile present/absent, DEPRECATED marker present/absent, import references) before any edit."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "tests/arch/test_mcp_fleet_catalog_contract.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test at tests/arch/test_workflow_api_service_naming.py asserting compose.yml's task-orchestrator service block does not use container_name 'task-orchestrator' (must be distinct from the real MCP task-orchestrator name, e.g. 'workflow-api'), and extend tests/arch/test_mcp_fleet_catalog_contract.py (or add adjacent assertions) to require services/router/Dockerfile and services/mcp-client/Dockerfile do not exist. Run now to confirm both fail against the current repo state.",
+      "expected_files": [
+        "tests/arch/test_workflow_api_service_naming.py"
+      ],
+      "validation": [
+        "The new naming test fails against current compose.yml (container_name is still 'task-orchestrator').",
+        "The extended Dockerfile-absence assertions fail against the current repo state for services/router and services/mcp-client."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Remove services/router/Dockerfile and services/mcp-client/Dockerfile so neither is startable via docker build. Add a DEPRECATED header comment (matching an existing DEPRECATED convention in the repo if one exists, else a plain top-of-file docstring/comment) to services/mcp-integration-bridge/main.py, services/router/*.py entrypoint(s), services/mcp-client/main.py, and services/dope-context/src/mcp/simple_server.py, each naming the kill-list source (this audit finding) and the canonical replacement (capture_client.py for mcp-integration-bridge per decisions-ledger.md; the real dope-context server.py for simple_server.py). In compose.yml, rename the task-orchestrator service's container_name from 'task-orchestrator' to 'workflow-api' (service key and healthcheck/ports/env stay as-is; only the container_name value and any same-file cross-references to it change). Update services/task-orchestrator/README.md if it documents the old container name.",
+      "validation": [
+        "services/router/Dockerfile and services/mcp-client/Dockerfile no longer exist.",
+        "All four dead modules carry a DEPRECATED marker citing this packet and the kill-list source.",
+        "compose.yml's task-orchestrator service block has container_name: workflow-api (or equivalent non-colliding name) and no other field in that block changed.",
+        "The real MCP task-orchestrator (not present in compose.yml -- it is the external ghcr.io/jpicklyk singleton) is untouched."
+      ],
+      "context_files": [
+        "services/mcp-integration-bridge/main.py",
+        "compose.yml",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet: finalize this TP JSON, add it to task-packets/INDEX.md, run schema validation, write the proof bundle (preflight, before/after test evidence, PAL step outputs), commit only allowlisted files, open the PR, and move the corresponding task-orchestrator item to review.",
+      "validation": [
+        "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-006-quarantine-killlist.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "pytest -q tests/arch/test_mcp_fleet_catalog_contract.py tests/arch/test_workflow_api_service_naming.py exits 0.",
+        "Only files in commit.allowlist are staged.",
+        "Proof bundle exists under proof/DMX-FLEET-P0-006-quarantine-killlist/ with PASS/FAIL/NOT_RUN per validation item."
+      ],
+      "context_files": [
+        "task-packets/generated/DMX-CONPORT-OPTIMAL/_AUTHORING_KIT.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-007-desktop-commander-upstream.json
+++ b/task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-007-desktop-commander-upstream.json
@@ -1,0 +1,118 @@
+{
+  "id": "DMX-FLEET-P0-007-desktop-commander-upstream",
+  "project": "dopemux-mvp",
+  "target": "Replace the broken desktop-commander container facade (docker/mcp-servers-source/desktop-commander/server.py, which calls macOS osascript from inside a Linux container so every tool call fails while its healthcheck reports healthy) with the real upstream DesktopCommanderMCP run directly on the host, and repoint every registry/catalog/global-config reference away from the SSE container facade to the host stdio process.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not leave a healthcheck that reports healthy while every underlying tool call fails.",
+    "This packet must remove the container facade's build/compose entrypoints so nothing dead is startable, per the kill-list decommissioning protocol used across this series.",
+    "This packet must not claim host-level desktop automation was exercised in this execution context if the host is not macOS or the upstream binary is unavailable -- mark that verification NOT_RUN with the exact reason."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p0",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P0-006-quarantine-killlist",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p0-007-desktop-commander-upstream",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "fix(mcp): replace desktop-commander container facade with host upstream",
+    "allowlist": [
+      "compose.yml",
+      "docker/mcp-servers/desktop-commander/Dockerfile",
+      "docker/mcp-servers-source/desktop-commander/**",
+      "src/dopemux/mcp/registry.yaml",
+      "docs/03-reference/mcp/desktop-commander.md",
+      "tests/arch/test_mcp_fleet_catalog_contract.py",
+      "tests/unit/mcp/test_desktop_commander_not_containerized.py",
+      "task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-007-desktop-commander-upstream.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P0-007-desktop-commander-upstream/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-007-desktop-commander-upstream.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-007-desktop-commander-upstream.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "pytest -q tests/unit/mcp/test_desktop_commander_not_containerized.py tests/arch/test_mcp_fleet_catalog_contract.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(mcp): run desktop-commander as real upstream on host, retire facade",
+    "body": "Fleet audit (claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md section 4 'GPT-Researcher / exa / desktop-commander' verdict and section 7.1 target-fleet table) and decisions-ledger.md ('FLEET / desktop-commander' row) both settle this: run real upstream DesktopCommanderMCP on the host, replacing the broken container facade. Direct inspection confirms docker/mcp-servers-source/desktop-commander/server.py:65,89,113 shells out to `osascript`, which does not exist inside the Linux container built by docker/mcp-servers/desktop-commander/Dockerfile, so every tool call (screenshot, window_list, focus_window, type_text) fails at runtime while compose.yml:599-603's healthcheck only curls /health and reports healthy regardless. The operator's Claude global config (~/.claude.json mcpServers.desktop-commander) already points at this broken facade (http://localhost:3012/sse). This packet removes the container facade's build/compose entrypoints, documents the host-run upstream replacement (the same DesktopCommanderMCP package already available as host-side MCP tools in operator sessions), and repoints the registry/catalog/doctrine references so the facade cannot be silently restarted.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": ["analyze", "planner", "codereview", "precommit"]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight: fresh dedicated worktree from origin/main, verify repo marker/origin/clean baseline. Re-confirm the facade is broken by direct inspection: docker/mcp-servers-source/desktop-commander/server.py's osascript calls, compose.yml's health-only healthcheck, the src/dopemux/mcp/registry.yaml dopemux-desktop-commander entry, and any reference to desktop-commander in Claude/Codex global config (read-only inspection of ~/.claude.json and ~/.codex/config.toml; do not edit files outside the repo).",
+      "commands": [
+        "grep -n 'osascript' docker/mcp-servers-source/desktop-commander/server.py",
+        "grep -n -A5 '^  desktop-commander:' compose.yml",
+        "grep -n -A6 'dopemux-desktop-commander' src/dopemux/mcp/registry.yaml"
+      ],
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Proof cites exact file:line evidence that the facade's tool calls depend on osascript inside a container image that has no macOS runtime, and that the healthcheck does not exercise any tool call."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docker/mcp-servers-source/desktop-commander/server.py",
+        "compose.yml",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test at tests/unit/mcp/test_desktop_commander_not_containerized.py asserting: (a) docker/mcp-servers/desktop-commander/Dockerfile no longer exists (the facade is not buildable), and (b) compose.yml contains no 'desktop-commander:' service block. Extend tests/arch/test_mcp_fleet_catalog_contract.py's dead-service-path list to include the desktop-commander container facade path. Run both now to confirm they fail against the current repo state (the facade still exists and builds).",
+      "expected_files": [
+        "tests/unit/mcp/test_desktop_commander_not_containerized.py"
+      ],
+      "validation": [
+        "The new test fails against the current repo because the facade's Dockerfile and compose service still exist."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Remove the desktop-commander service block from compose.yml and remove docker/mcp-servers/desktop-commander/Dockerfile (and, if it is a dead symlink target with no other consumer, docker/mcp-servers-source/desktop-commander/ source files, after confirming via grep that nothing else imports them). Update src/dopemux/mcp/registry.yaml's dopemux-desktop-commander entry to describe a host-run stdio launcher (local.command/args invoking the real upstream DesktopCommanderMCP package) instead of a docker block, keeping default_enabled/required_for_auto as they were (false) unless evidence shows otherwise. Author docs/03-reference/mcp/desktop-commander.md documenting the host-run replacement, the tool surface it exposes, and that it requires running on the operator's actual desktop OS (not inside a Linux container).",
+      "validation": [
+        "compose.yml no longer defines a desktop-commander service.",
+        "docker/mcp-servers/desktop-commander/Dockerfile does not exist.",
+        "src/dopemux/mcp/registry.yaml's desktop-commander entry describes a host/local launcher, not a docker block, and still parses as valid YAML.",
+        "docs/03-reference/mcp/desktop-commander.md exists and documents the host-run replacement and its tool surface."
+      ],
+      "context_files": [
+        "compose.yml",
+        "src/dopemux/mcp/registry.yaml"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet: finalize this TP JSON, add it to task-packets/INDEX.md, run schema validation, write the proof bundle (preflight, before/after test evidence, PAL step outputs), commit only allowlisted files, open the PR, and move the corresponding task-orchestrator item to review. Explicitly mark host-level desktop-automation smoke testing (actually invoking the real upstream DesktopCommanderMCP tool calls) as NOT_RUN if this execution context is not the operator's interactive desktop, with the reason stated, and note that ~/.claude.json / ~/.codex/config.toml are outside this repo and are not modified by this packet -- the operator must repoint their global MCP config to the host launcher documented in docs/03-reference/mcp/desktop-commander.md as a manual follow-up.",
+      "validation": [
+        "python -m jsonschema -i task-packets/generated/DMX-FLEET-P0/DMX-FLEET-P0-007-desktop-commander-upstream.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json exits 0.",
+        "pytest -q tests/unit/mcp/test_desktop_commander_not_containerized.py tests/arch/test_mcp_fleet_catalog_contract.py exits 0.",
+        "Only files in commit.allowlist are staged.",
+        "Proof bundle exists under proof/DMX-FLEET-P0-007-desktop-commander-upstream/ with PASS/FAIL/NOT_RUN per validation item, including an explicit NOT_RUN entry for any host-level desktop automation smoke test that could not run in this execution context."
+      ],
+      "context_files": [
+        "task-packets/generated/DMX-CONPORT-OPTIMAL/_AUTHORING_KIT.md"
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-001-unified-catalog-spec.json
+++ b/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-001-unified-catalog-spec.json
@@ -1,0 +1,106 @@
+{
+  "id": "DMX-FLEET-P1-001-unified-catalog-spec",
+  "project": "dopemux-mvp",
+  "target": "Produce a spec that closes the residual multi-registry drift: current origin/main already has a schema-validated fleet catalog (src/dopemux/mcp/fleet_catalog.py, schemas/mcp/fleet-catalog.schema.json, src/dopemux/mcp/default_catalog.yaml, mcp_catalog.yaml, tests/arch/test_mcp_fleet_catalog_contract.py) but src/dopemux/mcp/registry.yaml and services/registry.yaml still coexist as separate, non-generated sources of server/service truth; the spec must define how the two legacy registries are folded into or superseded by the canonical fleet catalog with dopemux as sole canonical writer.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must treat runtime code (src/dopemux/mcp/fleet_catalog.py, tests/arch/test_mcp_fleet_catalog_contract.py) as higher authority than the 2026-07-03 audit doc where they conflict.",
+    "This packet must not propose deleting src/dopemux/mcp/registry.yaml or services/registry.yaml without first enumerating every current reader of each file.",
+    "This packet must preserve dopemux as the sole canonical writer of generated MCP configuration artifacts."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P0-004-registry-dedup"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p1",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p1-001-unified-catalog-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(mcp-fleet): spec residual unified-catalog consolidation",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P1-001-unified-catalog-spec.md",
+      "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-001-unified-catalog-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p1-001-unified-catalog-spec/DMX-FLEET-P1-001-unified-catalog-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-001-unified-catalog-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-001-unified-catalog-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P1-001-unified-catalog-spec.md",
+      "grep -q 'registry.yaml' claudedocs/specs/DMX-FLEET-P1-001-unified-catalog-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(mcp-fleet): spec residual unified-catalog consolidation",
+    "body": "Authors the residual-closure spec for DMX-FLEET-P1-001. The 2026-07-03 audit (mcp-fleet-canonical-audit-and-target-design-2026-07-03.md \u00a76.1/\u00a78 Phase 1.1) scoped a from-scratch unified catalog merging mcp_catalog.yaml, src/dopemux/mcp/registry.yaml, and services/registry.yaml. Since that audit, origin/main shipped a schema-validated fleet catalog (fleet_catalog.py, fleet-catalog.schema.json, default_catalog.yaml, mcp_catalog.yaml, and a CI drift test), but src/dopemux/mcp/registry.yaml and services/registry.yaml still exist as separate, non-generated registries. This packet specs how to fold or retire the two residual registries without breaking their current readers.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md \u00a76.1 and \u00a78 Phase 1.1, and claudedocs/backlog/README.md's DMX-FLEET-P1 row for this packet. Then inspect current origin/main runtime truth: src/dopemux/mcp/fleet_catalog.py, schemas/mcp/fleet-catalog.schema.json, src/dopemux/mcp/default_catalog.yaml, mcp_catalog.yaml, tests/arch/test_mcp_fleet_catalog_contract.py, src/dopemux/mcp/registry.yaml, and services/registry.yaml. Identify every current reader of src/dopemux/mcp/registry.yaml and services/registry.yaml (grep imports/opens across src/, tests/, scripts/, docker/).",
+      "validation": [
+        "Proof lists the exact commit(s) that introduced fleet_catalog.py/default_catalog.yaml/fleet-catalog.schema.json (git log) and confirms whether they are already on origin/main.",
+        "Proof enumerates every reader of src/dopemux/mcp/registry.yaml and services/registry.yaml with file:line citations.",
+        "Proof states explicitly that the audit doc's Phase 1.1 premise (no unified catalog exists yet) is stale relative to current runtime code, citing the specific commits/files that supersede it."
+      ],
+      "context_files": [
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "claudedocs/backlog/README.md",
+        "claudedocs/backlog/decisions-ledger.md",
+        "src/dopemux/mcp/fleet_catalog.py",
+        "schemas/mcp/fleet-catalog.schema.json",
+        "tests/arch/test_mcp_fleet_catalog_contract.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-FLEET-P1-001-unified-catalog-spec.md covering: (a) current-state summary of what fleet_catalog.py already provides (schema, load/validate, compose-alignment check, codegen render functions) versus what the audit originally asked for; (b) scope of the residual gap \u2014 folding src/dopemux/mcp/registry.yaml and services/registry.yaml's still-needed fields (if any) into the canonical schema, or documenting why each remaining reader should migrate to the canonical catalog instead; (c) explicit interfaces: the canonical catalog's schema shape, the migration path for each identified reader, and the retirement plan (or justified keep-list) for the two legacy registry files; (d) invariants (dopemux as sole canonical writer; no silent drift; CI gate stays green throughout migration); (e) acceptance criteria (every legacy-registry reader migrated or the file is proven dead and removable; test_mcp_fleet_catalog_contract.py extended to cover any newly-folded fields); (f) phasing (safe order of migration per reader, coordinated with DMX-FLEET-P1-002 codegen and DMX-FLEET-P1-004 CI gates).",
+      "validation": [
+        "Spec file exists at claudedocs/specs/DMX-FLEET-P1-001-unified-catalog-spec.md.",
+        "Spec explicitly names src/dopemux/mcp/registry.yaml and services/registry.yaml and states their disposition (migrate fields / retire file / keep with justification) rather than assuming a greenfield build.",
+        "Spec covers scope, invariants, interfaces, acceptance criteria, and phasing as distinct sections.",
+        "Spec does not propose runtime code changes; it is planning-only."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the source audit doc and against the runtime evidence gathered in S1. Validate the packet JSON, update task-packets/INDEX.md, assemble the proof bundle, and commit only allowlisted files.",
+      "validation": [
+        "Spec is internally consistent with S1's evidence (no claim in the spec contradicts a cited file:line).",
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-002-codegen-pipeline-spec.json
+++ b/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-002-codegen-pipeline-spec.json
@@ -1,0 +1,104 @@
+{
+  "id": "DMX-FLEET-P1-002-codegen-pipeline-spec",
+  "project": "dopemux-mvp",
+  "target": "Produce a spec that closes the residual codegen gap: src/dopemux/mcp/fleet_catalog.py already renders .mcp.json, a Codex config.toml fragment, health-probe lists, and a doctrine doc from the canonical catalog, but the Codex renderer is explicitly dry-run/advisory only ('review before copying into .codex/config.toml') and there is no single command that writes all generated artifacts (.mcp.json, ~/.claude.json, ~/.codex/config.toml, compose port/env blocks, doctrine docs) through one codegen entrypoint with drift detection.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must treat src/dopemux/mcp/fleet_catalog.py as the existing canonical renderer and specify extension, not a parallel rewrite.",
+    "This packet must not propose writing directly to a user's live ~/.claude.json or ~/.codex/config.toml without an explicit backup/dry-run/confirm step.",
+    "This packet must preserve dopemux as the sole canonical writer of generated MCP configuration artifacts."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P1-001-unified-catalog-spec"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p1",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P1-001-unified-catalog-spec",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p1-002-codegen-pipeline-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(mcp-fleet): spec residual codegen write-through pipeline",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P1-002-codegen-pipeline-spec.md",
+      "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-002-codegen-pipeline-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p1-002-codegen-pipeline-spec/DMX-FLEET-P1-002-codegen-pipeline-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-002-codegen-pipeline-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-002-codegen-pipeline-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P1-002-codegen-pipeline-spec.md",
+      "grep -q 'fleet_catalog' claudedocs/specs/DMX-FLEET-P1-002-codegen-pipeline-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(mcp-fleet): spec residual codegen write-through pipeline",
+    "body": "Authors the residual-closure spec for DMX-FLEET-P1-002. The 2026-07-03 audit (mcp-fleet-canonical-audit-and-target-design-2026-07-03.md §6.1/§8 Phase 1.2) scoped codegen for .mcp.json, ~/.claude.json project entries, ~/.codex/config.toml, compose env blocks, health-probe lists, and doctrine docs from a unified catalog. src/dopemux/mcp/fleet_catalog.py already implements render functions for most of these, but the Codex fragment is dry-run only and there is no single write-through command with drift detection across all targets. This packet specs closing that gap.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md §6.1 and §8 Phase 1.2. Read the output of DMX-FLEET-P1-001-unified-catalog-spec if already authored. Inspect src/dopemux/mcp/fleet_catalog.py's render_per_worktree_mcp_json, render_singleton_mcp_servers, render_codex_config_fragment, render_health_probe_list, render_mcp_doctrine_doc, and generate_fleet_output_files. Inspect src/dopemux/commands/mcp_commands.py's mcp_init_cmd and the ~/.claude.json write path (_atomic_write_json, _claude_global_path, _backup_path). Determine exactly which of the six target artifacts (.mcp.json, ~/.claude.json, ~/.codex/config.toml, compose env blocks, health-probe lists, doctrine docs) are currently write-through versus dry-run/render-only.",
+      "validation": [
+        "Proof lists each of the six codegen targets with its current status (write-through / dry-run-only / not implemented) and file:line citation.",
+        "Proof states explicitly which parts of the audit's Phase 1.2 scope are already shipped, citing fleet_catalog.py and mcp_commands.py.",
+        "Proof identifies the exact dry-run boundary in render_codex_config_fragment and why it exists (no clobbering an operator's live Codex config without review)."
+      ],
+      "context_files": [
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "claudedocs/specs/DMX-FLEET-P1-001-unified-catalog-spec.md",
+        "src/dopemux/mcp/fleet_catalog.py",
+        "src/dopemux/commands/mcp_commands.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-FLEET-P1-002-codegen-pipeline-spec.md covering: (a) current-state summary of fleet_catalog.py's render/generate surface; (b) scope of the residual gap — a single `dopemux mcp codegen` (or extension of `mcp init`/`mcp ensure`) entrypoint that write-throughs every target with an explicit --dry-run default and --apply/--force to write, backing up any file it overwrites; (c) drift-detection design: how codegen output is compared against catalog state to detect and report drift (reusing test_mcp_fleet_catalog_contract.py's alignment-check pattern as the CI-side complement); (d) interfaces (CLI command signature, exit codes, output format); (e) invariants (never silently overwrite live ~/.claude.json or ~/.codex/config.toml, always backup before write, catalog remains sole source of truth); (f) acceptance criteria; (g) phasing relative to DMX-FLEET-P1-001 (registry consolidation) and DMX-FLEET-P1-004 (CI drift gates).",
+      "validation": [
+        "Spec file exists at claudedocs/specs/DMX-FLEET-P1-002-codegen-pipeline-spec.md.",
+        "Spec names fleet_catalog.py's existing render functions and states which remain reusable versus which need a write-through wrapper.",
+        "Spec covers scope, invariants, interfaces, acceptance criteria, and phasing as distinct sections.",
+        "Spec does not propose runtime code changes; it is planning-only."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the source audit doc and the runtime evidence gathered in S1. Validate the packet JSON, update task-packets/INDEX.md, assemble the proof bundle, and commit only allowlisted files.",
+      "validation": [
+        "Spec is internally consistent with S1's evidence.",
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-003-mcp-ensure-command.json
+++ b/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-003-mcp-ensure-command.json
@@ -1,0 +1,100 @@
+{
+  "id": "DMX-FLEET-P1-003-mcp-ensure-command",
+  "project": "dopemux-mvp",
+  "target": "Produce a spec that closes the residual gap in `dopemux mcp ensure`: the command already exists on origin/main (src/dopemux/commands/mcp_commands.py, mcp_ensure_cmd) with --fast (static prerequisite checks) and --full (compose up + ensure-pal.sh + task-orchestrator-http-singleton.sh + real MCP tools/list probes) modes, but the H3 SessionStart hook (.claude/hooks/mcp_health_probe.py) only prints remediation advice strings and never invokes `mcp ensure --fast` itself, so the audit's described end-to-end 'H3 calls ensure --fast instead of advising' behavior is not wired.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must treat src/dopemux/commands/mcp_commands.py's existing mcp_ensure_cmd as the canonical implementation and specify wiring/extension, not a parallel command.",
+    "This packet must preserve H3's fail-open behavior (advisory, non-blocking) if `mcp ensure --fast` is unavailable or errors.",
+    "This packet must not propose auto-remediating (--full behavior) from a SessionStart hook without explicit operator opt-in, given --full performs compose mutations."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P1-001-unified-catalog-spec",
+    "DMX-FLEET-P0-002-ensure-pal-managed"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p1",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P1-002-codegen-pipeline-spec",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p1-003-mcp-ensure-command",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(mcp-fleet): spec H3-to-mcp-ensure wiring",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P1-003-mcp-ensure-command.md",
+      "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-003-mcp-ensure-command.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p1-003-mcp-ensure-command/DMX-FLEET-P1-003-mcp-ensure-command/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-003-mcp-ensure-command.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-003-mcp-ensure-command.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P1-003-mcp-ensure-command.md",
+      "grep -q 'mcp_health_probe' claudedocs/specs/DMX-FLEET-P1-003-mcp-ensure-command.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(mcp-fleet): spec H3-to-mcp-ensure wiring",
+    "body": "Authors the residual-closure spec for DMX-FLEET-P1-003. The 2026-07-03 audit (mcp-fleet-canonical-audit-and-target-design-2026-07-03.md §6.1/§8 Phase 1.3) asked for an idempotent `dopemux mcp ensure` (+ --fast) with H3 calling it instead of advising. `mcp ensure --fast/--full` already ships on origin/main with the full daemon-check to compose-up to pal-recreate to orchestrator-singleton to capability-verify chain, but .claude/hooks/mcp_health_probe.py (H3) still only emits advisory remediation strings. This packet specs wiring H3 to actually invoke `mcp ensure --fast` and surface its structured result, fail-open.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md §6.1 and §8 Phase 1.3. Inspect src/dopemux/commands/mcp_commands.py's mcp_ensure_cmd, _ensure_fast_context, _ensure_fast_problems, _catalog_compose_services, and _run_mcp_tools_list_probes in full. Inspect .claude/hooks/mcp_health_probe.py end to end, including its cooldown cache mechanism, _SERVER_REMEDIATION mapping, and how its output reaches the model (SessionStart hook contract).",
+      "validation": [
+        "Proof confirms mcp_ensure_cmd's --fast and --full behavior with file:line citations, including exact timeout constants (DEFAULT_ENSURE_TIMEOUT_SECONDS, DEFAULT_COMPOSE_WAIT_TIMEOUT_SECONDS, DEFAULT_COMPOSE_UP_TIMEOUT_SECONDS).",
+        "Proof confirms mcp_health_probe.py never shells out to `dopemux mcp ensure` today (advisory-only), with file:line citation.",
+        "Proof measures or reasons about --fast's actual latency against the audit's '<2s cached fast-path' target using the static checks it performs (catalog load, .mcp.json diff, envrc presence, env var presence)."
+      ],
+      "context_files": [
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "src/dopemux/commands/mcp_commands.py",
+        ".claude/hooks/mcp_health_probe.py",
+        ".claude/settings.json"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-FLEET-P1-003-mcp-ensure-command.md covering: (a) current-state summary of mcp_ensure_cmd's shipped --fast/--full behavior; (b) scope of the residual gap — H3 invoking `dopemux mcp ensure --fast` (subprocess or in-process import) at SessionStart and folding its structured problems list into the existing cooldown-cached advisory output, replacing or supplementing the current _SERVER_REMEDIATION guesswork; (c) interfaces: how H3 captures ensure's exit code/output within its existing timeout and cooldown budget, and the max-3-remediation-option ADHD-friendly output contract; (d) invariants (fail-open if `dopemux` CLI is unavailable or times out; never trigger --full's compose mutations from a hook without explicit config opt-in; preserve existing cooldown cache to avoid re-running ensure every prompt); (e) acceptance criteria (H3's advisory output reflects real `mcp ensure --fast` results, not static guesses); (f) phasing relative to DMX-FLEET-P0-002 (PAL managed startup) which this depends on for a stable --full remediation path.",
+      "validation": [
+        "Spec file exists at claudedocs/specs/DMX-FLEET-P1-003-mcp-ensure-command.md.",
+        "Spec explicitly states mcp_ensure_cmd already exists and scopes only the H3 wiring gap, not a new ensure command.",
+        "Spec covers scope, invariants, interfaces, acceptance criteria, and phasing as distinct sections.",
+        "Spec does not propose runtime code changes; it is planning-only."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the source audit doc and the runtime evidence gathered in S1. Validate the packet JSON, update task-packets/INDEX.md, assemble the proof bundle, and commit only allowlisted files.",
+      "validation": [
+        "Spec is internally consistent with S1's evidence.",
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-004-ci-drift-gates.json
+++ b/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-004-ci-drift-gates.json
@@ -1,0 +1,110 @@
+{
+  "id": "DMX-FLEET-P1-004-ci-drift-gates",
+  "project": "dopemux-mvp",
+  "target": "Close the residual CI-drift-gate gap: tests/arch/test_mcp_fleet_catalog_contract.py already gates catalog-schema conformance, catalog-to-compose port alignment, personality-contract drift, dead-surface absence, and command-to-tool-surface drift for the canonical fleet catalog, but tests/arch/test_registry_compose_alignment.py independently gates services/registry.yaml against compose.yml using separate parsing logic with no shared assertions against the canonical catalog, so a drift between the legacy registry and the canonical catalog would not be caught by either suite; add a contract test asserting the two stay consistent (or, if DMX-FLEET-P1-001 retires the legacy registry first, delete the now-redundant suite).",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not weaken or delete tests/arch/test_mcp_fleet_catalog_contract.py's existing assertions.",
+    "This packet must not remove tests/arch/test_registry_compose_alignment.py unless DMX-FLEET-P1-001's registry-consolidation spec has been implemented and services/registry.yaml has no remaining readers; if that precondition is unmet, this packet must add a cross-consistency gate instead of deleting anything.",
+    "This packet must preserve the canonical writer (dopemux fleet_catalog.py) and treat services/registry.yaml as legacy/derived where both exist.",
+    "This packet must fail closed (CI red) on any newly-detected drift rather than warning only."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P1-002-codegen-pipeline-spec"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p1",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P1-003-mcp-ensure-command",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p1-004-ci-drift-gates",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "test(mcp-fleet): gate catalog-vs-legacy-registry consistency",
+    "allowlist": [
+      "tests/arch/test_mcp_fleet_catalog_contract.py",
+      "tests/arch/test_registry_compose_alignment.py",
+      "src/dopemux/mcp/fleet_catalog.py",
+      "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-004-ci-drift-gates.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p1-004-ci-drift-gates/DMX-FLEET-P1-004-ci-drift-gates/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-004-ci-drift-gates.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-004-ci-drift-gates.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py tests/arch/test_registry_compose_alignment.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "test(mcp-fleet): gate catalog-vs-legacy-registry consistency",
+    "body": "Closes the residual CI-drift-gate gap for DMX-FLEET-P1-004. The 2026-07-03 audit (mcp-fleet-canonical-audit-and-target-design-2026-07-03.md §6.1/§8 Phase 1.4) asked for catalog-to-generated-config and command-to-tool-surface drift gates; tests/arch/test_mcp_fleet_catalog_contract.py already implements both against the canonical fleet catalog. The residual gap is that tests/arch/test_registry_compose_alignment.py independently checks the legacy services/registry.yaml against compose.yml with no cross-check against the canonical catalog, so the two sources could silently diverge. This packet adds a contract test (or removes the now-redundant legacy suite if DMX-FLEET-P1-001's consolidation has landed) so drift between the legacy registry and canonical catalog fails CI.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean status. Record whether DMX-FLEET-P1-001's registry-consolidation spec has been implemented yet (check for services/registry.yaml's removal or a migration marker) to decide between the two allowed outcomes in this packet's target.",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "Proof records whether services/registry.yaml still exists and still has readers as of this run, deciding which of the two allowed remediations applies."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "tests/arch/test_mcp_fleet_catalog_contract.py",
+        "tests/arch/test_registry_compose_alignment.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test first: assert every docker_compose_service+port pair present in the legacy services/registry.yaml (if it still exists) also appears in the canonical fleet catalog's servers, and vice versa for any active/operator-managed lifecycle entries, so a future edit to only one file trips CI.",
+      "validation": [
+        "New test fails against current HEAD before implementation (services/registry.yaml and the canonical catalog are not cross-checked today).",
+        "Test failure message names the specific service/port mismatch, not a generic assertion error."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "If services/registry.yaml still exists and has active readers: implement the minimal cross-consistency check (reuse fleet_catalog.py's load_compose/_compose_host_ports helpers rather than duplicating parsing logic) so the new test passes. If services/registry.yaml has no remaining readers per S1: remove tests/arch/test_registry_compose_alignment.py and services/registry.yaml in this same packet only if DMX-FLEET-P1-001's spec explicitly authorizes it; otherwise stop and report the precondition as unmet rather than deleting speculatively.",
+      "validation": [
+        "New cross-consistency test passes.",
+        "Existing tests/arch/test_mcp_fleet_catalog_contract.py assertions still pass unmodified in behavior.",
+        "No file is deleted without an explicit authorizing precondition recorded in proof."
+      ],
+      "expected_files": [
+        "tests/arch/test_mcp_fleet_catalog_contract.py",
+        "src/dopemux/mcp/fleet_catalog.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet, update task-packets/INDEX.md, assemble the proof bundle, run the full arch test suite, validate the packet JSON, and commit only allowlisted files.",
+      "validation": [
+        "python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py tests/arch/test_registry_compose_alignment.py -q exits 0.",
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-005-orchestrator-autostart.json
+++ b/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-005-orchestrator-autostart.json
@@ -1,0 +1,103 @@
+{
+  "id": "DMX-FLEET-P1-005-orchestrator-autostart",
+  "project": "dopemux-mvp",
+  "target": "Spec auto-starting the task-orchestrator singleton at session start and refreshing its repo truth-pack to the deployed version: scripts/mcp-wrappers/task-orchestrator-http-singleton.sh already implements an idempotent singleton launcher (container-name and data-dir matching, per-worktree scoping) but is only invoked manually or as an H3 remediation suggestion string (.claude/hooks/mcp_health_probe.py's _SERVER_REMEDIATION), never auto-run; and no automation refreshes the deployed task-orchestrator's truth-pack when its version changes.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must preserve scripts/mcp-wrappers/task-orchestrator-http-singleton.sh's existing idempotent singleton semantics (container-name + data-dir matching to distinguish legit per-repo singletons from leaks) rather than replacing it.",
+    "This packet must preserve H3's fail-open, non-blocking SessionStart contract if autostart fails or times out.",
+    "This packet must not silently mutate a running task-orchestrator's data or state during a truth-pack refresh; refresh must be read-only against live task data."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p1",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P1-004-ci-drift-gates",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p1-005-orchestrator-autostart",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(orchestrator): spec autostart + truth-pack refresh",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P1-005-orchestrator-autostart.md",
+      "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-005-orchestrator-autostart.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p1-005-orchestrator-autostart/DMX-FLEET-P1-005-orchestrator-autostart/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-005-orchestrator-autostart.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-005-orchestrator-autostart.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P1-005-orchestrator-autostart.md",
+      "grep -q 'task-orchestrator-http-singleton' claudedocs/specs/DMX-FLEET-P1-005-orchestrator-autostart.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(orchestrator): spec autostart + truth-pack refresh",
+    "body": "Authors the spec for DMX-FLEET-P1-005. The 2026-07-03 audit (mcp-fleet-canonical-audit-and-target-design-2026-07-03.md §7.1/§8 Phase 1.5) asks for task-orchestrator auto-start via ensure and truth-pack regen at the deployed version. scripts/mcp-wrappers/task-orchestrator-http-singleton.sh already provides an idempotent singleton launcher, but it is invoked manually or only surfaced as advisory remediation text by the H3 SessionStart hook (.claude/hooks/mcp_health_probe.py) — never auto-run — and no mechanism refreshes the truth-pack when the deployed orchestrator version changes. This packet is genuinely unbuilt (confirmed by inspection, unlike several sibling P1 packets whose foundations already shipped) and specs the autostart + truth-pack-refresh wiring.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md §7.1 (task-orchestrator target-state row) and §8 Phase 1.5. Inspect scripts/mcp-wrappers/task-orchestrator-http-singleton.sh and scripts/mcp-wrappers/task-orchestrator-current-stdio.sh in full (container naming, singleton detection, dry-run mode). Inspect .claude/hooks/mcp_health_probe.py's _SERVER_REMEDIATION and confirm it never shells out. Search for any existing truth-pack regeneration automation (services/repo-truth-extractor/, reports/task-orchestratorrepo-truth-pack) and determine whether it runs on a schedule, on version change, or only manually.",
+      "validation": [
+        "Proof confirms with file:line citations that the singleton launcher exists but is not auto-invoked at SessionStart.",
+        "Proof confirms whether any truth-pack refresh automation exists today and its trigger (manual/scheduled/none), citing services/repo-truth-extractor/ and reports/ paths inspected.",
+        "Proof states the current deployed task-orchestrator version reference point (e.g. v3.8.0 snapshot in scripts/external-references/) so the spec can define what 'refresh to the deployed version' means concretely."
+      ],
+      "context_files": [
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "scripts/mcp-wrappers/task-orchestrator-http-singleton.sh",
+        "scripts/mcp-wrappers/task-orchestrator-current-stdio.sh",
+        ".claude/hooks/mcp_health_probe.py",
+        "scripts/external-references/README.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-FLEET-P1-005-orchestrator-autostart.md covering: (a) current-state summary of the singleton launcher and H3's advisory-only behavior; (b) scope: wiring H3 (or `dopemux mcp ensure --full`, whichever the DMX-FLEET-P1-003 spec designates as the autostart entrypoint) to actually invoke task-orchestrator-http-singleton.sh when the orchestrator is down, respecting the existing leak-vs-singleton distinction; (c) truth-pack refresh design: trigger condition (version mismatch detection against the deployed jar/image), read-only extraction process, and where the refreshed pack is written; (d) interfaces (script invocation contract, exit codes, output surfaced to the operator); (e) invariants (idempotent, fail-open from hooks, no data mutation during refresh, no duplicate containers); (f) acceptance criteria; (g) phasing relative to DMX-FLEET-P1-003's ensure-command wiring (this may fold into that command rather than being a separate autostart path — the spec must state which).",
+      "validation": [
+        "Spec file exists at claudedocs/specs/DMX-FLEET-P1-005-orchestrator-autostart.md.",
+        "Spec explicitly decides whether autostart is a new standalone mechanism or folds into `dopemux mcp ensure --full`'s existing task-orchestrator-http-singleton.sh call, avoiding duplicate remediation paths.",
+        "Spec covers scope, invariants, interfaces, acceptance criteria, and phasing as distinct sections.",
+        "Spec does not propose runtime code changes; it is planning-only."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the source audit doc and the runtime evidence gathered in S1. Validate the packet JSON, update task-packets/INDEX.md, assemble the proof bundle, and commit only allowlisted files.",
+      "validation": [
+        "Spec is internally consistent with S1's evidence.",
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-006-exa-retire-cleanup.json
+++ b/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-006-exa-retire-cleanup.json
@@ -1,0 +1,116 @@
+{
+  "id": "DMX-FLEET-P1-006-exa-retire-cleanup",
+  "project": "dopemux-mvp",
+  "target": "Finish the exa retirement (ADR-223, already merged to origin/main via commit 65313194a and enforced by tests/arch/test_mcp_fleet_catalog_contract.py's dead_service_names/quarantine assertions) by removing the remaining stale exa entries in scripts/mcp/wire_claude_mcp.py, scripts/utilities/fix_mcp_config.py, docker/mcp-servers-source/start-all-mcp-servers.sh, docker/mcp-servers-source/services/mcp-client/main.py, and scripts/ui/tmux_metamcp_controller.py, and confirming doctrine (~/.claude/MCP_Exa.md-equivalent project docs, .claude/modules) documents WebSearch as the fallback rather than exa.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not reintroduce exa as a startable, catalog-registered, or documented-as-live MCP server anywhere in the repo.",
+    "This packet must not delete a file that has live non-exa functionality still in use; remove only the exa-specific entries/lines within otherwise-live files, and only delete a whole file if it is exa-only and already named in tests/arch/test_mcp_fleet_catalog_contract.py's dead-surface list.",
+    "This packet must keep tests/arch/test_mcp_fleet_catalog_contract.py's existing exa-absence assertions green (test_exa_mcp_server_source_does_not_exist and dead_service_names checks) after the change, and may extend them.",
+    "This packet must preserve the canonical writer (dopemux fleet_catalog.py / catalog) as authoritative over any legacy script's server list."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p1",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P1-005-orchestrator-autostart",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p1-006-exa-retire-cleanup",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "chore(mcp): remove residual exa references (ADR-223 cleanup)",
+    "allowlist": [
+      "scripts/mcp/wire_claude_mcp.py",
+      "scripts/utilities/fix_mcp_config.py",
+      "docker/mcp-servers-source/start-all-mcp-servers.sh",
+      "docker/mcp-servers-source/services/mcp-client/main.py",
+      "scripts/ui/tmux_metamcp_controller.py",
+      "tests/arch/test_mcp_fleet_catalog_contract.py",
+      "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-006-exa-retire-cleanup.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p1-006-exa-retire-cleanup/DMX-FLEET-P1-006-exa-retire-cleanup/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-006-exa-retire-cleanup.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-006-exa-retire-cleanup.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q",
+      "! grep -riE '\"exa\"|'\"'\"'exa'\"'\"'' scripts/mcp/wire_claude_mcp.py scripts/utilities/fix_mcp_config.py docker/mcp-servers-source/start-all-mcp-servers.sh docker/mcp-servers-source/services/mcp-client/main.py scripts/ui/tmux_metamcp_controller.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "chore(mcp): remove residual exa references (ADR-223 cleanup)",
+    "body": "Finishes the exa retirement started by ADR-223 (docs/90-adr/adr-223-retire-exa-mcp-server.md, commit 65313194a) which already removed exa from the canonical fleet catalog and added dead-surface CI assertions in tests/arch/test_mcp_fleet_catalog_contract.py. This packet closes the remaining decisions-ledger.md item ('exa: retire, already shipped in #1002') by deleting the stale exa entries still present in scripts/mcp/wire_claude_mcp.py, scripts/utilities/fix_mcp_config.py, docker/mcp-servers-source/start-all-mcp-servers.sh, docker/mcp-servers-source/services/mcp-client/main.py, and scripts/ui/tmux_metamcp_controller.py, none of which are covered by the existing CI dead-surface grep because they are legacy scripts outside the catalog's own generated-output check.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Confirm docs/90-adr/adr-223-retire-exa-mcp-server.md is accepted and commit 65313194a is an ancestor of HEAD. Grep the full repo tree (excluding docs/archive/, proof/, claudedocs/, reports/, and audit_inputs/ which are historical record and out of scope) for remaining live exa references: scripts/mcp/wire_claude_mcp.py, scripts/utilities/fix_mcp_config.py, docker/mcp-servers-source/start-all-mcp-servers.sh, docker/mcp-servers-source/services/mcp-client/main.py, scripts/ui/tmux_metamcp_controller.py.",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "Proof confirms ADR-223 is accepted and cites the commit that landed the catalog-level retirement.",
+        "Proof lists every remaining live exa reference outside docs/archive, proof/, claudedocs/, reports/, audit_inputs/ with file:line citations, distinguishing 'live code path' from 'historical record'."
+      ],
+      "context_files": [
+        "docs/90-adr/adr-223-retire-exa-mcp-server.md",
+        "claudedocs/backlog/decisions-ledger.md",
+        "tests/arch/test_mcp_fleet_catalog_contract.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Extend tests/arch/test_mcp_fleet_catalog_contract.py (or add a focused new test in the same file) asserting none of the five identified legacy scripts contain an 'exa' server/service entry, so this class of drift cannot silently return. Confirm this new assertion fails against current HEAD before cleanup.",
+      "validation": [
+        "New test fails before the cleanup step because at least one of the five files still references exa.",
+        "Test failure message names the specific file and line pattern matched."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Remove the exa-specific entries from each of the five files: delete the 'exa' key/block from wire_claude_mcp.py's server dict, fix_mcp_config.py's Fix-4 block, mcp-client/main.py's configs['exa'] block, and any exa reference in tmux_metamcp_controller.py's role tool-lists; delete the `start_service \"exa\" \"3011\" \"mcp-exa\"` line from start-all-mcp-servers.sh. Do not delete any of the five files themselves unless the file becomes entirely empty of functional content as a result (verify each file's remaining content before considering deletion).",
+      "validation": [
+        "Each of the five files still parses/lints (python -m py_compile for .py files, bash -n for .sh files) after the edit.",
+        "None of the five files reference exa's server name, port 3011, or its API key env var after the edit.",
+        "No non-exa functionality in any of the five files was altered or removed."
+      ],
+      "expected_files": [
+        "scripts/mcp/wire_claude_mcp.py",
+        "scripts/utilities/fix_mcp_config.py",
+        "docker/mcp-servers-source/start-all-mcp-servers.sh",
+        "docker/mcp-servers-source/services/mcp-client/main.py",
+        "scripts/ui/tmux_metamcp_controller.py"
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Run the extended tests/arch/test_mcp_fleet_catalog_contract.py suite, confirm the new assertion now passes, materialize the packet, update task-packets/INDEX.md, assemble the proof bundle, validate the packet JSON, and commit only allowlisted files.",
+      "validation": [
+        "python -m pytest tests/arch/test_mcp_fleet_catalog_contract.py -q exits 0, including the new/extended assertion.",
+        "The verify grep command confirms zero remaining exa references in the five targeted files.",
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-007-token-truncation-utility-spec.json
+++ b/task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-007-token-truncation-utility-spec.json
@@ -1,0 +1,107 @@
+{
+  "id": "DMX-FLEET-P1-007-token-truncation-utility-spec",
+  "project": "dopemux-mvp",
+  "target": "Spec restoring the lost progressive-token-truncation pattern (docs/archive/mcp-servers/CONPORT_TOKEN_LIMIT_FIX.md: item-by-item token estimation, 9K budget stop, Zen-validated) as one shared fleet-wide utility applied at the MCP call_tool() boundary, rather than the current per-server, per-method reimplementation (ConPort's enhanced_server.py has its own _estimate_tokens/_truncate_decisions/_truncate_progress; other bulk-query servers have none), and distinct from src/dopemux/mcp/token_manager.py which is a role-based budget/quota tracker for MetaMCP, not a per-response truncation mechanism.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not conflate this shared truncation utility with src/dopemux/mcp/token_manager.py's existing role-based budget tracking; the spec must state explicitly how the two relate (composed together, or kept as separate concerns) rather than merging them silently.",
+    "This packet must preserve ConPort's already-validated 9K-budget progressive-truncation behavior as the reference implementation to generalize, not replace with an unvalidated new algorithm.",
+    "This packet must specify deterministic, order-preserving truncation (same input always truncates to the same output) so results remain reproducible for audit/replay."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p1",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P1-006-exa-retire-cleanup",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p1-007-token-truncation-utility-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(mcp-fleet): spec shared token-truncation boundary utility",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P1-007-token-truncation-utility-spec.md",
+      "task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-007-token-truncation-utility-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p1-007-token-truncation-utility-spec/DMX-FLEET-P1-007-token-truncation-utility-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-007-token-truncation-utility-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P1/DMX-FLEET-P1-007-token-truncation-utility-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P1-007-token-truncation-utility-spec.md",
+      "grep -q 'call_tool' claudedocs/specs/DMX-FLEET-P1-007-token-truncation-utility-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(mcp-fleet): spec shared token-truncation boundary utility",
+    "body": "Authors the spec for DMX-FLEET-P1-007, restoring a lost architectural pattern identified in the forgotten-features addendum (mcp-fleet-forgotten-features-addendum-2026-07-04.md §3b, items 8-9). ConPort's enhanced_server.py has a validated progressive-truncation implementation (docs/archive/mcp-servers/CONPORT_TOKEN_LIMIT_FIX.md: item-by-item token estimation, 9K budget stop) but it is reimplemented per-server/per-method rather than shared, and other bulk-query MCP servers have no equivalent protection. This packet specs one fleet-wide utility applied at the call_tool() TextContent boundary, explicitly distinguished from src/dopemux/mcp/token_manager.py's separate role-based budget-quota concern. This is the final packet of the DMX-FLEET-P1 series.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md §3b (items 8-9) and docs/archive/mcp-servers/CONPORT_TOKEN_LIMIT_FIX.md in full. Inspect docker/mcp-servers-source/conport/enhanced_server.py's _estimate_tokens, _truncate_decisions, and _truncate_progress implementations and every call site. Inspect src/dopemux/mcp/token_manager.py in full and confirm its scope (role-based budget tracking) is distinct from per-response truncation. Inspect src/dopemux/mcp/broker.py's call_tool and src/dopemux/mcp/server_manager.py's call_tool to identify the actual MCP tool-call boundary where a shared utility could intercept TextContent responses. Check which other bulk-query-capable servers (dope-context, dope-memory, Serena) currently lack any truncation protection.",
+      "validation": [
+        "Proof cites the exact ConPort truncation algorithm (item-by-item token estimate, 9K stop, stats dict) with file:line references.",
+        "Proof states explicitly that src/dopemux/mcp/token_manager.py is a distinct role-based budget/quota system, not a response-truncation mechanism, with file:line citation.",
+        "Proof identifies the concrete call_tool() interception points in broker.py and server_manager.py where a shared utility could be applied.",
+        "Proof lists which servers besides ConPort currently have no bulk-response truncation protection."
+      ],
+      "context_files": [
+        "claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md",
+        "docs/archive/mcp-servers/CONPORT_TOKEN_LIMIT_FIX.md",
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "src/dopemux/mcp/token_manager.py",
+        "src/dopemux/mcp/broker.py",
+        "src/dopemux/mcp/server_manager.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-FLEET-P1-007-token-truncation-utility-spec.md covering: (a) current-state summary of ConPort's validated but non-shared implementation and the absence of protection elsewhere; (b) scope: extract the algorithm into one shared module (proposed location under src/dopemux/mcp/, e.g. response_truncation.py) with a stable API (estimate_tokens, truncate_items, or a call_tool()-wrapping decorator/middleware); (c) interfaces: how ConPort and any other server would adopt the shared utility (import-and-call vs boundary middleware in broker.py/server_manager.py), migration path for ConPort's existing per-method calls without behavior regression; (d) relationship to token_manager.py (composed as two independent layers: token_manager for role/session budget enforcement, this utility for single-response-size safety; the spec must state they are not merged); (e) invariants (deterministic truncation, 9K default budget configurable per server, truncation stats surfaced to the caller so silent data loss is never hidden); (f) acceptance criteria (ConPort migrated to the shared utility with no test regression; at least one previously-unprotected bulk-query server gains protection); (g) phasing (land the shared module first with ConPort as the reference migration, then extend to other servers in follow-on packets).",
+      "validation": [
+        "Spec file exists at claudedocs/specs/DMX-FLEET-P1-007-token-truncation-utility-spec.md.",
+        "Spec names the call_tool() boundary in broker.py or server_manager.py as the interception point, per the addendum's item 9 framing.",
+        "Spec explicitly distinguishes this utility from token_manager.py's role-based budgets.",
+        "Spec covers scope, invariants, interfaces, acceptance criteria, and phasing as distinct sections.",
+        "Spec does not propose runtime code changes; it is planning-only."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the source addendum, the CONPORT_TOKEN_LIMIT_FIX reference implementation, and the runtime evidence gathered in S1. Validate the packet JSON, update task-packets/INDEX.md, assemble the proof bundle, and commit only allowlisted files. As this is the final packet of DMX-FLEET-P1, confirm the proof bundle also notes that the series' premise (per README) was reconciled against current origin/main runtime truth during this authoring pass, per the DMX-FLEET-P1-001 through -006 packets' proof bundles.",
+      "validation": [
+        "Spec is internally consistent with S1's evidence.",
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed.",
+        "Proof notes this packet's final_packet:true status and cross-references the series-wide reconciliation finding."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-001-event-source-wiring.json
+++ b/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-001-event-source-wiring.json
@@ -1,0 +1,116 @@
+{
+  "id": "DMX-FLEET-P2-001-event-source-wiring",
+  "project": "dopemux-mvp",
+  "target": "Produce the spec for wiring decision.logged/task.*/workflow.phase_changed at their real emission sources (ConPort decision-write path, workflow-kernel/task-orchestrator transitions) and for folding the standalone mcp-capture server into capture_client.py as a single capture path, reconciled against the current three-file PROMOTABLE_EVENT_TYPES synchronization runtime truth.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must ground every claim in current runtime code (capture_client.py, promotion.py, dopecon_bridge/promotable_mirror.py, native_hooks.py, services/mcp-capture/server.py), not in stale audit prose, and must cite exact file:line evidence for each authority-map row it revises.",
+    "This packet must reconcile the audit's two-file PROMOTABLE_EVENT_TYPES claim against the current three-file synchronization (capture_client.py, promotion.py, dopecon_bridge/promotable_mirror.py) and record the discrepancy explicitly.",
+    "This packet must not propose auto-writing ConPort from any non-canonical source.",
+    "This packet must preserve capture_client.emit_capture_event() as the single raw-capture entry point in its fold-in design."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p2",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p2-001-event-source-wiring",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(fleet-p2): spec event-source wiring + mcp-capture fold-in",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P2-001-event-source-wiring.md",
+      "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-001-event-source-wiring.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P2-001-event-source-wiring/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-001-event-source-wiring.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-001-event-source-wiring.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P2-001-event-source-wiring.md",
+      "grep -q 'mcp-capture' claudedocs/specs/DMX-FLEET-P2-001-event-source-wiring.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(fleet-p2): spec event-source wiring + mcp-capture fold-in",
+    "body": "Specs wiring decision.logged/task.*/workflow.phase_changed at their real emission sources (ConPort decision write, workflow-kernel/task-orchestrator transitions) per mcp-fleet-canonical-audit-and-target-design-2026-07-03.md sec 7.2, and specs folding the standalone mcp-capture server into capture_client.py per the backlog decisions ledger (FEAT/mcp-capture row). Reconciles the audit's two-file PROMOTABLE_EVENT_TYPES claim against the current three-file runtime (capture_client.py, promotion.py, dopecon_bridge/promotable_mirror.py). Planning-only; no runtime code changes.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline status before any inspection begins.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Primary checkout remains untouched."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Read-only inspect the current emission-source runtime truth: ConPort decision-write path (docker/mcp-servers-source/conport/enhanced_server.py log_decision/_log_decision), the dopecon-bridge mirror (services/dopecon-bridge/dopecon_bridge/routes.py and promotable_mirror.py), the promotion engine allowlist (services/working-memory-assistant/promotion/promotion.py PROMOTABLE_EVENT_TYPES), the capture client allowlist (src/dopemux/memory/capture_client.py PROMOTABLE_CAPTURE_EVENT_TYPES), native_hooks.py's existing PostToolUseFailure wiring, and the standalone mcp-capture server (services/mcp-capture/server.py, README.md). Identify exactly which promotable types already reach activity.events.v1 today versus which remain unwired at their real emission source, and confirm the current count and location of PROMOTABLE_EVENT_TYPES synchronization points (audit says two files; verify against runtime).",
+      "commands": [
+        "grep -n 'PROMOTABLE_EVENT_TYPES\\|PROMOTABLE_CAPTURE_EVENT_TYPES' src/dopemux/memory/capture_client.py services/working-memory-assistant/promotion/promotion.py services/dopecon-bridge/dopecon_bridge/promotable_mirror.py",
+        "grep -n 'decision.logged\\|progress.updated' services/dopecon-bridge/dopecon_bridge/routes.py",
+        "grep -n 'def log_decision\\|def _log_decision' docker/mcp-servers-source/conport/enhanced_server.py",
+        "sed -n '1,60p' services/mcp-capture/server.py"
+      ],
+      "validation": [
+        "Proof records the exact file:line evidence for each of the three (or however many are found) PROMOTABLE_EVENT_TYPES synchronization points, with any discrepancy from the two-file audit claim called out explicitly.",
+        "Proof records which promotable event types already have a real emission-source wire (e.g. decision.logged via dopecon-bridge mirror) versus which remain gap items (task.* at workflow-kernel/task-orchestrator transitions).",
+        "Proof records the standalone mcp-capture server's current capability surface (tools, entry points) as the fold-in source material."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Produce the spec at claudedocs/specs/DMX-FLEET-P2-001-event-source-wiring.md covering: (a) scope — wiring decision.logged at the ConPort decision-write path if not already real per S2, task.created/task.completed/task.failed/task.blocked/workflow.phase_changed at workflow-kernel/task-orchestrator transition points, and folding mcp-capture's capability into capture_client.py as the single capture entry point with the standalone server retired; (b) invariants — no auto ConPort writes from non-canonical sources, capture_client.emit_capture_event() remains the sole raw-capture entry point, fail-open capture semantics preserved, PROMOTABLE_EVENT_TYPES stays synchronized across every file that declares it; (c) interfaces — exact call sites and function signatures to be touched at each emission source, and the capture_client.py surface that absorbs mcp-capture's capability; (d) acceptance criteria — a runtime test plan proving each wired event type reaches activity.events.v1 and is promoted, and proving the standalone mcp-capture server is no longer required for any consumer; (e) phasing — ordering of the wiring work relative to DMX-FLEET-P2-002 through 005 and any risk/rollback notes for touching the ConPort decision-write path and workflow-kernel transitions.",
+      "validation": [
+        "claudedocs/specs/DMX-FLEET-P2-001-event-source-wiring.md exists and contains scope, invariants, interfaces, acceptance criteria, and phasing sections.",
+        "The spec explicitly addresses folding mcp-capture into capture_client.py, not merely mentioning it in passing.",
+        "The spec cites file:line evidence from S2 rather than restating the audit narrative uncritically.",
+        "No runtime source file outside claudedocs/specs/ is modified."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Self-review the spec against the source audit (mcp-fleet-canonical-audit-and-target-design-2026-07-03.md sec 7.2) and the decisions ledger's mcp-capture fold-in row, validate the packet JSON, and commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Self-review confirms the spec covers every item in sec 7.2's numbered list (1-4) and the decisions ledger's mcp-capture row, or explicitly notes any item deferred to a later packet with rationale.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-002-heartbeat-ratelimit.json
+++ b/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-002-heartbeat-ratelimit.json
@@ -1,0 +1,106 @@
+{
+  "id": "DMX-FLEET-P2-002-heartbeat-ratelimit",
+  "project": "dopemux-mvp",
+  "target": "Rate-limit session-active heartbeat events in the dope-memory eventbus consumer to stop chronicle spam, and normalize/backfill instance_id so heartbeat and promotable events carry a consistent, non-default identity.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change promotion semantics for non-heartbeat promotable events.",
+    "This packet must preserve fail-open capture semantics: a rate-limit or normalization failure must never break the emitting caller's turn.",
+    "This packet must not introduce a new default instance_id value beyond the existing documented default; normalization must make identity explicit, not silently invent one.",
+    "This packet must preserve the canonical writer for raw_activity_events and add a regression test for the rate-limit and normalization behavior."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p2",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P2-001-event-source-wiring",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p2-002-heartbeat-ratelimit",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "fix(dope-memory): rate-limit session-active heartbeats + normalize instance_id",
+    "allowlist": [
+      "services/working-memory-assistant/eventbus_consumer.py",
+      "services/working-memory-assistant/tests/**",
+      "src/dopemux/memory/capture_client.py",
+      "tests/unit/dopemux/memory/**",
+      "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-002-heartbeat-ratelimit.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P2-002-heartbeat-ratelimit/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-002-heartbeat-ratelimit.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-002-heartbeat-ratelimit.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python3 -m py_compile services/working-memory-assistant/eventbus_consumer.py src/dopemux/memory/capture_client.py",
+      "python3 -m pytest -q services/working-memory-assistant/tests/test_eventbus_consumer_heartbeat_ratelimit.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(dope-memory): rate-limit session-active heartbeats + normalize instance_id",
+    "body": "Rate-limits session-active heartbeat spam in the dope-memory eventbus consumer and normalizes/backfills instance_id per mcp-fleet-canonical-audit-and-target-design-2026-07-03.md sec 7.2 item 2. Adds a regression test proving heartbeats are throttled without dropping non-heartbeat high-signal events and that instance_id is consistently populated rather than silently defaulted.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline status.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Primary checkout remains untouched."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "services/working-memory-assistant/eventbus_consumer.py",
+        "src/dopemux/memory/capture_client.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write failing tests before code. Add a test proving session-active heartbeat events emitted faster than the rate-limit window are throttled/dropped by the eventbus consumer while non-heartbeat activity updates are never throttled, and a test proving instance_id normalization backfills a missing or blank instance_id to the documented default without overwriting an explicitly supplied instance_id.",
+      "validation": [
+        "New tests fail against current code because no rate-limit or normalization logic exists yet.",
+        "Tests assert both the throttling behavior and the non-heartbeat pass-through behavior."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement a minimal rate limiter for session-active heartbeat updates in the eventbus consumer's session tracker (update_activity/is_heartbeat_only path) and normalize instance_id at the capture_client.emit_capture_event() boundary so downstream consumers see a consistent, non-blank identity.",
+      "validation": [
+        "Heartbeat events within the rate-limit window are suppressed at the consumer without affecting session idle/reflection timers incorrectly.",
+        "instance_id normalization applies only when the field is missing or blank; an explicit caller-supplied instance_id is never overwritten.",
+        "No change to the PROMOTABLE_EVENT_TYPES allowlist or promotion semantics for non-heartbeat events."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet, update task-packets/INDEX.md, create the proof bundle, validate, commit, push, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "New and existing tests pass; git diff --check passes.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-003-instance-identity-propagation.json
+++ b/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-003-instance-identity-propagation.json
@@ -1,0 +1,110 @@
+{
+  "id": "DMX-FLEET-P2-003-instance-identity-propagation",
+  "project": "dopemux-mvp",
+  "target": "Produce the spec for moving workspace/instance identity into per-request parameters (tool arguments or headers) so worktree scoping is real for ConPort and dope-memory over shared HTTP servers, replacing the env-var-shaped isolation that cannot influence a remote container.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must specify fail-closed behavior: a request missing required identity parameters must be rejected, not silently routed to a shared/default identity.",
+    "This packet must ground the design in dope-context's existing per-request workspace_id pattern as the reference implementation, not invent a new pattern.",
+    "This packet must not weaken any existing worktree-scoped isolation while the migration is in flight; the spec must define a compatible transition path."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p2",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P2-002-heartbeat-ratelimit",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p2-003-instance-identity-propagation",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(fleet-p2): spec per-request instance identity propagation",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P2-003-instance-identity-propagation.md",
+      "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-003-instance-identity-propagation.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P2-003-instance-identity-propagation/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-003-instance-identity-propagation.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-003-instance-identity-propagation.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P2-003-instance-identity-propagation.md",
+      "grep -q 'fail closed\\|fail-closed' claudedocs/specs/DMX-FLEET-P2-003-instance-identity-propagation.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(fleet-p2): spec per-request instance identity propagation",
+    "body": "Specs moving workspace/instance identity into per-request tool parameters for ConPort and dope-memory per mcp-fleet-canonical-audit-and-target-design-2026-07-03.md sec 6.2 and 7.2 item 2, using dope-context's existing per-request workspace_id pattern as the reference. Defines fail-closed rejection of identity-less requests and a compatible transition path. Planning-only; no runtime code changes.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline status before any inspection begins.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Primary checkout remains untouched."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Read-only inspect the current identity-handling runtime truth: dope-context's per-request workspace_id parameter pattern (the reference implementation), the dope-memory eventbus consumer's instance_id parameter handling (services/working-memory-assistant/eventbus_consumer.py), ConPort's workspace_id handling (docker/mcp-servers-source/conport/enhanced_server.py), and any remaining env-var-shaped identity assumptions in .mcp.json or compose configs that cannot influence a remote/shared container.",
+      "commands": [
+        "grep -rn 'workspace_id' services/dope-context 2>/dev/null | head -30",
+        "grep -n 'instance_id' services/working-memory-assistant/eventbus_consumer.py",
+        "grep -n 'workspace_id' docker/mcp-servers-source/conport/enhanced_server.py | head -20",
+        "grep -n 'DOPEMUX_INSTANCE_ID\\|DOPE_MEMORY_INSTANCE_ID' -r . --include='*.yaml' --include='*.yml' --include='*.py' 2>/dev/null | grep -v node_modules | head -20"
+      ],
+      "validation": [
+        "Proof records the exact file:line evidence for dope-context's per-request identity pattern as the reference design.",
+        "Proof records every current env-var-shaped identity assumption in ConPort and dope-memory that this spec must replace or migrate.",
+        "Proof records whether any consumer already defaults to a shared identity when none is supplied, and where that default is fail-open today."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Produce the spec at claudedocs/specs/DMX-FLEET-P2-003-instance-identity-propagation.md covering: (a) scope — which tool surfaces (ConPort, dope-memory) move workspace_id/instance_id from env-var/compose-level configuration to explicit per-request tool arguments or headers, modeled on dope-context's existing pattern; (b) invariants — fail-closed rejection of requests missing required identity, no silent fallback to a shared default identity, backward-compatible transition so existing worktree-scoped consumers do not break mid-migration; (c) interfaces — exact tool schema changes (new required parameters) per affected MCP tool, and how the client-side wrapper or hook resolves workspace_id/instance_id before the call; (d) acceptance criteria — a test plan proving requests without identity are rejected and requests with identity route to the correct worktree-scoped data; (e) phasing — migration order relative to DMX-FLEET-P2-002's instance_id normalization work and any compatibility window needed for in-flight sessions.",
+      "validation": [
+        "claudedocs/specs/DMX-FLEET-P2-003-instance-identity-propagation.md exists and contains scope, invariants, interfaces, acceptance criteria, and phasing sections.",
+        "The spec explicitly defines fail-closed behavior for missing identity, not merely mentioning it.",
+        "The spec cites file:line evidence from S2 rather than restating the audit narrative uncritically.",
+        "No runtime source file outside claudedocs/specs/ is modified."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Self-review the spec against the source audit sections 6.2/7.2 and the decisions ledger, validate the packet JSON, and commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Self-review confirms the spec addresses the env-var-isolation-is-unimplementable finding from sec 5 and the per-request identity target from sec 6.2/7.2.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-004-skill-mirror-receipts.json
+++ b/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-004-skill-mirror-receipts.json
@@ -1,0 +1,110 @@
+{
+  "id": "DMX-FLEET-P2-004-skill-mirror-receipts",
+  "project": "dopemux-mvp",
+  "target": "Append a dope-memory mirror-receipt confirmation to the /decision, /caveat, and /followup skill commands so each ConPort write is visibly mirrored into the chronicle at the point of use, closing Memory Trinity Rule 1 beyond the gated CLI path.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not make ConPort write success conditional on the mirror receipt; the ConPort write remains canonical and authoritative regardless of mirror outcome.",
+    "This packet must preserve fail-open mirror semantics: a mirror-receipt failure must never block or roll back the underlying ConPort write.",
+    "This packet must preserve the canonical writer (ConPort) for decisions/caveats/followups and add a contract test proving the mirror receipt never overrides or duplicates canonical state.",
+    "This packet must not introduce a new promotable event type without adding it to every PROMOTABLE_EVENT_TYPES synchronization point identified in DMX-FLEET-P2-001."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p2",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P2-003-instance-identity-propagation",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p2-004-skill-mirror-receipts",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(skills): append dope-memory mirror-receipt confirmations to decision/caveat/followup",
+    "allowlist": [
+      ".claude/commands/decision.md",
+      ".claude/commands/caveat.md",
+      ".claude/commands/followup.md",
+      "services/dopecon-bridge/dopecon_bridge/promotable_mirror.py",
+      "tests/unit/test_dopecon_bridge_promotable_mirror.py",
+      "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-004-skill-mirror-receipts.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P2-004-skill-mirror-receipts/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-004-skill-mirror-receipts.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-004-skill-mirror-receipts.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python3 -m py_compile services/dopecon-bridge/dopecon_bridge/promotable_mirror.py",
+      "python3 -m pytest -q tests/unit/test_dopecon_bridge_promotable_mirror.py",
+      "grep -q 'mirror receipt' .claude/commands/decision.md .claude/commands/caveat.md .claude/commands/followup.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(skills): append dope-memory mirror-receipt confirmations to decision/caveat/followup",
+    "body": "Appends a visible dope-memory mirror-receipt confirmation step to the /decision, /caveat, and /followup skill commands per mcp-fleet-canonical-audit-and-target-design-2026-07-03.md sec 7.2 item 3 (Memory Trinity Rule 1). ConPort remains the sole canonical writer; the mirror receipt is a fail-open, non-authoritative confirmation surfaced to the operator at the point of use.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline status.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Primary checkout remains untouched."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        ".claude/commands/decision.md",
+        ".claude/commands/caveat.md",
+        ".claude/commands/followup.md",
+        "services/dopecon-bridge/dopecon_bridge/promotable_mirror.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test before code proving that services/dopecon-bridge/dopecon_bridge/promotable_mirror.py exposes a queryable confirmation (e.g. a returned mirror-receipt id or status) for decision.logged-class events that the skill instructions can reference, and that mirror failure does not raise or block the caller.",
+      "validation": [
+        "The new test fails against current code because no queryable confirmation surface exists yet, or documents that one already exists and pivots to asserting the skill-doc wiring instead.",
+        "Test asserts fail-open behavior: a simulated mirror failure does not propagate as an exception to the ConPort write path."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement the minimal mirror-receipt confirmation surface if not already present, then update .claude/commands/decision.md, .claude/commands/caveat.md, and .claude/commands/followup.md to instruct the calling agent to report the dope-memory mirror-receipt confirmation (or its fail-open absence) alongside the ConPort write result.",
+      "validation": [
+        "Each of the three skill command docs explicitly instructs surfacing a mirror-receipt confirmation after the canonical ConPort write.",
+        "The skill docs make clear the ConPort write is canonical and the mirror is a non-authoritative confirmation.",
+        "No change alters which system is the canonical writer for decisions, caveats, or followups."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet, update task-packets/INDEX.md, create the proof bundle, validate, commit, push, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "New and existing tests pass; git diff --check passes.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-005-dopecontext-indexing-enable.json
+++ b/task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-005-dopecontext-indexing-enable.json
@@ -1,0 +1,109 @@
+{
+  "id": "DMX-FLEET-P2-005-dopecontext-indexing-enable",
+  "project": "dopemux-mvp",
+  "target": "Flip ENABLE_DOPECONTEXT_INDEX=true with provenance pointers once the chronicle holds real curated content, completing the Memory Trinity loop by making decision/work-log entries semantically searchable via dope-context.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not enable indexing before DMX-FLEET-P2-001's event-source wiring has produced real curated chronicle content; this packet's precondition check must fail closed if the chronicle is still empty.",
+    "This packet must not resurrect the dead memory_{hash} collection or /index route claims; indexing must target dope-context's existing real collection/document model.",
+    "This packet must attach provenance pointers (source_adapter/promotion_rule/source_event_id or equivalent) to every indexed entry so indexed content is traceable back to its canonical ConPort or chronicle source.",
+    "This packet must preserve the canonical writer for chronicle entries (dope-memory) and for decisions (ConPort); dope-context remains a read-optimized projection, not a new authority.",
+    "This packet must not introduce or rely on the external Voyage embedding path without an explicit, already-approved cost guard; if no cost guard exists yet, this packet must gate indexing volume or defer to DMX-FLEET-P3-005."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P2-001-event-source-wiring"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p2",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P2-004-skill-mirror-receipts",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p2-005-dopecontext-indexing-enable",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(dope-context): enable chronicle indexing with provenance pointers",
+    "allowlist": [
+      "services/dope-context/**",
+      "services/working-memory-assistant/**",
+      "docker/compose/*.yml",
+      "docker/compose/**/*.yaml",
+      "tests/unit/dope_context/**",
+      "task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-005-dopecontext-indexing-enable.json",
+      "task-packets/INDEX.md",
+      "proof/DMX-FLEET-P2-005-dopecontext-indexing-enable/**"
+    ],
+    "verify": [
+      "python3 -m json.tool task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-005-dopecontext-indexing-enable.json >/dev/null",
+      "python3 -m jsonschema -i task-packets/generated/DMX-FLEET-P2/DMX-FLEET-P2-005-dopecontext-indexing-enable.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "grep -rn 'ENABLE_DOPECONTEXT_INDEX' services/working-memory-assistant services/dope-context docker/compose 2>/dev/null",
+      "python3 -m pytest -q tests/unit/dope_context/test_chronicle_indexing_provenance.py",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(dope-context): enable chronicle indexing with provenance pointers",
+    "body": "Flips ENABLE_DOPECONTEXT_INDEX=true per mcp-fleet-canonical-audit-and-target-design-2026-07-03.md sec 7.2 item 4, gated on DMX-FLEET-P2-001's event-source wiring having produced real curated chronicle content. Attaches provenance pointers to every indexed entry so indexed content remains traceable to its canonical ConPort/chronicle source, completing the Memory Trinity loop (Rule 2). Final packet in the DMX-FLEET-P2 memory-spine series.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline status. Verify DMX-FLEET-P2-001's event-source wiring is present on the base branch before proceeding; if absent, record the precondition failure and stop.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Precondition check for DMX-FLEET-P2-001 completion is recorded in proof as PASS or the packet stops with an explicit FAIL/blocker."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write failing tests before code. Add a test proving that indexing a chronicle work_log_entries row into dope-context attaches a provenance pointer (source_adapter/promotion_rule/source_event_id or equivalent) resolvable back to the originating ConPort decision or chronicle entry, and a test proving indexing is a no-op when the chronicle contains no real curated entries (empty-chronicle guard).",
+      "validation": [
+        "New tests fail against current code because ENABLE_DOPECONTEXT_INDEX is currently false/unwired for this path.",
+        "Tests assert both the provenance-pointer attachment and the empty-chronicle no-op guard."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement the minimal wiring to flip ENABLE_DOPECONTEXT_INDEX=true in the relevant compose/env configuration, route curated chronicle entries into dope-context's existing real collection/document model with provenance pointers attached, and gate indexing volume against the external Voyage embedding cost surface pending DMX-FLEET-P3-005's cost guard.",
+      "validation": [
+        "Indexed entries carry a provenance pointer traceable to the canonical ConPort/chronicle source.",
+        "No new dead-collection or dead-route pattern (e.g. memory_{hash}, /index) is introduced; only dope-context's existing real indexing surface is used.",
+        "Indexing volume is bounded or explicitly deferred with a documented rationale if no cost guard exists yet."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the packet, update task-packets/INDEX.md, create the proof bundle, validate, commit, push, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "New and existing tests pass; git diff --check passes.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-001-conport-jsonrpc-parity.json
+++ b/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-001-conport-jsonrpc-parity.json
@@ -1,0 +1,115 @@
+{
+  "id": "DMX-FLEET-P3-001-conport-jsonrpc-parity",
+  "project": "dopemux-mvp",
+  "target": "Produce a spec for ConPort packets 106/107/201/202 that closes JSON-RPC tool parity (13 of 17 SSE tools currently advertised), eliminates the GET /api/progress side-effect mutation, and adds a product-context and relationship-write API, without changing runtime code in this packet.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not mutate any live ConPort database.",
+    "This packet must classify missing or unresolved evidence as UNKNOWN rather than asserting it as fact."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p3",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/fleet-p3-001-conport-jsonrpc-parity",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(conport): spec JSON-RPC tool parity, GET-mutation kill, product context, relationship write API",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P3-001-conport-jsonrpc-parity.md",
+      "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-001-conport-jsonrpc-parity.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p3-001-conport-jsonrpc-parity/DMX-FLEET-P3-001-conport-jsonrpc-parity/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-001-conport-jsonrpc-parity.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-001-conport-jsonrpc-parity.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P3-001-conport-jsonrpc-parity.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(conport): spec JSON-RPC parity + GET-mutation kill + product context + relationship write API",
+    "body": "Specs the minimum ConPort surface work (fleet audit packets 106/107/201/202) that makes the 'knowledge graph' claim true: JSON-RPC advertises all 17 SSE tools (currently 13 of 17, 3 dark + 1 missing per enhanced_server.py), GET /api/progress no longer auto-forks (DOPEMUX_AUTO_FORK_PROGRESS default), a product-context surface, and a relationship write API replacing the current read-only traversal. No runtime code changes in this packet.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Read the source findings (fleet audit §4 ConPort verdict, §7.1 target row, §7.3 invariants, §8 Phase 3.1) and read-only inspect the current runtime surface: JSON-RPC dispatcher and tool schema list, the GET /api/progress route and its auto-fork handler, and the existing relationship/graph read path.",
+      "commands": [
+        "sed -n '1,60p' claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "grep -n \"_jsonrpc_result\\|_get_tool_schemas\\|add_get('/api/progress'\\|auto_fork_progress\" docker/mcp-servers-source/conport/enhanced_server.py",
+        "cat proof/tp5a_conport_full_surface_drift_0001/SURFACE_INVENTORY_JSONRPC.md"
+      ],
+      "validation": [
+        "Proof records the exact current JSON-RPC tool count vs SSE tool count with file:line citations.",
+        "Proof records the exact GET /api/progress route registration and the DOPEMUX_AUTO_FORK_PROGRESS default with file:line citations.",
+        "Proof records whether a relationship write API exists today (expected: none, read-only traversal only) with file:line citations."
+      ],
+      "context_files": [
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docker/mcp-servers-source/conport/SURFACE_INVENTORY.md",
+        "docs/systems/conport/surface-equivalence-and-drift.md"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Produce the spec at claudedocs/specs/DMX-FLEET-P3-001-conport-jsonrpc-parity.md covering: scope (packets 106 JSON-RPC parity, 107 kill GET-mutation, 201 product context, 202 relationship write API); invariants (append-only decisions preserved, no auth regressions, fail-closed on schema mismatch); interfaces (exact JSON-RPC method names to add, exact route/verb changes for /api/progress, product-context request/response shape, relationship write endpoint shape and allowed relationship vocabulary); acceptance criteria (JSON-RPC tools/list count equals SSE tool count; GET /api/progress is provably non-mutating; product context is readable/writable; relationship writes are auditable); and phasing across the four source packet numbers.",
+      "validation": [
+        "claudedocs/specs/DMX-FLEET-P3-001-conport-jsonrpc-parity.md exists and contains named sections: Scope, Invariants, Interfaces, Acceptance Criteria, Phasing.",
+        "The spec references the exact current-state evidence captured in S2 rather than asserting unverified claims.",
+        "The spec does not propose introducing a second semantic-search authority in ConPort (per decisions-ledger.md: dope-context owns semantic retrieval)."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Self-review the spec against the source audit sections and the decisions ledger, run packet validation, and commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Spec self-review confirms no runtime code files are included in the diff.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-002-serena-promotion.json
+++ b/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-002-serena-promotion.json
@@ -1,0 +1,119 @@
+{
+  "id": "DMX-FLEET-P3-002-serena-promotion",
+  "project": "dopemux-mvp",
+  "target": "Produce a spec that promotes the local 45-tool Serena candidate (services/serena/) to the canonical Serena surface per DMX-ADR-002, keeping the 6 write tools out of the default profile, and defines the archive/retire plan for the current upstream-wrapper split, without changing runtime code in this packet.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not place any of the 6 write tools into a default tool profile.",
+    "This packet must classify missing or unresolved evidence as UNKNOWN rather than asserting it as fact."
+  ],
+  "depends_on": [
+    "DMX-ADR-002-serena-promotion"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p3",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P3-001-conport-jsonrpc-parity",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/fleet-p3-002-serena-promotion",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(serena): spec promotion of local 45-tool candidate to canonical surface",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P3-002-serena-promotion.md",
+      "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-002-serena-promotion.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p3-002-serena-promotion/DMX-FLEET-P3-002-serena-promotion/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-002-serena-promotion.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-002-serena-promotion.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P3-002-serena-promotion.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(serena): spec promotion of local 45-tool Serena candidate to canonical",
+    "body": "Specs the Serena single-surface consolidation decided in DMX-ADR-002: promote services/serena/ (the local 45-tool candidate with genuinely implemented ADHD complexity banding) to canonical, retire/archive the current upstream-wrapper deployment and its phantom-path wrapper script, and keep the 6 write tools out of any default tool profile per the sanctioned read-only contract. No runtime code changes in this packet.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline. Confirm DMX-ADR-002-serena-promotion has been authored and its decision text.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "The ADR-002 decision text is quoted in proof, or proof records UNKNOWN if the ADR file is not yet present."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Read the source findings (fleet audit §4 Serena verdict, §7.1 target row; forgotten-features addendum §2.5 dormant ADHD modules table) and read-only inspect the current deployed wrapper, the local 45-tool candidate, and the wrapper's broken path reference.",
+      "commands": [
+        "grep -n 'Serena' claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "sed -n '89,109p' claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md",
+        "find services/serena -maxdepth 2 -type d",
+        "grep -rn 'v2/mcp_server.py' --include='*.sh' . 2>/dev/null"
+      ],
+      "validation": [
+        "Proof records the exact deployed-wrapper path and the exact nonexistent path it currently references, with file:line citations.",
+        "Proof records the count and names of the 6 write tools that must stay out of the default profile, with file:line citations.",
+        "Proof records which dormant ADHD modules (complexity banding, focus mode manager, etc.) live only in the local candidate per forgotten-features §2.5."
+      ],
+      "context_files": [
+        "services/serena",
+        "docs/90-adr/adr-serena-as-technical-context-plane.md",
+        "docs/90-adr/adr-202-serena-v2-production-validation.md"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Produce the spec at claudedocs/specs/DMX-FLEET-P3-002-serena-promotion.md covering: scope (promote local candidate to canonical; retire upstream-wrapper deployment); invariants (6 write tools excluded from default profile; no silent degradation; hardcoded-localhost infra parameterized); interfaces (final tool surface list split into default vs opt-in write profile; wrapper script fix or replacement); acceptance criteria (wrapper resolves to a real, existing entrypoint; default profile contains zero write tools; capability probe passes); archive/retire plan for the superseded upstream-wrapper path; and an explicit unblocking note that this promotion is a precondition for DMX-ADHD-WIRE-005/006.",
+      "validation": [
+        "claudedocs/specs/DMX-FLEET-P3-002-serena-promotion.md exists and contains named sections: Scope, Invariants, Interfaces, Acceptance Criteria, Archive/Retire Plan.",
+        "The spec explicitly enumerates the 6 write tools and confirms they are excluded from the default profile.",
+        "The spec references DMX-ADR-002-serena-promotion as the authorizing decision."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Self-review the spec against the source audit sections, the ADR, and the forgotten-features addendum, run packet validation, and commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Spec self-review confirms no runtime code files are included in the diff.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-003-complexity-unify-spec.json
+++ b/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-003-complexity-unify-spec.json
@@ -1,0 +1,112 @@
+{
+  "id": "DMX-FLEET-P3-003-complexity-unify-spec",
+  "project": "dopemux-mvp",
+  "target": "Produce a spec that picks the canonical complexity scorer among the three unwired implementations (Serena's CodeComplexityAnalyzer, dope-context's scorer, and the orchestrator's ADR-207 ML risk module) per DMX-ADR-004, and defines the wiring plan so every consumer shares one scorer, without changing runtime code in this packet.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not introduce a fourth complexity-scoring implementation.",
+    "This packet must classify missing or unresolved evidence as UNKNOWN rather than asserting it as fact."
+  ],
+  "depends_on": [
+    "DMX-ADR-004-complexity-scorer"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p3",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P3-002-serena-promotion",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/fleet-p3-003-complexity-unify-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(complexity): spec unification of the three unwired complexity scorers",
+    "allowlist": [
+      "claudedocs/specs/DMX-FLEET-P3-003-complexity-unify-spec.md",
+      "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-003-complexity-unify-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p3-003-complexity-unify-spec/DMX-FLEET-P3-003-complexity-unify-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-003-complexity-unify-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-003-complexity-unify-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-FLEET-P3-003-complexity-unify-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(complexity): spec unification of the three unwired complexity scorers",
+    "body": "Specs the complexity-scoring unification decided in DMX-ADR-004. Three separate, unwired complexity-scoring implementations exist today (Serena CodeComplexityAnalyzer, dope-context's ast-based scorer despite a Tree-sitter docstring claim, and the orchestrator's dormant ADR-207 ML risk module) and none is canonical. This packet picks one per the ADR and specs how every consumer (Serena, dope-context, task-orchestrator PRD scoring) wires to it. No runtime code changes in this packet.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline. Confirm DMX-ADR-004-complexity-scorer has been authored and record its decision text.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "The ADR-004 decision text is quoted in proof, or proof records UNKNOWN if the ADR file is not yet present."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Read the source findings (fleet audit §3.3 documented contradictions, §4 dope-context verdict on the Tree-sitter docstring claim, §7.1 target row; forgotten-features addendum §2.6 Task Complexity Scoring row) and read-only inspect all three current scorer implementations.",
+      "commands": [
+        "grep -n 'complexity' claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "sed -n '113,116p' claudedocs/mcp-fleet-forgotten-features-addendum-2026-07-04.md",
+        "grep -rln 'class CodeComplexityAnalyzer' services/serena",
+        "grep -rln 'complexity' docker/mcp-servers-source/dope-context 2>/dev/null services/dope-context 2>/dev/null"
+      ],
+      "validation": [
+        "Proof records the exact file path, scoring method (ast vs Tree-sitter vs ML), and score-band contract (0.0-1.0, 0-1) for each of the three implementations, with file:line citations.",
+        "Proof records that none of the three is currently wired to a live consumer, or cites the counter-evidence if one is."
+      ],
+      "context_files": [
+        "services/serena",
+        "docker/mcp-servers-source/dope-context"
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Produce the spec at claudedocs/specs/DMX-FLEET-P3-003-complexity-unify-spec.md covering: scope (which scorer is canonical per ADR-004 and why); invariants (single scorer, no fourth implementation, shared 0.0-1.0 band contract used by Serena's 0.0-0.3/0.3-0.6/0.6-1.0 ADHD framing already referenced in doctrine); interfaces (the canonical scorer's function signature/API and how Serena, dope-context, and task-orchestrator PRD scoring each call it); acceptance criteria (all three consumers return identical scores for identical input; the two non-canonical implementations are archived or delegate to the canonical one); and a migration/wiring plan ordered by consumer.",
+      "validation": [
+        "claudedocs/specs/DMX-FLEET-P3-003-complexity-unify-spec.md exists and contains named sections: Scope, Invariants, Interfaces, Acceptance Criteria, Migration Plan.",
+        "The spec names exactly one canonical scorer per DMX-ADR-004 and lists the other two as archived or delegating.",
+        "The spec preserves the existing 0.0-0.3/0.3-0.6/0.6-1.0 ADHD complexity band convention rather than inventing a new one."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Self-review the spec against the source audit sections, the forgotten-features addendum, and the ADR, run packet validation, and commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Spec self-review confirms no runtime code files are included in the diff.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-004-qdrant-gc.json
+++ b/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-004-qdrant-gc.json
@@ -1,0 +1,105 @@
+{
+  "id": "DMX-FLEET-P3-004-qdrant-gc",
+  "project": "dopemux-mvp",
+  "target": "Add garbage collection for orphaned dope-context Qdrant collections (code_{workspace_hash}/docs_{workspace_hash}) whose source worktree no longer exists, so deleted worktrees stop leaking permanent collections.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not delete a Qdrant collection whose source worktree still exists.",
+    "This packet must fail closed (skip deletion, log, and report) when worktree liveness cannot be determined.",
+    "This packet must not run destructive deletion without an explicit dry-run mode that lists candidates first."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p3",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P3-003-complexity-unify-spec",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/fleet-p3-004-qdrant-gc",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "fix(dope-context): garbage-collect orphaned Qdrant collections",
+    "allowlist": [
+      "services/dope-context/src/utils/workspace.py",
+      "services/dope-context/src/search/dense_search.py",
+      "services/dope-context/src/maintenance/__init__.py",
+      "services/dope-context/src/maintenance/collection_gc.py",
+      "services/dope-context/src/mcp/server.py",
+      "services/dope-context/tests/test_collection_gc.py",
+      "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-004-qdrant-gc.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p3-004-qdrant-gc/DMX-FLEET-P3-004-qdrant-gc/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-004-qdrant-gc.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-004-qdrant-gc.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest services/dope-context/tests/test_collection_gc.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(dope-context): garbage-collect orphaned Qdrant collections",
+    "body": "dope-context names collections code_{workspace_hash}/docs_{workspace_hash} keyed to the resolved worktree path (services/dope-context/src/utils/workspace.py get_collection_names) but nothing deletes them when the worktree is removed, so every deleted worktree leaks two permanent Qdrant collections. Adds a GC routine that lists collections via the Qdrant client, resolves each hash back to a worktree path (or a persisted workspace-path index), checks liveness against git worktree list, and deletes only provably orphaned collections behind a dry-run-first default. Fails closed (skip + report) when liveness cannot be determined.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "services/dope-context/src/utils/workspace.py",
+        "services/dope-context/src/search/dense_search.py"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test at services/dope-context/tests/test_collection_gc.py asserting: (a) a collection whose worktree path exists is never returned as a GC candidate; (b) a collection whose worktree path does not exist is returned as a candidate in dry-run mode without being deleted; (c) actual deletion only occurs when dry_run=False is explicitly passed; (d) an unresolvable workspace hash (no recorded path mapping) is skipped and reported, never deleted.",
+      "validation": [
+        "The new test file fails because collection_gc.py does not yet exist."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement services/dope-context/src/maintenance/collection_gc.py: list collections via the existing Qdrant client call pattern in dense_search.py (self.client.get_collections()), resolve each code_{hash}/docs_{hash} back to a workspace path using the same hashing scheme as get_collection_names() in workspace.py (persisting or reusing an existing hash-to-path index if one exists; otherwise maintain one), check liveness with `git worktree list --porcelain` output, and delete only orphaned collections via the existing delete_collection() primitive in dense_search.py. Default to dry-run; require an explicit flag/argument to actually delete. Wire an optional GC invocation into src/mcp/server.py near the existing clear_index tool, gated the same way (approval-required).",
+      "validation": [
+        "Dry-run mode lists candidates without calling delete_collection().",
+        "Live-run mode deletes only collections confirmed orphaned by git worktree list.",
+        "Unresolvable hash-to-path mappings are skipped and logged, never deleted.",
+        "New code does not alter get_collection_names() or delete_collection() call contracts used elsewhere."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run tests and packet validation, and commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "python -m pytest services/dope-context/tests/test_collection_gc.py -q passes.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-005-voyage-cost-guard.json
+++ b/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-005-voyage-cost-guard.json
@@ -1,0 +1,103 @@
+{
+  "id": "DMX-FLEET-P3-005-voyage-cost-guard",
+  "project": "dopemux-mvp",
+  "target": "Wire the existing but dead rate_limits.voyage_api config (multi_index_config.yaml) into VoyageEmbedder and VoyageReranker and add an enforced spend/request cap on top of the existing unenforced CostTracker, so external Voyage embedding calls cannot exceed a configured budget.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must fail closed: once the configured cap is reached, further Voyage calls must be rejected, not silently degraded to a different provider or allowed through.",
+    "This packet must not remove or weaken the existing CostTracker accounting.",
+    "This packet must not hardcode pricing or limits that duplicate the existing multi_index_config.yaml rate_limits.voyage_api block."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p3",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P3-004-qdrant-gc",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/fleet-p3-005-voyage-cost-guard",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "fix(dope-context): enforce Voyage embedding cost guard from existing config",
+    "allowlist": [
+      "services/dope-context/src/embeddings/voyage_embedder.py",
+      "services/dope-context/src/rerank/voyage_reranker.py",
+      "services/dope-context/config/multi_index_config.yaml",
+      "services/dope-context/tests/test_voyage_cost_guard.py",
+      "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-005-voyage-cost-guard.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p3-005-voyage-cost-guard/DMX-FLEET-P3-005-voyage-cost-guard/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-005-voyage-cost-guard.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-005-voyage-cost-guard.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest services/dope-context/tests/test_voyage_cost_guard.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(dope-context): enforce Voyage embedding cost guard from existing config",
+    "body": "multi_index_config.yaml already declares rate_limits.voyage_api (rpm/rpd/retry) but nothing reads it: VoyageEmbedder takes an unread rate_limit_rpm=2000 constructor default and CostTracker (in both voyage_embedder.py and the duplicate in voyage_reranker.py) tracks spend without ever capping it. Wires the existing YAML config into both classes and adds an enforced cap that rejects further calls once the configured rpm/rpd or spend threshold is hit, rather than accounting silently.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline.",
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "services/dope-context/src/embeddings/voyage_embedder.py",
+        "services/dope-context/src/rerank/voyage_reranker.py",
+        "services/dope-context/config/multi_index_config.yaml"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test at services/dope-context/tests/test_voyage_cost_guard.py asserting: (a) VoyageEmbedder reads rate_limits.voyage_api from multi_index_config.yaml instead of the hardcoded rate_limit_rpm=2000 default when no explicit override is passed; (b) once CostTracker.add_request accumulates requests/spend past the configured cap, the next embedding call raises a explicit guard exception rather than proceeding; (c) VoyageReranker enforces the same cap via the same config source (no independent duplicate limit).",
+      "validation": [
+        "The new test file fails because the cap is not currently enforced (CostTracker.add_request has no rejection path) and rate_limit_rpm is not sourced from YAML."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Modify VoyageEmbedder.__init__ (services/dope-context/src/embeddings/voyage_embedder.py) to load rate_limits.voyage_api from multi_index_config.yaml as the default rate_limit_rpm/rpd source, and extend CostTracker.add_request (same file) to raise a dedicated guard exception when the configured rpm/rpd or a spend cap is exceeded. Apply the equivalent change to VoyageReranker's CostTracker (services/dope-context/src/rerank/voyage_reranker.py), sourcing from the same config block rather than duplicating constants.",
+      "validation": [
+        "VoyageEmbedder and VoyageReranker both read the same multi_index_config.yaml rate_limits.voyage_api block.",
+        "Exceeding the configured cap raises before the outbound Voyage API call is made (fail closed, no silent pass-through).",
+        "Existing callers in src/mcp/server.py and src/pipeline/indexing_pipeline.py continue to construct VoyageEmbedder without required new arguments (backward compatible defaults)."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run tests and packet validation, and commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "python -m pytest services/dope-context/tests/test_voyage_cost_guard.py -q passes.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-006-loopback-binds.json
+++ b/task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-006-loopback-binds.json
@@ -1,0 +1,103 @@
+{
+  "id": "DMX-FLEET-P3-006-loopback-binds",
+  "project": "dopemux-mvp",
+  "target": "Close 0.0.0.0 exposure fleet-wide for conport, dope-memory, serena, and gptr-mcp by adding loopback-bind port publishing in compose.yml, matching the pattern already used by dope-context, adhd-engine, desktop-commander, leantime-bridge, and webhook-receiver.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change any exposed container port number, only the host bind address.",
+    "This packet must not remove or weaken any existing healthcheck.",
+    "This packet must preserve inter-container communication on the compose network (only host-published ports are restricted to loopback)."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p3",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P3-005-voyage-cost-guard",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/fleet-p3-006-loopback-binds",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "fix(compose): bind conport/dope-memory/serena/gptr-mcp published ports to loopback",
+    "allowlist": [
+      "compose.yml",
+      "tests/unit/compose/test_loopback_binds.py",
+      "task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-006-loopback-binds.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p3-006-loopback-binds/DMX-FLEET-P3-006-loopback-binds/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-006-loopback-binds.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P3/DMX-FLEET-P3-006-loopback-binds.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/compose/test_loopback_binds.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(compose): bind conport/dope-memory/serena/gptr-mcp ports to loopback",
+    "body": "compose.yml already uses a 127.0.0.1:PORT:PORT loopback-bind pattern for dope-context (line 367), adhd-engine (484), desktop-commander (595), leantime-bridge (615), and webhook-receiver (642), but conport (253-255), dope-memory (504), serena (547-548), and gptr-mcp (574) still publish with a bare PORT:PORT mapping, which Docker binds to 0.0.0.0 by default. Adds the same 127.0.0.1: prefix to these four services' port mappings, closing the standing 0.0.0.0 exposure family called out in the fleet audit (§7.3, §8 Phase 3.5). In-container app-level 0.0.0.0 binds (e.g. enhanced_server.py, dope_memory_main.py, serena wrapper.py, gptr wrapper.py) are unaffected by this packet since only the host-published port controls host-network exposure; that residual is noted as a follow-up if a hardening pass wants defense-in-depth inside the container.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean baseline. Re-grep compose.yml to confirm current line numbers for the four target services' port blocks before editing (line numbers may have drifted since the audit).",
+      "commands": [
+        "grep -n 'CONPORT_HTTP_PORT\\|CONPORT_MCP_PORT\\|CONPORT_INFO_PORT\\|DOPE_MEMORY_PORT\\|SERENA_PORT\\|SERENA_HTTP_PORT\\|GPT_RESEARCHER_PORT' compose.yml"
+      ],
+      "validation": [
+        "Worktree path, branch, origin, marker, base HEAD, and clean baseline are recorded in proof.",
+        "Current exact line numbers for all four services' port mappings are recorded in proof."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/backlog/_AUTHORING_CONTRACT.md",
+        "compose.yml"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test at tests/unit/compose/test_loopback_binds.py that parses compose.yml and asserts every published port mapping for conport, dope-memory, serena, and gptr-mcp includes a 127.0.0.1: host-bind prefix (matching the existing pattern already used by dope-context, adhd-engine, desktop-commander, leantime-bridge, and webhook-receiver).",
+      "validation": [
+        "The new test fails against the current compose.yml because conport/dope-memory/serena/gptr-mcp port mappings lack the 127.0.0.1: prefix."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Edit compose.yml to add the 127.0.0.1: prefix to the port mappings for conport (CONPORT_HTTP_PORT, CONPORT_MCP_PORT, CONPORT_INFO_PORT), dope-memory (DOPE_MEMORY_PORT), serena (SERENA_PORT, SERENA_HTTP_PORT), and gptr-mcp (GPT_RESEARCHER_PORT), following the exact syntax already used at the dope-context/adhd-engine/desktop-commander/leantime-bridge/webhook-receiver entries. Do not change port numbers, service names, healthchecks, or any other compose fields.",
+      "validation": [
+        "All four services' published ports now carry the 127.0.0.1: prefix.",
+        "No port numbers, healthcheck definitions, or other compose fields changed for these or any other service.",
+        "docker compose config (or equivalent static parse) still parses compose.yml without error."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run tests and packet validation, and commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "python -m pytest tests/unit/compose/test_loopback_binds.py -q passes.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-001-facade-g1-contract-test.json
+++ b/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-001-facade-g1-contract-test.json
@@ -1,0 +1,111 @@
+{
+  "id": "DMX-FLEET-P4-001-facade-g1-contract-test",
+  "project": "dopemux-mvp",
+  "target": "Close DCP read-only facade gap G1 by adding a CI contract test that asserts the MCP-registered tool set equals TOOL_CONTRACT.md's 12-tool contract, and by making the two transport-blocked tools (search_code_docs, get_index_status) fail-closed with an explicit pointer to the pending dope-context bridge rather than a bare BLOCKED envelope.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not implement the dope-context MCP-JSON-RPC bridge; that is DMX-FLEET-P4-002's scope.",
+    "This packet must not remove or weaken the BLOCKED fail-closed behavior for search_code_docs or get_index_status.",
+    "This packet must not change search_decisions list-mode behavior; the query-mode deferral (note in TOOL_CONTRACT.md section 1b) is out of scope.",
+    "This packet must preserve the canonical writer and add a contract test for this contract-sensitive MCP surface."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p4",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p4-001-facade-g1-contract-test",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "test(dcp-facade): add TOOL_CONTRACT parity gate for facade G1",
+    "allowlist": [
+      "services/dcp-readonly-facade/src/mcp/server.py",
+      "services/dcp-readonly-facade/src/dcp_facade/tools.py",
+      "services/dcp-readonly-facade/tests/test_mcp_server.py",
+      "services/dcp-readonly-facade/tests/test_tool_contract_parity.py",
+      "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-001-facade-g1-contract-test.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p4-001-facade-g1-contract-test/DMX-FLEET-P4-001-facade-g1-contract-test/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-001-facade-g1-contract-test.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-001-facade-g1-contract-test.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest services/dcp-readonly-facade/tests/test_mcp_server.py services/dcp-readonly-facade/tests/test_tool_contract_parity.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "test(dcp-facade): close G1 with a TOOL_CONTRACT parity gate",
+    "body": "Adds a CI contract test asserting the facade's MCP-registered tool set (services/dcp-readonly-facade/src/mcp/server.py) equals the 12-tool set documented in docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md, closing the fleet audit's G1 finding (3 of 12 contracted tools unwired). Also hardens the two transport-blocked tools (search_code_docs, get_index_status) so their BLOCKED envelopes explicitly cite the pending dope-context MCP-JSON-RPC bridge (DMX-FLEET-P4-002) rather than a bare status.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean status. Re-confirm current facade state: run the existing test_mcp_server.py suite and read TOOL_CONTRACT.md section 1c to reconstruct the exact 12-tool set and the two BLOCKED tools.",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "The 12-tool set from TOOL_CONTRACT.md and the current @mcp.tool() registrations in server.py are recorded in proof and shown to match before any change."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md",
+        "services/dcp-readonly-facade/src/mcp/server.py",
+        "services/dcp-readonly-facade/tests/test_mcp_server.py",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test in services/dcp-readonly-facade/tests/test_tool_contract_parity.py that parses (or hard-codes, if the doc has no machine-readable table) the tool names from TOOL_CONTRACT.md and asserts they equal set(mcp.tools) from server.py, plus a second assertion that search_code_docs and get_index_status envelopes include a limitations entry naming the dope-context bridge gap.",
+      "validation": [
+        "The new test fails before any source change because no assertion currently ties TOOL_CONTRACT.md's tool list to the live server.tools registration.",
+        "The test does not require live backend services (uses the RecordingFastMCP pattern already established in test_mcp_server.py)."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Make the minimal change needed to pass: if TOOL_CONTRACT.md already lists exactly the 12 registered tools, the parity assertion passes as-is and only the BLOCKED-envelope limitation text needs strengthening in tools.py for search_code_docs and get_index_status. Do not add, remove, or rename any tool function or its signature.",
+      "validation": [
+        "set(mcp.tools) in server.py still equals the 12 names in TOOL_CONTRACT.md after the change.",
+        "search_code_docs and get_index_status BLOCKED envelopes name the dope-context MCP transport bridge explicitly in their limitations field.",
+        "No tool signature, route_manifest.py ALLOWED_ROUTES/DENIED_ROUTES entry, or denylist token is altered."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run the full verify list, commit only allowlisted files, push, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "services/dcp-readonly-facade/tests/test_mcp_server.py and the new parity test both pass.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-002-dopecontext-bridge-spec.json
+++ b/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-002-dopecontext-bridge-spec.json
@@ -1,0 +1,89 @@
+{
+  "id": "DMX-FLEET-P4-002-dopecontext-bridge-spec",
+  "project": "dopemux-mvp",
+  "target": "Spec a minimal MCP-JSON-RPC read bridge that lets the DCP read-only facade's dope-context adapter issue real search_code/docs_search/index-status calls instead of permanently fail-closing to BLOCKED, while preserving the facade's untrusted-by-default, read-only, capped-result posture.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not implement the bridge; DMX-FLEET-P4-001's parity gate and this spec's own acceptance criteria define what a follow-on implementation packet must satisfy.",
+    "This packet must preserve the fail-closed default: until the bridge exists, search_code_docs and get_index_status remain BLOCKED.",
+    "This packet must not propose exposing any dope-context mutating tool (index control, sync, autonomous indexing control, or search_all) through the bridge."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p4",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P4-001-facade-g1-contract-test",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p4-002-dopecontext-bridge-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(dcp-facade): spec the dope-context MCP-JSON-RPC read bridge",
+    "allowlist": [
+      "claudedocs/specs/dmx-fleet-p4-002-dopecontext-bridge-spec.md",
+      "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-002-dopecontext-bridge-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p4-002-dopecontext-bridge-spec/DMX-FLEET-P4-002-dopecontext-bridge-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-002-dopecontext-bridge-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-002-dopecontext-bridge-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/dmx-fleet-p4-002-dopecontext-bridge-spec.md",
+      "grep -q 'Acceptance' claudedocs/specs/dmx-fleet-p4-002-dopecontext-bridge-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(dcp-facade): spec the dope-context MCP-JSON-RPC read bridge",
+    "body": "Produces the design spec for the minimal MCP-JSON-RPC read bridge that unblocks the DCP facade's dope-context adapter (search_code_docs, get_index_status), per the fleet audit's Phase 4.2 item. Spec-only: no runtime code changes. Feeds a future implementation packet and the DMX-FLEET-P4-001 contract-parity test.",
+    "base": "main"
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read the current dope-context adapter fail-closed stub, the facade's HTTP-only client, the dope-context MCP server's real tool surface, and the fleet audit's DCP verdict and Phase 4.2 item, without modifying any runtime code.",
+      "validation": [
+        "Proof records the exact fail-closed reason string and MAX_LIMIT constant from dcp_facade/dope_context.py.",
+        "Proof records dope-context's actual MCP tool surface (search_code, docs_search, search_all, index status/control) and which are candidates for read-bridge exposure vs. permanently denied."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "services/dcp-readonly-facade/src/dcp_facade/dope_context.py",
+        "services/dcp-readonly-facade/src/dcp_facade/tools.py",
+        "services/dcp-readonly-facade/src/dcp_facade/http_client.py",
+        "services/dcp-readonly-facade/src/dcp_facade/route_manifest.py",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/dmx-fleet-p4-002-dopecontext-bridge-spec.md covering: scope (search_code_docs and get_index_status only, no mutating dope-context tool), transport design (MCP JSON-RPC client vs. the facade's existing REST-only ReadOnlyHttpClient), invariants (read-only, capped results, per-project workspace identity, untrusted-by-default envelope), interfaces (function signatures the bridge exposes to dcp_facade.tools), acceptance criteria (what a follow-on implementation packet's tests must prove), and phasing (bridge-only now; DERIVED-to-CANONICAL authority upgrade deferred until inventory classification lands).",
+      "validation": [
+        "Spec file exists at claudedocs/specs/dmx-fleet-p4-002-dopecontext-bridge-spec.md.",
+        "Spec contains sections for Scope, Invariants, Interfaces, Acceptance, and Phasing.",
+        "Spec explicitly states it does not change search_decisions query-mode or any ConPort/task-orchestrator behavior."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the fleet audit's DCP verdict and TOOL_CONTRACT.md section 1c, validate the packet, and commit.",
+      "validation": [
+        "Spec's acceptance criteria are consistent with DMX-FLEET-P4-001's contract-parity test intent (tool set stays 12; BLOCKED becomes real data only when this bridge lands).",
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-003-lane-engine-wire.json
+++ b/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-003-lane-engine-wire.json
@@ -1,0 +1,116 @@
+{
+  "id": "DMX-FLEET-P4-003-lane-engine-wire",
+  "project": "dopemux-mvp",
+  "target": "Wire the currently dead-code decide_lane() function into a real dispatch point (a `dopemux dcp lane` CLI subcommand plus task-packet intake) so DCP lane routing has at least one non-test consumer, per the ADR-003 wire decision.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change decide_lane()'s pure-function contract: it must remain non-mutating of its inputs.",
+    "This packet must not introduce a lane dispatch path that bypasses decide_lane() for any task-packet intake flow it wires.",
+    "This packet must preserve fail-closed behavior for unresolved, blocked, unknown, or authority-conflicted routing inputs.",
+    "This packet must preserve the canonical writer and add a contract test for this lane-routing dispatch surface."
+  ],
+  "depends_on": [
+    "DMX-ADR-003-lane-engine-dispatch"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p4",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P4-002-dopecontext-bridge-spec",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p4-003-lane-engine-wire",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(dcp): wire decide_lane() into dopemux dcp lane and task-packet intake",
+    "allowlist": [
+      "src/dopemux/commands/dcp_commands.py",
+      "src/dopemux/dcp/lane_engine.py",
+      "src/dopemux/dcp/__init__.py",
+      "tests/unit/dcp/test_lane_engine.py",
+      "tests/unit/dopemux/commands/test_dcp_commands_lane.py",
+      "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-003-lane-engine-wire.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p4-003-lane-engine-wire/DMX-FLEET-P4-003-lane-engine-wire/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-003-lane-engine-wire.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-003-lane-engine-wire.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/dcp/test_lane_engine.py tests/unit/dopemux/commands/test_dcp_commands_lane.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): wire decide_lane() as a real dispatch point",
+    "body": "Adds a `dopemux dcp lane` CLI subcommand and a task-packet intake call site that invoke the existing decide_lane() function (src/dopemux/dcp/lane_engine.py:335), which today has zero non-test consumers per the fleet audit's DCP verdict. Implements the DMX-ADR-003 decision to wire lane routing as real dispatch rather than leave it as latent, unconsumed protection.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Confirm DMX-ADR-003 is accepted before proceeding; if not yet merged, record NOT_RUN and stop. Read decide_lane(), its RouteDecision/RoutingClassificationInput/LaneDecision types, the existing dcp_commands.py CLI group (classify, recommend-backend), and the current 1009-line test suite.",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "ADR-003 acceptance status is recorded in proof; execution stops with NOT_RUN if the ADR is not yet accepted."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docs/90-adr/adr-003-lane-engine-dispatch.md",
+        "src/dopemux/dcp/lane_engine.py",
+        "src/dopemux/dcp/__init__.py",
+        "src/dopemux/commands/dcp_commands.py",
+        "tests/unit/dcp/test_lane_engine.py",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write failing tests for a new `dopemux dcp lane` CLI subcommand (accepts a routing classification input, calls decide_lane(), prints the LaneDecision) and for a task-packet intake call site that invokes decide_lane() before packet execution begins.",
+      "validation": [
+        "tests/unit/dopemux/commands/test_dcp_commands_lane.py fails because the `lane` subcommand does not exist yet.",
+        "New tests assert decide_lane()'s fail-closed behavior (unresolved/blocked/unknown/authority-conflicted inputs) is preserved through the new call sites."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement the minimal `dopemux dcp lane` subcommand in dcp_commands.py and the task-packet intake call site, both delegating to the existing decide_lane() without modifying its pure-function contract.",
+      "validation": [
+        "decide_lane() itself is unchanged in signature and purity (no mutation of inputs).",
+        "The new CLI subcommand and intake call site are the only new non-test consumers introduced.",
+        "Fail-closed routing behavior (from lane_engine.py's existing _has_unknown_decision_contract, _has_blocking_stop_or_escalation logic) is exercised end-to-end by the new tests."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run the full verify list, commit only allowlisted files, push, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "All new and existing lane-engine and CLI tests pass.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-004-inventory-freshness-gate.json
+++ b/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-004-inventory-freshness-gate.json
@@ -1,0 +1,108 @@
+{
+  "id": "DMX-FLEET-P4-004-inventory-freshness-gate",
+  "project": "dopemux-mvp",
+  "target": "Add a CI verification that fails when the DCP facade's backend-surface inventory (RUNTIME_SURFACE_INVENTORY.md / READ_ONLY_SURFACE_INVENTORY.json) is stale relative to the facade's actual route_manifest.py and TOOL_CONTRACT.md, closing the fleet audit's 'surface inventory is point-in-time with no freshness gate' finding.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change route_manifest.py's ALLOWED_ROUTES or DENIED_ROUTES data.",
+    "This packet must not weaken any existing denylist test or the commit-verify grep for denied tokens.",
+    "This packet must fail closed (CI fails) when the inventory's recorded commit/date is older than the last change to route_manifest.py or TOOL_CONTRACT.md, rather than silently passing.",
+    "This packet must preserve the canonical writer and add a contract test for this contract-sensitive freshness surface."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P4-001-facade-g1-contract-test"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p4",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P4-003-lane-engine-wire",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p4-004-inventory-freshness-gate",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "test(dcp-facade): add inventory freshness CI gate",
+    "allowlist": [
+      "services/dcp-readonly-facade/tests/test_inventory_freshness.py",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_SURFACE_INVENTORY.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/READ_ONLY_SURFACE_INVENTORY.json",
+      "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-004-inventory-freshness-gate.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p4-004-inventory-freshness-gate/DMX-FLEET-P4-004-inventory-freshness-gate/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-004-inventory-freshness-gate.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-004-inventory-freshness-gate.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest services/dcp-readonly-facade/tests/test_inventory_freshness.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "test(dcp-facade): close the inventory freshness gap with a CI check",
+    "body": "Adds a CI test that fails when docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_SURFACE_INVENTORY.md and READ_ONLY_SURFACE_INVENTORY.json are older (by recorded commit or embedded date) than route_manifest.py or TOOL_CONTRACT.md, so the facade's backend-surface inventory cannot silently drift out of date. Closes the fleet audit's Phase 4.4 item; depends on DMX-FLEET-P4-001's contract-parity gate landing first.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Confirm DMX-FLEET-P4-001 has landed. Read the current inventory files' embedded date/commit markers and route_manifest.py's git history to determine a concrete, checkable freshness signal (e.g. embedded 'as of commit <sha>' front matter vs. git log of route_manifest.py since that sha).",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "The chosen freshness signal (embedded commit marker vs. git-log comparison) is recorded in proof with the exact fields/format it depends on."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_SURFACE_INVENTORY.md",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/READ_ONLY_SURFACE_INVENTORY.json",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md",
+        "services/dcp-readonly-facade/src/dcp_facade/route_manifest.py",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test in services/dcp-readonly-facade/tests/test_inventory_freshness.py that parses the inventory's embedded freshness marker and compares it against route_manifest.py's last-modified commit (via `git log -1 --format=%H -- <path>`), failing when the inventory predates the manifest.",
+      "validation": [
+        "The test fails today because no such comparison exists.",
+        "The test does not require network access or a live database; it operates on the repo's git history and the two static files."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "If the inventory files lack a machine-readable freshness marker, add a minimal 'as of commit <sha>' front-matter field to each and set it to the current HEAD commit at authoring time. Do not alter any ALLOWED_ROUTES/DENIED_ROUTES tables or TOOL_CONTRACT.md's tool rows.",
+      "validation": [
+        "The new freshness test passes against the current repo state.",
+        "route_manifest.py and TOOL_CONTRACT.md content are byte-identical except for any added freshness marker in the inventory files themselves.",
+        "Existing denylist tests (test_route_denylist.py) still pass unchanged."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run the full verify list, commit only allowlisted files, push, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "The new freshness test and the existing denylist/contract tests pass.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-005-facade-catalog-register.json
+++ b/task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-005-facade-catalog-register.json
@@ -1,0 +1,107 @@
+{
+  "id": "DMX-FLEET-P4-005-facade-catalog-register",
+  "project": "dopemux-mvp",
+  "target": "Register dcp-readonly-facade as an operator-run stdio entry in the unified MCP catalog, closing the gap where the facade is confirmed absent from mcp_catalog.yaml, services/registry.yaml, and src/dopemux/mcp/registry.yaml despite being a real, tested MCP server.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must register the facade as operator-run stdio, matching its actual deployment posture (not auto-started via compose).",
+    "This packet must not change any facade tool behavior, route_manifest.py data, or the facade's own registry.example.yaml.",
+    "This packet must not grant the facade any write capability or elevate its authority label beyond DERIVED/CANONICAL as already documented per tool in TOOL_CONTRACT.md.",
+    "This packet must preserve the canonical writer and add a contract test asserting the catalog entry exists and matches the facade's real tool count."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P1-001-unified-catalog-spec"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p4",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P4-004-inventory-freshness-gate",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p4-005-facade-catalog-register",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(mcp-catalog): register dcp-readonly-facade as operator-run stdio",
+    "allowlist": [
+      "mcp_catalog.yaml",
+      "tests/unit/dopemux/mcp/test_catalog_dcp_facade_entry.py",
+      "task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-005-facade-catalog-register.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p4-005-facade-catalog-register/DMX-FLEET-P4-005-facade-catalog-register/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-005-facade-catalog-register.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P4/DMX-FLEET-P4-005-facade-catalog-register.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/dopemux/mcp/test_catalog_dcp_facade_entry.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(mcp-catalog): register dcp-readonly-facade in the unified catalog",
+    "body": "Adds an operator-run stdio catalog entry for services/dcp-readonly-facade, which the fleet audit confirmed is absent from mcp_catalog.yaml, services/registry.yaml, and src/dopemux/mcp/registry.yaml despite being a real, 12-tool, 537/539-test MCP server. Closes the fleet audit's Phase 4.5 item; depends on DMX-FLEET-P1-001's unified catalog schema landing first, and is the final packet of the DMX-FLEET-P4 series.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Confirm DMX-FLEET-P1-001's unified catalog schema has landed; if the schema is not yet available, record the current mcp_catalog.yaml schema shape actually in use and proceed against that shape, noting the gap in proof. Read an existing stdio catalog entry (e.g. dope-context or pal-stdio) as the format template.",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "Proof records whether DMX-FLEET-P1-001's unified schema was available and which catalog schema shape this packet targets."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "mcp_catalog.yaml",
+        "services/dcp-readonly-facade/README.md",
+        "services/dcp-readonly-facade/registry.example.yaml",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test in tests/unit/dopemux/mcp/test_catalog_dcp_facade_entry.py asserting mcp_catalog.yaml contains a dcp-readonly-facade entry with transport stdio, an operator-run marker/annotation, and a tool count or tool list matching TOOL_CONTRACT.md's 12 tools.",
+      "validation": [
+        "The test fails before the catalog entry exists.",
+        "The test does not require Docker or a live process; it parses the static YAML."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Add the minimal dcp-readonly-facade entry to mcp_catalog.yaml following the existing stdio entry format, marked as operator-run (not docker_compose_service-backed) so it is not mistaken for an auto-started server.",
+      "validation": [
+        "The new catalog test passes.",
+        "No existing catalog entry is modified or reordered beyond the minimal insertion.",
+        "The entry does not declare docker_compose_service or auto-start behavior inconsistent with the facade's actual operator-run deployment."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run the full verify list, commit only allowlisted files, push, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "The new catalog entry test passes.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-001-e2e-acceptance.json
+++ b/task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-001-e2e-acceptance.json
@@ -1,0 +1,87 @@
+{
+  "id": "DMX-FLEET-P5-001-e2e-acceptance",
+  "project": "dopemux-mvp",
+  "target": "Spec the end-to-end fleet acceptance test: from a fresh worktree, `dopemux mcp ensure` brings every plane green, a decision logged in ConPort is mirrored to dope-memory and later recapped, and the chronicle content is retrievable via dope-context search, proving the memory spine and fleet-management loop actually close.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not fabricate acceptance results; where a dependency (mcp ensure, dope-context indexing) is not yet implemented, the spec marks the corresponding acceptance step as NOT_RUN / blocked-pending-dependency rather than asserting a result.",
+    "This packet must define the acceptance test as read-only against production data — it may create and later clean up ephemeral test worktrees and test ConPort/chronicle entries, but must not touch unrelated project data."
+  ],
+  "depends_on": [
+    "DMX-FLEET-P1-003-mcp-ensure-command",
+    "DMX-FLEET-P2-005-dopecontext-indexing-enable"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p5",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p5-001-e2e-acceptance",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(fleet): spec the end-to-end fleet acceptance test",
+    "allowlist": [
+      "claudedocs/specs/dmx-fleet-p5-001-e2e-acceptance.md",
+      "task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-001-e2e-acceptance.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p5-001-e2e-acceptance/DMX-FLEET-P5-001-e2e-acceptance/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-001-e2e-acceptance.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-001-e2e-acceptance.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/dmx-fleet-p5-001-e2e-acceptance.md",
+      "grep -q 'Acceptance' claudedocs/specs/dmx-fleet-p5-001-e2e-acceptance.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(fleet): spec the fresh-worktree-to-recall end-to-end acceptance test",
+    "body": "Produces the acceptance-test spec for the fleet audit's Phase 5.1 item: fresh worktree -> `dopemux mcp ensure` -> all planes green -> decision logged -> mirrored to dope-memory -> recapped -> retrieved via dope-context. Spec-only; depends on DMX-FLEET-P1-003 (mcp ensure) and DMX-FLEET-P2-005 (dope-context indexing enabled) landing before the spec's acceptance steps can actually run end-to-end.",
+    "base": "main"
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read the memory-spine fix plan (fleet audit section 7.2), the current capture_client event flow, the dope-memory recap tool, and the dope-context search tools, without modifying any runtime code. Confirm whether DMX-FLEET-P1-003 and DMX-FLEET-P2-005 have landed; record their status.",
+      "validation": [
+        "Proof records the current status (landed / not landed) of DMX-FLEET-P1-003 and DMX-FLEET-P2-005.",
+        "Proof records the exact promotable event types (decision.logged, task.*, workflow.phase_changed) and confirms which are currently wired at their real emission sources versus still pending."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/dmx-fleet-p5-001-e2e-acceptance.md covering: scope (single end-to-end run, not a general test-suite expansion), the exact ordered steps (fresh worktree creation -> `dopemux mcp ensure` -> per-plane health assertions -> log a test decision in ConPort -> assert dope-memory mirror receipt -> assert recap surfaces it -> assert dope-context search retrieves it with correct provenance pointer), invariants (read-only against real project data; ephemeral test artifacts cleaned up), acceptance criteria per step (pass/fail/not_run conditions), and phasing (which steps can run today vs. which are blocked on DMX-FLEET-P1-003/P2-005).",
+      "validation": [
+        "Spec file exists at claudedocs/specs/dmx-fleet-p5-001-e2e-acceptance.md.",
+        "Spec contains sections for Scope, Invariants, Ordered Steps, Acceptance, and Phasing.",
+        "Spec explicitly marks any step blocked on an unlanded dependency as NOT_RUN rather than assuming success."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the memory-spine fix plan and the DMX-FLEET-P5-002/003 packets' scope (docs reconciliation and proof discipline), validate the packet, and commit.",
+      "validation": [
+        "Spec's acceptance criteria are consistent with what DMX-FLEET-P5-003's proof-bundle template will need to capture.",
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-002-docs-reconciliation.json
+++ b/task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-002-docs-reconciliation.json
@@ -1,0 +1,94 @@
+{
+  "id": "DMX-FLEET-P5-002-docs-reconciliation",
+  "project": "dopemux-mvp",
+  "target": "Regenerate the fleet's per-server doctrine docs (~/.claude/MCP_*.md sources and their in-repo equivalents) to match live tools/list surfaces, and explicitly mark aspirational ADHD automation claims (break timers, forced hyperfocus pauses, automatic 30-minute checkpoints) as specification-only wherever they currently read as observed runtime behavior.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change any runtime code; it is a documentation-accuracy correction.",
+    "This packet must not remove documentation of a real capability; it may only correct claims that are currently false or unverified against the live surface.",
+    "This packet must distinguish, for every ADHD automation claim it touches, between 'observed runtime support' and 'planned/specification behavior' using those exact labels or equivalents already established in .claude/CLAUDE.md.",
+    "This packet must cite the specific file:line or tool-list evidence for every doctrine correction it makes."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p5",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P5-001-e2e-acceptance",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p5-002-docs-reconciliation",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(fleet): reconcile doctrine with live tool surfaces and mark aspirational ADHD automation",
+    "allowlist": [
+      "docs/03-reference/*.md",
+      ".claude/modules/shared/adhd-patterns.md",
+      "docs/systems/**/*.md",
+      "task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-002-docs-reconciliation.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p5-002-docs-reconciliation/DMX-FLEET-P5-002-docs-reconciliation/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-002-docs-reconciliation.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-002-docs-reconciliation.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(fleet): reconcile doctrine with reality; mark aspirational ADHD claims",
+    "body": "Corrects per-server doctrine docs to match live MCP tool surfaces (closing the fleet audit's 'commands reference tools no server exposes' finding, e.g. 6 broken ConPort references) and explicitly labels aspirational ADHD automation (break timers, forced hyperfocus pauses, automatic checkpoints) as specification-only rather than observed runtime behavior, per the fleet audit's Phase 5.2 item.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. For each dopemux-owned MCP server referenced in .claude/commands/* and docs/03-reference doctrine, compare documented tool names against the server's real tools/list output (or, if the server cannot be started live, its source-code tool registrations) to find drifted references.",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "A concrete list of drifted doctrine references (doc file, claimed tool, actual tool surface) is recorded in proof, including the ConPort references the fleet audit flagged as broken."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md",
+        ".claude/CLAUDE.md",
+        ".claude/modules/shared/adhd-patterns.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Correct each drifted doctrine reference to match the real tool surface, and for every ADHD automation claim identified as aspirational (not backed by a hook, `/loop`, or `ScheduleWakeup` schedule), rewrite it using the observed-vs-planned distinction already established in .claude/CLAUDE.md's Lifecycle Hooks section.",
+      "validation": [
+        "Every corrected doctrine reference cites the file:line or tools/list evidence it was checked against, recorded in proof.",
+        "No corrected doc claims automatic timer/break/checkpoint enforcement unless a specific hook or scheduled task actually implements it."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run the verify list, commit only allowlisted files, push, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed.",
+        "git diff --check passes."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-003-proof-discipline.json
+++ b/task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-003-proof-discipline.json
@@ -1,0 +1,102 @@
+{
+  "id": "DMX-FLEET-P5-003-proof-discipline",
+  "project": "dopemux-mvp",
+  "target": "Establish a per-packet proof-bundle template and a checker script under proof/ that verifies every proof bundle contains the fields AGENTS.md sections 8 and 9 require (TP path/ID, worktree path, branch, repo identity, files changed, validations with exit codes, codereview status, precommit status, commit SHA or exact blocker, residual risks, UNKNOWNs, cleanup status), so proof-bundle completeness is machine-checkable rather than reviewer-trusted.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change any existing proof bundle's content; it only adds a template and a checker.",
+    "This packet must fail closed: the checker must exit non-zero when a required proof field is missing, not warn-and-pass.",
+    "This packet must not become a canonical writer of proof content; it verifies structure only, and does not fabricate or infer field values on a packet's behalf."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-fleet-p5",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-FLEET-P5-002-docs-reconciliation",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-fleet-p5-003-proof-discipline",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(proof): add per-packet proof-bundle template and completeness checker",
+    "allowlist": [
+      "proof/_TEMPLATE/PROOF_BUNDLE_TEMPLATE.md",
+      "scripts/proof/check_proof_bundle.py",
+      "tests/unit/scripts/test_check_proof_bundle.py",
+      "task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-003-proof-discipline.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-fleet-p5-003-proof-discipline/DMX-FLEET-P5-003-proof-discipline/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-003-proof-discipline.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-FLEET-P5/DMX-FLEET-P5-003-proof-discipline.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "python -m pytest tests/unit/scripts/test_check_proof_bundle.py -q",
+      "python scripts/proof/check_proof_bundle.py proof/dmx-fleet-p5-003-proof-discipline/DMX-FLEET-P5-003-proof-discipline",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(proof): add a proof-bundle template and fail-closed completeness checker",
+    "body": "Adds proof/_TEMPLATE/PROOF_BUNDLE_TEMPLATE.md and scripts/proof/check_proof_bundle.py, which verifies a proof bundle directory contains every field AGENTS.md sections 8 and 9 require and exits non-zero on any missing field. Closes the fleet audit's Phase 5.3 item ('proof bundles per packet per AGENTS.md sections 8/9') and is the final packet of the DMX-FLEET-P5 series.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Read AGENTS.md sections 8 and 9 for the exact required proof-bundle fields, and sample 2-3 existing proof/ directories (e.g. proof/TP-DCP-MCP-RO-0006, proof/DMX-DCP-MODEL-ROUTING-MVP-0001) to learn the current de-facto structure before designing the template and checker.",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "The exact required field list from AGENTS.md sections 8 and 9 is recorded in proof, along with which of the sampled existing bundles already satisfy it and which do not."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/mcp-fleet-canonical-audit-and-target-design-2026-07-03.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write a failing test in tests/unit/scripts/test_check_proof_bundle.py asserting the checker script exits non-zero when a required field (e.g. commit SHA, codereview status, residual risks) is missing from a proof bundle directory, and exits zero when all required fields are present.",
+      "validation": [
+        "The test fails before scripts/proof/check_proof_bundle.py exists.",
+        "The test covers at least one missing-field failure case and one complete-bundle success case."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement proof/_TEMPLATE/PROOF_BUNDLE_TEMPLATE.md (a markdown skeleton with every AGENTS.md section 8/9 field as a heading) and scripts/proof/check_proof_bundle.py (a script that scans a given proof bundle directory's files for the required field markers and fails closed on any gap).",
+      "validation": [
+        "The new checker test passes.",
+        "Running the checker against this packet's own proof bundle (built in S4) exits zero.",
+        "Running the checker against a deliberately incomplete sample bundle exits non-zero with a clear message naming the missing field."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, build this packet's own proof bundle using the new template, run the full verify list including the checker against its own bundle, commit only allowlisted files, push, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "The checker script exits 0 against this packet's own proof bundle.",
+        "Only allowlisted files are staged and committed."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-MCF/DMX-MCF-002-transcript-ingest.json
+++ b/task-packets/generated/DMX-MCF/DMX-MCF-002-transcript-ingest.json
@@ -1,0 +1,137 @@
+{
+  "id": "DMX-MCF-002-transcript-ingest",
+  "project": "dopemux-mvp",
+  "target": "Build a one-shot, idempotent transcript-file ingest adapter that parses Claude Code session transcript JSONL into turn events and writes only to the dope-memory raw ledger (raw_activity_events) via the existing capture spine, with deterministic ids, stable-timestamp-or-quarantine, and a non-queryable dope-memory quarantine table (schema migration) for redaction failures.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not modify capture_client.py, redactor.py, promotion.py, or PROMOTABLE_CAPTURE_EVENT_TYPES.",
+    "This packet must write only to raw_activity_events via capture_client.emit_capture_event() -- no ConPort writes, no dope-context writes, no Redis requirement.",
+    "This packet must never ingest a turn lacking a source timestamp with datetime.now() -- it must quarantine that turn instead.",
+    "This packet must quarantine on redaction failure into a non-queryable dope-memory table (schema migration), never the queryable ledger.",
+    "This packet must never search, promote, mirror, or project quarantined records.",
+    "This packet must be idempotent: re-ingesting the same transcript file must not grow the ledger or the quarantine table.",
+    "This packet must fail open for the session: a malformed line or ingest error must never raise out of ingest_transcript_file.",
+    "This packet must preserve the canonical writer (dope-memory) and add a contract test proving the quarantine table is excluded from search/promotion/mirror/projection paths.",
+    "This packet must not build a file-watcher daemon or Codex transcript support -- both are explicitly out of scope."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-mcf",
+    "base_branch": "origin/main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-mcf-002-transcript-ingest",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(memory): transcript-file ingest into raw ledger with non-queryable quarantine table",
+    "allowlist": [
+      "src/dopemux/memory/transcript_ingest.py",
+      "src/dopemux/commands/memory_commands.py",
+      "tests/unit/test_transcript_ingest.py",
+      "tests/unit/test_cli_memory_ingest_transcript.py",
+      "services/working-memory-assistant/chronicle/migrations/v1_3_0_add_quarantine_table.sql",
+      "services/working-memory-assistant/chronicle/schema.sql",
+      "services/working-memory-assistant/tests/unit/test_chronicle_quarantine_table.py",
+      "task-packets/generated/DMX-MCF/DMX-MCF-002-transcript-ingest.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-mcf-002-transcript-ingest/DMX-MCF-002-transcript-ingest/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-MCF/DMX-MCF-002-transcript-ingest.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-MCF/DMX-MCF-002-transcript-ingest.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "mise exec -- python -m pytest tests/unit/test_transcript_ingest.py tests/unit/test_cli_memory_ingest_transcript.py -q",
+      "cd services/working-memory-assistant && mise exec -- python -m pytest tests/unit/test_chronicle_quarantine_table.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(memory): transcript-file ingest into raw ledger with non-queryable quarantine",
+    "body": "Implements TP-MCF-002 per claudedocs/plans/2026-07-04-tp-mcf-002-transcript-ingest.md: a one-shot, idempotent transcript-file ingest adapter (src/dopemux/memory/transcript_ingest.py) that parses Claude Code session JSONL into TranscriptTurn records and writes only to raw_activity_events via the existing capture spine. Per claudedocs/backlog/decisions-ledger.md (MCF-002 gate), redaction-failure and missing-source-timestamp turns are quarantined into a new non-queryable dope-memory table added via a chronicle schema migration -- superseding the build plan's filesystem-quarantine-directory draft. No ConPort or dope-context writes; no file-watcher daemon.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean status. Run the Task 1 transcript-format spike from the build plan (locate a real Claude Code transcript JSONL, inspect the schema, confirm the parse contract still holds; note any drift).",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "The observed transcript record-type distribution and message.content shapes are recorded in proof, with any drift from the plan's baseline schema noted explicitly."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/plans/2026-07-04-tp-mcf-002-transcript-ingest.md",
+        "claudedocs/tp-mcf-001-authority-map-2026-07-04.md",
+        "claudedocs/memory-context-fabric-interfaces-2026-07-04.md",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write failing tests for parse_transcript_line, turn_to_capture_envelope, and ingest_transcript_file before implementation, per the build plan's Tasks 2, 3, and 5 (TDD: red then green, one commit per task). The build plan's Task 4/5 tests that assert a filesystem quarantine_dir (e.g. write_quarantine_record, test_ingest_transcript_file_quarantines_missing_timestamp_turn) are superseded by the table-based contract test written in S4 of this packet -- do not port the filesystem-quarantine assertions verbatim; assert against the quarantine table instead.",
+      "validation": [
+        "Tests fail for the correct reason (module or attribute not found) before implementation exists.",
+        "Test coverage includes: user_prompt/assistant_response/tool_call/tool_result classification, non-turn/malformed-line skip, missing-timestamp handling, idempotent replay, and the no-ConPort/no-dope-context import structural test.",
+        "No test in this step asserts a filesystem quarantine directory or file -- quarantine assertions target the table added in S4."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement parse_transcript_line, turn_to_capture_envelope, and ingest_transcript_file in src/dopemux/memory/transcript_ingest.py per the build plan, plus the CLI subcommand dopemux memory ingest-transcript in src/dopemux/commands/memory_commands.py.",
+      "validation": [
+        "All transcript_ingest tests pass.",
+        "The module imports neither conport nor dope_context (structural import-scan test passes).",
+        "Re-running ingest_transcript_file against the same file is idempotent (ledger row count unchanged, ingested count 0 on the second run)."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Per claudedocs/backlog/decisions-ledger.md (MCF-002 gate: non-queryable dope-memory table, not a file path), add a chronicle schema migration (services/working-memory-assistant/chronicle/migrations/v1_3_0_add_quarantine_table.sql, applied via the existing apply_chronicle_migrations/sqlite_migrations.py mechanism) that creates a quarantine table holding only {event_id, ts, session_id, reason, original_keys, source_path, source_line} -- no payload content. Wire transcript_ingest.py's quarantine writer to insert into this table instead of a filesystem directory. Add a contract test proving the table is never referenced by any search, promotion, mirror, or dope-context-projection code path.",
+      "validation": [
+        "The migration is idempotent and additive (does not alter existing chronicle tables) and is picked up by apply_chronicle_migrations.",
+        "The quarantine table has no full-text/search index and is not referenced by promotion.py, capture_client.py's promotable paths, recap.py, or any dope-context indexing code.",
+        "A missing-source-timestamp turn and a redaction-failure turn both insert exactly one row into the quarantine table and zero rows into raw_activity_events.",
+        "Re-quarantining the same event_id is idempotent (no duplicate row)."
+      ],
+      "context_files": [
+        "services/working-memory-assistant/chronicle/schema.sql",
+        "services/working-memory-assistant/chronicle/sqlite_migrations.py",
+        "services/working-memory-assistant/chronicle/migrations/v1_2_1_scope_supersession_unique_index.sql"
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run all validations, run PAL codereview and precommit, commit only allowlisted files, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "All commit.verify commands pass or exact blockers are recorded as FAIL/NOT_RUN.",
+        "Only allowlisted files are staged and committed.",
+        "Proof bundle records worktree path, branch, commit SHA, PR URL, validations with exit codes, and residual risks."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-MCF/DMX-MCF-003-decision-candidate.json
+++ b/task-packets/generated/DMX-MCF/DMX-MCF-003-decision-candidate.json
@@ -1,0 +1,132 @@
+{
+  "id": "DMX-MCF-003-decision-candidate",
+  "project": "dopemux-mvp",
+  "target": "Add the conversation.decision_candidate event type end-to-end through the existing capture-to-promotion pipeline (both allowlists kept in sync, a sync-guard test, and a deterministic non-LLM promotion handler) so transcript-derived decision-looking turns become trust-lower curated-chronicle candidates -- never a ConPort write, never decision.logged.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must use only deterministic regex/string-heuristic detection -- no LLM calls, no network calls anywhere in this packet.",
+    "This packet must never auto-write ConPort. No import of httpx, requests, aiohttp, or any ConPort client anywhere in the new detector or promotion-handler code.",
+    "This packet must never emit or promote to decision.logged -- the candidate event type is conversation.decision_candidate, always.",
+    "This packet must add conversation.decision_candidate to both PROMOTABLE_CAPTURE_EVENT_TYPES (capture_client.py) and PROMOTABLE_EVENT_TYPES (promotion.py) and keep them synced via a sync-guard test.",
+    "This packet must encode trust only in details_json.trust=\"conversation-derived\" with promotion_rule=\"conversation_candidate_v1\" -- no schema trust column exists.",
+    "This packet must give a conversation-derived candidate a strictly lower importance_score than a real decision.logged promotion.",
+    "This packet must preserve the canonical writer (dope-memory promotion path) and add a contract test asserting no ConPort write occurs for this event type.",
+    "This packet must not implement promotion of a candidate to a canonical ConPort decision -- that explicit-gate step is out of scope."
+  ],
+  "depends_on": [
+    "DMX-MCF-002-transcript-ingest"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-mcf",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-MCF-002-transcript-ingest",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-mcf-003-decision-candidate",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(memory): deterministic conversation.decision_candidate detection and promotion",
+    "allowlist": [
+      "src/dopemux/memory/conversation_promotion.py",
+      "src/dopemux/memory/capture_client.py",
+      "services/working-memory-assistant/promotion/promotion.py",
+      "services/working-memory-assistant/tests/test_event_type_normalization.py",
+      "services/working-memory-assistant/tests/unit/test_promotion_rule_precedence.py",
+      "services/working-memory-assistant/tests/unit/test_promote_conversation_decision_candidate.py",
+      "tests/unit/test_conversation_promotion_detector.py",
+      "tests/unit/test_promotable_allowlist_sync.py",
+      "tests/unit/test_conversation_decision_candidate_emit.py",
+      "task-packets/generated/DMX-MCF/DMX-MCF-003-decision-candidate.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-mcf-003-decision-candidate/DMX-MCF-003-decision-candidate/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-MCF/DMX-MCF-003-decision-candidate.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-MCF/DMX-MCF-003-decision-candidate.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "mise exec -- python -m pytest tests/unit/test_conversation_promotion_detector.py tests/unit/test_promotable_allowlist_sync.py tests/unit/test_conversation_decision_candidate_emit.py -q",
+      "cd services/working-memory-assistant && mise exec -- python -m pytest tests/test_event_type_normalization.py tests/test_promotion_allowlist.py tests/unit/test_promotion_rule_precedence.py tests/unit/test_promote_conversation_decision_candidate.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(memory): deterministic conversation.decision_candidate detection and promotion",
+    "body": "Implements TP-MCF-003 per claudedocs/plans/2026-07-04-tp-mcf-003-deterministic-promotion.md: a pure regex-based decision-marker detector (src/dopemux/memory/conversation_promotion.py), the new conversation.decision_candidate event type added to both promotable allowlists with a sync-guard test, a one-line promotion_rule dispatch-precedence fix (backward-compatible, regression-tested), and a deterministic promotion handler producing trust-lower candidates (importance_score=4 vs 7, promotion_rule=conversation_candidate_v1, trust encoded in details_json only). No LLM, no auto ConPort writes, never decision.logged.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean status. Confirm baseline WMA promotion test suite is green before touching code.",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "Baseline test run for services/working-memory-assistant/tests/test_promotion_allowlist.py and tests/test_event_type_normalization.py is green and recorded."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/plans/2026-07-04-tp-mcf-003-deterministic-promotion.md",
+        "claudedocs/tp-mcf-001-authority-map-2026-07-04.md",
+        "claudedocs/memory-context-fabric-interfaces-2026-07-04.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write failing tests for detect_decision_candidate (deterministic marker detection, anchored patterns, negative cases for questions/hedged hypotheticals) before implementation, per the build plan's Task 1.",
+      "validation": [
+        "Tests fail because the module does not exist yet.",
+        "Test coverage includes all six marker patterns, min/max length boundaries, question-form rejection, and hedged-hypothetical rejection."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement detect_decision_candidate in src/dopemux/memory/conversation_promotion.py (pure function, no I/O, no LLM). Fix the promotion_rule dispatch-precedence clobber in promotion.py (one line, backward-compatible, regression-tested). Add conversation.decision_candidate to both PROMOTABLE_CAPTURE_EVENT_TYPES and PROMOTABLE_EVENT_TYPES with a sync-guard test. Implement the _promote_conversation_decision_candidate handler per the build plan's field choices (category=planning, entry_type=decision, importance_score=4, promotion_rule=conversation_candidate_v1, trust in details_json only).",
+      "validation": [
+        "All detector, sync-guard, and promotion-handler tests pass.",
+        "The regression test proves the promotion_rule dispatch fix is backward-compatible for all 7 pre-existing handlers.",
+        "A candidate's importance_score is strictly less than a real decision.logged promotion's importance_score.",
+        "Static import-scan tests confirm conversation_promotion.py and capture_client.py import no httpx/requests/aiohttp/ConPort client."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Add the emit-side acceptance tests proving emit_promotable_capture_event accepts the new type end-to-end through the real SQLite ledger, and that the emitted event_type is never decision.logged.",
+      "validation": [
+        "Emit-side tests pass against the real ledger path (tmp_path-isolated).",
+        "No ConPort write occurs anywhere in this packet's test suite (asserted structurally, not just by absence of a mock call)."
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run all validations (both the root and WMA test suites, using the scoped WMA command that excludes pre-existing unrelated collection errors), run PAL codereview and precommit, commit only allowlisted files, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "All commit.verify commands pass or exact blockers are recorded as FAIL/NOT_RUN.",
+        "Only allowlisted files are staged and committed.",
+        "Proof bundle records worktree path, branch, commit SHA, PR URL, validations with exit codes, and residual risks."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-MCF/DMX-MCF-004-sessionstart-recap.json
+++ b/task-packets/generated/DMX-MCF/DMX-MCF-004-sessionstart-recap.json
@@ -1,0 +1,120 @@
+{
+  "id": "DMX-MCF-004-sessionstart-recap",
+  "project": "dopemux-mvp",
+  "target": "Extend the existing native_hooks.py SessionStart injection path with a bounded, token-budgeted, authority-labeled Top-3 recap read directly from the local chronicle SQLite ledger, with a kill switch and no semantic fusion.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must never make a network call, ConPort call, or dope-context call from the recap module -- it is a local SQLite read only.",
+    "This packet must open the chronicle ledger strictly read-only (mode=ro URI) -- no INSERT/UPDATE/DELETE anywhere in recap.py.",
+    "This packet must never raise out of _on_session_start -- missing ledger, empty ledger, malformed rows, or a corrupt file must inject nothing, not fail the hook.",
+    "This packet must enforce a token budget on every ContextBundle, dropping whole items (never partial) and setting truncated=true when the budget is exceeded.",
+    "This packet must label every item with an authority_label and trust field per the interfaces spec section 2.4, with conversation-inferred items never outranking canonical ones.",
+    "This packet must not perform semantic fusion -- retrieval is limited to the local chronicle ledger only, Top-3 default.",
+    "This packet must provide an operator kill switch (DOPEMUX_RECAP_INJECTION=off) that disables recap injection entirely.",
+    "This packet must implement ContextItem and ContextBundle exactly per the interfaces spec section 2.4 field names and order."
+  ],
+  "depends_on": [
+    "DMX-MCF-003-decision-candidate"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-mcf",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-MCF-003-decision-candidate",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-mcf-004-sessionstart-recap",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "feat(memory): bounded SessionStart recap injection via native hooks",
+    "allowlist": [
+      "src/dopemux/memory/recap.py",
+      "src/dopemux/claude/native_hooks.py",
+      "tests/unit/test_recap.py",
+      "tests/test_native_hooks_workflow.py",
+      "task-packets/generated/DMX-MCF/DMX-MCF-004-sessionstart-recap.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-mcf-004-sessionstart-recap/DMX-MCF-004-sessionstart-recap/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-MCF/DMX-MCF-004-sessionstart-recap.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-MCF/DMX-MCF-004-sessionstart-recap.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "mise exec -- python -m pytest tests/unit/test_recap.py tests/test_native_hooks_workflow.py -q",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "feat(memory): bounded SessionStart recap injection via native hooks",
+    "body": "Implements TP-MCF-004 per claudedocs/plans/2026-07-04-tp-mcf-004-sessionstart-recap.md: a new src/dopemux/memory/recap.py module that reads the local chronicle SQLite ledger read-only (mode=ro), builds a Top-3 token-budgeted ContextBundle with authority labels (canonical vs conversation-inferred), and renders a deterministic markdown recap block. native_hooks.py's SessionStart handler is extended to append this recap as a fail-open fourth part of its existing context composition, gated by a DOPEMUX_RECAP_INJECTION kill switch. No semantic fusion, no network calls.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Preflight a fresh dedicated worktree from current origin/main. Verify repo marker, origin identity, branch, base HEAD, and clean status. Confirm baseline: tests/test_native_hooks_workflow.py passes (7 tests) before any edits.",
+      "validation": [
+        "Worktree path, branch, origin, marker, and clean baseline are recorded in proof.",
+        "Baseline native-hooks test run is green and recorded before any implementation edit."
+      ],
+      "context_files": [
+        "AGENTS.md",
+        "claudedocs/plans/2026-07-04-tp-mcf-004-sessionstart-recap.md",
+        "claudedocs/memory-context-fabric-interfaces-2026-07-04.md",
+        "claudedocs/tp-mcf-001-authority-map-2026-07-04.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Write failing tests for ContextItem/ContextBundle contracts, the token estimator, resolve_ledger_path, and build_recap_bundle (top-k selection, window filtering, workspace isolation, authority labeling, fail-open on missing/empty/corrupt ledger) before implementation, per the build plan's Tasks 1-2.",
+      "validation": [
+        "Tests fail because the recap module does not exist yet.",
+        "Test coverage includes curated-row canonical/high-trust labeling and conversation_candidate_v1-row conversation-inferred/conversation-derived labeling."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Implement recap.py: ContextItem, ContextBundle, estimate_tokens, resolve_ledger_path (delegating to capture_client._resolve_ledger_path), _connect_ro (mode=ro URI), build_recap_bundle, token-budget truncation (whole-item drop, most-recent-first prefix kept), and render_recap (deterministic markdown).",
+      "validation": [
+        "All recap.py unit tests pass.",
+        "A structural test confirms _connect_ro rejects INSERT/UPDATE/DELETE and that recap.py's source contains no write-SQL verbs.",
+        "A token-budget test confirms bundle.token_cost never exceeds the requested budget and truncated=true is set when items are dropped."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Wire the recap into native_hooks.py: add _recap_injection_enabled() (kill switch) and _emit_recap_context() (fail-open wrapper with a lazy import of dopemux.memory.recap), and append recap_ctx as the last element of the existing SessionStart context composition.",
+      "validation": [
+        "SessionStart hook tests confirm the recap block appears in additionalContext when the kill switch is unset, and is absent when DOPEMUX_RECAP_INJECTION=off.",
+        "A test proves an ImportError or exception inside the recap module never propagates out of _on_session_start."
+      ]
+    },
+    {
+      "id": "S5",
+      "task": "Materialize the generated packet, update task-packets/INDEX.md, create the proof bundle, run all validations, run PAL codereview and precommit, commit only allowlisted files, open a PR, and move the orchestrator item to review.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "All commit.verify commands pass or exact blockers are recorded as FAIL/NOT_RUN.",
+        "Only allowlisted files are staged and committed.",
+        "Proof bundle records worktree path, branch, commit SHA, PR URL, validations with exit codes, and residual risks."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-MCF/DMX-MCF-005-semantic-projection-spec.json
+++ b/task-packets/generated/DMX-MCF/DMX-MCF-005-semantic-projection-spec.json
@@ -1,0 +1,99 @@
+{
+  "id": "DMX-MCF-005-semantic-projection-spec",
+  "project": "dopemux-mvp",
+  "target": "Produce the semantic-memory projection spec for a derived dope-context memory_{hash} collection (privacy-safe embedding path), deferring the final go/no-go until real chronicle data exists from packets 002-004.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not implement or call any embedding provider.",
+    "This packet must resolve the privacy conflict named in the design spec: raw transcript content must never be sent to an external embedding provider (Voyage is external) without explicit redaction, approval, and provider policy.",
+    "This packet must name the exact ADR (DMX-ADR-001-semantic-memory-home) this spec depends on and reconcile with its decision (provisionally dope-context memory_{hash}, deferred).",
+    "This packet must state the deferred go/no-go criteria explicitly (recall-quality gap only measurable once the chronicle in packets 002-004 holds real content)."
+  ],
+  "depends_on": [
+    "DMX-MCF-004-sessionstart-recap",
+    "DMX-ADR-001-semantic-memory-home"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-mcf",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-MCF-004-sessionstart-recap",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-mcf-005-semantic-projection-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(memory): semantic-memory projection spec (deferred go/no-go)",
+    "allowlist": [
+      "claudedocs/specs/DMX-MCF-005-semantic-projection-spec.md",
+      "task-packets/generated/DMX-MCF/DMX-MCF-005-semantic-projection-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-mcf-005-semantic-projection-spec/DMX-MCF-005-semantic-projection-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-MCF/DMX-MCF-005-semantic-projection-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-MCF/DMX-MCF-005-semantic-projection-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-MCF-005-semantic-projection-spec.md",
+      "grep -q 'Privacy' claudedocs/specs/DMX-MCF-005-semantic-projection-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(memory): semantic-memory projection spec (deferred go/no-go)",
+    "body": "Produces the TP-MCF-005 planning spec (no runtime code) per claudedocs/memory-context-fabric-design-2026-07-04.md section 6 row TP-MCF-005: the derived dope-context memory_{hash} projection, its privacy-safe embedding options, and the explicit deferred go/no-go criteria tied to DMX-ADR-001 and real chronicle data from DMX-MCF-002/003/004.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read the design spec section 3 (Memory model) and section 6 (row TP-MCF-005), the interfaces spec section 3 (dope-context plane-interaction contract) and section 4 invariant 8 (locality), and DMX-ADR-001-semantic-memory-home once authored. Inspect the current dope-context runtime read-only: confirm code_{hash}/docs_{hash} collections exist and memory_{hash}/index_memory/search_memory do not (grep-verify, do not assume).",
+      "validation": [
+        "The spec's runtime-truth section cites exact file:line evidence for what dope-context does and does not support today.",
+        "No runtime code is changed in this step."
+      ],
+      "context_files": [
+        "claudedocs/memory-context-fabric-design-2026-07-04.md",
+        "claudedocs/memory-context-fabric-interfaces-2026-07-04.md",
+        "claudedocs/tp-mcf-001-authority-map-2026-07-04.md",
+        "claudedocs/backlog/decisions-ledger.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-MCF-005-semantic-projection-spec.md covering: scope (derived memory_{hash} collection, index_memory/search_memory surface), invariants (locality, provenance-only-lowers-trust, no external embedding of raw transcript without redaction+approval+policy), interfaces (request/response shapes matching ContextItem/ContextBundle), acceptance criteria, phasing, and the explicit deferred go/no-go gate (blocked until DMX-MCF-002/003/004 produce real chronicle content to measure recall quality against).",
+      "validation": [
+        "The spec file exists at claudedocs/specs/DMX-MCF-005-semantic-projection-spec.md.",
+        "The spec names the privacy conflict (Voyage is external) and resolves it with an explicit local-embedding-or-redaction-and-approval path, not a hand-wave.",
+        "The spec states the deferred go/no-go criteria and what unblocks it."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the design spec, interfaces spec, and decisions-ledger for consistency. Validate the packet JSON. Commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed.",
+        "No runtime code appears in the diff."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-MCF/DMX-MCF-006-conport-graph-spike-spec.json
+++ b/task-packets/generated/DMX-MCF/DMX-MCF-006-conport-graph-spike-spec.json
@@ -1,0 +1,100 @@
+{
+  "id": "DMX-MCF-006-conport-graph-spike-spec",
+  "project": "dopemux-mvp",
+  "target": "Run the mandatory AGE data-layer spike against the active Docker ConPort runtime, then produce the spec for graph.neighbors plus decision-genealogy MCP tools, falling back to a relationship-query projection only if the spike proves AGE traversal infeasible.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must run the AGE data-layer spike as its first task and record its outcome before writing the spec.",
+    "This packet must not claim graph.neighbors MCP parity exists today -- the authority map marks it dead code; this packet only specs implementing or verifying it.",
+    "This packet must name the fallback path (relationship-query projection via the existing GET /api/workspace-relationships -> get_related_decisions) if the spike shows AGE traversal is infeasible on the active runtime.",
+    "This packet must name the exact ADR (DMX-ADR-005-conport-graph-exposure) this spec depends on and reconcile with its decision."
+  ],
+  "depends_on": [
+    "DMX-ADR-005-conport-graph-exposure"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-mcf",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-MCF-005-semantic-projection-spec",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-mcf-006-conport-graph-spike-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(memory): ConPort graph spike results + graph.neighbors exposure spec",
+    "allowlist": [
+      "claudedocs/specs/DMX-MCF-006-conport-graph-spike-spec.md",
+      "task-packets/generated/DMX-MCF/DMX-MCF-006-conport-graph-spike-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-mcf-006-conport-graph-spike-spec/DMX-MCF-006-conport-graph-spike-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-MCF/DMX-MCF-006-conport-graph-spike-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-MCF/DMX-MCF-006-conport-graph-spike-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-MCF-006-conport-graph-spike-spec.md",
+      "grep -q 'Spike' claudedocs/specs/DMX-MCF-006-conport-graph-spike-spec.md",
+      "grep -q 'fallback' claudedocs/specs/DMX-MCF-006-conport-graph-spike-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(memory): ConPort graph spike results + graph.neighbors exposure spec",
+    "body": "Runs the mandatory AGE data-layer spike named as Task 1 in claudedocs/memory-context-fabric-design-2026-07-04.md section 6 row TP-MCF-006, then produces the spike-gated spec (no runtime code) for graph.neighbors + genealogy tools on the active Docker ConPort runtime, with an explicit relationship-query-projection fallback if the spike fails. Depends on DMX-ADR-005-conport-graph-exposure.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Run the AGE data-layer spike: read-only introspection of the active Docker ConPort runtime's AGE graph extension availability, existing workspace-relationships traversal (GET /api/workspace-relationships -> get_related_decisions), and the dead memory_server.py / quarantined conport_kg graph code, to determine whether graph.neighbors traversal is feasible to implement/verify on the active runtime. Mark live database introspection as NOT_RUN if no live ConPort database is available.",
+      "validation": [
+        "The spike outcome (feasible / infeasible / NOT_RUN with reason) is recorded in proof with exact evidence.",
+        "No runtime code is changed in this step; the spike is read-only introspection only."
+      ],
+      "context_files": [
+        "claudedocs/memory-context-fabric-design-2026-07-04.md",
+        "claudedocs/tp-mcf-001-authority-map-2026-07-04.md",
+        "claudedocs/backlog/decisions-ledger.md",
+        "docker/mcp-servers-source/conport/enhanced_server.py",
+        "docker/mcp-servers-source/conport/SURFACE_INVENTORY.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-MCF-006-conport-graph-spike-spec.md covering: the spike's methodology and outcome, scope for graph.neighbors + genealogy MCP tools (or the relationship-query-projection fallback if the spike failed), invariants (no fourth store, ConPort remains canonical writer for decisions/relationships), interfaces matching the ContextItem provenance shape, acceptance criteria, and phasing.",
+      "validation": [
+        "The spec file exists at claudedocs/specs/DMX-MCF-006-conport-graph-spike-spec.md.",
+        "The spec states the spike outcome explicitly and derives its recommended path (implement graph.neighbors vs relationship-query-projection-only) directly from that outcome, not from assumption.",
+        "The fallback path is fully specified, not just mentioned."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the design spec, authority map, and decisions-ledger for consistency. Validate the packet JSON. Commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed.",
+        "No runtime code appears in the diff."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-MCF/DMX-MCF-007-fabric-orchestrator-spec.json
+++ b/task-packets/generated/DMX-MCF/DMX-MCF-007-fabric-orchestrator-spec.json
@@ -1,0 +1,99 @@
+{
+  "id": "DMX-MCF-007-fabric-orchestrator-spec",
+  "project": "dopemux-mvp",
+  "target": "Spec the Fabric orchestrator and its context.recall / context.recap MCP surface, fusing whichever retrieval modalities (temporal, structural, semantic) exist at build time and degrading gracefully when a modality is unbuilt.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must specify the Fabric as a canonical-writer client and cross-plane reader/assembler only -- it must never own storage, truth, or domain authority, and must import no plane's storage internals.",
+    "This packet must specify graceful degradation: an unbuilt modality is omitted from the fused result, never faked.",
+    "This packet must specify context.recall and context.recap exactly per the interfaces spec section 1.1 signatures and section 2.4 ContextBundle/ContextItem schemas.",
+    "This packet must reconcile with the built primitives from DMX-MCF-002, DMX-MCF-003, and DMX-MCF-004 rather than re-specifying them."
+  ],
+  "depends_on": [
+    "DMX-MCF-002-transcript-ingest",
+    "DMX-MCF-003-decision-candidate",
+    "DMX-MCF-004-sessionstart-recap"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-mcf",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-MCF-006-conport-graph-spike-spec",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-mcf-007-fabric-orchestrator-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(memory): Fabric orchestrator + context.recall/context.recap MCP surface spec",
+    "allowlist": [
+      "claudedocs/specs/DMX-MCF-007-fabric-orchestrator-spec.md",
+      "task-packets/generated/DMX-MCF/DMX-MCF-007-fabric-orchestrator-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-mcf-007-fabric-orchestrator-spec/DMX-MCF-007-fabric-orchestrator-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-MCF/DMX-MCF-007-fabric-orchestrator-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-MCF/DMX-MCF-007-fabric-orchestrator-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-MCF-007-fabric-orchestrator-spec.md",
+      "grep -q 'graceful degradation' claudedocs/specs/DMX-MCF-007-fabric-orchestrator-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(memory): Fabric orchestrator + context.recall/context.recap MCP surface spec",
+    "body": "Produces the TP-MCF-007 planning spec (no runtime code) per claudedocs/memory-context-fabric-design-2026-07-04.md section 4 and section 6, and claudedocs/memory-context-fabric-interfaces-2026-07-04.md section 1.1/2.4: the Fabric orchestrator's context.recall/context.recap surface, fusing temporal (dope-memory), structural (ConPort), and semantic (dope-context) modalities with graceful degradation. Reconciles with the DMX-MCF-002/003/004 built primitives rather than re-specifying them.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read the design spec sections 1 (architecture), 3 (memory model / retrieval modalities), and 4 (retrieval + injection), and the interfaces spec sections 1 (public surface), 2.4 (schemas), 3 (plane-interaction contracts), and 4 (invariants). Inspect the actual DMX-MCF-002/003/004 implementations read-only to confirm what recap/detection primitives exist to build on.",
+      "validation": [
+        "The spec's dependency section cites the exact modules built by DMX-MCF-002/003/004 (transcript_ingest.py, conversation_promotion.py, recap.py) that the orchestrator will call.",
+        "No runtime code is changed in this step."
+      ],
+      "context_files": [
+        "claudedocs/memory-context-fabric-design-2026-07-04.md",
+        "claudedocs/memory-context-fabric-interfaces-2026-07-04.md",
+        "claudedocs/tp-mcf-001-authority-map-2026-07-04.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-MCF-007-fabric-orchestrator-spec.md covering: scope (context.recall/context.recap MCP tools, modality fusion logic), invariants (no plane-internal imports, canonical-writer-only writes, graceful degradation, token budget), interfaces (exact signatures from interfaces spec section 1.1, ContextBundle/ContextItem reuse from DMX-MCF-004's recap.py), acceptance criteria, and phasing (which modalities are available at which point given 002/003/004/005/006 status).",
+      "validation": [
+        "The spec file exists at claudedocs/specs/DMX-MCF-007-fabric-orchestrator-spec.md.",
+        "The spec explicitly states graceful-degradation behavior for each of the three modalities individually (temporal always available post-004; structural gated on DMX-MCF-006; semantic gated on DMX-MCF-005).",
+        "The spec includes a contract-test requirement: the Fabric package must import no plane's storage internals."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the design spec, interfaces spec, and the built DMX-MCF-002/003/004 modules for consistency. Validate the packet JSON. Commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed.",
+        "No runtime code appears in the diff."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-MCF/DMX-MCF-008-summarizer-spec.json
+++ b/task-packets/generated/DMX-MCF/DMX-MCF-008-summarizer-spec.json
@@ -1,0 +1,99 @@
+{
+  "id": "DMX-MCF-008-summarizer-spec",
+  "project": "dopemux-mvp",
+  "target": "Spec the LLM summarization worker that distills candidate-only conversation-derived content using a cheap default model under an explicit token/cost budget, never touching canonical ConPort decisions directly.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must not implement or call any LLM provider.",
+    "This packet must scope summarization to candidate-only content (conversation.decision_candidate and similar trust-lower classes) -- never canonical decisions or curated high-trust chronicle entries.",
+    "This packet must specify a cheap-model default and an explicit cost/token budget with a hard ceiling.",
+    "This packet must specify that summarizer output is itself trust-lower and carries provenance identifying it as LLM-derived, never silently merged into canonical fields.",
+    "This packet must depend on and reuse the conversation.decision_candidate schema from DMX-MCF-003 and the orchestrator surface from DMX-MCF-007 rather than re-specifying them."
+  ],
+  "depends_on": [
+    "DMX-MCF-003-decision-candidate",
+    "DMX-MCF-007-fabric-orchestrator-spec"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-mcf",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-MCF-007-fabric-orchestrator-spec",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-mcf-008-summarizer-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(memory): candidate-only LLM summarization worker spec (budgeted, cheap-model default)",
+    "allowlist": [
+      "claudedocs/specs/DMX-MCF-008-summarizer-spec.md",
+      "task-packets/generated/DMX-MCF/DMX-MCF-008-summarizer-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-mcf-008-summarizer-spec/DMX-MCF-008-summarizer-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-MCF/DMX-MCF-008-summarizer-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-MCF/DMX-MCF-008-summarizer-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-MCF-008-summarizer-spec.md",
+      "grep -q 'budget' claudedocs/specs/DMX-MCF-008-summarizer-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(memory): candidate-only LLM summarization worker spec (budgeted, cheap-model default)",
+    "body": "Produces the TP-MCF-008 planning spec (no runtime code) per claudedocs/memory-context-fabric-design-2026-07-04.md section 6 (Fabric orchestrator / summarizer / proactive injection row) and section 7 (summarization cost open decision): a candidate-only, cheap-model-default, budgeted LLM summarization worker. Depends on DMX-MCF-003's conversation.decision_candidate schema and DMX-MCF-007's orchestrator surface.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read the design spec section 6 (TP-MCF-007+ row) and section 7 (summarization cost open decision), and the interfaces spec section 2.3 (PromotedEntry trust encoding). Inspect the DMX-MCF-003 conversation_promotion.py and promotion.py handler read-only to confirm the exact candidate schema the summarizer will consume.",
+      "validation": [
+        "The spec's input-contract section cites the exact DecisionCandidate/PromotedEntry fields the summarizer consumes.",
+        "No runtime code is changed in this step."
+      ],
+      "context_files": [
+        "claudedocs/memory-context-fabric-design-2026-07-04.md",
+        "claudedocs/memory-context-fabric-interfaces-2026-07-04.md",
+        "claudedocs/tp-mcf-001-authority-map-2026-07-04.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-MCF-008-summarizer-spec.md covering: scope (candidate-only summarization, never canonical decisions), invariants (cheap-model default, hard token/cost ceiling, output is trust-lower and LLM-provenance-labeled, no silent merge into canonical fields), interfaces (input candidate schema, output summary schema with provenance), acceptance criteria, and phasing (what unblocks this: DMX-MCF-003 + DMX-MCF-007).",
+      "validation": [
+        "The spec file exists at claudedocs/specs/DMX-MCF-008-summarizer-spec.md.",
+        "The spec names an explicit cost/token budget mechanism, not just a stated intention.",
+        "The spec states the output provenance/trust labeling so a summarized entry can never be mistaken for a canonical one."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the design spec and DMX-MCF-003/007 for consistency. Validate the packet JSON. Commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed.",
+        "No runtime code appears in the diff."
+      ]
+    }
+  ]
+}

--- a/task-packets/generated/DMX-MCF/DMX-MCF-009-proactive-injection-spec.json
+++ b/task-packets/generated/DMX-MCF/DMX-MCF-009-proactive-injection-spec.json
@@ -1,0 +1,99 @@
+{
+  "id": "DMX-MCF-009-proactive-injection-spec",
+  "project": "dopemux-mvp",
+  "target": "Spec proactive mid-session context injection (Injection Phase 2) built on top of the Fabric orchestrator, gated by a rate limit, a relevance threshold, and an operator kill switch, so a bad surfacing is never worse than none.",
+  "invariants": [
+    "This packet must run from a fresh dedicated worktree based on origin/main.",
+    "This packet must only touch files in its commit.allowlist.",
+    "This packet must not change runtime code.",
+    "This packet must specify a rate limit bounding how often proactive injection can fire per session.",
+    "This packet must specify a relevance threshold below which no injection occurs -- silence is the safe default, not a low-confidence surfacing.",
+    "This packet must specify an operator kill switch that disables proactive injection entirely, independent of the DMX-MCF-004 SessionStart recap kill switch.",
+    "This packet must depend on and reuse the context.recall/context.recap surface from DMX-MCF-007 rather than re-specifying retrieval fusion.",
+    "This packet must state explicitly that this is the last phase in the design spec's phasing matrix and must not be built before DMX-MCF-007 lands."
+  ],
+  "depends_on": [
+    "DMX-MCF-007-fabric-orchestrator-spec"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".dopetaskroot",
+    "origin_hint": "DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "dmx-mcf",
+    "base_branch": "origin/main",
+    "parent_tp_id": "DMX-MCF-008-summarizer-spec",
+    "final_packet": true
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dmx-mcf-009-proactive-injection-spec",
+    "base_branch": "origin/main"
+  },
+  "commit": {
+    "message": "docs(memory): proactive mid-session injection spec (rate limit + relevance threshold + kill switch)",
+    "allowlist": [
+      "claudedocs/specs/DMX-MCF-009-proactive-injection-spec.md",
+      "task-packets/generated/DMX-MCF/DMX-MCF-009-proactive-injection-spec.json",
+      "task-packets/INDEX.md",
+      "proof/dmx-mcf-009-proactive-injection-spec/DMX-MCF-009-proactive-injection-spec/**"
+    ],
+    "verify": [
+      "python -m json.tool task-packets/generated/DMX-MCF/DMX-MCF-009-proactive-injection-spec.json >/dev/null",
+      "python -m jsonschema -i task-packets/generated/DMX-MCF/DMX-MCF-009-proactive-injection-spec.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "test -f claudedocs/specs/DMX-MCF-009-proactive-injection-spec.md",
+      "grep -q 'kill switch' claudedocs/specs/DMX-MCF-009-proactive-injection-spec.md",
+      "grep -q 'rate limit' claudedocs/specs/DMX-MCF-009-proactive-injection-spec.md",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "docs(memory): proactive mid-session injection spec (rate limit + relevance threshold + kill switch)",
+    "body": "Produces the TP-MCF-009 planning spec (no runtime code) per claudedocs/memory-context-fabric-design-2026-07-04.md section 4 (Injection Phase 2) and section 6: proactive mid-session context surfacing gated by a rate limit, a relevance threshold, and an independent kill switch. Depends on the DMX-MCF-007 orchestrator surface. This is the final packet in the DMX-MCF series.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": false,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Read the design spec section 4 (Injection Phase 2) and section 6 (TP-MCF-007+ row), and the interfaces spec section 1.3 (injection). Inspect the DMX-MCF-004 native_hooks.py SessionStart wiring read-only to confirm the extension points and kill-switch pattern to mirror for a mid-session variant.",
+      "validation": [
+        "The spec's extension-point section cites the exact hook or event points a mid-session injector would attach to, grounded in the DMX-MCF-004 implementation.",
+        "No runtime code is changed in this step."
+      ],
+      "context_files": [
+        "claudedocs/memory-context-fabric-design-2026-07-04.md",
+        "claudedocs/memory-context-fabric-interfaces-2026-07-04.md",
+        "claudedocs/tp-mcf-001-authority-map-2026-07-04.md"
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Produce claudedocs/specs/DMX-MCF-009-proactive-injection-spec.md covering: scope (mid-session proactive surfacing), invariants (rate limit, relevance threshold, independent kill switch, silence-over-low-confidence default), interfaces (reuse of ContextBundle/ContextItem from DMX-MCF-007), acceptance criteria, and phasing (explicitly the last phase, blocked on DMX-MCF-007).",
+      "validation": [
+        "The spec file exists at claudedocs/specs/DMX-MCF-009-proactive-injection-spec.md.",
+        "The spec names concrete default values or bounds for the rate limit and relevance threshold (not left as an open question).",
+        "The spec states the kill switch is independent of DMX-MCF-004's DOPEMUX_RECAP_INJECTION switch."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Self-review the spec against the design spec and DMX-MCF-007 for consistency. Validate the packet JSON. Commit only allowlisted files.",
+      "validation": [
+        "Task packet JSON parses and validates against dopetask-canonical-spec.json with exit code 0.",
+        "Only allowlisted files are staged and committed.",
+        "No runtime code appears in the diff."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Converts **all** actionable findings from the Memory Context Fabric thread and the three merged PRs (#1011 MCF, #1002 fleet audit, #1009 service P0) into **52 schema-valid dopeTask packets** across 9 series, plus a **task-orchestrator load-plan**.

**Scope of this PR**: authoring + validation + indexing + load-plan only. **No implementation.** The live task-orchestrator is **not** mutated — the operator runs `claudedocs/backlog/loadplan.json` when ready (per the approved plan's decision).

## What's here

- **52 packets** in `task-packets/generated/DMX-*/`:
  - `DMX-MCF` (8) — Memory Context Fabric 002–009
  - `DMX-FLEET-P0..P5` (33) — the fleet 5-phase roadmap
  - `DMX-ADHD-WIRE` (6) — forgotten-features wire-existing + resurrections
  - `DMX-ADR` (5) — decision records
- **Tiers**: B = implementation (mechanical steps), C = planning (deliverable = a spec), A = ADR.
- **`claudedocs/backlog/`**: `decisions-ledger.md` (11 operator-frozen decisions), `README.md` (finding→packet traceability + coverage cross-check), `_AUTHORING_CONTRACT.md`, `loadplan.json` (machine-readable), `ORCHESTRATOR_LOADPLAN.md` (human-readable + MCP call recipe).
- **`task-packets/INDEX.md`**: registry updated with all 52.

## Verification (independent of agent self-reports)

- ✅ **52/52** pass `jsonschema` against `dopetask-canonical-spec.json`; every `id` == filename stem.
- ✅ **0 dangling** `depends_on`; dependency **DAG acyclic**; 28 BLOCKS edges.
- ✅ Full **finding→packet coverage** cross-check (no inventory item dropped).

## Reconciliation with current `main` (runtime outranks the audit)

The fleet audit is dated 2026-07-03; `main` moved since. Authoring agents cross-checked every claim against live `origin/main` and found parts of Phase 0/1 **already shipped** (unified `fleet_catalog` + 20+-test CI drift suite, `dopemux mcp ensure`, exa retirement via ADR-223, P0 fixes `4974015c3`/`b63b4b4a7`). Affected packets were **reframed to verified residual gaps / regression-locks**, not greenfield — see README §Reconciliation. New drift found: `PROMOTABLE_EVENT_TYPES` now duplicated across **3** files, not 2.

## How to load (operator)

Run the 3-step recipe in `ORCHESTRATOR_LOADPLAN.md`: `create_work_tree` (root+epics+leaves) → `manage_dependencies` (28 edges) → verify with `query_items`/`get_blocked_items`/`get_next_item`. Items load as `QUEUE`; the BLOCKS DAG derives blocked state.

## Notes

- `bd85e784c` (MCF fork decisions) remains unmerged on `claude/memory-context-fabric` — land it or fold into a follow-up.
- No runtime behavior claimed (Docker planes down); this is a docs + packets + orchestrator-load-plan change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)