### PR TITLE
feat(dcp): migrate public facade to target registry v2

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md
@@ -1,132 +1,71 @@
 ---
 id: dcp-mcp-readonly-facade-local-run
-title: DCP Read-Only MCP Facade — Local Run & Test
+title: DCP Read-Only MCP Facade - Local V2 Run and Test
 type: reference
 owner: '@hu3mann'
 author: '@hu3mann'
-date: '2026-06-05'
-last_review: '2026-06-05'
-next_review: '2026-09-03'
-prelude: Local setup, registry configuration, and tests for the read-only MCP evidence facade scaffold for dopemux documentation and developer workflows.
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Local-only registry-v2 setup and test procedure for the DCP read-only MCP evidence facade.
 ---
+# Local V2 Run and Test
 
-# Facade Local Run & Test
+The public facade is local-only and defaults to stdio. It has no public
+listener, tunnel, connector, credential, backend adapter, or lifecycle action.
 
-The TP-DCP-MCP-RO-0004 scaffold lives at `services/dcp-readonly-facade/`. It is a
-loopback-only, read-only MCP server. This guide covers configuring the registry,
-running the server locally, and running the tests. (Tunnel/connector wiring is
-TP-DCP-MCP-RO-0007; backend adapters are 0005/0006.)
+## Configure the Registry
 
-## 1. Configure the registry (outside the repo, no secrets)
-
-The registry is the trust boundary. **Do not commit a populated registry.**
+Do not commit a populated registry. Copy the v2 example outside the repository:
 
 ```bash
 mkdir -p ~/.dopemux
-cp services/dcp-readonly-facade/registry.example.yaml ~/.dopemux/dcp-facade-registry.yaml
-# edit ~/.dopemux/dcp-facade-registry.yaml: set workspace_path, identity.project, enabled
-export DCP_FACADE_REGISTRY=~/.dopemux/dcp-facade-registry.yaml
+cp services/dcp-readonly-facade/registry.example.yaml ~/.dopemux/dcp-facade-registry-v2.yaml
+export DCP_FACADE_REGISTRY_V2=~/.dopemux/dcp-facade-registry-v2.yaml
 ```
 
-Resolution order for the registry path: `$DCP_FACADE_REGISTRY` → default
-`~/.dopemux/dcp-facade-registry.yaml`. A missing file loads an **empty** registry
-(every lookup returns `BLOCKED`) — fail-closed by design.
+The registry is the exposure-consent boundary. A target must be explicitly
+enabled and must pass approved-root, workspace, and `.repo_id` identity checks.
+A missing or malformed registry loads as empty and blocks every lookup.
 
-A project is only exposed when it has an `enabled: true` entry **and** the
-workspace passes resolution: contained in an `approved_root`, has a `.dopemux/`
-directory, validates as a workspace, and its `.repo_id` `project` (and `owner`
-if declared) match the entry's `identity`.
-
-## 2. Run the server (stdio)
+## Run Locally
 
 ```bash
 cd services/dcp-readonly-facade
-python -m src.mcp.server          # DCP_FACADE_TRANSPORT defaults to stdio
+python -m src.mcp.server
 ```
 
-`fastmcp` is an optional dependency (root `pyproject.toml` `[services]` extra).
-When it is not installed the server falls back to a no-op stub for import
-safety; install `fastmcp` for a live MCP endpoint.
+`DCP_FACADE_TRANSPORT` defaults to `stdio`. `fastmcp` is required for a live
+MCP endpoint; the import fallback exists only for constrained test environments.
 
-## 3. Run the tests
+## Tool Surface
+
+The server registers only:
+
+```text
+list_targets
+get_target_capabilities
+get_target_repo_state_snapshot
+list_target_proof_bundles
+fetch_target_proof_bundle
+get_target_runtime_receipt
+```
+
+All target-scoped tools accept `target_id`, not `project_id`. The legacy v1
+registry and backend-adapter functions are not loaded by external server mode.
+
+The runtime receipt reads local catalog and runtime-registry evidence only.
+An operator may set `DCP_FACADE_MCP_CATALOG` or
+`DOPEMUX_MCP_RUNTIME_REGISTRY` to choose local evidence files. Those paths are
+server configuration, never tool inputs, and are never returned to callers.
+
+## Run Tests
 
 ```bash
-python -m pytest -q services/dcp-readonly-facade/tests
+uv run --frozen pytest -q services/dcp-readonly-facade/tests
+uv run --frozen python -m compileall -q services/dcp-readonly-facade/src
 ```
 
-Tests build real temporary git workspaces (with `.dopemux/`, `.repo_id`, proof
-bundles) and exercise the fail-closed paths: unknown/disabled project → `BLOCKED`;
-symlink/cross-project/`..` proof access → `BLOCKED`; stale-proof and dirty-worktree
-→ `warnings`; absolute paths and secrets → redacted.
-
-## 4. Tools (Phase 1)
-
-| Tool | `project_id` | Returns |
-| --- | --- | --- |
-| `list_projects` | no | enabled projects + configured capabilities |
-| `get_project_capabilities` | yes | which backends are configured |
-| `get_repo_state_snapshot` | yes | branch / head_sha / dirty (read-only git) |
-| `list_proof_bundles` | yes | proof bundle ids under `<workspace>/proof/` (cap 20) |
-| `fetch_proof_bundle` | yes | one bundle's files (containment + symlink safe) |
-
-All return the canonical envelope (see
-[RESPONSE_ENVELOPE_SCHEMA.md](RESPONSE_ENVELOPE_SCHEMA.md)); missing/denied reads
-yield `PARTIAL`/`BLOCKED`, never guessed data.
-
-## 5. Service-backed read tools (TP-DCP-MCP-RO-0005)
-
-These call backend services over loopback HTTP. `base_url` + `workspace_id` come
-from the project's registry `service_profiles` (ConPort / dope-memory) — the
-caller never supplies a URL, host, port, route, or workspace id. Results are
-`CANONICAL`, redacted, and capped; a missing profile, denied route, or
-unreachable backend fails closed.
-
-| Tool | Backend route (read-only) | Caps |
-| --- | --- | --- |
-| `search_decisions` | ConPort `GET /api/decisions` (list). **`query` mode deferred** — `/api/search` 500s on the default backend (UUID not serialized); a query returns `PARTIAL` | limit ≤ 20 |
-| `search_progress` | ConPort `GET /api/progress` | limit ≤ 20 |
-| `search_chronicle` | dope-memory `POST /tools/memory_search` (side-effect-free read) | `top_k` ≤ 3 |
-| `replay_chronicle_session` | dope-memory `POST /tools/memory_replay_session` | `top_k` ≤ 3; mode defaults `replay_current` |
-
-### Allowed / denied route manifest
-
-The adapters can issue **only** the routes above (see `route_manifest.py`). POST
-is permitted **only** for the two side-effect-free dope-memory reads via an
-explicit path allowlist; there is no put/patch/delete and no generic request
-surface. **Denied** (structurally unreachable, regression-tested): ConPort
-`POST /api/decisions` / `POST /api/progress` / `*/custom_data`; dope-memory
-`memory_correct` / reflection / store / mark-issue / link-resolution;
-dopecon-bridge `/ddg/`; and any `/kg/` / `/route/pm` PM-write route.
-
-### `search_progress` is fail-closed (auto-fork hazard)
-
-ConPort's default enhanced server is **not** read-only for `GET /api/progress`:
-with `DOPEMUX_AUTO_FORK_PROGRESS=1` (the default), `_get_progress` *auto-forks
-(writes)* progress rows from shared when the requested workspace has none. The
-facade cannot suppress that per-request, so `search_progress` is **blocked by
-default** and only runs when the operator sets
-`service_profiles.conport.progress_readonly_safe: true` — which you should do
-**only after** setting `DOPEMUX_AUTO_FORK_PROGRESS=0` on that ConPort backend.
-(`search_decisions` / `search_chronicle` / `replay_chronicle_session` have no
-such write-on-read behavior.)
-
-### Security controls
-
-- **Loopback-only** `base_url` (validated via `ipaddress.is_loopback`; non-loopback / unspecified hosts rejected — SSRF guard).
-- **Response size cap** (`MAX_RESPONSE_BYTES`, streamed); oversized → fail closed.
-- **JSON parsed only for 2xx**; non-2xx → `PARTIAL` with no body.
-- `workspace_id` is percent-encoded as a single path segment (rejects `/` / `..`).
-- Backend payloads pass through the same redaction as local reads (paths + secrets).
-
-### Optional live tests
-
-The test suite mocks all HTTP (no live calls). To additionally run the
-opt-in live smoke tests against real local backends:
-
-```bash
-export DCP_FACADE_LIVE_TESTS=1
-export DCP_FACADE_REGISTRY=~/.dopemux/dcp-facade-registry.yaml   # must point at a real enabled project
-python -m pytest -q services/dcp-readonly-facade/tests/test_live_optional.py
-```
-
-They are **skipped by default** (no env flag → skipped).
+The suite uses temporary local repositories and fixture files. It performs no
+live service, provider, credential, container, or tunnel action. See
+[`MANUAL_VALIDATION.md`](MANUAL_VALIDATION.md) for the local operator checklist.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md
@@ -1,114 +1,57 @@
 ---
 id: dcp-mcp-readonly-manual-validation
-title: DCP Read-Only MCP Facade — Manual Validation Checklist
+title: DCP Read-Only MCP Facade - Local V2 Validation Checklist
 type: reference
 owner: '@hu3mann'
 author: '@hu3mann'
-date: '2026-06-10'
-last_review: '2026-06-10'
-next_review: '2026-09-08'
-prelude: Manual validation checklist (MCP inspector + ChatGPT connector) covering exposure, read tools, fail-closed denials, and freshness warnings for the read-only MCP evidence facade for dopemux documentation and developer workflows.
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Local-only manual validation checklist for the registry-v2 DCP read-only MCP evidence facade.
 ---
+# Local V2 Validation Checklist
 
-# Manual Validation Checklist
+This checklist validates local stdio behavior only. It does not authorize a
+tunnel, public listener, connector, provider account, credential, or live
+backend call.
 
