### PR TITLE
feat(mcp): TP-DMX-MCP-RUNTIME-004 port lease registry and live rebind

### DIFF
--- a/docs/02-how-to/mcp-setup-other-repos.md
+++ b/docs/02-how-to/mcp-setup-other-repos.md
@@ -72,10 +72,14 @@ This command:
 - Writes `.envrc.dopemux-mcp` with deterministic ports for this workspace path
 
 > [!NOTE]
-> **Port allocation is deterministic** (`base + sha1(path)[:4] % 100`).
-> `wrapper-singleton` services (e.g. `task-orchestrator` on `7890`) use fixed ports.
-> Cross-worktree collision risk remains until the port-lease packet; repair-config
-> emits `PORT_HASH_BUCKET_COLLISION_RISK` and does **not** live-rebind free ports.
+> **Port allocation (Packet 004):** preferred ports still use
+> `base + sha1(path)[:4] % 100` (or existing envrc values), but assignment goes
+> through the **lease registry** (`~/.dopemux/mcp/runtime/port-leases.json`).
+> Reserved singletons, active foreign leases, and live TCP sockets force **rebind**
+> to the next safe port. Override registry path with
+> `DOPEMUX_MCP_PORT_LEASE_REGISTRY` (tests must never use the real home registry).
+> `wrapper-singleton` services (e.g. `task-orchestrator` on `7890`) are fixed —
+> free/same-project reuse or **block**, never rebind.
 
 ### Step 3 — Repair config (previewable)
 
@@ -179,11 +183,11 @@ Fleet commands never start containers and never modify `~/.claude.json`.
 
 ## Current limitations
 
-* Port allocator still has `%100` birthday-collision risk (see RUNTIME-004 lease packet).
-* Live free-port rebind is **not** implemented.
-* `task-orchestrator` fixed port `7890` may block multi-project simultaneous use if
-  identity cannot be proven.
+* Preferred ports still derive from hash `%100` — leases rebind on conflict (no longer silent).
+* `task-orchestrator` fixed port `7890` blocks multi-project simultaneous use when another
+  project holds the lease (see RUNTIME-005 for deeper TO identity work).
 * Unlabeled existing containers are not adopted automatically.
+* Lease prune is not automatic; doctor may report `LEASE_STALE` without deleting.
 
 ---
 

--- a/docs/02-how-to/mcp-transport-and-port-bugs.md
+++ b/docs/02-how-to/mcp-transport-and-port-bugs.md
@@ -29,6 +29,13 @@ applied to `dopemux-mvp`.
 > `dopemux mcp repair-config --repo <path> --dry-run --json` then `--apply`.
 > Preserves custom mcpServers entries; never mutates `~/.claude.json`.
 > Runtime start remains `dopemux mcp start --repo <path>` (Packet 002).
+>
+> **Port leases (TP-DMX-MCP-RUNTIME-004):** hash offsets are *preferred* only.
+> Assignment uses `~/.dopemux/mcp/runtime/port-leases.json` (override
+> `DOPEMUX_MCP_PORT_LEASE_REGISTRY`), reserved singleton protection, live TCP
+> probes, and rebind when preferred ports are unsafe. Dry-run / `persist=False`
+> never write leases. Fixed-port `task-orchestrator` (7890) reuses or blocks —
+> it does not rebind.
 
 ---
 

--- a/docs/02-how-to/multi-instance-workflow.md
+++ b/docs/02-how-to/multi-instance-workflow.md
@@ -26,8 +26,9 @@ Zero context destruction through parallel ADHD-optimized development instances.
 > `dopemux mcp fleet init --repo <project> --worktrees <paths...> --apply` then
 > `dopemux mcp start --repo <worktree>` / `dopemux mcp fleet doctor --repo <project> --worktrees ...`.
 > Also: `init` → `repair-config` → `start` → `doctor` per worktree.
-> Do **not** env-inject foreign `.envrc.dopemux-mcp` into dopemux-mvp compose.
-> Registry: `~/.dopemux/mcp/runtime/instances.json`.
+> Port leases live in `~/.dopemux/mcp/runtime/port-leases.json` (cross-worktree collision
+> rebind). Do **not** env-inject foreign `.envrc.dopemux-mcp` into dopemux-mvp compose.
+> Runtime registry: `~/.dopemux/mcp/runtime/instances.json`.
 
 ## Overview
 

--- a/src/dopemux/commands/mcp_commands.py
+++ b/src/dopemux/commands/mcp_commands.py
@@ -731,57 +731,43 @@ def _allocate_ports(
     catalog: Dict[str, Any],
     *,
     project_root: str | None = None,
+    persist: bool = True,
+    dry_run: bool = False,
+    existing_envrc: Optional[Dict[str, str]] = None,
+    is_free_fn: Any = None,
+    source: str = "dopemux mcp init",
 ) -> Dict[str, int]:
     """
-    Compute ports for each per-worktree server, including any `extra_port_vars`
-    declared by the spec (e.g. conport exposes three host ports for one service).
-    Same hash offset is reused across a single server's primary + extras.
+    Allocate ports for each per-worktree server via the lease registry allocator.
+
+    Preferred ports still come from the legacy hash formula
+    (``base + sha1(path)[:4] % 100``) or existing envrc values, but assignment
+    only succeeds after reserved/lease/socket safety checks. Unsafe preferred
+    ports are rebound within the service base search window.
 
     Safety rules:
-    - ``wrapper-singleton`` services (one global instance, fixed port) are
-      assigned their ``default_port_base`` directly without any hash offset.
-    - All singleton-catalog reserved ports are pre-seeded into the collision
-      map so per-worktree hash offsets cannot land on them.
+    - Singleton reserved catalog ports are never assigned to project sidecars.
+    - Active leases owned by other projects/worktrees are never stolen.
+    - Live TCP sockets block assignment (except reuse of our own lease).
+    - ``wrapper-singleton`` services use fixed ``default_port_base`` (no rebind).
+    - ``dry_run=True`` / ``persist=False`` skips lease registry writes.
     """
-    assignments: Dict[str, int] = {}
-    # Pre-seed with singleton reserved ports so per-worktree allocations
-    # cannot collide with statically-assigned singleton ports (e.g. gptr-mcp).
-    seen_ports: Dict[int, str] = {
-        port: f"singleton:{name}"
-        for port, name in _singleton_reserved_ports(catalog).items()
-    }
+    from dopemux.mcp.port_allocator import allocate_ports_map
 
-    def _claim(
-        var: str, base: int, owner: str, key_path: str, *, fixed: bool = False
-    ) -> None:
-        port = base if fixed else _port_for(key_path, base)
-        if port in seen_ports:
-            raise click.ClickException(
-                f"Internal port collision: {owner}.{var} and "
-                f"{seen_ports[port]} both map to :{port}. "
-                f"Adjust the `default_port_base` for one of them in {CATALOG_FILENAME}."
-            )
-        seen_ports[port] = f"{owner}.{var}"
-        assignments[var] = port
-
-    for name in names:
-        spec = catalog["servers"].get(name)
-        if not spec or spec.get("scope") != "per-worktree":
-            continue
-        # wrapper-singleton: one global instance at a fixed port — no hash offset.
-        is_wrapper_singleton = spec.get("management_model") == "wrapper-singleton"
-        key_path = (
-            project_root
-            if spec.get("state_scope") == "per-repo" and project_root
-            else worktree
+    try:
+        return allocate_ports_map(
+            worktree,
+            names,
+            catalog,
+            project_root=project_root,
+            existing_envrc=existing_envrc,
+            persist=persist and not dry_run,
+            dry_run=dry_run,
+            source=source,
+            is_free_fn=is_free_fn,
         )
-        base = spec.get("default_port_base")
-        if base:
-            _claim(spec["port_var"], base, name, key_path, fixed=is_wrapper_singleton)
-        if not is_wrapper_singleton:
-            for extra in spec.get("extra_port_vars", []) or []:
-                _claim(extra["var"], extra["base"], name, key_path)
-    return assignments
+    except RuntimeError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 def _project_env_exports(worktree: str, project_root: str) -> Dict[str, str]:
@@ -1197,8 +1183,6 @@ def mcp_init_cmd(force: bool, extra: Tuple[str, ...]):
 
     mcp_json_path = repo_path / PROJECT_MCP_FILENAME
     envrc_path = repo_path / ENVRC_FILENAME
-
-    port_vars = _allocate_ports(repo, ordered, catalog, project_root=str(identity.project_root))
     config = _build_local_mcp_json(ordered, catalog)
 
     if envrc_path.exists() and not force:
@@ -1215,8 +1199,32 @@ def mcp_init_cmd(force: bool, extra: Tuple[str, ...]):
                 "Use --force to overwrite."
             )
         wrote_mcp_json = False
-    else:
+
+    # Allocate only after init preconditions pass so dry collisions do not write leases.
+    existing_env: Dict[str, str] = {}
+    if envrc_path.exists():
+        try:
+            from dopemux.mcp.envrc import load_envrc
+
+            parsed = load_envrc(envrc_path)
+            if parsed.values:
+                existing_env = dict(parsed.values)
+        except Exception:  # noqa: BLE001 — fall back to pure preferred formula
+            existing_env = {}
+    port_vars = _allocate_ports(
+        repo,
+        ordered,
+        catalog,
+        project_root=str(identity.project_root),
+        existing_envrc=existing_env or None,
+        source="dopemux mcp init",
+    )
+
+    if wrote_mcp_json:
         _atomic_write_json(mcp_json_path, config)
+    elif mcp_json_path.exists() and force:
+        _atomic_write_json(mcp_json_path, config)
+        wrote_mcp_json = True
 
     _write_envrc(envrc_path, port_vars, repo, str(identity.project_root))
 

--- a/src/dopemux/mcp/config_repair.py
+++ b/src/dopemux/mcp/config_repair.py
@@ -138,14 +138,30 @@ def _desired_env_map(
     *,
     allocate_ports_fn: Callable[..., Dict[str, int]],
     project_env_exports_fn: Callable[[str, str], Dict[str, str]],
+    dry_run: bool = True,
+    existing_envrc: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, str]:
     exports = {k: str(v) for k, v in project_env_exports_fn(worktree, project_root).items()}
-    ports = allocate_ports_fn(
-        worktree,
-        list(server_names),
-        catalog,
-        project_root=project_root,
-    )
+    # Lease-aware allocation: never persist on dry-run; prefer existing envrc ports.
+    try:
+        ports = allocate_ports_fn(
+            worktree,
+            list(server_names),
+            catalog,
+            project_root=project_root,
+            persist=not dry_run,
+            dry_run=dry_run,
+            existing_envrc=dict(existing_envrc or {}),
+            source="dopemux mcp repair-config",
+        )
+    except TypeError:
+        # Test doubles / legacy callables without lease kwargs
+        ports = allocate_ports_fn(
+            worktree,
+            list(server_names),
+            catalog,
+            project_root=project_root,
+        )
     for k, v in ports.items():
         exports[str(k)] = str(v)
     return exports
@@ -372,6 +388,8 @@ def plan_repair(
         catalog,
         allocate_ports_fn=allocate_ports_fn,
         project_env_exports_fn=project_env_exports_fn,
+        dry_run=dry_run,
+        existing_envrc=envrc_parsed.values if envrc_parsed.present else {},
     )
     owned_keys = _catalog_owned_env_keys(catalog, server_names)
 

--- a/src/dopemux/mcp/config_repair.py
+++ b/src/dopemux/mcp/config_repair.py
@@ -77,6 +77,10 @@ class RepairPlan:
     _write_mcp: bool = field(default=False, repr=False)
     _write_envrc: bool = field(default=False, repr=False)
     _write_agent: bool = field(default=False, repr=False)
+    # Deferred lease persistence: plan never writes the registry; apply does.
+    _lease_persist: Optional[Dict[str, Any]] = field(default=None, repr=False)
+    _allocate_ports_fn: Any = field(default=None, repr=False)
+    _catalog: Any = field(default=None, repr=False)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -140,17 +144,19 @@ def _desired_env_map(
     project_env_exports_fn: Callable[[str, str], Dict[str, str]],
     dry_run: bool = True,
     existing_envrc: Optional[Mapping[str, str]] = None,
+    persist_leases: bool = False,
 ) -> Dict[str, str]:
     exports = {k: str(v) for k, v in project_env_exports_fn(worktree, project_root).items()}
-    # Lease-aware allocation: never persist on dry-run; prefer existing envrc ports.
+    # Lease-aware allocation. Planning never persists; only explicit post-apply
+    # calls pass persist_leases=True so a blocked/failed apply cannot consume leases.
     try:
         ports = allocate_ports_fn(
             worktree,
             list(server_names),
             catalog,
             project_root=project_root,
-            persist=not dry_run,
-            dry_run=dry_run,
+            persist=persist_leases and not dry_run,
+            dry_run=dry_run or not persist_leases,
             existing_envrc=dict(existing_envrc or {}),
             source="dopemux mcp repair-config",
         )
