### PR TITLE
feat(dcp): add read-only runtime catalog join

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
@@ -24,7 +24,9 @@ prelude: Packet roadmap and dependency chain for the read-only MCP evidence faca
 | TP-DCP-MCP-RO-0006 | Dope Context And Task Orchestrator Read Adapters | HIGH | Add dope-context + task-orchestrator read adapters; deny `search_all`/index/sync/transition/PM/bridge. | 0005 |
 | TP-DCP-MCP-RO-0007 | Secure MCP Tunnel Integration Docs And Manual Validation | MEDIUM | Document loopback tunnel setup, redacted configs, manual validation, ChatGPT connector flow. | 0006 |
 | TP-DCP-MCP-RO-0008 | Hardening Cross Project Isolation And PR Readiness | HIGH | Cross-project isolation, injection/redaction, stale-proof, denylist regression, PR readiness. | 0007 |
-| TP-DCP-MCP-RO-0009 | ChatGPT MCP Exposure Target Contract ADR | HIGH | Record accepted `target_id`, runtime-resolution, ownership-evidence, and response-redaction contract; runtime implementation remains blocked until the target base contains the MCP runtime stack through PR #1031. | 0008 |
+| TP-DCP-MCP-RO-0009 | ChatGPT MCP Exposure Target Contract ADR | HIGH | Record accepted `target_id`, runtime-resolution, ownership-evidence, and response-redaction contract. **Done** — runtime follow-on work is now enabled by the landed MCP runtime stack. | 0008 |
+| TP-DCP-MCP-RO-0010 | Exposure Target Registry V2 And Pure Resolver Core | HIGH | Parse opaque target consent and resolve filesystem/repository identity without live I/O. **Done** — pure registry v2, resolver core, and capability separation landed. | 0009 |
+| TP-DCP-MCP-RO-0011 | Read-Only Runtime Registry And Catalog Join | HIGH | Join resolved targets with operational catalog/runtime evidence using exact scope checks; remain non-callable and fail closed. | 0010 |
 
 ## Sequencing rationale
 
@@ -35,6 +37,8 @@ The series is deliberately **docs-first → identity → local-only scaffold →
 3. **0005–0006** add service-backed reads one trust-tier at a time (structured memory first, then search + workflow), each with denylist tests.
 4. **0007** documents the tunnel without committing secrets.
 5. **0008** is the acceptance/hardening slice — no new features, only isolation, injection, redaction, and stale-proof regression tests.
-6. **0009** is the post-hardening contract ADR slice. It supersedes caller-facing `project_id` language for new exposure contracts with opaque `target_id` language, but does not change runtime code until the MCP runtime stack is current on the implementation base.
+6. **0009** is the post-hardening contract ADR slice. It supersedes caller-facing `project_id` language for new exposure contracts with opaque `target_id` language.
+7. **0010** implements consent parsing and local identity resolution only; it deliberately does not inspect runtime state or make service calls.
+8. **0011** consumes runtime/catalog records as operational evidence only. Live protocol verification, ownership adjudication, and backend adapter authorization remain later gates.
 
 Each packet emits a proof bundle under `proof/TP-DCP-MCP-RO-<n>/` (`PROOF.json`, `COMMAND_LOG.md`, `AUDIT.md`) per AGENTS.md §9.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/DECISIONS.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/DECISIONS.md
