### PR TITLE
feat(dcp): add loopback authenticated streamable HTTP ingress

### DIFF
--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md
@@ -30,6 +30,7 @@ prelude: Packet roadmap and dependency chain for the read-only MCP evidence faca
 | TP-DCP-MCP-RO-0011-REMEDIATION-01 | Runtime Catalog Join Generated Identity Remediation | HIGH | Correct the open 0011 PR so lifecycle-generated runtime IDs match without changing target authorization or live behavior. | 0011 |
 | TP-DCP-MCP-RO-0012 | Public Facade Target Contract Migration | HIGH | Migrate public FastMCP to registry-v2 opaque target_id local evidence tools. **Done** — merged PR #1057. | 0011-REMEDIATION-01 |
 | TP-DCP-MCP-RO-0013 | Connector Policy Schema And Auth Context | HIGH | Strict connector policy schema/loader and provider-neutral sealed auth context with target/tool authorization. **No public ingress.** | 0012 |
+| TP-DCP-MCP-RO-0014 | Loopback Streamable HTTP Ingress | HIGH | Auth-before-discovery loopback HTTP ingress, rate limits, redacted audit, start/stop/health. **No public bind/tunnel.** | 0013 |
 
 ## Sequencing rationale
 

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md
@@ -35,8 +35,11 @@ cd services/dcp-readonly-facade
 python -m src.mcp.server
 ```
 
-`DCP_FACADE_TRANSPORT` defaults to `stdio`. `fastmcp` is required for a live
-MCP endpoint; the import fallback exists only for constrained test environments.
+`DCP_FACADE_TRANSPORT` defaults to `stdio`. Set it to `streamable-http` for the
+loopback authenticated ingress (host pinned to `127.0.0.1`; see
+[`INGRESS_LOOPBACK_CONTRACT.md`](INGRESS_LOOPBACK_CONTRACT.md)). `fastmcp` is
+required for a full live MCP app; the import fallback exists for constrained
+test environments and still enforces auth on the placeholder `/mcp` surface.
 
 ## Tool Surface
 

--- a/docs/03-reference/dcp/chatgpt-mcp-readonly/INGRESS_LOOPBACK_CONTRACT.md
+++ b/docs/03-reference/dcp/chatgpt-mcp-readonly/INGRESS_LOOPBACK_CONTRACT.md
@@ -1,0 +1,96 @@
+---
+id: dcp-mcp-readonly-ingress-loopback-contract
+title: DCP Loopback Streamable HTTP Ingress Contract
+type: reference
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+prelude: Hardened loopback Streamable HTTP ingress with auth-before-discovery, rate limits, redacted audit, and start/stop/health for the DCP read-only facade.
+---
+
+# Loopback Streamable HTTP Ingress Contract
+
+Packet: **TP-DCP-MCP-RO-0014**
+
+## Scope
+
+This packet adds a **loopback-only** authenticated ingress in front of the facade
+MCP surface:
+
+- Pin bind host to `127.0.0.1` / loopback (reject `0.0.0.0` and LAN hosts)
+- Authenticate connector policy credentials **before** MCP discovery/dispatch
+- Per-connector rate and concurrency limits
+- Structured redacted audit events
+- Deterministic start / stop / health
+
+It does **not** create tunnels, public binds, provider credentials, backend
+adapters, or compose exposure defaults.
+
+## Modules
+
+| Module | Role |
+| --- | --- |
+| `dcp_facade.ingress` | ASGI auth middleware + protected MCP placeholder app |
+| `dcp_facade.loopback_server` | Loopback bind, uvicorn lifecycle, env wiring |
+| `dcp_facade.rate_limit` | Per-connector token bucket + concurrency |
+| `dcp_facade.ingress_audit` | Bounded redacted audit log |
+
+Depends on TP-0013: `connector_policy` + `auth_context`.
+
+## Transport selection
+
+| `DCP_FACADE_TRANSPORT` | Behavior |
+| --- | --- |
+| `stdio` (default) | Existing FastMCP stdio path; no listener |
+| `streamable-http` / `http` / `loopback-http` | Loopback ingress on `DCP_FACADE_INGRESS_HOST`:`DCP_FACADE_INGRESS_PORT` |
+
+Environment:
+
+```text
+DCP_FACADE_INGRESS_HOST=127.0.0.1   # required loopback
+DCP_FACADE_INGRESS_PORT=8765       # or 0 for ephemeral in tests
+DCP_FACADE_CONNECTOR_POLICY=/path/to/operator-policy.yaml
+```
+
+## Routes
+
+| Path | Auth | Behavior |
+| --- | --- | --- |
+| `/health`, `/healthz` | no | Liveness only; never lists tools |
+| `/mcp` (+ prefixes) | **required** | Discovery/dispatch only after sealed connector auth |
+| other non-health | **required** | Fail closed (no bypass surface) |
+
+Unauthenticated MCP requests return HTTP 401 with a generic authentication
+error and **no tool manifest**.
+
+## Rate limits
+
+After successful authentication, the connector's policy `rate_limit` applies:
+
+- `requests_per_minute` + `burst` (token bucket)
+- `max_concurrent` in-flight requests
+
+Exceeded limits return HTTP 429 without reflecting secrets or topology.
+
+## Audit
+
+Each decision records: timestamp, decision, path, method, connector_id (when
+known), credential fingerprint, status, generic reason, redaction categories.
+Raw bearer tokens never appear in audit dumps.
+
+## FastMCP coupling
+
+When FastMCP is installed and exposes an HTTP app factory, the loopback server
+attempts to wrap it. When FastMCP is absent (test/constrained envs), an
+authenticated placeholder MCP app serves a minimal tools list for contract tests.
+Either way, auth middleware remains outside the inner app.
+
+## Validation commands
+
+```text
+uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_ingress.py services/dcp-readonly-facade/tests/test_loopback_server.py
+uv run --frozen pytest -q services/dcp-readonly-facade/tests
+uv run --frozen python -m compileall -q services/dcp-readonly-facade/src
+```

--- a/proof/TP-DCP-MCP-RO-0014/AGY_AUDIT.md
+++ b/proof/TP-DCP-MCP-RO-0014/AGY_AUDIT.md
@@ -1,0 +1,26 @@
+# AGY Audit: TP-DCP-MCP-RO-0014
+
+## Provenance
+
+- Auditor: AGY / Google Antigravity CLI
+- Mode: single-turn local read-only prompt
+- Verdict: `PASS_WITH_RISKS`
+
+## Verified
+
+- Design requires loopback-only bind and auth-before-discovery for MCP paths.
+- Unauthenticated discovery is intended to fail without tool disclosure.
+- Audit path must not retain raw bearer tokens.
+- No tunnel creation is in scope for this packet.
+
+## Residual risks (accepted / deferred)
+
+- Host-level DNS rebinding and tunnel edge controls remain operator/host concerns;
+  this packet enforces application bind and auth gates only.
+- Full FastMCP HTTP app wrapping depends on optional fastmcp install; placeholder
+  authenticated app covers contract tests when FastMCP is absent.
+- Trusted `embedded-audit.yml` is not satisfied by this local AGY review.
+
+## Boundary
+
+Advisory only. Not workflow-issued embedded-audit proof.

--- a/proof/TP-DCP-MCP-RO-0014/AUDITOR_REPORT.md
+++ b/proof/TP-DCP-MCP-RO-0014/AUDITOR_REPORT.md
@@ -1,0 +1,16 @@
+# TP-DCP-MCP-RO-0014 Auditor Report
+
+## Verdict
+
+`SKIPPED` for canonical embedded-audit. Local-only direction; no runner/credentials
+for the trusted Claude audit route. AGY recorded separately as advisory.
+
+## Local Evidence
+
+- Focused ingress + loopback server tests passed.
+- Full facade suite passed (opt-in live test skipped).
+- Packet schema validation, compileall, pre-commit on allowlist, AGY PASS_WITH_RISKS.
+
+## Boundary
+
+Do not claim PR Steward or merge readiness from AGY alone.

--- a/proof/TP-DCP-MCP-RO-0014/COMMAND_LOG.md
+++ b/proof/TP-DCP-MCP-RO-0014/COMMAND_LOG.md
@@ -1,0 +1,19 @@
+# TP-DCP-MCP-RO-0014 Command Log
+
+Branch: `codex/dcp-mcp-ro-0014-loopback-ingress`
+Base: `origin/main` @ `4079da8387bae0cf8b2971de547f092a3f6b8408` (includes merged TP-0013 / PR #1059)
+
+| Command | Result |
+| --- | --- |
+| Package SHA-256 c0cb9d34…2447 | PASS (advisory) |
+| 0013 dependency on main | PASS |
+| 0014 collision search | PASS (none) |
+| Focused ingress/loopback tests | PASS (11) |
+| Full facade suite | PASS; 1 live skip |
+| compileall | PASS |
+| packet jsonschema | PASS |
+| pre-commit allowlist | PASS |
+| agy advisory | PASS_WITH_RISKS |
+| Trusted embedded audit / PR Steward | NOT_RUN / not claimed |
+
+No tunnel, public bind default, provider credential, or backend mutation run.

--- a/proof/TP-DCP-MCP-RO-0014/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0014/PROOF.json
@@ -1,0 +1,117 @@
+{
+  "packet_id": "TP-DCP-MCP-RO-0014",
+  "title": "Loopback Streamable HTTP Ingress",
+  "status": "VALIDATED_WITH_AUDIT_GAP",
+  "repo": "DDD-Enterprises/dopemux-mvp",
+  "branch": "codex/dcp-mcp-ro-0014-loopback-ingress",
+  "base_branch": "main",
+  "base_sha": "4079da8387bae0cf8b2971de547f092a3f6b8408",
+  "depends_on_verified": {
+    "TP-DCP-MCP-RO-0013": {
+      "pr": 1059,
+      "merge_commit": "4079da8387bae0cf8b2971de547f092a3f6b8408",
+      "status": "MERGED"
+    }
+  },
+  "scope": "Loopback-only Streamable HTTP ingress with auth-before-discovery, rate/concurrency limits, redacted audit, start/stop/health. Stdio remains default. No public bind, tunnel, real credentials, or backend adapters.",
+  "input_package": {
+    "sha256": "c0cb9d34f6ece116811c52cce0d1b517153dba0f8434c9abda9da6ff6d6a2447",
+    "authority": "advisory_only"
+  },
+  "files_changed": [
+    "services/dcp-readonly-facade/src/dcp_facade/ingress.py",
+    "services/dcp-readonly-facade/src/dcp_facade/loopback_server.py",
+    "services/dcp-readonly-facade/src/dcp_facade/rate_limit.py",
+    "services/dcp-readonly-facade/src/dcp_facade/ingress_audit.py",
+    "services/dcp-readonly-facade/src/mcp/server.py",
+    "services/dcp-readonly-facade/tests/test_ingress.py",
+    "services/dcp-readonly-facade/tests/test_loopback_server.py",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/INGRESS_LOOPBACK_CONTRACT.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md",
+    "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.json",
+    "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.md",
+    "task-packets/INDEX.md",
+    "proof/TP-DCP-MCP-RO-0014/PROOF.json",
+    "proof/TP-DCP-MCP-RO-0014/AUDITOR_REPORT.md",
+    "proof/TP-DCP-MCP-RO-0014/AGY_AUDIT.md",
+    "proof/TP-DCP-MCP-RO-0014/COMMAND_LOG.md"
+  ],
+  "validation": {
+    "PASS": [
+      {
+        "command": "focused ingress/loopback tests",
+        "exit_code": 0,
+        "result": "11 passed"
+      },
+      {
+        "command": "full facade suite",
+        "exit_code": 0,
+        "result": "passed; 1 live skipped"
+      },
+      {
+        "command": "compileall",
+        "exit_code": 0,
+        "result": "ok"
+      },
+      {
+        "command": "packet schema",
+        "exit_code": 0,
+        "result": "valid"
+      },
+      {
+        "command": "pre-commit allowlist",
+        "exit_code": 0,
+        "result": "ok"
+      },
+      {
+        "command": "agy advisory",
+        "exit_code": 0,
+        "result": "PASS_WITH_RISKS"
+      }
+    ],
+    "FAIL": [],
+    "NOT_RUN": [
+      {
+        "command": "Trusted embedded audit / PR Steward",
+        "reason": "local-only; AGY advisory only",
+        "mitigation": "readiness not claimed"
+      },
+      {
+        "command": "Tunnel / public provider live tests",
+        "reason": "out of scope and unauthorized",
+        "mitigation": "loopback-only packet"
+      }
+    ]
+  },
+  "local_agy_review": {
+    "status": "PASS_WITH_RISKS",
+    "ci_trust_status": "NOT_ACCEPTED"
+  },
+  "embedded_audit": {
+    "required": true,
+    "status": "SKIPPED",
+    "report_path": "proof/TP-DCP-MCP-RO-0014/AUDITOR_REPORT.md",
+    "skip_reason": "No trusted runner/Claude audit route; AGY is advisory only and does not satisfy embedded-audit.yml.",
+    "fixes_applied": [
+      "Loopback-only bind enforcement",
+      "Auth-before-discovery ASGI middleware",
+      "Per-connector rate/concurrency limits",
+      "Redacted structured audit log",
+      "Start/stop/health lifecycle"
+    ],
+    "remaining_risks": [
+      "Trusted embedded audit unavailable",
+      "Optional FastMCP HTTP app wrapping not always present in constrained envs"
+    ]
+  },
+  "residual_risks": [
+    "Operator must keep ingress on loopback and not publish tunnels without later authorization",
+    "Generated .claude/claude_config.json left unstaged"
+  ],
+  "rollback": "Revert TP-0014 commits; keep DCP_FACADE_TRANSPORT=stdio",
+  "pr": {
+    "status": "PENDING_CREATE",
+    "blocker": "Trusted embedded audit SKIPPED; merge readiness not claimed"
+  }
+}

--- a/proof/TP-DCP-MCP-RO-0014/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0014/PROOF.json
@@ -116,8 +116,11 @@
   ],
   "rollback": "Revert TP-0014 commits; keep DCP_FACADE_TRANSPORT=stdio",
   "pr": {
-    "status": "PENDING_CREATE",
-    "blocker": "Trusted embedded audit SKIPPED; merge readiness not claimed"
+    "number": 1060,
+    "status": "OPEN_NOT_READY",
+    "url": "https://github.com/DDD-Enterprises/dopemux-mvp/pull/1060",
+    "head_at_creation": "852f5c838",
+    "blocker": "Trusted embedded audit SKIPPED; AGY advisory only; merge readiness not claimed."
   },
   "implementation_commit": "b0d82b10aa006b2e9f36f998845a3ea33e165bde"
 }

--- a/proof/TP-DCP-MCP-RO-0014/PROOF.json
+++ b/proof/TP-DCP-MCP-RO-0014/PROOF.json
@@ -91,7 +91,12 @@
   "embedded_audit": {
     "required": true,
     "status": "SKIPPED",
+    "auditor_tool": "none",
+    "auditor_model": "unknown",
+    "invocation": null,
+    "exit_code": null,
     "report_path": "proof/TP-DCP-MCP-RO-0014/AUDITOR_REPORT.md",
+    "findings": [],
     "skip_reason": "No trusted runner/Claude audit route; AGY is advisory only and does not satisfy embedded-audit.yml.",
     "fixes_applied": [
       "Loopback-only bind enforcement",
@@ -113,5 +118,6 @@
   "pr": {
     "status": "PENDING_CREATE",
     "blocker": "Trusted embedded audit SKIPPED; merge readiness not claimed"
-  }
+  },
+  "implementation_commit": "b0d82b10aa006b2e9f36f998845a3ea33e165bde"
 }

--- a/services/dcp-readonly-facade/src/dcp_facade/ingress.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/ingress.py
@@ -1,0 +1,284 @@
+"""Provider-neutral authenticated ASGI ingress for loopback MCP (TP-0014).
+
+Auth runs before any MCP discovery/dispatch path. This module does not open
+sockets; see ``loopback_server`` for pinned loopback binding.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Awaitable, Callable, Iterable, Mapping, MutableMapping, Optional
+
+from .auth_context import (
+    GENERIC_AUTH_FAILURE,
+    ConnectorAuthContext,
+    MappingSecretResolver,
+    SecretResolver,
+    authenticate_bearer,
+    strip_untrusted_connector_headers,
+    verify_context_seal,
+)
+from .connector_policy import ConnectorPolicyStore
+from .ingress_audit import IngressAuditEvent, IngressAuditLog, now_ts
+from .rate_limit import ConnectorRateLimiter, RateLimitConfig
+
+ASGIApp = Callable[[dict, Callable, Callable], Awaitable[None]]
+
+# Paths that never disclose tools and may be unauthenticated.
+HEALTH_PATHS = frozenset({"/health", "/healthz"})
+# MCP/discovery/dispatch paths require authentication.
+PROTECTED_PREFIXES = ("/mcp", "/sse", "/messages", "/message")
+
+
+def _headers_map(scope_headers: Iterable[tuple[bytes, bytes]]) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for key, value in scope_headers:
+        out[key.decode("latin-1")] = value.decode("latin-1")
+    return out
+
+
+def _header_get(headers: Mapping[str, str], name: str) -> Optional[str]:
+    lowered = name.lower()
+    for key, value in headers.items():
+        if key.lower() == lowered:
+            return value
+    return None
+
+
+def _client_host(scope: Mapping[str, Any]) -> Optional[str]:
+    client = scope.get("client")
+    if isinstance(client, (list, tuple)) and client:
+        return str(client[0])
+    return None
+
+
+def _json_response(status: int, body: dict[str, Any]) -> tuple[int, list[tuple[bytes, bytes]], bytes]:
+    payload = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(payload)).encode("ascii")),
+        (b"cache-control", b"no-store"),
+    ]
+    return status, headers, payload
+
+
+async def _send_raw(send: Callable, status: int, headers: list[tuple[bytes, bytes]], body: bytes) -> None:
+    await send({"type": "http.response.start", "status": status, "headers": headers})
+    await send({"type": "http.response.body", "body": body, "more_body": False})
+
+
+def is_protected_path(path: str) -> bool:
+    if path in HEALTH_PATHS:
+        return False
+    return any(path == prefix or path.startswith(prefix + "/") for prefix in PROTECTED_PREFIXES)
+
+
+class AuthIngressMiddleware:
+    """ASGI middleware: strip forgeable headers, authenticate, rate-limit, audit."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        policy_store: ConnectorPolicyStore,
+        secret_resolver: Optional[SecretResolver] = None,
+        audit_log: Optional[IngressAuditLog] = None,
+        rate_limiter: Optional[ConnectorRateLimiter] = None,
+        require_auth_for_all_non_health: bool = True,
+    ) -> None:
+        self.app = app
+        self.policy_store = policy_store
+        self.secret_resolver = secret_resolver or MappingSecretResolver({})
+        self.audit_log = audit_log or IngressAuditLog()
+        self.rate_limiter = rate_limiter or ConnectorRateLimiter()
+        self.require_auth_for_all_non_health = require_auth_for_all_non_health
+
+    async def __call__(self, scope: dict, receive: Callable, send: Callable) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path") or "/"
+        method = (scope.get("method") or "GET").upper()
+        raw_headers = _headers_map(scope.get("headers") or [])
+        cleaned_headers, redactions = strip_untrusted_connector_headers(raw_headers)
+        client_host = _client_host(scope)
+
+        # Rebuild scope headers without forgeable connector claims; redact bearer
+        # is only for outbound audit copies — the app still needs Authorization
+        # for auth, so keep original Authorization in a private auth view.
+        auth_header = _header_get(raw_headers, "authorization")
+        scope_headers = []
+        for key, value in cleaned_headers.items():
+            if key.lower() == "authorization":
+                # Do not forward raw Authorization to the inner app.
+                continue
+            scope_headers.append((key.lower().encode("latin-1"), value.encode("latin-1")))
+        scope = dict(scope)
+        scope["headers"] = scope_headers
+        state: MutableMapping[str, Any] = scope.setdefault("state", {})  # type: ignore[assignment]
+
+        if path in HEALTH_PATHS:
+            status, headers, body = _json_response(
+                200,
+                {
+                    "status": "ok",
+                    "service": "dcp-readonly-facade-ingress",
+                    "auth_required_for_mcp": True,
+                },
+            )
+            self.audit_log.record(
+                IngressAuditEvent(
+                    ts=now_ts(),
+                    decision="allow_health",
+                    path=path,
+                    method=method,
+                    status_code=status,
+                    reason="health",
+                    client_host=client_host,
+                    redactions=redactions,
+                )
+            )
+            await _send_raw(send, status, headers, body)
+            return
+
+        needs_auth = is_protected_path(path) or self.require_auth_for_all_non_health
+        if not needs_auth:
+            await self.app(scope, receive, send)
+            return
+
+        context, decision = authenticate_bearer(
+            self.policy_store,
+            authorization_header=auth_header,
+            secret_resolver=self.secret_resolver,
+        )
+        if not decision.allowed or context is None or not verify_context_seal(context):
+            status, headers, body = _json_response(
+                401,
+                {"error": GENERIC_AUTH_FAILURE, "status": "BLOCKED"},
+            )
+            self.audit_log.record(
+                IngressAuditEvent(
+                    ts=now_ts(),
+                    decision="deny_auth",
+                    path=path,
+                    method=method,
+                    status_code=status,
+                    reason=GENERIC_AUTH_FAILURE,
+                    client_host=client_host,
+                    redactions=redactions + ["secrets"],
+                )
+            )
+            await _send_raw(send, status, headers, body)
+            return
+
+        rate_cfg = RateLimitConfig(
+            requests_per_minute=context.rate_limit_rpm,
+            burst=context.rate_limit_burst,
+            max_concurrent=context.rate_limit_max_concurrent,
+        )
+        rate = self.rate_limiter.allow(context.connector_id, rate_cfg)
+        if not rate.allowed:
+            status, headers, body = _json_response(
+                429,
+                {"error": "rate limit exceeded", "status": "BLOCKED"},
+            )
+            headers.append((b"retry-after", str(int(rate.retry_after_seconds or 1)).encode("ascii")))
+            self.audit_log.record(
+                IngressAuditEvent(
+                    ts=now_ts(),
+                    decision="deny_rate",
+                    path=path,
+                    method=method,
+                    connector_id=context.connector_id,
+                    credential_fingerprint=context.credential_fingerprint,
+                    audit_label=context.audit_label,
+                    status_code=status,
+                    reason=rate.reason,
+                    client_host=client_host,
+                    redactions=redactions,
+                )
+            )
+            await _send_raw(send, status, headers, body)
+            return
+
+        state["connector_auth_context"] = context
+        state["connector_id"] = context.connector_id
+
+        status_box = {"code": 200}
+
+        async def send_wrapper(message: dict) -> None:
+            if message.get("type") == "http.response.start":
+                status_box["code"] = int(message.get("status") or 200)
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+            self.audit_log.record(
+                IngressAuditEvent(
+                    ts=now_ts(),
+                    decision="allow",
+                    path=path,
+                    method=method,
+                    connector_id=context.connector_id,
+                    credential_fingerprint=context.credential_fingerprint,
+                    audit_label=context.audit_label,
+                    status_code=status_box["code"],
+                    reason="authenticated",
+                    client_host=client_host,
+                    redactions=redactions,
+                )
+            )
+        finally:
+            self.rate_limiter.release(context.connector_id)
+
+
+def build_protected_mcp_placeholder_app(
+    *,
+    tool_names: Optional[list[str]] = None,
+) -> ASGIApp:
+    """Minimal authenticated MCP-like app used when FastMCP HTTP app is unavailable.
+
+    Only reachable after AuthIngressMiddleware allows the request.
+    """
+
+    tools = tool_names or [
+        "list_targets",
+        "get_target_capabilities",
+        "get_target_repo_state_snapshot",
+        "list_target_proof_bundles",
+        "fetch_target_proof_bundle",
+        "get_target_runtime_receipt",
+    ]
+
+    async def app(scope: dict, receive: Callable, send: Callable) -> None:
+        if scope["type"] != "http":
+            return
+        path = scope.get("path") or "/"
+        method = (scope.get("method") or "GET").upper()
+        state = scope.get("state") or {}
+        context = state.get("connector_auth_context")
+        if not isinstance(context, ConnectorAuthContext) or not verify_context_seal(context):
+            status, headers, body = _json_response(401, {"error": GENERIC_AUTH_FAILURE})
+            await _send_raw(send, status, headers, body)
+            return
+
+        if path.startswith("/mcp") and method in {"GET", "POST"}:
+            # Discovery payload only after auth.
+            allowed = [name for name in tools if name in context.allowed_tools and name not in context.denied_tools]
+            status, headers, body = _json_response(
+                200,
+                {
+                    "status": "OK",
+                    "authenticated_connector": context.connector_id,
+                    "tools": [{"name": name} for name in allowed],
+                    "transport": "streamable-http-loopback",
+                },
+            )
+            await _send_raw(send, status, headers, body)
+            return
+
+        status, headers, body = _json_response(404, {"error": "not found"})
+        await _send_raw(send, status, headers, body)
+
+    return app

--- a/services/dcp-readonly-facade/src/dcp_facade/ingress_audit.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/ingress_audit.py
@@ -1,0 +1,69 @@
+"""Structured redacted audit events for the loopback ingress (TP-0014)."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Optional
+
+from .redaction import redact_value
+
+
+@dataclass
+class IngressAuditEvent:
+    ts: float
+    decision: str
+    path: str
+    method: str
+    connector_id: Optional[str] = None
+    credential_fingerprint: Optional[str] = None
+    audit_label: Optional[str] = None
+    status_code: int = 0
+    reason: str = ""
+    client_host: Optional[str] = None
+    redactions: list[str] = field(default_factory=list)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        raw = asdict(self)
+        clean, cats = redact_value(raw, [])
+        if isinstance(clean, dict):
+            clean["redactions"] = sorted(set(list(clean.get("redactions") or []) + cats))
+            return clean
+        return {"event": clean, "redactions": cats}
+
+
+class IngressAuditLog:
+    """In-memory bounded audit log for tests and local operators."""
+
+    def __init__(self, *, max_events: int = 1000):
+        self._max = max(1, max_events)
+        self._events: list[IngressAuditEvent] = []
+        self._lock = threading.Lock()
+
+    def record(self, event: IngressAuditEvent) -> IngressAuditEvent:
+        # Never retain raw Authorization-like material in reason/path.
+        clean_reason, cats = redact_value(event.reason, [])
+        event.reason = str(clean_reason)
+        event.redactions = sorted(set(event.redactions + cats))
+        with self._lock:
+            self._events.append(event)
+            if len(self._events) > self._max:
+                self._events = self._events[-self._max :]
+        return event
+
+    def events(self) -> list[IngressAuditEvent]:
+        with self._lock:
+            return list(self._events)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._events.clear()
+
+    def dump_json_lines(self) -> str:
+        return "\n".join(json.dumps(ev.to_public_dict(), sort_keys=True) for ev in self.events())
+
+
+def now_ts() -> float:
+    return time.time()

--- a/services/dcp-readonly-facade/src/dcp_facade/loopback_server.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/loopback_server.py
@@ -1,0 +1,237 @@
+"""Pinned loopback Streamable HTTP server lifecycle (TP-DCP-MCP-RO-0014).
+
+Only loopback hosts are accepted. Public binds (0.0.0.0, ::, LAN IPs) fail closed.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import uvicorn
+
+from .auth_context import MappingSecretResolver, SecretResolver
+from .connector_policy import ConnectorPolicyStore, load_connector_policy_path
+from .ingress import AuthIngressMiddleware, ASGIApp, build_protected_mcp_placeholder_app
+from .ingress_audit import IngressAuditLog
+from .rate_limit import ConnectorRateLimiter
+
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8765
+ENV_HOST = "DCP_FACADE_INGRESS_HOST"
+ENV_PORT = "DCP_FACADE_INGRESS_PORT"
+ENV_POLICY = "DCP_FACADE_CONNECTOR_POLICY"
+
+
+class NonLoopbackBindError(ValueError):
+    """Raised when a non-loopback bind is requested."""
+
+
+def assert_loopback_host(host: str) -> str:
+    normalized = (host or "").strip().lower()
+    if normalized not in LOOPBACK_HOSTS:
+        raise NonLoopbackBindError(
+            f"refusing non-loopback ingress bind host={host!r}; allowed={sorted(LOOPBACK_HOSTS)}"
+        )
+    # Prefer IPv4 loopback for deterministic tests and socket proof.
+    if normalized == "localhost":
+        return "127.0.0.1"
+    return "127.0.0.1" if normalized == "127.0.0.1" else normalized
+
+
+@dataclass
+class IngressHealth:
+    running: bool
+    host: Optional[str]
+    port: Optional[int]
+    bind: Optional[str]
+    auth_required: bool = True
+    transport: str = "streamable-http-loopback"
+
+
+class LoopbackIngressServer:
+    """Deterministic start/stop/health for the authenticated loopback ingress."""
+
+    def __init__(
+        self,
+        *,
+        app: Optional[ASGIApp] = None,
+        policy_store: Optional[ConnectorPolicyStore] = None,
+        secret_resolver: Optional[SecretResolver] = None,
+        audit_log: Optional[IngressAuditLog] = None,
+        rate_limiter: Optional[ConnectorRateLimiter] = None,
+        host: str = DEFAULT_HOST,
+        port: int = 0,
+    ) -> None:
+        self.host = assert_loopback_host(host)
+        self.port = int(port)
+        self.audit_log = audit_log or IngressAuditLog()
+        self.rate_limiter = rate_limiter or ConnectorRateLimiter()
+        self.policy_store = policy_store or ConnectorPolicyStore()
+        self.secret_resolver = secret_resolver or MappingSecretResolver({})
+        inner = app or build_protected_mcp_placeholder_app()
+        self.app = AuthIngressMiddleware(
+            inner,
+            policy_store=self.policy_store,
+            secret_resolver=self.secret_resolver,
+            audit_log=self.audit_log,
+            rate_limiter=self.rate_limiter,
+        )
+        self._server: Optional[uvicorn.Server] = None
+        self._thread: Optional[threading.Thread] = None
+        self._bound_host: Optional[str] = None
+        self._bound_port: Optional[int] = None
+
+    @property
+    def bound_url(self) -> Optional[str]:
+        if self._bound_host is None or self._bound_port is None:
+            return None
+        return f"http://{self._bound_host}:{self._bound_port}"
+
+    def health(self) -> IngressHealth:
+        running = bool(self._server is not None and self._thread is not None and self._thread.is_alive())
+        return IngressHealth(
+            running=running,
+            host=self._bound_host,
+            port=self._bound_port,
+            bind=f"{self._bound_host}:{self._bound_port}" if running else None,
+        )
+
+    def start(self, *, timeout_seconds: float = 5.0) -> IngressHealth:
+        if self.health().running:
+            return self.health()
+
+        host = assert_loopback_host(self.host)
+        config = uvicorn.Config(
+            self.app,
+            host=host,
+            port=self.port,
+            log_level="warning",
+            access_log=False,
+            lifespan="off",
+        )
+        server = uvicorn.Server(config)
+        # Prevent uvicorn installing signal handlers in a thread.
+        server.install_signal_handlers = lambda: None  # type: ignore[method-assign]
+
+        thread = threading.Thread(target=server.run, name="dcp-loopback-ingress", daemon=True)
+        self._server = server
+        self._thread = thread
+        thread.start()
+
+        deadline = time.time() + timeout_seconds
+        while time.time() < deadline:
+            # uvicorn sets server.servers after bind
+            servers = getattr(server, "servers", None) or []
+            for srv in servers:
+                sockets = getattr(srv, "sockets", None) or []
+                for sock in sockets:
+                    try:
+                        name = sock.getsockname()
+                    except OSError:
+                        continue
+                    bound_host, bound_port = name[0], int(name[1])
+                    # Force loopback proof even if platform returns expanded form.
+                    if bound_host not in LOOPBACK_HOSTS and not str(bound_host).startswith("127."):
+                        self.stop()
+                        raise NonLoopbackBindError(f"bound non-loopback address: {bound_host}")
+                    self._bound_host = "127.0.0.1" if bound_host in {"127.0.0.1", "localhost"} else bound_host
+                    self._bound_port = bound_port
+                    return self.health()
+            if server.started:
+                # Port may be available via config if already started.
+                if self.port and self.port > 0:
+                    self._bound_host = host
+                    self._bound_port = self.port
+                    return self.health()
+            time.sleep(0.02)
+
+        self.stop()
+        raise TimeoutError("loopback ingress failed to bind in time")
+
+    def stop(self, *, timeout_seconds: float = 5.0) -> IngressHealth:
+        server = self._server
+        thread = self._thread
+        if server is not None:
+            server.should_exit = True
+        if thread is not None and thread.is_alive():
+            thread.join(timeout=timeout_seconds)
+        self._server = None
+        self._thread = None
+        self._bound_host = None
+        self._bound_port = None
+        return self.health()
+
+
+def resolve_inner_mcp_app() -> ASGIApp:
+    """Prefer FastMCP HTTP app when installed; otherwise authenticated placeholder."""
+    try:
+        from mcp.server import mcp  # type: ignore
+
+        for attr in ("http_app", "streamable_http_app", "sse_app"):
+            factory = getattr(mcp, attr, None)
+            if callable(factory):
+                app = factory()
+                if app is not None:
+                    return app
+    except Exception:
+        pass
+    return build_protected_mcp_placeholder_app()
+
+
+def build_server_from_env(
+    *,
+    secret_resolver: Optional[SecretResolver] = None,
+    policy_store: Optional[ConnectorPolicyStore] = None,
+) -> LoopbackIngressServer:
+    host = assert_loopback_host(os.getenv(ENV_HOST, DEFAULT_HOST))
+    port = int(os.getenv(ENV_PORT, str(DEFAULT_PORT)))
+    store = policy_store
+    if store is None:
+        policy_path = os.getenv(ENV_POLICY)
+        if policy_path:
+            store = load_connector_policy_path(Path(policy_path).expanduser())
+        else:
+            store = ConnectorPolicyStore()
+            store.warnings.append("no connector policy configured; all MCP auth will fail closed")
+    return LoopbackIngressServer(
+        app=resolve_inner_mcp_app(),
+        policy_store=store,
+        secret_resolver=secret_resolver,
+        host=host,
+        port=port,
+    )
+
+
+def run_loopback_ingress_forever() -> None:
+    """CLI entry used by server.main for streamable-http transport."""
+    server = build_server_from_env()
+    health = server.start()
+    print(
+        f"dcp-readonly-facade loopback ingress listening on {health.bind} "
+        f"(auth required for /mcp; health on /health)",
+        flush=True,
+    )
+    try:
+        while server.health().running:
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.stop()
+
+
+def probe_loopback_bind(host: str = "127.0.0.1", port: int = 0) -> tuple[str, int]:
+    """Pure socket proof helper: bind loopback and return actual host/port."""
+    host = assert_loopback_host(host)
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind((host, port))
+        bound_host, bound_port = sock.getsockname()[:2]
+        return bound_host, int(bound_port)

--- a/services/dcp-readonly-facade/src/dcp_facade/rate_limit.py
+++ b/services/dcp-readonly-facade/src/dcp_facade/rate_limit.py
@@ -1,0 +1,90 @@
+"""Per-connector rate and concurrency limits (TP-DCP-MCP-RO-0014)."""
+
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class RateLimitConfig:
+    requests_per_minute: int
+    burst: int
+    max_concurrent: int
+
+
+@dataclass
+class RateLimitDecision:
+    allowed: bool
+    reason: str
+    code: str
+    retry_after_seconds: float = 0.0
+
+
+class ConnectorRateLimiter:
+    """Token-bucket + concurrency gate keyed by connector_id."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._buckets: dict[str, _Bucket] = {}
+        self._inflight: dict[str, int] = {}
+
+    def allow(self, connector_id: str, config: RateLimitConfig, *, now: Optional[float] = None) -> RateLimitDecision:
+        current = now if now is not None else time.monotonic()
+        with self._lock:
+            bucket = self._buckets.get(connector_id)
+            if bucket is None:
+                bucket = _Bucket(
+                    tokens=float(config.burst),
+                    updated_at=current,
+                    rpm=config.requests_per_minute,
+                    burst=config.burst,
+                )
+                self._buckets[connector_id] = bucket
+            else:
+                bucket.rpm = config.requests_per_minute
+                bucket.burst = config.burst
+
+            bucket.refill(current)
+            inflight = self._inflight.get(connector_id, 0)
+            if inflight >= config.max_concurrent:
+                return RateLimitDecision(
+                    allowed=False,
+                    reason="rate limit exceeded",
+                    code="max_concurrent",
+                    retry_after_seconds=0.5,
+                )
+            if bucket.tokens < 1.0:
+                return RateLimitDecision(
+                    allowed=False,
+                    reason="rate limit exceeded",
+                    code="requests_per_minute",
+                    retry_after_seconds=max(0.1, 60.0 / max(config.requests_per_minute, 1)),
+                )
+            bucket.tokens -= 1.0
+            self._inflight[connector_id] = inflight + 1
+            return RateLimitDecision(allowed=True, reason="ok", code="ok")
+
+    def release(self, connector_id: str) -> None:
+        with self._lock:
+            inflight = self._inflight.get(connector_id, 0)
+            if inflight <= 1:
+                self._inflight.pop(connector_id, None)
+            else:
+                self._inflight[connector_id] = inflight - 1
+
+
+class _Bucket:
+    def __init__(self, *, tokens: float, updated_at: float, rpm: int, burst: int):
+        self.tokens = tokens
+        self.updated_at = updated_at
+        self.rpm = rpm
+        self.burst = burst
+
+    def refill(self, now: float) -> None:
+        elapsed = max(0.0, now - self.updated_at)
+        self.updated_at = now
+        rate_per_sec = max(self.rpm, 1) / 60.0
+        self.tokens = min(float(self.burst), self.tokens + elapsed * rate_per_sec)

--- a/services/dcp-readonly-facade/src/mcp/server.py
+++ b/services/dcp-readonly-facade/src/mcp/server.py
@@ -2,7 +2,11 @@
 
 The external server loads only registry v2 from ``DCP_FACADE_REGISTRY_V2``.
 It exposes local, read-only target evidence only; backend adapters, public
-ingress, credentials, and runtime lifecycle operations are deliberately absent.
+ingress defaults, tunnels, and runtime lifecycle mutations remain out of scope.
+
+Stdio remains the default transport. Optional loopback Streamable HTTP ingress
+(``DCP_FACADE_TRANSPORT=streamable-http``) is pinned to 127.0.0.1 and requires
+connector authentication before MCP discovery/dispatch (TP-DCP-MCP-RO-0014).
 """
 
 from __future__ import annotations
@@ -72,7 +76,12 @@ async def get_target_runtime_receipt(target_id: str) -> dict:
 
 
 def main() -> None:
-    transport = os.getenv("DCP_FACADE_TRANSPORT", "stdio")
+    transport = os.getenv("DCP_FACADE_TRANSPORT", "stdio").strip().lower()
+    if transport in {"streamable-http", "http", "loopback-http"}:
+        from dcp_facade.loopback_server import run_loopback_ingress_forever
+
+        run_loopback_ingress_forever()
+        return
     mcp.run(transport=transport)
 
 

--- a/services/dcp-readonly-facade/tests/test_ingress.py
+++ b/services/dcp-readonly-facade/tests/test_ingress.py
@@ -1,0 +1,185 @@
+"""Authenticated loopback ingress tests (TP-DCP-MCP-RO-0014)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from dcp_facade.auth_context import MappingSecretResolver
+from dcp_facade.connector_policy import parse_connector_policy_document
+from dcp_facade.ingress import AuthIngressMiddleware, build_protected_mcp_placeholder_app
+from dcp_facade.ingress_audit import IngressAuditLog
+from dcp_facade.loopback_server import NonLoopbackBindError, assert_loopback_host, probe_loopback_bind
+from dcp_facade.rate_limit import ConnectorRateLimiter, RateLimitConfig
+
+
+def _policy(enabled: bool = True, rpm: int = 60, burst: int = 10, concurrent: int = 2) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0.0",
+        "connector_id": "chatgpt-dopemux-main",
+        "provider": "chatgpt",
+        "transport_class": "local_streamable_http",
+        "credential_ref": {
+            "kind": "environment",
+            "reference": "env:DCP_TEST_CONNECTOR_TOKEN",
+            "verification_fingerprint": "fp:chatgpt:testdigest01",
+            "rotation_group": "dcp-chatgpt",
+        },
+        "default_target_id": "dopemux-main",
+        "allowed_target_ids": ["dopemux-main"],
+        "multi_target_authorized": False,
+        "allowed_tools": [
+            "list_targets",
+            "get_target_capabilities",
+            "get_target_repo_state_snapshot",
+            "list_target_proof_bundles",
+            "fetch_target_proof_bundle",
+            "get_target_runtime_receipt",
+        ],
+        "denied_tools": ["mutation-tool-denied"],
+        "enabled": enabled,
+        "rate_limit": {
+            "requests_per_minute": rpm,
+            "burst": burst,
+            "max_concurrent": concurrent,
+            "deny_on_backend_unavailable": True,
+        },
+        "audit_label": "provider.chatgpt.dopemux-main",
+        "created_by": "operator-test",
+        "created_at": "2099-01-01T00:00:00Z",
+        "expires_at": "2099-02-01T00:00:00Z",
+        "last_verified_at": None,
+        "source_documentation_date": "2026-07-15",
+        "provider_account_class": "business",
+        "fail_closed": {
+            "unknown_target": "BLOCK",
+            "disabled_target": "BLOCK",
+            "unauthorized_target": "BLOCK",
+            "denied_tool": "BLOCK",
+            "expired_credential": "BLOCK",
+            "ambiguous_owner": "BLOCK",
+            "stale_runtime": "BLOCK",
+            "auth_failure": "BLOCK",
+            "missing_rate_policy": "BLOCK",
+            "provider_drift": "BLOCK",
+        },
+    }
+
+
+def _client(
+    *,
+    token: str = "test-token-alpha",
+    rpm: int = 60,
+    burst: int = 10,
+    concurrent: int = 2,
+    enabled: bool = True,
+) -> tuple[TestClient, IngressAuditLog]:
+    store = parse_connector_policy_document(_policy(enabled=enabled, rpm=rpm, burst=burst, concurrent=concurrent))
+    audit = IngressAuditLog()
+    app = AuthIngressMiddleware(
+        build_protected_mcp_placeholder_app(),
+        policy_store=store,
+        secret_resolver=MappingSecretResolver(
+            {("environment", "env:DCP_TEST_CONNECTOR_TOKEN"): token}
+        ),
+        audit_log=audit,
+        rate_limiter=ConnectorRateLimiter(),
+    )
+    return TestClient(app), audit
+
+
+def test_health_is_unauthenticated_and_does_not_list_tools():
+    client, audit = _client()
+    response = client.get("/health")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert "tools" not in body
+    assert any(ev.decision == "allow_health" for ev in audit.events())
+
+
+def test_unauthenticated_mcp_discovery_is_denied():
+    client, audit = _client()
+    response = client.get("/mcp")
+    assert response.status_code == 401
+    assert response.json()["error"] == "authentication failed"
+    assert "tools" not in response.json()
+    assert any(ev.decision == "deny_auth" for ev in audit.events())
+
+
+def test_forged_connector_header_does_not_authenticate():
+    client, _ = _client()
+    response = client.get(
+        "/mcp",
+        headers={
+            "X-DCP-Connector-Id": "chatgpt-dopemux-main",
+            "X-DCP-Connector-Seal": "forged",
+        },
+    )
+    assert response.status_code == 401
+
+
+def test_authenticated_mcp_discovery_lists_allowed_tools_only():
+    client, audit = _client()
+    response = client.get("/mcp", headers={"Authorization": "Bearer test-token-alpha"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["authenticated_connector"] == "chatgpt-dopemux-main"
+    names = {entry["name"] for entry in body["tools"]}
+    assert "list_targets" in names
+    assert "mutation-tool-denied" not in names
+    assert any(ev.decision == "allow" for ev in audit.events())
+    # Authorization value must not appear in audit dump.
+    dump = audit.dump_json_lines()
+    assert "test-token-alpha" not in dump
+    assert "Bearer test-token-alpha" not in dump
+
+
+def test_wrong_token_denied_without_reflection():
+    client, audit = _client()
+    response = client.get("/mcp", headers={"Authorization": "Bearer wrong-secret-token"})
+    assert response.status_code == 401
+    rendered = response.text + audit.dump_json_lines()
+    assert "wrong-secret-token" not in rendered
+
+
+def test_rate_limit_blocks_after_burst():
+    client, audit = _client(burst=2, rpm=2, concurrent=2)
+    headers = {"Authorization": "Bearer test-token-alpha"}
+    assert client.get("/mcp", headers=headers).status_code == 200
+    assert client.get("/mcp", headers=headers).status_code == 200
+    limited = client.get("/mcp", headers=headers)
+    assert limited.status_code == 429
+    assert limited.json()["error"] == "rate limit exceeded"
+    assert any(ev.decision == "deny_rate" for ev in audit.events())
+
+
+def test_rate_limiter_unit_concurrency():
+    limiter = ConnectorRateLimiter()
+    cfg = RateLimitConfig(requests_per_minute=100, burst=10, max_concurrent=1)
+    first = limiter.allow("c1", cfg)
+    second = limiter.allow("c1", cfg)
+    assert first.allowed is True
+    assert second.allowed is False
+    limiter.release("c1")
+    third = limiter.allow("c1", cfg)
+    assert third.allowed is True
+    limiter.release("c1")
+
+
+def test_non_loopback_host_rejected():
+    with pytest.raises(NonLoopbackBindError):
+        assert_loopback_host("0.0.0.0")
+    with pytest.raises(NonLoopbackBindError):
+        assert_loopback_host("192.168.1.10")
+
+
+def test_loopback_socket_probe_binds_127():
+    host, port = probe_loopback_bind("127.0.0.1", 0)
+    assert host in {"127.0.0.1", "0.0.0.0"} or host.startswith("127.")
+    # Platform may report 0.0.0.0 for INADDR_ANY when binding 127? On macOS getsockname is 127.0.0.1
+    assert port > 0
+    assert host == "127.0.0.1"

--- a/services/dcp-readonly-facade/tests/test_loopback_server.py
+++ b/services/dcp-readonly-facade/tests/test_loopback_server.py
@@ -1,0 +1,97 @@
+"""Loopback server start/stop/health lifecycle tests (TP-0014)."""
+
+from __future__ import annotations
+
+import httpx
+
+from dcp_facade.auth_context import MappingSecretResolver
+from dcp_facade.connector_policy import parse_connector_policy_document
+from dcp_facade.loopback_server import LoopbackIngressServer, NonLoopbackBindError, assert_loopback_host
+
+
+def _store():
+    return parse_connector_policy_document(
+        {
+            "schema_version": "1.0.0",
+            "connector_id": "chatgpt-dopemux-main",
+            "provider": "chatgpt",
+            "transport_class": "local_streamable_http",
+            "credential_ref": {
+                "kind": "environment",
+                "reference": "env:DCP_TEST_CONNECTOR_TOKEN",
+                "verification_fingerprint": "fp:chatgpt:testdigest01",
+                "rotation_group": "dcp-chatgpt",
+            },
+            "default_target_id": "dopemux-main",
+            "allowed_target_ids": ["dopemux-main"],
+            "multi_target_authorized": False,
+            "allowed_tools": ["list_targets", "get_target_capabilities"],
+            "denied_tools": [],
+            "enabled": True,
+            "rate_limit": {
+                "requests_per_minute": 60,
+                "burst": 10,
+                "max_concurrent": 2,
+                "deny_on_backend_unavailable": True,
+            },
+            "audit_label": "provider.chatgpt.dopemux-main",
+            "created_by": "operator-test",
+            "created_at": "2099-01-01T00:00:00Z",
+            "expires_at": "2099-02-01T00:00:00Z",
+            "last_verified_at": None,
+            "source_documentation_date": "2026-07-15",
+            "provider_account_class": "business",
+            "fail_closed": {
+                "unknown_target": "BLOCK",
+                "disabled_target": "BLOCK",
+                "unauthorized_target": "BLOCK",
+                "denied_tool": "BLOCK",
+                "expired_credential": "BLOCK",
+                "ambiguous_owner": "BLOCK",
+                "stale_runtime": "BLOCK",
+                "auth_failure": "BLOCK",
+                "missing_rate_policy": "BLOCK",
+                "provider_drift": "BLOCK",
+            },
+        }
+    )
+
+
+def test_server_start_stop_health_and_auth_gate():
+    server = LoopbackIngressServer(
+        policy_store=_store(),
+        secret_resolver=MappingSecretResolver(
+            {("environment", "env:DCP_TEST_CONNECTOR_TOKEN"): "live-token"}
+        ),
+        host="127.0.0.1",
+        port=0,
+    )
+    health = server.start()
+    assert health.running is True
+    assert health.host == "127.0.0.1"
+    assert health.port is not None and health.port > 0
+    assert health.auth_required is True
+    base = server.bound_url
+    assert base is not None
+
+    with httpx.Client(timeout=2.0) as client:
+        health_resp = client.get(f"{base}/health")
+        assert health_resp.status_code == 200
+        denied = client.get(f"{base}/mcp")
+        assert denied.status_code == 401
+        allowed = client.get(f"{base}/mcp", headers={"Authorization": "Bearer live-token"})
+        assert allowed.status_code == 200
+        assert allowed.json()["authenticated_connector"] == "chatgpt-dopemux-main"
+
+    stopped = server.stop()
+    assert stopped.running is False
+    assert server.bound_url is None
+
+
+def test_constructor_rejects_public_bind():
+    try:
+        LoopbackIngressServer(host="0.0.0.0", port=0)
+        assert False, "expected NonLoopbackBindError"
+    except NonLoopbackBindError:
+        pass
+    assert assert_loopback_host("127.0.0.1") == "127.0.0.1"

--- a/task-packets/INDEX.md
+++ b/task-packets/INDEX.md
@@ -136,6 +136,7 @@ A packet is superseded by another packet
 | TP-DCP-MCP-RO-0008 | DCP / MCP | Hardening Cross Project Isolation And PR Readiness | Active | N/A |
 | TP-DCP-MCP-RO-0012 | DCP / MCP | Public Facade Target Contract Migration | Active | TP-DCP-MCP-RO-0011-REMEDIATION-01 |
 | TP-DCP-MCP-RO-0013 | DCP / MCP | Connector Policy Schema And Auth Context | Active | TP-DCP-MCP-RO-0012 |
+| TP-DCP-MCP-RO-0014 | DCP / MCP | Loopback Streamable HTTP Ingress | Active | TP-DCP-MCP-RO-0013 |
 | DMX-DCP-PROMPT5-EXTRACT-RECON-001 | DCP / Prompt 5 | Extract Prompt 5 chat-history docs and reconcile PR/Task Orchestrator runway state | Active | N/A |
 
 ────────────────────────────────────────────────────────────

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.json
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.json
@@ -1,0 +1,116 @@
+{
+  "id": "TP-DCP-MCP-RO-0014",
+  "project": "dopemux-mvp",
+  "target": "Add hardened loopback Streamable HTTP ingress with auth-before-discovery, per-connector rate/concurrency limits, structured redacted audit, and deterministic start/stop/health without public binds or tunnels.",
+  "invariants": [
+    "Ingress binds only to loopback hosts; 0.0.0.0 and non-loopback hosts are rejected.",
+    "MCP discovery and dispatch paths require connector authentication before any tool listing.",
+    "Unauthenticated or forged connector headers never disclose tools or backend topology.",
+    "Per-connector rate and concurrency limits fail closed with generic errors.",
+    "Audit events never retain raw bearer tokens or secrets.",
+    "No tunnel, public compose bind default, provider credential, or backend adapter is introduced."
+  ],
+  "depends_on": [
+    "TP-DCP-MCP-RO-0013"
+  ],
+  "repo_binding": {
+    "project_id": "DDD-Enterprises/dopemux-mvp",
+    "repo_marker": "AGENTS.md",
+    "origin_hint": "https://github.com/DDD-Enterprises/dopemux-mvp.git",
+    "require_identity_match": true
+  },
+  "series": {
+    "id": "DCP-MCP-RO",
+    "base_branch": "main",
+    "parent_tp_id": "TP-DCP-MCP-RO-0013",
+    "final_packet": false
+  },
+  "execution": {
+    "agent": "codex",
+    "branch": "codex/dcp-mcp-ro-0014-loopback-ingress",
+    "base_branch": "main",
+    "stacked_because": "TP-DCP-MCP-RO-0013 connector policy/auth context is merged on main (PR #1059)."
+  },
+  "commit": {
+    "message": "feat(dcp): add loopback authenticated streamable HTTP ingress",
+    "allowlist": [
+      "services/dcp-readonly-facade/src/dcp_facade/ingress.py",
+      "services/dcp-readonly-facade/src/dcp_facade/loopback_server.py",
+      "services/dcp-readonly-facade/src/dcp_facade/rate_limit.py",
+      "services/dcp-readonly-facade/src/dcp_facade/ingress_audit.py",
+      "services/dcp-readonly-facade/src/mcp/server.py",
+      "services/dcp-readonly-facade/tests/test_ingress.py",
+      "services/dcp-readonly-facade/tests/test_loopback_server.py",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/INGRESS_LOOPBACK_CONTRACT.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/FACADE_LOCAL_RUN.md",
+      "docs/03-reference/dcp/chatgpt-mcp-readonly/BUILD_SERIES.md",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.json",
+      "task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.md",
+      "task-packets/INDEX.md",
+      "proof/TP-DCP-MCP-RO-0014/**"
+    ],
+    "verify": [
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_ingress.py services/dcp-readonly-facade/tests/test_loopback_server.py",
+      "uv run --frozen pytest -q services/dcp-readonly-facade/tests",
+      "uv run --frozen python -m compileall -q services/dcp-readonly-facade/src",
+      "python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json",
+      "git diff --check",
+      "pre-commit run --files <changed-files>"
+    ]
+  },
+  "pr": {
+    "title": "feat(dcp): add loopback authenticated streamable HTTP ingress",
+    "body": "Implements TP-DCP-MCP-RO-0014: loopback-only Streamable HTTP ingress with auth-before-discovery, rate/concurrency limits, redacted audit, and start/stop/health. Stdio remains default. No public bind, tunnel, or real credentials.",
+    "base": "main"
+  },
+  "pal_chain": {
+    "enabled": true,
+    "steps": [
+      "analyze",
+      "thinkdeep",
+      "challenge",
+      "planner",
+      "challenge",
+      "implement",
+      "secaudit",
+      "codereview",
+      "precommit",
+      "challenge"
+    ]
+  },
+  "steps": [
+    {
+      "id": "loopback-bind",
+      "task": "Implement pinned loopback host validation and deterministic start/stop/health for the Streamable HTTP ingress.",
+      "validation": [
+        "Non-loopback hosts are rejected.",
+        "Server binds 127.0.0.1 and reports health with host/port."
+      ]
+    },
+    {
+      "id": "auth-before-discovery",
+      "task": "Require connector authentication before MCP paths; deny unauthenticated initialize/list/call without tool disclosure.",
+      "validation": [
+        "Unauthenticated /mcp returns 401 without tools.",
+        "Authenticated /mcp returns allowed tools only.",
+        "Forgeable connector headers cannot authenticate."
+      ]
+    },
+    {
+      "id": "rate-audit",
+      "task": "Apply per-connector rate/concurrency limits and structured redacted audit events.",
+      "validation": [
+        "Burst exhaustion returns 429.",
+        "Audit dumps contain no raw bearer tokens."
+      ]
+    },
+    {
+      "id": "validate",
+      "task": "Run focused/full tests, compileall, packet schema validation, pre-commit, advisory AGY, open PR without merge.",
+      "validation": [
+        "Local validation captured in proof or marked NOT_RUN.",
+        "Trusted embedded audit is not claimed from AGY."
+      ]
+    }
+  ]
+}

--- a/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.md
+++ b/task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.md
@@ -1,0 +1,56 @@
+---
+id: TP-DCP-MCP-RO-0014
+title: Loopback Streamable HTTP Ingress
+type: explanation
+owner: '@hu3mann'
+author: '@codex'
+date: '2026-07-16'
+prelude: Hardened loopback Streamable HTTP ingress with auth-before-discovery for the DCP read-only facade.
+last_review: '2026-07-16'
+next_review: '2026-10-14'
+---
+# TP-DCP-MCP-RO-0014
+
+## Objective
+
+Add a loopback-only Streamable HTTP ingress that authenticates connectors
+before MCP discovery, enforces rate/concurrency limits, emits redacted audit
+events, and supports deterministic start/stop/health.
+
+## Scope
+
+IN:
+
+- Loopback host pin and non-loopback rejection
+- ASGI auth middleware over MCP paths
+- Rate/concurrency limits from connector policy
+- Structured redacted audit log
+- Server lifecycle + docs/tests/packet/proof
+- Optional `DCP_FACADE_TRANSPORT=streamable-http` wiring (stdio remains default)
+
+OUT:
+
+- Public binds, tunnels, provider setup, real credentials, backend adapters,
+  ownership probes, compose exposure, CI auditor routing changes
+
+## Validation
+
+```text
+uv run --frozen pytest -q services/dcp-readonly-facade/tests/test_ingress.py services/dcp-readonly-facade/tests/test_loopback_server.py
+uv run --frozen pytest -q services/dcp-readonly-facade/tests
+uv run --frozen python -m compileall -q services/dcp-readonly-facade/src
+uv run --frozen python -m jsonschema -i task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.json docs/03-reference/spec/dopetask/dopetask-canonical-spec.json
+git diff --check
+```
+
+## Stop Conditions
+
+- Implementation requires a non-loopback default bind or tunnel creation
+- Unauthenticated clients can list tools
+- Diff escapes the packet allowlist
+- Trusted audit is claimed from local AGY alone
+
+## Rollback
+
+Revert the TP-0014 commits and keep `DCP_FACADE_TRANSPORT=stdio`. No backend
+change is required.


### PR DESCRIPTION
## Summary

Implements **TP-DCP-MCP-RO-0014** on merged TP-0013 (#1059).

- Loopback-only Streamable HTTP ingress (`127.0.0.1` pin; non-loopback rejected)
- Auth-before-discovery ASGI middleware (401 + no tools without connector bearer)
- Per-connector rate/concurrency limits (429)
- Structured redacted audit events
- Deterministic start/stop/health
- Stdio remains default; optional `DCP_FACADE_TRANSPORT=streamable-http`

## Out of scope

Public binds, tunnels, real credentials, backend adapters, provider live setup.

## Validation (local)

- Focused ingress/loopback tests: 11 passed
- Full facade suite: passed (1 opt-in live skipped)
- compileall, packet schema, pre-commit: passed
- AGY: `PASS_WITH_RISKS` (advisory only)

## Readiness blockers

- Trusted embedded audit: SKIPPED / not claimed
- PR Steward / merge readiness: not claimed

## Packet / proof

- `task-packets/dcp/chatgpt-mcp-readonly/TP-DCP-MCP-RO-0014.json`
- `proof/TP-DCP-MCP-RO-0014/`

## Test plan

- [x] Local unit/ingress/loopback tests
- [ ] CI checks
- [ ] Trusted embedded audit (blocked without runner/credentials)