-> **Status.** `PROPOSED` operator procedure. Expected behaviors are `OBSERVED` from
-> the facade tools ([`FACADE_LOCAL_RUN.md`](FACADE_LOCAL_RUN.md),
-> [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md)) and the fail-closed model
-> ([`SECURITY_MODEL.md`](SECURITY_MODEL.md)). This checklist is **manual** — no
-> tunnel client and no connector automation runs in CI (packet invariant: *"No
-> running tunnel-client in CI", "No connector creation automation"*). Run it after
-> any tunnel or connector change.
+## Preconditions
 
-## 0. Preconditions
-
-- Registry configured with at least one `enabled` project
-  ([`FACADE_LOCAL_RUN.md`](FACADE_LOCAL_RUN.md) §1); `DCP_FACADE_REGISTRY` set.
-- Facade bind **verified loopback** ([`TUNNEL_INTEGRATION.md`](TUNNEL_INTEGRATION.md) §2).
-- The automated suite is green first (this is the structural baseline; the manual
-  steps below add live + connector coverage):
+- `DCP_FACADE_REGISTRY_V2` points to a local v2 registry with one enabled
+  target that passes workspace and `.repo_id` checks.
+- The automated local suite passes first:
 
   ```bash
-  python -m pytest -q services/dcp-readonly-facade/tests
+  uv run --frozen pytest -q services/dcp-readonly-facade/tests
   ```
 
-You can drive the tools two ways:
+## Target and Local Evidence
 
-- **MCP inspector** — point an MCP inspector/dev client at the facade endpoint
-  (stdio locally, or the loopback HTTP endpoint when transport is switched). Verify
-  against your inspector's current docs; tool names below are the contract surface.
-- **ChatGPT connector** — once the tunnel + connector are wired
-  ([`TUNNEL_INTEGRATION.md`](TUNNEL_INTEGRATION.md) §4), issue the same calls from
-  ChatGPT.
+| # | Action | Expected |
+| --- | --- | --- |
+| 1 | Call `list_targets()` | Only enabled opaque target IDs; no workspace path, URL, port, or runtime metadata. |
+| 2 | Call `get_target_capabilities(target_id)` | Static policy list; every entry reports `live: "UNKNOWN"` and `callable: false`. |
+| 3 | Call `get_target_repo_state_snapshot(target_id)` | Read-only branch, head SHA, and dirty state. |
+| 4 | Call `list_target_proof_bundles(target_id)` | Bounded proof metadata only. |
+| 5 | Call `fetch_target_proof_bundle(target_id, bundle_id)` | Containment-checked proof content with path and secret redaction. |
+| 6 | Call `get_target_runtime_receipt(target_id)` | Redacted `UNKNOWN`/`BLOCKED` candidate states only; no endpoint and no callable state. |
 
-Each call returns the canonical envelope (`project_id`, `branch`, `head_sha`,
-`dirty`, `source_system`, `authority_label`, `freshness`, `limitations`,
-`warnings`, `redactions`, `blocked_reasons`, `data`) — see
-[`RESPONSE_ENVELOPE_SCHEMA.md`](RESPONSE_ENVELOPE_SCHEMA.md). Confirm the envelope
-shape on every result.
+## Fail-Closed Checks
 
-## 1. Exposure — `list_projects`
+| # | Action | Expected |
+| --- | --- | --- |
+| 7 | Call a target-scoped tool with an unknown opaque ID | `BLOCKED`, no evidence data. |
+| 8 | Call with a path- or URL-shaped `target_id` | `BLOCKED`, `target_id: null`, and no reflected input. |
+| 9 | Use `../` or a symlink escape as `bundle_id` | `BLOCKED`; no file outside the proof root is read. |
+| 10 | Remove or corrupt the local catalog/runtime registry evidence | `PARTIAL`; receipt stays non-callable. |
+| 11 | Inspect tool manifest | Only the six v2 tools are registered; no adapter, mutation, generic fetch, endpoint, or lifecycle tool exists. |
 
-| # | Action | Expected | Pass |
-| --- | --- | --- | --- |
-| 1.1 | Call `list_projects` (no args) | Returns **only** `enabled: true` registry projects; disabled/unlisted projects absent | ☐ |
-| 1.2 | Disable a project in the registry, restart facade, call again | The project disappears from the list (exposure = registry entry + `enabled`, not eligibility) | ☐ |
-| 1.3 | Inspect a returned entry | No absolute host paths leak; capabilities reflect configured backends | ☐ |
+## Sign-off
 
-## 2. Repo evidence — `get_repo_state_snapshot`
+- [ ] All local checks pass.
+- [ ] No path, URL, port, secret, or operational topology appears in responses.
+- [ ] No target receipt reports `callable: true`.
+- [ ] No tunnel, connector, provider, live backend, or credential action ran.
 
-| # | Action | Expected | Pass |
-| --- | --- | --- | --- |
-| 2.1 | Call `get_repo_state_snapshot` with a valid `project_id` | Envelope carries `branch`, `head_sha`, `dirty` from a read-only git snapshot | ☐ |
-| 2.2 | Make the worktree dirty (touch a file), call again | `dirty: true` and a dirty-state `warning` is present (surfaced, not hidden) | ☐ |
-| 2.3 | Call with an **unknown** `project_id` | `BLOCKED` envelope with explicit `blocked_reasons`; no git data | ☐ |
-
-## 3. Proof bundles — `list_proof_bundles` / `fetch_proof_bundle`
-
-| # | Action | Expected | Pass |
-| --- | --- | --- | --- |
-| 3.1 | `list_proof_bundles(project_id)` | Bundle ids under `<workspace>/proof/`, capped at 20 | ☐ |
-| 3.2 | `list_proof_bundles(project_id, packet_id_filter="TP-DCP-MCP-RO-0007")` | Literal-substring match only (no regex semantics) | ☐ |
-| 3.3 | `fetch_proof_bundle(project_id, bundle_id)` for a real bundle | Returns bundle files; absolute paths redacted | ☐ |
-| 3.4 | `fetch_proof_bundle` with `../`, a symlink, or a cross-project id | `BLOCKED` (containment + symlink-escape prevention) | ☐ |
-
-## 4. Stale-proof + freshness warnings
-
-| # | Action | Expected | Pass |
-| --- | --- | --- | --- |
-| 4.1 | Fetch a proof bundle whose recorded `head_sha` ≠ current `head_sha` | Result includes a **stale-proof `warning`** (head_sha mismatch); data still returned, flagged not hidden | ☐ |
-| 4.2 | Fetch any bundle on a dirty worktree | A dirty-state `warning` accompanies the result | ☐ |
-| 4.3 | Confirm `freshness` is populated on every envelope | Present on success, partial, and blocked results | ☐ |
-
-## 5. Denied / fail-closed routes (the security gate)
-
-These confirm the mandatory denylist — the control that does **not** depend on the
-tunnel ([`SECURITY_MODEL.md`](SECURITY_MODEL.md) §3, [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md) §2).
-
-| # | Action | Expected | Pass |
-| --- | --- | --- | --- |
-| 5.1 | Confirm no write/transition tool is offered to the connector | Tool list contains read tools only; no `transition`, `manage_*`, `advance_item`, `claim_item`, `memory_correct`, `index_*`, `sync_*` | ☐ |
-| 5.2 | `search_progress` without `progress_readonly_safe: true` | `BLOCKED` (auto-fork write hazard — fail-closed by default) | ☐ |
-| 5.3 | `search_decisions(project_id, query="…")` (query mode) | `PARTIAL` with deferral note (ConPort `/api/search` 500s); list mode unaffected | ☐ |
-| 5.4 | `search_code_docs` / `get_index_status` (dope-context) | `BLOCKED` — MCP JSON-RPC transport not bridged in Phase 1 (fail-closed, not fabricated) | ☐ |
-| 5.5 | Any attempt to pass a raw path / URL / port / route / SQL / shell | Rejected — no tool accepts such input; only `project_id` + typed params | ☐ |
-| 5.6 | Confirm `search_all` and `dopecon-bridge` are unreachable | Not in the tool surface (side-effect / proxy denials) | ☐ |
-
-## 6. Authority + redaction spot-check
-
-| # | Action | Expected | Pass |
-| --- | --- | --- | --- |
-| 6.1 | Inspect `authority_label` on ConPort / task-orchestrator results | `CANONICAL`; facade never labels itself an authority | ☐ |
-| 6.2 | Inspect any result containing a path or token-like string | Absolute paths and secret patterns redacted before leaving the facade | ☐ |
-| 6.3 | Confirm task-orchestrator results carry the **workflow-view-only** limitation | Present on every task-orchestrator envelope | ☐ |
-
-## 7. Sign-off
-
-- [ ] Sections 1–6 pass.
-- [ ] Bind verified loopback; no backend port reachable through the tunnel.
-- [ ] No secrets in any committed file (run the scan in
-  [`FAILURE_RUNBOOK.md`](FAILURE_RUNBOOK.md) §6).
-- Record date, operator, facade `head_sha`, and any deviations in the run notes.
-
-> Any `FAIL` on §5 is a **blocking** result — do not expose the connector. Route
-> recovery through [`FAILURE_RUNBOOK.md`](FAILURE_RUNBOOK.md).
+Any failure in the fail-closed checks blocks further exposure work until a
+separate authorized packet resolves it.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md
@@ -41,7 +41,7 @@ backend call.
 | # | Action | Expected |
 | --- | --- | --- |
 | 7 | Call a target-scoped tool with an unknown opaque ID | `BLOCKED`, no evidence data. |
-| 8 | Call with a path- or URL-shaped `target_id` | `BLOCKED`, `target_id: null`, and no reflected input. |
+| 8 | Call with a path-, URL-, port-, or IPv4-shaped `target_id` | `BLOCKED`, `target_id: null`, and no reflected input. |
 | 9 | Use `../` or a symlink escape as `bundle_id` | `BLOCKED`; no file outside the proof root is read. |
 | 10 | Remove or corrupt the local catalog/runtime registry evidence | `PARTIAL`; receipt stays non-callable. |
 | 11 | Inspect tool manifest | Only the six v2 tools are registered; no adapter, mutation, generic fetch, endpoint, or lifecycle tool exists. |

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/README.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/README.md
@@ -1,27 +1,32 @@
 ---
 id: README
-title: Readme
+title: DCP Read-Only MCP Evidence Facade
 type: reference
 owner: '@hu3mann'
 author: '@hu3mann'
-date: '2026-06-11'
-last_review: '2026-06-11'
-next_review: '2026-09-09'
-prelude: Readme (reference) for dopemux documentation and developer workflows.
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Authority and local-only documentation for the registry-v2 DCP read-only MCP evidence facade.
 ---
-# ChatGPT MCP Read-Only Evidence Facade Discovery
+# DCP Read-Only MCP Evidence Facade
 
-Status: EVIDENCE_READY_WITH_GAPS
+Status: `LOCAL_IMPLEMENTATION_WITH_GAPS`
 
-This directory contains discovery artifacts for a future ChatGPT-accessible read-only Dopemux evidence facade. It is documentation and proof only; no tunnel setup, MCP exposure, service start, or implementation was performed in this packet.
+The public FastMCP entrypoint now uses the registry-v2 opaque `target_id`
+contract. It exposes only local target, repository, proof, static capability,
+and non-callable runtime-evidence receipts. It does not expose a listener,
+tunnel, connector, credential, backend adapter, or runtime lifecycle action.
 
-Primary artifacts:
+Primary current references:
 
-- `RUNTIME_SURFACE_INVENTORY.md`
-- `READ_ONLY_SURFACE_INVENTORY.json`
-- `PROOF_BUNDLE_AND_EVIDENCE_SOURCES.md`
-- `AUTHORITY_AND_RISK_REGISTER.md`
-- `PROPOSED_FACADE_TOOLS.md`
-- `DCP_THREAD_HANDOFF.md`
+- [`REGISTRY_V2_CONTRACT.md`](REGISTRY_V2_CONTRACT.md)
+- [`RUNTIME_CATALOG_JOIN_CONTRACT.md`](RUNTIME_CATALOG_JOIN_CONTRACT.md)
+- [`TOOL_CONTRACT.md`](TOOL_CONTRACT.md)
+- [`RESPONSE_ENVELOPE_SCHEMA.md`](RESPONSE_ENVELOPE_SCHEMA.md)
+- [`FACADE_LOCAL_RUN.md`](FACADE_LOCAL_RUN.md)
+- [`MANUAL_VALIDATION.md`](MANUAL_VALIDATION.md)
 
-Generated from saved source: `audit_inputs/gpt55_recon_source/CODEX_RECON_PACKS_SOURCE.md`.
+The older v1 `project_id` and direct-backend documents preserve implementation
+history but do not define the current public MCP manifest. Runtime and source
+truth continue to outrank generated or historical architecture artifacts.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/RESPONSE_ENVELOPE_SCHEMA.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/RESPONSE_ENVELOPE_SCHEMA.md
@@ -1,131 +1,54 @@
 ---
 id: dcp-mcp-readonly-response-envelope
-title: DCP Read-Only MCP Facade — Response Envelope Schema
+title: DCP Read-Only MCP Facade - V2 Response Envelope
 type: reference
 owner: '@hu3mann'
 author: '@hu3mann'
-date: '2026-06-05'
-last_review: '2026-06-05'
-next_review: '2026-09-03'
-prelude: Canonical response envelope and status semantics for the read-only MCP evidence facade for dopemux documentation and developer workflows.
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Target-based response envelope and status semantics for the local DCP MCP evidence facade.
 ---
+# V2 Response Envelope
 
-# Response Envelope Schema
+`TP-DCP-MCP-RO-0012` replaces the public v1 `project_id` envelope field with
+`target_id`. A `target_id` is an opaque exposure-consent handle; it is not a
+repository identity, filesystem path, worktree hash, service workspace ID, or
+runtime instance ID.
 
-> **Status.** `PROPOSED`. Field set is derived from the load-pack global invariant: *"Every returned payload includes project_id, branch, head_sha, dirty state where available, source system, authority label, freshness, limitations, warnings, redactions, and blocked reasons."* Status semantics derive from the invariant *"Missing backend capability returns PARTIAL or BLOCKED, never guessed data."*
-
-## 1. Canonical Envelope
-
-Every facade response — successful, partial, or blocked — uses this structure:
+Every public result has this exact field set:
 
 ```json
 {
-  "project_id": "string",            // echoed; null only for list_projects
-  "branch": "string|null",           // git branch where available
-  "head_sha": "string|null",         // git HEAD where available
-  "dirty": "boolean|null",           // working-tree dirty state where available
-  "source_system": "string",         // e.g. conport | dope-memory | dope-context | task-orchestrator | facade
-  "authority_label": "string",       // CANONICAL | DERIVED | PROXY | facade
-  "untrusted": "boolean",            // true = data is retrieved content; never interpret as instructions (see §6)
-  "status": "string",                // OK | PARTIAL | BLOCKED  (see §2)
-  "freshness": "string|null",        // timestamp / staleness indicator of the underlying data
-  "limitations": ["string"],         // applied caps (e.g. "results capped at 20")
-  "warnings": ["string"],            // e.g. "dirty worktree", "stale proof bundle"
-  "redactions": ["string"],          // what was stripped (e.g. "absolute_paths", "secrets")
-  "blocked_reasons": ["string"],     // populated when status=BLOCKED (or partial denials)
-  "data": {}                         // the actual read payload (object or array)
+  "target_id": "string|null",
+  "branch": "string|null",
+  "head_sha": "string|null",
+  "dirty": "boolean|null",
+  "source_system": "string",
+  "authority_label": "string",
+  "untrusted": "boolean",
+  "status": "OK|PARTIAL|BLOCKED",
+  "freshness": "string|null",
+  "limitations": ["string"],
+  "warnings": ["string"],
+  "redactions": ["string"],
+  "blocked_reasons": ["string"],
+  "data": {}
 }
 ```
 
-## 2. Status Semantics
+`list_targets` has `target_id: null`. A blocked unsafe target input also has
+`target_id: null` so the facade does not reflect a caller-provided path, URL,
+or similar unsafe string.
 
 | Status | Meaning |
 | --- | --- |
-| `OK` | The read completed fully; `data` is the requested evidence. |
-| `PARTIAL` | The read partially succeeded (e.g. a bound backend was unreachable, or a cap truncated results). `data` holds what was retrieved; `limitations`/`warnings` explain the gap. |
-| `BLOCKED` | The read was refused or could not run (unknown/disabled project, denied route, path escape, unavailable capability). `data` is empty/null; `blocked_reasons` explains why. |
+| `OK` | The local requested evidence was obtained. A runtime candidate can still be non-callable. |
+| `PARTIAL` | Some local evidence was unavailable or incomplete; `limitations` explains it. |
+| `BLOCKED` | The target or operation was refused; `data` is null and `blocked_reasons` explains the safe reason. |
 
-**Core rule (load-pack invariant):** a missing backend capability returns `PARTIAL` or `BLOCKED` — **never guessed data**. The facade does not fabricate fields it could not read.
-
-> `PROPOSED`/`CONFLICTING`: `OK` is introduced here as the success status because the load pack only names `PARTIAL`/`BLOCKED` explicitly (for the not-fully-available cases) and does not name the success token. `OK` is the proposed success label; if 0004 implementation chooses a different success token, this doc must be reconciled to it. No `DEGRADED`/`ERROR`/`SUCCESS` tokens are asserted unless implementation introduces them.
-
-## 3. Example — successful repo-state snapshot
-
-```json
-{
-  "project_id": "dopemux-mvp",
-  "branch": "main",
-  "head_sha": "9667f5e2d...",
-  "dirty": false,
-  "source_system": "facade",
-  "authority_label": "facade",
-  "untrusted": true,
-  "status": "OK",
-  "freshness": "2026-06-05T00:00:00Z",
-  "limitations": [],
-  "warnings": [],
-  "redactions": ["absolute_paths"],
-  "blocked_reasons": [],
-  "data": { "branch": "main", "head_sha": "9667f5e2d...", "dirty": false }
-}
-```
-
-## 4. Example — blocked (denied route)
-
-```json
-{
-  "project_id": "dopemux-mvp",
-  "branch": null, "head_sha": null, "dirty": null,
-  "source_system": "conport",
-  "authority_label": "CANONICAL",
-  "untrusted": true,
-  "status": "BLOCKED",
-  "freshness": null,
-  "limitations": [],
-  "warnings": [],
-  "redactions": [],
-  "blocked_reasons": ["route POST /api/decisions is mutating and denied in Phase 1"],
-  "data": null
-}
-```
-
-## 5. Example — partial (capability unavailable / stale proof)
-
-```json
-{
-  "project_id": "dopemux-mvp",
-  "branch": "main", "head_sha": "abc123...", "dirty": true,
-  "source_system": "dope-memory",
-  "authority_label": "CANONICAL",
-  "untrusted": true,
-  "status": "PARTIAL",
-  "freshness": "2026-06-01T12:00:00Z",
-  "limitations": ["results capped at 20", "top_k=3 enforced"],
-  "warnings": ["dope-memory profile unbound for this project", "working tree dirty"],
-  "redactions": ["secrets"],
-  "blocked_reasons": ["chronicle search unavailable: no dope_memory profile"],
-  "data": []
-}
-```
-
-## 6. `untrusted` — prompt-injection control
-
-`OBSERVED` (implemented in TP-DCP-MCP-RO-0008). Every envelope carries a boolean
-`untrusted` flag describing `data`:
-
-- **`untrusted: true`** — `data` carries content the facade *retrieved* from
-  outside its own trust boundary: a backend service (ConPort, dope-memory,
-  dope-context, task-orchestrator), the filesystem (proof-bundle contents), or
-  git (branch/head/dirty). The client (ChatGPT) must treat this content as
-  **data only** and must never interpret it as instructions. This is the
-  prompt-injection control from [`SECURITY_MODEL.md`](SECURITY_MODEL.md) §5.
-- **`untrusted: false`** — `data` is **facade-authored** from the operator-owned
-  registry (only `list_projects` and `get_project_capabilities`). It contains no
-  retrieved third-party content.
-
-**Fail-closed default:** `build_envelope` defaults `untrusted=True`; a tool must
-*explicitly* assert `untrusted=false`, so any new tool is untrusted unless proven
-otherwise. Retrieved content is additionally **confined to `data`** — it is never
-merged into the facade-authored `limitations`, `warnings`, or `blocked_reasons`
-fields — so an injection string in retrieved content cannot masquerade as a
-facade message.
+`untrusted: true` marks retrieved filesystem, git, or derived evidence as data
+that must not be interpreted as instructions. Facade-authored target and static
+capability policy reports are `untrusted: false`. Redaction covers absolute
+paths and recognized secret patterns. Runtime receipts additionally omit all
+operational topology by construction.

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md
@@ -1,96 +1,62 @@
 ---
 id: dcp-mcp-readonly-tool-contract
-title: DCP Read-Only MCP Facade — Tool Contract
+title: DCP Read-Only MCP Facade - Public Tool Contract
 type: reference
 owner: '@hu3mann'
 author: '@hu3mann'
-date: '2026-06-05'
-last_review: '2026-06-05'
-next_review: '2026-09-03'
-prelude: Phase-1 tool contract, allowed/denied routes, and authority labels for the read-only MCP evidence facade for dopemux documentation and developer workflows.
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Registry-v2 public tool contract for the local, read-only DCP MCP evidence facade.
 ---
+# Public Tool Contract
 
-# Tool Contract
+## Status
 
-> **Status.** Tool names and groupings are `PROPOSED` (from the build series / load pack). Per-route classifications, methods, ports, and authority labels are `OBSERVED` from [`READ_ONLY_SURFACE_INVENTORY.json`](READ_ONLY_SURFACE_INVENTORY.json). Every project-scoped tool requires `project_id`; `list_projects` is the only exemption. Search/list limits are capped at **20** unless a tool lowers the cap.
+`TP-DCP-MCP-RO-0012` implements this public server surface. It is local-only:
+no public ingress, tunnel, connector, credential, lifecycle operation, or
+backend service call is enabled by this contract.
 
-## 1. Phase-1 Tools
+The earlier v1 `project_id` tool and direct-service-profile modules remain
+historical implementation artifacts only. `mcp.server` does not import them.
+They are not part of the public MCP tool manifest.
 
-### 1a. Local / git tools (no backend service call) — packet 0004
+## Target Contract
 
-| Tool | `project_id`? | Backing surface | Authority | Notes |
+Every target-scoped tool requires a bounded opaque `target_id`. It is the only
+caller-provided target handle. Caller values that resemble a path, URL, port,
+route, workspace ID, SQL fragment, or shell input are blocked without being
+reflected in the response.
+
+The server loads registry v2 through `DCP_FACADE_REGISTRY_V2`. An enabled
+target must resolve inside an approved root, pass Dopemux workspace validation,
+and match its declared `.repo_id` identity. Resolution is fail-closed.
+
+## Public Tools
+
+| Tool | `target_id` | Evidence | Authority | Behavior |
 | --- | --- | --- | --- | --- |
-| `list_projects` | no | registry | facade | Returns approved (`enabled`) projects only. |
-| `get_project_capabilities` | yes | registry + reachability | facade | Reports which backends are bound/available. |
-| `get_repo_state_snapshot` | yes | local git (fixed cmd allowlist) | OBSERVED/git | branch, head_sha, dirty state. No arbitrary git. |
-| `list_proof_bundles` | yes | filesystem (proof roots) | OBSERVED/fs | optional `packet_id_filter` = **literal substring** (≤128 chars, **not** a regex — avoids ReDoS); bounded to proof roots; cap 20. |
-| `fetch_proof_bundle` | yes | filesystem (proof roots) | OBSERVED/fs | Cannot cross project root; symlink-escape blocked; bounded read (256KB/file). |
+| `list_targets` | no | registry-v2 policy | facade | Lists enabled opaque target IDs only. |
+| `get_target_capabilities` | required | static policy table | facade | Reports configured state; `live` remains `UNKNOWN` and `callable` is always `false`. |
+| `get_target_repo_state_snapshot` | required | local git | OBSERVED/git | Returns branch, head SHA, and dirty state. |
+| `list_target_proof_bundles` | required | local `proof/` | OBSERVED/fs | Literal bounded filter, cap 20, no traversal. |
+| `fetch_target_proof_bundle` | required | local `proof/` | OBSERVED/fs | Containment- and symlink-checked bounded file reads. |
+| `get_target_runtime_receipt` | required | local catalog and runtime registry | DERIVED | Returns a redacted, non-callable candidate receipt. |
 
-> **Note (0004 implementation):** `list_proof_bundles`' filter is a literal substring, not a regex. Accepting an untrusted caller-supplied regex is a ReDoS (catastrophic-backtracking) DoS surface; the scaffold therefore matches a bounded literal substring instead. The 0001 inventory / earlier drafts referred to a "packet_id regex" — superseded here for safety.
+`get_target_runtime_receipt` reads only local files: the resolved project's
+`mcp_catalog.yaml` (or operator-set `DCP_FACADE_MCP_CATALOG`) and the local
+runtime registry (or operator-set `DOPEMUX_MCP_RUNTIME_REGISTRY`). Missing or
+malformed evidence yields `PARTIAL`; a matching candidate remains `UNKNOWN`
+and `callable: false`. No endpoint, URL, port, container, or operational name
+is exposed.
 
-### 1b. ConPort + dope-memory read tools — packet 0005
+## Explicitly Absent
 
-| Tool | Backing surface (OBSERVED) | Method | Authority | Wrapper constraints |
-| --- | --- | --- | --- | --- |
-| `search_decisions` | conport `/api/decisions` (GET) — list only; `/api/search/{ws}` (GET) **deferred** ⚠️ | GET | CANONICAL | max-20; **`query` mode deferred** (note ‡) |
-| `search_progress` | conport `/api/progress` (GET) | GET | CANONICAL | max page; **fail-closed** unless `progress_readonly_safe` (note †) |
-| `search_chronicle` | dope-memory `/tools/memory_search` (POST) | POST | CANONICAL | POST allowed (side-effect-free read); `top_k=3` |
-| `replay_chronicle_session` | dope-memory `/tools/memory_replay_session` (POST) | POST | CANONICAL | session-bounded; prefer `replay_current` mode |
+The public manifest contains no backend adapter, generic fetch, endpoint
+selection, task transition, PM mutation, tunnel, ingress, connector, or
+runtime lifecycle tool. Existing adapter modules are deferred to a later
+authorized child packet with ownership and live-read evidence.
 
-> † **`search_progress` is fail-closed.** ConPort's default enhanced server auto-forks (writes) progress rows when a workspace has none (`DOPEMUX_AUTO_FORK_PROGRESS=1`), so a read can mutate. `search_progress` is BLOCKED unless the registry conport profile sets `progress_readonly_safe: true` — set only after `DOPEMUX_AUTO_FORK_PROGRESS=0` on the backend.
->
-> ‡ **`search_decisions` query mode is deferred.** ConPort `GET /api/search/{ws}` returns HTTP 500 in the default enhanced server (it builds the result without serializing the UUID `id` before `json.dumps`). The facade does not expose a broken read: a `query` returns `PARTIAL` with a deferral note; list mode (`GET /api/decisions`, which serializes ids) is unaffected. The `conport.search` adapter is implemented and ready for when the backend is fixed.
-
-### 1c. dope-context + task-orchestrator read tools — packet 0006
-
-| Tool | Backing surface | Source | Transport | Authority | Notes |
-| --- | --- | --- | --- | --- | --- |
-| `search_code_docs` | dope-context `search_code` + `docs_search` | `OBSERVED` (inventory) | MCP | DERIVED | Registered on the operator-run stdio facade; **returns BLOCKED in Phase 1** because MCP JSON-RPC transport is not yet bridged in the facade (REST-only client). Hits will be DERIVED until transport bridge + exact-source fetch exist. |
-| `get_index_status` | dope-context index status | `PROPOSED` (load-pack 0006 scope; **not** in inventory) | MCP | DERIVED | Registered on the operator-run stdio facade; **returns BLOCKED in Phase 1** because of the MCP transport gap + missing inventory classification. Requires formal inventory + classification before live allowlist wiring (Phase 2). |
-| `get_workflow_status_snapshot` | task-orchestrator `/queue` + `/blockers` + `/state` (GET) | `OBSERVED` (inventory + TP-0006 gap resolved) | HTTP | CANONICAL | Registered on the operator-run stdio facade; workflow-view only, **not** PM truth; strip identities. `/state` classified CONFIRMED_READ_ONLY in TP-0006 (see note below). |
-
-> **dope-context registration is fail-closed.** `search_code_docs` and
-> `get_index_status` are registered on the operator-run stdio MCP facade so
-> clients can discover the full packet 0006 surface, but both return BLOCKED in
-> Phase 1. dope-context exposes tools via MCP JSON-RPC at `/mcp` — not REST. The
-> facade's `ReadOnlyHttpClient` speaks REST only; no REST routes exist at
-> `/search/code`, `/search/docs`, or `/index/status`. `get_index_status` is
-> additionally `PROPOSED`-only (not in the discovery inventory). Both gaps must
-> be closed before Phase 2 can return live data: (1) transport bridge from facade
-> to MCP JSON-RPC, (2) formal inventory + classification of `get_index_status`
-> with read-only + side-effect evidence.
-
-> **`/state` gap resolved (TP-0006):** task-orchestrator exposes `/api/projects/{project_id}/workflow/state` as a first-class GET read endpoint (`project_workflow.py:385`, `@router.get("/state", response_model=WorkflowStateResult)`). Evidence: (1) confirmed GET at line 385; (2) existing PM adapter calls it (`src/dopemux/pm/adapters/orchestrator.py:48`); (3) no write path or side effects observed. **Classified CONFIRMED_READ_ONLY.** Added to `get_workflow_status_snapshot` backing-surface row above. The 0001 inventory gap is noted but not retroactively modified (0001 is a committed artifact).
-
-## 2. Denied Routes / Tools (Phase 1)
-
-`OBSERVED` denials from the inventory (`chatgpt_tunnel_suitability: DENY` or load-pack decision):
-
-| Surface | Reason |
-| --- | --- |
-| conport `POST /api/decisions` | MUTATING — writes decision records, publishes events. |
-| dope-memory `POST /tools/memory_correct` | MUTATING — inserts corrections/retractions into the chronicle ledger. |
-| task-orchestrator `POST .../workflow/transition` | MUTATING — mutates task status, updates sprint metrics. |
-| dopecon-bridge `GET /ddg/decisions` | PROXY — transport-confusion risk; read ConPort directly. |
-| dope-context `search_all` | READ_WITH_SIDE_EFFECT_RISK — network call to dopecon-bridge + Redis ops. |
-
-Also denied implicitly: any task-orchestrator transition / `manage_*` / `advance_item` / `claim_item` write tool, any dope-context `index_*` / `sync_*` / `clear_index` / `*_autonomous_*` control, ConPort `POST /api/progress` / `POST /api/custom_data`, and any generic search/fetch. No arbitrary path, URL, port, backend route, SQL, or shell is ever accepted on any tool.
-
-### Deferred reads (counted in the inventory's 7 denied)
-
-| Surface | Classification | Why deferred |
-| --- | --- | --- |
-| conport `GET /api/custom_data` | CONFIRMED_READ_ONLY | redaction-sensitive; not surfaced as a Phase-1 tool. |
-| conport `GET /api/search/{workspace_id}` *or* `GET /api/decisions` | CONFIRMED_READ_ONLY | one of the two backs `search_decisions`; the other is not separately exposed. |
-
-> `PROPOSED`/`CONFLICTING`: the inventory has no per-surface `phase_1_recommended` flag, so the exact identity of the second deferred read is inferred to reconcile to `deny_for_phase_1: 7`. Resolved concretely when `search_decisions` is implemented (0004/0005).
-
-## 3. Authority Labels
-
-Every tool result is enveloped (see [`RESPONSE_ENVELOPE_SCHEMA.md`](RESPONSE_ENVELOPE_SCHEMA.md)) with an `authority_label`:
-
-- `CANONICAL` — ConPort, dope-memory, dope-context `search_code`/`docs_search`, task-orchestrator queue/blockers.
-- `DERIVED` — fused/computed results (e.g. `search_all` if ever enabled; dope-context hits pending exact-source fetch).
-- `PROXY` — dopecon-bridge (denied in Phase 1).
-
-Retrieved content additionally retains `OBSERVED` / `PROPOSED` / `UNKNOWN` / `CONFLICTING` provenance where the facade can determine it, and is wrapped as untrusted for prompt-injection safety (see [`SECURITY_MODEL.md`](SECURITY_MODEL.md)).
+Every response uses the v2 [`RESPONSE_ENVELOPE_SCHEMA.md`](RESPONSE_ENVELOPE_SCHEMA.md).
+Paths and recognized secret patterns are redacted before a response leaves the
+facade.

--- a/proof/TP-DCP-MCP-RO-0012/AGY_AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0012/AGY_AUDIT.md
@@ -1,0 +1,33 @@
+# AGY Audit: TP-DCP-MCP-RO-0012
+
+## Provenance
+
+- Auditor: AGY / Google Antigravity CLI `1.1.3`
+- Model: default local model; the returned report did not identify one
+- Mode: single-turn local read-only prompt
+- Scope: implementation commit `f0d9452852dbc3883317cbae71f70d9a59f54d8e`
+- Verdict: `PASS_WITH_RISKS`
+
+## Verified by AGY
+
+- `mcp.server` loads `RegistryV2` through `load_registry_v2` and has no v1
+  registry/resolver imports.
+- The six public tools use `target_id`; the only non-target tool is
+  `list_targets`.
+- The new tool module uses local file evidence and the existing local Git
+  helper; it introduces no HTTP client, socket, container, or lifecycle call.
+- Unsafe path-, URL-, and token-shaped target values are blocked without
+  reflection.
+- Runtime receipt entries remain redacted and `callable: false`.
+
+## Findings
+
+1. LOW accepted risk: runtime-registry lookup has a documented home-relative
+   default. A missing file fails closed with a partial receipt.
+2. LOW accepted risk: test fixtures invoke the system Git binary to create
+   temporary repositories, consistent with the existing resolver test pattern.
+
+## Boundary
+
+This is independent local review evidence only. It does not satisfy the
+trusted `embedded-audit.yml` workflow proof requirement.

--- a/proof/TP-DCP-MCP-RO-0012/AGY_AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0012/AGY_AUDIT.md
@@ -5,8 +5,11 @@
 - Auditor: AGY / Google Antigravity CLI `1.1.3`
 - Model: default local model; the returned report did not identify one
 - Mode: single-turn local read-only prompt
-- Scope: implementation commit `f0d9452852dbc3883317cbae71f70d9a59f54d8e`
-- Verdict: `PASS_WITH_RISKS`
+- Scope:
+  - original implementation commit `f0d9452852dbc3883317cbae71f70d9a59f54d8e`
+  - locator-shaped target_id remediation review on uncommitted/post-proof work
+    for PR #1057 (Codex review P2)
+- Verdict: `PASS` (locator remediation); original surface was `PASS_WITH_RISKS`
 
 ## Verified by AGY
 
@@ -18,6 +21,9 @@
   helper; it introduces no HTTP client, socket, container, or lifecycle call.
 - Unsafe path-, URL-, and token-shaped target values are blocked without
   reflection.
+- Port-like all-digit and numeric-dotted locator values (e.g. `3020`,
+  `127.0.0.1`, `127.1`) are rejected in `_is_opaque_target_id` before any
+  envelope can echo them.
 - Runtime receipt entries remain redacted and `callable: false`.
 
 ## Findings
@@ -26,6 +32,11 @@
    default. A missing file fails closed with a partial receipt.
 2. LOW accepted risk: test fixtures invoke the system Git binary to create
    temporary repositories, consistent with the existing resolver test pattern.
+3. LOW accepted design trade-off: pure numeric target IDs are intentionally
+   rejected as port-like; operators should use non-numeric opaque handles.
+4. LOW residual: exotic non-dotted locator encodings (e.g. hex IP forms) are
+   not specially classified; charset + redaction still apply and values remain
+   non-callable.
 
 ## Boundary
 

--- a/proof/TP-DCP-MCP-RO-0012/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0012/AUDITOR_REPORT.md
@@ -9,11 +9,15 @@ readiness blocker.
 
 ## Local Evidence
 
-- Focused v2 target-contract and FastMCP registration tests passed.
+- Focused v2 target-contract and FastMCP registration tests passed (9 tests
+  after locator remediation).
 - The full facade suite passed with the intentionally opt-in live test skipped.
 - Source compilation, packet schema validation, scoped pre-commit, diff
   hygiene, and manual public-contract review passed.
-- A separate AGY review returned `PASS_WITH_RISKS`; see `AGY_AUDIT.md`.
+- Codex PR review P2 (locator-shaped target_id echo) was fixed and regression
+  covered.
+- A separate AGY review returned `PASS` for the locator remediation; see
+  `AGY_AUDIT.md`.
 
 ## Boundary
 

--- a/proof/TP-DCP-MCP-RO-0012/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0012/AUDITOR_REPORT.md
@@ -1,0 +1,22 @@
+# TP-DCP-MCP-RO-0012 Auditor Report
+
+## Verdict
+
+`SKIPPED` for the canonical embedded-audit field. The user directed local-only
+runs, no runner or credentials are available, and the repository's configured
+Claude audit route is unavailable. This field therefore remains an explicit
+readiness blocker.
+
+## Local Evidence
+
+- Focused v2 target-contract and FastMCP registration tests passed.
+- The full facade suite passed with the intentionally opt-in live test skipped.
+- Source compilation, packet schema validation, scoped pre-commit, diff
+  hygiene, and manual public-contract review passed.
+- A separate AGY review returned `PASS_WITH_RISKS`; see `AGY_AUDIT.md`.
+
+## Boundary
+
+The AGY review is local advisory evidence. It is not workflow-issued
+`embedded-audit.yml` proof and must not be used to claim trusted audit passage,
+PR Steward readiness, or merge readiness.

--- a/proof/TP-DCP-MCP-RO-0012/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0012/COMMAND_LOG.md
@@ -16,6 +16,7 @@ All commands below ran locally in the dedicated worktree on branch
 | `agy --prompt=<read-only TP-0012 audit prompt>` | PASS_WITH_RISKS; see `AGY_AUDIT.md` |
 | `python -m json.tool PROOF.json` and `python scripts/audit/validate_audit_proof.py PROOF.json` | PASS |
 | `pre-commit run --files proof/TP-DCP-MCP-RO-0012/*` | PASS |
+| `gh pr create` | PASS; opened PR #1057 with `OPEN_NOT_READY` audit boundary |
 | Trusted embedded audit / PR Steward | NOT_RUN; local-only direction, no runner or credentials, and no trusted Claude auditor route |
 
 No live facade, provider, connector, tunnel, backend, container, credential,

--- a/proof/TP-DCP-MCP-RO-0012/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0012/COMMAND_LOG.md
@@ -1,0 +1,22 @@
+# TP-DCP-MCP-RO-0012 Command Log
+
+All commands below ran locally in the dedicated worktree on branch
+`codex/dcp-mcp-ro-0012-target-contract`. The implementation commit is
+`f0d9452852dbc3883317cbae71f70d9a59f54d8e`.
+
+| Command | Result |
+| --- | --- |
+| Package ZIP integrity and manifest verification | PASS before child-packet implementation; source package hash recorded in `PROOF.json` |
+| `uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_tools_v2.py services/dcp-readonly-facade/tests/test_mcp_server.py` | PASS, 8 tests |
+| `uv run --frozen pytest -q services/dcp-readonly-facade/tests` | PASS; one intentionally opt-in live test skipped |
+| `uv run --frozen python -m compileall -q services/dcp-readonly-facade/src` | PASS |
+| Task packet JSON schema validation | PASS; jsonschema emitted only its CLI deprecation warning |
+| `pre-commit run --files <TP-0012 implementation allowlist>` | PASS |
+| `git diff --check` and cached allowlist review | PASS; unrelated fsmonitor IPC warning emitted |
+| `agy --prompt=<read-only TP-0012 audit prompt>` | PASS_WITH_RISKS; see `AGY_AUDIT.md` |
+| `python -m json.tool PROOF.json` and `python scripts/audit/validate_audit_proof.py PROOF.json` | PASS |
+| `pre-commit run --files proof/TP-DCP-MCP-RO-0012/*` | PASS |
+| Trusted embedded audit / PR Steward | NOT_RUN; local-only direction, no runner or credentials, and no trusted Claude auditor route |
+
+No live facade, provider, connector, tunnel, backend, container, credential,
+or runtime lifecycle operation was run.

--- a/proof/TP-DCP-MCP-RO-0012/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0012/COMMAND_LOG.md
@@ -2,22 +2,23 @@
 
 All commands below ran locally in the dedicated worktree on branch
 `codex/dcp-mcp-ro-0012-target-contract`. The implementation commit is
-`f0d9452852dbc3883317cbae71f70d9a59f54d8e`.
+`f0d9452852dbc3883317cbae71f70d9a59f54d8e`. Locator-shaped target_id
+remediation (Codex PR review P2) was validated after that commit.
 
 | Command | Result |
 | --- | --- |
 | Package ZIP integrity and manifest verification | PASS before child-packet implementation; source package hash recorded in `PROOF.json` |
-| `uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_tools_v2.py services/dcp-readonly-facade/tests/test_mcp_server.py` | PASS, 8 tests |
+| `uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_tools_v2.py services/dcp-readonly-facade/tests/test_mcp_server.py` | PASS, 9 tests after locator remediation |
 | `uv run --frozen pytest -q services/dcp-readonly-facade/tests` | PASS; one intentionally opt-in live test skipped |
 | `uv run --frozen python -m compileall -q services/dcp-readonly-facade/src` | PASS |
 | Task packet JSON schema validation | PASS; jsonschema emitted only its CLI deprecation warning |
-| `pre-commit run --files <TP-0012 implementation allowlist>` | PASS |
+| `pre-commit run --files <TP-0012 allowlist + remediation files>` | PASS |
 | `git diff --check` and cached allowlist review | PASS; unrelated fsmonitor IPC warning emitted |
-| `agy --prompt=<read-only TP-0012 audit prompt>` | PASS_WITH_RISKS; see `AGY_AUDIT.md` |
+| `agy --prompt=<read-only TP-0012 audit / locator remediation prompt>` | PASS (locator remediation); original surface PASS_WITH_RISKS; see `AGY_AUDIT.md` |
 | `python -m json.tool PROOF.json` and `python scripts/audit/validate_audit_proof.py PROOF.json` | PASS |
 | `pre-commit run --files proof/TP-DCP-MCP-RO-0012/*` | PASS |
 | `gh pr create` | PASS; opened PR #1057 with `OPEN_NOT_READY` audit boundary |
-| Trusted embedded audit / PR Steward | NOT_RUN; local-only direction, no runner or credentials, and no trusted Claude auditor route |
+| Trusted embedded audit / PR Steward | NOT_RUN / FAIL on required workflow gate; local-only direction; AGY does not satisfy `embedded-audit.yml` |
 
 No live facade, provider, connector, tunnel, backend, container, credential,
 or runtime lifecycle operation was run.

--- a/proof/TP-DCP-MCP-RO-0012/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0012/PROOF.json
@@ -1,0 +1,130 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0012",
+  "title": "Public Facade Target Contract Migration",
+  "status": "VALIDATED_WITH_AUDIT_GAP",
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "branch": "codex/dcp-mcp-ro-0012-target-contract",
+  "base_branch": "main",
+  "base_sha": "3f59ec29c9175e3b7ebdc68392365bb05296247d",
+  "implementation_commit": "f0d9452852dbc3883317cbae71f70d9a59f54d8e",
+  "pr": {
+    "status": "NOT_CREATED",
+    "url": null,
+    "blocker": "Proof publication is committed before the branch is pushed and a pull request is opened."
+  },
+  "scope": "Migrate the public DCP FastMCP server from the v1 project_id/direct-service contract to registry-v2 target_id-only local evidence tools. No backend adapter, network probe, tunnel, credential, public ingress, container operation, or runtime lifecycle mutation is included.",
+  "input_package": {
+    "path": "/Users/hue/Downloads/dopemux-multi-provider-mcp-supervisor-package.zip",
+    "sha256": "c0cb9d34f6ece116811c52cce0d1b517153dba0f8434c9abda9da6ff6d6a2447",
+    "archive_integrity": "PASS",
+    "manifest_hashes": "PASS"
+  },
+  "files_changed": [
+    "services/dcp-readonly-facade/src/dcp_facade/tools_v2.py",
+    "services/dcp-readonly-facade/src/mcp/server.py",
+    "services/dcp-readonly-facade/tests/test_tools_v2.py",
+    "services/dcp-readonly-facade/tests/test_mcp_server.py",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/RESPONSE_ENVELOPE_SCHEMA.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/README.md",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.json",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.md",
+    "task-packets/INDEX.md",
+    "proof/TP-DCP-MCP-RO-0012/PROOF.json",
+    "proof/TP-DCP-MCP-RO-0012/AUDITOR_REPORT.md",
+    "proof/TP-DCP-MCP-RO-0012/AGY_AUDIT.md",
+    "proof/TP-DCP-MCP-RO-0012/COMMAND_LOG.md"
+  ],
+  "validation": {
+    "PASS": [
+      {
+        "command": "uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_tools_v2.py services/dcp-readonly-facade/tests/test_mcp_server.py",
+        "exit_code": 0,
+        "result": "8 passed"
+      },
+      {
+        "command": "uv run --frozen pytest -q services/dcp-readonly-facade/tests",
+        "exit_code": 0,
+        "result": "full suite passed; 1 intentionally opt-in live test skipped"
+      },
+      {
+        "command": "uv run --frozen python -m compileall -q services/dcp-readonly-facade/src",
+        "exit_code": 0,
+        "result": "completed without diagnostics"
+      },
+      {
+        "command": "uv run --frozen python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "exit_code": 0,
+        "result": "valid; jsonschema emitted only its CLI deprecation warning"
+      },
+      {
+        "command": "pre-commit run --files <TP-0012 implementation allowlist>",
+        "exit_code": 0,
+        "result": "all applicable hooks passed"
+      },
+      {
+        "command": "manual source and cached-diff review",
+        "exit_code": 0,
+        "result": "v1 public imports and tool registrations absent; target-only signatures and non-callable runtime receipt verified"
+      },
+      {
+        "command": "agy --prompt=<read-only TP-0012 audit prompt>",
+        "exit_code": 0,
+        "result": "PASS_WITH_RISKS; two accepted low-severity environment/test-fixture risks; see AGY_AUDIT.md"
+      }
+    ],
+    "FAIL": [],
+    "NOT_RUN": [
+      {
+        "command": "Live DCP facade test",
+        "reason": "services/dcp-readonly-facade/tests/test_live_optional.py is intentionally opt-in and DCP_FACADE_LIVE_TESTS was not enabled.",
+        "mitigation": "No live behavior, transport, backend, provider, credential, or exposure change is in scope."
+      },
+      {
+        "command": "Trusted embedded audit and PR Steward",
+        "reason": "User direction is local-only; no runner or credentials are available, and the configured Claude audit route is unavailable.",
+        "mitigation": "Local AGY evidence is retained separately. The canonical workflow gate remains fail-closed and is not represented as passed."
+      }
+    ]
+  },
+  "local_agy_review": {
+    "tool": "AGY / Google Antigravity CLI",
+    "version": "1.1.3",
+    "model": "default local model; AGY response did not identify a model",
+    "mode": "single-turn read-only prompt; no CI, credentials, tunnel, or live-call setup authorized",
+    "audited_commit": "f0d9452852dbc3883317cbae71f70d9a59f54d8e",
+    "status": "PASS_WITH_RISKS",
+    "report_path": "proof/TP-DCP-MCP-RO-0012/AGY_AUDIT.md",
+    "ci_trust_status": "NOT_ACCEPTED: local AGY evidence is not workflow-issued embedded-audit proof."
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DCP-MCP-RO-0012/AUDITOR_REPORT.md",
+    "findings": [],
+    "fixes_applied": [
+      "Replaced the public FastMCP v1 registry and tool imports with registry-v2 target-only wiring.",
+      "Added target-bound local repository/proof/capability/runtime-receipt tools and redaction regressions.",
+      "Removed public direct backend adapter exposure from server mode."
+    ],
+    "remaining_risks": [
+      "No trusted embedded-audit proof is available under the local-only, no-runner, no-credentials constraint.",
+      "The opt-in live facade test was not run.",
+      "A local AGY PASS_WITH_RISKS review does not satisfy embedded-audit.yml."
+    ],
+    "skip_reason": "The repository's trusted embedded audit requires a configured runner/auditor route. Claude is unavailable and the user authorized local AGY evidence only; AGY is recorded separately and does not satisfy the trusted workflow contract."
+  },
+  "residual_risks": [
+    "No live runtime ownership, transport, backend, provider, credential, or freshness evidence is claimed.",
+    "Local runtime receipt input defaults to the documented runtime registry path and returns PARTIAL when missing or malformed.",
+    "The generated .claude/claude_config.json worktree delta is intentionally unstaged and unrelated."
+  ],
+  "rollback": "Revert implementation commit f0d9452852dbc3883317cbae71f70d9a59f54d8e and the following proof commit. Do not re-enable the v1 public server surface without a separately approved compatibility packet.",
+  "cleanup": "Dedicated worktree retained until PR creation and local status refresh complete."
+}

