### PR TITLE
feat(mcp): TP-DMX-MCP-RUNTIME-003 config repair, agent bootstrap, fleet

### DIFF
--- a/.claude/WORKTREE_MCP_SETUP.md
+++ b/.claude/WORKTREE_MCP_SETUP.md
@@ -8,6 +8,52 @@
 > Start applies labels + unique names + absolute `.dopemux` volume and records
 > `~/.dopemux/mcp/runtime/instances.json`. Unlabeled containers are never adopted.
 
+<!-- BEGIN DOPEMUX MCP SETUP -->
+# Worktree MCP Setup
+
+## Session Start
+
+```bash
+source .envrc.dopemux-mcp
+dopemux mcp doctor
+```
+
+If services are not running:
+
+```bash
+dopemux mcp start
+dopemux mcp doctor
+```
+
+## Healthy Sequence
+
+```bash
+dopemux mcp init
+dopemux mcp repair-config --dry-run
+dopemux mcp repair-config --apply
+dopemux mcp start
+source .envrc.dopemux-mcp
+dopemux mcp doctor
+```
+
+## Do Not Run
+
+Do not start this repo's MCP services by cd'ing into `dopemux-mvp` and injecting
+this repo's env into `docker compose up`.
+
+Do not replace global ConPort with local ConPort.
+
+Do not treat a listening port as healthy unless `dopemux mcp doctor` proves ownership.
+
+## Authority
+
+Dopemux manages MCP lifecycle and local config only.
+ConPort owns structured context.
+dope-memory owns chronicle receipts.
+task-orchestrator owns workflow views/transitions.
+dopecon-bridge is proxy/adapter only.
+<!-- END DOPEMUX MCP SETUP -->
+
 ## Overview
 
 Git worktrees allow parallel development on different branches without context-switching overhead. This guide explains how MCP servers are configured to work seamlessly across all worktrees.

--- a/docs/02-how-to/mcp-setup-other-repos.md
+++ b/docs/02-how-to/mcp-setup-other-repos.md
@@ -5,7 +5,7 @@ type: how-to
 owner: dopemux-infra
 date: 2026-07-06
 author: '@hu3mann'
-last_review: '2026-07-07'
+last_review: '2026-07-09'
 next_review: '2026-10-05'
 prelude: Running Dopemux MCP Servers in Other Projects (how-to) for dopemux documentation
   and developer workflows.
@@ -14,30 +14,39 @@ prelude: Running Dopemux MCP Servers in Other Projects (how-to) for dopemux docu
 
 This guide explains how to connect `conport`, `dope-memory`, and `task-orchestrator`
 MCP servers to any project — a new repo, a git worktree of another project, or a
-plain directory — using **dopemux** or manually (for Claude Code / vanilla code use).
+plain directory — using **dopemux** (recommended) or carefully documented manual steps.
+
+**Primary operator flow (safe):**
+
+```bash
+cd ~/code/your-other-project
+dopemux mcp init
+dopemux mcp repair-config --dry-run
+dopemux mcp repair-config --apply
+dopemux mcp start
+source .envrc.dopemux-mcp
+claude
+dopemux mcp doctor
+```
+
+Target repos do **not** need their own `compose.yml`. `dopemux mcp start` is home-aware
+(labeled sidecars + runtime registry). `doctor` / `status` load the target repo's
+`.envrc.dopemux-mcp` and do not require compose in cwd.
+
+> [!CAUTION]
+> **UNSAFE_DOC_RECIPE_REMOVED.** Do **not** start another repo's MCP services by
+> `cd`ing into `dopemux-mvp` and injecting that repo's env into `docker compose up`.
+> That pattern can replace primary `mcp-conport` and bind the wrong `.dopemux` volume.
+> Always use `dopemux mcp start --repo <target>` from the safe flow above.
 
 ---
 
 ## Prerequisites
 
-Before you begin, make sure:
-
-1. **Dopemux services are running** (from the `dopemux-mvp` repo):
-   ```bash
-   cd ~/code/dopemux-mvp
-   dopemux mcp up          # starts Docker Compose MCP stack
-   # or for the full stack:
-   dopemux mcp start-all
-   ```
-
-2. **Docker is running** and the MCP containers are healthy:
-   ```bash
-   docker ps | grep dopemux
-   # or
-   dopemux mcp status
-   ```
-
-3. **Your target workspace directory** is a git repository (required for `dopemux mcp init`).
+1. **Shared infrastructure** (postgres, redis, etc.) is already running from the primary
+   dopemux stack once. Sidecar start uses `--no-deps` and does not re-home those services.
+2. **Docker is running**.
+3. **Target workspace** is a git repository (`dopemux mcp init` requires git).
    If it is not a git repo yet, `git init` first.
 
 ---
@@ -50,59 +59,45 @@ Before you begin, make sure:
 cd ~/code/your-other-project   # must be a git repo
 ```
 
-### Step 2 — Initialise MCP config for the workspace
+### Step 2 — Initialise MCP config
 
 ```bash
 dopemux mcp init
 ```
 
 This command:
-- Reads `mcp_catalog.yaml` from the `dopemux-mvp` repo
-- Generates a `.mcp.json` in your project root with `conport`, `dope-memory`, and
-  `task-orchestrator` entries using `${VAR}` placeholders
-- Writes `.envrc.dopemux-mcp` with stable, collision-checked port numbers unique
-  to this workspace path
-
-Example output:
-```
-✅ Wrote .mcp.json
-✅ Wrote .envrc.dopemux-mcp
-Worktree:   /Users/hue/code/your-other-project
-Instance:   a3f2
-  CONPORT_HTTP_PORT=3044  (free)
-  CONPORT_MCP_PORT=3045   (free)
-  DOPE_MEMORY_PORT=3064   (free)
-  TASK_ORCHESTRATOR_HTTP_PORT=7890  (wrapper-singleton, fixed)
-```
+- Reads the catalog (`mcp_catalog.yaml` or bundled default)
+- Generates `.mcp.json` with catalog-owned services (`conport`, `dope-memory`,
+  `task-orchestrator`) using `${VAR}` placeholders
+- Writes `.envrc.dopemux-mcp` with deterministic ports for this workspace path
 
 > [!NOTE]
-> **Port allocation is deterministic**: the same workspace path always gets the same
-> ports.  `wrapper-singleton` services (like `task-orchestrator`) always use their
-> fixed port regardless of workspace.
+> **Port allocation is deterministic** (`base + sha1(path)[:4] % 100`).
+> `wrapper-singleton` services (e.g. `task-orchestrator` on `7890`) use fixed ports.
+> Cross-worktree collision risk remains until the port-lease packet; repair-config
+> emits `PORT_HASH_BUCKET_COLLISION_RISK` and does **not** live-rebind free ports.
 
-### Step 3 — Load the port variables into your shell
+### Step 3 — Repair config (previewable)
 
-The quickest way is to source the file directly:
 ```bash
-source .envrc.dopemux-mcp
+dopemux mcp repair-config --dry-run --json   # plan only; writes nothing
+dopemux mcp repair-config --apply            # local files only
 ```
 
-Or, for persistent loading with `direnv`:
+What `repair-config` does:
+
+- Fixes catalog-owned transport mismatches (e.g. dope-memory / task-orchestrator
+  must be `"type": "http"`, conport stays `"sse"`)
+- Regenerates or patches `.envrc.dopemux-mcp` using the same allocator as `init`
+- Creates/updates `.claude/WORKTREE_MCP_SETUP.md` (agent bootstrap)
+- **Preserves** unknown/custom `.mcp.json` entries
+- **Never** mutates `~/.claude.json` (use `dopemux mcp sync-globals` explicitly)
+- **Never** starts or stops containers
+
+### Step 4 — Start sidecars (repo-aware reconciler)
+
 ```bash
-# Add to .envrc in your project
-echo 'source .envrc.dopemux-mcp' >> .envrc
-direnv allow
-```
-
-### Step 4 — Start per-worktree containers (repo-aware reconciler)
-
-**Preferred path** (Packet 002):
-
-```bash
-cd ~/code/your-other-project
-dopemux mcp init          # if not already done
-dopemux mcp doctor        # truth gate (loads .envrc.dopemux-mcp)
-dopemux mcp start         # labeled sidecars + runtime registry
+dopemux mcp start
 # or from any cwd:
 dopemux mcp start --repo ~/code/your-other-project
 dopemux mcp start --repo ~/code/your-other-project --dry-run --json
@@ -110,13 +105,13 @@ dopemux mcp start --repo ~/code/your-other-project --dry-run --json
 
 What `mcp start` does:
 
-- Runs doctor preflight; **blocks** on transport mismatch, unlabeled port owners, wrong-project containers
-- Generates compose override with **unique container names** and **absolute** target `.dopemux` volume
+- Runs doctor preflight; **blocks** on transport mismatch, unlabeled port owners,
+  wrong-project containers
+- Generates compose override with **unique container names** and **absolute** target
+  `.dopemux` volume
 - Sets `dopemux.managed=true` + project labels
 - Writes operational registry: `~/.dopemux/mcp/runtime/instances.json`
 - Does **not** adopt unlabeled containers
-
-Shared infrastructure (postgres, redis, etc.) must already be running from the primary dopemux stack (`--no-deps` sidecars).
 
 ```bash
 dopemux mcp status --repo ~/code/your-other-project --json
@@ -124,42 +119,71 @@ dopemux mcp stop --repo ~/code/your-other-project
 # Compatibility: mcp up/down --repo → start/stop
 ```
 
-> [!CAUTION]
-> **Do not** use the old clipboard pattern (env-inject into dopemux-mvp compose).
-> It can replace `mcp-conport` and bind the wrong `.dopemux` data directory.
-
-<details>
-<summary>Legacy / high-risk compose path (not recommended)</summary>
+### Step 5 — Source env and verify
 
 ```bash
-# DANGEROUS — fixed names + relative volumes:
-cd ~/code/dopemux-mvp
-env $(cat ~/code/your-other-project/.envrc.dopemux-mcp | grep -v '^#' | xargs) \
-  docker compose -f compose.yml up -d conport dope-memory
-```
-</details>
+source .envrc.dopemux-mcp
+# or: echo 'source .envrc.dopemux-mcp' >> .envrc && direnv allow
 
-### Step 5 — Verify connectivity
-
-```bash
-dopemux mcp status --repo ~/code/your-other-project
 dopemux mcp doctor --repo ~/code/your-other-project
-
-# Full health report with transport-aware probing:
-~/code/dopemux-mvp/mcp_server_health_report.sh
+dopemux mcp status --repo ~/code/your-other-project
 ```
+
+Ownership is proven by labels/registry/probes — not by "port is listening" alone.
 
 ### Step 6 — Open Claude Code (or agy)
 
 ```bash
-# In your project directory (with envrc sourced):
 claude    # Claude Code
 # or
 agy       # Antigravity CLI
 ```
 
-Both clients read `.mcp.json` at session startup. Claude Code expands the `${VAR:-default}`
-placeholders using the environment; `agy` does the same.
+Both clients read `.mcp.json` at session startup and expand `${VAR:-default}` from the
+environment.
+
+---
+
+## Global singletons vs local project services
+
+| Surface | Command | Mutates |
+|---------|---------|---------|
+| Local `.mcp.json` + `.envrc.dopemux-mcp` | `mcp init`, `mcp repair-config` | Target repo only |
+| Global `~/.claude.json` singletons | `mcp sync-globals` (explicit `--apply`) | Home global config |
+| Runtime containers | `mcp start` / `stop` / `status` | Docker + runtime registry |
+
+`repair-config` does **not** call `sync-globals`. Keep local ConPort/dope-memory in the
+target worktree; do not duplicate them into global config.
+
+---
+
+## Fleet / many worktrees
+
+```bash
+dopemux mcp fleet init --repo ~/code/your-project \
+  --worktrees ~/code/your-project --worktrees ~/code/your-project-wt-feature \
+  --dry-run --json
+
+dopemux mcp fleet init --repo ~/code/your-project \
+  --worktrees ~/code/your-project --worktrees ~/code/your-project-wt-feature \
+  --apply
+
+dopemux mcp fleet doctor --repo ~/code/your-project \
+  --worktrees ~/code/your-project --worktrees ~/code/your-project-wt-feature \
+  --json
+```
+
+Fleet commands never start containers and never modify `~/.claude.json`.
+
+---
+
+## Current limitations
+
+* Port allocator still has `%100` birthday-collision risk (see RUNTIME-004 lease packet).
+* Live free-port rebind is **not** implemented.
+* `task-orchestrator` fixed port `7890` may block multi-project simultaneous use if
+  identity cannot be proven.
+* Unlabeled existing containers are not adopted automatically.
 
 ---
 
@@ -189,26 +213,19 @@ export DOPE_MEMORY_INSTANCE_ID=a3f2                  # any 4-char hash
 
 Save these to `.envrc.dopemux-mcp` in your project root and `source` it.
 
-### Step 2 — Start Docker services
+### Step 2 — Start Docker services (prefer dopemux)
 
-From the `dopemux-mvp` directory:
+Prefer the reconciler even for partial manual setups:
+
 ```bash
-cd ~/code/dopemux-mvp
-
-# Start conport for your workspace
-CONPORT_HTTP_PORT=3044 CONPORT_INFO_PORT=4044 CONPORT_MCP_PORT=3045 \
-DOPEMUX_WORKSPACE_ID=/Users/hue/code/your-other-project \
-  docker compose -f compose.yml up -d conport
-
-# Start dope-memory for your workspace
-DOPE_MEMORY_PORT=3064 \
-DOPE_MEMORY_WORKSPACE_ID=your-other-project \
-DOPE_MEMORY_INSTANCE_ID=a3f2 \
-  docker compose -f compose.yml up -d dope-memory
-
-# task-orchestrator is a singleton — start it once:
-docker compose -f compose.yml up -d task-orchestrator
+# After .envrc.dopemux-mcp and .mcp.json exist:
+dopemux mcp start --repo ~/code/your-other-project
 ```
+
+> [!CAUTION]
+> Do **not** start sidecars by injecting another project's env into
+> `dopemux-mvp/compose.yml`. Use `dopemux mcp start --repo <target>` so
+> container names, labels, and `.dopemux` volumes stay project-scoped.
 
 ### Step 3 — Write `.mcp.json`
 
