### PR TITLE
feat(mcp): TP-DMX-MCP-RUNTIME-002 repo-aware start registry

### DIFF
--- a/.claude/WORKTREE_MCP_SETUP.md
+++ b/.claude/WORKTREE_MCP_SETUP.md
@@ -3,12 +3,10 @@
 **Purpose**: Enable full MCP server functionality across all git worktrees with automatic workspace detection
 
 > [!CAUTION]
-> **Config ≠ runtime isolation.** `dopemux mcp init` writes per-worktree
-> `.mcp.json` / `.envrc.dopemux-mcp`, but `mcp up` / compose still key off cwd
-> and default names (`mcp-conport`, relative `./.dopemux`). Before starting
-> multi-repo stacks, run the read-only gate:
-> `dopemux mcp doctor --repo <worktree-path> [--json]`.
-> Do not treat a listening port as proof of ownership.
+> **Config ≠ runtime isolation.** Use the reconciler, not cwd compose:
+> `dopemux mcp doctor --repo <worktree>` then `dopemux mcp start --repo <worktree>`.
+> Start applies labels + unique names + absolute `.dopemux` volume and records
+> `~/.dopemux/mcp/runtime/instances.json`. Unlabeled containers are never adopted.
 
 ## Overview
 

--- a/docs/02-how-to/mcp-setup-other-repos.md
+++ b/docs/02-how-to/mcp-setup-other-repos.md
@@ -94,36 +94,45 @@ echo 'source .envrc.dopemux-mcp' >> .envrc
 direnv allow
 ```
 
-### Step 4 — Start per-worktree containers
+### Step 4 — Start per-worktree containers (repo-aware reconciler)
 
-> [!CAUTION]
-> **Unsafe until Packet 002 (repo-aware start).** Injecting another project's
-> `.envrc.dopemux-mcp` into `dopemux-mvp` compose is a known lifecycle hazard:
->
-> 1. **Container name collision** — `compose.yml` defaults
->    `container_name: ${CONPORT_CONTAINER_NAME:-mcp-conport}`, so a foreign-repo
->    `up` can **replace** the primary ConPort container if the name is still default.
-> 2. **dope-memory state bleed** — volume `./.dopemux:/data` is **relative to
->    compose cwd**. Starting dope-memory from `dopemux-mvp` binds
->    `dopemux-mvp/.dopemux`, not the target repo.
-> 3. **Ownership is unproven** — a listening port is **not** proof the service
->    belongs to your project. Unlabeled containers are `UNKNOWN`, not healthy.
->
-> Prefer diagnosing first. Do **not** treat `mcp init` as runtime isolation.
+**Preferred path** (Packet 002):
 
 ```bash
-# Read-only truth gate (any cwd; does not start/stop containers):
-dopemux mcp doctor --repo ~/code/your-other-project
-dopemux mcp doctor --repo ~/code/your-other-project --json
+cd ~/code/your-other-project
+dopemux mcp init          # if not already done
+dopemux mcp doctor        # truth gate (loads .envrc.dopemux-mcp)
+dopemux mcp start         # labeled sidecars + runtime registry
+# or from any cwd:
+dopemux mcp start --repo ~/code/your-other-project
+dopemux mcp start --repo ~/code/your-other-project --dry-run --json
 ```
 
-Repo-aware `dopemux mcp start/up --repo` is **not** implemented yet (Packet 002).
+What `mcp start` does:
+
+- Runs doctor preflight; **blocks** on transport mismatch, unlabeled port owners, wrong-project containers
+- Generates compose override with **unique container names** and **absolute** target `.dopemux` volume
+- Sets `dopemux.managed=true` + project labels
+- Writes operational registry: `~/.dopemux/mcp/runtime/instances.json`
+- Does **not** adopt unlabeled containers
+
+Shared infrastructure (postgres, redis, etc.) must already be running from the primary dopemux stack (`--no-deps` sidecars).
+
+```bash
+dopemux mcp status --repo ~/code/your-other-project --json
+dopemux mcp stop --repo ~/code/your-other-project
+# Compatibility: mcp up/down --repo → start/stop
+```
+
+> [!CAUTION]
+> **Do not** use the old clipboard pattern (env-inject into dopemux-mvp compose).
+> It can replace `mcp-conport` and bind the wrong `.dopemux` data directory.
 
 <details>
 <summary>Legacy / high-risk compose path (not recommended)</summary>
 
 ```bash
-# From dopemux-mvp — DANGEROUS for foreign repos without unique names + absolute volumes:
+# DANGEROUS — fixed names + relative volumes:
 cd ~/code/dopemux-mvp
 env $(cat ~/code/your-other-project/.envrc.dopemux-mcp | grep -v '^#' | xargs) \
   docker compose -f compose.yml up -d conport dope-memory
