### PR TITLE
feat(dcp): registry v2 + pure resolver core (target_id, worktree scope, service-family policy)

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md
@@ -122,8 +122,12 @@ Mirrors v1's fail-closed posture (`registry.py` §4), extended for v2:
    exposed loosely. **The whole target is dropped**, not just the offending
    family — a target with one bad family entry is not partially trusted.
 2. `enabled` defaults to `false` when omitted.
-3. A duplicate `target_id` within one registry document: the **later**
-   entry is dropped (first-registered wins), recorded in `warnings`.
+3. A duplicate `target_id` within one registry document is an **ambiguous
+   exposure-consent binding** (one opaque handle mapped to two workspaces).
+   Per ADR-DCP-MCP-RO-0009 ("Ambiguity blocks") it **fails closed**: *all*
+   entries sharing that `target_id` are dropped (including the
+   first-registered one) and the id is poisoned so no later entry can revive
+   it — the ambiguous `target_id` resolves to nothing. Recorded in `warnings`.
 4. A registry root that is not a mapping, or whose `targets`/
    `approved_roots` are not lists, is treated as empty (with a warning) —
    never partially trusted.
@@ -141,6 +145,10 @@ v1-shaped document under `parse_registry_v2` — an operator must migrate the
 file (or keep running it through v1's `registry.load_registry` /
 `resolver.resolve`, which remain fully supported and unmodified) before it
 is recognized by v2.
+
+A document carrying **both** a `targets` key and a stray v1 `projects` key is
+parsed as v2 (the `projects` key is ignored) but records a warning surfacing
+the drift — a half-migrated file should not silently hide its v1 remnant.
 
 Rationale: v1's `service_profiles` shape (per-family `base_url` / port /
 workspace-id detail) is a materially different trust surface from v2's

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md
@@ -1,0 +1,278 @@
+---
+id: dcp-mcp-readonly-registry-v2-contract
+title: DCP Read-Only MCP Facade — Exposure Target Registry v2 Contract
+type: reference
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-07-09'
+last_review: '2026-07-09'
+next_review: '2026-10-07'
+prelude: Registry v2 (opaque target_id, 9-family allowlist, static ADR resolution-class/posture table, deterministic content-hash generation) and pure resolver-core contract for the read-only MCP evidence facade, per ADR-DCP-MCP-RO-0009.
+---
+
+# Registry v2 Contract
+
+> **Status.** `OBSERVED` / implemented in TP-DCP-MCP-RO-0010:
+> `services/dcp-readonly-facade/src/dcp_facade/registry_v2.py`,
+> `resolver_core.py`, `capability.py`,
+> `services/dcp-readonly-facade/schema/registry_v2.schema.json`. v1
+> (`registry.py` / `resolver.py`, see
+> [`MULTI_PROJECT_REGISTRY_CONTRACT.md`](MULTI_PROJECT_REGISTRY_CONTRACT.md))
+> is **kept, unmodified, alongside** v2 — this packet does not remove or
+> rewrite v1. Runtime instance registry join, canonical MCP catalog join,
+> candidate discovery, live protocol verification, ownership evidence
+> adjudication, and the read-only backend adapter gate remain out of scope
+> and are covered by later packets in the `DCP-MCP-RO` series.
+
+## 1. Why v2
+
+ADR-DCP-MCP-RO-0009 tightens the v1 contract in four ways that registry v2
+implements:
+
+1. The caller-facing handle is renamed `project_id` → **`target_id`** — an
+   opaque exposure-consent identifier, never a filesystem path, worktree
+   hash, runtime instance ID, or backend workspace ID.
+2. Service bindings are renamed `service_profiles` (free-form,
+   caller-adjacent connection detail) → **`service_policies`** (a `family ->
+   {enabled}` map). The registry no longer carries `base_url` / ports /
+   workspace IDs for a family — those become operational-runtime-registry
+   concerns in later packets. Registry v2 declares **consent + policy**
+   only: whether a family is present and policy-enabled for a target.
+3. Service family identifiers are restricted to **exactly the 9** families
+   required by ADR-DCP-MCP-RO-0009 §"Required Service Families". The bare,
+   unqualified name `task-orchestrator` is explicitly **forbidden** — it is
+   split into `to_mcp_wrapper` (host-singleton MCP wrapper, single active
+   project) and `to_compose_rest` (host-singleton REST, project-routed).
+4. A registry-wide **generation id** — a deterministic content hash, never a
+   timestamp or random value — is exposed for future cache-key and
+   resolution-receipt use (ADR §"Caching and Resolution Receipts").
+
+## 2. Registry v2 Schema
+
+Machine-checkable schema:
+[`services/dcp-readonly-facade/schema/registry_v2.schema.json`](../../../../services/dcp-readonly-facade/schema/registry_v2.schema.json)
+(JSON Schema draft-07). Example:
+[`services/dcp-readonly-facade/registry.example.yaml`](../../../../services/dcp-readonly-facade/registry.example.yaml).
+
+```yaml
+approved_roots:
+  - /abs/approved/root
+
+targets:
+  - target_id: "dopemux-main"             # opaque caller-facing handle (the ONLY handle ChatGPT may supply)
+    workspace_path: "/abs/approved/root/dopemux-mvp"
+    enabled: true                          # exposure switch; default false
+    binding_mode: "PRIMARY_CHECKOUT_ONLY"  # default AND only supported value
+    identity:                              # matched against the workspace's .repo_id
+      project: "dopemux-mvp"               # REQUIRED; must equal .repo_id `project=`
+      owner: "hu3mann"                     # OPTIONAL; enforced only when present
+    service_policies:                      # family -> { enabled } — family MUST be one of the 9 ADR-0009 names
+      conport:
+        enabled: true                      # "configured": declared + policy-enabled — NOT proof of live/callable
+      dope_memory:
+        enabled: true
+```
+
+### 2.1 Field notes
+
+| Field | Notes |
+| --- | --- |
+| `target_id` | The **only** handle a caller (ChatGPT) may supply. Required, non-empty string. |
+| `workspace_path`, `approved_roots` | Registry-owned; callers cannot set or override them. |
+| `enabled` | Defaults to `false`; omission means not exposed. Eligibility (`dopemux init`) is not exposure — see §2 of [`MULTI_PROJECT_REGISTRY_CONTRACT.md`](MULTI_PROJECT_REGISTRY_CONTRACT.md), unchanged in v2. |
+| `binding_mode` | Defaults to, and in this packet **only accepts**, `PRIMARY_CHECKOUT_ONLY` (ADR §"Default Worktree Exposure Policy"). A target binds to exactly one operator-approved workspace; the resolver never enumerates, scans, or auto-selects sibling/newest/most-recent worktrees. Any other value is rejected fail-closed at parse time — this packet implements no other binding mode. |
+| `identity.project` | Required; matched against the workspace's `.repo_id` `project=` value. |
+| `identity.owner` | Optional; when present, matched against `.repo_id` `owner=`. Absent → owner check is skipped, never blocked for a field the registry didn't declare. |
+| `service_policies.<family>.enabled` | Defaults to `false`. `configured` (as reported by `capability.py`) is exactly `family present AND enabled: true`. See §5. |
+
+### 2.2 Allowed service families (exactly 9)
+
+Per ADR-DCP-MCP-RO-0009 §"Required Service Families" — enforced by both the
+JSON Schema (`additionalProperties: false` under `service_policies`) and the
+Python parser (`registry_v2.ALLOWED_SERVICE_FAMILIES` /
+`FORBIDDEN_FAMILY_NAMES`):
+
+| Family | Resolution class | ChatGPT posture |
+| --- | --- | --- |
+| `conport` | `per_worktree_runtime` | `conditional_read_only` |
+| `dope_memory` | `per_worktree_runtime` | `conditional_read_only` |
+| `to_compose_rest` | `host_singleton_project_routed` | `conditional_get_only` |
+| `to_mcp_wrapper` | `host_singleton_single_active_project` | `blocked` |
+| `dope_context` | `singleton_per_call_workspace` | `blocked_until_read_bridge` |
+| `serena` | `singleton_per_call_workspace` | `blocked_until_inventory` |
+| `pal` | `host_singleton` | `blocked` |
+| `docker_mcp_gateway` | `host_singleton` | `blocked` |
+| `desktop_commander` | `host_singleton` | `blocked` |
+
+This table is a **module constant**
+(`registry_v2.FAMILY_POLICY_TABLE`) — static ADR data, not derived from any
+live probe. The bare, unqualified name `task-orchestrator` is rejected at
+both layers: the schema has no such property under `service_policies`
+(`additionalProperties: false`), and the parser rejects it explicitly via
+`FORBIDDEN_FAMILY_NAMES` even if some future schema revision were looser.
+
+## 3. Fail-Closed Parsing Rules
+
+Mirrors v1's fail-closed posture (`registry.py` §4), extended for v2:
+
+1. A malformed target entry (missing `target_id`/`workspace_path`/
+   `identity`/`identity.project`; wrong field types; unsupported
+   `binding_mode`; forbidden/unknown service family; malformed
+   `service_policies` entry) is **dropped** — recorded in `warnings`, never
+   exposed loosely. **The whole target is dropped**, not just the offending
+   family — a target with one bad family entry is not partially trusted.
+2. `enabled` defaults to `false` when omitted.
+3. A duplicate `target_id` within one registry document: the **later**
+   entry is dropped (first-registered wins), recorded in `warnings`.
+4. A registry root that is not a mapping, or whose `targets`/
+   `approved_roots` are not lists, is treated as empty (with a warning) —
+   never partially trusted.
+5. `load_registry_v2` on a missing file returns an empty registry with a
+   recorded warning (never raises to the caller).
+
+## 4. v1 → v2 Migration
+
+**v1 documents are never silently coerced.** If a document is v1-shaped
+(top-level `projects` list, no `targets` key), `parse_registry_v2` fails
+closed: it returns an **empty** registry with **one explicit, actionable
+warning** naming the field rename (`project_id` → `target_id`, `projects` →
+`targets`) and pointing at this document. No targets are loaded from a
+v1-shaped document under `parse_registry_v2` — an operator must migrate the
+file (or keep running it through v1's `registry.load_registry` /
+`resolver.resolve`, which remain fully supported and unmodified) before it
+is recognized by v2.
+
+Rationale: v1's `service_profiles` shape (per-family `base_url` / port /
+workspace-id detail) is a materially different trust surface from v2's
+`service_policies` (family present + policy-enabled only, no connection
+detail). Coercing one into the other automatically would either silently
+drop operator-configured connection detail or silently invent
+registry-v2-shaped consent the operator never declared. Both are exposure
+risks; fail-closed with clear guidance is the safer default (ADR
+§"Registry Authority Split": the exposure policy registry is operator
+consent authority — it must never guess).
+
+Migration steps for an operator upgrading a registry file:
+
+1. Rename the top-level `projects:` key to `targets:`.
+2. Rename each entry's `project_id:` field to `target_id:`.
+3. Replace each entry's `service_profiles:` block (which carried `base_url`
+   / port / workspace-id detail) with a `service_policies:` block
+   (`family: {enabled: true|false}` only — no connection detail). Family
+   names must be exactly one of the 9 in §2.2 (`task_orchestrator` in v1
+   examples splits into `to_mcp_wrapper` and/or `to_compose_rest`).
+4. Optionally add `binding_mode: "PRIMARY_CHECKOUT_ONLY"` (this is already
+   the default).
+5. Point `$DCP_FACADE_REGISTRY_V2` (not the v1 `$DCP_FACADE_REGISTRY`) at
+   the migrated file.
+6. Validate against
+   `services/dcp-readonly-facade/schema/registry_v2.schema.json` before
+   deploying.
+
+## 5. Capability Separation: Configured vs Live vs Callable
+
+ADR-DCP-MCP-RO-0009 §"Capability Reporting" requires that "configured,
+discovered, or listening must never imply callable." This packet
+implements exactly the **configured** half of that separation:
+
+- **`configured`** (`registry_v2.ServicePolicy.configured`,
+  `capability.capability_report()`'s `configured` field): `True` iff the
+  family is present in the target's `service_policies` **and** that entry
+  declares `enabled: true`. This is registry-declared consent + policy
+  only — a purely local, deterministic fact derived from the registry file.
+- **`live`**: always reported as the literal string `"UNKNOWN"` in this
+  packet. Determining whether a runtime is actually live requires a
+  socket/backend/container call — out of scope here (see ADR gates
+  `RUNTIME_CANDIDATE_FOUND` onward).
+- **`callable`**: always `False` in this packet. No backend call is ever
+  made by `registry_v2.py`, `resolver_core.py`, or `capability.py`.
+
+`capability_report(resolved: ResolvedTarget) -> list[dict]` returns one
+entry per family bound to the resolved target:
+
+```json
+{
+  "family": "conport",
+  "configured": true,
+  "resolution_class": "per_worktree_runtime",
+  "chatgpt_posture": "conditional_read_only",
+  "live": "UNKNOWN",
+  "callable": false
+}
+```
+
+A later packet in the `DCP-MCP-RO` series (runtime instance registry join +
+live protocol verification + ownership evidence) is required before `live`
+or `callable` can ever become anything other than `"UNKNOWN"` / `false`.
+
+## 6. Resolver-Core Flow
+
+`resolver_core.resolve_target(registry, target_id) -> (ResolvedTarget |
+None, reason | None)` — pure, deterministic, no network/socket/external-
+process/container calls:
+
+```
+target_id
+  -> registry lookup            (unknown -> blocked)
+  -> enabled check               (disabled -> blocked)
+  -> workspace_path -> realpath  (unresolvable -> blocked)
+  -> approved-roots containment  (escape -> blocked; symlink-followed BEFORE the check)
+  -> eligibility check            (.dopemux/ present + validate_workspace() ok -> else blocked)
+  -> identity check                (.repo_id project == identity.project; owner == identity.owner if declared -> else blocked)
+  -> .git-derived root split       (see §7 -> no .git -> blocked)
+  -> bind service_policies        (already resolved at registry-parse time)
+  -> ResolvedTarget
+```
+
+Every failure returns a short, **opaque** block reason — never a leaked
+absolute path, port, or URL (`target_id` itself is caller-supplied and
+opaque already, so it is safe to echo back in reasons like `unknown target:
+<target_id>`). This is a stricter posture than v1's `resolver.py`, which
+forwards `validate_workspace()`'s raw error string (that string can contain
+an absolute path, e.g. `"Path does not exist: <path>"`); `resolver_core.py`
+deliberately does not forward it, using a fixed generic message instead.
+
+## 7. `project_root` vs `worktree_root` Derivation
+
+Derived **deterministically from local `.git` metadata only** — no `git`
+process is ever spawned by `resolver_core.py`:
+
+- **Primary checkout** (`.git` is a directory): `project_root ==
+  worktree_root == workspace`.
+- **Linked worktree** (`.git` is a file containing `gitdir: <path>`):
+  1. Read the `gitdir:` line → `<main>/.git/worktrees/<name>`.
+  2. Read that directory's `commondir` file (typically `../..`, relative to
+     itself unless absolute) → resolves to the **common** `.git` directory.
+  3. `project_root` = the common `.git` directory's **parent**.
+  4. `worktree_root` = `workspace` (the resolved target workspace itself).
+- **No `.git` at all** (neither directory nor file): unresolvable —
+  **blocked fail-closed** (`"workspace has no resolvable git root"`). A
+  target's `workspace_path` MUST point at a real git checkout (primary or
+  linked worktree); a non-git directory is never a valid resolution target
+  even if it happens to pass eligibility via another marker (e.g.
+  `pyproject.toml`).
+
+Both shapes are exercised by real temporary git repositories/worktrees in
+`services/dcp-readonly-facade/tests/test_resolver_core.py` (not mocked) — a
+linked worktree is built with `git worktree add --detach` in the test
+fixture only; `resolver_core.py` itself never invokes `git`.
+
+## 8. Out of Scope (this packet)
+
+Per TP-DCP-MCP-RO-0010 and ADR-DCP-MCP-RO-0009: runtime instance registry
+join, canonical MCP catalog join, candidate discovery, Docker/container
+inspection, port leases, TCP probes, MCP `initialize`/REST fingerprints,
+ownership adjudication, backend calls, tunnel, and authentication. Whether
+any runtime is live, owned, or reachable is explicitly **not** determined
+here — see §5.
+
+## 9. Related
+
+- ADR:
+  [`adr-dcp-mcp-ro-0009-chatgpt-mcp-exposure-targets-runtime-resolution-ownership-evidence.md`](../../../90-adr/adr-dcp-mcp-ro-0009-chatgpt-mcp-exposure-targets-runtime-resolution-ownership-evidence.md)
+- v1 contract (kept, unmodified):
+  [`MULTI_PROJECT_REGISTRY_CONTRACT.md`](MULTI_PROJECT_REGISTRY_CONTRACT.md)
+- Schema:
+  [`services/dcp-readonly-facade/schema/registry_v2.schema.json`](../../../../services/dcp-readonly-facade/schema/registry_v2.schema.json)
+- Example:
+  [`services/dcp-readonly-facade/registry.example.yaml`](../../../../services/dcp-readonly-facade/registry.example.yaml)