@@ -292,7 +309,8 @@ If you are using plain Claude Code without any dopemux tooling:
    export DOPEMUX_WORKSPACE_ID="$(pwd)"
    export DOPE_MEMORY_WORKSPACE_ID="$(basename $(pwd))"
    ```
-3. Make sure the Docker containers are running (see Part 2, Step 2).
+3. Make sure the Docker sidecars are running via `dopemux mcp start --repo .`
+   (see Part 2, Step 2).
 4. Launch `claude` from the project directory — it reads `.mcp.json` at startup.
 5. Verify with `/mcp` in the Claude Code session.
 

--- a/docs/02-how-to/mcp-setup-other-repos.md
+++ b/docs/02-how-to/mcp-setup-other-repos.md
@@ -72,10 +72,14 @@ This command:
 - Writes `.envrc.dopemux-mcp` with deterministic ports for this workspace path
 
 > [!NOTE]
-> **Port allocation is deterministic** (`base + sha1(path)[:4] % 100`).
-> `wrapper-singleton` services (e.g. `task-orchestrator` on `7890`) use fixed ports.
-> Cross-worktree collision risk remains until the port-lease packet; repair-config
-> emits `PORT_HASH_BUCKET_COLLISION_RISK` and does **not** live-rebind free ports.
+> **Port allocation (Packet 004):** preferred ports still use
+> `base + sha1(path)[:4] % 100` (or existing envrc values), but assignment goes
+> through the **lease registry** (`~/.dopemux/mcp/runtime/port-leases.json`).
+> Reserved singletons, active foreign leases, and live TCP sockets force **rebind**
+> to the next safe port. Override registry path with
+> `DOPEMUX_MCP_PORT_LEASE_REGISTRY` (tests must never use the real home registry).
+> `wrapper-singleton` services (e.g. `task-orchestrator` on `7890`) are fixed —
+> free/same-project reuse or **block**, never rebind.
 
 ### Step 3 — Repair config (previewable)
 
@@ -179,11 +183,11 @@ Fleet commands never start containers and never modify `~/.claude.json`.
 
 ## Current limitations
 
-* Port allocator still has `%100` birthday-collision risk (see RUNTIME-004 lease packet).
-* Live free-port rebind is **not** implemented.
-* `task-orchestrator` fixed port `7890` may block multi-project simultaneous use if
-  identity cannot be proven.
+* Preferred ports still derive from hash `%100` — leases rebind on conflict (no longer silent).
+* `task-orchestrator` fixed port `7890` blocks multi-project simultaneous use when another
+  project holds the lease (see RUNTIME-005 for deeper TO identity work).
 * Unlabeled existing containers are not adopted automatically.
+* Lease prune is not automatic; doctor may report `LEASE_STALE` without deleting.
 
 ---
 

--- a/docs/02-how-to/mcp-transport-and-port-bugs.md
+++ b/docs/02-how-to/mcp-transport-and-port-bugs.md
@@ -23,7 +23,12 @@ applied to `dopemux-mvp`.
 > birthday-risk / missing rebind, compose lifecycle hazards (fixed
 > `mcp-conport` name, relative `./.dopemux` volume), and refuses to treat
 > unlabeled listening ports as owned. It does **not** start or stop containers.
-> Repo-aware start/stop is a later packet.
+>
+> **Config repair (TP-DMX-MCP-RUNTIME-003):** fix transport mismatches without
+> hand-editing every worktree:
+> `dopemux mcp repair-config --repo <path> --dry-run --json` then `--apply`.
+> Preserves custom mcpServers entries; never mutates `~/.claude.json`.
+> Runtime start remains `dopemux mcp start --repo <path>` (Packet 002).
 
 ---
 

--- a/docs/02-how-to/mcp-transport-and-port-bugs.md
+++ b/docs/02-how-to/mcp-transport-and-port-bugs.md
@@ -29,6 +29,13 @@ applied to `dopemux-mvp`.
 > `dopemux mcp repair-config --repo <path> --dry-run --json` then `--apply`.
 > Preserves custom mcpServers entries; never mutates `~/.claude.json`.
 > Runtime start remains `dopemux mcp start --repo <path>` (Packet 002).
+>
+> **Port leases (TP-DMX-MCP-RUNTIME-004):** hash offsets are *preferred* only.
+> Assignment uses `~/.dopemux/mcp/runtime/port-leases.json` (override
+> `DOPEMUX_MCP_PORT_LEASE_REGISTRY`), reserved singleton protection, live TCP
+> probes, and rebind when preferred ports are unsafe. Dry-run / `persist=False`
+> never write leases. Fixed-port `task-orchestrator` (7890) reuses or blocks —
+> it does not rebind.
 
 ---
 

--- a/docs/02-how-to/multi-instance-workflow.md
+++ b/docs/02-how-to/multi-instance-workflow.md
@@ -26,8 +26,9 @@ Zero context destruction through parallel ADHD-optimized development instances.
 > `dopemux mcp fleet init --repo <project> --worktrees <paths...> --apply` then
 > `dopemux mcp start --repo <worktree>` / `dopemux mcp fleet doctor --repo <project> --worktrees ...`.
 > Also: `init` → `repair-config` → `start` → `doctor` per worktree.
-> Do **not** env-inject foreign `.envrc.dopemux-mcp` into dopemux-mvp compose.
-> Registry: `~/.dopemux/mcp/runtime/instances.json`.
+> Port leases live in `~/.dopemux/mcp/runtime/port-leases.json` (cross-worktree collision
+> rebind). Do **not** env-inject foreign `.envrc.dopemux-mcp` into dopemux-mvp compose.
+> Runtime registry: `~/.dopemux/mcp/runtime/instances.json`.
 
 ## Overview
 

--- a/docs/02-how-to/multi-instance-workflow.md
+++ b/docs/02-how-to/multi-instance-workflow.md
@@ -22,9 +22,12 @@ prelude: Multi-Instance Workflow Guide (how-to) for dopemux documentation and de
 
 Zero context destruction through parallel ADHD-optimized development instances.
 
-> **MCP sidecars (2026-07):** Prefer `dopemux mcp start --repo <worktree>` after
-> `dopemux mcp init` / `doctor`. Do not env-inject foreign `.envrc.dopemux-mcp`
-> into dopemux-mvp compose. Registry: `~/.dopemux/mcp/runtime/instances.json`.
+> **MCP sidecars (2026-07):** Safe multi-worktree config:
+> `dopemux mcp fleet init --repo <project> --worktrees <paths...> --apply` then
+> `dopemux mcp start --repo <worktree>` / `dopemux mcp fleet doctor --repo <project> --worktrees ...`.
+> Also: `init` → `repair-config` → `start` → `doctor` per worktree.
+> Do **not** env-inject foreign `.envrc.dopemux-mcp` into dopemux-mvp compose.
+> Registry: `~/.dopemux/mcp/runtime/instances.json`.
 
 ## Overview
 

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -733,57 +733,43 @@ def _allocate_ports(
     catalog: Dict[str, Any],
     *,
     project_root: str | None = None,
+    persist: bool = True,
+    dry_run: bool = False,
+    existing_envrc: Optional[Dict[str, str]] = None,
+    is_free_fn: Any = None,
+    source: str = "dopemux mcp init",
 ) -> Dict[str, int]:
     """
-    Compute ports for each per-worktree server, including any `extra_port_vars`
-    declared by the spec (e.g. conport exposes three host ports for one service).
-    Same hash offset is reused across a single server's primary + extras.
+    Allocate ports for each per-worktree server via the lease registry allocator.
+
+    Preferred ports still come from the legacy hash formula
+    (``base + sha1(path)[:4] % 100``) or existing envrc values, but assignment
+    only succeeds after reserved/lease/socket safety checks. Unsafe preferred
+    ports are rebound within the service base search window.
 
     Safety rules:
-    - ``wrapper-singleton`` services (one global instance, fixed port) are
-      assigned their ``default_port_base`` directly without any hash offset.
-    - All singleton-catalog reserved ports are pre-seeded into the collision
-      map so per-worktree hash offsets cannot land on them.
+    - Singleton reserved catalog ports are never assigned to project sidecars.
+    - Active leases owned by other projects/worktrees are never stolen.
+    - Live TCP sockets block assignment (except reuse of our own lease).
+    - ``wrapper-singleton`` services use fixed ``default_port_base`` (no rebind).
+    - ``dry_run=True`` / ``persist=False`` skips lease registry writes.
     """
-    assignments: Dict[str, int] = {}
-    # Pre-seed with singleton reserved ports so per-worktree allocations
-    # cannot collide with statically-assigned singleton ports (e.g. gptr-mcp).
-    seen_ports: Dict[int, str] = {
-        port: f"singleton:{name}"
-        for port, name in _singleton_reserved_ports(catalog).items()
-    }
+    from dopemux.mcp.port_allocator import allocate_ports_map
 
-    def _claim(
-        var: str, base: int, owner: str, key_path: str, *, fixed: bool = False
-    ) -> None:
-        port = base if fixed else _port_for(key_path, base)
-        if port in seen_ports:
-            raise click.ClickException(
-                f"Internal port collision: {owner}.{var} and "
-                f"{seen_ports[port]} both map to :{port}. "
-                f"Adjust the `default_port_base` for one of them in {CATALOG_FILENAME}."
-            )
-        seen_ports[port] = f"{owner}.{var}"
-        assignments[var] = port
-
-    for name in names:
-        spec = catalog["servers"].get(name)
-        if not spec or spec.get("scope") != "per-worktree":
-            continue
-        # wrapper-singleton: one global instance at a fixed port — no hash offset.
-        is_wrapper_singleton = spec.get("management_model") == "wrapper-singleton"
-        key_path = (
-            project_root
-            if spec.get("state_scope") == "per-repo" and project_root
-            else worktree
+    try:
+        return allocate_ports_map(
+            worktree,
+            names,
+            catalog,
+            project_root=project_root,
+            existing_envrc=existing_envrc,
+            persist=persist and not dry_run,
+            dry_run=dry_run,
+            source=source,
+            is_free_fn=is_free_fn,
         )
-        base = spec.get("default_port_base")
-        if base:
-            _claim(spec["port_var"], base, name, key_path, fixed=is_wrapper_singleton)
-        if not is_wrapper_singleton:
-            for extra in spec.get("extra_port_vars", []) or []:
-                _claim(extra["var"], extra["base"], name, key_path)
-    return assignments
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _project_env_exports(worktree: str, project_root: str) -> Dict[str, str]:
@@ -1199,8 +1185,6 @@ def mcp_init_cmd(force: bool, extra: Tuple[str, ...]):
 
     mcp_json_path = repo_path / PROJECT_MCP_FILENAME
     envrc_path = repo_path / ENVRC_FILENAME
-
-    port_vars = _allocate_ports(repo, ordered, catalog, project_root=str(identity.project_root))
     config = _build_local_mcp_json(ordered, catalog)
 
     if envrc_path.exists() and not force:
@@ -1217,8 +1201,32 @@ def mcp_init_cmd(force: bool, extra: Tuple[str, ...]):
                 "Use --force to overwrite."
             )
         wrote_mcp_json = False
-    else:
+
+    # Allocate only after init preconditions pass so dry collisions do not write leases.
+    existing_env: Dict[str, str] = {}
+    if envrc_path.exists():
+        try:
+            from dopemux.mcp.envrc import load_envrc
+
+            parsed = load_envrc(envrc_path)
+            if parsed.values:
+                existing_env = dict(parsed.values)
+        except Exception:  # noqa: BLE001 — fall back to pure preferred formula
+            existing_env = {}
+    port_vars = _allocate_ports(
+        repo,
+        ordered,
+        catalog,
+        project_root=str(identity.project_root),
+        existing_envrc=existing_env or None,
+        source="dopemux mcp init",
+    )
+
+    if wrote_mcp_json:
         _atomic_write_json(mcp_json_path, config)
+    elif mcp_json_path.exists() and force:
+        _atomic_write_json(mcp_json_path, config)
+        wrote_mcp_json = True
 
     _write_envrc(envrc_path, port_vars, repo, str(identity.project_root))
 

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -2,9 +2,10 @@
 MCP Server Management Commands
 
 Commands for starting, stopping, and monitoring MCP Docker servers
-(``up``/``down``/``status``/``logs``/``start-all``), plus MCP config
-scaffolding driven by repo-local or bundled ``mcp_catalog.yaml`` data
-(``init``/``add``/``remove``/``list``/``doctor``/``sync-globals``).
+(``start``/``stop``/``up``/``down``/``status``/``logs``/``start-all``), plus MCP
+config scaffolding driven by repo-local or bundled ``mcp_catalog.yaml`` data
+(``init``/``repair-config``/``fleet``/``add``/``remove``/``list``/``doctor``/
+``sync-globals``).
 
 The ``servers`` group is an alias for ``mcp`` for backward compatibility.
 """
@@ -1581,6 +1582,215 @@ def _mcp_doctor_legacy() -> None:
 def _functional_subset(entry: Dict[str, Any]) -> Dict[str, Any]:
     """Strip advisory fields (description) for diff purposes — they're documentation, not config."""
     return {k: v for k, v in entry.items() if k != "description"}
+
+
+def _resolve_repo_arg(repo_arg: Optional[Path]) -> Path:
+    """Resolve --repo or current git root to an absolute path."""
+    if repo_arg is not None:
+        return Path(repo_arg).expanduser().resolve()
+    repo = get_repo_root(fallback_cwd=False)
+    if not repo:
+        raise click.ClickException(
+            "Not inside a git repository. Pass --repo <path> to target another project."
+        )
+    return Path(repo).resolve()
+
+
+def _require_exactly_one_dry_run_or_apply(dry_run: bool, apply: bool) -> None:
+    if dry_run and apply:
+        raise click.ClickException("Pass exactly one of --dry-run or --apply (not both).")
+    if not dry_run and not apply:
+        raise click.ClickException(
+            "Pass exactly one of --dry-run or --apply. "
+            "Preview with --dry-run; write local config with --apply."
+        )
+
+
+@mcp.command("repair-config")
+@click.option(
+    "--repo",
+    "repo_arg",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    default=None,
+    help="Target repo/worktree (defaults to current git root).",
+)
+@click.option("--dry-run", is_flag=True, help="Plan only; write nothing.")
+@click.option("--apply", is_flag=True, help="Write local .mcp.json / envrc / agent bootstrap doc.")
+@click.option("--json", "json_output", is_flag=True, help="Emit repair plan JSON to stdout.")
+def mcp_repair_config_cmd(
+    repo_arg: Optional[Path],
+    dry_run: bool,
+    apply: bool,
+    json_output: bool,
+):
+    """
+    🔧 Repair local MCP config: .mcp.json transports, envrc, agent bootstrap
+
+    Previewable and idempotent. Never mutates ~/.claude.json and never starts
+    or stops containers. Unknown/custom mcpServers entries are preserved.
+
+    Examples:
+      dopemux mcp repair-config --dry-run --json
+      dopemux mcp repair-config --repo ~/code/other --apply
+    """
+    _require_exactly_one_dry_run_or_apply(dry_run, apply)
+
+    from dopemux.mcp.config_repair import apply_repair, format_repair_human, plan_repair
+
+    repo_path = _resolve_repo_arg(repo_arg)
+    catalog = _load_catalog()
+    catalog_path = _catalog_path()
+    catalog_paths = [str(catalog_path)] if catalog_path else ["bundled:default_catalog.yaml"]
+
+    plan = plan_repair(
+        repo_path,
+        catalog,
+        dry_run=dry_run,
+        catalog_paths=catalog_paths,
+        process_env=dict(os.environ),
+    )
+
+    if apply and plan.status != "BLOCKED":
+        plan.dry_run = False
+        plan = apply_repair(plan)
+
+    if json_output:
+        sys.stdout.write(plan.to_json())
+    else:
+        summary = format_repair_human(plan)
+        if plan.status in {"APPLIED", "NOOP"}:
+            console.logger.info(f"[success]{summary.rstrip()}[/success]")
+        elif plan.status == "BLOCKED":
+            console.logger.info(f"[error]{summary.rstrip()}[/error]")
+        else:
+            console.logger.info(f"[info]{summary.rstrip()}[/info]")
+
+    if plan.status == "BLOCKED":
+        sys.exit(2)
+
+
+@mcp.group("fleet")
+def mcp_fleet_group():
+    """
+    🚢 Fleet: multi-worktree MCP config init and doctor aggregation
+
+    Config-only operations. Does not start containers or mutate globals.
+    """
+
+
+@mcp_fleet_group.command("init")
+@click.option(
+    "--repo",
+    "repo_arg",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    help="Project root that owns the worktrees.",
+)
+@click.option(
+    "--worktrees",
+    "worktrees",
+    required=True,
+    multiple=True,
+    type=click.Path(path_type=Path),
+    help="Worktree paths (repeatable).",
+)
+@click.option("--dry-run", is_flag=True, help="Plan only; write nothing.")
+@click.option("--apply", is_flag=True, help="Apply repair-config per valid worktree.")
+@click.option("--json", "json_output", is_flag=True, help="Emit fleet-init JSON to stdout.")
+def mcp_fleet_init_cmd(
+    repo_arg: Path,
+    worktrees: Tuple[Path, ...],
+    dry_run: bool,
+    apply: bool,
+    json_output: bool,
+):
+    """
+    Scaffold/repair MCP config across worktrees (no container start).
+    """
+    _require_exactly_one_dry_run_or_apply(dry_run, apply)
+    if not worktrees:
+        raise click.ClickException("Pass at least one --worktrees path.")
+
+    from dopemux.mcp.fleet import fleet_init, format_fleet_init_human
+
+    catalog = _load_catalog()
+    catalog_path = _catalog_path()
+    catalog_paths = [str(catalog_path)] if catalog_path else ["bundled:default_catalog.yaml"]
+
+    report = fleet_init(
+        repo_arg,
+        list(worktrees),
+        catalog,
+        dry_run=dry_run,
+        apply=apply,
+        catalog_paths=catalog_paths,
+    )
+
+    if json_output:
+        sys.stdout.write(report.to_json())
+    else:
+        console.logger.info(f"[info]{format_fleet_init_human(report).rstrip()}[/info]")
+
+    if report.status in {"FAIL", "UNKNOWN"}:
+        sys.exit(1)
+
+
+@mcp_fleet_group.command("doctor")
+@click.option(
+    "--repo",
+    "repo_arg",
+    required=True,
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, path_type=Path),
+    help="Project root that owns the worktrees.",
+)
+@click.option(
+    "--worktrees",
+    "worktrees",
+    required=True,
+    multiple=True,
+    type=click.Path(path_type=Path),
+    help="Worktree paths (repeatable).",
+)
+@click.option("--json", "json_output", is_flag=True, help="Emit fleet-doctor JSON to stdout.")
+@click.option(
+    "--skip-docker/--probe-docker",
+    default=True,
+    help="Skip Docker inspection per worktree (default: skip for speed).",
+)
+def mcp_fleet_doctor_cmd(
+    repo_arg: Path,
+    worktrees: Tuple[Path, ...],
+    json_output: bool,
+    skip_docker: bool,
+):
+    """
+    Aggregate Packet 001 doctor results across worktrees (read-only).
+    """
+    if not worktrees:
+        raise click.ClickException("Pass at least one --worktrees path.")
+
+    from dopemux.mcp.fleet import fleet_doctor, format_fleet_doctor_human
+
+    catalog = _load_catalog()
+    catalog_path = _catalog_path()
+    catalog_paths = [str(catalog_path)] if catalog_path else ["bundled:default_catalog.yaml"]
+
+    report = fleet_doctor(
+        repo_arg,
+        list(worktrees),
+        catalog,
+        catalog_paths=catalog_paths,
+        skip_docker=skip_docker,
+        process_env=dict(os.environ),
+    )
+
+    if json_output:
+        sys.stdout.write(report.to_json())
+    else:
+        console.logger.info(f"[info]{format_fleet_doctor_human(report).rstrip()}[/info]")
+
+    if report.status in {"FAIL", "UNKNOWN"}:
+        sys.exit(1)
 
 
 @mcp.command("sync-globals")

--- a/src/dopemux/mcp/agent_bootstrap.py
+++ b/src/dopemux/mcp/agent_bootstrap.py
@@ -1,0 +1,213 @@
+"""Agent bootstrap doc generation for worktree MCP setup.
+
+Writes/updates ``.claude/WORKTREE_MCP_SETUP.md`` using marked sections only.
+Never mutates ``~/.claude.json`` or starts containers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+BEGIN_MARKER = "<!-- BEGIN DOPEMUX MCP SETUP -->"
+END_MARKER = "<!-- END DOPEMUX MCP SETUP -->"
+DEFAULT_RELATIVE_PATH = ".claude/WORKTREE_MCP_SETUP.md"
+
+
+def default_agent_doc_path(repo: Path | str) -> Path:
+    return Path(repo).expanduser().resolve() / DEFAULT_RELATIVE_PATH
+
+
+def bootstrap_section_body() -> str:
+    """Canonical marked-section body (without markers)."""
+    return """# Worktree MCP Setup
+
+## Purpose
+
+Safe, reversible MCP config and lifecycle for this worktree. Dopemux coordinates
+MCP startup and local config; it is not ConPort, dope-memory, task-orchestrator,
+bridge, PM, or chronicle authority.
+
+## Session Start
+
+```bash
+source .envrc.dopemux-mcp
+dopemux mcp doctor
+```
+
+If services are not running:
+
+```bash
+dopemux mcp start
+dopemux mcp doctor
+```
+
+## Healthy Sequence
+
+```bash
+dopemux mcp init                 # once per worktree (scaffolds config)
+dopemux mcp repair-config --dry-run
+dopemux mcp repair-config --apply
+dopemux mcp start
+source .envrc.dopemux-mcp
+dopemux mcp doctor
+```
+
+## Doctor / Start / Stop
+
+```bash
+dopemux mcp doctor --repo .
+dopemux mcp start --repo .
+dopemux mcp status --repo .
+dopemux mcp stop --repo .
+```
+
+## Do Not Run
+
+Do not start this repo's MCP services by cd'ing into `dopemux-mvp` and injecting
+this repo's env into `docker compose up`.
+
+Do not replace global ConPort with local ConPort.
+
+Do not treat a listening port as healthy unless `dopemux mcp doctor` proves ownership.
+
+Do not run `dopemux mcp sync-globals` unless you intentionally want to change
+`~/.claude.json` singletons. `repair-config` never mutates globals.
+
+## Authority
+
+| Surface | Authority |
+|---------|-----------|
+| Dopemux | MCP lifecycle / local config coordination only |
+| ConPort | Structured context (decisions, progress, KG) |
+| dope-memory | Chronicle / historical receipts |
+| task-orchestrator | Workflow views and transitions |
+| dopecon-bridge | Proxy / adapter only — not canonical writer |
+
+## Limitations (honest)
+
+* Port allocation uses hash `% 100` — collision risk across many worktrees
+  (`PORT_HASH_BUCKET_COLLISION_RISK`). Live free-port rebind is not implemented.
+* `task-orchestrator` uses fixed port `7890` (wrapper-singleton).
+* Unlabeled existing containers are not adopted automatically.
+* Cross-worktree port lease registry is a future packet (RUNTIME-004).
+
+## Evidence Capture
+
+When debugging MCP setup, capture:
+
+1. `dopemux mcp doctor --json` (or `--repo <path> --json`)
+2. `dopemux mcp repair-config --dry-run --json`
+3. `dopemux mcp status --json`
+4. Exit codes and paths only — never paste secrets or `.env` tokens
+"""
+
+
+def wrap_marked_section(body: str | None = None) -> str:
+    content = (body if body is not None else bootstrap_section_body()).rstrip() + "\n"
+    return f"{BEGIN_MARKER}\n{content}{END_MARKER}\n"
+
+
+@dataclass
+class AgentBootstrapPlan:
+    path: Path
+    kind: str  # create | update | append | noop
+    reason: str
+    before_exists: bool
+    content: str
+    safe: bool = True
+
+    def to_change_dict(self) -> Dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "kind": self.kind if self.kind != "noop" else "noop",
+            "reason": self.reason,
+            "service": None,
+            "before": {"exists": self.before_exists},
+            "after": {"kind": self.kind},
+            "safe": self.safe,
+        }
+
+
+def plan_agent_bootstrap(repo: Path | str, *, doc_path: Optional[Path] = None) -> AgentBootstrapPlan:
+    """Plan idempotent update of the agent bootstrap doc."""
+    path = Path(doc_path) if doc_path is not None else default_agent_doc_path(repo)
+    desired = wrap_marked_section()
+
+    if not path.exists():
+        return AgentBootstrapPlan(
+            path=path,
+            kind="create",
+            reason="AGENT_BOOTSTRAP_CREATED",
+            before_exists=False,
+            content=desired,
+        )
+
+    text = path.read_text(encoding="utf-8")
+    if BEGIN_MARKER in text and END_MARKER in text:
+        begin = text.index(BEGIN_MARKER)
+        end = text.index(END_MARKER) + len(END_MARKER)
+        # Preserve trailing newline after end marker if present
+        after_end = end
+        if after_end < len(text) and text[after_end] == "\n":
+            after_end += 1
+        new_text = text[:begin] + desired
+        if after_end < len(text):
+            # Ensure separation if remaining content
+            if not new_text.endswith("\n"):
+                new_text += "\n"
+            new_text += text[after_end:].lstrip("\n")
+            if text[after_end:] and not new_text.endswith("\n"):
+                new_text += "\n"
+        if new_text == text:
+            return AgentBootstrapPlan(
+                path=path,
+                kind="noop",
+                reason="AGENT_BOOTSTRAP_NOOP",
+                before_exists=True,
+                content=text,
+            )
+        return AgentBootstrapPlan(
+            path=path,
+            kind="update",
+            reason="AGENT_BOOTSTRAP_UPDATED",
+            before_exists=True,
+            content=new_text if new_text.endswith("\n") else new_text + "\n",
+        )
+
+    # File exists without markers — append bounded section
+    prefix = text if text.endswith("\n") else text + "\n"
+    return AgentBootstrapPlan(
+        path=path,
+        kind="append",
+        reason="AGENT_BOOTSTRAP_UPDATED",
+        before_exists=True,
+        content=prefix + "\n" + desired,
+    )
+
+
+def apply_agent_bootstrap(plan: AgentBootstrapPlan) -> None:
+    """Write the planned agent bootstrap doc. No-op when kind is noop."""
+    if plan.kind == "noop":
+        return
+    plan.path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = plan.path.with_suffix(plan.path.suffix + ".tmp")
+    tmp.write_text(plan.content, encoding="utf-8")
+    tmp.replace(plan.path)
+
+
+def verify_bootstrap_content(text: str) -> List[str]:
+    """Return list of missing required phrases (empty = ok)."""
+    required = [
+        "dopemux mcp start",
+        "dopemux mcp doctor",
+        "dopemux mcp stop",
+        "Do not start this repo's MCP services by cd'ing into `dopemux-mvp`",
+        "Authority",
+        "ConPort",
+        "dope-memory",
+        "task-orchestrator",
+    ]
+    missing = [r for r in required if r not in text]
+    return missing

--- a/src/dopemux/mcp/config_repair.py
+++ b/src/dopemux/mcp/config_repair.py
@@ -138,14 +138,30 @@ def _desired_env_map(
     *,
     allocate_ports_fn: Callable[..., Dict[str, int]],
     project_env_exports_fn: Callable[[str, str], Dict[str, str]],
+    dry_run: bool = True,
+    existing_envrc: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, str]:
     exports = {k: str(v) for k, v in project_env_exports_fn(worktree, project_root).items()}
-    ports = allocate_ports_fn(
-        worktree,
-        list(server_names),
-        catalog,
-        project_root=project_root,
-    )
+    # Lease-aware allocation: never persist on dry-run; prefer existing envrc ports.
+    try:
+        ports = allocate_ports_fn(
+            worktree,
+            list(server_names),
+            catalog,
+            project_root=project_root,
+            persist=not dry_run,
+            dry_run=dry_run,
+            existing_envrc=dict(existing_envrc or {}),
+            source="dopemux mcp repair-config",
+        )
+    except TypeError:
+        # Test doubles / legacy callables without lease kwargs
+        ports = allocate_ports_fn(
+            worktree,
+            list(server_names),
+            catalog,
+            project_root=project_root,
+        )
     for k, v in ports.items():
         exports[str(k)] = str(v)
     return exports
@@ -372,6 +388,8 @@ def plan_repair(
         catalog,
         allocate_ports_fn=allocate_ports_fn,
         project_env_exports_fn=project_env_exports_fn,
+        dry_run=dry_run,
+        existing_envrc=envrc_parsed.values if envrc_parsed.present else {},
     )
     owned_keys = _catalog_owned_env_keys(catalog, server_names)
 

--- a/src/dopemux/mcp/config_repair.py
+++ b/src/dopemux/mcp/config_repair.py
@@ -409,7 +409,7 @@ def plan_repair(
 
     envrc_missing = not envrc_parsed.present
     envrc_stale = False
-    if envrc_parsed.present and envrc_parsed.parse_status == "OK":
+    if envrc_parsed.present and envrc_parsed.parse_status in {"OK", "PARTIAL"}:
         for key, want in desired_env.items():
             if envrc_parsed.values.get(key) != want:
                 envrc_stale = True
@@ -418,6 +418,9 @@ def plan_repair(
             if key in desired_env and key not in envrc_parsed.values:
                 envrc_stale = True
                 break
+        # Partial parse is repairable (regenerate), not a hard block.
+        if envrc_parsed.parse_status == "PARTIAL":
+            envrc_stale = True
     elif envrc_parsed.present and envrc_parsed.parse_status == "ERROR":
         plan.blocking_findings.append(
             _block(

--- a/src/dopemux/mcp/config_repair.py
+++ b/src/dopemux/mcp/config_repair.py
@@ -77,6 +77,10 @@ class RepairPlan:
     _write_mcp: bool = field(default=False, repr=False)
     _write_envrc: bool = field(default=False, repr=False)
     _write_agent: bool = field(default=False, repr=False)
+    # Deferred lease persistence: plan never writes the registry; apply does.
+    _lease_persist: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    _allocate_ports_fn: Any = field(default=None, repr=False)
+    _catalog: Any = field(default=None, repr=False)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -140,17 +144,19 @@ def _desired_env_map(
     project_env_exports_fn: Callable[[str, str], Dict[str, str]],
     dry_run: bool = True,
     existing_envrc: Optional[Mapping[str, str]] = None,
+    persist_leases: bool = False,
 ) -> Dict[str, str]:
     exports = {k: str(v) for k, v in project_env_exports_fn(worktree, project_root).items()}
-    # Lease-aware allocation: never persist on dry-run; prefer existing envrc ports.
+    # Lease-aware allocation. Planning never persists; only explicit post-apply
+    # calls pass persist_leases=True so a blocked/failed apply cannot consume leases.
     try:
         ports = allocate_ports_fn(
             worktree,
             list(server_names),
             catalog,
             project_root=project_root,
-            persist=not dry_run,
-            dry_run=dry_run,
+            persist=persist_leases and not dry_run,
+            dry_run=dry_run or not persist_leases,
             existing_envrc=dict(existing_envrc or {}),
             source="dopemux mcp repair-config",
         )
@@ -381,6 +387,8 @@ def plan_repair(
         if is_catalog_owned(str(name), catalog) and name not in server_names:
             server_names.append(str(name))
 
+    # Always compute ports without writing leases during plan construction.
+    # Leases are persisted only after apply_repair successfully writes config.
     desired_env = _desired_env_map(
         worktree,
         project_root,
@@ -388,9 +396,18 @@ def plan_repair(
         catalog,
         allocate_ports_fn=allocate_ports_fn,
         project_env_exports_fn=project_env_exports_fn,
-        dry_run=dry_run,
+        dry_run=True,
+        persist_leases=False,
         existing_envrc=envrc_parsed.values if envrc_parsed.present else {},
     )
+    plan._allocate_ports_fn = allocate_ports_fn
+    plan._catalog = catalog
+    plan._lease_persist = {
+        "worktree": worktree,
+        "project_root": project_root,
+        "server_names": list(server_names),
+        "existing_envrc": dict(desired_env),
+    }
     owned_keys = _catalog_owned_env_keys(catalog, server_names)
 
     # Secret-like handling on existing envrc
@@ -570,6 +587,29 @@ def apply_repair(plan: RepairPlan) -> RepairPlan:
         plan.blocking_findings.append(_block("APPLY_IO_ERROR", str(exc)))
         plan.status = "BLOCKED"
         return plan
+
+    # Persist port leases only after config files were written successfully.
+    if plan._lease_persist and plan._allocate_ports_fn is not None and plan._catalog is not None:
+        lp = plan._lease_persist
+        try:
+            _desired_env_map(
+                str(lp["worktree"]),
+                str(lp["project_root"]),
+                list(lp.get("server_names") or []),
+                plan._catalog,
+                allocate_ports_fn=plan._allocate_ports_fn,
+                project_env_exports_fn=lambda w, p: {},
+                dry_run=False,
+                persist_leases=True,
+                existing_envrc=dict(lp.get("existing_envrc") or {}),
+            )
+        except Exception as exc:  # noqa: BLE001 — config already written; warn only
+            plan.warnings.append(
+                _warn(
+                    "LEASE_PERSIST_FAILED",
+                    f"Config applied but lease registry write failed: {exc}",
+                )
+            )
 
     plan.status = "APPLIED"
     plan.warnings.append(_warn("REPAIR_APPLIED", f"Wrote repairs under {repo}."))

--- a/src/dopemux/mcp/config_repair.py
+++ b/src/dopemux/mcp/config_repair.py
@@ -1,0 +1,580 @@
+"""MCP config repair planner/applier (Packet 003).
+
+Previewable local repair for ``.mcp.json``, ``.envrc.dopemux-mcp``, and agent
+bootstrap docs. Never starts/stops containers and never mutates ``~/.claude.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from .agent_bootstrap import (
+    apply_agent_bootstrap,
+    default_agent_doc_path,
+    plan_agent_bootstrap,
+)
+from .envrc import (
+    is_secret_like_key,
+    load_envrc,
+    parse_envrc_text,
+    redact_value,
+)
+from .mcp_json import (
+    PROJECT_MCP_FILENAME,
+    dump_mcp_json,
+    is_catalog_owned,
+    load_mcp_json_document,
+    plan_mcp_json_repairs,
+    write_mcp_json,
+)
+from .runtime_state import (
+    ENVRC_FILENAME,
+    load_global_claude,
+    resolve_identity_view,
+)
+
+SCHEMA_VERSION = "1.0"
+
+# Catalog-owned env keys regenerated from init generators (not secret-bearing).
+_IDENTITY_KEYS = {
+    "DOPEMUX_WORKSPACE_ID",
+    "DOPEMUX_WORKSPACE_ROOT",
+    "DOPEMUX_PROJECT_ROOT",
+    "TASK_ORCHESTRATOR_PROJECT_ROOT",
+    "DOPEMUX_INSTANCE_ID",
+    "DOPE_MEMORY_WORKSPACE_ID",
+    "DOPE_MEMORY_INSTANCE_ID",
+    "WORKSPACE_ID",
+}
+
+
+@dataclass
+class RepairPlan:
+    """Structured repair plan (JSON schema §8)."""
+
+    schema_version: str = SCHEMA_VERSION
+    operation: str = "repair-config"
+    dry_run: bool = True
+    status: str = "PLANNED"  # PLANNED|APPLIED|NOOP|BLOCKED|UNKNOWN
+    repo: str = ""
+    project_identity: Dict[str, Any] = field(default_factory=dict)
+    inputs: Dict[str, Any] = field(default_factory=dict)
+    planned_changes: List[Dict[str, Any]] = field(default_factory=list)
+    preserved_entries: List[Dict[str, Any]] = field(default_factory=list)
+    warnings: List[Dict[str, Any]] = field(default_factory=list)
+    blocking_findings: List[Dict[str, Any]] = field(default_factory=list)
+    next_actions: List[str] = field(default_factory=list)
+    # Internal apply payloads (not always dumped in full)
+    _mcp_servers: Dict[str, Any] = field(default_factory=dict, repr=False)
+    _mcp_other_keys: Dict[str, Any] = field(default_factory=dict, repr=False)
+    _envrc_text: Optional[str] = field(default=None, repr=False)
+    _agent_plan: Any = field(default=None, repr=False)
+    _write_mcp: bool = field(default=False, repr=False)
+    _write_envrc: bool = field(default=False, repr=False)
+    _write_agent: bool = field(default=False, repr=False)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "operation": self.operation,
+            "dry_run": self.dry_run,
+            "status": self.status,
+            "repo": self.repo,
+            "project_identity": dict(self.project_identity),
+            "inputs": dict(self.inputs),
+            "planned_changes": list(self.planned_changes),
+            "preserved_entries": list(self.preserved_entries),
+            "warnings": list(self.warnings),
+            "blocking_findings": list(self.blocking_findings),
+            "next_actions": list(self.next_actions),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2, sort_keys=False) + "\n"
+
+
+def _warn(code: str, message: str, **extra: Any) -> Dict[str, Any]:
+    item: Dict[str, Any] = {"code": code, "message": message}
+    item.update(extra)
+    return item
+
+
+def _block(code: str, message: str, **extra: Any) -> Dict[str, Any]:
+    return _warn(code, message, **extra)
+
+
+def _catalog_owned_env_keys(catalog: Mapping[str, Any], server_names: Sequence[str]) -> set[str]:
+    keys = set(_IDENTITY_KEYS)
+    servers = catalog.get("servers") or {}
+    for name in server_names:
+        spec = servers.get(name) or {}
+        if not isinstance(spec, dict):
+            continue
+        if not is_catalog_owned(str(name), catalog):
+            continue
+        port_var = spec.get("port_var")
+        if port_var:
+            keys.add(str(port_var))
+        for extra in spec.get("extra_port_vars") or []:
+            if isinstance(extra, dict) and extra.get("var"):
+                keys.add(str(extra["var"]))
+        for env_key in list(spec.get("requires_env") or []) + list(spec.get("optional_env") or []):
+            # Never treat secret-like required keys as regenerable owned keys
+            if not is_secret_like_key(str(env_key)):
+                keys.add(str(env_key))
+    return keys
+
+
+def _desired_env_map(
+    worktree: str,
+    project_root: str,
+    server_names: Sequence[str],
+    catalog: Mapping[str, Any],
+    *,
+    allocate_ports_fn: Callable[..., Dict[str, int]],
+    project_env_exports_fn: Callable[[str, str], Dict[str, str]],
+) -> Dict[str, str]:
+    exports = {k: str(v) for k, v in project_env_exports_fn(worktree, project_root).items()}
+    ports = allocate_ports_fn(
+        worktree,
+        list(server_names),
+        catalog,
+        project_root=project_root,
+    )
+    for k, v in ports.items():
+        exports[str(k)] = str(v)
+    return exports
+
+
+def _build_envrc_text(
+    worktree: str,
+    project_root: str,
+    desired: Mapping[str, str],
+    *,
+    preserve_values: Optional[Mapping[str, str]] = None,
+) -> str:
+    """Build envrc body: catalog-owned desired keys + preserved safe customs."""
+    lines = [
+        "# Generated by `dopemux mcp repair-config` / `dopemux mcp init`.",
+        f"# Worktree: {worktree}",
+        f"# Project:  {project_root}",
+        f"# Generated: {datetime.now(timezone.utc).astimezone().isoformat(timespec='seconds')}",
+        "",
+    ]
+    # Identity exports first (stable order)
+    identity_order = [
+        "DOPEMUX_WORKSPACE_ID",
+        "DOPEMUX_WORKSPACE_ROOT",
+        "DOPEMUX_PROJECT_ROOT",
+        "TASK_ORCHESTRATOR_PROJECT_ROOT",
+        "DOPEMUX_INSTANCE_ID",
+        "DOPE_MEMORY_WORKSPACE_ID",
+        "DOPE_MEMORY_INSTANCE_ID",
+        "WORKSPACE_ID",
+    ]
+    written: set[str] = set()
+    for key in identity_order:
+        if key in desired:
+            lines.append(f"export {key}={_shell_quote(desired[key])}")
+            written.add(key)
+    lines.append("")
+    # Port / remaining catalog keys sorted
+    for key in sorted(k for k in desired if k not in written):
+        lines.append(f"export {key}={_shell_quote(desired[key])}")
+        written.add(key)
+
+    # Preserve custom non-secret keys not in desired/catalog block
+    if preserve_values:
+        custom = []
+        for key, value in sorted(preserve_values.items()):
+            if key in written:
+                continue
+            if is_secret_like_key(key):
+                continue
+            custom.append((key, value))
+        if custom:
+            lines.append("")
+            lines.append("# Preserved non-catalog custom exports (repair-config)")
+            for key, value in custom:
+                lines.append(f"export {key}={_shell_quote(value)}")
+    return "\n".join(lines) + "\n"
+
+
+def _shell_quote(value: str) -> str:
+    import shlex
+
+    return shlex.quote(str(value))
+
+
+def plan_repair(
+    repo: Path | str,
+    catalog: Mapping[str, Any],
+    *,
+    dry_run: bool = True,
+    process_env: Optional[Mapping[str, str]] = None,
+    catalog_paths: Optional[Sequence[str]] = None,
+    allocate_ports_fn: Optional[Callable[..., Dict[str, int]]] = None,
+    project_env_exports_fn: Optional[Callable[[str, str], Dict[str, str]]] = None,
+    render_local_fn: Any = None,
+    global_claude_path: Optional[Path] = None,
+) -> RepairPlan:
+    """Build a deterministic repair plan for the target repo/worktree."""
+    repo_path = Path(repo).expanduser().resolve()
+    mcp_path = repo_path / PROJECT_MCP_FILENAME
+    envrc_path = repo_path / ENVRC_FILENAME
+    agent_path = default_agent_doc_path(repo_path)
+
+    plan = RepairPlan(
+        dry_run=dry_run,
+        status="PLANNED",
+        repo=str(repo_path),
+        inputs={
+            "mcp_json_path": str(mcp_path),
+            "envrc_path": str(envrc_path),
+            "catalog_paths": list(catalog_paths or []),
+            "agent_doc_path": str(agent_path),
+        },
+        next_actions=[
+            "dopemux mcp start",
+            "source .envrc.dopemux-mcp",
+            "dopemux mcp doctor",
+        ],
+    )
+
+    # Always emit allocator limitation warnings
+    plan.warnings.append(
+        _warn(
+            "PORT_HASH_BUCKET_COLLISION_RISK",
+            "Port allocation uses worktree hash % 100; multi-worktree collisions remain possible.",
+        )
+    )
+    plan.warnings.append(
+        _warn(
+            "PORT_REBIND_MISSING",
+            "Live free-port rebind is not implemented; repair reuses the deterministic allocator only.",
+        )
+    )
+    plan.warnings.append(
+        _warn(
+            "GLOBAL_CONFIG_NOT_MODIFIED",
+            "repair-config never mutates ~/.claude.json; use dopemux mcp sync-globals explicitly.",
+        )
+    )
+
+    # Identity
+    envrc_parsed = load_envrc(envrc_path)
+    identity = resolve_identity_view(repo_path, envrc_values=envrc_parsed.values)
+    plan.project_identity = {
+        "project_id": identity.project_id,
+        "workspace_id": identity.workspace_id,
+        "project_root": identity.project_root,
+        "worktree_root": identity.worktree_root,
+        "worktree_hash": identity.worktree_hash,
+        "identity_confidence": identity.identity_confidence,
+    }
+
+    worktree = identity.worktree_root or str(repo_path)
+    project_root = identity.project_root or str(repo_path)
+
+    # Lazy default generators (avoid circular import at module load)
+    if allocate_ports_fn is None or project_env_exports_fn is None:
+        from dopemux.commands import mcp_commands as _mc
+
+        if allocate_ports_fn is None:
+            allocate_ports_fn = _mc._allocate_ports
+        if project_env_exports_fn is None:
+            project_env_exports_fn = _mc._project_env_exports
+
+    # --- .mcp.json ---
+    mcp_doc = load_mcp_json_document(mcp_path)
+    if mcp_doc["parse_status"] == "ERROR":
+        plan.blocking_findings.append(
+            _block(
+                "MCP_JSON_PARSE_ERROR",
+                f"Malformed .mcp.json: {mcp_doc.get('error')}",
+            )
+        )
+        plan.status = "BLOCKED"
+        return plan
+
+    existing_servers = mcp_doc.get("servers") or {}
+    raw_doc = mcp_doc.get("raw_document") or {}
+    other_keys = {k: v for k, v in raw_doc.items() if k != "mcpServers"} if isinstance(raw_doc, dict) else {}
+
+    # Detect secret-like values inside mcp.json entries (block apply)
+    for name, entry in existing_servers.items():
+        if not isinstance(entry, dict):
+            continue
+        blob = json.dumps(entry)
+        if re.search(r"(?i)(BEGIN (RSA |OPENSSH )?PRIVATE KEY|password\s*=)", blob):
+            plan.blocking_findings.append(
+                _block(
+                    "MCP_JSON_SECRET_LIKE",
+                    f"Secret-like material detected in mcpServers.{name}; manual intervention required.",
+                    service=str(name),
+                )
+            )
+
+    merged_servers, mcp_changes, preserved = plan_mcp_json_repairs(
+        existing_servers,
+        catalog,
+        mcp_json_path=str(mcp_path),
+        include_defaults=True,
+        render_fn=render_local_fn,
+    )
+    plan.planned_changes.extend(mcp_changes)
+    plan.preserved_entries.extend(preserved)
+    plan._mcp_servers = merged_servers
+    plan._mcp_other_keys = other_keys
+    plan._write_mcp = bool(mcp_changes) or mcp_doc["parse_status"] == "MISSING"
+
+    if mcp_doc["parse_status"] == "MISSING":
+        plan.planned_changes.insert(
+            0,
+            {
+                "path": str(mcp_path),
+                "kind": "create",
+                "reason": "MISSING_MCP_JSON",
+                "service": None,
+                "before": None,
+                "after": {"servers": sorted(merged_servers.keys())},
+                "safe": True,
+            },
+        )
+        plan._write_mcp = True
+
+    # Annotate transport repair codes for report consumers
+    for ch in plan.planned_changes:
+        if ch.get("reason") == "TRANSPORT_MISMATCH":
+            ch["finding_code"] = "MCP_JSON_TRANSPORT_REPAIRED"
+        elif ch.get("reason") == "URL_MISMATCH":
+            ch["finding_code"] = "MCP_JSON_URL_REPAIRED"
+
+    # --- envrc ---
+    # Services for port allocation: defaults + any catalog-owned already present
+    server_names: List[str] = []
+    for name in (catalog.get("defaults") or {}).get("per_worktree") or []:
+        if is_catalog_owned(str(name), catalog) and name not in server_names:
+            server_names.append(str(name))
+    for name in existing_servers:
+        if is_catalog_owned(str(name), catalog) and name not in server_names:
+            server_names.append(str(name))
+
+    desired_env = _desired_env_map(
+        worktree,
+        project_root,
+        server_names,
+        catalog,
+        allocate_ports_fn=allocate_ports_fn,
+        project_env_exports_fn=project_env_exports_fn,
+    )
+    owned_keys = _catalog_owned_env_keys(catalog, server_names)
+
+    # Secret-like handling on existing envrc
+    secret_block = False
+    preserve_customs: Dict[str, str] = {}
+    if envrc_parsed.present and envrc_parsed.values:
+        for key, value in envrc_parsed.values.items():
+            if key in owned_keys:
+                continue
+            if is_secret_like_key(key):
+                plan.warnings.append(
+                    _warn(
+                        "ENVRC_SECRET_LIKE_VALUE_REDACTED",
+                        f"Secret-like key {key} redacted in plan; value not printed.",
+                        key=key,
+                        value=redact_value(key, value),
+                    )
+                )
+                # Uncertain preservation of secrets → block apply
+                secret_block = True
+                plan.blocking_findings.append(
+                    _block(
+                        "ENVRC_SECRET_LIKE_UNCERTAIN",
+                        f"Envrc contains secret-like key `{key}` that is not catalog-owned; "
+                        "apply blocked for manual review.",
+                        key=key,
+                    )
+                )
+            else:
+                preserve_customs[key] = value
+
+    if secret_block:
+        plan.status = "BLOCKED"
+
+    envrc_missing = not envrc_parsed.present
+    envrc_stale = False
+    if envrc_parsed.present and envrc_parsed.parse_status == "OK":
+        for key, want in desired_env.items():
+            if envrc_parsed.values.get(key) != want:
+                envrc_stale = True
+                break
+        for key in owned_keys:
+            if key in desired_env and key not in envrc_parsed.values:
+                envrc_stale = True
+                break
+    elif envrc_parsed.present and envrc_parsed.parse_status == "ERROR":
+        plan.blocking_findings.append(
+            _block(
+                "ENVRC_PARSE_ERROR",
+                f"Envrc parse errors: {'; '.join(envrc_parsed.errors)}",
+            )
+        )
+        plan.status = "BLOCKED"
+
+    new_envrc_text = _build_envrc_text(
+        worktree,
+        project_root,
+        desired_env,
+        preserve_values=preserve_customs,
+    )
+    plan._envrc_text = new_envrc_text
+
+    if envrc_missing:
+        plan.planned_changes.append(
+            {
+                "path": str(envrc_path),
+                "kind": "create",
+                "reason": "ENVRC_REGENERATED",
+                "service": None,
+                "before": None,
+                "after": {
+                    "keys": sorted(desired_env.keys()),
+                    "sample": {
+                        k: redact_value(k, desired_env[k])
+                        for k in sorted(desired_env.keys())[:8]
+                    },
+                },
+                "safe": not secret_block,
+            }
+        )
+        plan._write_envrc = True
+    elif envrc_stale and plan.status != "BLOCKED":
+        plan.planned_changes.append(
+            {
+                "path": str(envrc_path),
+                "kind": "rewrite",
+                "reason": "ENVRC_PATCHED",
+                "service": None,
+                "before": {
+                    "keys_present": list(envrc_parsed.keys_present),
+                },
+                "after": {
+                    "keys": sorted(desired_env.keys()) + sorted(preserve_customs.keys()),
+                },
+                "safe": not secret_block,
+            }
+        )
+        plan._write_envrc = True
+    elif not envrc_stale and not envrc_missing:
+        # noop envrc
+        pass
+
+    # --- agent bootstrap ---
+    agent_plan = plan_agent_bootstrap(repo_path, doc_path=agent_path)
+    plan._agent_plan = agent_plan
+    if agent_plan.kind != "noop":
+        plan.planned_changes.append(agent_plan.to_change_dict())
+        plan._write_agent = True
+
+    # --- global/local duplicate warnings (read-only) ---
+    global_info = load_global_claude(global_claude_path)
+    if global_info.get("parse_status") == "OK":
+        global_servers = global_info.get("servers") or {}
+        for name in merged_servers:
+            if name in global_servers and is_catalog_owned(str(name), catalog):
+                plan.warnings.append(
+                    _warn(
+                        "GLOBAL_LOCAL_DUPLICATE",
+                        f"`{name}` appears in both local .mcp.json and ~/.claude.json; "
+                        "prefer local per-worktree entry and clean global duplicates manually.",
+                        service=str(name),
+                    )
+                )
+
+    # Status synthesis
+    if plan.status == "BLOCKED":
+        plan.next_actions = [
+            "Resolve blocking_findings manually",
+            "dopemux mcp repair-config --dry-run --json",
+        ]
+        return plan
+
+    if not plan.planned_changes:
+        plan.status = "NOOP"
+        plan.warnings.append(_warn("REPAIR_NOOP", "Config already matches catalog-owned desired state."))
+    else:
+        plan.status = "PLANNED"
+        plan.warnings.append(
+            _warn("REPAIR_PLAN_CREATED", f"{len(plan.planned_changes)} planned change(s).")
+        )
+
+    return plan
+
+
+def apply_repair(plan: RepairPlan) -> RepairPlan:
+    """Apply a plan to the target repo. Never touches globals or Docker."""
+    if plan.status == "BLOCKED":
+        return plan
+    if plan.dry_run:
+        # Caller mistake — do not write
+        plan.blocking_findings.append(
+            _block("APPLY_ON_DRY_RUN", "apply_repair called with dry_run=True; refusing writes.")
+        )
+        plan.status = "BLOCKED"
+        return plan
+    if plan.status == "NOOP" and not (plan._write_mcp or plan._write_envrc or plan._write_agent):
+        return plan
+
+    repo = Path(plan.repo)
+    mcp_path = Path(plan.inputs["mcp_json_path"])
+    envrc_path = Path(plan.inputs["envrc_path"])
+
+    try:
+        if plan._write_mcp:
+            write_mcp_json(mcp_path, plan._mcp_servers, other_keys=plan._mcp_other_keys or None)
+        if plan._write_envrc and plan._envrc_text is not None:
+            envrc_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = envrc_path.with_suffix(envrc_path.suffix + ".tmp")
+            tmp.write_text(plan._envrc_text, encoding="utf-8")
+            tmp.replace(envrc_path)
+        if plan._write_agent and plan._agent_plan is not None:
+            apply_agent_bootstrap(plan._agent_plan)
+    except OSError as exc:
+        plan.blocking_findings.append(_block("APPLY_IO_ERROR", str(exc)))
+        plan.status = "BLOCKED"
+        return plan
+
+    plan.status = "APPLIED"
+    plan.warnings.append(_warn("REPAIR_APPLIED", f"Wrote repairs under {repo}."))
+    plan.dry_run = False
+    return plan
+
+
+def format_repair_human(plan: RepairPlan) -> str:
+    """Compact human summary for CLI."""
+    lines = [
+        f"repair-config {plan.status}  dry_run={plan.dry_run}",
+        f"repo: {plan.repo}",
+        f"changes: {len(plan.planned_changes)}  preserved: {len(plan.preserved_entries)}  "
+        f"warnings: {len(plan.warnings)}  blocking: {len(plan.blocking_findings)}",
+    ]
+    for ch in plan.planned_changes[:10]:
+        lines.append(
+            f"  • {ch.get('kind')} {ch.get('path')} "
+            f"[{ch.get('reason')}] service={ch.get('service')}"
+        )
+    if len(plan.planned_changes) > 10:
+        lines.append(f"  … {len(plan.planned_changes) - 10} more")
+    for b in plan.blocking_findings[:5]:
+        lines.append(f"  ✗ {b.get('code')}: {b.get('message')}")
+    if plan.next_actions:
+        lines.append("next:")
+        for a in plan.next_actions:
+            lines.append(f"  → {a}")
+    return "\n".join(lines) + "\n"

--- a/src/dopemux/mcp/doctor.py
+++ b/src/dopemux/mcp/doctor.py
@@ -193,8 +193,20 @@ def run_mcp_doctor(
     mcp_json = load_mcp_json(mcp_path)
     global_claude = load_global_claude(global_claude_path)
 
-    if envrc.present and envrc.parse_status == "OK":
+    if envrc.present and envrc.parse_status in {"OK", "PARTIAL"}:
         _add(findings, "ENVRC_FOUND", "INFO", f"Found {ENVRC_FILENAME}", evidence=[str(envrc_path)])
+        if envrc.parse_status == "PARTIAL":
+            _add(
+                findings,
+                "ENVRC_PARTIAL_PARSE",
+                "WARN",
+                (
+                    f"Partial parse of {ENVRC_FILENAME}: "
+                    f"{len(envrc.values)} keys loaded, {len(envrc.errors)} malformed line(s)"
+                ),
+                evidence=envrc.errors,
+                recommendation="Fix malformed lines or regenerate .envrc.dopemux-mcp.",
+            )
     elif not envrc.present:
         # Severity depends on whether mcp.json expects env-derived ports
         mcp_needs_env = False
@@ -303,7 +315,7 @@ def run_mcp_doctor(
             port = safe_port_int(doctor_env, str(key))
             if port is not None:
                 configured_ports[str(key)] = port
-            elif envrc.present and envrc.parse_status == "OK":
+            elif envrc.present and envrc.parse_status in {"OK", "PARTIAL"}:
                 _add(
                     findings,
                     "PORT_UNSET",

--- a/src/dopemux/mcp/doctor.py
+++ b/src/dopemux/mcp/doctor.py
@@ -380,19 +380,168 @@ def run_mcp_doctor(
                 ),
             )
 
-    # --- Port diagnostics ---
+    # --- Port diagnostics + lease registry ---
     worktree_for_ports = identity.worktree_root or str(repo_path)
     project_root_for_ports = identity.project_root
+
+    lease_registry_present = False
+    lease_allocator_healthy = False
+    try:
+        from .port_leases import PortLeaseRegistry
+
+        lease_reg = PortLeaseRegistry.load()
+        if lease_reg.parse_status == "ERROR":
+            _add(
+                findings,
+                "LEASE_REGISTRY_PARSE_ERROR",
+                "FAIL",
+                f"Lease registry unreadable: {lease_reg.error}",
+                evidence=[str(lease_reg.path)],
+                recommendation="Inspect ~/.dopemux/mcp/runtime/port-leases.json or set DOPEMUX_MCP_PORT_LEASE_REGISTRY.",
+            )
+        elif lease_reg.parse_status == "MISSING":
+            _add(
+                findings,
+                "LEASE_REGISTRY_MISSING",
+                "WARN",
+                f"No lease registry at {lease_reg.path}",
+                evidence=[str(lease_reg.path)],
+                recommendation="Run `dopemux mcp init` or `dopemux mcp repair-config --apply` to create leases.",
+            )
+            if envrc.present and configured_ports:
+                _add(
+                    findings,
+                    "LEGACY_ENVRC_WITHOUT_LEASE",
+                    "WARN",
+                    "Envrc ports present without lease registry entries",
+                    recommendation="Run `dopemux mcp repair-config --apply` to migrate ports into leases.",
+                )
+        else:
+            lease_registry_present = True
+            _add(
+                findings,
+                "LEASE_REGISTRY_FOUND",
+                "INFO",
+                f"Lease registry OK ({len(lease_reg.active_leases())} active)",
+                evidence=[str(lease_reg.path)],
+            )
+            # Envrc vs lease mismatch
+            for var, port in (configured_ports or {}).items():
+                matched = False
+                foreign = False
+                for L in lease_reg.active_leases():
+                    if int(L.get("port") or 0) != int(port):
+                        continue
+                    if L.get("worktree_root") in {worktree_for_ports, str(repo_path)} or (
+                        L.get("worktree_hash") and L.get("worktree_hash") == identity.worktree_hash
+                    ):
+                        matched = True
+                    else:
+                        foreign = True
+                if foreign and not matched:
+                    _add(
+                        findings,
+                        "LEASE_BELONGS_TO_OTHER_PROJECT",
+                        "FAIL",
+                        f"Envrc {var}={port} is leased to another project/worktree",
+                        evidence=[f"{var}={port}"],
+                        recommendation="Run `dopemux mcp repair-config --apply` to rebind.",
+                    )
+                elif not matched:
+                    # no lease for this envrc port
+                    ours = [
+                        L
+                        for L in lease_reg.active_leases()
+                        if L.get("port_var") == var
+                        and (
+                            L.get("worktree_root") in {worktree_for_ports, str(repo_path)}
+                            or L.get("worktree_hash") == identity.worktree_hash
+                        )
+                    ]
+                    if ours and int(ours[0].get("port") or 0) != int(port):
+                        _add(
+                            findings,
+                            "LEASE_ENVRC_MISMATCH",
+                            "FAIL",
+                            f"Envrc {var}={port} != lease {ours[0].get('port')}",
+                            evidence=[f"envrc={port}", f"lease={ours[0].get('port')}"],
+                            recommendation="Run `dopemux mcp repair-config --apply`.",
+                        )
+                    elif not ours:
+                        _add(
+                            findings,
+                            "LEGACY_ENVRC_WITHOUT_LEASE",
+                            "WARN",
+                            f"Envrc {var}={port} has no active lease for this worktree",
+                            recommendation="Run `dopemux mcp repair-config --apply`.",
+                        )
+                else:
+                    lease_allocator_healthy = True
+                    if not is_free(int(port)):
+                        _add(
+                            findings,
+                            "LEASE_PORT_OCCUPIED",
+                            "INFO",
+                            f"Leased port {port} ({var}) is listening (expected if services are up)",
+                            evidence=[f"{var}={port}"],
+                        )
+                    else:
+                        _add(
+                            findings,
+                            "LEASE_PORT_FREE",
+                            "INFO",
+                            f"Leased port {port} ({var}) is free (services may be stopped)",
+                            evidence=[f"{var}={port}"],
+                        )
+            # Stale leases for this worktree (active but free + no configured use)
+            for L in lease_reg.active_leases():
+                if L.get("worktree_root") not in {worktree_for_ports, str(repo_path)}:
+                    continue
+                lp = int(L.get("port") or 0)
+                if not lp:
+                    continue
+                if is_free(lp) and (
+                    not configured_ports
+                    or L.get("port_var") not in configured_ports
+                    or configured_ports.get(str(L.get("port_var"))) != lp
+                ):
+                    # only mark stale-ish when no envrc owns it
+                    if not configured_ports or str(L.get("port_var")) not in configured_ports:
+                        _add(
+                            findings,
+                            "LEASE_STALE",
+                            "WARN",
+                            f"Active lease {L.get('lease_id')} port {lp} looks unused",
+                            service=L.get("service"),
+                            evidence=[str(L.get("lease_id")), f"port={lp}"],
+                            recommendation="Explicit prune is not auto-run; re-init/repair if needed.",
+                        )
+    except Exception as exc:  # noqa: BLE001 — doctor remains best-effort
+        unknowns.append(f"lease registry inspection failed: {exc}")
+
     port_report = pd.diagnose_ports(
         worktree_for_ports,
         service_names,
         catalog,
         project_root=project_root_for_ports,
         configured_ports=configured_ports or None,
-        has_lease_registry=False,
-        has_live_rebind=False,
+        has_lease_registry=lease_registry_present,
+        has_live_rebind=lease_allocator_healthy or lease_registry_present,
     )
     for fdict in port_report.findings:
+        # Downgrade legacy hash bucket noise when lease allocator is active
+        code = fdict.get("code") or ""
+        sev = fdict.get("severity") or "INFO"
+        if lease_registry_present and code in {
+            "PORT_HASH_BUCKET_COLLISION_RISK",
+            "PORT_REBIND_MISSING",
+        }:
+            sev = "INFO"
+            fdict = dict(fdict)
+            fdict["message"] = (
+                f"{fdict.get('message', '')} (lease allocator active — preferred formula only)"
+            )
+            fdict["severity"] = sev
         findings.append(
             Finding(
                 code=fdict["code"],

--- a/src/dopemux/mcp/envrc.py
+++ b/src/dopemux/mcp/envrc.py
@@ -50,7 +50,7 @@ class EnvrcParseResult:
 
     path: Optional[Path]
     present: bool
-    parse_status: str  # OK | ERROR | MISSING
+    parse_status: str  # OK | PARTIAL | ERROR | MISSING
     values: Dict[str, str] = field(default_factory=dict)
     keys_present: List[str] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
@@ -206,7 +206,7 @@ def merge_envrc_into_environ(
 ) -> Dict[str, str]:
     """Return a new env mapping with envrc values applied (envrc wins when override=True)."""
     merged = dict(base or {})
-    if envrc.parse_status in {"OK", "ERROR"} and envrc.values:
+    if envrc.parse_status in {"OK", "PARTIAL", "ERROR"} and envrc.values:
         for key, value in envrc.values.items():
             if override or key not in merged:
                 merged[key] = value

--- a/src/dopemux/mcp/fleet.py
+++ b/src/dopemux/mcp/fleet.py
@@ -1,0 +1,412 @@
+"""Fleet/worktree MCP config helpers (Packet 003).
+
+``fleet init`` plans/applies local config across worktrees.
+``fleet doctor`` aggregates Packet 001 doctor reports.
+Neither mutates globals nor starts/stops containers.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from .config_repair import RepairPlan, apply_repair, plan_repair
+from .project_identity import ProjectIdentityError, resolve_project_identity
+
+SCHEMA_VERSION = "1.0"
+
+
+def _status_rank(status: str) -> int:
+    order = {
+        "PASS": 0,
+        "PASS_WITH_WARNINGS": 1,
+        "NOOP": 0,
+        "PLANNED": 1,
+        "APPLIED": 0,
+        "FAIL": 2,
+        "BLOCKED": 2,
+        "UNKNOWN": 3,
+    }
+    return order.get(status, 3)
+
+
+def _worst_status(statuses: Sequence[str]) -> str:
+    if not statuses:
+        return "UNKNOWN"
+    return max(statuses, key=_status_rank)
+
+
+def _paths_same_project(project_root: Path, worktree: Path) -> tuple[bool, str]:
+    """Return (ok, reason) whether worktree belongs to project_root."""
+    try:
+        project_root = project_root.expanduser().resolve()
+        worktree = worktree.expanduser().resolve()
+    except OSError as exc:
+        return False, f"path resolve failed: {exc}"
+
+    if not worktree.is_dir():
+        return False, "worktree path is not a directory"
+    if not project_root.is_dir():
+        return False, "project root is not a directory"
+
+    try:
+        identity = resolve_project_identity(
+            cwd=worktree,
+            env={"DOPEMUX_WORKSPACE_ROOT": str(worktree)},
+        )
+    except ProjectIdentityError as exc:
+        return False, f"identity resolution failed: {exc}"
+
+    try:
+        id_project = identity.project_root.resolve()
+        expected = project_root.resolve()
+    except OSError as exc:
+        return False, f"project root resolve failed: {exc}"
+
+    if id_project != expected:
+        # Also accept when worktree IS the project root itself
+        if worktree.resolve() == expected:
+            return True, "worktree is project root"
+        return (
+            False,
+            f"worktree project_root={id_project} does not match --repo {expected}",
+        )
+    return True, "FLEET_WORKTREE_VALID"
+
+
+@dataclass
+class FleetWorktreeResult:
+    path: str
+    status: str
+    code: str
+    message: str
+    repair: Optional[Dict[str, Any]] = None
+    top_findings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        out: Dict[str, Any] = {
+            "path": self.path,
+            "status": self.status,
+            "code": self.code,
+            "message": self.message,
+            "top_findings": list(self.top_findings),
+        }
+        if self.repair is not None:
+            out["repair"] = self.repair
+        return out
+
+
+@dataclass
+class FleetInitReport:
+    schema_version: str = SCHEMA_VERSION
+    operation: str = "fleet-init"
+    dry_run: bool = True
+    status: str = "UNKNOWN"
+    project_root: str = ""
+    worktrees: List[FleetWorktreeResult] = field(default_factory=list)
+    counts: Dict[str, int] = field(default_factory=dict)
+    next_actions: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "operation": self.operation,
+            "dry_run": self.dry_run,
+            "status": self.status,
+            "project_root": self.project_root,
+            "worktrees": [w.to_dict() for w in self.worktrees],
+            "counts": dict(self.counts),
+            "next_actions": list(self.next_actions),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2) + "\n"
+
+
+@dataclass
+class FleetDoctorReport:
+    schema_version: str = SCHEMA_VERSION
+    operation: str = "fleet-doctor"
+    status: str = "UNKNOWN"
+    project_root: str = ""
+    worktrees: List[Dict[str, Any]] = field(default_factory=list)
+    counts: Dict[str, int] = field(default_factory=dict)
+    next_actions: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "operation": self.operation,
+            "status": self.status,
+            "project_root": self.project_root,
+            "worktrees": list(self.worktrees),
+            "counts": dict(self.counts),
+            "next_actions": list(self.next_actions),
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2) + "\n"
+
+
+def fleet_init(
+    project_root: Path | str,
+    worktrees: Sequence[Path | str],
+    catalog: Mapping[str, Any],
+    *,
+    dry_run: bool = True,
+    apply: bool = False,
+    catalog_paths: Optional[Sequence[str]] = None,
+    **plan_kwargs: Any,
+) -> FleetInitReport:
+    """Plan or apply config repair across worktrees. Never starts containers."""
+    if dry_run and apply:
+        # Prefer dry-run semantics when both set; callers should prevent this.
+        apply = False
+    if not dry_run and not apply:
+        dry_run = True
+
+    root = Path(project_root).expanduser().resolve()
+    report = FleetInitReport(
+        dry_run=dry_run and not apply,
+        project_root=str(root),
+        counts={
+            "initialized": 0,
+            "already_valid": 0,
+            "repaired": 0,
+            "skipped": 0,
+            "failed": 0,
+            "unknown": 0,
+        },
+        next_actions=[
+            "dopemux mcp fleet doctor --repo <project> --worktrees <paths> --json",
+            "dopemux mcp start --repo <worktree>",
+        ],
+    )
+
+    statuses: List[str] = []
+    for raw in worktrees:
+        wt_path = Path(raw).expanduser()
+        try:
+            wt_path = wt_path.resolve()
+        except OSError:
+            result = FleetWorktreeResult(
+                path=str(raw),
+                status="FAIL",
+                code="FLEET_WORKTREE_INVALID",
+                message="path does not resolve",
+            )
+            report.worktrees.append(result)
+            report.counts["failed"] += 1
+            statuses.append("FAIL")
+            continue
+
+        ok, reason = _paths_same_project(root, wt_path)
+        if not ok:
+            result = FleetWorktreeResult(
+                path=str(wt_path),
+                status="FAIL",
+                code="FLEET_WORKTREE_INVALID",
+                message=reason,
+            )
+            report.worktrees.append(result)
+            report.counts["failed"] += 1
+            statuses.append("FAIL")
+            continue
+
+        try:
+            plan: RepairPlan = plan_repair(
+                wt_path,
+                catalog,
+                dry_run=not apply,
+                catalog_paths=catalog_paths,
+                **plan_kwargs,
+            )
+            if apply and plan.status != "BLOCKED":
+                plan.dry_run = False
+                plan = apply_repair(plan)
+        except Exception as exc:  # noqa: BLE001 — surface as failed worktree
+            result = FleetWorktreeResult(
+                path=str(wt_path),
+                status="UNKNOWN",
+                code="FLEET_WORKTREE_UNKNOWN",
+                message=str(exc),
+            )
+            report.worktrees.append(result)
+            report.counts["unknown"] += 1
+            statuses.append("UNKNOWN")
+            continue
+
+        if plan.status == "BLOCKED":
+            code = "FLEET_WORKTREE_SKIPPED"
+            bucket = "skipped"
+            st = "FAIL"
+        elif plan.status == "NOOP":
+            code = "FLEET_WORKTREE_VALID"
+            bucket = "already_valid"
+            st = "PASS"
+        elif plan.status == "APPLIED":
+            code = "FLEET_WORKTREE_REPAIRED"
+            bucket = "repaired"
+            st = "PASS"
+        elif plan.status == "PLANNED":
+            # dry-run planned repair counts as initialized (would init/repair)
+            code = "FLEET_WORKTREE_REPAIRED"
+            bucket = "initialized" if any(
+                c.get("reason") in {"MISSING_MCP_JSON", "ENVRC_REGENERATED"}
+                for c in plan.planned_changes
+            ) else "repaired"
+            st = "PASS_WITH_WARNINGS"
+        else:
+            code = "FLEET_WORKTREE_UNKNOWN"
+            bucket = "unknown"
+            st = "UNKNOWN"
+
+        report.counts[bucket] = report.counts.get(bucket, 0) + 1
+        statuses.append(st)
+        report.worktrees.append(
+            FleetWorktreeResult(
+                path=str(wt_path),
+                status=st,
+                code=code,
+                message=reason,
+                repair=plan.to_dict(),
+                top_findings=[c.get("reason") or "" for c in plan.planned_changes[:3]],
+            )
+        )
+
+    report.status = _worst_status(statuses)
+    return report
+
+
+def fleet_doctor(
+    project_root: Path | str,
+    worktrees: Sequence[Path | str],
+    catalog: Mapping[str, Any],
+    *,
+    catalog_paths: Optional[Sequence[str]] = None,
+    skip_docker: bool = True,
+    process_env: Optional[Mapping[str, str]] = None,
+    run_doctor_fn: Any = None,
+) -> FleetDoctorReport:
+    """Run repo-aware doctor for each worktree and aggregate."""
+    root = Path(project_root).expanduser().resolve()
+    report = FleetDoctorReport(
+        project_root=str(root),
+        counts={"pass": 0, "warn": 0, "fail": 0, "unknown": 0},
+        next_actions=[],
+    )
+
+    if run_doctor_fn is None:
+        from .doctor import run_mcp_doctor
+
+        run_doctor_fn = run_mcp_doctor
+
+    statuses: List[str] = []
+    for raw in worktrees:
+        wt_path = Path(raw).expanduser()
+        try:
+            wt_path = wt_path.resolve()
+        except OSError:
+            report.worktrees.append(
+                {
+                    "path": str(raw),
+                    "status": "UNKNOWN",
+                    "top_findings": ["PATH_UNRESOLVABLE"],
+                }
+            )
+            report.counts["unknown"] += 1
+            statuses.append("UNKNOWN")
+            continue
+
+        ok, reason = _paths_same_project(root, wt_path)
+        if not ok:
+            report.worktrees.append(
+                {
+                    "path": str(wt_path),
+                    "status": "FAIL",
+                    "top_findings": ["FLEET_WORKTREE_INVALID", reason],
+                }
+            )
+            report.counts["fail"] += 1
+            statuses.append("FAIL")
+            continue
+
+        try:
+            dr = run_doctor_fn(
+                str(wt_path),
+                catalog=catalog,
+                catalog_paths_checked=list(catalog_paths or []),
+                compose_path=None,
+                skip_docker=skip_docker,
+                process_env=dict(process_env or {}),
+            )
+            status = getattr(dr, "status", None) or (
+                dr.get("status") if isinstance(dr, dict) else "UNKNOWN"
+            )
+            findings = []
+            raw_findings = getattr(dr, "findings", None)
+            if raw_findings is None and isinstance(dr, dict):
+                raw_findings = dr.get("findings") or []
+            for f in list(raw_findings or [])[:3]:
+                if hasattr(f, "code"):
+                    findings.append(str(f.code))
+                elif isinstance(f, dict):
+                    findings.append(str(f.get("code") or f.get("id") or "FINDING"))
+                else:
+                    findings.append(str(f))
+        except Exception as exc:  # noqa: BLE001
+            status = "UNKNOWN"
+            findings = [f"DOCTOR_ERROR:{exc}"]
+
+        status_s = str(status)
+        if status_s == "PASS":
+            report.counts["pass"] += 1
+        elif status_s == "PASS_WITH_WARNINGS":
+            report.counts["warn"] += 1
+        elif status_s == "FAIL":
+            report.counts["fail"] += 1
+        else:
+            report.counts["unknown"] += 1
+        statuses.append(status_s)
+        report.worktrees.append(
+            {
+                "path": str(wt_path),
+                "status": status_s,
+                "top_findings": findings,
+            }
+        )
+
+    report.status = _worst_status(statuses)
+    if report.counts.get("fail") or report.counts.get("unknown"):
+        report.next_actions = [
+            "dopemux mcp repair-config --repo <failing-worktree> --dry-run --json",
+            "dopemux mcp repair-config --repo <failing-worktree> --apply",
+            "dopemux mcp start --repo <failing-worktree>",
+        ]
+    return report
+
+
+def format_fleet_init_human(report: FleetInitReport) -> str:
+    lines = [
+        f"fleet init {report.status}  dry_run={report.dry_run}",
+        f"project: {report.project_root}",
+        f"counts: {report.counts}",
+    ]
+    for wt in report.worktrees[:20]:
+        lines.append(f"  • {wt.path}: {wt.status} [{wt.code}] {wt.message}")
+    return "\n".join(lines) + "\n"
+
+
+def format_fleet_doctor_human(report: FleetDoctorReport, *, max_findings: int = 3) -> str:
+    lines = [
+        f"fleet doctor {report.status}",
+        f"project: {report.project_root}",
+        f"counts: pass={report.counts.get('pass', 0)} warn={report.counts.get('warn', 0)} "
+        f"fail={report.counts.get('fail', 0)} unknown={report.counts.get('unknown', 0)}",
+    ]
+    for wt in report.worktrees:
+        tops = ", ".join((wt.get("top_findings") or [])[:max_findings]) or "(none)"
+        lines.append(f"  • {wt.get('path')}: {wt.get('status')} — {tops}")
+    return "\n".join(lines) + "\n"

--- a/src/dopemux/mcp/instance_overlay.py
+++ b/src/dopemux/mcp/instance_overlay.py
@@ -1,42 +1,68 @@
+"""Instance-scoped env/compose overlays with unified port allocation.
+
+Historically used a letter/md5 base port map independent of ``mcp init``.
+Packet 004 routes catalog-aligned ports through the lease allocator when a
+catalog is available, keeping overlay generation consistent with init/repair.
+"""
+
+from __future__ import annotations
+
 import json
 import logging
 import re
-import os
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Mapping, Optional
 
 logger = logging.getLogger(__name__)
+
 
 class InstanceOverlayManager:
     """
     Generates instance-scoped env and compose overlays.
-    Handles deterministic port allocation.
+    Port assignment prefers the lease allocator (Packet 004).
     """
+
+    # Legacy offsets retained only as fallback when catalog/allocator unavailable
     PORT_OFFSETS = {
         "ConPort": 4,
         "Serena": 6,
         "Dope-Context": 10,
         "Dope-Memory": 20,
-        "LiteLLM": 1000 
+        "LiteLLM": 1000,
     }
 
-    def __init__(self, project_root: Path, instance_id: str):
-        self.project_root = project_root
-        self.instance_id = instance_id
-        self.instance_dir = self.project_root / ".dopemux" / "instances" / instance_id
+    def __init__(
+        self,
+        project_root: Path,
+        instance_id: str,
+        *,
+        catalog: Optional[Mapping[str, Any]] = None,
+        worktree: Optional[str | Path] = None,
+        persist_leases: bool = False,
+    ):
+        self.project_root = Path(project_root)
+        self.instance_id = instance_id or ""
+        self.instance_dir = self.project_root / ".dopemux" / "instances" / (instance_id or "A")
+        self.catalog = catalog
+        self.worktree = str(Path(worktree or project_root).resolve())
+        self.persist_leases = persist_leases
         self.base_port = self._calculate_base_port()
         self.port_map = self._generate_port_map()
+        self.env_ports: Dict[str, int] = {}
+        self._allocator_used = False
+        self._try_lease_allocator()
 
     def _calculate_base_port(self) -> int:
         if not self.instance_id:
             return 3000
-        
+
         first_char = self.instance_id[0].upper()
-        if 'A' <= first_char <= 'Z':
-            offset = ord(first_char) - ord('A')
+        if "A" <= first_char <= "Z":
+            offset = ord(first_char) - ord("A")
             return 3000 + (offset * 100)
-        
+
         import hashlib
+
         h = hashlib.md5(self.instance_id.encode()).hexdigest()
         offset = int(h[:2], 16) % 30
         return 3000 + (offset * 100)
@@ -47,99 +73,168 @@ class InstanceOverlayManager:
             ports[name] = self.base_port + offset
         return ports
 
+    def _try_lease_allocator(self) -> None:
+        """Prefer lease allocator for catalog per-worktree services."""
+        catalog = self.catalog
+        if catalog is None:
+            try:
+                from dopemux.commands.mcp_commands import _load_catalog
+
+                catalog = _load_catalog()
+            except Exception:  # noqa: BLE001
+                return
+        try:
+            from dopemux.mcp.port_allocator import allocate_ports_map
+
+            names = list((catalog.get("defaults") or {}).get("per_worktree") or [])
+            if not names:
+                return
+            ports = allocate_ports_map(
+                self.worktree,
+                names,
+                catalog,
+                project_root=str(self.project_root),
+                persist=self.persist_leases,
+                dry_run=not self.persist_leases,
+                source="InstanceOverlayManager",
+            )
+            self.env_ports = dict(ports)
+            # Map into legacy port_map keys used by compose overlay writers
+            if "CONPORT_HTTP_PORT" in ports:
+                self.port_map["ConPort"] = ports["CONPORT_HTTP_PORT"]
+            if "DOPE_MEMORY_PORT" in ports:
+                self.port_map["Dope-Memory"] = ports["DOPE_MEMORY_PORT"]
+            self._allocator_used = True
+            logger.info(
+                "InstanceOverlayManager using lease allocator ports for %s",
+                self.worktree,
+            )
+        except Exception as exc:  # noqa: BLE001 — fall back to legacy map
+            logger.warning(
+                "InstanceOverlayManager lease allocator unavailable (%s); using legacy map",
+                exc,
+            )
+
     def materialize(self) -> Dict[str, Any]:
         """Generates the overlay files in .dopemux/instances/<id>/"""
         self.instance_dir.mkdir(parents=True, exist_ok=True)
-        
+
         env_path = self.write_mcp_env()
         compose_path = self.write_compose_override()
-        
-        # Save port map for reports
+
         with open(self.instance_dir / "PORT_MAP.json", "w") as f:
-            json.dump(self.port_map, f, indent=2)
+            json.dump(
+                {
+                    "port_map": self.port_map,
+                    "env_ports": self.env_ports,
+                    "allocator_used": self._allocator_used,
+                    "base_port": self.base_port,
+                },
+                f,
+                indent=2,
+            )
 
         return {
             "instance_dir": str(self.instance_dir),
             "env_path": str(env_path),
             "compose_path": str(compose_path),
             "port_map": self.port_map,
+            "env_ports": self.env_ports,
+            "allocator_used": self._allocator_used,
             "base_port": self.base_port,
-            "compose_project_name": self.get_compose_project_name()
+            "compose_project_name": self.get_compose_project_name(),
         }
 
     def get_compose_project_name(self) -> str:
         project_id = self.project_root.name
         name = f"dopemux_{project_id}_{self.instance_id}".lower()
-        # Sanitize for Docker Compose
-        return re.sub(r'[^a-z0-9_-]', '_', name)
+        return re.sub(r"[^a-z0-9_-]", "_", name)
 
     def write_mcp_env(self) -> Path:
         env_path = self.instance_dir / "mcp.env"
-        
-        # Safely get ports
-        def get_p(name): return self.port_map.get(name, 0)
+
+        def get_p(name: str) -> int:
+            return int(self.port_map.get(name, 0))
+
+        # Prefer lease env_ports when present
+        conport_http = self.env_ports.get("CONPORT_HTTP_PORT", get_p("ConPort"))
+        conport_mcp = self.env_ports.get("CONPORT_MCP_PORT", get_p("ConPort") + 1)
+        conport_info = self.env_ports.get("CONPORT_INFO_PORT", get_p("ConPort") + 1000)
+        dope_memory = self.env_ports.get("DOPE_MEMORY_PORT", get_p("Dope-Memory"))
 
         lines = [
             f"# Generated for instance: {self.instance_id}",
+            f"# allocator_used={self._allocator_used}",
             f"COMPOSE_PROJECT_NAME={self.get_compose_project_name()}",
             "COMPOSE_FILE=compose.yml",
             f"DOPEMUX_INSTANCE_ID={self.instance_id}",
             f"CONPORT_CONTAINER_NAME={'mcp-conport' if not self.instance_id or self.instance_id == 'A' else f'mcp-conport_{self.instance_id}'}",
             f"SERENA_CONTAINER_NAME={'dopemux-mcp-serena' if not self.instance_id or self.instance_id == 'A' else f'dopemux-mcp-serena_{self.instance_id}'}",
-            f"CONPORT_HTTP_PORT={get_p('ConPort')}",
-            f"CONPORT_MCP_PORT={get_p('ConPort') + 1}",
-            f"CONPORT_INFO_PORT={get_p('ConPort') + 1000}",
+            f"CONPORT_HTTP_PORT={conport_http}",
+            f"CONPORT_MCP_PORT={conport_mcp}",
+            f"CONPORT_INFO_PORT={conport_info}",
             f"SERENA_PORT={get_p('Serena')}",
             f"SERENA_HTTP_PORT={get_p('Serena') + 1000}",
             f"DOPE_CONTEXT_PORT={get_p('Dope-Context')}",
-            f"DOPE_MEMORY_PORT={get_p('Dope-Memory')}",
+            f"DOPE_MEMORY_PORT={dope_memory}",
             f"PAL_PORT={self.base_port + 3}",
             f"EXA_PORT={self.base_port + 11}",
             f"DESKTOP_COMMANDER_PORT={self.base_port + 12}",
             f"LEANTIME_BRIDGE_PORT={self.base_port + 15}",
             f"GPT_RESEARCHER_PORT={self.base_port + 9}",
-            f"DOPEMUX_CONPORT_PORT={get_p('ConPort')}",
+            f"DOPEMUX_CONPORT_PORT={conport_http}",
             f"DOPEMUX_SERENA_PORT={get_p('Serena')}",
             f"DOPEMUX_CONTEXT_PORT={get_p('Dope-Context')}",
-            f"DOPEMUX_MEMORY_PORT={get_p('Dope-Memory')}",
+            f"DOPEMUX_MEMORY_PORT={dope_memory}",
             f"DOPEMUX_LITELLM_PORT={get_p('LiteLLM')}",
         ]
-        
+        if "TASK_ORCHESTRATOR_HTTP_PORT" in self.env_ports:
+            lines.append(
+                f"TASK_ORCHESTRATOR_HTTP_PORT={self.env_ports['TASK_ORCHESTRATOR_HTTP_PORT']}"
+            )
+
         with open(env_path, "w") as f:
             f.write("\n".join(lines) + "\n")
         return env_path
 
     def write_compose_override(self) -> Path:
         compose_path = self.instance_dir / "mcp.compose.override.yml"
-        
-        # Helper to generate service override only if port exists
+
         services = []
-        if "ConPort" in self.port_map:
+        if "ConPort" in self.port_map or "CONPORT_HTTP_PORT" in self.env_ports:
+            http = self.env_ports.get("CONPORT_HTTP_PORT", self.port_map.get("ConPort", 0))
+            mcp = self.env_ports.get("CONPORT_MCP_PORT", http + 1)
+            info = self.env_ports.get("CONPORT_INFO_PORT", http + 1000)
             services.append(
                 "  conport:\n"
                 f"    container_name: {'mcp-conport' if not self.instance_id or self.instance_id == 'A' else f'mcp-conport_{self.instance_id}'}\n"
                 "    ports:\n"
-                f"      - \"{self.port_map['ConPort']}:3004\"\n"
-                f"      - \"{self.port_map['ConPort'] + 1}:3005\"\n"
-                f"      - \"{self.port_map['ConPort'] + 1000}:4004\""
+                f'      - "{http}:3004"\n'
+                f'      - "{mcp}:3005"\n'
+                f'      - "{info}:4004"'
             )
         if "Serena" in self.port_map:
             services.append(
                 "  serena:\n"
                 f"    container_name: {'dopemux-mcp-serena' if not self.instance_id or self.instance_id == 'A' else f'dopemux-mcp-serena_{self.instance_id}'}\n"
                 "    ports:\n"
-                f"      - \"{self.port_map['Serena']}:3006\"\n"
-                f"      - \"{self.port_map['Serena'] + 1000}:4006\""
+                f'      - "{self.port_map["Serena"]}:3006"\n'
+                f'      - "{self.port_map["Serena"] + 1000}:4006"'
             )
         if "Dope-Context" in self.port_map:
-            services.append(f"  dope-context:\n    ports:\n      - \"{self.port_map['Dope-Context']}:3010\"")
-        if "Dope-Memory" in self.port_map:
-            services.append(f"  dope-memory:\n    ports:\n      - \"{self.port_map['Dope-Memory']}:3020\"")
+            services.append(
+                f"  dope-context:\n    ports:\n      - \"{self.port_map['Dope-Context']}:3010\""
+            )
+        mem = self.env_ports.get("DOPE_MEMORY_PORT", self.port_map.get("Dope-Memory"))
+        if mem:
+            services.append(f'  dope-memory:\n    ports:\n      - "{mem}:3020"')
         if "LiteLLM" in self.port_map:
-            services.append(f"  litellm:\n    ports:\n      - \"{self.port_map['LiteLLM']}:4000\"")
+            services.append(
+                f"  litellm:\n    ports:\n      - \"{self.port_map['LiteLLM']}:4000\""
+            )
 
         content = "services:\n" + "\n".join(services)
-        
+
         with open(compose_path, "w") as f:
             f.write(content)
         return compose_path

--- a/src/dopemux/mcp/instance_overlay.py
+++ b/src/dopemux/mcp/instance_overlay.py
@@ -109,7 +109,11 @@ class InstanceOverlayManager:
                 "InstanceOverlayManager using lease allocator ports for %s",
                 self.worktree,
             )
-        except Exception as exc:  # noqa: BLE001 — fall back to legacy map
+        except RuntimeError:
+            # Allocation BLOCKED (collision / occupied fixed port / etc.) —
+            # do not fall back to the unsafe legacy map; surface the failure.
+            raise
+        except Exception as exc:  # noqa: BLE001 — unexpected errors fall back
             logger.warning(
                 "InstanceOverlayManager lease allocator unavailable (%s); using legacy map",
                 exc,

--- a/src/dopemux/mcp/lease_migration.py
+++ b/src/dopemux/mcp/lease_migration.py
@@ -10,7 +10,6 @@ from .port_allocator import (
     AllocatorIdentity,
     allocate_ports,
     instance_id_for_path,
-    preferred_port_for_path,
 )
 from .port_leases import PortLeaseRegistry, default_lease_registry_path
 

--- a/src/dopemux/mcp/lease_migration.py
+++ b/src/dopemux/mcp/lease_migration.py
@@ -1,0 +1,112 @@
+"""Migrate legacy hash-only envrc ports into the lease registry when safe."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from .envrc import load_envrc, safe_port_int
+from .port_allocator import (
+    AllocatorIdentity,
+    allocate_ports,
+    instance_id_for_path,
+    preferred_port_for_path,
+)
+from .port_leases import PortLeaseRegistry, default_lease_registry_path
+
+
+def migrate_envrc_to_leases(
+    repo: Path | str,
+    catalog: Mapping[str, Any],
+    *,
+    service_names: Optional[Sequence[str]] = None,
+    project_root: Optional[str] = None,
+    registry_path: Optional[Path] = None,
+    persist: bool = True,
+    dry_run: bool = False,
+    is_free_fn=None,
+) -> Dict[str, Any]:
+    """Import envrc ports as preferred values and acquire leases.
+
+    Returns a report dict with status, ports, warnings, rebinds.
+    """
+    repo_path = Path(repo).expanduser().resolve()
+    envrc = load_envrc(repo_path / ".envrc.dopemux-mcp")
+    env_values = dict(envrc.values) if envrc.present else {}
+
+    names = list(
+        service_names
+        or (catalog.get("defaults") or {}).get("per_worktree")
+        or []
+    )
+    proj = str(Path(project_root or repo_path).expanduser().resolve())
+    wt = str(repo_path)
+    wt_hash = instance_id_for_path(wt)
+
+    identity = AllocatorIdentity(
+        project_id=Path(proj).name,
+        workspace_id=env_values.get("DOPEMUX_WORKSPACE_ID") or wt,
+        project_root=proj,
+        worktree_root=wt,
+        project_hash=None,
+        worktree_hash=env_values.get("DOPEMUX_INSTANCE_ID") or wt_hash,
+        instance_id=env_values.get("DOPEMUX_INSTANCE_ID") or wt_hash,
+    )
+
+    warnings: List[Dict[str, Any]] = []
+    if not envrc.present:
+        warnings.append(
+            {
+                "code": "LEGACY_ENVRC_WITHOUT_LEASE",
+                "message": "No .envrc.dopemux-mcp; allocator will create fresh leases.",
+            }
+        )
+    else:
+        warnings.append(
+            {
+                "code": "LEGACY_HASH_ALLOCATOR_MIGRATED",
+                "message": "Migrating envrc ports through lease allocator.",
+            }
+        )
+
+    result = allocate_ports(
+        names,
+        catalog,
+        worktree=wt,
+        project_root=proj,
+        identity=identity,
+        existing_envrc=env_values,
+        registry_path=registry_path or default_lease_registry_path(),
+        persist=persist and not dry_run,
+        dry_run=dry_run,
+        source="dopemux mcp migration",
+        is_free_fn=is_free_fn,
+    )
+    report = result.to_dict()
+    report["warnings"] = warnings + list(result.warnings)
+    report["envrc_present"] = envrc.present
+    report["legacy_ports"] = {
+        k: safe_port_int(env_values, k)
+        for k in env_values
+        if k.endswith("_PORT") or k.endswith("_PORTS")
+    }
+    return report
+
+
+def formula_preferred_ports(
+    worktree: str,
+    service_names: Sequence[str],
+    catalog: Mapping[str, Any],
+    *,
+    project_root: Optional[str] = None,
+) -> Dict[str, int]:
+    """Compute pure preferred formula ports (no lease, no rebind)."""
+    from .port_allocator import build_role_requests
+
+    reqs = build_role_requests(
+        service_names,
+        catalog,
+        worktree=worktree,
+        project_root=project_root,
+    )
+    return {r.port_var: int(r.preferred or r.base) for r in reqs}

--- a/src/dopemux/mcp/lifecycle.py
+++ b/src/dopemux/mcp/lifecycle.py
@@ -6,6 +6,7 @@ Uses Packet 001 doctor for preflight. Never adopts unlabeled containers.
 from __future__ import annotations
 
 import json
+import re
 import socket
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -426,6 +427,18 @@ def run_lifecycle(
                 "service": None,
             }
         )
+    elif envrc.parse_status == "PARTIAL":
+        warnings.append(
+            {
+                "code": "ENVRC_PARTIAL_PARSE",
+                "severity": "WARN",
+                "message": (
+                    f"envrc partial parse: {len(envrc.values)} keys loaded, "
+                    f"{len(envrc.errors)} malformed line(s)"
+                ),
+                "service": None,
+            }
+        )
     if not mcp_json.get("present"):
         blocking.append(
             {
@@ -512,13 +525,19 @@ def run_lifecycle(
     container_names = {
         svc: dr.container_name_for(slug, worktree_hash, svc) for svc in selected
     }
-    # TO wrapper uses task-orchestrator-<state_id>; prefer project_hash short form
+    # Match wrapper scripts/mcp-wrappers/task-orchestrator-*-{stdio,http}:
+    # state_id = <project-slug>-<sha256(project_root)[:16]> (== ProjectIdentity.project_id)
+    # container_name = task-orchestrator-${state_id}
     if "task-orchestrator" in selected:
-        # Match wrapper: task-orchestrator-${workspace_id} where state_id is project hash-ish
-        # Use our deterministic name for managed lifecycle; note wrapper uses different name
-        container_names["task-orchestrator"] = (
-            f"task-orchestrator-{project_hash}" if project_hash else container_names["task-orchestrator"]
-        )
+        to_state_id = identity.project_id
+        if not to_state_id and project_hash:
+            # Fallback: identity-style slug (keeps . _ - like the wrapper), not docker slug.
+            to_slug = re.sub(
+                r"[^a-z0-9._-]+", "-", Path(project_root).name.lower()
+            ).strip("-") or "workspace"
+            to_state_id = f"{to_slug}-{project_hash}"
+        if to_state_id:
+            container_names["task-orchestrator"] = f"task-orchestrator-{to_state_id}"
 
     labels_by_service: Dict[str, Dict[str, str]] = {}
     for svc in selected:

--- a/src/dopemux/mcp/lifecycle.py
+++ b/src/dopemux/mcp/lifecycle.py
@@ -492,6 +492,84 @@ def run_lifecycle(
     compose_proj = dr.compose_project_name(slug, worktree_hash)
 
     ports = _extract_ports(doctor_env, selected, catalog)
+
+    # Lease registry consistency (start only — recommend repair-config on mismatch)
+    if op == "start":
+        try:
+            from .port_leases import PortLeaseRegistry
+
+            lease_reg = PortLeaseRegistry.load()
+            if lease_reg.parse_status == "ERROR":
+                blocking.append(
+                    {
+                        "code": "LEASE_REGISTRY_PARSE_ERROR",
+                        "severity": "FAIL",
+                        "message": f"Lease registry unreadable: {lease_reg.error}",
+                        "service": None,
+                    }
+                )
+            elif lease_reg.parse_status == "OK":
+                for var, port in ports.items():
+                    ours = [
+                        L
+                        for L in lease_reg.active_leases()
+                        if L.get("port_var") == var
+                        and (
+                            L.get("worktree_root") == (identity.worktree_root or str(target))
+                            or L.get("worktree_hash") == identity.worktree_hash
+                        )
+                    ]
+                    foreign = lease_reg.find_active_by_port(int(port))
+                    if foreign and not lease_reg.identity_matches(
+                        foreign,
+                        worktree_root=identity.worktree_root or str(target),
+                        project_root=identity.project_root,
+                        worktree_hash=identity.worktree_hash,
+                    ):
+                        blocking.append(
+                            {
+                                "code": "LEASE_BELONGS_TO_OTHER_PROJECT",
+                                "severity": "FAIL",
+                                "message": f"Port {port} ({var}) leased to another project",
+                                "service": None,
+                            }
+                        )
+                    elif ours and int(ours[0].get("port") or 0) != int(port):
+                        blocking.append(
+                            {
+                                "code": "LEASE_ENVRC_MISMATCH",
+                                "severity": "FAIL",
+                                "message": (
+                                    f"Envrc {var}={port} != lease {ours[0].get('port')}; "
+                                    "run `dopemux mcp repair-config --apply`"
+                                ),
+                                "service": None,
+                            }
+                        )
+                    elif not ours:
+                        warnings.append(
+                            {
+                                "code": "LEGACY_ENVRC_WITHOUT_LEASE",
+                                "severity": "WARN",
+                                "message": f"No lease for envrc {var}={port}",
+                                "service": None,
+                            }
+                        )
+                    else:
+                        # Port became occupied by non-lease holder after lease
+                        if not is_free(int(port)):
+                            # listening is OK if we will start/reuse — only block if foreign docker
+                            pass
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                {
+                    "code": "LEASE_UNKNOWN_OWNER",
+                    "severity": "WARN",
+                    "message": f"Lease check skipped: {exc}",
+                    "service": None,
+                }
+            )
+
     # Missing required ports for selected services
     for name in selected:
         spec = (catalog.get("servers") or {}).get(name) or {}

--- a/src/dopemux/mcp/mcp_json.py
+++ b/src/dopemux/mcp/mcp_json.py
@@ -1,0 +1,299 @@
+"""Safe .mcp.json load/merge helpers for config repair.
+
+Only catalog-owned per-worktree services may be modified. Unknown and custom
+entries are always preserved. Never mutates global (~/.claude.json) config.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+from urllib.parse import urlparse
+
+PROJECT_MCP_FILENAME = ".mcp.json"
+
+# Functional fields compared/repaired for catalog-owned HTTP/SSE entries.
+_FUNCTIONAL_KEYS = ("type", "url", "command", "args", "env")
+
+
+def is_catalog_owned(name: str, catalog: Mapping[str, Any]) -> bool:
+    """True when the service is a catalog per-worktree entry managed by init/repair."""
+    spec = (catalog.get("servers") or {}).get(name)
+    if not isinstance(spec, dict):
+        return False
+    if spec.get("scope") != "per-worktree":
+        return False
+    # Explicit external/manual markers (if present) are not rewritten.
+    if spec.get("management_model") in {"external", "manual"}:
+        return False
+    if spec.get("lifecycle") == "decision-required":
+        return False
+    return True
+
+
+def catalog_owned_names(catalog: Mapping[str, Any]) -> List[str]:
+    """Stable ordered list of catalog-owned per-worktree service names."""
+    names: List[str] = []
+    defaults = list((catalog.get("defaults") or {}).get("per_worktree") or [])
+    for name in defaults:
+        if is_catalog_owned(str(name), catalog) and name not in names:
+            names.append(str(name))
+    for name, spec in (catalog.get("servers") or {}).items():
+        if is_catalog_owned(str(name), catalog) and name not in names:
+            names.append(str(name))
+    return names
+
+
+def load_mcp_json_document(path: Path | str | None) -> Dict[str, Any]:
+    """Load .mcp.json for repair planning.
+
+    Returns keys: path, present, parse_status, servers, error, raw_document.
+    """
+    if path is None:
+        return {
+            "path": None,
+            "present": False,
+            "parse_status": "MISSING",
+            "servers": {},
+            "error": None,
+            "raw_document": {},
+        }
+    mcp_path = Path(path).expanduser()
+    if not mcp_path.exists():
+        return {
+            "path": str(mcp_path),
+            "present": False,
+            "parse_status": "MISSING",
+            "servers": {},
+            "error": None,
+            "raw_document": {},
+        }
+    try:
+        data = json.loads(mcp_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "path": str(mcp_path),
+            "present": True,
+            "parse_status": "ERROR",
+            "servers": {},
+            "error": str(exc),
+            "raw_document": {},
+        }
+    if not isinstance(data, dict):
+        return {
+            "path": str(mcp_path),
+            "present": True,
+            "parse_status": "ERROR",
+            "servers": {},
+            "error": "root is not a JSON object",
+            "raw_document": {},
+        }
+    servers = data.get("mcpServers") or {}
+    if not isinstance(servers, dict):
+        return {
+            "path": str(mcp_path),
+            "present": True,
+            "parse_status": "ERROR",
+            "servers": {},
+            "error": "mcpServers is not a mapping",
+            "raw_document": data,
+        }
+    return {
+        "path": str(mcp_path),
+        "present": True,
+        "parse_status": "OK",
+        "servers": dict(servers),
+        "error": None,
+        "raw_document": data,
+    }
+
+
+def _functional_subset(entry: Mapping[str, Any]) -> Dict[str, Any]:
+    return {k: entry[k] for k in _FUNCTIONAL_KEYS if k in entry}
+
+
+def _url_is_repairable(url: Optional[str]) -> bool:
+    if not url or not isinstance(url, str):
+        return True  # missing → can set template
+    if "${" in url:
+        # Template placeholders are always candidate for catalog template replace
+        # when host is local or still a placeholder.
+        return True
+    try:
+        parsed = urlparse(url)
+    except Exception:  # noqa: BLE001
+        return False
+    host = (parsed.hostname or "").lower()
+    if host and host not in {"localhost", "127.0.0.1"}:
+        return False
+    # userinfo credentials → never rewrite
+    if parsed.username or parsed.password:
+        return False
+    if "@" in url.split("://", 1)[-1].split("/", 1)[0]:
+        return False
+    return True
+
+
+def render_catalog_entry(
+    name: str,
+    catalog: Mapping[str, Any],
+    *,
+    render_fn: Any = None,
+) -> Dict[str, Any]:
+    """Render desired catalog-owned entry.
+
+    ``render_fn`` defaults to lazy import of mcp_commands._render_local_entry
+    so tests can inject a pure renderer without loading the CLI module.
+    """
+    spec = (catalog.get("servers") or {})[name]
+    if render_fn is not None:
+        return dict(render_fn(name, spec))
+    from dopemux.commands.mcp_commands import _render_local_entry
+
+    return dict(_render_local_entry(name, spec))
+
+
+def plan_mcp_json_repairs(
+    existing_servers: Mapping[str, Any],
+    catalog: Mapping[str, Any],
+    *,
+    mcp_json_path: str,
+    include_defaults: bool = True,
+    render_fn: Any = None,
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Plan catalog-owned repairs while preserving unknown entries.
+
+    Returns (merged_servers, planned_changes, preserved_entries).
+    """
+    merged: Dict[str, Any] = {str(k): dict(v) if isinstance(v, dict) else v for k, v in existing_servers.items()}
+    planned: List[Dict[str, Any]] = []
+    preserved: List[Dict[str, Any]] = []
+
+    # Preserve unknown / non-catalog-owned first (record for report).
+    for name, entry in existing_servers.items():
+        if not is_catalog_owned(str(name), catalog):
+            preserved.append(
+                {
+                    "path": mcp_json_path,
+                    "service": str(name),
+                    "reason": "not catalog-owned",
+                }
+            )
+
+    # Names to ensure: existing catalog-owned + defaults (when include_defaults).
+    targets: List[str] = []
+    for name in existing_servers:
+        if is_catalog_owned(str(name), catalog) and name not in targets:
+            targets.append(str(name))
+    if include_defaults:
+        for name in (catalog.get("defaults") or {}).get("per_worktree") or []:
+            if is_catalog_owned(str(name), catalog) and name not in targets:
+                targets.append(str(name))
+
+    for name in sorted(targets):  # deterministic planned_changes order
+        desired = render_catalog_entry(name, catalog, render_fn=render_fn)
+        current = existing_servers.get(name)
+        if not isinstance(current, dict):
+            # Create missing catalog-owned entry
+            merged[name] = desired
+            planned.append(
+                {
+                    "path": mcp_json_path,
+                    "kind": "create" if not existing_servers else "json_patch",
+                    "reason": "MISSING_CATALOG_ENTRY",
+                    "service": name,
+                    "before": None,
+                    "after": _functional_subset(desired),
+                    "safe": True,
+                }
+            )
+            continue
+
+        # Non-localhost / credential URLs: preserve URL, only repair type if safe
+        current_url = current.get("url")
+        url_ok = _url_is_repairable(current_url if isinstance(current_url, str) else None)
+
+        new_entry = dict(current)
+        change_reasons: List[str] = []
+
+        desired_type = desired.get("type")
+        if desired_type and current.get("type") != desired_type:
+            new_entry["type"] = desired_type
+            change_reasons.append("TRANSPORT_MISMATCH")
+
+        if url_ok and desired.get("url") and current.get("url") != desired.get("url"):
+            new_entry["url"] = desired["url"]
+            change_reasons.append("URL_MISMATCH")
+        elif not url_ok and desired.get("url") and current.get("url") != desired.get("url"):
+            # Explicitly do not change non-local URLs
+            preserved.append(
+                {
+                    "path": mcp_json_path,
+                    "service": name,
+                    "reason": "non-localhost or credential URL preserved",
+                }
+            )
+
+        # Align env / command / args only when present in desired catalog entry
+        for key in ("env", "command", "args"):
+            if key in desired and current.get(key) != desired.get(key):
+                # Only patch if current is missing or clearly wrong for catalog-owned
+                if key not in current or current.get(key) != desired.get(key):
+                    new_entry[key] = desired[key]
+                    if "CATALOG_FIELD_DRIFT" not in change_reasons:
+                        change_reasons.append("CATALOG_FIELD_DRIFT")
+
+        # Preserve description if user has one and desired also has one: prefer catalog
+        if "description" in desired:
+            new_entry["description"] = desired["description"]
+
+        if _functional_subset(new_entry) != _functional_subset(current) or change_reasons:
+            if not change_reasons:
+                continue
+            merged[name] = new_entry
+            # One planned change per primary reason (deterministic)
+            primary = change_reasons[0]
+            reason_code = {
+                "TRANSPORT_MISMATCH": "TRANSPORT_MISMATCH",
+                "URL_MISMATCH": "URL_MISMATCH",
+                "CATALOG_FIELD_DRIFT": "CATALOG_FIELD_DRIFT",
+            }.get(primary, primary)
+            planned.append(
+                {
+                    "path": mcp_json_path,
+                    "kind": "json_patch",
+                    "reason": reason_code,
+                    "service": name,
+                    "before": _functional_subset(current),
+                    "after": _functional_subset(new_entry),
+                    "safe": True,
+                }
+            )
+        else:
+            merged[name] = dict(current)
+
+    return merged, planned, preserved
+
+
+def dump_mcp_json(servers: Mapping[str, Any], *, other_keys: Optional[Mapping[str, Any]] = None) -> str:
+    """Deterministic pretty JSON for .mcp.json (stable key ordering)."""
+    ordered_servers = {k: servers[k] for k in sorted(servers.keys())}
+    doc: Dict[str, Any] = {}
+    if other_keys:
+        for k in sorted(other_keys.keys()):
+            if k == "mcpServers":
+                continue
+            doc[k] = other_keys[k]
+    doc["mcpServers"] = ordered_servers
+    return json.dumps(doc, indent=2, sort_keys=False) + "\n"
+
+
+def write_mcp_json(path: Path, servers: Mapping[str, Any], *, other_keys: Optional[Mapping[str, Any]] = None) -> None:
+    """Atomic write of .mcp.json."""
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    text = dump_mcp_json(servers, other_keys=other_keys)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    tmp.replace(path)

--- a/src/dopemux/mcp/port_allocator.py
+++ b/src/dopemux/mcp/port_allocator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 from urllib.parse import urlparse
 
 from .port_leases import (
@@ -304,6 +304,8 @@ def allocate_ports(
         project_root=proj,
         existing_envrc=existing_envrc,
     )
+    # Track per-role outcomes so overall status can become REUSED when appropriate.
+    role_statuses: List[str] = []
 
     for req in reqs:
         preferred = int(req.preferred if req.preferred is not None else req.base)
@@ -311,14 +313,21 @@ def allocate_ports(
         status_local = "ASSIGNED"
         rebind_reason: Optional[str] = None
 
-        # 1) Existing valid lease for this identity/service/role
-        existing = registry.find_active_for_identity(
-            service=req.service,
-            port_role=req.port_role,
-            worktree_root=identity.worktree_root if req.scope == "worktree" else None,
-            project_root=identity.project_root if req.scope == "project" else identity.project_root,
-            worktree_hash=identity.worktree_hash,
-        )
+        # 1) Existing valid lease for this identity/service/role.
+        # Worktree-scoped requests must not pick up project-scoped leases.
+        if req.scope == "project":
+            existing = registry.find_active_for_identity(
+                service=req.service,
+                port_role=req.port_role,
+                project_root=identity.project_root,
+            )
+        else:
+            existing = registry.find_active_for_identity(
+                service=req.service,
+                port_role=req.port_role,
+                worktree_root=identity.worktree_root,
+                worktree_hash=identity.worktree_hash,
+            )
         if existing:
             ep = int(existing["port"])
             if ep in plan_ports and plan_ports[ep] != f"{req.service}.{req.port_var}":
@@ -359,7 +368,8 @@ def allocate_ports(
                     )
 
         if assigned is None and req.fixed:
-            # Fixed-port services: never rebind
+            # Fixed-port services: never rebind. Block on foreign lease OR
+            # unknown occupant (live socket) before leasing.
             cand = preferred
             conflict = blocked.get(cand) or plan_ports.get(cand)
             other = registry.find_active_by_port(cand)
@@ -372,6 +382,15 @@ def allocate_ports(
             ):
                 other_ok = False
             free = is_free(cand)
+            ours_listening = bool(
+                other
+                and registry.identity_matches(
+                    other,
+                    worktree_root=identity.worktree_root,
+                    project_root=identity.project_root,
+                    worktree_hash=identity.worktree_hash,
+                )
+            )
             if conflict or not other_ok:
                 result.status = "BLOCKED"
                 result.blocking_findings.append(
@@ -386,7 +405,7 @@ def allocate_ports(
                     }
                 )
                 return result
-            if not free and not other_ok:
+            if not free and not ours_listening:
                 result.status = "BLOCKED"
                 result.blocking_findings.append(
                     {
@@ -500,6 +519,7 @@ def allocate_ports(
 
         plan_ports[assigned] = f"{req.service}.{req.port_var}"
         result.ports[req.port_var] = assigned
+        role_statuses.append(status_local)
 
         lease = PortLease(
             lease_id=make_lease_id(
@@ -570,12 +590,13 @@ def allocate_ports(
             )
             return result
 
-    if result.status not in {"BLOCKED", "REBIND"} and all(
-        w.get("code") == "LEASE_REUSED" for w in result.warnings if w.get("code", "").startswith("LEASE_")
+    # Pure reuse: every role was REUSED (ignore registry bookkeeping warnings).
+    if (
+        result.status not in {"BLOCKED", "REBIND"}
+        and role_statuses
+        and all(s == "REUSED" for s in role_statuses)
     ):
-        # purely reused
-        if any(w.get("code") == "LEASE_REUSED" for w in result.warnings):
-            result.status = "REUSED"
+        result.status = "REUSED"
 
     if not result.ports and not result.blocking_findings:
         result.status = "UNKNOWN"

--- a/src/dopemux/mcp/port_allocator.py
+++ b/src/dopemux/mcp/port_allocator.py
@@ -1,0 +1,618 @@
+"""Unified MCP port allocator with lease registry + live rebind.
+
+Replaces hash-only policy as the runtime assignment authority while still
+using hash-derived ports as *preferred* candidates when safe.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
+
+from .port_leases import (
+    PortLease,
+    PortLeaseRegistry,
+    default_lease_registry_path,
+    make_lease_id,
+)
+from .socket_probe import port_is_free
+
+# Default search window beyond base when rebinding
+DEFAULT_SEARCH_SPAN = 100
+
+
+def preferred_port_for_path(worktree_path: str, base_port: int) -> int:
+    """Legacy preferred formula: base + sha1(abspath)[:4] % 100."""
+    offset = int(
+        hashlib.sha1(str(Path(worktree_path).resolve()).encode("utf-8")).hexdigest()[:4],
+        16,
+    ) % 100
+    return int(base_port) + offset
+
+
+def instance_id_for_path(worktree_path: str) -> str:
+    return hashlib.sha1(str(Path(worktree_path).resolve()).encode("utf-8")).hexdigest()[:4]
+
+
+def singleton_reserved_ports(catalog: Mapping[str, Any]) -> Dict[int, str]:
+    reserved: Dict[int, str] = {}
+    for name, spec in (catalog.get("servers") or {}).items():
+        if not isinstance(spec, dict) or spec.get("scope") != "singleton":
+            continue
+        explicit = spec.get("reserved_port")
+        if explicit is not None:
+            try:
+                reserved[int(explicit)] = name
+            except (TypeError, ValueError):
+                pass
+        raw_url = spec.get("url")
+        if raw_url:
+            try:
+                port = urlparse(str(raw_url)).port
+                if port:
+                    reserved[port] = name
+            except Exception:  # noqa: BLE001
+                pass
+    return reserved
+
+
+@dataclass
+class PortRoleRequest:
+    service: str
+    port_role: str
+    port_var: str
+    base: int
+    fixed: bool = False
+    scope: str = "worktree"  # worktree | project | singleton
+    preferred: Optional[int] = None
+
+
+@dataclass
+class AllocationResult:
+    status: str  # ASSIGNED|REUSED|REBIND|BLOCKED|UNKNOWN
+    ports: Dict[str, int] = field(default_factory=dict)  # port_var -> port
+    leases: List[Dict[str, Any]] = field(default_factory=list)
+    rebinds: List[Dict[str, Any]] = field(default_factory=list)
+    warnings: List[Dict[str, Any]] = field(default_factory=list)
+    blocking_findings: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "ports": dict(self.ports),
+            "leases": list(self.leases),
+            "rebinds": list(self.rebinds),
+            "warnings": list(self.warnings),
+            "blocking_findings": list(self.blocking_findings),
+        }
+
+
+def _role_from_var(port_var: str, service: str) -> str:
+    upper = port_var.upper()
+    if "INFO" in upper:
+        return "info"
+    if "HTTP" in upper and "MCP" not in upper:
+        return "http"
+    if "MCP" in upper or upper.endswith("_PORT"):
+        # primary MCP port: sse for conport-ish, http otherwise
+        if service == "conport" and "HTTP" not in upper:
+            return "sse"
+        return "http"
+    return "http"
+
+
+def build_role_requests(
+    service_names: Sequence[str],
+    catalog: Mapping[str, Any],
+    *,
+    worktree: str,
+    project_root: Optional[str] = None,
+    existing_envrc: Optional[Mapping[str, str]] = None,
+) -> List[PortRoleRequest]:
+    """Expand catalog services into port-role allocation requests."""
+    reqs: List[PortRoleRequest] = []
+    env = existing_envrc or {}
+    for name in service_names:
+        spec = (catalog.get("servers") or {}).get(name) or {}
+        if not isinstance(spec, dict) or spec.get("scope") != "per-worktree":
+            continue
+        is_fixed = spec.get("management_model") == "wrapper-singleton"
+        key_path = (
+            project_root
+            if spec.get("state_scope") == "per-repo" and project_root
+            else worktree
+        )
+        scope = "project" if spec.get("state_scope") == "per-repo" else "worktree"
+        base = spec.get("default_port_base")
+        port_var = spec.get("port_var")
+        if base and port_var:
+            pref = preferred_port_for_path(str(key_path), int(base)) if not is_fixed else int(base)
+            if str(port_var) in env:
+                try:
+                    pref = int(str(env[str(port_var)]).strip())
+                except ValueError:
+                    pass
+            reqs.append(
+                PortRoleRequest(
+                    service=str(name),
+                    port_role=_role_from_var(str(port_var), str(name)),
+                    port_var=str(port_var),
+                    base=int(base),
+                    fixed=is_fixed,
+                    scope=scope,
+                    preferred=pref,
+                )
+            )
+        if not is_fixed:
+            for extra in spec.get("extra_port_vars") or []:
+                if not isinstance(extra, dict):
+                    continue
+                var = extra.get("var")
+                ebase = extra.get("base")
+                if not var or ebase is None:
+                    continue
+                pref = preferred_port_for_path(str(key_path), int(ebase))
+                if str(var) in env:
+                    try:
+                        pref = int(str(env[str(var)]).strip())
+                    except ValueError:
+                        pass
+                reqs.append(
+                    PortRoleRequest(
+                        service=str(name),
+                        port_role=_role_from_var(str(var), str(name)),
+                        port_var=str(var),
+                        base=int(ebase),
+                        fixed=False,
+                        scope=scope,
+                        preferred=pref,
+                    )
+                )
+    return reqs
+
+
+def _candidate_ports(preferred: int, base: int, *, span: int = DEFAULT_SEARCH_SPAN) -> List[int]:
+    """Deterministic search order: preferred, then base..base+span, then preferred±."""
+    seen = set()
+    out: List[int] = []
+
+    def add(p: int) -> None:
+        if 1 <= p <= 65535 and p not in seen:
+            seen.add(p)
+            out.append(p)
+
+    add(int(preferred))
+    for p in range(int(base), int(base) + span + 1):
+        add(p)
+    # widen slightly around preferred if base range exhausted
+    for delta in range(1, span + 1):
+        add(int(preferred) + delta)
+        add(int(preferred) - delta)
+    return out
+
+
+@dataclass
+class AllocatorIdentity:
+    project_id: Optional[str]
+    workspace_id: Optional[str]
+    project_root: str
+    worktree_root: str
+    project_hash: Optional[str]
+    worktree_hash: str
+    instance_id: str
+
+
+def allocate_ports(
+    service_names: Sequence[str],
+    catalog: Mapping[str, Any],
+    *,
+    worktree: str,
+    project_root: Optional[str] = None,
+    identity: Optional[AllocatorIdentity] = None,
+    existing_envrc: Optional[Mapping[str, str]] = None,
+    registry: Optional[PortLeaseRegistry] = None,
+    registry_path: Optional[Path] = None,
+    persist: bool = True,
+    dry_run: bool = False,
+    source: str = "dopemux mcp init",
+    is_free_fn: Optional[Callable[[int], bool]] = None,
+    extra_blocked_ports: Optional[Mapping[int, str]] = None,
+) -> AllocationResult:
+    """Allocate ports for services with lease + live socket safety.
+
+    ``persist=False`` or ``dry_run=True`` skips registry writes.
+    """
+    is_free = is_free_fn or (lambda p: port_is_free(p))
+    wt = str(Path(worktree).expanduser().resolve())
+    proj = str(Path(project_root or worktree).expanduser().resolve())
+    wt_hash = instance_id_for_path(wt)
+    if identity is None:
+        identity = AllocatorIdentity(
+            project_id=Path(proj).name,
+            workspace_id=wt,
+            project_root=proj,
+            worktree_root=wt,
+            project_hash=None,
+            worktree_hash=wt_hash,
+            instance_id=wt_hash,
+        )
+
+    result = AllocationResult(status="ASSIGNED")
+
+    # Load registry
+    if registry is None:
+        path = registry_path or default_lease_registry_path()
+        registry = PortLeaseRegistry.load(path)
+    if registry.parse_status == "ERROR":
+        result.status = "BLOCKED"
+        result.blocking_findings.append(
+            {
+                "code": "LEASE_REGISTRY_PARSE_ERROR",
+                "message": f"Lease registry unreadable: {registry.error}",
+                "path": str(registry.path),
+            }
+        )
+        return result
+
+    if registry.parse_status == "MISSING":
+        result.warnings.append(
+            {
+                "code": "LEASE_REGISTRY_MISSING",
+                "message": f"No lease registry yet at {registry.path}; will create on first write.",
+            }
+        )
+    else:
+        result.warnings.append(
+            {
+                "code": "LEASE_REGISTRY_FOUND",
+                "message": f"Using lease registry {registry.path}",
+            }
+        )
+
+    reserved = singleton_reserved_ports(catalog)
+    registry.set_reserved_from_catalog(reserved)
+
+    blocked: Dict[int, str] = {p: f"singleton:{n}" for p, n in reserved.items()}
+    if extra_blocked_ports:
+        blocked.update({int(k): str(v) for k, v in extra_blocked_ports.items()})
+
+    # Seed blocked with other projects' active leases
+    for L in registry.active_leases():
+        port = int(L.get("port") or 0)
+        if not port:
+            continue
+        same = registry.identity_matches(
+            L,
+            worktree_root=identity.worktree_root,
+            project_root=identity.project_root,
+            worktree_hash=identity.worktree_hash,
+            project_id=identity.project_id,
+        )
+        if not same:
+            blocked[port] = (
+                f"lease:{L.get('service')}:{L.get('worktree_root') or L.get('project_root')}"
+            )
+
+    plan_ports: Dict[int, str] = {}  # port -> owner key in this allocation
+    reqs = build_role_requests(
+        service_names,
+        catalog,
+        worktree=wt,
+        project_root=proj,
+        existing_envrc=existing_envrc,
+    )
+
+    for req in reqs:
+        preferred = int(req.preferred if req.preferred is not None else req.base)
+        assigned: Optional[int] = None
+        status_local = "ASSIGNED"
+        rebind_reason: Optional[str] = None
+
+        # 1) Existing valid lease for this identity/service/role
+        existing = registry.find_active_for_identity(
+            service=req.service,
+            port_role=req.port_role,
+            worktree_root=identity.worktree_root if req.scope == "worktree" else None,
+            project_root=identity.project_root if req.scope == "project" else identity.project_root,
+            worktree_hash=identity.worktree_hash,
+        )
+        if existing:
+            ep = int(existing["port"])
+            if ep in plan_ports and plan_ports[ep] != f"{req.service}.{req.port_var}":
+                # conflict within plan — fall through to rebind
+                pass
+            elif ep in blocked and not registry.identity_matches(
+                existing,
+                worktree_root=identity.worktree_root,
+                project_root=identity.project_root,
+                worktree_hash=identity.worktree_hash,
+            ):
+                pass
+            elif is_free(ep) or registry.identity_matches(
+                existing,
+                worktree_root=identity.worktree_root,
+                project_root=identity.project_root,
+                worktree_hash=identity.worktree_hash,
+            ):
+                # Reuse lease if free OR still ours (may be running)
+                other = registry.find_active_by_port(ep)
+                if other and not registry.identity_matches(
+                    other,
+                    worktree_root=identity.worktree_root,
+                    project_root=identity.project_root,
+                    worktree_hash=identity.worktree_hash,
+                ):
+                    pass
+                else:
+                    assigned = ep
+                    status_local = "REUSED"
+                    result.warnings.append(
+                        {
+                            "code": "LEASE_REUSED",
+                            "service": req.service,
+                            "port_role": req.port_role,
+                            "port": ep,
+                        }
+                    )
+
+        if assigned is None and req.fixed:
+            # Fixed-port services: never rebind
+            cand = preferred
+            conflict = blocked.get(cand) or plan_ports.get(cand)
+            other = registry.find_active_by_port(cand)
+            other_ok = True
+            if other and not registry.identity_matches(
+                other,
+                worktree_root=identity.worktree_root,
+                project_root=identity.project_root,
+                worktree_hash=identity.worktree_hash,
+            ):
+                other_ok = False
+            free = is_free(cand)
+            if conflict or not other_ok:
+                result.status = "BLOCKED"
+                result.blocking_findings.append(
+                    {
+                        "code": "ALLOCATOR_FIXED_PORT_BLOCKED",
+                        "service": req.service,
+                        "port": cand,
+                        "message": (
+                            f"Fixed port {cand} for {req.service} is blocked "
+                            f"({conflict or 'foreign lease'})."
+                        ),
+                    }
+                )
+                return result
+            if not free and not other_ok:
+                result.status = "BLOCKED"
+                result.blocking_findings.append(
+                    {
+                        "code": "LEASE_PORT_OCCUPIED",
+                        "service": req.service,
+                        "port": cand,
+                        "message": f"Fixed port {cand} occupied by unknown process.",
+                    }
+                )
+                return result
+            assigned = cand
+            status_local = "REUSED" if other else "ASSIGNED"
+            result.warnings.append(
+                {
+                    "code": "ALLOCATOR_FIXED_PORT_REUSED" if other else "ALLOCATOR_ASSIGNED_PREFERRED",
+                    "service": req.service,
+                    "port": cand,
+                }
+            )
+        elif assigned is None:
+            # Search candidates
+            for cand in _candidate_ports(preferred, req.base):
+                if cand in reserved:
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "PORT_RESERVED_COLLISION"
+                    continue
+                if cand in blocked:
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "LEASE_BELONGS_TO_OTHER_PROJECT"
+                    continue
+                if cand in plan_ports:
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "ALLOCATOR_CROSS_SERVICE_COLLISION_AVOIDED"
+                    continue
+                other = registry.find_active_by_port(cand)
+                if other and not registry.identity_matches(
+                    other,
+                    worktree_root=identity.worktree_root,
+                    project_root=identity.project_root,
+                    worktree_hash=identity.worktree_hash,
+                ):
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "LEASE_BELONGS_TO_OTHER_WORKTREE"
+                    continue
+                if not is_free(cand):
+                    # occupied — only ok if our lease
+                    if other and registry.identity_matches(
+                        other,
+                        worktree_root=identity.worktree_root,
+                        project_root=identity.project_root,
+                        worktree_hash=identity.worktree_hash,
+                    ):
+                        assigned = cand
+                        status_local = "REUSED"
+                        break
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "LEASE_PORT_OCCUPIED"
+                    continue
+                assigned = cand
+                if cand == preferred:
+                    status_local = "ASSIGNED"
+                    result.warnings.append(
+                        {
+                            "code": "ALLOCATOR_ASSIGNED_PREFERRED",
+                            "service": req.service,
+                            "port_role": req.port_role,
+                            "port": cand,
+                        }
+                    )
+                else:
+                    status_local = "REBIND"
+                    rebind_reason = rebind_reason or "ALLOCATOR_REBOUND_FROM_PREFERRED"
+                break
+
+        if assigned is None:
+            result.status = "BLOCKED"
+            result.blocking_findings.append(
+                {
+                    "code": "ALLOCATOR_NO_SAFE_PORT",
+                    "service": req.service,
+                    "port_role": req.port_role,
+                    "port_var": req.port_var,
+                    "preferred": preferred,
+                    "message": f"No safe port for {req.service}.{req.port_var} near base {req.base}.",
+                }
+            )
+            return result
+
+        if status_local == "REBIND" or (assigned != preferred and not req.fixed):
+            result.rebinds.append(
+                {
+                    "role": req.port_role,
+                    "service": req.service,
+                    "port_var": req.port_var,
+                    "preferred": preferred,
+                    "assigned": assigned,
+                    "reason": rebind_reason or "ALLOCATOR_REBOUND_FROM_PREFERRED",
+                }
+            )
+            result.warnings.append(
+                {
+                    "code": "LEASE_REBOUND",
+                    "service": req.service,
+                    "preferred": preferred,
+                    "assigned": assigned,
+                    "reason": rebind_reason,
+                }
+            )
+            if result.status not in {"BLOCKED"}:
+                result.status = "REBIND"
+
+        plan_ports[assigned] = f"{req.service}.{req.port_var}"
+        result.ports[req.port_var] = assigned
+
+        lease = PortLease(
+            lease_id=make_lease_id(
+                project_slug=str(identity.project_id or Path(identity.project_root).name),
+                worktree_hash=identity.worktree_hash,
+                service=req.service,
+                port_role=req.port_role,
+                port=assigned,
+            ),
+            port=assigned,
+            service=req.service,
+            port_role=req.port_role,
+            port_var=req.port_var,
+            project_id=identity.project_id,
+            workspace_id=identity.workspace_id,
+            project_root=identity.project_root,
+            worktree_root=identity.worktree_root,
+            project_hash=identity.project_hash,
+            worktree_hash=identity.worktree_hash,
+            instance_id=identity.instance_id,
+            scope=req.scope,
+            source=source,
+            status="active",
+            preferred=(assigned == preferred),
+            reserved=False,
+            notes=[] if assigned == preferred else [f"rebound from {preferred}"],
+        )
+        entry = lease.to_dict()
+        result.leases.append(entry)
+        if not dry_run and persist:
+            registry.upsert_lease(lease)
+
+        if status_local == "ASSIGNED" and assigned == preferred:
+            result.warnings.append(
+                {
+                    "code": "LEASE_CREATED",
+                    "service": req.service,
+                    "port": assigned,
+                }
+            )
+
+    # Cross-worktree collision avoided summary
+    if any(r.get("reason") == "LEASE_BELONGS_TO_OTHER_WORKTREE" for r in result.rebinds):
+        result.warnings.append(
+            {
+                "code": "ALLOCATOR_CROSS_WORKTREE_COLLISION_AVOIDED",
+                "message": "Rebound at least one port to avoid another worktree's lease.",
+            }
+        )
+    if any(r.get("reason") == "ALLOCATOR_CROSS_SERVICE_COLLISION_AVOIDED" for r in result.rebinds):
+        result.warnings.append(
+            {
+                "code": "ALLOCATOR_CROSS_SERVICE_COLLISION_AVOIDED",
+                "message": "Rebound to avoid intra-plan cross-service collision.",
+            }
+        )
+
+    if not dry_run and persist and result.leases:
+        try:
+            registry.save()
+        except OSError as exc:
+            result.status = "BLOCKED"
+            result.blocking_findings.append(
+                {
+                    "code": "LEASE_REGISTRY_PARSE_ERROR",
+                    "message": f"Failed to write lease registry: {exc}",
+                }
+            )
+            return result
+
+    if result.status not in {"BLOCKED", "REBIND"} and all(
+        w.get("code") == "LEASE_REUSED" for w in result.warnings if w.get("code", "").startswith("LEASE_")
+    ):
+        # purely reused
+        if any(w.get("code") == "LEASE_REUSED" for w in result.warnings):
+            result.status = "REUSED"
+
+    if not result.ports and not result.blocking_findings:
+        result.status = "UNKNOWN"
+
+    return result
+
+
+def allocate_ports_map(
+    worktree: str,
+    names: Sequence[str],
+    catalog: Mapping[str, Any],
+    *,
+    project_root: str | None = None,
+    existing_envrc: Optional[Mapping[str, str]] = None,
+    persist: bool = True,
+    dry_run: bool = False,
+    source: str = "dopemux mcp init",
+    registry_path: Optional[Path] = None,
+    is_free_fn: Optional[Callable[[int], bool]] = None,
+) -> Dict[str, int]:
+    """Drop-in replacement shape for ``_allocate_ports`` → {port_var: port}.
+
+    Raises RuntimeError on BLOCKED (callers may convert to ClickException).
+    """
+    result = allocate_ports(
+        names,
+        catalog,
+        worktree=worktree,
+        project_root=project_root,
+        existing_envrc=existing_envrc,
+        persist=persist and not dry_run,
+        dry_run=dry_run,
+        source=source,
+        registry_path=registry_path,
+        is_free_fn=is_free_fn,
+    )
+    if result.status == "BLOCKED":
+        msgs = "; ".join(f["message"] for f in result.blocking_findings if f.get("message"))
+        raise RuntimeError(msgs or "Port allocation blocked")
+    return dict(result.ports)

--- a/src/dopemux/mcp/port_leases.py
+++ b/src/dopemux/mcp/port_leases.py
@@ -13,7 +13,6 @@ import json
 import os
 import re
 import tempfile
-from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -246,13 +245,33 @@ class PortLeaseRegistry:
         project_root: Optional[str] = None,
         worktree_hash: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
+        """Find an active lease for the given identity.
+
+        Worktree-scoped lookups (``worktree_root`` / ``worktree_hash``) never
+        return project-scoped leases. Project-scoped lookups (``project_root``
+        only, or when no worktree identity is supplied) only match
+        ``scope == \"project\"`` entries.
+        """
+        looking_worktree = worktree_root is not None or worktree_hash is not None
+        looking_project = project_root is not None and not looking_worktree
+
         for L in self.active_leases():
             if L.get("service") != service or L.get("port_role") != port_role:
                 continue
-            if worktree_hash and L.get("worktree_hash") == worktree_hash:
-                return L
-            if worktree_root and L.get("worktree_root") == worktree_root:
-                return L
+            if looking_worktree:
+                # Do not reuse a project-scoped lease for a worktree-scoped request.
+                if L.get("scope") == "project":
+                    continue
+                if worktree_hash and L.get("worktree_hash") == worktree_hash:
+                    return L
+                if worktree_root and L.get("worktree_root") == worktree_root:
+                    return L
+                continue
+            if looking_project:
+                if L.get("scope") == "project" and L.get("project_root") == project_root:
+                    return L
+                continue
+            # Fallback when no identity keys provided (legacy callers).
             if project_root and L.get("project_root") == project_root and L.get("scope") == "project":
                 return L
         return None
@@ -291,14 +310,34 @@ class PortLeaseRegistry:
         leases = self.leases()
         out: List[Dict[str, Any]] = []
         replaced = False
+        entry_scope = str(entry.get("scope") or "worktree")
         for L in leases:
             same_id = L.get("lease_id") and L.get("lease_id") == entry.get("lease_id")
-            same_slot = (
-                L.get("service") == entry.get("service")
-                and L.get("port_role") == entry.get("port_role")
-                and L.get("worktree_root") == entry.get("worktree_root")
-                and L.get("status") == "active"
-            )
+            if entry_scope == "project":
+                # Project-scoped leases dedupe across worktrees of the same project.
+                same_project = False
+                if entry.get("project_root") and L.get("project_root") == entry.get("project_root"):
+                    same_project = True
+                elif (
+                    not entry.get("project_root")
+                    and entry.get("project_id")
+                    and L.get("project_id") == entry.get("project_id")
+                ):
+                    same_project = True
+                same_slot = (
+                    L.get("status") == "active"
+                    and L.get("service") == entry.get("service")
+                    and L.get("port_role") == entry.get("port_role")
+                    and (L.get("scope") or "worktree") == "project"
+                    and same_project
+                )
+            else:
+                same_slot = (
+                    L.get("service") == entry.get("service")
+                    and L.get("port_role") == entry.get("port_role")
+                    and L.get("worktree_root") == entry.get("worktree_root")
+                    and L.get("status") == "active"
+                )
             if same_id or same_slot:
                 if not replaced:
                     # preserve created_at

--- a/src/dopemux/mcp/port_leases.py
+++ b/src/dopemux/mcp/port_leases.py
@@ -1,0 +1,389 @@
+"""Operational MCP port lease registry.
+
+Path default: ~/.dopemux/mcp/runtime/port-leases.json
+Override: DOPEMUX_MCP_PORT_LEASE_REGISTRY
+
+Operational state only — never domain truth for ConPort / dope-memory / TO.
+No secrets. Atomic writes. Tests must override the registry path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+SCHEMA_VERSION = "1.0"
+ALLOCATOR_VERSION = "1"
+REGISTRY_ENV = "DOPEMUX_MCP_PORT_LEASE_REGISTRY"
+DEFAULT_RELATIVE = Path(".dopemux/mcp/runtime/port-leases.json")
+
+
+class LeaseRegistryError(RuntimeError):
+    """Registry load/save failure that blocks allocation."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_lease_registry_path() -> Path:
+    override = os.environ.get(REGISTRY_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    return (Path.home() / DEFAULT_RELATIVE).resolve()
+
+
+def empty_registry() -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "updated_at": _utc_now(),
+        "allocator_version": ALLOCATOR_VERSION,
+        "leases": [],
+        "reserved_ports": [],
+    }
+
+
+def _slug(value: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+    return s[:48] or "x"
+
+
+def make_lease_id(
+    *,
+    project_slug: str,
+    worktree_hash: str,
+    service: str,
+    port_role: str,
+    port: int,
+) -> str:
+    return f"lease_{_slug(project_slug)}_{worktree_hash}_{_slug(service)}_{_slug(port_role)}_{port}"
+
+
+@dataclass
+class PortLease:
+    lease_id: str
+    port: int
+    protocol: str = "tcp"
+    bind_host: str = "127.0.0.1"
+    service: str = ""
+    port_role: str = "http"
+    port_var: str = ""
+    project_id: Optional[str] = None
+    workspace_id: Optional[str] = None
+    project_root: Optional[str] = None
+    worktree_root: Optional[str] = None
+    project_hash: Optional[str] = None
+    worktree_hash: Optional[str] = None
+    instance_id: Optional[str] = None
+    scope: str = "worktree"  # project|worktree|singleton
+    source: str = "dopemux mcp init"
+    status: str = "active"  # active|stale|released|unknown
+    preferred: bool = True
+    reserved: bool = False
+    created_at: str = field(default_factory=_utc_now)
+    updated_at: str = field(default_factory=_utc_now)
+    last_verified_at: Optional[str] = None
+    notes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "lease_id": self.lease_id,
+            "port": int(self.port),
+            "protocol": self.protocol,
+            "bind_host": self.bind_host,
+            "service": self.service,
+            "port_role": self.port_role,
+            "port_var": self.port_var,
+            "project_id": self.project_id,
+            "workspace_id": self.workspace_id,
+            "project_root": self.project_root,
+            "worktree_root": self.worktree_root,
+            "project_hash": self.project_hash,
+            "worktree_hash": self.worktree_hash,
+            "instance_id": self.instance_id,
+            "scope": self.scope,
+            "source": self.source,
+            "status": self.status,
+            "preferred": self.preferred,
+            "reserved": self.reserved,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "last_verified_at": self.last_verified_at,
+            "notes": list(self.notes),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "PortLease":
+        d = dict(raw)
+        return cls(
+            lease_id=str(d.get("lease_id") or ""),
+            port=int(d["port"]),
+            protocol=str(d.get("protocol") or "tcp"),
+            bind_host=str(d.get("bind_host") or "127.0.0.1"),
+            service=str(d.get("service") or ""),
+            port_role=str(d.get("port_role") or "http"),
+            port_var=str(d.get("port_var") or ""),
+            project_id=d.get("project_id"),
+            workspace_id=d.get("workspace_id"),
+            project_root=d.get("project_root"),
+            worktree_root=d.get("worktree_root"),
+            project_hash=d.get("project_hash"),
+            worktree_hash=d.get("worktree_hash"),
+            instance_id=d.get("instance_id"),
+            scope=str(d.get("scope") or "worktree"),
+            source=str(d.get("source") or "unknown"),
+            status=str(d.get("status") or "unknown"),
+            preferred=bool(d.get("preferred", True)),
+            reserved=bool(d.get("reserved", False)),
+            created_at=str(d.get("created_at") or _utc_now()),
+            updated_at=str(d.get("updated_at") or _utc_now()),
+            last_verified_at=d.get("last_verified_at"),
+            notes=list(d.get("notes") or []),
+        )
+
+
+@dataclass
+class PortLeaseRegistry:
+    """In-memory lease registry with atomic persistence."""
+
+    path: Path
+    data: Dict[str, Any] = field(default_factory=empty_registry)
+    present: bool = False
+    parse_status: str = "MISSING"  # OK | ERROR | MISSING
+    error: Optional[str] = None
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None, *, create_missing: bool = False) -> "PortLeaseRegistry":
+        reg_path = path or default_lease_registry_path()
+        if not reg_path.exists():
+            if create_missing:
+                reg_path.parent.mkdir(parents=True, exist_ok=True)
+                reg = cls(path=reg_path, data=empty_registry(), present=False, parse_status="MISSING")
+                reg.save()
+                reg.present = True
+                reg.parse_status = "OK"
+                return reg
+            return cls(path=reg_path, data=empty_registry(), present=False, parse_status="MISSING")
+
+        try:
+            raw = json.loads(reg_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return cls(
+                path=reg_path,
+                data=empty_registry(),
+                present=True,
+                parse_status="ERROR",
+                error=str(exc),
+            )
+        if not isinstance(raw, dict):
+            return cls(
+                path=reg_path,
+                data=empty_registry(),
+                present=True,
+                parse_status="ERROR",
+                error="registry root is not an object",
+            )
+        leases = raw.get("leases")
+        if leases is None:
+            leases = []
+        if not isinstance(leases, list):
+            return cls(
+                path=reg_path,
+                data=empty_registry(),
+                present=True,
+                parse_status="ERROR",
+                error="registry leases is not a list",
+            )
+        data = dict(raw)
+        data["leases"] = leases
+        data.setdefault("schema_version", SCHEMA_VERSION)
+        data.setdefault("allocator_version", ALLOCATOR_VERSION)
+        data.setdefault("reserved_ports", [])
+        data.setdefault("updated_at", _utc_now())
+        return cls(path=reg_path, data=data, present=True, parse_status="OK")
+
+    def require_writable(self) -> None:
+        if self.parse_status == "ERROR":
+            raise LeaseRegistryError(
+                f"Lease registry parse failed at {self.path}: {self.error}. "
+                "Allocation is blocked."
+            )
+
+    def leases(self) -> List[Dict[str, Any]]:
+        return list(self.data.get("leases") or [])
+
+    def active_leases(self) -> List[Dict[str, Any]]:
+        return [L for L in self.leases() if L.get("status") == "active"]
+
+    def reserved_ports(self) -> List[Dict[str, Any]]:
+        return list(self.data.get("reserved_ports") or [])
+
+    def set_reserved_from_catalog(self, reserved: Dict[int, str], *, source: str = "catalog") -> None:
+        self.data["reserved_ports"] = [
+            {"port": int(p), "service": name, "source": source, "reason": "singleton"}
+            for p, name in sorted(reserved.items())
+        ]
+
+    def find_active_by_port(self, port: int) -> Optional[Dict[str, Any]]:
+        for L in self.active_leases():
+            if int(L.get("port") or 0) == int(port):
+                return L
+        return None
+
+    def find_active_for_identity(
+        self,
+        *,
+        service: str,
+        port_role: str,
+        worktree_root: Optional[str] = None,
+        project_root: Optional[str] = None,
+        worktree_hash: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        for L in self.active_leases():
+            if L.get("service") != service or L.get("port_role") != port_role:
+                continue
+            if worktree_hash and L.get("worktree_hash") == worktree_hash:
+                return L
+            if worktree_root and L.get("worktree_root") == worktree_root:
+                return L
+            if project_root and L.get("project_root") == project_root and L.get("scope") == "project":
+                return L
+        return None
+
+    def identity_matches(
+        self,
+        lease: Dict[str, Any],
+        *,
+        worktree_root: Optional[str],
+        project_root: Optional[str],
+        worktree_hash: Optional[str],
+        project_id: Optional[str] = None,
+    ) -> bool:
+        # Project-scoped leases (e.g. task-orchestrator) are shared across worktrees
+        # of the same project root.
+        if lease.get("scope") == "project":
+            if project_root and lease.get("project_root"):
+                return lease.get("project_root") == project_root
+            if project_id and lease.get("project_id"):
+                return lease.get("project_id") == project_id
+            return False
+
+        if worktree_hash and lease.get("worktree_hash") and lease.get("worktree_hash") != worktree_hash:
+            return False
+        if worktree_root and lease.get("worktree_root") and lease.get("worktree_root") != worktree_root:
+            return False
+        if project_id and lease.get("project_id") and lease.get("project_id") != project_id:
+            if worktree_root and lease.get("worktree_root") == worktree_root:
+                return True
+            return False
+        return True
+
+    def upsert_lease(self, lease: PortLease | Dict[str, Any]) -> Dict[str, Any]:
+        entry = lease.to_dict() if isinstance(lease, PortLease) else dict(lease)
+        entry["updated_at"] = _utc_now()
+        leases = self.leases()
+        out: List[Dict[str, Any]] = []
+        replaced = False
+        for L in leases:
+            same_id = L.get("lease_id") and L.get("lease_id") == entry.get("lease_id")
+            same_slot = (
+                L.get("service") == entry.get("service")
+                and L.get("port_role") == entry.get("port_role")
+                and L.get("worktree_root") == entry.get("worktree_root")
+                and L.get("status") == "active"
+            )
+            if same_id or same_slot:
+                if not replaced:
+                    # preserve created_at
+                    entry.setdefault("created_at", L.get("created_at") or _utc_now())
+                    out.append(entry)
+                    replaced = True
+                # drop old
+                continue
+            out.append(L)
+        if not replaced:
+            entry.setdefault("created_at", _utc_now())
+            out.append(entry)
+        self.data["leases"] = out
+        self.data["updated_at"] = _utc_now()
+        return entry
+
+    def mark_released(
+        self,
+        *,
+        service: Optional[str] = None,
+        worktree_root: Optional[str] = None,
+        port: Optional[int] = None,
+        lease_id: Optional[str] = None,
+    ) -> int:
+        count = 0
+        now = _utc_now()
+        for L in self.leases():
+            match = False
+            if lease_id and L.get("lease_id") == lease_id:
+                match = True
+            if port is not None and int(L.get("port") or 0) == int(port):
+                match = True
+            if service and worktree_root:
+                if L.get("service") == service and L.get("worktree_root") == worktree_root:
+                    match = True
+            if match and L.get("status") == "active":
+                L["status"] = "released"
+                L["updated_at"] = now
+                count += 1
+        if count:
+            self.data["updated_at"] = now
+        return count
+
+    def mark_stale(self, lease_id: str) -> bool:
+        for L in self.leases():
+            if L.get("lease_id") == lease_id and L.get("status") == "active":
+                L["status"] = "stale"
+                L["updated_at"] = _utc_now()
+                self.data["updated_at"] = _utc_now()
+                return True
+        return False
+
+    def active_ports(self) -> Dict[int, Dict[str, Any]]:
+        return {int(L["port"]): L for L in self.active_leases() if L.get("port") is not None}
+
+    def save(self) -> None:
+        self.require_writable()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.data["updated_at"] = _utc_now()
+        payload = json.dumps(self.data, indent=2, sort_keys=False) + "\n"
+        # Atomic write via same-dir tempfile
+        fd, tmp_name = tempfile.mkstemp(prefix=".port-leases.", suffix=".tmp", dir=str(self.path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_name, self.path)
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+        self.present = True
+        self.parse_status = "OK"
+
+    def to_report_dict(self) -> Dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "present": self.present,
+            "parse_status": self.parse_status,
+            "error": self.error,
+            "active_lease_count": len(self.active_leases()),
+            "lease_count": len(self.leases()),
+            "allocator_version": self.data.get("allocator_version"),
+            "schema_version": self.data.get("schema_version"),
+        }

--- a/src/dopemux/mcp/runtime_state.py
+++ b/src/dopemux/mcp/runtime_state.py
@@ -83,7 +83,31 @@ def resolve_identity_view(
     """Resolve project identity for doctor; never raises — degrades to UNKNOWN."""
     evidence: List[str] = []
     env_map = dict(envrc_values or {})
-    env_map.setdefault("DOPEMUX_WORKSPACE_ROOT", str(repo_path))
+    # --repo / explicit target path must win over ambient shell exports.
+    # setdefault would leave a foreign DOPEMUX_WORKSPACE_ROOT in place and
+    # resolve_project_identity would diagnose the previously sourced repo.
+    repo_str = str(Path(repo_path).expanduser().resolve())
+    prior_ws = env_map.get("DOPEMUX_WORKSPACE_ROOT")
+    env_map["DOPEMUX_WORKSPACE_ROOT"] = repo_str
+    if prior_ws:
+        try:
+            prior_ws_res = str(Path(prior_ws).expanduser().resolve())
+        except OSError:
+            prior_ws_res = str(prior_ws)
+        if prior_ws_res != repo_str:
+            # Foreign ambient workspace — scrub project roots that rode along with it.
+            env_map["DOPEMUX_PROJECT_ROOT"] = repo_str
+            prior_pr = env_map.get("TASK_ORCHESTRATOR_PROJECT_ROOT")
+            if prior_pr:
+                try:
+                    prior_pr_res = str(Path(prior_pr).expanduser().resolve())
+                except OSError:
+                    prior_pr_res = str(prior_pr)
+                if prior_pr_res == prior_ws_res:
+                    env_map["TASK_ORCHESTRATOR_PROJECT_ROOT"] = repo_str
+            evidence.append(
+                f"forced identity to target path (ambient DOPEMUX_WORKSPACE_ROOT={prior_ws})"
+            )
 
     try:
         identity: ProjectIdentity = resolve_project_identity(cwd=repo_path, env=env_map)
@@ -389,9 +413,11 @@ def compose_lifecycle_diagnostics(
     findings_seed: List[Dict[str, Any]] = []
 
     text = ""
+    compose_readable = False
     if compose_path and compose_path.is_file():
         try:
             text = compose_path.read_text(encoding="utf-8")
+            compose_readable = True
         except OSError as exc:
             findings_seed.append(
                 {
@@ -405,7 +431,7 @@ def compose_lifecycle_diagnostics(
             )
 
     # Fixed container name default for conport
-    if text:
+    if compose_readable and text:
         if "CONPORT_CONTAINER_NAME:-mcp-conport" in text or re.search(
             r"container_name:\s*\$\{CONPORT_CONTAINER_NAME:-\s*mcp-conport\s*\}", text
         ):

--- a/src/dopemux/mcp/socket_probe.py
+++ b/src/dopemux/mcp/socket_probe.py
@@ -6,7 +6,6 @@ Never starts processes. Timeout-bounded connect checks only.
 from __future__ import annotations
 
 import socket
-from typing import Optional
 
 
 DEFAULT_TIMEOUT_S = 0.25

--- a/src/dopemux/mcp/socket_probe.py
+++ b/src/dopemux/mcp/socket_probe.py
@@ -1,0 +1,55 @@
+"""Bounded TCP socket probes for MCP port allocation (read-only).
+
+Never starts processes. Timeout-bounded connect checks only.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Optional
+
+
+DEFAULT_TIMEOUT_S = 0.25
+DEFAULT_HOST = "127.0.0.1"
+
+
+def port_is_free(port: int, host: str = DEFAULT_HOST, *, timeout_s: float = DEFAULT_TIMEOUT_S) -> bool:
+    """True if nothing accepts TCP connections on (host, port)."""
+    if not (1 <= int(port) <= 65535):
+        return False
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(timeout_s)
+    try:
+        return sock.connect_ex((host, int(port))) != 0
+    except OSError:
+        # Treat probe failure as unknown/occupied to fail closed for allocation
+        return False
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+
+def port_is_listening(
+    port: int, host: str = DEFAULT_HOST, *, timeout_s: float = DEFAULT_TIMEOUT_S
+) -> bool:
+    """True if something accepts TCP connections on (host, port)."""
+    return not port_is_free(port, host, timeout_s=timeout_s)
+
+
+def probe_port(
+    port: int,
+    host: str = DEFAULT_HOST,
+    *,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+) -> dict:
+    """Return a structured probe result for doctor/allocator reports."""
+    free = port_is_free(port, host, timeout_s=timeout_s)
+    return {
+        "port": int(port),
+        "host": host,
+        "free": free,
+        "listening": not free,
+        "timeout_s": timeout_s,
+    }

--- a/tests/mcp/test_provision.py
+++ b/tests/mcp/test_provision.py
@@ -48,12 +48,14 @@ def test_provision_idempotency(temp_project):
         assert path1 == path2
 
 def test_instance_overlay_uniqueness(temp_project):
+    # Empty catalog skips lease allocator so this exercises the legacy port map.
+    empty_catalog = {"defaults": {"per_worktree": []}, "servers": {}}
     # Instance A
-    manager_a = InstanceOverlayManager(temp_project, "A")
+    manager_a = InstanceOverlayManager(temp_project, "A", catalog=empty_catalog)
     overlay_a = manager_a.materialize()
     
     # Instance B
-    manager_b = InstanceOverlayManager(temp_project, "B")
+    manager_b = InstanceOverlayManager(temp_project, "B", catalog=empty_catalog)
     overlay_b = manager_b.materialize()
     
     assert overlay_a["base_port"] == 3000
@@ -172,5 +174,29 @@ def test_provision_broken_symlink_cleanup(temp_project):
         assert os.readlink(path) == str(pkg_mcp)
 
 def test_instance_overlay_no_id(temp_project):
-    manager = InstanceOverlayManager(temp_project, "")
+    empty_catalog = {"defaults": {"per_worktree": []}, "servers": {}}
+    manager = InstanceOverlayManager(temp_project, "", catalog=empty_catalog)
     assert manager.base_port == 3000
+
+
+def test_instance_overlay_reraises_allocator_blocked(temp_project):
+    """BLOCKED allocation must not fall back to the legacy colliding map."""
+
+    def boom(*_a, **_k):
+        raise RuntimeError("Fixed port 7890 occupied by unknown process.")
+
+    catalog = {
+        "defaults": {"per_worktree": ["task-orchestrator"]},
+        "servers": {
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "state_scope": "per-repo",
+                "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
+                "default_port_base": 7890,
+                "management_model": "wrapper-singleton",
+            }
+        },
+    }
+    with patch("dopemux.mcp.port_allocator.allocate_ports_map", side_effect=boom):
+        with pytest.raises(RuntimeError, match="Fixed port 7890"):
+            InstanceOverlayManager(temp_project, "A", catalog=catalog)

--- a/tests/unit/test_mcp_agent_bootstrap.py
+++ b/tests/unit/test_mcp_agent_bootstrap.py
@@ -1,0 +1,85 @@
+"""Unit tests for agent bootstrap doc generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dopemux.mcp.agent_bootstrap import (
+    BEGIN_MARKER,
+    END_MARKER,
+    apply_agent_bootstrap,
+    bootstrap_section_body,
+    plan_agent_bootstrap,
+    verify_bootstrap_content,
+    wrap_marked_section,
+)
+
+
+def test_create_new_doc(tmp_path: Path):
+    repo = tmp_path / "r"
+    repo.mkdir()
+    plan = plan_agent_bootstrap(repo)
+    assert plan.kind == "create"
+    assert plan.reason == "AGENT_BOOTSTRAP_CREATED"
+    apply_agent_bootstrap(plan)
+    text = plan.path.read_text()
+    assert BEGIN_MARKER in text
+    assert END_MARKER in text
+    assert verify_bootstrap_content(text) == []
+    assert "dopemux mcp start" in text
+    assert "dopemux mcp doctor" in text
+    assert "Do not start this repo's MCP services by cd'ing into `dopemux-mvp`" in text
+    assert "Authority" in text
+
+
+def test_update_marked_section(tmp_path: Path):
+    repo = tmp_path / "r"
+    repo.mkdir()
+    path = repo / ".claude" / "WORKTREE_MCP_SETUP.md"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        "# Header kept\n\n"
+        f"{BEGIN_MARKER}\nOLD CONTENT\n{END_MARKER}\n\n"
+        "# Footer kept\n"
+    )
+    plan = plan_agent_bootstrap(repo)
+    assert plan.kind == "update"
+    apply_agent_bootstrap(plan)
+    text = path.read_text()
+    assert "# Header kept" in text
+    assert "# Footer kept" in text
+    assert "OLD CONTENT" not in text
+    assert "dopemux mcp start" in text
+
+
+def test_append_when_no_markers(tmp_path: Path):
+    repo = tmp_path / "r"
+    repo.mkdir()
+    path = repo / ".claude" / "WORKTREE_MCP_SETUP.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# Existing unrelated guide\n\nKeep me.\n")
+    plan = plan_agent_bootstrap(repo)
+    assert plan.kind == "append"
+    apply_agent_bootstrap(plan)
+    text = path.read_text()
+    assert "Keep me." in text
+    assert BEGIN_MARKER in text
+    assert text.index("Keep me.") < text.index(BEGIN_MARKER)
+
+
+def test_noop_when_identical(tmp_path: Path):
+    repo = tmp_path / "r"
+    repo.mkdir()
+    plan = plan_agent_bootstrap(repo)
+    apply_agent_bootstrap(plan)
+    plan2 = plan_agent_bootstrap(repo)
+    assert plan2.kind == "noop"
+    mtime = plan.path.stat().st_mtime_ns
+    apply_agent_bootstrap(plan2)
+    assert plan.path.stat().st_mtime_ns == mtime
+
+
+def test_body_contains_required_phrases():
+    body = bootstrap_section_body()
+    assert verify_bootstrap_content(wrap_marked_section(body)) == []
+    assert "PORT_HASH_BUCKET_COLLISION_RISK" in body or "hash" in body.lower()

--- a/tests/unit/test_mcp_commands_catalog.py
+++ b/tests/unit/test_mcp_commands_catalog.py
@@ -133,21 +133,25 @@ def test_allocate_ports_raises_on_cross_server_collision():
         },
     }
 
-    with pytest.raises(click.ClickException) as excinfo:
-        mcp_commands._allocate_ports("/tmp/wt-collide", ["alpha", "beta"], catalog)
+    # Packet 004: cross-service preferred collisions rebind instead of hard-fail
+    ports = mcp_commands._allocate_ports(
+        "/tmp/wt-collide",
+        ["alpha", "beta"],
+        catalog,
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
+    )
+    assert ports["ALPHA_PORT"] != ports["BETA_PORT"]
 
-    msg = str(excinfo.value.message)
-    assert "Internal port collision" in msg
-    assert "alpha" in msg
-    assert "beta" in msg
 
-
-def test_allocate_ports_wrapper_singleton_uses_fixed_base_port():
+def test_allocate_ports_wrapper_singleton_uses_fixed_base_port(tmp_path, monkeypatch):
     """wrapper-singleton services must NOT have a workspace hash offset applied.
 
     task-orchestrator is the canonical wrapper-singleton; its port must always
     equal default_port_base regardless of the workspace path hash.
     """
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(tmp_path / "leases.json"))
     catalog = {
         "version": 1,
         "servers": {
@@ -163,17 +167,24 @@ def test_allocate_ports_wrapper_singleton_uses_fixed_base_port():
     }
 
     # Two completely different workspace paths must yield the same fixed port
+    # (dry-run so concurrent multi-project fixed-port leases are not written)
     result_a = mcp_commands._allocate_ports(
         "/Users/alice/code/project-a",
         ["task-orchestrator"],
         catalog,
         project_root="/Users/alice/code/project-a",
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
     )
     result_b = mcp_commands._allocate_ports(
         "/Users/bob/totally-different-path/zyx",
         ["task-orchestrator"],
         catalog,
         project_root="/Users/bob/totally-different-path/zyx",
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
     )
 
     assert result_a["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
@@ -210,19 +221,17 @@ def test_allocate_ports_raises_on_singleton_port_collision(monkeypatch):
         },
     }
 
-    # Force _port_for to return the singleton port regardless of input
-    monkeypatch.setattr(mcp_commands, "_port_for", lambda _path, _base: SINGLETON_PORT)
-
-    with pytest.raises(click.ClickException) as excinfo:
-        mcp_commands._allocate_ports(
-            "/Users/hue/code/dNh_CRM",
-            ["conport"],
-            catalog,
-        )
-
-    msg = str(excinfo.value.message)
-    assert "collision" in msg.lower()
-    assert str(SINGLETON_PORT) in msg or "gpt-researcher" in msg or "singleton" in msg
+    # Prefer reserved port via envrc; allocator must rebind away from singleton
+    ports = mcp_commands._allocate_ports(
+        "/Users/hue/code/dNh_CRM",
+        ["conport"],
+        catalog,
+        existing_envrc={"CONPORT_HTTP_PORT": str(SINGLETON_PORT)},
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
+    )
+    assert ports["CONPORT_HTTP_PORT"] != SINGLETON_PORT
 
 
 def test_allocate_ports_raises_on_url_singleton_port_collision(monkeypatch):
@@ -245,42 +254,52 @@ def test_allocate_ports_raises_on_url_singleton_port_collision(monkeypatch):
         },
     }
 
-    monkeypatch.setattr(mcp_commands, "_port_for", lambda _path, _base: SINGLETON_PORT)
+    ports = mcp_commands._allocate_ports(
+        "/tmp/wt",
+        ["conport"],
+        catalog,
+        existing_envrc={"CONPORT_HTTP_PORT": str(SINGLETON_PORT)},
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
+    )
+    assert ports["CONPORT_HTTP_PORT"] != SINGLETON_PORT
 
-    with pytest.raises(click.ClickException) as excinfo:
-        mcp_commands._allocate_ports("/tmp/wt", ["conport"], catalog)
 
-    assert "collision" in str(excinfo.value.message).lower()
-
-
-def test_allocate_ports_uses_project_root_for_per_repo_state():
+def test_allocate_ports_uses_project_root_for_per_repo_state(tmp_path, monkeypatch):
     catalog = {
         "version": 1,
         "servers": {
             "task-orchestrator": {
                 "scope": "per-worktree",
                 "state_scope": "per-repo",
+                "management_model": "wrapper-singleton",
                 "transport": "http",
                 "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
                 "default_port_base": 7890,
             },
         },
     }
+    reg = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg))
 
     main = mcp_commands._allocate_ports(
         "/tmp/repo",
         ["task-orchestrator"],
         catalog,
         project_root="/tmp/shared-project",
+        is_free_fn=lambda p: True,
     )
     linked = mcp_commands._allocate_ports(
         "/tmp/repo-linked",
         ["task-orchestrator"],
         catalog,
         project_root="/tmp/shared-project",
+        is_free_fn=lambda p: True,
     )
 
     assert linked == main
+    assert main["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
 
 
 def test_project_identity_is_shared_across_linked_worktrees(tmp_path):

--- a/tests/unit/test_mcp_commands_repair.py
+++ b/tests/unit/test_mcp_commands_repair.py
@@ -1,0 +1,167 @@
+"""CLI tests for repair-config and fleet commands."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+from click.testing import CliRunner
+
+from dopemux.commands import mcp_commands
+
+
+def _catalog() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "defaults": {"per_worktree": ["dope-memory"]},
+        "servers": {
+            "dope-memory": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "url_template": "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp",
+                "port_var": "DOPE_MEMORY_PORT",
+                "default_port_base": 3020,
+                "management_model": "compose-service",
+            }
+        },
+    }
+
+
+def _git_init(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True, capture_output=True)
+    (path / "README").write_text("x\n")
+    subprocess.run(["git", "add", "README"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True, capture_output=True)
+
+
+@pytest.fixture
+def fixture_repo(tmp_path, monkeypatch):
+    repo = tmp_path / "fixture"
+    _git_init(repo)
+    (repo / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "dope-memory": {"type": "sse", "url": "http://localhost:3060/mcp"},
+                    "custom": {"type": "http", "url": "http://localhost:1/x"},
+                }
+            }
+        )
+        + "\n"
+    )
+    monkeypatch.setattr(mcp_commands, "_load_catalog", lambda: _catalog())
+    monkeypatch.setattr(mcp_commands, "_catalog_path", lambda: None)
+    monkeypatch.setattr(
+        mcp_commands,
+        "get_repo_root",
+        lambda fallback_cwd=False: str(repo),
+    )
+    return repo
+
+
+def test_repair_config_requires_flag(fixture_repo):
+    runner = CliRunner()
+    result = runner.invoke(mcp_commands.mcp, ["repair-config", "--repo", str(fixture_repo)])
+    assert result.exit_code != 0
+    assert "exactly one" in result.output.lower() or "dry-run" in result.output.lower()
+
+
+def test_repair_config_rejects_both_flags(fixture_repo):
+    runner = CliRunner()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        ["repair-config", "--repo", str(fixture_repo), "--dry-run", "--apply"],
+    )
+    assert result.exit_code != 0
+
+
+def test_repair_config_dry_run_json(fixture_repo):
+    runner = CliRunner()
+    before = (fixture_repo / ".mcp.json").read_text()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        ["repair-config", "--repo", str(fixture_repo), "--dry-run", "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["operation"] == "repair-config"
+    assert data["dry_run"] is True
+    assert data["status"] in {"PLANNED", "NOOP"}
+    assert (fixture_repo / ".mcp.json").read_text() == before
+
+
+def test_repair_config_apply_json(fixture_repo):
+    runner = CliRunner()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        ["repair-config", "--repo", str(fixture_repo), "--apply", "--json"],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["status"] == "APPLIED"
+    mcp = json.loads((fixture_repo / ".mcp.json").read_text())
+    assert mcp["mcpServers"]["dope-memory"]["type"] == "http"
+    assert mcp["mcpServers"]["custom"]["url"] == "http://localhost:1/x"
+    assert (fixture_repo / ".envrc.dopemux-mcp").is_file()
+
+
+def test_fleet_init_dry_run_json(fixture_repo, monkeypatch):
+    runner = CliRunner()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        [
+            "fleet",
+            "init",
+            "--repo",
+            str(fixture_repo),
+            "--worktrees",
+            str(fixture_repo),
+            "--dry-run",
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["operation"] == "fleet-init"
+    assert data["dry_run"] is True
+
+
+def test_fleet_doctor_json(fixture_repo, monkeypatch):
+    # Avoid real docker/network in doctor
+    from dopemux.mcp import doctor as doctor_mod
+
+    class FakeReport:
+        status = "PASS"
+        findings = []
+        exit_code = 0
+
+        def to_json(self):
+            return "{}"
+
+    monkeypatch.setattr(
+        doctor_mod,
+        "run_mcp_doctor",
+        lambda *a, **k: FakeReport(),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        mcp_commands.mcp,
+        [
+            "fleet",
+            "doctor",
+            "--repo",
+            str(fixture_repo),
+            "--worktrees",
+            str(fixture_repo),
+            "--json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["operation"] == "fleet-doctor"

--- a/tests/unit/test_mcp_config_repair.py
+++ b/tests/unit/test_mcp_config_repair.py
@@ -277,6 +277,51 @@ def test_port_limitation_warnings(tmp_path: Path):
     assert "PORT_REBIND_MISSING" in codes
 
 
+def test_plan_does_not_persist_leases_until_apply(tmp_path: Path):
+    """Planning must not write leases even when dry_run=False (apply path)."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    calls: list[dict] = []
+
+    def tracking_alloc(
+        worktree: str,
+        names: List[str],
+        catalog: Dict[str, Any],
+        *,
+        project_root: str | None = None,
+        persist: bool = True,
+        dry_run: bool = False,
+        existing_envrc: Dict[str, str] | None = None,
+        source: str = "",
+        **_kwargs: Any,
+    ):
+        calls.append({"persist": persist, "dry_run": dry_run, "source": source})
+        return _alloc(worktree, names, catalog, project_root=project_root)
+
+    plan = cr.plan_repair(
+        repo,
+        _catalog(),
+        dry_run=False,  # simulate --apply planning
+        allocate_ports_fn=tracking_alloc,
+        project_env_exports_fn=_exports,
+        render_local_fn=_render,
+        global_claude_path=repo / "no-global.json",
+    )
+    assert plan.status in {"PLANNED", "NOOP"}
+    # Plan-time allocation must never persist
+    assert calls, "allocator should have been invoked during plan"
+    assert all(c["persist"] is False or c["dry_run"] is True for c in calls)
+
+    plan.dry_run = False
+    plan_calls_before_apply = len(calls)
+    applied = cr.apply_repair(plan)
+    assert applied.status == "APPLIED"
+    # Apply should re-invoke allocator with persist enabled
+    post = calls[plan_calls_before_apply:]
+    assert post, "allocator should re-run on apply for lease persistence"
+    assert any(c["persist"] is True and c["dry_run"] is False for c in post)
+
+
 def test_is_catalog_owned():
     cat = _catalog()
     assert mj.is_catalog_owned("conport", cat) is True

--- a/tests/unit/test_mcp_config_repair.py
+++ b/tests/unit/test_mcp_config_repair.py
@@ -1,0 +1,297 @@
+"""Unit tests for MCP config repair (TP-DMX-MCP-RUNTIME-003)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from dopemux.mcp import config_repair as cr
+from dopemux.mcp import mcp_json as mj
+
+
+def _catalog() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "defaults": {"per_worktree": ["conport", "dope-memory", "task-orchestrator"]},
+        "servers": {
+            "conport": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "url_template": "http://localhost:${CONPORT_MCP_PORT:-3005}/sse",
+                "port_var": "CONPORT_MCP_PORT",
+                "default_port_base": 3005,
+                "extra_port_vars": [
+                    {"var": "CONPORT_HTTP_PORT", "base": 3004},
+                    {"var": "CONPORT_INFO_PORT", "base": 4004},
+                ],
+                "requires_env": ["DOPEMUX_WORKSPACE_ID"],
+                "management_model": "compose-service",
+            },
+            "dope-memory": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "url_template": "http://localhost:${DOPE_MEMORY_PORT:-3020}/mcp",
+                "port_var": "DOPE_MEMORY_PORT",
+                "default_port_base": 3020,
+                "management_model": "compose-service",
+            },
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "state_scope": "per-repo",
+                "transport": "http",
+                "url_template": "http://127.0.0.1:${TASK_ORCHESTRATOR_HTTP_PORT:-7890}/mcp",
+                "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
+                "default_port_base": 7890,
+                "management_model": "wrapper-singleton",
+            },
+            "pal": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": "http://localhost:3003/mcp",
+            },
+        },
+    }
+
+
+def _render(name: str, spec: Dict[str, Any]) -> Dict[str, Any]:
+    entry: Dict[str, Any] = {"type": spec.get("transport", "http")}
+    if "url_template" in spec or "url" in spec:
+        entry["url"] = spec.get("url_template") or spec.get("url")
+    env_keys = list(spec.get("requires_env") or [])
+    if env_keys:
+        entry["env"] = {k: f"${{{k}:-}}" for k in env_keys}
+    return entry
+
+
+def _alloc(worktree: str, names: List[str], catalog: Dict[str, Any], *, project_root: str | None = None):
+    # Deterministic fake ports for tests
+    out = {}
+    for name in names:
+        spec = catalog["servers"][name]
+        if spec.get("port_var"):
+            base = int(spec.get("default_port_base") or 3000)
+            out[spec["port_var"]] = base + 10
+        for extra in spec.get("extra_port_vars") or []:
+            out[extra["var"]] = int(extra["base"]) + 10
+    return out
+
+
+def _exports(worktree: str, project_root: str) -> Dict[str, str]:
+    return {
+        "DOPEMUX_WORKSPACE_ID": worktree,
+        "DOPEMUX_WORKSPACE_ROOT": worktree,
+        "DOPEMUX_PROJECT_ROOT": project_root,
+        "TASK_ORCHESTRATOR_PROJECT_ROOT": project_root,
+        "DOPEMUX_INSTANCE_ID": "abcd",
+        "DOPE_MEMORY_WORKSPACE_ID": Path(worktree).name,
+        "DOPE_MEMORY_INSTANCE_ID": "abcd",
+        "WORKSPACE_ID": worktree,
+    }
+
+
+def _plan(repo: Path, **kwargs):
+    return cr.plan_repair(
+        repo,
+        _catalog(),
+        dry_run=kwargs.pop("dry_run", True),
+        allocate_ports_fn=_alloc,
+        project_env_exports_fn=_exports,
+        render_local_fn=_render,
+        global_claude_path=repo / "no-global-claude.json",
+        **kwargs,
+    )
+
+
+def test_dry_run_writes_nothing(tmp_path: Path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    mcp = {
+        "mcpServers": {
+            "dope-memory": {"type": "sse", "url": "http://localhost:3060/mcp"},
+            "custom-svc": {"type": "http", "url": "http://localhost:9999/mcp"},
+        }
+    }
+    mcp_path = repo / ".mcp.json"
+    mcp_path.write_text(json.dumps(mcp, indent=2) + "\n")
+    before = mcp_path.read_text()
+
+    plan = _plan(repo, dry_run=True)
+    assert plan.status == "PLANNED"
+    assert plan.dry_run is True
+    assert mcp_path.read_text() == before
+    assert not (repo / ".envrc.dopemux-mcp").exists()
+    assert not (repo / ".claude" / "WORKTREE_MCP_SETUP.md").exists()
+
+
+def test_apply_repairs_transport_and_preserves_custom(tmp_path: Path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    mcp = {
+        "mcpServers": {
+            "conport": {
+                "type": "sse",
+                "url": "http://localhost:${CONPORT_MCP_PORT:-3005}/sse",
+            },
+            "dope-memory": {"type": "sse", "url": "http://localhost:3060/mcp"},
+            "task-orchestrator": {"type": "sse", "url": "http://localhost:7890/mcp"},
+            "custom-svc": {"type": "http", "url": "http://localhost:9999/mcp"},
+        }
+    }
+    (repo / ".mcp.json").write_text(json.dumps(mcp, indent=2) + "\n")
+
+    plan = _plan(repo, dry_run=True)
+    assert any(c.get("service") == "dope-memory" and c.get("reason") == "TRANSPORT_MISMATCH" for c in plan.planned_changes)
+    assert any(c.get("service") == "task-orchestrator" for c in plan.planned_changes)
+    assert any(p.get("service") == "custom-svc" for p in plan.preserved_entries)
+
+    plan.dry_run = False
+    applied = cr.apply_repair(plan)
+    assert applied.status == "APPLIED"
+
+    data = json.loads((repo / ".mcp.json").read_text())
+    assert data["mcpServers"]["dope-memory"]["type"] == "http"
+    assert data["mcpServers"]["task-orchestrator"]["type"] == "http"
+    assert data["mcpServers"]["conport"]["type"] == "sse"
+    assert data["mcpServers"]["custom-svc"]["url"] == "http://localhost:9999/mcp"
+    assert (repo / ".envrc.dopemux-mcp").is_file()
+    assert (repo / ".claude" / "WORKTREE_MCP_SETUP.md").is_file()
+
+
+def test_noop_when_already_valid(tmp_path: Path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    servers = {}
+    for name in ("conport", "dope-memory", "task-orchestrator"):
+        servers[name] = _render(name, _catalog()["servers"][name])
+    (repo / ".mcp.json").write_text(json.dumps({"mcpServers": servers}, indent=2) + "\n")
+
+    # Write matching envrc
+    env_map = _exports(str(repo), str(repo))
+    env_map.update({k: str(v) for k, v in _alloc(str(repo), list(servers), _catalog(), project_root=str(repo)).items()})
+    lines = [f"export {k}={v}" for k, v in env_map.items()]
+    (repo / ".envrc.dopemux-mcp").write_text("\n".join(lines) + "\n")
+
+    # Pre-write matching agent bootstrap
+    from dopemux.mcp.agent_bootstrap import apply_agent_bootstrap, plan_agent_bootstrap
+
+    ap = plan_agent_bootstrap(repo)
+    apply_agent_bootstrap(ap)
+
+    plan = _plan(repo, dry_run=True)
+    assert plan.status == "NOOP"
+    assert plan.planned_changes == []
+
+
+def test_missing_mcp_json_creates(tmp_path: Path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    plan = _plan(repo, dry_run=False)
+    plan.dry_run = False
+    applied = cr.apply_repair(plan)
+    assert applied.status == "APPLIED"
+    data = json.loads((repo / ".mcp.json").read_text())
+    assert "conport" in data["mcpServers"]
+    assert "dope-memory" in data["mcpServers"]
+
+
+def test_malformed_mcp_json_blocks(tmp_path: Path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    (repo / ".mcp.json").write_text("{not-json\n")
+    plan = _plan(repo)
+    assert plan.status == "BLOCKED"
+    assert any(b.get("code") == "MCP_JSON_PARSE_ERROR" for b in plan.blocking_findings)
+
+
+def test_non_localhost_url_not_modified(tmp_path: Path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    mcp = {
+        "mcpServers": {
+            "dope-memory": {
+                "type": "sse",
+                "url": "https://remote.example.com/mcp",
+            }
+        }
+    }
+    (repo / ".mcp.json").write_text(json.dumps(mcp) + "\n")
+    plan = _plan(repo, dry_run=False)
+    plan.dry_run = False
+    cr.apply_repair(plan)
+    data = json.loads((repo / ".mcp.json").read_text())
+    assert data["mcpServers"]["dope-memory"]["url"] == "https://remote.example.com/mcp"
+    # type may still be repaired
+    assert data["mcpServers"]["dope-memory"]["type"] == "http"
+
+
+def test_secret_like_envrc_blocks_apply(tmp_path: Path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    (repo / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"conport": _render("conport", _catalog()["servers"]["conport"])}}) + "\n"
+    )
+    (repo / ".envrc.dopemux-mcp").write_text(
+        "export DOPEMUX_WORKSPACE_ID=/x\nexport OPENAI_API_KEY=sk-secret\n"
+    )
+    plan = _plan(repo, dry_run=True)
+    assert plan.status == "BLOCKED"
+    assert any(b.get("code") == "ENVRC_SECRET_LIKE_UNCERTAIN" for b in plan.blocking_findings)
+    assert any(w.get("code") == "ENVRC_SECRET_LIKE_VALUE_REDACTED" for w in plan.warnings)
+    # dry-run must not write
+    assert "sk-secret" not in plan.to_json()
+
+
+def test_no_global_mutation(tmp_path: Path, monkeypatch):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    global_path = tmp_path / "fake-claude.json"
+    global_path.write_text(json.dumps({"mcpServers": {"conport": {"type": "sse"}}}) + "\n")
+    before = global_path.read_text()
+
+    plan = _plan(repo)
+    # force global path via plan_repair kw
+    plan = cr.plan_repair(
+        repo,
+        _catalog(),
+        dry_run=False,
+        allocate_ports_fn=_alloc,
+        project_env_exports_fn=_exports,
+        render_local_fn=_render,
+        global_claude_path=global_path,
+    )
+    plan.dry_run = False
+    cr.apply_repair(plan)
+    assert global_path.read_text() == before
+    assert any(w.get("code") == "GLOBAL_CONFIG_NOT_MODIFIED" for w in plan.warnings)
+
+
+def test_port_limitation_warnings(tmp_path: Path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    plan = _plan(repo)
+    codes = {w.get("code") for w in plan.warnings}
+    assert "PORT_HASH_BUCKET_COLLISION_RISK" in codes
+    assert "PORT_REBIND_MISSING" in codes
+
+
+def test_is_catalog_owned():
+    cat = _catalog()
+    assert mj.is_catalog_owned("conport", cat) is True
+    assert mj.is_catalog_owned("pal", cat) is False
+    assert mj.is_catalog_owned("custom", cat) is False
+
+
+def test_json_schema_shape(tmp_path: Path):
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    plan = _plan(repo)
+    d = plan.to_dict()
+    assert d["schema_version"] == "1.0"
+    assert d["operation"] == "repair-config"
+    assert "project_identity" in d
+    assert "planned_changes" in d
+    assert "next_actions" in d
+    assert "dopemux mcp start" in d["next_actions"]

--- a/tests/unit/test_mcp_doctor_repo_aware.py
+++ b/tests/unit/test_mcp_doctor_repo_aware.py
@@ -12,7 +12,11 @@ from click.testing import CliRunner
 from dopemux.commands import mcp_commands
 from dopemux.mcp.doctor import format_human_summary, run_mcp_doctor
 from dopemux.mcp.project_identity import resolve_project_identity
-from dopemux.mcp.runtime_state import build_desired_services, compose_lifecycle_diagnostics
+from dopemux.mcp.runtime_state import (
+    build_desired_services,
+    compose_lifecycle_diagnostics,
+    resolve_identity_view,
+)
 
 
 def _catalog():
@@ -194,6 +198,40 @@ services:
     assert any(
         "DOPEMUX_WORKSPACE_ID" in r for r in diag2["identity_env_risks"]
     )
+
+
+def test_build_desired_services_unions_catalog_defaults():
+    catalog = _catalog()
+    # Only conport in mcp.json — defaults still include dope-memory + task-orchestrator
+    desired = build_desired_services(
+        catalog,
+        {"conport": {"type": "sse", "url": "http://localhost:3005/sse"}},
+        {"CONPORT_MCP_PORT": "3005", "DOPE_MEMORY_PORT": "3020"},
+    )
+    names = {s.name for s in desired}
+    assert "conport" in names
+    assert "dope-memory" in names
+    assert "task-orchestrator" in names
+
+
+def test_resolve_identity_forces_repo_over_ambient(tmp_path: Path):
+    target = tmp_path / "target-repo"
+    target.mkdir()
+    (target / ".git").mkdir()
+    foreign = tmp_path / "foreign-repo"
+    foreign.mkdir()
+    (foreign / ".git").mkdir()
+
+    view = resolve_identity_view(
+        target,
+        envrc_values={
+            "DOPEMUX_WORKSPACE_ROOT": str(foreign),
+            "DOPEMUX_PROJECT_ROOT": str(foreign),
+            "TASK_ORCHESTRATOR_PROJECT_ROOT": str(foreign),
+        },
+    )
+    assert view.worktree_root == str(target.resolve())
+    assert any("forced identity" in e for e in view.evidence)
 
 
 def test_compose_no_hazard_minimal():

--- a/tests/unit/test_mcp_envrc.py
+++ b/tests/unit/test_mcp_envrc.py
@@ -61,6 +61,25 @@ def test_parse_malformed_line():
     assert any("malformed" in e for e in errors)
 
 
+def test_load_envrc_partial_keeps_values(tmp_path: Path):
+    """Malformed lines must not mark partial parses as ERROR when keys loaded."""
+    path = tmp_path / ".envrc.dopemux-mcp"
+    path.write_text(
+        "not a valid line\n"
+        "export CONPORT_MCP_PORT=3041\n"
+        "export DOPEMUX_INSTANCE_ID=abcd\n"
+        "also bad\n"
+    )
+    result = load_envrc(path)
+    assert result.present is True
+    assert result.parse_status == "PARTIAL"
+    assert result.values["CONPORT_MCP_PORT"] == "3041"
+    assert result.values["DOPEMUX_INSTANCE_ID"] == "abcd"
+    assert len(result.errors) >= 2
+    merged = merge_envrc_into_environ({}, result)
+    assert merged["CONPORT_MCP_PORT"] == "3041"
+
+
 def test_secret_like_redaction():
     assert is_secret_like_key("OPENAI_API_KEY") is True
     assert is_secret_like_key("CONPORT_MCP_PORT") is False

--- a/tests/unit/test_mcp_envrc.py
+++ b/tests/unit/test_mcp_envrc.py
@@ -129,3 +129,26 @@ def test_merge_envrc_into_environ_override(tmp_path: Path):
     merged = merge_envrc_into_environ({"CONPORT_MCP_PORT": "3005", "OTHER": "x"}, parsed)
     assert merged["CONPORT_MCP_PORT"] == "3041"
     assert merged["OTHER"] == "x"
+
+
+def test_repair_envrc_regeneration_keys(tmp_path: Path):
+    """Envrc repair path produces catalog-owned port keys without secrets."""
+    from dopemux.mcp.config_repair import _build_envrc_text
+
+    text = _build_envrc_text(
+        "/tmp/wt",
+        "/tmp/proj",
+        {
+            "DOPEMUX_WORKSPACE_ID": "/tmp/wt",
+            "DOPEMUX_PROJECT_ROOT": "/tmp/proj",
+            "DOPEMUX_INSTANCE_ID": "abcd",
+            "CONPORT_MCP_PORT": "3015",
+            "DOPE_MEMORY_PORT": "3030",
+            "CUSTOM_SAFE": "keep-me",
+        },
+        preserve_values={"CUSTOM_SAFE": "keep-me", "OPENAI_API_KEY": "sk-x"},
+    )
+    assert "export CONPORT_MCP_PORT=3015" in text
+    assert "export CUSTOM_SAFE=keep-me" in text
+    assert "OPENAI_API_KEY" not in text
+    assert "sk-x" not in text

--- a/tests/unit/test_mcp_envrc.py
+++ b/tests/unit/test_mcp_envrc.py
@@ -62,7 +62,7 @@ def test_parse_malformed_line():
 
 
 def test_load_envrc_partial_keeps_values(tmp_path: Path):
-    """Malformed lines must not mark partial parses as ERROR when keys loaded."""
+    """Malformed lines must not hard-fail when keys loaded (parse_status OK)."""
     path = tmp_path / ".envrc.dopemux-mcp"
     path.write_text(
         "not a valid line\n"
@@ -72,7 +72,7 @@ def test_load_envrc_partial_keeps_values(tmp_path: Path):
     )
     result = load_envrc(path)
     assert result.present is True
-    assert result.parse_status == "PARTIAL"
+    assert result.parse_status == "OK"
     assert result.values["CONPORT_MCP_PORT"] == "3041"
     assert result.values["DOPEMUX_INSTANCE_ID"] == "abcd"
     assert len(result.errors) >= 2

--- a/tests/unit/test_mcp_fleet.py
+++ b/tests/unit/test_mcp_fleet.py
@@ -1,0 +1,192 @@
+"""Unit tests for fleet init/doctor (TP-DMX-MCP-RUNTIME-003)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from dopemux.mcp import fleet as fl
+
+
+def _catalog() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "defaults": {"per_worktree": ["conport"]},
+        "servers": {
+            "conport": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "url_template": "http://localhost:${CONPORT_MCP_PORT}/sse",
+                "port_var": "CONPORT_MCP_PORT",
+                "default_port_base": 3005,
+                "management_model": "compose-service",
+            }
+        },
+    }
+
+
+def _render(name: str, spec: Dict[str, Any]) -> Dict[str, Any]:
+    return {"type": spec["transport"], "url": spec.get("url_template") or spec.get("url")}
+
+
+def _alloc(worktree, names, catalog, *, project_root=None):
+    return {"CONPORT_MCP_PORT": 3015}
+
+
+def _exports(worktree, project_root):
+    return {
+        "DOPEMUX_WORKSPACE_ID": worktree,
+        "DOPEMUX_WORKSPACE_ROOT": worktree,
+        "DOPEMUX_PROJECT_ROOT": project_root,
+        "TASK_ORCHESTRATOR_PROJECT_ROOT": project_root,
+        "DOPEMUX_INSTANCE_ID": "ffff",
+        "DOPE_MEMORY_WORKSPACE_ID": Path(worktree).name,
+        "DOPE_MEMORY_INSTANCE_ID": "ffff",
+        "WORKSPACE_ID": worktree,
+    }
+
+
+def _git_init(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "t"], cwd=path, check=True, capture_output=True)
+    (path / "README").write_text("x\n")
+    subprocess.run(["git", "add", "README"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=path, check=True, capture_output=True)
+
+
+def _git_worktree(main: Path, wt: Path, branch: str) -> None:
+    subprocess.run(
+        ["git", "worktree", "add", "-b", branch, str(wt)],
+        cwd=main,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_fleet_init_dry_run_multi(tmp_path: Path):
+    main = tmp_path / "main"
+    _git_init(main)
+    wt = tmp_path / "wt-a"
+    _git_worktree(main, wt, "feature-a")
+
+    report = fl.fleet_init(
+        main,
+        [main, wt],
+        _catalog(),
+        dry_run=True,
+        apply=False,
+        allocate_ports_fn=_alloc,
+        project_env_exports_fn=_exports,
+        render_local_fn=_render,
+        global_claude_path=tmp_path / "no-global.json",
+    )
+    assert report.operation == "fleet-init"
+    assert report.dry_run is True
+    assert len(report.worktrees) == 2
+    # dry-run must not write
+    assert not (main / ".mcp.json").exists()
+    assert not (wt / ".mcp.json").exists()
+    assert report.counts["failed"] == 0
+
+
+def test_fleet_init_apply(tmp_path: Path):
+    main = tmp_path / "main"
+    _git_init(main)
+    wt = tmp_path / "wt-b"
+    _git_worktree(main, wt, "feature-b")
+
+    report = fl.fleet_init(
+        main,
+        [main, wt],
+        _catalog(),
+        dry_run=False,
+        apply=True,
+        allocate_ports_fn=_alloc,
+        project_env_exports_fn=_exports,
+        render_local_fn=_render,
+        global_claude_path=tmp_path / "no-global.json",
+    )
+    assert (main / ".mcp.json").is_file()
+    assert (wt / ".mcp.json").is_file()
+    assert report.counts["failed"] == 0
+    assert report.counts["repaired"] + report.counts["initialized"] >= 1
+
+
+def test_fleet_wrong_repo_blocked(tmp_path: Path):
+    a = tmp_path / "repo-a"
+    b = tmp_path / "repo-b"
+    _git_init(a)
+    _git_init(b)
+
+    report = fl.fleet_init(
+        a,
+        [b],
+        _catalog(),
+        dry_run=True,
+        allocate_ports_fn=_alloc,
+        project_env_exports_fn=_exports,
+        render_local_fn=_render,
+        global_claude_path=tmp_path / "no-global.json",
+    )
+    assert report.counts["failed"] == 1
+    assert report.worktrees[0].code == "FLEET_WORKTREE_INVALID"
+    assert report.status == "FAIL"
+
+
+def test_fleet_invalid_path(tmp_path: Path):
+    main = tmp_path / "main"
+    _git_init(main)
+    report = fl.fleet_init(
+        main,
+        [tmp_path / "does-not-exist"],
+        _catalog(),
+        dry_run=True,
+        allocate_ports_fn=_alloc,
+        project_env_exports_fn=_exports,
+        render_local_fn=_render,
+    )
+    assert report.counts["failed"] >= 1
+
+
+def test_fleet_doctor_aggregates(tmp_path: Path):
+    main = tmp_path / "main"
+    _git_init(main)
+
+    def fake_doctor(path, **kwargs):
+        m = MagicMock()
+        m.status = "PASS_WITH_WARNINGS"
+        m.findings = [MagicMock(code="TRANSPORT_MISMATCH")]
+        return m
+
+    report = fl.fleet_doctor(
+        main,
+        [main],
+        _catalog(),
+        skip_docker=True,
+        run_doctor_fn=fake_doctor,
+    )
+    assert report.operation == "fleet-doctor"
+    assert report.counts["warn"] == 1
+    assert report.worktrees[0]["top_findings"] == ["TRANSPORT_MISMATCH"]
+    assert report.status == "PASS_WITH_WARNINGS"
+
+
+def test_fleet_doctor_json_shape(tmp_path: Path):
+    main = tmp_path / "main"
+    _git_init(main)
+
+    def fake_doctor(path, **kwargs):
+        return {"status": "PASS", "findings": []}
+
+    report = fl.fleet_doctor(main, [main], _catalog(), run_doctor_fn=fake_doctor)
+    d = json.loads(report.to_json())
+    assert d["schema_version"] == "1.0"
+    assert "counts" in d
+    assert d["counts"]["pass"] == 1

--- a/tests/unit/test_mcp_lease_migration.py
+++ b/tests/unit/test_mcp_lease_migration.py
@@ -1,0 +1,61 @@
+"""Tests for legacy envrc → lease migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from dopemux.mcp.lease_migration import migrate_envrc_to_leases
+from dopemux.mcp.port_leases import PortLeaseRegistry
+
+
+def _catalog() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "defaults": {"per_worktree": ["dope-memory"]},
+        "servers": {
+            "dope-memory": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "port_var": "DOPE_MEMORY_PORT",
+                "default_port_base": 3020,
+                "management_model": "compose-service",
+            }
+        },
+    }
+
+
+def test_migrate_missing_envrc(tmp_path: Path, monkeypatch):
+    reg = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg))
+    report = migrate_envrc_to_leases(
+        tmp_path,
+        _catalog(),
+        registry_path=reg,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert report["status"] in {"ASSIGNED", "REUSED", "REBIND"}
+    assert "DOPE_MEMORY_PORT" in report["ports"]
+
+
+def test_migrate_existing_envrc_preferred(tmp_path: Path, monkeypatch):
+    reg = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg))
+    (tmp_path / ".envrc.dopemux-mcp").write_text(
+        "export DOPE_MEMORY_PORT=3033\nexport DOPEMUX_WORKSPACE_ID=/x\n"
+    )
+    report = migrate_envrc_to_leases(
+        tmp_path,
+        _catalog(),
+        registry_path=reg,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    # Preferred 3033 if free
+    assert report["ports"]["DOPE_MEMORY_PORT"] == 3033
+    assert any(
+        w.get("code") == "LEGACY_HASH_ALLOCATOR_MIGRATED" for w in report["warnings"]
+    )
+    loaded = PortLeaseRegistry.load(reg)
+    assert any(int(L["port"]) == 3033 for L in loaded.active_leases())

--- a/tests/unit/test_mcp_lifecycle.py
+++ b/tests/unit/test_mcp_lifecycle.py
@@ -193,6 +193,48 @@ def test_start_dry_run_planned(tmp_path: Path, monkeypatch):
     assert not reg.exists()
 
 
+def test_task_orchestrator_container_name_matches_wrapper_state_id(tmp_path: Path):
+    """TO name must be task-orchestrator-<slug>-<hash>, not hash-only."""
+    import hashlib
+
+    repo = _fixture_repo(tmp_path)
+    reg = tmp_path / "reg" / "instances.json"
+    product = tmp_path / "product"
+    product.mkdir()
+    (product / "compose.yml").write_text("services: {}\n")
+    (product / "scripts" / "mcp-wrappers").mkdir(parents=True)
+    (product / "scripts" / "mcp-wrappers" / "task-orchestrator-http-singleton.sh").write_text(
+        "#!/bin/bash\n"
+    )
+
+    result = run_lifecycle(
+        "start",
+        repo=repo,
+        services=["task-orchestrator"],
+        catalog=_catalog(),
+        dry_run=True,
+        registry_path=reg,
+        docker_runner=_docker_empty(),
+        product_root=product,
+        process_env={},
+        skip_doctor=True,
+    )
+    assert result.status in {"PLANNED", "BLOCKED", "OK"}
+    # project_id from identity is slug-hash; wrapper uses task-orchestrator-${state_id}
+    project_root = str(repo.resolve())
+    project_hash = hashlib.sha256(project_root.encode("utf-8")).hexdigest()[:16]
+    expected_prefix = f"task-orchestrator-dnh_crm-{project_hash}"
+    # Fixture repo name is dNh_CRM → slug dnh_crm (identity-style keeps _)
+    to_svc = next((s for s in result.services if s.get("service") == "task-orchestrator"), None)
+    assert to_svc is not None, result.services
+    cname = to_svc.get("container_name") or ""
+    assert cname.startswith("task-orchestrator-")
+    assert project_hash in cname
+    assert cname == expected_prefix or cname.endswith(f"-{project_hash}")
+    # Must not be hash-only form
+    assert cname != f"task-orchestrator-{project_hash}"
+
+
 def test_start_blocks_transport_mismatch(tmp_path: Path):
     repo = _fixture_repo(tmp_path)
     # Break transport

--- a/tests/unit/test_mcp_port_allocator.py
+++ b/tests/unit/test_mcp_port_allocator.py
@@ -1,0 +1,215 @@
+"""Tests for lease-aware port allocator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Set
+
+import pytest
+
+from dopemux.mcp.port_allocator import (
+    allocate_ports,
+    allocate_ports_map,
+    preferred_port_for_path,
+    singleton_reserved_ports,
+)
+from dopemux.mcp.port_leases import PortLease, PortLeaseRegistry
+
+
+def _catalog() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "defaults": {"per_worktree": ["conport", "dope-memory", "task-orchestrator"]},
+        "servers": {
+            "pal": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": "http://localhost:3003/mcp",
+            },
+            "serena": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": "http://localhost:3006/mcp",
+            },
+            "conport": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "port_var": "CONPORT_MCP_PORT",
+                "default_port_base": 3005,
+                "extra_port_vars": [
+                    {"var": "CONPORT_HTTP_PORT", "base": 3004},
+                    {"var": "CONPORT_INFO_PORT", "base": 4004},
+                ],
+                "management_model": "compose-service",
+            },
+            "dope-memory": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "port_var": "DOPE_MEMORY_PORT",
+                "default_port_base": 3020,
+                "management_model": "compose-service",
+            },
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "state_scope": "per-repo",
+                "transport": "http",
+                "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
+                "default_port_base": 7890,
+                "management_model": "wrapper-singleton",
+            },
+        },
+    }
+
+
+def test_preferred_formula_stable(tmp_path: Path):
+    a = preferred_port_for_path(str(tmp_path), 3005)
+    b = preferred_port_for_path(str(tmp_path), 3005)
+    assert a == b
+    assert 3005 <= a <= 3104
+
+
+def test_singleton_reserved_from_catalog():
+    r = singleton_reserved_ports(_catalog())
+    assert 3003 in r
+    assert 3006 in r
+
+
+def test_assign_preferred_when_free(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    free: Set[int] = set()  # all free via always-true
+
+    result = allocate_ports(
+        ["conport", "dope-memory", "task-orchestrator"],
+        _catalog(),
+        worktree=str(tmp_path / "wt"),
+        project_root=str(tmp_path / "wt"),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert result.status in {"ASSIGNED", "REUSED", "REBIND"}
+    assert "CONPORT_MCP_PORT" in result.ports
+    assert "DOPE_MEMORY_PORT" in result.ports
+    assert result.ports["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
+    # all ports unique
+    assert len(set(result.ports.values())) == len(result.ports)
+    # no reserved collision
+    assert 3003 not in result.ports.values()
+    assert 3006 not in result.ports.values()
+    reg = PortLeaseRegistry.load(reg_path)
+    assert len(reg.active_leases()) >= 3
+
+
+def test_rebind_when_preferred_reserved(tmp_path: Path, monkeypatch):
+    """Force preferred path onto reserved by mocking preferred via envrc."""
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    # Prefer reserved singleton port for dope-memory
+    result = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(tmp_path / "wt"),
+        project_root=str(tmp_path / "wt"),
+        existing_envrc={"DOPE_MEMORY_PORT": "3003"},
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert result.ports["DOPE_MEMORY_PORT"] != 3003
+    assert any(r.get("preferred") == 3003 for r in result.rebinds) or result.status == "REBIND"
+
+
+def test_cross_worktree_lease_collision_avoided(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    wt_a = tmp_path / "a"
+    wt_b = tmp_path / "b"
+    wt_a.mkdir()
+    wt_b.mkdir()
+
+    r1 = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(wt_a),
+        project_root=str(wt_a),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    port_a = r1.ports["DOPE_MEMORY_PORT"]
+
+    # Force B to prefer A's port
+    r2 = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(wt_b),
+        project_root=str(wt_b),
+        existing_envrc={"DOPE_MEMORY_PORT": str(port_a)},
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert r2.ports["DOPE_MEMORY_PORT"] != port_a
+    assert r2.status in {"REBIND", "ASSIGNED"}
+
+
+def test_dry_run_does_not_write(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(tmp_path),
+        registry_path=reg_path,
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
+    )
+    assert not reg_path.exists() or PortLeaseRegistry.load(reg_path).active_leases() == []
+
+
+def test_fixed_port_blocked_when_foreign_lease(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    reg = PortLeaseRegistry.load(reg_path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="foreign_to",
+            port=7890,
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/other",
+            worktree_hash="zzzz",
+            project_root="/other",
+            status="active",
+        )
+    )
+    reg.save()
+
+    result = allocate_ports(
+        ["task-orchestrator"],
+        _catalog(),
+        worktree=str(tmp_path),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert result.status == "BLOCKED"
+    assert any(b.get("code") == "ALLOCATOR_FIXED_PORT_BLOCKED" for b in result.blocking_findings)
+
+
+def test_allocate_ports_map_drop_in(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    ports = allocate_ports_map(
+        str(tmp_path),
+        ["conport"],
+        _catalog(),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        is_free_fn=lambda p: True,
+    )
+    assert "CONPORT_MCP_PORT" in ports
+    assert "CONPORT_HTTP_PORT" in ports

--- a/tests/unit/test_mcp_port_allocator.py
+++ b/tests/unit/test_mcp_port_allocator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 import pytest
 
@@ -77,7 +77,6 @@ def test_singleton_reserved_from_catalog():
 def test_assign_preferred_when_free(tmp_path: Path, monkeypatch):
     reg_path = tmp_path / "leases.json"
     monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
-    free: Set[int] = set()  # all free via always-true
 
     result = allocate_ports(
         ["conport", "dope-memory", "task-orchestrator"],
@@ -213,3 +212,97 @@ def test_allocate_ports_map_drop_in(tmp_path: Path, monkeypatch):
     )
     assert "CONPORT_MCP_PORT" in ports
     assert "CONPORT_HTTP_PORT" in ports
+
+
+def test_fixed_port_blocked_when_occupied_unknown(tmp_path: Path, monkeypatch):
+    """Fixed port with no foreign lease but a live socket must BLOCK, not lease."""
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+
+    result = allocate_ports(
+        ["task-orchestrator"],
+        _catalog(),
+        worktree=str(tmp_path),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: False,  # 7890 occupied by unknown process
+    )
+    assert result.status == "BLOCKED"
+    assert any(b.get("code") == "LEASE_PORT_OCCUPIED" for b in result.blocking_findings)
+    # Must not write a lease for the occupied fixed port
+    reg = PortLeaseRegistry.load(reg_path)
+    assert reg.find_active_by_port(7890) is None
+
+
+def test_status_reused_on_second_allocation(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    wt = str(tmp_path / "wt")
+    (tmp_path / "wt").mkdir()
+
+    r1 = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=wt,
+        project_root=wt,
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert r1.status in {"ASSIGNED", "REUSED"}
+    port = r1.ports["DOPE_MEMORY_PORT"]
+
+    r2 = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=wt,
+        project_root=wt,
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert r2.ports["DOPE_MEMORY_PORT"] == port
+    assert r2.status == "REUSED"
+
+
+def test_worktree_scoped_does_not_reuse_project_lease(tmp_path: Path, monkeypatch):
+    """A worktree-scoped service must not adopt a project-scoped lease slot."""
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    proj = str(wt)
+
+    reg = PortLeaseRegistry.load(reg_path, create_missing=True)
+    # Malformed/legacy: project-scoped lease for a normally worktree service
+    reg.upsert_lease(
+        PortLease(
+            lease_id="proj_dm",
+            port=3099,
+            service="dope-memory",
+            port_role="http",
+            port_var="DOPE_MEMORY_PORT",
+            worktree_root=str(wt),
+            worktree_hash="dead",
+            project_root=proj,
+            scope="project",
+            status="active",
+        )
+    )
+    reg.save()
+
+    result = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(wt),
+        project_root=proj,
+        existing_envrc={"DOPE_MEMORY_PORT": "3101"},
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert result.ports["DOPE_MEMORY_PORT"] == 3101
+    assert not any(
+        w.get("code") == "LEASE_REUSED" and w.get("port") == 3099 for w in result.warnings
+    )

--- a/tests/unit/test_mcp_port_leases.py
+++ b/tests/unit/test_mcp_port_leases.py
@@ -113,3 +113,97 @@ def test_release(tmp_path: Path):
     n = reg.mark_released(port=3060)
     assert n == 1
     assert reg.active_leases() == []
+
+
+def test_project_scoped_upsert_dedupes_across_worktrees(tmp_path: Path):
+    path = tmp_path / "leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="to_wt_a",
+            port=7890,
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/proj/wt-a",
+            project_root="/proj",
+            scope="project",
+            status="active",
+        )
+    )
+    reg.upsert_lease(
+        PortLease(
+            lease_id="to_wt_b",
+            port=7890,
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/proj/wt-b",
+            project_root="/proj",
+            scope="project",
+            status="active",
+        )
+    )
+    active = [
+        L
+        for L in reg.active_leases()
+        if L.get("service") == "task-orchestrator" and L.get("scope") == "project"
+    ]
+    assert len(active) == 1
+    assert active[0]["worktree_root"] == "/proj/wt-b"
+
+
+def test_find_active_for_identity_separates_scopes(tmp_path: Path):
+    path = tmp_path / "leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="proj",
+            port=7890,
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/proj/wt-a",
+            project_root="/proj",
+            worktree_hash="aaaa",
+            scope="project",
+            status="active",
+        )
+    )
+    reg.upsert_lease(
+        PortLease(
+            lease_id="wt",
+            port=3040,
+            service="dope-memory",
+            port_role="http",
+            worktree_root="/proj/wt-a",
+            project_root="/proj",
+            worktree_hash="aaaa",
+            scope="worktree",
+            status="active",
+        )
+    )
+    # Worktree lookup must not return project-scoped lease
+    assert (
+        reg.find_active_for_identity(
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/proj/wt-a",
+            worktree_hash="aaaa",
+        )
+        is None
+    )
+    # Project lookup returns project lease
+    found = reg.find_active_for_identity(
+        service="task-orchestrator",
+        port_role="http",
+        project_root="/proj",
+    )
+    assert found is not None
+    assert found["port"] == 7890
+    # Worktree lookup returns worktree lease
+    found_wt = reg.find_active_for_identity(
+        service="dope-memory",
+        port_role="http",
+        worktree_root="/proj/wt-a",
+        worktree_hash="aaaa",
+    )
+    assert found_wt is not None
+    assert found_wt["port"] == 3040

--- a/tests/unit/test_mcp_port_leases.py
+++ b/tests/unit/test_mcp_port_leases.py
@@ -1,0 +1,115 @@
+"""Tests for port lease registry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dopemux.mcp.port_leases import (
+    LeaseRegistryError,
+    PortLease,
+    PortLeaseRegistry,
+    make_lease_id,
+)
+
+
+def test_make_lease_id_stable():
+    a = make_lease_id(
+        project_slug="dNh_CRM",
+        worktree_hash="8d6d",
+        service="conport",
+        port_role="http",
+        port=3040,
+    )
+    b = make_lease_id(
+        project_slug="dNh_CRM",
+        worktree_hash="8d6d",
+        service="conport",
+        port_role="http",
+        port=3040,
+    )
+    assert a == b
+    assert "3040" in a
+
+
+def test_registry_missing(tmp_path: Path):
+    reg = PortLeaseRegistry.load(tmp_path / "port-leases.json")
+    assert reg.parse_status == "MISSING"
+    assert reg.active_leases() == []
+
+
+def test_atomic_upsert_and_reload(tmp_path: Path):
+    path = tmp_path / "port-leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    lease = PortLease(
+        lease_id="lease_test_conport_http_3040",
+        port=3040,
+        service="conport",
+        port_role="http",
+        port_var="CONPORT_HTTP_PORT",
+        worktree_root="/tmp/wt",
+        project_root="/tmp/proj",
+        worktree_hash="abcd",
+        status="active",
+    )
+    reg.upsert_lease(lease)
+    reg.save()
+
+    reg2 = PortLeaseRegistry.load(path)
+    assert reg2.parse_status == "OK"
+    assert len(reg2.active_leases()) == 1
+    assert reg2.find_active_by_port(3040)["service"] == "conport"
+
+
+def test_identity_match_and_foreign(tmp_path: Path):
+    path = tmp_path / "leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="l1",
+            port=3050,
+            service="dope-memory",
+            port_role="http",
+            worktree_root="/a",
+            worktree_hash="aaaa",
+            status="active",
+        )
+    )
+    reg.save()
+    foreign = reg.find_active_by_port(3050)
+    assert foreign is not None
+    assert reg.identity_matches(
+        foreign, worktree_root="/a", project_root="/p", worktree_hash="aaaa"
+    )
+    assert not reg.identity_matches(
+        foreign, worktree_root="/b", project_root="/p", worktree_hash="bbbb"
+    )
+
+
+def test_parse_error_blocks_save(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    reg = PortLeaseRegistry.load(path)
+    assert reg.parse_status == "ERROR"
+    with pytest.raises(LeaseRegistryError):
+        reg.save()
+
+
+def test_release(tmp_path: Path):
+    path = tmp_path / "leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="l1",
+            port=3060,
+            service="conport",
+            port_role="sse",
+            worktree_root="/w",
+            status="active",
+        )
+    )
+    n = reg.mark_released(port=3060)
+    assert n == 1
+    assert reg.active_leases() == []

--- a/tests/unit/test_mcp_socket_probe.py
+++ b/tests/unit/test_mcp_socket_probe.py
@@ -1,0 +1,21 @@
+"""Tests for bounded socket probes."""
+
+from dopemux.mcp.socket_probe import port_is_free, port_is_listening, probe_port
+
+
+def test_probe_port_structure():
+    # Port 1 is typically free or filtered; just validate structure
+    result = probe_port(1)
+    assert result["port"] == 1
+    assert "free" in result
+    assert result["listening"] is (not result["free"])
+
+
+def test_port_is_free_invalid():
+    assert port_is_free(0) is False
+    assert port_is_free(99999) is False
+
+
+def test_port_is_listening_inverse_of_free():
+    free = port_is_free(1)
+    assert port_is_listening(1) is (not free)


### PR DESCRIPTION
## Summary

Implements **TP-DMX-MCP-RUNTIME-003** only (stacked on RUNTIME-002).

- `dopemux mcp repair-config --dry-run|--apply [--json] [--repo]`
- `dopemux mcp fleet init|doctor --repo … --worktrees …`
- Preserves unknown/custom `.mcp.json` entries; never mutates `~/.claude.json`; never starts/stops containers
- Replaces unsafe env-inject → `dopemux-mvp/compose.yml` recipe with `init → repair-config → start → doctor`

### Stack / merge order

| Order | PR | Packet |
|------:|----|--------|
| 1 | #1022 | RUNTIME-001 doctor |
| 2 | #1023 | RUNTIME-002 start/status |
| 3 | **#1027 (this)** | RUNTIME-003 repair-config / fleet / docs |

**Base branch:** `codex/tp-dmx-mcp-runtime-002-repo-aware-start-registry` (PR #1023)  
**Worktree:** `/Users/hue/code/dopemux-mcp-runtime-003`

Merge this after #1023 lands (or merge the stack in order). Diff here is **003 only** (+~2.6k / −106).

## Test plan

- [x] Unit: config repair, fleet, agent bootstrap, CLI repair, envrc, doctor regression
- [x] `compileall` on mcp modules
- [x] Docs: unsafe compose/env recipe removed; safe flow documented
- [ ] Live dNh_CRM `--apply` intentionally skipped (fixtures only)