### PR TITLE
fix(mcp): recognize healthy reserved singleton via MCP identity probe

### DIFF
--- a/src/dopemux/mcp/port_allocator.py
+++ b/src/dopemux/mcp/port_allocator.py
@@ -23,6 +23,17 @@ from .socket_probe import port_is_free
 # Default search window beyond base when rebinding
 DEFAULT_SEARCH_SPAN = 100
 
+# Expected MCP ``serverInfo.name`` prefix for each reserved-singleton service.
+# A reserved singleton (e.g. task-orchestrator on :7890) never writes a port
+# lease, so a healthy live singleton cannot be recognized by lease identity.
+# When such a port is occupied, the allocator probes the MCP ``initialize``
+# handshake and treats a matching ``serverInfo.name`` as the legitimate
+# singleton (assign the port, no lease). Services absent from this map fail
+# closed (an occupied reserved port with no matching lease stays BLOCKED).
+RESERVED_SINGLETON_IDENTITY_PREFIX: Dict[str, str] = {
+    "task-orchestrator": "mcp-task-orchestrator",
+}
+
 
 def preferred_port_for_path(worktree_path: str, base_port: int) -> int:
     """Legacy preferred formula: base + sha1(abspath)[:4] % 100."""
@@ -98,6 +109,10 @@ class PortRoleRequest:
     scope: str = "worktree"  # worktree | project | singleton | reserved_singleton
     preferred: Optional[int] = None
     lease: bool = True  # False => export port only, never write lease
+    # Expected MCP serverInfo.name prefix for a reserved singleton on this port.
+    # Set only for explicitly-declared reserved singletons; None => never probe.
+    identity_name: Optional[str] = None
+    identity_path: str = "/mcp"
 
 
 @dataclass