--- a/proof/TP-DCP-MCP-RO-0012/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0012/PROOF.json
@@ -8,9 +8,11 @@
   "base_sha": "3f59ec29c9175e3b7ebdc68392365bb05296247d",
   "implementation_commit": "f0d9452852dbc3883317cbae71f70d9a59f54d8e",
   "pr": {
-    "status": "NOT_CREATED",
-    "url": null,
-    "blocker": "Proof publication is committed before the branch is pushed and a pull request is opened."
+    "number": 1057,
+    "status": "OPEN_NOT_READY",
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1057",
+    "head_at_creation": "bc1d664321001dfc52da9b2927c8829d24c612b9",
+    "blocker": "Trusted embedded audit is required but SKIPPED under the local-only, no-runner, no-credentials constraint. PR Steward and merge readiness are not claimed."
   },
   "scope": "Migrate the public DCP FastMCP server from the v1 project_id/direct-service contract to registry-v2 target_id-only local evidence tools. No backend adapter, network probe, tunnel, credential, public ingress, container operation, or runtime lifecycle mutation is included.",
   "input_package": {
@@ -126,5 +128,5 @@
     "The generated .claude/claude_config.json worktree delta is intentionally unstaged and unrelated."
   ],
   "rollback": "Revert implementation commit f0d9452852dbc3883317cbae71f70d9a59f54d8e and the following proof commit. Do not re-enable the v1 public server surface without a separately approved compatibility packet.",
