### PR TITLE
fix(audit): run PAL audit runner as a package module

### DIFF
--- a/.github/workflows/embedded-audit.yml
+++ b/.github/workflows/embedded-audit.yml
@@ -159,7 +159,7 @@ jobs:
           } > ../embedded-audit-artifacts/PAL_CLINK_AUDIT_INPUT.md
           set +e
           if [ -f scripts/audit/pal_clink_runner.py ]; then
-            python scripts/audit/pal_clink_runner.py \
+            python -m scripts.audit.pal_clink_runner \
               --route-json ../embedded-audit-artifacts/AUDITOR_ROUTE.json \
               --prompt ../embedded-audit-artifacts/PAL_CLINK_AUDIT_INPUT.md \
               --pal-output-json ../embedded-audit-artifacts/PAL_CLINK_AUDIT_OUTPUT.json \

--- a/proof/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR/AUDITOR_REPORT.md
+++ b/proof/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR/AUDITOR_REPORT.md
@@ -1,0 +1,8 @@
+# Embedded Audit Receipt
+
+Status: `SKIPPED`
+
+No supported independent embedded-auditor invocation was available in this
+session. The local regression tests, module invocation check, YAML parse, task
+packet validation, and internal code review are recorded in `PROOF.json`; they
+do not substitute for an external audit receipt.

--- a/proof/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR/PROOF.json
+++ b/proof/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR/PROOF.json
@@ -1,0 +1,137 @@
+{
+  "packet_id": "TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR",
+  "repository": "DDD-Enterprises/dopemux-mvp",
+  "worktree": "/Users/hue/.codex/worktrees/dmx-audit-ci-provenance-104r",
+  "branch": "codex/audit-ci-provenance-104-import-path-repair",
+  "base_sha": "db9b844fc7b1731af953b7c996581082fb3f096f",
+  "head_binding": {
+    "status": "REQUIRES_POST_COMMIT_FINAL_SUMMARY",
+    "reason": "A proof file cannot truthfully contain the SHA of the commit that contains it."
+  },
+  "executed": false,
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR/AUDITOR_REPORT.md",
+    "findings": [],
+    "fixes_applied": [],
+    "remaining_risks": [
+      "The credentialed GitHub Actions PAL clink route was not run locally.",
+      "The external GPT-5.5 expert review was blocked by provider quota HTTP 429.",
+      "No independent exact-head audit receipt exists for this local repair branch."
+    ],
+    "skip_reason": "No supported independent embedded-auditor invocation was available in this session; local validation and internal code review do not substitute for an external audit receipt."
+  },
+  "root_cause": {
+    "observed": "The trusted workflow runs from trusted-source but invoked scripts/audit/pal_clink_runner.py directly. Its imports of scripts.audit.* then fail because direct script execution does not put the trusted checkout root on sys.path.",
+    "reproduction": {
+      "command": "python scripts/audit/pal_clink_runner.py --help",
+      "exit_code": 1,
+      "result": "ModuleNotFoundError: No module named 'scripts'"
+    },
+    "control": {
+      "command": "uv run --frozen python -m scripts.audit.pal_clink_runner --help",
+      "exit_code": 0,
+      "result": "The runner argparse help was emitted."
+    }
+  },
+  "slices": [
+    {
+      "id": "workflow-invocation",
+      "files": [
+        ".github/workflows/embedded-audit.yml"
+      ],
+      "change": "Run the PAL clink runner as scripts.audit.pal_clink_runner in Python module mode while retaining the trusted-source working directory and every existing argument."
+    },
+    {
+      "id": "regression-test",
+      "files": [
+        "tests/audit/test_run_embedded_audit.py"
+      ],
+      "change": "Require the exact PAL runner step to retain trusted-source and package-module invocation."
+    }
+  ],
+  "validations": [
+    {
+      "status": "PASS",
+      "command": "uv run --frozen pytest -q tests/audit/test_run_embedded_audit.py",
+      "exit_code": 0,
+      "result": "27 passed"
+    },
+    {
+      "status": "PASS",
+      "command": "uv run --frozen pytest -q tests/audit/test_pal_clink_runner.py",
+      "exit_code": 0,
+      "result": "39 passed"
+    },
+    {
+      "status": "PASS",
+      "command": "uv run --frozen python -m scripts.audit.pal_clink_runner --help",
+      "exit_code": 0,
+      "result": "Module invocation resolves package imports."
+    },
+    {
+      "status": "PASS",
+      "command": "uv run --frozen python -c <yaml-safe-load embedded-audit.yml>",
+      "exit_code": 0,
+      "result": "embedded-audit.yml: YAML PASS"
+    },
+    {
+      "status": "PASS",
+      "command": "uv run --frozen dopemux orchestrator packet validate task-packets/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR.json",
+      "exit_code": 0,
+      "result": "dopetask-canonical-spec validation passed"
+    },
+    {
+      "status": "PASS",
+      "command": "uv run --frozen pre-commit run --files .github/workflows/embedded-audit.yml tests/audit/test_run_embedded_audit.py task-packets/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR.json proof/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR/PROOF.json proof/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR/AUDITOR_REPORT.md",
+      "exit_code": 0,
+      "result": "All applicable hooks passed; remaining hooks skipped because no matching files were supplied."
+    },
+    {
+      "status": "PASS",
+      "command": "git diff --check",
+      "exit_code": 0,
+      "result": "No whitespace errors."
+    },
+    {
+      "status": "PASS",
+      "command": "PAL codereview internal review",
+      "exit_code": 0,
+      "result": "No code-level findings; reviewed workflow, runner, proof emitter, regression test, and task packet."
+    },
+    {
+      "status": "NOT_RUN",
+      "command": "PAL codereview external expert review (gpt-5.5)",
+      "exit_code": null,
+      "result": "Blocked by provider quota HTTP 429 after repository inspection; no expert verdict was returned."
+    }
+  ],
+  "scope": {
+    "allowlist": [
+      ".github/workflows/embedded-audit.yml",
+      "tests/audit/test_run_embedded_audit.py",
+      "task-packets/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR.json",
+      "proof/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR/**"
+    ],
+    "unrelated_preserved": [
+      ".claude/claude_config.json (worktree-specific configuration mutation; not staged)"
+    ]
+  },
+  "residual_risks": [
+    "The credentialed GitHub Actions route and external PAL CLI were not run locally.",
+    "A passing local module invocation does not itself produce an independent audit verdict or a final PR Steward READY receipt.",
+    "PR #1040 remains draft and blocked on an exact-head independent audit receipt and supervisor ADR decision."
+  ],
+  "unknowns": [
+    "Whether the configured GitHub Actions PAL clink client and least-privilege token are currently available to the hosted runner."
+  ],
+  "cleanup": {
+    "status": "PENDING_PR_PUBLICATION",
+    "note": "The dedicated worktree is retained until the repair branch is pushed and its pull request is created."
+  }
+}