@@ -46,6 +46,11 @@ Accepted in ADR-DCP-MCP-RO-0009. New ChatGPT exposure contracts use an opaque `t
 - *Rejected alternative:* keep public `project_id` / static backend binding as the remote exposure identity. Rejected: it blurs consent with backend/runtime identity and cannot safely distinguish primary checkouts, sibling worktrees, reserved singletons, and stale or wrong-project listeners.
 - *Implementation note:* Existing facade docs and code may still contain earlier `project_id` terminology. `TP-DCP-MCP-RO-0009` records the accepted contract; runtime/API migration remains a separate implementation slice.
 
+### D8 — Runtime registry and catalog are operational evidence, never consent
+TP-DCP-MCP-RO-0011 joins an already-resolved exposure target to the canonical MCP catalog and operational runtime registry through explicit service-family mappings and exact project/worktree scope checks. A matching record can produce internal candidate state only; it cannot make a family live, owned, or callable.
+- *Rejected alternative:* treat a catalog declaration, listening port, runtime instance, or lease as exposure authorization. Rejected: those surfaces are operational state and can be stale, ambiguous, or bound to another project.
+- *Implementation note:* `to_mcp_wrapper` and `to_compose_rest` remain blocked. Live protocol fingerprints, ownership evidence, mount/data scope, and adapter calls are later gates.
+
 ## Open Items Carried Forward
 
 - `UNKNOWN` (inventory `unresolved_questions`): *"Should dope-memory be queried directly, or should all chronicle reads be multiplexed through a facade wrapper to normalize output for ChatGPT?"* — to be resolved in 0005.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_CATALOG_JOIN_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_CATALOG_JOIN_CONTRACT.md
@@ -1,0 +1,60 @@
+---
+id: dcp-mcp-readonly-runtime-catalog-join-contract
+title: DCP Read-Only MCP Facade - Runtime Registry And Catalog Join Contract
+type: reference
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-11'
+last_review: '2026-07-11'
+next_review: '2026-10-09'
+prelude: Internal, read-only join contract for operational MCP catalog and runtime evidence after target identity resolution.
+---
+
+# Runtime Registry And Catalog Join Contract
+
+Status: implemented in TP-DCP-MCP-RO-0011 as a pure facade-local join. This contract is intentionally narrower than live runtime authorization.
+
+## Authority boundary
+
+The exposure policy registry is the consent authority. TP-0010 resolves its `target_id` to a validated `ResolvedTarget`. The canonical MCP catalog describes operational service names and static management semantics. The runtime registry records operational instances. The latter two inputs are advisory evidence only and are read-only to this facade.
+
+The join never starts, stops, repairs, adopts, reconciles, probes, or calls a service. A joined candidate remains `callable: false` until later gates independently verify liveness, protocol identity, ownership, project identity, worktree/data scope, freshness, read-only route policy, and redaction.
+
+## Explicit family mapping
+
+The facade accepts only the nine ADR family names from registry v2. The join uses this fixed translation:
+
+| Facade family | Catalog name | TP-0011 posture |
+| --- | --- | --- |
+| `conport` | `conport` | Candidate join allowed; still non-callable |
+| `dope_memory` | `dope-memory` | Candidate join allowed; still non-callable |
+| `to_compose_rest` | none | Blocked; route isolation is not proven |
+| `to_mcp_wrapper` | `task-orchestrator` | Blocked; reserved singleton and write-capable |
+| `dope_context` | `dope-context` | Blocked until read bridge |
+| `serena` | `serena` | Blocked until inventory |
+| `pal` | `pal` | Blocked |
+| `docker_mcp_gateway` | `MCP_DOCKER` | Blocked |
+| `desktop_commander` | `desktop-commander` | Blocked |
+
+No hyphen/underscore normalization or caller-supplied operational name is accepted. The bare `task-orchestrator` name remains forbidden as a facade policy family.
+
+## Candidate matching
+
+For `conport` and `dope_memory`, a runtime record is a candidate only when all of these match exactly after local path canonicalization:
+
+1. Runtime `service` equals the explicit catalog name.
+2. Runtime `project_id` equals the resolved exposure identity project.
+3. Runtime `project_root` equals the resolved project root.
+4. Runtime `worktree_root` equals the resolved worktree root.
+
+Project name, worktree hash, port, container name, compose name, URL, or lease alone never matches a candidate. One candidate produces internal state `UNKNOWN` because liveness and ownership are not proven. Zero candidates produce `UNAVAILABLE`. Multiple candidates produce `BLOCKED` and no candidate is selected.
+
+Missing or malformed catalog/runtime input produces `UNKNOWN`. Catalog policy drift produces `BLOCKED`. Disabled or blocked exposure policy produces `BLOCKED`.
+
+## Public redaction
+
+The public result contains only the facade family, capability state, an opaque reason, and `callable: false`. It does not contain paths, ports, URLs, hostnames, container names or IDs, runtime instance IDs, lease IDs, raw runtime records, or backend workspace IDs.
+
+## Out of scope
+
+TP-0011 does not implement live TCP/MCP/REST verification, Docker or mount inspection, ownership evidence tiers, freshness checks, caching, resolution receipts, adapter rewiring, tunnel/authentication, or remote ChatGPT exposure.

--- a/proof/TP-DCP-MCP-RO-0011/AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0011/AUDIT.md
@@ -9,8 +9,10 @@ blocks ambiguity, and serializes no operational infrastructure fields.
 
 The external Gemini codereview completed its inspection phase with zero reported
 issues. Its final provider call was unavailable because the configured Gemini
-quota returned HTTP 429 / `RESOURCE_EXHAUSTED`. A local review of the complete
-changed module, tests, schema, packet, and contract found no additional issue.
+quota returned HTTP 429 / `RESOURCE_EXHAUSTED`. Follow-up GitHub review found a
+mutable internal `callable` constructor input and a public-contract wording
+mismatch; both were corrected and covered by focused tests. The local review
+also corrected the proof rollback instruction and duplicate risk wording.
 
 Accepted risks and unknowns:
 

--- a/proof/TP-DCP-MCP-RO-0011/AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0011/AUDIT.md
@@ -6,6 +6,8 @@ The implementation is a pure, facade-local join. It accepts already-loaded
 catalog/runtime mappings, uses explicit service-family translation, requires
 exact project/worktree identity for the two conditionally readable families,
 blocks ambiguity, and serializes no operational infrastructure fields.
+Any non-mapping member in the runtime instance list invalidates the complete
+operational input rather than being silently discarded.
 
 The external Gemini codereview completed its inspection phase with zero reported
 issues. Its final provider call was unavailable because the configured Gemini

--- a/proof/TP-DCP-MCP-RO-0011/AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0011/AUDIT.md
@@ -1,0 +1,23 @@
+# TP-DCP-MCP-RO-0011 Audit
+
+Verdict: `PASS_WITH_RISKS`
+
+The implementation is a pure, facade-local join. It accepts already-loaded
+catalog/runtime mappings, uses explicit service-family translation, requires
+exact project/worktree identity for the two conditionally readable families,
+blocks ambiguity, and serializes no operational infrastructure fields.
+
+The external Gemini codereview completed its inspection phase with zero reported
+issues. Its final provider call was unavailable because the configured Gemini
+quota returned HTTP 429 / `RESOURCE_EXHAUSTED`. A local review of the complete
+changed module, tests, schema, packet, and contract found no additional issue.
+
+Accepted risks and unknowns:
+
+- No live protocol, ownership, mount/data scope, freshness, or backend evidence
+  is evaluated; these are later gates.
+- `to_mcp_wrapper` and `to_compose_rest` remain blocked.
+- Existing v1 facade tools still use `project_id` and are intentionally not
+  rewired by this packet.
+- The schema change aligns two fields already present in the restored canonical
+  catalog; it does not change catalog values or runtime behavior.

--- a/proof/TP-DCP-MCP-RO-0011/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0011/AUDITOR_REPORT.md
@@ -1,0 +1,25 @@
+# TP-DCP-MCP-RO-0011 Auditor Report
+
+## Review result
+
+`PASS_WITH_RISKS` for local acceptance. No blocking, high, medium, or low
+findings were identified during the available review.
+
+## External review evidence
+
+- Provider: Gemini `gemini-3.1-pro-preview`
+- Step 1: completed inspection checkpoint; reported `issues_found: 0`.
+- Step 2: provider call returned `429 RESOURCE_EXHAUSTED` because the configured
+  quota for the model is zero.
+- Mitigation: local review of all changed source, tests, schema, packet, and
+  contract files plus the complete targeted validation suite.
+
+## Reviewed invariants
+
+- Explicit facade-family to catalog-name mapping only.
+- Exact canonical project-root and worktree-root matching.
+- Ambiguous candidate sets block without selection.
+- Missing/malformed operational data remains `UNKNOWN`.
+- Blocked Task Orchestrator families never become callable.
+- Public serialization omits paths, ports, URLs, containers, instance IDs,
+  lease IDs, and raw runtime records.

--- a/proof/TP-DCP-MCP-RO-0011/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0011/AUDITOR_REPORT.md
@@ -22,6 +22,7 @@ mismatch; no unresolved blocking finding remains.
 - Exact canonical project-root and worktree-root matching.
 - Ambiguous candidate sets block without selection.
 - Missing/malformed operational data remains `UNKNOWN`.
+- Any non-mapping runtime instance invalidates the complete runtime input.
 - Blocked Task Orchestrator families never become callable.
 - Public serialization omits paths, ports, URLs, containers, instance IDs,
   lease IDs, and raw runtime records.

--- a/proof/TP-DCP-MCP-RO-0011/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0011/AUDITOR_REPORT.md
@@ -2,8 +2,10 @@
 
 ## Review result
 
-`PASS_WITH_RISKS` for local acceptance. No blocking, high, medium, or low
-findings were identified during the available review.
+`PASS_WITH_RISKS` for local acceptance. The original available review reported
+no blocking, high, medium, or low findings. Follow-up GitHub review identified
+and resolved a non-callable-state hardening issue and a public-contract wording
+mismatch; no unresolved blocking finding remains.
 
 ## External review evidence
 

--- a/proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md
@@ -14,7 +14,7 @@ Pull request: https://github.com/DDD-Enterprises/dopemux-mvp/pull/1041
 
 ```text
 pytest -q services/dcp-readonly-facade/tests/test_runtime_catalog_join.py
-10 passed
+11 passed
 
 pytest -q services/dcp-readonly-facade/tests
 PASS; 1 live optional test skipped