-  "cleanup": "Dedicated worktree retained until PR creation and local status refresh complete."
+  "cleanup": "Dedicated worktree retained while PR #1057 remains open."
 }

--- a/proof/TP-DCP-MCP-RO-0012/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0012/PROOF.json
@@ -12,9 +12,9 @@
     "status": "OPEN_NOT_READY",
     "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1057",
     "head_at_creation": "bc1d664321001dfc52da9b2927c8829d24c612b9",
-    "blocker": "Trusted embedded audit is required but SKIPPED under the local-only, no-runner, no-credentials constraint. PR Steward and merge readiness are not claimed."
+    "blocker": "Trusted embedded audit is required but remains a readiness blocker under the local-only, no-runner, no-credentials constraint. Independent embedded audit CI reported FAILURE on prior head; AGY does not satisfy embedded-audit.yml. PR Steward and merge readiness are not claimed."
   },
-  "scope": "Migrate the public DCP FastMCP server from the v1 project_id/direct-service contract to registry-v2 target_id-only local evidence tools. No backend adapter, network probe, tunnel, credential, public ingress, container operation, or runtime lifecycle mutation is included.",
+  "scope": "Migrate the public DCP FastMCP server from the v1 project_id/direct-service contract to registry-v2 target_id-only local evidence tools. No backend adapter, network probe, tunnel, credential, public ingress, container operation, or runtime lifecycle mutation is included. Includes Codex review remediation rejecting locator-shaped (all-digit / numeric-dotted) target_id values without reflection.",
   "input_package": {
     "path": "/Users/hue/Downloads/dopemux-multi-provider-mcp-supervisor-package.zip",
     "sha256": "c0cb9d34f6ece116811c52cce0d1b517153dba0f8434c9abda9da6ff6d6a2447",
@@ -39,12 +39,18 @@
     "proof/TP-DCP-MCP-RO-0012/AGY_AUDIT.md",
     "proof/TP-DCP-MCP-RO-0012/COMMAND_LOG.md"
   ],