--- a/task-packets/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR.json
+++ b/task-packets/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR.json
@@ -1,0 +1,95 @@
+{
+  "id": "TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR",
+  "project": "dopemux-mvp",
+  "target": "Repair the trusted embedded-audit PAL clink runner invocation so package imports resolve from the trusted checkout, while preserving fail-closed proof enforcement.",
+  "invariants": [
+    "The workflow continues to execute audit code only from trusted default-branch source.",
+    "Missing, malformed, skipped, or unexecuted audit evidence remains non-READY and fails closed.",
+    "The repair does not add credentials, mutate pull requests, alter branch protection, or change PR Steward behavior.",
+    "The repair is limited to the PAL runner import invocation and its regression proof."
+  ],
+  "depends_on": [
+    "TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DMX-MERGE-INTEGRITY",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DMX-MERGE-INTEGRITY-0004-TRUSTED-AUDIT-FOUNDATION",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/audit-ci-provenance-104-import-path-repair",
+    "base_branch": "main",
+    "stacked_because": "PR #1042 fail-closed enforcement is correct but its PAL runner invocation is not import-safe when executed as a script."
+  },
+  "commit": {
+    "message": "fix(audit): run PAL audit runner as a package module",
+    "allowlist": [
+      ".github/workflows/embedded-audit.yml",
+      "tests/audit/test_run_embedded_audit.py",
+      "task-packets/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR.json",
+      "proof/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR/**"
+    ],
+    "verify": [
+      "uv run --frozen pytest -q tests/audit/test_run_embedded_audit.py",
+      "uv run --frozen python -m scripts.audit.pal_clink_runner --help",
+      "uv run --frozen dopemux orchestrator packet validate task-packets/TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR.json",
+      "git diff --check"
+    ]
+  },
+  "pr": {
+    "title": "fix(audit): run PAL audit runner as a package module",
+    "body": "## Summary\n- Runs the trusted PAL clink audit runner in package mode so `scripts.*` imports resolve in the workflow checkout.\n- Adds a focused regression assertion for the workflow invocation.\n\n## Scope\nNo credentials, branch protection, PR mutation, or PR Steward behavior changes. Existing fail-closed enforcement remains unchanged.\n\n## Validation\nFocused audit workflow test, module help invocation, task-packet validation, and diff hygiene.\n\n## NOT_RUN\nCredentialed external-auditor execution remains outside this repair and requires a separate live receipt.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "planner",
+      "codereview",
+      "precommit"
+    ]
+  },
+  "steps": [
+    {
+      "id": "S1",
+      "task": "Reproduce the workflow runner import failure and compare it with package-module invocation from the trusted checkout.",
+      "validation": [
+        "Direct script execution fails with ModuleNotFoundError for scripts.",
+        "python -m scripts.audit.pal_clink_runner --help succeeds from the repository root."
+      ]
+    },
+    {
+      "id": "S2",
+      "task": "Add a focused regression test requiring the embedded-audit PAL runner step to use package-module invocation.",
+      "validation": [
+        "The new test fails before the workflow change because the script-path invocation is present."
+      ]
+    },
+    {
+      "id": "S3",
+      "task": "Change only the PAL clink runner workflow command from script execution to package-module execution.",
+      "validation": [
+        "The focused audit workflow test passes.",
+        "The module help invocation succeeds.",
+        "Fail-closed proof enforcement remains unchanged in the diff."
+      ]
+    },
+    {
+      "id": "S4",
+      "task": "Validate packet schema, focused tests, diff hygiene, precommit, and capture a proof bundle without claiming a credentialed external audit ran.",
+      "validation": [
+        "All packet commit.verify commands pass or are reported as NOT_RUN with an exact blocker.",
+        "Only commit.allowlist paths are staged."
+      ]
+    }
+  ]
+}

