### PR TITLE
fix(mcp): pal-stdio stdio health probe + ensure-script; diagnose model_context outage

### DIFF
--- a/claudedocs/pal-stdio-model-context-diagnosis-2026-07-16.md
+++ b/claudedocs/pal-stdio-model-context-diagnosis-2026-07-16.md
@@ -1,0 +1,117 @@
+# pal-stdio "No module named 'utils.model_context'" — Diagnosis (2026-07-16)
+
+**Reported symptom:** During the installer audit (earlier session 59c47fc6, 2026-07-16), every
+pal-stdio workflow tool call (planner / codereview / precommit) failed server-side with
+`No module named 'utils.model_context'`, blocking the mandated PAL chain (recorded in memory
+`installer-audit-2026-07-16`, line 20). Hypotheses to test: stale venv/image, or source-layout
+change removing `utils/model_context` from PYTHONPATH.
+
+## Verdict
+
+Both hypotheses **DISPROVEN** as persistent causes. The current running container is healthy;
+the module is present, is a proper package, imports correctly at startup and lazily, and there
+is **no `sys.path`/PYTHONPATH mutation in the request path** that could shadow it. There is
+**no static code/image/layout defect to patch.**
+
+**Root cause of the audit-time error: UNKNOWN.** I did not demonstrate the mechanism that
+produced it. What is proven: the three named hypotheses are false, the current server is healthy
+end-to-end, and the audit-time traceback was not retained in the container log — so the trigger
+is unresolved. The container was already healthy when this investigation began (externally
+restarted ~18:15, ~4 min before the first probe). **No fix was applied by me** — I diagnosed and
+verified; I did not repair.
+
+A **separate, current** blocker was discovered and is the real thing standing between the user
+and a working PAL chain: native provider credentials are broken (OpenAI key 401, Gemini quota
+hard-zero); only OpenRouter works. This blocks real PAL model calls even though the import path
+is fine.
+
+## Launch path
+
+`~/.claude.json` → `mcpServers.pal-stdio`:
+```
+docker exec -i mcp-pal-stdio /app/.venv/bin/python server.py
+```
+- Container `mcp-pal-stdio`, image `dopemux-pal-stdio:latest` (id 3cf5521b, built 2026-07-03).
+- Image bakes the full PAL server via `COPY docker/mcp-servers/pal/pal-mcp-server/ .`
+  (`docker/mcp-servers-source/pal-stdio/Dockerfile`). **No bind mounts** — code is a build-time snapshot.
+- WorkingDir=/app, PYTHONPATH unset. `python server.py` ⇒ `sys.path[0]='/app'` (absolute, robust).
+
+## Evidence (all current, this session)
+
+| Check | Result |
+|---|---|
+| `/app/utils/model_context.py` present + `utils/__init__.py` present | YES (proper package) |
+| `find_spec('utils.model_context')` in container | `/app/utils/model_context.py` |
+| Import at server startup | Succeeds (server logs `utils.model_context` DEBUG lines) |
+| Container `model_context.py` vs host source | **byte-identical** |
+| Container `tools/workflow/workflow_mixin.py` vs host source | **byte-identical** |
+| git history of `utils/model_context.py` | only a deps bump; no rename/move |
+| pal source tree dirty? | clean |
+| `os.chdir` / subprocess / threadpool in workflow path | none (import is fully in-process) |
+| `sys.path.insert/append` / PYTHONPATH writes in request path | none (only in tests + docker healthcheck; `chat.working_directory` does expanduser + file-write only, no chdir/path-insert) |
+| Container recreated today? | No — created 2026-07-04; only restarted 18:15 (ExitCode=0) |
+| All 3 pal containers restart time | ~18:15 together = Docker-daemon/compose restart, not a crash |
+| `listmodels` | PASS |
+| single-step `planner` (self-contained, no model call) | PASS |
+| single-step `codereview` → `_call_expert_analysis` → provider | Reached provider (no ModuleNotFound); failed only on OpenAI 401 |
+
+## Why the import error can't be a persistent path defect
+
+`server.py` is launched as a script from WorkingDir `/app`, so `sys.path[0]` is the absolute
+`/app`. It stays `/app` regardless of any later `os.chdir` (and there is none). The module is a
+real package on that path. Startup and lazy in-process imports both resolve. There is no
+subprocess/executor that would run the import under a different `sys.path`. So normal operation
+cannot yield `No module named 'utils.model_context'`. The audit-time occurrence was transient
+(most plausibly a Docker daemon/container state hiccup; the audit-time traceback was not retained
+in `/app/logs/mcp_server.log`, which only held older Gemini-429 tracebacks).
+
+## Separate current blocker: provider credentials
+
+- OpenAI (native): `401 Incorrect API key` (`sk-svcac…6K4A`).
+- Gemini (native): `429 RESOURCE_EXHAUSTED`, `quota_limit_value: 0` in region `us-south1`
+  (hard-zero quota, not transient rate limiting).
+- OpenRouter: **works** — clean `chat` success with `openai/gpt-5-nano` (provider_used=openrouter).
+  (Note: `anthropic/claude-3.5-haiku` slug returns OpenRouter 404 "no endpoints" — auth is fine,
+  slug unavailable.)
+
+**Implication:** PAL chain runs today only via OpenRouter model slugs. Native OpenAI/Gemini
+model selections will fail with provider errors (different from the import error). Fixing the
+native keys is a secrets/env change (update `.env`/compose, recreate container) — for the user
+to authorize.
+
+## Recommended actions
+
+1. **No code/image change required** for the import error itself — verified healthy.
+2. **Durability (prevent recurrence):** the pal-stdio/pal containers are fragile (see memory
+   `reference-pal-mcp-container`). Add an idempotent ensure/restart step so a degraded container
+   self-heals rather than surfacing as a cryptic import error. Interim recovery = restart the
+   container: `docker restart mcp-pal-stdio`.
+3. **Provider creds:** refresh the native OpenAI key and Gemini project quota, OR pin PAL to
+   OpenRouter model slugs, so the chain isn't silently blocked at the model layer.
+
+## Actions taken (2026-07-16 follow-up, user approved items 1/2/3)
+
+1. **Import error (item 1):** nothing to patch — verified healthy. Recovery path is now the
+   ensure-script below (or `docker restart mcp-pal-stdio`).
+2. **Provider creds (item 2):** did NOT modify secret values (I can't enter/rotate API keys).
+   - The invalid key lives in `.env` `OPENAI_API_KEY=sk-svcacct…` (401); `GEMINI_API_KEY` maps to
+     the quota-0 project. Both come into the container via `compose.yml` service `pal-stdio`.
+   - No clean *server-side* reroute exists: PAL tools require an explicit `model` arg, so
+     `DEFAULT_MODEL` won't redirect bare native names (`gpt-5-mini` → native OpenAI → 401).
+   - **Verified working today:** a full single-step `codereview` (workflow expert-analysis path)
+     completed end-to-end with `openai/gpt-5-nano` (`provider_used: openrouter`). So the PAL chain
+     is usable now via OpenRouter slugs (`openai/…`, `google/…`). User action to restore native
+     providers: replace `OPENAI_API_KEY` in `.env` with a valid key + fix the Gemini project quota,
+     then `docker compose up -d pal-stdio` to recreate with the new env.
+3. **Durability (item 3):** added `scripts/ensure_pal_stdio.sh` — idempotent, fail-closed:
+   ensures the container is up, probes real stdio health via an MCP `initialize`, restarts once and
+   re-probes if degraded, exits non-zero if still broken. Also extended
+   `scripts/mcp_health_check.sh` with a read-only stdio check for `mcp-pal-stdio` (the port-based
+   script previously couldn't see the exec-based server at all) and made all checks non-fatal so the
+   scan reports every server instead of aborting on the first HTTP failure.
+
+## Files touched
+
+- `claudedocs/pal-stdio-model-context-diagnosis-2026-07-16.md` (this report)
+- `scripts/ensure_pal_stdio.sh` (new, executable)
+- `scripts/mcp_health_check.sh` (added stdio check; checks made non-fatal)

--- a/scripts/ensure_pal_stdio.sh
+++ b/scripts/ensure_pal_stdio.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# ensure_pal_stdio.sh — make the pal-stdio MCP server usable, idempotently.
+#
+# Why this exists:
+#   pal-stdio is an exec-based MCP server (Docker MCP Toolkit / Claude Code run
+#   `docker exec -i mcp-pal-stdio /app/.venv/bin/python server.py`). It has NO
+#   port, so scripts/mcp_health_check.sh (port/HTTP based) never covers it. The
+#   container can be "Up" yet fail every tool call — the exact state seen during
+#   the 2026-07-16 installer audit ("No module named 'utils.model_context'").
+#   This script probes the *actual* stdio protocol and self-heals once.
+#
+#   Diagnosis: claudedocs/pal-stdio-model-context-diagnosis-2026-07-16.md
+#
+# Behaviour (fail-closed):
+#   1. ensure the container is running (docker compose up -d pal-stdio if not)
+#   2. probe stdio health via an MCP `initialize` handshake
+#   3. if the probe fails, restart the container once and re-probe
+#      (NOTE: a restart drops any active exec'd stdio sessions in that container)
+#   4. exit 0 only when a valid serverInfo response is observed; else exit 1
+#
+# Health here means "server imports + MCP registry are OK" — it is independent of
+# model-provider credentials (initialize makes no provider call). A healthy probe
+# with failing tool calls points at provider creds, not this server.
+set -euo pipefail
+
+CONTAINER="mcp-pal-stdio"
+COMPOSE_SERVICE="pal-stdio"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INIT_REQ='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ensure_pal_stdio","version":"1"}}}'
+
+log() { printf '%s\n' "$*" >&2; }
+
+# Portable bounded-timeout wrapper (macOS lacks GNU timeout by default).
+TIMEOUT_BIN=""
+for c in timeout gtimeout; do
+  if command -v "$c" >/dev/null 2>&1; then TIMEOUT_BIN="$c"; break; fi
+done
+
+is_running() {
+  [ "$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || echo false)" = "true" ]
+}
+
+# Returns 0 iff server.py answers `initialize` with a serverInfo result.
+probe() {
+  local out
+  if [ -n "$TIMEOUT_BIN" ]; then
+    out="$(printf '%s\n' "$INIT_REQ" | "$TIMEOUT_BIN" 30 docker exec -i "$CONTAINER" /app/.venv/bin/python server.py 2>/dev/null | head -c 4000 || true)"
+  else
+    out="$(printf '%s\n' "$INIT_REQ" | docker exec -i "$CONTAINER" /app/.venv/bin/python server.py 2>/dev/null | head -c 4000 || true)"
+  fi
+  printf '%s' "$out" | grep -q '"serverInfo"'
+}
+
+# 1. Ensure the container is running.
+if ! is_running; then
+  log "⚠️  $CONTAINER is not running — starting via docker compose"
+  ( cd "$REPO_ROOT" && docker compose up -d "$COMPOSE_SERVICE" >/dev/null )
+  sleep 2
+fi
+
+# 2. Probe stdio health.
+if probe; then
+  log "✅ $CONTAINER healthy (MCP initialize OK)"
+  exit 0
+fi
+
+# 3. Self-heal: restart once, then re-probe.
+log "❌ $CONTAINER is up but the stdio probe failed — restarting once"
+docker restart "$CONTAINER" >/dev/null 2>&1 || {
+  log "🚨 docker restart $CONTAINER failed"
+  exit 1
+}
+sleep 2
+if probe; then
+  log "✅ $CONTAINER healthy after restart"
+  exit 0
+fi
+
+# 4. Fail closed.
+log "🚨 $CONTAINER still unhealthy after restart — needs manual investigation"
+log "   see: claudedocs/pal-stdio-model-context-diagnosis-2026-07-16.md"
+exit 1

--- a/scripts/mcp_health_check.sh
+++ b/scripts/mcp_health_check.sh
@@ -5,6 +5,12 @@ echo "🔍 Dopemux MCP Server Health Check"
 echo "=================================="
 echo
 
+# Accumulate failures so we can report every check, then exit non-zero if any failed.
+FAILURES=0
+record_failure() {
+    FAILURES=$((FAILURES + 1))
+}
+
 # Health check function
 check_health() {
     local name=$1
@@ -82,27 +88,27 @@ check_stdio_mcp() {
     fi
 }
 
-# Main checks
+# Main checks — report everything, then fail closed if any check failed.
 echo "🏥 Health Checks:"
 echo "----------------"
 
-check_health "Dope-Context" 3010 || true
-check_health "PAL" 3003 || true
-check_health "ConPort" 3004 || true
+check_health "Dope-Context" 3010 || record_failure
+check_health "PAL" 3003 || record_failure
+check_health "ConPort" 3004 || record_failure
 
 echo
 echo "🔌 MCP Endpoint Checks:"
 echo "----------------------"
 
-check_mcp_endpoint "Dope-Context" 3010 || true
-check_mcp_endpoint "PAL" 3003 || true
-check_mcp_endpoint "ConPort" 3004 || true
+check_mcp_endpoint "Dope-Context" 3010 || record_failure
+check_mcp_endpoint "PAL" 3003 || record_failure
+check_mcp_endpoint "ConPort" 3004 || record_failure
 
 echo
 echo "🔌 Stdio MCP Checks:"
 echo "-------------------"
 
-check_stdio_mcp "PAL (stdio)" "mcp-pal-stdio" || true
+check_stdio_mcp "PAL (stdio)" "mcp-pal-stdio" || record_failure
 
 echo
 echo "📊 Summary:"
@@ -111,3 +117,9 @@ echo "Dope-Context and ConPort have MCP endpoints at /mcp (POST required)."
 echo "PAL runs two servers: HTTP :3003 (mcp-pal) and stdio (mcp-pal-stdio, exec-based)."
 echo "A healthy stdio probe means server+registry are OK; model calls still depend on"
 echo "provider credentials (OpenAI/Gemini/OpenRouter)."
+if [ "$FAILURES" -gt 0 ]; then
+    echo "❌ $FAILURES check(s) failed"
+    exit 1
+fi
+echo "✅ All checks passed"
+exit 0

--- a/scripts/mcp_health_check.sh
+++ b/scripts/mcp_health_check.sh
@@ -49,27 +49,65 @@ check_mcp_endpoint() {
     fi
 }
 
+# Stdio MCP check function (exec-based servers have no port).
+# Probes the actual MCP protocol via an `initialize` handshake over `docker exec`.
+check_stdio_mcp() {
+    local name=$1
+    local container=$2
+
+    echo "🔌 Checking $name stdio ($container)..."
+
+    if [ "$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || echo false)" != "true" ]; then
+        echo "❌ $name container '$container' not running"
+        return 1
+    fi
+
+    local init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"healthcheck","version":"0"}}}'
+    local tbin=""
+    for c in timeout gtimeout; do command -v "$c" >/dev/null 2>&1 && { tbin="$c"; break; }; done
+
+    local out
+    if [ -n "$tbin" ]; then
+        out="$(printf '%s\n' "$init" | "$tbin" 30 docker exec -i "$container" /app/.venv/bin/python server.py 2>/dev/null | head -c 4000 || true)"
+    else
+        out="$(printf '%s\n' "$init" | docker exec -i "$container" /app/.venv/bin/python server.py 2>/dev/null | head -c 4000 || true)"
+    fi
+
+    if printf '%s' "$out" | grep -q '"serverInfo"'; then
+        echo "✅ $name stdio server responding (initialize OK)"
+        return 0
+    else
+        echo "❌ $name stdio server not responding — try: scripts/ensure_pal_stdio.sh"
+        return 1
+    fi
+}
+
 # Main checks
 echo "🏥 Health Checks:"
 echo "----------------"
 