@@ -381,6 +387,8 @@ def plan_repair(
         if is_catalog_owned(str(name), catalog) and name not in server_names:
             server_names.append(str(name))
 
+    # Always compute ports without writing leases during plan construction.
+    # Leases are persisted only after apply_repair successfully writes config.
     desired_env = _desired_env_map(
         worktree,
         project_root,
@@ -388,9 +396,18 @@ def plan_repair(
         catalog,
         allocate_ports_fn=allocate_ports_fn,
         project_env_exports_fn=project_env_exports_fn,
-        dry_run=dry_run,
+        dry_run=True,
+        persist_leases=False,
         existing_envrc=envrc_parsed.values if envrc_parsed.present else {},
     )
+    plan._allocate_ports_fn = allocate_ports_fn
+    plan._catalog = catalog
+    plan._lease_persist = {
+        "worktree": worktree,
+        "project_root": project_root,
+        "server_names": list(server_names),
+        "existing_envrc": dict(desired_env),
+    }
     owned_keys = _catalog_owned_env_keys(catalog, server_names)
 
     # Secret-like handling on existing envrc
@@ -570,6 +587,29 @@ def apply_repair(plan: RepairPlan) -> RepairPlan:
         plan.blocking_findings.append(_block("APPLY_IO_ERROR", str(exc)))
         plan.status = "BLOCKED"
         return plan
+
+    # Persist port leases only after config files were written successfully.
+    if plan._lease_persist and plan._allocate_ports_fn is not None and plan._catalog is not None:
+        lp = plan._lease_persist
+        try:
+            _desired_env_map(
+                str(lp["worktree"]),
+                str(lp["project_root"]),
+                list(lp.get("server_names") or []),
+                plan._catalog,
+                allocate_ports_fn=plan._allocate_ports_fn,
+                project_env_exports_fn=lambda w, p: {},
+                dry_run=False,
+                persist_leases=True,
+                existing_envrc=dict(lp.get("existing_envrc") or {}),
+            )
+        except Exception as exc:  # noqa: BLE001 — config already written; warn only
+            plan.warnings.append(
+                _warn(
+                    "LEASE_PERSIST_FAILED",
+                    f"Config applied but lease registry write failed: {exc}",
+                )
+            )
 
     plan.status = "APPLIED"
     plan.warnings.append(_warn("REPAIR_APPLIED", f"Wrote repairs under {repo}."))

--- a/src/dopemux/mcp/doctor.py
+++ b/src/dopemux/mcp/doctor.py
@@ -379,19 +379,168 @@ def run_mcp_doctor(
                 ),
             )
 
-    # --- Port diagnostics ---
+    # --- Port diagnostics + lease registry ---
     worktree_for_ports = identity.worktree_root or str(repo_path)
     project_root_for_ports = identity.project_root
+
+    lease_registry_present = False
+    lease_allocator_healthy = False
+    try:
+        from .port_leases import PortLeaseRegistry
+
+        lease_reg = PortLeaseRegistry.load()
+        if lease_reg.parse_status == "ERROR":
+            _add(
+                findings,
+                "LEASE_REGISTRY_PARSE_ERROR",
+                "FAIL",
+                f"Lease registry unreadable: {lease_reg.error}",
+                evidence=[str(lease_reg.path)],
+                recommendation="Inspect ~/.dopemux/mcp/runtime/port-leases.json or set DOPEMUX_MCP_PORT_LEASE_REGISTRY.",
+            )
+        elif lease_reg.parse_status == "MISSING":
+            _add(
+                findings,
+                "LEASE_REGISTRY_MISSING",
+                "WARN",
+                f"No lease registry at {lease_reg.path}",
+                evidence=[str(lease_reg.path)],
+                recommendation="Run `dopemux mcp init` or `dopemux mcp repair-config --apply` to create leases.",
+            )
+            if envrc.present and configured_ports:
+                _add(
+                    findings,
+                    "LEGACY_ENVRC_WITHOUT_LEASE",
+                    "WARN",
+                    "Envrc ports present without lease registry entries",
+                    recommendation="Run `dopemux mcp repair-config --apply` to migrate ports into leases.",
+                )
+        else:
+            lease_registry_present = True
+            _add(
+                findings,
+                "LEASE_REGISTRY_FOUND",
+                "INFO",
+                f"Lease registry OK ({len(lease_reg.active_leases())} active)",
+                evidence=[str(lease_reg.path)],
+            )
+            # Envrc vs lease mismatch
+            for var, port in (configured_ports or {}).items():
+                matched = False
+                foreign = False
+                for L in lease_reg.active_leases():
+                    if int(L.get("port") or 0) != int(port):
+                        continue
+                    if L.get("worktree_root") in {worktree_for_ports, str(repo_path)} or (
+                        L.get("worktree_hash") and L.get("worktree_hash") == identity.worktree_hash
+                    ):
+                        matched = True
+                    else:
+                        foreign = True
+                if foreign and not matched:
+                    _add(
+                        findings,
+                        "LEASE_BELONGS_TO_OTHER_PROJECT",
+                        "FAIL",
+                        f"Envrc {var}={port} is leased to another project/worktree",
+                        evidence=[f"{var}={port}"],
+                        recommendation="Run `dopemux mcp repair-config --apply` to rebind.",
+                    )
+                elif not matched:
+                    # no lease for this envrc port
+                    ours = [
+                        L
+                        for L in lease_reg.active_leases()
+                        if L.get("port_var") == var
+                        and (
+                            L.get("worktree_root") in {worktree_for_ports, str(repo_path)}
+                            or L.get("worktree_hash") == identity.worktree_hash
+                        )
+                    ]
+                    if ours and int(ours[0].get("port") or 0) != int(port):
+                        _add(
+                            findings,
+                            "LEASE_ENVRC_MISMATCH",
+                            "FAIL",
+                            f"Envrc {var}={port} != lease {ours[0].get('port')}",
+                            evidence=[f"envrc={port}", f"lease={ours[0].get('port')}"],
+                            recommendation="Run `dopemux mcp repair-config --apply`.",
+                        )
+                    elif not ours:
+                        _add(
+                            findings,
+                            "LEGACY_ENVRC_WITHOUT_LEASE",
+                            "WARN",
+                            f"Envrc {var}={port} has no active lease for this worktree",
+                            recommendation="Run `dopemux mcp repair-config --apply`.",
+                        )
+                else:
+                    lease_allocator_healthy = True
+                    if not is_free(int(port)):
+                        _add(
+                            findings,
+                            "LEASE_PORT_OCCUPIED",
+                            "INFO",
+                            f"Leased port {port} ({var}) is listening (expected if services are up)",
+                            evidence=[f"{var}={port}"],
+                        )
+                    else:
+                        _add(
+                            findings,
+                            "LEASE_PORT_FREE",
+                            "INFO",
+                            f"Leased port {port} ({var}) is free (services may be stopped)",
+                            evidence=[f"{var}={port}"],
+                        )
+            # Stale leases for this worktree (active but free + no configured use)
+            for L in lease_reg.active_leases():
+                if L.get("worktree_root") not in {worktree_for_ports, str(repo_path)}:
+                    continue
+                lp = int(L.get("port") or 0)
+                if not lp:
+                    continue
+                if is_free(lp) and (
+                    not configured_ports
+                    or L.get("port_var") not in configured_ports
+                    or configured_ports.get(str(L.get("port_var"))) != lp
+                ):
+                    # only mark stale-ish when no envrc owns it
+                    if not configured_ports or str(L.get("port_var")) not in configured_ports:
+                        _add(
+                            findings,
+                            "LEASE_STALE",
+                            "WARN",
+                            f"Active lease {L.get('lease_id')} port {lp} looks unused",
+                            service=L.get("service"),
+                            evidence=[str(L.get("lease_id")), f"port={lp}"],
+                            recommendation="Explicit prune is not auto-run; re-init/repair if needed.",
+                        )
+    except Exception as exc:  # noqa: BLE001 — doctor remains best-effort
+        unknowns.append(f"lease registry inspection failed: {exc}")
+
     port_report = pd.diagnose_ports(
         worktree_for_ports,
         service_names,
         catalog,
         project_root=project_root_for_ports,
         configured_ports=configured_ports or None,
-        has_lease_registry=False,
-        has_live_rebind=False,
+        has_lease_registry=lease_registry_present,
+        has_live_rebind=lease_allocator_healthy or lease_registry_present,
     )
     for fdict in port_report.findings:
+        # Downgrade legacy hash bucket noise when lease allocator is active
+        code = fdict.get("code") or ""
+        sev = fdict.get("severity") or "INFO"
+        if lease_registry_present and code in {
+            "PORT_HASH_BUCKET_COLLISION_RISK",
+            "PORT_REBIND_MISSING",
+        }:
+            sev = "INFO"
+            fdict = dict(fdict)
+            fdict["message"] = (
+                f"{fdict.get('message', '')} (lease allocator active — preferred formula only)"
+            )
+            fdict["severity"] = sev
         findings.append(
             Finding(
                 code=fdict["code"],

--- a/src/dopemux/mcp/instance_overlay.py
+++ b/src/dopemux/mcp/instance_overlay.py
@@ -1,42 +1,68 @@
+"""Instance-scoped env/compose overlays with unified port allocation.
+
+Historically used a letter/md5 base port map independent of ``mcp init``.
+Packet 004 routes catalog-aligned ports through the lease allocator when a
+catalog is available, keeping overlay generation consistent with init/repair.
+"""
+
+from __future__ import annotations
+
 import json
 import logging
 import re
-import os
 from pathlib import Path
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Mapping, Optional
 
 logger = logging.getLogger(__name__)
+
 
 class InstanceOverlayManager:
     """
     Generates instance-scoped env and compose overlays.
-    Handles deterministic port allocation.
+    Port assignment prefers the lease allocator (Packet 004).
     """
+
+    # Legacy offsets retained only as fallback when catalog/allocator unavailable
     PORT_OFFSETS = {
         "ConPort": 4,
         "Serena": 6,
         "Dope-Context": 10,
         "Dope-Memory": 20,
-        "LiteLLM": 1000 
+        "LiteLLM": 1000,
     }
 
-    def __init__(self, project_root: Path, instance_id: str):
-        self.project_root = project_root
-        self.instance_id = instance_id
-        self.instance_dir = self.project_root / ".dopemux" / "instances" / instance_id
+    def __init__(
+        self,
+        project_root: Path,
+        instance_id: str,
+        *,
+        catalog: Optional[Mapping[str, Any]] = None,
+        worktree: Optional[str | Path] = None,
+        persist_leases: bool = False,
+    ):
+        self.project_root = Path(project_root)
+        self.instance_id = instance_id or ""
+        self.instance_dir = self.project_root / ".dopemux" / "instances" / (instance_id or "A")
+        self.catalog = catalog
+        self.worktree = str(Path(worktree or project_root).resolve())
+        self.persist_leases = persist_leases
         self.base_port = self._calculate_base_port()
         self.port_map = self._generate_port_map()
+        self.env_ports: Dict[str, int] = {}
+        self._allocator_used = False
+        self._try_lease_allocator()
 
     def _calculate_base_port(self) -> int:
         if not self.instance_id:
             return 3000
-        
+
         first_char = self.instance_id[0].upper()
-        if 'A' <= first_char <= 'Z':
-            offset = ord(first_char) - ord('A')
+        if "A" <= first_char <= "Z":
+            offset = ord(first_char) - ord("A")
             return 3000 + (offset * 100)
-        
+
         import hashlib
+
         h = hashlib.md5(self.instance_id.encode()).hexdigest()
         offset = int(h[:2], 16) % 30
         return 3000 + (offset * 100)
@@ -47,99 +73,168 @@ class InstanceOverlayManager:
             ports[name] = self.base_port + offset
         return ports
 
+    def _try_lease_allocator(self) -> None:
+        """Prefer lease allocator for catalog per-worktree services."""
+        catalog = self.catalog
+        if catalog is None:
+            try:
+                from dopemux.commands.mcp_commands import _load_catalog
+
+                catalog = _load_catalog()
+            except Exception:  # noqa: BLE001
+                return
+        try:
+            from dopemux.mcp.port_allocator import allocate_ports_map
+
+            names = list((catalog.get("defaults") or {}).get("per_worktree") or [])
+            if not names:
+                return
+            ports = allocate_ports_map(
+                self.worktree,
+                names,
+                catalog,
+                project_root=str(self.project_root),
+                persist=self.persist_leases,
+                dry_run=not self.persist_leases,
+                source="InstanceOverlayManager",
+            )
+            self.env_ports = dict(ports)
+            # Map into legacy port_map keys used by compose overlay writers
+            if "CONPORT_HTTP_PORT" in ports:
+                self.port_map["ConPort"] = ports["CONPORT_HTTP_PORT"]
+            if "DOPE_MEMORY_PORT" in ports:
+                self.port_map["Dope-Memory"] = ports["DOPE_MEMORY_PORT"]
+            self._allocator_used = True
+            logger.info(
+                "InstanceOverlayManager using lease allocator ports for %s",
+                self.worktree,
+            )
+        except Exception as exc:  # noqa: BLE001 — fall back to legacy map
+            logger.warning(
+                "InstanceOverlayManager lease allocator unavailable (%s); using legacy map",
+                exc,
+            )
+
     def materialize(self) -> Dict[str, Any]:
         """Generates the overlay files in .dopemux/instances/<id>/"""
         self.instance_dir.mkdir(parents=True, exist_ok=True)
-        
+
         env_path = self.write_mcp_env()
         compose_path = self.write_compose_override()
-        
-        # Save port map for reports
+
         with open(self.instance_dir / "PORT_MAP.json", "w") as f:
-            json.dump(self.port_map, f, indent=2)
+            json.dump(
+                {
+                    "port_map": self.port_map,
+                    "env_ports": self.env_ports,
+                    "allocator_used": self._allocator_used,
+                    "base_port": self.base_port,
+                },
+                f,
+                indent=2,
+            )
 
         return {
             "instance_dir": str(self.instance_dir),
             "env_path": str(env_path),
             "compose_path": str(compose_path),
             "port_map": self.port_map,
+            "env_ports": self.env_ports,
+            "allocator_used": self._allocator_used,
             "base_port": self.base_port,
-            "compose_project_name": self.get_compose_project_name()
+            "compose_project_name": self.get_compose_project_name(),
         }
 
     def get_compose_project_name(self) -> str:
         project_id = self.project_root.name
         name = f"dopemux_{project_id}_{self.instance_id}".lower()
-        # Sanitize for Docker Compose
-        return re.sub(r'[^a-z0-9_-]', '_', name)
+        return re.sub(r"[^a-z0-9_-]", "_", name)
 
     def write_mcp_env(self) -> Path:
         env_path = self.instance_dir / "mcp.env"
-        
-        # Safely get ports
-        def get_p(name): return self.port_map.get(name, 0)
+
+        def get_p(name: str) -> int:
+            return int(self.port_map.get(name, 0))
+
+        # Prefer lease env_ports when present
+        conport_http = self.env_ports.get("CONPORT_HTTP_PORT", get_p("ConPort"))
+        conport_mcp = self.env_ports.get("CONPORT_MCP_PORT", get_p("ConPort") + 1)
+        conport_info = self.env_ports.get("CONPORT_INFO_PORT", get_p("ConPort") + 1000)
+        dope_memory = self.env_ports.get("DOPE_MEMORY_PORT", get_p("Dope-Memory"))
 
         lines = [
             f"# Generated for instance: {self.instance_id}",
+            f"# allocator_used={self._allocator_used}",
             f"COMPOSE_PROJECT_NAME={self.get_compose_project_name()}",
             "COMPOSE_FILE=compose.yml",
             f"DOPEMUX_INSTANCE_ID={self.instance_id}",
             f"CONPORT_CONTAINER_NAME={'mcp-conport' if not self.instance_id or self.instance_id == 'A' else f'mcp-conport_{self.instance_id}'}",
             f"SERENA_CONTAINER_NAME={'dopemux-mcp-serena' if not self.instance_id or self.instance_id == 'A' else f'dopemux-mcp-serena_{self.instance_id}'}",
-            f"CONPORT_HTTP_PORT={get_p('ConPort')}",
-            f"CONPORT_MCP_PORT={get_p('ConPort') + 1}",
-            f"CONPORT_INFO_PORT={get_p('ConPort') + 1000}",
+            f"CONPORT_HTTP_PORT={conport_http}",
+            f"CONPORT_MCP_PORT={conport_mcp}",
+            f"CONPORT_INFO_PORT={conport_info}",
             f"SERENA_PORT={get_p('Serena')}",
             f"SERENA_HTTP_PORT={get_p('Serena') + 1000}",
             f"DOPE_CONTEXT_PORT={get_p('Dope-Context')}",
-            f"DOPE_MEMORY_PORT={get_p('Dope-Memory')}",
+            f"DOPE_MEMORY_PORT={dope_memory}",
             f"PAL_PORT={self.base_port + 3}",
             f"EXA_PORT={self.base_port + 11}",
             f"DESKTOP_COMMANDER_PORT={self.base_port + 12}",
             f"LEANTIME_BRIDGE_PORT={self.base_port + 15}",
             f"GPT_RESEARCHER_PORT={self.base_port + 9}",
-            f"DOPEMUX_CONPORT_PORT={get_p('ConPort')}",
+            f"DOPEMUX_CONPORT_PORT={conport_http}",
             f"DOPEMUX_SERENA_PORT={get_p('Serena')}",
             f"DOPEMUX_CONTEXT_PORT={get_p('Dope-Context')}",
-            f"DOPEMUX_MEMORY_PORT={get_p('Dope-Memory')}",
+            f"DOPEMUX_MEMORY_PORT={dope_memory}",
             f"DOPEMUX_LITELLM_PORT={get_p('LiteLLM')}",
         ]
-        
+        if "TASK_ORCHESTRATOR_HTTP_PORT" in self.env_ports:
+            lines.append(
+                f"TASK_ORCHESTRATOR_HTTP_PORT={self.env_ports['TASK_ORCHESTRATOR_HTTP_PORT']}"
+            )
+
         with open(env_path, "w") as f:
             f.write("\n".join(lines) + "\n")
         return env_path
 
     def write_compose_override(self) -> Path:
         compose_path = self.instance_dir / "mcp.compose.override.yml"
-        
-        # Helper to generate service override only if port exists
+
         services = []
-        if "ConPort" in self.port_map:
+        if "ConPort" in self.port_map or "CONPORT_HTTP_PORT" in self.env_ports:
+            http = self.env_ports.get("CONPORT_HTTP_PORT", self.port_map.get("ConPort", 0))
+            mcp = self.env_ports.get("CONPORT_MCP_PORT", http + 1)
+            info = self.env_ports.get("CONPORT_INFO_PORT", http + 1000)
             services.append(
                 "  conport:\n"
                 f"    container_name: {'mcp-conport' if not self.instance_id or self.instance_id == 'A' else f'mcp-conport_{self.instance_id}'}\n"
                 "    ports:\n"
-                f"      - \"{self.port_map['ConPort']}:3004\"\n"
-                f"      - \"{self.port_map['ConPort'] + 1}:3005\"\n"
-                f"      - \"{self.port_map['ConPort'] + 1000}:4004\""
+                f'      - "{http}:3004"\n'
+                f'      - "{mcp}:3005"\n'
+                f'      - "{info}:4004"'
             )
         if "Serena" in self.port_map:
             services.append(
                 "  serena:\n"
                 f"    container_name: {'dopemux-mcp-serena' if not self.instance_id or self.instance_id == 'A' else f'dopemux-mcp-serena_{self.instance_id}'}\n"
                 "    ports:\n"
-                f"      - \"{self.port_map['Serena']}:3006\"\n"
-                f"      - \"{self.port_map['Serena'] + 1000}:4006\""
+                f'      - "{self.port_map["Serena"]}:3006"\n'
+                f'      - "{self.port_map["Serena"] + 1000}:4006"'
             )
         if "Dope-Context" in self.port_map:
-            services.append(f"  dope-context:\n    ports:\n      - \"{self.port_map['Dope-Context']}:3010\"")
-        if "Dope-Memory" in self.port_map:
-            services.append(f"  dope-memory:\n    ports:\n      - \"{self.port_map['Dope-Memory']}:3020\"")
+            services.append(
+                f"  dope-context:\n    ports:\n      - \"{self.port_map['Dope-Context']}:3010\""
+            )
+        mem = self.env_ports.get("DOPE_MEMORY_PORT", self.port_map.get("Dope-Memory"))
+        if mem:
+            services.append(f'  dope-memory:\n    ports:\n      - "{mem}:3020"')
         if "LiteLLM" in self.port_map:
-            services.append(f"  litellm:\n    ports:\n      - \"{self.port_map['LiteLLM']}:4000\"")
+            services.append(
+                f"  litellm:\n    ports:\n      - \"{self.port_map['LiteLLM']}:4000\""
+            )
 
         content = "services:\n" + "\n".join(services)
-        
+
         with open(compose_path, "w") as f:
             f.write(content)
         return compose_path

--- a/src/dopemux/mcp/instance_overlay.py
+++ b/src/dopemux/mcp/instance_overlay.py
@@ -109,7 +109,11 @@ class InstanceOverlayManager:
                 "InstanceOverlayManager using lease allocator ports for %s",
                 self.worktree,
             )
-        except Exception as exc:  # noqa: BLE001 — fall back to legacy map
+        except RuntimeError:
+            # Allocation BLOCKED (collision / occupied fixed port / etc.) —
+            # do not fall back to the unsafe legacy map; surface the failure.
+            raise
+        except Exception as exc:  # noqa: BLE001 — unexpected errors fall back
             logger.warning(
                 "InstanceOverlayManager lease allocator unavailable (%s); using legacy map",
                 exc,

--- a/src/dopemux/mcp/lease_migration.py
+++ b/src/dopemux/mcp/lease_migration.py
@@ -10,7 +10,6 @@ from .port_allocator import (
     AllocatorIdentity,
     allocate_ports,
     instance_id_for_path,
-    preferred_port_for_path,
 )
 from .port_leases import PortLeaseRegistry, default_lease_registry_path
 

--- a/src/dopemux/mcp/lease_migration.py
+++ b/src/dopemux/mcp/lease_migration.py
@@ -1,0 +1,112 @@
+"""Migrate legacy hash-only envrc ports into the lease registry when safe."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+from .envrc import load_envrc, safe_port_int
+from .port_allocator import (
+    AllocatorIdentity,
+    allocate_ports,
+    instance_id_for_path,
+    preferred_port_for_path,
+)
+from .port_leases import PortLeaseRegistry, default_lease_registry_path
+
+
+def migrate_envrc_to_leases(
+    repo: Path | str,
+    catalog: Mapping[str, Any],
+    *,
+    service_names: Optional[Sequence[str]] = None,
+    project_root: Optional[str] = None,
+    registry_path: Optional[Path] = None,
+    persist: bool = True,
+    dry_run: bool = False,
+    is_free_fn=None,
+) -> Dict[str, Any]:
+    """Import envrc ports as preferred values and acquire leases.
+
+    Returns a report dict with status, ports, warnings, rebinds.
+    """
+    repo_path = Path(repo).expanduser().resolve()
+    envrc = load_envrc(repo_path / ".envrc.dopemux-mcp")
+    env_values = dict(envrc.values) if envrc.present else {}
+
+    names = list(
+        service_names
+        or (catalog.get("defaults") or {}).get("per_worktree")
+        or []
+    )
+    proj = str(Path(project_root or repo_path).expanduser().resolve())
+    wt = str(repo_path)
+    wt_hash = instance_id_for_path(wt)
+
+    identity = AllocatorIdentity(
+        project_id=Path(proj).name,
+        workspace_id=env_values.get("DOPEMUX_WORKSPACE_ID") or wt,
+        project_root=proj,
+        worktree_root=wt,
+        project_hash=None,
+        worktree_hash=env_values.get("DOPEMUX_INSTANCE_ID") or wt_hash,
+        instance_id=env_values.get("DOPEMUX_INSTANCE_ID") or wt_hash,
+    )
+
+    warnings: List[Dict[str, Any]] = []
+    if not envrc.present:
+        warnings.append(
+            {
+                "code": "LEGACY_ENVRC_WITHOUT_LEASE",
+                "message": "No .envrc.dopemux-mcp; allocator will create fresh leases.",
+            }
+        )
+    else:
+        warnings.append(
+            {
+                "code": "LEGACY_HASH_ALLOCATOR_MIGRATED",
+                "message": "Migrating envrc ports through lease allocator.",
+            }
+        )
+
+    result = allocate_ports(
+        names,
+        catalog,
+        worktree=wt,
+        project_root=proj,
+        identity=identity,
+        existing_envrc=env_values,
+        registry_path=registry_path or default_lease_registry_path(),
+        persist=persist and not dry_run,
+        dry_run=dry_run,
+        source="dopemux mcp migration",
+        is_free_fn=is_free_fn,
+    )
+    report = result.to_dict()
+    report["warnings"] = warnings + list(result.warnings)
+    report["envrc_present"] = envrc.present
+    report["legacy_ports"] = {
+        k: safe_port_int(env_values, k)
+        for k in env_values
+        if k.endswith("_PORT") or k.endswith("_PORTS")
+    }
+    return report
+
+
+def formula_preferred_ports(
+    worktree: str,
+    service_names: Sequence[str],
+    catalog: Mapping[str, Any],
+    *,
+    project_root: Optional[str] = None,
+) -> Dict[str, int]:
+    """Compute pure preferred formula ports (no lease, no rebind)."""
+    from .port_allocator import build_role_requests
+
+    reqs = build_role_requests(
+        service_names,
+        catalog,
+        worktree=worktree,
+        project_root=project_root,
+    )
+    return {r.port_var: int(r.preferred or r.base) for r in reqs}

--- a/src/dopemux/mcp/lifecycle.py
+++ b/src/dopemux/mcp/lifecycle.py
@@ -492,6 +492,84 @@ def run_lifecycle(
     compose_proj = dr.compose_project_name(slug, worktree_hash)
 
     ports = _extract_ports(doctor_env, selected, catalog)
+
+    # Lease registry consistency (start only — recommend repair-config on mismatch)
+    if op == "start":
+        try:
+            from .port_leases import PortLeaseRegistry
+
+            lease_reg = PortLeaseRegistry.load()
+            if lease_reg.parse_status == "ERROR":
+                blocking.append(
+                    {
+                        "code": "LEASE_REGISTRY_PARSE_ERROR",
+                        "severity": "FAIL",
+                        "message": f"Lease registry unreadable: {lease_reg.error}",
+                        "service": None,
+                    }
+                )
+            elif lease_reg.parse_status == "OK":
+                for var, port in ports.items():
+                    ours = [
+                        L
+                        for L in lease_reg.active_leases()
+                        if L.get("port_var") == var
+                        and (
+                            L.get("worktree_root") == (identity.worktree_root or str(target))
+                            or L.get("worktree_hash") == identity.worktree_hash
+                        )
+                    ]
+                    foreign = lease_reg.find_active_by_port(int(port))
+                    if foreign and not lease_reg.identity_matches(
+                        foreign,
+                        worktree_root=identity.worktree_root or str(target),
+                        project_root=identity.project_root,
+                        worktree_hash=identity.worktree_hash,
+                    ):
+                        blocking.append(
+                            {
+                                "code": "LEASE_BELONGS_TO_OTHER_PROJECT",
+                                "severity": "FAIL",
+                                "message": f"Port {port} ({var}) leased to another project",
+                                "service": None,
+                            }
+                        )
+                    elif ours and int(ours[0].get("port") or 0) != int(port):
+                        blocking.append(
+                            {
+                                "code": "LEASE_ENVRC_MISMATCH",
+                                "severity": "FAIL",
+                                "message": (
+                                    f"Envrc {var}={port} != lease {ours[0].get('port')}; "
+                                    "run `dopemux mcp repair-config --apply`"
+                                ),
+                                "service": None,
+                            }
+                        )
+                    elif not ours:
+                        warnings.append(
+                            {
+                                "code": "LEGACY_ENVRC_WITHOUT_LEASE",
+                                "severity": "WARN",
+                                "message": f"No lease for envrc {var}={port}",
+                                "service": None,
+                            }
+                        )
+                    else:
+                        # Port became occupied by non-lease holder after lease
+                        if not is_free(int(port)):
+                            # listening is OK if we will start/reuse — only block if foreign docker
+                            pass
+        except Exception as exc:  # noqa: BLE001
+            warnings.append(
+                {
+                    "code": "LEASE_UNKNOWN_OWNER",
+                    "severity": "WARN",
+                    "message": f"Lease check skipped: {exc}",
+                    "service": None,
+                }
+            )
+
     # Missing required ports for selected services
     for name in selected:
         spec = (catalog.get("servers") or {}).get(name) or {}

--- a/src/dopemux/mcp/port_allocator.py
+++ b/src/dopemux/mcp/port_allocator.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import hashlib
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence
 from urllib.parse import urlparse
 
 from .port_leases import (
@@ -304,6 +304,8 @@ def allocate_ports(
         project_root=proj,
         existing_envrc=existing_envrc,
     )
+    # Track per-role outcomes so overall status can become REUSED when appropriate.
+    role_statuses: List[str] = []
 
     for req in reqs:
         preferred = int(req.preferred if req.preferred is not None else req.base)
@@ -311,14 +313,21 @@ def allocate_ports(
         status_local = "ASSIGNED"
         rebind_reason: Optional[str] = None
 
-        # 1) Existing valid lease for this identity/service/role
-        existing = registry.find_active_for_identity(
-            service=req.service,
-            port_role=req.port_role,
-            worktree_root=identity.worktree_root if req.scope == "worktree" else None,
-            project_root=identity.project_root if req.scope == "project" else identity.project_root,
-            worktree_hash=identity.worktree_hash,
-        )
+        # 1) Existing valid lease for this identity/service/role.
+        # Worktree-scoped requests must not pick up project-scoped leases.
+        if req.scope == "project":
+            existing = registry.find_active_for_identity(
+                service=req.service,
+                port_role=req.port_role,
+                project_root=identity.project_root,
+            )
+        else:
+            existing = registry.find_active_for_identity(
+                service=req.service,
+                port_role=req.port_role,
+                worktree_root=identity.worktree_root,
+                worktree_hash=identity.worktree_hash,
+            )
         if existing:
             ep = int(existing["port"])
             if ep in plan_ports and plan_ports[ep] != f"{req.service}.{req.port_var}":
@@ -359,7 +368,8 @@ def allocate_ports(
                     )
 
         if assigned is None and req.fixed:
-            # Fixed-port services: never rebind
+            # Fixed-port services: never rebind. Block on foreign lease OR
+            # unknown occupant (live socket) before leasing.
             cand = preferred
             conflict = blocked.get(cand) or plan_ports.get(cand)
             other = registry.find_active_by_port(cand)
@@ -372,6 +382,15 @@ def allocate_ports(
             ):
                 other_ok = False
             free = is_free(cand)
+            ours_listening = bool(
+                other
+                and registry.identity_matches(
+                    other,
+                    worktree_root=identity.worktree_root,
+                    project_root=identity.project_root,
+                    worktree_hash=identity.worktree_hash,
+                )
+            )
             if conflict or not other_ok:
                 result.status = "BLOCKED"
                 result.blocking_findings.append(
@@ -386,7 +405,7 @@ def allocate_ports(
                     }
                 )
                 return result
-            if not free and not other_ok:
+            if not free and not ours_listening:
                 result.status = "BLOCKED"
                 result.blocking_findings.append(
                     {
@@ -500,6 +519,7 @@ def allocate_ports(
 
         plan_ports[assigned] = f"{req.service}.{req.port_var}"
         result.ports[req.port_var] = assigned
+        role_statuses.append(status_local)
 
         lease = PortLease(
             lease_id=make_lease_id(
@@ -570,12 +590,13 @@ def allocate_ports(
             )
             return result
 
-    if result.status not in {"BLOCKED", "REBIND"} and all(
-        w.get("code") == "LEASE_REUSED" for w in result.warnings if w.get("code", "").startswith("LEASE_")
+    # Pure reuse: every role was REUSED (ignore registry bookkeeping warnings).
+    if (
+        result.status not in {"BLOCKED", "REBIND"}
+        and role_statuses
+        and all(s == "REUSED" for s in role_statuses)
     ):
-        # purely reused
-        if any(w.get("code") == "LEASE_REUSED" for w in result.warnings):
-            result.status = "REUSED"
+        result.status = "REUSED"
 
     if not result.ports and not result.blocking_findings:
         result.status = "UNKNOWN"

--- a/src/dopemux/mcp/port_allocator.py
+++ b/src/dopemux/mcp/port_allocator.py
@@ -1,0 +1,618 @@
+"""Unified MCP port allocator with lease registry + live rebind.
+
+Replaces hash-only policy as the runtime assignment authority while still
+using hash-derived ports as *preferred* candidates when safe.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import urlparse
+
+from .port_leases import (
+    PortLease,
+    PortLeaseRegistry,
+    default_lease_registry_path,
+    make_lease_id,
+)
+from .socket_probe import port_is_free
+
+# Default search window beyond base when rebinding
+DEFAULT_SEARCH_SPAN = 100
+
+
+def preferred_port_for_path(worktree_path: str, base_port: int) -> int:
+    """Legacy preferred formula: base + sha1(abspath)[:4] % 100."""
+    offset = int(
+        hashlib.sha1(str(Path(worktree_path).resolve()).encode("utf-8")).hexdigest()[:4],
+        16,
+    ) % 100
+    return int(base_port) + offset
+
+
+def instance_id_for_path(worktree_path: str) -> str:
+    return hashlib.sha1(str(Path(worktree_path).resolve()).encode("utf-8")).hexdigest()[:4]
+
+
+def singleton_reserved_ports(catalog: Mapping[str, Any]) -> Dict[int, str]:
+    reserved: Dict[int, str] = {}
+    for name, spec in (catalog.get("servers") or {}).items():
+        if not isinstance(spec, dict) or spec.get("scope") != "singleton":
+            continue
+        explicit = spec.get("reserved_port")
+        if explicit is not None:
+            try:
+                reserved[int(explicit)] = name
+            except (TypeError, ValueError):
+                pass
+        raw_url = spec.get("url")
+        if raw_url:
+            try:
+                port = urlparse(str(raw_url)).port
+                if port:
+                    reserved[port] = name
+            except Exception:  # noqa: BLE001
+                pass
+    return reserved
+
+
+@dataclass
+class PortRoleRequest:
+    service: str
+    port_role: str
+    port_var: str
+    base: int
+    fixed: bool = False
+    scope: str = "worktree"  # worktree | project | singleton
+    preferred: Optional[int] = None
+
+
+@dataclass
+class AllocationResult:
+    status: str  # ASSIGNED|REUSED|REBIND|BLOCKED|UNKNOWN
+    ports: Dict[str, int] = field(default_factory=dict)  # port_var -> port
+    leases: List[Dict[str, Any]] = field(default_factory=list)
+    rebinds: List[Dict[str, Any]] = field(default_factory=list)
+    warnings: List[Dict[str, Any]] = field(default_factory=list)
+    blocking_findings: List[Dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "ports": dict(self.ports),
+            "leases": list(self.leases),
+            "rebinds": list(self.rebinds),
+            "warnings": list(self.warnings),
+            "blocking_findings": list(self.blocking_findings),
+        }
+
+
+def _role_from_var(port_var: str, service: str) -> str:
+    upper = port_var.upper()
+    if "INFO" in upper:
+        return "info"
+    if "HTTP" in upper and "MCP" not in upper:
+        return "http"
+    if "MCP" in upper or upper.endswith("_PORT"):
+        # primary MCP port: sse for conport-ish, http otherwise
+        if service == "conport" and "HTTP" not in upper:
+            return "sse"
+        return "http"
+    return "http"
+
+
+def build_role_requests(
+    service_names: Sequence[str],
+    catalog: Mapping[str, Any],
+    *,
+    worktree: str,
+    project_root: Optional[str] = None,
+    existing_envrc: Optional[Mapping[str, str]] = None,
+) -> List[PortRoleRequest]:
+    """Expand catalog services into port-role allocation requests."""
+    reqs: List[PortRoleRequest] = []
+    env = existing_envrc or {}
+    for name in service_names:
+        spec = (catalog.get("servers") or {}).get(name) or {}
+        if not isinstance(spec, dict) or spec.get("scope") != "per-worktree":
+            continue
+        is_fixed = spec.get("management_model") == "wrapper-singleton"
+        key_path = (
+            project_root
+            if spec.get("state_scope") == "per-repo" and project_root
+            else worktree
+        )
+        scope = "project" if spec.get("state_scope") == "per-repo" else "worktree"
+        base = spec.get("default_port_base")
+        port_var = spec.get("port_var")
+        if base and port_var:
+            pref = preferred_port_for_path(str(key_path), int(base)) if not is_fixed else int(base)
+            if str(port_var) in env:
+                try:
+                    pref = int(str(env[str(port_var)]).strip())
+                except ValueError:
+                    pass
+            reqs.append(
+                PortRoleRequest(
+                    service=str(name),
+                    port_role=_role_from_var(str(port_var), str(name)),
+                    port_var=str(port_var),
+                    base=int(base),
+                    fixed=is_fixed,
+                    scope=scope,
+                    preferred=pref,
+                )
+            )
+        if not is_fixed:
+            for extra in spec.get("extra_port_vars") or []:
+                if not isinstance(extra, dict):
+                    continue
+                var = extra.get("var")
+                ebase = extra.get("base")
+                if not var or ebase is None:
+                    continue
+                pref = preferred_port_for_path(str(key_path), int(ebase))
+                if str(var) in env:
+                    try:
+                        pref = int(str(env[str(var)]).strip())
+                    except ValueError:
+                        pass
+                reqs.append(
+                    PortRoleRequest(
+                        service=str(name),
+                        port_role=_role_from_var(str(var), str(name)),
+                        port_var=str(var),
+                        base=int(ebase),
+                        fixed=False,
+                        scope=scope,
+                        preferred=pref,
+                    )
+                )
+    return reqs
+
+
+def _candidate_ports(preferred: int, base: int, *, span: int = DEFAULT_SEARCH_SPAN) -> List[int]:
+    """Deterministic search order: preferred, then base..base+span, then preferred±."""
+    seen = set()
+    out: List[int] = []
+
+    def add(p: int) -> None:
+        if 1 <= p <= 65535 and p not in seen:
+            seen.add(p)
+            out.append(p)
+
+    add(int(preferred))
+    for p in range(int(base), int(base) + span + 1):
+        add(p)
+    # widen slightly around preferred if base range exhausted
+    for delta in range(1, span + 1):
+        add(int(preferred) + delta)
+        add(int(preferred) - delta)
+    return out
+
+
+@dataclass
+class AllocatorIdentity:
+    project_id: Optional[str]
+    workspace_id: Optional[str]
+    project_root: str
+    worktree_root: str
+    project_hash: Optional[str]
+    worktree_hash: str
+    instance_id: str
+
+
+def allocate_ports(
+    service_names: Sequence[str],
+    catalog: Mapping[str, Any],
+    *,
+    worktree: str,
+    project_root: Optional[str] = None,
+    identity: Optional[AllocatorIdentity] = None,
+    existing_envrc: Optional[Mapping[str, str]] = None,
+    registry: Optional[PortLeaseRegistry] = None,
+    registry_path: Optional[Path] = None,
+    persist: bool = True,
+    dry_run: bool = False,
+    source: str = "dopemux mcp init",
+    is_free_fn: Optional[Callable[[int], bool]] = None,
+    extra_blocked_ports: Optional[Mapping[int, str]] = None,
+) -> AllocationResult:
+    """Allocate ports for services with lease + live socket safety.
+
+    ``persist=False`` or ``dry_run=True`` skips registry writes.
+    """
+    is_free = is_free_fn or (lambda p: port_is_free(p))
+    wt = str(Path(worktree).expanduser().resolve())
+    proj = str(Path(project_root or worktree).expanduser().resolve())
+    wt_hash = instance_id_for_path(wt)
+    if identity is None:
+        identity = AllocatorIdentity(
+            project_id=Path(proj).name,
+            workspace_id=wt,
+            project_root=proj,
+            worktree_root=wt,
+            project_hash=None,
+            worktree_hash=wt_hash,
+            instance_id=wt_hash,
+        )
+
+    result = AllocationResult(status="ASSIGNED")
+
+    # Load registry
+    if registry is None:
+        path = registry_path or default_lease_registry_path()
+        registry = PortLeaseRegistry.load(path)
+    if registry.parse_status == "ERROR":
+        result.status = "BLOCKED"
+        result.blocking_findings.append(
+            {
+                "code": "LEASE_REGISTRY_PARSE_ERROR",
+                "message": f"Lease registry unreadable: {registry.error}",
+                "path": str(registry.path),
+            }
+        )
+        return result
+
+    if registry.parse_status == "MISSING":
+        result.warnings.append(
+            {
+                "code": "LEASE_REGISTRY_MISSING",
+                "message": f"No lease registry yet at {registry.path}; will create on first write.",
+            }
+        )
+    else:
+        result.warnings.append(
+            {
+                "code": "LEASE_REGISTRY_FOUND",
+                "message": f"Using lease registry {registry.path}",
+            }
+        )
+
+    reserved = singleton_reserved_ports(catalog)
+    registry.set_reserved_from_catalog(reserved)
+
+    blocked: Dict[int, str] = {p: f"singleton:{n}" for p, n in reserved.items()}
+    if extra_blocked_ports:
+        blocked.update({int(k): str(v) for k, v in extra_blocked_ports.items()})
+
+    # Seed blocked with other projects' active leases
+    for L in registry.active_leases():
+        port = int(L.get("port") or 0)
+        if not port:
+            continue
+        same = registry.identity_matches(
+            L,
+            worktree_root=identity.worktree_root,
+            project_root=identity.project_root,
+            worktree_hash=identity.worktree_hash,
+            project_id=identity.project_id,
+        )
+        if not same:
+            blocked[port] = (
+                f"lease:{L.get('service')}:{L.get('worktree_root') or L.get('project_root')}"
+            )
+
+    plan_ports: Dict[int, str] = {}  # port -> owner key in this allocation
+    reqs = build_role_requests(
+        service_names,
+        catalog,
+        worktree=wt,
+        project_root=proj,
+        existing_envrc=existing_envrc,
+    )
+
+    for req in reqs:
+        preferred = int(req.preferred if req.preferred is not None else req.base)
+        assigned: Optional[int] = None
+        status_local = "ASSIGNED"
+        rebind_reason: Optional[str] = None
+
+        # 1) Existing valid lease for this identity/service/role
+        existing = registry.find_active_for_identity(
+            service=req.service,
+            port_role=req.port_role,
+            worktree_root=identity.worktree_root if req.scope == "worktree" else None,
+            project_root=identity.project_root if req.scope == "project" else identity.project_root,
+            worktree_hash=identity.worktree_hash,
+        )
+        if existing:
+            ep = int(existing["port"])
+            if ep in plan_ports and plan_ports[ep] != f"{req.service}.{req.port_var}":
+                # conflict within plan — fall through to rebind
+                pass
+            elif ep in blocked and not registry.identity_matches(
+                existing,
+                worktree_root=identity.worktree_root,
+                project_root=identity.project_root,
+                worktree_hash=identity.worktree_hash,
+            ):
+                pass
+            elif is_free(ep) or registry.identity_matches(
+                existing,
+                worktree_root=identity.worktree_root,
+                project_root=identity.project_root,
+                worktree_hash=identity.worktree_hash,
+            ):
+                # Reuse lease if free OR still ours (may be running)
+                other = registry.find_active_by_port(ep)
+                if other and not registry.identity_matches(
+                    other,
+                    worktree_root=identity.worktree_root,
+                    project_root=identity.project_root,
+                    worktree_hash=identity.worktree_hash,
+                ):
+                    pass
+                else:
+                    assigned = ep
+                    status_local = "REUSED"
+                    result.warnings.append(
+                        {
+                            "code": "LEASE_REUSED",
+                            "service": req.service,
+                            "port_role": req.port_role,
+                            "port": ep,
+                        }
+                    )
+
+        if assigned is None and req.fixed:
+            # Fixed-port services: never rebind
+            cand = preferred
+            conflict = blocked.get(cand) or plan_ports.get(cand)
+            other = registry.find_active_by_port(cand)
+            other_ok = True
+            if other and not registry.identity_matches(
+                other,
+                worktree_root=identity.worktree_root,
+                project_root=identity.project_root,
+                worktree_hash=identity.worktree_hash,
+            ):
+                other_ok = False
+            free = is_free(cand)
+            if conflict or not other_ok:
+                result.status = "BLOCKED"
+                result.blocking_findings.append(
+                    {
+                        "code": "ALLOCATOR_FIXED_PORT_BLOCKED",
+                        "service": req.service,
+                        "port": cand,
+                        "message": (
+                            f"Fixed port {cand} for {req.service} is blocked "
+                            f"({conflict or 'foreign lease'})."
+                        ),
+                    }
+                )
+                return result
+            if not free and not other_ok:
+                result.status = "BLOCKED"
+                result.blocking_findings.append(
+                    {
+                        "code": "LEASE_PORT_OCCUPIED",
+                        "service": req.service,
+                        "port": cand,
+                        "message": f"Fixed port {cand} occupied by unknown process.",
+                    }
+                )
+                return result
+            assigned = cand
+            status_local = "REUSED" if other else "ASSIGNED"
+            result.warnings.append(
+                {
+                    "code": "ALLOCATOR_FIXED_PORT_REUSED" if other else "ALLOCATOR_ASSIGNED_PREFERRED",
+                    "service": req.service,
+                    "port": cand,
+                }
+            )
+        elif assigned is None:
+            # Search candidates
+            for cand in _candidate_ports(preferred, req.base):
+                if cand in reserved:
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "PORT_RESERVED_COLLISION"
+                    continue
+                if cand in blocked:
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "LEASE_BELONGS_TO_OTHER_PROJECT"
+                    continue
+                if cand in plan_ports:
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "ALLOCATOR_CROSS_SERVICE_COLLISION_AVOIDED"
+                    continue
+                other = registry.find_active_by_port(cand)
+                if other and not registry.identity_matches(
+                    other,
+                    worktree_root=identity.worktree_root,
+                    project_root=identity.project_root,
+                    worktree_hash=identity.worktree_hash,
+                ):
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "LEASE_BELONGS_TO_OTHER_WORKTREE"
+                    continue
+                if not is_free(cand):
+                    # occupied — only ok if our lease
+                    if other and registry.identity_matches(
+                        other,
+                        worktree_root=identity.worktree_root,
+                        project_root=identity.project_root,
+                        worktree_hash=identity.worktree_hash,
+                    ):
+                        assigned = cand
+                        status_local = "REUSED"
+                        break
+                    if cand == preferred:
+                        rebind_reason = rebind_reason or "LEASE_PORT_OCCUPIED"
+                    continue
+                assigned = cand
+                if cand == preferred:
+                    status_local = "ASSIGNED"
+                    result.warnings.append(
+                        {
+                            "code": "ALLOCATOR_ASSIGNED_PREFERRED",
+                            "service": req.service,
+                            "port_role": req.port_role,
+                            "port": cand,
+                        }
+                    )
+                else:
+                    status_local = "REBIND"
+                    rebind_reason = rebind_reason or "ALLOCATOR_REBOUND_FROM_PREFERRED"
+                break
+
+        if assigned is None:
+            result.status = "BLOCKED"
+            result.blocking_findings.append(
+                {
+                    "code": "ALLOCATOR_NO_SAFE_PORT",
+                    "service": req.service,
+                    "port_role": req.port_role,
+                    "port_var": req.port_var,
+                    "preferred": preferred,
+                    "message": f"No safe port for {req.service}.{req.port_var} near base {req.base}.",
+                }
+            )
+            return result
+
+        if status_local == "REBIND" or (assigned != preferred and not req.fixed):
+            result.rebinds.append(
+                {
+                    "role": req.port_role,
+                    "service": req.service,
+                    "port_var": req.port_var,
+                    "preferred": preferred,
+                    "assigned": assigned,
+                    "reason": rebind_reason or "ALLOCATOR_REBOUND_FROM_PREFERRED",
+                }
+            )
+            result.warnings.append(
+                {
+                    "code": "LEASE_REBOUND",
+                    "service": req.service,
+                    "preferred": preferred,
+                    "assigned": assigned,
+                    "reason": rebind_reason,
+                }
+            )
+            if result.status not in {"BLOCKED"}:
+                result.status = "REBIND"
+
+        plan_ports[assigned] = f"{req.service}.{req.port_var}"
+        result.ports[req.port_var] = assigned
+
+        lease = PortLease(
+            lease_id=make_lease_id(
+                project_slug=str(identity.project_id or Path(identity.project_root).name),
+                worktree_hash=identity.worktree_hash,
+                service=req.service,
+                port_role=req.port_role,
+                port=assigned,
+            ),
+            port=assigned,
+            service=req.service,
+            port_role=req.port_role,
+            port_var=req.port_var,
+            project_id=identity.project_id,
+            workspace_id=identity.workspace_id,
+            project_root=identity.project_root,
+            worktree_root=identity.worktree_root,
+            project_hash=identity.project_hash,
+            worktree_hash=identity.worktree_hash,
+            instance_id=identity.instance_id,
+            scope=req.scope,
+            source=source,
+            status="active",
+            preferred=(assigned == preferred),
+            reserved=False,
+            notes=[] if assigned == preferred else [f"rebound from {preferred}"],
+        )
+        entry = lease.to_dict()
+        result.leases.append(entry)
+        if not dry_run and persist:
+            registry.upsert_lease(lease)
+
+        if status_local == "ASSIGNED" and assigned == preferred:
+            result.warnings.append(
+                {
+                    "code": "LEASE_CREATED",
+                    "service": req.service,
+                    "port": assigned,
+                }
+            )
+
+    # Cross-worktree collision avoided summary
+    if any(r.get("reason") == "LEASE_BELONGS_TO_OTHER_WORKTREE" for r in result.rebinds):
+        result.warnings.append(
+            {
+                "code": "ALLOCATOR_CROSS_WORKTREE_COLLISION_AVOIDED",
+                "message": "Rebound at least one port to avoid another worktree's lease.",
+            }
+        )
+    if any(r.get("reason") == "ALLOCATOR_CROSS_SERVICE_COLLISION_AVOIDED" for r in result.rebinds):
+        result.warnings.append(
+            {
+                "code": "ALLOCATOR_CROSS_SERVICE_COLLISION_AVOIDED",
+                "message": "Rebound to avoid intra-plan cross-service collision.",
+            }
+        )
+
+    if not dry_run and persist and result.leases:
+        try:
+            registry.save()
+        except OSError as exc:
+            result.status = "BLOCKED"
+            result.blocking_findings.append(
+                {
+                    "code": "LEASE_REGISTRY_PARSE_ERROR",
+                    "message": f"Failed to write lease registry: {exc}",
+                }
+            )
+            return result
+
+    if result.status not in {"BLOCKED", "REBIND"} and all(
+        w.get("code") == "LEASE_REUSED" for w in result.warnings if w.get("code", "").startswith("LEASE_")
+    ):
+        # purely reused
+        if any(w.get("code") == "LEASE_REUSED" for w in result.warnings):
+            result.status = "REUSED"
+
+    if not result.ports and not result.blocking_findings:
+        result.status = "UNKNOWN"
+
+    return result
+
+
+def allocate_ports_map(
+    worktree: str,
+    names: Sequence[str],
+    catalog: Mapping[str, Any],
+    *,
+    project_root: str | None = None,
+    existing_envrc: Optional[Mapping[str, str]] = None,
+    persist: bool = True,
+    dry_run: bool = False,
+    source: str = "dopemux mcp init",
+    registry_path: Optional[Path] = None,
+    is_free_fn: Optional[Callable[[int], bool]] = None,
+) -> Dict[str, int]:
+    """Drop-in replacement shape for ``_allocate_ports`` → {port_var: port}.
+
+    Raises RuntimeError on BLOCKED (callers may convert to ClickException).
+    """
+    result = allocate_ports(
+        names,
+        catalog,
+        worktree=worktree,
+        project_root=project_root,
+        existing_envrc=existing_envrc,
+        persist=persist and not dry_run,
+        dry_run=dry_run,
+        source=source,
+        registry_path=registry_path,
+        is_free_fn=is_free_fn,
+    )
+    if result.status == "BLOCKED":
+        msgs = "; ".join(f["message"] for f in result.blocking_findings if f.get("message"))
+        raise RuntimeError(msgs or "Port allocation blocked")
+    return dict(result.ports)

--- a/src/dopemux/mcp/port_leases.py
+++ b/src/dopemux/mcp/port_leases.py
@@ -13,7 +13,6 @@ import json
 import os
 import re
 import tempfile
-from copy import deepcopy
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -246,13 +245,33 @@ class PortLeaseRegistry:
         project_root: Optional[str] = None,
         worktree_hash: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
+        """Find an active lease for the given identity.
+
+        Worktree-scoped lookups (``worktree_root`` / ``worktree_hash``) never
+        return project-scoped leases. Project-scoped lookups (``project_root``
+        only, or when no worktree identity is supplied) only match
+        ``scope == \"project\"`` entries.
+        """
+        looking_worktree = worktree_root is not None or worktree_hash is not None
+        looking_project = project_root is not None and not looking_worktree
+
         for L in self.active_leases():
             if L.get("service") != service or L.get("port_role") != port_role:
                 continue
-            if worktree_hash and L.get("worktree_hash") == worktree_hash:
-                return L
-            if worktree_root and L.get("worktree_root") == worktree_root:
-                return L
+            if looking_worktree:
+                # Do not reuse a project-scoped lease for a worktree-scoped request.
+                if L.get("scope") == "project":
+                    continue
+                if worktree_hash and L.get("worktree_hash") == worktree_hash:
+                    return L
+                if worktree_root and L.get("worktree_root") == worktree_root:
+                    return L
+                continue
+            if looking_project:
+                if L.get("scope") == "project" and L.get("project_root") == project_root:
+                    return L
+                continue
+            # Fallback when no identity keys provided (legacy callers).
             if project_root and L.get("project_root") == project_root and L.get("scope") == "project":
                 return L
         return None
@@ -291,14 +310,34 @@ class PortLeaseRegistry:
         leases = self.leases()
         out: List[Dict[str, Any]] = []
         replaced = False
+        entry_scope = str(entry.get("scope") or "worktree")
         for L in leases:
             same_id = L.get("lease_id") and L.get("lease_id") == entry.get("lease_id")
-            same_slot = (
-                L.get("service") == entry.get("service")
-                and L.get("port_role") == entry.get("port_role")
-                and L.get("worktree_root") == entry.get("worktree_root")
-                and L.get("status") == "active"
-            )
+            if entry_scope == "project":
+                # Project-scoped leases dedupe across worktrees of the same project.
+                same_project = False
+                if entry.get("project_root") and L.get("project_root") == entry.get("project_root"):
+                    same_project = True
+                elif (
+                    not entry.get("project_root")
+                    and entry.get("project_id")
+                    and L.get("project_id") == entry.get("project_id")
+                ):
+                    same_project = True
+                same_slot = (
+                    L.get("status") == "active"
+                    and L.get("service") == entry.get("service")
+                    and L.get("port_role") == entry.get("port_role")
+                    and (L.get("scope") or "worktree") == "project"
+                    and same_project
+                )
+            else:
+                same_slot = (
+                    L.get("service") == entry.get("service")
+                    and L.get("port_role") == entry.get("port_role")
+                    and L.get("worktree_root") == entry.get("worktree_root")
+                    and L.get("status") == "active"
+                )
             if same_id or same_slot:
                 if not replaced:
                     # preserve created_at

--- a/src/dopemux/mcp/port_leases.py
+++ b/src/dopemux/mcp/port_leases.py
@@ -1,0 +1,389 @@
+"""Operational MCP port lease registry.
+
+Path default: ~/.dopemux/mcp/runtime/port-leases.json
+Override: DOPEMUX_MCP_PORT_LEASE_REGISTRY
+
+Operational state only — never domain truth for ConPort / dope-memory / TO.
+No secrets. Atomic writes. Tests must override the registry path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from copy import deepcopy
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+SCHEMA_VERSION = "1.0"
+ALLOCATOR_VERSION = "1"
+REGISTRY_ENV = "DOPEMUX_MCP_PORT_LEASE_REGISTRY"
+DEFAULT_RELATIVE = Path(".dopemux/mcp/runtime/port-leases.json")
+
+
+class LeaseRegistryError(RuntimeError):
+    """Registry load/save failure that blocks allocation."""
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def default_lease_registry_path() -> Path:
+    override = os.environ.get(REGISTRY_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    return (Path.home() / DEFAULT_RELATIVE).resolve()
+
+
+def empty_registry() -> Dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "updated_at": _utc_now(),
+        "allocator_version": ALLOCATOR_VERSION,
+        "leases": [],
+        "reserved_ports": [],
+    }
+
+
+def _slug(value: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+    return s[:48] or "x"
+
+
+def make_lease_id(
+    *,
+    project_slug: str,
+    worktree_hash: str,
+    service: str,
+    port_role: str,
+    port: int,
+) -> str:
+    return f"lease_{_slug(project_slug)}_{worktree_hash}_{_slug(service)}_{_slug(port_role)}_{port}"
+
+
+@dataclass
+class PortLease:
+    lease_id: str
+    port: int
+    protocol: str = "tcp"
+    bind_host: str = "127.0.0.1"
+    service: str = ""
+    port_role: str = "http"
+    port_var: str = ""
+    project_id: Optional[str] = None
+    workspace_id: Optional[str] = None
+    project_root: Optional[str] = None
+    worktree_root: Optional[str] = None
+    project_hash: Optional[str] = None
+    worktree_hash: Optional[str] = None
+    instance_id: Optional[str] = None
+    scope: str = "worktree"  # project|worktree|singleton
+    source: str = "dopemux mcp init"
+    status: str = "active"  # active|stale|released|unknown
+    preferred: bool = True
+    reserved: bool = False
+    created_at: str = field(default_factory=_utc_now)
+    updated_at: str = field(default_factory=_utc_now)
+    last_verified_at: Optional[str] = None
+    notes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "lease_id": self.lease_id,
+            "port": int(self.port),
+            "protocol": self.protocol,
+            "bind_host": self.bind_host,
+            "service": self.service,
+            "port_role": self.port_role,
+            "port_var": self.port_var,
+            "project_id": self.project_id,
+            "workspace_id": self.workspace_id,
+            "project_root": self.project_root,
+            "worktree_root": self.worktree_root,
+            "project_hash": self.project_hash,
+            "worktree_hash": self.worktree_hash,
+            "instance_id": self.instance_id,
+            "scope": self.scope,
+            "source": self.source,
+            "status": self.status,
+            "preferred": self.preferred,
+            "reserved": self.reserved,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "last_verified_at": self.last_verified_at,
+            "notes": list(self.notes),
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Dict[str, Any]) -> "PortLease":
+        d = dict(raw)
+        return cls(
+            lease_id=str(d.get("lease_id") or ""),
+            port=int(d["port"]),
+            protocol=str(d.get("protocol") or "tcp"),
+            bind_host=str(d.get("bind_host") or "127.0.0.1"),
+            service=str(d.get("service") or ""),
+            port_role=str(d.get("port_role") or "http"),
+            port_var=str(d.get("port_var") or ""),
+            project_id=d.get("project_id"),
+            workspace_id=d.get("workspace_id"),
+            project_root=d.get("project_root"),
+            worktree_root=d.get("worktree_root"),
+            project_hash=d.get("project_hash"),
+            worktree_hash=d.get("worktree_hash"),
+            instance_id=d.get("instance_id"),
+            scope=str(d.get("scope") or "worktree"),
+            source=str(d.get("source") or "unknown"),
+            status=str(d.get("status") or "unknown"),
+            preferred=bool(d.get("preferred", True)),
+            reserved=bool(d.get("reserved", False)),
+            created_at=str(d.get("created_at") or _utc_now()),
+            updated_at=str(d.get("updated_at") or _utc_now()),
+            last_verified_at=d.get("last_verified_at"),
+            notes=list(d.get("notes") or []),
+        )
+
+
+@dataclass
+class PortLeaseRegistry:
+    """In-memory lease registry with atomic persistence."""
+
+    path: Path
+    data: Dict[str, Any] = field(default_factory=empty_registry)
+    present: bool = False
+    parse_status: str = "MISSING"  # OK | ERROR | MISSING
+    error: Optional[str] = None
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None, *, create_missing: bool = False) -> "PortLeaseRegistry":
+        reg_path = path or default_lease_registry_path()
+        if not reg_path.exists():
+            if create_missing:
+                reg_path.parent.mkdir(parents=True, exist_ok=True)
+                reg = cls(path=reg_path, data=empty_registry(), present=False, parse_status="MISSING")
+                reg.save()
+                reg.present = True
+                reg.parse_status = "OK"
+                return reg
+            return cls(path=reg_path, data=empty_registry(), present=False, parse_status="MISSING")
+
+        try:
+            raw = json.loads(reg_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return cls(
+                path=reg_path,
+                data=empty_registry(),
+                present=True,
+                parse_status="ERROR",
+                error=str(exc),
+            )
+        if not isinstance(raw, dict):
+            return cls(
+                path=reg_path,
+                data=empty_registry(),
+                present=True,
+                parse_status="ERROR",
+                error="registry root is not an object",
+            )
+        leases = raw.get("leases")
+        if leases is None:
+            leases = []
+        if not isinstance(leases, list):
+            return cls(
+                path=reg_path,
+                data=empty_registry(),
+                present=True,
+                parse_status="ERROR",
+                error="registry leases is not a list",
+            )
+        data = dict(raw)
+        data["leases"] = leases
+        data.setdefault("schema_version", SCHEMA_VERSION)
+        data.setdefault("allocator_version", ALLOCATOR_VERSION)
+        data.setdefault("reserved_ports", [])
+        data.setdefault("updated_at", _utc_now())
+        return cls(path=reg_path, data=data, present=True, parse_status="OK")
+
+    def require_writable(self) -> None:
+        if self.parse_status == "ERROR":
+            raise LeaseRegistryError(
+                f"Lease registry parse failed at {self.path}: {self.error}. "
+                "Allocation is blocked."
+            )
+
+    def leases(self) -> List[Dict[str, Any]]:
+        return list(self.data.get("leases") or [])
+
+    def active_leases(self) -> List[Dict[str, Any]]:
+        return [L for L in self.leases() if L.get("status") == "active"]
+
+    def reserved_ports(self) -> List[Dict[str, Any]]:
+        return list(self.data.get("reserved_ports") or [])
+
+    def set_reserved_from_catalog(self, reserved: Dict[int, str], *, source: str = "catalog") -> None:
+        self.data["reserved_ports"] = [
+            {"port": int(p), "service": name, "source": source, "reason": "singleton"}
+            for p, name in sorted(reserved.items())
+        ]
+
+    def find_active_by_port(self, port: int) -> Optional[Dict[str, Any]]:
+        for L in self.active_leases():
+            if int(L.get("port") or 0) == int(port):
+                return L
+        return None
+
+    def find_active_for_identity(
+        self,
+        *,
+        service: str,
+        port_role: str,
+        worktree_root: Optional[str] = None,
+        project_root: Optional[str] = None,
+        worktree_hash: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        for L in self.active_leases():
+            if L.get("service") != service or L.get("port_role") != port_role:
+                continue
+            if worktree_hash and L.get("worktree_hash") == worktree_hash:
+                return L
+            if worktree_root and L.get("worktree_root") == worktree_root:
+                return L
+            if project_root and L.get("project_root") == project_root and L.get("scope") == "project":
+                return L
+        return None
+
+    def identity_matches(
+        self,
+        lease: Dict[str, Any],
+        *,
+        worktree_root: Optional[str],
+        project_root: Optional[str],
+        worktree_hash: Optional[str],
+        project_id: Optional[str] = None,
+    ) -> bool:
+        # Project-scoped leases (e.g. task-orchestrator) are shared across worktrees
+        # of the same project root.
+        if lease.get("scope") == "project":
+            if project_root and lease.get("project_root"):
+                return lease.get("project_root") == project_root
+            if project_id and lease.get("project_id"):
+                return lease.get("project_id") == project_id
+            return False
+
+        if worktree_hash and lease.get("worktree_hash") and lease.get("worktree_hash") != worktree_hash:
+            return False
+        if worktree_root and lease.get("worktree_root") and lease.get("worktree_root") != worktree_root:
+            return False
+        if project_id and lease.get("project_id") and lease.get("project_id") != project_id:
+            if worktree_root and lease.get("worktree_root") == worktree_root:
+                return True
+            return False
+        return True
+
+    def upsert_lease(self, lease: PortLease | Dict[str, Any]) -> Dict[str, Any]:
+        entry = lease.to_dict() if isinstance(lease, PortLease) else dict(lease)
+        entry["updated_at"] = _utc_now()
+        leases = self.leases()
+        out: List[Dict[str, Any]] = []
+        replaced = False
+        for L in leases:
+            same_id = L.get("lease_id") and L.get("lease_id") == entry.get("lease_id")
+            same_slot = (
+                L.get("service") == entry.get("service")
+                and L.get("port_role") == entry.get("port_role")
+                and L.get("worktree_root") == entry.get("worktree_root")
+                and L.get("status") == "active"
+            )
+            if same_id or same_slot:
+                if not replaced:
+                    # preserve created_at
+                    entry.setdefault("created_at", L.get("created_at") or _utc_now())
+                    out.append(entry)
+                    replaced = True
+                # drop old
+                continue
+            out.append(L)
+        if not replaced:
+            entry.setdefault("created_at", _utc_now())
+            out.append(entry)
+        self.data["leases"] = out
+        self.data["updated_at"] = _utc_now()
+        return entry
+
+    def mark_released(
+        self,
+        *,
+        service: Optional[str] = None,
+        worktree_root: Optional[str] = None,
+        port: Optional[int] = None,
+        lease_id: Optional[str] = None,
+    ) -> int:
+        count = 0
+        now = _utc_now()
+        for L in self.leases():
+            match = False
+            if lease_id and L.get("lease_id") == lease_id:
+                match = True
+            if port is not None and int(L.get("port") or 0) == int(port):
+                match = True
+            if service and worktree_root:
+                if L.get("service") == service and L.get("worktree_root") == worktree_root:
+                    match = True
+            if match and L.get("status") == "active":
+                L["status"] = "released"
+                L["updated_at"] = now
+                count += 1
+        if count:
+            self.data["updated_at"] = now
+        return count
+
+    def mark_stale(self, lease_id: str) -> bool:
+        for L in self.leases():
+            if L.get("lease_id") == lease_id and L.get("status") == "active":
+                L["status"] = "stale"
+                L["updated_at"] = _utc_now()
+                self.data["updated_at"] = _utc_now()
+                return True
+        return False
+
+    def active_ports(self) -> Dict[int, Dict[str, Any]]:
+        return {int(L["port"]): L for L in self.active_leases() if L.get("port") is not None}
+
+    def save(self) -> None:
+        self.require_writable()
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.data["updated_at"] = _utc_now()
+        payload = json.dumps(self.data, indent=2, sort_keys=False) + "\n"
+        # Atomic write via same-dir tempfile
+        fd, tmp_name = tempfile.mkstemp(prefix=".port-leases.", suffix=".tmp", dir=str(self.path.parent))
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp_name, self.path)
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+        self.present = True
+        self.parse_status = "OK"
+
+    def to_report_dict(self) -> Dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "present": self.present,
+            "parse_status": self.parse_status,
+            "error": self.error,
+            "active_lease_count": len(self.active_leases()),
+            "lease_count": len(self.leases()),
+            "allocator_version": self.data.get("allocator_version"),
+            "schema_version": self.data.get("schema_version"),
+        }

--- a/src/dopemux/mcp/socket_probe.py
+++ b/src/dopemux/mcp/socket_probe.py
@@ -6,7 +6,6 @@ Never starts processes. Timeout-bounded connect checks only.
 from __future__ import annotations
 
 import socket
-from typing import Optional
 
 
 DEFAULT_TIMEOUT_S = 0.25

--- a/src/dopemux/mcp/socket_probe.py
+++ b/src/dopemux/mcp/socket_probe.py
@@ -1,0 +1,55 @@
+"""Bounded TCP socket probes for MCP port allocation (read-only).
+
+Never starts processes. Timeout-bounded connect checks only.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Optional
+
+
+DEFAULT_TIMEOUT_S = 0.25
+DEFAULT_HOST = "127.0.0.1"
+
+
+def port_is_free(port: int, host: str = DEFAULT_HOST, *, timeout_s: float = DEFAULT_TIMEOUT_S) -> bool:
+    """True if nothing accepts TCP connections on (host, port)."""
+    if not (1 <= int(port) <= 65535):
+        return False
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(timeout_s)
+    try:
+        return sock.connect_ex((host, int(port))) != 0
+    except OSError:
+        # Treat probe failure as unknown/occupied to fail closed for allocation
+        return False
+    finally:
+        try:
+            sock.close()
+        except OSError:
+            pass
+
+
+def port_is_listening(
+    port: int, host: str = DEFAULT_HOST, *, timeout_s: float = DEFAULT_TIMEOUT_S
+) -> bool:
+    """True if something accepts TCP connections on (host, port)."""
+    return not port_is_free(port, host, timeout_s=timeout_s)
+
+
+def probe_port(
+    port: int,
+    host: str = DEFAULT_HOST,
+    *,
+    timeout_s: float = DEFAULT_TIMEOUT_S,
+) -> dict:
+    """Return a structured probe result for doctor/allocator reports."""
+    free = port_is_free(port, host, timeout_s=timeout_s)
+    return {
+        "port": int(port),
+        "host": host,
+        "free": free,
+        "listening": not free,
+        "timeout_s": timeout_s,
+    }

--- a/tests/mcp/test_provision.py
+++ b/tests/mcp/test_provision.py
@@ -48,12 +48,14 @@ def test_provision_idempotency(temp_project):
         assert path1 == path2
 
 def test_instance_overlay_uniqueness(temp_project):
+    # Empty catalog skips lease allocator so this exercises the legacy port map.
+    empty_catalog = {"defaults": {"per_worktree": []}, "servers": {}}
     # Instance A
-    manager_a = InstanceOverlayManager(temp_project, "A")
+    manager_a = InstanceOverlayManager(temp_project, "A", catalog=empty_catalog)
     overlay_a = manager_a.materialize()
     
     # Instance B
-    manager_b = InstanceOverlayManager(temp_project, "B")
+    manager_b = InstanceOverlayManager(temp_project, "B", catalog=empty_catalog)
     overlay_b = manager_b.materialize()
     
     assert overlay_a["base_port"] == 3000
@@ -172,5 +174,29 @@ def test_provision_broken_symlink_cleanup(temp_project):
         assert os.readlink(path) == str(pkg_mcp)
 
 def test_instance_overlay_no_id(temp_project):
-    manager = InstanceOverlayManager(temp_project, "")
+    empty_catalog = {"defaults": {"per_worktree": []}, "servers": {}}
+    manager = InstanceOverlayManager(temp_project, "", catalog=empty_catalog)
     assert manager.base_port == 3000
+
+
+def test_instance_overlay_reraises_allocator_blocked(temp_project):
+    """BLOCKED allocation must not fall back to the legacy colliding map."""
+
+    def boom(*_a, **_k):
+        raise RuntimeError("Fixed port 7890 occupied by unknown process.")
+
+    catalog = {
+        "defaults": {"per_worktree": ["task-orchestrator"]},
+        "servers": {
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "state_scope": "per-repo",
+                "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
+                "default_port_base": 7890,
+                "management_model": "wrapper-singleton",
+            }
+        },
+    }
+    with patch("dopemux.mcp.port_allocator.allocate_ports_map", side_effect=boom):
+        with pytest.raises(RuntimeError, match="Fixed port 7890"):
+            InstanceOverlayManager(temp_project, "A", catalog=catalog)

--- a/tests/unit/test_mcp_commands_catalog.py
+++ b/tests/unit/test_mcp_commands_catalog.py
@@ -133,21 +133,25 @@ def test_allocate_ports_raises_on_cross_server_collision():
         },
     }
 