+  "review_remediation": {
+    "source": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1057#discussion_r3599375736",
+    "severity": "P2",
+    "summary": "Reject locator-shaped target_id values (all-digit ports and numeric-dotted IP-like forms) before they can be echoed on unknown-target block paths.",
+    "fix": "Extended _is_opaque_target_id with _ALL_DIGITS and _NUMERIC_DOTTED guards; added regression tests; updated MANUAL_VALIDATION.md."
+  },
   "validation": {
     "PASS": [
       {
         "command": "uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_tools_v2.py services/dcp-readonly-facade/tests/test_mcp_server.py",
         "exit_code": 0,
-        "result": "8 passed"
+        "result": "9 passed (includes locator-shaped target_id regression)"
       },
       {
         "command": "uv run --frozen pytest -q services/dcp-readonly-facade/tests",
@@ -62,19 +68,19 @@
         "result": "valid; jsonschema emitted only its CLI deprecation warning"
       },
       {
-        "command": "pre-commit run --files <TP-0012 implementation allowlist>",
+        "command": "pre-commit run --files <TP-0012 allowlist + remediation files>",
         "exit_code": 0,
         "result": "all applicable hooks passed"
       },
       {
         "command": "manual source and cached-diff review",
         "exit_code": 0,
-        "result": "v1 public imports and tool registrations absent; target-only signatures and non-callable runtime receipt verified"
+        "result": "v1 public imports and tool registrations absent; target-only signatures, non-callable runtime receipt, and locator-shaped no-reflection verified"
       },
       {
-        "command": "agy --prompt=<read-only TP-0012 audit prompt>",
+        "command": "agy --prompt=<read-only TP-0012 locator remediation audit prompt>",
         "exit_code": 0,
-        "result": "PASS_WITH_RISKS; two accepted low-severity environment/test-fixture risks; see AGY_AUDIT.md"
+        "result": "PASS for locator remediation; residual low design/edge notes recorded in AGY_AUDIT.md"
       }
     ],
     "FAIL": [],
@@ -86,7 +92,7 @@
       },
       {
         "command": "Trusted embedded audit and PR Steward",
-        "reason": "User direction is local-only; no runner or credentials are available, and the configured Claude audit route is unavailable.",
+        "reason": "User direction is local-only; no runner or credentials are available, and the configured Claude audit route is unavailable. Prior CI independent embedded audit reported FAILURE on head 3c6fa3be; AGY is advisory only.",
         "mitigation": "Local AGY evidence is retained separately. The canonical workflow gate remains fail-closed and is not represented as passed."
       }
     ]
@@ -97,7 +103,8 @@
     "model": "default local model; AGY response did not identify a model",
     "mode": "single-turn read-only prompt; no CI, credentials, tunnel, or live-call setup authorized",
     "audited_commit": "f0d9452852dbc3883317cbae71f70d9a59f54d8e",
-    "status": "PASS_WITH_RISKS",
+    "remediation_review": "locator-shaped target_id no-reflection (PR #1057 Codex P2)",
+    "status": "PASS",
     "report_path": "proof/TP-DCP-MCP-RO-0012/AGY_AUDIT.md",
     "ci_trust_status": "NOT_ACCEPTED: local AGY evidence is not workflow-issued embedded-audit proof."
   },
@@ -113,20 +120,23 @@
     "fixes_applied": [
       "Replaced the public FastMCP v1 registry and tool imports with registry-v2 target-only wiring.",
       "Added target-bound local repository/proof/capability/runtime-receipt tools and redaction regressions.",
-      "Removed public direct backend adapter exposure from server mode."
+      "Removed public direct backend adapter exposure from server mode.",
+      "Rejected locator-shaped (all-digit and numeric-dotted) target_id values without reflection (Codex P2)."
     ],
     "remaining_risks": [
       "No trusted embedded-audit proof is available under the local-only, no-runner, no-credentials constraint.",
       "The opt-in live facade test was not run.",
-      "A local AGY PASS_WITH_RISKS review does not satisfy embedded-audit.yml."
+      "A local AGY PASS review does not satisfy embedded-audit.yml.",
+      "CI independent embedded audit previously FAILED on proof-refresh head; re-check after remediation push."
     ],
     "skip_reason": "The repository's trusted embedded audit requires a configured runner/auditor route. Claude is unavailable and the user authorized local AGY evidence only; AGY is recorded separately and does not satisfy the trusted workflow contract."
   },
   "residual_risks": [
     "No live runtime ownership, transport, backend, provider, credential, or freshness evidence is claimed.",
     "Local runtime receipt input defaults to the documented runtime registry path and returns PARTIAL when missing or malformed.",
-    "The generated .claude/claude_config.json worktree delta is intentionally unstaged and unrelated."
+    "The generated .claude/claude_config.json worktree delta is intentionally unstaged and unrelated.",
+    "Pure numeric operator target IDs are intentionally rejected as port-like (design trade-off)."
   ],
-  "rollback": "Revert implementation commit f0d9452852dbc3883317cbae71f70d9a59f54d8e and the following proof commit. Do not re-enable the v1 public server surface without a separately approved compatibility packet.",
+  "rollback": "Revert implementation commit f0d9452852dbc3883317cbae71f70d9a59f54d8e and subsequent proof/remediation commits. Do not re-enable the v1 public server surface without a separately approved compatibility packet.",
   "cleanup": "Dedicated worktree retained while PR #1057 remains open."
 }

--- a/services/dcp-readonly-facade/src/dcp_facade/tools_v2.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/tools_v2.py
@@ -27,6 +27,12 @@ from .runtime_catalog_join import join_runtime_catalog
 
 _MAX_FILTER_LEN = 128
 _TARGET_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+# Locator-shaped values can match the opaque charset (e.g. "3020", "127.0.0.1")
+# but must not be accepted or echoed at the public boundary.
+_ALL_DIGITS = re.compile(r"^\d+$")
+# Full IPv4 and shortened numeric-dotted forms (e.g. "127.1") that some
+# resolvers expand to addresses.
+_NUMERIC_DOTTED = re.compile(r"^\d+(?:\.\d+)+$")
 _RUNTIME_REGISTRY_ENV = "DOPEMUX_MCP_RUNTIME_REGISTRY"
 _CATALOG_ENV = "DCP_FACADE_MCP_CATALOG"
 