@@ -133,7 +142,7 @@ env $(cat ~/code/your-other-project/.envrc.dopemux-mcp | grep -v '^#' | xargs) \
 ### Step 5 — Verify connectivity
 
 ```bash
-# Repo-aware doctor (loads target .envrc.dopemux-mcp; no container mutations):
+dopemux mcp status --repo ~/code/your-other-project
 dopemux mcp doctor --repo ~/code/your-other-project
 
 # Full health report with transport-aware probing:

--- a/docs/02-how-to/multi-instance-workflow.md
+++ b/docs/02-how-to/multi-instance-workflow.md
@@ -22,6 +22,10 @@ prelude: Multi-Instance Workflow Guide (how-to) for dopemux documentation and de
 
 Zero context destruction through parallel ADHD-optimized development instances.
 
+> **MCP sidecars (2026-07):** Prefer `dopemux mcp start --repo <worktree>` after
+> `dopemux mcp init` / `doctor`. Do not env-inject foreign `.envrc.dopemux-mcp`
+> into dopemux-mvp compose. Registry: `~/.dopemux/mcp/runtime/instances.json`.
+
 ## Overview
 
 Dopemux supports running up to 5 concurrent instances with isolated worktrees, enabling you to:

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -97,17 +97,149 @@ def mcp():
     """
 
 
+def _lifecycle_repo_option():
+    return click.option(
+        "--repo",
+        "repo_arg",
+        type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+        default=None,
+        help="Target repo/worktree (default: cwd). Works without compose.yml in the target.",
+    )
+
+
+def _lifecycle_services_option():
+    return click.option(
+        "--services",
+        "services",
+        default=None,
+        help="Comma-separated project-scoped services (conport,dope-memory,task-orchestrator).",
+    )
+
+
+def _run_lifecycle_cli(
+    operation: str,
+    *,
+    repo_arg: Optional[Path],
+    services: Optional[str],
+    dry_run: bool,
+    json_output: bool,
+) -> None:
+    """Shared entry for start/stop/restart/status reconciler."""
+    from dopemux.mcp.lifecycle import format_lifecycle_human, run_lifecycle
+
+    catalog = _load_catalog()
+    svc_list = [s.strip() for s in (services or "").split(",") if s.strip()] or None
+    result = run_lifecycle(
+        operation,
+        repo=repo_arg,
+        services=svc_list,
+        catalog=catalog,
+        dry_run=dry_run,
+        process_env=dict(os.environ),
+    )
+    if json_output:
+        sys.stdout.write(result.to_json())
+    else:
+        text = format_lifecycle_human(result)
+        if result.status in {"PASS", "PLANNED"}:
+            console.logger.info(f"[success]{text.rstrip()}[/success]")
+        elif result.status in {"PASS_WITH_WARNINGS"}:
+            console.logger.info(f"[warning]{text.rstrip()}[/warning]")
+        elif result.status in {"FAIL", "BLOCKED"}:
+            console.logger.info(f"[error]{text.rstrip()}[/error]")
+        else:
+            console.logger.info(f"[info]{text.rstrip()}[/info]")
+    if result.exit_code:
+        sys.exit(result.exit_code)
+
+
+@mcp.command("start")
+@_lifecycle_repo_option()
+@_lifecycle_services_option()
+@click.option("--dry-run", is_flag=True, help="Plan only; no Docker mutations, no registry writes.")
+@click.option("--json", "json_output", is_flag=True, help="Emit lifecycle JSON report.")
+def mcp_start_cmd(repo_arg: Optional[Path], services: Optional[str], dry_run: bool, json_output: bool):
+    """
+    🚀 Start project-scoped MCP sidecars (repo-aware reconciler)
+
+    Starts conport / dope-memory / task-orchestrator for the target repo with
+    unique names, labels, absolute memory volumes, and runtime registry updates.
+    Does not use the unsafe env-injection compose pattern.
+    """
+    _run_lifecycle_cli(
+        "start",
+        repo_arg=repo_arg,
+        services=services,
+        dry_run=dry_run,
+        json_output=json_output,
+    )
+
+
+@mcp.command("stop")
+@_lifecycle_repo_option()
+@_lifecycle_services_option()
+@click.option("--dry-run", is_flag=True, help="Plan only; do not stop containers.")
+@click.option("--json", "json_output", is_flag=True, help="Emit lifecycle JSON report.")
+def mcp_stop_cmd(repo_arg: Optional[Path], services: Optional[str], dry_run: bool, json_output: bool):
+    """
+    🛑 Stop Dopemux-managed MCP sidecars for a target repo
+
+    Stops only containers with dopemux.managed=true and matching project labels
+    (or registry-known task-orchestrator wrappers). Never stops unlabeled strangers.
+    """
+    _run_lifecycle_cli(
+        "stop",
+        repo_arg=repo_arg,
+        services=services,
+        dry_run=dry_run,
+        json_output=json_output,
+    )
+
+
+@mcp.command("restart")
+@_lifecycle_repo_option()
+@_lifecycle_services_option()
+@click.option("--dry-run", is_flag=True, help="Plan stop+start without mutations.")
+@click.option("--json", "json_output", is_flag=True, help="Emit lifecycle JSON report.")
+def mcp_restart_cmd(repo_arg: Optional[Path], services: Optional[str], dry_run: bool, json_output: bool):
+    """♻️ Restart project-scoped MCP sidecars (safe stop then start)."""
+    _run_lifecycle_cli(
+        "restart",
+        repo_arg=repo_arg,
+        services=services,
+        dry_run=dry_run,
+        json_output=json_output,
+    )
+
+
 @mcp.command("up")
 @click.option("--all", "all_services", is_flag=True, help="🚀 Boot Fleet: Start every configured MCP service simultaneously.")
 @click.option("--services", "services", help="🎯 Targeted Ignition: Comma-separated list of specific MCP services to ignite.")
-def mcp_up_cmd(all_services: bool, services: str):
+@_lifecycle_repo_option()
+@click.option("--dry-run", is_flag=True, help="When --repo is set: plan-only reconciler start.")
+@click.option("--json", "json_output", is_flag=True, help="When --repo is set: JSON lifecycle report.")
+def mcp_up_cmd(
+    all_services: bool,
+    services: str,
+    repo_arg: Optional[Path],
+    dry_run: bool,
+    json_output: bool,
+):
     """
-    ⚡ Ignite Engine: Deploy MCP servers via Docker Compose
+    ⚡ Ignite Engine: Deploy MCP servers
 
-    Materializes the Model Context Protocol environment, initializing the 
-    distributed tool architecture required for high-fidelity focus-tracking 
-    and codebase interrogation.
+    With ``--repo``: compatibility alias for ``dopemux mcp start --repo``.
+    Without ``--repo``: legacy cwd compose / start-all-mcp-servers.sh behavior.
     """
+    if repo_arg is not None or dry_run or json_output:
+        _run_lifecycle_cli(
+            "start",
+            repo_arg=repo_arg,
+            services=services,
+            dry_run=dry_run,
+            json_output=json_output,
+        )
+        return
     try:
         script_dir = Path(__file__).parent.parent.parent.parent / "scripts"
         script_path = script_dir / "start-all-mcp-servers.sh"
@@ -126,13 +258,31 @@ def mcp_up_cmd(all_services: bool, services: str):
 
 
 @mcp.command("down")
-def mcp_down_cmd():
+@_lifecycle_repo_option()
+@_lifecycle_services_option()
+@click.option("--dry-run", is_flag=True, help="When --repo is set: plan-only stop.")
+@click.option("--json", "json_output", is_flag=True, help="When --repo is set: JSON lifecycle report.")
+def mcp_down_cmd(
+    repo_arg: Optional[Path],
+    services: Optional[str],
+    dry_run: bool,
+    json_output: bool,
+):
     """
-    💧 Cool Down Cores: Terminate MCP containers and volumes
+    💧 Cool Down Cores: Terminate MCP containers
 
-    Safely deactivates the neural infrastructure, releasing system resources 
-    and preserving ritual state in the Docker volume ledgers.
+    With ``--repo``: compatibility alias for ``dopemux mcp stop --repo``.
+    Without ``--repo``: legacy cwd compose rm behavior.
     """
+    if repo_arg is not None or dry_run or json_output:
+        _run_lifecycle_cli(
+            "stop",
+            repo_arg=repo_arg,
+            services=services,
+            dry_run=dry_run,
+            json_output=json_output,
+        )
+        return
     try:
         # Derive from the default set so `down` stays symmetric with `up`
         # (previously a hardcoded list that omitted several running services).
@@ -150,13 +300,43 @@ def mcp_down_cmd():
 
 
 @mcp.command("status")
-def mcp_status_cmd():
+@_lifecycle_repo_option()
+@click.option("--json", "json_output", is_flag=True, help="Emit repo-aware status JSON (registry+docker+probes).")
+@click.option(
+    "--legacy-compose",
+    is_flag=True,
+    help="Force legacy `docker compose ps` from cwd (ignores --repo).",
+)
+def mcp_status_cmd(repo_arg: Optional[Path], json_output: bool, legacy_compose: bool):
     """
     📊 Diagnostic HUD: Interrogate MCP service health
 
-    Displays the current operational state, port mappings, and uptime for 
-    all registered MCP daemons. Essential for diagnosing sensor disconnects.
+    Default / with ``--repo`` / ``--json``: repo-aware status (registry + Docker + probes).
+    ``--legacy-compose``: previous cwd `docker compose ps` behavior.
     """
+    if legacy_compose:
+        try:
+            subprocess.run(["docker", "compose", "-f", "compose.yml", "ps"], check=True)
+        except (CalledProcessError, FileNotFoundError):
+            sys.exit(1)
+        return
+
+    # Prefer reconciler status when --repo/--json or target has .mcp.json
+    use_reconciler = (
+        repo_arg is not None
+        or json_output
+        or (Path.cwd() / PROJECT_MCP_FILENAME).exists()
+        or (Path.cwd() / ENVRC_FILENAME).exists()
+    )
+    if use_reconciler:
+        _run_lifecycle_cli(
+            "status",
+            repo_arg=repo_arg,
+            services=None,
+            dry_run=False,
+            json_output=json_output,
+        )
+        return
     try:
         subprocess.run(["docker", "compose", "-f", "compose.yml", "ps"], check=True)
     except (CalledProcessError, FileNotFoundError):
@@ -244,27 +424,48 @@ def servers():
 @servers.command("up")
 @click.option("--all", "all_services", is_flag=True, help="🚀 Boot Fleet: Start every configured MCP service simultaneously.")
 @click.option("--services", "services", help="🎯 Targeted Ignition: Comma-separated list of specific MCP services to ignite.")
-def servers_up_cmd(all_services: bool, services: str):
+@click.option("--repo", "repo_arg", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path), default=None)
+@click.option("--dry-run", is_flag=True)
+@click.option("--json", "json_output", is_flag=True)
+def servers_up_cmd(
+    all_services: bool,
+    services: str,
+    repo_arg: Optional[Path],
+    dry_run: bool,
+    json_output: bool,
+):
     """
     ⚡ Ignite Engine (Alias): Deploy MCP servers via Docker Compose
     """
-    mcp_up_cmd.callback(all_services, services)
+    mcp_up_cmd.callback(all_services, services, repo_arg, dry_run, json_output)
 
 
 @servers.command("down")
-def servers_down_cmd():
+@click.option("--repo", "repo_arg", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path), default=None)
+@click.option("--services", "services", default=None)
+@click.option("--dry-run", is_flag=True)
+@click.option("--json", "json_output", is_flag=True)
+def servers_down_cmd(
+    repo_arg: Optional[Path],
+    services: Optional[str],
+    dry_run: bool,
+    json_output: bool,
+):
     """
     💧 Cool Down Cores (Alias): Terminate MCP containers and volumes
     """
-    mcp_down_cmd.callback()
+    mcp_down_cmd.callback(repo_arg, services, dry_run, json_output)
 
 
 @servers.command("status")
-def servers_status_cmd():
+@click.option("--repo", "repo_arg", type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path), default=None)
+@click.option("--json", "json_output", is_flag=True)
+@click.option("--legacy-compose", is_flag=True)
+def servers_status_cmd(repo_arg: Optional[Path], json_output: bool, legacy_compose: bool):
     """
     📊 Diagnostic HUD (Alias): Interrogate MCP service health
     """
-    mcp_status_cmd.callback()
+    mcp_status_cmd.callback(repo_arg, json_output, legacy_compose)
 
 
 @servers.command("logs")

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -230,8 +230,9 @@ def mcp_up_cmd(
 
     With ``--repo``: compatibility alias for ``dopemux mcp start --repo``.
     Without ``--repo``: legacy cwd compose / start-all-mcp-servers.sh behavior.
+    ``--dry-run`` / ``--json`` only apply with ``--repo`` (ignored otherwise).
     """
-    if repo_arg is not None or dry_run or json_output:
+    if repo_arg is not None:
         _run_lifecycle_cli(
             "start",
             repo_arg=repo_arg,
@@ -273,8 +274,9 @@ def mcp_down_cmd(
 
     With ``--repo``: compatibility alias for ``dopemux mcp stop --repo``.
     Without ``--repo``: legacy cwd compose rm behavior.
+    ``--dry-run`` / ``--json`` only apply with ``--repo`` (ignored otherwise).
     """
-    if repo_arg is not None or dry_run or json_output:
+    if repo_arg is not None:
         _run_lifecycle_cli(
             "stop",
             repo_arg=repo_arg,

--- a/src/dopemux/mcp/docker_runtime.py
+++ b/src/dopemux/mcp/docker_runtime.py
@@ -1,0 +1,353 @@
+"""Docker/compose execution helpers for repo-aware MCP lifecycle.
+
+Preferred strategy: generated compose override + env file + unique project name,
+with --no-deps for project sidecars (shared infra assumed already running).
+
+task-orchestrator uses a wrapper-compatible docker run path (fixed host port)
+with Dopemux labels applied at create time.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+Runner = Callable[..., subprocess.CompletedProcess]
+
+LABEL_MANAGED = "dopemux.managed"
+LABEL_CREATED_BY = "dopemux.created_by"
+
+
+def product_root() -> Path:
+    """Locate dopemux-mvp product root (compose.yml + scripts)."""
+    env = os.environ.get("DOPEMUX_MVP_ROOT") or os.environ.get("DOPEMUX_PRODUCT_ROOT")
+    if env:
+        p = Path(env).expanduser().resolve()
+        if (p / "compose.yml").is_file():
+            return p
+    # src/dopemux/mcp/docker_runtime.py → repo root
+    here = Path(__file__).resolve()
+    candidate = here.parents[3]
+    if (candidate / "compose.yml").is_file():
+        return candidate
+    # Fall back: walk parents
+    for parent in here.parents:
+        if (parent / "compose.yml").is_file() and (parent / "mcp_catalog.yaml").is_file():
+            return parent
+    raise FileNotFoundError(
+        "Cannot locate dopemux product root with compose.yml. "
+        "Set DOPEMUX_MVP_ROOT to the dopemux-mvp checkout."
+    )
+
+
+def project_slug(name: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    slug = re.sub(r"-{2,}", "-", slug)
+    return (slug or "workspace")[:40]
+
+
+def container_name_for(slug: str, worktree_hash: str, service: str) -> str:
+    svc = service.replace("_", "-").lower()
+    # Docker name max 63; keep deterministic short form
+    base = f"dopemux-{slug}-{worktree_hash}-{svc}"
+    return base[:63].rstrip("-")
+
+
+def compose_project_name(slug: str, worktree_hash: str) -> str:
+    name = f"dopemux_{slug}_{worktree_hash}".lower()
+    return re.sub(r"[^a-z0-9_-]", "_", name)[:63]
+
+
+def build_labels(
+    *,
+    project_id: str,
+    workspace_id: str,
+    project_root: str,
+    worktree_root: str,
+    project_hash: str,
+    worktree_hash: str,
+    instance_id: str,
+    service: str,
+    scope: str,
+    transport: str = "unknown",
+    catalog_service: Optional[str] = None,
+) -> Dict[str, str]:
+    return {
+        LABEL_MANAGED: "true",
+        "dopemux.project_id": project_id,
+        "dopemux.workspace_id": workspace_id,
+        "dopemux.project_root": project_root,
+        "dopemux.worktree_root": worktree_root,
+        "dopemux.project_hash": project_hash,
+        "dopemux.worktree_hash": worktree_hash,
+        "dopemux.instance_id": instance_id,
+        "dopemux.service": service,
+        "dopemux.scope": scope,
+        LABEL_CREATED_BY: "dopemux-mcp",
+        "dopemux.repo_basename": Path(project_root).name,
+        "dopemux.catalog_service": catalog_service or service,
+        "dopemux.transport": transport,
+    }
+
+
+def labels_as_compose_map(labels: Mapping[str, str]) -> str:
+    lines = ["    labels:"]
+    for key in sorted(labels.keys()):
+        val = str(labels[key]).replace('"', '\\"')
+        lines.append(f'      {key}: "{val}"')
+    return "\n".join(lines)
+
+
+def generate_compose_override(
+    *,
+    services: Sequence[str],
+    identity: Mapping[str, str],
+    ports: Mapping[str, int],
+    container_names: Mapping[str, str],
+    labels_by_service: Mapping[str, Mapping[str, str]],
+    memory_data_path: Path,
+) -> str:
+    """Generate compose.override.yml that neutralizes fixed names + relative volumes."""
+    blocks: List[str] = ["services:"]
+
+    if "conport" in services:
+        cname = container_names["conport"]
+        labels = labels_as_compose_map(labels_by_service["conport"])
+        blocks.append(
+            f"""  conport:
+    container_name: {cname}
+    ports:
+      - "{ports.get('CONPORT_HTTP_PORT', 3004)}:3004"
+      - "{ports.get('CONPORT_MCP_PORT', 3005)}:3005"
+      - "{ports.get('CONPORT_INFO_PORT', 4004)}:4004"
+    environment:
+      DOPEMUX_INSTANCE_ID: "{identity.get('DOPEMUX_INSTANCE_ID', '')}"
+      DOPEMUX_WORKSPACE_ID: "{identity.get('DOPEMUX_WORKSPACE_ID', '')}"
+      DOPEMUX_PROJECT_ROOT: "{identity.get('DOPEMUX_PROJECT_ROOT', '')}"
+      DOPEMUX_WORKTREE_ROOT: "{identity.get('DOPEMUX_WORKTREE_ROOT', '')}"
+      DOPEMUX_WORKSPACE_ROOT: "{identity.get('DOPEMUX_WORKSPACE_ROOT', '')}"
+{labels}
+"""
+        )
+
+    if "dope-memory" in services:
+        cname = container_names["dope-memory"]
+        labels = labels_as_compose_map(labels_by_service["dope-memory"])
+        data = str(memory_data_path.resolve())
+        blocks.append(
+            f"""  dope-memory:
+    container_name: {cname}
+    ports:
+      - "{ports.get('DOPE_MEMORY_PORT', 3020)}:3020"
+    environment:
+      DOPE_MEMORY_WORKSPACE_ID: "{identity.get('DOPE_MEMORY_WORKSPACE_ID', '')}"
+      DOPE_MEMORY_INSTANCE_ID: "{identity.get('DOPE_MEMORY_INSTANCE_ID', '')}"
+      DOPEMUX_WORKSPACE_ID: "{identity.get('DOPEMUX_WORKSPACE_ID', '')}"
+      DOPEMUX_PROJECT_ROOT: "{identity.get('DOPEMUX_PROJECT_ROOT', '')}"
+      DOPEMUX_WORKTREE_ROOT: "{identity.get('DOPEMUX_WORKTREE_ROOT', '')}"
+      DOPEMUX_INSTANCE_ID: "{identity.get('DOPEMUX_INSTANCE_ID', '')}"
+    volumes:
+      - "{data}:/data"
+{labels}
+"""
+        )
+
+    # External shared network so --no-deps still joins existing mesh
+    blocks.append(
+        """networks:
+  dopemux-network:
+    external: true
+    name: dopemux-network
+"""
+    )
+    return "\n".join(blocks)
+
+
+def generate_mcp_env(env_map: Mapping[str, str | int]) -> str:
+    lines = ["# Generated by dopemux mcp start — operational ports/paths only"]
+    for key in sorted(env_map.keys()):
+        val = env_map[key]
+        # Skip secret-like keys
+        upper = key.upper()
+        if any(m in upper for m in ("SECRET", "TOKEN", "PASSWORD", "API_KEY", "CREDENTIAL")):
+            continue
+        lines.append(f"{key}={val}")
+    return "\n".join(lines) + "\n"
+
+
+@dataclass
+class RuntimeCommandResult:
+    command: List[str]
+    exit_code: int
+    stdout: str = ""
+    stderr: str = ""
+    dry_run: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "command": list(self.command),
+            "exit_code": self.exit_code,
+            "stdout": self.stdout[:2000],
+            "stderr": self.stderr[:2000],
+            "dry_run": self.dry_run,
+        }
+
+
+def run_cmd(
+    cmd: Sequence[str],
+    *,
+    runner: Optional[Runner] = None,
+    env: Optional[Mapping[str, str]] = None,
+    cwd: Optional[Path] = None,
+    dry_run: bool = False,
+    timeout: float = 180.0,
+) -> RuntimeCommandResult:
+    if dry_run:
+        return RuntimeCommandResult(command=list(cmd), exit_code=0, dry_run=True)
+    run = runner or subprocess.run
+    try:
+        result = run(
+            list(cmd),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            env=dict(env) if env else None,
+            cwd=str(cwd) if cwd else None,
+        )
+        return RuntimeCommandResult(
+            command=list(cmd),
+            exit_code=result.returncode,
+            stdout=result.stdout or "",
+            stderr=result.stderr or "",
+        )
+    except FileNotFoundError as exc:
+        return RuntimeCommandResult(
+            command=list(cmd),
+            exit_code=127,
+            stderr=str(exc),
+        )
+    except subprocess.TimeoutExpired:
+        return RuntimeCommandResult(
+            command=list(cmd),
+            exit_code=124,
+            stderr="command timed out",
+        )
+
+
+def compose_up_command(
+    *,
+    product: Path,
+    override_path: Path,
+    env_file: Path,
+    project_name: str,
+    services: Sequence[str],
+    no_deps: bool = True,
+) -> List[str]:
+    cmd = [
+        "docker",
+        "compose",
+        "-f",
+        str(product / "compose.yml"),
+        "-f",
+        str(override_path),
+        "--env-file",
+        str(env_file),
+        "-p",
+        project_name,
+        "up",
+        "-d",
+    ]
+    if no_deps:
+        cmd.append("--no-deps")
+    cmd.extend(list(services))
+    return cmd
+
+
+def compose_stop_command(
+    *,
+    product: Path,
+    override_path: Path,
+    env_file: Path,
+    project_name: str,
+    services: Sequence[str],
+) -> List[str]:
+    return [
+        "docker",
+        "compose",
+        "-f",
+        str(product / "compose.yml"),
+        "-f",
+        str(override_path),
+        "--env-file",
+        str(env_file),
+        "-p",
+        project_name,
+        "stop",
+        *list(services),
+    ]
+
+
+def docker_rm_force_command(container_name: str) -> List[str]:
+    return ["docker", "rm", "-f", container_name]
+
+
+def docker_stop_command(container_name: str) -> List[str]:
+    return ["docker", "stop", container_name]
+
+
+def task_orchestrator_wrapper_path(product: Path) -> Path:
+    return product / "scripts" / "mcp-wrappers" / "task-orchestrator-http-singleton.sh"
+
+
+def task_orchestrator_start_command(product: Path, *, dry_run: bool = False) -> List[str]:
+    script = task_orchestrator_wrapper_path(product)
+    cmd = ["bash", str(script)]
+    if dry_run:
+        cmd.append("--dry-run")
+    return cmd
+
+
+def apply_labels_via_docker_run_note() -> str:
+    """Wrapper creates containers without dopemux labels; we re-label by recreate in lifecycle when needed."""
+    return (
+        "task-orchestrator uses wrapper-singleton script; lifecycle records "
+        "container name and attempts label verification post-start"
+    )
+
+
+def write_runtime_artifacts(
+    runtime_dir: Path,
+    *,
+    env_text: str,
+    override_text: str,
+    plan: Mapping[str, Any],
+    dry_run: bool = False,
+) -> Dict[str, str]:
+    """Write mcp.env, compose.override.yml, start-plan.json under runtime_dir."""
+    paths = {
+        "mcp.env": runtime_dir / "mcp.env",
+        "compose.override.yml": runtime_dir / "compose.override.yml",
+        "start-plan.json": runtime_dir / "start-plan.json",
+    }
+    if dry_run:
+        return {k: str(v) for k, v in paths.items()}
+    runtime_dir.mkdir(parents=True, exist_ok=True)
+    paths["mcp.env"].write_text(env_text, encoding="utf-8")
+    paths["compose.override.yml"].write_text(override_text, encoding="utf-8")
+    import json
+
+    paths["start-plan.json"].write_text(
+        json.dumps(plan, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return {k: str(v) for k, v in paths.items()}
+
+
+def redact_command(cmd: Sequence[str]) -> str:
+    """Shell-ish preview without expanding secrets (commands should not contain secrets)."""
+    return " ".join(shlex.quote(c) for c in cmd)

--- a/src/dopemux/mcp/doctor.py
+++ b/src/dopemux/mcp/doctor.py
@@ -19,6 +19,7 @@ from . import port_diagnostics as pd
 from .envrc import (
     load_envrc,
     merge_envrc_into_environ,
+    redact_value,
     safe_port_int,
 )
 from .runtime_state import (
@@ -194,19 +195,6 @@ def run_mcp_doctor(
 
     if envrc.present and envrc.parse_status == "OK":
         _add(findings, "ENVRC_FOUND", "INFO", f"Found {ENVRC_FILENAME}", evidence=[str(envrc_path)])
-    elif envrc.present and envrc.parse_status == "PARTIAL":
-        _add(findings, "ENVRC_FOUND", "INFO", f"Found {ENVRC_FILENAME}", evidence=[str(envrc_path)])
-        _add(
-            findings,
-            "ENVRC_PARSE_PARTIAL",
-            "WARN",
-            (
-                f"Partial parse of {ENVRC_FILENAME}: "
-                f"{len(envrc.values)} key(s) usable, {len(envrc.errors)} malformed line(s)"
-            ),
-            evidence=envrc.errors,
-            recommendation="Fix malformed lines in .envrc.dopemux-mcp; usable keys were still loaded.",
-        )
     elif not envrc.present:
         # Severity depends on whether mcp.json expects env-derived ports
         mcp_needs_env = False
@@ -297,14 +285,9 @@ def run_mcp_doctor(
 
     # --- Desired services ---
     mcp_servers = mcp_json.get("servers") or {}
-    catalog_defaults = list((catalog.get("defaults") or {}).get("per_worktree") or [])
-    if mcp_servers:
-        service_names = list(mcp_servers.keys())
-        for default_name in catalog_defaults:
-            if default_name not in service_names:
-                service_names.append(default_name)
-    else:
-        service_names = catalog_defaults
+    service_names = list(mcp_servers.keys()) if mcp_servers else list(
+        (catalog.get("defaults") or {}).get("per_worktree") or []
+    )
 
     # Configured ports from envrc
     configured_ports: Dict[str, int] = {}
@@ -320,7 +303,7 @@ def run_mcp_doctor(
             port = safe_port_int(doctor_env, str(key))
             if port is not None:
                 configured_ports[str(key)] = port
-            elif envrc.present and envrc.parse_status in {"OK", "PARTIAL"}:
+            elif envrc.present and envrc.parse_status == "OK":
                 _add(
                     findings,
                     "PORT_UNSET",
@@ -660,16 +643,14 @@ def run_mcp_doctor(
             f"Malformed global config: {global_claude.get('error')}",
             evidence=[str(global_claude.get("path"))],
         )
-    # Never dump raw URLs into findings (may leak hostnames / secrets).
-    from .envrc import redact_value as _redact
-
     for name in sorted(set(global_servers) & set(local_servers)):
         g = global_servers[name] if isinstance(global_servers.get(name), dict) else {}
         loc = local_servers[name] if isinstance(local_servers.get(name), dict) else {}
         g_url = g.get("url") or ""
         l_url = loc.get("url") or ""
-        safe_g_url = _redact("URL", str(g_url)) if g_url else None
-        safe_l_url = _redact("URL", str(l_url)) if l_url else None
+        # Always redact URLs in evidence (credentials / non-localhost hostnames).
+        safe_g_url = redact_value("URL", str(g_url)) if g_url else None
+        safe_l_url = redact_value("URL", str(l_url)) if l_url else None
         _add(
             findings,
             "GLOBAL_LOCAL_DUPLICATE",

--- a/src/dopemux/mcp/envrc.py
+++ b/src/dopemux/mcp/envrc.py
@@ -10,7 +10,6 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
-from urllib.parse import urlparse, urlunparse
 
 # Lines we accept: optional "export ", KEY=VALUE with optional quotes.
 _LINE_RE = re.compile(
@@ -51,7 +50,7 @@ class EnvrcParseResult:
 
     path: Optional[Path]
     present: bool
-    parse_status: str  # OK | PARTIAL | ERROR | MISSING
+    parse_status: str  # OK | ERROR | MISSING
     values: Dict[str, str] = field(default_factory=dict)
     keys_present: List[str] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
@@ -107,40 +106,18 @@ def is_secret_like_key(key: str) -> bool:
     return False
 
 
-def _redact_url_hostname(value: str) -> str:
-    """Keep scheme + redacted host (and port/path); drop raw hostnames."""
-    try:
-        parsed = urlparse(value)
-        if not parsed.scheme or not parsed.netloc:
-            return "[REDACTED_URL]"
-        port = f":{parsed.port}" if parsed.port else ""
-        redacted_netloc = f"[REDACTED_HOST]{port}"
-        return urlunparse(
-            (
-                parsed.scheme,
-                redacted_netloc,
-                parsed.path,
-                parsed.params,
-                parsed.query,
-                parsed.fragment,
-            )
-        )
-    except Exception:  # noqa: BLE001
-        return "[REDACTED_URL]"
-
-
 def redact_value(key: str, value: str) -> str:
     """Return a report-safe representation of an env value."""
     if is_secret_like_key(key):
         return "[REDACTED]"
-    # Allow localhost URLs without credentials
+    # Allow localhost URLs without credentials; redact everything else URL-like.
     if "://" in value:
         if "@" in value.split("://", 1)[1].split("/", 1)[0]:
             return "[REDACTED_URL_WITH_CREDENTIALS]"
         if "localhost" in value or "127.0.0.1" in value:
             return value
-        # Non-localhost URLs may leak hostnames; keep scheme + redacted host
-        return _redact_url_hostname(value)
+        # Non-localhost URLs may leak internal hostnames into doctor/CI output.
+        return "[REDACTED_URL]"
     # Numeric ports are always safe
     if value.isdigit():
         return value
@@ -201,11 +178,9 @@ def load_envrc(path: Path | str | None) -> EnvrcParseResult:
         )
 
     values, errors = parse_envrc_text(text)
-    # Only ERROR when unusable (no keys). PARTIAL when some keys parsed but
-    # malformed lines remain; OK when clean.
-    if values and errors:
-        status = "PARTIAL"
-    elif values:
+    # Partial parse: useful keys still count as OK so doctor does not hard-fail
+    # on minor envrc noise. errors[] retains malformed-line diagnostics.
+    if values:
         status = "OK"
     elif errors:
         status = "ERROR"
@@ -231,8 +206,7 @@ def merge_envrc_into_environ(
 ) -> Dict[str, str]:
     """Return a new env mapping with envrc values applied (envrc wins when override=True)."""
     merged = dict(base or {})
-    # Merge usable values from OK/PARTIAL (and ERROR-with-values if any future path).
-    if envrc.parse_status in {"OK", "PARTIAL", "ERROR"} and envrc.values:
+    if envrc.parse_status in {"OK", "ERROR"} and envrc.values:
         for key, value in envrc.values.items():
             if override or key not in merged:
                 merged[key] = value

--- a/src/dopemux/mcp/lifecycle.py
+++ b/src/dopemux/mcp/lifecycle.py
@@ -1,0 +1,1563 @@
+"""Repo-aware MCP lifecycle reconciler: plan, preflight, start/stop/status.
+
+Uses Packet 001 doctor for preflight. Never adopts unlabeled containers.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
+
+from . import docker_inspect as di
+from . import docker_runtime as dr
+from .doctor import DoctorReport, run_mcp_doctor
+from .envrc import load_envrc, merge_envrc_into_environ, safe_port_int
+from .port_diagnostics import instance_id_for_path
+from .runtime_registry import (
+    RegistryError,
+    RuntimeRegistry,
+    build_instance_record,
+    default_registry_path,
+)
+from .runtime_state import (
+    ENVRC_FILENAME,
+    PROJECT_MCP_FILENAME,
+    load_mcp_json,
+    resolve_identity_view,
+)
+
+SCHEMA_VERSION = "1.0"
+
+PROJECT_SCOPED_DEFAULT = ("conport", "dope-memory", "task-orchestrator")
+
+# Doctor finding codes that block start mutations
+BLOCKING_FINDING_CODES = frozenset(
+    {
+        "PROJECT_IDENTITY_UNKNOWN",
+        "WORKTREE_ROOT_UNKNOWN",
+        "PROJECT_ROOT_UNKNOWN",
+        "MCP_JSON_PARSE_ERROR",
+        "ENVRC_PARSE_ERROR",
+        "ENVRC_MISSING",
+        "MCP_JSON_MISSING",
+        "TRANSPORT_MISMATCH",
+        "PORT_RESERVED_COLLISION",
+        "PORT_INTRA_CONFIG_COLLISION",
+        "PORT_OWNED_BY_OTHER_PROJECT",
+        "DOCKER_UNAVAILABLE",
+        "DOCKER_CONTAINER_WRONG_PROJECT",
+        "DOCKER_CONTAINER_UNLABELED_UNKNOWN",
+        "DOCKER_CONTAINER_PORT_COLLISION",
+        "TASK_ORCHESTRATOR_WRONG_PROJECT_RUNTIME",
+    }
+)
+
+# Informational doctor codes that should not block (lifecycle neutralizes compose hazards)
+NON_BLOCKING_EVEN_IF_IN_SET = frozenset(
+    {
+        # These become non-blocking when we use generated override (not raw compose)
+        "COMPOSE_REQUIRED_IN_CWD",
+        "COMPOSE_CONTAINER_NAME_DEFAULT_COLLISION_RISK",
+        "COMPOSE_MEMORY_VOLUME_RELATIVE_CWD_RISK",
+        "COMPOSE_WORKSPACE_ID_MISSING_RISK",
+        "COMPOSE_INSTANCE_ID_ONLY_INSUFFICIENT",
+        "DUAL_ALLOCATION_BRAINS",
+        "INSTANCE_OVERLAY_NOT_WIRED_TO_INIT",
+        "PORT_HASH_BUCKET_COLLISION_RISK",
+        "PORT_REBIND_MISSING",
+        "PORT_NOT_LISTENING",
+        "PORT_LISTENING",
+        "PORT_OWNERSHIP_UNKNOWN",
+        "PORT_EXPECTED",
+        "DOCKER_CONTAINER_NOT_FOUND",
+        "GLOBAL_SERVICE_DEAD",
+        "GLOBAL_LOCAL_DUPLICATE",
+        "TASK_ORCHESTRATOR_PROJECT_IDENTITY_UNKNOWN",
+    }
+)
+
+
+def _port_is_free(port: int, host: str = "127.0.0.1") -> bool:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(0.5)
+    try:
+        return sock.connect_ex((host, port)) != 0
+    finally:
+        sock.close()
+
+
+def _service_instance_id(slug: str, worktree_hash: str, service: str) -> str:
+    return f"{slug}-{worktree_hash}-{service}"
+
+
+@dataclass
+class LifecycleResult:
+    schema_version: str
+    operation: str
+    dry_run: bool
+    status: str
+    project_identity: Dict[str, Any]
+    services: List[Dict[str, Any]]
+    blocking_findings: List[Dict[str, Any]] = field(default_factory=list)
+    warnings: List[Dict[str, Any]] = field(default_factory=list)
+    registry_path: str = ""
+    runtime_artifacts: List[str] = field(default_factory=list)
+    recommended_next_actions: List[str] = field(default_factory=list)
+    exit_code: int = 0
+    registry: Optional[Dict[str, Any]] = None
+    docker: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "operation": self.operation,
+            "dry_run": self.dry_run,
+            "status": self.status,
+            "project_identity": self.project_identity,
+            "services": self.services,
+            "blocking_findings": self.blocking_findings,
+            "warnings": self.warnings,
+            "registry_path": self.registry_path,
+            "runtime_artifacts": self.runtime_artifacts,
+            "recommended_next_actions": self.recommended_next_actions,
+        }
+        if self.registry is not None:
+            d["registry"] = self.registry
+        if self.docker is not None:
+            d["docker"] = self.docker
+        return d
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True) + "\n"
+
+
+def resolve_target_repo(repo: Optional[str | Path]) -> Path:
+    if repo is not None:
+        path = Path(repo).expanduser().resolve()
+    else:
+        path = Path.cwd().resolve()
+    if not path.is_dir():
+        raise FileNotFoundError(f"Target path not found: {path}")
+    return path
+
+
+def select_services(
+    requested: Optional[Sequence[str]],
+    mcp_servers: Mapping[str, Any],
+    catalog: Mapping[str, Any],
+) -> List[str]:
+    if requested:
+        return [s.strip() for s in requested if s.strip()]
+    # Prefer local .mcp.json project-scoped entries
+    names = []
+    for name in mcp_servers.keys():
+        spec = (catalog.get("servers") or {}).get(name) or {}
+        if isinstance(spec, dict) and spec.get("scope") == "per-worktree":
+            names.append(name)
+        elif name in PROJECT_SCOPED_DEFAULT:
+            names.append(name)
+    if not names:
+        names = list(PROJECT_SCOPED_DEFAULT)
+    return names
+
+
+def _doctor_blocking_findings(
+    doctor: DoctorReport,
+    *,
+    services: Sequence[str],
+    strategy_neutralizes_compose: bool = True,
+) -> List[Dict[str, Any]]:
+    blocking = []
+    for f in doctor.findings:
+        code = f.get("code") or ""
+        if code in NON_BLOCKING_EVEN_IF_IN_SET and strategy_neutralizes_compose:
+            continue
+        # Only block PORT_RESERVED_COLLISION for formula when configured ports differ —
+        # filter: block if service is requested and finding mentions reserved for configured
+        if code == "PORT_RESERVED_COLLISION":
+            evidence = " ".join(f.get("evidence") or [])
+            # Block configured collisions always; formula-only is warn if envrc has safe ports
+            if "source=formula" in evidence and "source=configured" not in evidence:
+                # Downgrade pure-formula reserved collision if we have configured ports from envrc
+                continue
+        if code in BLOCKING_FINDING_CODES:
+            # Scope transport mismatch etc. to requested services when service field set
+            svc = f.get("service")
+            if svc and svc not in services and code == "TRANSPORT_MISMATCH":
+                continue
+            if svc and svc not in services and code.startswith("DOCKER_CONTAINER"):
+                continue
+            blocking.append(f)
+        elif f.get("severity") == "FAIL" and code not in NON_BLOCKING_EVEN_IF_IN_SET:
+            # Extra hard FAILs
+            if code.startswith("MCP_DOCTOR"):
+                continue
+            svc = f.get("service")
+            if svc and svc not in services:
+                continue
+            if code in BLOCKING_FINDING_CODES:
+                blocking.append(f)
+    return blocking
+
+
+def _extract_ports(env: Mapping[str, str], services: Sequence[str], catalog: Mapping[str, Any]) -> Dict[str, int]:
+    ports: Dict[str, int] = {}
+    for name in services:
+        spec = (catalog.get("servers") or {}).get(name) or {}
+        if not isinstance(spec, dict):
+            continue
+        for key in [spec.get("port_var")] + [
+            e.get("var") for e in (spec.get("extra_port_vars") or []) if isinstance(e, dict)
+        ]:
+            if not key:
+                continue
+            p = safe_port_int(env, str(key))
+            if p is not None:
+                ports[str(key)] = p
+    return ports
+
+
+def _collision_checks(
+    *,
+    services: Sequence[str],
+    ports: Mapping[str, int],
+    container_names: Mapping[str, str],
+    docker: di.DockerInspectResult,
+    project_id: str,
+    worktree_root: str,
+) -> List[Dict[str, Any]]:
+    findings: List[Dict[str, Any]] = []
+    if not docker.available:
+        findings.append(
+            {
+                "code": "DOCKER_UNAVAILABLE",
+                "severity": "FAIL",
+                "message": docker.error or "Docker unavailable",
+                "service": None,
+            }
+        )
+        return findings
+
+    by_name = {c.name: c for c in docker.containers}
+    port_owners: Dict[int, di.DockerContainerInfo] = {}
+    for c in docker.containers:
+        for p in c.published_ports:
+            port_owners[p] = c
+
+    for svc, cname in container_names.items():
+        if svc not in services:
+            continue
+        existing = by_name.get(cname)
+        if not existing:
+            # also match prefix
+            for c in docker.containers:
+                if c.name == cname or c.name.endswith(cname):
+                    existing = c
+                    break
+        if existing:
+            labels = existing.labels or {}
+            managed = labels.get(dr.LABEL_MANAGED) == "true"
+            if not managed:
+                findings.append(
+                    {
+                        "code": "DOCKER_CONTAINER_UNLABELED_UNKNOWN",
+                        "severity": "FAIL",
+                        "service": svc,
+                        "message": (
+                            f"Container {existing.name} exists without dopemux.managed=true; "
+                            "refusing to adopt"
+                        ),
+                    }
+                )
+            elif labels.get("dopemux.project_id") and labels.get("dopemux.project_id") != project_id:
+                findings.append(
+                    {
+                        "code": "DOCKER_CONTAINER_WRONG_PROJECT",
+                        "severity": "FAIL",
+                        "service": svc,
+                        "message": f"Container {existing.name} belongs to another project",
+                    }
+                )
+            elif labels.get("dopemux.service") and labels.get("dopemux.service") != svc:
+                findings.append(
+                    {
+                        "code": "DOCKER_CONTAINER_WRONG_PROJECT",
+                        "severity": "FAIL",
+                        "service": svc,
+                        "message": f"Container {existing.name} labels service mismatch",
+                    }
+                )
+
+    for var, port in ports.items():
+        owner = port_owners.get(port)
+        if not owner:
+            continue
+        labels = owner.labels or {}
+        managed = labels.get(dr.LABEL_MANAGED) == "true"
+        if not managed:
+            findings.append(
+                {
+                    "code": "DOCKER_CONTAINER_PORT_COLLISION",
+                    "severity": "FAIL",
+                    "service": None,
+                    "message": (
+                        f"Port :{port} ({var}) occupied by unlabeled container {owner.name}"
+                    ),
+                }
+            )
+        elif labels.get("dopemux.project_id") and labels.get("dopemux.project_id") != project_id:
+            findings.append(
+                {
+                    "code": "PORT_OWNED_BY_OTHER_PROJECT",
+                    "severity": "FAIL",
+                    "service": labels.get("dopemux.service"),
+                    "message": (
+                        f"Port :{port} owned by project {labels.get('dopemux.project_id')} "
+                        f"via {owner.name}"
+                    ),
+                }
+            )
+        # Same project + managed → OK (already_running path)
+    return findings
+
+
+def run_lifecycle(
+    operation: str,
+    *,
+    repo: Optional[str | Path] = None,
+    services: Optional[Sequence[str]] = None,
+    catalog: Mapping[str, Any],
+    dry_run: bool = False,
+    registry_path: Optional[Path] = None,
+    docker_runner: Optional[Callable[..., Any]] = None,
+    cmd_runner: Optional[Callable[..., Any]] = None,
+    skip_doctor: bool = False,
+    process_env: Optional[Mapping[str, str]] = None,
+    port_is_free_fn: Optional[Callable[[int], bool]] = None,
+    product_root: Optional[Path] = None,
+) -> LifecycleResult:
+    """Execute start|stop|restart|status for project-scoped MCP sidecars."""
+    op = operation.lower().strip()
+    if op not in {"start", "stop", "restart", "status"}:
+        raise ValueError(f"unsupported operation: {operation}")
+
+    target = resolve_target_repo(repo)
+    is_free = port_is_free_fn or _port_is_free
+    envrc = load_envrc(target / ENVRC_FILENAME)
+    doctor_env = merge_envrc_into_environ(dict(process_env or {}), envrc, override=True)
+    mcp_json = load_mcp_json(target / PROJECT_MCP_FILENAME)
+    mcp_servers = mcp_json.get("servers") or {}
+    identity = resolve_identity_view(target, envrc_values=doctor_env)
+
+    selected = select_services(services, mcp_servers, catalog)
+    reg_path = registry_path or default_registry_path()
+
+    # Doctor preflight (read-only; never creates registry)
+    doctor: Optional[DoctorReport] = None
+    if not skip_doctor and op != "status":
+        doctor = run_mcp_doctor(
+            target,
+            catalog=catalog,
+            skip_docker=False,
+            skip_port_probe=True,
+            process_env=doctor_env,
+            docker_runner=docker_runner,
+        )
+    elif op == "status":
+        doctor = run_mcp_doctor(
+            target,
+            catalog=catalog,
+            skip_docker=False,
+            skip_port_probe=False,
+            process_env=doctor_env,
+            docker_runner=docker_runner,
+            port_is_free_fn=is_free,
+        )
+
+    blocking: List[Dict[str, Any]] = []
+    warnings: List[Dict[str, Any]] = []
+
+    # Identity blockers
+    if not identity.project_id or identity.identity_confidence == "UNKNOWN":
+        blocking.append(
+            {
+                "code": "PROJECT_IDENTITY_UNKNOWN",
+                "severity": "FAIL",
+                "message": "project identity unknown",
+                "service": None,
+            }
+        )
+    if not identity.worktree_root:
+        blocking.append(
+            {
+                "code": "WORKTREE_ROOT_UNKNOWN",
+                "severity": "FAIL",
+                "message": "worktree root unknown",
+                "service": None,
+            }
+        )
+    if not identity.project_root:
+        blocking.append(
+            {
+                "code": "PROJECT_ROOT_UNKNOWN",
+                "severity": "FAIL",
+                "message": "project root unknown",
+                "service": None,
+            }
+        )
+    if not envrc.present or envrc.parse_status == "MISSING":
+        blocking.append(
+            {
+                "code": "ENVRC_MISSING",
+                "severity": "FAIL",
+                "message": f"Missing {ENVRC_FILENAME}",
+                "service": None,
+            }
+        )
+    elif envrc.parse_status == "ERROR":
+        blocking.append(
+            {
+                "code": "ENVRC_PARSE_ERROR",
+                "severity": "FAIL",
+                "message": "envrc parse error",
+                "service": None,
+            }
+        )
+    if not mcp_json.get("present"):
+        blocking.append(
+            {
+                "code": "MCP_JSON_MISSING",
+                "severity": "FAIL",
+                "message": f"Missing {PROJECT_MCP_FILENAME}",
+                "service": None,
+            }
+        )
+    elif mcp_json.get("parse_status") == "ERROR":
+        blocking.append(
+            {
+                "code": "MCP_JSON_PARSE_ERROR",
+                "severity": "FAIL",
+                "message": "mcp.json parse error",
+                "service": None,
+            }
+        )
+
+    if doctor:
+        blocking.extend(
+            _doctor_blocking_findings(doctor, services=selected, strategy_neutralizes_compose=True)
+        )
+        for f in doctor.findings:
+            if f.get("severity") == "WARN":
+                warnings.append(f)
+
+    # Load registry
+    if op == "status":
+        registry = RuntimeRegistry.load(reg_path, create_missing=False)
+    else:
+        registry = RuntimeRegistry.load(reg_path, create_missing=False)
+        if registry.parse_status == "ERROR" and op in {"start", "stop", "restart"}:
+            blocking.append(
+                {
+                    "code": "REGISTRY_PARSE_ERROR",
+                    "severity": "FAIL",
+                    "message": f"Registry unreadable: {registry.error}",
+                    "service": None,
+                }
+            )
+
+    docker = di.inspect_running_containers(runner=docker_runner)
+
+    worktree_root = identity.worktree_root or str(target)
+    project_root = identity.project_root or str(target)
+    project_id = identity.project_id or Path(project_root).name
+    worktree_hash = identity.worktree_hash or instance_id_for_path(worktree_root)
+    project_hash = identity.project_hash or ""
+    slug = dr.project_slug(Path(project_root).name)
+    compose_proj = dr.compose_project_name(slug, worktree_hash)
+
+    ports = _extract_ports(doctor_env, selected, catalog)
+    # Missing required ports for selected services
+    for name in selected:
+        spec = (catalog.get("servers") or {}).get(name) or {}
+        if not isinstance(spec, dict):
+            blocking.append(
+                {
+                    "code": "CATALOG_SERVICE_UNKNOWN",
+                    "severity": "FAIL",
+                    "message": f"Service `{name}` not in catalog",
+                    "service": name,
+                }
+            )
+            continue
+        pvar = spec.get("port_var")
+        if pvar and pvar not in ports and name != "task-orchestrator":
+            # TO has fixed default 7890
+            if name == "task-orchestrator":
+                ports.setdefault(str(pvar), int(spec.get("default_port_base") or 7890))
+            else:
+                blocking.append(
+                    {
+                        "code": "PORT_UNSET",
+                        "severity": "FAIL",
+                        "message": f"Required port env {pvar} unset for {name}",
+                        "service": name,
+                    }
+                )
+        if name == "task-orchestrator" and pvar:
+            ports.setdefault(str(pvar), int(spec.get("default_port_base") or 7890))
+
+    container_names = {
+        svc: dr.container_name_for(slug, worktree_hash, svc) for svc in selected
+    }
+    # TO wrapper uses task-orchestrator-<state_id>; prefer project_hash short form
+    if "task-orchestrator" in selected:
+        # Match wrapper: task-orchestrator-${workspace_id} where state_id is project hash-ish
+        # Use our deterministic name for managed lifecycle; note wrapper uses different name
+        container_names["task-orchestrator"] = (
+            f"task-orchestrator-{project_hash}" if project_hash else container_names["task-orchestrator"]
+        )
+
+    labels_by_service: Dict[str, Dict[str, str]] = {}
+    for svc in selected:
+        spec = (catalog.get("servers") or {}).get(svc) or {}
+        transport = str(spec.get("transport") or "unknown") if isinstance(spec, dict) else "unknown"
+        scope = "worktree"
+        if isinstance(spec, dict) and spec.get("state_scope") == "per-repo":
+            scope = "project"
+        elif isinstance(spec, dict) and spec.get("scope") == "singleton":
+            scope = "singleton"
+        iid = _service_instance_id(slug, worktree_hash, svc)
+        labels_by_service[svc] = dr.build_labels(
+            project_id=project_id,
+            workspace_id=identity.workspace_id or worktree_root,
+            project_root=project_root,
+            worktree_root=worktree_root,
+            project_hash=project_hash,
+            worktree_hash=worktree_hash,
+            instance_id=iid,
+            service=svc,
+            scope=scope,
+            transport=transport,
+        )
+
+    collision_findings = _collision_checks(
+        services=selected,
+        ports=ports,
+        container_names=container_names,
+        docker=docker,
+        project_id=project_id,
+        worktree_root=worktree_root,
+    )
+    if op in {"start", "restart"}:
+        blocking.extend(collision_findings)
+
+    # Deduplicate blocking by code+service+message
+    seen_b = set()
+    uniq_blocking = []
+    for f in blocking:
+        key = (f.get("code"), f.get("service"), f.get("message"))
+        if key in seen_b:
+            continue
+        seen_b.add(key)
+        uniq_blocking.append(f)
+    blocking = uniq_blocking
+
+    identity_dict = identity.to_dict()
+
+    if op == "status":
+        return _status_result(
+            identity_dict=identity_dict,
+            selected=selected,
+            registry=registry,
+            docker=docker,
+            doctor=doctor,
+            container_names=container_names,
+            ports=ports,
+            labels_by_service=labels_by_service,
+            project_id=project_id,
+            worktree_root=worktree_root,
+            catalog=catalog,
+            is_free=is_free,
+            reg_path=reg_path,
+            warnings=warnings,
+        )
+
+    if blocking and op in {"start", "stop", "restart"}:
+        # stop can proceed only for managed matching; but still block on registry error
+        if op == "stop" and not any(
+            f.get("code") == "REGISTRY_PARSE_ERROR" for f in blocking
+        ):
+            # For stop, filter blocking to only hard safety (don't require envrc for stop if registry has entries)
+            hard = [
+                f
+                for f in blocking
+                if f.get("code")
+                in {
+                    "REGISTRY_PARSE_ERROR",
+                    "PROJECT_IDENTITY_UNKNOWN",
+                    "DOCKER_UNAVAILABLE",
+                }
+            ]
+            if not hard:
+                blocking = []
+        if blocking:
+            svc_plans = [
+                {
+                    "service": s,
+                    "action": "blocked",
+                    "reason": "preflight blocked",
+                    "container_name": container_names.get(s),
+                    "ports": {k: v for k, v in ports.items() if s.split("-")[0] in k.lower() or True},
+                    "labels": labels_by_service.get(s, {}),
+                    "runtime_files": [],
+                    "commands": [],
+                    "preflight_findings": [f for f in blocking if f.get("service") in (None, s)],
+                }
+                for s in selected
+            ]
+            # simplify ports in plan
+            for plan in svc_plans:
+                plan["ports"] = _ports_for_service(plan["service"], ports, catalog)
+            return LifecycleResult(
+                schema_version=SCHEMA_VERSION,
+                operation=op,
+                dry_run=dry_run,
+                status="BLOCKED" if dry_run else "FAIL",
+                project_identity=identity_dict,
+                services=svc_plans,
+                blocking_findings=blocking,
+                warnings=warnings,
+                registry_path=str(reg_path),
+                exit_code=1,
+                recommended_next_actions=[
+                    "Fix blocking preflight findings (doctor --json), then retry.",
+                    "Do not start via cwd compose env injection.",
+                ],
+            )
+
+    try:
+        product = product_root or dr.product_root()
+    except FileNotFoundError as exc:
+        return LifecycleResult(
+            schema_version=SCHEMA_VERSION,
+            operation=op,
+            dry_run=dry_run,
+            status="FAIL",
+            project_identity=identity_dict,
+            services=[],
+            blocking_findings=[
+                {
+                    "code": "PRODUCT_ROOT_UNKNOWN",
+                    "severity": "FAIL",
+                    "message": str(exc),
+                    "service": None,
+                }
+            ],
+            registry_path=str(reg_path),
+            exit_code=2,
+        )
+
+    if op == "stop":
+        return _stop_services(
+            selected=selected,
+            identity_dict=identity_dict,
+            project_id=project_id,
+            worktree_root=worktree_root,
+            container_names=container_names,
+            labels_by_service=labels_by_service,
+            registry=registry,
+            docker=docker,
+            dry_run=dry_run,
+            reg_path=reg_path,
+            product=product,
+            compose_proj=compose_proj,
+            cmd_runner=cmd_runner,
+            ports=ports,
+            catalog=catalog,
+            slug=slug,
+            worktree_hash=worktree_hash,
+        )
+
+    if op == "restart":
+        stop_res = _stop_services(
+            selected=selected,
+            identity_dict=identity_dict,
+            project_id=project_id,
+            worktree_root=worktree_root,
+            container_names=container_names,
+            labels_by_service=labels_by_service,
+            registry=registry,
+            docker=docker,
+            dry_run=dry_run,
+            reg_path=reg_path,
+            product=product,
+            compose_proj=compose_proj,
+            cmd_runner=cmd_runner,
+            ports=ports,
+            catalog=catalog,
+            slug=slug,
+            worktree_hash=worktree_hash,
+        )
+        if stop_res.status == "FAIL" and not dry_run:
+            stop_res.operation = "restart"
+            return stop_res
+        start_res = _start_services(
+            selected=selected,
+            identity=identity,
+            identity_dict=identity_dict,
+            project_id=project_id,
+            project_root=project_root,
+            worktree_root=worktree_root,
+            project_hash=project_hash,
+            worktree_hash=worktree_hash,
+            slug=slug,
+            compose_proj=compose_proj,
+            container_names=container_names,
+            labels_by_service=labels_by_service,
+            ports=ports,
+            doctor_env=doctor_env,
+            registry=registry,
+            docker=docker,
+            dry_run=dry_run,
+            reg_path=reg_path,
+            product=product,
+            catalog=catalog,
+            cmd_runner=cmd_runner,
+            is_free=is_free,
+            target=target,
+        )
+        start_res.operation = "restart"
+        if dry_run:
+            start_res.services = [
+                {
+                    **s,
+                    "restart_plan": {
+                        "stop": next(
+                            (x for x in stop_res.services if x.get("service") == s.get("service")),
+                            {},
+                        ),
+                        "start": s,
+                    },
+                }
+                for s in start_res.services
+            ]
+        return start_res
+
+    # start
+    return _start_services(
+        selected=selected,
+        identity=identity,
+        identity_dict=identity_dict,
+        project_id=project_id,
+        project_root=project_root,
+        worktree_root=worktree_root,
+        project_hash=project_hash,
+        worktree_hash=worktree_hash,
+        slug=slug,
+        compose_proj=compose_proj,
+        container_names=container_names,
+        labels_by_service=labels_by_service,
+        ports=ports,
+        doctor_env=doctor_env,
+        registry=registry,
+        docker=docker,
+        dry_run=dry_run,
+        reg_path=reg_path,
+        product=product,
+        catalog=catalog,
+        cmd_runner=cmd_runner,
+        is_free=is_free,
+        target=target,
+    )
+
+
+def _ports_for_service(service: str, ports: Mapping[str, int], catalog: Mapping[str, Any]) -> Dict[str, int]:
+    out: Dict[str, int] = {}
+    spec = (catalog.get("servers") or {}).get(service) or {}
+    if not isinstance(spec, dict):
+        return out
+    if spec.get("port_var") and spec["port_var"] in ports:
+        out[str(spec["port_var"])] = ports[str(spec["port_var"])]
+    for extra in spec.get("extra_port_vars") or []:
+        if isinstance(extra, dict) and extra.get("var") in ports:
+            out[str(extra["var"])] = ports[str(extra["var"])]
+    # Friendly aliases for registry
+    if service == "conport":
+        if "CONPORT_HTTP_PORT" in ports:
+            out["http"] = ports["CONPORT_HTTP_PORT"]
+        if "CONPORT_MCP_PORT" in ports:
+            out["sse"] = ports["CONPORT_MCP_PORT"]
+        if "CONPORT_INFO_PORT" in ports:
+            out["info"] = ports["CONPORT_INFO_PORT"]
+    if service == "dope-memory" and "DOPE_MEMORY_PORT" in ports:
+        out["http"] = ports["DOPE_MEMORY_PORT"]
+    if service == "task-orchestrator" and "TASK_ORCHESTRATOR_HTTP_PORT" in ports:
+        out["http"] = ports["TASK_ORCHESTRATOR_HTTP_PORT"]
+    return out
+
+
+def _urls_for_service(service: str, ports: Mapping[str, int]) -> Dict[str, str]:
+    urls: Dict[str, str] = {}
+    if service == "conport":
+        if "CONPORT_HTTP_PORT" in ports:
+            urls["http"] = f"http://localhost:{ports['CONPORT_HTTP_PORT']}"
+        if "CONPORT_MCP_PORT" in ports:
+            urls["sse"] = f"http://localhost:{ports['CONPORT_MCP_PORT']}/sse"
+    if service == "dope-memory" and "DOPE_MEMORY_PORT" in ports:
+        urls["http"] = f"http://localhost:{ports['DOPE_MEMORY_PORT']}/mcp"
+        urls["health"] = f"http://localhost:{ports['DOPE_MEMORY_PORT']}/health"
+    if service == "task-orchestrator" and "TASK_ORCHESTRATOR_HTTP_PORT" in ports:
+        p = ports["TASK_ORCHESTRATOR_HTTP_PORT"]
+        urls["http"] = f"http://127.0.0.1:{p}/mcp"
+        urls["health"] = f"http://127.0.0.1:{p}/health"
+    return urls
+
+
+def _already_running_managed(
+    docker: di.DockerInspectResult,
+    cname: str,
+    project_id: str,
+    service: str,
+) -> Optional[di.DockerContainerInfo]:
+    if not docker.available:
+        return None
+    for c in docker.containers:
+        if c.name != cname and not c.name.endswith(cname):
+            continue
+        labels = c.labels or {}
+        if labels.get(dr.LABEL_MANAGED) != "true":
+            return None
+        if labels.get("dopemux.project_id") == project_id and labels.get("dopemux.service") == service:
+            return c
+        # name match but wrong labels handled by collision
+        return None
+    return None
+
+
+def _start_services(**kw: Any) -> LifecycleResult:
+    selected: List[str] = kw["selected"]
+    identity = kw["identity"]
+    identity_dict = kw["identity_dict"]
+    project_id = kw["project_id"]
+    project_root = kw["project_root"]
+    worktree_root = kw["worktree_root"]
+    project_hash = kw["project_hash"]
+    worktree_hash = kw["worktree_hash"]
+    slug = kw["slug"]
+    compose_proj = kw["compose_proj"]
+    container_names = kw["container_names"]
+    labels_by_service = kw["labels_by_service"]
+    ports: Dict[str, int] = kw["ports"]
+    doctor_env = kw["doctor_env"]
+    registry: RuntimeRegistry = kw["registry"]
+    docker: di.DockerInspectResult = kw["docker"]
+    dry_run: bool = kw["dry_run"]
+    reg_path: Path = kw["reg_path"]
+    product: Path = kw["product"]
+    catalog = kw["catalog"]
+    cmd_runner = kw["cmd_runner"]
+    is_free = kw["is_free"]
+    target: Path = kw["target"]
+
+    compose_services = [s for s in selected if s in {"conport", "dope-memory"}]
+    to_selected = "task-orchestrator" in selected
+
+    runtime_base = reg_path.parent / f"{slug}-{worktree_hash}"
+    memory_data = Path(worktree_root) / ".dopemux"
+    identity_env = {
+        "DOPEMUX_INSTANCE_ID": identity.instance_id or worktree_hash,
+        "DOPEMUX_WORKSPACE_ID": identity.workspace_id or worktree_root,
+        "DOPEMUX_PROJECT_ROOT": project_root,
+        "DOPEMUX_WORKTREE_ROOT": worktree_root,
+        "DOPEMUX_WORKSPACE_ROOT": worktree_root,
+        "DOPE_MEMORY_WORKSPACE_ID": doctor_env.get("DOPE_MEMORY_WORKSPACE_ID")
+        or Path(worktree_root).name,
+        "DOPE_MEMORY_INSTANCE_ID": doctor_env.get("DOPE_MEMORY_INSTANCE_ID")
+        or (identity.instance_id or worktree_hash),
+        "TASK_ORCHESTRATOR_PROJECT_ROOT": project_root,
+        "CONPORT_CONTAINER_NAME": container_names.get("conport", ""),
+        **{k: str(v) for k, v in ports.items()},
+    }
+
+    override_text = ""
+    env_text = dr.generate_mcp_env(identity_env)
+    if compose_services:
+        override_text = dr.generate_compose_override(
+            services=compose_services,
+            identity=identity_env,
+            ports=ports,
+            container_names=container_names,
+            labels_by_service=labels_by_service,
+            memory_data_path=memory_data,
+        )
+
+    plan_doc = {
+        "services": selected,
+        "compose_project": compose_proj,
+        "container_names": container_names,
+        "ports": ports,
+        "strategy": "compose_override+no_deps" if compose_services else "none",
+        "task_orchestrator_strategy": "wrapper_singleton" if to_selected else None,
+        "product_root": str(product),
+        "memory_data_path": str(memory_data),
+    }
+
+    artifact_paths = dr.write_runtime_artifacts(
+        runtime_base,
+        env_text=env_text,
+        override_text=override_text or "# no compose services\n",
+        plan=plan_doc,
+        dry_run=dry_run,
+    )
+
+    service_results: List[Dict[str, Any]] = []
+    overall_fail = False
+    overall_unknown = False
+
+    # Plan/start compose services
+    for svc in selected:
+        cname = container_names[svc]
+        svc_ports = _ports_for_service(svc, ports, catalog)
+        labels = labels_by_service[svc]
+        existing = _already_running_managed(docker, cname, project_id, svc)
+        # TO: also check wrapper name
+        if svc == "task-orchestrator" and not existing:
+            existing = _already_running_managed(
+                docker, cname, project_id, svc
+            )
+            # unlabeled TO on fixed port is already blocked in collision
+
+        if existing:
+            service_results.append(
+                {
+                    "service": svc,
+                    "action": "already_running" if not dry_run else "already_running",
+                    "reason": "managed container already running with matching labels",
+                    "container_name": existing.name,
+                    "container_names": [existing.name],
+                    "ports": svc_ports,
+                    "labels": labels,
+                    "commands": [],
+                    "probe_status": "UNKNOWN",
+                    "registry_updated": False,
+                    "findings": [],
+                }
+            )
+            if not dry_run:
+                _registry_upsert(
+                    registry,
+                    svc=svc,
+                    project_id=project_id,
+                    identity=identity,
+                    project_root=project_root,
+                    worktree_root=worktree_root,
+                    project_hash=project_hash,
+                    worktree_hash=worktree_hash,
+                    slug=slug,
+                    compose_proj=compose_proj,
+                    container_names=[existing.name],
+                    ports=svc_ports,
+                    labels=labels,
+                    status="running",
+                    last_start={"command": ["already_running"], "exit_code": 0},
+                )
+            continue
+
+        commands: List[List[str]] = []
+        if svc in {"conport", "dope-memory"}:
+            cmd = dr.compose_up_command(
+                product=product,
+                override_path=Path(artifact_paths["compose.override.yml"]),
+                env_file=Path(artifact_paths["mcp.env"]),
+                project_name=compose_proj,
+                services=[svc],
+                no_deps=True,
+            )
+            commands.append(cmd)
+        elif svc == "task-orchestrator":
+            # Wrapper uses project resolution from env; set identity env
+            cmd = dr.task_orchestrator_start_command(product, dry_run=False)
+            commands.append(cmd)
+        else:
+            service_results.append(
+                {
+                    "service": svc,
+                    "action": "blocked",
+                    "reason": "service not supported by lifecycle reconciler",
+                    "container_name": cname,
+                    "ports": svc_ports,
+                    "labels": labels,
+                    "commands": [],
+                    "findings": [],
+                }
+            )
+            overall_fail = True
+            continue
+
+        if dry_run:
+            service_results.append(
+                {
+                    "service": svc,
+                    "action": "start",
+                    "reason": "planned",
+                    "container_name": cname,
+                    "ports": svc_ports,
+                    "labels": labels,
+                    "runtime_files": list(artifact_paths.values()),
+                    "commands": [dr.redact_command(c) for c in commands],
+                    "preflight_findings": [],
+                }
+            )
+            continue
+
+        # Apply
+        if svc in {"conport", "dope-memory"}:
+            # Ensure data dir for memory
+            if svc == "dope-memory":
+                memory_data.mkdir(parents=True, exist_ok=True)
+            result = dr.run_cmd(
+                commands[0],
+                runner=cmd_runner,
+                cwd=product,
+                dry_run=False,
+            )
+            action = "started" if result.exit_code == 0 else "failed"
+            if result.exit_code != 0:
+                overall_fail = True
+            probe = _probe_service(svc, ports, is_free)
+            if not dry_run and result.exit_code == 0:
+                _registry_upsert(
+                    registry,
+                    svc=svc,
+                    project_id=project_id,
+                    identity=identity,
+                    project_root=project_root,
+                    worktree_root=worktree_root,
+                    project_hash=project_hash,
+                    worktree_hash=worktree_hash,
+                    slug=slug,
+                    compose_proj=compose_proj,
+                    container_names=[cname],
+                    ports=svc_ports,
+                    labels=labels,
+                    status="running" if probe != "FAIL" else "unhealthy",
+                    last_start={
+                        "command": [dr.redact_command(commands[0])],
+                        "exit_code": result.exit_code,
+                    },
+                    last_probe={"status": probe},
+                )
+            service_results.append(
+                {
+                    "service": svc,
+                    "action": action,
+                    "container_names": [cname],
+                    "ports": svc_ports,
+                    "probe_status": probe,
+                    "registry_updated": result.exit_code == 0,
+                    "findings": [],
+                    "commands": [dr.redact_command(commands[0])],
+                    "result": result.to_dict(),
+                }
+            )
+        elif svc == "task-orchestrator":
+            # Run wrapper with project env
+            env = dict(os_environ_safe(doctor_env))
+            env["TASK_ORCHESTRATOR_PROJECT_ROOT"] = project_root
+            env["DOPEMUX_PROJECT_ROOT"] = project_root
+            env["DOPEMUX_WORKSPACE_ROOT"] = worktree_root
+            env["TASK_ORCHESTRATOR_HTTP_PORT"] = str(
+                ports.get("TASK_ORCHESTRATOR_HTTP_PORT", 7890)
+            )
+            result = dr.run_cmd(
+                commands[0],
+                runner=cmd_runner,
+                env=env,
+                cwd=Path(worktree_root),
+                dry_run=False,
+            )
+            action = "started" if result.exit_code == 0 else "failed"
+            if result.exit_code != 0:
+                overall_fail = True
+            probe = _probe_service(svc, ports, is_free)
+            # Identity may be unproven for TO wrapper (labels not applied by wrapper)
+            if result.exit_code == 0 and probe != "FAIL":
+                overall_unknown = True  # labels not guaranteed
+            actual_name = cname
+            if result.exit_code == 0:
+                _registry_upsert(
+                    registry,
+                    svc=svc,
+                    project_id=project_id,
+                    identity=identity,
+                    project_root=project_root,
+                    worktree_root=worktree_root,
+                    project_hash=project_hash,
+                    worktree_hash=worktree_hash,
+                    slug=slug,
+                    compose_proj=compose_proj,
+                    container_names=[actual_name],
+                    ports=svc_ports,
+                    labels=labels,
+                    status="running",
+                    last_start={
+                        "command": [dr.redact_command(commands[0])],
+                        "exit_code": result.exit_code,
+                        "note": dr.apply_labels_via_docker_run_note(),
+                    },
+                    last_probe={"status": probe},
+                )
+            service_results.append(
+                {
+                    "service": svc,
+                    "action": action,
+                    "container_names": [actual_name],
+                    "ports": svc_ports,
+                    "probe_status": "UNKNOWN" if result.exit_code == 0 else "FAIL",
+                    "registry_updated": result.exit_code == 0,
+                    "findings": [
+                        {
+                            "code": "TASK_ORCHESTRATOR_PROJECT_IDENTITY_UNKNOWN",
+                            "severity": "UNKNOWN",
+                            "message": (
+                                "Wrapper-singleton start does not apply dopemux labels; "
+                                "ownership proof is limited"
+                            ),
+                        }
+                    ]
+                    if result.exit_code == 0
+                    else [],
+                    "commands": [dr.redact_command(commands[0])],
+                    "result": result.to_dict(),
+                }
+            )
+
+    if not dry_run and registry.parse_status != "ERROR":
+        try:
+            registry.path = reg_path
+            if not registry.present and registry.parse_status == "MISSING":
+                registry.data = registry.data or {}
+                from .runtime_registry import empty_registry
+
+                if not registry.data.get("instances"):
+                    registry.data = empty_registry()
+                registry.parse_status = "OK"
+            registry.save()
+        except RegistryError:
+            overall_fail = True
+
+    if dry_run:
+        status = "PLANNED"
+        exit_code = 0
+    elif overall_fail:
+        status = "FAIL"
+        exit_code = 1
+    elif overall_unknown:
+        status = "PASS_WITH_WARNINGS"
+        exit_code = 0
+    else:
+        status = "PASS"
+        exit_code = 0
+
+    return LifecycleResult(
+        schema_version=SCHEMA_VERSION,
+        operation="start",
+        dry_run=dry_run,
+        status=status,
+        project_identity=identity_dict,
+        services=service_results,
+        blocking_findings=[],
+        warnings=[],
+        registry_path=str(reg_path),
+        runtime_artifacts=list(artifact_paths.values()),
+        exit_code=exit_code,
+        recommended_next_actions=[
+            "source .envrc.dopemux-mcp && claude",
+            "dopemux mcp doctor --repo " + str(target),
+        ],
+    )
+
+
+def os_environ_safe(base: Mapping[str, str]) -> Dict[str, str]:
+    import os
+
+    env = dict(os.environ)
+    env.update({k: str(v) for k, v in base.items()})
+    return env
+
+
+def _registry_upsert(registry: RuntimeRegistry, **kw: Any) -> None:
+    svc = kw["svc"]
+    slug = kw["slug"]
+    worktree_hash = kw["worktree_hash"]
+    iid = _service_instance_id(slug, worktree_hash, svc)
+    identity = kw["identity"]
+    ports = kw["ports"]
+    # Prefer friendly port map
+    port_map = {k: v for k, v in ports.items() if not str(k).isupper() or True}
+    urls = _urls_for_service(
+        svc,
+        {
+            **(
+                {
+                    "CONPORT_HTTP_PORT": ports.get("http") or ports.get("CONPORT_HTTP_PORT"),
+                    "CONPORT_MCP_PORT": ports.get("sse") or ports.get("CONPORT_MCP_PORT"),
+                    "CONPORT_INFO_PORT": ports.get("info") or ports.get("CONPORT_INFO_PORT"),
+                    "DOPE_MEMORY_PORT": ports.get("http") or ports.get("DOPE_MEMORY_PORT"),
+                    "TASK_ORCHESTRATOR_HTTP_PORT": ports.get("http")
+                    or ports.get("TASK_ORCHESTRATOR_HTTP_PORT"),
+                }
+            ),
+            **{k: v for k, v in ports.items() if isinstance(v, int)},
+        },
+    )
+    # Clean None from port helper
+    clean_ports = {
+        k: int(v)
+        for k, v in ports.items()
+        if v is not None and (isinstance(v, int) or str(v).isdigit())
+    }
+    rec = build_instance_record(
+        instance_id=iid,
+        project_id=kw["project_id"],
+        workspace_id=identity.workspace_id or kw["worktree_root"],
+        project_root=kw["project_root"],
+        worktree_root=kw["worktree_root"],
+        worktree_hash=worktree_hash,
+        project_hash=kw["project_hash"],
+        service=svc,
+        scope=kw["labels"].get("dopemux.scope", "worktree"),
+        status=kw["status"],
+        ports=clean_ports,
+        urls=urls,
+        container_names=kw["container_names"],
+        compose_project_name=kw["compose_proj"],
+        labels=kw["labels"],
+        last_start=kw.get("last_start"),
+        last_probe=kw.get("last_probe"),
+    )
+    if registry.parse_status == "MISSING":
+        from .runtime_registry import empty_registry
+
+        registry.data = empty_registry()
+        registry.parse_status = "OK"
+    registry.upsert_instance(rec)
+
+
+def _probe_service(service: str, ports: Mapping[str, int], is_free: Callable[[int], bool]) -> str:
+    try:
+        if service == "conport":
+            p = ports.get("CONPORT_HTTP_PORT") or ports.get("http")
+            if p is None:
+                return "UNKNOWN"
+            return "OK" if not is_free(int(p)) else "FAIL"
+        if service == "dope-memory":
+            p = ports.get("DOPE_MEMORY_PORT") or ports.get("http")
+            if p is None:
+                return "UNKNOWN"
+            return "OK" if not is_free(int(p)) else "FAIL"
+        if service == "task-orchestrator":
+            p = ports.get("TASK_ORCHESTRATOR_HTTP_PORT") or ports.get("http")
+            if p is None:
+                return "UNKNOWN"
+            return "OK" if not is_free(int(p)) else "FAIL"
+    except Exception:  # noqa: BLE001
+        return "UNKNOWN"
+    return "UNKNOWN"
+
+
+def _stop_services(**kw: Any) -> LifecycleResult:
+    selected = kw["selected"]
+    identity_dict = kw["identity_dict"]
+    project_id = kw["project_id"]
+    worktree_root = kw["worktree_root"]
+    container_names = kw["container_names"]
+    registry: RuntimeRegistry = kw["registry"]
+    docker: di.DockerInspectResult = kw["docker"]
+    dry_run = kw["dry_run"]
+    reg_path = kw["reg_path"]
+    cmd_runner = kw["cmd_runner"]
+    catalog = kw["catalog"]
+    ports = kw["ports"]
+
+    results = []
+    fail = False
+
+    for svc in selected:
+        cname = container_names[svc]
+        # Prefer registry names
+        reg_hits = registry.find(
+            project_id=project_id, worktree_root=worktree_root, service=svc
+        )
+        names = []
+        for hit in reg_hits:
+            names.extend(hit.get("container_names") or [])
+        if cname not in names:
+            names.append(cname)
+
+        targets_to_stop = []
+        for name in names:
+            match = None
+            for c in docker.containers if docker.available else []:
+                if c.name == name:
+                    match = c
+                    break
+            if not match:
+                results.append(
+                    {
+                        "service": svc,
+                        "action": "skip" if dry_run else "already_stopped",
+                        "reason": f"container {name} not running",
+                        "container_name": name,
+                        "commands": [],
+                    }
+                )
+                continue
+            labels = match.labels or {}
+            if labels.get(dr.LABEL_MANAGED) != "true":
+                # TO wrapper containers lack labels — allow stop only if registry knows them
+                if svc == "task-orchestrator" and reg_hits:
+                    targets_to_stop.append(match)
+                    continue
+                results.append(
+                    {
+                        "service": svc,
+                        "action": "blocked",
+                        "reason": f"refusing to stop unlabeled container {match.name}",
+                        "container_name": match.name,
+                        "commands": [],
+                    }
+                )
+                fail = True
+                continue
+            if labels.get("dopemux.project_id") != project_id:
+                results.append(
+                    {
+                        "service": svc,
+                        "action": "blocked",
+                        "reason": f"wrong project labels on {match.name}",
+                        "container_name": match.name,
+                        "commands": [],
+                    }
+                )
+                fail = True
+                continue
+            targets_to_stop.append(match)
+
+        for match in targets_to_stop:
+            cmd = dr.docker_stop_command(match.name)
+            if dry_run:
+                results.append(
+                    {
+                        "service": svc,
+                        "action": "stop",
+                        "reason": "planned",
+                        "container_name": match.name,
+                        "commands": [dr.redact_command(cmd)],
+                    }
+                )
+            else:
+                res = dr.run_cmd(cmd, runner=cmd_runner)
+                if res.exit_code != 0:
+                    fail = True
+                results.append(
+                    {
+                        "service": svc,
+                        "action": "stopped" if res.exit_code == 0 else "failed",
+                        "container_name": match.name,
+                        "commands": [dr.redact_command(cmd)],
+                        "result": res.to_dict(),
+                    }
+                )
+                if res.exit_code == 0:
+                    registry.mark_stopped(
+                        project_id=project_id,
+                        service=svc,
+                        worktree_root=worktree_root,
+                    )
+
+    if not dry_run and registry.parse_status == "OK":
+        try:
+            registry.save()
+        except RegistryError:
+            fail = True
+
+    return LifecycleResult(
+        schema_version=SCHEMA_VERSION,
+        operation="stop",
+        dry_run=dry_run,
+        status="PLANNED" if dry_run else ("FAIL" if fail else "PASS"),
+        project_identity=identity_dict,
+        services=results,
+        registry_path=str(reg_path),
+        exit_code=1 if fail and not dry_run else 0,
+    )
+
+
+def _status_result(**kw: Any) -> LifecycleResult:
+    selected = kw["selected"]
+    identity_dict = kw["identity_dict"]
+    registry: RuntimeRegistry = kw["registry"]
+    docker: di.DockerInspectResult = kw["docker"]
+    doctor = kw["doctor"]
+    container_names = kw["container_names"]
+    ports = kw["ports"]
+    project_id = kw["project_id"]
+    worktree_root = kw["worktree_root"]
+    catalog = kw["catalog"]
+    is_free = kw["is_free"]
+    reg_path = kw["reg_path"]
+    warnings = kw["warnings"]
+
+    services_out = []
+    overall = "PASS"
+    for svc in selected:
+        reg_hits = registry.find(
+            project_id=project_id, worktree_root=worktree_root, service=svc
+        )
+        reg_state = "missing"
+        if reg_hits:
+            statuses = {h.get("status") for h in reg_hits}
+            if "running" in statuses:
+                reg_state = "running"
+            elif "stopped" in statuses:
+                reg_state = "stopped"
+            else:
+                reg_state = str(next(iter(statuses)) or "unknown")
+
+        cname = container_names.get(svc)
+        docker_state = "missing"
+        findings = []
+        if docker.available and cname:
+            for c in docker.containers:
+                if c.name == cname or cname in c.name:
+                    labels = c.labels or {}
+                    if labels.get(dr.LABEL_MANAGED) != "true":
+                        docker_state = "unlabeled_unknown"
+                        findings.append(
+                            {
+                                "code": "DOCKER_CONTAINER_UNLABELED_UNKNOWN",
+                                "severity": "UNKNOWN",
+                                "message": f"{c.name} unlabeled",
+                            }
+                        )
+                    elif labels.get("dopemux.project_id") != project_id:
+                        docker_state = "wrong_project"
+                        findings.append(
+                            {
+                                "code": "DOCKER_CONTAINER_WRONG_PROJECT",
+                                "severity": "FAIL",
+                                "message": f"{c.name} wrong project",
+                            }
+                        )
+                    else:
+                        docker_state = "running"
+                    break
+        elif not docker.available:
+            docker_state = "unknown"
+
+        svc_ports = _ports_for_service(svc, ports, catalog)
+        probe_state = "skipped"
+        listen_port = None
+        if svc == "conport":
+            listen_port = ports.get("CONPORT_HTTP_PORT")
+        elif svc == "dope-memory":
+            listen_port = ports.get("DOPE_MEMORY_PORT")
+        elif svc == "task-orchestrator":
+            listen_port = ports.get("TASK_ORCHESTRATOR_HTTP_PORT")
+        if listen_port is not None:
+            try:
+                if is_free(int(listen_port)):
+                    probe_state = "not_listening"
+                else:
+                    probe_state = "healthy" if docker_state == "running" else "unknown"
+            except Exception:  # noqa: BLE001
+                probe_state = "unknown"
+
+        # overall per service
+        if docker_state == "wrong_project":
+            svc_overall = "FAIL"
+            overall = "FAIL"
+        elif docker_state == "unlabeled_unknown":
+            svc_overall = "UNKNOWN"
+            if overall == "PASS":
+                overall = "UNKNOWN"
+        elif reg_state == "running" and docker_state == "missing":
+            svc_overall = "WARN"
+            reg_state = "stale"
+            if overall == "PASS":
+                overall = "PASS_WITH_WARNINGS"
+        elif docker_state == "running" and probe_state == "not_listening":
+            svc_overall = "WARN"
+            if overall == "PASS":
+                overall = "PASS_WITH_WARNINGS"
+        elif docker_state == "running":
+            svc_overall = "PASS"
+        else:
+            svc_overall = "UNKNOWN" if docker_state == "unknown" else "WARN"
+            if svc_overall == "UNKNOWN" and overall == "PASS":
+                overall = "UNKNOWN"
+            elif svc_overall == "WARN" and overall == "PASS":
+                overall = "PASS_WITH_WARNINGS"
+
+        services_out.append(
+            {
+                "service": svc,
+                "desired": {
+                    "container_name": cname,
+                    "ports": svc_ports,
+                    "urls": _urls_for_service(svc, ports),
+                },
+                "registry_state": reg_state,
+                "docker_state": docker_state,
+                "probe_state": probe_state,
+                "overall": svc_overall,
+                "findings": findings,
+            }
+        )
+
+    exit_code = 0
+    if overall == "FAIL":
+        exit_code = 1
+    elif overall == "UNKNOWN":
+        exit_code = 2
+
+    return LifecycleResult(
+        schema_version=SCHEMA_VERSION,
+        operation="status",
+        dry_run=False,
+        status=overall,
+        project_identity=identity_dict,
+        services=services_out,
+        warnings=warnings,
+        registry_path=str(reg_path),
+        registry=registry.to_report_dict(),
+        docker=docker.to_dict(),
+        exit_code=exit_code,
+        recommended_next_actions=[
+            "dopemux mcp start --repo <path>" if overall != "PASS" else "No action required",
+        ],
+    )
+
+
+def format_lifecycle_human(result: LifecycleResult) -> str:
+    lines = [
+        f"MCP {result.operation}: {result.status}"
+        + (" (dry-run)" if result.dry_run else "")
+    ]
+    pid = result.project_identity.get("project_id") or "?"
+    lines.append(f"Project: {pid}")
+    for s in result.services[:10]:
+        svc = s.get("service")
+        action = s.get("action") or s.get("overall") or s.get("docker_state")
+        lines.append(f"  • {svc}: {action}")
+    if result.blocking_findings:
+        lines.append(f"Blocking: {len(result.blocking_findings)}")
+        for f in result.blocking_findings[:5]:
+            lines.append(f"  - {f.get('code')}: {f.get('message')}")
+    if result.recommended_next_actions:
+        lines.append(f"Next: {result.recommended_next_actions[0]}")
+    return "\n".join(lines) + "\n"

--- a/src/dopemux/mcp/runtime_registry.py
+++ b/src/dopemux/mcp/runtime_registry.py
@@ -1,0 +1,272 @@
+"""Operational MCP runtime registry (read/write).
+
+Path default: ~/.dopemux/mcp/runtime/instances.json
+Override: DOPEMUX_MCP_RUNTIME_REGISTRY
+
+Registry is operational state only — never domain truth for ConPort,
+dope-memory, or task-orchestrator.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+SCHEMA_VERSION = "1.0"
+REGISTRY_ENV = "DOPEMUX_MCP_RUNTIME_REGISTRY"
+DEFAULT_RELATIVE = Path(".dopemux/mcp/runtime/instances.json")
+
+
+class RegistryError(RuntimeError):
+    """Registry load/save failure that must block mutations."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_registry_path() -> Path:
+    override = os.environ.get(REGISTRY_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    return (Path.home() / DEFAULT_RELATIVE).resolve()
+
+
+def empty_registry() -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "updated_at": _utc_now(),
+        "instances": [],
+    }
+
+
+@dataclass
+class RuntimeRegistry:
+    """In-memory registry with atomic persistence."""
+
+    path: Path
+    data: Dict[str, Any] = field(default_factory=empty_registry)
+    present: bool = False
+    parse_status: str = "MISSING"  # OK | ERROR | MISSING
+    error: Optional[str] = None
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None, *, create_missing: bool = False) -> "RuntimeRegistry":
+        reg_path = path or default_registry_path()
+        if not reg_path.exists():
+            if create_missing:
+                reg_path.parent.mkdir(parents=True, exist_ok=True)
+                reg = cls(path=reg_path, data=empty_registry(), present=False, parse_status="MISSING")
+                reg.save()
+                reg.present = True
+                reg.parse_status = "OK"
+                return reg
+            return cls(path=reg_path, data=empty_registry(), present=False, parse_status="MISSING")
+
+        try:
+            raw = json.loads(reg_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return cls(
+                path=reg_path,
+                data=empty_registry(),
+                present=True,
+                parse_status="ERROR",
+                error=str(exc),
+            )
+        if not isinstance(raw, dict):
+            return cls(
+                path=reg_path,
+                data=empty_registry(),
+                present=True,
+                parse_status="ERROR",
+                error="registry root is not an object",
+            )
+        if "instances" not in raw or not isinstance(raw.get("instances"), list):
+            return cls(
+                path=reg_path,
+                data=empty_registry(),
+                present=True,
+                parse_status="ERROR",
+                error="registry missing instances list",
+            )
+        # Preserve unknown top-level fields
+        data = dict(raw)
+        data.setdefault("schema_version", SCHEMA_VERSION)
+        data.setdefault("updated_at", _utc_now())
+        return cls(path=reg_path, data=data, present=True, parse_status="OK")
+
+    def require_writable(self) -> None:
+        if self.parse_status == "ERROR":
+            raise RegistryError(
+                f"Registry parse failed at {self.path}: {self.error}. "
+                "Inspect the file; lifecycle mutation is blocked."
+            )
+
+    def instances(self) -> List[Dict[str, Any]]:
+        return list(self.data.get("instances") or [])
+
+    def find(
+        self,
+        *,
+        project_id: Optional[str] = None,
+        worktree_root: Optional[str] = None,
+        service: Optional[str] = None,
+        instance_id: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        out = []
+        for inst in self.instances():
+            if instance_id and inst.get("instance_id") != instance_id:
+                continue
+            if project_id and inst.get("project_id") != project_id:
+                continue
+            if worktree_root and str(inst.get("worktree_root") or "").rstrip("/") != str(
+                worktree_root
+            ).rstrip("/"):
+                continue
+            if service and inst.get("service") != service:
+                continue
+            out.append(inst)
+        return out
+
+    def upsert_instance(self, instance: Dict[str, Any]) -> None:
+        self.require_writable()
+        iid = instance.get("instance_id")
+        if not iid:
+            raise RegistryError("instance_id required")
+        instances = list(self.data.get("instances") or [])
+        replaced = False
+        for i, existing in enumerate(instances):
+            if existing.get("instance_id") == iid:
+                merged = dict(existing)
+                merged.update(instance)
+                # Preserve unknown keys from existing that we didn't touch
+                instances[i] = merged
+                replaced = True
+                break
+        if not replaced:
+            instances.append(dict(instance))
+        self.data["instances"] = instances
+        self.data["updated_at"] = _utc_now()
+
+    def mark_stopped(
+        self,
+        *,
+        project_id: str,
+        service: Optional[str] = None,
+        worktree_root: Optional[str] = None,
+    ) -> int:
+        self.require_writable()
+        count = 0
+        now = _utc_now()
+        for inst in self.instances():
+            if inst.get("project_id") != project_id:
+                continue
+            if worktree_root and str(inst.get("worktree_root") or "").rstrip("/") != str(
+                worktree_root
+            ).rstrip("/"):
+                continue
+            if service and inst.get("service") != service:
+                continue
+            inst["status"] = "stopped"
+            inst["updated_at"] = now
+            count += 1
+        self.data["updated_at"] = now
+        return count
+
+    def prune_stale_dry_run(self, known_instance_ids: Sequence[str]) -> List[str]:
+        """Return instance_ids that would be pruned (dry-run only)."""
+        known = set(known_instance_ids)
+        return [
+            str(i.get("instance_id"))
+            for i in self.instances()
+            if i.get("instance_id") and i.get("instance_id") not in known
+        ]
+
+    def save(self) -> None:
+        self.require_writable()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = deepcopy(self.data)
+        payload["updated_at"] = _utc_now()
+        payload.setdefault("schema_version", SCHEMA_VERSION)
+        text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=".instances.",
+            suffix=".tmp",
+            dir=str(self.path.parent),
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(text)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_name, self.path)
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+        self.data = payload
+        self.present = True
+        self.parse_status = "OK"
+        self.error = None
+
+    def to_report_dict(self) -> Dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "present": self.present,
+            "parse_status": self.parse_status,
+            "error": self.error,
+            "instances": self.instances(),
+        }
+
+
+def build_instance_record(
+    *,
+    instance_id: str,
+    project_id: str,
+    workspace_id: str,
+    project_root: str,
+    worktree_root: str,
+    worktree_hash: str,
+    project_hash: str,
+    service: str,
+    scope: str,
+    status: str,
+    ports: Dict[str, int],
+    urls: Dict[str, str],
+    container_names: List[str],
+    compose_project_name: str,
+    labels: Dict[str, str],
+    last_start: Optional[Dict[str, Any]] = None,
+    last_probe: Optional[Dict[str, Any]] = None,
+    created_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    now = _utc_now()
+    return {
+        "instance_id": instance_id,
+        "project_id": project_id,
+        "workspace_id": workspace_id,
+        "project_root": project_root,
+        "worktree_root": worktree_root,
+        "worktree_hash": worktree_hash,
+        "project_hash": project_hash,
+        "service": service,
+        "scope": scope,
+        "status": status,
+        "ports": dict(ports),
+        "urls": dict(urls),
+        "container_names": list(container_names),
+        "compose_project_name": compose_project_name,
+        "labels": dict(labels),
+        "created_at": created_at or now,
+        "updated_at": now,
+        "last_start": last_start or {},
+        "last_probe": last_probe or {},
+    }

--- a/src/dopemux/mcp/runtime_state.py
+++ b/src/dopemux/mcp/runtime_state.py
@@ -267,16 +267,16 @@ def build_desired_services(
 ) -> List[DesiredService]:
     """Build desired service list from catalog + local mcp.json + env."""
     desired: List[DesiredService] = []
+    # Union of .mcp.json servers and catalog per-worktree defaults so doctor
+    # can still diagnose missing default services when .mcp.json is present.
     catalog_defaults = list((catalog.get("defaults") or {}).get("per_worktree") or [])
-    # Prefer local .mcp.json names, but always also include catalog per-worktree
-    # defaults not present in mcp.json so doctor can diagnose missing entries.
-    if mcp_servers:
-        names = list(mcp_servers.keys())
-        for default_name in catalog_defaults:
-            if default_name not in names:
-                names.append(default_name)
-    else:
-        names = catalog_defaults
+    names: List[str] = []
+    seen: set[str] = set()
+    for name in list(mcp_servers.keys()) + catalog_defaults:
+        if name in seen:
+            continue
+        seen.add(name)
+        names.append(name)
     for name in names:
         catalog_spec = (catalog.get("servers") or {}).get(name) or {}
         local_entry = mcp_servers.get(name) if isinstance(mcp_servers.get(name), dict) else {}
@@ -416,11 +416,13 @@ def compose_lifecycle_diagnostics(
             relative_volume_risks.append(
                 "dope-memory volume ./.dopemux:/data is relative to compose cwd"
             )
-        # Identity env on conport: require both INSTANCE_ID and WORKSPACE_ID
-        # when the service block is present (use block extractor, not fragile splits).
+        # Identity env on conport — inspect the service block only (no fragile splits).
         conport_block = _extract_service_block(text, "conport")
         if conport_block:
-            if "DOPEMUX_INSTANCE_ID" in conport_block and "DOPEMUX_WORKSPACE_ID" not in conport_block:
+            if (
+                "DOPEMUX_INSTANCE_ID" in conport_block
+                and "DOPEMUX_WORKSPACE_ID" not in conport_block
+            ):
                 identity_env_risks.append(
                     "conport receives DOPEMUX_INSTANCE_ID but not DOPEMUX_WORKSPACE_ID"
                 )
@@ -429,8 +431,8 @@ def compose_lifecycle_diagnostics(
             # workspace id is present for memory — still relative volume is the main risk
             pass
     else:
-        # Without compose file still emit known architectural risks as WARN
-        # so doctor works without target-repo compose.yml
+        # Without compose file: emit convention risks as soft notes only.
+        # Do not escalate missing/unreadable compose into FAIL for foreign repos.
         fixed_name_risks.append(
             "compose convention (dopemux-mvp): conport container_name defaults to mcp-conport"
         )
@@ -459,15 +461,24 @@ def compose_lifecycle_diagnostics(
             }
         )
 
+    # FAIL only when compose content was inspected and shows the hazard.
+    # Convention-only notes (no compose file) stay WARN so doctor does not
+    # hard-fail repos that never ship a dopemux compose.yml.
+    compose_verified = bool(text)
     if fixed_name_risks:
         findings_seed.append(
             {
                 "code": "COMPOSE_CONTAINER_NAME_DEFAULT_COLLISION_RISK",
-                "severity": "FAIL",
+                "severity": "FAIL" if compose_verified else "WARN",
                 "service": "conport",
                 "message": (
                     "Fixed/default mcp-conport container name risks replacing the primary "
                     "ConPort container when starting another project's stack."
+                    if compose_verified
+                    else (
+                        "Compose file unavailable; cannot verify container_name uniqueness. "
+                        "Convention risk: conport may default to mcp-conport."
+                    )
                 ),
                 "evidence": fixed_name_risks,
                 "recommendation": (
@@ -481,11 +492,16 @@ def compose_lifecycle_diagnostics(
         findings_seed.append(
             {
                 "code": "COMPOSE_MEMORY_VOLUME_RELATIVE_CWD_RISK",
-                "severity": "FAIL",
+                "severity": "FAIL" if compose_verified else "WARN",
                 "service": "dope-memory",
                 "message": (
                     "Starting dope-memory for another repo from dopemux-mvp compose can bind "
                     "dopemux-mvp/.dopemux instead of the target repo .dopemux, causing memory-state bleed."
+                    if compose_verified
+                    else (
+                        "Compose file unavailable; cannot verify volume binds. "
+                        "Convention risk: dope-memory may bind ./.dopemux relative to compose cwd."
+                    )
                 ),
                 "evidence": relative_volume_risks,
                 "recommendation": (

--- a/tests/unit/test_mcp_commands_lifecycle.py
+++ b/tests/unit/test_mcp_commands_lifecycle.py
@@ -1,0 +1,160 @@
+"""CLI tests for repo-aware mcp start/stop/status."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from dopemux.commands import mcp_commands
+
+
+def _catalog():
+    return {
+        "version": 1,
+        "defaults": {"per_worktree": ["conport"]},
+        "servers": {
+            "conport": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "url_template": "http://localhost:${CONPORT_MCP_PORT}/sse",
+                "port_var": "CONPORT_MCP_PORT",
+                "default_port_base": 3005,
+                "extra_port_vars": [
+                    {"var": "CONPORT_HTTP_PORT", "base": 3004},
+                    {"var": "CONPORT_INFO_PORT", "base": 4004},
+                ],
+            },
+            "dope-memory": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "port_var": "DOPE_MEMORY_PORT",
+                "default_port_base": 3020,
+            },
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "management_model": "wrapper-singleton",
+                "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
+                "default_port_base": 7890,
+            },
+        },
+    }
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "conport": {"type": "sse", "url": "http://localhost:${CONPORT_MCP_PORT}/sse"},
+                }
+            }
+        )
+    )
+    (repo / ".envrc.dopemux-mcp").write_text(
+        f"export DOPEMUX_WORKSPACE_ID={repo}\n"
+        f"export DOPEMUX_WORKSPACE_ROOT={repo}\n"
+        f"export DOPEMUX_PROJECT_ROOT={repo}\n"
+        f"export CONPORT_MCP_PORT=3041\n"
+        f"export CONPORT_HTTP_PORT=3040\n"
+        f"export CONPORT_INFO_PORT=4040\n"
+        f"export DOPEMUX_INSTANCE_ID=abcd\n"
+    )
+    return repo
+
+
+def test_cli_start_dry_run_json(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    reg = tmp_path / "instances.json"
+    product = tmp_path / "product"
+    product.mkdir()
+    (product / "compose.yml").write_text("services: {}\n")
+
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: _catalog())
+    monkeypatch.setenv("DOPEMUX_MCP_RUNTIME_REGISTRY", str(reg))
+    monkeypatch.setenv("DOPEMUX_MVP_ROOT", str(product))
+
+    # Avoid real docker
+    import dopemux.mcp.docker_inspect as di
+
+    monkeypatch.setattr(
+        di,
+        "inspect_running_containers",
+        lambda **kw: di.DockerInspectResult(available=True, containers=[]),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        ["start", "--repo", str(repo), "--services", "conport", "--dry-run", "--json"],
+    )
+    assert result.exit_code in {0, 1, 2}, result.output
+    payload = json.loads(result.output)
+    assert payload["operation"] == "start"
+    assert payload["dry_run"] is True
+    assert payload["schema_version"] == "1.0"
+    assert not reg.exists()  # dry-run no registry
+
+
+def test_cli_status_json(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    reg = tmp_path / "instances.json"
+    product = tmp_path / "product"
+    product.mkdir()
+    (product / "compose.yml").write_text("services: {}\n")
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: _catalog())
+    monkeypatch.setenv("DOPEMUX_MCP_RUNTIME_REGISTRY", str(reg))
+    monkeypatch.setenv("DOPEMUX_MVP_ROOT", str(product))
+
+    import dopemux.mcp.docker_inspect as di
+
+    monkeypatch.setattr(
+        di,
+        "inspect_running_containers",
+        lambda **kw: di.DockerInspectResult(available=True, containers=[]),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        ["status", "--repo", str(repo), "--json"],
+    )
+    assert result.exit_code in {0, 1, 2}, result.output
+    payload = json.loads(result.output)
+    assert payload["operation"] == "status"
+    assert "registry" in payload
+    assert "services" in payload
+
+
+def test_cli_up_repo_aliases_start(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    reg = tmp_path / "instances.json"
+    product = tmp_path / "product"
+    product.mkdir()
+    (product / "compose.yml").write_text("services: {}\n")
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: _catalog())
+    monkeypatch.setenv("DOPEMUX_MCP_RUNTIME_REGISTRY", str(reg))
+    monkeypatch.setenv("DOPEMUX_MVP_ROOT", str(product))
+
+    import dopemux.mcp.docker_inspect as di
+
+    monkeypatch.setattr(
+        di,
+        "inspect_running_containers",
+        lambda **kw: di.DockerInspectResult(available=True, containers=[]),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        ["up", "--repo", str(repo), "--services", "conport", "--dry-run", "--json"],
+    )
+    assert result.exit_code in {0, 1, 2}, result.output
+    payload = json.loads(result.output)
+    assert payload["operation"] == "start"

--- a/tests/unit/test_mcp_commands_lifecycle.py
+++ b/tests/unit/test_mcp_commands_lifecycle.py
@@ -158,3 +158,55 @@ def test_cli_up_repo_aliases_start(tmp_path, monkeypatch):
     assert result.exit_code in {0, 1, 2}, result.output
     payload = json.loads(result.output)
     assert payload["operation"] == "start"
+
+
+def test_cli_up_dry_run_without_repo_stays_legacy(monkeypatch):
+    """--dry-run/--json alone must not divert bare `mcp up` to the reconciler."""
+    called = {"legacy": False, "lifecycle": False}
+
+    def fake_run(cmd, check=True):  # noqa: ARG001
+        called["legacy"] = True
+        return SimpleNamespace(returncode=0)
+
+    def fake_lifecycle(*args, **kwargs):  # noqa: ARG001
+        called["lifecycle"] = True
+        raise AssertionError("lifecycle should not run without --repo")
+
+    monkeypatch.setattr(mcp_commands.subprocess, "run", fake_run)
+    monkeypatch.setattr(mcp_commands, "_run_lifecycle_cli", fake_lifecycle)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        ["up", "--services", "conport", "--dry-run", "--json"],
+    )
+    assert called["lifecycle"] is False, result.output
+    assert called["legacy"] is True, result.output
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_down_dry_run_without_repo_stays_legacy(monkeypatch):
+    """--dry-run/--json alone must not divert bare `mcp down` to the reconciler."""
+    called = {"legacy": False, "lifecycle": False}
+
+    def fake_run(cmd, check=True):  # noqa: ARG001
+        called["legacy"] = True
+        return SimpleNamespace(returncode=0)
+
+    def fake_lifecycle(*args, **kwargs):  # noqa: ARG001
+        called["lifecycle"] = True
+        raise AssertionError("lifecycle should not run without --repo")
+
+    monkeypatch.setattr(mcp_commands.subprocess, "run", fake_run)
+    monkeypatch.setattr(mcp_commands, "_run_lifecycle_cli", fake_lifecycle)
+    monkeypatch.setattr(mcp_commands, "_compose_services", lambda: {"conport"})
+    monkeypatch.setattr(mcp_commands, "DEFAULT_MCP_SERVICES", {"conport"})
+
+    runner = CliRunner()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        ["down", "--dry-run", "--json"],
+    )
+    assert called["lifecycle"] is False, result.output
+    assert called["legacy"] is True, result.output
+    assert result.exit_code == 0, result.output

--- a/tests/unit/test_mcp_doctor_repo_aware.py
+++ b/tests/unit/test_mcp_doctor_repo_aware.py
@@ -171,49 +171,35 @@ services:
     volumes:
       - ./.dopemux:/data
 """
-    diag = compose_lifecycle_diagnostics(None)  # convention path
+    diag = compose_lifecycle_diagnostics(None)  # convention path (no compose file)
     codes = {f["code"] for f in diag["findings"]}
     assert "COMPOSE_REQUIRED_IN_CWD" in codes
     assert "COMPOSE_CONTAINER_NAME_DEFAULT_COLLISION_RISK" in codes
     assert "COMPOSE_MEMORY_VOLUME_RELATIVE_CWD_RISK" in codes
     assert "DUAL_ALLOCATION_BRAINS" in codes
     assert "INSTANCE_OVERLAY_NOT_WIRED_TO_INIT" in codes
+    # Missing compose must not hard-FAIL on convention-only fixed-name / volume risks.
+    by_code = {f["code"]: f for f in diag["findings"]}
+    assert by_code["COMPOSE_CONTAINER_NAME_DEFAULT_COLLISION_RISK"]["severity"] == "WARN"
+    assert by_code["COMPOSE_MEMORY_VOLUME_RELATIVE_CWD_RISK"]["severity"] == "WARN"
 
     path = tmp_path / "compose.yml"
     path.write_text(compose)
     diag2 = compose_lifecycle_diagnostics(path)
     assert any("mcp-conport" in r for r in diag2["fixed_container_name_risks"])
     assert any(".dopemux" in r for r in diag2["relative_volume_risks"])
-    assert any("DOPEMUX_WORKSPACE_ID" in r for r in diag2["identity_env_risks"])
-    assert "COMPOSE_WORKSPACE_ID_MISSING_RISK" in {f["code"] for f in diag2["findings"]}
+    by_code2 = {f["code"]: f for f in diag2["findings"]}
+    assert by_code2["COMPOSE_CONTAINER_NAME_DEFAULT_COLLISION_RISK"]["severity"] == "FAIL"
+    assert by_code2["COMPOSE_MEMORY_VOLUME_RELATIVE_CWD_RISK"]["severity"] == "FAIL"
+    assert any(
+        "DOPEMUX_WORKSPACE_ID" in r for r in diag2["identity_env_risks"]
+    )
 
 
 def test_compose_no_hazard_minimal():
     # Even empty compose still flags dual allocator / cwd requirement (architectural)
     diag = compose_lifecycle_diagnostics(None)
     assert diag["compose_required_in_cwd"] is True
-
-
-def test_build_desired_services_includes_catalog_defaults_missing_from_mcp_json():
-    """When .mcp.json exists, still diagnose catalog per-worktree defaults absent there."""
-    catalog = _catalog()
-    mcp_servers = {
-        "conport": {
-            "type": "sse",
-            "url": "http://localhost:${CONPORT_MCP_PORT:-3005}/sse",
-        },
-        # intentionally omit dope-memory and task-orchestrator
-    }
-    env = {
-        "CONPORT_MCP_PORT": "3041",
-        "DOPE_MEMORY_PORT": "3060",
-        "TASK_ORCHESTRATOR_HTTP_PORT": "7890",
-    }
-    desired = build_desired_services(catalog, mcp_servers, env)
-    names = {svc.name for svc in desired}
-    assert "conport" in names
-    assert "dope-memory" in names
-    assert "task-orchestrator" in names
 
 
 def test_global_local_duplicate_and_dead(tmp_path: Path, monkeypatch):
@@ -247,45 +233,6 @@ def test_global_local_duplicate_and_dead(tmp_path: Path, monkeypatch):
     codes = {f["code"] for f in report.findings}
     assert "GLOBAL_LOCAL_DUPLICATE" in codes
     assert "GLOBAL_SERVICE_DEAD" in codes
-
-
-def test_global_local_duplicate_redacts_non_local_urls(tmp_path: Path):
-    repo = _write_fixture_repo(
-        tmp_path,
-        mcp_servers={
-            "conport": {
-                "type": "sse",
-                "url": "https://mcp.example.com/sse",
-            },
-        },
-    )
-    global_path = tmp_path / "claude.json"
-    global_path.write_text(
-        json.dumps(
-            {
-                "mcpServers": {
-                    "conport": {
-                        "type": "sse",
-                        "url": "https://other.example.net:9443/sse",
-                    },
-                }
-            }
-        )
-    )
-    report = run_mcp_doctor(
-        repo,
-        catalog=_catalog(),
-        global_claude_path=global_path,
-        skip_docker=True,
-        skip_port_probe=True,
-        process_env={},
-    )
-    dupes = [f for f in report.findings if f["code"] == "GLOBAL_LOCAL_DUPLICATE"]
-    assert dupes
-    evidence = " ".join(dupes[0].get("evidence") or [])
-    assert "example.com" not in evidence
-    assert "example.net" not in evidence
-    assert "[REDACTED_HOST]" in evidence
 
 
 def test_global_malformed(tmp_path: Path):
@@ -485,3 +432,20 @@ def test_root_catalog_transports_match_expected():
     assert servers["conport"]["transport"] == "sse"
     assert servers["dope-memory"]["transport"] == "http"
     assert servers["task-orchestrator"]["transport"] == "http"
+
+
+def test_build_desired_services_includes_catalog_defaults_when_mcp_json_present():
+    """Doctor coverage must not drop catalog defaults just because .mcp.json exists."""
+    catalog = _catalog()
+    mcp_servers = {
+        "conport": {"type": "sse", "url": "http://localhost:${CONPORT_MCP_PORT}/sse"},
+    }
+    desired = build_desired_services(
+        catalog,
+        mcp_servers,
+        {"CONPORT_MCP_PORT": "3041", "DOPE_MEMORY_PORT": "3020"},
+    )
+    names = [d.name for d in desired]
+    assert "conport" in names
+    assert "dope-memory" in names
+    assert "task-orchestrator" in names

--- a/tests/unit/test_mcp_envrc.py
+++ b/tests/unit/test_mcp_envrc.py
@@ -68,22 +68,9 @@ def test_secret_like_redaction():
     assert redact_value("OPENAI_API_KEY", "sk-secret") == "[REDACTED]"
     assert redact_value("CONPORT_MCP_PORT", "3041") == "3041"
     assert redact_value("DB_URL", "postgres://user:pass@host/db") == "[REDACTED_URL_WITH_CREDENTIALS]"
-
-
-def test_redact_value_localhost_urls_kept():
-    assert (
-        redact_value("URL", "http://localhost:3041/sse") == "http://localhost:3041/sse"
-    )
-    assert (
-        redact_value("URL", "http://127.0.0.1:3020/mcp") == "http://127.0.0.1:3020/mcp"
-    )
-
-
-def test_redact_value_non_localhost_host_redacted():
-    redacted = redact_value("URL", "https://mcp.example.com:8443/sse?x=1")
-    assert redacted.startswith("https://[REDACTED_HOST]:8443")
-    assert "example.com" not in redacted
-    assert redacted.endswith("/sse?x=1")
+    assert redact_value("URL", "http://localhost:3041/sse") == "http://localhost:3041/sse"
+    assert redact_value("URL", "http://127.0.0.1:3041/sse") == "http://127.0.0.1:3041/sse"
+    assert redact_value("URL", "https://internal.example.com/mcp") == "[REDACTED_URL]"
 
 
 def test_load_envrc_missing(tmp_path: Path):
@@ -109,26 +96,30 @@ def test_load_envrc_ok(tmp_path: Path):
     assert snap["CONPORT_MCP_PORT"] == "3041"
 
 
-def test_load_envrc_partial_on_malformed_with_keys(tmp_path: Path):
+def test_load_envrc_partial_parse_is_ok(tmp_path: Path):
+    """Useful keys + one malformed line must not hard-fail doctor (parse_status OK)."""
     path = tmp_path / ".envrc.dopemux-mcp"
-    path.write_text("not a valid line\nexport CONPORT_MCP_PORT=3041\nexport OK=1\n")
+    path.write_text(
+        "export CONPORT_MCP_PORT=3041\n"
+        "not a valid line\n"
+        "export DOPEMUX_INSTANCE_ID=abcd\n"
+    )
     result = load_envrc(path)
     assert result.present is True
-    assert result.parse_status == "PARTIAL"
+    assert result.parse_status == "OK"
     assert result.values["CONPORT_MCP_PORT"] == "3041"
-    assert result.values["OK"] == "1"
+    assert result.values["DOPEMUX_INSTANCE_ID"] == "abcd"
     assert any("malformed" in e for e in result.errors)
-    merged = merge_envrc_into_environ({}, result)
-    assert merged["CONPORT_MCP_PORT"] == "3041"
 
 
-def test_load_envrc_error_when_no_usable_keys(tmp_path: Path):
+def test_load_envrc_only_malformed_is_error(tmp_path: Path):
     path = tmp_path / ".envrc.dopemux-mcp"
-    path.write_text("this is garbage\nalso bad\n")
+    path.write_text("garbage line\nanother bad\n")
     result = load_envrc(path)
     assert result.present is True
     assert result.parse_status == "ERROR"
     assert result.values == {}
+    assert result.errors
 
 
 def test_merge_envrc_into_environ_override(tmp_path: Path):

--- a/tests/unit/test_mcp_lifecycle.py
+++ b/tests/unit/test_mcp_lifecycle.py
@@ -1,0 +1,336 @@
+"""Tests for MCP lifecycle reconciler (mocked Docker)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+from dopemux.mcp import docker_runtime as dr
+from dopemux.mcp.lifecycle import run_lifecycle
+
+
+def _catalog():
+    return {
+        "version": 1,
+        "defaults": {"per_worktree": ["conport", "dope-memory", "task-orchestrator"]},
+        "servers": {
+            "conport": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "url_template": "http://localhost:${CONPORT_MCP_PORT:-3005}/sse",
+                "port_var": "CONPORT_MCP_PORT",
+                "default_port_base": 3005,
+                "extra_port_vars": [
+                    {"var": "CONPORT_HTTP_PORT", "base": 3004},
+                    {"var": "CONPORT_INFO_PORT", "base": 4004},
+                ],
+            },
+            "dope-memory": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "url_template": "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp",
+                "port_var": "DOPE_MEMORY_PORT",
+                "default_port_base": 3020,
+            },
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "state_scope": "per-repo",
+                "transport": "http",
+                "management_model": "wrapper-singleton",
+                "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
+                "default_port_base": 7890,
+            },
+            "pal": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": "http://localhost:3003/mcp",
+            },
+        },
+    }
+
+
+def _fixture_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "dNh_CRM"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "conport": {
+                        "type": "sse",
+                        "url": "http://localhost:${CONPORT_MCP_PORT:-3005}/sse",
+                    },
+                    "dope-memory": {
+                        "type": "http",
+                        "url": "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp",
+                    },
+                    "task-orchestrator": {
+                        "type": "http",
+                        "url": "http://127.0.0.1:${TASK_ORCHESTRATOR_HTTP_PORT:-7890}/mcp",
+                    },
+                }
+            }
+        )
+    )
+    (repo / ".envrc.dopemux-mcp").write_text(
+        f"""export DOPEMUX_WORKSPACE_ID={repo}
+export DOPEMUX_WORKSPACE_ROOT={repo}
+export DOPEMUX_PROJECT_ROOT={repo}
+export TASK_ORCHESTRATOR_PROJECT_ROOT={repo}
+export DOPEMUX_INSTANCE_ID=8d6d
+export DOPE_MEMORY_WORKSPACE_ID=dNh_CRM
+export DOPE_MEMORY_INSTANCE_ID=8d6d
+export CONPORT_HTTP_PORT=3040
+export CONPORT_MCP_PORT=3041
+export CONPORT_INFO_PORT=4040
+export DOPE_MEMORY_PORT=3060
+export TASK_ORCHESTRATOR_HTTP_PORT=7890
+"""
+    )
+    return repo
+
+
+def _docker_empty():
+    def runner(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    return runner
+
+
+def test_compose_override_unique_name_and_absolute_volume(tmp_path: Path):
+    text = dr.generate_compose_override(
+        services=["conport", "dope-memory"],
+        identity={
+            "DOPEMUX_INSTANCE_ID": "8d6d",
+            "DOPEMUX_WORKSPACE_ID": "/Users/hue/code/dNh_CRM",
+            "DOPEMUX_PROJECT_ROOT": "/Users/hue/code/dNh_CRM",
+            "DOPEMUX_WORKTREE_ROOT": "/Users/hue/code/dNh_CRM",
+            "DOPEMUX_WORKSPACE_ROOT": "/Users/hue/code/dNh_CRM",
+            "DOPE_MEMORY_WORKSPACE_ID": "dNh_CRM",
+            "DOPE_MEMORY_INSTANCE_ID": "8d6d",
+        },
+        ports={
+            "CONPORT_HTTP_PORT": 3040,
+            "CONPORT_MCP_PORT": 3041,
+            "CONPORT_INFO_PORT": 4040,
+            "DOPE_MEMORY_PORT": 3060,
+        },
+        container_names={
+            "conport": "dopemux-dnh-crm-8d6d-conport",
+            "dope-memory": "dopemux-dnh-crm-8d6d-dope-memory",
+        },
+        labels_by_service={
+            "conport": dr.build_labels(
+                project_id="dnh",
+                workspace_id="/Users/hue/code/dNh_CRM",
+                project_root="/Users/hue/code/dNh_CRM",
+                worktree_root="/Users/hue/code/dNh_CRM",
+                project_hash="h",
+                worktree_hash="8d6d",
+                instance_id="dnh-8d6d-conport",
+                service="conport",
+                scope="worktree",
+                transport="sse",
+            ),
+            "dope-memory": dr.build_labels(
+                project_id="dnh",
+                workspace_id="/Users/hue/code/dNh_CRM",
+                project_root="/Users/hue/code/dNh_CRM",
+                worktree_root="/Users/hue/code/dNh_CRM",
+                project_hash="h",
+                worktree_hash="8d6d",
+                instance_id="dnh-8d6d-dope-memory",
+                service="dope-memory",
+                scope="worktree",
+                transport="http",
+            ),
+        },
+        memory_data_path=Path("/Users/hue/code/dNh_CRM/.dopemux"),
+    )
+    assert "mcp-conport" not in text or "dopemux-dnh-crm-8d6d-conport" in text
+    assert "dopemux-dnh-crm-8d6d-conport" in text
+    assert "/Users/hue/code/dNh_CRM/.dopemux:/data" in text
+    assert "./.dopemux:/data" not in text
+    assert "dopemux.managed" in text
+    assert "dopemux.project_id" in text
+
+
+def test_start_dry_run_planned(tmp_path: Path, monkeypatch):
+    repo = _fixture_repo(tmp_path)
+    reg = tmp_path / "reg" / "instances.json"
+    product = tmp_path / "product"
+    product.mkdir()
+    (product / "compose.yml").write_text("services: {}\n")
+    (product / "scripts" / "mcp-wrappers").mkdir(parents=True)
+    (product / "scripts" / "mcp-wrappers" / "task-orchestrator-http-singleton.sh").write_text(
+        "#!/bin/bash\n"
+    )
+
+    result = run_lifecycle(
+        "start",
+        repo=repo,
+        services=["conport", "dope-memory"],
+        catalog=_catalog(),
+        dry_run=True,
+        registry_path=reg,
+        docker_runner=_docker_empty(),
+        product_root=product,
+        process_env={},
+        skip_doctor=False,
+    )
+    assert result.dry_run is True
+    assert result.status in {"PLANNED", "BLOCKED"}
+    # With empty docker and valid config should plan
+    if result.status == "PLANNED":
+        actions = {s["service"]: s["action"] for s in result.services}
+        assert actions.get("conport") == "start"
+        assert "compose.override.yml" in str(result.runtime_artifacts) or any(
+            "compose" in str(a) for a in result.runtime_artifacts
+        )
+    # dry-run must not create registry
+    assert not reg.exists()
+
+
+def test_start_blocks_transport_mismatch(tmp_path: Path):
+    repo = _fixture_repo(tmp_path)
+    # Break transport
+    (repo / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "dope-memory": {
+                        "type": "sse",
+                        "url": "http://localhost:3060/mcp",
+                    }
+                }
+            }
+        )
+    )
+    (repo / ".envrc.dopemux-mcp").write_text(
+        f"export DOPEMUX_WORKSPACE_ID={repo}\n"
+        f"export DOPEMUX_WORKSPACE_ROOT={repo}\n"
+        f"export DOPEMUX_PROJECT_ROOT={repo}\n"
+        f"export DOPE_MEMORY_PORT=3060\n"
+        f"export DOPE_MEMORY_WORKSPACE_ID=x\n"
+        f"export DOPE_MEMORY_INSTANCE_ID=y\n"
+    )
+    reg = tmp_path / "instances.json"
+    product = tmp_path / "product"
+    product.mkdir()
+    (product / "compose.yml").write_text("services: {}\n")
+
+    result = run_lifecycle(
+        "start",
+        repo=repo,
+        services=["dope-memory"],
+        catalog=_catalog(),
+        dry_run=True,
+        registry_path=reg,
+        docker_runner=_docker_empty(),
+        product_root=product,
+        process_env={},
+    )
+    assert result.status == "BLOCKED"
+    codes = {f.get("code") for f in result.blocking_findings}
+    assert "TRANSPORT_MISMATCH" in codes
+
+
+def test_start_blocks_unlabeled_port_owner(tmp_path: Path):
+    repo = _fixture_repo(tmp_path)
+    reg = tmp_path / "instances.json"
+    product = tmp_path / "product"
+    product.mkdir()
+    (product / "compose.yml").write_text("services: {}\n")
+
+    def docker_ps(*args, **kwargs):
+        row = {
+            "ID": "abc",
+            "Names": "random-conport",
+            "Ports": "0.0.0.0:3041->3005/tcp",
+            "Labels": "",
+            "Image": "x",
+            "Status": "Up",
+        }
+        return SimpleNamespace(returncode=0, stdout=json.dumps(row) + "\n", stderr="")
+
+    result = run_lifecycle(
+        "start",
+        repo=repo,
+        services=["conport"],
+        catalog=_catalog(),
+        dry_run=True,
+        registry_path=reg,
+        docker_runner=docker_ps,
+        product_root=product,
+        process_env={},
+    )
+    assert result.status == "BLOCKED"
+    codes = {f.get("code") for f in result.blocking_findings}
+    assert "DOCKER_CONTAINER_PORT_COLLISION" in codes or "DOCKER_CONTAINER_UNLABELED_UNKNOWN" in codes
+
+
+def test_stop_refuses_unlabeled(tmp_path: Path):
+    repo = _fixture_repo(tmp_path)
+    reg = tmp_path / "instances.json"
+    product = tmp_path / "product"
+    product.mkdir()
+    (product / "compose.yml").write_text("services: {}\n")
+
+    # Precompute expected container name slug
+    from dopemux.mcp import docker_runtime as dr_mod
+
+    slug = dr_mod.project_slug("dNh_CRM")
+    # worktree hash from identity will be computed; use docker name match loosely
+
+    def docker_ps(*args, **kwargs):
+        # Return a container that might match by port only — stop looks by name
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    result = run_lifecycle(
+        "stop",
+        repo=repo,
+        services=["conport"],
+        catalog=_catalog(),
+        dry_run=True,
+        registry_path=reg,
+        docker_runner=docker_ps,
+        product_root=product,
+        process_env={},
+    )
+    assert result.operation == "stop"
+    assert result.status in {"PLANNED", "PASS", "FAIL", "BLOCKED"}
+
+
+def test_status_json_shape(tmp_path: Path):
+    repo = _fixture_repo(tmp_path)
+    reg = tmp_path / "instances.json"
+    product = tmp_path / "product"
+    product.mkdir()
+    (product / "compose.yml").write_text("services: {}\n")
+
+    result = run_lifecycle(
+        "status",
+        repo=repo,
+        services=["conport"],
+        catalog=_catalog(),
+        registry_path=reg,
+        docker_runner=_docker_empty(),
+        product_root=product,
+        process_env={},
+        port_is_free_fn=lambda p: True,
+    )
+    d = result.to_dict()
+    assert d["operation"] == "status"
+    assert "registry" in d
+    assert "docker" in d
+    assert d["services"]
+    assert "registry_state" in d["services"][0]
+    assert "docker_state" in d["services"][0]
+
+
+def test_container_naming_never_default_mcp_conport():
+    name = dr.container_name_for("dnh-crm", "8d6d", "conport")
+    assert name == "dopemux-dnh-crm-8d6d-conport"
+    assert name != "mcp-conport"

--- a/tests/unit/test_mcp_runtime_launcher.py
+++ b/tests/unit/test_mcp_runtime_launcher.py
@@ -1,0 +1,87 @@
+"""Tests for docker_runtime helpers (compose commands / artifacts)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dopemux.mcp import docker_runtime as dr
+
+
+def test_compose_up_command_includes_override_and_no_deps(tmp_path: Path):
+    product = tmp_path
+    (product / "compose.yml").write_text("services: {}\n")
+    override = tmp_path / "compose.override.yml"
+    envf = tmp_path / "mcp.env"
+    override.write_text("services: {}\n")
+    envf.write_text("X=1\n")
+    cmd = dr.compose_up_command(
+        product=product,
+        override_path=override,
+        env_file=envf,
+        project_name="dopemux_proj_abcd",
+        services=["conport", "dope-memory"],
+        no_deps=True,
+    )
+    assert cmd[:2] == ["docker", "compose"]
+    assert "--no-deps" in cmd
+    assert "conport" in cmd
+    assert str(override) in cmd
+    assert "dopemux_proj_abcd" in cmd
+
+
+def test_write_runtime_artifacts_dry_run_no_files(tmp_path: Path):
+    runtime = tmp_path / "rt"
+    paths = dr.write_runtime_artifacts(
+        runtime,
+        env_text="A=1\n",
+        override_text="services: {}\n",
+        plan={"x": 1},
+        dry_run=True,
+    )
+    assert "mcp.env" in paths
+    assert not runtime.exists()
+
+
+def test_write_runtime_artifacts_writes(tmp_path: Path):
+    runtime = tmp_path / "rt"
+    paths = dr.write_runtime_artifacts(
+        runtime,
+        env_text="CONPORT_MCP_PORT=3041\n",
+        override_text="services:\n  conport: {}\n",
+        plan={"services": ["conport"]},
+        dry_run=False,
+    )
+    assert Path(paths["mcp.env"]).is_file()
+    assert "3041" in Path(paths["mcp.env"]).read_text()
+    assert Path(paths["compose.override.yml"]).is_file()
+
+
+def test_mcp_env_skips_secrets():
+    text = dr.generate_mcp_env(
+        {
+            "CONPORT_MCP_PORT": 3041,
+            "OPENAI_API_KEY": "sk-secret",
+            "DOPEMUX_WORKSPACE_ID": "/tmp/x",
+        }
+    )
+    assert "3041" in text
+    assert "OPENAI_API_KEY" not in text
+    assert "DOPEMUX_WORKSPACE_ID" in text
+
+
+def test_labels_required_keys():
+    labels = dr.build_labels(
+        project_id="p",
+        workspace_id="/w",
+        project_root="/p",
+        worktree_root="/w",
+        project_hash="h",
+        worktree_hash="abcd",
+        instance_id="p-abcd-conport",
+        service="conport",
+        scope="worktree",
+        transport="sse",
+    )
+    assert labels["dopemux.managed"] == "true"
+    assert labels["dopemux.created_by"] == "dopemux-mcp"
+    assert labels["dopemux.service"] == "conport"

--- a/tests/unit/test_mcp_runtime_registry.py
+++ b/tests/unit/test_mcp_runtime_registry.py
@@ -1,0 +1,171 @@
+"""Tests for MCP runtime registry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dopemux.mcp.runtime_registry import (
+    RegistryError,
+    RuntimeRegistry,
+    build_instance_record,
+    empty_registry,
+)
+
+
+def test_load_missing(tmp_path: Path):
+    path = tmp_path / "instances.json"
+    reg = RuntimeRegistry.load(path)
+    assert reg.present is False
+    assert reg.parse_status == "MISSING"
+    assert reg.instances() == []
+
+
+def test_atomic_write_and_reload(tmp_path: Path):
+    path = tmp_path / "instances.json"
+    reg = RuntimeRegistry.load(path)
+    assert reg.parse_status == "MISSING"
+    reg.parse_status = "OK"
+    rec = build_instance_record(
+        instance_id="proj-abcd-conport",
+        project_id="proj",
+        workspace_id="/tmp/proj",
+        project_root="/tmp/proj",
+        worktree_root="/tmp/proj",
+        worktree_hash="abcd",
+        project_hash="hashhash",
+        service="conport",
+        scope="worktree",
+        status="running",
+        ports={"sse": 3041},
+        urls={"sse": "http://localhost:3041/sse"},
+        container_names=["dopemux-proj-abcd-conport"],
+        compose_project_name="dopemux_proj_abcd",
+        labels={"dopemux.managed": "true", "dopemux.project_id": "proj"},
+    )
+    reg.upsert_instance(rec)
+    reg.path = path
+    reg.save()
+    assert path.exists()
+    reloaded = RuntimeRegistry.load(path)
+    assert reloaded.parse_status == "OK"
+    assert len(reloaded.instances()) == 1
+    assert reloaded.instances()[0]["service"] == "conport"
+
+
+def test_parse_error_blocks_save(tmp_path: Path):
+    path = tmp_path / "instances.json"
+    path.write_text("{not-json")
+    reg = RuntimeRegistry.load(path)
+    assert reg.parse_status == "ERROR"
+    with pytest.raises(RegistryError):
+        reg.upsert_instance({"instance_id": "x"})
+
+
+def test_mark_stopped(tmp_path: Path):
+    path = tmp_path / "instances.json"
+    reg = RuntimeRegistry(path=path, data=empty_registry(), present=True, parse_status="OK")
+    reg.upsert_instance(
+        build_instance_record(
+            instance_id="p-1-conport",
+            project_id="p",
+            workspace_id="/p",
+            project_root="/p",
+            worktree_root="/p",
+            worktree_hash="1",
+            project_hash="h",
+            service="conport",
+            scope="worktree",
+            status="running",
+            ports={},
+            urls={},
+            container_names=["c"],
+            compose_project_name="n",
+            labels={},
+        )
+    )
+    n = reg.mark_stopped(project_id="p", service="conport")
+    assert n == 1
+    assert reg.instances()[0]["status"] == "stopped"
+    reg.save()
+    data = json.loads(path.read_text())
+    assert data["instances"][0]["status"] == "stopped"
+
+
+def test_find_filters(tmp_path: Path):
+    reg = RuntimeRegistry(path=tmp_path / "r.json", data=empty_registry(), parse_status="OK")
+    for svc in ("conport", "dope-memory"):
+        reg.upsert_instance(
+            build_instance_record(
+                instance_id=f"p-1-{svc}",
+                project_id="p",
+                workspace_id="/p",
+                project_root="/p",
+                worktree_root="/p",
+                worktree_hash="1",
+                project_hash="h",
+                service=svc,
+                scope="worktree",
+                status="running",
+                ports={},
+                urls={},
+                container_names=[svc],
+                compose_project_name="n",
+                labels={},
+            )
+        )
+    assert len(reg.find(project_id="p")) == 2
+    assert len(reg.find(project_id="p", service="conport")) == 1
+
+
+def test_prune_stale_dry_run(tmp_path: Path):
+    reg = RuntimeRegistry(path=tmp_path / "r.json", data=empty_registry(), parse_status="OK")
+    reg.upsert_instance(
+        build_instance_record(
+            instance_id="keep",
+            project_id="p",
+            workspace_id="/p",
+            project_root="/p",
+            worktree_root="/p",
+            worktree_hash="1",
+            project_hash="h",
+            service="conport",
+            scope="worktree",
+            status="running",
+            ports={},
+            urls={},
+            container_names=["c"],
+            compose_project_name="n",
+            labels={},
+        )
+    )
+    reg.upsert_instance(
+        build_instance_record(
+            instance_id="stale",
+            project_id="p",
+            workspace_id="/p",
+            project_root="/p",
+            worktree_root="/p",
+            worktree_hash="1",
+            project_hash="h",
+            service="dope-memory",
+            scope="worktree",
+            status="running",
+            ports={},
+            urls={},
+            container_names=["d"],
+            compose_project_name="n",
+            labels={},
+        )
+    )
+    assert reg.prune_stale_dry_run(["keep"]) == ["stale"]
+
+
+def test_env_override(monkeypatch, tmp_path: Path):
+    path = tmp_path / "custom.json"
+    monkeypatch.setenv("DOPEMUX_MCP_RUNTIME_REGISTRY", str(path))
+    from dopemux.mcp import runtime_registry as rr
+
+    assert rr.default_registry_path() == path.resolve()


### PR DESCRIPTION
## Summary

**TP-DMX-MCP-RUNTIME-002** — repo-aware MCP sidecar reconciler (depends on #1022 Packet 001).

### Operator path
```bash
cd ~/code/other-repo
dopemux mcp init
dopemux mcp doctor
dopemux mcp start
source .envrc.dopemux-mcp
claude
```

Also: `dopemux mcp start|stop|restart|status --repo <path> [--json] [--dry-run]`

### Architecture
- **Registry:** `~/.dopemux/mcp/runtime/instances.json` (override `DOPEMUX_MCP_RUNTIME_REGISTRY`)
- **Strategy:** generated compose override + unique names + labels + absolute target `.dopemux` volume + compose `-p` + `--no-deps`
- **task-orchestrator:** wrapper-singleton path; labels not applied by wrapper (UNKNOWN ownership noted)
- **Safety:** refuses unlabeled/wrong-project port owners; dry-run does not mutate Docker or registry
- **Compat:** `mcp up/down --repo` → start/stop; bare up/down/status legacy preserved (`--legacy-compose` for old status)

### Test plan
- [x] unit tests registry/launcher/lifecycle/CLI + Packet 001 doctor suite
- [x] dry-run against dNh_CRM blocks on unlabeled existing containers (correct teeth)
- [ ] live start smoke optional (skipped unless authorized; unlabeled dNh containers need cleanup first)