-    with pytest.raises(click.ClickException) as excinfo:
-        mcp_commands._allocate_ports("/tmp/wt-collide", ["alpha", "beta"], catalog)
+    # Packet 004: cross-service preferred collisions rebind instead of hard-fail
+    ports = mcp_commands._allocate_ports(
+        "/tmp/wt-collide",
+        ["alpha", "beta"],
+        catalog,
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
+    )
+    assert ports["ALPHA_PORT"] != ports["BETA_PORT"]
 
-    msg = str(excinfo.value.message)
-    assert "Internal port collision" in msg
-    assert "alpha" in msg
-    assert "beta" in msg
 
-
-def test_allocate_ports_wrapper_singleton_uses_fixed_base_port():
+def test_allocate_ports_wrapper_singleton_uses_fixed_base_port(tmp_path, monkeypatch):
     """wrapper-singleton services must NOT have a workspace hash offset applied.
 
     task-orchestrator is the canonical wrapper-singleton; its port must always
     equal default_port_base regardless of the workspace path hash.
     """
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(tmp_path / "leases.json"))
     catalog = {
         "version": 1,
         "servers": {
@@ -163,17 +167,24 @@ def test_allocate_ports_wrapper_singleton_uses_fixed_base_port():
     }
 
     # Two completely different workspace paths must yield the same fixed port
+    # (dry-run so concurrent multi-project fixed-port leases are not written)
     result_a = mcp_commands._allocate_ports(
         "/Users/alice/code/project-a",
         ["task-orchestrator"],
         catalog,
         project_root="/Users/alice/code/project-a",
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
     )
     result_b = mcp_commands._allocate_ports(
         "/Users/bob/totally-different-path/zyx",
         ["task-orchestrator"],
         catalog,
         project_root="/Users/bob/totally-different-path/zyx",
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
     )
 
     assert result_a["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
@@ -210,19 +221,17 @@ def test_allocate_ports_raises_on_singleton_port_collision(monkeypatch):
         },
     }
 