@@ -49,8 +55,15 @@ _TARGET_ENVELOPE_FIELDS = (
 
 
 def _is_opaque_target_id(value: object) -> bool:
-    """Accept only bounded opaque identifiers at the public boundary."""
+    """Accept only bounded opaque identifiers at the public boundary.
+
+    Port-like all-digit values and numeric-dotted locator values are rejected
+    even though they match the opaque charset, so they cannot be echoed on
+    unknown-target block paths.
+    """
     if not isinstance(value, str) or not _TARGET_ID_PATTERN.fullmatch(value):
+        return False
+    if _ALL_DIGITS.fullmatch(value) or _NUMERIC_DOTTED.fullmatch(value):
         return False
     redacted, categories = redact_value(value, [])
     return not categories and redacted == value

--- a/services/dcp-readonly-facade/src/dcp_facade/tools_v2.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/tools_v2.py
@@ -1,0 +1,305 @@
+"""Public v2 tools for the DCP read-only MCP facade.
+
+This module is the external contract boundary. It resolves only opaque
+``target_id`` values through registry v2, performs local filesystem evidence
+reads, and never selects an endpoint or invokes a backend adapter. Runtime
+catalog evidence remains advisory and is always serialized as non-callable.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from . import envelope as E
+from .capability import capability_report
+from .gitstate import repo_state
+from .proofs import MAX_BUNDLES, fetch_bundle, list_bundles
+from .redaction import redact_value
+from .registry_v2 import RegistryV2
+from .resolver_core import ResolvedTarget, resolve_target
+from .runtime_catalog_join import join_runtime_catalog
+
+_MAX_FILTER_LEN = 128
+_TARGET_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_RUNTIME_REGISTRY_ENV = "DOPEMUX_MCP_RUNTIME_REGISTRY"
+_CATALOG_ENV = "DCP_FACADE_MCP_CATALOG"
+
+_TARGET_ENVELOPE_FIELDS = (
+    "target_id",
+    "branch",
+    "head_sha",
+    "dirty",
+    "source_system",
+    "authority_label",
+    "untrusted",
+    "status",
+    "freshness",
+    "limitations",
+    "warnings",
+    "redactions",
+    "blocked_reasons",
+    "data",
+)
+
+
+def _is_opaque_target_id(value: object) -> bool:
+    """Accept only bounded opaque identifiers at the public boundary."""
+    if not isinstance(value, str) or not _TARGET_ID_PATTERN.fullmatch(value):
+        return False
+    redacted, categories = redact_value(value, [])
+    return not categories and redacted == value
+
+
+def _build_envelope(
+    *,
+    target_id: Optional[str],
+    status: str,
+    source_system: str,
+    authority_label: str,
+    data: Any = None,
+    branch: Optional[str] = None,
+    head_sha: Optional[str] = None,
+    dirty: Optional[bool] = None,
+    freshness: Optional[str] = None,
+    untrusted: bool = True,
+    limitations: Optional[list[str]] = None,
+    warnings: Optional[list[str]] = None,
+    redactions: Optional[list[str]] = None,
+    blocked_reasons: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """Build the v2 target envelope without carrying a v1 project_id field."""
+    values = {
+        "target_id": target_id,
+        "branch": branch,
+        "head_sha": head_sha,
+        "dirty": dirty,
+        "source_system": source_system,
+        "authority_label": authority_label,
+        "untrusted": untrusted,
+        "status": status,
+        "freshness": freshness,
+        "limitations": list(limitations or []),
+        "warnings": list(warnings or []),
+        "redactions": list(redactions or []),
+        "blocked_reasons": list(blocked_reasons or []),
+        "data": data,
+    }
+    return {field: values[field] for field in _TARGET_ENVELOPE_FIELDS}
+
+
+def _blocked(target_id: Optional[str], reason: str) -> dict[str, Any]:
+    return _build_envelope(
+        target_id=target_id,
+        status=E.BLOCKED,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FACADE,
+        data=None,
+        blocked_reasons=[reason],
+    )
+
+
+def _resolve(registry: RegistryV2, target_id: object) -> tuple[Optional[ResolvedTarget], dict | None]:
+    """Resolve a public target without reflecting unsafe caller input."""
+    if not _is_opaque_target_id(target_id):
+        return None, _blocked(None, "target_id is required or invalid")
+
+    resolved, reason = resolve_target(registry, target_id)
+    if resolved is not None:
+        return resolved, None
+    if reason and reason.startswith("target disabled"):
+        public_reason = "target disabled"
+    elif reason and reason.startswith("unknown target"):
+        public_reason = "target is not authorized"
+    else:
+        public_reason = "target resolution blocked"
+    return None, _blocked(target_id, public_reason)
+
+
+def _redact(data: Any, resolved: ResolvedTarget) -> tuple[Any, list[str]]:
+    return redact_value(data, [str(resolved.workspace), str(resolved.project_root), str(resolved.worktree_root)])
+
+
+def _load_yaml_mapping(path: Path) -> Optional[dict[str, Any]]:
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError, UnicodeError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _load_runtime_registry() -> tuple[dict[str, Any], bool]:
+    raw_path = os.getenv(_RUNTIME_REGISTRY_ENV)
+    path = (
+        Path(raw_path).expanduser()
+        if raw_path
+        else Path.home() / ".dopemux" / "mcp" / "runtime" / "instances.json"
+    )
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, UnicodeError):
+        return {"parse_status": "MISSING", "instances": []}, False
+    if not isinstance(payload, dict) or not isinstance(payload.get("instances"), list):
+        return {"parse_status": "ERROR", "instances": []}, False
+    clean = dict(payload)
+    clean["parse_status"] = "OK"
+    return clean, True
+
+
+def _load_catalog(resolved: ResolvedTarget) -> tuple[dict[str, Any], bool]:
+    raw_path = os.getenv(_CATALOG_ENV)
+    path = Path(raw_path).expanduser() if raw_path else resolved.project_root / "mcp_catalog.yaml"
+    catalog = _load_yaml_mapping(path)
+    if catalog is None or not isinstance(catalog.get("servers"), dict):
+        return {}, False
+    return catalog, True
+
+
+def list_targets(registry: RegistryV2) -> dict[str, Any]:
+    """List enabled opaque target IDs without exposing workspace metadata."""
+    targets = [
+        {"target_id": target.target_id}
+        for target in sorted(registry.enabled_targets(), key=lambda item: item.target_id)
+        if _is_opaque_target_id(target.target_id)
+    ]
+    return _build_envelope(
+        target_id=None,
+        status=E.OK,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FACADE,
+        data={"registry_generation": registry.generation, "targets": targets},
+        untrusted=False,
+    )
+
+
+def get_target_capabilities(registry: RegistryV2, target_id: object) -> dict[str, Any]:
+    """Report static policy capabilities; none are live or callable here."""
+    resolved, blocked = _resolve(registry, target_id)
+    if blocked is not None:
+        return blocked
+    assert resolved is not None
+    data, redactions = _redact(
+        {
+            "target_id": resolved.target.target_id,
+            "capabilities": capability_report(resolved),
+        },
+        resolved,
+    )
+    return _build_envelope(
+        target_id=resolved.target.target_id,
+        status=E.OK,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FACADE,
+        data=data,
+        untrusted=False,
+        redactions=redactions,
+    )
+
+
+def get_target_repo_state_snapshot(registry: RegistryV2, target_id: object) -> dict[str, Any]:
+    """Return a target workspace's read-only git state snapshot."""
+    resolved, blocked = _resolve(registry, target_id)
+    if blocked is not None:
+        return blocked
+    assert resolved is not None
+    state = repo_state(resolved.workspace)
+    status = E.OK if state["head_sha"] is not None else E.PARTIAL
+    limitations = [] if status == E.OK else ["git state unavailable"]
+    warnings = ["dirty worktree"] if state["dirty"] else []
+    data, redactions = _redact(
+        {"branch": state["branch"], "head_sha": state["head_sha"], "dirty": state["dirty"]},
+        resolved,
+    )
+    return _build_envelope(
+        target_id=resolved.target.target_id,
+        status=status,
+        source_system=E.SOURCE_GIT,
+        authority_label=E.AUTHORITY_GIT,
+        data=data,
+        branch=state["branch"],
+        head_sha=state["head_sha"],
+        dirty=state["dirty"],
+        limitations=limitations,
+        warnings=warnings,
+        redactions=redactions,
+    )
+
+
+def list_target_proof_bundles(
+    registry: RegistryV2, target_id: object, packet_id_filter: Optional[str] = None
+) -> dict[str, Any]:
+    """List bounded proof bundle metadata under a resolved target workspace."""
+    resolved, blocked = _resolve(registry, target_id)
+    if blocked is not None:
+        return blocked
+    assert resolved is not None
+    if packet_id_filter is not None and (
+        not isinstance(packet_id_filter, str) or len(packet_id_filter) > _MAX_FILTER_LEN
+    ):
+        return _blocked(resolved.target.target_id, "invalid packet_id_filter")
+    bundles, truncated = list_bundles(resolved.workspace, packet_id_filter, cap=MAX_BUNDLES)
+    data, redactions = _redact({"bundles": bundles}, resolved)
+    limitations = [f"results capped at {MAX_BUNDLES}"] if truncated else []
+    return _build_envelope(
+        target_id=resolved.target.target_id,
+        status=E.OK,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FS,
+        data=data,
+        limitations=limitations,
+        redactions=redactions,
+    )
+
+
+def fetch_target_proof_bundle(registry: RegistryV2, target_id: object, bundle_id: object) -> dict[str, Any]:
+    """Fetch a containment-checked proof bundle for a resolved target."""
+    resolved, blocked = _resolve(registry, target_id)
+    if blocked is not None:
+        return blocked
+    assert resolved is not None
+    head_sha = repo_state(resolved.workspace)["head_sha"]
+    data, reason, warnings = fetch_bundle(resolved.workspace, bundle_id, current_head=head_sha)
+    if reason is not None:
+        return _blocked(resolved.target.target_id, reason)
+    clean, redactions = _redact(data, resolved)
+    return _build_envelope(
+        target_id=resolved.target.target_id,
+        status=E.OK,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_FS,
+        data=clean,
+        head_sha=head_sha,
+        warnings=warnings,
+        redactions=redactions,
+    )
+
+
+def get_target_runtime_receipt(registry: RegistryV2, target_id: object) -> dict[str, Any]:
+    """Join local runtime evidence without selecting a callable backend."""
+    resolved, blocked = _resolve(registry, target_id)
+    if blocked is not None:
+        return blocked
+    assert resolved is not None
+    catalog, catalog_available = _load_catalog(resolved)
+    runtime_registry, runtime_available = _load_runtime_registry()
+    receipt = join_runtime_catalog(resolved, catalog, runtime_registry).to_public_dict()
+    data, redactions = _redact(receipt, resolved)
+    limitations: list[str] = []
+    if not catalog_available:
+        limitations.append("canonical catalog unavailable")
+    if not runtime_available:
+        limitations.append("operational runtime registry unavailable")
+    return _build_envelope(
+        target_id=resolved.target.target_id,
+        status=E.OK if not limitations else E.PARTIAL,
+        source_system=E.SOURCE_FACADE,
+        authority_label=E.AUTHORITY_DERIVED,
+        data=data,
+        limitations=limitations,
+        redactions=redactions,
+    )

--- a/services/dcp-readonly-facade/src/mcp/server.py
+++ b/services/dcp-readonly-facade/src/mcp/server.py
@@ -1,12 +1,8 @@
-"""DCP read-only MCP evidence facade — FastMCP server (Phase 1 scaffold).
+"""DCP read-only MCP facade — v2 target-contract FastMCP server.
 
-Thin wiring layer: each MCP tool delegates to the pure ``dcp_facade.tools``
-functions, which return canonical envelopes. The registry is loaded once from
-``$DCP_FACADE_REGISTRY`` (or the default path). Loopback-only binding is the
-operator's responsibility per SECURITY_MODEL.md; this scaffold defaults to
-stdio transport.
-
-Run locally:  python -m src.mcp.server   (from services/dcp-readonly-facade)
+The external server loads only registry v2 from ``DCP_FACADE_REGISTRY_V2``.
+It exposes local, read-only target evidence only; backend adapters, public
+ingress, credentials, and runtime lifecycle operations are deliberately absent.
 """
 
 from __future__ import annotations
@@ -16,129 +12,63 @@ import sys
 from pathlib import Path
 from typing import Optional
 
-# Make the facade package and repo `src` (for dopemux) importable when run
-# directly (mirrors the services/dope-context bootstrap pattern).
 _HERE = Path(__file__).resolve()
-_FACADE_SRC = _HERE.parents[1]            # services/dcp-readonly-facade/src
-_REPO_ROOT = _HERE.parents[4]             # repo root
-for _p in (str(_FACADE_SRC), str(_REPO_ROOT / "src")):
-    if _p not in sys.path:
-        sys.path.insert(0, _p)
+_FACADE_SRC = _HERE.parents[1]
+_REPO_ROOT = _HERE.parents[4]
+for _path in (str(_FACADE_SRC), str(_REPO_ROOT / "src")):
+    if _path not in sys.path:
+        sys.path.insert(0, _path)
 
 try:
     from fastmcp import FastMCP
 except ImportError:  # pragma: no cover - constrained envs
     from mcp.fastmcp_stub import FastMCP  # type: ignore
 
-from dcp_facade import tools
-from dcp_facade.registry import Registry, load_registry
+from dcp_facade import tools_v2
+from dcp_facade.registry_v2 import RegistryV2, load_registry_v2
 
 mcp = FastMCP("dcp-readonly-facade")
 
-# Registry is loaded once at import; reloaded only on process restart.
-_REGISTRY: Registry = load_registry(os.getenv("DCP_FACADE_REGISTRY"))
+# Reload only on process restart. The v1 registry is not imported by this server.
+_REGISTRY: RegistryV2 = load_registry_v2(os.getenv("DCP_FACADE_REGISTRY_V2"))
 
 
 @mcp.tool()
-async def list_projects() -> dict:
-    """List the projects the facade exposes (enabled registry entries only)."""
-    return tools.list_projects(_REGISTRY)
+async def list_targets() -> dict:
+    """List enabled opaque target IDs from the operator-owned v2 registry."""
+    return tools_v2.list_targets(_REGISTRY)
 
 
 @mcp.tool()
-async def get_project_capabilities(project_id: str) -> dict:
-    """Report which backends are configured for a project."""
-    return tools.get_project_capabilities(_REGISTRY, project_id)
+async def get_target_capabilities(target_id: str) -> dict:
+    """Report static policy capabilities; all remain non-callable here."""
+    return tools_v2.get_target_capabilities(_REGISTRY, target_id)
 
 
 @mcp.tool()
-async def get_repo_state_snapshot(project_id: str) -> dict:
-    """Return the project's git branch/head/dirty snapshot (read-only)."""
-    return tools.get_repo_state_snapshot(_REGISTRY, project_id)
+async def get_target_repo_state_snapshot(target_id: str) -> dict:
+    """Return a resolved target's local git state snapshot."""
+    return tools_v2.get_target_repo_state_snapshot(_REGISTRY, target_id)
 
 
 @mcp.tool()
-async def list_proof_bundles(project_id: str, packet_id_filter: Optional[str] = None) -> dict:
-    """List proof bundles under the project's proof/ directory.
-
-    ``packet_id_filter`` is an optional literal substring of the bundle id
-    (not a regex). Results are capped at 20.
-    """
-    return tools.list_proof_bundles(_REGISTRY, project_id, packet_id_filter)
-
-
-@mcp.tool()
-async def fetch_proof_bundle(project_id: str, bundle_id: str) -> dict:
-    """Fetch a single proof bundle's files (containment + symlink safe)."""
-    return tools.fetch_proof_bundle(_REGISTRY, project_id, bundle_id)
-
-
-@mcp.tool()
-async def search_decisions(project_id: str, query: Optional[str] = None, limit: int = 20) -> dict:
-    """Read ConPort decisions for a project (GET; workspace-bound; cap 20)."""
-    return tools.search_decisions(_REGISTRY, project_id, query, limit)
-
-
-@mcp.tool()
-async def search_progress(project_id: str, status: Optional[str] = None, limit: int = 20) -> dict:
-    """Read ConPort progress entries for a project (GET; workspace-bound; cap 20)."""
-    return tools.search_progress(_REGISTRY, project_id, status, limit)
-
-
-@mcp.tool()
-async def search_chronicle(project_id: str, query: str = "", top_k: int = 3) -> dict:
-    """Search the dope-memory chronicle for a project (read-only POST; top_k cap 3)."""
-    return tools.search_chronicle(_REGISTRY, project_id, query, top_k)
-
-
-@mcp.tool()
-async def replay_chronicle_session(
-    project_id: str, session_id: str, mode: str = "replay_current", top_k: int = 3
+async def list_target_proof_bundles(
+    target_id: str, packet_id_filter: Optional[str] = None
 ) -> dict:
-    """Replay a dope-memory chronicle session (read-only POST; replay_current default)."""
-    return tools.replay_chronicle_session(_REGISTRY, project_id, session_id, mode, top_k)
+    """List bounded proof bundle metadata for a resolved target."""
+    return tools_v2.list_target_proof_bundles(_REGISTRY, target_id, packet_id_filter)
 
 
 @mcp.tool()
-async def search_code_docs(
-    project_id: str,
-    query: str,
-    top_k: int = 20,
-    kind: str = "code",
-    profile: Optional[str] = None,
-    filter_doc_type: Optional[str] = None,
-) -> dict:
-    """Search dope-context code/docs through the read-only facade.
-
-    Phase 1 registers the tool for operator-run stdio discovery, but the pure
-    facade function returns BLOCKED until a dope-context MCP JSON-RPC bridge is
-    implemented and inventoried.
-    """
-    return tools.search_code_docs(
-        _REGISTRY,
-        project_id,
-        query,
-        top_k,
-        kind=kind,
-        profile=profile,
-        filter_doc_type=filter_doc_type,
-    )
+async def fetch_target_proof_bundle(target_id: str, bundle_id: str) -> dict:
+    """Fetch a containment-checked proof bundle for a resolved target."""
+    return tools_v2.fetch_target_proof_bundle(_REGISTRY, target_id, bundle_id)
 
 
 @mcp.tool()
-async def get_index_status(project_id: str) -> dict:
-    """Return dope-context index status envelope.
-
-    Phase 1 fail-closes because the dope-context transport bridge and formal
-    inventory classification are not complete.
-    """
-    return tools.get_index_status(_REGISTRY, project_id)
-
-
-@mcp.tool()
-async def get_workflow_status_snapshot(project_id: str) -> dict:
-    """Read task-orchestrator workflow queue/blockers/state as a snapshot."""
-    return tools.get_workflow_status_snapshot(_REGISTRY, project_id)
+async def get_target_runtime_receipt(target_id: str) -> dict:
+    """Return redacted, non-callable runtime catalog evidence for a target."""
+    return tools_v2.get_target_runtime_receipt(_REGISTRY, target_id)
 
 
 def main() -> None:

--- a/services/dcp-readonly-facade/tests/test_mcp_server.py
+++ b/services/dcp-readonly-facade/tests/test_mcp_server.py
@@ -1,14 +1,10 @@
-"""DCP read-only MCP server wiring tests.
-
-These tests replace the optional FastMCP dependency with a recording stub before
-importing ``mcp.server``. That keeps the assertions focused on stdio facade tool
-registration and delegation without opening network or MCP transports.
-"""
+"""FastMCP v2 public-surface registration tests."""
 
 from __future__ import annotations
 
 import asyncio
 import importlib
+import inspect
 import sys
 import types
 
@@ -37,7 +33,8 @@ class RecordingFastMCP:
 @pytest.fixture()
 def server_module(monkeypatch, tmp_path):
     RecordingFastMCP.instances = []
-    monkeypatch.setenv("DCP_FACADE_REGISTRY", str(tmp_path / "missing-registry.yaml"))
+    monkeypatch.setenv("DCP_FACADE_REGISTRY_V2", str(tmp_path / "missing-registry-v2.yaml"))
+    monkeypatch.delenv("DCP_FACADE_REGISTRY", raising=False)
     monkeypatch.setitem(sys.modules, "fastmcp", types.SimpleNamespace(FastMCP=RecordingFastMCP))
     sys.modules.pop("mcp.server", None)
     module = importlib.import_module("mcp.server")
@@ -46,95 +43,36 @@ def server_module(monkeypatch, tmp_path):
     sys.modules.pop("mcp.server", None)
 
 
-def test_mcp_server_registers_packet_0006_tools(server_module):
-    _, mcp = server_module
+def test_mcp_server_registers_v2_target_tools_only(server_module):
+    server, mcp = server_module
+
     assert mcp.name == "dcp-readonly-facade"
     assert set(mcp.tools) == {
-        "list_projects",
-        "get_project_capabilities",
-        "get_repo_state_snapshot",
-        "list_proof_bundles",
-        "fetch_proof_bundle",
-        "search_decisions",
-        "search_progress",
-        "search_chronicle",
-        "replay_chronicle_session",
-        "search_code_docs",
-        "get_index_status",
-        "get_workflow_status_snapshot",
+        "list_targets",
+        "get_target_capabilities",
+        "get_target_repo_state_snapshot",
+        "list_target_proof_bundles",
+        "fetch_target_proof_bundle",
+        "get_target_runtime_receipt",
     }
+    assert type(server._REGISTRY).__name__ == "RegistryV2"
+    for name, tool in mcp.tools.items():
+        if name != "list_targets":
+            assert "target_id" in inspect.signature(tool).parameters
 
 
-def test_search_code_docs_delegates_to_pure_facade_function(server_module, monkeypatch):
+def test_v2_server_delegates_target_id_to_pure_facade_function(server_module, monkeypatch):
     server, _ = server_module
     captured = {}
-    sentinel = {"status": "BLOCKED", "data": None}
+    sentinel = {"status": "OK", "target_id": "target-main"}
 
-    def fake_search_code_docs(
-        registry,
-        project_id,
-        query,
-        top_k,
-        *,
-        kind,
-        profile,
-        filter_doc_type,
-    ):
-        captured.update(
-            {
-                "registry": registry,
-                "project_id": project_id,
-                "query": query,
-                "top_k": top_k,
-                "kind": kind,
-                "profile": profile,
-                "filter_doc_type": filter_doc_type,
-            }
-        )
+    def fake_snapshot(registry, target_id):
+        captured.update({"registry": registry, "target_id": target_id})
         return sentinel
 
-    monkeypatch.setattr(server.tools, "search_code_docs", fake_search_code_docs)
-    result = asyncio.run(
-        server.search_code_docs(
-            "dopemux",
-            "catalog contract",
-            top_k=7,
-            kind="docs",
-            profile="implementation",
-            filter_doc_type="md",
-        )
-    )
+    monkeypatch.setattr(server.tools_v2, "get_target_repo_state_snapshot", fake_snapshot)
+
+    result = asyncio.run(server.get_target_repo_state_snapshot("target-main"))
 
     assert result is sentinel
-    assert captured == {
-        "registry": server._REGISTRY,
-        "project_id": "dopemux",
-        "query": "catalog contract",
-        "top_k": 7,
-        "kind": "docs",
-        "profile": "implementation",
-        "filter_doc_type": "md",
-    }
-
-
-def test_status_wrappers_delegate_to_pure_facade_functions(server_module, monkeypatch):
-    server, _ = server_module
-    captured = []
-
-    def fake_index_status(registry, project_id):
-        captured.append(("index", registry, project_id))
-        return {"status": "BLOCKED"}
-
-    def fake_workflow_snapshot(registry, project_id):
-        captured.append(("workflow", registry, project_id))
-        return {"status": "OK"}
-
-    monkeypatch.setattr(server.tools, "get_index_status", fake_index_status)
-    monkeypatch.setattr(server.tools, "get_workflow_status_snapshot", fake_workflow_snapshot)
-
-    assert asyncio.run(server.get_index_status("dopemux")) == {"status": "BLOCKED"}
-    assert asyncio.run(server.get_workflow_status_snapshot("dopemux")) == {"status": "OK"}
-    assert captured == [
-        ("index", server._REGISTRY, "dopemux"),
-        ("workflow", server._REGISTRY, "dopemux"),
-    ]
+    assert captured == {"registry": server._REGISTRY, "target_id": "target-main"}

--- a/services/dcp-readonly-facade/tests/test_tools_v2.py
+++ b/services/dcp-readonly-facade/tests/test_tools_v2.py
@@ -119,6 +119,18 @@ def test_token_shaped_target_input_is_blocked_without_reflection():
     assert unsafe not in repr(envelope)
 
 
+def test_locator_shaped_target_ids_are_blocked_without_reflection():
+    """Port-like and numeric-dotted IDs must not be echoed as opaque target_id."""
+    registry = parse_registry_v2({"targets": []})
+    for unsafe in ("3020", "8080", "127.0.0.1", "1.2.3.4", "127.1"):
+        envelope = tools_v2.get_target_capabilities(registry, unsafe)
+
+        assert envelope["status"] == E.BLOCKED, unsafe
+        assert envelope["target_id"] is None, unsafe
+        assert unsafe not in repr(envelope), unsafe
+        assert tools_v2._is_opaque_target_id(unsafe) is False
+
+
 def test_repo_and_proof_tools_use_target_id(tmp_path: Path):
     workspace, head_sha = _workspace(
         tmp_path, bundles={"TP-TEST-0001": {"head_sha": "stale-head"}}

--- a/services/dcp-readonly-facade/tests/test_tools_v2.py
+++ b/services/dcp-readonly-facade/tests/test_tools_v2.py
@@ -1,0 +1,203 @@
+"""Public v2 facade tools: target_id-only, local evidence, fail-closed."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import yaml
+
+from dopemux.mcp.project_identity import ProjectIdentity
+
+from dcp_facade import envelope as E
+from dcp_facade.registry_v2 import parse_registry_v2
+from dcp_facade import tools_v2
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def _workspace(tmp_path: Path, *, bundles: dict[str, dict] | None = None) -> tuple[Path, str]:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _git(workspace, "init", "-q")
+    _git(workspace, "config", "user.email", "tests@example.invalid")
+    _git(workspace, "config", "user.name", "Facade Tests")
+    (workspace / ".dopemux").mkdir()
+    (workspace / ".repo_id").write_text("project=test-project\nowner=test-owner\n")
+    (workspace / "README.md").write_text("fixture\n")
+    _git(workspace, "add", ".repo_id", "README.md")
+    _git(workspace, "commit", "-qm", "fixture")
+    head_sha = _git(workspace, "rev-parse", "HEAD")
+
+    for bundle_id, proof in (bundles or {}).items():
+        bundle = workspace / "proof" / bundle_id
+        bundle.mkdir(parents=True)
+        (bundle / "PROOF.json").write_text(json.dumps(proof))
+    return workspace, head_sha
+
+
+def _registry(workspace: Path, *, target_id: str = "target-main"):
+    return parse_registry_v2(
+        {
+            "approved_roots": [str(workspace.parent)],
+            "targets": [
+                {
+                    "target_id": target_id,
+                    "workspace_path": str(workspace),
+                    "enabled": True,
+                    "identity": {"project": "test-project", "owner": "test-owner"},
+                    "service_policies": {
+                        "conport": {"enabled": True},
+                        "dope_memory": {"enabled": True},
+                    },
+                }
+            ],
+        }
+    )
+
+
+def test_list_targets_reports_enabled_opaque_ids_only(tmp_path: Path):
+    workspace, _ = _workspace(tmp_path)
+    registry = _registry(workspace)
+
+    envelope = tools_v2.list_targets(registry)
+
+    assert envelope["status"] == E.OK
+    assert envelope["target_id"] is None
+    assert envelope["data"] == {
+        "registry_generation": registry.generation,
+        "targets": [{"target_id": "target-main"}],
+    }
+    assert str(workspace) not in repr(envelope)
+
+
+def test_target_capabilities_resolve_v2_target_and_stay_non_callable(tmp_path: Path):
+    workspace, _ = _workspace(tmp_path)
+
+    envelope = tools_v2.get_target_capabilities(_registry(workspace), "target-main")
+
+    assert envelope["status"] == E.OK
+    assert envelope["target_id"] == "target-main"
+    assert envelope["data"]["target_id"] == "target-main"
+    assert {entry["family"] for entry in envelope["data"]["capabilities"]} == {
+        "conport",
+        "dope_memory",
+    }
+    assert all(entry["live"] == "UNKNOWN" for entry in envelope["data"]["capabilities"])
+    assert all(entry["callable"] is False for entry in envelope["data"]["capabilities"])
+    assert "project_id" not in envelope
+    assert str(workspace) not in repr(envelope)
+
+
+def test_unsafe_target_input_is_blocked_without_reflection():
+    registry = parse_registry_v2({"targets": []})
+    unsafe = "http://127.0.0.1:3020/private/secret"
+
+    envelope = tools_v2.get_target_capabilities(registry, unsafe)
+
+    assert envelope["status"] == E.BLOCKED
+    assert envelope["target_id"] is None
+    rendered = repr(envelope)
+    for forbidden in ("http", "127.0.0.1", "3020", "private", "secret"):
+        assert forbidden not in rendered
+
+
+def test_token_shaped_target_input_is_blocked_without_reflection():
+    registry = parse_registry_v2({"targets": []})
+    unsafe = "sk-abcdefghijklmnopqrstuvwxyz"
+
+    envelope = tools_v2.get_target_capabilities(registry, unsafe)
+
+    assert envelope["status"] == E.BLOCKED
+    assert envelope["target_id"] is None
+    assert unsafe not in repr(envelope)
+
+
+def test_repo_and_proof_tools_use_target_id(tmp_path: Path):
+    workspace, head_sha = _workspace(
+        tmp_path, bundles={"TP-TEST-0001": {"head_sha": "stale-head"}}
+    )
+    registry = _registry(workspace)
+
+    snapshot = tools_v2.get_target_repo_state_snapshot(registry, "target-main")
+    bundles = tools_v2.list_target_proof_bundles(registry, "target-main", "TP-TEST")
+    bundle = tools_v2.fetch_target_proof_bundle(registry, "target-main", "TP-TEST-0001")
+
+    assert snapshot["status"] == E.OK
+    assert snapshot["head_sha"] == head_sha
+    assert bundles["data"]["bundles"] == [{"bundle_id": "TP-TEST-0001", "files": ["PROOF.json"]}]
+    assert bundle["target_id"] == "target-main"
+    assert bundle["data"]["stale"] is True
+    assert any(warning.startswith("stale proof bundle") for warning in bundle["warnings"])
+    assert str(workspace) not in repr([snapshot, bundles, bundle])
+
+
+def test_runtime_receipt_is_redacted_and_never_callable(tmp_path: Path, monkeypatch):
+    workspace, _ = _workspace(tmp_path)
+    registry = _registry(workspace)
+    identity = ProjectIdentity(
+        worktree_root=workspace.resolve(), project_root=workspace.resolve(), git_common_dir=None
+    )
+    catalog_path = tmp_path / "catalog.yaml"
+    runtime_path = tmp_path / "instances.json"
+    catalog_path.write_text(
+        yaml.safe_dump(
+            {
+                "servers": {
+                    "conport": {
+                        "scope": "per-worktree",
+                        "identity_scope": "per-worktree",
+                        "management_model": "compose-service",
+                    }
+                }
+            }
+        )
+    )
+    runtime_path.write_text(
+        json.dumps(
+            {
+                "instances": [
+                    {
+                        "service": "conport",
+                        "project_id": identity.project_id,
+                        "project_root": str(workspace),
+                        "worktree_root": str(workspace),
+                        "urls": {"mcp": "http://127.0.0.1:3020/mcp"},
+                        "ports": {"mcp": 3020},
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setenv("DCP_FACADE_MCP_CATALOG", str(catalog_path))
+    monkeypatch.setenv("DOPEMUX_MCP_RUNTIME_REGISTRY", str(runtime_path))
+
+    envelope = tools_v2.get_target_runtime_receipt(registry, "target-main")
+
+    assert envelope["status"] == E.OK
+    assert envelope["data"] == {
+        "services": [
+            {
+                "family": "conport",
+                "state": "UNKNOWN",
+                "callable": False,
+                "reason": "runtime candidate joined; live verification required",
+            },
+            {
+                "family": "dope_memory",
+                "state": "BLOCKED",
+                "callable": False,
+                "reason": "canonical catalog policy mismatch",
+            },
+        ]
+    }
+    rendered = repr(envelope)
+    for forbidden in (str(workspace), str(catalog_path), str(runtime_path), "127.0.0.1", "3020"):
+        assert forbidden not in rendered
+    assert all(service["callable"] is False for service in envelope["data"]["services"])

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -134,6 +134,7 @@ A packet is superseded by another packet
 | TP-DCP-MCP-RO-0006 | DCP / MCP | Dope Context And Task Orchestrator Read Adapters | Active | N/A |
 | TP-DCP-MCP-RO-0007 | DCP / MCP | Secure MCP Tunnel Integration Docs And Manual Validation | Active | N/A |
 | TP-DCP-MCP-RO-0008 | DCP / MCP | Hardening Cross Project Isolation And PR Readiness | Active | N/A |
+| TP-DCP-MCP-RO-0012 | DCP / MCP | Public Facade Target Contract Migration | Active | TP-DCP-MCP-RO-0011-REMEDIATION-01 |
 | DMX-DCP-PROMPT5-EXTRACT-RECON-001 | DCP / Prompt 5 | Extract Prompt 5 chat-history docs and reconcile PR/Task Orchestrator runway state | Active | N/A |
 
 ────────────────────────────────────────────────────────────

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.json
@@ -1,0 +1,111 @@
+{
+  "id": "TP-DCP-MCP-RO-0012",
+  "project": "dopemux-mvp",
+  "target": "Migrate the public DCP read-only MCP facade from the v1 project_id registry and direct service bindings to registry-v2 opaque target_id resolution, local evidence receipts, and non-callable capability reporting.",
+  "invariants": [
+    "The public MCP server loads registry-v2 only and does not import or expose the v1 Registry/Resolver contract.",
+    "Every target-scoped tool accepts only an opaque target_id; callers cannot provide filesystem paths, URLs, ports, routes, workspace IDs, SQL, or shell input.",
+    "Runtime catalog and runtime-registry evidence is read locally only, remains advisory, and never makes a service callable.",
+    "No backend adapter invocation, network probe, tunnel, credential, container operation, or runtime lifecycle mutation is introduced.",
+    "All public responses redact absolute paths, URLs, ports, secrets, and raw unsafe target-shaped input."
+  ],
+  "depends_on": [
+    "TP-DCP-MCP-RO-0011-REMEDIATION-01"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DCP-MCP-RO",
+    "base_branch": "main",
+    "parent_tp_id": null,
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dcp-mcp-ro-0012-target-contract",
+    "base_branch": "main",
+    "stacked_because": "TP-DCP-MCP-RO-0011 runtime catalog identity remediation is merged on the verified base."
+  },
+  "commit": {
+    "message": "feat(dcp): migrate public facade to target registry v2",
+    "allowlist": [
+      "services/dcp-readonly-facade/src/dcp_facade/tools_v2.py",
+      "services/dcp-readonly-facade/src/mcp/server.py",
+      "services/dcp-readonly-facade/tests/test_tools_v2.py",
+      "services/dcp-readonly-facade/tests/test_mcp_server.py",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/TOOL_CONTRACT.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/RESPONSE_ENVELOPE_SCHEMA.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/MANUAL_VALIDATION.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/README.md",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.md",
+      "task-packets/INDEX.md",
+      "proof/TP-DCP-MCP-RO-0012/**"
+    ],
+    "verify": [
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests",
+      "uv run --frozen python -m compileall -q services/dcp-readonly-facade/src",
+      "python -m json.tool task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.json",
+      "python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "git diff --check",
+      "pre-commit run --files <changed-files>"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): migrate public facade to target registry v2",
+    "body": "Migrates the public DCP read-only facade to the v2 opaque target contract. Backend adapters remain deferred: this change exposes only local target, repository, proof, static capability, and non-callable runtime-evidence receipts. No public ingress, runtime lifecycle, credentials, or live backend calls are added.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "v2-public-surface",
+      "task": "Replace the FastMCP public v1 project_id surface with target_id-only registry-v2 tool wiring and remove direct backend adapter exposure from external server mode.",
+      "validation": [
+        "Server registration tests prove v1 public tools and DCP_FACADE_REGISTRY are absent from external server mode.",
+        "Every target-scoped tool signature requires target_id."
+      ]
+    },
+    {
+      "id": "local-evidence-receipts",
+      "task": "Implement target resolution, repository/proof reads, static capability reporting, and redacted non-callable runtime catalog receipts with local file reads only.",
+      "validation": [
+        "Focused tests cover enabled target resolution, blocked unknown/unsafe target input, proof containment, and non-callable runtime evidence.",
+        "Focused tests prove public responses contain no path, URL, port, or runtime endpoint values."
+      ]
+    },
+    {
+      "id": "contract-docs",
+      "task": "Update the public tool, envelope, local-run, manual-validation, and overview documents to label the v1 surface historical and describe the v2-only contract.",
+      "validation": [
+        "Documentation names target_id as the sole caller-visible target handle and identifies live backend adapters as deferred."
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Run packet schema validation, focused and full facade tests, compileall, diff hygiene, local independent review, and configured pre-commit checks before publication.",
+      "validation": [
+        "All local validation outputs are captured in proof or marked NOT_RUN with the blocker.",
+        "The independent audit status is not represented as trusted CI evidence."
+      ]
+    }
+  ]
+}

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.md
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.md
@@ -1,0 +1,69 @@
+---
+id: TP-DCP-MCP-RO-0012
+title: Public Facade Target Contract Migration
+type: explanation
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+prelude: Migrate the public DCP read-only MCP facade to the registry-v2 opaque target contract while retaining fail-closed local evidence behavior.
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+---
+# TP-DCP-MCP-RO-0012
+
+## Objective
+
+Replace the external FastMCP v1 `project_id` contract with the registry-v2
+opaque `target_id` contract. The public surface must resolve only
+operator-approved targets and expose local repository, proof, static policy,
+and non-callable runtime-evidence receipts.
+
+## Scope
+
+IN:
+
+- Registry-v2-only server wiring and target-scoped public tools.
+- Local repository and proof reads behind resolved targets.
+- Static capability reports and redacted non-callable runtime receipts.
+- V2 public-contract documentation, tests, packet, index, and proof.
+
+OUT:
+
+- Backend adapters, network/protocol probes, tunnels, ingress, credentials,
+  container operations, runtime lifecycle changes, and populated registries.
+
+## Invariants
+
+- V1 `registry.py`, `resolver.py`, and direct service profiles are not imported
+  by external server mode.
+- A target is a bounded opaque identifier, never a path, URL, port, route,
+  workspace ID, SQL fragment, or shell command.
+- Local runtime catalog evidence is advisory only and always serializes with
+  `callable: false`.
+- Unavailable or malformed local evidence yields `PARTIAL` or `BLOCKED`;
+  it never selects or calls a backend.
+- The generated `.claude/claude_config.json` delta remains outside the packet
+  allowlist and will not be staged.
+
+## Validation
+
+```text
+uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_tools_v2.py services/dcp-readonly-facade/tests/test_mcp_server.py
+uv run --frozen pytest -q services/dcp-readonly-facade/tests
+uv run --frozen python -m compileall -q services/dcp-readonly-facade/src
+uv run --frozen python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0012.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+git diff --check
+```
+
+## Stop Conditions
+
+- The public tool surface requires direct backend URLs or a caller-selected
+  path, port, route, or workspace ID.
+- A runtime receipt can become callable or leak operational topology.
+- The change requires a file outside the allowlist.
+- A live service, provider, or credential is needed to complete local tests.
+
+## Rollback
+
+Revert the single TP-0012 commit. Do not re-enable the v1 public surface
+without a separately approved disabled compatibility path and its own review.


### PR DESCRIPTION
## Scope

Migrates the public DCP FastMCP facade from the v1 project_id/direct-service surface to the registry-v2 opaque target_id contract.

- Registers only local target, repository, proof, static capability, and non-callable runtime-receipt tools.
- Removes v1 registry/tools and direct backend adapter exposure from public server mode.
- Adds path/URL/token reflection and non-callable runtime receipt regressions.
- Updates the public DCP contract and local-only run documentation.

## Local Validation

- Focused v2 server/tool tests: PASS (8).
- Full facade suite: PASS; 1 intentional opt-in live test skipped.
- Compile, packet schema, diff hygiene, and scoped pre-commit: PASS.
- Local AGY review: PASS_WITH_RISKS; two accepted low-severity environment/fixture risks.

## Audit Boundary

proof/TP-DCP-MCP-RO-0012/PROOF.json is VALIDATED_WITH_AUDIT_GAP. The repository embedded audit is required but SKIPPED under the current local-only, no-runner, no-credentials constraint; local AGY evidence is not trusted workflow proof. No live service, provider, connector, tunnel, credential, ingress, lifecycle, or backend call ran.

This PR is not represented as merge-ready.