--- a/proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md
@@ -1,0 +1,55 @@
+# TP-DCP-MCP-RO-0011 Command Log
+
+Worktree: `/Users/hue/.codex/worktrees/6b98/dopemux-mvp`
+
+Branch: `codex/dcp-mcp-ro-0011-runtime-catalog-join`
+
+Base: `origin/main` at `b176747b339685e781de04268c46b7ae123abfbf`
+
+Implementation commit: `485c87444f90235853f5e1b52c64c1ed852bdd1a`
+
+## PASS
+
+```text
+pytest -q services/dcp-readonly-facade/tests
+207 passed, 1 skipped
+
+pytest -q tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_runtime_registry.py
+32 passed
+
+python -m compileall -q services/dcp-readonly-facade
+exit 0
+
+TP packet validation against docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+PASS
+
+fleet-catalog.schema.json Draft7Validator.check_schema
+PASS
+
+purity scan for forbidden network/socket/subprocess imports and calls
+PASS: no forbidden I/O imports/calls
+
+secret scan over changed source/tests/docs/packet files
+PASS: no secret patterns
+
+git diff HEAD^ HEAD --check
+PASS
+
+pre-commit run --files <scoped packet files>
+PASS
+```
+
+## FAIL
+
+None.
+
+## NOT_RUN
+
+```text
+External Gemini codereview final step
+Provider returned 429 RESOURCE_EXHAUSTED; configured quota is zero.
+```
+
+Live protocol, ownership, mount/data scope, freshness, Docker, socket, backend,
+tunnel, and authentication checks were not run because they are explicitly out
+of scope for TP-0011.

--- a/proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md
@@ -13,8 +13,11 @@ Pull request: https://github.com/DDD-Enterprises/dopemux-mvp/pull/1041
 ## PASS
 
 ```text
+pytest -q services/dcp-readonly-facade/tests/test_runtime_catalog_join.py
+10 passed
+
 pytest -q services/dcp-readonly-facade/tests
-207 passed, 1 skipped
+PASS; 1 live optional test skipped
 
 pytest -q tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_runtime_registry.py
 32 passed
@@ -28,13 +31,13 @@ PASS
 fleet-catalog.schema.json Draft7Validator.check_schema
 PASS
 
-purity scan for forbidden network/socket/subprocess imports and calls
+AST purity scan for forbidden network/socket/subprocess imports and calls
 PASS: no forbidden I/O imports/calls
 
 secret scan over changed source/tests/docs/packet files
 PASS: no secret patterns
 
-git diff HEAD^ HEAD --check
+git diff --check
 PASS
 
 pre-commit run --files <scoped packet files>

--- a/proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md
@@ -8,6 +8,8 @@ Base: `origin/main` at `b176747b339685e781de04268c46b7ae123abfbf`
 
 Implementation commit: `485c87444f90235853f5e1b52c64c1ed852bdd1a`
 
+Pull request: https://github.com/DDD-Enterprises/dopemux-mvp/pull/1041
+
 ## PASS
 
 ```text

--- a/proof/TP-DCP-MCP-RO-0011/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0011/PROOF.json
@@ -31,7 +31,7 @@
   ],
   "validation": {
     "PASS": [
-      {"command": "pytest -q services/dcp-readonly-facade/tests/test_runtime_catalog_join.py", "exit_code": 0, "result": "10 passed"},
+      {"command": "pytest -q services/dcp-readonly-facade/tests/test_runtime_catalog_join.py", "exit_code": 0, "result": "11 passed"},
       {"command": "pytest -q services/dcp-readonly-facade/tests", "exit_code": 0, "result": "PASS; 1 live optional test skipped"},
       {"command": "pytest -q tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_runtime_registry.py", "exit_code": 0, "result": "32 passed"},
       {"command": "python -m compileall -q services/dcp-readonly-facade", "exit_code": 0},
@@ -61,7 +61,8 @@
       "Added the two catalog schema fields already present in the restored task-orchestrator catalog entry.",
       "Removed the repository-rejected auxiliary superpowers plan artifact from the packet allowlist.",
       "Made RuntimeCatalogEntry.callable computed and non-overridable so internal and public non-callable state cannot diverge.",
-      "Aligned the packet public-serialization invariant with the redacted public capability shape."
+      "Aligned the packet public-serialization invariant with the redacted public capability shape.",
+      "Treat any non-mapping runtime registry member as malformed input so mixed valid and invalid records fail closed."
     ],
     "remaining_risks": [
       "External Gemini final review verdict unavailable due to provider quota.",

--- a/proof/TP-DCP-MCP-RO-0011/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0011/PROOF.json
@@ -1,0 +1,78 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0011",
+  "title": "Read-Only Runtime Registry And Catalog Join",
+  "branch": "codex/dcp-mcp-ro-0011-runtime-catalog-join",
+  "base_branch": "main",
+  "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
+  "implementation_commit": "485c87444f90235853f5e1b52c64c1ed852bdd1a",
+  "pr_url": null,
+  "scope": "Pure facade-local join of TP-0010 resolved targets with canonical catalog and operational runtime evidence. No live I/O, backend calls, ownership proof, adapter rewiring, or Task Orchestrator exposure.",
+  "runtime_code_changed": true,
+  "backend_code_changed": false,
+  "network_or_socket_code_introduced": false,
+  "executor_provenance": {
+    "implementation": "Codex",
+    "codereview": "Gemini external inspection checkpoint plus local review",
+    "note": "The external Gemini final review call was unavailable because the configured provider quota returned 429 RESOURCE_EXHAUSTED; no clean external verdict is claimed."
+  },
+  "files_changed": [
+    "services/dcp-readonly-facade/src/dcp_facade/runtime_catalog_join.py",
+    "services/dcp-readonly-facade/tests/test_runtime_catalog_join.py",
+    "schemas/mcp/fleet-catalog.schema.json",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_CATALOG_JOIN_CONTRACT.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/DECISIONS.md",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.json",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.md",
+    "proof/TP-DCP-MCP-RO-0011/PROOF.json",
+    "proof/TP-DCP-MCP-RO-0011/AUDIT.md",
+    "proof/TP-DCP-MCP-RO-0011/AUDITOR_REPORT.md",
+    "proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md"
+  ],
+  "validation": {
+    "PASS": [
+      {"command": "pytest -q services/dcp-readonly-facade/tests", "exit_code": 0, "result": "207 passed, 1 skipped (live optional)"},
+      {"command": "pytest -q tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_runtime_registry.py", "exit_code": 0, "result": "32 passed"},
+      {"command": "python -m compileall -q services/dcp-readonly-facade", "exit_code": 0},
+      {"command": "TP packet validation against dopetask-canonical-spec.json", "exit_code": 0},
+      {"command": "fleet-catalog.schema.json Draft7Validator.check_schema", "exit_code": 0},
+      {"command": "purity scan for forbidden I/O imports/calls", "exit_code": 0},
+      {"command": "secret scan over changed files", "exit_code": 0},
+      {"command": "git diff HEAD^ HEAD --check", "exit_code": 0},
+      {"command": "pre-commit run --files scoped packet files", "exit_code": 0}
+    ],
+    "FAIL": [],
+    "NOT_RUN": [
+      {"command": "External Gemini codereview final step", "reason": "provider returned 429 RESOURCE_EXHAUSTED; configured quota is zero", "mitigation": "external inspection checkpoint reported zero issues; complete local review and deterministic validation performed"},
+      {"command": "Live protocol, ownership, mount/data scope, freshness, Docker, socket, backend, tunnel, and authentication checks", "reason": "explicitly out of scope for TP-0011"}
+    ]
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "PASS_WITH_RISKS",
+    "auditor_tool": "gemini-cli",
+    "auditor_model": "gemini",
+    "invocation": "Gemini codereview step 1 inspected the changed files and returned issues_found=0; step 2 was attempted and returned provider quota error 429 RESOURCE_EXHAUSTED. Local review and deterministic validation completed as mitigation.",
+    "exit_code": 0,
+    "report_path": "proof/TP-DCP-MCP-RO-0011/AUDITOR_REPORT.md",
+    "findings": [],
+    "fixes_applied": [
+      "Added the two catalog schema fields already present in the restored task-orchestrator catalog entry.",
+      "Removed the repository-rejected auxiliary superpowers plan artifact from the packet allowlist."
+    ],
+    "remaining_risks": [
+      "External Gemini final review verdict unavailable due provider quota.",
+      "Live liveness, protocol, ownership, mount/data scope, freshness, and backend authorization remain later gates.",
+      "Existing v1 facade tools remain project_id-based and are intentionally not rewired."
+    ],
+    "skip_reason": null
+  },
+  "residual_risks": [
+    "External Gemini final review verdict unavailable due provider quota.",
+    "No live runtime or ownership evidence is claimed.",
+    "to_mcp_wrapper and to_compose_rest remain blocked.",
+    "No PR URL exists until publication."
+  ],
+  "rollback": "git revert 485c87444f90235853f5e1b52c64c1ed852bdd1a",
+  "cleanup": "Dedicated implementation branch remains for PR publication; unrelated occupied 0011 worktree was not modified."
+}

--- a/proof/TP-DCP-MCP-RO-0011/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0011/PROOF.json
@@ -12,7 +12,7 @@
   "network_or_socket_code_introduced": false,
   "executor_provenance": {
     "implementation": "Codex",
-    "codereview": "Gemini external inspection checkpoint plus local review",
+    "codereview": "Gemini external inspection checkpoint, GitHub review reconciliation, and local review",
     "note": "The external Gemini final review call was unavailable because the configured provider quota returned 429 RESOURCE_EXHAUSTED; no clean external verdict is claimed."
   },
   "files_changed": [
@@ -31,14 +31,15 @@
   ],
   "validation": {
     "PASS": [
-      {"command": "pytest -q services/dcp-readonly-facade/tests", "exit_code": 0, "result": "207 passed, 1 skipped (live optional)"},
+      {"command": "pytest -q services/dcp-readonly-facade/tests/test_runtime_catalog_join.py", "exit_code": 0, "result": "10 passed"},
+      {"command": "pytest -q services/dcp-readonly-facade/tests", "exit_code": 0, "result": "PASS; 1 live optional test skipped"},
       {"command": "pytest -q tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_runtime_registry.py", "exit_code": 0, "result": "32 passed"},
       {"command": "python -m compileall -q services/dcp-readonly-facade", "exit_code": 0},
       {"command": "TP packet validation against dopetask-canonical-spec.json", "exit_code": 0},
       {"command": "fleet-catalog.schema.json Draft7Validator.check_schema", "exit_code": 0},
-      {"command": "purity scan for forbidden I/O imports/calls", "exit_code": 0},
+      {"command": "AST purity scan for forbidden I/O imports/calls", "exit_code": 0},
       {"command": "secret scan over changed files", "exit_code": 0},
-      {"command": "git diff HEAD^ HEAD --check", "exit_code": 0},
+      {"command": "git diff --check", "exit_code": 0},
       {"command": "pre-commit run --files scoped packet files", "exit_code": 0}
     ],
     "FAIL": [],
@@ -58,21 +59,22 @@
     "findings": [],
     "fixes_applied": [
       "Added the two catalog schema fields already present in the restored task-orchestrator catalog entry.",
-      "Removed the repository-rejected auxiliary superpowers plan artifact from the packet allowlist."
+      "Removed the repository-rejected auxiliary superpowers plan artifact from the packet allowlist.",
+      "Made RuntimeCatalogEntry.callable computed and non-overridable so internal and public non-callable state cannot diverge.",
+      "Aligned the packet public-serialization invariant with the redacted public capability shape."
     ],
     "remaining_risks": [
-      "External Gemini final review verdict unavailable due provider quota.",
+      "External Gemini final review verdict unavailable due to provider quota.",
       "Live liveness, protocol, ownership, mount/data scope, freshness, and backend authorization remain later gates.",
       "Existing v1 facade tools remain project_id-based and are intentionally not rewired."
     ],
     "skip_reason": null
   },
   "residual_risks": [
-    "External Gemini final review verdict unavailable due provider quota.",
+    "External Gemini final review verdict unavailable due to provider quota.",
     "No live runtime or ownership evidence is claimed.",
-    "to_mcp_wrapper and to_compose_rest remain blocked.",
-    "External Gemini final review verdict unavailable due provider quota."
+    "to_mcp_wrapper and to_compose_rest remain blocked."
   ],
-  "rollback": "git revert 485c87444f90235853f5e1b52c64c1ed852bdd1a",
-  "cleanup": "PR #1041 published; unrelated occupied 0011 worktree was not modified."
+  "rollback": "Revert the merge or squash commit for PR #1041. Before merge, revert the branch commits in reverse order so implementation, proof, and PR metadata roll back together.",
+  "cleanup": "PR #1041 published; branch-owner worktree used only for scoped review fixes."
 }

