### PR TITLE
feat(dcp): add connector policy schema and auth context

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
@@ -28,6 +28,8 @@ prelude: Packet roadmap and dependency chain for the read-only MCP evidence faca
 | TP-DCP-MCP-RO-0010 | Exposure Target Registry V2 And Pure Resolver Core | HIGH | Parse opaque target consent and resolve filesystem/repository identity without live I/O. **Done** — pure registry v2, resolver core, and capability separation landed. | 0009 |
 | TP-DCP-MCP-RO-0011 | Read-Only Runtime Registry And Catalog Join | HIGH | Join resolved targets with operational catalog/runtime evidence using exact scope checks; remain non-callable and fail closed. | 0010 |
 | TP-DCP-MCP-RO-0011-REMEDIATION-01 | Runtime Catalog Join Generated Identity Remediation | HIGH | Correct the open 0011 PR so lifecycle-generated runtime IDs match without changing target authorization or live behavior. | 0011 |
+| TP-DCP-MCP-RO-0012 | Public Facade Target Contract Migration | HIGH | Migrate public FastMCP to registry-v2 opaque target_id local evidence tools. **Done** — merged PR #1057. | 0011-REMEDIATION-01 |
+| TP-DCP-MCP-RO-0013 | Connector Policy Schema And Auth Context | HIGH | Strict connector policy schema/loader and provider-neutral sealed auth context with target/tool authorization. **No public ingress.** | 0012 |
 
 ## Sequencing rationale
 

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/CONNECTOR_POLICY_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/CONNECTOR_POLICY_CONTRACT.md
@@ -1,0 +1,112 @@
+---
+id: dcp-mcp-readonly-connector-policy-contract
+title: DCP Connector Policy And Auth Context Contract
+type: reference
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Strict non-secret connector policy schema/loader and provider-neutral authentication context for the DCP read-only facade series.
+---
+
+# Connector Policy And Auth Context Contract
+
+Packet: **TP-DCP-MCP-RO-0013**
+
+## Scope
+
+This packet lands **authentication and authorization primitives only**:
+
+- JSON Schema for one connector policy record
+- Fail-closed YAML/JSON loader and in-memory store
+- Provider-neutral bearer authentication against non-secret credential references
+- Target and tool authorization from the sealed connector context
+- Header stripping/redaction for forgeable connector-identity claims
+
+It does **not** add a public listener, tunnel, ingress middleware wiring, populated
+operator credentials, backend adapters, or live provider setup.
+
+## Schema
+
+Canonical schema:
+
+`services/dcp-readonly-facade/schema/connector_policy.schema.json`
+
+Repository example (templates only, all `enabled: false`):
+
+`docs/03-reference/dcp/chatgpt-mcp-readonly/CONNECTOR_POLICY_EXAMPLE.yaml`
+
+Populated operator records must live **outside** the repository (for example under
+an operator-owned path referenced by `DCP_FACADE_CONNECTOR_POLICY`).
+
+### Required semantics beyond JSON Schema
+
+| Rule | Behavior |
+| --- | --- |
+| `default_target_id` | When non-null, must appear in `allowed_target_ids` |
+| `multi_target_authorized: false` | At most one allowed target |
+| `credential_ref.reference` | Non-secret locator only; secret-like values are rejected |
+| `fail_closed.*` | Every key must be `BLOCK` |
+| Duplicate `connector_id` | Ambiguous; drop the id entirely |
+| `rate_limit.deny_on_backend_unavailable` | Must be `true` |
+
+## Authentication
+
+Module: `dcp_facade.auth_context`
+
+1. Extract a bearer token from `Authorization` or a direct test token.
+2. Resolve the connector's `credential_ref` through a secret resolver.
+   - Production default: `EnvironmentSecretResolver` for `env:VAR` references only.
+   - `os_keychain`, `secret_manager`, `oauth_client`, and `mtls_identity` kinds fail
+     closed until a resolver is injected by a later authorized packet.
+3. Constant-time compare the resolved secret to the presented token.
+4. Deny when the connector is missing, disabled, expired, ambiguous, or unresolved.
+5. On success, emit a sealed `ConnectorAuthContext` that **never stores the raw secret**.
+
+Public failure reason is always a generic authentication failure for unknown,
+disabled, expired, or wrong-credential cases.
+
+## Authorization
+
+After authentication:
+
+| Check | Result |
+| --- | --- |
+| `authorize_target` | Allow only targets in `allowed_target_ids` |
+| `authorize_tool` | Allow only tools in `allowed_tools` minus `denied_tools` |
+| `resolve_request_target` | Use explicit target, else default/single-allowed target |
+
+A context whose seal does not verify is treated as forged and denied.
+
+## Non-forgeable context
+
+- Connector-identity headers (`X-DCP-Connector-Id`, seal headers, etc.) are never
+  authoritative. `context_from_untrusted_headers` always denies.
+- `strip_untrusted_connector_headers` removes those claims and redacts bearer values.
+- Trusted contexts are created only by `authenticate_bearer` and sealed with a
+  process-local HMAC key (`DCP_FACADE_AUTH_SEAL_KEY` when set).
+
+## Rotation and revocation
+
+- Credential rotation updates the secret behind the same non-secret reference.
+- Old tokens fail after rotation; new tokens succeed.
+- Disabling a connector (`enabled: false`) or expiring it revokes access without
+  deleting audit labels or fingerprints.
+
+## Deferred to later packets
+
+| Concern | Packet |
+| --- | --- |
+| Loopback Streamable HTTP ingress + auth-before-discovery | TP-0014 |
+| Live ownership verification and safe adapters | TP-0015 |
+| Provider setup guides with current commands | TP-0016 |
+| Live cross-provider acceptance | TP-0017 |
+
+## Validation commands
+
+```text
+uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_connector_policy.py services/dcp-readonly-facade/tests/test_auth_context.py
+uv run --frozen pytest -q services/dcp-readonly-facade/tests
+uv run --frozen python -m compileall -q services/dcp-readonly-facade/src
+```

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/CONNECTOR_POLICY_EXAMPLE.yaml
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/CONNECTOR_POLICY_EXAMPLE.yaml
@@ -1,0 +1,144 @@
+schema_version: "1.0.0"
+examples_only: true
+records:
+  - schema_version: "1.0.0"
+    connector_id: "chatgpt-dopemux-main"
+    provider: "chatgpt"
+    transport_class: "openai_secure_mcp_tunnel"
+    credential_ref:
+      kind: "secret_manager"
+      reference: "<SECRET_MANAGER_REFERENCE_CHATGPT_DCP>"
+      verification_fingerprint: "fp:chatgpt:redacteddigest"
+      rotation_group: "dcp-chatgpt"
+    default_target_id: "dopemux-main"
+    allowed_target_ids: ["dopemux-main"]
+    multi_target_authorized: false
+    allowed_tools: ["read-decisions", "memory-search"]
+    denied_tools: ["mutation-tool-denied"]
+    enabled: false
+    rate_limit:
+      requests_per_minute: 30
+      burst: 5
+      max_concurrent: 2
+      deny_on_backend_unavailable: true
+    audit_label: "provider.chatgpt.dopemux-main"
+    created_by: "operator-placeholder"
+    created_at: "2099-01-01T00:00:00Z"
+    expires_at: "2099-02-01T00:00:00Z"
+    last_verified_at: null
+    source_documentation_date: "2026-07-15"
+    provider_account_class: "business"
+    provider_metadata:
+      public_hostname_label: null
+      server_name: "dopemux"
+      account_or_workspace_ref: "<OPAQUE_CHATGPT_WORKSPACE_REF>"
+    fail_closed: &fail_closed
+      unknown_target: "BLOCK"
+      disabled_target: "BLOCK"
+      unauthorized_target: "BLOCK"
+      denied_tool: "BLOCK"
+      expired_credential: "BLOCK"
+      ambiguous_owner: "BLOCK"
+      stale_runtime: "BLOCK"
+      auth_failure: "BLOCK"
+      missing_rate_policy: "BLOCK"
+      provider_drift: "BLOCK"
+
+  - schema_version: "1.0.0"
+    connector_id: "grok-feature-review-a7"
+    provider: "grok"
+    transport_class: "public_streamable_http"
+    credential_ref:
+      kind: "environment"
+      reference: "env:DOPEMUX_GROK_CONNECTOR_TOKEN"
+      verification_fingerprint: "fp:grok:redacteddigest"
+      rotation_group: "dcp-grok"
+    default_target_id: "feature-review-a7"
+    allowed_target_ids: ["feature-review-a7"]
+    multi_target_authorized: false
+    allowed_tools: ["read-decisions"]
+    denied_tools: ["mutation-tool-denied"]
+    enabled: false
+    rate_limit:
+      requests_per_minute: 20
+      burst: 4
+      max_concurrent: 1
+      deny_on_backend_unavailable: true
+    audit_label: "provider.grok.feature-review-a7"
+    created_by: "operator-placeholder"
+    created_at: "2099-01-01T00:00:00Z"
+    expires_at: "2099-02-01T00:00:00Z"
+    last_verified_at: null
+    source_documentation_date: "2026-06-14"
+    provider_account_class: "individual"
+    provider_metadata:
+      public_hostname_label: "grok-mcp.example.invalid"
+      server_name: "dopemux"
+      account_or_workspace_ref: "<OPAQUE_GROK_ACCOUNT_REF>"
+    fail_closed: *fail_closed
+
+  - schema_version: "1.0.0"
+    connector_id: "gemini-api-bounded"
+    provider: "gemini_api"
+    transport_class: "public_streamable_http"
+    credential_ref:
+      kind: "secret_manager"
+      reference: "<SECRET_MANAGER_REFERENCE_GEMINI_DCP>"
+      verification_fingerprint: "fp:gemini:redacteddigest"
+      rotation_group: "dcp-gemini-api"
+    default_target_id: "dopemux-main"
+    allowed_target_ids: ["dopemux-main"]
+    multi_target_authorized: false
+    allowed_tools: ["read-decisions"]
+    denied_tools: ["mutation-tool-denied"]
+    enabled: false
+    rate_limit:
+      requests_per_minute: 10
+      burst: 2
+      max_concurrent: 1
+      deny_on_backend_unavailable: true
+    audit_label: "provider.gemini-api.dopemux-main"
+    created_by: "operator-placeholder"
+    created_at: "2099-01-01T00:00:00Z"
+    expires_at: "2099-02-01T00:00:00Z"
+    last_verified_at: null
+    source_documentation_date: "2026-07-09"
+    provider_account_class: "api_project"
+    provider_metadata:
+      public_hostname_label: "gemini-mcp.example.invalid"
+      server_name: "dopemux"
+      account_or_workspace_ref: "<OPAQUE_GEMINI_PROJECT_REF>"
+    fail_closed: *fail_closed
+
+  - schema_version: "1.0.0"
+    connector_id: "antigravity-local-feature-a7"
+    provider: "gemini_cli"
+    transport_class: "local_streamable_http"
+    credential_ref:
+      kind: "os_keychain"
+      reference: "<OS_KEYCHAIN_REFERENCE_LOCAL_DCP>"
+      verification_fingerprint: "fp:local-antigravity:redacteddigest"
+      rotation_group: "dcp-local-gemini"
+    default_target_id: "feature-review-a7"
+    allowed_target_ids: ["feature-review-a7"]
+    multi_target_authorized: false
+    allowed_tools: ["read-decisions", "memory-search"]
+    denied_tools: ["mutation-tool-denied"]
+    enabled: false
+    rate_limit:
+      requests_per_minute: 60
+      burst: 10
+      max_concurrent: 2
+      deny_on_backend_unavailable: true
+    audit_label: "local.gemini-cli.feature-review-a7"
+    created_by: "operator-placeholder"
+    created_at: "2099-01-01T00:00:00Z"
+    expires_at: null
+    last_verified_at: null
+    source_documentation_date: "2026-07-16"
+    provider_account_class: "local_operator"
+    provider_metadata:
+      public_hostname_label: null
+      server_name: "dopemuxlocal"
+      account_or_workspace_ref: "<OPAQUE_LOCAL_PROFILE_REF>"
+    fail_closed: *fail_closed