@@ -173,6 +188,17 @@ def build_role_requests(
                     pref = int(str(env[str(port_var)]).strip())
                 except ValueError:
                     pass
+            # Positive-identity probing only for *explicitly* declared reserved
+            # singletons (port_policy / reserved_port). The back-compat heuristic
+            # recognition (default_port_base 7890 + TASK_ORCHESTRATOR_HTTP_PORT)
+            # deliberately does not opt in, so it stays fail-closed on an
+            # occupied port with no matching lease.
+            identity_name: Optional[str] = None
+            if is_reserved and (
+                spec.get("port_policy") == "reserved_singleton"
+                or spec.get("reserved_port") is not None
+            ):
+                identity_name = RESERVED_SINGLETON_IDENTITY_PREFIX.get(str(name))
             reqs.append(
                 PortRoleRequest(
                     service=str(name),
@@ -183,6 +209,7 @@ def build_role_requests(
                     scope=scope,
                     preferred=pref,
                     lease=not is_reserved,
+                    identity_name=identity_name,
                 )
             )
         if not is_fixed and not is_reserved:
@@ -258,6 +285,7 @@ def allocate_ports(
     dry_run: bool = False,
     source: str = "dopemux mcp init",
     is_free_fn: Optional[Callable[[int], bool]] = None,
+    singleton_probe_fn: Optional[Callable[[int, str], Optional[str]]] = None,
     extra_blocked_ports: Optional[Mapping[int, str]] = None,
 ) -> AllocationResult:
     """Allocate ports for services with lease + live socket safety.
@@ -265,6 +293,13 @@ def allocate_ports(
     ``persist=False`` or ``dry_run=True`` skips registry writes.
     """
     is_free = is_free_fn or (lambda p: port_is_free(p))
+
+    def _default_singleton_probe(port: int, path: str) -> Optional[str]:
+        from .task_orchestrator_identity import probe_mcp_server_name
+
+        return probe_mcp_server_name(int(port), path=path)
+
+    singleton_probe = singleton_probe_fn or _default_singleton_probe
     wt = str(Path(worktree).expanduser().resolve())
     proj = str(Path(project_root or worktree).expanduser().resolve())
     wt_hash = instance_id_for_path(wt)
@@ -353,8 +388,11 @@ def allocate_ports(
         rebind_reason: Optional[str] = None
 
         # Reserved host singletons (e.g. TO:7890): never project-leased.
-        # Still fail-closed if the reserved port is occupied by an unknown process
-        # (no matching lease identity) — do not pretend the singleton is free.
+        # A reserved singleton never writes a lease, so a healthy live singleton
+        # can never be recognized by lease identity. When the port is occupied
+        # with no matching lease, positively identify the occupant via the MCP
+        # ``initialize`` handshake (serverInfo.name) before failing closed: a
+        # matching singleton is OK (assign, no lease); an unknown occupant BLOCKS.
         if not req.lease or req.scope == "reserved_singleton":
             free = is_free(preferred)
             other = registry.find_active_by_port(preferred)
@@ -368,19 +406,43 @@ def allocate_ports(
                 )
             )
             if not free and not ours:
-                result.status = "BLOCKED"
-                result.blocking_findings.append(
+                probed_name: Optional[str] = None
+                singleton_ok = False
+                if req.identity_name:
+                    probed_name = singleton_probe(preferred, req.identity_path)
+                    singleton_ok = bool(
+                        probed_name
+                        and str(probed_name).strip().lower().startswith(
+                            req.identity_name.strip().lower()
+                        )
+                    )
+                if not singleton_ok:
+                    result.status = "BLOCKED"
+                    result.blocking_findings.append(
+                        {
+                            "code": "LEASE_PORT_OCCUPIED",
+                            "service": req.service,
+                            "port": preferred,
+                            "message": (
+                                f"Reserved singleton port {preferred} for {req.service} "
+                                "is occupied by an unknown process."
+                            ),
+                        }
+                    )
+                    return result
+                result.warnings.append(
                     {
-                        "code": "LEASE_PORT_OCCUPIED",
+                        "code": "ALLOCATOR_RESERVED_SINGLETON_IDENTIFIED",
                         "service": req.service,
                         "port": preferred,
+                        "server_name": probed_name,
                         "message": (
-                            f"Reserved singleton port {preferred} for {req.service} "
-                            "is occupied by an unknown process."
+                            f"Reserved singleton port {preferred} occupied by live "
+                            f"{req.service} MCP server ({probed_name}); assigning "
+                            "without a lease."
                         ),
                     }
                 )
-                return result
             assigned = preferred
             result.ports[req.port_var] = assigned
             result.warnings.append(

--- a/src/dopemux/mcp/task_orchestrator_identity.py
+++ b/src/dopemux/mcp/task_orchestrator_identity.py
@@ -210,6 +210,70 @@ def probe_wrapper_metadata(
     return None
 
 
+def probe_mcp_server_name(
+    port: int = DEFAULT_TO_PORT,
+    *,
+    host: str = "127.0.0.1",
+    path: str = "/mcp",
+    timeout_s: float = 1.0,
+    opener: Optional[Callable[[str, bytes, Dict[str, str]], Any]] = None,
+) -> Optional[str]:
+    """MCP ``initialize`` handshake → ``result.serverInfo.name`` (fail-closed).
+
+    Positively identifies a live reserved-singleton occupant (e.g. the Task
+    Orchestrator on :7890) via the MCP protocol handshake, without relying on a
+    port lease — reserved singletons never write leases, so lease identity can
+    never prove ownership of a healthy live singleton.
+
+    Any error, timeout, or non-JSON/malformed response returns ``None`` so
+    callers fail closed (treat the occupant as unknown). The upstream Task
+    Orchestrator answers this handshake with a plain ``application/json`` body.
+    """
+    url = f"http://{host}:{int(port)}{path}"
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "dopemux-allocator-probe", "version": "1"},
+            },
+        }
+    ).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+
+    def _default_post(u: str, body: bytes, hdrs: Dict[str, str]) -> Any:
+        req = urllib.request.Request(u, data=body, headers=hdrs, method="POST")
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:  # noqa: S310 — localhost probe
+            return resp.read()
+
+    post = opener or _default_post
+    try:
+        raw = post(url, payload, headers)
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError, ValueError):
+        return None
+    try:
+        text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else str(raw)
+        body = json.loads(text)
+    except (json.JSONDecodeError, ValueError, AttributeError, UnicodeDecodeError):
+        return None
+    if not isinstance(body, dict):
+        return None
+    result = body.get("result")
+    if not isinstance(result, dict):
+        return None
+    info = result.get("serverInfo")
+    if not isinstance(info, dict):
+        return None
+    name = info.get("name")
+    return str(name) if name else None
+
+
 def probe_http_info(
     port: int = DEFAULT_TO_PORT,
     *,

--- a/tests/unit/test_mcp_port_allocator.py
+++ b/tests/unit/test_mcp_port_allocator.py
@@ -299,3 +299,148 @@ def test_worktree_scoped_does_not_reuse_project_lease(tmp_path: Path, monkeypatc
     assert not any(
         w.get("code") == "LEASE_REUSED" and w.get("port") == 3099 for w in result.warnings
     )
+
+
+def _reserved_singleton_catalog() -> Dict[str, Any]:
+    """Catalog whose TO entry declares explicit reserved-singleton markers."""
+    cat = _catalog()
+    cat["servers"]["task-orchestrator"]["port_policy"] = "reserved_singleton"
+    cat["servers"]["task-orchestrator"]["reserved_port"] = 7890
+    return cat
+
+
+def test_reserved_singleton_assigned_when_live_singleton_identified(tmp_path: Path, monkeypatch):
+    """RUNTIME regression: a healthy live singleton on the reserved port is
+    identified via the MCP handshake and ASSIGNED (never leased), not BLOCKED.
+
+    Reproduces the ``dopemux mcp init --force`` fail-closed bug where a healthy
+    task-orchestrator on :7890 was permanently unrecognized (it never writes a
+    lease, so the lease-only legitimacy check could never succeed).
+    """
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+
+    result = allocate_ports(
+        ["task-orchestrator"],
+        _reserved_singleton_catalog(),
+        worktree=str(tmp_path),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: False,  # :7890 occupied by the live singleton
+        singleton_probe_fn=lambda port, path: "mcp-task-orchestrator-current",
+    )
+
+    assert result.status != "BLOCKED"
+    assert result.ports["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
+    assert any(
+        w.get("code") == "ALLOCATOR_RESERVED_SINGLETON_IDENTIFIED" for w in result.warnings
+    )
+    # A reserved singleton is never written as a lease.
+    assert not any(int(L.get("port") or 0) == 7890 for L in result.leases)
+    reg = PortLeaseRegistry.load(reg_path)
+    assert reg.find_active_by_port(7890) is None
+
+
+def test_reserved_singleton_blocked_when_identity_mismatch(tmp_path: Path, monkeypatch):
+    """Occupied reserved port whose serverInfo.name does NOT match stays fail-closed."""
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+
+    result = allocate_ports(
+        ["task-orchestrator"],
+        _reserved_singleton_catalog(),
+        worktree=str(tmp_path),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: False,
+        singleton_probe_fn=lambda port, path: "some-other-mcp-server",
+    )
+
+    assert result.status == "BLOCKED"
+    assert any(b.get("code") == "LEASE_PORT_OCCUPIED" for b in result.blocking_findings)
+    reg = PortLeaseRegistry.load(reg_path)
+    assert reg.find_active_by_port(7890) is None
+
+
+def test_reserved_singleton_blocked_when_probe_unreachable(tmp_path: Path, monkeypatch):
+    """Occupied reserved port where the identity probe fails (None) stays fail-closed."""
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+
+    result = allocate_ports(
+        ["task-orchestrator"],
+        _reserved_singleton_catalog(),
+        worktree=str(tmp_path),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: False,
+        singleton_probe_fn=lambda port, path: None,  # unreachable / non-MCP occupant
+    )
+
+    assert result.status == "BLOCKED"
+    assert any(b.get("code") == "LEASE_PORT_OCCUPIED" for b in result.blocking_findings)
+
+
+def test_reserved_singleton_free_port_never_probes(tmp_path: Path, monkeypatch):
+    """When the reserved port is free, assign without probing (singleton not up yet)."""
+    reg_path = tmp_path / "leases.json"
+    monkeypatch.setenv("DOPEMUX_MCP_PORT_LEASE_REGISTRY", str(reg_path))
+    calls: list[int] = []
+
+    def _boom(port: int, path: str):
+        calls.append(port)
+        raise AssertionError("probe must not run when the reserved port is free")
+
+    result = allocate_ports(
+        ["task-orchestrator"],
+        _reserved_singleton_catalog(),
+        worktree=str(tmp_path),
+        project_root=str(tmp_path),
+        registry_path=reg_path,
+        persist=True,
+        is_free_fn=lambda p: True,  # nothing listening on :7890 yet
+        singleton_probe_fn=_boom,
+    )
+
+    assert calls == []
+    assert result.status != "BLOCKED"
+    assert result.ports["TASK_ORCHESTRATOR_HTTP_PORT"] == 7890
+
+
+def test_probe_mcp_server_name_parses_serverinfo():
+    """The MCP-handshake probe extracts result.serverInfo.name from a JSON body."""
+    from dopemux.mcp.task_orchestrator_identity import probe_mcp_server_name
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_post(url: str, body: bytes, headers: Dict[str, str]) -> bytes:
+        captured["url"] = url
+        return (
+            b'{"jsonrpc":"2.0","id":1,"result":{"serverInfo":'
+            b'{"name":"mcp-task-orchestrator-current","version":"3.8.0"}}}'
+        )
+
+    name = probe_mcp_server_name(7890, opener=_fake_post)
+    assert name == "mcp-task-orchestrator-current"
+    assert captured["url"] == "http://127.0.0.1:7890/mcp"
+
+
+def test_probe_mcp_server_name_fails_closed_on_bad_response():
+    """Non-JSON / malformed / error responses return None (fail closed)."""
+    from dopemux.mcp.task_orchestrator_identity import probe_mcp_server_name
+
+    def _garbage(url: str, body: bytes, headers: Dict[str, str]) -> bytes:
+        return b"not json at all"
+
+    def _raises(url: str, body: bytes, headers: Dict[str, str]) -> bytes:
+        raise OSError("connection refused")
+
+    def _no_serverinfo(url: str, body: bytes, headers: Dict[str, str]) -> bytes:
+        return b'{"jsonrpc":"2.0","id":1,"result":{}}'
+
+    assert probe_mcp_server_name(7890, opener=_garbage) is None
+    assert probe_mcp_server_name(7890, opener=_raises) is None
+    assert probe_mcp_server_name(7890, opener=_no_serverinfo) is None


### PR DESCRIPTION
## Problem

`dopemux mcp init --force` fails closed with **"Reserved singleton port 7890 for task-orchestrator is occupied by an unknown process"** even when the legitimate task-orchestrator singleton (v3.8.0, answering JSON-RPC `initialize` on `http://127.0.0.1:7890/mcp`) is the occupant.

Root cause in `src/dopemux/mcp/port_allocator.py`: for `scope=reserved_singleton` the port is (correctly) *never project-leased*, yet the only way an occupant is recognized as legitimate is `registry.find_active_by_port` + `identity_matches` — a lease-based check that can **never** succeed for a service that never writes leases. Net effect: allocation is permanently blocked whenever the singleton is healthy, which is exactly when it should succeed.

## Fix

Add a **positive identity probe** for reserved singletons. When the reserved port is occupied with no matching lease, perform the MCP `initialize` handshake and check `result.serverInfo.name`:

- Match (`mcp-task-orchestrator*`) → assign the port, **no lease** (singleton policy preserved).
- Unknown / unreachable / non-MCP occupant → stay **BLOCKED** (fail-closed preserved).

Probing is gated on **explicit** reserved-singleton markers (`port_policy: reserved_singleton` / `reserved_port`), so the back-compat heuristic recognition path stays fail-closed and unchanged. The expected server-name lives in a code constant (`RESERVED_SINGLETON_IDENTITY_PREFIX`) rather than a new catalog field, since the catalog schema is strict (`$defs.server: additionalProperties=false`) and there is exactly one reserved singleton in the fleet.

## Changes
- `port_allocator.py` — identity constant, `PortRoleRequest.identity_name/path`, marker-gated population, injectable `singleton_probe_fn`, probe-before-block logic.
- `task_orchestrator_identity.py` — new `probe_mcp_server_name()` (JSON-only, fail-closed, injectable opener for tests).
- `tests/unit/test_mcp_port_allocator.py` — 6 new tests: identified→ASSIGNED, identity-mismatch→BLOCKED, probe-unreachable→BLOCKED, free-port-never-probes, probe JSON-parse, probe fail-closed.

## Validation
- **PASS** — `tests/unit/test_mcp_port_allocator.py` 17/17; full `tests/unit` + `tests/mcp` suites green (2 pre-existing unrelated quarantine skips). New tests inject `singleton_probe_fn`, so they are hermetic/CI-safe; verified no pre-existing test drives the real occupied-7890 branch without injection.
- **PASS** — live `dopemux mcp init --force` now completes and regenerates `.envrc.dopemux-mcp` with `TASK_ORCHESTRATOR_HTTP_PORT=7890` (no lease written for 7890).
- **NOT_RUN** — `tests/integration`; residual risk assessed ~zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)