--- a/proof/TP-DCP-MCP-RO-0011/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0011/PROOF.json
@@ -5,7 +5,7 @@
   "base_branch": "main",
   "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
   "implementation_commit": "485c87444f90235853f5e1b52c64c1ed852bdd1a",
-  "pr_url": null,
+  "pr_url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1041",
   "scope": "Pure facade-local join of TP-0010 resolved targets with canonical catalog and operational runtime evidence. No live I/O, backend calls, ownership proof, adapter rewiring, or Task Orchestrator exposure.",
   "runtime_code_changed": true,
   "backend_code_changed": false,
@@ -71,8 +71,8 @@
     "External Gemini final review verdict unavailable due provider quota.",
     "No live runtime or ownership evidence is claimed.",
     "to_mcp_wrapper and to_compose_rest remain blocked.",
-    "No PR URL exists until publication."
+    "External Gemini final review verdict unavailable due provider quota."
   ],
   "rollback": "git revert 485c87444f90235853f5e1b52c64c1ed852bdd1a",
-  "cleanup": "Dedicated implementation branch remains for PR publication; unrelated occupied 0011 worktree was not modified."
+  "cleanup": "PR #1041 published; unrelated occupied 0011 worktree was not modified."
 }

--- a/schemas/mcp/fleet-catalog.schema.json
+++ b/schemas/mcp/fleet-catalog.schema.json
@@ -46,7 +46,10 @@
           "enum": ["singleton", "per-worktree"]
         },
         "state_scope": {
-          "enum": ["per-repo", "per-worktree"]
+          "enum": ["per-repo", "per-worktree", "single_active_project"]
+        },
+        "port_policy": {
+          "enum": ["reserved_singleton"]
         },
         "transport": {
           "enum": ["http", "sse", "stdio"]

--- a/services/dcp-readonly-facade/src/dcp_facade/runtime_catalog_join.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/runtime_catalog_join.py
@@ -56,15 +56,19 @@ class RuntimeCatalogEntry:
     catalog_name: Optional[str]
     state: str
     candidate_count: int
-    callable: bool
     reason: str
+
+    @property
+    def callable(self) -> bool:
+        """Candidate evidence is never callable in this packet."""
+        return False
 
     def to_public_dict(self) -> dict[str, Any]:
         """Return the redacted public capability shape."""
         return {
             "family": self.family,
             "state": self.state,
-            "callable": False,
+            "callable": self.callable,
             "reason": self.reason,
         }
 
@@ -149,7 +153,6 @@ def _entry(
         catalog_name=catalog_name,
         state=state,
         candidate_count=candidate_count,
-        callable=False,
         reason=reason,
     )
 

--- a/services/dcp-readonly-facade/src/dcp_facade/runtime_catalog_join.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/runtime_catalog_join.py
@@ -107,7 +107,9 @@ def _runtime_instances(runtime_registry: Any) -> Optional[list[Mapping[str, Any]
     instances = runtime_registry.get("instances")
     if not isinstance(instances, list):
         return None
-    return [instance for instance in instances if isinstance(instance, Mapping)]
+    if any(not isinstance(instance, Mapping) for instance in instances):
+        return None
+    return instances
 
 
 def _catalog_matches_contract(family: str, spec: Any) -> bool:

--- a/services/dcp-readonly-facade/src/dcp_facade/runtime_catalog_join.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/runtime_catalog_join.py
@@ -1,0 +1,271 @@
+"""Pure runtime-registry/catalog join for TP-DCP-MCP-RO-0011.
+
+This module consumes already-loaded operational mappings. It performs no
+network, socket, subprocess, Docker, lease, backend, or write operation.
+
+The runtime registry and catalog are evidence inputs only. They do not grant
+exposure consent or ownership, and a matching record never makes a service
+callable. Public serialization intentionally omits operational names and all
+infrastructure details.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, Optional
+
+from .resolver_core import ResolvedTarget
+
+
+# Explicit operational-name translation. The facade family names remain the
+# only contract-facing names; no spelling heuristic is permitted here.
+FAMILY_CATALOG_MAP: dict[str, Optional[str]] = {
+    "conport": "conport",
+    "dope_memory": "dope-memory",
+    "to_compose_rest": None,
+    "to_mcp_wrapper": "task-orchestrator",
+    "dope_context": "dope-context",
+    "serena": "serena",
+    "pal": "pal",
+    "docker_mcp_gateway": "MCP_DOCKER",
+    "desktop_commander": "desktop-commander",
+}
+
+# Static catalog attributes required for the two currently conditionally
+# readable per-worktree services. Other families are blocked in this packet.
+PER_WORKTREE_CATALOG_CONTRACT: dict[str, dict[str, str]] = {
+    "conport": {
+        "scope": "per-worktree",
+        "identity_scope": "per-worktree",
+        "management_model": "compose-service",
+    },
+    "dope_memory": {
+        "scope": "per-worktree",
+        "identity_scope": "per-worktree",
+        "management_model": "compose-service",
+    },
+}
+
+
+@dataclass(frozen=True)
+class RuntimeCatalogEntry:
+    """Internal joined state for one configured facade service family."""
+
+    family: str
+    catalog_name: Optional[str]
+    state: str
+    candidate_count: int
+    callable: bool
+    reason: str
+
+    def to_public_dict(self) -> dict[str, Any]:
+        """Return the redacted public capability shape."""
+        return {
+            "family": self.family,
+            "state": self.state,
+            "callable": False,
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class RuntimeCatalogJoin:
+    """Internal aggregate result; all entries are non-callable."""
+
+    entries: tuple[RuntimeCatalogEntry, ...]
+
+    def to_public_dict(self) -> dict[str, list[dict[str, Any]]]:
+        return {"services": [entry.to_public_dict() for entry in self.entries]}
+
+
+def _canonical_path(value: Any) -> Optional[Path]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return Path(value).expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _catalog_servers(catalog: Any) -> Optional[Mapping[str, Any]]:
+    if not isinstance(catalog, Mapping):
+        return None
+    servers = catalog.get("servers")
+    return servers if isinstance(servers, Mapping) else None
+
+
+def _runtime_instances(runtime_registry: Any) -> Optional[list[Mapping[str, Any]]]:
+    if not isinstance(runtime_registry, Mapping):
+        return None
+    if runtime_registry.get("parse_status", "OK") != "OK":
+        return None
+    instances = runtime_registry.get("instances")
+    if not isinstance(instances, list):
+        return None
+    return [instance for instance in instances if isinstance(instance, Mapping)]
+
+
+def _catalog_matches_contract(family: str, spec: Any) -> bool:
+    if not isinstance(spec, Mapping):
+        return False
+    expected = PER_WORKTREE_CATALOG_CONTRACT.get(family)
+    if expected is None:
+        return False
+    return all(spec.get(key) == value for key, value in expected.items())
+
+
+def _runtime_matches_target(
+    instance: Mapping[str, Any],
+    *,
+    family: str,
+    catalog_name: str,
+    resolved: ResolvedTarget,
+) -> bool:
+    """Match evidence identity exactly; do not treat it as ownership proof."""
+    if instance.get("service") != catalog_name:
+        return False
+    if instance.get("project_id") != resolved.target.identity_project:
+        return False
+    project_root = _canonical_path(instance.get("project_root"))
+    worktree_root = _canonical_path(instance.get("worktree_root"))
+    if project_root != resolved.project_root.resolve():
+        return False
+    if worktree_root != resolved.worktree_root.resolve():
+        return False
+    return family in PER_WORKTREE_CATALOG_CONTRACT
+
+
+def _entry(
+    family: str,
+    *,
+    catalog_name: Optional[str],
+    state: str,
+    candidate_count: int,
+    reason: str,
+) -> RuntimeCatalogEntry:
+    return RuntimeCatalogEntry(
+        family=family,
+        catalog_name=catalog_name,
+        state=state,
+        candidate_count=candidate_count,
+        callable=False,
+        reason=reason,
+    )
+
+
+def _join_family(
+    resolved: ResolvedTarget,
+    family: str,
+    catalog: Any,
+    runtime_registry: Any,
+) -> RuntimeCatalogEntry:
+    policy = resolved.service_policies[family]
+    if not policy.configured:
+        return _entry(
+            family,
+            catalog_name=FAMILY_CATALOG_MAP.get(family),
+            state="BLOCKED",
+            candidate_count=0,
+            reason="service policy disabled",
+        )
+
+    catalog_name = FAMILY_CATALOG_MAP.get(family)
+    if catalog_name is None:
+        return _entry(
+            family,
+            catalog_name=None,
+            state="BLOCKED",
+            candidate_count=0,
+            reason="service family has no supported catalog binding",
+        )
+
+    if policy.chatgpt_posture.startswith("blocked"):
+        return _entry(
+            family,
+            catalog_name=catalog_name,
+            state="BLOCKED",
+            candidate_count=0,
+            reason="service family blocked by exposure policy",
+        )
+
+    servers = _catalog_servers(catalog)
+    if servers is None:
+        return _entry(
+            family,
+            catalog_name=catalog_name,
+            state="UNKNOWN",
+            candidate_count=0,
+            reason="canonical catalog unavailable",
+        )
+    spec = servers.get(catalog_name)
+    if not _catalog_matches_contract(family, spec):
+        return _entry(
+            family,
+            catalog_name=catalog_name,
+            state="BLOCKED",
+            candidate_count=0,
+            reason="canonical catalog policy mismatch",
+        )
+
+    instances = _runtime_instances(runtime_registry)
+    if instances is None:
+        return _entry(
+            family,
+            catalog_name=catalog_name,
+            state="UNKNOWN",
+            candidate_count=0,
+            reason="operational runtime registry unavailable",
+        )
+
+    matches = [
+        instance
+        for instance in instances
+        if _runtime_matches_target(
+            instance,
+            family=family,
+            catalog_name=catalog_name,
+            resolved=resolved,
+        )
+    ]
+    if len(matches) == 0:
+        return _entry(
+            family,
+            catalog_name=catalog_name,
+            state="UNAVAILABLE",
+            candidate_count=0,
+            reason="no matching runtime candidate",
+        )
+    if len(matches) > 1:
+        return _entry(
+            family,
+            catalog_name=catalog_name,
+            state="BLOCKED",
+            candidate_count=len(matches),
+            reason="ambiguous runtime candidates",
+        )
+    return _entry(
+        family,
+        catalog_name=catalog_name,
+        state="UNKNOWN",
+        candidate_count=1,
+        reason="runtime candidate joined; live verification required",
+    )
+
+
+def join_runtime_catalog(
+    resolved: ResolvedTarget,
+    catalog: Any,
+    runtime_registry: Any,
+) -> RuntimeCatalogJoin:
+    """Join operational evidence to a previously resolved exposure target.
+
+    The function accepts already-loaded mappings so callers control file
+    authority and tests remain deterministic. It never returns a selected
+    endpoint or a callable result.
+    """
+    entries = tuple(
+        _join_family(resolved, family, catalog, runtime_registry)
+        for family in sorted(resolved.service_policies)
+    )
+    return RuntimeCatalogJoin(entries=entries)

--- a/services/dcp-readonly-facade/tests/test_runtime_catalog_join.py
+++ b/services/dcp-readonly-facade/tests/test_runtime_catalog_join.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from dcp_facade.registry_v2 import FAMILY_POLICY_TABLE, ExposureTarget, ServicePolicy
 from dcp_facade.resolver_core import ResolvedTarget
-from dcp_facade.runtime_catalog_join import join_runtime_catalog
+from dcp_facade.runtime_catalog_join import RuntimeCatalogEntry, join_runtime_catalog
 
 
 def _resolved(*families: str) -> ResolvedTarget:
@@ -226,3 +228,15 @@ def test_public_result_redacts_operational_details():
     }
     for forbidden in ("runtime-secret-id", "3020", "127.0.0.1", "/approved"):
         assert forbidden not in rendered
+
+
+def test_runtime_catalog_entry_rejects_callable_override():
+    with pytest.raises(TypeError):
+        RuntimeCatalogEntry(
+            family="conport",
+            catalog_name="conport",
+            state="UNKNOWN",
+            candidate_count=1,
+            callable=True,
+            reason="runtime candidate joined; live verification required",
+        )

--- a/services/dcp-readonly-facade/tests/test_runtime_catalog_join.py
+++ b/services/dcp-readonly-facade/tests/test_runtime_catalog_join.py
@@ -150,6 +150,19 @@ def test_malformed_runtime_registry_is_unknown_and_non_callable():
     assert entry.callable is False
 
 
+def test_malformed_runtime_member_blocks_candidate_join():
+    runtime = _runtime(service="conport")
+    runtime["instances"].append([])
+
+    result = join_runtime_catalog(_resolved("conport"), _catalog(), runtime)
+
+    entry = result.entries[0]
+    assert entry.state == "UNKNOWN"
+    assert entry.candidate_count == 0
+    assert entry.reason == "operational runtime registry unavailable"
+    assert entry.callable is False
+
+
 def test_catalog_policy_drift_blocks_candidate_join():
     catalog = _catalog()
     catalog["servers"]["conport"]["management_model"] = "wrapper-singleton"

--- a/services/dcp-readonly-facade/tests/test_runtime_catalog_join.py
+++ b/services/dcp-readonly-facade/tests/test_runtime_catalog_join.py
@@ -1,0 +1,228 @@
+"""TP-DCP-MCP-RO-0011 runtime/catalog join contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dcp_facade.registry_v2 import FAMILY_POLICY_TABLE, ExposureTarget, ServicePolicy
+from dcp_facade.resolver_core import ResolvedTarget
+from dcp_facade.runtime_catalog_join import join_runtime_catalog
+
+
+def _resolved(*families: str) -> ResolvedTarget:
+    workspace = Path("/approved/dopemux-mvp")
+    target = ExposureTarget(
+        target_id="dopemux-main",
+        workspace_path=str(workspace),
+        enabled=True,
+        binding_mode="PRIMARY_CHECKOUT_ONLY",
+        identity_project="dopemux-mvp",
+        identity_owner="hu3mann",
+        service_policies={
+            family: ServicePolicy(
+                family=family,
+                configured=True,
+                resolution_class=FAMILY_POLICY_TABLE[family][0],
+                chatgpt_posture=FAMILY_POLICY_TABLE[family][1],
+            )
+            for family in families
+        },
+    )
+    return ResolvedTarget(
+        target=target,
+        workspace=workspace,
+        project_root=Path("/approved"),
+        worktree_root=workspace,
+        service_policies=target.service_policies,
+    )
+
+
+def _catalog() -> dict:
+    return {
+        "servers": {
+            "conport": {
+                "scope": "per-worktree",
+                "transport": "sse",
+                "identity_scope": "per-worktree",
+                "management_model": "compose-service",
+            },
+            "dope-memory": {
+                "scope": "per-worktree",
+                "transport": "http",
+                "identity_scope": "per-worktree",
+                "management_model": "compose-service",
+            },
+            "task-orchestrator": {
+                "scope": "per-worktree",
+                "state_scope": "single_active_project",
+                "transport": "http",
+                "identity_scope": "per-repo",
+                "management_model": "wrapper-singleton",
+            },
+        }
+    }
+
+
+def _runtime(*, service: str, project_root: str = "/approved", worktree_root: str = "/approved/dopemux-mvp") -> dict:
+    return {
+        "parse_status": "OK",
+        "present": True,
+        "instances": [
+            {
+                "instance_id": "runtime-secret-id",
+                "project_id": "dopemux-mvp",
+                "project_root": project_root,
+                "worktree_root": worktree_root,
+                "service": service,
+                "status": "running",
+                "ports": {"http": 3020},
+                "urls": {"mcp": "http://127.0.0.1:3020/mcp"},
+            }
+        ],
+    }
+
+
+def test_exact_per_worktree_join_is_non_callable_and_maps_operational_name():
+    result = join_runtime_catalog(
+        _resolved("dope_memory"),
+        _catalog(),
+        _runtime(service="dope-memory"),
+    )
+
+    entry = result.entries[0]
+    assert entry.family == "dope_memory"
+    assert entry.catalog_name == "dope-memory"
+    assert entry.candidate_count == 1
+    assert entry.state == "UNKNOWN"
+    assert entry.callable is False
+
+
+def test_wrapper_family_stays_blocked_even_when_operational_record_exists():
+    result = join_runtime_catalog(
+        _resolved("to_mcp_wrapper"),
+        _catalog(),
+        _runtime(service="task-orchestrator"),
+    )
+
+    entry = result.entries[0]
+    assert entry.family == "to_mcp_wrapper"
+    assert entry.state == "BLOCKED"
+    assert entry.callable is False
+
+
+def test_scope_mismatch_does_not_join_by_project_name_alone():
+    result = join_runtime_catalog(
+        _resolved("conport"),
+        _catalog(),
+        _runtime(service="conport", worktree_root="/approved/other-worktree"),
+    )
+
+    entry = result.entries[0]
+    assert entry.state == "UNAVAILABLE"
+    assert entry.candidate_count == 0
+    assert entry.callable is False
+
+
+def test_duplicate_matching_candidates_block_without_selection():
+    runtime = _runtime(service="conport")
+    runtime["instances"].append(dict(runtime["instances"][0], instance_id="runtime-secret-id-2"))
+
+    result = join_runtime_catalog(_resolved("conport"), _catalog(), runtime)
+
+    entry = result.entries[0]
+    assert entry.state == "BLOCKED"
+    assert entry.candidate_count == 2
+    assert entry.callable is False
+
+
+def test_malformed_runtime_registry_is_unknown_and_non_callable():
+    result = join_runtime_catalog(
+        _resolved("conport"),
+        _catalog(),
+        {"parse_status": "ERROR", "instances": "not-a-list"},
+    )
+
+    entry = result.entries[0]
+    assert entry.state == "UNKNOWN"
+    assert entry.candidate_count == 0
+    assert entry.callable is False
+
+
+def test_catalog_policy_drift_blocks_candidate_join():
+    catalog = _catalog()
+    catalog["servers"]["conport"]["management_model"] = "wrapper-singleton"
+
+    result = join_runtime_catalog(
+        _resolved("conport"),
+        catalog,
+        _runtime(service="conport"),
+    )
+
+    entry = result.entries[0]
+    assert entry.state == "BLOCKED"
+    assert entry.reason == "canonical catalog policy mismatch"
+    assert entry.callable is False
+
+
+def test_compose_rest_has_no_supported_catalog_binding():
+    result = join_runtime_catalog(
+        _resolved("to_compose_rest"),
+        _catalog(),
+        _runtime(service="task-orchestrator"),
+    )
+
+    entry = result.entries[0]
+    assert entry.state == "BLOCKED"
+    assert entry.catalog_name is None
+    assert entry.callable is False
+
+
+def test_unknown_direct_task_orchestrator_family_is_blocked():
+    resolved = _resolved("conport")
+    resolved = ResolvedTarget(
+        target=resolved.target,
+        workspace=resolved.workspace,
+        project_root=resolved.project_root,
+        worktree_root=resolved.worktree_root,
+        service_policies={
+            "task-orchestrator": ServicePolicy(
+                family="task-orchestrator",
+                configured=True,
+                resolution_class="host_singleton_single_active_project",
+                chatgpt_posture="blocked",
+            )
+        },
+    )
+    result = join_runtime_catalog(
+        resolved,
+        _catalog(),
+        _runtime(service="task-orchestrator"),
+    )
+
+    entry = result.entries[0]
+    assert entry.state == "BLOCKED"
+    assert entry.catalog_name is None
+    assert entry.callable is False
+
+
+def test_public_result_redacts_operational_details():
+    result = join_runtime_catalog(
+        _resolved("dope_memory"),
+        _catalog(),
+        _runtime(service="dope-memory"),
+    )
+
+    public = result.to_public_dict()
+    rendered = repr(public)
+    assert public == {
+        "services": [
+            {
+                "family": "dope_memory",
+                "state": "UNKNOWN",
+                "callable": False,
+                "reason": "runtime candidate joined; live verification required",
+            }
+        ]
+    }
+    for forbidden in ("runtime-secret-id", "3020", "127.0.0.1", "/approved"):
+        assert forbidden not in rendered

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.json
@@ -11,7 +11,7 @@
     "to_mcp_wrapper and to_compose_rest remain BLOCKED; the join never makes Task Orchestrator callable.",
     "Configured, discovered, live, ownership-verified, and callable remain separate states; callable is always false in this packet.",
     "No socket, network, subprocess, Docker, backend, port-lease, tunnel, authentication, adapter, or facade API migration behavior is introduced.",
-    "Public serialization contains only service family, capability state, candidate count, callable=false, and opaque reasons.",
+    "Public serialization contains only service family, capability state, callable=false, and opaque reasons.",
     "STOP IF: the required result would need live protocol verification, ownership adjudication, mount inspection, or backend I/O."
   ],
   "depends_on": [

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.json
@@ -1,0 +1,149 @@
+{
+  "id": "TP-DCP-MCP-RO-0011",
+  "project": "dopemux-mvp",
+  "target": "Join the TP-0010 resolved exposure target to the canonical MCP catalog and operational runtime registry using explicit service-family mappings and exact scope checks. Produce only internal non-callable candidate state; do not probe, call, expose, mutate, or rewire any backend.",
+  "invariants": [
+    "target_id remains the only caller-facing handle; runtime IDs, paths, ports, URLs, container names, leases, and backend workspace IDs are never caller inputs or public output.",
+    "The exposure policy registry remains consent authority; the operational runtime registry and canonical MCP catalog are read-only operational/advisory inputs.",
+    "The join uses an explicit fixed mapping for all nine ADR service families; no hyphen/underscore heuristic and no bare task-orchestrator facade family is accepted.",
+    "Per-worktree candidates require canonical project_root and worktree_root equality with the already-resolved target; project name or hash alone never authorizes a match.",
+    "Zero candidates, malformed or missing operational inputs, and ambiguous candidates fail closed without selecting an endpoint.",
+    "to_mcp_wrapper and to_compose_rest remain BLOCKED; the join never makes Task Orchestrator callable.",
+    "Configured, discovered, live, ownership-verified, and callable remain separate states; callable is always false in this packet.",
+    "No socket, network, subprocess, Docker, backend, port-lease, tunnel, authentication, adapter, or facade API migration behavior is introduced.",
+    "Public serialization contains only service family, capability state, candidate count, callable=false, and opaque reasons.",
+    "STOP IF: the required result would need live protocol verification, ownership adjudication, mount inspection, or backend I/O."
+  ],
+  "depends_on": [
+    "TP-DCP-MCP-RO-0009",
+    "TP-DCP-MCP-RO-0010"
+  ],
+  "repo_binding": {
+    "project_id": "dopemux-mvp",
+    "repo_marker": ".repo_id",
+    "origin_hint": "github.com/DDD-Enterprises/dopemux-mvp",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DCP-MCP-RO",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DCP-MCP-RO-0010",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dcp-mcp-ro-0011-runtime-catalog-join",
+    "base_branch": "main",
+    "stacked_because": "TP-0010 explicitly leaves runtime registry and canonical MCP catalog join out of scope."
+  },
+  "commit": {
+    "message": "feat(dcp): add read-only runtime catalog join",
+    "allowlist": [
+      "services/dcp-readonly-facade/src/dcp_facade/runtime_catalog_join.py",
+      "services/dcp-readonly-facade/tests/test_runtime_catalog_join.py",
+      "schemas/mcp/fleet-catalog.schema.json",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_CATALOG_JOIN_CONTRACT.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/DECISIONS.md",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.md",
+      "proof/TP-DCP-MCP-RO-0011/**"
+    ],
+    "verify": [
+      "python -m pytest -q services/dcp-readonly-facade/tests/test_runtime_catalog_join.py",
+      "python -m pytest -q services/dcp-readonly-facade/tests",
+      "python -m pytest -q tests/arch/test_mcp_fleet_catalog_contract.py tests/unit/test_mcp_runtime_registry.py",
+      "python -m compileall -q services/dcp-readonly-facade",
+      "git diff --check",
+      "pre-commit run --files <allowlisted-files>"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): add read-only runtime catalog join",
+    "body": "Implements TP-DCP-MCP-RO-0011: join TP-0010 resolved exposure targets with the canonical MCP catalog and operational runtime registry using explicit family mappings and exact scope matching. The result remains internal, redacted, and non-callable; no probes, backend calls, adapter rewiring, or Task Orchestrator exposure are introduced.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Implement the pure runtime/catalog join module with explicit nine-family mappings, exact project/worktree scope matching, internal candidate state, and redacted public serialization.",
+      "requirements": [
+        "Expose join_runtime_catalog(resolved, catalog, runtime_registry) with dependency-injected mappings.",
+        "Map conport to conport and dope_memory to dope-memory explicitly; map blocked families only for contract validation.",
+        "Treat to_compose_rest as unresolved/blocked and to_mcp_wrapper as blocked even when task-orchestrator records exist.",
+        "Never select a candidate when the runtime registry is malformed, missing, or ambiguous."
+      ],
+      "expected_files": [
+        "services/dcp-readonly-facade/src/dcp_facade/runtime_catalog_join.py"
+      ],
+      "context_files": [
+        "services/dcp-readonly-facade/src/dcp_facade/registry_v2.py",
+        "services/dcp-readonly-facade/src/dcp_facade/resolver_core.py",
+        "src/dopemux/mcp/runtime_registry.py",
+        "mcp_catalog.yaml",
+        "docs/90-adr/adr-dcp-mcp-ro-0009-chatgpt-mcp-exposure-targets-runtime-resolution-ownership-evidence.md"
+      ],
+      "validation": [
+        "Focused join tests pass.",
+        "Purity scan finds no network, socket, subprocess, Docker, or write primitives in the new module.",
+        "Public serialization contains no infrastructure detail."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Add TDD coverage for exact matches, missing and malformed inputs, catalog drift, ambiguity, blocked Task Orchestrator families, and public redaction.",
+      "requirements": [
+        "Use real dataclasses and mapping fixtures rather than mocking the join implementation.",
+        "Cover candidate count zero, one, and multiple without endpoint selection.",
+        "Assert callable is false for every result."
+      ],
+      "expected_files": [
+        "services/dcp-readonly-facade/tests/test_runtime_catalog_join.py"
+      ],
+      "context_files": [
+        "services/dcp-readonly-facade/tests/test_registry_v2.py",
+        "services/dcp-readonly-facade/tests/test_resolver_core.py",
+        "services/dcp-readonly-facade/tests/test_capability.py"
+      ],
+      "validation": [
+        "Every new test is observed failing before its production behavior is implemented.",
+        "The focused test file passes after implementation.",
+        "The full facade suite remains green with only the existing live-optional skip."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Document the runtime/catalog join contract and record packet proof with true validation results.",
+      "requirements": [
+        "Document authority split, explicit mappings, exact scope checks, blocked families, and exclusions.",
+        "Record the implementation branch, commit, PR, commands, exit codes, audit status, risks, and unknowns.",
+        "Do not claim live ownership, liveness, protocol, mount, or backend verification."
+      ],
+      "expected_files": [
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_CATALOG_JOIN_CONTRACT.md",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+        "docs/03-reference/dcp/chatgpt-mcp-readonly/DECISIONS.md",
+        "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.json",
+        "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.md",
+        "proof/TP-DCP-MCP-RO-0011/PROOF.json",
+        "proof/TP-DCP-MCP-RO-0011/AUDIT.md",
+        "proof/TP-DCP-MCP-RO-0011/AUDITOR_REPORT.md",
+        "proof/TP-DCP-MCP-RO-0011/COMMAND_LOG.md"
+      ],
+      "validation": [
+        "Packet JSON validates against dopetask-canonical-spec.json.",
+        "Proof JSON and embedded audit validate against their schemas.",
+        "Markdown, secret, diff, and pre-commit checks pass."
+      ]
+    }
+  ]
+}

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.md
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.md
@@ -1,0 +1,23 @@
+---
+id: TP-DCP-MCP-RO-0011
+title: Read-Only Runtime Registry And Catalog Join
+type: explanation
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-11'
+last_review: '2026-07-11'
+next_review: '2026-10-09'
+prelude: Join TP-0010 resolved exposure targets with operational MCP runtime and catalog evidence without making any backend callable.
+---
+
+# TP-DCP-MCP-RO-0011 — Read-Only Runtime Registry And Catalog Join
+
+Objective: Add the smallest runtime-aware DCP slice after TP-0010. The join consumes a resolved target, the canonical catalog, and operational runtime records through explicit inputs, then returns internal non-callable candidate state.
+
+Scope: explicit nine-family mapping, exact project/worktree scope matching for per-worktree services, catalog contract validation, ambiguity blocking, missing-input `UNKNOWN`, blocked-family handling, and public redaction.
+
+Out of scope: sockets, TCP/MCP/REST probes, Docker/container inspection, port leases, ownership adjudication, mount evidence, backend calls, adapter rewiring, tunnel/authentication, caching, receipts, and Task Orchestrator exposure.
+
+The exposure policy registry remains consent authority. The runtime registry and catalog are operational/advisory evidence only. `to_mcp_wrapper` and `to_compose_rest` remain blocked.
+
+See the JSON packet for invariants, allowlist, validation commands, and proof obligations.


### PR DESCRIPTION
## Objective
Implement TP-DCP-MCP-RO-0011: join TP-0010 resolved exposure targets with the canonical MCP catalog and operational runtime registry using explicit family mappings and exact scope matching.

## Scope
- Pure, dependency-injected facade-local join.
- Exact project/worktree matching for `conport` and `dope_memory`.
- Ambiguity blocks; missing operational data remains `UNKNOWN`.
- `to_mcp_wrapper` and `to_compose_rest` remain blocked.
- No probes, backend calls, adapter rewiring, tunnel, or authentication.
- Align catalog schema with fields already present in the restored canonical catalog.

## Evidence
- Packet: `task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0011.json`
- Contract: `docs/03-reference/dcp/chatgpt-mcp-readonly/RUNTIME_CATALOG_JOIN_CONTRACT.md`
- Proof: `proof/TP-DCP-MCP-RO-0011/PROOF.json`

## Validation
- `pytest -q services/dcp-readonly-facade/tests`: 207 passed, 1 skipped.
- Catalog/runtime tests: 32 passed.
- Compileall, packet/schema validation, purity scan, secret scan, diff check, and pre-commit: PASS.

## Embedded audit
`PASS_WITH_RISKS`. Gemini inspection reported zero findings; the final external review call was unavailable due provider quota `429 RESOURCE_EXHAUSTED`. Local review and deterministic validation completed.

## Risks and unknowns
Live protocol, ownership, mount/data scope, freshness, Docker, socket, and backend authorization remain later gates. Existing v1 facade tools remain intentionally unre-wired.

## Rollback
Revert implementation commit `485c87444f90235853f5e1b52c64c1ed852bdd1a`.

## Proof bundle
`proof/TP-DCP-MCP-RO-0011/`