--- a/proof/TP-DCP-MCP-RO-0013/AGY_AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0013/AGY_AUDIT.md
@@ -1,0 +1,33 @@
+# AGY Audit: TP-DCP-MCP-RO-0013
+
+## Provenance
+
+- Auditor: AGY / Google Antigravity CLI `1.1.3`
+- Mode: single-turn local read-only prompt
+- Scope: `connector_policy.py`, `auth_context.py`
+- Verdict: `PASS_WITH_RISKS` (pre-hardening notes), remediations applied locally
+
+## Verified by AGY
+
+- Raw secrets are not retained on sealed `ConnectorAuthContext`.
+- Auth failures remain generic for public reasons.
+- Untrusted connector headers are stripped/denied.
+- Target/tool authorization is deny-by-default.
+- No public listener, socket, or tunnel code is present.
+
+## Findings And Local Response
+
+1. **Rotation via dual connector_id** — AGY noted duplicate `connector_id` drops
+   both records. **Accepted design:** connector identity remains unique;
+   rotation updates the secret behind the same non-secret reference (covered by
+   rotation tests). Dual live tokens under one id are intentionally not supported.
+2. **Short secret in reference** — hardened locator requirements (`env:VAR` and
+   kind-specific prefixes) and broader secret-like detection; regression test added.
+3. **Seal delimiter ambiguity** — seal material now uses structured JSON encoding.
+4. **Linear scan without connector hint** — accepted residual DoS risk for large
+   stores; ingress rate limits deferred to TP-0014.
+
+## Boundary
+
+Local AGY evidence is advisory only. It does **not** satisfy
+`embedded-audit.yml` or PR Steward readiness.

--- a/proof/TP-DCP-MCP-RO-0013/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0013/AUDITOR_REPORT.md
@@ -1,0 +1,20 @@
+# TP-DCP-MCP-RO-0013 Auditor Report
+
+## Verdict
+
+`SKIPPED` for the canonical embedded-audit field. User direction is local-only,
+no runner or credentials are available for the trusted Claude audit route, and
+AGY is recorded separately as advisory evidence only.
+
+## Local Evidence
+
+- Focused connector-policy and auth-context tests passed.
+- Full facade suite passed with the opt-in live test skipped.
+- Schema validation, compileall, pre-commit on allowlisted files, and diff
+  hygiene passed.
+- AGY returned `PASS_WITH_RISKS`; seal/locator hardenings applied before commit.
+
+## Boundary
+
+Do not treat AGY as trusted `embedded-audit.yml` proof. Merge readiness and PR
+Steward remain unclaimed.

--- a/proof/TP-DCP-MCP-RO-0013/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0013/COMMAND_LOG.md
@@ -1,0 +1,21 @@
+# TP-DCP-MCP-RO-0013 Command Log
+
+Worktree branch: `codex/dcp-mcp-ro-0013-connector-auth`  
+Base: `origin/main` at `65a1aa29e` (includes merged TP-0012 / PR #1057)
+
+| Command | Result |
+| --- | --- |
+| Package ZIP SHA-256 `c0cb9d34…2447` | PASS (advisory package integrity) |
+| Live PR/packet collision search for 0013 | PASS; no open PR or packet collision |
+| Dedicated worktree from `origin/main` | PASS |
+| `uv run --frozen python -m jsonschema -i …TP-DCP-MCP-RO-0013.json …dopetask-canonical-spec.json` | PASS (CLI deprecation warning only) |
+| `uv run --frozen pytest -q …test_connector_policy.py …test_auth_context.py` | PASS (25 tests) |
+| `uv run --frozen pytest -q services/dcp-readonly-facade/tests` | PASS; 1 opt-in live test skipped |
+| `uv run --frozen python -m compileall -q services/dcp-readonly-facade/src` | PASS |
+| `git diff --check` | PASS |
+| `pre-commit run --files <allowlist>` | PASS |
+| `agy --prompt=<TP-0013 read-only audit>` | PASS_WITH_RISKS; hardenings applied; see `AGY_AUDIT.md` |
+| Trusted embedded audit / PR Steward | NOT_RUN / CI may FAIL; not claimed |
+
+No live facade, provider, tunnel, credential vault, container, or lifecycle
+operation was executed.

--- a/proof/TP-DCP-MCP-RO-0013/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0013/PROOF.json
@@ -125,7 +125,11 @@
   "rollback": "Revert the TP-0013 commit(s). Public FastMCP server is unchanged by this packet.",
   "cleanup": "Dedicated worktree retained while the PR remains open.",
   "pr": {
-    "status": "PENDING_CREATE",
-    "blocker": "Trusted embedded audit SKIPPED; PR Steward and merge readiness not claimed."
-  }
+    "number": 1059,
+    "status": "OPEN_NOT_READY",
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1059",
+    "head_at_creation": "cd299a8d0796063d661e43f2f6a03486e74c5771",
+    "blocker": "Trusted embedded audit SKIPPED under local-only constraints; AGY advisory only; PR Steward and merge readiness not claimed."
+  },
+  "implementation_commit": "cd299a8d0796063d661e43f2f6a03486e74c5771"
 }

--- a/proof/TP-DCP-MCP-RO-0013/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0013/PROOF.json
@@ -1,0 +1,131 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0013",
+  "title": "Connector Policy Schema And Auth Context",
+  "status": "VALIDATED_WITH_AUDIT_GAP",
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "branch": "codex/dcp-mcp-ro-0013-connector-auth",
+  "base_branch": "main",
+  "base_sha": "65a1aa29e5562d6b7c806ef4ff50522fd7c735f7",
+  "depends_on_verified": {
+    "TP-DCP-MCP-RO-0012": {
+      "pr": 1057,
+      "merge_commit": "65a1aa29e5562d6b7c806ef4ff50522fd7c735f7",
+      "status": "MERGED"
+    }
+  },
+  "scope": "Strict connector policy schema/loader and provider-neutral sealed auth context with target/tool authorization, header redaction, and rotation/revocation tests. No public ingress, tunnels, real credentials, backend adapters, or lifecycle mutations.",
+  "input_package": {
+    "path": "/Users/hue/Downloads/dopemux-multi-provider-mcp-supervisor-package.zip",
+    "sha256": "c0cb9d34f6ece116811c52cce0d1b517153dba0f8434c9abda9da6ff6d6a2447",
+    "archive_integrity": "PASS",
+    "authority": "advisory_only"
+  },
+  "files_changed": [
+    "services/dcp-readonly-facade/src/dcp_facade/connector_policy.py",
+    "services/dcp-readonly-facade/src/dcp_facade/auth_context.py",
+    "services/dcp-readonly-facade/schema/connector_policy.schema.json",
+    "services/dcp-readonly-facade/tests/test_connector_policy.py",
+    "services/dcp-readonly-facade/tests/test_auth_context.py",
+    "services/dcp-readonly-facade/tests/fixtures/connector_policy/valid_enabled.yaml",
+    "services/dcp-readonly-facade/tests/fixtures/connector_policy/disabled.yaml",
+    "services/dcp-readonly-facade/tests/fixtures/connector_policy/expired.yaml",
+    "services/dcp-readonly-facade/tests/fixtures/connector_policy/multi_record_store.yaml",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/CONNECTOR_POLICY_CONTRACT.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/CONNECTOR_POLICY_EXAMPLE.yaml",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.json",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.md",
+    "task-packets/INDEX.md",
+    "proof/TP-DCP-MCP-RO-0013/PROOF.json",
+    "proof/TP-DCP-MCP-RO-0013/AUDITOR_REPORT.md",
+    "proof/TP-DCP-MCP-RO-0013/AGY_AUDIT.md",
+    "proof/TP-DCP-MCP-RO-0013/COMMAND_LOG.md"
+  ],
+  "validation": {
+    "PASS": [
+      {
+        "command": "uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_connector_policy.py services/dcp-readonly-facade/tests/test_auth_context.py",
+        "exit_code": 0,
+        "result": "25 passed"
+      },
+      {
+        "command": "uv run --frozen pytest -q services/dcp-readonly-facade/tests",
+        "exit_code": 0,
+        "result": "full suite passed; 1 intentionally opt-in live test skipped"
+      },
+      {
+        "command": "uv run --frozen python -m compileall -q services/dcp-readonly-facade/src",
+        "exit_code": 0,
+        "result": "completed without diagnostics"
+      },
+      {
+        "command": "uv run --frozen python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+        "exit_code": 0,
+        "result": "valid"
+      },
+      {
+        "command": "pre-commit run --files <TP-0013 allowlist>",
+        "exit_code": 0,
+        "result": "all applicable hooks passed"
+      },
+      {
+        "command": "agy --prompt=<TP-0013 read-only audit>",
+        "exit_code": 0,
+        "result": "PASS_WITH_RISKS; locator/seal hardenings applied; see AGY_AUDIT.md"
+      }
+    ],
+    "FAIL": [],
+    "NOT_RUN": [
+      {
+        "command": "Live DCP facade / provider / tunnel tests",
+        "reason": "Out of packet scope; no runner/credentials/tunnels authorized.",
+        "mitigation": "Public server remains stdio/local target tools only; auth primitives are not wired to a public listener in this packet."
+      },
+      {
+        "command": "Trusted embedded audit and PR Steward",
+        "reason": "Local-only direction; Claude trusted audit route unavailable; AGY is advisory only.",
+        "mitigation": "Recorded as readiness blockers; not claimed as passed."
+      }
+    ]
+  },
+  "local_agy_review": {
+    "tool": "AGY / Google Antigravity CLI",
+    "version": "1.1.3",
+    "status": "PASS_WITH_RISKS",
+    "report_path": "proof/TP-DCP-MCP-RO-0013/AGY_AUDIT.md",
+    "ci_trust_status": "NOT_ACCEPTED: local AGY evidence is not workflow-issued embedded-audit proof."
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
+    "report_path": "proof/TP-DCP-MCP-RO-0013/AUDITOR_REPORT.md",
+    "findings": [],
+    "fixes_applied": [
+      "Added connector policy schema/loader with fail-closed semantics.",
+      "Added sealed provider-neutral auth context with target/tool authorization.",
+      "Rejected secret-like and non-locator credential references.",
+      "Structured JSON seal material to avoid list delimiter ambiguity."
+    ],
+    "remaining_risks": [
+      "Trusted embedded audit not available under local-only constraints.",
+      "Auth primitives are not yet wired to hardened Streamable HTTP ingress (TP-0014).",
+      "Linear credential scan without connector hint remains a residual DoS consideration for large stores."
+    ],
+    "skip_reason": "Trusted embedded audit requires configured runner/auditor route. Claude unavailable; AGY recorded separately and does not satisfy embedded-audit.yml."
+  },
+  "residual_risks": [
+    "No live ownership, provider, tunnel, or ingress behavior is claimed.",
+    "Generated .claude/claude_config.json worktree delta remains unstaged and unrelated.",
+    "Operator-populated policy files must remain outside the repository."
+  ],
+  "rollback": "Revert the TP-0013 commit(s). Public FastMCP server is unchanged by this packet.",
+  "cleanup": "Dedicated worktree retained while the PR remains open.",
+  "pr": {
+    "status": "PENDING_CREATE",
+    "blocker": "Trusted embedded audit SKIPPED; PR Steward and merge readiness not claimed."
+  }
+}