--- a/tests/audit/test_run_embedded_audit.py
+++ b/tests/audit/test_run_embedded_audit.py
@@ -225,6 +225,17 @@ def test_embedded_audit_workflow_uses_trusted_source_and_least_privilege() -> No
     assert "persist-credentials: false" in text
 
 
+def test_embedded_audit_workflow_invokes_pal_runner_as_package_module() -> None:
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+    runner_step = text.split("- name: Run PAL clink audit", 1)[1].split(
+        "- name: Emit independent embedded audit proof", 1
+    )[0]
+
+    assert "working-directory: trusted-source" in runner_step
+    assert "python -m scripts.audit.pal_clink_runner" in runner_step
+    assert "python scripts/audit/pal_clink_runner.py" not in runner_step
+
+
 def test_embedded_audit_workflow_handles_pull_request_target_metadata() -> None:
     """Regression: trigger is pull_request_target; shell must not only match pull_request."""
     text = WORKFLOW_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Run the trusted PAL clink audit runner as `python -m scripts.audit.pal_clink_runner`, preserving its existing working directory and arguments.
- Add a regression test that binds the package invocation to the trusted runner step.
- Include Task Packet `TP-DMX-AUDIT-CI-PROVENANCE-104R-IMPORT-PATH-REPAIR` and schema-valid fail-closed proof.

## Validation
- `uv run --frozen pytest -q tests/audit/test_run_embedded_audit.py` (27 passed)
- `uv run --frozen pytest -q tests/audit/test_pal_clink_runner.py` (39 passed)
- `uv run --frozen python -m scripts.audit.pal_clink_runner --help`
- YAML parse, Task Packet validation, proof-schema validation, precommit, and `git diff --check`

## Not Run
- Credentialed GitHub Actions PAL clink audit and an independent exact-head auditor receipt.
- External GPT-5.5 code-review verdict (provider quota HTTP 429); an internal PAL review found no code-level issues.

## Scope
No credential, branch-protection, pull-request-mutation, or PR Steward behavior changes. This PR does not promote or modify PR #1040.