-    # Force _port_for to return the singleton port regardless of input
-    monkeypatch.setattr(mcp_commands, "_port_for", lambda _path, _base: SINGLETON_PORT)
-
-    with pytest.raises(click.ClickException) as excinfo:
-        mcp_commands._allocate_ports(
-            "/Users/hue/code/dNh_CRM",
-            ["conport"],
-            catalog,
-        )
-
-    msg = str(excinfo.value.message)
-    assert "collision" in msg.lower()
-    assert str(SINGLETON_PORT) in msg or "gpt-researcher" in msg or "singleton" in msg
+    # Prefer reserved port via envrc; allocator must rebind away from singleton
+    ports = mcp_commands._allocate_ports(
+        "/Users/hue/code/dNh_CRM",
+        ["conport"],
+        catalog,
+        existing_envrc={"CONPORT_HTTP_PORT": str(SINGLETON_PORT)},
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
+    )
+    assert ports["CONPORT_HTTP_PORT"] != SINGLETON_PORT
 
 
 def test_allocate_ports_raises_on_url_singleton_port_collision(monkeypatch):
@@ -245,42 +254,52 @@ def test_allocate_ports_raises_on_url_singleton_port_collision(monkeypatch):
         },
     }
 
-    monkeypatch.setattr(mcp_commands, "_port_for", lambda _path, _base: SINGLETON_PORT)
+    ports = mcp_commands._allocate_ports(
+        "/tmp/wt",
+        ["conport"],
+        catalog,
+        existing_envrc={"CONPORT_HTTP_PORT": str(SINGLETON_PORT)},
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
+    )
+    assert ports["CONPORT_HTTP_PORT"] != SINGLETON_PORT
 