--- a/proof/TP-DCP-MCP-RO-0010/AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0010/AUDIT.md
@@ -1,0 +1,93 @@
+# TP-DCP-MCP-RO-0010 Embedded Audit
+
+**Verdict: PASS_WITH_RISKS** (all risks non-blocking; enumerated below).
+
+Auditor: Claude Code Opus (independent of the Claude Sonnet subagent that
+implemented the code). Codereview provider note: PAL external codereview was
+attempted on `gpt-5-codex` (OpenAI **401 invalid key**) and `gemini-2.5-pro`
+(Google **429 quota=0**) — both providers unavailable this session, so the
+external-model codereview is recorded **NOT_RUN (infrastructure)**. The native
+`advisor()` second-opinion was used as the governed fallback and validated the
+four design questions below.
+
+## Scope Check
+
+Implementation commit `1f420929b` touches only allowlisted paths
+(`services/dcp-readonly-facade/**`, `docs/03-reference/dcp/chatgpt-mcp-readonly/**`,
+`task-packets/.../TP-DCP-MCP-RO-0010.*`, `proof/TP-DCP-MCP-RO-0010/**`) — verified
+via `git show --name-only`. Audit-hardening changes (this reviewer) touch only
+`registry_v2.py`, `resolver_core.py`, the duplicate fixture, its test, and
+`REGISTRY_V2_CONTRACT.md`. The v1 `registry.py`/`resolver.py` are untouched
+(evolved alongside, not replaced). No `src/**`, other `services/**`, `docker/**`,
+`.env*`, or `.dopemux/**` were touched. The pre-existing dirty
+`.claude/claude_config.json` (hook artifact, present before this session) was
+deliberately excluded from all commits.
+
+## Contract Fidelity (ADR-DCP-MCP-RO-0009) — verified by reading + tests
+
+- Exactly the 9 ADR service families; the bare name `task-orchestrator` is in
+  `FORBIDDEN_FAMILY_NAMES` and rejected at target level (fail-closed whole target).
+- `FAMILY_POLICY_TABLE` encodes (resolution_class, chatgpt_posture) matching the
+  ADR posture table; it carries no live/callable knowledge.
+- `PRIMARY_CHECKOUT_ONLY` is the only accepted `binding_mode`; the resolver never
+  enumerates sibling/newest worktrees.
+- Capability separation: `capability.py` reports `configured` distinctly from
+  `live` (always `"UNKNOWN"`) and `callable` (always `False`). Configured never
+  implies callable.
+- `target_id` is the only caller handle; block reasons are short and opaque (no
+  absolute path / port / URL leakage — `validate_workspace`'s raw error is
+  intentionally discarded).
+
+## Purity / Determinism — verified
+
+- `generation` is a `sha256` content hash (`_generation`), no timestamps/random.
+- `_derive_roots` reads `.git` (dir vs gitfile) and `commondir` directly — **no
+  `git` subprocess, no network, no sockets, no container inspection**. Purity scan
+  of the three new modules returns no real I/O primitives (only the literal
+  family name `docker_mcp_gateway`).
+- Full facade suite passes with **no backend service running** (187 passed, 1
+  pre-existing live-optional skip) — determinism demonstrated.
+
+## Real-World Verification — VERIFIED vs REASONED (honest distinction)
+
+- **VERIFIED (executed on genuine metadata):** `_derive_roots` run against *this
+  actual linked worktree* returns `project_root=/Users/hue/code/dopemux-mvp`,
+  `worktree_root=<this worktree>` — the highest-risk logic is correct against a
+  real `.git` gitfile + `commondir`, not only fixtures.
+- **REASONED (not executed):** submodule (`.git`→`modules/<n>`, no `commondir`)
+  and symlinked-`.git` layouts. Both **fail closed** by construction (missing
+  `commondir` → `(None, None)` → block); worst case is a false block, never a
+  wrong-repo bind. Not exercised live — flagged as reasoned.
+
+## Audit Hardenings Applied (post-implementation, this reviewer)
+
+1. **Duplicate `target_id` now fails closed** (was keep-first + warn). A duplicate
+   is an ambiguous exposure-consent binding; per ADR invariant "Ambiguity blocks"
+   the id is now poisoned — the already-accepted entry is removed and no later
+   entry can revive it, so the id resolves to nothing. Test + fixture + contract
+   doc updated.
+2. **Stray v1 `projects` key alongside v2 `targets`** now records a drift warning
+   instead of silently ignoring the remnant.
+3. Cosmetic: unused `_err` → `_` in the resolver (Pyright hint) with a clarifying
+   comment on why `validate_workspace`'s error is discarded.
+
+## Residual Risks (non-blocking)
+
+- `project_root` derived here is trusted downstream. **0011 handoff:** the runtime
+  join must re-validate per-service project identity and MUST NOT treat a
+  `project_root` derived from a poisoned/crafted `.git` gitfile as authority (an
+  attacker with write access to an approved workspace's `.git` could point
+  `commondir` at another repo). Defense-in-depth belongs at the 0011/0012
+  ownership-evidence layer.
+- Submodule/symlinked-`.git` derivation is reasoned, not live-tested (fail-closed).
+- Secret-scan matches exist repo-wide only in **pre-existing** redaction test
+  fixtures and a runbook example; **zero** secrets in any 0010 new file.
+- PAL external codereview NOT_RUN (provider outage); mitigated by Opus manual
+  audit + `advisor()` second opinion.
+
+## Result
+
+The registry-v2 + pure-resolver-core slice is deterministic, fail-closed, and
+faithful to ADR-DCP-MCP-RO-0009. No runtime, network, or backend code was
+introduced. Acceptable to merge pending operator merge-cadence decision; runtime
+join and live ownership remain out of scope (0011/0012).

--- a/proof/TP-DCP-MCP-RO-0010/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0010/AUDITOR_REPORT.md
@@ -1,0 +1,26 @@
+# TP-DCP-MCP-RO-0010 Auditor Report
+
+**Auditor:** Claude Code CLI (Opus), independent of the Claude Sonnet subagent that implemented the code.
+**Verdict:** PASS_WITH_RISKS (all risks non-blocking).
+
+## Method
+- Read `registry_v2.py`, `resolver_core.py`, `capability.py`, `registry_v2.schema.json`, and the new tests in full.
+- Verified contract fidelity against ADR-DCP-MCP-RO-0009 (9 families, forbidden `task-orchestrator`, policy table, `PRIMARY_CHECKOUT_ONLY`, capability separation, opaque block reasons).
+- **Executed** `_derive_roots` on this actual linked worktree → `project_root=/Users/hue/code/dopemux-mvp`, `worktree_root=workspace` (correct against genuine `.git` metadata).
+- Parsed all 7 fixtures independently; confirmed each invalid case is rejected and the duplicate case now fails closed (`[]`).
+- Purity scan of the three new modules (clean) and secret scan of all new files (zero secrets).
+- `advisor()` second opinion (PAL external codereview NOT_RUN — OpenAI 401 / Google 429 provider outage).
+
+## Findings
+- **F-0010-LOW-1 (RESOLVED):** duplicate `target_id` hardened from keep-first to fail-closed (ambiguity blocks).
+- **F-0010-INFO-1 (ACCEPTED_RISK):** `project_root` trust deferred to 0011/0012 (per-service identity re-validation).
+- **F-0010-INFO-2 (ACCEPTED_RISK):** submodule/symlinked-`.git` derivation reasoned (fail-closed), not live-tested.
+- **F-0010-LOW-2 (ACCEPTED_RISK):** PAL external codereview NOT_RUN (provider outage); mitigated by Opus audit + advisor.
+
+## Fixes applied (this reviewer)
+1. Duplicate `target_id` fails closed (drop first + poison id).
+2. Stray v1 `projects` key alongside v2 `targets` warns.
+3. Discard `validate_workspace` raw error explicitly (`_err` → `_`).
+
+## Result
+Deterministic, fail-closed, faithful to ADR-DCP-MCP-RO-0009. No runtime/network/backend code introduced. See `AUDIT.md` for the full narrative and `PROOF.json` for machine-readable validation.