--- a/services/dcp-readonly-facade/schema/connector_policy.schema.json
+++ b/services/dcp-readonly-facade/schema/connector_policy.schema.json
@@ -1,0 +1,381 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dopemux.local/schemas/dcp-connector-policy-1.0.0.json",
+  "title": "Dopemux DCP Connector Policy Record",
+  "description": "Strict non-secret policy for one authenticated provider or local MCP connector. Populated records live outside the repository.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "connector_id",
+    "provider",
+    "transport_class",
+    "credential_ref",
+    "default_target_id",
+    "allowed_target_ids",
+    "allowed_tools",
+    "denied_tools",
+    "enabled",
+    "rate_limit",
+    "audit_label",
+    "created_by",
+    "created_at",
+    "expires_at",
+    "last_verified_at",
+    "source_documentation_date",
+    "provider_account_class",
+    "fail_closed"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "1.0.0"
+    },
+    "connector_id": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]{2,63}$"
+    },
+    "provider": {
+      "type": "string",
+      "enum": [
+        "chatgpt",
+        "openai_api",
+        "grok",
+        "xai_api",
+        "gemini_api",
+        "gemini_deep_research",
+        "gemini_cli",
+        "antigravity_managed"
+      ]
+    },
+    "transport_class": {
+      "type": "string",
+      "enum": [
+        "openai_secure_mcp_tunnel",
+        "public_streamable_http",
+        "public_sse",
+        "local_streamable_http",
+        "local_sse",
+        "local_stdio"
+      ]
+    },
+    "credential_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "reference",
+        "verification_fingerprint",
+        "rotation_group"
+      ],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "enum": [
+            "environment",
+            "os_keychain",
+            "secret_manager",
+            "oauth_client",
+            "mtls_identity"
+          ]
+        },
+        "reference": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Non-secret locator only. Must not contain the credential value."
+        },
+        "verification_fingerprint": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9:_-]{8,128}$",
+          "description": "Non-reversible identifier used for audit correlation."
+        },
+        "rotation_group": {
+          "type": "string",
+          "pattern": "^[a-z][a-z0-9-]{2,63}$"
+        }
+      }
+    },
+    "default_target_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "pattern": "^[a-z][a-z0-9-]{2,63}$",
+      "description": "When non-null, must also appear in allowed_target_ids. Enforce this semantic constraint in the loader."
+    },
+    "allowed_target_ids": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9-]{2,63}$"
+      }
+    },
+    "multi_target_authorized": {
+      "type": "boolean",
+      "default": false
+    },
+    "allowed_tools": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9_.:-]{1,128}$"
+      }
+    },
+    "denied_tools": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^[A-Za-z0-9_.:-]{1,128}$"
+      }
+    },
+    "enabled": {
+      "type": "boolean"
+    },
+    "rate_limit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requests_per_minute",
+        "burst",
+        "max_concurrent",
+        "deny_on_backend_unavailable"
+      ],
+      "properties": {
+        "requests_per_minute": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10000
+        },
+        "burst": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        "max_concurrent": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 100
+        },
+        "deny_on_backend_unavailable": {
+          "type": "boolean",
+          "const": true
+        }
+      }
+    },
+    "audit_label": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9.-]{2,127}$"
+    },
+    "created_by": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "expires_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "last_verified_at": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "format": "date-time"
+    },
+    "source_documentation_date": {
+      "type": "string",
+      "format": "date"
+    },
+    "provider_account_class": {
+      "type": "string",
+      "enum": [
+        "individual",
+        "pro",
+        "business",
+        "enterprise",
+        "education",
+        "api_project",
+        "local_operator",
+        "unknown"
+      ]
+    },
+    "provider_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "public_hostname_label": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[A-Za-z0-9.-]{1,253}$",
+          "description": "Redacted or template hostname label only in repository examples."
+        },
+        "server_name": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[a-z0-9_-]{1,63}$"
+        },
+        "account_or_workspace_ref": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "maxLength": 128,
+          "description": "Opaque non-secret reference."
+        }
+      }
+    },
+    "fail_closed": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "unknown_target",
+        "disabled_target",
+        "unauthorized_target",
+        "denied_tool",
+        "expired_credential",
+        "ambiguous_owner",
+        "stale_runtime",
+        "auth_failure",
+        "missing_rate_policy",
+        "provider_drift"
+      ],
+      "properties": {
+        "unknown_target": {
+          "type": "string",
+          "const": "BLOCK"
+        },
+        "disabled_target": {
+          "type": "string",
+          "const": "BLOCK"
+        },
+        "unauthorized_target": {
+          "type": "string",
+          "const": "BLOCK"
+        },
+        "denied_tool": {
+          "type": "string",
+          "const": "BLOCK"
+        },
+        "expired_credential": {
+          "type": "string",
+          "const": "BLOCK"
+        },
+        "ambiguous_owner": {
+          "type": "string",
+          "const": "BLOCK"
+        },
+        "stale_runtime": {
+          "type": "string",
+          "const": "BLOCK"
+        },
+        "auth_failure": {
+          "type": "string",
+          "const": "BLOCK"
+        },
+        "missing_rate_policy": {
+          "type": "string",
+          "const": "BLOCK"
+        },
+        "provider_drift": {
+          "type": "string",
+          "const": "BLOCK"
+        }
+      }
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "transport_class": {
+            "enum": [
+              "public_streamable_http",
+              "public_sse",
+              "openai_secure_mcp_tunnel"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "multi_target_authorized": {
+            "const": false
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "allowed_target_ids": {
+            "maxItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "provider": {
+            "const": "antigravity_managed"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "transport_class": {
+            "const": "public_streamable_http"
+          },
+          "provider_metadata": {
+            "required": [
+              "server_name"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "provider": {
+            "const": "gemini_cli"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "transport_class": {
+            "enum": [
+              "local_streamable_http",
+              "local_sse",
+              "local_stdio"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/services/dcp-readonly-facade/src/dcp_facade/auth_context.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/auth_context.py
@@ -1,0 +1,460 @@
+"""Provider-neutral connector authentication context (TP-DCP-MCP-RO-0013).
+
+Authentication and target/tool authorization primitives only. No public
+listener, tunnel, or backend call is performed here. Raw credential values are
+never retained on the trusted context object.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Mapping, Optional, Protocol
+
+from .connector_policy import ConnectorPolicy, ConnectorPolicyStore
+from .redaction import redact_value
+
+# Generic public reason — never distinguish missing/disabled/unknown connector.
+GENERIC_AUTH_FAILURE = "authentication failed"
+GENERIC_TARGET_DENY = "target not authorized"
+GENERIC_TOOL_DENY = "tool not authorized"
+GENERIC_EXPIRED = "authentication failed"
+GENERIC_DISABLED = "authentication failed"
+
+# Inbound headers that claim connector identity must never be trusted as auth.
+UNTRUSTED_CONNECTOR_HEADERS = (
+    "x-dcp-connector-id",
+    "x-dcp-connector-context",
+    "x-dcp-auth-context",
+    "x-dcp-connector-seal",
+    "x-connector-id",
+    "x-authenticated-connector",
+)
+
+_BEARER_RE = re.compile(r"(?i)^bearer\s+(\S+)$")
+_ENV_REF_RE = re.compile(r"^env:([A-Za-z_][A-Za-z0-9_]*)$")
+
+
+class SecretResolver(Protocol):
+    """Resolve a non-secret credential reference to a raw secret for verification."""
+
+    def resolve(self, kind: str, reference: str) -> Optional[str]:
+        ...
+
+
+class EnvironmentSecretResolver:
+    """Resolve ``env:VAR`` references from process environment only."""
+
+    def resolve(self, kind: str, reference: str) -> Optional[str]:
+        if kind != "environment":
+            return None
+        match = _ENV_REF_RE.fullmatch(reference.strip())
+        if not match:
+            return None
+        value = os.environ.get(match.group(1))
+        if value is None or value == "":
+            return None
+        return value
+
+
+class MappingSecretResolver:
+    """Test helper: explicit kind/reference map to secret values."""
+
+    def __init__(self, mapping: Mapping[tuple[str, str], str]):
+        self._mapping = dict(mapping)
+
+    def resolve(self, kind: str, reference: str) -> Optional[str]:
+        return self._mapping.get((kind, reference))
+
+
+@dataclass(frozen=True)
+class AuthDecision:
+    allowed: bool
+    reason: str
+    connector_id: Optional[str] = None
+    code: str = "ok"
+
+    def to_public_dict(self) -> dict:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "connector_id": self.connector_id if self.allowed else None,
+            "code": self.code if self.allowed else "denied",
+        }
+
+
+@dataclass(frozen=True)
+class ConnectorAuthContext:
+    """Trusted connector context. Construct only via authenticate_* helpers."""
+
+    connector_id: str
+    provider: str
+    transport_class: str
+    audit_label: str
+    credential_fingerprint: str
+    rotation_group: str
+    allowed_target_ids: tuple[str, ...]
+    default_target_id: Optional[str]
+    allowed_tools: tuple[str, ...]
+    denied_tools: tuple[str, ...]
+    rate_limit_rpm: int
+    rate_limit_burst: int
+    rate_limit_max_concurrent: int
+    expires_at: Optional[str]
+    seal: str
+
+    def to_public_dict(self) -> dict:
+        """Public-safe view: no seal material that could aid forgery replay beyond id."""
+        return {
+            "connector_id": self.connector_id,
+            "provider": self.provider,
+            "transport_class": self.transport_class,
+            "audit_label": self.audit_label,
+            "credential_fingerprint": self.credential_fingerprint,
+            "rotation_group": self.rotation_group,
+            "allowed_target_ids": list(self.allowed_target_ids),
+            "default_target_id": self.default_target_id,
+            "allowed_tools": list(self.allowed_tools),
+            "denied_tools": list(self.denied_tools),
+            "rate_limit": {
+                "requests_per_minute": self.rate_limit_rpm,
+                "burst": self.rate_limit_burst,
+                "max_concurrent": self.rate_limit_max_concurrent,
+            },
+            "expires_at": self.expires_at,
+        }
+
+
+# Process-local sealing key. Not a credential store; prevents reconstructing a
+# trusted context from untrusted headers without going through authenticate.
+_SEAL_KEY = os.environ.get("DCP_FACADE_AUTH_SEAL_KEY", "").encode("utf-8") or secrets.token_bytes(32)
+
+
+def _seal_material(fields: Mapping[str, object]) -> str:
+    # Structured JSON avoids delimiter ambiguity across list/string fields.
+    payload = json.dumps(fields, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    digest = hmac.new(_SEAL_KEY, payload.encode("utf-8"), hashlib.sha256).hexdigest()
+    return digest
+
+
+def _context_seal_fields(
+    *,
+    connector_id: str,
+    provider: str,
+    transport_class: str,
+    audit_label: str,
+    credential_fingerprint: str,
+    rotation_group: str,
+    allowed_target_ids: tuple[str, ...],
+    default_target_id: Optional[str],
+    allowed_tools: tuple[str, ...],
+    denied_tools: tuple[str, ...],
+    rate_limit_rpm: int,
+    rate_limit_burst: int,
+    rate_limit_max_concurrent: int,
+    expires_at: Optional[str],
+) -> dict[str, object]:
+    return {
+        "connector_id": connector_id,
+        "provider": provider,
+        "transport_class": transport_class,
+        "audit_label": audit_label,
+        "credential_fingerprint": credential_fingerprint,
+        "rotation_group": rotation_group,
+        "allowed_target_ids": list(allowed_target_ids),
+        "default_target_id": default_target_id,
+        "allowed_tools": list(allowed_tools),
+        "denied_tools": list(denied_tools),
+        "rpm": rate_limit_rpm,
+        "burst": rate_limit_burst,
+        "max_concurrent": rate_limit_max_concurrent,
+        "expires_at": expires_at,
+    }
+
+
+def _build_context(policy: ConnectorPolicy) -> ConnectorAuthContext:
+    fields = _context_seal_fields(
+        connector_id=policy.connector_id,
+        provider=policy.provider,
+        transport_class=policy.transport_class,
+        audit_label=policy.audit_label,
+        credential_fingerprint=policy.credential_ref.verification_fingerprint,
+        rotation_group=policy.credential_ref.rotation_group,
+        allowed_target_ids=policy.allowed_target_ids,
+        default_target_id=policy.default_target_id,
+        allowed_tools=policy.allowed_tools,
+        denied_tools=policy.denied_tools,
+        rate_limit_rpm=policy.rate_limit.requests_per_minute,
+        rate_limit_burst=policy.rate_limit.burst,
+        rate_limit_max_concurrent=policy.rate_limit.max_concurrent,
+        expires_at=policy.expires_at,
+    )
+    return ConnectorAuthContext(
+        connector_id=policy.connector_id,
+        provider=policy.provider,
+        transport_class=policy.transport_class,
+        audit_label=policy.audit_label,
+        credential_fingerprint=policy.credential_ref.verification_fingerprint,
+        rotation_group=policy.credential_ref.rotation_group,
+        allowed_target_ids=policy.allowed_target_ids,
+        default_target_id=policy.default_target_id,
+        allowed_tools=policy.allowed_tools,
+        denied_tools=policy.denied_tools,
+        rate_limit_rpm=policy.rate_limit.requests_per_minute,
+        rate_limit_burst=policy.rate_limit.burst,
+        rate_limit_max_concurrent=policy.rate_limit.max_concurrent,
+        expires_at=policy.expires_at,
+        seal=_seal_material(fields),
+    )
+
+
+def verify_context_seal(context: ConnectorAuthContext) -> bool:
+    """Return True only if the context seal matches sealed policy fields."""
+    fields = _context_seal_fields(
+        connector_id=context.connector_id,
+        provider=context.provider,
+        transport_class=context.transport_class,
+        audit_label=context.audit_label,
+        credential_fingerprint=context.credential_fingerprint,
+        rotation_group=context.rotation_group,
+        allowed_target_ids=context.allowed_target_ids,
+        default_target_id=context.default_target_id,
+        allowed_tools=context.allowed_tools,
+        denied_tools=context.denied_tools,
+        rate_limit_rpm=context.rate_limit_rpm,
+        rate_limit_burst=context.rate_limit_burst,
+        rate_limit_max_concurrent=context.rate_limit_max_concurrent,
+        expires_at=context.expires_at,
+    )
+    expected = _seal_material(fields)
+    return hmac.compare_digest(expected, context.seal)
+
+
+def context_from_untrusted_headers(headers: Mapping[str, str]) -> AuthDecision:
+    """Always deny. Connector context headers are never authoritative."""
+    return AuthDecision(allowed=False, reason=GENERIC_AUTH_FAILURE, code="untrusted_headers")
+
+
+def strip_untrusted_connector_headers(
+    headers: Mapping[str, str],
+) -> tuple[dict[str, str], list[str]]:
+    """Remove forgeable connector-identity headers; return clean map + redactions."""
+    cleaned: dict[str, str] = {}
+    redactions: list[str] = []
+    for key, value in headers.items():
+        lowered = key.lower()
+        if lowered in UNTRUSTED_CONNECTOR_HEADERS:
+            redactions.append(f"stripped:{lowered}")
+            continue
+        clean_value, categories = redact_value(value, [])
+        if categories:
+            redactions.extend(categories)
+            cleaned[key] = str(clean_value)
+        else:
+            cleaned[key] = value
+    # Also redact Authorization values in returned copy when present.
+    for key in list(cleaned):
+        if key.lower() == "authorization":
+            cleaned[key] = "Bearer <redacted>"
+            if "secrets" not in redactions:
+                redactions.append("secrets")
+    return cleaned, sorted(set(redactions))
+
+
+def extract_bearer_token(authorization_header: Optional[str]) -> Optional[str]:
+    if not authorization_header or not isinstance(authorization_header, str):
+        return None
+    match = _BEARER_RE.match(authorization_header.strip())
+    if not match:
+        return None
+    token = match.group(1).strip()
+    return token or None
+
+
+def authenticate_bearer(
+    store: ConnectorPolicyStore,
+    *,
+    authorization_header: Optional[str] = None,
+    presented_token: Optional[str] = None,
+    connector_id_hint: Optional[str] = None,
+    secret_resolver: Optional[SecretResolver] = None,
+    now: Optional[datetime] = None,
+) -> tuple[Optional[ConnectorAuthContext], AuthDecision]:
+    """Authenticate a connector via bearer token against policy credential refs.
+
+    On any failure returns a generic authentication failure without reflecting
+    tokens, missing connector ids, or secret values.
+    """
+    resolver = secret_resolver or EnvironmentSecretResolver()
+    token = presented_token if presented_token is not None else extract_bearer_token(authorization_header)
+    if not token:
+        return None, AuthDecision(allowed=False, reason=GENERIC_AUTH_FAILURE, code="missing_token")
+
+    candidates: list[ConnectorPolicy]
+    if connector_id_hint:
+        # Hint is optional and never sufficient alone.
+        policy = store.get(connector_id_hint)
+        candidates = [policy] if policy is not None else []
+    else:
+        candidates = list(store.policies.values())
+
+    matched: Optional[ConnectorPolicy] = None
+    for policy in candidates:
+        secret = resolver.resolve(policy.credential_ref.kind, policy.credential_ref.reference)
+        if secret is None:
+            continue
+        if hmac.compare_digest(secret, token):
+            if matched is not None:
+                # Ambiguous credential binding — fail closed.
+                return None, AuthDecision(allowed=False, reason=GENERIC_AUTH_FAILURE, code="ambiguous")
+            matched = policy
+
+    if matched is None:
+        return None, AuthDecision(allowed=False, reason=GENERIC_AUTH_FAILURE, code="auth_failure")
+
+    if not matched.enabled:
+        return None, AuthDecision(allowed=False, reason=GENERIC_DISABLED, code="disabled")
+
+    if matched.is_expired(now):
+        return None, AuthDecision(allowed=False, reason=GENERIC_EXPIRED, code="expired")
+
+    context = _build_context(matched)
+    if not verify_context_seal(context):
+        return None, AuthDecision(allowed=False, reason=GENERIC_AUTH_FAILURE, code="seal_failure")
+
+    return context, AuthDecision(
+        allowed=True,
+        reason="authenticated",
+        connector_id=matched.connector_id,
+        code="ok",
+    )
+
+
+def authorize_target(context: ConnectorAuthContext, target_id: object) -> AuthDecision:
+    if not verify_context_seal(context):
+        return AuthDecision(allowed=False, reason=GENERIC_AUTH_FAILURE, code="forged_context")
+    if not isinstance(target_id, str) or not target_id:
+        return AuthDecision(
+            allowed=False,
+            reason=GENERIC_TARGET_DENY,
+            connector_id=context.connector_id,
+            code="invalid_target",
+        )
+    if target_id not in context.allowed_target_ids:
+        return AuthDecision(
+            allowed=False,
+            reason=GENERIC_TARGET_DENY,
+            connector_id=context.connector_id,
+            code="unauthorized_target",
+        )
+    return AuthDecision(
+        allowed=True,
+        reason="target authorized",
+        connector_id=context.connector_id,
+        code="ok",
+    )
+
+
+def authorize_tool(context: ConnectorAuthContext, tool_name: object) -> AuthDecision:
+    if not verify_context_seal(context):
+        return AuthDecision(allowed=False, reason=GENERIC_AUTH_FAILURE, code="forged_context")
+    if not isinstance(tool_name, str) or not tool_name:
+        return AuthDecision(
+            allowed=False,
+            reason=GENERIC_TOOL_DENY,
+            connector_id=context.connector_id,
+            code="invalid_tool",
+        )
+    if tool_name in context.denied_tools:
+        return AuthDecision(
+            allowed=False,
+            reason=GENERIC_TOOL_DENY,
+            connector_id=context.connector_id,
+            code="denied_tool",
+        )
+    if tool_name not in context.allowed_tools:
+        return AuthDecision(
+            allowed=False,
+            reason=GENERIC_TOOL_DENY,
+            connector_id=context.connector_id,
+            code="unauthorized_tool",
+        )
+    return AuthDecision(
+        allowed=True,
+        reason="tool authorized",
+        connector_id=context.connector_id,
+        code="ok",
+    )
+
+
+def resolve_request_target(
+    context: ConnectorAuthContext, requested_target_id: Optional[str]
+) -> tuple[Optional[str], AuthDecision]:
+    """Resolve caller target or connector default under multi-target rules."""
+    if not verify_context_seal(context):
+        return None, AuthDecision(allowed=False, reason=GENERIC_AUTH_FAILURE, code="forged_context")
+    if requested_target_id:
+        decision = authorize_target(context, requested_target_id)
+        return (requested_target_id if decision.allowed else None), decision
+    if context.default_target_id and context.default_target_id in context.allowed_target_ids:
+        return context.default_target_id, AuthDecision(
+            allowed=True,
+            reason="default target applied",
+            connector_id=context.connector_id,
+            code="ok",
+        )
+    if len(context.allowed_target_ids) == 1:
+        only = context.allowed_target_ids[0]
+        return only, AuthDecision(
+            allowed=True,
+            reason="single allowed target applied",
+            connector_id=context.connector_id,
+            code="ok",
+        )
+    return None, AuthDecision(
+        allowed=False,
+        reason=GENERIC_TARGET_DENY,
+        connector_id=context.connector_id,
+        code="target_required",
+    )
+
+
+def forge_context_attempt(
+    **kwargs: object,
+) -> ConnectorAuthContext:
+    """Test helper that builds an unsealed/forged context-like object.
+
+    Production callers must not use this. Seal will not verify unless kwargs
+    include a correctly computed seal for the process key.
+    """
+    base = {
+        "connector_id": str(kwargs.get("connector_id", "forged-connector")),
+        "provider": str(kwargs.get("provider", "chatgpt")),
+        "transport_class": str(kwargs.get("transport_class", "local_stdio")),
+        "audit_label": str(kwargs.get("audit_label", "forged.label")),
+        "credential_fingerprint": str(kwargs.get("credential_fingerprint", "fp:forged")),
+        "rotation_group": str(kwargs.get("rotation_group", "forged-group")),
+        "allowed_target_ids": tuple(kwargs.get("allowed_target_ids", ("dopemux-main",))),  # type: ignore[arg-type]
+        "default_target_id": kwargs.get("default_target_id", "dopemux-main"),
+        "allowed_tools": tuple(kwargs.get("allowed_tools", ("list_targets",))),  # type: ignore[arg-type]
+        "denied_tools": tuple(kwargs.get("denied_tools", ())),  # type: ignore[arg-type]
+        "rate_limit_rpm": int(kwargs.get("rate_limit_rpm", 10)),  # type: ignore[arg-type]
+        "rate_limit_burst": int(kwargs.get("rate_limit_burst", 1)),  # type: ignore[arg-type]
+        "rate_limit_max_concurrent": int(kwargs.get("rate_limit_max_concurrent", 1)),  # type: ignore[arg-type]
+        "expires_at": kwargs.get("expires_at"),
+        "seal": str(kwargs.get("seal", "invalid-seal")),
+    }
+    return ConnectorAuthContext(**base)  # type: ignore[arg-type]
+
+
+def redact_authorization_header(value: str) -> str:
+    clean, _ = redact_value(value, [])
+    if isinstance(clean, str) and clean.lower().startswith("bearer "):
+        return "Bearer <redacted>"
+    return str(clean)

--- a/services/dcp-readonly-facade/src/dcp_facade/connector_policy.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/connector_policy.py
@@ -1,0 +1,371 @@
+"""Strict connector policy schema/loader (TP-DCP-MCP-RO-0013).
+
+Loads non-secret connector policy records from operator-owned documents.
+Populated production policy lives outside the repository; repository examples
+are templates only. This module never stores raw credential values and never
+opens network sockets or listeners.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional
+
+import yaml
+from jsonschema import Draft202012Validator
+
+from .redaction import redact_value
+
+SCHEMA_VERSION = "1.0.0"
+ENV_POLICY_PATH = "DCP_FACADE_CONNECTOR_POLICY"
+DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[2] / "schema" / "connector_policy.schema.json"
+
+_FAIL_CLOSED_KEYS = (
+    "unknown_target",
+    "disabled_target",
+    "unauthorized_target",
+    "denied_tool",
+    "expired_credential",
+    "ambiguous_owner",
+    "stale_runtime",
+    "auth_failure",
+    "missing_rate_policy",
+    "provider_drift",
+)
+
+# Reject credential references that look like embedded secret material rather
+# than non-secret locators (env:/keychain:/manager: style).
+_SECRET_LIKE = re.compile(
+    r"(?i)(sk-[A-Za-z0-9_\-]{8,}|gh[pousr]_[A-Za-z0-9]{16,}|AKIA[0-9A-Z]{16}|"
+    r"bearer\s+[A-Za-z0-9._\-]{8,}|password\s*[=:]\s*\S+)"
+)
+
+
+@dataclass(frozen=True)
+class CredentialRef:
+    kind: str
+    reference: str
+    verification_fingerprint: str
+    rotation_group: str
+
+
+@dataclass(frozen=True)
+class RateLimitPolicy:
+    requests_per_minute: int
+    burst: int
+    max_concurrent: int
+    deny_on_backend_unavailable: bool = True
+
+
+@dataclass(frozen=True)
+class ConnectorPolicy:
+    """One independently revocable connector identity and authorization map."""
+
+    schema_version: str
+    connector_id: str
+    provider: str
+    transport_class: str
+    credential_ref: CredentialRef
+    default_target_id: Optional[str]
+    allowed_target_ids: tuple[str, ...]
+    multi_target_authorized: bool
+    allowed_tools: tuple[str, ...]
+    denied_tools: tuple[str, ...]
+    enabled: bool
+    rate_limit: RateLimitPolicy
+    audit_label: str
+    created_by: str
+    created_at: str
+    expires_at: Optional[str]
+    last_verified_at: Optional[str]
+    source_documentation_date: str
+    provider_account_class: str
+    fail_closed: Mapping[str, str]
+    provider_metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def is_expired(self, now: Optional[datetime] = None) -> bool:
+        if self.expires_at is None:
+            return False
+        current = now or datetime.now(timezone.utc)
+        expiry = _parse_datetime(self.expires_at)
+        if expiry is None:
+            return True
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=timezone.utc)
+        return current >= expiry
+
+
+@dataclass
+class ConnectorPolicyStore:
+    """In-memory index of validated connector policies."""
+
+    policies: dict[str, ConnectorPolicy] = field(default_factory=dict)
+    warnings: list[str] = field(default_factory=list)
+    source_label: str = "inline"
+
+    def get(self, connector_id: str) -> Optional[ConnectorPolicy]:
+        return self.policies.get(connector_id)
+
+    def by_fingerprint(self, fingerprint: str) -> list[ConnectorPolicy]:
+        return [
+            policy
+            for policy in self.policies.values()
+            if policy.credential_ref.verification_fingerprint == fingerprint
+        ]
+
+    def enabled_policies(self) -> list[ConnectorPolicy]:
+        return [policy for policy in self.policies.values() if policy.enabled]
+
+
+def load_schema(path: Optional[Path] = None) -> dict[str, Any]:
+    schema_path = path or DEFAULT_SCHEMA_PATH
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+def schema_validator(schema: Optional[dict[str, Any]] = None) -> Draft202012Validator:
+    document = schema if schema is not None else load_schema()
+    Draft202012Validator.check_schema(document)
+    return Draft202012Validator(document)
+
+
+def parse_connector_policy_document(
+    raw: Any,
+    *,
+    schema: Optional[dict[str, Any]] = None,
+    source_label: str = "inline",
+) -> ConnectorPolicyStore:
+    """Parse a connector policy document or single record fail-closed."""
+    store = ConnectorPolicyStore(source_label=source_label)
+    validator = schema_validator(schema)
+    records = _extract_records(raw, store)
+    for index, record in enumerate(records):
+        policy, error = _parse_record(record, validator)
+        if error is not None:
+            store.warnings.append(f"record[{index}]: {error}")
+            continue
+        assert policy is not None
+        if policy.connector_id in store.policies:
+            store.warnings.append(
+                f"record[{index}]: duplicate connector_id dropped ({policy.connector_id})"
+            )
+            # Ambiguous identity: drop both.
+            store.policies.pop(policy.connector_id, None)
+            continue
+        store.policies[policy.connector_id] = policy
+    return store
+
+
+def load_connector_policy_path(
+    path: Path,
+    *,
+    schema: Optional[dict[str, Any]] = None,
+) -> ConnectorPolicyStore:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        store = ConnectorPolicyStore(source_label=str(path))
+        store.warnings.append(f"policy file unreadable: {exc.__class__.__name__}")
+        return store
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError:
+        store = ConnectorPolicyStore(source_label=str(path))
+        store.warnings.append("policy file YAML parse error")
+        return store
+    return parse_connector_policy_document(raw, schema=schema, source_label=str(path.name))
+
+
+def resolve_policy_path(explicit: Optional[str] = None) -> Path:
+    import os
+
+    raw = explicit or os.getenv(ENV_POLICY_PATH)
+    if not raw:
+        raise ValueError("connector policy path not configured")
+    return Path(raw).expanduser()
+
+
+def public_policy_receipt(policy: ConnectorPolicy) -> dict[str, Any]:
+    """Serialize non-secret policy fields for tests/audit (no raw credentials)."""
+    return {
+        "connector_id": policy.connector_id,
+        "provider": policy.provider,
+        "transport_class": policy.transport_class,
+        "enabled": policy.enabled,
+        "default_target_id": policy.default_target_id,
+        "allowed_target_ids": list(policy.allowed_target_ids),
+        "allowed_tools": list(policy.allowed_tools),
+        "denied_tools": list(policy.denied_tools),
+        "credential_fingerprint": policy.credential_ref.verification_fingerprint,
+        "rotation_group": policy.credential_ref.rotation_group,
+        "credential_kind": policy.credential_ref.kind,
+        "credential_reference": policy.credential_ref.reference,
+        "audit_label": policy.audit_label,
+        "expires_at": policy.expires_at,
+        "rate_limit": {
+            "requests_per_minute": policy.rate_limit.requests_per_minute,
+            "burst": policy.rate_limit.burst,
+            "max_concurrent": policy.rate_limit.max_concurrent,
+            "deny_on_backend_unavailable": policy.rate_limit.deny_on_backend_unavailable,
+        },
+    }
+
+
+def _extract_records(raw: Any, store: ConnectorPolicyStore) -> list[dict[str, Any]]:
+    if isinstance(raw, dict) and isinstance(raw.get("records"), list):
+        if raw.get("examples_only") is True:
+            store.warnings.append("document marked examples_only; records are templates")
+        out: list[dict[str, Any]] = []
+        for item in raw["records"]:
+            if isinstance(item, dict):
+                out.append(item)
+            else:
+                store.warnings.append("non-object record dropped")
+        return out
+    if isinstance(raw, dict):
+        return [raw]
+    if isinstance(raw, list):
+        out = []
+        for item in raw:
+            if isinstance(item, dict):
+                out.append(item)
+            else:
+                store.warnings.append("non-object record dropped")
+        return out
+    store.warnings.append("policy document must be object or list")
+    return []
+
+
+def _parse_record(
+    record: dict[str, Any], validator: Draft202012Validator
+) -> tuple[Optional[ConnectorPolicy], Optional[str]]:
+    errors = sorted(validator.iter_errors(record), key=lambda err: list(err.path))
+    if errors:
+        return None, f"schema: {errors[0].message}"
+
+    cred_raw = record["credential_ref"]
+    reference = cred_raw["reference"]
+    kind = cred_raw["kind"]
+    if kind == "environment" and not reference.startswith("env:"):
+        return None, "environment credential_ref.reference must use env:VAR form"
+    if not _is_locator_reference(kind, reference):
+        return None, "credential_ref.reference must be a non-secret locator"
+    if _looks_like_secret(reference):
+        return None, "credential_ref.reference appears to contain secret material"
+
+    # Defense in depth: run redaction categories over reference/fingerprint.
+    _, categories = redact_value(reference, [])
+    if categories:
+        return None, "credential_ref.reference failed redaction hygiene"
+
+    default_target = record.get("default_target_id")
+    allowed_targets = tuple(record["allowed_target_ids"])
+    if default_target is not None and default_target not in allowed_targets:
+        return None, "default_target_id must appear in allowed_target_ids"
+
+    multi = bool(record.get("multi_target_authorized", False))
+    if not multi and len(allowed_targets) > 1:
+        return None, "multi_target_authorized is false but multiple targets listed"
+
+    rate_raw = record["rate_limit"]
+    if rate_raw.get("deny_on_backend_unavailable") is not True:
+        return None, "rate_limit.deny_on_backend_unavailable must be true"
+    for key in ("requests_per_minute", "burst", "max_concurrent"):
+        if key not in rate_raw:
+            return None, "missing_rate_policy"
+
+    fail_closed = record["fail_closed"]
+    for key in _FAIL_CLOSED_KEYS:
+        if fail_closed.get(key) != "BLOCK":
+            return None, f"fail_closed.{key} must be BLOCK"
+
+    if record.get("schema_version") != SCHEMA_VERSION:
+        return None, "unsupported schema_version"
+
+    if record.get("expires_at") is not None and _parse_datetime(record["expires_at"]) is None:
+        return None, "expires_at is not a valid date-time"
+
+    policy = ConnectorPolicy(
+        schema_version=record["schema_version"],
+        connector_id=record["connector_id"],
+        provider=record["provider"],
+        transport_class=record["transport_class"],
+        credential_ref=CredentialRef(
+            kind=cred_raw["kind"],
+            reference=reference,
+            verification_fingerprint=cred_raw["verification_fingerprint"],
+            rotation_group=cred_raw["rotation_group"],
+        ),
+        default_target_id=default_target,
+        allowed_target_ids=allowed_targets,
+        multi_target_authorized=multi,
+        allowed_tools=tuple(record["allowed_tools"]),
+        denied_tools=tuple(record.get("denied_tools") or ()),
+        enabled=bool(record["enabled"]),
+        rate_limit=RateLimitPolicy(
+            requests_per_minute=int(rate_raw["requests_per_minute"]),
+            burst=int(rate_raw["burst"]),
+            max_concurrent=int(rate_raw["max_concurrent"]),
+            deny_on_backend_unavailable=True,
+        ),
+        audit_label=record["audit_label"],
+        created_by=record["created_by"],
+        created_at=record["created_at"],
+        expires_at=record.get("expires_at"),
+        last_verified_at=record.get("last_verified_at"),
+        source_documentation_date=record["source_documentation_date"],
+        provider_account_class=record["provider_account_class"],
+        fail_closed=dict(fail_closed),
+        provider_metadata=dict(record.get("provider_metadata") or {}),
+    )
+    return policy, None
+
+
+def _is_locator_reference(kind: str, value: str) -> bool:
+    """Require non-secret locator forms; reject bare password-like strings."""
+    if value.startswith("<") and value.endswith(">"):
+        return True  # repository template placeholder only
+    if kind == "environment":
+        return bool(re.fullmatch(r"env:[A-Za-z_][A-Za-z0-9_]*", value))
+    if kind == "os_keychain":
+        return value.startswith(("keychain:", "os_keychain:", "<"))
+    if kind == "secret_manager":
+        return value.startswith(("secret:", "sm:", "secret_manager:", "<"))
+    if kind == "oauth_client":
+        return value.startswith(("oauth:", "oauth_client:", "<"))
+    if kind == "mtls_identity":
+        return value.startswith(("mtls:", "mtls_identity:", "<"))
+    return False
+
+
+def _looks_like_secret(value: str) -> bool:
+    if _SECRET_LIKE.search(value):
+        return True
+    # High-entropy blobs without a locator prefix are treated as secret-like.
+    if re.fullmatch(r"[A-Za-z0-9+/=_\-]{16,}", value):
+        if value.startswith(("env:", "keychain:", "secret:", "sm:", "oauth:", "mtls:")):
+            return False
+        if value.startswith("<") and value.endswith(">"):
+            return False
+        return True
+    return False
+
+
+def _parse_datetime(value: str) -> Optional[datetime]:
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def iter_enabled_tool_names(policy: ConnectorPolicy) -> Iterable[str]:
+    denied = set(policy.denied_tools)
+    for tool in policy.allowed_tools:
+        if tool not in denied:
+            yield tool

--- a/services/dcp-readonly-facade/tests/fixtures/connector_policy/disabled.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/connector_policy/disabled.yaml
@@ -1,0 +1,38 @@
+schema_version: "1.0.0"
+connector_id: "chatgpt-disabled"
+provider: "chatgpt"
+transport_class: "openai_secure_mcp_tunnel"
+credential_ref:
+  kind: "environment"
+  reference: "env:DCP_TEST_DISABLED_TOKEN"
+  verification_fingerprint: "fp:chatgpt:disabled01"
+  rotation_group: "dcp-chatgpt"
+default_target_id: "dopemux-main"
+allowed_target_ids: ["dopemux-main"]
+multi_target_authorized: false
+allowed_tools: ["list_targets"]
+denied_tools: []
+enabled: false
+rate_limit:
+  requests_per_minute: 10
+  burst: 1
+  max_concurrent: 1
+  deny_on_backend_unavailable: true
+audit_label: "provider.chatgpt.disabled"
+created_by: "operator-test"
+created_at: "2099-01-01T00:00:00Z"
+expires_at: "2099-02-01T00:00:00Z"
+last_verified_at: null
+source_documentation_date: "2026-07-15"
+provider_account_class: "business"
+fail_closed:
+  unknown_target: "BLOCK"
+  disabled_target: "BLOCK"
+  unauthorized_target: "BLOCK"
+  denied_tool: "BLOCK"
+  expired_credential: "BLOCK"
+  ambiguous_owner: "BLOCK"
+  stale_runtime: "BLOCK"
+  auth_failure: "BLOCK"
+  missing_rate_policy: "BLOCK"
+  provider_drift: "BLOCK"

--- a/services/dcp-readonly-facade/tests/fixtures/connector_policy/expired.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/connector_policy/expired.yaml
@@ -1,0 +1,38 @@
+schema_version: "1.0.0"
+connector_id: "chatgpt-expired"
+provider: "chatgpt"
+transport_class: "openai_secure_mcp_tunnel"
+credential_ref:
+  kind: "environment"
+  reference: "env:DCP_TEST_EXPIRED_TOKEN"
+  verification_fingerprint: "fp:chatgpt:expired01"
+  rotation_group: "dcp-chatgpt"
+default_target_id: "dopemux-main"
+allowed_target_ids: ["dopemux-main"]
+multi_target_authorized: false
+allowed_tools: ["list_targets"]
+denied_tools: []
+enabled: true
+rate_limit:
+  requests_per_minute: 10
+  burst: 1
+  max_concurrent: 1
+  deny_on_backend_unavailable: true
+audit_label: "provider.chatgpt.expired"
+created_by: "operator-test"
+created_at: "2020-01-01T00:00:00Z"
+expires_at: "2020-02-01T00:00:00Z"
+last_verified_at: null
+source_documentation_date: "2026-07-15"
+provider_account_class: "business"
+fail_closed:
+  unknown_target: "BLOCK"
+  disabled_target: "BLOCK"
+  unauthorized_target: "BLOCK"
+  denied_tool: "BLOCK"
+  expired_credential: "BLOCK"
+  ambiguous_owner: "BLOCK"
+  stale_runtime: "BLOCK"
+  auth_failure: "BLOCK"
+  missing_rate_policy: "BLOCK"
+  provider_drift: "BLOCK"

--- a/services/dcp-readonly-facade/tests/fixtures/connector_policy/multi_record_store.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/connector_policy/multi_record_store.yaml
@@ -1,0 +1,73 @@
+schema_version: "1.0.0"
+examples_only: false
+records:
+  - schema_version: "1.0.0"
+    connector_id: "chatgpt-dopemux-main"
+    provider: "chatgpt"
+    transport_class: "openai_secure_mcp_tunnel"
+    credential_ref:
+      kind: "environment"
+      reference: "env:DCP_TEST_CONNECTOR_TOKEN"
+      verification_fingerprint: "fp:chatgpt:testdigest01"
+      rotation_group: "dcp-chatgpt"
+    default_target_id: "dopemux-main"
+    allowed_target_ids: ["dopemux-main"]
+    multi_target_authorized: false
+    allowed_tools:
+      - "list_targets"
+      - "get_target_capabilities"
+      - "get_target_repo_state_snapshot"
+    denied_tools:
+      - "mutation-tool-denied"
+    enabled: true
+    rate_limit:
+      requests_per_minute: 30
+      burst: 5
+      max_concurrent: 2
+      deny_on_backend_unavailable: true
+    audit_label: "provider.chatgpt.dopemux-main"
+    created_by: "operator-test"
+    created_at: "2099-01-01T00:00:00Z"
+    expires_at: "2099-02-01T00:00:00Z"
+    last_verified_at: null
+    source_documentation_date: "2026-07-15"
+    provider_account_class: "business"
+    fail_closed: &fail_closed
+      unknown_target: "BLOCK"
+      disabled_target: "BLOCK"
+      unauthorized_target: "BLOCK"
+      denied_tool: "BLOCK"
+      expired_credential: "BLOCK"
+      ambiguous_owner: "BLOCK"
+      stale_runtime: "BLOCK"
+      auth_failure: "BLOCK"
+      missing_rate_policy: "BLOCK"
+      provider_drift: "BLOCK"
+  - schema_version: "1.0.0"
+    connector_id: "grok-feature-review-a7"
+    provider: "grok"
+    transport_class: "public_streamable_http"
+    credential_ref:
+      kind: "environment"
+      reference: "env:DCP_TEST_GROK_TOKEN"
+      verification_fingerprint: "fp:grok:testdigest02"
+      rotation_group: "dcp-grok"
+    default_target_id: "feature-review-a7"
+    allowed_target_ids: ["feature-review-a7"]
+    multi_target_authorized: false
+    allowed_tools: ["list_targets"]
+    denied_tools: ["mutation-tool-denied"]
+    enabled: true
+    rate_limit:
+      requests_per_minute: 20
+      burst: 4
+      max_concurrent: 1
+      deny_on_backend_unavailable: true
+    audit_label: "provider.grok.feature-review-a7"
+    created_by: "operator-test"
+    created_at: "2099-01-01T00:00:00Z"
+    expires_at: "2099-02-01T00:00:00Z"
+    last_verified_at: null
+    source_documentation_date: "2026-06-14"
+    provider_account_class: "individual"
+    fail_closed: *fail_closed

--- a/services/dcp-readonly-facade/tests/fixtures/connector_policy/valid_enabled.yaml
+++ b/services/dcp-readonly-facade/tests/fixtures/connector_policy/valid_enabled.yaml
@@ -1,0 +1,46 @@
+schema_version: "1.0.0"
+connector_id: "chatgpt-dopemux-main"
+provider: "chatgpt"
+transport_class: "openai_secure_mcp_tunnel"
+credential_ref:
+  kind: "environment"
+  reference: "env:DCP_TEST_CONNECTOR_TOKEN"
+  verification_fingerprint: "fp:chatgpt:testdigest01"
+  rotation_group: "dcp-chatgpt"
+default_target_id: "dopemux-main"
+allowed_target_ids: ["dopemux-main"]
+multi_target_authorized: false
+allowed_tools:
+  - "list_targets"
+  - "get_target_capabilities"
+  - "get_target_repo_state_snapshot"
+denied_tools:
+  - "mutation-tool-denied"
+enabled: true
+rate_limit:
+  requests_per_minute: 30
+  burst: 5
+  max_concurrent: 2
+  deny_on_backend_unavailable: true
+audit_label: "provider.chatgpt.dopemux-main"
+created_by: "operator-test"
+created_at: "2099-01-01T00:00:00Z"
+expires_at: "2099-02-01T00:00:00Z"
+last_verified_at: null
+source_documentation_date: "2026-07-15"
+provider_account_class: "business"
+provider_metadata:
+  public_hostname_label: null
+  server_name: "dopemux"
+  account_or_workspace_ref: "<OPAQUE_CHATGPT_WORKSPACE_REF>"
+fail_closed:
+  unknown_target: "BLOCK"
+  disabled_target: "BLOCK"
+  unauthorized_target: "BLOCK"
+  denied_tool: "BLOCK"
+  expired_credential: "BLOCK"
+  ambiguous_owner: "BLOCK"
+  stale_runtime: "BLOCK"
+  auth_failure: "BLOCK"
+  missing_rate_policy: "BLOCK"
+  provider_drift: "BLOCK"

--- a/services/dcp-readonly-facade/tests/test_auth_context.py
+++ b/services/dcp-readonly-facade/tests/test_auth_context.py
@@ -1,0 +1,224 @@
+"""Provider-neutral auth context tests (TP-DCP-MCP-RO-0013)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+from dcp_facade import auth_context as AUTH
+from dcp_facade import connector_policy as CP
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "connector_policy"
+
+
+def _store(name: str) -> CP.ConnectorPolicyStore:
+    raw = yaml.safe_load((_FIXTURES / name).read_text(encoding="utf-8"))
+    return CP.parse_connector_policy_document(raw)
+
+
+def _resolver(token: str = "test-token-alpha", ref: str = "env:DCP_TEST_CONNECTOR_TOKEN"):
+    return AUTH.MappingSecretResolver({("environment", ref): token})
+
+
+def test_authenticate_bearer_success():
+    store = _store("valid_enabled.yaml")
+    context, decision = AUTH.authenticate_bearer(
+        store,
+        authorization_header="Bearer test-token-alpha",
+        secret_resolver=_resolver(),
+    )
+    assert decision.allowed is True
+    assert context is not None
+    assert context.connector_id == "chatgpt-dopemux-main"
+    assert "test-token-alpha" not in repr(context)
+    assert AUTH.verify_context_seal(context) is True
+
+
+def test_missing_token_is_generic_failure():
+    store = _store("valid_enabled.yaml")
+    context, decision = AUTH.authenticate_bearer(store, authorization_header=None)
+    assert context is None
+    assert decision.allowed is False
+    assert decision.reason == AUTH.GENERIC_AUTH_FAILURE
+    assert decision.connector_id is None
+
+
+def test_wrong_token_is_generic_failure():
+    store = _store("valid_enabled.yaml")
+    context, decision = AUTH.authenticate_bearer(
+        store,
+        authorization_header="Bearer wrong-token",
+        secret_resolver=_resolver(),
+    )
+    assert context is None
+    assert decision.allowed is False
+    assert decision.reason == AUTH.GENERIC_AUTH_FAILURE
+    assert "wrong-token" not in repr(decision)
+
+
+def test_disabled_connector_fails_closed(monkeypatch):
+    store = _store("disabled.yaml")
+    resolver = AUTH.MappingSecretResolver(
+        {("environment", "env:DCP_TEST_DISABLED_TOKEN"): "disabled-token"}
+    )
+    context, decision = AUTH.authenticate_bearer(
+        store,
+        presented_token="disabled-token",
+        secret_resolver=resolver,
+    )
+    assert context is None
+    assert decision.allowed is False
+    assert decision.reason == AUTH.GENERIC_AUTH_FAILURE
+
+
+def test_expired_connector_fails_closed():
+    store = _store("expired.yaml")
+    resolver = AUTH.MappingSecretResolver(
+        {("environment", "env:DCP_TEST_EXPIRED_TOKEN"): "expired-token"}
+    )
+    context, decision = AUTH.authenticate_bearer(
+        store,
+        presented_token="expired-token",
+        secret_resolver=resolver,
+        now=datetime(2021, 1, 1, tzinfo=timezone.utc),
+    )
+    assert context is None
+    assert decision.allowed is False
+    assert decision.reason == AUTH.GENERIC_AUTH_FAILURE
+
+
+def test_missing_credential_resolution_fails_closed():
+    store = _store("valid_enabled.yaml")
+    # Default env resolver has no token set.
+    context, decision = AUTH.authenticate_bearer(
+        store,
+        authorization_header="Bearer test-token-alpha",
+    )
+    assert context is None
+    assert decision.allowed is False
+
+
+def test_target_and_tool_authorization_matrix():
+    store = _store("valid_enabled.yaml")
+    context, decision = AUTH.authenticate_bearer(
+        store,
+        presented_token="test-token-alpha",
+        secret_resolver=_resolver(),
+    )
+    assert decision.allowed and context is not None
+
+    ok_target = AUTH.authorize_target(context, "dopemux-main")
+    deny_target = AUTH.authorize_target(context, "other-target")
+    ok_tool = AUTH.authorize_tool(context, "list_targets")
+    deny_tool = AUTH.authorize_tool(context, "mutation-tool-denied")
+    unknown_tool = AUTH.authorize_tool(context, "not-a-tool")
+
+    assert ok_target.allowed is True
+    assert deny_target.allowed is False and deny_target.reason == AUTH.GENERIC_TARGET_DENY
+    assert ok_tool.allowed is True
+    assert deny_tool.allowed is False and deny_tool.reason == AUTH.GENERIC_TOOL_DENY
+    assert unknown_tool.allowed is False
+
+
+def test_forged_context_cannot_authorize():
+    forged = AUTH.forge_context_attempt(
+        connector_id="chatgpt-dopemux-main",
+        allowed_target_ids=("dopemux-main",),
+        allowed_tools=("list_targets",),
+        seal="not-a-real-seal",
+    )
+    assert AUTH.verify_context_seal(forged) is False
+    assert AUTH.authorize_target(forged, "dopemux-main").allowed is False
+    assert AUTH.authorize_tool(forged, "list_targets").allowed is False
+
+
+def test_untrusted_headers_never_authenticate():
+    decision = AUTH.context_from_untrusted_headers(
+        {
+            "X-DCP-Connector-Id": "chatgpt-dopemux-main",
+            "X-DCP-Connector-Seal": "anything",
+            "Authorization": "Bearer test-token-alpha",
+        }
+    )
+    assert decision.allowed is False
+    assert decision.reason == AUTH.GENERIC_AUTH_FAILURE
+
+
+def test_header_redaction_strips_connector_claims_and_bearer():
+    cleaned, redactions = AUTH.strip_untrusted_connector_headers(
+        {
+            "X-DCP-Connector-Id": "chatgpt-dopemux-main",
+            "Authorization": "Bearer super-secret-token-value",
+            "Accept": "application/json",
+        }
+    )
+    assert "X-DCP-Connector-Id" not in cleaned
+    assert cleaned["Authorization"] == "Bearer <redacted>"
+    assert cleaned["Accept"] == "application/json"
+    assert "super-secret-token-value" not in repr(cleaned)
+    assert any(item.startswith("stripped:") for item in redactions)
+    assert "secrets" in redactions
+
+
+def test_credential_rotation_revokes_old_token():
+    store = _store("valid_enabled.yaml")
+    old = AUTH.MappingSecretResolver(
+        {("environment", "env:DCP_TEST_CONNECTOR_TOKEN"): "token-v1"}
+    )
+    new = AUTH.MappingSecretResolver(
+        {("environment", "env:DCP_TEST_CONNECTOR_TOKEN"): "token-v2"}
+    )
+
+    ctx_old, decision_old = AUTH.authenticate_bearer(
+        store, presented_token="token-v1", secret_resolver=old
+    )
+    assert decision_old.allowed and ctx_old is not None
+
+    # After rotation, old token no longer resolves.
+    ctx_stale, decision_stale = AUTH.authenticate_bearer(
+        store, presented_token="token-v1", secret_resolver=new
+    )
+    assert ctx_stale is None and decision_stale.allowed is False
+
+    ctx_new, decision_new = AUTH.authenticate_bearer(
+        store, presented_token="token-v2", secret_resolver=new
+    )
+    assert decision_new.allowed and ctx_new is not None
+    # Identity remains independently revocable by connector_id; fingerprint stable.
+    assert ctx_new.connector_id == ctx_old.connector_id
+    assert ctx_new.credential_fingerprint == ctx_old.credential_fingerprint
+
+
+def test_independent_connectors_do_not_cross_authorize():
+    store = _store("multi_record_store.yaml")
+    resolver = AUTH.MappingSecretResolver(
+        {
+            ("environment", "env:DCP_TEST_CONNECTOR_TOKEN"): "chatgpt-token",
+            ("environment", "env:DCP_TEST_GROK_TOKEN"): "grok-token",
+        }
+    )
+    chatgpt, d1 = AUTH.authenticate_bearer(
+        store, presented_token="chatgpt-token", secret_resolver=resolver
+    )
+    grok, d2 = AUTH.authenticate_bearer(
+        store, presented_token="grok-token", secret_resolver=resolver
+    )
+    assert d1.allowed and d2.allowed
+    assert chatgpt is not None and grok is not None
+    assert AUTH.authorize_target(chatgpt, "feature-review-a7").allowed is False
+    assert AUTH.authorize_target(grok, "dopemux-main").allowed is False
+    assert AUTH.authorize_target(chatgpt, "dopemux-main").allowed is True
+    assert AUTH.authorize_target(grok, "feature-review-a7").allowed is True
+
+
+def test_resolve_request_target_default():
+    store = _store("valid_enabled.yaml")
+    context, _ = AUTH.authenticate_bearer(
+        store, presented_token="test-token-alpha", secret_resolver=_resolver()
+    )
+    assert context is not None
+    target, decision = AUTH.resolve_request_target(context, None)
+    assert decision.allowed is True
+    assert target == "dopemux-main"

--- a/services/dcp-readonly-facade/tests/test_connector_policy.py
+++ b/services/dcp-readonly-facade/tests/test_connector_policy.py
@@ -1,0 +1,128 @@
+"""Connector policy schema/loader tests (TP-DCP-MCP-RO-0013)."""
+
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+from jsonschema import Draft202012Validator
+
+from dcp_facade import connector_policy as CP
+
+_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "schema" / "connector_policy.schema.json"
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "connector_policy"
+_DOC_EXAMPLE = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "03-reference"
+    / "dcp"
+    / "chatgpt-mcp-readonly"
+    / "CONNECTOR_POLICY_EXAMPLE.yaml"
+)
+
+
+def _schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _load(name: str):
+    return yaml.safe_load((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def test_schema_is_self_valid():
+    Draft202012Validator.check_schema(_schema())
+
+
+def test_schema_accepts_valid_fixture():
+    Draft202012Validator(_schema()).validate(_load("valid_enabled.yaml"))
+
+
+def test_doc_example_records_validate():
+    doc = yaml.safe_load(_DOC_EXAMPLE.read_text(encoding="utf-8"))
+    validator = Draft202012Validator(_schema())
+    assert doc.get("examples_only") is True
+    for record in doc["records"]:
+        validator.validate(record)
+
+
+def test_loader_accepts_valid_record():
+    store = CP.parse_connector_policy_document(_load("valid_enabled.yaml"))
+    assert "chatgpt-dopemux-main" in store.policies
+    policy = store.get("chatgpt-dopemux-main")
+    assert policy is not None
+    assert policy.enabled is True
+    assert policy.default_target_id == "dopemux-main"
+    assert "list_targets" in policy.allowed_tools
+
+
+def test_loader_rejects_secret_like_credential_reference():
+    raw = _load("valid_enabled.yaml")
+    raw["credential_ref"]["reference"] = "sk-abcdefghijklmnopqrstuvwxyz"
+    store = CP.parse_connector_policy_document(raw)
+    assert store.policies == {}
+    assert any(
+        "secret material" in warning or "locator" in warning or "env:VAR" in warning
+        for warning in store.warnings
+    )
+
+
+def test_loader_rejects_bare_short_password_as_reference():
+    raw = _load("valid_enabled.yaml")
+    raw["credential_ref"]["reference"] = "ShortPassw0rd!!!!"
+    store = CP.parse_connector_policy_document(raw)
+    assert store.policies == {}
+
+
+def test_loader_rejects_default_target_not_in_allowlist():
+    raw = _load("valid_enabled.yaml")
+    raw["default_target_id"] = "other-target"
+    store = CP.parse_connector_policy_document(raw)
+    assert store.policies == {}
+    assert any("default_target_id" in warning for warning in store.warnings)
+
+
+def test_loader_rejects_non_block_fail_closed():
+    raw = _load("valid_enabled.yaml")
+    raw["fail_closed"]["auth_failure"] = "ALLOW"
+    store = CP.parse_connector_policy_document(raw)
+    assert store.policies == {}
+
+
+def test_multi_record_store_loads_independent_identities():
+    store = CP.parse_connector_policy_document(_load("multi_record_store.yaml"))
+    assert set(store.policies) == {"chatgpt-dopemux-main", "grok-feature-review-a7"}
+    assert store.get("chatgpt-dopemux-main").provider == "chatgpt"
+    assert store.get("grok-feature-review-a7").provider == "grok"
+
+
+def test_duplicate_connector_id_drops_ambiguous_identity():
+    raw = _load("multi_record_store.yaml")
+    duplicate = deepcopy(raw["records"][0])
+    duplicate["audit_label"] = "provider.chatgpt.duplicate"
+    raw["records"].append(duplicate)
+    store = CP.parse_connector_policy_document(raw)
+    assert "chatgpt-dopemux-main" not in store.policies
+    assert "grok-feature-review-a7" in store.policies
+    assert any("duplicate connector_id" in warning for warning in store.warnings)
+
+
+def test_public_receipt_has_no_raw_secret_material():
+    store = CP.parse_connector_policy_document(_load("valid_enabled.yaml"))
+    policy = store.get("chatgpt-dopemux-main")
+    assert policy is not None
+    receipt = CP.public_policy_receipt(policy)
+    rendered = repr(receipt)
+    assert "sk-" not in rendered
+    assert receipt["credential_reference"] == "env:DCP_TEST_CONNECTOR_TOKEN"
+    assert receipt["credential_fingerprint"].startswith("fp:")
+
+
+def test_expired_helper():
+    store = CP.parse_connector_policy_document(_load("expired.yaml"))
+    policy = store.get("chatgpt-expired")
+    assert policy is not None
+    assert policy.is_expired() is True

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -135,6 +135,7 @@ A packet is superseded by another packet
 | TP-DCP-MCP-RO-0007 | DCP / MCP | Secure MCP Tunnel Integration Docs And Manual Validation | Active | N/A |
 | TP-DCP-MCP-RO-0008 | DCP / MCP | Hardening Cross Project Isolation And PR Readiness | Active | N/A |
 | TP-DCP-MCP-RO-0012 | DCP / MCP | Public Facade Target Contract Migration | Active | TP-DCP-MCP-RO-0011-REMEDIATION-01 |
+| TP-DCP-MCP-RO-0013 | DCP / MCP | Connector Policy Schema And Auth Context | Active | TP-DCP-MCP-RO-0012 |
 | DMX-DCP-PROMPT5-EXTRACT-RECON-001 | DCP / Prompt 5 | Extract Prompt 5 chat-history docs and reconcile PR/Task Orchestrator runway state | Active | N/A |
 
 ────────────────────────────────────────────────────────────

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.json
@@ -1,0 +1,115 @@
+{
+  "id": "TP-DCP-MCP-RO-0013",
+  "project": "dopemux-mvp",
+  "target": "Implement strict connector policy schema/loader and provider-neutral authentication context with independently revocable connector identities and target/tool authorization, without public ingress or real credentials.",
+  "invariants": [
+    "Connector policy records store only non-secret credential references and fingerprints; raw secrets never enter the repository or auth context objects.",
+    "Authentication failures for missing, disabled, expired, wrong, or unknown connectors remain generic and do not reflect secrets or topology.",
+    "Trusted connector context is sealed and cannot be forged from inbound identity headers.",
+    "Target and tool authorization are deny-by-default from the authenticated connector policy only.",
+    "No public listener, tunnel, backend adapter, credential vault population, or runtime lifecycle mutation is introduced."
+  ],
+  "depends_on": [
+    "TP-DCP-MCP-RO-0012"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DCP-MCP-RO",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DCP-MCP-RO-0012",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dcp-mcp-ro-0013-connector-auth",
+    "base_branch": "main",
+    "stacked_because": "TP-DCP-MCP-RO-0012 public target contract is merged on main (PR #1057)."
+  },
+  "commit": {
+    "message": "feat(dcp): add connector policy schema and auth context",
+    "allowlist": [
+      "services/dcp-readonly-facade/src/dcp_facade/connector_policy.py",
+      "services/dcp-readonly-facade/src/dcp_facade/auth_context.py",
+      "services/dcp-readonly-facade/schema/connector_policy.schema.json",
+      "services/dcp-readonly-facade/tests/test_connector_policy.py",
+      "services/dcp-readonly-facade/tests/test_auth_context.py",
+      "services/dcp-readonly-facade/tests/fixtures/connector_policy/**",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/CONNECTOR_POLICY_CONTRACT.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/CONNECTOR_POLICY_EXAMPLE.yaml",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.md",
+      "task-packets/INDEX.md",
+      "proof/TP-DCP-MCP-RO-0013/**"
+    ],
+    "verify": [
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_connector_policy.py services/dcp-readonly-facade/tests/test_auth_context.py",
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests",
+      "uv run --frozen python -m compileall -q services/dcp-readonly-facade/src",
+      "python -m json.tool task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.json",
+      "python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "git diff --check",
+      "pre-commit run --files <changed-files>"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): add connector policy schema and auth context",
+    "body": "Implements TP-DCP-MCP-RO-0013: strict connector policy schema/loader and provider-neutral authentication context with sealed non-forgeable connector identity, target/tool authorization, header redaction, and rotation/revocation tests. No public ingress, tunnels, real credentials, or backend mutations.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "secaudit",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "policy-schema-loader",
+      "task": "Land the connector policy JSON Schema, fail-closed document loader, semantic constraints, and redacted repository example templates.",
+      "validation": [
+        "Schema self-validates and accepts the repository example records.",
+        "Loader rejects secret-like credential references, invalid default targets, and non-BLOCK fail_closed values."
+      ]
+    },
+    {
+      "id": "auth-context",
+      "task": "Implement provider-neutral bearer authentication, sealed connector context, target/tool authorization, and untrusted-header stripping without a public listener.",
+      "validation": [
+        "Missing, disabled, expired, and wrong credentials fail with generic authentication errors.",
+        "Forged context and connector-identity headers cannot authorize targets or tools.",
+        "Rotation invalidates old tokens while preserving independent connector identity."
+      ]
+    },
+    {
+      "id": "docs-packet-proof",
+      "task": "Document the contract, register the packet in the series index, and emit local proof with advisory AGY review only.",
+      "validation": [
+        "Packet validates against dopetask-canonical-spec.json.",
+        "Proof marks trusted embedded audit as SKIPPED/NOT_RUN and does not claim merge readiness."
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Run focused and full facade tests, compileall, diff hygiene, pre-commit on allowlisted files, and open a PR without merge.",
+      "validation": [
+        "All local validation outputs are captured in proof or marked NOT_RUN with the blocker.",
+        "No real credentials, tunnels, or public ingress changes appear in the diff."
+      ]
+    }
+  ]
+}

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.md
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.md
@@ -1,0 +1,64 @@
+---
+id: TP-DCP-MCP-RO-0013
+title: Connector Policy Schema And Auth Context
+type: explanation
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+prelude: Strict connector policy schema/loader and provider-neutral authentication context for the DCP read-only multi-provider series.
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+---
+# TP-DCP-MCP-RO-0013
+
+## Objective
+
+Implement the connector policy contract and provider-neutral authentication
+context so later ingress can authorize independently revocable connectors
+before target resolution and tool dispatch.
+
+## Scope
+
+IN:
+
+- Connector policy JSON Schema and fail-closed loader/store.
+- Bearer authentication against non-secret credential references.
+- Sealed connector auth context; target/tool authorization.
+- Header stripping/redaction for forgeable connector claims.
+- Contract docs, redacted examples, tests, packet, proof.
+
+OUT:
+
+- Public listeners, tunnels, provider setup, real credentials, backend
+  adapters, ownership probes, compose/CI auditor routing, populated operator
+  policy files.
+
+## Invariants
+
+- Raw secrets never enter the repository, policy documents, or sealed context.
+- Auth failures stay generic across missing/disabled/expired/wrong identity.
+- Connector-identity headers are never trusted as authentication.
+- Deny-by-default for targets and tools outside the connector allowlists.
+- No public ingress or live backend/provider action in this packet.
+
+## Validation
+
+```text
+uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_connector_policy.py services/dcp-readonly-facade/tests/test_auth_context.py
+uv run --frozen pytest -q services/dcp-readonly-facade/tests
+uv run --frozen python -m compileall -q services/dcp-readonly-facade/src
+uv run --frozen python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+git diff --check
+```
+
+## Stop Conditions
+
+- Implementation requires a public bind, tunnel, or real provider credential.
+- Diff includes files outside the packet allowlist.
+- Auth context can be forged from headers or retains raw secrets.
+- Trusted embedded audit is claimed from local AGY evidence.
+
+## Rollback
+
+Revert the TP-0013 commit stack. Auth primitives are unused by the public
+FastMCP server in this packet, so rollback does not change live exposure.


### PR DESCRIPTION
## Summary

Implements **TP-DCP-MCP-RO-0013** on top of merged TP-0012 (#1057).

- Strict connector policy JSON Schema + fail-closed loader/store
- Provider-neutral sealed bearer authentication context
- Target/tool authorization, header stripping/redaction, rotation tests
- Redacted repository examples only (`enabled: false` templates)
- **No** public listener, tunnel, real credentials, backend adapters, or lifecycle changes

## Validation (local)

- Focused tests: 25 passed (`test_connector_policy`, `test_auth_context`)
- Full facade suite: passed (1 opt-in live test skipped)
- compileall, packet schema validation, pre-commit on allowlist: passed
- AGY local review: `PASS_WITH_RISKS` (advisory only; seal/locator hardenings applied)

## Readiness blockers (explicit)

- Trusted **embedded audit**: SKIPPED / not claimed (local-only; AGY ≠ `embedded-audit.yml`)
- **PR Steward** readiness: not claimed
- **Merge readiness**: not claimed

## Packet / proof

- `task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0013.json`
- `proof/TP-DCP-MCP-RO-0013/`

## Test plan

- [x] Local focused + full facade tests
- [ ] CI unit/docs checks
- [ ] Trusted embedded audit (blocked without runner/credentials)
- [ ] Operator review of auth/policy surface before TP-0014 ingress wiring