### PR TITLE
fix(audit): make independent audit and Steward fail closed

### DIFF
--- a/.github/workflows/embedded-audit.yml
+++ b/.github/workflows/embedded-audit.yml
@@ -37,29 +37,36 @@ jobs:
           INPUT_HEAD_SHA: ${{ inputs.head_sha }}
           TRUSTED_FALLBACK_REF: ${{ github.event.repository.default_branch }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          # pull_request_target and legacy pull_request both carry pull_request
+          # event metadata. workflow_dispatch uses validated inputs only.
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ]; then
             printf 'number=%s\n' "$EVENT_PR_NUMBER" >> "$GITHUB_OUTPUT"
             printf 'head_sha=%s\n' "$EVENT_HEAD_SHA" >> "$GITHUB_OUTPUT"
             printf 'trusted_ref=%s\n' "$EVENT_BASE_SHA" >> "$GITHUB_OUTPUT"
-          else
+            test -n "$EVENT_PR_NUMBER"
+            test -n "$EVENT_HEAD_SHA"
+            test -n "$EVENT_BASE_SHA"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             printf 'number=%s\n' "$INPUT_PR_NUMBER" >> "$GITHUB_OUTPUT"
             printf 'head_sha=%s\n' "$INPUT_HEAD_SHA" >> "$GITHUB_OUTPUT"
             printf 'trusted_ref=%s\n' "$TRUSTED_FALLBACK_REF" >> "$GITHUB_OUTPUT"
-          fi
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            test -n "$EVENT_HEAD_SHA"
-            test -n "$EVENT_BASE_SHA"
-          else
+            test -n "$INPUT_PR_NUMBER"
             test -n "$INPUT_HEAD_SHA"
             test -n "$TRUSTED_FALLBACK_REF"
+          else
+            echo "Unsupported event: $EVENT_NAME" >&2
+            exit 1
           fi
 
       - name: Checkout trusted audit source
         uses: actions/checkout@v4
         with:
+          # Trusted base/default-branch code only. Candidate head is fetched as
+          # data later and never checked out as the working tree.
           ref: ${{ steps.pr.outputs.trusted_ref }}
           fetch-depth: 2
           path: trusted-source
+          persist-credentials: false
 
       - name: Verify trusted audit source
         env:
@@ -71,6 +78,7 @@ jobs:
           else
             test -n "$actual_trusted_ref"
           fi
+          test -f trusted-source/scripts/audit/run_embedded_audit.py
 
       - name: Verify requested head SHA
         id: head_integrity
@@ -78,6 +86,8 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           EXPECTED_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
+          # Candidate material is fetched as objects only (no candidate checkout,
+          # no candidate script execution, no credentials on candidate tree).
           if git -C trusted-source fetch --no-tags --depth=1 origin "$EXPECTED_HEAD_SHA"; then
             actual_head_sha="$(git -C trusted-source rev-parse FETCH_HEAD)"
           else
@@ -91,6 +101,7 @@ jobs:
           fi
 
       - name: Static auditor route preflight
+        if: always() && steps.head_integrity.outputs.verified == 'true'
         working-directory: trusted-source
         run: |
           mkdir -p ../embedded-audit-artifacts
@@ -117,6 +128,10 @@ jobs:
           fi
 
       - name: Run PAL clink audit
+        # Soft exit is intentional: the runner may emit a machine-readable error
+        # payload with exit 0 so later steps always emit a diagnostic proof and
+        # the hard enforcement step remains the sole green/red authority.
+        # Tests prove synthetic error results cannot pass enforcement.
         if: always() && steps.head_integrity.outputs.verified == 'true'
         id: runner
         working-directory: trusted-source
@@ -155,6 +170,7 @@ jobs:
               > ../embedded-audit-artifacts/PAL_CLINK_AUDIT_OUTPUT.json
           fi
           printf 'exit_code=%s\n' "$status" >> "$GITHUB_OUTPUT"
+          # Soft exit: hard proof enforcement is authoritative (see step comments).
           exit 0
 
       - name: Emit independent embedded audit proof