-check_health "Dope-Context" 3010
-check_health "PAL" 3003
-check_health "ConPort" 3004
+check_health "Dope-Context" 3010 || true
+check_health "PAL" 3003 || true
+check_health "ConPort" 3004 || true
 
 echo
 echo "🔌 MCP Endpoint Checks:"
 echo "----------------------"
 
-check_mcp_endpoint "Dope-Context" 3010
-check_mcp_endpoint "PAL" 3003
-check_mcp_endpoint "ConPort" 3004
+check_mcp_endpoint "Dope-Context" 3010 || true
+check_mcp_endpoint "PAL" 3003 || true
+check_mcp_endpoint "ConPort" 3004 || true
+
+echo
+echo "🔌 Stdio MCP Checks:"
+echo "-------------------"
+
+check_stdio_mcp "PAL (stdio)" "mcp-pal-stdio" || true
 
 echo
 echo "📊 Summary:"
 echo "-----------"
-echo "All MCP servers are running and healthy."
 echo "Dope-Context and ConPort have MCP endpoints at /mcp (POST required)."
-echo "PAL appears to be using a different transport (likely stdio)."
-echo
-echo "✅ MCP infrastructure ready for Vibe integration"
+echo "PAL runs two servers: HTTP :3003 (mcp-pal) and stdio (mcp-pal-stdio, exec-based)."
+echo "A healthy stdio probe means server+registry are OK; model calls still depend on"
+echo "provider credentials (OpenAI/Gemini/OpenRouter)."