-    with pytest.raises(click.ClickException) as excinfo:
-        mcp_commands._allocate_ports("/tmp/wt", ["conport"], catalog)
 
-    assert "collision" in str(excinfo.value.message).lower()
-
-
-def test_allocate_ports_uses_project_root_for_per_repo_state():
+def test_allocate_ports_uses_project_root_for_per_repo_state(tmp_path, monkeypatch):
     catalog = {
         "version": 1,
         "servers": {
             "task-orchestrator": {
                 "scope": "per-worktree",
                 "state_scope": "per-repo",
+                "management_model": "wrapper-singleton",
                 "transport": "http",
                 "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
                 "default_port_base": 7890,
             },
         },
     }
+    reg = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg))
 
     main = mcp_commands._allocate_ports(
         "/tmp/repo",
         ["task-orchestrator"],
         catalog,
         project_root="/tmp/shared-project",
+        is_free_fn=lambda p: True,
     )
     linked = mcp_commands._allocate_ports(
         "/tmp/repo-linked",
         ["task-orchestrator"],
         catalog,
         project_root="/tmp/shared-project",
+        is_free_fn=lambda p: True,
     )
 
     assert linked == main
+    assert main["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
 
 
 def test_project_identity_is_shared_across_linked_worktrees(tmp_path):

--- a/tests/unit/test_mcp_config_repair.py
+++ b/tests/unit/test_mcp_config_repair.py
@@ -277,6 +277,51 @@ def test_port_limitation_warnings(tmp_path: Path):
     assert "PORT_REBIND_MISSING" in codes
 
 
+def test_plan_does_not_persist_leases_until_apply(tmp_path: Path):
+    """Planning must not write leases even when dry_run=False (apply path)."""
+    repo = tmp_path / "proj"
+    repo.mkdir()
+    calls: list[dict] = []
+
+    def tracking_alloc(
+        worktree: str,
+        names: List[str],
+        catalog: Dict[str, Any],
+        *,
+        project_root: str | None = None,
+        persist: bool = True,
+        dry_run: bool = False,
+        existing_envrc: Dict[str, str] | None = None,
+        source: str = "",
+        **_kwargs: Any,
+    ):
+        calls.append({"persist": persist, "dry_run": dry_run, "source": source})
+        return _alloc(worktree, names, catalog, project_root=project_root)
+
+    plan = cr.plan_repair(
+        repo,
+        _catalog(),
+        dry_run=False,  # simulate --apply planning
+        allocate_ports_fn=tracking_alloc,
+        project_env_exports_fn=_exports,
+        render_local_fn=_render,
+        global_claude_path=repo / "no-global.json",
+    )
+    assert plan.status in {"PLANNED", "NOOP"}
+    # Plan-time allocation must never persist
+    assert calls, "allocator should have been invoked during plan"
+    assert all(c["persist"] is False or c["dry_run"] is True for c in calls)
+
+    plan.dry_run = False
+    plan_calls_before_apply = len(calls)
+    applied = cr.apply_repair(plan)
+    assert applied.status == "APPLIED"
+    # Apply should re-invoke allocator with persist enabled
+    post = calls[plan_calls_before_apply:]
+    assert post, "allocator should re-run on apply for lease persistence"
+    assert any(c["persist"] is True and c["dry_run"] is False for c in post)
+
+
 def test_is_catalog_owned():
     cat = _catalog()
     assert mj.is_catalog_owned("conport", cat) is True

--- a/tests/unit/test_mcp_lease_migration.py
+++ b/tests/unit/test_mcp_lease_migration.py
@@ -1,0 +1,61 @@
+"""Tests for legacy envrc → lease migration."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+from dopemux.mcp.lease_migration import migrate_envrc_to_leases
+from dopemux.mcp.port_leases import PortLeaseRegistry
+
+
+def _catalog() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "defaults": {"per_worktree": ["dope-memory"]},
+        "servers": {
+            "dope-memory": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "port_var": "DOPE_MEMORY_PORT",
+                "default_port_base": 3020,
+                "management_model": "compose-service",
+            }
+        },
+    }
+
+
+def test_migrate_missing_envrc(tmp_path: Path, monkeypatch):
+    reg = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg))
+    report = migrate_envrc_to_leases(
+        tmp_path,
+        _catalog(),
+        registry_path=reg,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert report["status"] in {"ASSIGNED", "REUSED", "REBIND"}
+    assert "DOPE_MEMORY_PORT" in report["ports"]
+
+
+def test_migrate_existing_envrc_preferred(tmp_path: Path, monkeypatch):
+    reg = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg))
+    (tmp_path / ".envrc.dopemux-mcp").write_text(
+        "export DOPE_MEMORY_PORT=3033\nexport DOPEMUX_WORKSPACE_ID=/x\n"
+    )
+    report = migrate_envrc_to_leases(
+        tmp_path,
+        _catalog(),
+        registry_path=reg,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    # Preferred 3033 if free
+    assert report["ports"]["DOPE_MEMORY_PORT"] == 3033
+    assert any(
+        w.get("code") == "LEGACY_HASH_ALLOCATOR_MIGRATED" for w in report["warnings"]
+    )
+    loaded = PortLeaseRegistry.load(reg)
+    assert any(int(L["port"]) == 3033 for L in loaded.active_leases())

--- a/tests/unit/test_mcp_port_allocator.py
+++ b/tests/unit/test_mcp_port_allocator.py
@@ -1,0 +1,215 @@
+"""Tests for lease-aware port allocator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Set
+
+import pytest
+
+from dopemux.mcp.port_allocator import (
+    allocate_ports,
+    allocate_ports_map,
+    preferred_port_for_path,
+    singleton_reserved_ports,
+)
+from dopemux.mcp.port_leases import PortLease, PortLeaseRegistry
+
+
+def _catalog() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "defaults": {"per_worktree": ["conport", "dope-memory", "task-orchestrator"]},
+        "servers": {
+            "pal": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": "http://localhost:3003/mcp",
+            },
+            "serena": {
+                "scope": "singleton",
+                "transport": "http",
+                "url": "http://localhost:3006/mcp",
+            },
+            "conport": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "port_var": "CONPORT_MCP_PORT",
+                "default_port_base": 3005,
+                "extra_port_vars": [
+                    {"var": "CONPORT_HTTP_PORT", "base": 3004},
+                    {"var": "CONPORT_INFO_PORT", "base": 4004},
+                ],
+                "management_model": "compose-service",
+            },
+            "dope-memory": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "port_var": "DOPE_MEMORY_PORT",
+                "default_port_base": 3020,
+                "management_model": "compose-service",
+            },
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "state_scope": "per-repo",
+                "transport": "http",
+                "port_var": "TASK_ORCHESTRATOR_HTTP_PORT",
+                "default_port_base": 7890,
+                "management_model": "wrapper-singleton",
+            },
+        },
+    }
+
+
+def test_preferred_formula_stable(tmp_path: Path):
+    a = preferred_port_for_path(str(tmp_path), 3005)
+    b = preferred_port_for_path(str(tmp_path), 3005)
+    assert a == b
+    assert 3005 <= a <= 3104
+
+
+def test_singleton_reserved_from_catalog():
+    r = singleton_reserved_ports(_catalog())
+    assert 3003 in r
+    assert 3006 in r
+
+
+def test_assign_preferred_when_free(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    free: Set[int] = set()  # all free via always-true
+
+    result = allocate_ports(
+        ["conport", "dope-memory", "task-orchestrator"],
+        _catalog(),
+        worktree=str(tmp_path / "wt"),
+        project_root=str(tmp_path / "wt"),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert result.status in {"ASSIGNED", "REUSED", "REBIND"}
+    assert "CONPORT_MCP_PORT" in result.ports
+    assert "DOPE_MEMORY_PORT" in result.ports
+    assert result.ports["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
+    # all ports unique
+    assert len(set(result.ports.values())) == len(result.ports)
+    # no reserved collision
+    assert 3003 not in result.ports.values()
+    assert 3006 not in result.ports.values()
+    reg = PortLeaseRegistry.load(reg_path)
+    assert len(reg.active_leases()) >= 3
+
+
+def test_rebind_when_preferred_reserved(tmp_path: Path, monkeypatch):
+    """Force preferred path onto reserved by mocking preferred via envrc."""
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    # Prefer reserved singleton port for dope-memory
+    result = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(tmp_path / "wt"),
+        project_root=str(tmp_path / "wt"),
+        existing_envrc={"DOPE_MEMORY_PORT": "3003"},
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert result.ports["DOPE_MEMORY_PORT"] != 3003
+    assert any(r.get("preferred") == 3003 for r in result.rebinds) or result.status == "REBIND"
+
+
+def test_cross_worktree_lease_collision_avoided(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    wt_a = tmp_path / "a"
+    wt_b = tmp_path / "b"
+    wt_a.mkdir()
+    wt_b.mkdir()
+
+    r1 = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(wt_a),
+        project_root=str(wt_a),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    port_a = r1.ports["DOPE_MEMORY_PORT"]
+
+    # Force B to prefer A's port
+    r2 = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(wt_b),
+        project_root=str(wt_b),
+        existing_envrc={"DOPE_MEMORY_PORT": str(port_a)},
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert r2.ports["DOPE_MEMORY_PORT"] != port_a
+    assert r2.status in {"REBIND", "ASSIGNED"}
+
+
+def test_dry_run_does_not_write(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(tmp_path),
+        registry_path=reg_path,
+        persist=False,
+        dry_run=True,
+        is_free_fn=lambda p: True,
+    )
+    assert not reg_path.exists() or PortLeaseRegistry.load(reg_path).active_leases() == []
+
+
+def test_fixed_port_blocked_when_foreign_lease(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    reg = PortLeaseRegistry.load(reg_path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="foreign_to",
+            port=7890,
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/other",
+            worktree_hash="zzzz",
+            project_root="/other",
+            status="active",
+        )
+    )
+    reg.save()
+
+    result = allocate_ports(
+        ["task-orchestrator"],
+        _catalog(),
+        worktree=str(tmp_path),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert result.status == "BLOCKED"
+    assert any(b.get("code") == "ALLOCATOR_FIXED_PORT_BLOCKED" for b in result.blocking_findings)
+
+
+def test_allocate_ports_map_drop_in(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    ports = allocate_ports_map(
+        str(tmp_path),
+        ["conport"],
+        _catalog(),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        is_free_fn=lambda p: True,
+    )
+    assert "CONPORT_MCP_PORT" in ports
+    assert "CONPORT_HTTP_PORT" in ports

--- a/tests/unit/test_mcp_port_allocator.py
+++ b/tests/unit/test_mcp_port_allocator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Set
+from typing import Any, Dict
 
 import pytest
 
@@ -77,7 +77,6 @@ def test_singleton_reserved_from_catalog():
 def test_assign_preferred_when_free(tmp_path: Path, monkeypatch):
     reg_path = tmp_path / "leases.json"
     monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
-    free: Set[int] = set()  # all free via always-true
 
     result = allocate_ports(
         ["conport", "dope-memory", "task-orchestrator"],
@@ -213,3 +212,97 @@ def test_allocate_ports_map_drop_in(tmp_path: Path, monkeypatch):
     )
     assert "CONPORT_MCP_PORT" in ports
     assert "CONPORT_HTTP_PORT" in ports
+
+
+def test_fixed_port_blocked_when_occupied_unknown(tmp_path: Path, monkeypatch):
+    """Fixed port with no foreign lease but a live socket must BLOCK, not lease."""
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+
+    result = allocate_ports(
+        ["task-orchestrator"],
+        _catalog(),
+        worktree=str(tmp_path),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: False,  # 7890 occupied by unknown process
+    )
+    assert result.status == "BLOCKED"
+    assert any(b.get("code") == "LEASE_PORT_OCCUPIED" for b in result.blocking_findings)
+    # Must not write a lease for the occupied fixed port
+    reg = PortLeaseRegistry.load(reg_path)
+    assert reg.find_active_by_port(7890) is None
+
+
+def test_status_reused_on_second_allocation(tmp_path: Path, monkeypatch):
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    wt = str(tmp_path / "wt")
+    (tmp_path / "wt").mkdir()
+
+    r1 = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=wt,
+        project_root=wt,
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert r1.status in {"ASSIGNED", "REUSED"}
+    port = r1.ports["DOPE_MEMORY_PORT"]
+
+    r2 = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=wt,
+        project_root=wt,
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert r2.ports["DOPE_MEMORY_PORT"] == port
+    assert r2.status == "REUSED"
+
+
+def test_worktree_scoped_does_not_reuse_project_lease(tmp_path: Path, monkeypatch):
+    """A worktree-scoped service must not adopt a project-scoped lease slot."""
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    proj = str(wt)
+
+    reg = PortLeaseRegistry.load(reg_path, create_missing=True)
+    # Malformed/legacy: project-scoped lease for a normally worktree service
+    reg.upsert_lease(
+        PortLease(
+            lease_id="proj_dm",
+            port=3099,
+            service="dope-memory",
+            port_role="http",
+            port_var="DOPE_MEMORY_PORT",
+            worktree_root=str(wt),
+            worktree_hash="dead",
+            project_root=proj,
+            scope="project",
+            status="active",
+        )
+    )
+    reg.save()
+
+    result = allocate_ports(
+        ["dope-memory"],
+        _catalog(),
+        worktree=str(wt),
+        project_root=proj,
+        existing_envrc={"DOPE_MEMORY_PORT": "3101"},
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,
+    )
+    assert result.ports["DOPE_MEMORY_PORT"] == 3101
+    assert not any(
+        w.get("code") == "LEASE_REUSED" and w.get("port") == 3099 for w in result.warnings
+    )

--- a/tests/unit/test_mcp_port_leases.py
+++ b/tests/unit/test_mcp_port_leases.py
@@ -113,3 +113,97 @@ def test_release(tmp_path: Path):
     n = reg.mark_released(port=3060)
     assert n == 1
     assert reg.active_leases() == []
+
+
+def test_project_scoped_upsert_dedupes_across_worktrees(tmp_path: Path):
+    path = tmp_path / "leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="to_wt_a",
+            port=7890,
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/proj/wt-a",
+            project_root="/proj",
+            scope="project",
+            status="active",
+        )
+    )
+    reg.upsert_lease(
+        PortLease(
+            lease_id="to_wt_b",
+            port=7890,
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/proj/wt-b",
+            project_root="/proj",
+            scope="project",
+            status="active",
+        )
+    )
+    active = [
+        L
+        for L in reg.active_leases()
+        if L.get("service") == "task-orchestrator" and L.get("scope") == "project"
+    ]
+    assert len(active) == 1
+    assert active[0]["worktree_root"] == "/proj/wt-b"
+
+
+def test_find_active_for_identity_separates_scopes(tmp_path: Path):
+    path = tmp_path / "leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="proj",
+            port=7890,
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/proj/wt-a",
+            project_root="/proj",
+            worktree_hash="aaaa",
+            scope="project",
+            status="active",
+        )
+    )
+    reg.upsert_lease(
+        PortLease(
+            lease_id="wt",
+            port=3040,
+            service="dope-memory",
+            port_role="http",
+            worktree_root="/proj/wt-a",
+            project_root="/proj",
+            worktree_hash="aaaa",
+            scope="worktree",
+            status="active",
+        )
+    )
+    # Worktree lookup must not return project-scoped lease
+    assert (
+        reg.find_active_for_identity(
+            service="task-orchestrator",
+            port_role="http",
+            worktree_root="/proj/wt-a",
+            worktree_hash="aaaa",
+        )
+        is None
+    )
+    # Project lookup returns project lease
+    found = reg.find_active_for_identity(
+        service="task-orchestrator",
+        port_role="http",
+        project_root="/proj",
+    )
+    assert found is not None
+    assert found["port"] == 7890
+    # Worktree lookup returns worktree lease
+    found_wt = reg.find_active_for_identity(
+        service="dope-memory",
+        port_role="http",
+        worktree_root="/proj/wt-a",
+        worktree_hash="aaaa",
+    )
+    assert found_wt is not None
+    assert found_wt["port"] == 3040

--- a/tests/unit/test_mcp_port_leases.py
+++ b/tests/unit/test_mcp_port_leases.py
@@ -1,0 +1,115 @@
+"""Tests for port lease registry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dopemux.mcp.port_leases import (
+    LeaseRegistryError,
+    PortLease,
+    PortLeaseRegistry,
+    make_lease_id,
+)
+
+
+def test_make_lease_id_stable():
+    a = make_lease_id(
+        project_slug="dNh_CRM",
+        worktree_hash="8d6d",
+        service="conport",
+        port_role="http",
+        port=3040,
+    )
+    b = make_lease_id(
+        project_slug="dNh_CRM",
+        worktree_hash="8d6d",
+        service="conport",
+        port_role="http",
+        port=3040,
+    )
+    assert a == b
+    assert "3040" in a
+
+
+def test_registry_missing(tmp_path: Path):
+    reg = PortLeaseRegistry.load(tmp_path / "port-leases.json")
+    assert reg.parse_status == "MISSING"
+    assert reg.active_leases() == []
+
+
+def test_atomic_upsert_and_reload(tmp_path: Path):
+    path = tmp_path / "port-leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    lease = PortLease(
+        lease_id="lease_test_conport_http_3040",
+        port=3040,
+        service="conport",
+        port_role="http",
+        port_var="CONPORT_HTTP_PORT",
+        worktree_root="/tmp/wt",
+        project_root="/tmp/proj",
+        worktree_hash="abcd",
+        status="active",
+    )
+    reg.upsert_lease(lease)
+    reg.save()
+
+    reg2 = PortLeaseRegistry.load(path)
+    assert reg2.parse_status == "OK"
+    assert len(reg2.active_leases()) == 1
+    assert reg2.find_active_by_port(3040)["service"] == "conport"
+
+
+def test_identity_match_and_foreign(tmp_path: Path):
+    path = tmp_path / "leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="l1",
+            port=3050,
+            service="dope-memory",
+            port_role="http",
+            worktree_root="/a",
+            worktree_hash="aaaa",
+            status="active",
+        )
+    )
+    reg.save()
+    foreign = reg.find_active_by_port(3050)
+    assert foreign is not None
+    assert reg.identity_matches(
+        foreign, worktree_root="/a", project_root="/p", worktree_hash="aaaa"
+    )
+    assert not reg.identity_matches(
+        foreign, worktree_root="/b", project_root="/p", worktree_hash="bbbb"
+    )
+
+
+def test_parse_error_blocks_save(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_text("{not json", encoding="utf-8")
+    reg = PortLeaseRegistry.load(path)
+    assert reg.parse_status == "ERROR"
+    with pytest.raises(LeaseRegistryError):
+        reg.save()
+
+
+def test_release(tmp_path: Path):
+    path = tmp_path / "leases.json"
+    reg = PortLeaseRegistry.load(path, create_missing=True)
+    reg.upsert_lease(
+        PortLease(
+            lease_id="l1",
+            port=3060,
+            service="conport",
+            port_role="sse",
+            worktree_root="/w",
+            status="active",
+        )
+    )
+    n = reg.mark_released(port=3060)
+    assert n == 1
+    assert reg.active_leases() == []

--- a/tests/unit/test_mcp_socket_probe.py
+++ b/tests/unit/test_mcp_socket_probe.py
@@ -1,0 +1,21 @@
+"""Tests for bounded socket probes."""
+
+from dopemux.mcp.socket_probe import port_is_free, port_is_listening, probe_port
+
+
+def test_probe_port_structure():
+    # Port 1 is typically free or filtered; just validate structure
+    result = probe_port(1)
+    assert result["port"] == 1
+    assert "free" in result
+    assert result["listening"] is (not result["free"])
+
+
+def test_port_is_free_invalid():
+    assert port_is_free(0) is False
+    assert port_is_free(99999) is False
+
+
+def test_port_is_listening_inverse_of_free():
+    free = port_is_free(1)
+    assert port_is_listening(1) is (not free)


### PR DESCRIPTION
## Summary

Implements **TP-DMX-MCP-RUNTIME-004** only (stacked on RUNTIME-003).

- Port lease registry: `~/.dopemux/mcp/runtime/port-leases.json` (`DOPEMUX_MCP_PORT_LEASE_REGISTRY` override)
- Unified allocator: preferred hash/envrc ports → reserved check → lease check → live TCP probe → assign or rebind
- Fixed-port task-orchestrator (7890): reuse same project or **block** (no rebind)
- Wired into `mcp init`, `repair-config`, `doctor`, `start`, and `InstanceOverlayManager`
- Dry-run / `persist=False` never writes leases; tests use temp registries only

### Stack / merge order

| Order | PR | Packet |
|------:|----|--------|
| 1 | #1022 | RUNTIME-001 doctor |
| 2 | #1023 | RUNTIME-002 start/status |
| 3 | #1027 | RUNTIME-003 repair-config / fleet |
| 4 | **this** | RUNTIME-004 port leases / rebind |

**Base branch:** `codex/tp-dmx-mcp-runtime-003-config-repair-agent-bootstrap` (#1027)  
**Worktree:** `/Users/hue/code/dopemux-mcp-runtime-004`

## Test plan

- [x] `test_mcp_port_leases` / `test_mcp_port_allocator` / `test_mcp_socket_probe` / `test_mcp_lease_migration`
- [x] Catalog / config repair / doctor / lifecycle regressions
- [x] `compileall` on mcp modules
- [ ] Live multi-worktree rebind smoke on dNh (optional / not required)