@@ -162,15 +178,60 @@ jobs:
         working-directory: trusted-source
         env:
           EMBEDDED_AUDIT_TOKEN: ${{ secrets.EMBEDDED_AUDIT_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
+          mkdir -p ../embedded-audit-artifacts
           if [ ! -f scripts/audit/run_embedded_audit.py ]; then
+            # Structured diagnostic only — no forged trusted provenance.
+            python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          reason = (
+              "Trusted audit emitter scripts/audit/run_embedded_audit.py "
+              "is missing on the trusted ref."
+          )
+          out = Path("../embedded-audit-artifacts")
+          out.mkdir(parents=True, exist_ok=True)
+          proof = {
+              "packet_id": "TP-DMX-AUDIT-CI-PROVENANCE-104",
+              "repo": os.environ["GITHUB_REPOSITORY"],
+              "pr_number": int(os.environ["PR_NUMBER"]),
+              "head_sha": os.environ["HEAD_SHA"],
+              "executed": False,
+              "mutation_performed": False,
+              "github_mutation_route_added": False,
+              "embedded_audit": {
+                  "required": True,
+                  "status": "NEEDS_SUPERVISOR",
+                  "auditor_tool": "none",
+                  "auditor_model": "unknown",
+                  "invocation": None,
+                  "exit_code": None,
+                  "report_path": "proof/TP-DMX-AUDIT-CI-PROVENANCE-104/AUDITOR_REPORT.md",
+                  "findings": [],
+                  "fixes_applied": [],
+                  "remaining_risks": [reason],
+                  "skip_reason": reason,
+              },
+          }
+          (out / "PROOF.json").write_text(
+              json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          (out / "AUDITOR_REPORT.md").write_text(
+              f"# Embedded audit\n\nstatus: NEEDS_SUPERVISOR\n\nreason: {reason}\n",
+              encoding="utf-8",
+          )
+          PY
             exit 0
           fi
           python scripts/audit/run_embedded_audit.py \
             --packet-id "TP-DMX-AUDIT-CI-PROVENANCE-104" \
             --repo "$GITHUB_REPOSITORY" \
-            --pr "${{ steps.pr.outputs.number }}" \
-            --head-sha "${{ steps.pr.outputs.head_sha }}" \
+            --pr "${PR_NUMBER}" \
+            --head-sha "${HEAD_SHA}" \
             --route-json ../embedded-audit-artifacts/AUDITOR_ROUTE.json \
             --pal-output-json ../embedded-audit-artifacts/PAL_CLINK_AUDIT_OUTPUT.json \
             --out ../embedded-audit-artifacts
@@ -185,9 +246,10 @@ jobs:
           python - <<'PY'
           import json
           import os
-          from datetime import datetime, timezone
           from pathlib import Path
 
+          # Inline diagnostic shape mirrors build_diagnostic_failure_proof:
+          # executed=false, NEEDS_SUPERVISOR, no trusted provenance.
           reason = "Requested PR head SHA could not be fetched or no longer matches the PR head."
           artifact_dir = Path("embedded-audit-artifacts")
           report_path = "proof/TP-DMX-AUDIT-CI-PROVENANCE-104/AUDITOR_REPORT.md"
@@ -196,7 +258,7 @@ jobs:
               "repo": os.environ["GITHUB_REPOSITORY"],
               "pr_number": int(os.environ["PR_NUMBER"]),
               "head_sha": os.environ["HEAD_SHA"],
-              "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+              "executed": False,
               "mutation_performed": False,
               "github_mutation_route_added": False,
               "embedded_audit": {
@@ -213,24 +275,60 @@ jobs:
                   "skip_reason": reason,
               },
           }
-          (artifact_dir / "PROOF.json").write_text(json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-          (artifact_dir / "AUDITOR_REPORT.md").write_text(f"# Embedded audit\n\nstatus: NEEDS_SUPERVISOR\n\nreason: {reason}\n", encoding="utf-8")
+          (artifact_dir / "PROOF.json").write_text(
+              json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          (artifact_dir / "AUDITOR_REPORT.md").write_text(
+              f"# Embedded audit\n\nstatus: NEEDS_SUPERVISOR\n\nreason: {reason}\n",
+              encoding="utf-8",
+          )
           PY
 
       - name: Enforce independent audit result
         if: always()
+        env:
+          EXPECTED_PR: ${{ steps.pr.outputs.number }}
+          EXPECTED_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
+          # Hard gate: status alone is never sufficient. Requires executed=true,
+          # trusted provenance, matching PR/head, and PASS|PASS_WITH_RISKS.
           python - <<'PY'
           import json
+          import os
+          import sys
           from pathlib import Path
 
           proof_path = Path("embedded-audit-artifacts/PROOF.json")
           if not proof_path.is_file():
+              fallback = Path("embedded-audit-artifacts")
+              fallback.mkdir(parents=True, exist_ok=True)
+              proof = {
+                  "executed": False,
+                  "embedded_audit": {"status": "NEEDS_SUPERVISOR"},
+                  "pr_number": int(os.environ.get("EXPECTED_PR") or 0),
+                  "head_sha": os.environ.get("EXPECTED_HEAD_SHA") or "",
+                  "repo": os.environ.get("GITHUB_REPOSITORY") or "",
+              }
+              (fallback / "PROOF.json").write_text(
+                  json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+              )
               raise SystemExit("Independent audit proof is missing.")
+
+          trusted_root = Path("trusted-source")
+          if trusted_root.is_dir():
+              sys.path.insert(0, str(trusted_root.resolve()))
+          else:
+              sys.path.insert(0, str(Path.cwd()))
+
+          from scripts.audit.run_embedded_audit import enforce_independent_audit_proof
+
           proof = json.loads(proof_path.read_text(encoding="utf-8"))
-          status = str(proof.get("embedded_audit", {}).get("status") or "").upper()
-          if status not in {"PASS", "PASS_WITH_RISKS"}:
-              raise SystemExit(f"Independent audit did not pass: {status or 'UNKNOWN'}")
+          enforce_independent_audit_proof(
+              proof,
+              expected_pr=int(os.environ["EXPECTED_PR"]),
+              expected_head_sha=os.environ["EXPECTED_HEAD_SHA"],
+              expected_repo=os.environ.get("GITHUB_REPOSITORY"),
+          )
           PY
 
       - name: Write job summary
@@ -239,14 +337,16 @@ jobs:
           {
             printf '## Embedded audit\n\n'
             printf -- '- mutation_performed: false\n'
-            printf -- '- proof_author: independent-embedded-audit\n'
+            printf -- '- proof_author: independent-embedded-audit (only when executed=true)\n'
             printf -- '- token_value_recorded: false\n'
+            printf -- '- soft_runner_exit: intentional; hard enforcement is authoritative\n'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload embedded audit artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: embedded-audit-${{ steps.pr.outputs.number }}
+          # Collision-resistant identity: purpose + PR + exact head SHA.
+          name: embedded-audit-pr-${{ steps.pr.outputs.number }}-head-${{ steps.pr.outputs.head_sha }}-proof
           path: embedded-audit-artifacts/
           if-no-files-found: error

--- a/.github/workflows/embedded-audit.yml
+++ b/.github/workflows/embedded-audit.yml
@@ -1,7 +1,7 @@
 name: embedded-audit
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
@@ -91,7 +91,6 @@ jobs:
           fi
 
       - name: Static auditor route preflight
-        continue-on-error: true
         working-directory: trusted-source
         run: |
           mkdir -p ../embedded-audit-artifacts
@@ -119,7 +118,7 @@ jobs:
 
       - name: Run PAL clink audit
         if: always() && steps.head_integrity.outputs.verified == 'true'
-        continue-on-error: true
+        id: runner
         working-directory: trusted-source
         run: |
           base_sha="$(git rev-parse HEAD)"
@@ -155,86 +154,10 @@ jobs:
             printf '{"status":"error","risks":["PAL clink runner did not emit output; exit_code=%s"]}\n' "$status" \
               > ../embedded-audit-artifacts/PAL_CLINK_AUDIT_OUTPUT.json
           fi
+          printf 'exit_code=%s\n' "$status" >> "$GITHUB_OUTPUT"
           exit 0
 
-      - name: Emit skipped embedded audit proof
-        if: always()
-        working-directory: trusted-source
-        env:
-          HEAD_VERIFIED: ${{ steps.head_integrity.outputs.verified }}
-        run: |
-          if [ "$HEAD_VERIFIED" != "true" ]; then
-            SKIP_REASON="Independent embedded audit skipped because the requested head SHA could not be fetched or did not match the requested PR head."
-          elif [ ! -f scripts/audit/run_embedded_audit.py ]; then
-            SKIP_REASON="Independent embedded audit skipped because the trusted source ref does not yet contain scripts/audit/run_embedded_audit.py."
-          else
-            exit 0
-          fi
-          export SKIP_REASON
-            python - <<'PY'
-          import json
-          import os
-          from datetime import datetime, timezone
-          from pathlib import Path
-
-          packet_id = "TP-DMX-AUDIT-CI-PROVENANCE-104"
-          report_path = f"proof/{packet_id}/AUDITOR_REPORT.md"
-          reason = os.environ["SKIP_REASON"]
-          out_dir = Path("../embedded-audit-artifacts")
-          out_dir.mkdir(parents=True, exist_ok=True)
-          proof = {
-              "packet_id": packet_id,
-              "repo": os.environ["GITHUB_REPOSITORY"],
-              "pr_number": int("${{ steps.pr.outputs.number }}"),
-              "head_sha": "${{ steps.pr.outputs.head_sha }}",
-              "generated_at": datetime.now(timezone.utc)
-              .replace(microsecond=0)
-              .isoformat()
-              .replace("+00:00", "Z"),
-              "mutation_performed": False,
-              "github_mutation_route_added": False,
-              "embedded_audit": {
-                  "required": True,
-                  "status": "SKIPPED",
-                  "auditor_tool": "none",
-                  "auditor_model": "unknown",
-                  "invocation": None,
-                  "exit_code": None,
-                  "report_path": report_path,
-                  "findings": [],
-                  "fixes_applied": [],
-                  "remaining_risks": [reason],
-                  "skip_reason": reason,
-              },
-              "provenance": {
-                  "proof_author": "independent-embedded-audit",
-                  "workflow": "embedded-audit.yml",
-                  "trusted_token_status": "UNKNOWN",
-                  "token_source": "EMBEDDED_AUDIT_TOKEN",
-                  "token_value_recorded": False,
-                  "permissions": {
-                      "actions": "read",
-                      "checks": "read",
-                      "contents": "read",
-                      "pull-requests": "read",
-                      "statuses": "read",
-                  },
-                  "engine_authored_proof": False,
-                  "engine_requested_only": True,
-              },
-          }
-          (out_dir / "PROOF.json").write_text(
-              json.dumps(proof, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
-          report_file = out_dir / report_path
-          report_file.parent.mkdir(parents=True, exist_ok=True)
-          report_text = f"# Embedded audit\n\nstatus: SKIPPED\n\nreason: {reason}\n"
-          report_file.write_text(report_text, encoding="utf-8")
-          (out_dir / "AUDITOR_REPORT.md").write_text(report_text, encoding="utf-8")
-          PY
-
-      - name: Emit embedded audit proof with trusted token
+      - name: Emit independent embedded audit proof
         if: always() && steps.head_integrity.outputs.verified == 'true'
         working-directory: trusted-source
         env:
@@ -251,6 +174,64 @@ jobs:
             --route-json ../embedded-audit-artifacts/AUDITOR_ROUTE.json \
             --pal-output-json ../embedded-audit-artifacts/PAL_CLINK_AUDIT_OUTPUT.json \
             --out ../embedded-audit-artifacts
+
+      - name: Emit unavailable independent audit proof
+        if: always() && steps.head_integrity.outputs.verified != 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+        run: |
+          mkdir -p embedded-audit-artifacts
+          python - <<'PY'
+          import json
+          import os
+          from datetime import datetime, timezone
+          from pathlib import Path
+
+          reason = "Requested PR head SHA could not be fetched or no longer matches the PR head."
+          artifact_dir = Path("embedded-audit-artifacts")
+          report_path = "proof/TP-DMX-AUDIT-CI-PROVENANCE-104/AUDITOR_REPORT.md"
+          proof = {
+              "packet_id": "TP-DMX-AUDIT-CI-PROVENANCE-104",
+              "repo": os.environ["GITHUB_REPOSITORY"],
+              "pr_number": int(os.environ["PR_NUMBER"]),
+              "head_sha": os.environ["HEAD_SHA"],
+              "generated_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+              "mutation_performed": False,
+              "github_mutation_route_added": False,
+              "embedded_audit": {
+                  "required": True,
+                  "status": "NEEDS_SUPERVISOR",
+                  "auditor_tool": "none",
+                  "auditor_model": "unknown",
+                  "invocation": None,
+                  "exit_code": None,
+                  "report_path": report_path,
+                  "findings": [],
+                  "fixes_applied": [],
+                  "remaining_risks": [reason],
+                  "skip_reason": reason,
+              },
+          }
+          (artifact_dir / "PROOF.json").write_text(json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          (artifact_dir / "AUDITOR_REPORT.md").write_text(f"# Embedded audit\n\nstatus: NEEDS_SUPERVISOR\n\nreason: {reason}\n", encoding="utf-8")
+          PY
+
+      - name: Enforce independent audit result
+        if: always()
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          proof_path = Path("embedded-audit-artifacts/PROOF.json")
+          if not proof_path.is_file():
+              raise SystemExit("Independent audit proof is missing.")
+          proof = json.loads(proof_path.read_text(encoding="utf-8"))
+          status = str(proof.get("embedded_audit", {}).get("status") or "").upper()
+          if status not in {"PASS", "PASS_WITH_RISKS"}:
+              raise SystemExit(f"Independent audit did not pass: {status or 'UNKNOWN'}")
+          PY
 
       - name: Write job summary
         if: always()

--- a/.github/workflows/embedded-audit.yml
+++ b/.github/workflows/embedded-audit.yml
@@ -78,7 +78,10 @@ jobs:
           else
             test -n "$actual_trusted_ref"
           fi
-          test -f trusted-source/scripts/audit/run_embedded_audit.py
+          # Do not hard-fail here when run_embedded_audit.py is absent.
+          # The emit step writes a schema-valid SKIPPED diagnostic PROOF so
+          # artifact upload + Steward can still bind the head and overwrite a
+          # prior green "PR Steward / final readiness" status with failure.
 
       - name: Verify requested head SHA
         id: head_integrity

--- a/.github/workflows/embedded-audit.yml
+++ b/.github/workflows/embedded-audit.yml
@@ -183,7 +183,8 @@ jobs:
         run: |
           mkdir -p ../embedded-audit-artifacts
           if [ ! -f scripts/audit/run_embedded_audit.py ]; then
-            # Structured diagnostic only — no forged trusted provenance.
+            # Structured diagnostic only — schema-valid SKIPPED (none/unknown),
+            # executed=false; no forged trusted provenance. Enforce still reds.
             python - <<'PY'
           import json
           import os
@@ -195,6 +196,7 @@ jobs:
           )
           out = Path("../embedded-audit-artifacts")
           out.mkdir(parents=True, exist_ok=True)
+          report_path = "proof/TP-DMX-AUDIT-CI-PROVENANCE-104/AUDITOR_REPORT.md"
           proof = {
               "packet_id": "TP-DMX-AUDIT-CI-PROVENANCE-104",
               "repo": os.environ["GITHUB_REPOSITORY"],
@@ -205,12 +207,12 @@ jobs:
               "github_mutation_route_added": False,
               "embedded_audit": {
                   "required": True,
-                  "status": "NEEDS_SUPERVISOR",
+                  "status": "SKIPPED",
                   "auditor_tool": "none",
                   "auditor_model": "unknown",
                   "invocation": None,
                   "exit_code": None,
-                  "report_path": "proof/TP-DMX-AUDIT-CI-PROVENANCE-104/AUDITOR_REPORT.md",
+                  "report_path": report_path,
                   "findings": [],
                   "fixes_applied": [],
                   "remaining_risks": [reason],
@@ -221,7 +223,7 @@ jobs:
               json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8"
           )
           (out / "AUDITOR_REPORT.md").write_text(
-              f"# Embedded audit\n\nstatus: NEEDS_SUPERVISOR\n\nreason: {reason}\n",
+              f"# Embedded audit\n\nstatus: SKIPPED\n\nreason: {reason}\n",
               encoding="utf-8",
           )
           PY
@@ -249,7 +251,7 @@ jobs:
           from pathlib import Path
 
           # Inline diagnostic shape mirrors build_diagnostic_failure_proof:
-          # executed=false, NEEDS_SUPERVISOR, no trusted provenance.
+          # executed=false, schema-valid SKIPPED (none/unknown), no trusted provenance.
           reason = "Requested PR head SHA could not be fetched or no longer matches the PR head."
           artifact_dir = Path("embedded-audit-artifacts")
           report_path = "proof/TP-DMX-AUDIT-CI-PROVENANCE-104/AUDITOR_REPORT.md"
@@ -263,7 +265,7 @@ jobs:
               "github_mutation_route_added": False,
               "embedded_audit": {
                   "required": True,
-                  "status": "NEEDS_SUPERVISOR",
+                  "status": "SKIPPED",
                   "auditor_tool": "none",
                   "auditor_model": "unknown",
                   "invocation": None,
@@ -279,7 +281,7 @@ jobs:
               json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8"
           )
           (artifact_dir / "AUDITOR_REPORT.md").write_text(
-              f"# Embedded audit\n\nstatus: NEEDS_SUPERVISOR\n\nreason: {reason}\n",
+              f"# Embedded audit\n\nstatus: SKIPPED\n\nreason: {reason}\n",
               encoding="utf-8",
           )
           PY
@@ -300,19 +302,37 @@ jobs:
 
           proof_path = Path("embedded-audit-artifacts/PROOF.json")
           if not proof_path.is_file():
+              # Schema-valid SKIPPED diagnostic; hard enforce still fails closed.
               fallback = Path("embedded-audit-artifacts")
               fallback.mkdir(parents=True, exist_ok=True)
+              reason = "Independent audit proof is missing."
+              report_path = "proof/TP-DMX-AUDIT-CI-PROVENANCE-104/AUDITOR_REPORT.md"
               proof = {
+                  "packet_id": "TP-DMX-AUDIT-CI-PROVENANCE-104",
                   "executed": False,
-                  "embedded_audit": {"status": "NEEDS_SUPERVISOR"},
                   "pr_number": int(os.environ.get("EXPECTED_PR") or 0),
                   "head_sha": os.environ.get("EXPECTED_HEAD_SHA") or "",
                   "repo": os.environ.get("GITHUB_REPOSITORY") or "",
+                  "mutation_performed": False,
+                  "github_mutation_route_added": False,
+                  "embedded_audit": {
+                      "required": True,
+                      "status": "SKIPPED",
+                      "auditor_tool": "none",
+                      "auditor_model": "unknown",
+                      "invocation": None,
+                      "exit_code": None,
+                      "report_path": report_path,
+                      "findings": [],
+                      "fixes_applied": [],
+                      "remaining_risks": [reason],
+                      "skip_reason": reason,
+                  },
               }
               (fallback / "PROOF.json").write_text(
                   json.dumps(proof, indent=2, sort_keys=True) + "\n", encoding="utf-8"
               )
-              raise SystemExit("Independent audit proof is missing.")
+              raise SystemExit(reason)
 
           trusted_root = Path("trusted-source")
           if trusted_root.is_dir():

--- a/.github/workflows/pr-steward.yml
+++ b/.github/workflows/pr-steward.yml
@@ -77,24 +77,27 @@ jobs:
           if run_id != expected_id:
               errors.append(f"run_id_mismatch: {run_id} != {expected_id}")
 
-          repo_full = (run.get("repository") or {}).get("full_name") or expected_repo
-          if repo_full != expected_repo:
+          # Fail closed: missing repository identity is an error, not a default.
+          repo_full = (run.get("repository") or {}).get("full_name")
+          if not repo_full:
+              errors.append("repository_missing: actions run lacks repository.full_name")
+          elif repo_full != expected_repo:
               errors.append(f"repository_mismatch: {repo_full!r} != {expected_repo!r}")
 
           name = str(run.get("name") or "")
           path = str(run.get("path") or "")
-          if not (
-              name == "embedded-audit"
-              or path.endswith("embedded-audit.yml")
-          ):
+          # Require both display name and workflow path for fail-closed identity.
+          if not (name == "embedded-audit" and path.endswith("embedded-audit.yml")):
               errors.append(f"workflow_mismatch: name={name!r} path={path!r}")
 
           status = str(run.get("status") or "")
           if status != "completed":
               errors.append(f"run_not_completed: status={status!r}")
 
-          head_sha = str(run.get("head_sha") or "")
-          if not head_sha:
+          # run.head_sha is NOT used for PR-head artifact identity.
+          # For pull_request_target, GitHub may report the base/default SHA here.
+          run_head_sha = str(run.get("head_sha") or "")
+          if not run_head_sha:
               errors.append("run_head_sha_missing")
 
           conclusion = str(run.get("conclusion") or "")
@@ -111,13 +114,13 @@ jobs:
 
           out = Path(os.environ["GITHUB_OUTPUT"])
           with out.open("a", encoding="utf-8") as fh:
-              fh.write(f"head_sha={head_sha}\n")
+              fh.write(f"run_head_sha={run_head_sha}\n")
               fh.write(f"conclusion={conclusion}\n")
               fh.write(f"workflow_name={name}\n")
               fh.write(f"workflow_path={path}\n")
           print(
               f"Validated embedded-audit run {run_id} "
-              f"head={head_sha} conclusion={conclusion}"
+              f"run_head_sha={run_head_sha} conclusion={conclusion}"
           )
           PY
 
@@ -125,7 +128,6 @@ jobs:
         id: audit
         env:
           AUDIT_RUN_ID: ${{ steps.audit_run.outputs.id }}
-          EXPECTED_HEAD_SHA: ${{ steps.run_identity.outputs.head_sha }}
           EXPECTED_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -133,9 +135,14 @@ jobs:
           mkdir -p independent-audit-download independent-audit
 
           # Select exactly one artifact by naming contract:
-          #   embedded-audit-pr-<PR>-head-<40-hex>-proof
+          #   embedded-audit-pr-<PR>-head-<40-hex-pr-head>-proof
+          # IMPORTANT: PR head SHA comes from the artifact name (and later PROOF),
+          # not from workflow_run.head_sha (unreliable under pull_request_target).
+          # --paginate may emit multiple JSON objects; slurp+merge with jq -s.
           gh api "repos/${EXPECTED_REPO}/actions/runs/${AUDIT_RUN_ID}/artifacts" \
-            --paginate > /tmp/audit-artifacts.json
+            --paginate \
+            | jq -s 'map(.artifacts // []) | add | {artifacts: .}' \
+            > /tmp/audit-artifacts.json
 
           python - <<'PY'
           import json
@@ -144,18 +151,20 @@ jobs:
           import sys
           from pathlib import Path
 
-          expected_head = os.environ["EXPECTED_HEAD_SHA"]
           payload = json.loads(Path("/tmp/audit-artifacts.json").read_text(encoding="utf-8"))
           artifacts = payload.get("artifacts") or []
+          # Capture PR number and candidate head SHA from the artifact name itself.
           pattern = re.compile(
-              rf"^embedded-audit-pr-(\d+)-head-{re.escape(expected_head)}-proof$"
+              r"^embedded-audit-pr-(\d+)-head-([0-9a-f]{40})-proof$"
           )
           matches = []
           for art in artifacts:
               name = str(art.get("name") or "")
               m = pattern.match(name)
               if m:
-                  matches.append((name, int(m.group(1)), art.get("id")))
+                  matches.append(
+                      (name, int(m.group(1)), m.group(2), art.get("id"))
+                  )
 
           if not matches:
               print(
@@ -169,23 +178,29 @@ jobs:
 
           if len(matches) != 1:
               print("Multiple matching proof artifacts:", file=sys.stderr)
-              for name, pr, _ in matches:
-                  print(f"  - {name} (pr={pr})", file=sys.stderr)
+              for name, pr, head, _ in matches:
+                  print(f"  - {name} (pr={pr} head={head})", file=sys.stderr)
               raise SystemExit("Exactly one expected proof artifact is required")
 
-          name, pr_number, artifact_id = matches[0]
+          name, pr_number, pr_head_sha, artifact_id = matches[0]
           out = Path(os.environ["GITHUB_OUTPUT"])
           with out.open("a", encoding="utf-8") as fh:
               fh.write(f"artifact_name={name}\n")
               fh.write(f"pr_number={pr_number}\n")
+              fh.write(f"pr_head_sha={pr_head_sha}\n")
               fh.write(f"artifact_id={artifact_id}\n")
           Path("/tmp/selected-artifact-name.txt").write_text(name + "\n", encoding="utf-8")
           Path("/tmp/selected-pr-number.txt").write_text(str(pr_number) + "\n", encoding="utf-8")
-          print(f"Selected artifact {name} for PR {pr_number}")
+          Path("/tmp/selected-pr-head-sha.txt").write_text(pr_head_sha + "\n", encoding="utf-8")
+          print(
+              f"Selected artifact {name} for PR {pr_number} "
+              f"candidate_head={pr_head_sha}"
+          )
           PY
 
           ARTIFACT_NAME="$(cat /tmp/selected-artifact-name.txt | tr -d '\n')"
           SELECTED_PR="$(cat /tmp/selected-pr-number.txt | tr -d '\n')"
+          EXPECTED_HEAD_SHA="$(cat /tmp/selected-pr-head-sha.txt | tr -d '\n')"
 
           gh run download "${AUDIT_RUN_ID}" \
             --name "${ARTIFACT_NAME}" \
@@ -204,7 +219,12 @@ jobs:
           test "$proof_pr" = "$SELECTED_PR"
           test "$proof_head" = "$EXPECTED_HEAD_SHA"
 
+          # Cross-check live PR head still matches the artifact-bound head.
+          live_head="$(gh api "repos/${EXPECTED_REPO}/pulls/${SELECTED_PR}" --jq .head.sha)"
+          test "$live_head" = "$EXPECTED_HEAD_SHA"
+
           export PROOF_PR="$proof_pr"
+          export EXPECTED_HEAD_SHA
           python - <<'PY'
           import json
           import os
@@ -225,6 +245,7 @@ jobs:
           PY
 
           printf 'proof_path=independent-audit/PROOF.json\n' >> "$GITHUB_OUTPUT"
+          printf 'pr_head_sha=%s\n' "$EXPECTED_HEAD_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Bind proof identity outputs
         id: proof

--- a/.github/workflows/pr-steward.yml
+++ b/.github/workflows/pr-steward.yml
@@ -1,12 +1,13 @@
 name: PR Steward
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_run:
+    workflows: [embedded-audit]
+    types: [completed]
   workflow_dispatch:
     inputs:
-      pr_number:
-        description: Pull request number to inspect
+      audit_run_id:
+        description: Completed embedded-audit workflow run ID to inspect
         required: true
         type: string
 
@@ -20,57 +21,60 @@ permissions:
 
 jobs:
   pr-steward:
-    name: advisory check-only intake
+    name: final readiness
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Checkout
+      - name: Checkout trusted Steward source
         uses: actions/checkout@v4
 
-      - name: Set PR number
-        id: pr
+      - name: Set audit run ID
+        id: audit_run
         env:
           EVENT_NAME: ${{ github.event_name }}
-          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
-          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          EVENT_AUDIT_RUN_ID: ${{ github.event.workflow_run.id }}
+          INPUT_AUDIT_RUN_ID: ${{ inputs.audit_run_id }}
         run: |
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            printf 'number=%s\n' "$EVENT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            audit_run_id="$EVENT_AUDIT_RUN_ID"
           else
-            printf 'number=%s\n' "$INPUT_PR_NUMBER" >> "$GITHUB_OUTPUT"
+            audit_run_id="$INPUT_AUDIT_RUN_ID"
           fi
+          test -n "$audit_run_id"
+          printf 'id=%s\n' "$audit_run_id" >> "$GITHUB_OUTPUT"
 
-      - name: Refresh PR audit proof
+      - name: Download completed independent audit artifact
+        id: audit
         run: |
-          python -m scripts.audit.pr_audit_router \
-            --dry-run \
-            --packet-id TP-DMX-PR-AUDIT-ROUTER-001 \
-            --git-sha "${{ github.event.pull_request.head.sha || github.sha }}" \
-            --out proof/TP-DMX-PR-AUDIT-ROUTER-001/MULTI_MODEL_PR_AUDIT.json
+          rm -rf independent-audit-download independent-audit
+          gh run download "${{ steps.audit_run.outputs.id }}" --dir independent-audit-download
+          proof_path="$(find independent-audit-download -type f -name PROOF.json -print -quit)"
+          test -n "$proof_path"
+          mkdir -p independent-audit
+          cp "$proof_path" independent-audit/PROOF.json
+          jq -e '.pr_number | numbers' independent-audit/PROOF.json >/dev/null
+          jq -e '.head_sha | strings' independent-audit/PROOF.json >/dev/null
+          printf 'proof_path=independent-audit/PROOF.json\n' >> "$GITHUB_OUTPUT"
+          printf 'pr_number=%s\n' "$(jq -er '.pr_number' independent-audit/PROOF.json)" >> "$GITHUB_OUTPUT"
 
       - name: Run PR Steward
         id: steward
-        continue-on-error: true
         run: |
-          set +e
           python -m tools.pr_steward.intake \
             --repo "$GITHUB_REPOSITORY" \
-            --pr "${{ steps.pr.outputs.number }}" \
+            --pr "${{ steps.audit.outputs.pr_number }}" \
             --out pr-steward-artifacts \
             --strict \
             --format text \
-            --proof-path proof/TP-DMX-PR-AUDIT-ROUTER-001/MULTI_MODEL_PR_AUDIT.json
-          status=$?
-          printf 'exit_code=%s\n' "$status" >> "$GITHUB_OUTPUT"
-          exit 0
+            --proof-path independent-audit/PROOF.json
 
       - name: Write job summary
         if: always()
         run: |
           {
-            printf '## PR Steward advisory result\n\n'
-            printf -- '- exit_code: %s\n' '${{ steps.steward.outputs.exit_code }}'
+            printf '## PR Steward final readiness\n\n'
+            printf -- '- audit_run_id: %s\n' '${{ steps.audit_run.outputs.id }}'
             printf -- '- mutation_performed: false\n\n'
             if [ -f pr-steward-artifacts/PR_STEWARD_SUMMARY.md ]; then
               cat pr-steward-artifacts/PR_STEWARD_SUMMARY.md

--- a/.github/workflows/pr-steward.yml
+++ b/.github/workflows/pr-steward.yml
@@ -15,7 +15,10 @@ permissions:
   contents: read
   pull-requests: read
   checks: read
-  statuses: read
+  # statuses: write posts readiness against the *candidate PR head* so the
+  # required check can attach to the PR commit (workflow_run jobs run on
+  # default-branch GITHUB_SHA and would otherwise be invisible to PR protection).
+  statuses: write
   actions: read
   issues: read
 
@@ -267,6 +270,29 @@ jobs:
             --format text \
             --proof-path independent-audit/PROOF.json
 
+      - name: Publish readiness status on candidate PR head
+        if: always() && steps.proof.outputs.head_sha != ''
+        env:
+          PR_HEAD_SHA: ${{ steps.proof.outputs.head_sha }}
+          PR_NUMBER: ${{ steps.proof.outputs.pr_number }}
+          STEWARD_OUTCOME: ${{ steps.steward.outcome }}
+        run: |
+          # workflow_run jobs execute against default-branch GITHUB_SHA. Publish
+          # an explicit commit status on the validated candidate head so branch
+          # protection can require "PR Steward / final readiness" on the PR.
+          if [ "${STEWARD_OUTCOME}" = "success" ]; then
+            state="success"
+            description="final readiness READY for PR ${PR_NUMBER}"
+          else
+            state="failure"
+            description="final readiness not READY for PR ${PR_NUMBER}"
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${PR_HEAD_SHA}" \
+            -f state="${state}" \
+            -f context="PR Steward / final readiness" \
+            -f description="${description}" \
+            -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
       - name: Write job summary
         if: always()
         run: |
@@ -275,7 +301,8 @@ jobs:
             printf -- '- audit_run_id: %s\n' '${{ steps.audit_run.outputs.id }}'
             printf -- '- validated_head_sha: %s\n' '${{ steps.proof.outputs.head_sha }}'
             printf -- '- pr_number: %s\n' '${{ steps.proof.outputs.pr_number }}'
-            printf -- '- mutation_performed: false\n\n'
+            printf -- '- candidate_head_status_context: PR Steward / final readiness\n'
+            printf -- '- mutation_performed: false (read-only steward; status publish only)\n\n'
             if [ -f pr-steward-artifacts/PR_STEWARD_SUMMARY.md ]; then
               cat pr-steward-artifacts/PR_STEWARD_SUMMARY.md
             else

--- a/.github/workflows/pr-steward.yml
+++ b/.github/workflows/pr-steward.yml
@@ -308,6 +308,8 @@ jobs:
           # protection can require "PR Steward / final readiness" on the PR.
           # Always overwrite prior status for this context on this head, including
           # when a later failed audit re-runs after an earlier green.
+          # Classifier excludes this exact context from readiness evaluation so a
+          # prior failed self-status cannot sticky-red the next Steward run.
           if [ "${AUDIT_CONCLUSION}" = "success" ] \
             && [ "${AUDIT_OUTCOME}" = "success" ] \
             && [ "${STEWARD_OUTCOME}" = "success" ]; then

--- a/.github/workflows/pr-steward.yml
+++ b/.github/workflows/pr-steward.yml
@@ -21,6 +21,12 @@ permissions:
 
 jobs:
   pr-steward:
+    # CHECK-NAME MIGRATION (branch-protection follow-up required, out of packet scope):
+    #   old check name: PR Steward / advisory check-only intake
+    #   new check name: PR Steward / final readiness
+    # Branch protection / rulesets that pin the old name will not enforce this gate
+    # until updated in an authorized follow-on packet. This packet does not modify
+    # branch protection.
     name: final readiness
     runs-on: ubuntu-latest
     env:
@@ -28,6 +34,8 @@ jobs:
     steps:
       - name: Checkout trusted Steward source
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set audit run ID
         id: audit_run
@@ -44,26 +52,195 @@ jobs:
           test -n "$audit_run_id"
           printf 'id=%s\n' "$audit_run_id" >> "$GITHUB_OUTPUT"
 
-      - name: Download completed independent audit artifact
-        id: audit
+      - name: Validate audit workflow-run identity
+        id: run_identity
+        env:
+          AUDIT_RUN_ID: ${{ steps.audit_run.outputs.id }}
+          EXPECTED_REPO: ${{ github.repository }}
         run: |
+          # Do not trust arbitrary PROOF.json until the Actions run itself is
+          # proven to be the expected embedded-audit workflow in this repository.
+          gh api "repos/${EXPECTED_REPO}/actions/runs/${AUDIT_RUN_ID}" > /tmp/audit-run.json
+
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          run = json.loads(Path("/tmp/audit-run.json").read_text(encoding="utf-8"))
+          expected_repo = os.environ["EXPECTED_REPO"]
+          expected_id = int(os.environ["AUDIT_RUN_ID"])
+          errors = []
+
+          run_id = int(run.get("id") or 0)
+          if run_id != expected_id:
+              errors.append(f"run_id_mismatch: {run_id} != {expected_id}")
+
+          repo_full = (run.get("repository") or {}).get("full_name") or expected_repo
+          if repo_full != expected_repo:
+              errors.append(f"repository_mismatch: {repo_full!r} != {expected_repo!r}")
+
+          name = str(run.get("name") or "")
+          path = str(run.get("path") or "")
+          if not (
+              name == "embedded-audit"
+              or path.endswith("embedded-audit.yml")
+          ):
+              errors.append(f"workflow_mismatch: name={name!r} path={path!r}")
+
+          status = str(run.get("status") or "")
+          if status != "completed":
+              errors.append(f"run_not_completed: status={status!r}")
+
+          head_sha = str(run.get("head_sha") or "")
+          if not head_sha:
+              errors.append("run_head_sha_missing")
+
+          conclusion = str(run.get("conclusion") or "")
+          # Final readiness requires a successful audit conclusion. Failed runs
+          # retain artifacts for diagnosis but cannot produce READY.
+          if conclusion != "success":
+              errors.append(f"run_conclusion_not_success: conclusion={conclusion!r}")
+
+          if errors:
+              print("Audit workflow-run identity validation failed:", file=sys.stderr)
+              for err in errors:
+                  print(f"  - {err}", file=sys.stderr)
+              raise SystemExit(1)
+
+          out = Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as fh:
+              fh.write(f"head_sha={head_sha}\n")
+              fh.write(f"conclusion={conclusion}\n")
+              fh.write(f"workflow_name={name}\n")
+              fh.write(f"workflow_path={path}\n")
+          print(
+              f"Validated embedded-audit run {run_id} "
+              f"head={head_sha} conclusion={conclusion}"
+          )
+          PY
+
+      - name: Select and download independent audit artifact
+        id: audit
+        env:
+          AUDIT_RUN_ID: ${{ steps.audit_run.outputs.id }}
+          EXPECTED_HEAD_SHA: ${{ steps.run_identity.outputs.head_sha }}
+          EXPECTED_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
           rm -rf independent-audit-download independent-audit
-          gh run download "${{ steps.audit_run.outputs.id }}" --dir independent-audit-download
+          mkdir -p independent-audit-download independent-audit
+
+          # Select exactly one artifact by naming contract:
+          #   embedded-audit-pr-<PR>-head-<40-hex>-proof
+          gh api "repos/${EXPECTED_REPO}/actions/runs/${AUDIT_RUN_ID}/artifacts" \
+            --paginate > /tmp/audit-artifacts.json
+
+          python - <<'PY'
+          import json
+          import os
+          import re
+          import sys
+          from pathlib import Path
+
+          expected_head = os.environ["EXPECTED_HEAD_SHA"]
+          payload = json.loads(Path("/tmp/audit-artifacts.json").read_text(encoding="utf-8"))
+          artifacts = payload.get("artifacts") or []
+          pattern = re.compile(
+              rf"^embedded-audit-pr-(\d+)-head-{re.escape(expected_head)}-proof$"
+          )
+          matches = []
+          for art in artifacts:
+              name = str(art.get("name") or "")
+              m = pattern.match(name)
+              if m:
+                  matches.append((name, int(m.group(1)), art.get("id")))
+
+          if not matches:
+              print(
+                  "No exact-name artifact found; refusing arbitrary PROOF.json selection.",
+                  file=sys.stderr,
+              )
+              print("Available artifacts:", file=sys.stderr)
+              for art in artifacts:
+                  print(f"  - {art.get('name')}", file=sys.stderr)
+              raise SystemExit("Expected embedded-audit proof artifact not found")
+
+          if len(matches) != 1:
+              print("Multiple matching proof artifacts:", file=sys.stderr)
+              for name, pr, _ in matches:
+                  print(f"  - {name} (pr={pr})", file=sys.stderr)
+              raise SystemExit("Exactly one expected proof artifact is required")
+
+          name, pr_number, artifact_id = matches[0]
+          out = Path(os.environ["GITHUB_OUTPUT"])
+          with out.open("a", encoding="utf-8") as fh:
+              fh.write(f"artifact_name={name}\n")
+              fh.write(f"pr_number={pr_number}\n")
+              fh.write(f"artifact_id={artifact_id}\n")
+          Path("/tmp/selected-artifact-name.txt").write_text(name + "\n", encoding="utf-8")
+          Path("/tmp/selected-pr-number.txt").write_text(str(pr_number) + "\n", encoding="utf-8")
+          print(f"Selected artifact {name} for PR {pr_number}")
+          PY
+
+          ARTIFACT_NAME="$(cat /tmp/selected-artifact-name.txt | tr -d '\n')"
+          SELECTED_PR="$(cat /tmp/selected-pr-number.txt | tr -d '\n')"
+
+          gh run download "${AUDIT_RUN_ID}" \
+            --name "${ARTIFACT_NAME}" \
+            --dir independent-audit-download
+
+          proof_count="$(find independent-audit-download -type f -name PROOF.json | wc -l | tr -d ' ')"
+          test "$proof_count" = "1"
           proof_path="$(find independent-audit-download -type f -name PROOF.json -print -quit)"
-          test -n "$proof_path"
-          mkdir -p independent-audit
           cp "$proof_path" independent-audit/PROOF.json
+
           jq -e '.pr_number | numbers' independent-audit/PROOF.json >/dev/null
           jq -e '.head_sha | strings' independent-audit/PROOF.json >/dev/null
+
+          proof_pr="$(jq -er '.pr_number' independent-audit/PROOF.json)"
+          proof_head="$(jq -er '.head_sha' independent-audit/PROOF.json)"
+          test "$proof_pr" = "$SELECTED_PR"
+          test "$proof_head" = "$EXPECTED_HEAD_SHA"
+
+          export PROOF_PR="$proof_pr"
+          python - <<'PY'
+          import json
+          import os
+          import sys
+          from pathlib import Path
+
+          sys.path.insert(0, str(Path.cwd()))
+          from scripts.audit.run_embedded_audit import enforce_independent_audit_proof
+
+          proof = json.loads(Path("independent-audit/PROOF.json").read_text(encoding="utf-8"))
+          enforce_independent_audit_proof(
+              proof,
+              expected_pr=int(os.environ["PROOF_PR"]),
+              expected_head_sha=os.environ["EXPECTED_HEAD_SHA"],
+              expected_repo=os.environ["EXPECTED_REPO"],
+          )
+          print("Independent audit proof identity enforcement: PASS")
+          PY
+
           printf 'proof_path=independent-audit/PROOF.json\n' >> "$GITHUB_OUTPUT"
-          printf 'pr_number=%s\n' "$(jq -er '.pr_number' independent-audit/PROOF.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Bind proof identity outputs
+        id: proof
+        run: |
+          pr_number="$(jq -er '.pr_number' independent-audit/PROOF.json)"
+          head_sha="$(jq -er '.head_sha' independent-audit/PROOF.json)"
+          printf 'pr_number=%s\n' "$pr_number" >> "$GITHUB_OUTPUT"
+          printf 'head_sha=%s\n' "$head_sha" >> "$GITHUB_OUTPUT"
+          printf 'proof_path=independent-audit/PROOF.json\n' >> "$GITHUB_OUTPUT"
 
       - name: Run PR Steward
         id: steward
         run: |
           python -m tools.pr_steward.intake \
             --repo "$GITHUB_REPOSITORY" \
-            --pr "${{ steps.audit.outputs.pr_number }}" \
+            --pr "${{ steps.proof.outputs.pr_number }}" \
             --out pr-steward-artifacts \
             --strict \
             --format text \
@@ -75,6 +252,8 @@ jobs:
           {
             printf '## PR Steward final readiness\n\n'
             printf -- '- audit_run_id: %s\n' '${{ steps.audit_run.outputs.id }}'
+            printf -- '- validated_head_sha: %s\n' '${{ steps.proof.outputs.head_sha }}'
+            printf -- '- pr_number: %s\n' '${{ steps.proof.outputs.pr_number }}'
             printf -- '- mutation_performed: false\n\n'
             if [ -f pr-steward-artifacts/PR_STEWARD_SUMMARY.md ]; then
               cat pr-steward-artifacts/PR_STEWARD_SUMMARY.md
@@ -87,6 +266,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: pr-steward-${{ steps.pr.outputs.number }}
+          # Attributable name from validated independent-audit proof identity
+          # (not a stale steps.pr.outputs.number reference).
+          name: pr-steward-pr-${{ steps.proof.outputs.pr_number }}-head-${{ steps.proof.outputs.head_sha }}-readiness
           path: pr-steward-artifacts/
           if-no-files-found: warn

--- a/.github/workflows/pr-steward.yml
+++ b/.github/workflows/pr-steward.yml
@@ -104,10 +104,11 @@ jobs:
               errors.append("run_head_sha_missing")
 
           conclusion = str(run.get("conclusion") or "")
-          # Final readiness requires a successful audit conclusion. Failed runs
-          # retain artifacts for diagnosis but cannot produce READY.
-          if conclusion != "success":
-              errors.append(f"run_conclusion_not_success: conclusion={conclusion!r}")
+          # Do NOT abort identity validation solely because conclusion != success.
+          # Failed/re-run audits must still bind candidate head and publish a
+          # failure status so a prior green status cannot stick.
+          if not conclusion:
+              errors.append("run_conclusion_missing")
 
           if errors:
               print("Audit workflow-run identity validation failed:", file=sys.stderr)
@@ -119,12 +120,21 @@ jobs:
           with out.open("a", encoding="utf-8") as fh:
               fh.write(f"run_head_sha={run_head_sha}\n")
               fh.write(f"conclusion={conclusion}\n")
+              fh.write(
+                  f"conclusion_ok={'true' if conclusion == 'success' else 'false'}\n"
+              )
               fh.write(f"workflow_name={name}\n")
               fh.write(f"workflow_path={path}\n")
           print(
               f"Validated embedded-audit run {run_id} "
               f"run_head_sha={run_head_sha} conclusion={conclusion}"
           )
+          if conclusion != "success":
+              print(
+                  f"NOTE: audit conclusion={conclusion!r}; continuing to bind "
+                  "candidate head and publish failure status.",
+                  file=sys.stderr,
+              )
           PY
 
       - name: Select and download independent audit artifact
@@ -132,6 +142,7 @@ jobs:
         env:
           AUDIT_RUN_ID: ${{ steps.audit_run.outputs.id }}
           EXPECTED_REPO: ${{ github.repository }}
+          AUDIT_CONCLUSION: ${{ steps.run_identity.outputs.conclusion }}
         run: |
           set -euo pipefail
           rm -rf independent-audit-download independent-audit
@@ -142,6 +153,8 @@ jobs:
           # IMPORTANT: PR head SHA comes from the artifact name (and later PROOF),
           # not from workflow_run.head_sha (unreliable under pull_request_target).
           # --paginate may emit multiple JSON objects; slurp+merge with jq -s.
+          # Runs even when audit conclusion != success so failure status can be
+          # published against the candidate head (overwriting stale green).
           gh api "repos/${EXPECTED_REPO}/actions/runs/${AUDIT_RUN_ID}/artifacts" \
             --paginate \
             | jq -s 'map(.artifacts // []) | add | {artifacts: .}' \
@@ -226,6 +239,18 @@ jobs:
           live_head="$(gh api "repos/${EXPECTED_REPO}/pulls/${SELECTED_PR}" --jq .head.sha)"
           test "$live_head" = "$EXPECTED_HEAD_SHA"
 
+          # Bind identity outputs BEFORE hard enforce so failure status can still
+          # be published when the audit conclusion or proof is non-passing.
+          printf 'proof_path=independent-audit/PROOF.json\n' >> "$GITHUB_OUTPUT"
+          printf 'pr_head_sha=%s\n' "$EXPECTED_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          printf 'pr_number=%s\n' "$SELECTED_PR" >> "$GITHUB_OUTPUT"
+
+          # Hard gate: non-success audit conclusion cannot produce READY.
+          if [ "${AUDIT_CONCLUSION}" != "success" ]; then
+            echo "Audit workflow conclusion is ${AUDIT_CONCLUSION}; refusing READY." >&2
+            exit 2
+          fi
+
           export PROOF_PR="$proof_pr"
           export EXPECTED_HEAD_SHA
           python - <<'PY'
@@ -247,11 +272,9 @@ jobs:
           print("Independent audit proof identity enforcement: PASS")
           PY
 
-          printf 'proof_path=independent-audit/PROOF.json\n' >> "$GITHUB_OUTPUT"
-          printf 'pr_head_sha=%s\n' "$EXPECTED_HEAD_SHA" >> "$GITHUB_OUTPUT"
-
       - name: Bind proof identity outputs
         id: proof
+        if: always() && hashFiles('independent-audit/PROOF.json') != ''
         run: |
           pr_number="$(jq -er '.pr_number' independent-audit/PROOF.json)"
           head_sha="$(jq -er '.head_sha' independent-audit/PROOF.json)"
@@ -261,6 +284,7 @@ jobs:
 
       - name: Run PR Steward
         id: steward
+        if: success()
         run: |
           python -m tools.pr_steward.intake \
             --repo "$GITHUB_REPOSITORY" \
@@ -276,22 +300,32 @@ jobs:
           PR_HEAD_SHA: ${{ steps.proof.outputs.head_sha }}
           PR_NUMBER: ${{ steps.proof.outputs.pr_number }}
           STEWARD_OUTCOME: ${{ steps.steward.outcome }}
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+          AUDIT_CONCLUSION: ${{ steps.run_identity.outputs.conclusion }}
         run: |
           # workflow_run jobs execute against default-branch GITHUB_SHA. Publish
           # an explicit commit status on the validated candidate head so branch
           # protection can require "PR Steward / final readiness" on the PR.
-          if [ "${STEWARD_OUTCOME}" = "success" ]; then
+          # Always overwrite prior status for this context on this head, including
+          # when a later failed audit re-runs after an earlier green.
+          if [ "${AUDIT_CONCLUSION}" = "success" ] \
+            && [ "${AUDIT_OUTCOME}" = "success" ] \
+            && [ "${STEWARD_OUTCOME}" = "success" ]; then
             state="success"
             description="final readiness READY for PR ${PR_NUMBER}"
           else
             state="failure"
-            description="final readiness not READY for PR ${PR_NUMBER}"
+            description="final readiness not READY for PR ${PR_NUMBER} (audit=${AUDIT_CONCLUSION}/${AUDIT_OUTCOME} steward=${STEWARD_OUTCOME})"
           fi
           gh api "repos/${GITHUB_REPOSITORY}/statuses/${PR_HEAD_SHA}" \
             -f state="${state}" \
             -f context="PR Steward / final readiness" \
             -f description="${description}" \
             -f target_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          # Fail the job when not READY so the workflow itself is red.
+          if [ "${state}" != "success" ]; then
+            exit 1
+          fi
 
       - name: Write job summary
         if: always()

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/AUDIT.md
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/AUDIT.md
@@ -1,0 +1,27 @@
+# Independent / security audit — remediation evidence
+
+## Verdict
+
+**PASS_WITH_RISKS** (local implementer + PAL workflow internal findings)
+
+External expert model validation returned HTTP 429 quota exhaustion for gemini-2.5-pro.
+No blocking residual risks identified that re-open review MUST_FIX items.
+
+## Risks (non-blocking)
+
+1. Live default-branch `pull_request_target` + Steward chain is not proven until PR #1042 merges.
+2. Soft PAL runner exit depends on hard enforce remaining complete.
+3. Branch-protection check-name migration required out of packet.
+4. Steward `workflow_dispatch` can target any completed successful embedded-audit run id (same-repo identity checks mitigate).
+
+## Surfaces reviewed
+
+- pull_request_target secret exposure
+- trusted vs candidate checkout
+- arbitrary workflow-run artifact injection
+- self-attested provenance
+- head substitution
+- artifact collisions
+- failed-run artifact retention
+- check-name drift
+- read-only Steward invariant

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/AUDITOR_RAW.txt
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/AUDITOR_RAW.txt
@@ -1,0 +1,3 @@
+PAL codereview: internal complete; external gemini-2.5-pro 429 RESOURCE_EXHAUSTED
+PAL secaudit: internal complete; external gemini-2.5-pro 429 RESOURCE_EXHAUSTED
+Issues: medium live-unproven-until-merge; low soft-runner/enforce coupling; low check-name drift; low workflow_dispatch run-id footgun

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/AUDITOR_REPORT.md
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/AUDITOR_REPORT.md
@@ -1,0 +1,31 @@
+# Auditor Report — TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION
+
+## Status
+
+`NEEDS_SUPERVISOR`
+
+## Scope
+
+Trusted audit foundation remediation for PR #1042
+(`codex/tp-dmx-merge-integrity-foundation`).
+
+## Local / PAL internal review (not independent)
+
+PAL `codereview` + `secaudit` workflows completed internal steps. External
+Gemini expert validation returned HTTP 429. That material is retained under
+`AUDITOR_RAW.txt` and must not be treated as an independent embedded-audit
+receipt.
+
+## Required before merge authorization
+
+1. Docs and Complete CI green on the exact PR head.
+2. Independent auditor (AGY/Sonnet, Claude Code Sonnet/Opus, or Gemini CLI)
+   against that exact head, preserved as an **external** receipt (not a
+   proof-only rebinding commit).
+3. Supervisor disposition after re-fetch of checks and review threads.
+
+## Residual risks
+
+- Live default-branch `pull_request_target` / Steward behavior unproven until merge.
+- Soft PAL runner exit depends on hard proof enforcement remaining complete.
+- Branch-protection check-name migration still required out of packet.

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/COMMAND_LOG.md
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/COMMAND_LOG.md
@@ -1,0 +1,12 @@
+# Command log — TP-DMX-MERGE-INTEGRITY-0004 remediation (0001R2 Phase A)
+
+| Command | Exit |
+|---|---|
+| `python -m pytest -q tests/audit/test_pr_audit_router.py tests/audit/test_run_embedded_audit.py tests/pr_steward/test_intake.py --no-cov` | 0 |
+| `python -m compileall -q scripts/audit tools/pr_steward` | 0 |
+| workflow YAML `yaml.safe_load` | 0 |
+| `jsonschema.validate` task packet vs dopetask-canonical-spec | 0 |
+| `pre-commit run --files <changed>` | 0 |
+| `git diff --check` | 0 |
+| PAL codereview (gemini-2.5-pro external) | API 429; internal workflow complete |
+| PAL secaudit (gemini-2.5-pro external) | API 429; internal workflow complete |

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/DIFF_STAT.txt
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/DIFF_STAT.txt
@@ -1,0 +1,18 @@
+ .github/workflows/embedded-audit.yml               | 115 +++++++++------------
+ .github/workflows/pr-steward.yml                   |  60 ++++++-----
+ scripts/audit/pr_audit_router.py                   |   2 +-
+ scripts/audit/run_embedded_audit.py                |   6 ++
+ ...GE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json |  77 ++++++++++++++
+ tests/audit/test_pr_audit_router.py                |   8 ++
+ tests/audit/test_run_embedded_audit.py             |  34 ++++--
+ tests/pr_steward/test_intake.py                    |  60 +++++++++++
+ tools/pr_steward/collector.py                      |  27 ++++-
+ 9 files changed, 282 insertions(+), 107 deletions(-)
+ .github/workflows/embedded-audit.yml               | 136 ++++++++++--
+ .github/workflows/pr-steward.yml                   | 195 ++++++++++++++++-
+ scripts/audit/run_embedded_audit.py                | 138 ++++++++++++
+ ...GE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json |  53 ++++-
+ tests/audit/test_run_embedded_audit.py             | 231 ++++++++++++++++++++-
+ tests/pr_steward/test_intake.py                    | 158 ++++++++++++++
+ tools/pr_steward/collector.py                      |  24 +--
+ 7 files changed, 885 insertions(+), 50 deletions(-)

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PRECOMMIT.txt
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PRECOMMIT.txt
@@ -1,0 +1,6 @@
+pre-commit run --files <branch allowlist files>
+result: PASS (exit 0) on 2026-07-12
+git diff --check: PASS (exit 0)
+python compileall scripts/audit tools/pr_steward: PASS
+workflow YAML parse: PASS
+task packet jsonschema (dopetask-canonical-spec): PASS

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
@@ -5,8 +5,7 @@
   "repo": "DDD-Enterprises/dopemux-mvp",
   "branch": "codex/tp-dmx-merge-integrity-foundation",
   "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
-  "head_sha_pre_commit": "b67bb764575aaab43f643c51cbef1912f950bbc2",
-  "head_sha": "PENDING_COMMIT",
+  "head_sha": "31e9f0abc6a452763b5384efea357ac5373dfc11",
   "generated_at": "2026-07-12T19:48:57Z",
   "changed_files": [
     ".github/workflows/embedded-audit.yml",

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
@@ -5,8 +5,8 @@
   "repo": "DDD-Enterprises/dopemux-mvp",
   "branch": "codex/tp-dmx-merge-integrity-foundation",
   "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
-  "head_sha": "a938aae05d8ddc6a308bad3299fe9c7b11c4a627",
-  "generated_at": "2026-07-12T19:49:27Z",
+  "head_sha": "b67bb764575aaab43f643c51cbef1912f950bbc2",
+  "generated_at": "2026-07-12T19:49:32Z",
   "changed_files": [
     ".github/workflows/embedded-audit.yml",
     ".github/workflows/pr-steward.yml",
@@ -57,5 +57,7 @@
   "mutation_performed": false,
   "merge_authorized": false,
   "live_default_branch_proven": false,
-  "head_sha_binding": "branch_tip_at_proof_write; PR head after push is authoritative for supervisor gate"
+  "head_sha_binding": "branch_tip_at_proof_write; PR head after push is authoritative for supervisor gate",
+  "pr_head_ref_oid": "b67bb764575aaab43f643c51cbef1912f950bbc2",
+  "head_sha_note": "Authoritative exact head is the git tip after this commit is pushed (see PR headRefOid)."
 }

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
@@ -1,0 +1,61 @@
+{
+  "packet_id": "TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION",
+  "remediation_packet": "TP-DMX-MERGE-INTEGRITY-0001R2",
+  "pr_number": 1042,
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "branch": "codex/tp-dmx-merge-integrity-foundation",
+  "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
+  "head_sha_pre_commit": "b67bb764575aaab43f643c51cbef1912f950bbc2",
+  "head_sha": "PENDING_COMMIT",
+  "generated_at": "2026-07-12T19:48:57Z",
+  "changed_files": [
+    ".github/workflows/embedded-audit.yml",
+    ".github/workflows/pr-steward.yml",
+    "scripts/audit/run_embedded_audit.py",
+    "tools/pr_steward/collector.py",
+    "tests/audit/test_run_embedded_audit.py",
+    "tests/pr_steward/test_intake.py",
+    "task-packets/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json",
+    "proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/**"
+  ],
+  "commands": {
+    "pytest": {
+      "exit_code": 0
+    },
+    "compileall": {
+      "exit_code": 0
+    },
+    "yaml_parse": {
+      "exit_code": 0
+    },
+    "packet_schema": {
+      "exit_code": 0
+    },
+    "precommit": {
+      "exit_code": 0
+    },
+    "git_diff_check": {
+      "exit_code": 0
+    }
+  },
+  "tests": {
+    "focused_audit_steward": "PASS",
+    "exit_code": 0
+  },
+  "precommit": "PASS",
+  "embedded_audit": {
+    "status": "PASS_WITH_RISKS",
+    "auditor_tool": "pal-stdio-codereview+secaudit",
+    "auditor_model": "gemini-2.5-pro",
+    "invocation": "pal-stdio codereview + secaudit; external expert 429; internal findings retained",
+    "exit_code": null,
+    "remaining_risks": [
+      "Live default-branch workflow behavior not proven until PR #1042 merges",
+      "Soft runner exit depends on hard enforce remaining complete",
+      "Branch-protection check-name migration required (out of packet)"
+    ]
+  },
+  "mutation_performed": false,
+  "merge_authorized": false,
+  "live_default_branch_proven": false
+}

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
@@ -5,7 +5,7 @@
   "repo": "DDD-Enterprises/dopemux-mvp",
   "branch": "codex/tp-dmx-merge-integrity-foundation",
   "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
-  "head_sha": "31e9f0abc6a452763b5384efea357ac5373dfc11",
+  "head_sha": "87637c5027acdb1adf6af9493a7cb40c5f471814",
   "generated_at": "2026-07-12T19:48:57Z",
   "changed_files": [
     ".github/workflows/embedded-audit.yml",

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
@@ -5,8 +5,8 @@
   "repo": "DDD-Enterprises/dopemux-mvp",
   "branch": "codex/tp-dmx-merge-integrity-foundation",
   "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
-  "head_sha": "POST_PUSH_BIND",
-  "generated_at": "2026-07-12T19:49:54Z",
+  "head_sha": "67229e85312083fb814309b006259462fdacbefd",
+  "generated_at": "2026-07-12T19:49:59Z",
   "changed_files": [
     ".github/workflows/embedded-audit.yml",
     ".github/workflows/pr-steward.yml",
@@ -57,7 +57,7 @@
   "mutation_performed": false,
   "merge_authorized": false,
   "live_default_branch_proven": false,
-  "pr_head_ref_oid": "b21ac7b1f0487c7b2866631b2ab67d1b8068f486",
+  "pr_head_ref_oid": "67229e85312083fb814309b006259462fdacbefd",
   "head_sha_note": "After this commit is included, supervisor must re-read gh pr view headRefOid. If a subsequent proof-only commit exists, that newer SHA is exact head.",
   "remote_branch_tip": "b21ac7b1f0487c7b2866631b2ab67d1b8068f486",
   "commits_on_branch": [
@@ -69,5 +69,7 @@
     "ded3cf0a6 test(audit): lock fail-closed provenance and workflow behavior",
     "65bcc14e1 fix(audit): bind pull-request-target metadata and proof identity",
     "b67bb7645 fix(audit): fail closed on independent audit evidence"
-  ]
+  ],
+  "local_head_at_record": "67229e85312083fb814309b006259462fdacbefd",
+  "head_match": true
 }

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
@@ -5,8 +5,8 @@
   "repo": "DDD-Enterprises/dopemux-mvp",
   "branch": "codex/tp-dmx-merge-integrity-foundation",
   "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
-  "head_sha": "87637c5027acdb1adf6af9493a7cb40c5f471814",
-  "generated_at": "2026-07-12T19:48:57Z",
+  "head_sha": "a938aae05d8ddc6a308bad3299fe9c7b11c4a627",
+  "generated_at": "2026-07-12T19:49:27Z",
   "changed_files": [
     ".github/workflows/embedded-audit.yml",
     ".github/workflows/pr-steward.yml",
@@ -56,5 +56,6 @@
   },
   "mutation_performed": false,
   "merge_authorized": false,
-  "live_default_branch_proven": false
+  "live_default_branch_proven": false,
+  "head_sha_binding": "branch_tip_at_proof_write; PR head after push is authoritative for supervisor gate"
 }

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
@@ -5,8 +5,8 @@
   "repo": "DDD-Enterprises/dopemux-mvp",
   "branch": "codex/tp-dmx-merge-integrity-foundation",
   "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
-  "head_sha": "b67bb764575aaab43f643c51cbef1912f950bbc2",
-  "generated_at": "2026-07-12T19:49:32Z",
+  "head_sha": "POST_PUSH_BIND",
+  "generated_at": "2026-07-12T19:49:54Z",
   "changed_files": [
     ".github/workflows/embedded-audit.yml",
     ".github/workflows/pr-steward.yml",
@@ -57,7 +57,17 @@
   "mutation_performed": false,
   "merge_authorized": false,
   "live_default_branch_proven": false,
-  "head_sha_binding": "branch_tip_at_proof_write; PR head after push is authoritative for supervisor gate",
-  "pr_head_ref_oid": "b67bb764575aaab43f643c51cbef1912f950bbc2",
-  "head_sha_note": "Authoritative exact head is the git tip after this commit is pushed (see PR headRefOid)."
+  "pr_head_ref_oid": "b21ac7b1f0487c7b2866631b2ab67d1b8068f486",
+  "head_sha_note": "After this commit is included, supervisor must re-read gh pr view headRefOid. If a subsequent proof-only commit exists, that newer SHA is exact head.",
+  "remote_branch_tip": "b21ac7b1f0487c7b2866631b2ab67d1b8068f486",
+  "commits_on_branch": [
+    "b21ac7b1f docs(proof): bind PROOF to published PR head SHA",
+    "cfd114cd3 docs(proof): finalize PROOF binding fields for supervisor gate",
+    "a938aae05 docs(proof): rebind PROOF head to tip",
+    "aba75afbf docs(proof): bind PROOF.json to remediation head SHA",
+    "b04262385 docs(proof): add trusted-audit foundation evidence",
+    "ded3cf0a6 test(audit): lock fail-closed provenance and workflow behavior",
+    "65bcc14e1 fix(audit): bind pull-request-target metadata and proof identity",
+    "b67bb7645 fix(audit): fail closed on independent audit evidence"
+  ]
 }

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/PROOF.json
@@ -5,8 +5,8 @@
   "repo": "DDD-Enterprises/dopemux-mvp",
   "branch": "codex/tp-dmx-merge-integrity-foundation",
   "base_sha": "b176747b339685e781de04268c46b7ae123abfbf",
-  "head_sha": "67229e85312083fb814309b006259462fdacbefd",
-  "generated_at": "2026-07-12T19:49:59Z",
+  "head_sha": "SEE_PR_HEAD_REF_OID",
+  "generated_at": "2026-07-12T20:15:00Z",
   "changed_files": [
     ".github/workflows/embedded-audit.yml",
     ".github/workflows/pr-steward.yml",
@@ -35,6 +35,9 @@
     },
     "git_diff_check": {
       "exit_code": 0
+    },
+    "validate_audit_proof": {
+      "exit_code": 0
     }
   },
   "tests": {
@@ -43,33 +46,43 @@
   },
   "precommit": "PASS",
   "embedded_audit": {
-    "status": "PASS_WITH_RISKS",
-    "auditor_tool": "pal-stdio-codereview+secaudit",
-    "auditor_model": "gemini-2.5-pro",
-    "invocation": "pal-stdio codereview + secaudit; external expert 429; internal findings retained",
-    "exit_code": null,
+    "required": true,
+    "status": "NEEDS_SUPERVISOR",
+    "auditor_tool": "pal-mcp-clink",
+    "auditor_model": "gemini",
+    "invocation": "pal-stdio codereview+secaudit internal complete; external Gemini expert 429; independent exact-head auditor still required",
+    "exit_code": 1,
+    "report_path": "proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/AUDITOR_REPORT.md",
+    "findings": [
+      {
+        "id": "F-0004-DOCS-SCHEMA-1",
+        "severity": "HIGH",
+        "title": "Committed PROOF.json failed embedded_audit schema (docs CI)",
+        "status": "RESOLVED",
+        "body": "proof-embedded-audit-schema rejected invalid auditor_tool/auditor_model enums and missing required embedded_audit fields. Fixed to schema-valid NEEDS_SUPERVISOR object with AUDITOR_REPORT.md."
+      },
+      {
+        "id": "F-0004-INDEP-1",
+        "severity": "BLOCKING",
+        "title": "Independent exact-head auditor receipt missing",
+        "status": "OPEN",
+        "body": "PAL internal findings and a 429 external expert attempt are not an independent embedded-auditor gate. Supervisor requires AGY/Sonnet, Claude Code, or Gemini CLI receipt bound to the exact PR head, stored externally without a proof-only rebinding commit."
+      }
+    ],
+    "fixes_applied": [
+      "Schema-valid embedded_audit object and AUDITOR_REPORT.md for docs CI",
+      "pull_request_target metadata + hard proof enforcement + Steward run identity (code)"
+    ],
     "remaining_risks": [
       "Live default-branch workflow behavior not proven until PR #1042 merges",
       "Soft runner exit depends on hard enforce remaining complete",
-      "Branch-protection check-name migration required (out of packet)"
-    ]
+      "Branch-protection check-name migration required (out of packet)",
+      "Independent exact-head auditor receipt is external and must match PR headRefOid"
+    ],
+    "skip_reason": null
   },
   "mutation_performed": false,
   "merge_authorized": false,
   "live_default_branch_proven": false,
-  "pr_head_ref_oid": "67229e85312083fb814309b006259462fdacbefd",
-  "head_sha_note": "After this commit is included, supervisor must re-read gh pr view headRefOid. If a subsequent proof-only commit exists, that newer SHA is exact head.",
-  "remote_branch_tip": "b21ac7b1f0487c7b2866631b2ab67d1b8068f486",
-  "commits_on_branch": [
-    "b21ac7b1f docs(proof): bind PROOF to published PR head SHA",
-    "cfd114cd3 docs(proof): finalize PROOF binding fields for supervisor gate",
-    "a938aae05 docs(proof): rebind PROOF head to tip",
-    "aba75afbf docs(proof): bind PROOF.json to remediation head SHA",
-    "b04262385 docs(proof): add trusted-audit foundation evidence",
-    "ded3cf0a6 test(audit): lock fail-closed provenance and workflow behavior",
-    "65bcc14e1 fix(audit): bind pull-request-target metadata and proof identity",
-    "b67bb7645 fix(audit): fail closed on independent audit evidence"
-  ],
-  "local_head_at_record": "67229e85312083fb814309b006259462fdacbefd",
-  "head_match": true
+  "head_sha_note": "Authoritative exact head is GitHub PR headRefOid after this commit is pushed. Do not treat head_sha string as final-head evidence."
 }

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/REVIEW_ITEM_LEDGER.json
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/REVIEW_ITEM_LEDGER.json
@@ -1,0 +1,50 @@
+{
+  "pr": 1042,
+  "items": [
+    {
+      "path": ".github/workflows/embedded-audit.yml",
+      "classification": "FIXED",
+      "summary": "Enforce required executed+provenance+PR+head; pull_request_target metadata; structured failure proofs",
+      "tests": ["test_embedded_audit_workflow_handles_pull_request_target_metadata", "test_enforce_rejects_spoof_and_mismatch_shapes", "test_collector_and_enforce_parity_matrix"]
+    },
+    {
+      "path": ".github/workflows/pr-steward.yml",
+      "classification": "FIXED",
+      "summary": "Validate workflow-run identity; exact artifact name; proof-bound PR number for upload name",
+      "tests": ["test_pr_steward_workflow_uses_completed_independent_audit_artifact"]
+    },
+    {
+      "path": ".github/workflows/embedded-audit.yml",
+      "line_hint": 158,
+      "classification": "FIXED",
+      "summary": "Documented intentional soft runner exit; hard enforce is authoritative; synthetic error cannot pass",
+      "tests": ["test_synthetic_runner_error_payload_cannot_pass_enforcement"]
+    },
+    {
+      "path": ".github/workflows/embedded-audit.yml",
+      "line_hint": 167,
+      "classification": "FIXED",
+      "summary": "Missing emitter writes NEEDS_SUPERVISOR diagnostic proof without forged provenance",
+      "tests": ["test_diagnostic_failure_proof_has_no_trusted_provenance"]
+    },
+    {
+      "path": "tests/audit/test_run_embedded_audit.py",
+      "classification": "FIXED",
+      "summary": "Added metadata, enforce, parity, and Steward workflow assertions",
+      "tests": ["test_embedded_audit_workflow_handles_pull_request_target_metadata"]
+    },
+    {
+      "path": "tools/pr_steward/collector.py",
+      "classification": "FIXED",
+      "summary": "Collector delegates to shared independent_audit_errors; negatives for provenance spoof and malformed dry_run",
+      "tests": ["test_live_collection_rejects_pass_with_executed_true_missing_provenance", "test_independent_audit_errors_rejects_malformed_dry_run_string"]
+    },
+    {
+      "path": ".github/workflows/pr-steward.yml",
+      "line_hint": 24,
+      "classification": "FIXED",
+      "summary": "Check-name migration recorded in workflow comments, packet invariants, and PR body; branch protection out of scope",
+      "tests": ["test_pr_steward_workflow_uses_completed_independent_audit_artifact"]
+    }
+  ]
+}

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/SUMMARY.md
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/SUMMARY.md
@@ -1,0 +1,21 @@
+# SUMMARY — Trusted Audit Foundation remediation (PR #1042)
+
+## Packet
+TP-DMX-MERGE-INTEGRITY-0001R2 Phase A / TP-DMX-MERGE-INTEGRITY-0004 foundation
+
+## Changes
+- Fix `pull_request_target` metadata handling in embedded-audit workflow
+- Shared hard proof enforcement (`executed`, provenance, PR, head, status)
+- Structured diagnostic failure proofs without forged trusted provenance
+- Steward workflow-run identity + exact one named proof artifact
+- Collision-resistant artifact names; fix stale Steward upload name
+- Negative test matrix + collector/enforce parity
+- Check-name migration recorded (branch protection out of scope)
+
+## Validation
+- Focused pytest: PASS (exit 0)
+- pre-commit / diff-check: PASS
+- Independent audit: PASS_WITH_RISKS (live default-branch unproven until merge)
+
+## Merge
+NEEDS_SUPERVISOR — implementer must not merge.

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/SUMMARY.md
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/SUMMARY.md
@@ -19,3 +19,12 @@ TP-DMX-MERGE-INTEGRITY-0001R2 Phase A / TP-DMX-MERGE-INTEGRITY-0004 foundation
 
 ## Merge
 NEEDS_SUPERVISOR — implementer must not merge.
+
+## Exact published head (supervisor gate)
+
+- local HEAD: 
+- PR headRefOid: 
+- match: true
+- recorded_at: 2026-07-12T19:49:59Z
+
+If match is false, re-fetch before disposition. Do not merge on stale head.

--- a/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/SUMMARY.md
+++ b/proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/SUMMARY.md
@@ -15,16 +15,14 @@ TP-DMX-MERGE-INTEGRITY-0001R2 Phase A / TP-DMX-MERGE-INTEGRITY-0004 foundation
 ## Validation
 - Focused pytest: PASS (exit 0)
 - pre-commit / diff-check: PASS
-- Independent audit: PASS_WITH_RISKS (live default-branch unproven until merge)
+- Independent audit: NEEDS_SUPERVISOR (schema-valid local/PAL notes; external exact-head receipt required)
 
 ## Merge
 NEEDS_SUPERVISOR — implementer must not merge.
 
-## Exact published head (supervisor gate)
+## Exact head policy
 
-- local HEAD: 
-- PR headRefOid: 
-- match: true
-- recorded_at: 2026-07-12T19:49:59Z
+Authoritative exact head is GitHub `headRefOid` for PR #1042 after push.
+Committed `PROOF.json` uses `head_sha: SEE_PR_HEAD_REF_OID` and must not be
+treated as final-head evidence. Independent auditor receipt is external.
 
-If match is false, re-fetch before disposition. Do not merge on stale head.

--- a/scripts/audit/pr_audit_router.py
+++ b/scripts/audit/pr_audit_router.py
@@ -204,7 +204,7 @@ def _build_proof(
         "executed": False,
         "execution_results": [],
         "embedded_audit": {
-            "status": "PASS",
+            "status": "NEEDS_SUPERVISOR",
             "report_path": f"proof/{packet_id}/AUDITOR_REPORT.md",
         },
     }

--- a/scripts/audit/run_embedded_audit.py
+++ b/scripts/audit/run_embedded_audit.py
@@ -88,8 +88,13 @@ def independent_audit_errors(
             )
 
     if expected_repo is not None:
-        proof_repo = str(payload.get("repo") or "")
-        if proof_repo and proof_repo != expected_repo:
+        proof_repo = str(payload.get("repo") or "").strip()
+        if not proof_repo:
+            errors.append(
+                "audit_repo_missing: final readiness requires proof.repo when "
+                "expected_repo is provided"
+            )
+        elif proof_repo != expected_repo:
             errors.append(
                 f"audit_repo_mismatch: proof repo={proof_repo!r} "
                 f"expected={expected_repo}"

--- a/scripts/audit/run_embedded_audit.py
+++ b/scripts/audit/run_embedded_audit.py
@@ -101,6 +101,12 @@ def build_embedded_audit_proof(
         "pr_number": int(pr_number),
         "head_sha": head_sha,
         "generated_at": generated_at or _utc_now_seconds(),
+        "executed": bool(
+            token_present
+            and not route_error
+            and not pal_output_error
+            and pal_output is not None
+        ),
         "mutation_performed": False,
         "github_mutation_route_added": False,
         "embedded_audit": embedded_audit,

--- a/scripts/audit/run_embedded_audit.py
+++ b/scripts/audit/run_embedded_audit.py
@@ -151,6 +151,10 @@ def build_diagnostic_failure_proof(
 
     Used for workflow failure paths (missing emitter, head mismatch, etc.).
     Must not forge independent-embedded-audit provenance.
+
+    Schema rule: auditor_tool=none / auditor_model=unknown are only valid with
+    status=SKIPPED. Hard enforcement still rejects executed!=true, so SKIPPED
+    remains red while the artifact stays schema-valid.
     """
     report_path = f"proof/{packet_id}/AUDITOR_REPORT.md"
     return {
@@ -162,19 +166,7 @@ def build_diagnostic_failure_proof(
         "executed": False,
         "mutation_performed": False,
         "github_mutation_route_added": False,
-        "embedded_audit": {
-            "required": True,
-            "status": "NEEDS_SUPERVISOR",
-            "auditor_tool": "none",
-            "auditor_model": "unknown",
-            "invocation": None,
-            "exit_code": None,
-            "report_path": report_path,
-            "findings": [],
-            "fixes_applied": [],
-            "remaining_risks": [reason],
-            "skip_reason": reason,
-        },
+        "embedded_audit": _skipped_audit(report_path=report_path, reason=reason),
     }
 
 

--- a/scripts/audit/run_embedded_audit.py
+++ b/scripts/audit/run_embedded_audit.py
@@ -24,6 +24,8 @@ from tools.auditor_router.pal_clink import normalize_pal_clink_audit_output
 
 TOKEN_ENV_VAR = "EMBEDDED_AUDIT_TOKEN"
 PROOF_AUTHOR = "independent-embedded-audit"
+WORKFLOW_NAME = "embedded-audit.yml"
+PASSING_AUDIT_STATUSES = frozenset({"PASS", "PASS_WITH_RISKS"})
 
 
 def _utc_now_seconds() -> str:
@@ -33,6 +35,142 @@ def _utc_now_seconds() -> str:
         .isoformat()
         .replace("+00:00", "Z")
     )
+
+
+def independent_audit_errors(
+    payload: Mapping[str, Any],
+    *,
+    expected_pr: int | None = None,
+    expected_head_sha: str | None = None,
+    expected_repo: str | None = None,
+) -> list[str]:
+    """Return fail-closed errors for an independent-audit proof payload.
+
+    Shared by the embedded-audit workflow hard gate and PR Steward collector so
+    both surfaces accept and reject the same proof shapes.
+    """
+    if not isinstance(payload, Mapping):
+        return ["audit_proof_malformed: root is not an object"]
+
+    errors: list[str] = []
+
+    if "dry_run" in payload:
+        dry_run = payload.get("dry_run")
+        if dry_run is True:
+            errors.append(
+                "audit_proof_dry_run: final readiness requires an executed audit"
+            )
+        elif dry_run is not False:
+            errors.append(
+                "audit_proof_malformed_dry_run: dry_run must be a boolean when present"
+            )
+
+    if payload.get("executed") is not True:
+        errors.append("audit_not_executed: final readiness requires executed=true")
+
+    if expected_pr is not None:
+        try:
+            proof_pr = int(payload.get("pr_number"))  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            proof_pr = None
+        if proof_pr != int(expected_pr):
+            errors.append(
+                f"audit_pr_mismatch: proof pr_number={payload.get('pr_number')!r} "
+                f"expected={expected_pr}"
+            )
+
+    if expected_head_sha is not None:
+        proof_head = str(payload.get("head_sha") or "")
+        if proof_head != expected_head_sha:
+            errors.append(
+                f"audit_head_mismatch: proof head_sha={proof_head!r} "
+                f"expected={expected_head_sha}"
+            )
+
+    if expected_repo is not None:
+        proof_repo = str(payload.get("repo") or "")
+        if proof_repo and proof_repo != expected_repo:
+            errors.append(
+                f"audit_repo_mismatch: proof repo={proof_repo!r} "
+                f"expected={expected_repo}"
+            )
+
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, Mapping):
+        errors.append(
+            "audit_provenance_missing: final readiness requires trusted provenance"
+        )
+        return errors
+    if provenance.get("proof_author") != PROOF_AUTHOR:
+        errors.append("audit_provenance_untrusted: unexpected proof author")
+    if provenance.get("workflow") != WORKFLOW_NAME:
+        errors.append("audit_provenance_untrusted: unexpected workflow")
+    return errors
+
+
+def enforce_independent_audit_proof(
+    payload: Mapping[str, Any],
+    *,
+    expected_pr: int | None = None,
+    expected_head_sha: str | None = None,
+    expected_repo: str | None = None,
+) -> None:
+    """Raise SystemExit unless the proof is a passing independent audit."""
+    errors = independent_audit_errors(
+        payload,
+        expected_pr=expected_pr,
+        expected_head_sha=expected_head_sha,
+        expected_repo=expected_repo,
+    )
+    if errors:
+        raise SystemExit("; ".join(errors))
+
+    embedded = payload.get("embedded_audit")
+    if not isinstance(embedded, Mapping):
+        raise SystemExit("audit_status_missing: embedded_audit object required")
+    status = str(embedded.get("status") or "").upper()
+    if status not in PASSING_AUDIT_STATUSES:
+        raise SystemExit(f"Independent audit did not pass: {status or 'UNKNOWN'}")
+
+
+def build_diagnostic_failure_proof(
+    *,
+    packet_id: str,
+    repo: str,
+    pr_number: int,
+    head_sha: str,
+    reason: str,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Emit a fail-closed diagnostic proof without trusted provenance.
+
+    Used for workflow failure paths (missing emitter, head mismatch, etc.).
+    Must not forge independent-embedded-audit provenance.
+    """
+    report_path = f"proof/{packet_id}/AUDITOR_REPORT.md"
+    return {
+        "packet_id": packet_id,
+        "repo": repo,
+        "pr_number": int(pr_number),
+        "head_sha": head_sha,
+        "generated_at": generated_at or _utc_now_seconds(),
+        "executed": False,
+        "mutation_performed": False,
+        "github_mutation_route_added": False,
+        "embedded_audit": {
+            "required": True,
+            "status": "NEEDS_SUPERVISOR",
+            "auditor_tool": "none",
+            "auditor_model": "unknown",
+            "invocation": None,
+            "exit_code": None,
+            "report_path": report_path,
+            "findings": [],
+            "fixes_applied": [],
+            "remaining_risks": [reason],
+            "skip_reason": reason,
+        },
+    }
 
 
 def build_embedded_audit_proof(

--- a/task-packets/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json
+++ b/task-packets/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json
@@ -1,13 +1,17 @@
 {
   "id": "TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION",
   "project": "dopemux-mvp",
-  "target": "Make independent embedded-audit and final PR Steward evidence fail closed, trusted-source-only, and bound to the live pull-request head.",
+  "target": "Make independent embedded-audit and final PR Steward evidence fail closed, trusted-source-only, bound to the live pull-request head, with hard proof enforcement (executed+provenance+identity) and workflow-run artifact identity.",
   "invariants": [
     "Audit and final-readiness workflow logic runs from trusted default-branch source and never checks out or executes candidate-branch workflow code.",
     "Dry-run, skipped, missing, malformed, stale, wrong-head, and unproven audit evidence cannot produce PASS or READY.",
+    "Hard enforcement requires executed=true, trusted provenance, matching PR/head, and embedded_audit.status in {PASS, PASS_WITH_RISKS}.",
+    "pull_request_target metadata is handled explicitly; workflow scripts never treat only pull_request event name as the sole branch.",
+    "PR Steward validates Actions run identity before downloading artifacts and selects exactly one named proof artifact.",
     "Artifacts are retained for diagnosis even when the required audit or final Steward job fails.",
     "PR Steward remains read-only.",
-    "This packet does not change branch protection, merge state, rulesets, or the reserved-singleton port allocator."
+    "This packet does not change branch protection, merge state, rulesets, or the reserved-singleton port allocator.",
+    "CHECK-NAME MIGRATION: old='PR Steward / advisory check-only intake' new='PR Steward / final readiness'; branch-protection follow-up required (out of packet scope)."
   ],
   "depends_on": [],
   "repo_binding": {
@@ -29,7 +33,7 @@
     "stacked_because": "Must land before PR #1040 can receive trusted current-head audit and final-readiness evidence."
   },
   "commit": {
-    "message": "fix(audit): fail closed on independent audit evidence",
+    "message": "fix(audit): bind pull-request-target metadata and proof identity",
     "allowlist": [
       ".github/workflows/embedded-audit.yml",
       ".github/workflows/pr-steward.yml",
@@ -39,7 +43,8 @@
       "tests/audit/test_pr_audit_router.py",
       "tests/audit/test_run_embedded_audit.py",
       "tests/pr_steward/test_intake.py",
-      "task-packets/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json"
+      "task-packets/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json",
+      "proof/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION/**"
     ],
     "verify": [
       "uv run pytest -q tests/audit/test_pr_audit_router.py tests/audit/test_run_embedded_audit.py tests/pr_steward/test_intake.py --no-cov",
@@ -50,28 +55,58 @@
   },
   "pr": {
     "title": "fix(audit): make independent audit and Steward fail closed",
-    "body": "Trusted audit and final-readiness foundation for merge-integrity. No merge or branch-protection mutation is performed.",
+    "body": "Trusted audit and final-readiness foundation for merge-integrity.\n\nCHECK-NAME MIGRATION (branch-protection follow-up required):\n- old: PR Steward / advisory check-only intake\n- new: PR Steward / final readiness\n- embedded-audit job: independent embedded audit\n\nNo merge or branch-protection mutation is performed by this PR.",
     "base": "main"
   },
   "pal_chain": {
     "enabled": true,
-    "steps": ["analyze", "thinkdeep", "challenge", "planner", "challenge", "implement", "codereview", "precommit", "challenge"]
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
   },
   "steps": [
     {
+      "id": "proof-identity-hard-gate",
+      "task": "Bind pull_request_target metadata, hard-enforce independent-audit proof (executed+provenance+PR+head+status), emit structured diagnostic proofs without forged provenance, and require Steward workflow-run identity plus exact artifact naming (embedded-audit-pr-<n>-head-<sha>-proof).",
+      "validation": [
+        "Focused tests cover pull_request_target metadata, spoof matrices, soft-runner/hard-enforce, and Steward run-identity/artifact selection strings."
+      ]
+    },
+    {
       "id": "audit-proof-fail-closed",
       "task": "Require independent audit execution provenance and fail the workflow when required evidence is not passing.",
-      "validation": ["Focused audit tests first fail then pass for dry-run and skipped evidence."]
+      "validation": [
+        "Focused audit tests first fail then pass for dry-run and skipped evidence."
+      ]
     },
     {
       "id": "steward-artifact-binding",
       "task": "Make final Steward download and validate the completed independent-audit artifact for the current PR head.",
-      "validation": ["Focused Steward tests reject advisory or wrong-head proof and accept a matching independent artifact."]
+      "validation": [
+        "Focused Steward tests reject advisory or wrong-head proof and accept a matching independent artifact."
+      ]
     },
     {
       "id": "validate",
       "task": "Run focused tests, YAML and packet parsing, diff hygiene, and pre-commit before publication.",
-      "validation": ["All commands pass or external prerequisites are reported as blocking."]
+      "validation": [
+        "All commands pass or external prerequisites are reported as blocking."
+      ]
+    },
+    {
+      "id": "check-name-migration-record",
+      "task": "Record check-name migration for supervisor branch-protection follow-up: old 'PR Steward / advisory check-only intake' -> new 'PR Steward / final readiness'. Do not modify branch protection in this packet.",
+      "validation": [
+        "Migration string present in packet invariants and PR body after publication."
+      ]
     }
   ]
 }

--- a/task-packets/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json
+++ b/task-packets/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json
@@ -1,0 +1,77 @@
+{
+  "id": "TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION",
+  "project": "dopemux-mvp",
+  "target": "Make independent embedded-audit and final PR Steward evidence fail closed, trusted-source-only, and bound to the live pull-request head.",
+  "invariants": [
+    "Audit and final-readiness workflow logic runs from trusted default-branch source and never checks out or executes candidate-branch workflow code.",
+    "Dry-run, skipped, missing, malformed, stale, wrong-head, and unproven audit evidence cannot produce PASS or READY.",
+    "Artifacts are retained for diagnosis even when the required audit or final Steward job fails.",
+    "PR Steward remains read-only.",
+    "This packet does not change branch protection, merge state, rulesets, or the reserved-singleton port allocator."
+  ],
+  "depends_on": [],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MERGE-INTEGRITY",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/tp-dmx-merge-integrity-foundation",
+    "base_branch": "main",
+    "stacked_because": "Must land before PR #1040 can receive trusted current-head audit and final-readiness evidence."
+  },
+  "commit": {
+    "message": "fix(audit): fail closed on independent audit evidence",
+    "allowlist": [
+      ".github/workflows/embedded-audit.yml",
+      ".github/workflows/pr-steward.yml",
+      "scripts/audit/run_embedded_audit.py",
+      "scripts/audit/pr_audit_router.py",
+      "tools/pr_steward/collector.py",
+      "tests/audit/test_pr_audit_router.py",
+      "tests/audit/test_run_embedded_audit.py",
+      "tests/pr_steward/test_intake.py",
+      "task-packets/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json"
+    ],
+    "verify": [
+      "uv run pytest -q tests/audit/test_pr_audit_router.py tests/audit/test_run_embedded_audit.py tests/pr_steward/test_intake.py --no-cov",
+      "python -m json.tool task-packets/TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION.json",
+      "git diff --check",
+      "pre-commit run --files <changed-files>"
+    ]
+  },
+  "pr": {
+    "title": "fix(audit): make independent audit and Steward fail closed",
+    "body": "Trusted audit and final-readiness foundation for merge-integrity. No merge or branch-protection mutation is performed.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": ["analyze", "thinkdeep", "challenge", "planner", "challenge", "implement", "codereview", "precommit", "challenge"]
+  },
+  "steps": [
+    {
+      "id": "audit-proof-fail-closed",
+      "task": "Require independent audit execution provenance and fail the workflow when required evidence is not passing.",
+      "validation": ["Focused audit tests first fail then pass for dry-run and skipped evidence."]
+    },
+    {
+      "id": "steward-artifact-binding",
+      "task": "Make final Steward download and validate the completed independent-audit artifact for the current PR head.",
+      "validation": ["Focused Steward tests reject advisory or wrong-head proof and accept a matching independent artifact."]
+    },
+    {
+      "id": "validate",
+      "task": "Run focused tests, YAML and packet parsing, diff hygiene, and pre-commit before publication.",
+      "validation": ["All commands pass or external prerequisites are reported as blocking."]
+    }
+  ]
+}

--- a/tests/audit/test_pr_audit_router.py
+++ b/tests/audit/test_pr_audit_router.py
@@ -221,6 +221,14 @@ class TestWriteProofArtifact:
         proof = json.loads(path.read_text())
         assert proof["dry_run"] is True
 
+    def test_dry_run_proof_is_not_a_passing_embedded_audit(self, tmp_path: Path) -> None:
+        plan = _make_plan(dry_run=True)
+        path = write_proof_artifact(plan, out=tmp_path, packet_id="TP-003")
+        proof = json.loads(path.read_text())
+
+        assert proof["executed"] is False
+        assert proof["embedded_audit"]["status"] == "NEEDS_SUPERVISOR"
+
     def test_proof_resolutions_include_blocking_flag(self, tmp_path: Path) -> None:
         resolutions = (
             RouteResolution(cli_name="claude-audit", available=False, blocking=True),

--- a/tests/audit/test_run_embedded_audit.py
+++ b/tests/audit/test_run_embedded_audit.py
@@ -12,6 +12,7 @@ from scripts.audit.run_embedded_audit import build_embedded_audit_proof, run_cli
 ROOT = Path(__file__).resolve().parents[2]
 SCHEMA_PATH = ROOT / "schemas" / "proof" / "embedded_audit.schema.json"
 WORKFLOW_PATH = ROOT / ".github" / "workflows" / "embedded-audit.yml"
+STEWARD_WORKFLOW_PATH = ROOT / ".github" / "workflows" / "pr-steward.yml"
 
 
 def _schema() -> dict:
@@ -57,6 +58,7 @@ def test_build_embedded_audit_proof_normalizes_pass_with_redacted_provenance() -
 
     jsonschema.Draft7Validator(_schema()).validate(proof["embedded_audit"])
     assert proof["embedded_audit"]["status"] == "PASS"
+    assert proof["executed"] is True
     assert proof["embedded_audit"]["auditor_tool"] == "pal-mcp-clink"
     assert proof["provenance"]["proof_author"] == "independent-embedded-audit"
     assert proof["provenance"]["trusted_token_status"] == "AVAILABLE"
@@ -80,6 +82,7 @@ def test_build_embedded_audit_proof_skips_fail_closed_without_trusted_token() ->
 
     jsonschema.Draft7Validator(_schema()).validate(proof["embedded_audit"])
     assert proof["embedded_audit"]["status"] == "SKIPPED"
+    assert proof["executed"] is False
     assert proof["embedded_audit"]["auditor_tool"] == "none"
     assert proof["provenance"]["trusted_token_status"] == "UNKNOWN"
     assert "separate least-privilege token" in proof["embedded_audit"]["skip_reason"]
@@ -118,6 +121,7 @@ def test_run_cli_writes_proof_and_auditor_report(tmp_path: Path) -> None:
     proof = json.loads((out_dir / "PROOF.json").read_text(encoding="utf-8"))
     jsonschema.Draft7Validator(_schema()).validate(proof["embedded_audit"])
     assert proof["embedded_audit"]["status"] == "PASS"
+    assert proof["executed"] is True
     report_text = (out_dir / proof["embedded_audit"]["report_path"]).read_text(
         encoding="utf-8"
     )
@@ -153,6 +157,7 @@ def test_run_cli_skips_when_route_json_is_missing(tmp_path: Path) -> None:
     proof = json.loads((out_dir / "PROOF.json").read_text(encoding="utf-8"))
     jsonschema.Draft7Validator(_schema()).validate(proof["embedded_audit"])
     assert proof["embedded_audit"]["status"] == "SKIPPED"
+    assert proof["executed"] is False
     assert "auditor route JSON" in proof["embedded_audit"]["skip_reason"]
     assert (out_dir / proof["embedded_audit"]["report_path"]).is_file()
 
@@ -190,20 +195,21 @@ def test_run_cli_skips_when_supplied_pal_output_json_is_missing(
     proof = json.loads((out_dir / "PROOF.json").read_text(encoding="utf-8"))
     jsonschema.Draft7Validator(_schema()).validate(proof["embedded_audit"])
     assert proof["embedded_audit"]["status"] == "SKIPPED"
+    assert proof["executed"] is False
     assert "PAL clink output JSON" in proof["embedded_audit"]["skip_reason"]
     assert (out_dir / proof["embedded_audit"]["report_path"]).is_file()
 
 
-def test_embedded_audit_workflow_is_read_only_and_not_pull_request_target() -> None:
+def test_embedded_audit_workflow_uses_trusted_source_and_least_privilege() -> None:
     text = WORKFLOW_PATH.read_text(encoding="utf-8")
     permissions = text.split("permissions:\n", 1)[1].split("\njobs:", 1)[0]
 
-    assert "pull_request_target" not in text
+    assert "pull_request_target:" in text
+    assert "pull_request:" not in text
     assert "contents: read" in text
     assert "pull-requests: read" in text
     assert "checks: read" in text
     assert "statuses: read" in text
-    assert "continue-on-error: true" in text
     assert ": write" not in permissions
     assert "scripts/audit/run_embedded_audit.py" in text
 
@@ -218,15 +224,14 @@ def test_embedded_audit_workflow_runs_emitter_from_trusted_source() -> None:
     assert "TRUSTED_FALLBACK_SHA" not in text
     assert "working-directory: trusted-source" in text
     assert "id: head_integrity" in text
-    assert "HEAD_VERIFIED: ${{ steps.head_integrity.outputs.verified }}" in text
-    assert 'if [ "$HEAD_VERIFIED" != "true" ]; then' in text
-    assert "Emit skipped embedded audit proof" in text
-    assert "Emit embedded audit proof with trusted token" in text
+    assert "Emit independent embedded audit proof" in text
+    assert "Enforce independent audit result" in text
     assert "EMBEDDED_AUDIT_TOKEN: ${{ secrets.EMBEDDED_AUDIT_TOKEN }}" in text
     assert "refs/pull/${PR_NUMBER}/head" in text
     assert 'pr_head_sha" = "$EXPECTED_HEAD_SHA"' in text
-    assert "requested head SHA could not be fetched or did not match" in text
-    assert "ref does not yet contain scripts/audit/run_embedded_audit.py" in text
+    assert "Requested PR head SHA could not be fetched or no longer matches the PR head." in text
+    assert "Emit skipped embedded audit proof" not in text
+    assert "NEEDS_SUPERVISOR" in text
     assert "git -C trusted-source fetch --no-tags --depth=1 origin" in text
     assert "Checkout requested head" not in text
     assert "ref: ${{ steps.pr.outputs.head_sha }}" not in text
@@ -255,3 +260,14 @@ def test_embedded_audit_workflow_runs_emitter_from_trusted_source() -> None:
         'if [ "$actual_head_sha" = "$EXPECTED_HEAD_SHA" ] '
         '&& [ "$pr_head_sha" = "$EXPECTED_HEAD_SHA" ]; then'
     ) in text
+
+
+def test_pr_steward_workflow_uses_completed_independent_audit_artifact() -> None:
+    text = STEWARD_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    assert "workflow_run:" in text
+    assert "workflows: [embedded-audit]" in text
+    assert "gh run download" in text
+    assert "independent-audit/PROOF.json" in text
+    assert "--proof-path independent-audit/PROOF.json" in text
+    assert "scripts.audit.pr_audit_router" not in text

--- a/tests/audit/test_run_embedded_audit.py
+++ b/tests/audit/test_run_embedded_audit.py
@@ -307,7 +307,8 @@ def test_pr_steward_workflow_uses_completed_independent_audit_artifact() -> None
     assert "--proof-path independent-audit/PROOF.json" in text
     assert "scripts.audit.pr_audit_router" not in text
     assert "Validate audit workflow-run identity" in text
-    assert "run_conclusion_not_success" in text
+    assert "conclusion_ok=" in text
+    assert "publish failure status" in text or "Publish readiness status" in text
     assert "repository_missing" in text
     assert 'name == "embedded-audit" and path.endswith("embedded-audit.yml")' in text
     assert "embedded-audit-pr-" in text

--- a/tests/audit/test_run_embedded_audit.py
+++ b/tests/audit/test_run_embedded_audit.py
@@ -308,6 +308,8 @@ def test_pr_steward_workflow_uses_completed_independent_audit_artifact() -> None
     assert "scripts.audit.pr_audit_router" not in text
     assert "Validate audit workflow-run identity" in text
     assert "run_conclusion_not_success" in text
+    assert "repository_missing" in text
+    assert 'name == "embedded-audit" and path.endswith("embedded-audit.yml")' in text
     assert "embedded-audit-pr-" in text
     assert "Exactly one expected proof artifact is required" in text
     # Artifact name must use validated proof identity, not stale steps.pr.
@@ -317,6 +319,12 @@ def test_pr_steward_workflow_uses_completed_independent_audit_artifact() -> None
     assert "advisory check-only intake" in text  # documented old name for migration
     assert "enforce_independent_audit_proof" in text
     assert "persist-credentials: false" in text
+    # PR head for artifact selection comes from artifact name, not run.head_sha
+    # (unreliable under pull_request_target).
+    assert "EXPECTED_HEAD_SHA: ${{ steps.run_identity.outputs.head_sha }}" not in text
+    assert r"^embedded-audit-pr-(\d+)-head-([0-9a-f]{40})-proof$" in text
+    assert "jq -s" in text
+    assert "live_head" in text
 
 
 def _passing_proof(**overrides: object) -> dict:
@@ -386,6 +394,20 @@ def test_enforce_rejects_spoof_and_mismatch_shapes(
             expected_repo="DDD-Enterprises/dopemux-mvp",
         )
     assert expected_fragment in str(exc.value)
+
+
+def test_independent_audit_errors_rejects_missing_repo_when_expected() -> None:
+    proof = _passing_proof()
+    proof.pop("repo", None)
+    errors = independent_audit_errors(
+        proof, expected_repo="DDD-Enterprises/dopemux-mvp"
+    )
+    assert any("audit_repo_missing" in e for e in errors)
+    proof["repo"] = ""
+    errors = independent_audit_errors(
+        proof, expected_repo="DDD-Enterprises/dopemux-mvp"
+    )
+    assert any("audit_repo_missing" in e for e in errors)
 
 
 def test_enforce_rejects_status_pass_without_execution() -> None:

--- a/tests/audit/test_run_embedded_audit.py
+++ b/tests/audit/test_run_embedded_audit.py
@@ -448,11 +448,69 @@ def test_diagnostic_failure_proof_has_no_trusted_provenance() -> None:
         reason="missing emitter",
     )
     assert proof["executed"] is False
-    assert proof["embedded_audit"]["status"] == "NEEDS_SUPERVISOR"
+    assert proof["embedded_audit"]["status"] == "SKIPPED"
+    assert proof["embedded_audit"]["auditor_tool"] == "none"
+    assert proof["embedded_audit"]["auditor_model"] == "unknown"
+    assert proof["embedded_audit"]["invocation"] is None
+    assert proof["embedded_audit"]["exit_code"] is None
+    assert proof["embedded_audit"]["skip_reason"] == "missing emitter"
     assert "provenance" not in proof
+    jsonschema.Draft7Validator(_schema()).validate(proof["embedded_audit"])
     errors = independent_audit_errors(proof)
     assert any("audit_not_executed" in e for e in errors)
     assert any("provenance" in e for e in errors)
+    with pytest.raises(SystemExit):
+        enforce_independent_audit_proof(
+            proof, expected_pr=1042, expected_head_sha="c" * 40
+        )
+
+
+def test_diagnostic_missing_emitter_workflow_shape_is_schema_valid_skipped() -> None:
+    """Missing-emitter branch must emit SKIPPED+none/unknown (schema), not NEEDS_SUPERVISOR."""
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    # Both diagnostic paths use schema-valid SKIPPED with none/unknown.
+    assert "missing on the trusted ref" in text
+    assert "could not be fetched or no longer matches the PR head" in text
+    assert '"status": "SKIPPED"' in text
+    assert '"auditor_tool": "none"' in text
+    assert '"auditor_model": "unknown"' in text
+    # Invalid combo must not appear in diagnostic emission blocks.
+    # (PASS_WITH_RISKS / NEEDS_SUPERVISOR may still appear elsewhere for other reasons.)
+    missing_emitter_block = text.split("is missing on the trusted ref.", 1)[1][:1200]
+    assert '"status": "SKIPPED"' in missing_emitter_block
+    assert '"status": "NEEDS_SUPERVISOR"' not in missing_emitter_block
+    head_mismatch_block = text.split(
+        "could not be fetched or no longer matches the PR head.", 1
+    )[1][:1200]
+    assert '"status": "SKIPPED"' in head_mismatch_block
+    assert '"status": "NEEDS_SUPERVISOR"' not in head_mismatch_block
+
+
+def test_diagnostic_head_mismatch_and_missing_emitter_proofs_schema_and_enforce() -> None:
+    """Both diagnostic shapes: schema-valid SKIPPED; hard enforce still fails closed."""
+    reasons = (
+        "Trusted audit emitter scripts/audit/run_embedded_audit.py is missing on the trusted ref.",
+        "Requested PR head SHA could not be fetched or no longer matches the PR head.",
+    )
+    for reason in reasons:
+        proof = build_diagnostic_failure_proof(
+            packet_id="TP-DMX-AUDIT-CI-PROVENANCE-104",
+            repo="DDD-Enterprises/dopemux-mvp",
+            pr_number=1042,
+            head_sha="d" * 40,
+            reason=reason,
+        )
+        jsonschema.Draft7Validator(_schema()).validate(proof["embedded_audit"])
+        assert proof["executed"] is False
+        assert proof["embedded_audit"]["status"] == "SKIPPED"
+        with pytest.raises(SystemExit) as exc:
+            enforce_independent_audit_proof(
+                proof,
+                expected_pr=1042,
+                expected_head_sha="d" * 40,
+                expected_repo="DDD-Enterprises/dopemux-mvp",
+            )
+        assert "audit_not_executed" in str(exc.value)
 
 
 def test_collector_and_enforce_parity_matrix() -> None:

--- a/tests/audit/test_run_embedded_audit.py
+++ b/tests/audit/test_run_embedded_audit.py
@@ -5,8 +5,16 @@ import json
 from pathlib import Path
 
 import jsonschema
+import pytest
 
-from scripts.audit.run_embedded_audit import build_embedded_audit_proof, run_cli
+from scripts.audit.run_embedded_audit import (
+    build_diagnostic_failure_proof,
+    build_embedded_audit_proof,
+    enforce_independent_audit_proof,
+    independent_audit_errors,
+    run_cli,
+)
+from tools.pr_steward.collector import _independent_audit_errors
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -205,13 +213,30 @@ def test_embedded_audit_workflow_uses_trusted_source_and_least_privilege() -> No
     permissions = text.split("permissions:\n", 1)[1].split("\njobs:", 1)[0]
 
     assert "pull_request_target:" in text
-    assert "pull_request:" not in text
+    # Trigger must not use untrusted pull_request alone; legacy name may appear
+    # only inside metadata shell equality checks.
+    assert "on:\n  pull_request_target:" in text or "on:\n  pull_request_target" in text
     assert "contents: read" in text
     assert "pull-requests: read" in text
     assert "checks: read" in text
     assert "statuses: read" in text
     assert ": write" not in permissions
     assert "scripts/audit/run_embedded_audit.py" in text
+    assert "persist-credentials: false" in text
+
+
+def test_embedded_audit_workflow_handles_pull_request_target_metadata() -> None:
+    """Regression: trigger is pull_request_target; shell must not only match pull_request."""
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert 'EVENT_NAME" = "pull_request_target"' in text or \
+        "\"$EVENT_NAME\" = \"pull_request_target\"" in text or \
+        '[ "$EVENT_NAME" = "pull_request_target" ]' in text
+    assert '[ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ]' in text
+    assert '[ "$EVENT_NAME" = "workflow_dispatch" ]' in text
+    assert "EVENT_PR_NUMBER" in text
+    assert "EVENT_HEAD_SHA" in text
+    assert "INPUT_PR_NUMBER" in text
+    assert "INPUT_HEAD_SHA" in text
 
 
 def test_embedded_audit_workflow_runs_emitter_from_trusted_source() -> None:
@@ -226,12 +251,14 @@ def test_embedded_audit_workflow_runs_emitter_from_trusted_source() -> None:
     assert "id: head_integrity" in text
     assert "Emit independent embedded audit proof" in text
     assert "Enforce independent audit result" in text
+    assert "enforce_independent_audit_proof" in text
     assert "EMBEDDED_AUDIT_TOKEN: ${{ secrets.EMBEDDED_AUDIT_TOKEN }}" in text
     assert "refs/pull/${PR_NUMBER}/head" in text
     assert 'pr_head_sha" = "$EXPECTED_HEAD_SHA"' in text
     assert "Requested PR head SHA could not be fetched or no longer matches the PR head." in text
     assert "Emit skipped embedded audit proof" not in text
     assert "NEEDS_SUPERVISOR" in text
+    assert '"executed": False' in text or '"executed": false' in text
     assert "git -C trusted-source fetch --no-tags --depth=1 origin" in text
     assert "Checkout requested head" not in text
     assert "ref: ${{ steps.pr.outputs.head_sha }}" not in text
@@ -260,6 +287,14 @@ def test_embedded_audit_workflow_runs_emitter_from_trusted_source() -> None:
         'if [ "$actual_head_sha" = "$EXPECTED_HEAD_SHA" ] '
         '&& [ "$pr_head_sha" = "$EXPECTED_HEAD_SHA" ]; then'
     ) in text
+    # Soft runner exit is intentional; hard enforcement is authoritative.
+    assert "Soft exit is intentional" in text or "soft_runner_exit" in text
+    assert "missing on the trusted ref" in text
+    assert "embedded-audit-pr-${{ steps.pr.outputs.number }}-head-${{ steps.pr.outputs.head_sha }}-proof" in text
+    # Candidate must not be checked out as working tree with secrets.
+    assert "path: candidate" not in text
+    assert "EMBEDDED_AUDIT_TOKEN" in text
+    # Token only appears in emit step context (trusted scripts), not in candidate checkout.
 
 
 def test_pr_steward_workflow_uses_completed_independent_audit_artifact() -> None:
@@ -271,3 +306,195 @@ def test_pr_steward_workflow_uses_completed_independent_audit_artifact() -> None
     assert "independent-audit/PROOF.json" in text
     assert "--proof-path independent-audit/PROOF.json" in text
     assert "scripts.audit.pr_audit_router" not in text
+    assert "Validate audit workflow-run identity" in text
+    assert "run_conclusion_not_success" in text
+    assert "embedded-audit-pr-" in text
+    assert "Exactly one expected proof artifact is required" in text
+    # Artifact name must use validated proof identity, not stale steps.pr.
+    assert "name: pr-steward-${{ steps.pr.outputs.number }}" not in text
+    assert "pr-steward-pr-${{ steps.proof.outputs.pr_number }}-head-${{ steps.proof.outputs.head_sha }}-readiness" in text
+    assert "final readiness" in text
+    assert "advisory check-only intake" in text  # documented old name for migration
+    assert "enforce_independent_audit_proof" in text
+    assert "persist-credentials: false" in text
+
+
+def _passing_proof(**overrides: object) -> dict:
+    proof: dict = {
+        "packet_id": "TP-DMX-AUDIT-CI-PROVENANCE-104",
+        "repo": "DDD-Enterprises/dopemux-mvp",
+        "pr_number": 1042,
+        "head_sha": "a" * 40,
+        "executed": True,
+        "dry_run": False,
+        "embedded_audit": {
+            "status": "PASS",
+            "report_path": "proof/x/AUDITOR_REPORT.md",
+        },
+        "provenance": {
+            "proof_author": "independent-embedded-audit",
+            "workflow": "embedded-audit.yml",
+        },
+    }
+    proof.update(overrides)
+    return proof
+
+
+def test_enforce_accepts_passing_independent_audit() -> None:
+    proof = _passing_proof()
+    enforce_independent_audit_proof(
+        proof,
+        expected_pr=1042,
+        expected_head_sha="a" * 40,
+        expected_repo="DDD-Enterprises/dopemux-mvp",
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides,expected_fragment",
+    [
+        ({"executed": False}, "audit_not_executed"),
+        ({"provenance": None}, "audit_provenance_missing"),
+        (
+            {"provenance": {"proof_author": "self", "workflow": "embedded-audit.yml"}},
+            "unexpected proof author",
+        ),
+        (
+            {
+                "provenance": {
+                    "proof_author": "independent-embedded-audit",
+                    "workflow": "other.yml",
+                }
+            },
+            "unexpected workflow",
+        ),
+        ({"pr_number": 999}, "audit_pr_mismatch"),
+        ({"head_sha": "b" * 40}, "audit_head_mismatch"),
+        ({"dry_run": True}, "audit_proof_dry_run"),
+        ({"dry_run": "true"}, "audit_proof_malformed_dry_run"),
+    ],
+)
+def test_enforce_rejects_spoof_and_mismatch_shapes(
+    overrides: dict, expected_fragment: str
+) -> None:
+    proof = _passing_proof(**overrides)
+    with pytest.raises(SystemExit) as exc:
+        enforce_independent_audit_proof(
+            proof,
+            expected_pr=1042,
+            expected_head_sha="a" * 40,
+            expected_repo="DDD-Enterprises/dopemux-mvp",
+        )
+    assert expected_fragment in str(exc.value)
+
+
+def test_enforce_rejects_status_pass_without_execution() -> None:
+    """status=PASS alone must never green the gate."""
+    proof = _passing_proof(executed=False)
+    proof["embedded_audit"]["status"] = "PASS"
+    with pytest.raises(SystemExit) as exc:
+        enforce_independent_audit_proof(
+            proof,
+            expected_pr=1042,
+            expected_head_sha="a" * 40,
+        )
+    assert "audit_not_executed" in str(exc.value)
+
+
+def test_enforce_rejects_non_passing_status_even_when_executed() -> None:
+    proof = _passing_proof()
+    proof["embedded_audit"]["status"] = "NEEDS_SUPERVISOR"
+    with pytest.raises(SystemExit) as exc:
+        enforce_independent_audit_proof(
+            proof,
+            expected_pr=1042,
+            expected_head_sha="a" * 40,
+        )
+    assert "did not pass" in str(exc.value)
+
+
+def test_diagnostic_failure_proof_has_no_trusted_provenance() -> None:
+    proof = build_diagnostic_failure_proof(
+        packet_id="TP-DMX-AUDIT-CI-PROVENANCE-104",
+        repo="DDD-Enterprises/dopemux-mvp",
+        pr_number=1042,
+        head_sha="c" * 40,
+        reason="missing emitter",
+    )
+    assert proof["executed"] is False
+    assert proof["embedded_audit"]["status"] == "NEEDS_SUPERVISOR"
+    assert "provenance" not in proof
+    errors = independent_audit_errors(proof)
+    assert any("audit_not_executed" in e for e in errors)
+    assert any("provenance" in e for e in errors)
+
+
+def test_collector_and_enforce_parity_matrix() -> None:
+    """Both surfaces must accept/reject the same cases."""
+    cases = [
+        (_passing_proof(), True),
+        (_passing_proof(executed=False), False),
+        (_passing_proof(provenance=None), False),
+        (
+            _passing_proof(
+                provenance={
+                    "proof_author": "forged",
+                    "workflow": "embedded-audit.yml",
+                }
+            ),
+            False,
+        ),
+        (
+            _passing_proof(
+                provenance={
+                    "proof_author": "independent-embedded-audit",
+                    "workflow": "wrong.yml",
+                }
+            ),
+            False,
+        ),
+        (_passing_proof(dry_run=True, executed=True), False),
+        (_passing_proof(dry_run="true"), False),
+        (_passing_proof(head_sha="d" * 40), True),  # no expected head in collector
+    ]
+    for proof, expect_ok in cases:
+        collector_errors = _independent_audit_errors(proof)
+        shared_errors = independent_audit_errors(proof)
+        assert collector_errors == shared_errors
+        assert (not shared_errors) is expect_ok
+        if expect_ok and proof.get("head_sha") == "a" * 40:
+            enforce_independent_audit_proof(
+                proof, expected_pr=1042, expected_head_sha="a" * 40
+            )
+        if not expect_ok:
+            # status may still be PASS; enforce must still fail on identity errors
+            with pytest.raises(SystemExit):
+                enforce_independent_audit_proof(
+                    proof,
+                    expected_pr=1042,
+                    expected_head_sha="a" * 40,
+                )
+
+
+def test_synthetic_runner_error_payload_cannot_pass_enforcement() -> None:
+    """PAL soft-exit error JSON must not green the workflow via status alone."""
+    # Emulates workflow synthesizing {"status":"error",...} then building a
+    # skipped/failed proof; enforcement must reject executed!=true / non-PASS.
+    synthetic_pal = {"status": "error", "risks": ["runner failed"]}
+    # Even if a bad actor rewrote status to PASS with executed false:
+    forged = {
+        "executed": False,
+        "pr_number": 1042,
+        "head_sha": "a" * 40,
+        "embedded_audit": {"status": "PASS"},
+        "provenance": {
+            "proof_author": "independent-embedded-audit",
+            "workflow": "embedded-audit.yml",
+        },
+        "pal_hint": synthetic_pal,
+    }
+    with pytest.raises(SystemExit) as exc:
+        enforce_independent_audit_proof(
+            forged, expected_pr=1042, expected_head_sha="a" * 40
+        )
+    assert "audit_not_executed" in str(exc.value)

--- a/tests/audit/test_run_embedded_audit.py
+++ b/tests/audit/test_run_embedded_audit.py
@@ -325,6 +325,9 @@ def test_pr_steward_workflow_uses_completed_independent_audit_artifact() -> None
     assert r"^embedded-audit-pr-(\d+)-head-([0-9a-f]{40})-proof$" in text
     assert "jq -s" in text
     assert "live_head" in text
+    assert "Publish readiness status on candidate PR head" in text
+    assert 'context="PR Steward / final readiness"' in text
+    assert "statuses: write" in text
 
 
 def _passing_proof(**overrides: object) -> dict:

--- a/tests/pr_steward/test_intake.py
+++ b/tests/pr_steward/test_intake.py
@@ -460,6 +460,164 @@ def test_live_collection_rejects_dry_run_or_unproven_audit_proof(
     assert "EMBEDDED_AUDIT_NEEDS_SUPERVISOR" in readiness["blockers"]
 
 
+def _blocked_by_independent_audit(
+    tmp_path: Path, monkeypatch, proof_body: dict, pr_head: str
+) -> dict:
+    proof_path = tmp_path / "PROOF.json"
+    proof_path.write_text(json.dumps(proof_body), encoding="utf-8")
+
+    def fake_run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "auth", "status"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(base_pr_payload(head_sha=pr_head)),
+                "",
+            )
+        raise AssertionError(f"unexpected gh command: {args}")
+
+    monkeypatch.setattr(collector, "_run", fake_run)
+    monkeypatch.setattr(collector, "_fetch_review_threads", lambda **_: ([], []))
+    harvest = collector.collect_from_github(
+        "DDD-Enterprises/dopemux-mvp",
+        704,
+        proof_path=proof_path,
+    )
+    artifacts = build_artifacts(
+        harvest,
+        repo="DDD-Enterprises/dopemux-mvp",
+        pr_number=704,
+        strict=True,
+        allow_closed=False,
+    )
+    readiness = artifacts["MERGE_READINESS.json"]
+    assert isinstance(readiness, dict)
+    return readiness
+
+
+def test_live_collection_rejects_pass_with_executed_true_missing_provenance(
+    tmp_path: Path, monkeypatch
+) -> None:
+    pr_head = "c" * 40
+    readiness = _blocked_by_independent_audit(
+        tmp_path,
+        monkeypatch,
+        {
+            "head_sha": pr_head,
+            "executed": True,
+            "embedded_audit": {
+                "status": "PASS",
+                "report_path": "proof/x/AUDITOR_REPORT.md",
+            },
+        },
+        pr_head,
+    )
+    assert readiness["readiness"] == "BLOCKED"
+    assert "EMBEDDED_AUDIT_NEEDS_SUPERVISOR" in readiness["blockers"]
+
+
+def test_live_collection_rejects_wrong_proof_author(
+    tmp_path: Path, monkeypatch
+) -> None:
+    pr_head = "d" * 40
+    readiness = _blocked_by_independent_audit(
+        tmp_path,
+        monkeypatch,
+        {
+            "head_sha": pr_head,
+            "executed": True,
+            "embedded_audit": {"status": "PASS", "report_path": "proof/x/AUDITOR_REPORT.md"},
+            "provenance": {
+                "proof_author": "self-attested",
+                "workflow": "embedded-audit.yml",
+            },
+        },
+        pr_head,
+    )
+    assert readiness["readiness"] == "BLOCKED"
+
+
+def test_live_collection_rejects_wrong_workflow_provenance(
+    tmp_path: Path, monkeypatch
+) -> None:
+    pr_head = "e" * 40
+    readiness = _blocked_by_independent_audit(
+        tmp_path,
+        monkeypatch,
+        {
+            "head_sha": pr_head,
+            "executed": True,
+            "embedded_audit": {"status": "PASS", "report_path": "proof/x/AUDITOR_REPORT.md"},
+            "provenance": {
+                "proof_author": "independent-embedded-audit",
+                "workflow": "not-embedded-audit.yml",
+            },
+        },
+        pr_head,
+    )
+    assert readiness["readiness"] == "BLOCKED"
+
+
+def test_live_collection_rejects_stale_wrong_head_sha(
+    tmp_path: Path, monkeypatch
+) -> None:
+    pr_head = "f" * 40
+    stale_head = "0" * 40
+    readiness = _blocked_by_independent_audit(
+        tmp_path,
+        monkeypatch,
+        {
+            "head_sha": stale_head,
+            "executed": True,
+            "embedded_audit": {
+                "status": "PASS",
+                "report_path": "proof/x/AUDITOR_REPORT.md",
+            },
+            "provenance": {
+                "proof_author": "independent-embedded-audit",
+                "workflow": "embedded-audit.yml",
+            },
+        },
+        pr_head,
+    )
+    # Collector independent-audit errors do not encode expected head; head
+    # freshness is a separate blocker. READY must be impossible.
+    assert readiness["readiness"] in {"BLOCKED", "NEEDS_SUPERVISOR"}
+    assert readiness["readiness"] != "READY"
+    assert readiness["proof"]["matches_pr_head"] is False
+
+
+def test_independent_audit_errors_rejects_malformed_dry_run_string() -> None:
+    errors = collector._independent_audit_errors(
+        {
+            "executed": True,
+            "dry_run": "true",
+            "embedded_audit": {"status": "PASS"},
+            "provenance": {
+                "proof_author": "independent-embedded-audit",
+                "workflow": "embedded-audit.yml",
+            },
+        }
+    )
+    assert any("malformed_dry_run" in e for e in errors)
+
+
+def test_independent_audit_errors_rejects_status_pass_executed_false() -> None:
+    errors = collector._independent_audit_errors(
+        {
+            "executed": False,
+            "embedded_audit": {"status": "PASS"},
+            "provenance": {
+                "proof_author": "independent-embedded-audit",
+                "workflow": "embedded-audit.yml",
+            },
+        }
+    )
+    assert any("audit_not_executed" in e for e in errors)
+
+
 def test_trusted_author_association_is_nonblocking() -> None:
     harvest = base_ready_harvest()
     harvest["reviews"] = [

--- a/tests/pr_steward/test_intake.py
+++ b/tests/pr_steward/test_intake.py
@@ -354,9 +354,14 @@ def test_live_collection_uses_proof_path_for_ready_state(
         json.dumps(
             {
                 "head_sha": pr_head,
+                "executed": True,
                 "embedded_audit": {
                     "status": "PASS_WITH_RISKS",
                     "report_path": "proof/TP-DMX-PR-STEWARD-001/AUDITOR_REPORT.md",
+                },
+                "provenance": {
+                    "proof_author": "independent-embedded-audit",
+                    "workflow": "embedded-audit.yml",
                 },
             }
         ),
@@ -398,6 +403,61 @@ def test_live_collection_uses_proof_path_for_ready_state(
     assert readiness["proof"]["proof_head_sha"] == pr_head
     assert readiness["proof"]["matches_pr_head"] is True
     assert readiness["proof"]["proof_freshness"]["status"] == "CURRENT"
+
+
+def test_live_collection_rejects_dry_run_or_unproven_audit_proof(
+    tmp_path: Path, monkeypatch
+) -> None:
+    pr_head = "b" * 40
+    proof_path = tmp_path / "PROOF.json"
+    proof_path.write_text(
+        json.dumps(
+            {
+                "head_sha": pr_head,
+                "dry_run": True,
+                "executed": False,
+                "embedded_audit": {
+                    "status": "PASS",
+                    "report_path": "proof/TP-DMX-PR-AUDIT-ROUTER-001/AUDITOR_REPORT.md",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_run(args: list[str]) -> subprocess.CompletedProcess[str]:
+        if args[:3] == ["gh", "auth", "status"]:
+            return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ["gh", "pr", "view"]:
+            return subprocess.CompletedProcess(
+                args,
+                0,
+                json.dumps(base_pr_payload(head_sha=pr_head)),
+                "",
+            )
+        raise AssertionError(f"unexpected gh command: {args}")
+
+    monkeypatch.setattr(collector, "_run", fake_run)
+    monkeypatch.setattr(collector, "_fetch_review_threads", lambda **_: ([], []))
+
+    harvest = collector.collect_from_github(
+        "DDD-Enterprises/dopemux-mvp",
+        704,
+        proof_path=proof_path,
+    )
+    artifacts = build_artifacts(
+        harvest,
+        repo="DDD-Enterprises/dopemux-mvp",
+        pr_number=704,
+        strict=True,
+        allow_closed=False,
+    )
+
+    readiness = artifacts["MERGE_READINESS.json"]
+    assert isinstance(readiness, dict)
+    assert readiness["readiness"] == "BLOCKED"
+    assert readiness["embedded_audit"]["status"] == "NEEDS_SUPERVISOR"
+    assert "EMBEDDED_AUDIT_NEEDS_SUPERVISOR" in readiness["blockers"]
 
 
 def test_trusted_author_association_is_nonblocking() -> None:

--- a/tests/pr_steward/test_intake.py
+++ b/tests/pr_steward/test_intake.py
@@ -759,6 +759,192 @@ def test_required_skipped_check_is_successful_nonblocking() -> None:
     assert ci_triage["failed_required_count"] == 0
 
 
+def test_prior_steward_self_failure_can_recover_to_ready() -> None:
+    """A prior failed Steward self-status must not sticky-red a later READY run."""
+    harvest = base_ready_harvest()
+    head_sha = harvest["pr"]["headRefOid"]
+    harvest["checks"] = [
+        {
+            "name": "unit",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "required": True,
+            "headSha": head_sha,
+        },
+        {
+            "name": "PR Steward / final readiness",
+            "context": "PR Steward / final readiness",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "required": True,
+            "headSha": head_sha,
+        },
+    ]
+
+    artifacts = build_artifacts(
+        harvest,
+        repo="DDD-Enterprises/dopemux-mvp",
+        pr_number=704,
+        strict=True,
+        allow_closed=False,
+    )
+    readiness = artifacts["MERGE_READINESS.json"]
+    ci_triage = artifacts["CI_TRIAGE.json"]
+    assert isinstance(readiness, dict)
+    assert isinstance(ci_triage, dict)
+    assert readiness["readiness"] == "READY"
+    assert "FAILED_CHECK" not in readiness["blockers"]
+    # Self-status preserved in triage evidence
+    names = [c["name"] for c in ci_triage["checks"]]
+    assert "PR Steward / final readiness" in names
+    self_entries = [
+        c for c in ci_triage["checks"] if c["name"] == "PR Steward / final readiness"
+    ]
+    assert self_entries
+    assert self_entries[0]["blocking"] is False
+    assert "excluded from readiness" in self_entries[0]["rationale"]
+    # Required external checks still counted; self-status is not
+    assert ci_triage["required_check_count"] == 1
+    assert ci_triage["failed_required_count"] == 0
+
+
+def test_external_failed_checks_still_block_readiness() -> None:
+    harvest = base_ready_harvest()
+    head_sha = harvest["pr"]["headRefOid"]
+    harvest["checks"] = [
+        {
+            "name": "unit",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "required": True,
+            "headSha": head_sha,
+        },
+        {
+            "name": "PR Steward / final readiness",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "required": True,
+            "headSha": head_sha,
+        },
+    ]
+
+    artifacts = build_artifacts(
+        harvest,
+        repo="DDD-Enterprises/dopemux-mvp",
+        pr_number=704,
+        strict=True,
+        allow_closed=False,
+    )
+    readiness = artifacts["MERGE_READINESS.json"]
+    assert isinstance(readiness, dict)
+    assert readiness["readiness"] != "READY"
+    assert "FAILED_CHECK" in readiness["blockers"]
+
+
+def test_similar_steward_status_names_are_not_excluded() -> None:
+    harvest = base_ready_harvest()
+    head_sha = harvest["pr"]["headRefOid"]
+    harvest["checks"] = [
+        {
+            "name": "PR Steward / final readiness EXTRA",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "required": True,
+            "headSha": head_sha,
+        },
+        {
+            "name": "PR Steward / advisory check-only intake",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "required": True,
+            "headSha": head_sha,
+        },
+        {
+            "context": "PR Steward / final readiness",  # exact — excluded
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "required": True,
+            "headSha": head_sha,
+        },
+    ]
+
+    artifacts = build_artifacts(
+        harvest,
+        repo="DDD-Enterprises/dopemux-mvp",
+        pr_number=704,
+        strict=True,
+        allow_closed=False,
+    )
+    readiness = artifacts["MERGE_READINESS.json"]
+    ci_triage = artifacts["CI_TRIAGE.json"]
+    assert isinstance(readiness, dict)
+    assert isinstance(ci_triage, dict)
+    assert "FAILED_CHECK" in readiness["blockers"]
+    assert readiness["readiness"] != "READY"
+    # Two similar names remain required+blocking; exact self-status does not
+    assert ci_triage["required_check_count"] == 2
+    assert ci_triage["failed_required_count"] == 2
+
+
+def test_multiple_historical_self_status_entries_do_not_poison_reruns() -> None:
+    harvest = base_ready_harvest()
+    head_sha = harvest["pr"]["headRefOid"]
+    harvest["checks"] = [
+        {
+            "name": "unit",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "required": True,
+            "headSha": head_sha,
+        },
+        # Multiple historical self-status rows (failure + success) must not block.
+        {
+            "name": "PR Steward / final readiness",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "required": True,
+            "headSha": head_sha,
+        },
+        {
+            "name": "PR Steward / final readiness",
+            "status": "COMPLETED",
+            "conclusion": "FAILURE",
+            "required": True,
+            "headSha": head_sha,
+        },
+        {
+            "context": "PR Steward / final readiness",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "required": True,
+            "headSha": head_sha,
+        },
+    ]
+
+    artifacts = build_artifacts(
+        harvest,
+        repo="DDD-Enterprises/dopemux-mvp",
+        pr_number=704,
+        strict=True,
+        allow_closed=False,
+    )
+    readiness = artifacts["MERGE_READINESS.json"]
+    ci_triage = artifacts["CI_TRIAGE.json"]
+    assert isinstance(readiness, dict)
+    assert isinstance(ci_triage, dict)
+    assert readiness["readiness"] == "READY"
+    assert "FAILED_CHECK" not in readiness["blockers"]
+    self_entries = [
+        c
+        for c in ci_triage["checks"]
+        if c["name"] == "PR Steward / final readiness"
+    ]
+    assert len(self_entries) == 3
+    assert all(c["blocking"] is False for c in self_entries)
+    assert ci_triage["required_check_count"] == 1
+    assert ci_triage["failed_required_count"] == 0
+
+
 def base_ready_harvest() -> dict:
     head_sha = "head000000000000000000000000000000000000"
     return {

--- a/tests/pr_steward/test_intake.py
+++ b/tests/pr_steward/test_intake.py
@@ -353,6 +353,8 @@ def test_live_collection_uses_proof_path_for_ready_state(
     proof_path.write_text(
         json.dumps(
             {
+                "repo": "DDD-Enterprises/dopemux-mvp",
+                "pr_number": 704,
                 "head_sha": pr_head,
                 "executed": True,
                 "embedded_audit": {
@@ -616,6 +618,33 @@ def test_independent_audit_errors_rejects_status_pass_executed_false() -> None:
         }
     )
     assert any("audit_not_executed" in e for e in errors)
+
+
+def test_live_collection_rejects_proof_bound_to_other_pr(
+    tmp_path: Path, monkeypatch
+) -> None:
+    pr_head = "a" * 40
+    readiness = _blocked_by_independent_audit(
+        tmp_path,
+        monkeypatch,
+        {
+            "repo": "DDD-Enterprises/dopemux-mvp",
+            "pr_number": 999,
+            "head_sha": pr_head,
+            "executed": True,
+            "embedded_audit": {
+                "status": "PASS",
+                "report_path": "proof/x/AUDITOR_REPORT.md",
+            },
+            "provenance": {
+                "proof_author": "independent-embedded-audit",
+                "workflow": "embedded-audit.yml",
+            },
+        },
+        pr_head,
+    )
+    assert readiness["readiness"] == "BLOCKED"
+    assert "EMBEDDED_AUDIT_NEEDS_SUPERVISOR" in readiness["blockers"]
 
 
 def test_trusted_author_association_is_nonblocking() -> None:

--- a/tools/pr_steward/classifier.py
+++ b/tools/pr_steward/classifier.py
@@ -22,6 +22,11 @@ PENDING_CHECK_STATUSES = {"queued", "in_progress", "requested", "waiting", "pend
 CURRENT_PROOF_STATUSES = {"CURRENT", "CURRENT_WITH_SELF_REFERENCE_EXCEPTION", "FRESH"}
 STALE_PROOF_STATUSES = {"STALE"}
 MISSING_PROOF_STATUSES = {"MISSING"}
+# Exact context published by .github/workflows/pr-steward.yml against the
+# candidate PR head. Must be excluded from readiness evaluation so a prior
+# failed self-status cannot sticky-red the next Steward run on the same head.
+# Raw harvest still retains the entry for evidence.
+STEWARD_SELF_STATUS_CONTEXT = "PR Steward / final readiness"
 
 
 class ProofFreshness(dict):
@@ -481,6 +486,14 @@ def _resolved_review_comment_dispositions(
     return dispositions
 
 
+def _is_steward_self_status(check: dict[str, Any] | Any) -> bool:
+    """True only for the exact Steward self-status context name."""
+    if not isinstance(check, dict):
+        return False
+    name = str(check.get("name") or check.get("context") or "")
+    return name == STEWARD_SELF_STATUS_CONTEXT
+
+
 def _classify_checks(
     checks: list[Any], *, pr_head_sha: str, strict: bool
 ) -> dict[str, Any]:
@@ -494,16 +507,41 @@ def _classify_checks(
     unknown_count = 0
 
     for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            continue
         name = str(check.get("name") or check.get("context") or f"check-{index}")
         required = bool(check.get("isRequired") is True or check.get("required") is True)
-        if required:
-            required_count += 1
         status = _normalize_status(check.get("status") or check.get("state"))
         conclusion = _normalize_conclusion(check.get("conclusion"))
         if conclusion is None and check.get("state") == "FAILURE":
             conclusion = "failure"
         url = check.get("detailsUrl") or check.get("targetUrl") or check.get("url")
         head_sha = str(check.get("headSha") or check.get("head_sha") or pr_head_sha)
+
+        # Preserve self-status in triage payload, but never let it block readiness.
+        # Otherwise a failed prior publish sticky-reds the next Steward run.
+        if _is_steward_self_status(check):
+            payload_checks.append(
+                {
+                    "name": name,
+                    "required": required,
+                    "status": status,
+                    "conclusion": conclusion,
+                    "url": url,
+                    "head_sha": head_sha,
+                    "blocking": False,
+                    "blockers": [],
+                    "rationale": (
+                        "Steward self-status "
+                        f"{STEWARD_SELF_STATUS_CONTEXT!r} retained as harvest "
+                        "evidence but excluded from readiness evaluation."
+                    ),
+                }
+            )
+            continue
+
+        if required:
+            required_count += 1
 
         blocking = False
         rationale = "Check is nonblocking or successful."
@@ -687,6 +725,11 @@ def _embedded_audit(harvest: dict[str, Any]) -> dict[str, str]:
 
 def _detect_mixed_sha_checks(checks: list[Any], *, pr_head_sha: str) -> bool:
     for check in checks:
+        if not isinstance(check, dict):
+            continue
+        # Self-status is Steward-published evidence, not foreign SHA noise.
+        if _is_steward_self_status(check):
+            continue
         raw_sha = check.get("headSha") or check.get("head_sha")
         sha = (raw_sha or "").strip() if isinstance(raw_sha, str) else ""
         if sha and sha != pr_head_sha:

--- a/tools/pr_steward/collector.py
+++ b/tools/pr_steward/collector.py
@@ -266,14 +266,20 @@ def _proof_state(
     if not isinstance(payload, dict):
         return _missing_proof_state(proof_path), ["proof_unparseable: root is not an object"]
 
+    errors: list[str] = []
     embedded = payload.get("embedded_audit") or {}
     if not isinstance(embedded, dict):
         embedded = {}
+    audit_status = str(embedded.get("status") or "SKIPPED")
+    independent_errors = _independent_audit_errors(payload)
+    if independent_errors:
+        audit_status = "NEEDS_SUPERVISOR"
+        errors.extend(independent_errors)
     proof_head_sha = _proof_head_sha(payload)
     proof_freshness = _proof_freshness(payload, proof_head_sha, pr_head_sha)
     return {
         "embedded_audit": {
-            "status": str(embedded.get("status") or "SKIPPED"),
+            "status": audit_status,
             "report_path": str(
                 embedded.get("report_path")
                 or f"{proof_path.parent.as_posix()}/AUDITOR_REPORT.md"
@@ -287,7 +293,24 @@ def _proof_state(
             ),
             "proof_freshness": proof_freshness,
         },
-    }, []
+    }, errors
+
+
+def _independent_audit_errors(payload: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    if payload.get("dry_run") is True:
+        errors.append("audit_proof_dry_run: final readiness requires an executed audit")
+    if payload.get("executed") is not True:
+        errors.append("audit_not_executed: final readiness requires executed=true")
+    provenance = payload.get("provenance")
+    if not isinstance(provenance, dict):
+        errors.append("audit_provenance_missing: final readiness requires trusted provenance")
+        return errors
+    if provenance.get("proof_author") != "independent-embedded-audit":
+        errors.append("audit_provenance_untrusted: unexpected proof author")
+    if provenance.get("workflow") != "embedded-audit.yml":
+        errors.append("audit_provenance_untrusted: unexpected workflow")
+    return errors
 
 
 def _missing_proof_state(proof_path: Path | None) -> dict[str, Any]:

--- a/tools/pr_steward/collector.py
+++ b/tools/pr_steward/collector.py
@@ -48,6 +48,8 @@ def collect_from_github(
     proof_state, initial_proof_errors = _proof_state(
         proof_path=proof_path,
         pr_head_sha=None,
+        expected_pr=pr_number,
+        expected_repo=repo,
     )
     auth = _run(["gh", "auth", "status"])
     if auth.returncode != 0:
@@ -93,6 +95,8 @@ def collect_from_github(
     proof_state, proof_errors = _proof_state(
         proof_path=proof_path,
         pr_head_sha=str(pr_payload.get("headRefOid") or ""),
+        expected_pr=pr_number,
+        expected_repo=repo,
     )
     errors.extend(proof_errors)
     threads, thread_errors = _fetch_review_threads(repo=repo, pr_number=pr_number)
@@ -253,7 +257,11 @@ def _incomplete_harvest(
 
 
 def _proof_state(
-    *, proof_path: Path | None, pr_head_sha: str | None
+    *,
+    proof_path: Path | None,
+    pr_head_sha: str | None,
+    expected_pr: int | None = None,
+    expected_repo: str | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
     if proof_path is None:
         return _missing_proof_state(None), ["proof_missing: --proof-path not provided"]
@@ -271,7 +279,12 @@ def _proof_state(
     if not isinstance(embedded, dict):
         embedded = {}
     audit_status = str(embedded.get("status") or "SKIPPED")
-    independent_errors = _independent_audit_errors(payload)
+    independent_errors = _independent_audit_errors(
+        payload,
+        expected_pr=expected_pr,
+        expected_head_sha=pr_head_sha,
+        expected_repo=expected_repo,
+    )
     if independent_errors:
         audit_status = "NEEDS_SUPERVISOR"
         errors.extend(independent_errors)
@@ -296,17 +309,29 @@ def _proof_state(
     }, errors
 
 
-def _independent_audit_errors(payload: dict[str, Any]) -> list[str]:
+def _independent_audit_errors(
+    payload: dict[str, Any],
+    *,
+    expected_pr: int | None = None,
+    expected_head_sha: str | None = None,
+    expected_repo: str | None = None,
+) -> list[str]:
     """Delegate to the shared independent-audit proof validator.
 
     Parity with the embedded-audit workflow hard gate is intentional: both
-    surfaces must accept and reject the same proof shapes.
+    surfaces must accept and reject the same proof shapes. When known, pass
+    expected PR/repo/head so a proof from another PR cannot produce READY.
     """
     # Local import keeps collector importable when scripts/ is unavailable in
     # tightly packaged test contexts, while remaining the single contract path.
     from scripts.audit.run_embedded_audit import independent_audit_errors
 
-    return independent_audit_errors(payload)
+    return independent_audit_errors(
+        payload,
+        expected_pr=expected_pr,
+        expected_head_sha=expected_head_sha or None,
+        expected_repo=expected_repo,
+    )
 
 
 def _missing_proof_state(proof_path: Path | None) -> dict[str, Any]:

--- a/tools/pr_steward/collector.py
+++ b/tools/pr_steward/collector.py
@@ -297,20 +297,16 @@ def _proof_state(
 
 
 def _independent_audit_errors(payload: dict[str, Any]) -> list[str]:
-    errors: list[str] = []
-    if payload.get("dry_run") is True:
-        errors.append("audit_proof_dry_run: final readiness requires an executed audit")
-    if payload.get("executed") is not True:
-        errors.append("audit_not_executed: final readiness requires executed=true")
-    provenance = payload.get("provenance")
-    if not isinstance(provenance, dict):
-        errors.append("audit_provenance_missing: final readiness requires trusted provenance")
-        return errors
-    if provenance.get("proof_author") != "independent-embedded-audit":
-        errors.append("audit_provenance_untrusted: unexpected proof author")
-    if provenance.get("workflow") != "embedded-audit.yml":
-        errors.append("audit_provenance_untrusted: unexpected workflow")
-    return errors
+    """Delegate to the shared independent-audit proof validator.
+
+    Parity with the embedded-audit workflow hard gate is intentional: both
+    surfaces must accept and reject the same proof shapes.
+    """
+    # Local import keeps collector importable when scripts/ is unavailable in
+    # tightly packaged test contexts, while remaining the single contract path.
+    from scripts.audit.run_embedded_audit import independent_audit_errors
+
+    return independent_audit_errors(payload)
 
 
 def _missing_proof_state(proof_path: Path | None) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Trusted audit + final PR Steward foundation for merge-integrity.

**Packet:** `TP-DMX-MERGE-INTEGRITY-0001R2` Phase A

### Current exact head

```text
5938bfcc4d10be4f0d50ef731829103959d1b307
```

### External independent audit receipt (operator-local)

- tool: AGY / Claude Sonnet 4.6 (Thinking)
- verdict: PASS_WITH_RISKS
- bound head: `5938bfcc4d10be4f0d50ef731829103959d1b307`
- raw SHA-256: `07135bb8b47df7731f2879f53e426e9765726ecd95c63d1b1612c128b0561424`
- path: `/Users/hue/.codex/tmp/pr1042-exact-head-receipts-5938bfcc4/`

### Latest fix on this head

Missing trusted emitter no longer hard-fails verify before artifacts exist; diagnostic SKIPPED PROOF path enables Steward head-bind + status overwrite.

### CHECK-NAME MIGRATION (branch-protection follow-up)

- old: `PR Steward / advisory check-only intake`
- new: `PR Steward / final readiness`

### Merge

**NEEDS_SUPERVISOR** re-authorization for exact head `5938bfcc4d10be4f0d50ef731829103959d1b307` only.