### PR DESCRIPTION
## Summary

The `pal-stdio` MCP server failed the installer audit on 2026-07-16 with `No module named 'utils.model_context'` on every workflow tool call (planner/codereview/precommit), blocking the mandated PAL chain.

**Diagnosis** (full report: `claudedocs/pal-stdio-model-context-diagnosis-2026-07-16.md`): the stale-image / stale-venv / layout-change hypotheses are **all disproven**. The module is present, is a proper package (`utils/__init__.py`), imports at startup and lazily, is byte-identical to source, and there is **no `os.chdir` or `sys.path`/PYTHONPATH mutation in the request path** that could shadow it. The container was already healthy when investigated (it had been externally restarted ~18:15). Audit-time root cause is **UNKNOWN** (the traceback was not retained). There is **no code/image/layout defect to patch**.

Separately discovered — the *real* current blocker to the PAL chain — **provider credentials**: native OpenAI key `401`, Gemini quota hard-zero; **OpenRouter works**.

## Changes

- **`scripts/ensure_pal_stdio.sh`** (new): idempotent, fail-closed ensure/recover for the exec-based server. Ensures the container is up → probes real stdio health via an MCP `initialize` handshake → restarts once and re-probes if degraded → exits non-zero if still broken. Closes the documented "no ensure-script" gap for pal-stdio.
- **`scripts/mcp_health_check.sh`**: adds a read-only stdio check for `mcp-pal-stdio` (the port-based script could not see the exec server at all), and makes all checks non-fatal so the scan reports every server instead of aborting on the first HTTP failure.
- **`claudedocs/pal-stdio-model-context-diagnosis-2026-07-16.md`**: the evidence-backed diagnosis + recovery recipe.

**No secrets touched.** Restoring native OpenAI/Gemini is an operator action: rotate `.env` `OPENAI_API_KEY` + fix the Gemini quota, then `docker compose up -d pal-stdio`. Until then the PAL chain runs via OpenRouter model slugs (`openai/…`, `google/…`).

## Validation

- **PASS** — `scripts/ensure_pal_stdio.sh` (healthy, exit 0); `scripts/mcp_health_check.sh` full run (pal-stdio stdio ✅); `bash -n` on both scripts; `listmodels`; single-step `planner`; single-step `codereview` expert-analysis path **end-to-end via OpenRouter** (`provider_used: openrouter`).
- **FAIL (operator action, out of scope)** — native OpenAI `401`, native Gemini `429`/quota-0.
- **NOT_RUN** — reproduction of the original `ModuleNotFound` (not a static defect; could not reproduce).

## Risk / rollback

Additive tooling + docs only; no runtime/service code changed. The self-heal `docker restart` in the ensure-script drops any active exec'd stdio sessions in that container (only fires when the probe already failed). Rollback: revert this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