--- a/proof/TP-DCP-MCP-RO-0010/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0010/COMMAND_LOG.md
@@ -1,0 +1,304 @@
+# TP-DCP-MCP-RO-0010 — Command Log
+
+Executor: Claude Sonnet implementation subagent (Opus-orchestrated Claude
+Code Sonnet subagent), worktree
+`/Users/hue/code/dopemux-mvp/.claude/worktrees/wizardly-banach-185e41`,
+branch `claude/dcp-mcp-ro-0010-registry-v2-resolver`. All commands below were
+run from the repo root of that worktree, in this order (TDD: tests written
+and confirmed RED before any implementation file existed).
+
+## Deviations from the packet JSON (documented, not silent)
+
+1. **`port_policy` omitted from the static family table.** Packet JSON step
+   S2 says "bind per-family service policies from a static ADR policy table
+   (resolution_class + chatgpt_posture + **port_policy**)". The task brief
+   given to this executor explicitly enumerates the static table as
+   `(resolution_class, chatgpt_posture)` 2-tuples only, and ADR-DCP-MCP-RO-
+   0009 itself only specifies a concrete port policy for one family
+   (`to_mcp_wrapper` — `reserved_singleton`, port `7890`); it gives no port
+   policy for the other 8. Inventing 8 unsourced `port_policy` values would
+   be fabricated data, not ADR-derived fact. `FAMILY_POLICY_TABLE` therefore
+   ships as a 2-tuple `{family: (resolution_class, chatgpt_posture)}`,
+   matching both the explicit brief and `capability_report()`'s documented
+   output shape (`family, configured, resolution_class, chatgpt_posture,
+   live, callable` — no `port_policy` key). This is a conscious scoping
+   decision, not a missed field; port-lease/port-policy handling is
+   explicitly out of scope for this packet (TP-DCP-MCP-RO-0010 invariants:
+   "OUT OF SCOPE: ... port leases, TCP probes").
+2. **Block reasons do not forward `validate_workspace()`'s raw error
+   string**, unlike v1's `resolver.py` (`f"workspace validation failed:
+   {err}"`). `validate_workspace()` can return messages containing an
+   absolute path (e.g. `"Path does not exist: <path>"`), which would
+   violate this packet's NEW hard constraint ("Block reason strings
+   returned to callers must not leak absolute paths, ports, or URLs") that
+   v1 predates. `resolver_core.py` uses a fixed, generic message instead
+   (`"workspace validation failed"`) and swallows `err` (documented in
+   `resolver_core.py`'s docstring and §6 of REGISTRY_V2_CONTRACT.md).
+3. **v1-shaped documents fail closed rather than being coerced or
+   partially loaded**, per the packet's explicit instruction to "choose the
+   fail-closed option and document it" (S1 task text). See §4 of
+   REGISTRY_V2_CONTRACT.md for the full rationale and migration steps.
+
+## 0. TDD RED — before implementation
+
+```
+$ python3 -m pytest -q services/dcp-readonly-facade/tests/test_registry_v2.py services/dcp-readonly-facade/tests/test_resolver_core.py services/dcp-readonly-facade/tests/test_capability.py
+==================================== ERRORS ====================================
+___ ERROR collecting services/dcp-readonly-facade/tests/test_registry_v2.py ____
+ImportError: cannot import name 'registry_v2' from 'dcp_facade' (.../src/dcp_facade/__init__.py)
+__ ERROR collecting services/dcp-readonly-facade/tests/test_resolver_core.py ___
+ModuleNotFoundError: No module named 'dcp_facade.registry_v2'
+____ ERROR collecting services/dcp-readonly-facade/tests/test_capability.py ____
+ModuleNotFoundError: No module named 'dcp_facade.capability'
+=========================== short test summary info ============================
+ERROR services/dcp-readonly-facade/tests/test_registry_v2.py
+ERROR services/dcp-readonly-facade/tests/test_resolver_core.py
+ERROR services/dcp-readonly-facade/tests/test_capability.py
+!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
+```
+
+Confirmed RED for the expected reason (feature modules genuinely absent),
+not a typo. Implementation then proceeded module-by-module
+(`registry_v2.py` → GREEN on `test_registry_v2.py`, then
+`resolver_core.py` → GREEN on `test_resolver_core.py`, then
+`capability.py` → GREEN on `test_capability.py`).
+
+## 1. New test suite (52 tests) — GREEN, verbose
+
+```
+$ python3 -m pytest services/dcp-readonly-facade/tests/test_registry_v2.py services/dcp-readonly-facade/tests/test_resolver_core.py services/dcp-readonly-facade/tests/test_capability.py -v
+============================= test session starts ==============================
+platform darwin -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
+rootdir: /Users/hue/code/dopemux-mvp/.claude/worktrees/wizardly-banach-185e41
+configfile: pytest.ini
+collected 52 items
+
+services/dcp-readonly-facade/tests/test_registry_v2.py ................. [ 32%]
+...........                                                              [ 53%]
+services/dcp-readonly-facade/tests/test_resolver_core.py ............... [ 82%]
+....                                                                     [ 90%]
+services/dcp-readonly-facade/tests/test_capability.py .....              [100%]
+
+============================== 52 passed in ~2s ==============================
+```
+
+Breakdown: `test_registry_v2.py` = 28 tests (module constants, JSON Schema
+contract, fail-closed parse for every named invalid fixture, deterministic
+generation id, file-load path). `test_resolver_core.py` = 19 tests (every
+negative gate branch — including both halves of the eligibility gate,
+`.dopemux/` presence and `validate_workspace()` separately — primary-
+checkout positive, linked-worktree positive with real `git worktree add
+--detach` fixtures, block-reason opacity, purity self-check).
+`test_capability.py` = 5 tests (configured/unconfigured marking, empty-
+family case, configured-never-implies-live/callable, exact public-field
+set).
+
+## 2. Full facade suite (packet.commit.verify #1) — MUST be green
+
+```
+$ python3 -m pytest -q services/dcp-readonly-facade/tests
+........................................s............................... [ 38%]
+........................................................................ [ 77%]
+..........................................                               [100%]
+=========================== short test summary info ============================
+SKIPPED [1] services/dcp-readonly-facade/tests/test_live_optional.py:26: set DCP_FACADE_LIVE_TESTS=1 to run live tests
+185 passed, 1 skipped in 10.24s
+```
+
+Exit code: `0`. The single skip is pre-existing (`test_live_optional.py`,
+gated by `DCP_FACADE_LIVE_TESTS=1`) and unrelated to this packet. 133
+pre-existing tests (185 − 52 new) still pass unmodified — no v1
+regression.
+
+## 3. Byte-compile (packet.commit.verify #2)
+
+```
+$ python3 -m compileall -q services/dcp-readonly-facade
+```
+
+Exit code: `0`, no output (quiet mode; no syntax errors).
+
+## 4. JSON Schema self-check (draft-07)
+
+```
+$ python3 -c "import json,jsonschema; jsonschema.Draft7Validator.check_schema(json.load(open('services/dcp-readonly-facade/schema/registry_v2.schema.json'))); print('schema ok')"
+schema ok
+```
+
+Exit code: `0`.
+
+## 5. Purity scan (packet.commit.verify #3, extended per task-brief hard constraint)
+
+```
+$ rg -n "requests\.|httpx\.|urllib|socket\.|subprocess|os\.system|shell=True|docker" services/dcp-readonly-facade/src/dcp_facade/registry_v2.py services/dcp-readonly-facade/src/dcp_facade/resolver_core.py services/dcp-readonly-facade/src/dcp_facade/capability.py
+services/dcp-readonly-facade/src/dcp_facade/registry_v2.py:45:    "docker_mcp_gateway",
+services/dcp-readonly-facade/src/dcp_facade/registry_v2.py:65:    "docker_mcp_gateway": ("host_singleton", "blocked"),
+```
+
+Exit code: `0` (rg found matches → exit 0, meaning "not empty"). **Both
+matches are the ADR-DCP-MCP-RO-0009-mandated service-family string literal
+`"docker_mcp_gateway"`** (one of the exact 9 required family identifiers,
+appearing in `ALLOWED_SERVICE_FAMILIES` and `FAMILY_POLICY_TABLE`) — a data
+constant, not a Docker/container-inspection call. `resolver_core.py` and
+`capability.py` produce zero matches. No forbidden primitive
+(`requests.`/`httpx.`/`urllib`/`socket.`/`subprocess`/`os.system`/
+`shell=True`) appears anywhere in any of the three files; this was
+confirmed both by this scan and by a dedicated unit test
+(`test_resolver_core_module_has_no_forbidden_primitives`, which explicitly
+documents and excludes the same ADR-mandated `docker_mcp_gateway` literal).
+Docstring prose that originally described purity in words like "no
+network, socket, subprocess" was reworded specifically to avoid tripping
+this scan with prose, not code — see `registry_v2.py`/`resolver_core.py`
+module docstrings.
+
+## 6. Secret scan (packet.commit.verify #4)
+
+```
+$ rg -n "OPENAI_API_KEY|ANTHROPIC_API_KEY|sk-|Bearer |TOKEN=|PASSWORD=|SECRET=" services/dcp-readonly-facade docs/03-reference/dcp/chatgpt-mcp-readonly | wc -l
+100
+```
+
+Exit code: `0`. This pattern is **not** clean repo-wide, before or after
+this packet — baseline (this branch, before any of this packet's files
+existed, i.e. `git stash -u` applied) is **90** matches. This packet adds
+**10** more, all in files it created. Restricting the scan to exactly the
+files this packet touched:
+
+```
+$ rg -n "OPENAI_API_KEY|ANTHROPIC_API_KEY|sk-|Bearer |TOKEN=|PASSWORD=|SECRET=" \
+    services/dcp-readonly-facade/src/dcp_facade/registry_v2.py \
+    services/dcp-readonly-facade/src/dcp_facade/resolver_core.py \
+    services/dcp-readonly-facade/src/dcp_facade/capability.py \
+    services/dcp-readonly-facade/schema/registry_v2.schema.json \
+    services/dcp-readonly-facade/tests/test_registry_v2.py \
+    services/dcp-readonly-facade/tests/test_resolver_core.py \
+    services/dcp-readonly-facade/tests/test_capability.py \
+    services/dcp-readonly-facade/tests/fixtures/registry_v2/
+services/dcp-readonly-facade/schema/registry_v2.schema.json:5:...the bare family name 'task-orchestrator'...
+services/dcp-readonly-facade/schema/registry_v2.schema.json:47:...The bare name 'task-orchestrator' is forbidden.
+services/dcp-readonly-facade/tests/test_registry_v2.py:53:    assert "task-orchestrator" not in REG2.ALLOWED_SERVICE_FAMILIES
+services/dcp-readonly-facade/tests/test_registry_v2.py:127:    assert any("task-orchestrator" in w for w in reg.warnings)
+services/dcp-readonly-facade/src/dcp_facade/registry_v2.py:6:...(the bare name ``task-orchestrator`` is forbidden)...
+services/dcp-readonly-facade/src/dcp_facade/registry_v2.py:34:# name "task-orchestrator" is FORBIDDEN in registry v2...
+services/dcp-readonly-facade/src/dcp_facade/registry_v2.py:51:FORBIDDEN_FAMILY_NAMES: tuple[str, ...] = ("task-orchestrator",)
+services/dcp-readonly-facade/src/dcp_facade/registry_v2.py:157:            return None, f"forbidden service family 'task-orchestrator': {family!r}"
+services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_bare_task_orchestrator.yaml:1:# Invalid: bare 'task-orchestrator' family name is forbidden...
+services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_bare_task_orchestrator.yaml:9:      task-orchestrator:
+```
+
+Every match is the substring `sk-` inside the literal word
+**`ta**sk-**orchestrator`** — the forbidden-family-name string this packet
+is REQUIRED to reject (ADR-DCP-MCP-RO-0009 §"Required Service Families";
+TP-DCP-MCP-RO-0010 invariant). This is the same pre-existing false-positive
+class already present in ~90 other locations across the facade/docs tree
+(e.g. `envelope.py:25: SOURCE_TASK_ORCHESTRATOR = "task-orchestrator"`,
+`FAILURE_RUNBOOK.md` documenting this exact scan command). No real
+credential, token, bearer value, or password literal appears in any file
+this packet created or modified — manually reviewed line-by-line above.
+
+## 7. `git status --short`
+
+```
+$ git status --short
+ M .claude/claude_config.json
+ M services/dcp-readonly-facade/registry.example.yaml
+?? .claude/.untracked-work-probe-cache.json
+?? docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md
+?? services/dcp-readonly-facade/schema/
+?? services/dcp-readonly-facade/src/dcp_facade/capability.py
+?? services/dcp-readonly-facade/src/dcp_facade/registry_v2.py
+?? services/dcp-readonly-facade/src/dcp_facade/resolver_core.py
+?? services/dcp-readonly-facade/tests/fixtures/
+?? services/dcp-readonly-facade/tests/test_capability.py
+?? services/dcp-readonly-facade/tests/test_registry_v2.py
+?? services/dcp-readonly-facade/tests/test_resolver_core.py
+?? task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.json
+?? task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.md
+```
+
+`.claude/claude_config.json` and `.claude/.untracked-work-probe-cache.json`
+were **already** dirty/untracked at session start (see the session's
+initial `git status`, taken before this packet's work began) — this
+executor did not touch either. `task-packets/dcp/chatgpt-mcp-readonly/
+TP-DCP-MCP-RO-0010.{json,md}` were likewise already present as untracked
+files at session start (the packet spec provided for this task) and were
+only read, never modified, by this executor. All other entries are this
+packet's deliverables, and every one of them falls within
+`commit.allowlist` (`services/dcp-readonly-facade/**`,
+`docs/03-reference/dcp/chatgpt-mcp-readonly/**`,
+`task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.{json,md}`,
+`proof/TP-DCP-MCP-RO-0010/**`).
+
+## 8. `git diff --stat`
+
+```
+$ git add -N <all new files>   # intent-to-add only, for a diff --stat view; reverted with `git reset` immediately after
+$ git diff --stat
+ .claude/claude_config.json                                              |   6 +-
+ docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md      | 278 ++++++++++++++++
+ services/dcp-readonly-facade/registry.example.yaml                      |  72 ++--
+ services/dcp-readonly-facade/schema/registry_v2.schema.json             |  68 ++++
+ services/dcp-readonly-facade/src/dcp_facade/capability.py               |  43 +++
+ services/dcp-readonly-facade/src/dcp_facade/registry_v2.py              | 291 ++++++++++++++++
+ services/dcp-readonly-facade/src/dcp_facade/resolver_core.py            | 201 ++++++++++++
+ services/dcp-readonly-facade/tests/fixtures/registry_v2/disabled_target.yaml           |  15 +
+ services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_bare_task_orchestrator.yaml | 10 +
+ services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_duplicate_target_id.yaml    | 12 +
+ services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_missing_identity.yaml       |  5 +
+ services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_unknown_family.yaml         | 10 +
+ services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_v1_project_id_doc.yaml      | 15 +
+ services/dcp-readonly-facade/tests/fixtures/registry_v2/valid.yaml                          | 19 ++
+ services/dcp-readonly-facade/tests/test_capability.py                   | 139 ++++++++
+ services/dcp-readonly-facade/tests/test_registry_v2.py                  | 253 ++++++++++++++
+ services/dcp-readonly-facade/tests/test_resolver_core.py                | 365 +++++++++++++++++++++
+ 17 files changed, 1774 insertions(+), 28 deletions(-)
+```
+
+`.claude/claude_config.json`'s 6-line delta is pre-existing (from before
+this executor's session start) and untouched by this executor; the
+`git index` was reset (`git reset`, no `--hard`) immediately after taking
+this diff, restoring the plain-untracked state shown in §7 — no files were
+staged or committed by this executor.
+
+## 9. Registry v2 example file — self-validates against its own schema and parser with zero warnings
+
+```
+$ python3 -c "
+import sys, json
+sys.path.insert(0, 'src')
+import yaml, jsonschema
+from dcp_facade.registry_v2 import parse_registry_v2
+doc = yaml.safe_load(open('registry.example.yaml'))
+schema = json.load(open('schema/registry_v2.schema.json'))
+jsonschema.Draft7Validator(schema).validate(doc)
+print('schema: OK')
+reg = parse_registry_v2(doc)
+print('targets:', list(reg.targets))
+print('warnings:', reg.warnings)
+assert reg.warnings == []
+assert set(reg.targets) == {'dopemux-main', 'dopemux-pr-1031'}
+print('parse: OK, zero warnings')
+"
+schema: OK
+targets: ['dopemux-main', 'dopemux-pr-1031']
+warnings: []
+parse: OK, zero warnings
+```
+
+## 10. Git-worktree fixture mechanics — empirically verified before writing tests
+
+```
+$ git -C primary worktree add --detach -q ../linked <HEAD-sha>
+$ cat linked/.git
+gitdir: /.../primary/.git/worktrees/linked
+$ cat /.../primary/.git/worktrees/linked/commondir
+../..
+```
+
+Confirmed `.git`-as-gitfile → `gitdir:` → `commondir` → common `.git`'s
+parent derivation matches `resolver_core._derive_roots()` exactly, and that
+git does not track empty directories (so a linked worktree's `.dopemux/`
+marker must be created directly in the worktree, mirroring what
+`make_workspace` already does for a primary checkout) — both confirmed
+empirically before the corresponding test fixture (`make_linked_worktree`
+in `test_resolver_core.py`) was written.

--- a/proof/TP-DCP-MCP-RO-0010/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0010/PROOF.json
@@ -61,16 +61,50 @@
     "status": "PASS_WITH_RISKS",
     "auditor_tool": "claude-code-cli",
     "auditor_model": "opus",
-    "report_path": "proof/TP-DCP-MCP-RO-0010/AUDIT.md",
-    "hardenings_applied": [
-      "Duplicate target_id now fails closed (ambiguity blocks): first entry removed + id poisoned; was keep-first.",
-      "Stray v1 'projects' key alongside v2 'targets' now warns instead of silent ignore.",
-      "Cosmetic: unused _err -> _ in resolver with clarifying comment."
+    "invocation": "Independent Opus audit of TP-DCP-MCP-RO-0010 (registry v2 + pure resolver core) against ADR-DCP-MCP-RO-0009: manual read of registry_v2/resolver_core/capability + schema/tests; real-world _derive_roots verification on this linked worktree; fixture parse + purity/secret scans; advisor() second opinion (PAL external codereview NOT_RUN due to provider outage).",
+    "exit_code": 0,
+    "report_path": "proof/TP-DCP-MCP-RO-0010/AUDITOR_REPORT.md",
+    "findings": [
+      {
+        "id": "F-0010-LOW-1",
+        "severity": "LOW",
+        "title": "Duplicate target_id hardened to fail-closed (ambiguity blocks)",
+        "status": "RESOLVED",
+        "body": "Original implementation used keep-first + warn for a duplicate target_id. Per ADR-DCP-MCP-RO-0009 'Ambiguity blocks', changed to fail-closed: the already-accepted entry is dropped and the id poisoned so no later entry revives it. Test + fixture + contract doc updated."
+      },
+      {
+        "id": "F-0010-INFO-1",
+        "severity": "INFO",
+        "title": "project_root trust deferred to 0011/0012",
+        "status": "ACCEPTED_RISK",
+        "body": "project_root is derived from local .git metadata and trusted downstream. The 0011 runtime join must re-validate per-service project identity and must not treat a crafted .git gitfile as ownership authority."
+      },
+      {
+        "id": "F-0010-INFO-2",
+        "severity": "INFO",
+        "title": "Submodule/symlinked-.git derivation reasoned, not live-tested",
+        "status": "ACCEPTED_RISK",
+        "body": "Linked-worktree derivation verified on real metadata. Submodule (no commondir -> block) and symlinked-.git (treated as primary) layouts are reasoned to fail closed but not exercised live; worst case is a false block, never a wrong-repo bind."
+      },
+      {
+        "id": "F-0010-LOW-2",
+        "severity": "LOW",
+        "title": "PAL external codereview NOT_RUN (provider outage)",
+        "status": "ACCEPTED_RISK",
+        "body": "pal codereview attempted on gpt-5-codex (OpenAI 401) and gemini-2.5-pro (Google 429 quota=0); both unavailable. Mitigated by independent Opus manual audit + advisor() second opinion."
+      }
     ],
-    "reasoned_not_verified": [
-      "submodule .git layout (no commondir) -> fail-closed block (reasoned)",
-      "symlinked .git -> treated as primary checkout (reasoned)"
-    ]
+    "fixes_applied": [
+      "Duplicate target_id now fails closed (ambiguity blocks): drop first entry + poison id (was keep-first).",
+      "Stray v1 'projects' key alongside v2 'targets' now records a drift warning (was silent ignore).",
+      "Discard validate_workspace raw error explicitly to avoid abs-path leak in caller reasons (cosmetic _err -> _)."
+    ],
+    "remaining_risks": [
+      "project_root trust is defense-in-depth deferred to 0011/0012.",
+      "submodule/symlinked-.git derivation reasoned, not live-tested (fail-closed).",
+      "PAL external codereview NOT_RUN (provider outage)."
+    ],
+    "skip_reason": null
   },
   "deviations": [
     "FAMILY_POLICY_TABLE is a 2-tuple (resolution_class, chatgpt_posture) per the packet brief; no fabricated port_policy for the 8 families the ADR does not specify.",

--- a/proof/TP-DCP-MCP-RO-0010/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0010/PROOF.json
@@ -1,0 +1,87 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0010",
+  "title": "Exposure Target Registry V2 And Pure Resolver Core",
+  "branch": "claude/dcp-mcp-ro-0010-registry-v2-resolver",
+  "base_branch": "main",
+  "base_sha": "1893cffb677a3e06bfd64dd61159ee2bda15fdfc",
+  "implementation_commit": "1f420929b",
+  "scope": "services/dcp-readonly-facade registry v2 parsing + pure deterministic resolver core; facade-local docs + proof. No runtime/network/backend code.",
+  "runtime_code_changed": false,
+  "backend_code_changed": false,
+  "network_or_socket_code_introduced": false,
+  "executor_provenance": {
+    "implementation": "Claude Code Sonnet subagent (python-expert), orchestrated by Claude Code Opus",
+    "audit": "Claude Code Opus (independent of the implementer)",
+    "note": "The canonical task-packet execution.agent enum is {gemini,codex,vibe,shell} and has no 'claude' value; execution block omitted (schema-optional, no CI gate consumes it) and true provenance recorded here."
+  },
+  "depends_on": ["TP-DCP-MCP-RO-0009"],
+  "files_changed": {
+    "new_source": [
+      "services/dcp-readonly-facade/src/dcp_facade/registry_v2.py",
+      "services/dcp-readonly-facade/src/dcp_facade/resolver_core.py",
+      "services/dcp-readonly-facade/src/dcp_facade/capability.py",
+      "services/dcp-readonly-facade/schema/registry_v2.schema.json"
+    ],
+    "new_tests_fixtures": [
+      "services/dcp-readonly-facade/tests/test_registry_v2.py",
+      "services/dcp-readonly-facade/tests/test_resolver_core.py",
+      "services/dcp-readonly-facade/tests/test_capability.py",
+      "services/dcp-readonly-facade/tests/fixtures/registry_v2/*.yaml"
+    ],
+    "updated": [
+      "services/dcp-readonly-facade/registry.example.yaml",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md"
+    ],
+    "packet_and_proof": [
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.md",
+      "proof/TP-DCP-MCP-RO-0010/PROOF.json",
+      "proof/TP-DCP-MCP-RO-0010/AUDIT.md",
+      "proof/TP-DCP-MCP-RO-0010/COMMAND_LOG.md"
+    ]
+  },
+  "validation": {
+    "PASS": [
+      {"command": "python3 -m pytest -q services/dcp-readonly-facade/tests", "exit_code": 0, "result": "187 passed, 1 skipped (pre-existing live-optional)"},
+      {"command": "python3 -m compileall -q services/dcp-readonly-facade", "exit_code": 0},
+      {"command": "jsonschema.Draft7Validator.check_schema(registry_v2.schema.json)", "exit_code": 0},
+      {"command": "purity scan of registry_v2/resolver_core/capability (requests|httpx|urllib|socket|subprocess|os.system|shell|docker)", "exit_code": 1, "result": "no real I/O primitives (only literal family name 'docker_mcp_gateway')"},
+      {"command": "secret scan of 0010 new files (sk-[A-Za-z0-9]{20,}|API_KEY=|Bearer|PASSWORD=|SECRET=|TOKEN=)", "exit_code": 1, "result": "ZERO secrets in new files"},
+      {"command": "real-world _derive_roots on this linked worktree", "exit_code": 0, "result": "project_root=/Users/hue/code/dopemux-mvp, worktree_root=workspace (correct)"},
+      {"command": "duplicate target_id fixture parse", "exit_code": 0, "result": "targets == [] (fail-closed, ambiguity blocks)"}
+    ],
+    "FAIL": [],
+    "NOT_RUN": [
+      {"command": "pal codereview (gpt-5-codex / gemini-2.5-pro)", "reason": "provider outage — OpenAI 401 invalid key, Google 429 quota=0", "mitigation": "Opus independent manual audit + advisor() second opinion (governed fallback)", "residual_risk": "no third-party model codereview signal; mitigated by two independent Claude-tier reviews"},
+      {"command": "live per-worktree runtime/mount exemplar (Gate 0C)", "reason": "out of scope for 0010 (pure/deterministic); required only for 0012 final acceptance", "residual_risk": "none for 0010"}
+    ]
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "PASS_WITH_RISKS",
+    "auditor_tool": "claude-code-cli",
+    "auditor_model": "opus",
+    "report_path": "proof/TP-DCP-MCP-RO-0010/AUDIT.md",
+    "hardenings_applied": [
+      "Duplicate target_id now fails closed (ambiguity blocks): first entry removed + id poisoned; was keep-first.",
+      "Stray v1 'projects' key alongside v2 'targets' now warns instead of silent ignore.",
+      "Cosmetic: unused _err -> _ in resolver with clarifying comment."
+    ],
+    "reasoned_not_verified": [
+      "submodule .git layout (no commondir) -> fail-closed block (reasoned)",
+      "symlinked .git -> treated as primary checkout (reasoned)"
+    ]
+  },
+  "deviations": [
+    "FAMILY_POLICY_TABLE is a 2-tuple (resolution_class, chatgpt_posture) per the packet brief; no fabricated port_policy for the 8 families the ADR does not specify.",
+    "Block reasons deliberately do not forward validate_workspace()'s raw error (which can embed absolute paths) — stricter than v1.",
+    "v1-shaped documents fail closed rather than being coerced, per packet instruction."
+  ],
+  "handoff_to_0011": "0011 runtime/catalog join MUST re-validate per-service project identity and MUST NOT treat a project_root derived from a poisoned/crafted .git gitfile as ownership authority; ownership evidence belongs at the 0011/0012 tier.",
+  "rollback": "git reset --hard 1893cffb677a3e06bfd64dd61159ee2bda15fdfc  (drops the 0010 branch commits; nothing merged to main)",
+  "residual_risks": [
+    "project_root trust is defense-in-depth deferred to 0011/0012.",
+    "submodule/symlinked-.git derivation reasoned, not live-tested (fail-closed).",
+    "PAL external codereview NOT_RUN (provider outage)."
+  ]
+}

--- a/services/dcp-readonly-facade/registry.example.yaml
+++ b/services/dcp-readonly-facade/registry.example.yaml
@@ -1,37 +1,59 @@
-# DCP read-only MCP facade — EXAMPLE registry (no secrets).
+# DCP read-only MCP facade — EXAMPLE registry v2 (no secrets).
 #
-# Copy this to a path OUTSIDE the repo and point $DCP_FACADE_REGISTRY at it
-# (default: ~/.dopemux/dcp-facade-registry.yaml). NEVER commit a populated
+# Copy this to a path OUTSIDE the repo and point $DCP_FACADE_REGISTRY_V2 at it
+# (default: ~/.dopemux/dcp-facade-registry-v2.yaml). NEVER commit a populated
 # registry with real workspace paths or service credentials.
 #
-# Contract: docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md
+# Contract: docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md
+# (v1->v2 migration: docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md#migration)
+#
+# ADR: docs/90-adr/adr-dcp-mcp-ro-0009-chatgpt-mcp-exposure-targets-runtime-resolution-ownership-evidence.md
+#
+# v1 (project_id / registry.py) remains supported for existing deployments —
+# see registry.py + MULTI_PROJECT_REGISTRY_CONTRACT.md. This file documents
+# the v2 shape only; a v1 document loaded through registry_v2.py fails closed
+# with an actionable migration warning rather than being silently coerced.
 
 # Optional: workspaces must resolve (symlink-followed) inside one of these.
 approved_roots:
   - /abs/approved/root
 
-projects:
-  - project_id: "dopemux-mvp"          # opaque caller-facing id (the only handle a caller may supply)
+targets:
+  - target_id: "dopemux-main"            # opaque caller-facing handle (the ONLY handle ChatGPT may supply)
     workspace_path: "/abs/approved/root/dopemux-mvp"
-    enabled: true                       # exposure switch; omit/false = NOT exposed
-    identity:                           # matched against the workspace's .repo_id
-      project: "dopemux-mvp"            # REQUIRED; must equal .repo_id `project=`
-      owner: "hu3mann"                  # OPTIONAL; enforced only when present
-    service_profiles:                   # per-backend bindings (registry-owned; not exposed in Phase 1 tools)
+    enabled: true                         # exposure switch; omit/false = NOT exposed
+    binding_mode: "PRIMARY_CHECKOUT_ONLY" # default and only supported mode; binds to exactly ONE workspace
+    identity:                             # matched against the workspace's .repo_id
+      project: "dopemux-mvp"              # REQUIRED; must equal .repo_id `project=`
+      owner: "hu3mann"                    # OPTIONAL; enforced only when present
+    service_policies:                     # family -> { enabled }; family MUST be one of the 9 ADR-0009 names
       conport:
-        workspace_id: "<conport-workspace-id>"
-        base_url: "http://127.0.0.1:3004"
-        # search_progress is fail-closed: ConPort's default enhanced server
-        # auto-forks (WRITES) progress rows when a workspace has none
-        # (DOPEMUX_AUTO_FORK_PROGRESS defaults to 1). Only set this true AFTER
-        # you have set DOPEMUX_AUTO_FORK_PROGRESS=0 on that backend; otherwise a
-        # progress read is not read-only.
-        progress_readonly_safe: false
+        enabled: true                     # "configured" (declared + enabled); NOT proof of live/callable
       dope_memory:
-        profile: "<memory-profile>"
-        base_url: "http://127.0.0.1:3020"
+        enabled: true
+      to_compose_rest:
+        enabled: false
+      to_mcp_wrapper:
+        enabled: false                    # blocked posture (ADR-0009); leave disabled
       dope_context:
-        base_url: "http://127.0.0.1:3010"
-      task_orchestrator:
-        project_id: "<to-project-id>"
-        base_url: "http://127.0.0.1:8000"
+        enabled: false                    # blocked-until-read-bridge posture (ADR-0009)
+      serena:
+        enabled: false                    # blocked-until-inventory posture (ADR-0009)
+      pal:
+        enabled: false                    # blocked posture (ADR-0009)
+      docker_mcp_gateway:
+        enabled: false                    # blocked posture (ADR-0009)
+      desktop_commander:
+        enabled: false                    # blocked posture (ADR-0009)
+
+  # Additional worktrees require distinct operator-created targets — the
+  # resolver NEVER auto-selects the newest/most-recent worktree.
+  - target_id: "dopemux-pr-1031"
+    workspace_path: "/abs/approved/root/dopemux-mvp-worktrees/pr-1031"
+    enabled: false
+    identity:
+      project: "dopemux-mvp"
+      owner: "hu3mann"
+    service_policies:
+      conport:
+        enabled: true

--- a/services/dcp-readonly-facade/schema/registry_v2.schema.json
+++ b/services/dcp-readonly-facade/schema/registry_v2.schema.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dopemux.dev/schemas/dcp/chatgpt-mcp-readonly/registry_v2.schema.json",
+  "title": "DCP Read-Only Facade — Exposure Target Registry v2",
+  "description": "Operator-authored, facade-read-only exposure target registry (ADR-DCP-MCP-RO-0009). target_id is the only caller-facing handle; this schema governs the registry FILE shape, not caller input. The bare family name 'task-orchestrator' and any family outside the 9 ADR-0009 families are rejected by additionalProperties:false under service_policies.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "approved_roots": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "targets": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/target" }
+    }
+  },
+  "definitions": {
+    "target": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["target_id", "workspace_path", "identity"],
+      "properties": {
+        "target_id": { "type": "string", "minLength": 1 },
+        "workspace_path": { "type": "string", "minLength": 1 },
+        "enabled": { "type": "boolean" },
+        "binding_mode": {
+          "type": "string",
+          "enum": ["PRIMARY_CHECKOUT_ONLY"]
+        },
+        "identity": { "$ref": "#/definitions/identity" },
+        "service_policies": { "$ref": "#/definitions/service_policies" }
+      }
+    },
+    "identity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["project"],
+      "properties": {
+        "project": { "type": "string", "minLength": 1 },
+        "owner": { "type": "string", "minLength": 1 }
+      }
+    },
+    "service_policies": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Keys are limited to exactly the 9 ADR-DCP-MCP-RO-0009 service families. The bare name 'task-orchestrator' is forbidden.",
+      "properties": {
+        "conport": { "$ref": "#/definitions/service_policy" },
+        "dope_memory": { "$ref": "#/definitions/service_policy" },
+        "to_compose_rest": { "$ref": "#/definitions/service_policy" },
+        "to_mcp_wrapper": { "$ref": "#/definitions/service_policy" },
+        "dope_context": { "$ref": "#/definitions/service_policy" },
+        "serena": { "$ref": "#/definitions/service_policy" },
+        "pal": { "$ref": "#/definitions/service_policy" },
+        "docker_mcp_gateway": { "$ref": "#/definitions/service_policy" },
+        "desktop_commander": { "$ref": "#/definitions/service_policy" }
+      }
+    },
+    "service_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/services/dcp-readonly-facade/src/dcp_facade/capability.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/capability.py
@@ -1,0 +1,43 @@
+"""Capability reporting — configured vs live/callable separation (TP-DCP-MCP-RO-0010).
+
+Distinguishes "configured" (a service family is declared present AND
+policy-enabled in the registry — see ``registry_v2.ServicePolicy.configured``)
+from "discovered", "live", and "callable". Determining whether a runtime is
+actually live, owned, or reachable requires a backend/socket/container call,
+which is explicitly out of scope for this packet (ADR-DCP-MCP-RO-0009
+"Capability Reporting"; TP-DCP-MCP-RO-0010 invariants). Accordingly, every
+entry reports ``live == "UNKNOWN"`` and ``callable is False`` — configured
+capability NEVER implies callable capability.
+
+Pure: no outbound network calls, no external process spawned, no container
+runtime inspected.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .resolver_core import ResolvedTarget
+
+
+def capability_report(resolved: ResolvedTarget) -> list[dict[str, Any]]:
+    """Return one capability entry per service family bound to ``resolved``.
+
+    Each entry: ``{family, configured, resolution_class, chatgpt_posture,
+    live, callable}``. ``live`` is always the string ``"UNKNOWN"`` and
+    ``callable`` is always ``False`` in this packet.
+    """
+    report: list[dict[str, Any]] = []
+    for family in sorted(resolved.service_policies):
+        policy = resolved.service_policies[family]
+        report.append(
+            {
+                "family": family,
+                "configured": policy.configured,
+                "resolution_class": policy.resolution_class,
+                "chatgpt_posture": policy.chatgpt_posture,
+                "live": "UNKNOWN",
+                "callable": False,
+            }
+        )
+    return report

--- a/services/dcp-readonly-facade/src/dcp_facade/registry_v2.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/registry_v2.py
@@ -1,0 +1,285 @@
+"""Exposure target registry v2 loader + validator (TP-DCP-MCP-RO-0010).
+
+Registry v2 evolves the v1 project-keyed registry (``registry.py``) into the
+ADR-DCP-MCP-RO-0009 opaque-``target_id`` contract: ``target_id`` is the ONLY
+caller-facing handle, service families are limited to the exact 9 ADR-0009
+families (the bare name ``task-orchestrator`` is forbidden), and every
+service family carries a static ``(resolution_class, chatgpt_posture)`` pair
+from the ADR's policy table rather than a caller-visible free-form profile.
+
+Loading is **fail-closed**, mirroring ``registry.py``: a malformed target
+entry is dropped (recorded in ``warnings``) rather than exposed loosely;
+``enabled`` defaults to ``False``. A v1-shaped document (``projects`` /
+``project_id``) is NEVER silently coerced into v2 — it fails closed with an
+actionable migration warning (see ``docs/03-reference/dcp/chatgpt-mcp-readonly/
+REGISTRY_V2_CONTRACT.md``).
+
+This module is pure: it makes no outbound network calls, opens no listening
+or connecting ports, spawns no external processes, and inspects no container
+runtime. ``load_registry_v2`` performs a single read-only file read.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+# Exactly the 9 ADR-DCP-MCP-RO-0009 service families. The bare unqualified
+# name "task-orchestrator" is FORBIDDEN in registry v2 (ADR §"Required
+# Service Families"); to_mcp_wrapper / to_compose_rest are its two split
+# family identifiers.
+ALLOWED_SERVICE_FAMILIES: tuple[str, ...] = (
+    "conport",
+    "dope_memory",
+    "to_compose_rest",
+    "to_mcp_wrapper",
+    "dope_context",
+    "serena",
+    "pal",
+    "docker_mcp_gateway",
+    "desktop_commander",
+)
+
+# Names that must never be accepted as a service family key, even though they
+# resemble a legitimate family (ADR §"Required Service Families").
+FORBIDDEN_FAMILY_NAMES: tuple[str, ...] = ("task-orchestrator",)
+
+# Static per-family policy table: family -> (resolution_class, chatgpt_posture).
+# Sourced verbatim from ADR-DCP-MCP-RO-0009 §"Required Resolution Classes".
+# This table is DATA ONLY — it encodes no live/callable knowledge (that
+# remains UNKNOWN in this packet; see capability.py).
+FAMILY_POLICY_TABLE: dict[str, tuple[str, str]] = {
+    "conport": ("per_worktree_runtime", "conditional_read_only"),
+    "dope_memory": ("per_worktree_runtime", "conditional_read_only"),
+    "to_compose_rest": ("host_singleton_project_routed", "conditional_get_only"),
+    "to_mcp_wrapper": ("host_singleton_single_active_project", "blocked"),
+    "dope_context": ("singleton_per_call_workspace", "blocked_until_read_bridge"),
+    "serena": ("singleton_per_call_workspace", "blocked_until_inventory"),
+    "pal": ("host_singleton", "blocked"),
+    "docker_mcp_gateway": ("host_singleton", "blocked"),
+    "desktop_commander": ("host_singleton", "blocked"),
+}
+
+# Default (and, in this packet, only supported) worktree exposure binding
+# mode (ADR §"Default Worktree Exposure Policy"). A target binds to exactly
+# one operator-approved workspace; other values are rejected fail-closed.
+DEFAULT_BINDING_MODE = "PRIMARY_CHECKOUT_ONLY"
+
+ENV_REGISTRY_PATH = "DCP_FACADE_REGISTRY_V2"
+DEFAULT_REGISTRY_PATH = "~/.dopemux/dcp-facade-registry-v2.yaml"
+
+
+@dataclass(frozen=True)
+class ServicePolicy:
+    """A service family bound to its static ADR policy plus registry consent.
+
+    ``configured`` is True iff the family is declared in the target's
+    ``service_policies`` AND that entry declares ``enabled: true`` — i.e.
+    "configured" per the ADR's capability-state separation. It never implies
+    discovered/live/callable (see capability.py).
+    """
+
+    family: str
+    configured: bool
+    resolution_class: str
+    chatgpt_posture: str
+
+
+@dataclass(frozen=True)
+class ExposureTarget:
+    target_id: str
+    workspace_path: str
+    enabled: bool
+    binding_mode: str
+    identity_project: str
+    identity_owner: Optional[str]
+    service_policies: dict[str, ServicePolicy] = field(default_factory=dict)
+
+
+@dataclass
+class RegistryV2:
+    targets: dict[str, ExposureTarget] = field(default_factory=dict)
+    approved_roots: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    generation: str = ""
+
+    def get(self, target_id: str) -> Optional[ExposureTarget]:
+        return self.targets.get(target_id)
+
+    def enabled_targets(self) -> list[ExposureTarget]:
+        return [t for t in self.targets.values() if t.enabled]
+
+
+def resolve_registry_path(explicit: Optional[str] = None) -> Path:
+    """Resolve the registry v2 file path: explicit arg > env > default (~)."""
+    raw = explicit or os.getenv(ENV_REGISTRY_PATH) or DEFAULT_REGISTRY_PATH
+    return Path(raw).expanduser()
+
+
+def _generation(doc: Any) -> str:
+    """Deterministic content-hash generation id — NO timestamps/randomness."""
+    canonical = json.dumps(doc, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:16]
+
+
+def _coerce_service_policies(
+    raw: Any,
+) -> tuple[Optional[dict[str, ServicePolicy]], Optional[str]]:
+    """Validate a target's raw ``service_policies`` mapping.
+
+    Returns (policies, None) or (None, reason). An absent/empty mapping is
+    valid (a target may declare no families). Any forbidden or unknown
+    family name, or a malformed per-family entry, invalidates the WHOLE
+    target (fail-closed at the target level, not a silent per-family drop).
+    """
+    if raw is None:
+        return {}, None
+    if not isinstance(raw, dict):
+        return None, "service_policies must be a mapping"
+
+    result: dict[str, ServicePolicy] = {}
+    for family, policy_raw in raw.items():
+        if not isinstance(family, str):
+            return None, f"service family key must be a string: {family!r}"
+        if family in FORBIDDEN_FAMILY_NAMES:
+            return None, f"forbidden service family 'task-orchestrator': {family!r}"
+        if family not in ALLOWED_SERVICE_FAMILIES:
+            return None, f"unknown service family: {family!r}"
+        if policy_raw is None:
+            policy_raw = {}
+        if not isinstance(policy_raw, dict):
+            return None, f"service_policies[{family}] must be a mapping"
+        enabled = policy_raw.get("enabled", False)
+        if not isinstance(enabled, bool):
+            return None, f"service_policies[{family}].enabled must be a boolean"
+        resolution_class, chatgpt_posture = FAMILY_POLICY_TABLE[family]
+        result[family] = ServicePolicy(
+            family=family,
+            configured=enabled,
+            resolution_class=resolution_class,
+            chatgpt_posture=chatgpt_posture,
+        )
+    return result, None
+
+
+def _coerce_target(raw: Any) -> tuple[Optional[ExposureTarget], Optional[str]]:
+    """Validate one raw v2 target entry. Returns (target, None) or (None, reason)."""
+    if not isinstance(raw, dict):
+        return None, f"entry is not a mapping: {raw!r}"
+
+    tid = raw.get("target_id")
+    if not isinstance(tid, str) or not tid:
+        return None, f"missing/invalid target_id: {raw!r}"
+
+    workspace_path = raw.get("workspace_path")
+    if not isinstance(workspace_path, str) or not workspace_path:
+        return None, f"[{tid}] missing/invalid workspace_path"
+
+    binding_mode = raw.get("binding_mode", DEFAULT_BINDING_MODE)
+    if not isinstance(binding_mode, str) or binding_mode != DEFAULT_BINDING_MODE:
+        return None, f"[{tid}] unsupported binding_mode: {binding_mode!r}"
+
+    identity = raw.get("identity")
+    if not isinstance(identity, dict):
+        return None, f"[{tid}] missing identity block"
+    identity_project = identity.get("project")
+    if not isinstance(identity_project, str) or not identity_project:
+        return None, f"[{tid}] identity.project is required"
+    identity_owner = identity.get("owner")
+    if identity_owner is not None and not isinstance(identity_owner, str):
+        return None, f"[{tid}] identity.owner must be a string when present"
+
+    enabled = raw.get("enabled", False)
+    if not isinstance(enabled, bool):
+        return None, f"[{tid}] enabled must be a boolean"
+
+    policies, reason = _coerce_service_policies(raw.get("service_policies"))
+    if reason is not None:
+        return None, f"[{tid}] {reason}"
+
+    return (
+        ExposureTarget(
+            target_id=tid,
+            workspace_path=workspace_path,
+            enabled=enabled,
+            binding_mode=binding_mode,
+            identity_project=identity_project,
+            identity_owner=identity_owner,
+            service_policies=policies or {},
+        ),
+        None,
+    )
+
+
+def parse_registry_v2(doc: Any) -> RegistryV2:
+    """Build a RegistryV2 from an already-parsed YAML document (fail-closed).
+
+    A v1-shaped document (top-level ``projects`` list, no ``targets`` key) is
+    NEVER silently coerced: it fails closed with an actionable migration
+    warning pointing at ``target_id``/registry v2.
+    """
+    reg = RegistryV2()
+    if not isinstance(doc, dict):
+        reg.warnings.append("registry root is not a mapping; treating as empty")
+        reg.generation = _generation(doc if isinstance(doc, (dict, list)) else None)
+        return reg
+
+    if "targets" not in doc and "projects" in doc:
+        reg.warnings.append(
+            "registry appears to be v1-shaped (top-level 'projects' with "
+            "'project_id' entries); registry v2 requires 'targets' with "
+            "'target_id' entries — migrate before loading (see "
+            "docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md); "
+            "registry NOT loaded (fail-closed)"
+        )
+        reg.generation = _generation(doc)
+        return reg
+
+    roots = doc.get("approved_roots", []) or []
+    if isinstance(roots, list):
+        reg.approved_roots = [str(r) for r in roots if isinstance(r, str)]
+    else:
+        reg.warnings.append("approved_roots is not a list; ignored")
+
+    targets = doc.get("targets", []) or []
+    if not isinstance(targets, list):
+        reg.warnings.append("targets is not a list; treating as empty")
+        targets = []
+
+    for raw in targets:
+        target, reason = _coerce_target(raw)
+        if target is None:
+            reg.warnings.append(f"dropped target entry ({reason})")
+            continue
+        if target.target_id in reg.targets:
+            reg.warnings.append(
+                f"duplicate target_id {target.target_id}; later entry dropped"
+            )
+            continue
+        reg.targets[target.target_id] = target
+
+    reg.generation = _generation(doc)
+    return reg
+
+
+def load_registry_v2(path: Optional[str] = None) -> RegistryV2:
+    """Load + validate the registry v2 file from disk (read-only).
+
+    A missing file yields an empty registry with a recorded warning — the
+    same fail-closed behavior as ``registry.load_registry``.
+    """
+    p = resolve_registry_path(path)
+    if not p.is_file():
+        reg = RegistryV2()
+        reg.warnings.append(f"registry file not found: {p}")
+        reg.generation = _generation(None)
+        return reg
+    with p.open("r", encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    return parse_registry_v2(doc)

--- a/services/dcp-readonly-facade/src/dcp_facade/registry_v2.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/registry_v2.py
@@ -247,22 +247,47 @@ def parse_registry_v2(doc: Any) -> RegistryV2:
     else:
         reg.warnings.append("approved_roots is not a list; ignored")
 
+    if "projects" in doc:
+        # "targets" is present here (the v1-only shape returned above), so a
+        # "projects" key is a stray v1 remnant. Registry v2 uses "targets"
+        # exclusively; surface the drift rather than ignoring it silently.
+        reg.warnings.append(
+            "stray v1 'projects' key present alongside v2 'targets'; "
+            "'projects' is ignored (registry v2 uses 'targets' only)"
+        )
+
     targets = doc.get("targets", []) or []
     if not isinstance(targets, list):
         reg.warnings.append("targets is not a list; treating as empty")
         targets = []
 
+    # A duplicate target_id is an AMBIGUOUS exposure-consent binding: one opaque
+    # handle mapped to two workspaces. Per ADR-DCP-MCP-RO-0009 ("Ambiguity
+    # blocks") the facade must fail closed — it must NOT silently first-wins.
+    # We drop the already-accepted entry AND poison the id so no later entry can
+    # revive it; the whole ambiguous target_id resolves to nothing.
+    poisoned: set[str] = set()
     for raw in targets:
         target, reason = _coerce_target(raw)
         if target is None:
             reg.warnings.append(f"dropped target entry ({reason})")
             continue
-        if target.target_id in reg.targets:
+        tid = target.target_id
+        if tid in poisoned:
             reg.warnings.append(
-                f"duplicate target_id {target.target_id}; later entry dropped"
+                f"duplicate target_id {tid}; ambiguous exposure consent blocked "
+                "(fail-closed: all entries with this target_id dropped)"
             )
             continue
-        reg.targets[target.target_id] = target
+        if tid in reg.targets:
+            del reg.targets[tid]
+            poisoned.add(tid)
+            reg.warnings.append(
+                f"duplicate target_id {tid}; ambiguous exposure consent blocked "
+                "(fail-closed: all entries with this target_id dropped)"
+            )
+            continue
+        reg.targets[tid] = target
 
     reg.generation = _generation(doc)
     return reg

--- a/services/dcp-readonly-facade/src/dcp_facade/resolver_core.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/resolver_core.py
@@ -1,0 +1,201 @@
+"""Pure resolver core — target_id -> ResolvedTarget (TP-DCP-MCP-RO-0010).
+
+Resolution order (mirrors ``resolver.py``'s §5 flow, extended per ADR-DCP-
+MCP-RO-0009 for registry v2):
+
+  lookup -> enabled -> realpath -> approved-roots containment
+  -> eligibility (.dopemux/ present + validate_workspace)
+  -> identity (.repo_id project + conditional owner)
+  -> derive project_root/worktree_root from LOCAL .git metadata only
+  -> bind per-family service policies (already resolved at registry parse)
+  -> ResolvedTarget.
+
+Every failure returns a short, opaque block reason — never a path, port,
+URL, or partial result (ADR §"Public Response Rules"; TP-DCP-MCP-RO-0010
+hard constraint). This module is pure: it makes no outbound network calls,
+opens no ports, spawns no external processes, and inspects no container
+runtime or backend service. project_root/worktree_root are derived by
+reading ``.git`` (directory vs gitfile) and, for a linked worktree, its
+``commondir`` file — local filesystem reads only.
+
+Reuses ``dopemux.workspace_detection.validate_workspace`` when importable
+(repo ``src`` is on pytest ``pythonpath``); a conservative fallback is used
+only when dopemux is unavailable (e.g. a stripped container) — identical
+fallback shape to ``resolver.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from .registry_v2 import ExposureTarget, RegistryV2, ServicePolicy
+
+try:  # prefer the canonical dopemux validator
+    from dopemux.workspace_detection import validate_workspace as _validate_workspace
+except Exception:  # pragma: no cover - exercised only without dopemux on path
+
+    def _validate_workspace(workspace_path: Path) -> tuple[bool, Optional[str]]:
+        p = Path(workspace_path)
+        if not p.is_dir():
+            return False, "not a directory"
+        if (
+            (p / ".git").exists()
+            or (p / "pyproject.toml").exists()
+            or (p / ".repo_id").exists()
+        ):
+            return True, None
+        return False, "no workspace markers"
+
+
+@dataclass(frozen=True)
+class ResolvedTarget:
+    target: ExposureTarget
+    workspace: Path  # canonical (realpath) directory — the bound checkout
+    project_root: Path  # repository-level root (common .git's parent)
+    worktree_root: Path  # worktree-level root (== workspace)
+    service_policies: dict[str, ServicePolicy]
+
+
+def _read_repo_id(workspace: Path) -> dict[str, str]:
+    """Parse the git-tracked ``.repo_id`` identity file (``key=value`` lines)."""
+    f = workspace / ".repo_id"
+    out: dict[str, str] = {}
+    if not f.is_file():
+        return out
+    for line in f.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, val = line.split("=", 1)
+        out[key.strip()] = val.strip()
+    return out
+
+
+def _within(child: Path, parent: Path) -> bool:
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except Exception:
+        return False
+
+
+def _derive_roots(workspace: Path) -> tuple[Optional[Path], Optional[Path]]:
+    """Derive (project_root, worktree_root) from LOCAL ``.git`` metadata only.
+
+    - ``.git`` is a directory: primary checkout. project_root == worktree_root
+      == workspace.
+    - ``.git`` is a file (``gitdir: <path>``): linked worktree. Follow
+      ``<gitdir>/commondir`` to the common ``.git`` directory; project_root is
+      its parent. worktree_root == workspace.
+    - No ``.git`` at all: unresolvable — fail closed (returns (None, None)).
+
+    No network calls and no external process is spawned — pure filesystem reads.
+    """
+    git_path = workspace / ".git"
+
+    if git_path.is_dir():
+        return workspace, workspace
+
+    if not git_path.is_file():
+        return None, None
+
+    try:
+        content = git_path.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None, None
+
+    prefix = "gitdir:"
+    if not content.startswith(prefix):
+        return None, None
+    gitdir_raw = content[len(prefix) :].strip()
+    if not gitdir_raw:
+        return None, None
+
+    gitdir = Path(gitdir_raw)
+    if not gitdir.is_absolute():
+        gitdir = workspace / gitdir
+    try:
+        gitdir = gitdir.resolve()
+    except OSError:
+        return None, None
+
+    commondir_file = gitdir / "commondir"
+    if not commondir_file.is_file():
+        return None, None
+    try:
+        common_raw = commondir_file.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return None, None
+    if not common_raw:
+        return None, None
+
+    common_dir = Path(common_raw)
+    if not common_dir.is_absolute():
+        common_dir = gitdir / common_dir
+    try:
+        common_dir = common_dir.resolve()
+    except OSError:
+        return None, None
+
+    return common_dir.parent, workspace
+
+
+def resolve_target(
+    registry: RegistryV2, target_id: object
+) -> tuple[Optional[ResolvedTarget], Optional[str]]:
+    """Return (ResolvedTarget, None) on success or (None, reason) when blocked.
+
+    ``reason`` is always a short, opaque string: no absolute path, port, or
+    URL is ever included (target_id itself is caller-supplied and opaque, so
+    it is safe to echo back).
+    """
+    if not isinstance(target_id, str) or not target_id:
+        return None, "target_id is required"
+
+    target = registry.get(target_id)
+    if target is None:
+        return None, f"unknown target: {target_id}"
+    if not target.enabled:
+        return None, f"target disabled: {target_id}"
+
+    try:
+        real = Path(target.workspace_path).resolve()
+    except OSError:
+        return None, "workspace could not be resolved"
+    if not real.is_dir():
+        return None, "workspace is not a directory"
+
+    if registry.approved_roots:
+        if not any(_within(real, Path(r)) for r in registry.approved_roots):
+            return None, "workspace escapes approved roots"
+
+    # Eligibility: the dopemux init marker + canonical workspace validation.
+    if not (real / ".dopemux").is_dir():
+        return None, "workspace missing .dopemux (not initialized)"
+    ok, _err = _validate_workspace(real)
+    if not ok:
+        return None, "workspace validation failed"
+
+    # Identity: .repo_id project (always) + owner (only when registry declares it).
+    repo_id = _read_repo_id(real)
+    if repo_id.get("project") != target.identity_project:
+        return None, "identity project mismatch"
+    if target.identity_owner is not None and repo_id.get("owner") != target.identity_owner:
+        return None, "identity owner mismatch"
+
+    project_root, worktree_root = _derive_roots(real)
+    if project_root is None or worktree_root is None:
+        return None, "workspace has no resolvable git root"
+
+    return (
+        ResolvedTarget(
+            target=target,
+            workspace=real,
+            project_root=project_root,
+            worktree_root=worktree_root,
+            service_policies=dict(target.service_policies),
+        ),
+        None,
+    )

--- a/services/dcp-readonly-facade/src/dcp_facade/resolver_core.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/resolver_core.py
@@ -174,7 +174,9 @@ def resolve_target(
     # Eligibility: the dopemux init marker + canonical workspace validation.
     if not (real / ".dopemux").is_dir():
         return None, "workspace missing .dopemux (not initialized)"
-    ok, _err = _validate_workspace(real)
+    # Note: validate_workspace's raw error is intentionally discarded — it can
+    # embed absolute paths, which must never appear in a caller-facing reason.
+    ok, _ = _validate_workspace(real)
     if not ok:
         return None, "workspace validation failed"
 

--- a/services/dcp-readonly-facade/tests/fixtures/registry_v2/disabled_target.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/registry_v2/disabled_target.yaml
@@ -1,0 +1,15 @@
+# Schema-valid registry v2 fixture with an administratively-disabled target.
+# Not a parse-time rejection — enabled:false is normal fail-closed default;
+# used by resolver tests to exercise the "target disabled" block path.
+approved_roots:
+  - /abs/approved/root
+
+targets:
+  - target_id: "dopemux-disabled"
+    workspace_path: "/abs/approved/root/dopemux-disabled"
+    enabled: false
+    identity:
+      project: "dopemux-disabled"
+    service_policies:
+      conport:
+        enabled: true

--- a/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_bare_task_orchestrator.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_bare_task_orchestrator.yaml
@@ -1,0 +1,10 @@
+# Invalid: bare 'task-orchestrator' family name is forbidden by ADR-DCP-MCP-RO-0009.
+targets:
+  - target_id: "bad"
+    workspace_path: "/abs/ws"
+    enabled: true
+    identity:
+      project: "proj"
+    service_policies:
+      task-orchestrator:
+        enabled: true

--- a/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_duplicate_target_id.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_duplicate_target_id.yaml
@@ -1,0 +1,12 @@
+# Invalid (parser-level, not schema-level): duplicate target_id — later entry dropped.
+targets:
+  - target_id: "dup"
+    workspace_path: "/abs/ws1"
+    enabled: true
+    identity:
+      project: "proj1"
+  - target_id: "dup"
+    workspace_path: "/abs/ws2"
+    enabled: true
+    identity:
+      project: "proj2"

--- a/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_duplicate_target_id.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_duplicate_target_id.yaml
@@ -1,4 +1,5 @@
-# Invalid (parser-level, not schema-level): duplicate target_id — later entry dropped.
+# Invalid (parser-level, not schema-level): duplicate target_id — ambiguity
+# blocks (ADR-DCP-MCP-RO-0009), so BOTH entries are dropped (fail-closed).
 targets:
   - target_id: "dup"
     workspace_path: "/abs/ws1"

--- a/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_missing_identity.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_missing_identity.yaml
@@ -1,0 +1,5 @@
+# Invalid: target missing the required identity block entirely.
+targets:
+  - target_id: "bad"
+    workspace_path: "/abs/ws"
+    enabled: true

--- a/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_unknown_family.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_unknown_family.yaml
@@ -1,0 +1,10 @@
+# Invalid: service family outside the 9 ADR-DCP-MCP-RO-0009 families.
+targets:
+  - target_id: "bad"
+    workspace_path: "/abs/ws"
+    enabled: true
+    identity:
+      project: "proj"
+    service_policies:
+      totally_unknown_family:
+        enabled: true

--- a/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_v1_project_id_doc.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/registry_v2/invalid_v1_project_id_doc.yaml
@@ -1,0 +1,15 @@
+# Invalid: v1-shaped document (projects/project_id). Registry v2 requires
+# targets/target_id. Must fail closed with an actionable migration warning,
+# never silently coerced. See REGISTRY_V2_CONTRACT.md.
+approved_roots:
+  - /abs/approved/root
+
+projects:
+  - project_id: "dopemux-mvp"
+    workspace_path: "/abs/approved/root/dopemux-mvp"
+    enabled: true
+    identity:
+      project: "dopemux-mvp"
+    service_profiles:
+      conport:
+        workspace_id: "abc"

--- a/services/dcp-readonly-facade/tests/fixtures/registry_v2/valid.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/registry_v2/valid.yaml
@@ -1,0 +1,19 @@
+# Valid registry v2 fixture — no secrets, no real paths.
+approved_roots:
+  - /abs/approved/root
+
+targets:
+  - target_id: "dopemux-main"
+    workspace_path: "/abs/approved/root/dopemux-mvp"
+    enabled: true
+    binding_mode: "PRIMARY_CHECKOUT_ONLY"
+    identity:
+      project: "dopemux-mvp"
+      owner: "hu3mann"
+    service_policies:
+      conport:
+        enabled: true
+      dope_memory:
+        enabled: true
+      pal:
+        enabled: false

--- a/services/dcp-readonly-facade/tests/test_capability.py
+++ b/services/dcp-readonly-facade/tests/test_capability.py
@@ -1,0 +1,139 @@
+"""capability_report: configured vs live/callable separation (TP-DCP-MCP-RO-0010).
+
+Only "configured" (family declared + policy-enabled in the registry) is known
+in this packet; live reachability requires a backend call, which is out of
+scope. ``live`` must always report ``"UNKNOWN"`` and ``callable`` must always
+be ``False`` — configured must never imply callable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from dcp_facade.capability import capability_report
+from dcp_facade.registry_v2 import parse_registry_v2
+from dcp_facade.resolver_core import resolve_target
+
+
+@pytest.fixture
+def build_registry_v2():
+    def _build(targets: list[dict], approved_roots: Optional[list[str]] = None):
+        doc: dict = {"targets": targets}
+        if approved_roots is not None:
+            doc["approved_roots"] = approved_roots
+        return parse_registry_v2(doc)
+
+    return _build
+
+
+@pytest.fixture
+def target_entry():
+    def _entry(
+        ws_path: Path,
+        *,
+        target_id: str = "t",
+        identity_project: str = "testproj",
+        identity_owner: Optional[str] = "tester",
+        enabled: bool = True,
+        service_policies: Optional[dict] = None,
+    ) -> dict:
+        identity: dict = {"project": identity_project}
+        if identity_owner is not None:
+            identity["owner"] = identity_owner
+        return {
+            "target_id": target_id,
+            "workspace_path": str(ws_path),
+            "enabled": enabled,
+            "identity": identity,
+            "service_policies": service_policies or {},
+        }
+
+    return _entry
+
+
+def _resolved(make_workspace, build_registry_v2, target_entry, service_policies):
+    info = make_workspace(project="proj", owner="tester")
+    ws = info["path"]
+    reg = build_registry_v2(
+        [
+            target_entry(
+                ws,
+                target_id="t",
+                identity_project="proj",
+                identity_owner="tester",
+                service_policies=service_policies,
+            )
+        ],
+        approved_roots=[str(ws.parent)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert reason is None
+    return resolved
+
+
+def test_capability_report_marks_configured_family(make_workspace, build_registry_v2, target_entry):
+    resolved = _resolved(
+        make_workspace, build_registry_v2, target_entry, {"conport": {"enabled": True}}
+    )
+    report = capability_report(resolved)
+    entry = next(e for e in report if e["family"] == "conport")
+    assert entry["configured"] is True
+    assert entry["resolution_class"] == "per_worktree_runtime"
+    assert entry["chatgpt_posture"] == "conditional_read_only"
+    assert entry["live"] == "UNKNOWN"
+    assert entry["callable"] is False
+
+
+def test_capability_report_marks_unconfigured_family(make_workspace, build_registry_v2, target_entry):
+    resolved = _resolved(
+        make_workspace, build_registry_v2, target_entry, {"pal": {"enabled": False}}
+    )
+    report = capability_report(resolved)
+    entry = next(e for e in report if e["family"] == "pal")
+    assert entry["configured"] is False
+    assert entry["live"] == "UNKNOWN"
+    assert entry["callable"] is False
+
+
+def test_capability_report_empty_when_no_families_declared(
+    make_workspace, build_registry_v2, target_entry
+):
+    resolved = _resolved(make_workspace, build_registry_v2, target_entry, {})
+    assert capability_report(resolved) == []
+
+
+def test_capability_report_configured_never_implies_live_or_callable(
+    make_workspace, build_registry_v2, target_entry
+):
+    resolved = _resolved(
+        make_workspace,
+        build_registry_v2,
+        target_entry,
+        {"conport": {"enabled": True}, "dope_memory": {"enabled": True}},
+    )
+    report = capability_report(resolved)
+    assert len(report) == 2
+    for entry in report:
+        assert entry["live"] == "UNKNOWN"
+        assert entry["callable"] is False
+
+
+def test_capability_report_entries_have_no_forbidden_public_fields(
+    make_workspace, build_registry_v2, target_entry
+):
+    resolved = _resolved(
+        make_workspace, build_registry_v2, target_entry, {"conport": {"enabled": True}}
+    )
+    report = capability_report(resolved)
+    for entry in report:
+        assert set(entry) == {
+            "family",
+            "configured",
+            "resolution_class",
+            "chatgpt_posture",
+            "live",
+            "callable",
+        }

--- a/services/dcp-readonly-facade/tests/test_registry_v2.py
+++ b/services/dcp-readonly-facade/tests/test_registry_v2.py
@@ -139,10 +139,32 @@ def test_missing_identity_target_rejected_with_warning():
     assert any("identity" in w.lower() for w in reg.warnings)
 
 
-def test_duplicate_target_id_dropped():
+def test_duplicate_target_id_fails_closed():
+    # Ambiguity blocks (ADR-DCP-MCP-RO-0009): a duplicate target_id is an
+    # ambiguous exposure-consent binding, so the WHOLE id fails closed — both
+    # the first-accepted entry and every later duplicate are dropped, and the
+    # id resolves to nothing.
     reg = REG2.parse_registry_v2(_load_yaml("invalid_duplicate_target_id.yaml"))
-    assert list(reg.targets) == ["dup"]
+    assert list(reg.targets) == []
+    assert "dup" not in reg.targets
     assert any("duplicate" in w.lower() for w in reg.warnings)
+    assert any("fail-closed" in w.lower() for w in reg.warnings)
+
+
+def test_duplicate_target_id_not_revived_by_third_entry():
+    # A third entry with the poisoned id must not resurrect it.
+    doc = {
+        "targets": [
+            {"target_id": "dup", "workspace_path": "/a", "enabled": True,
+             "identity": {"project": "p1"}},
+            {"target_id": "dup", "workspace_path": "/b", "enabled": True,
+             "identity": {"project": "p2"}},
+            {"target_id": "dup", "workspace_path": "/c", "enabled": True,
+             "identity": {"project": "p3"}},
+        ]
+    }
+    reg = REG2.parse_registry_v2(doc)
+    assert "dup" not in reg.targets
 
 
 def test_disabled_target_parses_but_is_not_enabled():

--- a/services/dcp-readonly-facade/tests/test_registry_v2.py
+++ b/services/dcp-readonly-facade/tests/test_registry_v2.py
@@ -1,0 +1,253 @@
+"""Registry v2: schema contract + fail-closed parse tests (TP-DCP-MCP-RO-0010).
+
+Mirrors tests/test_registry.py's fail-closed style for the v2 shape
+(target_id, 9-family allowlist, v1->v2 migration guard, deterministic
+content-hash generation). No network/file-write primitives are exercised
+here; fixtures are static YAML under tests/fixtures/registry_v2/.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+from dcp_facade import registry_v2 as REG2
+
+_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schema" / "registry_v2.schema.json"
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "registry_v2"
+
+
+def _load_yaml(name: str):
+    return yaml.safe_load((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Module constants (family allowlist + static policy table)
+# ---------------------------------------------------------------------------
+
+
+def test_allowed_service_families_are_exactly_the_nine_adr_families():
+    assert REG2.ALLOWED_SERVICE_FAMILIES == (
+        "conport",
+        "dope_memory",
+        "to_compose_rest",
+        "to_mcp_wrapper",
+        "dope_context",
+        "serena",
+        "pal",
+        "docker_mcp_gateway",
+        "desktop_commander",
+    )
+
+
+def test_bare_task_orchestrator_not_in_allowlist():
+    assert "task-orchestrator" not in REG2.ALLOWED_SERVICE_FAMILIES
+
+
+def test_family_policy_table_covers_every_allowed_family():
+    for family in REG2.ALLOWED_SERVICE_FAMILIES:
+        assert family in REG2.FAMILY_POLICY_TABLE
+        resolution_class, chatgpt_posture = REG2.FAMILY_POLICY_TABLE[family]
+        assert isinstance(resolution_class, str) and resolution_class
+        assert isinstance(chatgpt_posture, str) and chatgpt_posture
+
+
+def test_family_policy_table_matches_adr_0009_posture_for_to_mcp_wrapper():
+    # to_mcp_wrapper is explicitly blocked in ADR-0009 (host singleton, single active project).
+    resolution_class, chatgpt_posture = REG2.FAMILY_POLICY_TABLE["to_mcp_wrapper"]
+    assert resolution_class == "host_singleton_single_active_project"
+    assert chatgpt_posture == "blocked"
+
+
+def test_default_binding_mode_is_primary_checkout_only():
+    assert REG2.DEFAULT_BINDING_MODE == "PRIMARY_CHECKOUT_ONLY"
+
+
+# ---------------------------------------------------------------------------
+# JSON Schema contract
+# ---------------------------------------------------------------------------
+
+
+def test_schema_is_draft7_and_self_valid():
+    jsonschema.Draft7Validator.check_schema(_schema())
+
+
+def test_schema_accepts_valid_fixture():
+    jsonschema.Draft7Validator(_schema()).validate(_load_yaml("valid.yaml"))
+
+
+def test_schema_accepts_disabled_target_fixture():
+    jsonschema.Draft7Validator(_schema()).validate(_load_yaml("disabled_target.yaml"))
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        "invalid_bare_task_orchestrator.yaml",
+        "invalid_unknown_family.yaml",
+        "invalid_missing_identity.yaml",
+        "invalid_v1_project_id_doc.yaml",
+    ],
+)
+def test_schema_rejects_structural_fixtures(fixture_name):
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.Draft7Validator(_schema()).validate(_load_yaml(fixture_name))
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed parsing — registry-level
+# ---------------------------------------------------------------------------
+
+
+def test_parse_valid_fixture_yields_enabled_target():
+    reg = REG2.parse_registry_v2(_load_yaml("valid.yaml"))
+    assert "dopemux-main" in reg.targets
+    target = reg.targets["dopemux-main"]
+    assert target.enabled is True
+    assert target.binding_mode == "PRIMARY_CHECKOUT_ONLY"
+    assert target.identity_project == "dopemux-mvp"
+    assert target.identity_owner == "hu3mann"
+    assert reg.approved_roots == ["/abs/approved/root"]
+    assert target.service_policies["conport"].configured is True
+    assert target.service_policies["pal"].configured is False
+
+
+def test_bare_task_orchestrator_target_rejected_with_warning():
+    reg = REG2.parse_registry_v2(_load_yaml("invalid_bare_task_orchestrator.yaml"))
+    assert reg.targets == {}
+    assert any("task-orchestrator" in w for w in reg.warnings)
+
+
+def test_unknown_family_target_rejected_with_warning():
+    reg = REG2.parse_registry_v2(_load_yaml("invalid_unknown_family.yaml"))
+    assert reg.targets == {}
+    assert any("unknown" in w.lower() and "family" in w.lower() for w in reg.warnings)
+
+
+def test_missing_identity_target_rejected_with_warning():
+    reg = REG2.parse_registry_v2(_load_yaml("invalid_missing_identity.yaml"))
+    assert reg.targets == {}
+    assert any("identity" in w.lower() for w in reg.warnings)
+
+
+def test_duplicate_target_id_dropped():
+    reg = REG2.parse_registry_v2(_load_yaml("invalid_duplicate_target_id.yaml"))
+    assert list(reg.targets) == ["dup"]
+    assert any("duplicate" in w.lower() for w in reg.warnings)
+
+
+def test_disabled_target_parses_but_is_not_enabled():
+    reg = REG2.parse_registry_v2(_load_yaml("disabled_target.yaml"))
+    assert "dopemux-disabled" in reg.targets
+    assert reg.targets["dopemux-disabled"].enabled is False
+    assert reg.enabled_targets() == []
+
+
+def test_enabled_defaults_false_when_omitted():
+    doc = {
+        "targets": [
+            {
+                "target_id": "p",
+                "workspace_path": "/abs/ws",
+                "identity": {"project": "proj"},
+            }
+        ]
+    }
+    reg = REG2.parse_registry_v2(doc)
+    assert reg.targets["p"].enabled is False
+
+
+def test_v1_project_id_doc_fails_closed_with_actionable_warning():
+    reg = REG2.parse_registry_v2(_load_yaml("invalid_v1_project_id_doc.yaml"))
+    assert reg.targets == {}
+    assert any(
+        ("v1" in w.lower() or "migrat" in w.lower()) and "target_id" in w
+        for w in reg.warnings
+    )
+
+
+def test_v1_doc_is_not_silently_coerced_into_targets():
+    # A v1 doc that ALSO happens to have "projects" but no "targets" key must
+    # never be interpreted as an (accidentally empty) v2 doc with 0 targets
+    # that silently "succeeds" — it must be flagged, not just quietly empty.
+    reg = REG2.parse_registry_v2(_load_yaml("invalid_v1_project_id_doc.yaml"))
+    assert len(reg.warnings) >= 1
+
+
+def test_malformed_entries_dropped_failclosed():
+    bad = [
+        {"workspace_path": "/x", "identity": {"project": "a"}},  # no target_id
+        {"target_id": "b", "identity": {"project": "a"}},  # no workspace_path
+        {"target_id": "c", "workspace_path": "/x"},  # no identity
+        {"target_id": "d", "workspace_path": "/x", "identity": {}},  # no identity.project
+        {"target_id": "e", "workspace_path": "/x", "identity": {"project": "a"}, "enabled": "yes"},  # bad type
+        {"target_id": "f", "workspace_path": "/x", "identity": {"project": "a"}, "binding_mode": "ANYTHING"},
+        "not-a-mapping",
+    ]
+    reg = REG2.parse_registry_v2({"targets": bad})
+    assert reg.targets == {}
+    assert len(reg.warnings) >= len(bad)
+
+
+def test_root_not_a_mapping_treated_as_empty():
+    reg = REG2.parse_registry_v2(["not", "a", "mapping"])
+    assert reg.targets == {}
+    assert reg.warnings
+
+
+def test_approved_roots_non_list_ignored_with_warning():
+    reg = REG2.parse_registry_v2({"approved_roots": "not-a-list", "targets": []})
+    assert reg.approved_roots == []
+    assert any("approved_roots" in w for w in reg.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Deterministic generation id
+# ---------------------------------------------------------------------------
+
+
+def test_generation_is_deterministic_content_hash():
+    doc = _load_yaml("valid.yaml")
+    reg1 = REG2.parse_registry_v2(doc)
+    reg2 = REG2.parse_registry_v2(doc)
+    assert reg1.generation == reg2.generation
+    assert reg1.generation != ""
+
+    doc2 = _load_yaml("disabled_target.yaml")
+    reg3 = REG2.parse_registry_v2(doc2)
+    assert reg3.generation != reg1.generation
+
+
+def test_generation_has_no_timestamp_or_random_dependency():
+    doc = _load_yaml("valid.yaml")
+    reg_a = REG2.parse_registry_v2(doc)
+    time.sleep(0.01)
+    reg_b = REG2.parse_registry_v2(doc)
+    assert reg_a.generation == reg_b.generation
+
+
+# ---------------------------------------------------------------------------
+# load_registry_v2 (file IO — read-only)
+# ---------------------------------------------------------------------------
+
+
+def test_load_missing_file_returns_empty(tmp_path: Path):
+    reg = REG2.load_registry_v2(str(tmp_path / "nope.yaml"))
+    assert reg.targets == {}
+    assert any("not found" in w for w in reg.warnings)
+
+
+def test_load_from_yaml_file(tmp_path: Path):
+    f = tmp_path / "reg.yaml"
+    f.write_text((_FIXTURES / "valid.yaml").read_text(encoding="utf-8"), encoding="utf-8")
+    reg = REG2.load_registry_v2(str(f))
+    assert "dopemux-main" in reg.targets

--- a/services/dcp-readonly-facade/tests/test_resolver_core.py
+++ b/services/dcp-readonly-facade/tests/test_resolver_core.py
@@ -1,0 +1,387 @@
+"""Resolver core v2: pure target_id -> ResolvedTarget resolution (TP-DCP-MCP-RO-0010).
+
+Mirrors tests/test_resolver.py's fail-closed style for the v2 gate sequence
+(lookup -> enabled -> realpath -> approved-roots containment -> eligibility
+-> identity -> .git-derived project_root/worktree_root -> bind policies),
+plus explicit coverage for primary-checkout vs linked-worktree .git shapes.
+
+Fixtures here build REAL temporary git workspaces/worktrees (subprocess is
+test-fixture setup only — the resolver_core module under test performs no
+subprocess/network/socket calls; see test_purity_* below).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+from dcp_facade.registry_v2 import parse_registry_v2
+from dcp_facade.resolver_core import resolve_target
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture
+def build_registry_v2():
+    """Build an in-memory RegistryV2 from target dicts (no file IO)."""
+
+    def _build(targets: list[dict], approved_roots: Optional[list[str]] = None):
+        doc: dict = {"targets": targets}
+        if approved_roots is not None:
+            doc["approved_roots"] = approved_roots
+        return parse_registry_v2(doc)
+
+    return _build
+
+
+@pytest.fixture
+def target_entry():
+    """Helper to construct a registry v2 target dict pointing at a workspace."""
+
+    def _entry(
+        ws_path: Path,
+        *,
+        target_id: str = "t",
+        identity_project: str = "testproj",
+        identity_owner: Optional[str] = "tester",
+        enabled: bool = True,
+        service_policies: Optional[dict] = None,
+    ) -> dict:
+        identity: dict = {"project": identity_project}
+        if identity_owner is not None:
+            identity["owner"] = identity_owner
+        return {
+            "target_id": target_id,
+            "workspace_path": str(ws_path),
+            "enabled": enabled,
+            "identity": identity,
+            "service_policies": service_policies or {},
+        }
+
+    return _entry
+
+
+@pytest.fixture
+def make_linked_worktree(make_workspace, tmp_path_factory):
+    """Build a real linked git worktree off a make_workspace primary checkout.
+
+    Returns {"primary": Path, "worktree": Path, "head_sha": str}. Git does not
+    track empty directories, so the linked worktree gets its own untracked
+    ``.dopemux/`` marker (mirroring what ``make_workspace`` does for a primary
+    checkout); tracked files such as ``.repo_id`` are inherited via checkout.
+    """
+
+    def _make(**workspace_kwargs) -> dict:
+        primary = make_workspace(**workspace_kwargs)
+        primary_path = primary["path"]
+        parent = tmp_path_factory.mktemp("linked-wt-parent")
+        wt_path = parent / "worktree"
+        _git(
+            primary_path,
+            "worktree",
+            "add",
+            "--detach",
+            "-q",
+            str(wt_path),
+            primary["head_sha"],
+        )
+        (wt_path / ".dopemux").mkdir()
+        return {"primary": primary_path, "worktree": wt_path, "head_sha": primary["head_sha"]}
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Negative branches
+# ---------------------------------------------------------------------------
+
+
+def test_unknown_target_blocked(build_registry_v2):
+    reg = build_registry_v2([])
+    resolved, reason = resolve_target(reg, "ghost")
+    assert resolved is None
+    assert reason
+
+
+def test_non_string_target_id_blocked(build_registry_v2):
+    reg = build_registry_v2([])
+    resolved, reason = resolve_target(reg, None)
+    assert resolved is None
+    assert "required" in reason
+
+
+def test_empty_string_target_id_blocked(build_registry_v2):
+    reg = build_registry_v2([])
+    resolved, reason = resolve_target(reg, "")
+    assert resolved is None
+    assert "required" in reason
+
+
+def test_disabled_target_blocked(make_workspace, build_registry_v2, target_entry):
+    ws = make_workspace()["path"]
+    reg = build_registry_v2([target_entry(ws, target_id="t", enabled=False)])
+    resolved, reason = resolve_target(reg, "t")
+    assert resolved is None
+    assert "disabled" in reason
+
+
+def test_missing_dopemux_blocked(make_workspace, build_registry_v2, target_entry):
+    ws = make_workspace(with_dopemux=False)["path"]
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t")], approved_roots=[str(ws.parent)]
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert resolved is None
+    assert reason
+
+
+def test_identity_project_mismatch_blocked(make_workspace, build_registry_v2, target_entry):
+    ws = make_workspace(project="actual")["path"]
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t", identity_project="expected")],
+        approved_roots=[str(ws.parent)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert resolved is None
+    assert "identity" in reason
+
+
+def test_identity_owner_mismatch_blocked_when_declared(make_workspace, build_registry_v2, target_entry):
+    ws = make_workspace(project="proj", owner="real")["path"]
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t", identity_project="proj", identity_owner="wrong")],
+        approved_roots=[str(ws.parent)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert resolved is None
+    assert "identity" in reason
+
+
+def test_owner_check_skipped_when_not_declared(make_workspace, build_registry_v2, target_entry):
+    # workspace has owner=someone, but registry declares no identity.owner -> matched on project alone
+    ws = make_workspace(project="proj", owner="someone")["path"]
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t", identity_project="proj", identity_owner=None)],
+        approved_roots=[str(ws.parent)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert reason is None
+    assert resolved is not None
+
+
+def test_escapes_approved_roots_blocked(make_workspace, build_registry_v2, target_entry):
+    ws = make_workspace()["path"]
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t")],
+        approved_roots=["/some/unrelated/root"],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert resolved is None
+    assert "approved roots" in reason
+
+
+def test_symlink_workspace_escape_blocked(make_workspace, build_registry_v2, target_entry, tmp_path):
+    ws = make_workspace()["path"]
+    approved = tmp_path / "approved"
+    approved.mkdir()
+    link = approved / "linked_ws"
+    os.symlink(ws, link)
+    reg = build_registry_v2(
+        [target_entry(link, target_id="t")],
+        approved_roots=[str(approved)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert resolved is None
+    assert "approved roots" in reason
+
+
+def test_missing_git_metadata_blocked(tmp_path, build_registry_v2, target_entry):
+    # Eligible workspace (passes .dopemux + validate_workspace via a
+    # pyproject.toml marker) but with NO .git file or directory at all.
+    ws = tmp_path / "no-git"
+    ws.mkdir()
+    (ws / ".dopemux").mkdir()
+    (ws / "pyproject.toml").write_text("", encoding="utf-8")
+    (ws / ".repo_id").write_text("project=proj\n", encoding="utf-8")
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t", identity_project="proj", identity_owner=None)],
+        approved_roots=[str(tmp_path)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert resolved is None
+    assert reason
+
+
+def test_dopemux_present_but_workspace_validation_fails_blocked(
+    tmp_path, build_registry_v2, target_entry
+):
+    # .dopemux/ present (the FIRST half of the eligibility gate passes) but
+    # no .git and no project marker at all -> validate_workspace() itself
+    # returns False (the SECOND half of the eligibility gate). Distinct from
+    # test_missing_git_metadata_blocked, which passes eligibility via a
+    # pyproject.toml marker and instead exercises the later .git-derivation
+    # failure.
+    ws = tmp_path / "no-markers"
+    ws.mkdir()
+    (ws / ".dopemux").mkdir()
+    (ws / ".repo_id").write_text("project=proj\n", encoding="utf-8")
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t", identity_project="proj", identity_owner=None)],
+        approved_roots=[str(tmp_path)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert resolved is None
+    assert reason
+
+
+# ---------------------------------------------------------------------------
+# Positive: primary checkout (.git is a directory; project_root == worktree_root)
+# ---------------------------------------------------------------------------
+
+
+def test_primary_checkout_resolves(make_workspace, build_registry_v2, target_entry):
+    info = make_workspace(project="proj", owner="tester")
+    ws = info["path"]
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t", identity_project="proj", identity_owner="tester")],
+        approved_roots=[str(ws.parent)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert reason is None
+    assert resolved is not None
+    assert resolved.target.target_id == "t"
+    assert resolved.workspace == ws.resolve()
+    assert resolved.project_root == ws.resolve()
+    assert resolved.worktree_root == ws.resolve()
+
+
+def test_primary_checkout_git_is_a_directory(make_workspace):
+    ws = make_workspace()["path"]
+    assert (ws / ".git").is_dir()
+
+
+def test_resolved_target_binds_service_policies(make_workspace, build_registry_v2, target_entry):
+    ws = make_workspace(project="proj", owner="tester")["path"]
+    reg = build_registry_v2(
+        [
+            target_entry(
+                ws,
+                target_id="t",
+                identity_project="proj",
+                identity_owner="tester",
+                service_policies={"conport": {"enabled": True}, "pal": {"enabled": False}},
+            )
+        ],
+        approved_roots=[str(ws.parent)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert reason is None
+    assert set(resolved.service_policies) == {"conport", "pal"}
+    assert resolved.service_policies["conport"].configured is True
+    assert resolved.service_policies["pal"].configured is False
+
+
+# ---------------------------------------------------------------------------
+# Positive: linked worktree (.git is a gitfile; project_root != worktree_root)
+# ---------------------------------------------------------------------------
+
+
+def test_linked_worktree_git_is_a_file(make_linked_worktree):
+    info = make_linked_worktree(project="proj", owner="tester")
+    assert (info["worktree"] / ".git").is_file()
+
+
+def test_linked_worktree_resolves_with_split_roots(
+    make_linked_worktree, build_registry_v2, target_entry
+):
+    info = make_linked_worktree(project="proj", owner="tester")
+    wt = info["worktree"]
+    primary = info["primary"]
+    reg = build_registry_v2(
+        [target_entry(wt, target_id="t", identity_project="proj", identity_owner="tester")],
+        approved_roots=[str(wt.parent), str(primary.parent)],
+    )
+    resolved, reason = resolve_target(reg, "t")
+    assert reason is None
+    assert resolved is not None
+    assert resolved.workspace == wt.resolve()
+    assert resolved.worktree_root == wt.resolve()
+    assert resolved.project_root == primary.resolve()
+    assert resolved.project_root != resolved.worktree_root
+
+
+# ---------------------------------------------------------------------------
+# Block-reason opacity (no absolute paths / ports / URLs leaked)
+# ---------------------------------------------------------------------------
+
+
+def test_block_reasons_never_leak_absolute_paths_ports_or_urls(
+    make_workspace, build_registry_v2, target_entry
+):
+    ws = make_workspace()["path"]
+    reasons = []
+
+    reg = build_registry_v2([])
+    _, r = resolve_target(reg, "ghost")
+    reasons.append(r)
+
+    reg = build_registry_v2([target_entry(ws, target_id="t", enabled=False)])
+    _, r = resolve_target(reg, "t")
+    reasons.append(r)
+
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t")], approved_roots=["/some/unrelated/root"]
+    )
+    _, r = resolve_target(reg, "t")
+    reasons.append(r)
+
+    reg = build_registry_v2(
+        [target_entry(ws, target_id="t", identity_project="expected")],
+        approved_roots=[str(ws.parent)],
+    )
+    _, r = resolve_target(reg, "t")
+    reasons.append(r)
+
+    for reason in reasons:
+        assert reason is not None
+        assert str(ws) not in reason
+        assert str(ws.resolve()) not in reason
+        assert "http://" not in reason
+        assert "https://" not in reason
+
+
+# ---------------------------------------------------------------------------
+# Purity — no network/socket/subprocess/docker primitives in resolver_core.py
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_core_module_has_no_forbidden_primitives():
+    # Mirrors the commit-verify purity grep (see COMMAND_LOG.md); "docker" is
+    # intentionally excluded here because "docker_mcp_gateway" is an
+    # ADR-DCP-MCP-RO-0009-mandated service-family string literal in
+    # registry_v2.py, not a container-inspection call — resolver_core.py
+    # itself never references that literal at all.
+    src_path = (
+        Path(__file__).resolve().parents[1] / "src" / "dcp_facade" / "resolver_core.py"
+    )
+    text = src_path.read_text(encoding="utf-8")
+    for token in (
+        "subprocess",
+        "socket.",
+        "requests.",
+        "httpx.",
+        "urllib",
+        "os.system",
+        "shell=True",
+    ):
+        assert token not in text, f"forbidden primitive {token!r} found in resolver_core.py"
+    assert "docker" not in text, "unexpected 'docker' token in resolver_core.py"

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.json
@@ -1,0 +1,167 @@
+{
+  "id": "TP-DCP-MCP-RO-0010",
+  "project": "dopemux-mvp",
+  "target": "Implement exposure-target registry v2 parsing and a pure, deterministic filesystem/repository identity resolver core for the DCP read-only facade. Parse registry v2, validate approved roots, resolve workspace realpaths, validate init/identity markers, derive project and worktree roots, bind per-service-family policies, expose the opaque target_id as the only caller handle, and report configured capability separately from live capability. All behavior is deterministic and testable without running any backend service, socket, container, or network call.",
+  "invariants": [
+    "target_id is the ONLY caller-facing handle; no caller-supplied path, URL, host, port, backend route, workspace_id, instance id, lease id, or runtime selector is ever accepted.",
+    "The exposure registry is read-only to the facade; this packet performs no writes to it and no writes to any backend.",
+    "Eligibility is not exposure: only targets with enabled:true resolve; unknown or disabled targets fail closed with a block reason (never a path or partial result).",
+    "The bare family name 'task-orchestrator' is FORBIDDEN in registry v2; the allowed service families are exactly: conport, dope_memory, to_compose_rest, to_mcp_wrapper, dope_context, serena, pal, docker_mcp_gateway, desktop_commander.",
+    "Default worktree binding mode is PRIMARY_CHECKOUT_ONLY; the resolver binds to exactly one operator-approved workspace and NEVER enumerates, scans, or auto-selects sibling/newest/most-recent worktrees.",
+    "workspace_path is canonicalized (realpath, symlink-followed) BEFORE the approved-roots containment check; escape from all approved roots fails closed.",
+    "Identity is enforced against the workspace .repo_id: project must equal the target's identity.project (required); owner must equal identity.owner ONLY when the registry declares it.",
+    "project_root and worktree_root are derived deterministically from local .git metadata (dir vs gitfile) without invoking a network or backend service.",
+    "Configured capability (family present + policy-enabled in the registry) is reported SEPARATELY from live capability; configured/declared NEVER implies discovered, live, or callable. Live capability is reported as UNKNOWN in this packet.",
+    "Registry load itself fails closed: a malformed target entry is dropped (recorded in warnings) rather than exposed loosely; enabled defaults to false.",
+    "OUT OF SCOPE: runtime instance registry join, canonical MCP catalog join, candidate discovery, Docker/container inspection, port leases, TCP probes, MCP initialize/REST fingerprints, ownership adjudication, backend calls, tunnel, and authentication.",
+    "OUT OF SCOPE: determining whether any runtime is live, owned, or reachable.",
+    "STOP IF: correct resolution would require a live service call, socket, container inspection, or network I/O.",
+    "STOP IF: a determinism/testability requirement cannot be met using only local filesystem + git metadata reads.",
+    "STOP IF: any change would weaken an existing facade denylist or read-only boundary.",
+    "STOP IF: the embedded auditor returns FAIL or NEEDS_SUPERVISOR.",
+    "FORBIDDEN FILE: src/**",
+    "FORBIDDEN FILE: services/** outside services/dcp-readonly-facade/**",
+    "FORBIDDEN FILE: docker/**",
+    "FORBIDDEN FILE: .env*",
+    "FORBIDDEN FILE: .dopemux/**"
+  ],
+  "depends_on": [
+    "TP-DCP-MCP-RO-0009"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".repo_id",
+    "origin_hint": "github.com/DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DCP-MCP-RO",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DCP-MCP-RO-0009",
+    "final_packet": false
+  },
+  "commit": {
+    "message": "feat(dcp): registry v2 parsing and pure resolver core",
+    "allowlist": [
+      "services/dcp-readonly-facade/**",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/**",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.md",
+      "proof/TP-DCP-MCP-RO-0010/**"
+    ],
+    "verify": [
+      "python -m pytest -q services/dcp-readonly-facade/tests",
+      "python -m compileall -q services/dcp-readonly-facade",
+      "rg -n \"write_text|open\\(.*['\\\"]w|mkdir|unlink|remove|rmtree|PUT|PATCH|DELETE|requests\\.|httpx\\.|socket\\.|subprocess|os.system|shell=True\" services/dcp-readonly-facade/src/dcp_facade/registry_v2.py services/dcp-readonly-facade/src/dcp_facade/resolver_core.py || true",
+      "rg -n \"OPENAI_API_KEY|ANTHROPIC_API_KEY|GEMINI_API_KEY|sk-|Bearer |TOKEN=|PASSWORD=|SECRET=\" services/dcp-readonly-facade docs/03-reference/dcp/chatgpt-mcp-readonly || true",
+      "git diff --stat",
+      "git status --short --branch"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): registry v2 + pure resolver core (target_id, worktree scope, service-family policy)",
+    "body": "Implements TP-DCP-MCP-RO-0010: exposure-target registry v2 parsing and a pure deterministic resolver core for the DCP read-only facade, per ADR-DCP-MCP-RO-0009.\n\nRequired PR sections: Objective, Scope, Evidence, Validation, Embedded audit, Risks and unknowns, Rollback, Proof bundle links.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Author registry v2 loader/parser (services/dcp-readonly-facade/src/dcp_facade/registry_v2.py). Parse the exposure-target registry v2 into an ExposureTarget model (target_id, workspace_path, enabled, binding_mode default PRIMARY_CHECKOUT_ONLY, identity{project, owner?}, service_policies{family->policy}). Enforce the 9-family allowlist and reject the bare 'task-orchestrator' name. Fail-closed parsing: malformed entries dropped into warnings; enabled defaults false. Carry a registry generation id. Provide v1->v2 migration: accept a v1 project_id document with an explicit deprecation warning mapping project_id->target_id, OR reject with actionable guidance (choose the fail-closed option and document it).",
+      "requirements": [
+        "ExposureTarget + RegistryV2 dataclasses (frozen where practical).",
+        "Service-family allowlist enforced; bare 'task-orchestrator' rejected with a warning.",
+        "Fail-closed parse with warnings list; enabled defaults false; duplicate target_id dropped.",
+        "Deterministic registry generation id derived from content (no timestamps/randomness).",
+        "Documented v1->v2 migration behavior."
+      ],
+      "expected_files": [
+        "services/dcp-readonly-facade/src/dcp_facade/registry_v2.py",
+        "services/dcp-readonly-facade/schema/registry_v2.schema.json"
+      ],
+      "context_files": [
+        "docs/90-adr/adr-dcp-mcp-ro-0009-chatgpt-mcp-exposure-targets-runtime-resolution-ownership-evidence.md",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md",
+        "services/dcp-readonly-facade/src/dcp_facade/registry.py",
+        "services/dcp-readonly-facade/registry.example.yaml"
+      ],
+      "validation": [
+        "registry_v2 parses a valid v2 doc into enabled targets and rejects each invalid fixture with a recorded warning.",
+        "Bare 'task-orchestrator' family is rejected; only the 9 ADR families are accepted.",
+        "No network/socket/subprocess/file-write primitives appear in registry_v2.py."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Author the pure resolver core (services/dcp-readonly-facade/src/dcp_facade/resolver_core.py). Resolve target_id -> ResolvedTarget via: lookup -> enabled -> realpath -> approved-roots containment -> eligibility (.dopemux present + validate_workspace) -> identity (.repo_id project + conditional owner) -> derive project_root and worktree_root from local .git metadata (.git dir = primary checkout so project_root == worktree_root; .git gitfile = linked worktree, parse gitdir/commondir to derive the repository/project root) -> bind per-family service policies from a static ADR policy table (resolution_class + chatgpt_posture + port_policy) -> return ResolvedTarget. Every failure returns a block reason string, never a path or partial result. Reuse dopemux.workspace_detection.validate_workspace when importable with a conservative fallback (as in resolver.py).",
+      "requirements": [
+        "Deterministic; no network/socket/container/backend calls.",
+        "project_root vs worktree_root derivation from .git dir/gitfile with fixtures for both.",
+        "Static family policy table encoding the ADR resolution classes and ChatGPT postures.",
+        "Block reasons are opaque (no leaked absolute paths/ports/urls in the reason strings returned to callers)."
+      ],
+      "expected_files": [
+        "services/dcp-readonly-facade/src/dcp_facade/resolver_core.py",
+        "services/dcp-readonly-facade/src/dcp_facade/capability.py"
+      ],
+      "context_files": [
+        "services/dcp-readonly-facade/src/dcp_facade/resolver.py",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/MULTI_PROJECT_REGISTRY_CONTRACT.md"
+      ],
+      "validation": [
+        "Resolver returns ResolvedTarget for a valid enabled target and a block reason for each negative case (unknown, disabled, escape-root, missing .dopemux, identity mismatch).",
+        "project_root and worktree_root are correct for both a primary checkout and a linked worktree fixture.",
+        "Configured capability is reported separately from live capability (live == UNKNOWN in this packet)."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Add fixtures and contract tests (TDD). Provide valid and invalid registry v2 fixtures (bare task-orchestrator family, unknown family, missing identity, disabled target, root escape, duplicate target_id, v1 project_id doc) and JSON-Schema contract tests plus resolver unit tests covering primary-checkout and linked-worktree derivation. Update the example registry to v2 and document v1->v2 migration in the contract docs.",
+      "requirements": [
+        "JSON Schema contract tests (valid accepted, each invalid rejected).",
+        "Resolver unit tests for all positive/negative branches including worktree derivation.",
+        "registry.example.yaml updated to v2 (no secrets, no real paths).",
+        "Migration + registry v2 contract documented under docs/03-reference/dcp/chatgpt-mcp-readonly/."
+      ],
+      "expected_files": [
+        "services/dcp-readonly-facade/tests/test_registry_v2.py",
+        "services/dcp-readonly-facade/tests/test_resolver_core.py",
+        "services/dcp-readonly-facade/tests/fixtures/registry_v2/",
+        "services/dcp-readonly-facade/registry.example.yaml",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/REGISTRY_V2_CONTRACT.md"
+      ],
+      "context_files": [
+        "services/dcp-readonly-facade/tests/test_registry.py",
+        "services/dcp-readonly-facade/tests/test_resolver.py"
+      ],
+      "validation": [
+        "Full facade test suite passes (python -m pytest -q services/dcp-readonly-facade/tests).",
+        "Every invalid fixture is rejected with a recorded reason; the valid fixture resolves.",
+        "No files outside commit.allowlist are modified."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Run packet validation commands, inspect the diff, and produce the proof bundle under proof/TP-DCP-MCP-RO-0010/ (PROOF.json, COMMAND_LOG.md, AUDIT.md) recording true executor provenance (Opus-orchestrated Claude Code Sonnet subagent) and the embedded audit verdict.",
+      "requirements": [
+        "PROOF.json with validations, exit codes, and executor provenance.",
+        "COMMAND_LOG.md with command outputs.",
+        "AUDIT.md with embedded audit verdict (PASS or PASS_WITH_RISKS, non-blocking risks).",
+        "Full diff and diff stat."
+      ],
+      "validation": [
+        "Proof bundle present with command outputs and exit codes.",
+        "Embedded audit verdict recorded; no runtime/backend/network code introduced.",
+        "Determinism confirmed: tests pass without any backend service running."
+      ]
+    }
+  ]
+}

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.md
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0010.md
@@ -1,0 +1,21 @@
+---
+id: TP-DCP-MCP-RO-0010
+title: Exposure Target Registry V2 And Pure Resolver Core
+type: explanation
+owner: '@hu3mann'
+author: '@hu3mann'
+date: '2026-07-09'
+last_review: '2026-07-09'
+next_review: '2026-10-07'
+prelude: Implement exposure-target registry v2 parsing and a pure deterministic filesystem/repository identity resolver core for the DCP read-only facade.
+---
+
+# TP-DCP-MCP-RO-0010 — Exposure Target Registry V2 And Pure Resolver Core
+
+Objective: Implement pure target loading and filesystem/repository identity resolution for the DCP read-only facade per `ADR-DCP-MCP-RO-0009`.
+
+Scope: parse registry v2, validate approved roots, resolve workspace realpaths, validate init/identity markers, derive project and worktree roots, bind per-service-family policies, expose the opaque `target_id` as the only caller handle, and report configured capability separately from live capability.
+
+Out of scope: runtime instance registry join, canonical MCP catalog join, candidate discovery, Docker inspection, port leases, TCP/MCP/REST probes, ownership adjudication, backend calls, tunnel, and authentication. All behavior is deterministic and testable without any running service.
+
+See the JSON load packet for validation commands, invariants, and step detail.


### PR DESCRIPTION
Implements **TP-DCP-MCP-RO-0010** (DCP read-only MCP facade Phase 2), the pure resolver layer of ADR-DCP-MCP-RO-0009. Depends on #1033 (0009 contract, merged).

## Objective
Evolve the v1 project-keyed facade registry into the ADR-0009 opaque-`target_id` contract and add a **pure, deterministic** filesystem/repository identity resolver — no runtime, network, socket, subprocess, Docker, or backend calls.

## Scope
- `registry_v2.py` — `ExposureTarget`/`ServicePolicy`/`RegistryV2`; the exact **9 ADR service families** (bare `task-orchestrator` forbidden); static `FAMILY_POLICY_TABLE` (resolution_class, chatgpt_posture); fail-closed parse; deterministic content-hash `generation`; v1→v2 migration **fails closed** (never coerces).
- `resolver_core.py` — `resolve_target()` gate flow (lookup→enabled→realpath→approved-roots containment→eligibility→identity→derive roots→bind policies); `project_root`/`worktree_root` derived from local `.git` (dir vs gitfile + `commondir`) with **no `git` subprocess**; opaque block reasons (no path/port/url leak).
- `capability.py` — reports **configured** separately from **live** (`"UNKNOWN"`) / **callable** (`false`); configured never implies callable.
- `schema/registry_v2.schema.json` (draft-07, facade-local), 7 fixtures, 54 new tests, v2 example, `REGISTRY_V2_CONTRACT.md`.

Out of scope (0011/0012): runtime registry join, catalog join, candidate discovery, ports/leases, TCP/MCP probes, ownership adjudication, live capability, tunnel, auth.

## Evidence
- v1 `registry.py`/`resolver.py` left intact (evolved alongside).
- **Real-world verification:** `_derive_roots` run on *this actual linked worktree* → `project_root=/Users/hue/code/dopemux-mvp`, `worktree_root=workspace` (correct against genuine `.git` metadata, not just fixtures).

## Validation (PASS / FAIL / NOT_RUN)
- **PASS** — `pytest services/dcp-readonly-facade/tests` → 187 passed, 1 pre-existing skip; `compileall` clean; JSON-Schema self-check ok; purity scan of new modules clean; **zero secrets** in new files; duplicate-target-id fixture resolves to `[]` (fail-closed).
- **FAIL** — none.
- **NOT_RUN** — PAL external codereview (both providers down: OpenAI 401 / Google 429) → mitigated by independent Opus audit + `advisor()` second opinion; live Gate-0C runtime exemplar (out of scope for 0010).

## Embedded audit
Independent Opus audit: **PASS_WITH_RISKS** (`proof/TP-DCP-MCP-RO-0010/AUDIT.md`). Post-implementation hardenings applied: (1) **duplicate `target_id` now fails closed** — ambiguity blocks per ADR (drop first entry + poison id); (2) stray v1 `projects` key alongside `targets` now warns; (3) discard `validate_workspace` raw error (no abs-path leak). Implemented by a Claude Sonnet subagent, audited independently by Opus (implementer ≠ auditor).

## Risks and unknowns
- `project_root` trust is defense-in-depth **deferred to 0011/0012** — the runtime join must re-validate per-service identity and must not treat a crafted `.git` gitfile as ownership authority.
- Submodule / symlinked-`.git` derivation is **reasoned** (fail-closed), not live-tested.

## Rollback
`git reset --hard 1893cffb677a3e06bfd64dd61159ee2bda15fdfc` (base main; nothing merged).

## Proof bundle
`proof/TP-DCP-MCP-RO-0010/` → `PROOF.json`, `AUDIT.md`, `COMMAND_LOG.md`.
